### PR TITLE
fix(plugin-openai): retry transient stream-start failures on the live-streaming path

### DIFF
--- a/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Shape tests for live-stream start retry: a transient provider error that
+ * kills the stream BEFORE its first token (Cerebras's "Encountered a server
+ * error, please try again" arrives via `onError` with an empty stream, or as
+ * a throw on the first pull) retries with backoff, because nothing has
+ * reached the user yet. Mid-stream and non-transient failures stay fatal.
+ * Mocked `ai` SDK (fresh stream objects per call — generators are single-use),
+ * no network; the live Cerebras failure this fences rode the incident log.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const aiMocks = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  streamText: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  generateText: aiMocks.generateText,
+  streamText: aiMocks.streamText,
+  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  Output: { object: () => ({}) },
+}));
+
+vi.mock("../providers", () => ({
+  createOpenAIClient: () => ({
+    chat: (modelName: string) => ({ modelName }),
+    responses: (modelName: string) => ({ modelName }),
+  }),
+}));
+
+function createRuntime() {
+  return {
+    character: { name: "Ada", system: "system prompt" },
+    emitEvent: vi.fn(),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+    getSetting: vi.fn(() => undefined),
+  } as never;
+}
+
+const TRANSIENT = {
+  message: "Encountered a server error, please try again",
+  type: "server_error",
+};
+
+function successResult(tokens: string[]) {
+  return {
+    textStream: (async function* textStream() {
+      for (const token of tokens) yield token;
+    })(),
+    fullStream: (async function* fullStream() {})(),
+    text: Promise.resolve(tokens.join("")),
+    toolCalls: Promise.resolve([]),
+    finishReason: Promise.resolve("stop"),
+    usage: Promise.resolve({ inputTokens: 5, outputTokens: 5 }),
+  };
+}
+
+/** An attempt whose provider error surfaces via onError with an empty stream. */
+function emptyErroredResult(onError: (arg: { error: unknown }) => void, error: unknown) {
+  return {
+    textStream: (async function* textStream() {
+      onError({ error });
+    })(),
+    fullStream: (async function* fullStream() {})(),
+    text: Promise.resolve(""),
+    toolCalls: Promise.resolve([]),
+    finishReason: Promise.resolve("error"),
+    usage: Promise.resolve(undefined),
+  };
+}
+
+async function collect(stream: { textStream: AsyncIterable<string> }) {
+  const chunks: string[] = [];
+  for await (const chunk of stream.textStream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+describe("live-stream start retry", () => {
+  beforeEach(() => {
+    aiMocks.streamText.mockReset();
+    aiMocks.generateText.mockReset();
+  });
+
+  it("retries a transient onError-with-empty-stream failure and delivers the second attempt", async () => {
+    let call = 0;
+    aiMocks.streamText.mockImplementation((args: { onError: (a: { error: unknown }) => void }) => {
+      call++;
+      return Promise.resolve(
+        call === 1 ? emptyErroredResult(args.onError, TRANSIENT) : successResult(["hel", "lo"])
+      );
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    await expect(collect(stream)).resolves.toEqual(["hel", "lo"]);
+    expect(aiMocks.streamText).toHaveBeenCalledTimes(2);
+  }, 20_000);
+
+  it("retries a transient throw on the first pull", async () => {
+    let call = 0;
+    aiMocks.streamText.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return Promise.resolve({
+          textStream: (async function* textStream() {
+            throw TRANSIENT;
+          })(),
+          fullStream: (async function* fullStream() {})(),
+          text: Promise.resolve(""),
+          toolCalls: Promise.resolve([]),
+          finishReason: Promise.resolve("error"),
+          usage: Promise.resolve(undefined),
+        });
+      }
+      return Promise.resolve(successResult(["ok"]));
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    await expect(collect(stream)).resolves.toEqual(["ok"]);
+    expect(aiMocks.streamText).toHaveBeenCalledTimes(2);
+  }, 20_000);
+
+  it("does NOT retry a non-transient pre-token failure; the error surfaces to the consumer", async () => {
+    aiMocks.streamText.mockImplementation((args: { onError: (a: { error: unknown }) => void }) =>
+      Promise.resolve(
+        emptyErroredResult(args.onError, { message: "invalid request: bad schema", status: 400 })
+      )
+    );
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    await expect(collect(stream)).rejects.toMatchObject({
+      message: "invalid request: bad schema",
+    });
+    expect(aiMocks.streamText).toHaveBeenCalledTimes(1);
+  }, 20_000);
+
+  it("retries a transient pre-token failure on the streamStructured fullStream path", async () => {
+    let call = 0;
+    aiMocks.streamText.mockImplementation((args: { onError: (a: { error: unknown }) => void }) => {
+      call++;
+      if (call === 1) {
+        // The structured path consumes fullStream, so the transient error
+        // must surface on THAT pull.
+        return Promise.resolve({
+          textStream: (async function* textStream() {})(),
+          fullStream: (async function* fullStream() {
+            args.onError({ error: TRANSIENT });
+          })(),
+          text: Promise.resolve(""),
+          toolCalls: Promise.resolve([]),
+          finishReason: Promise.resolve("error"),
+          usage: Promise.resolve(undefined),
+        });
+      }
+      return Promise.resolve({
+        textStream: (async function* textStream() {})(),
+        fullStream: (async function* fullStream() {
+          yield { type: "tool-input-start", id: "c1", toolName: "HANDLE_RESPONSE" };
+          yield {
+            type: "tool-input-delta",
+            toolCallId: "c1",
+            inputTextDelta: '{"replyText":"hi"}',
+          };
+          yield { type: "tool-input-end", id: "c1" };
+          yield { type: "finish", finishReason: "tool-calls" };
+        })(),
+        text: Promise.resolve(""),
+        toolCalls: Promise.resolve([{ toolName: "HANDLE_RESPONSE", input: { replyText: "hi" } }]),
+        finishReason: Promise.resolve("tool-calls"),
+        usage: Promise.resolve({ inputTokens: 10, outputTokens: 8 }),
+      });
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "stage-1",
+      stream: true,
+      streamStructured: true,
+      toolChoice: "required",
+    } as never)) as { textStream: AsyncIterable<string>; text: Promise<string> };
+
+    await expect(collect(stream)).resolves.toEqual(['{"replyText":"hi"}']);
+    await expect(stream.text).resolves.toBe('{"replyText":"hi"}');
+    expect(aiMocks.streamText).toHaveBeenCalledTimes(2);
+  }, 20_000);
+
+  it("non-streaming: a transient generateText rejection retries and returns the second attempt", async () => {
+    let call = 0;
+    aiMocks.generateText.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.reject(TRANSIENT);
+      return Promise.resolve({
+        text: "recovered",
+        toolCalls: [],
+        finishReason: "stop",
+        usage: { inputTokens: 4, outputTokens: 2 },
+        providerMetadata: undefined,
+      });
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const result = await handleTextSmall(createRuntime(), { prompt: "hi" } as never);
+
+    expect(result).toBe("recovered");
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(2);
+  }, 20_000);
+
+  it("non-streaming: a genuine validation 400 does not retry", async () => {
+    aiMocks.generateText.mockRejectedValue({
+      statusCode: 400,
+      message: "invalid request: required field missing",
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    await expect(handleTextSmall(createRuntime(), { prompt: "hi" } as never)).rejects.toMatchObject(
+      { statusCode: 400 }
+    );
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+  }, 20_000);
+
+  it("buffered planner stream (FULL_ACTION_SURFACE): transient failure retries and replays the buffered text", async () => {
+    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
+    try {
+      let call = 0;
+      // consumeStreamWithTransientRetry does not await streamText — return
+      // plain result objects, not promises.
+      aiMocks.streamText.mockImplementation(
+        (args: { onError: (a: { error: unknown }) => void }) => {
+          call++;
+          if (call === 1) {
+            return {
+              textStream: (async function* textStream() {
+                args.onError({ error: TRANSIENT });
+              })(),
+              toolCalls: Promise.resolve([]),
+              finishReason: Promise.resolve("error"),
+              usage: Promise.resolve(undefined),
+            };
+          }
+          return {
+            textStream: (async function* textStream() {
+              yield "planned ";
+              yield "output";
+            })(),
+            toolCalls: Promise.resolve([]),
+            finishReason: Promise.resolve("stop"),
+            usage: Promise.resolve({ inputTokens: 9, outputTokens: 3 }),
+          };
+        }
+      );
+
+      const { handleTextSmall } = await import("../models/text");
+      const stream = (await handleTextSmall(createRuntime(), {
+        prompt: "plan",
+        stream: true,
+      } as never)) as { textStream: AsyncIterable<string>; text: Promise<string> };
+
+      await expect(collect(stream)).resolves.toEqual(["planned output"]);
+      await expect(stream.text).resolves.toBe("planned output");
+      expect(aiMocks.streamText).toHaveBeenCalledTimes(2);
+    } finally {
+      delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+    }
+  }, 20_000);
+
+  it("non-streaming with native tools (the coding-build path): transient failure retries and tool calls survive", async () => {
+    let call = 0;
+    aiMocks.generateText.mockImplementation(() => {
+      call++;
+      // Cerebras's overload wears an HTTP 400 with transient wording on this
+      // path — the exact #16334 scenario.
+      if (call === 1) {
+        return Promise.reject({
+          statusCode: 400,
+          message: "Encountered a server error, please try again",
+        });
+      }
+      return Promise.resolve({
+        text: "",
+        toolCalls: [{ toolName: "lookup", input: { q: "answer" } }],
+        finishReason: "tool-calls",
+        usage: { inputTokens: 12, outputTokens: 6 },
+        providerMetadata: undefined,
+      });
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const result = (await handleTextSmall(createRuntime(), {
+      prompt: "call a tool",
+      tools: { lookup: { description: "Lookup", inputSchema: { type: "object" } } },
+      toolChoice: { type: "tool", toolName: "lookup" },
+      responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+    } as never)) as { toolCalls?: Array<{ toolName: string }> };
+
+    expect(result.toolCalls?.[0]?.toolName).toBe("lookup");
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(2);
+  }, 20_000);
+
+  it("does NOT retry once a token has been delivered — mid-stream failures stay fatal", async () => {
+    aiMocks.streamText.mockImplementation((args: { onError: (a: { error: unknown }) => void }) =>
+      Promise.resolve({
+        textStream: (async function* textStream() {
+          yield "partial ";
+          args.onError({ error: TRANSIENT });
+        })(),
+        fullStream: (async function* fullStream() {})(),
+        text: Promise.resolve("partial "),
+        toolCalls: Promise.resolve([]),
+        finishReason: Promise.resolve("error"),
+        usage: Promise.resolve(undefined),
+      })
+    );
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    await expect(collect(stream)).rejects.toMatchObject({
+      message: "Encountered a server error, please try again",
+    });
+    expect(aiMocks.streamText).toHaveBeenCalledTimes(1);
+  }, 20_000);
+});

--- a/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
@@ -59,6 +59,7 @@ function successResult(tokens: string[]) {
 /** An attempt whose provider error surfaces via onError with an empty stream. */
 function emptyErroredResult(onError: (arg: { error: unknown }) => void, error: unknown) {
   return {
+    // biome-ignore lint/correctness/useYield: error-only stream fixture — the provider error surfaces via onError, no tokens.
     textStream: (async function* textStream() {
       onError({ error });
     })(),
@@ -109,6 +110,7 @@ describe("live-stream start retry", () => {
       call++;
       if (call === 1) {
         return Promise.resolve({
+          // biome-ignore lint/correctness/useYield: throw-only stream fixture — fails on the first pull.
           textStream: (async function* textStream() {
             throw TRANSIENT;
           })(),
@@ -160,6 +162,7 @@ describe("live-stream start retry", () => {
         // must surface on THAT pull.
         return Promise.resolve({
           textStream: (async function* textStream() {})(),
+          // biome-ignore lint/correctness/useYield: error-only stream fixture — the provider error surfaces via onError, no tokens.
           fullStream: (async function* fullStream() {
             args.onError({ error: TRANSIENT });
           })(),
@@ -246,6 +249,7 @@ describe("live-stream start retry", () => {
           call++;
           if (call === 1) {
             return {
+              // biome-ignore lint/correctness/useYield: error-only stream fixture — the provider error surfaces via onError, no tokens.
               textStream: (async function* textStream() {
                 args.onError({ error: TRANSIENT });
               })(),

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1673,12 +1673,67 @@ async function generateTextByModelType(
     let capturedStreamError: unknown;
     let companionStreamError: unknown;
     let telemetryFinalized = false;
-    const result = await streamText({
-      ...generateParams,
-      onError: ({ error }: { error: unknown }) => {
-        capturedStreamError = error;
-      },
-    });
+    // Live streaming retries ONLY when the attempt dies before its first
+    // token: Cerebras's transient 500s surface through `onError` with an
+    // empty stream (or as a throw on the first pull), and at that point
+    // nothing has reached the user, so a fresh attempt is invisible. Once a
+    // token has been delivered a failure stays fatal — replaying a partial
+    // stream would double-deliver text. The first item is pre-pulled here and
+    // replayed by the generator below; abandoned attempts get their companion
+    // promises defused so an errored, unconsumed result cannot surface as an
+    // unhandled rejection.
+    let result!: Awaited<ReturnType<typeof streamText>>;
+    let streamIterator!: AsyncIterator<unknown>;
+    let firstItem: IteratorResult<unknown> | undefined;
+    for (let attempt = 0; ; attempt++) {
+      capturedStreamError = undefined;
+      result = await streamText({
+        ...generateParams,
+        onError: ({ error }: { error: unknown }) => {
+          capturedStreamError = error;
+        },
+      });
+      const source = params.streamStructured === true ? result.fullStream : result.textStream;
+      streamIterator = (source as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+      try {
+        firstItem = await streamIterator.next();
+      } catch (error) {
+        firstItem = undefined;
+        capturedStreamError ??= error;
+      }
+      const failedBeforeFirstToken =
+        capturedStreamError !== undefined && (firstItem === undefined || firstItem.done === true);
+      if (
+        !failedBeforeFirstToken ||
+        attempt >= 3 ||
+        !isTransientProviderError(capturedStreamError)
+      ) {
+        break;
+      }
+      for (const companion of [result.text, result.usage, result.finishReason, result.toolCalls]) {
+        void Promise.resolve(companion).catch(() => {
+          // error-policy:J5 suppression — this attempt is being abandoned and
+          // retried; its failure is observed via capturedStreamError.
+        });
+      }
+      const backoffMs = Math.min(3000, 300 * 2 ** attempt) + Math.floor(Math.random() * 200);
+      logger.warn(
+        `[OpenAI] transient stream-start error (attempt ${attempt + 1}/3), retrying in ${backoffMs}ms: ${
+          (capturedStreamError as { message?: string })?.message ?? String(capturedStreamError)
+        }`
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+    // Replays the pre-pulled first item, then continues the committed attempt.
+    const iterateStream = async function* (): AsyncGenerator<unknown> {
+      if (firstItem && !firstItem.done) yield firstItem.value;
+      if (firstItem?.done) return;
+      for (;;) {
+        const next = await streamIterator.next();
+        if (next.done) return;
+        yield next.value;
+      }
+    };
     let structuredTextSettled = false;
     let resolveStructuredText: (text: string) => void = () => {};
     let rejectStructuredText: (error: unknown) => void = () => {};
@@ -1764,7 +1819,7 @@ async function generateTextByModelType(
             // visible. The authoritative parse still comes from toolCalls.
             // Gated on streamStructured so planner/coding tool-call JSON never
             // leaks into a visible stream.
-            for await (const part of result.fullStream) {
+            for await (const part of iterateStream()) {
               // The AI SDK renamed these delta fields across v6 minors
               // (`tool-input-delta`: delta→inputTextDelta), and the workspace's
               // declared (^6.0.30) and hoisted (6.0.174) copies disagree — read
@@ -1785,10 +1840,10 @@ async function generateTextByModelType(
               yield chunk;
             }
           } else {
-            for await (const chunk of result.textStream) {
-              responseChunks.push(chunk);
-              params.onStreamChunk?.(chunk);
-              yield chunk;
+            for await (const chunk of iterateStream()) {
+              responseChunks.push(chunk as string);
+              params.onStreamChunk?.(chunk as string);
+              yield chunk as string;
             }
           }
         } catch (error) {


### PR DESCRIPTION
## What

Regular chat streams through the LIVE streaming branch of `generateTextByModelType`, which called `streamText` once with no retry — the transient-retry shield only covered the non-streaming and buffered planner paths. A single transient Cerebras 500 ("Encountered a server error, please try again", which the AI SDK surfaces via `onError` with an **empty stream**, not a throw) therefore killed the whole user turn with an apology relay. Observed live 4x on 2026-07-15/16, including a user-visible app-build failure.

The live path now pre-pulls the first stream item and retries with bounded exponential backoff **only when the attempt dies before its first token** (empty stream + captured transient error, or a transient throw on the first pull) — nothing has reached the user at that point, so a fresh attempt is invisible. Once any token is delivered, failures stay fatal: replaying a partial stream would double-deliver text. Abandoned attempts' companion promises are defused so an errored, unconsumed result can't surface as an unhandled rejection. Transient classification reuses the existing `isTransientProviderError` (Cerebras's status-less transient shape and overload-worded 400s included; genuine validation errors never retry).

## Evidence

| Type | Evidence |
|---|---|
| Backend logs | Incident log excerpt + post-fix live probes: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/retry-incident.txt |
| Tests | 9 shape fences (mocked AI SDK, fresh per-call streams): plain + streamStructured pre-token retries, throw-on-first-pull, buffered planner-path retry, the #16334 tools-under-transient-400 scenario, non-transient 400 never retried, mid-stream never retried. Full plugin suite 131 passed. `models/text.ts` at 57% lines from the changed suite alone. |
| Live proof | Same deployment, dist rebuilt + restarted: the exact failing app-build prompt completes end to end (site delivered), casual/live-info probes single-message at ~2.4s. |
| Screenshots / video | N/A - model-provider resilience change; the user-visible effect is turn success vs apology, shown in the backend-log evidence. |

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend-only model-provider change; user-visible effect is turn success vs apology relay, shown in backend-logs.`

<!-- evidence-row:after-screenshots -->
`N/A - backend-only model-provider change; user-visible effect is turn success vs apology relay, shown in backend-logs.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live incident + post-fix probe transcript in backend-logs.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/retry-incident.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
`N/A - no model-behavior change; this is transport resilience around the provider call. The post-fix live turn (app build completing end-to-end) is in backend-logs.`

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/retry-incident.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
