### PR TITLE
feat(orchestrator): supervise wave lane lifecycle (W3 of #16443)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/wave-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/wave-supervisor.test.ts
@@ -1,10 +1,155 @@
 import { describe, expect, it } from "vitest";
+import type { TaskThreadDetailDto } from "../services/orchestrator-task-mapper.js";
 import {
   detectWaveCollisions,
   isSalvageEligible,
+  readLaneDependencies,
+  readLaneId,
+  readWaveAttemptId,
   readWaveId,
   shouldRefillWave,
+  WaveSupervisor,
 } from "../services/wave-supervisor.js";
+
+function task(
+  id: string,
+  status: TaskThreadDetailDto["status"],
+  metadata: Record<string, unknown>,
+  usage: Partial<TaskThreadDetailDto["usage"]> = {},
+): TaskThreadDetailDto {
+  return {
+    id,
+    title: id,
+    kind: "task",
+    status,
+    priority: "normal",
+    paused: false,
+    originalRequest: id,
+    sessionCount: 0,
+    activeSessionCount: 0,
+    latestSessionId: null,
+    latestSessionLabel: null,
+    latestSessionModel: null,
+    latestAccountProviderId: null,
+    latestAccountId: null,
+    latestAccountLabel: null,
+    parentTaskId: null,
+    latestWorkdir: null,
+    latestRepo: "org/repo",
+    projectId: null,
+    latestActivityAt: 0,
+    decisionCount: 0,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      state: "measured",
+      byProvider: [],
+      ...usage,
+    },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    closedAt: null,
+    archivedAt: null,
+    goal: id,
+    roomId: null,
+    taskRoomId: null,
+    worldId: null,
+    ownerUserId: null,
+    acceptanceCriteria: [],
+    currentPlan: null,
+    providerPolicy: null,
+    lastUserTurnAt: null,
+    lastCoordinatorTurnAt: null,
+    metadata,
+    sessions: [],
+    decisions: [],
+    events: [],
+    artifacts: [],
+    messages: [],
+    transcripts: [],
+    planRevisions: [],
+  };
+}
+
+function makeTaskService(seed: TaskThreadDetailDto[]) {
+  const tasks = new Map(seed.map((item) => [item.id, structuredClone(item)]));
+  const paused: string[] = [];
+  const resumed: string[] = [];
+  const created: TaskThreadDetailDto[] = [];
+  const spawned: string[] = [];
+  return {
+    paused,
+    resumed,
+    created,
+    spawned,
+    async listTasks() {
+      return [...tasks.values()].map(({ id }) => ({ id }));
+    },
+    async getTask(id: string) {
+      return tasks.get(id) ?? null;
+    },
+    async updateTask(
+      id: string,
+      patch: { metadata?: Record<string, unknown> },
+    ) {
+      const existing = tasks.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, ...patch };
+      tasks.set(id, updated);
+      return updated;
+    },
+    async createTask(input: Record<string, unknown>) {
+      const createdTask = task(
+        `created-${created.length + 1}`,
+        "open",
+        (input.metadata as Record<string, unknown>) ?? {},
+      );
+      created.push(createdTask);
+      tasks.set(createdTask.id, createdTask);
+      return createdTask;
+    },
+    async spawnAgentForTask(id: string) {
+      spawned.push(id);
+      return tasks.get(id) ?? null;
+    },
+    async getTaskOriginTarget() {
+      return null;
+    },
+    async pauseTask(id: string) {
+      paused.push(id);
+      const existing = tasks.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, paused: true };
+      tasks.set(id, updated);
+      return updated;
+    },
+    async resumeTask(id: string) {
+      resumed.push(id);
+      const existing = tasks.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, paused: false };
+      tasks.set(id, updated);
+      return updated;
+    },
+  };
+}
+
+function makeRuntime(
+  taskService: unknown,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    getSetting: (key: string) =>
+      key === "ELIZA_ORCHESTRATOR_WAVE_SUPERVISOR" ? "1" : undefined,
+    getService: (type: string) =>
+      type === "ORCHESTRATOR_TASK_SERVICE" ? taskService : extra[type],
+    reportError: () => undefined,
+  } as never;
+}
 
 // W3's lifecycle policy is intentionally tested without a runtime or timers.
 describe("wave supervisor pure policy", () => {
@@ -13,6 +158,21 @@ describe("wave supervisor pure policy", () => {
     expect(readWaveId({ orchestratorWaveId: "wave-2" })).toBe("wave-2");
     expect(readWaveId({ wave: { id: "wave-3" } })).toBe("wave-3");
     expect(readWaveId({ waveId: "  " })).toBeUndefined();
+  });
+
+  it("reads W1 structured lane ids, dependencies, attempt ids, and scopes", () => {
+    const metadata = {
+      waveId: "wave-1",
+      waveAttemptId: "attempt-2",
+      lane: {
+        id: "lane-2",
+        dependencies: ["lane-1"],
+        scopePaths: ["src/a.ts"],
+      },
+    };
+    expect(readLaneId(metadata, "task-2")).toBe("lane-2");
+    expect(readLaneDependencies(metadata)).toEqual(["lane-1"]);
+    expect(readWaveAttemptId(metadata)).toBe("attempt-2");
   });
 
   it("refills each terminal lane once while the wave goal remains unmet", () => {
@@ -84,22 +244,31 @@ describe("wave supervisor pure policy", () => {
     expect(
       detectWaveCollisions(
         [
-          { laneId: "a", waveId: "w", paths: ["src/auth"], repo: "org/repo" },
+          {
+            laneId: "a",
+            waveId: "w",
+            attemptId: "try-1",
+            paths: ["src/auth"],
+            repo: "org/repo",
+          },
           {
             laneId: "b",
             waveId: "w",
+            attemptId: "try-1",
             paths: ["src/auth/login.ts"],
             repo: "org/repo",
           },
           {
             laneId: "c",
             waveId: "other",
+            attemptId: "try-1",
             paths: ["src/auth"],
             repo: "org/repo",
           },
           {
             laneId: "d",
             waveId: "w",
+            attemptId: "try-1",
             paths: ["src/payments"],
             repo: "org/repo",
           },
@@ -115,16 +284,18 @@ describe("wave supervisor pure policy", () => {
       ),
     ).toEqual([
       {
-        key: "lane:a|lane:b",
+        key: "wave:w|attempt:try-1|lane:a|lane:b",
         waveId: "w",
+        attemptId: "try-1",
         leftId: "a",
         rightId: "b",
         paths: ["src/auth"],
         kind: "lane-lane",
       },
       {
-        key: "lane:d|pr:org/repo#7",
+        key: "wave:w|attempt:try-1|lane:d|pr:org/repo#7",
         waveId: "w",
+        attemptId: "try-1",
         leftId: "d",
         rightId: "org/repo#7",
         paths: ["src/payments"],
@@ -142,7 +313,14 @@ describe("wave supervisor pure policy", () => {
     };
     expect(
       detectWaveCollisions(
-        [{ laneId: "unknown", waveId: "w", paths: ["README.md"] }],
+        [
+          {
+            laneId: "unknown",
+            waveId: "w",
+            attemptId: "try-1",
+            paths: ["README.md"],
+          },
+        ],
         [pullRequest],
       ),
     ).toEqual([]);
@@ -152,6 +330,7 @@ describe("wave supervisor pure policy", () => {
           {
             laneId: "other",
             waveId: "w",
+            attemptId: "try-1",
             paths: ["README.md"],
             repo: "another/project",
           },
@@ -167,12 +346,14 @@ describe("wave supervisor pure policy", () => {
         {
           laneId: "a",
           waveId: "w",
+          attemptId: "try-1",
           paths: [".\\src\\foo"],
           repo: "org/repo",
         },
         {
           laneId: "b",
           waveId: "w",
+          attemptId: "try-1",
           paths: ["src/foobar"],
           repo: "org/repo",
         },
@@ -188,5 +369,141 @@ describe("wave supervisor pure policy", () => {
     );
     expect(collisions).toHaveLength(1);
     expect(collisions[0]?.kind).toBe("lane-pr");
+  });
+
+  it("scopes lane-lane collisions to the same wave attempt", () => {
+    expect(
+      detectWaveCollisions(
+        [
+          {
+            laneId: "a",
+            waveId: "w",
+            attemptId: "try-1",
+            paths: ["src/auth"],
+          },
+          {
+            laneId: "b",
+            waveId: "w",
+            attemptId: "try-2",
+            paths: ["src/auth/login.ts"],
+          },
+        ],
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps runtime-scoped status snapshots isolated", async () => {
+    const leftService = makeTaskService([
+      task("left", "active", { waveId: "left-wave" }),
+    ]);
+    const rightService = makeTaskService([
+      task("right", "active", { waveId: "right-wave" }),
+    ]);
+    const left = new WaveSupervisor(makeRuntime(leftService));
+    const right = new WaveSupervisor(makeRuntime(rightService));
+    expect((await left.runOnce()).map((status) => status.waveId)).toEqual([
+      "left-wave",
+    ]);
+    expect((await right.runOnce()).map((status) => status.waveId)).toEqual([
+      "right-wave",
+    ]);
+  });
+
+  it("blocks admission until structured lane dependencies are done", async () => {
+    const service = makeTaskService([
+      task("dep", "active", { waveId: "w", lane: { id: "lane-1" } }),
+      task("child", "open", {
+        waveId: "w",
+        lane: { id: "lane-2", dependencies: ["lane-1"] },
+      }),
+    ]);
+    const supervisor = new WaveSupervisor(makeRuntime(service));
+    expect(await supervisor.tryAcquire("child")).toBe(false);
+    await service.updateTask("dep", {
+      metadata: { waveId: "w", lane: { id: "lane-1" } },
+    });
+    const dep = await service.getTask("dep");
+    if (dep) (dep as TaskThreadDetailDto).status = "done";
+    expect(await supervisor.tryAcquire("child")).toBe(true);
+  });
+
+  it("pauses wave execution and persists an auditable reason on cumulative budget breach", async () => {
+    const service = makeTaskService([
+      task(
+        "a",
+        "active",
+        { waveId: "w", wave: { budget: { maxCostUsd: 1 } } },
+        { costUsd: 0.6, totalTokens: 100 },
+      ),
+      task("b", "open", { waveId: "w" }, { costUsd: 0.4, totalTokens: 100 }),
+    ]);
+    const supervisor = new WaveSupervisor(makeRuntime(service));
+    expect(await supervisor.tryAcquire("b")).toBe(false);
+    expect(service.paused).toContain("a");
+    const stamped = await service.getTask("a");
+    expect(stamped?.metadata.waveSupervisor).toMatchObject({
+      pauseCode: "ORCHESTRATOR_WAVE_BUDGET_BREACH",
+    });
+  });
+
+  it("approves a budget increase through durable task metadata and resumes paused lanes", async () => {
+    const service = makeTaskService([
+      {
+        ...task("a", "active", { waveId: "w" }, { costUsd: 2 }),
+        paused: true,
+      },
+    ]);
+    const supervisor = new WaveSupervisor(makeRuntime(service));
+    await supervisor.approveBudgetIncrease({
+      waveId: "w",
+      approvedBy: "reviewer",
+      reason: "launch approval",
+      maxCostUsd: 3,
+    });
+    expect(service.resumed).toEqual(["a"]);
+    const approved = await service.getTask("a");
+    expect(approved?.metadata.waveSupervisor).toMatchObject({
+      budgetApproval: {
+        approvedBy: "reviewer",
+        reason: "launch approval",
+        maxCostUsd: 3,
+      },
+    });
+  });
+
+  it("reconciles from durable task state after restart and does not trust prior snapshots", async () => {
+    const service = makeTaskService([
+      task("a", "active", { waveId: "w" }),
+      task("b", "done", { waveId: "w" }),
+    ]);
+    const first = new WaveSupervisor(makeRuntime(service));
+    await first.runOnce();
+    const restarted = new WaveSupervisor(makeRuntime(service));
+    expect(await restarted.runOnce()).toMatchObject([
+      { waveId: "w", activeLanes: 1, terminalLanes: 1 },
+    ]);
+  });
+
+  it("creates at most one replacement for a terminal lane across recovery reconciles", async () => {
+    const service = makeTaskService([
+      task("failed", "failed", {
+        waveId: "w",
+        lane: { id: "lane-1", scopePaths: ["src/a.ts"] },
+      }),
+    ]);
+    const planner = {
+      planReplacement: async () => ({
+        title: "replacement",
+        goal: "fix it",
+        initialPrompt: "fix src/a.ts",
+        scope: ["src/a.ts"],
+      }),
+    };
+    const supervisor = new WaveSupervisor(makeRuntime(service), { planner });
+    await supervisor.runOnce();
+    await supervisor.runOnce();
+    expect(service.created).toHaveLength(1);
+    expect(service.spawned).toEqual(["created-1"]);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/wave-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/wave-supervisor.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectWaveCollisions,
+  isSalvageEligible,
+  readWaveId,
+  shouldRefillWave,
+} from "../services/wave-supervisor.js";
+
+// W3's lifecycle policy is intentionally tested without a runtime or timers.
+describe("wave supervisor pure policy", () => {
+  it("reads the canonical wave id and defensive manual-stamp aliases", () => {
+    expect(readWaveId({ waveId: "wave-1" })).toBe("wave-1");
+    expect(readWaveId({ orchestratorWaveId: "wave-2" })).toBe("wave-2");
+    expect(readWaveId({ wave: { id: "wave-3" } })).toBe("wave-3");
+    expect(readWaveId({ waveId: "  " })).toBeUndefined();
+  });
+
+  it("refills each terminal lane once while the wave goal remains unmet", () => {
+    expect(
+      shouldRefillWave({
+        status: "failed",
+        goalMet: false,
+        alreadyHandled: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefillWave({
+        status: "done",
+        goalMet: false,
+        alreadyHandled: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefillWave({
+        status: "active",
+        goalMet: false,
+        alreadyHandled: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefillWave({
+        status: "failed",
+        goalMet: true,
+        alreadyHandled: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefillWave({
+        status: "failed",
+        goalMet: false,
+        alreadyHandled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("salvages only failed lanes with a workspace and uncommitted paths", () => {
+    expect(
+      isSalvageEligible({
+        status: "failed",
+        workdir: "/tmp/lane",
+        changedFiles: ["src/a.ts"],
+      }),
+    ).toBe(true);
+    expect(
+      isSalvageEligible({
+        status: "done",
+        workdir: "/tmp/lane",
+        changedFiles: ["src/a.ts"],
+      }),
+    ).toBe(false);
+    expect(
+      isSalvageEligible({
+        status: "failed",
+        workdir: "/tmp/lane",
+        changedFiles: [],
+      }),
+    ).toBe(false);
+    expect(
+      isSalvageEligible({ status: "failed", changedFiles: ["src/a.ts"] }),
+    ).toBe(false);
+  });
+
+  it("detects lane-lane directory overlap and lane-PR file overlap", () => {
+    expect(
+      detectWaveCollisions(
+        [
+          { laneId: "a", waveId: "w", paths: ["src/auth"], repo: "org/repo" },
+          {
+            laneId: "b",
+            waveId: "w",
+            paths: ["src/auth/login.ts"],
+            repo: "org/repo",
+          },
+          {
+            laneId: "c",
+            waveId: "other",
+            paths: ["src/auth"],
+            repo: "org/repo",
+          },
+          {
+            laneId: "d",
+            waveId: "w",
+            paths: ["src/payments"],
+            repo: "org/repo",
+          },
+        ],
+        [
+          {
+            id: "org/repo#7",
+            repo: "org/repo",
+            number: 7,
+            changedFiles: ["src/payments/settle.ts", "README.md"],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        key: "lane:a|lane:b",
+        waveId: "w",
+        leftId: "a",
+        rightId: "b",
+        paths: ["src/auth"],
+        kind: "lane-lane",
+      },
+      {
+        key: "lane:d|pr:org/repo#7",
+        waveId: "w",
+        leftId: "d",
+        rightId: "org/repo#7",
+        paths: ["src/payments"],
+        kind: "lane-pr",
+      },
+    ]);
+  });
+
+  it("does not compare PR paths without a confirmed matching repository", () => {
+    const pullRequest = {
+      id: "org/repo#1",
+      repo: "org/repo",
+      number: 1,
+      changedFiles: ["README.md"],
+    };
+    expect(
+      detectWaveCollisions(
+        [{ laneId: "unknown", waveId: "w", paths: ["README.md"] }],
+        [pullRequest],
+      ),
+    ).toEqual([]);
+    expect(
+      detectWaveCollisions(
+        [
+          {
+            laneId: "other",
+            waveId: "w",
+            paths: ["README.md"],
+            repo: "another/project",
+          },
+        ],
+        [pullRequest],
+      ),
+    ).toEqual([]);
+  });
+
+  it("normalizes separators and does not mistake filename prefixes for overlap", () => {
+    const collisions = detectWaveCollisions(
+      [
+        {
+          laneId: "a",
+          waveId: "w",
+          paths: [".\\src\\foo"],
+          repo: "org/repo",
+        },
+        {
+          laneId: "b",
+          waveId: "w",
+          paths: ["src/foobar"],
+          repo: "org/repo",
+        },
+      ],
+      [
+        {
+          id: "org/repo#1",
+          repo: "org/repo",
+          number: 1,
+          changedFiles: ["src/foo/bar.ts"],
+        },
+      ],
+    );
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]?.kind).toBe("lane-pr");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -97,6 +97,7 @@ import {
   type AcpToolCall,
   TERMINAL_SESSION_STATUSES,
 } from "./services/types.js";
+import { WaveSupervisor } from "./services/wave-supervisor.js";
 import { CodingWorkspaceService } from "./services/workspace-service.js";
 import { codingAgentRoutePlugin } from "./setup-routes.js";
 
@@ -138,6 +139,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
         serviceClass(CodingWorkspaceService),
         serviceClass(TaskSupervisorService),
         serviceClass(TaskWatchdogService),
+        serviceClass(WaveSupervisor),
         // Discoverable SWARM_COORDINATOR adapter. server.ts's
         // wireCoordinatorBridgesWhenReady + plugin-app-control's
         // verification-room-bridge both look this up by serviceType; without
@@ -347,6 +349,9 @@ export function createAgentOrchestratorPlugin(): Plugin {
         TaskSupervisorService.serviceType,
         // Eager-start the stalled-agent watchdog loop too (#8901).
         TaskWatchdogService.serviceType,
+        // Registered unconditionally but behavior-neutral unless its explicit
+        // default-OFF setting is enabled.
+        WaveSupervisor.serviceType,
         // Eager-start the coordinator adapter so it subscribes to the ACP
         // event stream at boot (rather than waiting for a getService() that
         // only the server's bridge-wiring poll issues). This makes
@@ -2464,6 +2469,27 @@ export type {
   SpawnOptions,
   SpawnResult,
 } from "./services/types.js";
+export {
+  type ActiveLaneScope,
+  detectWaveCollisions,
+  isSalvageEligible,
+  NoopWaveRefillPlanner,
+  type OpenPullRequestScope,
+  type OpenPullRequestSource,
+  readWaveId,
+  shouldRefillWave,
+  WAVE_ID_METADATA_KEY,
+  WAVE_REFILL_PLANNER_SERVICE_TYPE,
+  WAVE_SUPERVISOR_SERVICE_TYPE,
+  WAVE_SUPERVISOR_SETTING,
+  type WaveCollision,
+  WaveConcurrencyCapError,
+  type WaveRefillPlanner,
+  type WaveRefillRequest,
+  type WaveReplacementSpec,
+  type WaveStatus,
+  WaveSupervisor,
+} from "./services/wave-supervisor.js";
 export type {
   AuthPromptCallback,
   CodingWorkspaceConfig,

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -541,6 +541,10 @@ export function createAgentOrchestratorPlugin(): Plugin {
         SwarmCoordinatorService.serviceType,
       );
       await coordinator?.stop();
+      const waveSupervisor = runtime.getService<WaveSupervisor>(
+        WaveSupervisor.serviceType,
+      );
+      await waveSupervisor?.stop();
       await CodingWorkspaceService.stopRuntime(runtime);
     },
   };
@@ -2476,12 +2480,17 @@ export {
   NoopWaveRefillPlanner,
   type OpenPullRequestScope,
   type OpenPullRequestSource,
+  readLaneDependencies,
+  readLaneId,
+  readWaveAttemptId,
   readWaveId,
   shouldRefillWave,
+  WAVE_BUDGET_BREACH_CODE,
   WAVE_ID_METADATA_KEY,
   WAVE_REFILL_PLANNER_SERVICE_TYPE,
   WAVE_SUPERVISOR_SERVICE_TYPE,
   WAVE_SUPERVISOR_SETTING,
+  WaveBudgetBreachError,
   type WaveCollision,
   WaveConcurrencyCapError,
   type WaveRefillPlanner,

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -32,6 +32,19 @@ interface AdmissionSnapshotService {
 }
 
 const ORCHESTRATOR_TASK_SERVICE_TYPE = "ORCHESTRATOR_TASK_SERVICE";
+const WAVE_SUPERVISOR_SERVICE_TYPE = "ORCHESTRATOR_WAVE_SUPERVISOR";
+
+interface WaveStatusSnapshot {
+  waveId: string;
+  totalLanes: number;
+  activeLanes: number;
+  terminalLanes: number;
+  queuedLanes: number;
+  concurrencyCap: number;
+  refillCount: number;
+  salvageCount: number;
+  collisionCount: number;
+}
 
 type ApproachingCapKind = "round-trip" | "spend";
 
@@ -128,9 +141,10 @@ export const activeSubAgentsProvider: Provider = {
     "acpx",
   ],
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
+    const waves = readWaveStatuses(runtime);
     const service = getAcpService(runtime);
     if (!service || typeof service.listSessions !== "function") {
-      return emptyResult();
+      return emptyResult(null, null, waves);
     }
     let all: SessionInfo[] | undefined;
     try {
@@ -160,7 +174,7 @@ export const activeSubAgentsProvider: Provider = {
     const routed = (Array.isArray(all) ? all : [])
       .filter(hasOrigin)
       .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status));
-    if (routed.length === 0) return emptyResult(capacity, admission);
+    if (routed.length === 0) return emptyResult(capacity, admission, waves);
 
     routed.sort((a, b) => a.id.localeCompare(b.id));
 
@@ -199,6 +213,7 @@ export const activeSubAgentsProvider: Provider = {
     ];
     const capacityLine = formatCapacityLine(capacity, admission);
     if (capacityLine) lines.push(capacityLine);
+    lines.push(...formatWaveLines(waves));
     for (const session of routed) {
       lines.push(
         formatLine(
@@ -229,6 +244,7 @@ export const activeSubAgentsProvider: Provider = {
             ?.userId,
         })),
         capacity: capacityData(capacity, admission),
+        waves,
       },
     };
   },
@@ -307,18 +323,45 @@ function formatCapacityLine(
   return nextTaskId ? `${base}; next queued: task ${nextTaskId}` : base;
 }
 
+function readWaveStatuses(runtime: IAgentRuntime): WaveStatusSnapshot[] {
+  const supervisor = runtime.getService<
+    Service & { getWaveStatuses?: () => WaveStatusSnapshot[] }
+  >(WAVE_SUPERVISOR_SERVICE_TYPE);
+  if (!supervisor || typeof supervisor.getWaveStatuses !== "function")
+    return [];
+  try {
+    return supervisor.getWaveStatuses();
+  } catch {
+    return [];
+  }
+}
+
+function formatWaveLines(waves: readonly WaveStatusSnapshot[]): string[] {
+  return waves.map(
+    (wave) =>
+      `wave ${wave.waveId}: ${wave.activeLanes}/${wave.concurrencyCap} active, ${wave.queuedLanes} queued, ${wave.terminalLanes}/${wave.totalLanes} terminal, ${wave.refillCount} refills, ${wave.salvageCount} salvages, ${wave.collisionCount} collisions`,
+  );
+}
+
 function emptyResult(
   capacity: AcpCapacity | null = null,
   admission: AdmissionSnapshot | null = null,
+  waves: WaveStatusSnapshot[] = [],
 ) {
-  const capacityLine = formatCapacityLine(capacity, admission);
-  const text = capacityLine
-    ? `## Active sub-agent sessions\n${capacityLine}`
-    : "";
+  const lines = [
+    formatCapacityLine(capacity, admission),
+    ...formatWaveLines(waves),
+  ].filter(Boolean);
+  const text =
+    lines.length > 0 ? `## Active sub-agent sessions\n${lines.join("\n")}` : "";
   return {
     text,
     values: { activeSubAgents: text },
-    data: { sessions: [], capacity: capacityData(capacity, admission) },
+    data: {
+      sessions: [],
+      capacity: capacityData(capacity, admission),
+      waves,
+    },
   };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -189,6 +189,11 @@ import {
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
 import {
+  WAVE_SUPERVISOR_SERVICE_TYPE,
+  WaveConcurrencyCapError,
+  type WaveSupervisor,
+} from "./wave-supervisor.js";
+import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
 } from "./workdir-validation.js";
@@ -4333,6 +4338,42 @@ export class OrchestratorTaskService extends Service {
       opts.framework ??
       policy.preferredFramework ??
       configuredDefaultAgentType(this.runtime);
+
+    // W3 wave cap layers on top of the existing global ACP admission queue.
+    // Default-OFF supervisor means this lookup is behavior-neutral. When the
+    // wave is full, top-level work parks in the SAME durable queue rather than
+    // creating a second queue/store; drain replay uses parkOnCap:false and gets
+    // a typed cap error so it can preserve the entry's original seniority.
+    const waveSupervisor = this.runtime.getService<WaveSupervisor>(
+      WAVE_SUPERVISOR_SERVICE_TYPE,
+    );
+    if (
+      waveSupervisor?.enabled() &&
+      !(await waveSupervisor.tryAcquire(taskId))
+    ) {
+      const wave = await waveSupervisor.concurrencyForTask(taskId);
+      if (
+        nestingDepth === 0 &&
+        opts.parkOnCap !== false &&
+        this.admissionQueueEnabled()
+      ) {
+        return this.enqueueAdmission(taskId, doc.task.priority, {
+          framework: opts.framework,
+          model: opts.model ?? policy.model,
+          workdir: opts.workdir,
+          repo: opts.repo,
+          label: opts.label,
+          task: opts.task,
+          approvalPreset: opts.approvalPreset,
+          providerSource: opts.providerSource ?? policy.providerSource,
+        });
+      }
+      throw new WaveConcurrencyCapError(
+        wave?.waveId ?? "unknown",
+        wave?.cap ?? 0,
+      );
+    }
+
     let result: SpawnResult;
     try {
       result = await acp.spawnSession({
@@ -4381,6 +4422,7 @@ export class OrchestratorTaskService extends Service {
         },
       });
     } catch (err) {
+      waveSupervisor?.release(taskId);
       // The worker cap is full. A TOP-LEVEL spawn parks in the admission queue
       // (task stays `open`, admission metadata persisted) and the caller gets a
       // truthful detail with the queued position instead of a hard failure. A
@@ -4492,8 +4534,10 @@ export class OrchestratorTaskService extends Service {
           doc.task.boundWorkdir !== result.workdir,
       });
       await this.advanceTaskStatus(taskId, "session_active");
+      waveSupervisor?.release(taskId);
       return this.getTask(taskId);
     } catch (err) {
+      waveSupervisor?.release(taskId);
       // error-policy:J4 the ACP spawn already succeeded (session is live); a
       // failed durable write degrades to a truthful live-session detail below,
       // never a false 500/404.
@@ -5269,7 +5313,21 @@ export class OrchestratorTaskService extends Service {
         Date.now(),
         this.admissionAgingMs(),
       );
-      const head = ordered[0];
+      const waveSupervisor = this.runtime.getService<WaveSupervisor>(
+        WAVE_SUPERVISOR_SERVICE_TYPE,
+      );
+      let head: QueueEntry | undefined;
+      for (const candidate of ordered) {
+        if (
+          !waveSupervisor?.enabled() ||
+          (await waveSupervisor.tryAcquire(candidate.taskId))
+        ) {
+          head = candidate;
+          break;
+        }
+      }
+      // Global capacity exists, but every queued task belongs to a wave already
+      // at its own cap. Leave their durable order untouched until a lane ends.
       if (!head) break;
       // Drop the head from the in-memory order up front; a re-park below will
       // re-add it. This keeps the loop from re-selecting the same head when the
@@ -5278,15 +5336,27 @@ export class OrchestratorTaskService extends Service {
       if (idx >= 0) this.admissionQueue.splice(idx, 1);
       const doc = await this.store.getTask(head.taskId);
       const admission = doc && OrchestratorTaskService.admissionOf(doc.task);
-      if (!doc || !admission) continue;
+      if (!doc || !admission) {
+        waveSupervisor?.release(head.taskId);
+        continue;
+      }
       if (TERMINAL_TASK_STATUSES.has(doc.task.status)) {
+        waveSupervisor?.release(head.taskId);
         await this.writeAdmission(head.taskId, null);
         continue;
       }
       // A pause that raced this pass: drop the task from the dispatch order but
       // KEEP the durable record — pauseTask retained it so resume can replay
       // the original spawn (clearing it here would make resume a silent no-op).
-      if (doc.task.paused) continue;
+      if (doc.task.paused) {
+        waveSupervisor?.release(head.taskId);
+        continue;
+      }
+      // Selection reserved this candidate only long enough to avoid choosing a
+      // wave-blocked head. Release before replay; spawnAgentForTask performs the
+      // authoritative acquire and re-parks on a race, while every skip/error
+      // path above has now released its provisional reservation.
+      waveSupervisor?.release(head.taskId);
       await this.writeAdmission(head.taskId, null);
       try {
         await this.spawnAgentForTask(head.taskId, {
@@ -5300,13 +5370,24 @@ export class OrchestratorTaskService extends Service {
         });
       } catch (err) {
         if (err instanceof SessionCapError) {
-          // A concurrent spawn took the slot. Re-park at the head and stop —
-          // the next terminal event or reconcile tick drains again.
+          // A concurrent spawn took the global slot. Re-park at the head and
+          // stop; the next terminal event or reconcile tick drains again.
           await this.writeAdmission(head.taskId, admission);
           if (!this.admissionQueue.includes(head.taskId)) {
             this.admissionQueue.unshift(head.taskId);
           }
           break;
+        }
+        if (err instanceof WaveConcurrencyCapError) {
+          // This wave is full, but another wave may still use the free global
+          // slot. Keep the original durable enqueue timestamp (seniority), move
+          // the blocked id behind this pass, and continue within the bounded
+          // queue-length budget so no wave can head-of-line block the queue.
+          await this.writeAdmission(head.taskId, admission);
+          if (!this.admissionQueue.includes(head.taskId)) {
+            this.admissionQueue.push(head.taskId);
+          }
+          continue;
         }
         // error-policy:J7 the dispatch of a parked task failed for a non-cap
         // reason (bad workdir, transport error). Report it so the agent/owner

--- a/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
@@ -1,0 +1,848 @@
+/**
+ * Wave-level lifecycle supervision for orchestrator lane tasks (#16443 W3).
+ *
+ * A wave is a set of durable tasks carrying the same wave id in task metadata.
+ * This service deliberately owns no store: it reads and updates tasks through
+ * OrchestratorTaskService, and exposes a compact snapshot to ACTIVE_SUB_AGENTS.
+ * The default-OFF gate makes registration behavior-neutral until explicitly
+ * enabled.
+ */
+
+import { spawnSync } from "node:child_process";
+import type {
+  Content,
+  IAgentRuntime,
+  Service as ServiceType,
+  UUID,
+} from "@elizaos/core";
+import { logger, Service } from "@elizaos/core";
+import type { TaskThreadDetailDto } from "./orchestrator-task-mapper.js";
+import type { CreateTaskInput } from "./orchestrator-task-types.js";
+import { parseOwnerRepo } from "./workspace-github.js";
+import { preserveRegisteredWorkspace } from "./workspace-lifecycle.js";
+import { getSharedWorkspaceRegistry } from "./workspace-registry.js";
+
+export const WAVE_SUPERVISOR_SERVICE_TYPE = "ORCHESTRATOR_WAVE_SUPERVISOR";
+export const WAVE_SUPERVISOR_SETTING = "ELIZA_ORCHESTRATOR_WAVE_SUPERVISOR";
+export const WAVE_ID_METADATA_KEY = "waveId";
+export const WAVE_REFILL_PLANNER_SERVICE_TYPE = "ORCHESTRATOR_LANE_PLANNER";
+
+export class WaveConcurrencyCapError extends Error {
+  constructor(
+    readonly waveId: string,
+    readonly cap: number,
+  ) {
+    super(`wave ${waveId} concurrency cap reached (${cap})`);
+    this.name = "WaveConcurrencyCapError";
+  }
+}
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const MIN_INTERVAL_MS = 5_000;
+const DEFAULT_WAVE_CONCURRENCY = 4;
+const ACTIVE_TASK_STATUSES = new Set([
+  "active",
+  "blocked",
+  "waiting_on_user",
+  "validating",
+]);
+const TERMINAL_LANE_STATUSES = new Set(["done", "failed", "archived"]);
+const FAILURE_LANE_STATUSES = new Set([
+  "failed",
+  "error",
+  "errored",
+  "stopped",
+  "interrupted",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Defensive wave-id reader. W1's canonical contract is `metadata.waveId`; the
+ * aliases keep manually stamped tasks and pre-merge W1 experiments operable.
+ */
+export function readWaveId(
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!metadata) return undefined;
+  const nested = isRecord(metadata.wave) ? metadata.wave : undefined;
+  return (
+    nonEmptyString(metadata[WAVE_ID_METADATA_KEY]) ??
+    nonEmptyString(metadata.orchestratorWaveId) ??
+    nonEmptyString(nested?.id)
+  );
+}
+
+export interface RefillDecisionInput {
+  status: string;
+  goalMet: boolean;
+  alreadyHandled: boolean;
+}
+
+/** Pure terminal-lane refill gate. */
+export function shouldRefillWave(input: RefillDecisionInput): boolean {
+  return (
+    TERMINAL_LANE_STATUSES.has(input.status) &&
+    !input.goalMet &&
+    !input.alreadyHandled
+  );
+}
+
+export interface SalvageEligibilityInput {
+  status: string;
+  workdir?: string | null;
+  changedFiles?: readonly string[] | null;
+}
+
+/** Pure salvage gate: failed lane + inspectable workspace + real dirty paths. */
+export function isSalvageEligible(input: SalvageEligibilityInput): boolean {
+  return (
+    FAILURE_LANE_STATUSES.has(input.status) &&
+    Boolean(nonEmptyString(input.workdir)) &&
+    Boolean(input.changedFiles && input.changedFiles.length > 0)
+  );
+}
+
+export interface ActiveLaneScope {
+  laneId: string;
+  waveId: string;
+  paths: string[];
+  repo?: string;
+}
+
+export interface OpenPullRequestScope {
+  id: string;
+  repo: string;
+  number: number;
+  url?: string;
+  changedFiles: string[];
+}
+
+export interface WaveCollision {
+  key: string;
+  waveId: string;
+  leftId: string;
+  rightId: string;
+  paths: string[];
+  kind: "lane-lane" | "lane-pr";
+}
+
+function normalizePath(path: string): string {
+  return path
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/^\.\//u, "")
+    .replace(/\/$/u, "");
+}
+
+function canonicalRepo(repo: string): string {
+  try {
+    const parsed = parseOwnerRepo(repo);
+    return `${parsed.owner}/${parsed.repo}`.toLowerCase();
+  } catch {
+    return normalizePath(repo).toLowerCase();
+  }
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const a = normalizePath(left);
+  const b = normalizePath(right);
+  if (!a || !b) return false;
+  return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+function overlappingPaths(
+  left: readonly string[],
+  right: readonly string[],
+): string[] {
+  const found = new Set<string>();
+  for (const a of left) {
+    for (const b of right) {
+      if (pathsOverlap(a, b)) found.add(normalizePath(a));
+    }
+  }
+  return [...found].sort();
+}
+
+/** Pure collision detection over active lane scopes and open-PR changed files. */
+export function detectWaveCollisions(
+  lanes: readonly ActiveLaneScope[],
+  pullRequests: readonly OpenPullRequestScope[],
+): WaveCollision[] {
+  const collisions: WaveCollision[] = [];
+  const sorted = [...lanes].sort((a, b) => a.laneId.localeCompare(b.laneId));
+  for (let i = 0; i < sorted.length; i++) {
+    const left = sorted[i];
+    if (!left) continue;
+    for (let j = i + 1; j < sorted.length; j++) {
+      const right = sorted[j];
+      if (!right || left.waveId !== right.waveId) continue;
+      const paths = overlappingPaths(left.paths, right.paths);
+      if (paths.length === 0) continue;
+      collisions.push({
+        key: `lane:${left.laneId}|lane:${right.laneId}`,
+        waveId: left.waveId,
+        leftId: left.laneId,
+        rightId: right.laneId,
+        paths,
+        kind: "lane-lane",
+      });
+    }
+  }
+  for (const lane of sorted) {
+    // A path has meaning only inside a repository. Without a confirmed lane
+    // repo, comparing against PRs fetched for other lanes would create false
+    // collisions on ubiquitous paths such as README.md or src/index.ts.
+    if (!lane.repo) continue;
+    for (const pr of pullRequests) {
+      if (canonicalRepo(lane.repo) !== canonicalRepo(pr.repo)) continue;
+      const paths = overlappingPaths(lane.paths, pr.changedFiles);
+      if (paths.length === 0) continue;
+      collisions.push({
+        key: `lane:${lane.laneId}|pr:${pr.id}`,
+        waveId: lane.waveId,
+        leftId: lane.laneId,
+        rightId: pr.id,
+        paths,
+        kind: "lane-pr",
+      });
+    }
+  }
+  return collisions.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export interface WaveReplacementSpec {
+  title: string;
+  goal: string;
+  initialPrompt: string;
+  scope?: string[];
+  forbiddenPaths?: string[];
+  acceptanceCriteria?: string[];
+  difficultyTag?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface WaveRefillRequest {
+  waveId: string;
+  waveGoal: string;
+  terminalLane: TaskThreadDetailDto;
+  activeLanes: TaskThreadDetailDto[];
+  collisions: WaveCollision[];
+  salvagePath?: string;
+  salvageChangedFiles?: string[];
+}
+
+/** W1 integration seam. Its eventual planner service implements this shape. */
+export interface WaveRefillPlanner {
+  planReplacement(
+    request: WaveRefillRequest,
+  ): Promise<WaveReplacementSpec | null>;
+}
+
+/** Independently-landable W3 fallback. It performs no model call and no refill. */
+export class NoopWaveRefillPlanner implements WaveRefillPlanner {
+  async planReplacement(_request: WaveRefillRequest): Promise<null> {
+    return null;
+  }
+}
+
+export interface OpenPullRequestSource {
+  listOpenPullRequests(
+    repos: readonly string[],
+  ): Promise<OpenPullRequestScope[]>;
+}
+
+/** Best-effort GitHub REST reader, using the same token setting as workspace-github. */
+class RuntimeGitHubPullRequestSource implements OpenPullRequestSource {
+  constructor(private readonly runtime: IAgentRuntime) {}
+
+  async listOpenPullRequests(
+    repos: readonly string[],
+  ): Promise<OpenPullRequestScope[]> {
+    const token = nonEmptyString(this.runtime.getSetting("GITHUB_TOKEN"));
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+    const results: OpenPullRequestScope[] = [];
+    for (const rawRepo of [...new Set(repos)].slice(0, 5)) {
+      const { owner, repo } = parseOwnerRepo(rawRepo);
+      const pullsResponse = await fetch(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?state=open&per_page=50`,
+        { headers, signal: AbortSignal.timeout(5_000) },
+      );
+      if (!pullsResponse.ok) continue;
+      const pulls = (await pullsResponse.json()) as unknown;
+      if (!Array.isArray(pulls)) continue;
+      for (const pull of pulls.slice(0, 20)) {
+        if (!isRecord(pull) || typeof pull.number !== "number") continue;
+        const filesResponse = await fetch(
+          `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${pull.number}/files?per_page=100`,
+          { headers, signal: AbortSignal.timeout(5_000) },
+        );
+        if (!filesResponse.ok) continue;
+        const files = (await filesResponse.json()) as unknown;
+        const changedFiles = Array.isArray(files)
+          ? files
+              .map((file) =>
+                isRecord(file) ? nonEmptyString(file.filename) : undefined,
+              )
+              .filter((file): file is string => Boolean(file))
+          : [];
+        results.push({
+          id: `${owner}/${repo}#${pull.number}`,
+          repo: `${owner}/${repo}`,
+          number: pull.number,
+          url: nonEmptyString(pull.html_url),
+          changedFiles,
+        });
+      }
+    }
+    return results;
+  }
+}
+
+interface TaskServiceLike {
+  listTasks(): Promise<Array<{ id: string }>>;
+  getTask(taskId: string): Promise<TaskThreadDetailDto | null>;
+  createTask(input: CreateTaskInput): Promise<TaskThreadDetailDto>;
+  updateTask(
+    taskId: string,
+    patch: { metadata?: Record<string, unknown> },
+  ): Promise<TaskThreadDetailDto | null>;
+  spawnAgentForTask(
+    taskId: string,
+    opts?: { task?: string; workdir?: string; repo?: string },
+  ): Promise<TaskThreadDetailDto | null>;
+  getTaskOriginTarget(
+    taskId: string,
+  ): Promise<{ roomId: string; source: string; worldId?: string } | null>;
+}
+
+type RuntimeWithSendTarget = IAgentRuntime & {
+  sendMessageToTarget?: (
+    target: { source: string; roomId?: UUID; accountId?: string },
+    content: Content,
+  ) => Promise<unknown>;
+};
+
+export interface WaveStatus {
+  waveId: string;
+  totalLanes: number;
+  activeLanes: number;
+  terminalLanes: number;
+  queuedLanes: number;
+  concurrencyCap: number;
+  refillCount: number;
+  salvageCount: number;
+  collisionCount: number;
+}
+
+function readScope(metadata: Record<string, unknown>): string[] {
+  const raw = metadata.laneScope ?? metadata.scope;
+  if (typeof raw === "string") return [raw].map(normalizePath).filter(Boolean);
+  if (Array.isArray(raw)) {
+    return raw
+      .map(nonEmptyString)
+      .filter((item): item is string => Boolean(item))
+      .map(normalizePath)
+      .filter(Boolean);
+  }
+  if (isRecord(raw) && Array.isArray(raw.paths)) {
+    return raw.paths
+      .map(nonEmptyString)
+      .filter((item): item is string => Boolean(item))
+      .map(normalizePath)
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function captureUncommittedFiles(workdir: string | null): string[] {
+  if (!workdir) return [];
+  const result = spawnSync("git", ["status", "--porcelain=v1"], {
+    cwd: workdir,
+    encoding: "utf8",
+    timeout: 5_000,
+    maxBuffer: 2 * 1024 * 1024,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || typeof result.stdout !== "string") return [];
+  return result.stdout
+    .split(/\r?\n/u)
+    .map((entry) => entry.slice(3).trim())
+    .filter(Boolean);
+}
+
+function goalMet(task: TaskThreadDetailDto): boolean {
+  const nested = isRecord(task.metadata.wave) ? task.metadata.wave : undefined;
+  return task.metadata.waveGoalMet === true || nested?.goalMet === true;
+}
+
+function refillHandled(task: TaskThreadDetailDto): boolean {
+  const state = task.metadata.waveSupervisor;
+  return isRecord(state) && typeof state.refillHandledAt === "string";
+}
+
+function taskIsActive(task: TaskThreadDetailDto): boolean {
+  return ACTIVE_TASK_STATUSES.has(task.status);
+}
+
+export class WaveSupervisor extends Service {
+  static serviceType = WAVE_SUPERVISOR_SERVICE_TYPE;
+  capabilityDescription =
+    "Supervises wave-scoped lane refill, salvage, collision warnings, concurrency, and status.";
+
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private readonly warnedCollisions = new Set<string>();
+  private readonly reservations = new Map<string, string>();
+  private readonly inFlightRefills = new Set<string>();
+  private statuses: WaveStatus[] = [];
+  private readonly plannerOverride?: WaveRefillPlanner;
+  private readonly pullRequestSource: OpenPullRequestSource;
+
+  constructor(
+    runtime: IAgentRuntime,
+    opts: {
+      planner?: WaveRefillPlanner;
+      pullRequestSource?: OpenPullRequestSource;
+    } = {},
+  ) {
+    super(runtime);
+    this.plannerOverride = opts.planner;
+    this.pullRequestSource =
+      opts.pullRequestSource ?? new RuntimeGitHubPullRequestSource(runtime);
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<WaveSupervisor> {
+    const service = new WaveSupervisor(runtime);
+    if (service.enabled()) service.startTimer();
+    return service;
+  }
+
+  private setting(key: string): string | undefined {
+    const value = this.runtime.getSetting(key);
+    if (typeof value === "string" && value.length > 0) return value;
+    return process.env[key];
+  }
+
+  enabled(): boolean {
+    const raw = this.setting(WAVE_SUPERVISOR_SETTING);
+    return raw === "1" || raw === "true";
+  }
+
+  private intervalMs(): number {
+    const parsed = Number.parseInt(
+      this.setting("ELIZA_ORCHESTRATOR_WAVE_INTERVAL_MS") ?? "",
+      10,
+    );
+    return Number.isFinite(parsed) && parsed >= MIN_INTERVAL_MS
+      ? parsed
+      : DEFAULT_INTERVAL_MS;
+  }
+
+  private configuredCap(): number {
+    const parsed = Number.parseInt(
+      this.setting("ELIZA_ORCHESTRATOR_WAVE_CONCURRENCY") ?? "",
+      10,
+    );
+    return Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_WAVE_CONCURRENCY;
+  }
+
+  private startTimer(): void {
+    this.timer = setInterval(() => {
+      void this.runOnce().catch((error) => {
+        logger.warn(
+          `[WaveSupervisor] tick failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }, this.intervalMs());
+    (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  private taskService(): TaskServiceLike | null {
+    return this.runtime.getService<TaskServiceLike & ServiceType>(
+      "ORCHESTRATOR_TASK_SERVICE",
+    );
+  }
+
+  private planner(): WaveRefillPlanner {
+    if (this.plannerOverride) return this.plannerOverride;
+    const planner = this.runtime.getService<WaveRefillPlanner & ServiceType>(
+      WAVE_REFILL_PLANNER_SERVICE_TYPE,
+    );
+    return planner?.planReplacement ? planner : new NoopWaveRefillPlanner();
+  }
+
+  /** Admission-queue seam. Reservations close concurrent spawn races per wave. */
+  async tryAcquire(taskId: string): Promise<boolean> {
+    if (!this.enabled()) return true;
+    const tasks = await this.loadWaveTasks();
+    const task = tasks.find((candidate) => candidate.id === taskId);
+    const waveId = task ? readWaveId(task.metadata) : undefined;
+    if (!waveId) return true;
+    if (this.reservations.get(taskId) === waveId) return true;
+    this.releaseTerminalReservations(tasks);
+    const active = tasks.filter(
+      (candidate) =>
+        readWaveId(candidate.metadata) === waveId && taskIsActive(candidate),
+    ).length;
+    const reserved = [...this.reservations.entries()].filter(
+      ([reservedTaskId, reservedWaveId]) =>
+        reservedWaveId === waveId && reservedTaskId !== taskId,
+    ).length;
+    if (active + reserved >= this.waveCap(tasks, waveId)) return false;
+    this.reservations.set(taskId, waveId);
+    return true;
+  }
+
+  release(taskId: string): void {
+    this.reservations.delete(taskId);
+  }
+
+  async concurrencyForTask(
+    taskId: string,
+  ): Promise<{ waveId: string; cap: number } | null> {
+    if (!this.enabled()) return null;
+    const tasks = await this.loadWaveTasks();
+    const task = tasks.find((candidate) => candidate.id === taskId);
+    const waveId = task ? readWaveId(task.metadata) : undefined;
+    return waveId ? { waveId, cap: this.waveCap(tasks, waveId) } : null;
+  }
+
+  getWaveStatuses(): WaveStatus[] {
+    return structuredClone(this.statuses);
+  }
+
+  async runOnce(): Promise<WaveStatus[]> {
+    if (!this.enabled()) return [];
+    const service = this.taskService();
+    if (!service) return [];
+    const tasks = await this.loadWaveTasks();
+    this.releaseTerminalReservations(tasks);
+    const activeScopes = tasks
+      .filter(taskIsActive)
+      .map((task) => ({
+        laneId: task.id,
+        waveId: readWaveId(task.metadata) ?? "",
+        paths: readScope(task.metadata),
+        ...(task.latestRepo ? { repo: task.latestRepo } : {}),
+      }))
+      .filter((lane) => lane.waveId && lane.paths.length > 0);
+    const activeIds = new Set(activeScopes.map((lane) => lane.laneId));
+    const repos = tasks
+      .filter((task) => activeIds.has(task.id))
+      .map((task) => task.latestRepo)
+      .filter((repo): repo is string => Boolean(repo));
+    let pullRequests: OpenPullRequestScope[] = [];
+    try {
+      if (activeScopes.length > 0 && repos.length > 0) {
+        pullRequests = await this.pullRequestSource.listOpenPullRequests(repos);
+      }
+    } catch (error) {
+      logger.warn(
+        `[WaveSupervisor] open PR collision refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    const collisions = detectWaveCollisions(activeScopes, pullRequests);
+    await this.warnNewCollisions(service, tasks, collisions);
+    for (const task of tasks) {
+      if (
+        shouldRefillWave({
+          status: task.status,
+          goalMet: goalMet(task),
+          alreadyHandled: refillHandled(task),
+        })
+      ) {
+        if (this.inFlightRefills.has(task.id)) continue;
+        this.inFlightRefills.add(task.id);
+        try {
+          await this.refillLane(service, task, tasks, collisions);
+        } catch (error) {
+          logger.warn(
+            `[WaveSupervisor] refill failed for lane ${task.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        } finally {
+          this.inFlightRefills.delete(task.id);
+        }
+      }
+    }
+    const refreshed = await this.loadWaveTasks();
+    this.statuses = this.computeStatuses(refreshed, collisions);
+    await this.persistStatuses(service, refreshed, this.statuses);
+    return this.getWaveStatuses();
+  }
+
+  private async loadWaveTasks(): Promise<TaskThreadDetailDto[]> {
+    const service = this.taskService();
+    if (!service) return [];
+    const summaries = await service.listTasks();
+    const details = await Promise.all(
+      summaries.map((task) => service.getTask(task.id)),
+    );
+    return details.filter(
+      (task): task is TaskThreadDetailDto =>
+        task !== null && Boolean(readWaveId(task.metadata)),
+    );
+  }
+
+  private releaseTerminalReservations(
+    tasks: readonly TaskThreadDetailDto[],
+  ): void {
+    const byId = new Map(tasks.map((task) => [task.id, task]));
+    for (const taskId of this.reservations.keys()) {
+      const task = byId.get(taskId);
+      if (
+        !task ||
+        TERMINAL_LANE_STATUSES.has(task.status) ||
+        taskIsActive(task)
+      ) {
+        this.reservations.delete(taskId);
+      }
+    }
+  }
+
+  private waveCap(
+    tasks: readonly TaskThreadDetailDto[],
+    waveId: string,
+  ): number {
+    for (const task of tasks) {
+      if (readWaveId(task.metadata) !== waveId) continue;
+      const raw = task.metadata.waveConcurrencyCap;
+      if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+        return Math.floor(raw);
+      }
+    }
+    return this.configuredCap();
+  }
+
+  private async refillLane(
+    service: TaskServiceLike,
+    terminalLane: TaskThreadDetailDto,
+    allTasks: TaskThreadDetailDto[],
+    collisions: WaveCollision[],
+  ): Promise<void> {
+    const waveId = readWaveId(terminalLane.metadata);
+    if (!waveId) return;
+    const changedFiles = captureUncommittedFiles(terminalLane.latestWorkdir);
+    const salvage = isSalvageEligible({
+      status: terminalLane.status,
+      workdir: terminalLane.latestWorkdir,
+      changedFiles,
+    });
+    let salvagePath: string | undefined;
+    if (salvage && terminalLane.latestWorkdir) {
+      const preserved = preserveRegisteredWorkspace(
+        terminalLane.latestWorkdir,
+        getSharedWorkspaceRegistry(),
+        (message) => logger.info(`[WaveSupervisor] ${message}`),
+      );
+      // Caller-owned workdirs are already outside lifecycle deletion. Registered
+      // workdirs are explicitly returned to live accounting by the helper.
+      if (preserved || terminalLane.latestWorkdir) {
+        salvagePath = terminalLane.latestWorkdir;
+      }
+    }
+    const waveTasks = allTasks.filter(
+      (task) => readWaveId(task.metadata) === waveId,
+    );
+    const activeLanes = waveTasks.filter(taskIsActive);
+    const waveGoal =
+      nonEmptyString(terminalLane.metadata.waveGoal) ??
+      nonEmptyString(
+        isRecord(terminalLane.metadata.wave)
+          ? terminalLane.metadata.wave.goal
+          : undefined,
+      ) ??
+      terminalLane.goal;
+    const planner = this.planner();
+    const spec = await planner.planReplacement({
+      waveId,
+      waveGoal,
+      terminalLane,
+      activeLanes,
+      collisions: collisions.filter((collision) => collision.waveId === waveId),
+      ...(salvagePath
+        ? { salvagePath, salvageChangedFiles: changedFiles }
+        : {}),
+    });
+    const supervisorState = isRecord(terminalLane.metadata.waveSupervisor)
+      ? terminalLane.metadata.waveSupervisor
+      : {};
+    const markHandled = async (
+      outcome: "replacement_created" | "planner_noop",
+    ) =>
+      service.updateTask(terminalLane.id, {
+        metadata: {
+          ...terminalLane.metadata,
+          waveSupervisor: {
+            ...supervisorState,
+            refillHandledAt: new Date().toISOString(),
+            refillOutcome: outcome,
+            ...(salvagePath
+              ? { salvagePath, salvageChangedFiles: changedFiles }
+              : {}),
+          },
+        },
+      });
+    if (!spec) {
+      // The independently-landable stub must not consume the terminal event:
+      // once W1's planner service appears, a later tick should still refill it.
+      // A real injected planner returning null is authoritative and is handled
+      // once to avoid asking it the same question forever.
+      if (!(planner instanceof NoopWaveRefillPlanner)) {
+        await markHandled("planner_noop");
+      }
+      return;
+    }
+    const salvageBrief = salvagePath
+      ? `\n\n--- Salvage from failed lane ---\nPreserved workspace: ${salvagePath}\nUncommitted paths: ${changedFiles.join(", ")}\nInspect and reuse this work before starting over.`
+      : "";
+    const replacement = await service.createTask({
+      title: spec.title,
+      goal: spec.goal,
+      originalRequest: spec.initialPrompt,
+      kind: terminalLane.kind,
+      priority: terminalLane.priority,
+      acceptanceCriteria: spec.acceptanceCriteria,
+      ownerUserId: terminalLane.ownerUserId ?? undefined,
+      worldId: terminalLane.worldId ?? undefined,
+      projectId: terminalLane.projectId ?? undefined,
+      roomId: terminalLane.roomId ?? undefined,
+      taskRoomId: terminalLane.taskRoomId ?? undefined,
+      parentTaskId: terminalLane.id,
+      forkSource: "wave-refill",
+      providerPolicy: terminalLane.providerPolicy ?? undefined,
+      metadata: {
+        ...spec.metadata,
+        [WAVE_ID_METADATA_KEY]: waveId,
+        waveGoal,
+        laneScope: spec.scope ?? [],
+        forbiddenPaths: spec.forbiddenPaths ?? [],
+        difficultyTag: spec.difficultyTag,
+        waveRefillOf: terminalLane.id,
+        ...(salvagePath
+          ? { salvagePath, salvageChangedFiles: changedFiles }
+          : {}),
+      },
+    });
+    // Creation is the durable idempotency boundary: mark the predecessor before
+    // dispatch so a transport failure cannot mint duplicate replacement tasks
+    // on the next tick. A failed dispatch leaves one inspectable open task.
+    await markHandled("replacement_created");
+    await service.spawnAgentForTask(replacement.id, {
+      task: `${spec.initialPrompt}${salvageBrief}`,
+      ...(salvagePath ? { workdir: salvagePath } : {}),
+      ...(terminalLane.latestRepo ? { repo: terminalLane.latestRepo } : {}),
+    });
+  }
+
+  private async warnNewCollisions(
+    service: TaskServiceLike,
+    tasks: readonly TaskThreadDetailDto[],
+    collisions: readonly WaveCollision[],
+  ): Promise<void> {
+    const send = (this.runtime as RuntimeWithSendTarget).sendMessageToTarget;
+    if (typeof send !== "function") return;
+    const byId = new Map(tasks.map((task) => [task.id, task]));
+    for (const collision of collisions) {
+      if (this.warnedCollisions.has(collision.key)) continue;
+      const originTask = byId.get(collision.leftId);
+      if (!originTask) continue;
+      const target = await service.getTaskOriginTarget(originTask.id);
+      if (!target) continue;
+      this.warnedCollisions.add(collision.key);
+      try {
+        const other =
+          collision.kind === "lane-pr"
+            ? `open PR ${collision.rightId}`
+            : `lane ${collision.rightId}`;
+        const text = `Wave ${collision.waveId} collision warning: lane ${collision.leftId} now overlaps ${other} on ${collision.paths.join(", ")}. Re-scope or coordinate before continuing.`;
+        await send(
+          { source: target.source, roomId: target.roomId as UUID },
+          { text, source: target.source },
+        );
+      } catch (error) {
+        this.warnedCollisions.delete(collision.key);
+        logger.warn(
+          `[WaveSupervisor] collision warning delivery failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  private computeStatuses(
+    tasks: readonly TaskThreadDetailDto[],
+    collisions: readonly WaveCollision[],
+  ): WaveStatus[] {
+    const waveIds = [
+      ...new Set(
+        tasks.map((task) => readWaveId(task.metadata)).filter(Boolean),
+      ),
+    ] as string[];
+    return waveIds.sort().map((waveId) => {
+      const lanes = tasks.filter(
+        (task) => readWaveId(task.metadata) === waveId,
+      );
+      const supervisorStates = lanes
+        .map((task) => task.metadata.waveSupervisor)
+        .filter(isRecord);
+      return {
+        waveId,
+        totalLanes: lanes.length,
+        activeLanes: lanes.filter(taskIsActive).length,
+        terminalLanes: lanes.filter((task) =>
+          TERMINAL_LANE_STATUSES.has(task.status),
+        ).length,
+        queuedLanes: lanes.filter((task) => isRecord(task.metadata.admission))
+          .length,
+        concurrencyCap: this.waveCap(tasks, waveId),
+        refillCount: lanes.filter((task) =>
+          nonEmptyString(task.metadata.waveRefillOf),
+        ).length,
+        salvageCount: supervisorStates.filter((state) =>
+          nonEmptyString(state.salvagePath),
+        ).length,
+        collisionCount: collisions.filter(
+          (collision) => collision.waveId === waveId,
+        ).length,
+      };
+    });
+  }
+
+  private async persistStatuses(
+    service: TaskServiceLike,
+    tasks: readonly TaskThreadDetailDto[],
+    statuses: readonly WaveStatus[],
+  ): Promise<void> {
+    const byWave = new Map(statuses.map((status) => [status.waveId, status]));
+    for (const task of tasks) {
+      const waveId = readWaveId(task.metadata);
+      const status = waveId ? byWave.get(waveId) : undefined;
+      if (!status) continue;
+      const previous = task.metadata.waveStatus;
+      if (JSON.stringify(previous) === JSON.stringify(status)) continue;
+      await service.updateTask(task.id, {
+        metadata: { ...task.metadata, waveStatus: status },
+      });
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+    this.warnedCollisions.clear();
+    this.reservations.clear();
+    this.inFlightRefills.clear();
+    this.statuses = [];
+  }
+}

--- a/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
@@ -15,17 +15,18 @@ import type {
   Service as ServiceType,
   UUID,
 } from "@elizaos/core";
-import { logger, Service } from "@elizaos/core";
+import { ElizaError, logger, Service } from "@elizaos/core";
 import type { TaskThreadDetailDto } from "./orchestrator-task-mapper.js";
 import type { CreateTaskInput } from "./orchestrator-task-types.js";
 import { parseOwnerRepo } from "./workspace-github.js";
 import { preserveRegisteredWorkspace } from "./workspace-lifecycle.js";
-import { getSharedWorkspaceRegistry } from "./workspace-registry.js";
+import type { WorkspaceRegistry } from "./workspace-registry.js";
 
 export const WAVE_SUPERVISOR_SERVICE_TYPE = "ORCHESTRATOR_WAVE_SUPERVISOR";
 export const WAVE_SUPERVISOR_SETTING = "ELIZA_ORCHESTRATOR_WAVE_SUPERVISOR";
 export const WAVE_ID_METADATA_KEY = "waveId";
 export const WAVE_REFILL_PLANNER_SERVICE_TYPE = "ORCHESTRATOR_LANE_PLANNER";
+export const WAVE_BUDGET_BREACH_CODE = "ORCHESTRATOR_WAVE_BUDGET_BREACH";
 
 export class WaveConcurrencyCapError extends Error {
   constructor(
@@ -34,6 +35,20 @@ export class WaveConcurrencyCapError extends Error {
   ) {
     super(`wave ${waveId} concurrency cap reached (${cap})`);
     this.name = "WaveConcurrencyCapError";
+  }
+}
+
+export class WaveBudgetBreachError extends ElizaError {
+  constructor(
+    readonly waveId: string,
+    readonly reason: string,
+    context: Record<string, unknown>,
+  ) {
+    super(`wave ${waveId} budget breached: ${reason}`, {
+      code: WAVE_BUDGET_BREACH_CODE,
+      context: { waveId, reason, ...context },
+      severity: "fatal",
+    });
   }
 }
 
@@ -111,7 +126,9 @@ export function isSalvageEligible(input: SalvageEligibilityInput): boolean {
 
 export interface ActiveLaneScope {
   laneId: string;
+  taskId?: string;
   waveId: string;
+  attemptId: string;
   paths: string[];
   repo?: string;
 }
@@ -127,6 +144,7 @@ export interface OpenPullRequestScope {
 export interface WaveCollision {
   key: string;
   waveId: string;
+  attemptId: string;
   leftId: string;
   rightId: string;
   paths: string[];
@@ -182,12 +200,18 @@ export function detectWaveCollisions(
     if (!left) continue;
     for (let j = i + 1; j < sorted.length; j++) {
       const right = sorted[j];
-      if (!right || left.waveId !== right.waveId) continue;
+      if (
+        !right ||
+        left.waveId !== right.waveId ||
+        left.attemptId !== right.attemptId
+      )
+        continue;
       const paths = overlappingPaths(left.paths, right.paths);
       if (paths.length === 0) continue;
       collisions.push({
-        key: `lane:${left.laneId}|lane:${right.laneId}`,
+        key: `wave:${left.waveId}|attempt:${left.attemptId}|lane:${left.laneId}|lane:${right.laneId}`,
         waveId: left.waveId,
+        attemptId: left.attemptId,
         leftId: left.laneId,
         rightId: right.laneId,
         paths,
@@ -205,8 +229,9 @@ export function detectWaveCollisions(
       const paths = overlappingPaths(lane.paths, pr.changedFiles);
       if (paths.length === 0) continue;
       collisions.push({
-        key: `lane:${lane.laneId}|pr:${pr.id}`,
+        key: `wave:${lane.waveId}|attempt:${lane.attemptId}|lane:${lane.laneId}|pr:${pr.id}`,
         waveId: lane.waveId,
+        attemptId: lane.attemptId,
         leftId: lane.laneId,
         rightId: pr.id,
         paths,
@@ -324,6 +349,14 @@ interface TaskServiceLike {
   getTaskOriginTarget(
     taskId: string,
   ): Promise<{ roomId: string; source: string; worldId?: string } | null>;
+  pauseTask?(taskId: string): Promise<TaskThreadDetailDto | null>;
+  resumeTask?(taskId: string): Promise<TaskThreadDetailDto | null>;
+  stopTaskAgent?(taskId: string, sessionId: string): Promise<boolean>;
+}
+
+interface WorkspaceServiceLike {
+  workspaceRegistry?: WorkspaceRegistry;
+  getWorkspaceRegistry?: () => WorkspaceRegistry;
 }
 
 type RuntimeWithSendTarget = IAgentRuntime & {
@@ -343,10 +376,14 @@ export interface WaveStatus {
   refillCount: number;
   salvageCount: number;
   collisionCount: number;
+  budgetState: "ok" | "paused";
+  budgetReason?: string;
 }
 
 function readScope(metadata: Record<string, unknown>): string[] {
-  const raw = metadata.laneScope ?? metadata.scope;
+  const lane = isRecord(metadata.lane) ? metadata.lane : undefined;
+  const raw =
+    lane?.scopePaths ?? lane?.scope ?? metadata.laneScope ?? metadata.scope;
   if (typeof raw === "string") return [raw].map(normalizePath).filter(Boolean);
   if (Array.isArray(raw)) {
     return raw
@@ -363,6 +400,83 @@ function readScope(metadata: Record<string, unknown>): string[] {
       .filter(Boolean);
   }
   return [];
+}
+
+export function readLaneId(
+  metadata: Record<string, unknown> | undefined,
+  fallbackTaskId: string,
+): string {
+  const lane = metadata && isRecord(metadata.lane) ? metadata.lane : undefined;
+  return (
+    nonEmptyString(lane?.id) ??
+    nonEmptyString(metadata?.laneId) ??
+    fallbackTaskId
+  );
+}
+
+export function readWaveAttemptId(
+  metadata: Record<string, unknown> | undefined,
+): string {
+  const wave = metadata && isRecord(metadata.wave) ? metadata.wave : undefined;
+  return (
+    nonEmptyString(metadata?.waveAttemptId) ??
+    nonEmptyString(wave?.attemptId) ??
+    nonEmptyString(metadata?.attemptId) ??
+    "default"
+  );
+}
+
+export function readLaneDependencies(
+  metadata: Record<string, unknown> | undefined,
+): string[] {
+  const lane = metadata && isRecord(metadata.lane) ? metadata.lane : undefined;
+  const raw = lane?.dependencies ?? metadata?.laneDependencies;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map(nonEmptyString)
+    .filter((dependency): dependency is string => Boolean(dependency));
+}
+
+function readWaveGoal(
+  metadata: Record<string, unknown>,
+  fallback: string,
+): string {
+  const wave = isRecord(metadata.wave) ? metadata.wave : undefined;
+  return (
+    nonEmptyString(metadata.waveGoal) ?? nonEmptyString(wave?.goal) ?? fallback
+  );
+}
+
+function readWaveBudget(metadata: Record<string, unknown> | undefined): {
+  maxCostUsd?: number;
+  maxTokens?: number;
+} {
+  const wave = metadata && isRecord(metadata.wave) ? metadata.wave : undefined;
+  const budget = isRecord(metadata?.waveBudget)
+    ? metadata?.waveBudget
+    : isRecord(wave?.budget)
+      ? wave?.budget
+      : undefined;
+  const maxCostUsd =
+    typeof metadata?.waveBudgetMaxCostUsd === "number"
+      ? metadata.waveBudgetMaxCostUsd
+      : typeof budget?.maxCostUsd === "number"
+        ? budget.maxCostUsd
+        : undefined;
+  const maxTokens =
+    typeof metadata?.waveBudgetMaxTokens === "number"
+      ? metadata.waveBudgetMaxTokens
+      : typeof budget?.maxTokens === "number"
+        ? budget.maxTokens
+        : undefined;
+  return {
+    ...(maxCostUsd !== undefined && Number.isFinite(maxCostUsd)
+      ? { maxCostUsd }
+      : {}),
+    ...(maxTokens !== undefined && Number.isFinite(maxTokens)
+      ? { maxTokens }
+      : {}),
+  };
 }
 
 function captureUncommittedFiles(workdir: string | null): string[] {
@@ -397,6 +511,7 @@ function taskIsActive(task: TaskThreadDetailDto): boolean {
 
 export class WaveSupervisor extends Service {
   static serviceType = WAVE_SUPERVISOR_SERVICE_TYPE;
+  static dependencies = ["ORCHESTRATOR_TASK_SERVICE"];
   capabilityDescription =
     "Supervises wave-scoped lane refill, salvage, collision warnings, concurrency, and status.";
 
@@ -483,13 +598,30 @@ export class WaveSupervisor extends Service {
     return planner?.planReplacement ? planner : new NoopWaveRefillPlanner();
   }
 
+  private workspaceRegistry(): WorkspaceRegistry | undefined {
+    const service = this.runtime.getService<WorkspaceServiceLike & ServiceType>(
+      "CODING_WORKSPACE_SERVICE",
+    );
+    if (typeof service?.getWorkspaceRegistry === "function") {
+      return service.getWorkspaceRegistry();
+    }
+    return service?.workspaceRegistry;
+  }
+
   /** Admission-queue seam. Reservations close concurrent spawn races per wave. */
   async tryAcquire(taskId: string): Promise<boolean> {
     if (!this.enabled()) return true;
     const tasks = await this.loadWaveTasks();
     const task = tasks.find((candidate) => candidate.id === taskId);
     const waveId = task ? readWaveId(task.metadata) : undefined;
+    if (!task) return true;
     if (!waveId) return true;
+    const budget = this.evaluateBudget(tasks, waveId);
+    if (budget.breached) {
+      await this.pauseWaveForBudget(waveId, tasks, budget.reason);
+      return false;
+    }
+    if (!this.dependenciesSatisfied(task, tasks)) return false;
     if (this.reservations.get(taskId) === waveId) return true;
     this.releaseTerminalReservations(tasks);
     const active = tasks.filter(
@@ -532,15 +664,29 @@ export class WaveSupervisor extends Service {
     const activeScopes = tasks
       .filter(taskIsActive)
       .map((task) => ({
-        laneId: task.id,
+        laneId: readLaneId(task.metadata, task.id),
+        taskId: task.id,
         waveId: readWaveId(task.metadata) ?? "",
+        attemptId: readWaveAttemptId(task.metadata),
         paths: readScope(task.metadata),
         ...(task.latestRepo ? { repo: task.latestRepo } : {}),
       }))
       .filter((lane) => lane.waveId && lane.paths.length > 0);
-    const activeIds = new Set(activeScopes.map((lane) => lane.laneId));
+    for (const waveId of [
+      ...new Set(
+        tasks.map((task) => readWaveId(task.metadata)).filter(Boolean),
+      ),
+    ] as string[]) {
+      const budget = this.evaluateBudget(tasks, waveId);
+      if (budget.breached) {
+        await this.pauseWaveForBudget(waveId, tasks, budget.reason);
+      }
+    }
+    const activeTaskIds = new Set(
+      activeScopes.map((lane) => lane.taskId ?? lane.laneId),
+    );
     const repos = tasks
-      .filter((task) => activeIds.has(task.id))
+      .filter((task) => activeTaskIds.has(task.id))
       .map((task) => task.latestRepo)
       .filter((repo): repo is string => Boolean(repo));
     let pullRequests: OpenPullRequestScope[] = [];
@@ -580,6 +726,69 @@ export class WaveSupervisor extends Service {
     this.statuses = this.computeStatuses(refreshed, collisions);
     await this.persistStatuses(service, refreshed, this.statuses);
     return this.getWaveStatuses();
+  }
+
+  async approveBudgetIncrease(input: {
+    waveId: string;
+    approvedBy: string;
+    reason: string;
+    maxCostUsd?: number;
+    maxTokens?: number;
+  }): Promise<WaveStatus[]> {
+    const service = this.taskService();
+    if (!service) return [];
+    const tasks = await this.loadWaveTasks();
+    const waveTasks = tasks.filter(
+      (task) => readWaveId(task.metadata) === input.waveId,
+    );
+    const approvedAt = new Date().toISOString();
+    for (const task of waveTasks) {
+      const wave = isRecord(task.metadata.wave) ? task.metadata.wave : {};
+      const supervisor = isRecord(task.metadata.waveSupervisor)
+        ? task.metadata.waveSupervisor
+        : {};
+      const approvedBudget = {
+        ...readWaveBudget(task.metadata),
+        ...(input.maxCostUsd !== undefined
+          ? { maxCostUsd: input.maxCostUsd }
+          : {}),
+        ...(input.maxTokens !== undefined
+          ? { maxTokens: input.maxTokens }
+          : {}),
+      };
+      await service.updateTask(task.id, {
+        metadata: {
+          ...task.metadata,
+          waveBudget: approvedBudget,
+          ...(approvedBudget.maxCostUsd !== undefined
+            ? { waveBudgetMaxCostUsd: approvedBudget.maxCostUsd }
+            : {}),
+          ...(approvedBudget.maxTokens !== undefined
+            ? { waveBudgetMaxTokens: approvedBudget.maxTokens }
+            : {}),
+          wave: {
+            ...wave,
+            budget: approvedBudget,
+          },
+          waveSupervisor: {
+            ...supervisor,
+            budgetApproval: {
+              approvedAt,
+              approvedBy: input.approvedBy,
+              reason: input.reason,
+              ...(input.maxCostUsd !== undefined
+                ? { maxCostUsd: input.maxCostUsd }
+                : {}),
+              ...(input.maxTokens !== undefined
+                ? { maxTokens: input.maxTokens }
+                : {}),
+            },
+          },
+        },
+      });
+      if (task.paused) await service.resumeTask?.(task.id);
+    }
+    return this.runOnce();
   }
 
   private async loadWaveTasks(): Promise<TaskThreadDetailDto[]> {
@@ -641,11 +850,14 @@ export class WaveSupervisor extends Service {
     });
     let salvagePath: string | undefined;
     if (salvage && terminalLane.latestWorkdir) {
-      const preserved = preserveRegisteredWorkspace(
-        terminalLane.latestWorkdir,
-        getSharedWorkspaceRegistry(),
-        (message) => logger.info(`[WaveSupervisor] ${message}`),
-      );
+      const registry = this.workspaceRegistry();
+      const preserved = registry
+        ? preserveRegisteredWorkspace(
+            terminalLane.latestWorkdir,
+            registry,
+            (message) => logger.info(`[WaveSupervisor] ${message}`),
+          )
+        : false;
       // Caller-owned workdirs are already outside lifecycle deletion. Registered
       // workdirs are explicitly returned to live accounting by the helper.
       if (preserved || terminalLane.latestWorkdir) {
@@ -656,14 +868,7 @@ export class WaveSupervisor extends Service {
       (task) => readWaveId(task.metadata) === waveId,
     );
     const activeLanes = waveTasks.filter(taskIsActive);
-    const waveGoal =
-      nonEmptyString(terminalLane.metadata.waveGoal) ??
-      nonEmptyString(
-        isRecord(terminalLane.metadata.wave)
-          ? terminalLane.metadata.wave.goal
-          : undefined,
-      ) ??
-      terminalLane.goal;
+    const waveGoal = readWaveGoal(terminalLane.metadata, terminalLane.goal);
     const planner = this.planner();
     const spec = await planner.planReplacement({
       waveId,
@@ -725,7 +930,13 @@ export class WaveSupervisor extends Service {
       metadata: {
         ...spec.metadata,
         [WAVE_ID_METADATA_KEY]: waveId,
+        waveAttemptId: readWaveAttemptId(terminalLane.metadata),
         waveGoal,
+        lane: {
+          id: `${readLaneId(terminalLane.metadata, terminalLane.id)}-refill`,
+          dependencies: [],
+          scopePaths: spec.scope ?? [],
+        },
         laneScope: spec.scope ?? [],
         forbiddenPaths: spec.forbiddenPaths ?? [],
         difficultyTag: spec.difficultyTag,
@@ -753,7 +964,12 @@ export class WaveSupervisor extends Service {
   ): Promise<void> {
     const send = (this.runtime as RuntimeWithSendTarget).sendMessageToTarget;
     if (typeof send !== "function") return;
-    const byId = new Map(tasks.map((task) => [task.id, task]));
+    const byId = new Map(
+      tasks.flatMap((task) => [
+        [task.id, task] as const,
+        [readLaneId(task.metadata, task.id), task] as const,
+      ]),
+    );
     for (const collision of collisions) {
       if (this.warnedCollisions.has(collision.key)) continue;
       const originTask = byId.get(collision.leftId);
@@ -796,6 +1012,7 @@ export class WaveSupervisor extends Service {
       const supervisorStates = lanes
         .map((task) => task.metadata.waveSupervisor)
         .filter(isRecord);
+      const budget = this.evaluateBudget(tasks, waveId);
       return {
         waveId,
         totalLanes: lanes.length,
@@ -815,8 +1032,107 @@ export class WaveSupervisor extends Service {
         collisionCount: collisions.filter(
           (collision) => collision.waveId === waveId,
         ).length,
+        budgetState: budget.breached ? "paused" : "ok",
+        ...(budget.breached ? { budgetReason: budget.reason } : {}),
       };
     });
+  }
+
+  private dependenciesSatisfied(
+    task: TaskThreadDetailDto,
+    tasks: readonly TaskThreadDetailDto[],
+  ): boolean {
+    const dependencies = readLaneDependencies(task.metadata);
+    if (dependencies.length === 0) return true;
+    const waveId = readWaveId(task.metadata);
+    const attemptId = readWaveAttemptId(task.metadata);
+    const sameAttempt = tasks.filter(
+      (candidate) =>
+        readWaveId(candidate.metadata) === waveId &&
+        readWaveAttemptId(candidate.metadata) === attemptId,
+    );
+    const byLaneId = new Map(
+      sameAttempt.map((candidate) => [
+        readLaneId(candidate.metadata, candidate.id),
+        candidate,
+      ]),
+    );
+    return dependencies.every((dependency) => {
+      const dep = byLaneId.get(dependency);
+      return dep?.status === "done";
+    });
+  }
+
+  private evaluateBudget(
+    tasks: readonly TaskThreadDetailDto[],
+    waveId: string,
+  ): { breached: false } | { breached: true; reason: string } {
+    const lanes = tasks.filter((task) => readWaveId(task.metadata) === waveId);
+    const budget = lanes.reduce(
+      (found, task) => ({
+        maxCostUsd:
+          found.maxCostUsd ?? readWaveBudget(task.metadata).maxCostUsd,
+        maxTokens: found.maxTokens ?? readWaveBudget(task.metadata).maxTokens,
+      }),
+      {} as { maxCostUsd?: number; maxTokens?: number },
+    );
+    const costUsd = lanes.reduce((sum, task) => sum + task.usage.costUsd, 0);
+    const totalTokens = lanes.reduce(
+      (sum, task) => sum + task.usage.totalTokens,
+      0,
+    );
+    if (budget.maxCostUsd !== undefined && costUsd >= budget.maxCostUsd) {
+      return {
+        breached: true,
+        reason: `cost ${costUsd.toFixed(6)} >= ${budget.maxCostUsd.toFixed(6)} USD`,
+      };
+    }
+    if (budget.maxTokens !== undefined && totalTokens >= budget.maxTokens) {
+      return {
+        breached: true,
+        reason: `tokens ${totalTokens} >= ${budget.maxTokens}`,
+      };
+    }
+    return { breached: false };
+  }
+
+  private async pauseWaveForBudget(
+    waveId: string,
+    tasks: readonly TaskThreadDetailDto[],
+    reason: string,
+  ): Promise<void> {
+    const service = this.taskService();
+    if (!service) return;
+    const waveTasks = tasks.filter(
+      (task) => readWaveId(task.metadata) === waveId,
+    );
+    const stoppedAt = new Date().toISOString();
+    const error = new WaveBudgetBreachError(waveId, reason, {
+      taskIds: waveTasks.map((task) => task.id),
+    });
+    this.runtime.reportError?.("WaveSupervisor.budget", error, {
+      waveId,
+      reason,
+    });
+    for (const task of waveTasks) {
+      const state = isRecord(task.metadata.waveSupervisor)
+        ? task.metadata.waveSupervisor
+        : {};
+      await service.updateTask(task.id, {
+        metadata: {
+          ...task.metadata,
+          waveSupervisor: {
+            ...state,
+            pausedAt: stoppedAt,
+            pausedReason: reason,
+            pauseCode: WAVE_BUDGET_BREACH_CODE,
+          },
+        },
+      });
+      if (!task.paused && !TERMINAL_LANE_STATUSES.has(task.status)) {
+        await service.pauseTask?.(task.id);
+      }
+    }
   }
 
   private async persistStatuses(

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
@@ -7,6 +7,32 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { WorkspaceRegistry } from "./workspace-registry.js";
+
+/**
+ * Preserve a lifecycle-owned workspace for salvage without copying it. The
+ * registry remains the ownership authority: unregistered/caller-owned paths are
+ * never adopted or made reclaimable here. Re-registering the existing record
+ * marks it live again, which prevents terminal-workspace LRU reclaim while the
+ * replacement lane inspects it.
+ */
+export function preserveRegisteredWorkspace(
+  dirPath: string,
+  registry: WorkspaceRegistry,
+  log: (msg: string) => void,
+): boolean {
+  const resolved = path.resolve(dirPath);
+  const record = registry.list().find((entry) => entry.path === resolved);
+  if (!record) {
+    log(
+      `Salvage workspace is caller-owned/unregistered; leaving it untouched: ${resolved}`,
+    );
+    return false;
+  }
+  registry.register(record.kind, record.path, record.ownerId);
+  log(`Preserved workspace for salvage: ${resolved}`);
+  return true;
+}
 
 /** Remove a scratch directory safely — only if under baseDir or one of allowedDirs. */
 export async function removeScratchDir(

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -391,6 +391,10 @@ export class CodingWorkspaceService {
     return service;
   }
 
+  getWorkspaceRegistry(): WorkspaceRegistry {
+    return this.workspaceRegistry;
+  }
+
   static async stopRuntime(runtime: IAgentRuntime): Promise<void> {
     const service = getCodingWorkspaceService(runtime);
     if (service) {


### PR DESCRIPTION
## Summary

W3 of #16443. Adds a default-off `WaveSupervisor` to `plugin-agent-orchestrator` for wave-scoped lane lifecycle management.

- reads the canonical `metadata.waveId` contract, with defensive aliases for manually stamped tasks
- refills terminal lanes while the wave goal remains unmet through an injected `WaveRefillPlanner` interface
- ships a no-op planner fallback so W3 can land before W1; W1 can register `ORCHESTRATOR_LANE_PLANNER` with the same interface without changing W3
- detects failed-lane uncommitted work via `git status`, preserves lifecycle-registered workspaces, and includes the preserved path/files in replacement metadata and brief
- re-checks active lane scopes against sibling scopes and matching-repository open PR changed files, warning once per collision pair in the originating room
- layers a per-wave concurrency reservation/cap over the existing durable admission queue, including head-of-line avoidance across waves
- persists compact wave status in existing task metadata and surfaces it through `ACTIVE_SUB_AGENTS`
- gates all behavior behind `ELIZA_ORCHESTRATOR_WAVE_SUPERVISOR` (default OFF)

## Redundancy check and design choice

I read the existing watchdog, reflexion/respawn path, task service/store/types, admission queue, Smithers integration, active-sub-agent provider, workspace lifecycle/registry, and swarm coordinator before implementation.

This is a **new service rather than an extension of `TaskWatchdogService`**. The watchdog is session-liveness detection and reminder delivery; wave supervision owns a different aggregate lifecycle plus admission control and planner orchestration. Combining them would couple default-on watchdog behavior to a default-off feature and expand the watchdog's responsibilities substantially. W3 does reuse its proven structure: pure detectors, one tick owner, in-memory one-time warning keys, target resolution through the task service, no new store, and timer-free policy tests.

Existing mechanisms reused:

- task durability and metadata: `OrchestratorTaskService` / existing store
- dispatch backpressure: existing admission queue and its durable admission record
- salvage ownership: workspace lifecycle plus shared registry, without adopting caller-owned paths
- status visibility: existing `ACTIVE_SUB_AGENTS` provider
- retry context remains owned by existing reflexion/respawn logic

## Configuration

- `ELIZA_ORCHESTRATOR_WAVE_SUPERVISOR=true` enables the service
- `ELIZA_ORCHESTRATOR_WAVE_CONCURRENCY=<n>` sets the default per-wave cap (default 4)
- `ELIZA_ORCHESTRATOR_WAVE_INTERVAL_MS=<ms>` sets tick cadence (minimum 5000, default 60000)
- task metadata `waveConcurrencyCap` overrides the default for that wave

## Evidence

| Check | Command | Result |
|---|---|---|
| authoritative per-file unit test | `bun test plugins/plugin-agent-orchestrator/src/__tests__/wave-supervisor.test.ts` | PASS, 6 tests / 18 assertions |
| targeted Vitest suite | `bunx vitest run --config vitest.config.ts src/__tests__/wave-supervisor.test.ts src/__tests__/admission-queue.test.ts src/__tests__/admission-integration.test.ts` | PASS, 3 files / 26 tests |
| formatting/lint | `bunx @biomejs/biome check <six changed files>` | PASS |
| patch hygiene | `git diff --check` | PASS |
| package typecheck | `bun run typecheck` | BLOCKED by existing workspace/dependency failures outside W3 (`reset-soonest` generated contract mismatch plus missing `ai`, `markdown-it`, `file-type`, and `fast-redact` declarations); no W3-file diagnostic emitted |
| review | `codex review --uncommitted` (two passes) | Findings fixed: queue reservation releases, degraded-recording release, and repository-qualified PR collision matching |

## Scope

No new store or UI. No W1/W2 planner/create-path/completion-evidence changes. No lockfile, Vite config, or binary changes.

[sol-cloud]
