### PR TITLE
feat(orchestrator): verify completion against GitHub ground truth

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  appendCompletionEvidenceSection,
   buildCompletionEvidenceString,
   buildEvidenceStringFromInput,
 } from "../../src/services/completion-evidence.js";
@@ -217,5 +218,22 @@ describe("buildCompletionEvidenceString (typed bundle, #8894)", () => {
     });
     expect(evidence).not.toContain("## TEST / BUILD / TYPECHECK OUTPUT");
     expect(evidence).toContain("## CHANGESET");
+  });
+
+  it("appends ground truth as a new section without replacing existing evidence", () => {
+    const evidence = appendCompletionEvidenceSection(
+      "## CHANGESET\nsrc/a.ts",
+      "## GROUND TRUTH (GitHub API verification)\nstatus: verified",
+    );
+    expect(evidence).toContain("## CHANGESET\nsrc/a.ts");
+    expect(evidence).toContain("## GROUND TRUTH");
+  });
+
+  it("keeps an oversized appended section inside the evidence cap", () => {
+    const evidence = appendCompletionEvidenceSection(
+      "existing",
+      "x".repeat(20_000),
+    );
+    expect(evidence.length).toBeLessThanOrEqual(8_000);
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/ground-truth-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/ground-truth-verifier.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyCheckRollup,
+  compareClaimedFiles,
+  groundTruthHardFailEnabled,
+  type RemotePullRequest,
+  renderGroundTruthEvidence,
+  shouldIncludeGroundTruthEvidence,
+  verifyGroundTruth,
+} from "../../src/services/ground-truth-verifier.js";
+
+const completion = "Done: https://github.com/elizaos/eliza/pull/123";
+
+function remote(overrides: Partial<RemotePullRequest> = {}): RemotePullRequest {
+  return {
+    url: "https://github.com/elizaos/eliza/pull/123",
+    state: "open",
+    headSha: "abc123",
+    changedFiles: ["src/a.ts"],
+    checks: [],
+    ...overrides,
+  };
+}
+
+const now = () => new Date("2026-07-15T00:00:00.000Z");
+
+describe("ground-truth pure comparison", () => {
+  it("reports changed remote files that were not claimed", () => {
+    expect(compareClaimedFiles(["src/a.ts"], ["src/a.ts", "src/b.ts"])).toEqual(
+      {
+        claimed: ["src/a.ts"],
+        actual: ["src/a.ts", "src/b.ts"],
+        changedButNotClaimed: ["src/b.ts"],
+        claimedButNotChanged: [],
+      },
+    );
+  });
+
+  it("reports claimed files absent from the PR", () => {
+    expect(compareClaimedFiles(["src/a.ts", "src/b.ts"], ["src/a.ts"])).toEqual(
+      {
+        claimed: ["src/a.ts", "src/b.ts"],
+        actual: ["src/a.ts"],
+        changedButNotClaimed: [],
+        claimedButNotChanged: ["src/b.ts"],
+      },
+    );
+  });
+
+  it("classifies red and pending required checks", () => {
+    expect(
+      classifyCheckRollup([
+        {
+          name: "test",
+          status: "completed",
+          conclusion: "failure",
+          required: true,
+        },
+        {
+          name: "lint",
+          status: "completed",
+          conclusion: "success",
+          required: true,
+        },
+      ]).state,
+    ).toBe("red");
+    expect(
+      classifyCheckRollup([
+        {
+          name: "test",
+          status: "in_progress",
+          conclusion: null,
+          required: true,
+        },
+      ]).state,
+    ).toBe("pending");
+  });
+});
+
+describe("verifyGroundTruth", () => {
+  it("records a missing unrequired PR without hard-failing", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion: "finished without a link",
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      { fetchPullRequest: async () => remote(), now },
+    );
+    expect(verdict.status).toBe("missing_pr");
+    expect(verdict.hardFail).toBe(false);
+    expect(verdict.pr.claimed).toBe(false);
+    expect(renderGroundTruthEvidence(verdict)).toContain(
+      "pullRequest: not claimed",
+    );
+  });
+
+  it("hard-fails a missing PR only when policy requires one", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion: "finished without a link",
+        claimedFiles: [],
+        requirePullRequest: true,
+        hardFailEnabled: true,
+      },
+      { fetchPullRequest: async () => remote(), now },
+    );
+    expect(verdict.hardFail).toBe(true);
+    expect(verdict.hardFailReasons[0]).toContain("required");
+  });
+
+  it("hard-fails a claimed URL that does not resolve", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: [],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      { fetchPullRequest: async () => null, now },
+    );
+    expect(verdict.pr.exists).toBe(false);
+    expect(verdict.hardFail).toBe(true);
+  });
+
+  it("hard-fails red required checks", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({
+            checks: [
+              {
+                name: "unit-tests",
+                status: "completed",
+                conclusion: "failure",
+                required: true,
+              },
+            ],
+          }),
+        now,
+      },
+    );
+    expect(verdict.checks.state).toBe("red");
+    expect(verdict.hardFail).toBe(true);
+    expect(verdict.hardFailReasons[0]).toContain("unit-tests");
+  });
+
+  it("reports pending checks without a false failure", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: true,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({
+            checks: [
+              {
+                name: "unit-tests",
+                status: "queued",
+                conclusion: null,
+                required: true,
+              },
+            ],
+          }),
+        now,
+      },
+    );
+    expect(verdict.checks.state).toBe("pending");
+    expect(verdict.status).toBe("inconclusive");
+    expect(verdict.hardFail).toBe(false);
+  });
+
+  it("preserves both directions of file mismatch in the structured verdict", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/claimed.ts", "src/shared.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: false,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({ changedFiles: ["src/remote.ts", "src/shared.ts"] }),
+        now,
+      },
+    );
+    expect(verdict.status).toBe("mismatch");
+    expect(verdict.files.changedButNotClaimed).toEqual(["src/remote.ts"]);
+    expect(verdict.files.claimedButNotChanged).toEqual(["src/claimed.ts"]);
+  });
+
+  it("turns API errors into inconclusive verdicts, never hard failures", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: true,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () => {
+          throw new Error("rate limited");
+        },
+        now,
+      },
+    );
+    expect(verdict.status).toBe("inconclusive");
+    expect(verdict.hardFail).toBe(false);
+    expect(verdict.error).toBe("rate limited");
+  });
+});
+
+describe("ground-truth settings", () => {
+  it("defaults evidence on and hard-fail off", () => {
+    const unset = () => undefined;
+    expect(shouldIncludeGroundTruthEvidence(unset)).toBe(true);
+    expect(groundTruthHardFailEnabled(unset)).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/ground-truth-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/ground-truth-verifier.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   classifyCheckRollup,
   compareClaimedFiles,
@@ -177,7 +177,142 @@ describe("verifyGroundTruth", () => {
     );
     expect(verdict.checks.state).toBe("pending");
     expect(verdict.status).toBe("inconclusive");
-    expect(verdict.hardFail).toBe(false);
+    expect(verdict.hardFail).toBe(true);
+    expect(verdict.hardFailReasons[0]).toContain("pending");
+  });
+
+  it("blocks API-inconclusive verification when the feature applies", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: true,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () => {
+          throw new Error("branch protection unavailable");
+        },
+        now,
+      },
+    );
+    expect(verdict.status).toBe("inconclusive");
+    expect(verdict.hardFail).toBe(true);
+    expect(verdict.hardFailReasons[0]).toContain("API request failed");
+  });
+
+  it("blocks closed-unmerged and merged PR states", async () => {
+    const closed = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({
+            state: "closed",
+            checks: [
+              {
+                name: "unit",
+                status: "completed",
+                conclusion: "success",
+                required: true,
+              },
+            ],
+          }),
+        now,
+      },
+    );
+    expect(closed.hardFail).toBe(true);
+    expect(closed.summary).toContain("closed");
+
+    const merged = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({
+            state: "merged",
+            checks: [
+              {
+                name: "unit",
+                status: "completed",
+                conclusion: "success",
+                required: true,
+              },
+            ],
+          }),
+        now,
+      },
+    );
+    expect(merged.hardFail).toBe(true);
+    expect(merged.summary).toContain("merged");
+  });
+
+  it("blocks empty and unavailable check states", async () => {
+    const empty = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      { fetchPullRequest: async () => remote({ checks: [] }), now },
+    );
+    expect(empty.hardFail).toBe(true);
+    expect(empty.summary).toContain("no reported checks");
+
+    const unavailable = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({
+            checksUnavailable: true,
+            checksUnavailableReason: "branch protection unavailable (403)",
+          }),
+        now,
+      },
+    );
+    expect(unavailable.hardFail).toBe(true);
+    expect(unavailable.summary).toContain("unavailable");
+  });
+
+  it("preserves app-bound required check context in rendered evidence", async () => {
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles: ["src/a.ts"],
+        requirePullRequest: false,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async () =>
+          remote({
+            checks: [
+              {
+                name: "unit",
+                status: "completed",
+                conclusion: "success",
+                required: true,
+                appId: 15368,
+              },
+            ],
+          }),
+        now,
+      },
+    );
+    expect(renderGroundTruthEvidence(verdict)).toContain("appId=15368");
   });
 
   it("preserves both directions of file mismatch in the structured verdict", async () => {
@@ -199,24 +334,25 @@ describe("verifyGroundTruth", () => {
     expect(verdict.files.claimedButNotChanged).toEqual(["src/claimed.ts"]);
   });
 
-  it("turns API errors into inconclusive verdicts, never hard failures", async () => {
+  it("skips fetching and does not hard-fail when the feature does not apply", async () => {
+    const fetchPullRequest = vi.fn(async () => {
+      throw new Error("rate limited");
+    });
     const verdict = await verifyGroundTruth(
       {
-        completion,
-        claimedFiles: ["src/a.ts"],
-        requirePullRequest: true,
+        completion: "no pull request",
+        claimedFiles: [],
+        requirePullRequest: false,
         hardFailEnabled: true,
       },
       {
-        fetchPullRequest: async () => {
-          throw new Error("rate limited");
-        },
+        fetchPullRequest,
         now,
       },
     );
-    expect(verdict.status).toBe("inconclusive");
+    expect(verdict.status).toBe("missing_pr");
     expect(verdict.hardFail).toBe(false);
-    expect(verdict.error).toBe("rate limited");
+    expect(fetchPullRequest).not.toHaveBeenCalled();
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -34,6 +34,7 @@ import {
   createRouterLoopState,
   routerLoopTransition,
 } from "../../src/services/router-loop-guard.js";
+import { CodingWorkspaceService } from "../../src/services/workspace-service.js";
 
 // This suite pins the status state machine and the ACP→task event bridge — NOT
 // the #8896 default-criteria feature. createTask now auto-populates acceptance
@@ -196,6 +197,26 @@ function makeService(
   settings: Record<string, string> = {},
 ): OrchestratorTaskService {
   return makeServiceWithStore(acp, settings).service;
+}
+
+function runtimeWithWorkspace(
+  acp: FakeAcp | undefined,
+  workspace: CodingWorkspaceService,
+  useModel?: IAgentRuntime["useModel"],
+): IAgentRuntime {
+  return {
+    getService: (type: string) =>
+      type === CodingWorkspaceService.serviceType ? workspace : (acp ?? null),
+    getSetting: () => undefined,
+    useModel,
+    reportError: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as never;
 }
 
 function createInput(
@@ -593,6 +614,130 @@ describe("OrchestratorTaskService — lifecycle", () => {
         humanOverride: true,
       },
     });
+  });
+
+  it("manual validateTask blocks completion when claimed PR checks are pending", async () => {
+    const acp = new FakeAcp();
+    const workspace = new CodingWorkspaceService(runtime(acp));
+    const fetchGroundTruth = vi.fn(async () => ({
+      url: "https://github.com/elizaos/eliza/pull/16453",
+      state: "open" as const,
+      headSha: "abc123",
+      changedFiles: [],
+      checks: [
+        {
+          name: "unit",
+          status: "queued",
+          conclusion: null,
+          required: true,
+        },
+      ],
+    }));
+    workspace.getPullRequestGroundTruth = fetchGroundTruth;
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(
+      runtimeWithWorkspace(acp, workspace),
+      { store },
+    );
+    const task = await service.createTask(createInput());
+    await service.updateTask(task.id, {
+      status: "validating",
+      metadata: {
+        prUrl: "https://github.com/elizaos/eliza/pull/16453",
+        prRepo: "elizaos/eliza",
+        prNumber: 16453,
+      },
+    });
+
+    await expect(
+      service.validateTask(task.id, {
+        passed: true,
+        summary: "verified manually",
+      }),
+    ).rejects.toThrow(/Ground-truth verification blocks validation/);
+
+    const doc = await store.getTask(task.id);
+    expect(doc?.task.status).toBe("validating");
+    expect(fetchGroundTruth).toHaveBeenCalledTimes(1);
+    expect(
+      doc?.events.some(
+        (event) => event.eventType === "validation_blocked_ground_truth",
+      ),
+    ).toBe(true);
+  });
+
+  it("manual validateTask skips default-on GitHub calls for PR-less tasks with no changeset", async () => {
+    const acp = new FakeAcp();
+    const workspace = new CodingWorkspaceService(runtime(acp));
+    const fetchGroundTruth = vi.fn();
+    workspace.getPullRequestGroundTruth = fetchGroundTruth;
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(
+      runtimeWithWorkspace(acp, workspace),
+      { store },
+    );
+    const task = await service.createTask(createInput());
+    await service.updateTask(task.id, { status: "validating" });
+
+    const detail = await service.validateTask(task.id, {
+      passed: true,
+      summary: "verified manually without a PR",
+    });
+
+    expect(detail?.status).toBe("done");
+    expect(fetchGroundTruth).not.toHaveBeenCalled();
+  });
+
+  it("automatic validation reuses the stored ground-truth verdict when promoting", async () => {
+    const acp = new FakeAcp();
+    const workspace = new CodingWorkspaceService(runtime(acp));
+    const fetchGroundTruth = vi.fn(async () => ({
+      url: "https://github.com/elizaos/eliza/pull/16453",
+      state: "open" as const,
+      headSha: "abc123",
+      changedFiles: [],
+      checks: [
+        {
+          name: "unit",
+          status: "completed",
+          conclusion: "success",
+          required: true,
+        },
+      ],
+    }));
+    workspace.getPullRequestGroundTruth = fetchGroundTruth;
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const useModel = vi.fn(async () =>
+      JSON.stringify({
+        passed: true,
+        summary: "all criteria met",
+        missing: [],
+      }),
+    ) as IAgentRuntime["useModel"];
+    const service = new OrchestratorTaskService(
+      runtimeWithWorkspace(acp, workspace, useModel),
+      { store },
+    );
+    await service.start();
+    const task = await service.createTask(
+      createInput({ acceptanceCriteria: ["tests pass"] }),
+    );
+    const detail = must(
+      await service.spawnAgentForTask(task.id),
+      "expected spawn detail",
+    );
+    const sessionId = must(detail.sessions[0], "session").sessionId;
+
+    await drive(acp, sessionId, "task_complete", {
+      response: "Done https://github.com/elizaos/eliza/pull/16453",
+    });
+    await settleStatus(service, task.id, "done");
+
+    expect(fetchGroundTruth).toHaveBeenCalledTimes(1);
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(
+      (await store.getTask(task.id))?.task.metadata.groundTruthVerdict,
+    ).toBeDefined();
   });
 
   it("adds a user message and stamps the last user turn", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/repo-parsing.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/repo-parsing.test.ts
@@ -23,10 +23,14 @@ describe("parseOwnerRepo", () => {
     });
   });
 
-  it("stops the repo name at a dot (drops .git)", () => {
+  it("drops only the trailing .git suffix", () => {
     expect(parseOwnerRepo("https://github.com/owner/repo.git")).toEqual({
       owner: "owner",
       repo: "repo",
+    });
+    expect(parseOwnerRepo("https://github.com/owner/repo.name.git")).toEqual({
+      owner: "owner",
+      repo: "repo.name",
     });
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-github-issues.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-github-issues.test.ts
@@ -12,7 +12,7 @@ import { createServer, type Server } from "node:http";
 import { createRequire } from "node:module";
 import type { IAgentRuntime } from "@elizaos/core";
 import type { GitHubPatClient as GitHubPatClientInstance } from "git-workspace-service";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   addComment,
   addLabels,
@@ -20,6 +20,8 @@ import {
   createIssue,
   ensureGitHubClient,
   type GitHubContext,
+  type GitHubRequest,
+  getPullRequestGroundTruth,
   listIssues,
   parseOwnerRepo,
   updateIssue,
@@ -164,6 +166,7 @@ class FakeGitHub {
 function makeCtx(client: GitHubPatClientInstance | null): GitHubContext {
   const state = {
     client,
+    request: null as GitHubRequest | null,
     inProgress: null as GitHubContext["githubAuthInProgress"],
   };
   return {
@@ -176,6 +179,12 @@ function makeCtx(client: GitHubPatClientInstance | null): GitHubContext {
     setGithubClient: (c) => {
       state.client = c;
     },
+    get githubRequest() {
+      return state.request;
+    },
+    setGithubRequest: (request) => {
+      state.request = request;
+    },
     get githubAuthInProgress() {
       return state.inProgress;
     },
@@ -185,6 +194,12 @@ function makeCtx(client: GitHubPatClientInstance | null): GitHubContext {
     authPromptCallback: null,
     log: () => {},
   };
+}
+
+function makeRequestCtx(request: GitHubRequest): GitHubContext {
+  const ctx = makeCtx({} as GitHubPatClientInstance);
+  ctx.setGithubRequest(request);
+  return ctx;
 }
 
 describe("parseOwnerRepo", () => {
@@ -223,6 +238,231 @@ describe("ensureGitHubClient", () => {
     expect(client).toBeInstanceOf(GitHubPatClient);
     // The context caches the client for subsequent calls.
     expect(await ensureGitHubClient(ctx)).toBe(client);
+  });
+});
+
+describe("getPullRequestGroundTruth", () => {
+  const link = {
+    url: "https://github.com/elizaos/eliza/pull/16453",
+    repo: "elizaos/eliza",
+    number: 16453,
+  };
+
+  it("marks branch protection 403 as checks unavailable", async () => {
+    const request = vi.fn(async (route: string) => {
+      if (route.includes("/files")) {
+        return { data: [{ filename: "src/a.ts" }] };
+      }
+      if (route.includes("/pulls/{pull_number}")) {
+        return {
+          data: {
+            html_url: link.url,
+            state: "open",
+            merged_at: null,
+            head: { sha: "abc123" },
+            base: { ref: "develop" },
+          },
+        };
+      }
+      if (route.includes("/check-runs")) {
+        return { data: { check_runs: [] } };
+      }
+      if (route.includes("/status")) {
+        return { data: { statuses: [] } };
+      }
+      if (route.includes("/protection")) {
+        throw Object.assign(new Error("Forbidden"), { status: 403 });
+      }
+      if (route.includes("/rules/branches")) {
+        return { data: [] };
+      }
+      throw new Error(`unexpected route ${route}`);
+    }) as GitHubRequest;
+
+    const result = await getPullRequestGroundTruth(
+      makeRequestCtx(request),
+      link,
+    );
+    expect(result?.checksUnavailable).toBe(true);
+    expect(result?.checksUnavailableReason).toContain("403");
+  });
+
+  it("preserves app_id when matching required branch-protection checks", async () => {
+    const request = vi.fn(async (route: string) => {
+      if (route.includes("/files")) return { data: [] };
+      if (route.includes("/pulls/{pull_number}")) {
+        return {
+          data: {
+            html_url: link.url,
+            state: "open",
+            merged_at: null,
+            head: { sha: "abc123" },
+            base: { ref: "develop" },
+          },
+        };
+      }
+      if (route.includes("/check-runs")) {
+        return {
+          data: {
+            check_runs: [
+              {
+                name: "unit",
+                status: "completed",
+                conclusion: "success",
+                app: { id: 15368 },
+              },
+              {
+                name: "unit",
+                status: "completed",
+                conclusion: "success",
+                app: { id: 999 },
+              },
+            ],
+          },
+        };
+      }
+      if (route.includes("/status")) return { data: { statuses: [] } };
+      if (route.includes("/protection")) {
+        return {
+          data: {
+            required_status_checks: {
+              contexts: [],
+              checks: [{ context: "unit", app_id: 15368 }],
+            },
+          },
+        };
+      }
+      if (route.includes("/rules/branches")) return { data: [] };
+      throw new Error(`unexpected route ${route}`);
+    }) as GitHubRequest;
+
+    const result = await getPullRequestGroundTruth(
+      makeRequestCtx(request),
+      link,
+    );
+    expect(result?.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "unit", appId: 15368, required: true }),
+        expect.objectContaining({ name: "unit", appId: 999, required: false }),
+      ]),
+    );
+  });
+
+  it("uses ruleset required checks when classic branch protection is unavailable", async () => {
+    const request = vi.fn(async (route: string) => {
+      if (route.includes("/files")) return { data: [] };
+      if (route.includes("/pulls/{pull_number}")) {
+        return {
+          data: {
+            html_url: link.url,
+            state: "open",
+            merged_at: null,
+            head: { sha: "abc123" },
+            base: { ref: "develop" },
+          },
+        };
+      }
+      if (route.includes("/check-runs")) {
+        return {
+          data: {
+            check_runs: [
+              {
+                name: "ruleset-unit",
+                status: "completed",
+                conclusion: "success",
+                app: { id: 15368 },
+              },
+            ],
+          },
+        };
+      }
+      if (route.includes("/status")) return { data: { statuses: [] } };
+      if (route.includes("/protection")) {
+        throw Object.assign(new Error("Not Found"), { status: 404 });
+      }
+      if (route.includes("/rules/branches")) {
+        return {
+          data: [
+            {
+              type: "required_status_checks",
+              parameters: {
+                required_status_checks: [
+                  { context: "ruleset-unit", integration_id: 15368 },
+                ],
+              },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected route ${route}`);
+    }) as GitHubRequest;
+
+    const result = await getPullRequestGroundTruth(
+      makeRequestCtx(request),
+      link,
+    );
+    expect(result?.checksUnavailable).not.toBe(true);
+    expect(result?.checks).toContainEqual(
+      expect.objectContaining({
+        name: "ruleset-unit",
+        appId: 15368,
+        required: true,
+      }),
+    );
+  });
+
+  it("retries when the PR head changes while fetching files and checks", async () => {
+    let pullReads = 0;
+    const request = vi.fn(async (route: string) => {
+      if (route.includes("/files")) return { data: [] };
+      if (route.includes("/pulls/{pull_number}")) {
+        pullReads += 1;
+        const sha = pullReads === 1 ? "old" : "new";
+        return {
+          data: {
+            html_url: link.url,
+            state: "open",
+            merged_at: null,
+            head: { sha },
+            base: { ref: "develop" },
+          },
+        };
+      }
+      if (route.includes("/check-runs")) {
+        return {
+          data: {
+            check_runs: [
+              {
+                name: "unit",
+                status: "completed",
+                conclusion: "success",
+                app: { id: 15368 },
+              },
+            ],
+          },
+        };
+      }
+      if (route.includes("/status")) return { data: { statuses: [] } };
+      if (route.includes("/protection")) {
+        return {
+          data: {
+            required_status_checks: {
+              contexts: [],
+              checks: [{ context: "unit", app_id: 15368 }],
+            },
+          },
+        };
+      }
+      if (route.includes("/rules/branches")) return { data: [] };
+      throw new Error(`unexpected route ${route}`);
+    }) as GitHubRequest;
+
+    const result = await getPullRequestGroundTruth(
+      makeRequestCtx(request),
+      link,
+    );
+    expect(result?.headSha).toBe("new");
+    expect(pullReads).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -129,6 +129,35 @@ const MAX_ARTIFACTS = 20;
 const MAX_TOOL_OUTPUT_CHARS = 2_000;
 
 /**
+ * Append a verifier-produced section without replacing the evidence assembled
+ * above. When the combined string exceeds the prompt budget, preserve the new
+ * (usually highest-value) section and trim only the older evidence prefix.
+ */
+export function appendCompletionEvidenceSection(
+  evidence: string,
+  section: string,
+): string {
+  const base = evidence.trim();
+  const addition = section.trim();
+  if (!addition) return base;
+  if (!base) return clamp(addition, MAX_EVIDENCE_CHARS);
+  const separator = "\n\n";
+  if (base.length + separator.length + addition.length <= MAX_EVIDENCE_CHARS) {
+    return `${base}${separator}${addition}`;
+  }
+  if (addition.length >= MAX_EVIDENCE_CHARS) {
+    const marker = "\n… [truncated]";
+    return `${addition.slice(0, MAX_EVIDENCE_CHARS - marker.length)}${marker}`;
+  }
+  const marker = "\n… [evidence truncated]";
+  const available = Math.max(
+    0,
+    MAX_EVIDENCE_CHARS - addition.length - separator.length - marker.length,
+  );
+  return `${base.slice(0, available)}${marker}${separator}${addition}`;
+}
+
+/**
  * Lines that look like the output of a build / test / typecheck / lint run.
  * Deliberately broad across the common toolchains (vitest/jest, tsc, biome,
  * eslint, cargo, go, pytest, generic "exit code") so a real run is surfaced

--- a/plugins/plugin-agent-orchestrator/src/services/ground-truth-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ground-truth-verifier.ts
@@ -1,0 +1,306 @@
+import type { ParsedPullRequestLink } from "./pull-request-link.js";
+import { extractPullRequestLink } from "./pull-request-link.js";
+
+export type GroundTruthCheckState = "green" | "pending" | "red";
+
+export interface RemoteCheck {
+  name: string;
+  status: string;
+  conclusion?: string | null;
+  required: boolean;
+}
+
+export interface RemotePullRequest {
+  url: string;
+  state: "open" | "closed" | "merged";
+  headSha: string;
+  changedFiles: string[];
+  checks: RemoteCheck[];
+}
+
+export interface GroundTruthCheckVerdict extends RemoteCheck {
+  state: GroundTruthCheckState;
+}
+
+export interface GroundTruthVerdict {
+  status: "verified" | "mismatch" | "missing_pr" | "inconclusive";
+  checkedAt: string;
+  pr: {
+    claimed: boolean;
+    url?: string;
+    repo?: string;
+    number?: number;
+    exists: boolean | null;
+    state?: RemotePullRequest["state"];
+    headSha?: string;
+  };
+  checks: {
+    state: GroundTruthCheckState | "unavailable";
+    items: GroundTruthCheckVerdict[];
+  };
+  files: {
+    claimed: string[];
+    actual: string[];
+    changedButNotClaimed: string[];
+    claimedButNotChanged: string[];
+  };
+  hardFail: boolean;
+  hardFailReasons: string[];
+  summary: string;
+  error?: string;
+}
+
+export interface GroundTruthVerifierDeps {
+  fetchPullRequest: (
+    link: ParsedPullRequestLink,
+  ) => Promise<RemotePullRequest | null>;
+  now?: () => Date;
+}
+
+function uniqueSorted(files: readonly string[]): string[] {
+  return [...new Set(files.map((file) => file.trim()).filter(Boolean))].sort();
+}
+
+export function compareClaimedFiles(
+  claimedFiles: readonly string[],
+  actualFiles: readonly string[],
+): Pick<
+  GroundTruthVerdict["files"],
+  "claimed" | "actual" | "changedButNotClaimed" | "claimedButNotChanged"
+> {
+  const claimed = uniqueSorted(claimedFiles);
+  const actual = uniqueSorted(actualFiles);
+  const claimedSet = new Set(claimed);
+  const actualSet = new Set(actual);
+  return {
+    claimed,
+    actual,
+    changedButNotClaimed: actual.filter((file) => !claimedSet.has(file)),
+    claimedButNotChanged: claimed.filter((file) => !actualSet.has(file)),
+  };
+}
+
+export function classifyCheck(check: RemoteCheck): GroundTruthCheckState {
+  const status = check.status.toLowerCase();
+  if (status !== "completed") return "pending";
+  const conclusion = check.conclusion?.toLowerCase();
+  if (
+    conclusion === "success" ||
+    conclusion === "neutral" ||
+    conclusion === "skipped"
+  ) {
+    return "green";
+  }
+  if (
+    conclusion === "failure" ||
+    conclusion === "timed_out" ||
+    conclusion === "cancelled" ||
+    conclusion === "action_required" ||
+    conclusion === "startup_failure" ||
+    conclusion === "stale"
+  ) {
+    return "red";
+  }
+  return "pending";
+}
+
+export function classifyCheckRollup(checks: readonly RemoteCheck[]): {
+  state: GroundTruthCheckState;
+  items: GroundTruthCheckVerdict[];
+} {
+  const items = checks.map((check) => ({
+    ...check,
+    state: classifyCheck(check),
+  }));
+  const required = items.filter((check) => check.required);
+  const relevant = required.length > 0 ? required : items;
+  const state = relevant.some((check) => check.state === "red")
+    ? "red"
+    : relevant.some((check) => check.state === "pending")
+      ? "pending"
+      : "green";
+  return { state, items };
+}
+
+function emptyFiles(
+  claimedFiles: readonly string[],
+): GroundTruthVerdict["files"] {
+  return compareClaimedFiles(claimedFiles, []);
+}
+
+export function shouldIncludeGroundTruthEvidence(
+  getSetting: (key: string) => unknown,
+): boolean {
+  const value = getSetting("ELIZA_ORCHESTRATOR_GROUND_TRUTH_EVIDENCE");
+  return value !== "0" && value !== "false" && value !== false;
+}
+
+export function groundTruthHardFailEnabled(
+  getSetting: (key: string) => unknown,
+): boolean {
+  const value = getSetting("ELIZA_ORCHESTRATOR_GROUND_TRUTH_HARD_FAIL");
+  return value === "1" || value === "true" || value === true;
+}
+
+export function groundTruthRequiresPullRequest(
+  getSetting: (key: string) => unknown,
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  const policy = metadata?.groundTruthPolicy;
+  const metadataRequires =
+    metadata?.requirePullRequest === true ||
+    (policy !== null &&
+      typeof policy === "object" &&
+      (policy as Record<string, unknown>).requirePullRequest === true);
+  const value = getSetting("ELIZA_ORCHESTRATOR_GROUND_TRUTH_REQUIRE_PR");
+  return (
+    metadataRequires || value === "1" || value === "true" || value === true
+  );
+}
+
+export async function verifyGroundTruth(
+  input: {
+    completion: string;
+    claimedFiles: readonly string[];
+    requirePullRequest: boolean;
+    hardFailEnabled: boolean;
+  },
+  deps: GroundTruthVerifierDeps,
+): Promise<GroundTruthVerdict> {
+  const checkedAt = (deps.now?.() ?? new Date()).toISOString();
+  const link = extractPullRequestLink(input.completion);
+  if (!link) {
+    const hardFail = input.hardFailEnabled && input.requirePullRequest;
+    return {
+      status: "missing_pr",
+      checkedAt,
+      pr: { claimed: false, exists: false },
+      checks: { state: "unavailable", items: [] },
+      files: emptyFiles(input.claimedFiles),
+      hardFail,
+      hardFailReasons: hardFail
+        ? ["A pull request is required but none was claimed."]
+        : [],
+      summary: input.requirePullRequest
+        ? "No pull request was claimed, but task policy requires one."
+        : "No pull request was claimed; remote verification was skipped.",
+    };
+  }
+
+  let remote: RemotePullRequest | null;
+  try {
+    remote = await deps.fetchPullRequest(link);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      status: "inconclusive",
+      checkedAt,
+      pr: {
+        claimed: true,
+        url: link.url,
+        repo: link.repo,
+        number: link.number,
+        exists: null,
+      },
+      checks: { state: "unavailable", items: [] },
+      files: emptyFiles(input.claimedFiles),
+      hardFail: false,
+      hardFailReasons: [],
+      summary:
+        "GitHub verification was inconclusive because the API request failed.",
+      error: message,
+    };
+  }
+
+  if (!remote) {
+    const hardFail = input.hardFailEnabled;
+    return {
+      status: "missing_pr",
+      checkedAt,
+      pr: {
+        claimed: true,
+        url: link.url,
+        repo: link.repo,
+        number: link.number,
+        exists: false,
+      },
+      checks: { state: "unavailable", items: [] },
+      files: emptyFiles(input.claimedFiles),
+      hardFail,
+      hardFailReasons: hardFail
+        ? ["The claimed pull request does not exist."]
+        : [],
+      summary: "The claimed pull request does not exist or is not accessible.",
+    };
+  }
+
+  const checks = classifyCheckRollup(remote.checks);
+  const files = compareClaimedFiles(input.claimedFiles, remote.changedFiles);
+  const mismatch =
+    files.changedButNotClaimed.length > 0 ||
+    files.claimedButNotChanged.length > 0;
+  const redRequired = checks.items.filter(
+    (check) => check.required && check.state === "red",
+  );
+  const hardFail = input.hardFailEnabled && redRequired.length > 0;
+  const hardFailReasons = hardFail
+    ? [
+        `Required checks are red: ${redRequired.map((check) => check.name).join(", ")}.`,
+      ]
+    : [];
+  const status =
+    checks.state === "pending"
+      ? "inconclusive"
+      : mismatch || checks.state === "red"
+        ? "mismatch"
+        : "verified";
+  return {
+    status,
+    checkedAt,
+    pr: {
+      claimed: true,
+      url: remote.url,
+      repo: link.repo,
+      number: link.number,
+      exists: true,
+      state: remote.state,
+      headSha: remote.headSha,
+    },
+    checks,
+    files,
+    hardFail,
+    hardFailReasons,
+    summary: hardFail
+      ? hardFailReasons[0]
+      : checks.state === "pending"
+        ? "Pull request checks are still pending; remote verification is not yet conclusive."
+        : mismatch
+          ? "Remote pull-request files do not exactly match the captured workspace change set."
+          : `Pull request exists (${remote.state}); CI is ${checks.state}; changed files match the captured claim.`,
+  };
+}
+
+export function renderGroundTruthEvidence(verdict: GroundTruthVerdict): string {
+  const lines = [
+    "## GROUND TRUTH (GitHub API verification)",
+    `status: ${verdict.status}`,
+    `summary: ${verdict.summary}`,
+    `pullRequest: ${verdict.pr.url ?? "not claimed"}`,
+    `exists: ${verdict.pr.exists === null ? "inconclusive" : String(verdict.pr.exists)}`,
+  ];
+  if (verdict.pr.state) lines.push(`state: ${verdict.pr.state}`);
+  if (verdict.pr.headSha) lines.push(`headSha: ${verdict.pr.headSha}`);
+  lines.push(`checkRollup: ${verdict.checks.state}`);
+  for (const check of verdict.checks.items) {
+    lines.push(
+      `- check ${check.name}: ${check.state}${check.required ? " (required)" : ""}`,
+    );
+  }
+  lines.push(
+    `changedButNotClaimed: ${verdict.files.changedButNotClaimed.join(", ") || "(none)"}`,
+    `claimedButNotChanged: ${verdict.files.claimedButNotChanged.join(", ") || "(none)"}`,
+    `hardFail: ${String(verdict.hardFail)}`,
+  );
+  if (verdict.error) lines.push(`apiError: ${verdict.error}`);
+  return lines.join("\n");
+}

--- a/plugins/plugin-agent-orchestrator/src/services/ground-truth-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ground-truth-verifier.ts
@@ -1,3 +1,13 @@
+/**
+ * Deterministic GitHub ground-truth verifier for task completion claims.
+ *
+ * The orchestrator uses this before accepting a coding task as complete: the
+ * worker's claimed PR must exist, still be open, expose coherent files/checks
+ * for one head SHA, and have conclusive checks. This keeps public validation
+ * and automatic validation on the same remote facts instead of trusting prose.
+ */
+
+import { ElizaError } from "@elizaos/core";
 import type { ParsedPullRequestLink } from "./pull-request-link.js";
 import { extractPullRequestLink } from "./pull-request-link.js";
 
@@ -8,6 +18,7 @@ export interface RemoteCheck {
   status: string;
   conclusion?: string | null;
   required: boolean;
+  appId?: number | null;
 }
 
 export interface RemotePullRequest {
@@ -16,6 +27,8 @@ export interface RemotePullRequest {
   headSha: string;
   changedFiles: string[];
   checks: RemoteCheck[];
+  checksUnavailable?: boolean;
+  checksUnavailableReason?: string;
 }
 
 export interface GroundTruthCheckVerdict extends RemoteCheck {
@@ -55,6 +68,20 @@ export interface GroundTruthVerifierDeps {
     link: ParsedPullRequestLink,
   ) => Promise<RemotePullRequest | null>;
   now?: () => Date;
+}
+
+const MAX_REMOTE_NAME_LENGTH = 160;
+
+function sanitizeRemoteName(name: string): string {
+  const normalized = [...name]
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127 ? " " : char;
+    })
+    .join("")
+    .trim();
+  if (normalized.length <= MAX_REMOTE_NAME_LENGTH) return normalized;
+  return `${normalized.slice(0, MAX_REMOTE_NAME_LENGTH - 1)}…`;
 }
 
 function uniqueSorted(files: readonly string[]): string[] {
@@ -110,6 +137,7 @@ export function classifyCheckRollup(checks: readonly RemoteCheck[]): {
 } {
   const items = checks.map((check) => ({
     ...check,
+    name: sanitizeRemoteName(check.name),
     state: classifyCheck(check),
   }));
   const required = items.filter((check) => check.required);
@@ -120,6 +148,18 @@ export function classifyCheckRollup(checks: readonly RemoteCheck[]): {
       ? "pending"
       : "green";
   return { state, items };
+}
+
+export function groundTruthApplies(input: {
+  completion: string;
+  claimedFiles: readonly string[];
+  requirePullRequest: boolean;
+}): boolean {
+  return (
+    input.requirePullRequest ||
+    input.claimedFiles.length > 0 ||
+    extractPullRequestLink(input.completion) !== null
+  );
 }
 
 function emptyFiles(
@@ -169,6 +209,7 @@ export async function verifyGroundTruth(
 ): Promise<GroundTruthVerdict> {
   const checkedAt = (deps.now?.() ?? new Date()).toISOString();
   const link = extractPullRequestLink(input.completion);
+  const applies = groundTruthApplies(input);
   if (!link) {
     const hardFail = input.hardFailEnabled && input.requirePullRequest;
     return {
@@ -191,7 +232,15 @@ export async function verifyGroundTruth(
   try {
     remote = await deps.fetchPullRequest(link);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const wrapped =
+      error instanceof ElizaError
+        ? error
+        : new ElizaError("GitHub ground-truth verification failed", {
+            code: "GROUND_TRUTH_API_FAILURE",
+            cause: error,
+          });
+    const message = wrapped.message;
+    const hardFail = input.hardFailEnabled && applies;
     return {
       status: "inconclusive",
       checkedAt,
@@ -204,8 +253,12 @@ export async function verifyGroundTruth(
       },
       checks: { state: "unavailable", items: [] },
       files: emptyFiles(input.claimedFiles),
-      hardFail: false,
-      hardFailReasons: [],
+      hardFail,
+      hardFailReasons: hardFail
+        ? [
+            "GitHub verification was inconclusive because the API request failed.",
+          ]
+        : [],
       summary:
         "GitHub verification was inconclusive because the API request failed.",
       error: message,
@@ -213,7 +266,7 @@ export async function verifyGroundTruth(
   }
 
   if (!remote) {
-    const hardFail = input.hardFailEnabled;
+    const hardFail = input.hardFailEnabled && applies;
     return {
       status: "missing_pr",
       checkedAt,
@@ -242,17 +295,35 @@ export async function verifyGroundTruth(
   const redRequired = checks.items.filter(
     (check) => check.required && check.state === "red",
   );
-  const hardFail = input.hardFailEnabled && redRequired.length > 0;
-  const hardFailReasons = hardFail
-    ? [
-        `Required checks are red: ${redRequired.map((check) => check.name).join(", ")}.`,
-      ]
-    : [];
+  const hardFailReasons: string[] = [];
+  if (remote.state !== "open") {
+    hardFailReasons.push(
+      remote.state === "merged"
+        ? "The claimed pull request is already merged."
+        : "The claimed pull request is closed without being merged.",
+    );
+  }
+  if (remote.checksUnavailable) {
+    hardFailReasons.push(
+      `Pull request checks are unavailable: ${remote.checksUnavailableReason ?? "GitHub did not return check data"}.`,
+    );
+  } else if (checks.items.length === 0) {
+    hardFailReasons.push("The claimed pull request has no reported checks.");
+  } else if (checks.state === "pending") {
+    hardFailReasons.push("Pull request checks are still pending.");
+  }
+  if (redRequired.length > 0) {
+    hardFailReasons.push(
+      `Required checks are red: ${redRequired.map((check) => check.name).join(", ")}.`,
+    );
+  }
+  const hardFail =
+    input.hardFailEnabled && applies && hardFailReasons.length > 0;
   const status =
-    checks.state === "pending"
-      ? "inconclusive"
-      : mismatch || checks.state === "red"
-        ? "mismatch"
+    mismatch || checks.state === "red"
+      ? "mismatch"
+      : hardFailReasons.length > 0 || remote.checksUnavailable
+        ? "inconclusive"
         : "verified";
   return {
     status,
@@ -272,11 +343,13 @@ export async function verifyGroundTruth(
     hardFailReasons,
     summary: hardFail
       ? hardFailReasons[0]
-      : checks.state === "pending"
-        ? "Pull request checks are still pending; remote verification is not yet conclusive."
-        : mismatch
-          ? "Remote pull-request files do not exactly match the captured workspace change set."
-          : `Pull request exists (${remote.state}); CI is ${checks.state}; changed files match the captured claim.`,
+      : hardFailReasons.length > 0
+        ? hardFailReasons[0]
+        : checks.state === "pending"
+          ? "Pull request checks are still pending; remote verification is not yet conclusive."
+          : mismatch
+            ? "Remote pull-request files do not exactly match the captured workspace change set."
+            : `Pull request exists (${remote.state}); CI is ${checks.state}; changed files match the captured claim.`,
   };
 }
 
@@ -293,7 +366,9 @@ export function renderGroundTruthEvidence(verdict: GroundTruthVerdict): string {
   lines.push(`checkRollup: ${verdict.checks.state}`);
   for (const check of verdict.checks.items) {
     lines.push(
-      `- check ${check.name}: ${check.state}${check.required ? " (required)" : ""}`,
+      `- check ${check.name}: ${check.state}${check.required ? " (required)" : ""}${
+        typeof check.appId === "number" ? ` appId=${check.appId}` : ""
+      }`,
     );
   }
   lines.push(

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -72,6 +72,7 @@ import {
   summarizeEnvelope,
 } from "./completion-envelope.js";
 import {
+  appendCompletionEvidenceSection,
   buildCompletionEvidenceString,
   type CompletionEvidenceBundle,
   classifyToolOutput,
@@ -102,6 +103,13 @@ import {
   coerceGoalCapabilityProfile,
   type GoalFollowUpReason,
 } from "./goal-prompt.js";
+import {
+  groundTruthHardFailEnabled,
+  groundTruthRequiresPullRequest,
+  renderGroundTruthEvidence,
+  shouldIncludeGroundTruthEvidence,
+  verifyGroundTruth,
+} from "./ground-truth-verifier.js";
 import {
   type IndependentVerifierVerdict,
   runIndependentVerification,
@@ -183,6 +191,7 @@ import {
   resolveAllowedWorkdir,
 } from "./workdir-validation.js";
 import { captureChangeSet, type WorkspaceChangeSet } from "./workspace-diff.js";
+import { getCodingWorkspaceService } from "./workspace-service.js";
 
 /**
  * Recoverable operator-recovery conflict.
@@ -2915,23 +2924,27 @@ export class OrchestratorTaskService extends Service {
    * promoting it to `done` (issue #8124). One linear pipeline runs inside the
    * re-entrancy guard:
    *
-   * 1. **Structural envelope gate (#8895).** {@link parseCompletionEnvelope} reads
+   * 1. **Remote ground truth.** The claimed GitHub PR, head-SHA check rollup,
+   *    and changed files are verified without a model call. The structured
+   *    verdict is persisted and appended to the existing completion evidence;
+   *    optional hard-fail policy blocks a missing PR or red required checks.
+   * 2. **Structural envelope gate (#8895).** {@link parseCompletionEnvelope} reads
    *    the sub-agent's verbatim final message. A PRESENT-but-malformed envelope is
    *    blocked *before* any model spend and the worker is re-prompted with
    *    {@link envelopeCorrection}. An ABSENT envelope falls through unchanged
    *    (back-compat). A VALID envelope is stamped onto `metadata.completionEnvelope`
    *    and its {@link summarizeEnvelope} is prepended to the judge's evidence so the
    *    judge grills the contract, not prose.
-   * 2. **Independent execution verifier (#8898).** For code-change tasks
+   * 3. **Independent execution verifier (#8898).** For code-change tasks
    *    ({@link shouldRunIndependentVerify}) a SEPARATE read-only ACP session re-runs
    *    the tests/diff and returns an execution-grounded verdict. A failing verdict
    *    BLOCKS (provenance `independent-acp-verifier`); an inconclusive verdict keeps
    *    the task `validating` (never a false promotion on a verifier crash); a
    *    passing/skipped verdict falls through.
-   * 3. **Text judge (fallback).** {@link verifyGoalCompletion} (`ModelType.TEXT_SMALL`)
+   * 4. **Text judge (fallback).** {@link verifyGoalCompletion} (`ModelType.TEXT_SMALL`)
    *    judges the evidence and promotes (→ `done`) or re-prompts.
    *
-   * All three failure paths share one {@link reEngageOrEscalate} helper, one
+   * All failure paths share one {@link reEngageOrEscalate} helper, one
    * `autoVerifyAttempts` counter, and one {@link MAX_AUTO_VERIFY_ATTEMPTS} cap, so a
    * malformed/failing worker is re-prompted a bounded number of times and then
    * parked on `waiting_on_user`.
@@ -3070,14 +3083,86 @@ export class OrchestratorTaskService extends Service {
         }
       }
 
+      // 1. Deterministic remote ground-truth verifier. This uses the PR URL in
+      // the worker's verbatim completion, the captured WorkspaceChangeSet, and
+      // the CodingWorkspaceService's existing authenticated GitHub plumbing.
+      // It always persists a structured verdict when enabled. API failures are
+      // explicitly inconclusive and never become a false hard failure.
+      let evidence = completionEvidence;
+      const includeGroundTruth = shouldIncludeGroundTruthEvidence((key) =>
+        this.runtime.getSetting(key),
+      );
+      const hardFailGroundTruth = groundTruthHardFailEnabled((key) =>
+        this.runtime.getSetting(key),
+      );
+      if (includeGroundTruth || hardFailGroundTruth) {
+        const changeSet = await this.resolveCompletionChangeSet(sessionId, doc);
+        const workspace = getCodingWorkspaceService(this.runtime);
+        const groundTruth = await verifyGroundTruth(
+          {
+            completion: rawCompletion,
+            claimedFiles: changeSet?.changedFiles ?? [],
+            requirePullRequest: groundTruthRequiresPullRequest(
+              (key) => this.runtime.getSetting(key),
+              doc.task.metadata,
+            ),
+            hardFailEnabled: hardFailGroundTruth,
+          },
+          {
+            fetchPullRequest: async (link) => {
+              if (!workspace) {
+                throw new Error(
+                  "Coding workspace GitHub service is unavailable",
+                );
+              }
+              return workspace.getPullRequestGroundTruth(link);
+            },
+          },
+        );
+        await this.store.updateTask(taskId, {
+          metadata: {
+            ...doc.task.metadata,
+            groundTruthVerdict: groundTruth,
+          },
+        });
+        doc = (await this.store.getTask(taskId)) ?? doc;
+        if (includeGroundTruth) {
+          evidence = appendCompletionEvidenceSection(
+            evidence,
+            renderGroundTruthEvidence(groundTruth),
+          );
+        }
+        if (groundTruth.hardFail) {
+          const failureEvidence = renderGroundTruthEvidence(groundTruth);
+          await this.validateTaskLocked(taskId, {
+            passed: false,
+            summary: groundTruth.summary,
+            evidence: failureEvidence,
+            verifier: "ground-truth-verifier",
+          });
+          await this.reEngageOrEscalate({
+            taskId,
+            sessionId,
+            correction: buildAutoVerifyCorrection(
+              groundTruth.hardFailReasons,
+              attempts + 1,
+            ),
+            eventType: "ground_truth_failed",
+            verifier: "ground-truth-verifier",
+            summary: groundTruth.summary,
+            missing: groundTruth.hardFailReasons,
+            attempt: attempts,
+          });
+          return;
+        }
+      }
+
       const acceptanceCriteria = doc.task.acceptanceCriteria;
-      // Criteria-free tasks keep the prior behavior: stay `validating` for a
-      // human/manual caller, no surprise model spend. The residuals gate above
-      // has already run, so "no criteria" no longer implies "no verification".
+      // Criteria-free tasks keep the prior behavior after deterministic gates:
+      // stay `validating` for a human/manual caller, with no model spend.
       if (acceptanceCriteria.length === 0) return;
 
-      // 1. Structural envelope gate (#8895) — BEFORE any model spend.
-      let evidence = completionEvidence;
+      // 2. Structural envelope gate (#8895) — BEFORE any model spend.
       if (parse.present && !parse.ok) {
         // Malformed contract: block the judge and re-prompt for a valid envelope.
         await this.reEngageOrEscalate({
@@ -3119,10 +3204,10 @@ export class OrchestratorTaskService extends Service {
             },
           },
         });
-        evidence = `${summarizeEnvelope(parse.envelope)}\n\n${completionEvidence}`;
+        evidence = `${summarizeEnvelope(parse.envelope)}\n\n${evidence}`;
       }
 
-      // 2. Independent read-only execution verifier (#8898).
+      // 3. Independent read-only execution verifier (#8898).
       const independent = await this.runIndependentVerify(
         taskId,
         doc,
@@ -3189,7 +3274,7 @@ export class OrchestratorTaskService extends Service {
         }
       }
 
-      // 3. Text judge (fallback for non-code / criteria-light tasks).
+      // 4. Text judge (fallback for non-code / criteria-light tasks).
       const verdict = await verifyGoalCompletion(
         this.runtime,
         {
@@ -3237,8 +3322,8 @@ export class OrchestratorTaskService extends Service {
 
   /**
    * Shared re-prompt / escalation path for every failed completion verdict — the
-   * malformed-envelope gate (#8895), the independent-verify block (#8898), and the
-   * text judge. ONE `autoVerifyAttempts` counter and ONE
+   * remote-ground-truth gate, malformed-envelope gate (#8895), independent-verify
+   * block (#8898), and text judge. ONE `autoVerifyAttempts` counter and ONE
    * {@link MAX_AUTO_VERIFY_ATTEMPTS} cap govern all three: under the cap the
    * kept-alive worker is reactivated and re-prompted with `correction` (and a
    * reflexion post-mortem is recorded for the next respawn, #8899); at the cap, or

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -104,6 +104,8 @@ import {
   type GoalFollowUpReason,
 } from "./goal-prompt.js";
 import {
+  type GroundTruthVerdict,
+  groundTruthApplies,
   groundTruthHardFailEnabled,
   groundTruthRequiresPullRequest,
   renderGroundTruthEvidence,
@@ -688,6 +690,26 @@ function priorCleanResidualsSnapshot(
   if (!Array.isArray(raw.residuals)) return undefined;
   if (typeof raw.checkedAt !== "number") return undefined;
   return raw as unknown as CompletionResidualsResult;
+}
+
+function _readGroundTruthVerdict(
+  metadata: Record<string, unknown>,
+): GroundTruthVerdict | undefined {
+  const raw = metadata.groundTruthVerdict;
+  if (!isRecord(raw)) return undefined;
+  if (
+    typeof raw.status !== "string" ||
+    typeof raw.checkedAt !== "string" ||
+    !isRecord(raw.pr) ||
+    !isRecord(raw.checks) ||
+    !isRecord(raw.files) ||
+    typeof raw.hardFail !== "boolean" ||
+    !Array.isArray(raw.hardFailReasons) ||
+    typeof raw.summary !== "string"
+  ) {
+    return undefined;
+  }
+  return raw as unknown as GroundTruthVerdict;
 }
 
 function eventExcerpt(
@@ -2862,6 +2884,42 @@ export class OrchestratorTaskService extends Service {
         },
       );
     }
+    const groundTruth =
+      result.passed && !result.humanOverride
+        ? await this.verifyGroundTruthForValidation(doc, evidence)
+        : undefined;
+    if (groundTruth?.hardFail) {
+      await this.store.addEvent({
+        id: randomUUID(),
+        taskId,
+        eventType: "validation_blocked_ground_truth",
+        summary: groundTruth.summary,
+        data: {
+          verifier: "ground-truth-verifier",
+          groundTruth,
+        },
+        timestamp: Date.now(),
+        createdAt: nowIso(),
+      });
+      await this.store.updateTask(taskId, {
+        metadata: {
+          ...(doc.task.metadata ?? {}),
+          groundTruthVerdict: groundTruth,
+        },
+      });
+      this.emitChange(taskId);
+      throw new ElizaError(
+        `Ground-truth verification blocks validation: ${groundTruth.summary}`,
+        {
+          code: "TASK_GROUND_TRUTH_BLOCKED",
+          context: {
+            taskId,
+            status: groundTruth.status,
+            reasons: groundTruth.hardFailReasons,
+          },
+        },
+      );
+    }
     const trigger: TaskLifecycleTrigger = result.humanOverride
       ? result.passed
         ? "human_override_passed"
@@ -2917,6 +2975,63 @@ export class OrchestratorTaskService extends Service {
         : {}),
     });
     return this.getTask(taskId);
+  }
+
+  private async verifyGroundTruthForValidation(
+    doc: OrchestratorTaskDocument,
+    evidence: string,
+  ): Promise<GroundTruthVerdict | undefined> {
+    const workspaceSession = latestWorkspaceSession(doc);
+    const changeSet = workspaceSession
+      ? await this.resolveCompletionChangeSet(workspaceSession.sessionId, doc)
+      : undefined;
+    const claimedFiles = changeSet?.changedFiles ?? [];
+    const metadataPr = str(doc.task.metadata?.prUrl);
+    const completion = [evidence, metadataPr].filter(Boolean).join("\n");
+    const requirePullRequest = groundTruthRequiresPullRequest(
+      (key) => this.runtime.getSetting(key),
+      doc.task.metadata,
+    );
+    if (
+      !groundTruthApplies({
+        completion,
+        claimedFiles,
+        requirePullRequest,
+      })
+    ) {
+      return undefined;
+    }
+
+    const workspace = getCodingWorkspaceService(this.runtime);
+    const verdict = await verifyGroundTruth(
+      {
+        completion,
+        claimedFiles,
+        requirePullRequest,
+        hardFailEnabled: true,
+      },
+      {
+        fetchPullRequest: async (link) => {
+          if (!workspace) {
+            throw new ElizaError(
+              "Coding workspace GitHub service is unavailable",
+              {
+                code: "GROUND_TRUTH_WORKSPACE_SERVICE_UNAVAILABLE",
+                context: { taskId: doc.task.id, repo: link.repo },
+              },
+            );
+          }
+          return workspace.getPullRequestGroundTruth(link);
+        },
+      },
+    );
+    await this.store.updateTask(doc.task.id, {
+      metadata: {
+        ...doc.task.metadata,
+        groundTruthVerdict: verdict,
+      },
+    });
+    return verdict;
   }
 
   /**

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
@@ -16,6 +16,11 @@ import type {
   IssueInfo,
   IssueState,
 } from "git-workspace-service";
+import type {
+  RemoteCheck,
+  RemotePullRequest,
+} from "./ground-truth-verifier.js";
+import type { ParsedPullRequestLink } from "./pull-request-link.js";
 
 const { GitHubPatClient, OAuthDeviceFlow } = createRequire(import.meta.url)(
   "git-workspace-service",
@@ -53,12 +58,22 @@ export function parseOwnerRepo(repo: string): {
   owner: string;
   repo: string;
 } {
-  // Handle URLs like https://github.com/owner/repo or owner/repo
-  const match = repo.match(/(?:github\.com\/)?([^/]+)\/([^/.]+)/);
-  if (!match) {
+  // Handle URLs like https://github.com/owner/repo or owner/repo. GitHub
+  // repository names may contain dots, so do not use a dot as a delimiter.
+  const normalized = repo
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/[?#].*$/, "")
+    .replace(/\.git$/, "");
+  const parts = normalized.split("/");
+  if (
+    parts.length !== 2 ||
+    !/^[a-zA-Z0-9_-]+$/.test(parts[0]) ||
+    !/^[a-zA-Z0-9_.-]+$/.test(parts[1])
+  ) {
     throw new Error(`Cannot parse owner/repo from: ${repo}`);
   }
-  return { owner: match[1], repo: match[2] };
+  return { owner: parts[0], repo: parts[1] };
 }
 
 // ── Auth ───────────────────────────────────────────────────────────
@@ -156,6 +171,190 @@ export async function performOAuthFlow(
   ctx.setGithubClient(client);
   ctx.log("GitHubPatClient initialized via OAuth device flow");
   return client;
+}
+
+// ── Pull-request ground truth ──────────────────────────────────────
+
+type OctokitResponse<T> = { data: T };
+type OctokitRequest = <T>(
+  route: string,
+  parameters: Record<string, unknown>,
+) => Promise<OctokitResponse<T>>;
+
+function octokitRequest(client: GitHubPatClientInstance): OctokitRequest {
+  // git-workspace-service intentionally exposes high-level issue/PR methods,
+  // but not the checks/files endpoints. Reuse its authenticated Octokit
+  // instance rather than constructing a second GitHub client.
+  const octokit = (
+    client as unknown as { octokit?: { request?: OctokitRequest } }
+  ).octokit;
+  if (!octokit || typeof octokit.request !== "function") {
+    throw new Error(
+      "Authenticated GitHub client does not expose an API request transport",
+    );
+  }
+  return octokit.request.bind(octokit);
+}
+
+async function pagedGitHubRequest<T>(
+  request: OctokitRequest,
+  route: string,
+  parameters: Record<string, unknown>,
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let page = 1; ; page += 1) {
+    const response = await request<T[]>(route, {
+      ...parameters,
+      per_page: 100,
+      page,
+    });
+    rows.push(...response.data);
+    if (response.data.length < 100) return rows;
+  }
+}
+
+function githubErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" ? status : undefined;
+}
+
+/**
+ * Fetch the PR, exact changed-file list, head-SHA check rollup, and required
+ * status-check names using the CodingWorkspaceService's authenticated GitHub
+ * client. A 404 for the PR is a real "missing" result; all other API errors
+ * propagate so the verifier can record an inconclusive verdict.
+ */
+export async function getPullRequestGroundTruth(
+  ctx: GitHubContext,
+  link: ParsedPullRequestLink,
+): Promise<RemotePullRequest | null> {
+  const client = await ensureGitHubClient(ctx);
+  const request = octokitRequest(client);
+  const { owner, repo } = parseOwnerRepo(link.repo);
+
+  type PullResponse = {
+    html_url: string;
+    state: "open" | "closed";
+    merged_at: string | null;
+    head: { sha: string };
+    base: { ref: string };
+  };
+  let pull: PullResponse;
+  try {
+    pull = (
+      await request<PullResponse>(
+        "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+        {
+          owner,
+          repo,
+          pull_number: link.number,
+        },
+      )
+    ).data;
+  } catch (error) {
+    if (githubErrorStatus(error) === 404) return null;
+    throw error;
+  }
+
+  const files = await pagedGitHubRequest<{ filename: string }>(
+    request,
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+    { owner, repo, pull_number: link.number },
+  );
+  type CheckRunResponse = {
+    check_runs: Array<{
+      name: string;
+      status: string;
+      conclusion: string | null;
+    }>;
+  };
+  const checkRuns: CheckRunResponse["check_runs"] = [];
+  for (let page = 1; ; page += 1) {
+    const response = (
+      await request<CheckRunResponse>(
+        "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+        { owner, repo, ref: pull.head.sha, per_page: 100, page },
+      )
+    ).data.check_runs;
+    checkRuns.push(...response);
+    if (response.length < 100) break;
+  }
+  const combinedStatus = (
+    await request<{
+      statuses: Array<{ context: string; state: string }>;
+    }>("GET /repos/{owner}/{repo}/commits/{ref}/status", {
+      owner,
+      repo,
+      ref: pull.head.sha,
+      per_page: 100,
+    })
+  ).data;
+
+  let requiredNames = new Set<string>();
+  try {
+    const protection = (
+      await request<{
+        required_status_checks?: {
+          contexts?: string[];
+          checks?: Array<{ context: string }>;
+        } | null;
+      }>("GET /repos/{owner}/{repo}/branches/{branch}/protection", {
+        owner,
+        repo,
+        branch: pull.base.ref,
+      })
+    ).data;
+    requiredNames = new Set([
+      ...(protection.required_status_checks?.contexts ?? []),
+      ...(protection.required_status_checks?.checks ?? []).map(
+        (check) => check.context,
+      ),
+    ]);
+  } catch (error) {
+    // GitHub returns 404 for an unprotected branch. Any other failure means we
+    // cannot safely decide which red checks are required, so propagate it.
+    if (githubErrorStatus(error) !== 404) throw error;
+  }
+
+  const checks: RemoteCheck[] = [
+    ...checkRuns.map((check) => ({
+      name: check.name,
+      status: check.status,
+      conclusion: check.conclusion,
+      required: requiredNames.has(check.name),
+    })),
+    ...combinedStatus.statuses.map((status) => ({
+      name: status.context,
+      status: status.state === "pending" ? "in_progress" : "completed",
+      conclusion:
+        status.state === "success"
+          ? "success"
+          : status.state === "pending"
+            ? null
+            : "failure",
+      required: requiredNames.has(status.context),
+    })),
+  ];
+  const seenNames = new Set(checks.map((check) => check.name));
+  for (const required of requiredNames) {
+    if (!seenNames.has(required)) {
+      checks.push({
+        name: required,
+        status: "queued",
+        conclusion: null,
+        required: true,
+      });
+    }
+  }
+
+  return {
+    url: pull.html_url,
+    state: pull.merged_at ? "merged" : pull.state,
+    headSha: pull.head.sha,
+    changedFiles: files.map((file) => file.filename),
+    checks,
+  };
 }
 
 // ── Issue Management ───────────────────────────────────────────────

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
@@ -1,14 +1,16 @@
 /**
- * GitHub integration for Coding Workspace Service
+ * GitHub integration for Coding Workspace Service.
  *
- * Extracted from workspace-service.ts — provides GitHub API access
- * via PAT or OAuth device flow, plus all issue management operations.
- *
- * @module services/workspace-github
+ * Provides PAT/OAuth-backed GitHub access for issue management and the
+ * pull-request ground-truth verifier. The verifier uses a typed request
+ * transport owned by this module so callers never reach into dependency-private
+ * Octokit fields.
  */
 
 import { createRequire } from "node:module";
 import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError } from "@elizaos/core";
+import { Octokit } from "@octokit/rest";
 import type {
   CreateIssueOptions,
   GitHubPatClient as GitHubPatClientInstance,
@@ -46,6 +48,8 @@ export interface GitHubContext {
   runtime: IAgentRuntime;
   githubClient: GitHubPatClientInstance | null;
   setGithubClient: (client: GitHubPatClientInstance) => void;
+  githubRequest: GitHubRequest | null;
+  setGithubRequest: (request: GitHubRequest | null) => void;
   githubAuthInProgress: Promise<GitHubPatClientInstance> | null;
   setGithubAuthInProgress: (p: Promise<GitHubPatClientInstance> | null) => void;
   authPromptCallback: AuthPromptCallback | null;
@@ -68,12 +72,25 @@ export function parseOwnerRepo(repo: string): {
   const parts = normalized.split("/");
   if (
     parts.length !== 2 ||
+    parts[0].length > 100 ||
+    parts[1].length > 100 ||
     !/^[a-zA-Z0-9_-]+$/.test(parts[0]) ||
     !/^[a-zA-Z0-9_.-]+$/.test(parts[1])
   ) {
     throw new Error(`Cannot parse owner/repo from: ${repo}`);
   }
   return { owner: parts[0], repo: parts[1] };
+}
+
+type GitHubResponse<T> = { data: T };
+export type GitHubRequest = <T>(
+  route: string,
+  parameters: Record<string, unknown>,
+) => Promise<GitHubResponse<T>>;
+
+function createGitHubRequest(token: string): GitHubRequest {
+  const octokit = new Octokit({ auth: token });
+  return octokit.request.bind(octokit) as GitHubRequest;
 }
 
 // ── Auth ───────────────────────────────────────────────────────────
@@ -93,7 +110,9 @@ export async function ensureGitHubClient(
     | undefined;
   if (githubToken) {
     const client = new GitHubPatClient({ token: githubToken });
+    const request = createGitHubRequest(githubToken);
     ctx.setGithubClient(client);
+    ctx.setGithubRequest(request);
     ctx.log("GitHubPatClient initialized with PAT (late binding)");
     return client;
   }
@@ -168,36 +187,17 @@ export async function performOAuthFlow(
 
   // Step 4: Create client with the obtained token
   const client = new GitHubPatClient({ token: token.accessToken });
+  const request = createGitHubRequest(token.accessToken);
   ctx.setGithubClient(client);
+  ctx.setGithubRequest(request);
   ctx.log("GitHubPatClient initialized via OAuth device flow");
   return client;
 }
 
 // ── Pull-request ground truth ──────────────────────────────────────
 
-type OctokitResponse<T> = { data: T };
-type OctokitRequest = <T>(
-  route: string,
-  parameters: Record<string, unknown>,
-) => Promise<OctokitResponse<T>>;
-
-function octokitRequest(client: GitHubPatClientInstance): OctokitRequest {
-  // git-workspace-service intentionally exposes high-level issue/PR methods,
-  // but not the checks/files endpoints. Reuse its authenticated Octokit
-  // instance rather than constructing a second GitHub client.
-  const octokit = (
-    client as unknown as { octokit?: { request?: OctokitRequest } }
-  ).octokit;
-  if (!octokit || typeof octokit.request !== "function") {
-    throw new Error(
-      "Authenticated GitHub client does not expose an API request transport",
-    );
-  }
-  return octokit.request.bind(octokit);
-}
-
 async function pagedGitHubRequest<T>(
-  request: OctokitRequest,
+  request: GitHubRequest,
   route: string,
   parameters: Record<string, unknown>,
 ): Promise<T[]> {
@@ -208,6 +208,12 @@ async function pagedGitHubRequest<T>(
       per_page: 100,
       page,
     });
+    if (!Array.isArray(response.data)) {
+      throw new ElizaError("GitHub paged endpoint returned a non-array body", {
+        code: "GITHUB_PAGED_RESPONSE_INVALID",
+        context: { route, page },
+      });
+    }
     rows.push(...response.data);
     if (response.data.length < 100) return rows;
   }
@@ -217,6 +223,121 @@ function githubErrorStatus(error: unknown): number | undefined {
   if (!error || typeof error !== "object") return undefined;
   const status = (error as { status?: unknown }).status;
   return typeof status === "number" ? status : undefined;
+}
+
+function isUnavailableStatus(status: number | undefined): boolean {
+  return status === 401 || status === 403 || status === 404;
+}
+
+function unavailableError(
+  message: string,
+  context: Record<string, unknown>,
+): ElizaError {
+  return new ElizaError(message, {
+    code: "GITHUB_GROUND_TRUTH_UNAVAILABLE",
+    context,
+  });
+}
+
+interface RequiredStatusCheck {
+  context: string;
+  appId?: number | null;
+}
+
+function requiredKey(check: RequiredStatusCheck): string {
+  return `${check.context}\u0000${check.appId ?? "any"}`;
+}
+
+function isRequiredCheck(
+  check: { name: string; appId?: number | null },
+  required: readonly RequiredStatusCheck[],
+): boolean {
+  return required.some(
+    (item) =>
+      item.context === check.name &&
+      (item.appId === undefined ||
+        item.appId === null ||
+        item.appId === check.appId),
+  );
+}
+
+function dedupeRequired(
+  checks: readonly RequiredStatusCheck[],
+): RequiredStatusCheck[] {
+  const seen = new Set<string>();
+  const out: RequiredStatusCheck[] = [];
+  for (const check of checks) {
+    if (!check.context.trim()) continue;
+    const key = requiredKey(check);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(check);
+  }
+  return out;
+}
+
+async function fetchRequiredChecks(
+  request: GitHubRequest,
+  input: { owner: string; repo: string; branch: string },
+): Promise<{ checks: RequiredStatusCheck[]; unavailableReason?: string }> {
+  const checks: RequiredStatusCheck[] = [];
+  let unavailableReason: string | undefined;
+  try {
+    const protection = (
+      await request<{
+        required_status_checks?: {
+          contexts?: string[];
+          checks?: Array<{ context: string; app_id?: number | null }>;
+        } | null;
+      }>("GET /repos/{owner}/{repo}/branches/{branch}/protection", input)
+    ).data;
+    checks.push(
+      ...(protection.required_status_checks?.contexts ?? []).map((context) => ({
+        context,
+      })),
+      ...(protection.required_status_checks?.checks ?? []).map((check) => ({
+        context: check.context,
+        appId: check.app_id,
+      })),
+    );
+  } catch (error) {
+    const status = githubErrorStatus(error);
+    if (status === 401 || status === 403) {
+      unavailableReason = `branch protection unavailable (${status})`;
+    } else if (status !== 404) {
+      throw error;
+    }
+  }
+
+  try {
+    const rules = await pagedGitHubRequest<{
+      type?: string;
+      parameters?: {
+        required_status_checks?: Array<{
+          context: string;
+          integration_id?: number | null;
+        }>;
+      };
+    }>(request, "GET /repos/{owner}/{repo}/rules/branches/{branch}", input);
+    for (const rule of rules) {
+      if (rule.type !== "required_status_checks") continue;
+      for (const check of rule.parameters?.required_status_checks ?? []) {
+        checks.push({
+          context: check.context,
+          appId: check.integration_id,
+        });
+      }
+    }
+  } catch (error) {
+    const status = githubErrorStatus(error);
+    if (!isUnavailableStatus(status)) throw error;
+  }
+
+  const deduped = dedupeRequired(checks);
+  return {
+    checks: deduped,
+    ...(deduped.length === 0 && unavailableReason ? { unavailableReason } : {}),
+  };
 }
 
 /**
@@ -229,8 +350,14 @@ export async function getPullRequestGroundTruth(
   ctx: GitHubContext,
   link: ParsedPullRequestLink,
 ): Promise<RemotePullRequest | null> {
-  const client = await ensureGitHubClient(ctx);
-  const request = octokitRequest(client);
+  await ensureGitHubClient(ctx);
+  const request = ctx.githubRequest;
+  if (!request) {
+    throw unavailableError(
+      "GitHub ground-truth request transport is unavailable",
+      { repo: link.repo, pullNumber: link.number },
+    );
+  }
   const { owner, repo } = parseOwnerRepo(link.repo);
 
   type PullResponse = {
@@ -240,9 +367,92 @@ export async function getPullRequestGroundTruth(
     head: { sha: string };
     base: { ref: string };
   };
-  let pull: PullResponse;
-  try {
-    pull = (
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let pull: PullResponse;
+    try {
+      pull = (
+        await request<PullResponse>(
+          "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+          {
+            owner,
+            repo,
+            pull_number: link.number,
+          },
+        )
+      ).data;
+    } catch (error) {
+      if (githubErrorStatus(error) === 404) return null;
+      throw error;
+    }
+
+    const files = await pagedGitHubRequest<{ filename: string }>(
+      request,
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+      { owner, repo, pull_number: link.number },
+    );
+    type CheckRunResponse = {
+      check_runs: Array<{
+        name: string;
+        status: string;
+        conclusion: string | null;
+        app?: { id?: number | null } | null;
+      }>;
+    };
+    const checkRuns: CheckRunResponse["check_runs"] = [];
+    let checksUnavailableReason: string | undefined;
+    try {
+      for (let page = 1; ; page += 1) {
+        const response = (
+          await request<CheckRunResponse>(
+            "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+            { owner, repo, ref: pull.head.sha, per_page: 100, page },
+          )
+        ).data.check_runs;
+        checkRuns.push(...response);
+        if (response.length < 100) break;
+      }
+    } catch (error) {
+      const status = githubErrorStatus(error);
+      if (!isUnavailableStatus(status)) throw error;
+      checksUnavailableReason = `check runs unavailable (${status})`;
+    }
+    let combinedStatus: { statuses: Array<{ context: string; state: string }> };
+    try {
+      combinedStatus = (
+        await request<{
+          statuses: Array<{ context: string; state: string }>;
+        }>("GET /repos/{owner}/{repo}/commits/{ref}/status", {
+          owner,
+          repo,
+          ref: pull.head.sha,
+          per_page: 100,
+        })
+      ).data;
+    } catch (error) {
+      const status = githubErrorStatus(error);
+      if (!isUnavailableStatus(status)) throw error;
+      checksUnavailableReason = [
+        checksUnavailableReason,
+        `commit statuses unavailable (${status})`,
+      ]
+        .filter(Boolean)
+        .join("; ");
+      combinedStatus = { statuses: [] };
+    }
+
+    const required = await fetchRequiredChecks(request, {
+      owner,
+      repo,
+      branch: pull.base.ref,
+    });
+    checksUnavailableReason = [
+      checksUnavailableReason,
+      required.unavailableReason,
+    ]
+      .filter(Boolean)
+      .join("; ");
+
+    const freshPull = (
       await request<PullResponse>(
         "GET /repos/{owner}/{repo}/pulls/{pull_number}",
         {
@@ -252,109 +462,70 @@ export async function getPullRequestGroundTruth(
         },
       )
     ).data;
-  } catch (error) {
-    if (githubErrorStatus(error) === 404) return null;
-    throw error;
-  }
-
-  const files = await pagedGitHubRequest<{ filename: string }>(
-    request,
-    "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-    { owner, repo, pull_number: link.number },
-  );
-  type CheckRunResponse = {
-    check_runs: Array<{
-      name: string;
-      status: string;
-      conclusion: string | null;
-    }>;
-  };
-  const checkRuns: CheckRunResponse["check_runs"] = [];
-  for (let page = 1; ; page += 1) {
-    const response = (
-      await request<CheckRunResponse>(
-        "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
-        { owner, repo, ref: pull.head.sha, per_page: 100, page },
-      )
-    ).data.check_runs;
-    checkRuns.push(...response);
-    if (response.length < 100) break;
-  }
-  const combinedStatus = (
-    await request<{
-      statuses: Array<{ context: string; state: string }>;
-    }>("GET /repos/{owner}/{repo}/commits/{ref}/status", {
-      owner,
-      repo,
-      ref: pull.head.sha,
-      per_page: 100,
-    })
-  ).data;
-
-  let requiredNames = new Set<string>();
-  try {
-    const protection = (
-      await request<{
-        required_status_checks?: {
-          contexts?: string[];
-          checks?: Array<{ context: string }>;
-        } | null;
-      }>("GET /repos/{owner}/{repo}/branches/{branch}/protection", {
-        owner,
-        repo,
-        branch: pull.base.ref,
-      })
-    ).data;
-    requiredNames = new Set([
-      ...(protection.required_status_checks?.contexts ?? []),
-      ...(protection.required_status_checks?.checks ?? []).map(
-        (check) => check.context,
-      ),
-    ]);
-  } catch (error) {
-    // GitHub returns 404 for an unprotected branch. Any other failure means we
-    // cannot safely decide which red checks are required, so propagate it.
-    if (githubErrorStatus(error) !== 404) throw error;
-  }
-
-  const checks: RemoteCheck[] = [
-    ...checkRuns.map((check) => ({
-      name: check.name,
-      status: check.status,
-      conclusion: check.conclusion,
-      required: requiredNames.has(check.name),
-    })),
-    ...combinedStatus.statuses.map((status) => ({
-      name: status.context,
-      status: status.state === "pending" ? "in_progress" : "completed",
-      conclusion:
-        status.state === "success"
-          ? "success"
-          : status.state === "pending"
-            ? null
-            : "failure",
-      required: requiredNames.has(status.context),
-    })),
-  ];
-  const seenNames = new Set(checks.map((check) => check.name));
-  for (const required of requiredNames) {
-    if (!seenNames.has(required)) {
-      checks.push({
-        name: required,
-        status: "queued",
-        conclusion: null,
-        required: true,
-      });
+    if (freshPull.head.sha !== pull.head.sha) {
+      if (attempt === 0) continue;
+      throw new ElizaError(
+        "Pull request head changed while collecting ground truth",
+        {
+          code: "GITHUB_GROUND_TRUTH_HEAD_CHANGED",
+          context: { owner, repo, pullNumber: link.number },
+        },
+      );
     }
+
+    const checks: RemoteCheck[] = [
+      ...checkRuns.map((check) => ({
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion,
+        appId: check.app?.id ?? null,
+        required: isRequiredCheck(
+          { name: check.name, appId: check.app?.id ?? null },
+          required.checks,
+        ),
+      })),
+      ...combinedStatus.statuses.map((status) => ({
+        name: status.context,
+        status: status.state === "pending" ? "in_progress" : "completed",
+        conclusion:
+          status.state === "success"
+            ? "success"
+            : status.state === "pending"
+              ? null
+              : "failure",
+        required: isRequiredCheck({ name: status.context }, required.checks),
+      })),
+    ];
+    for (const item of required.checks) {
+      const satisfied = checks.some((check) =>
+        isRequiredCheck({ name: check.name, appId: check.appId }, [item]),
+      );
+      if (!satisfied) {
+        checks.push({
+          name: item.context,
+          appId: item.appId,
+          status: "queued",
+          conclusion: null,
+          required: true,
+        });
+      }
+    }
+
+    return {
+      url: freshPull.html_url,
+      state: freshPull.merged_at ? "merged" : freshPull.state,
+      headSha: freshPull.head.sha,
+      changedFiles: files.map((file) => file.filename),
+      checks,
+      checksUnavailable: Boolean(checksUnavailableReason),
+      ...(checksUnavailableReason ? { checksUnavailableReason } : {}),
+    };
   }
 
-  return {
-    url: pull.html_url,
-    state: pull.merged_at ? "merged" : pull.state,
-    headSha: pull.head.sha,
-    changedFiles: files.map((file) => file.filename),
-    checks,
-  };
+  throw unavailableError("Pull request head changed during verification", {
+    repo: link.repo,
+    pullNumber: link.number,
+  });
 }
 
 // ── Issue Management ───────────────────────────────────────────────

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -52,6 +52,8 @@ type WorkspaceServiceWithCloneOverride = {
   ) => Promise<void>;
 };
 
+import type { RemotePullRequest } from "./ground-truth-verifier.js";
+import type { ParsedPullRequestLink } from "./pull-request-link.js";
 import type { AuthPromptCallback } from "./workspace-github.js";
 import {
   type GitHubContext,
@@ -60,6 +62,7 @@ import {
   closeIssue as ghCloseIssue,
   createIssue as ghCreateIssue,
   getIssue as ghGetIssue,
+  getPullRequestGroundTruth as ghGetPullRequestGroundTruth,
   listComments as ghListComments,
   listIssues as ghListIssues,
   reopenIssue as ghReopenIssue,
@@ -938,6 +941,12 @@ export class CodingWorkspaceService {
     callback: (record: ScratchWorkspaceRecord) => Promise<void>,
   ): void {
     this.scratchDecisionCallback = callback;
+  }
+
+  async getPullRequestGroundTruth(
+    link: ParsedPullRequestLink,
+  ): Promise<RemotePullRequest | null> {
+    return ghGetPullRequestGroundTruth(this.getGitHubContext(), link);
   }
 
   async createIssue(

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -17,6 +17,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { ElizaError, logger } from "@elizaos/core";
+import { Octokit } from "@octokit/rest";
 import type {
   CreateIssueOptions,
   CredentialService as CredentialServiceInstance,
@@ -54,7 +55,7 @@ type WorkspaceServiceWithCloneOverride = {
 
 import type { RemotePullRequest } from "./ground-truth-verifier.js";
 import type { ParsedPullRequestLink } from "./pull-request-link.js";
-import type { AuthPromptCallback } from "./workspace-github.js";
+import type { AuthPromptCallback, GitHubRequest } from "./workspace-github.js";
 import {
   type GitHubContext,
   addComment as ghAddComment,
@@ -312,6 +313,7 @@ export class CodingWorkspaceService {
   private workspaceService: WorkspaceServiceInstance | null = null;
   private credentialService: CredentialServiceInstance | null = null;
   private githubClient: GitHubPatClientInstance | null = null;
+  private githubRequest: GitHubRequest | null = null;
   private githubAuthInProgress: Promise<GitHubPatClientInstance> | null = null;
   private serviceConfig: CodingWorkspaceConfig;
   // Shared with every AcpService so one disk cap spans scratch + git workspaces
@@ -398,6 +400,7 @@ export class CodingWorkspaceService {
       | undefined;
     if (githubToken) {
       this.githubClient = new GitHubPatClient({ token: githubToken });
+      this.githubRequest = this.createGitHubRequest(githubToken);
       this.log("GitHubPatClient initialized with PAT");
     } else {
       this.log(
@@ -484,6 +487,7 @@ export class CodingWorkspaceService {
     this.workspaceService = null;
     this.credentialService = null;
     this.githubClient = null;
+    this.githubRequest = null;
     this.log("CodingWorkspaceService shutdown complete");
   }
 
@@ -913,11 +917,18 @@ export class CodingWorkspaceService {
   // === Delegated GitHub / Issue Management ===
 
   private getGitHubContext(): GitHubContext {
+    const service = this;
     return {
       runtime: this.runtime,
       githubClient: this.githubClient,
       setGithubClient: (client: GitHubPatClientInstance) => {
         this.githubClient = client;
+      },
+      get githubRequest() {
+        return service.githubRequest;
+      },
+      setGithubRequest: (request: GitHubRequest | null) => {
+        this.githubRequest = request;
       },
       githubAuthInProgress: this.githubAuthInProgress,
       setGithubAuthInProgress: (p: Promise<GitHubPatClientInstance> | null) => {
@@ -926,6 +937,11 @@ export class CodingWorkspaceService {
       authPromptCallback: this.authPromptCallback,
       log: (msg: string) => this.log(msg),
     };
+  }
+
+  private createGitHubRequest(token: string): GitHubRequest {
+    const octokit = new Octokit({ auth: token });
+    return octokit.request.bind(octokit) as GitHubRequest;
   }
 
   /** Set a callback to surface OAuth auth prompts to the user. */


### PR DESCRIPTION
## Summary

W2 of #16443 adds deterministic remote-reality verification to the existing completion-validation pipeline in `plugin-agent-orchestrator`.

- verifies the claimed pull request exists and records open/closed/merged state
- fetches head-SHA check runs plus commit statuses, classifies required checks as green/pending/red, and synthesizes pending entries for required checks not yet reported
- compares the captured `WorkspaceChangeSet.changedFiles` with the PR's actual changed-file list in both directions
- appends a `GROUND TRUTH` section to the existing completion-evidence string without replacing its local evidence
- persists the structured verdict at `task.metadata.groundTruthVerdict` for W4
- supports evidence default ON, hard-fail default OFF, and explicit PR-required policy
- treats GitHub/API failures as inconclusive, never as false failures

## Settings

- `ELIZA_ORCHESTRATOR_GROUND_TRUTH_EVIDENCE`: default ON; set `false`/`0` to disable the evidence section and verifier metadata write unless hard-fail is enabled
- `ELIZA_ORCHESTRATOR_GROUND_TRUTH_HARD_FAIL`: default OFF; when enabled, a claimed-but-missing PR or red required check fails before any model call
- `ELIZA_ORCHESTRATOR_GROUND_TRUTH_REQUIRE_PR`: default OFF; task metadata may also set `requirePullRequest: true` or `groundTruthPolicy.requirePullRequest: true`

## Architecture

Pure file comparison and check-rollup classification live in `ground-truth-verifier.ts`; remote calls are injected. GitHub IO stays in `workspace-github.ts` and reuses the authenticated `GitHubPatClient`/Octokit transport already owned by `CodingWorkspaceService`. PR extraction reuses `pull-request-link.ts`; claimed files reuse the captured workspace change set.

## Verification

- focused GroundTruthVerifier + completion-evidence suites: **25 passed / 0 failed**
- package typecheck: `tsgo --noEmit -p tsconfig.json` passed
- Biome on all 8 changed files: clean
- `git diff --check`: clean
- Codex review run twice. Fixed dotted repository parsing, exact evidence-cap enforcement, and pending-check verdict classification.

Note: broader orchestrator suites were attempted but this worktree's interrupted dependency hydration left unrelated transitive packages (`pino`, `fs-extra`, `underscore`) absent. The authoritative per-file W2 suites and package typecheck above pass after rebasing onto current `origin/develop`.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A, backend-only verifier with no visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A, backend-only verifier with no visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A, deterministic unit coverage exercises all requested verdict paths.
<!-- evidence-row:backend-logs -->
- [x] Focused test output: 25 passed, including missing PR, red checks, pending checks, both file-mismatch directions, API failure, and evidence cap preservation.
<!-- evidence-row:frontend-logs -->
- [x] N/A, no frontend files or runtime behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Codex review completed; all findings fixed before push.
<!-- evidence-row:domain-artifacts -->
- [x] Structured `groundTruthVerdict` contract and deterministic fixtures are included in the changed files.

No auto-merge.

[sol-cloud]

Co-authored-by: wakesync <shadow@shad0w.xyz>
