### PR TITLE
feat(orchestrator): add gated lane planner (W1 of #16443)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
@@ -11,12 +11,20 @@ import type {
   State,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@octokit/rest", () => ({
+  Octokit: class Octokit {},
+}));
+
 import { tasksAction } from "../actions/tasks.ts";
 import {
   createDeterministicLanePlan,
   LanePlannerService,
+  laneReadiness,
+  sanitizeLaneBranchName,
   scopeSetsOverlap,
 } from "../services/lane-planner.ts";
+import { CodingWorkspaceService } from "../services/workspace-service.ts";
 
 const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const MSG = "11111111-1111-4111-8111-111111111111";
@@ -83,6 +91,8 @@ function makeTaskService() {
       return { id: `task-${seq}`, ...input };
     }),
     attachSession: vi.fn(async () => undefined),
+    getTask: vi.fn(async (): Promise<unknown> => null),
+    listTasks: vi.fn(async (): Promise<Array<{ id: string }>> => []),
   };
 }
 
@@ -98,6 +108,7 @@ function makeRuntime(
   settings: Record<string, string | undefined>,
   acp = makeAcp(),
   taskService = makeTaskService(),
+  extraServices: Record<string, unknown> = {},
 ): IAgentRuntime & {
   acp: ReturnType<typeof makeAcp>;
   taskService: ReturnType<typeof makeTaskService>;
@@ -113,6 +124,7 @@ function makeRuntime(
     },
     getSetting: (key: string) => settings[key],
     getService: (type: string) => {
+      if (type in extraServices) return extraServices[type];
       if (type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE") {
         return acp;
       }
@@ -193,6 +205,74 @@ describe("LanePlannerService deterministic planning", () => {
         ),
       }),
     ).toThrow(/at most 6 lanes; received 7/i);
+  });
+
+  it("rejects unknown dependency refs before planning", () => {
+    expect(() =>
+      createDeterministicLanePlan({
+        task: "parent",
+        tasks: [
+          "Update plugins/plugin-agent-orchestrator/src/services/a.ts",
+          "Update packages/core/src/runtime.ts",
+        ],
+        dependencies: { "lane-2": ["lane-9"] },
+      }),
+    ).toThrow(/unknown lane/i);
+  });
+
+  it("rejects dependency cycles before planning", () => {
+    expect(() =>
+      createDeterministicLanePlan({
+        task: "parent",
+        tasks: [
+          "Update plugins/plugin-agent-orchestrator/src/services/a.ts",
+          "Update packages/core/src/runtime.ts",
+        ],
+        dependencies: { "lane-1": ["lane-2"], "lane-2": ["lane-1"] },
+      }),
+    ).toThrow(/cycle/i);
+  });
+
+  it("sanitizes bounded non-colliding branch names for duplicate titles", () => {
+    const plan = createDeterministicLanePlan({
+      task: "parent",
+      tasks: [
+        "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+        "Update plugins/plugin-agent-orchestrator/src/actions/tasks.ts",
+      ],
+      title: "Fix: Lane Planner!!!",
+    });
+    const branches = plan.lanes.map((lane) => lane.branchName);
+    expect(branches[0]).toMatch(/^eliza\/lane\/fix-lane-planner/);
+    expect(branches[1]).toMatch(/-2$/);
+    expect(new Set(branches).size).toBe(2);
+    expect(branches.every((branch) => branch.length <= 80)).toBe(true);
+    expect(sanitizeLaneBranchName("../../bad; rm -rf /")).toMatch(
+      /^eliza\/lane\//,
+    );
+  });
+
+  it("uses semantic dependency blockers for readiness", () => {
+    const lane = {
+      id: "lane-2",
+      dependencies: ["lane-1", "lane-3"],
+    };
+
+    expect(
+      laneReadiness(
+        lane,
+        new Set(["lane-1"]),
+        new Set(),
+        new Map([["lane-3", "waiting_on_user"]]),
+      ),
+    ).toEqual({
+      ready: false,
+      blockers: ["lane-3: waiting_on_user"],
+    });
+    expect(laneReadiness(lane, new Set(["lane-1", "lane-3"]))).toEqual({
+      ready: true,
+      blockers: [],
+    });
   });
 
   it("annotates open PR collisions from an injected provider", async () => {
@@ -392,6 +472,235 @@ describe("TASKS create lane planner integration", () => {
     );
     expect(acp.spawnSession).toHaveBeenCalledTimes(2);
     expect(taskService.createTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps maxParallel backlog queued until earlier lanes finish", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+    const events: string[] = [];
+    acp.sendPrompt.mockImplementation(async (sessionId: string) => {
+      events.push(`${sessionId}:start`);
+      await Promise.resolve();
+      events.push(`${sessionId}:finish`);
+      return { stopReason: "end_turn", finalText: "done" };
+    });
+
+    await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          maxParallel: 1,
+          agents: [
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+            "Update packages/core/src/runtime.ts",
+            "Update packages/shared/src/contracts/chat.ts",
+          ].join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(acp.spawnSession).toHaveBeenCalledTimes(3);
+    expect(events).toEqual([
+      "sess-1:start",
+      "sess-1:finish",
+      "sess-2:start",
+      "sess-2:finish",
+      "sess-3:start",
+      "sess-3:finish",
+    ]);
+  });
+
+  it("honors dependency order even when maxParallel has spare slots", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+    const events: string[] = [];
+    acp.sendPrompt.mockImplementation(async (sessionId: string) => {
+      events.push(`${sessionId}:start`);
+      await Promise.resolve();
+      events.push(`${sessionId}:finish`);
+      return { stopReason: "end_turn", finalText: "done" };
+    });
+
+    await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          maxParallel: 3,
+          dependencies: { "lane-2": ["lane-1"] },
+          agents: [
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+            "Update packages/core/src/runtime.ts",
+            "Update packages/shared/src/contracts/chat.ts",
+          ].join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    // Lane 3 is independent and may claim sess-2. Dependent lane 2 must wait
+    // for lane 1 and therefore claims sess-3 in this deterministic fixture.
+    expect(events.indexOf("sess-3:start")).toBeGreaterThan(
+      events.indexOf("sess-1:finish"),
+    );
+    expect(acp.spawnSession).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects invalid dependency graphs through the public TASKS create surface", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    const result = await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          dependencies: { "lane-1": ["lane-2"], "lane-2": ["lane-1"] },
+          agents: [
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+            "Update packages/core/src/runtime.ts",
+          ].join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("LANE_DEPENDENCY_CYCLE");
+    expect(acp.spawnSession).not.toHaveBeenCalled();
+    expect(taskService.createTask).not.toHaveBeenCalled();
+  });
+
+  it("reuses the active session via CodingWorkspaceService.findActiveSessionForTask", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    taskService.getTask.mockResolvedValue({
+      task: {
+        id: "task-existing",
+        title: "Existing",
+        goal: "Existing",
+        kind: "coding",
+        status: "active",
+        priority: "normal",
+        originalRequest: "Existing",
+        acceptanceCriteria: [],
+        paused: false,
+        archived: false,
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+        lastActivityAt: 1,
+        metadata: {},
+      },
+      sessions: [
+        {
+          id: "row-1",
+          taskId: "task-existing",
+          sessionId: "sess-active",
+          framework: "codex",
+          label: "Agent",
+          originalTask: "Existing",
+          workdir: process.cwd(),
+          status: "ready",
+          decisionCount: 0,
+          autoResolvedCount: 0,
+          registeredAt: 1,
+          lastActivityAt: 10,
+          idleCheckCount: 0,
+          taskDelivered: false,
+          lastSeenDecisionIndex: 0,
+          spawnedAt: 1,
+          retryCount: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cacheTokens: 0,
+          costUsd: 0,
+          usageState: "unavailable",
+          metadata: {},
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+      ],
+      events: [],
+      messages: [],
+      usage: [],
+      artifacts: [],
+      decisions: [],
+      planRevisions: [],
+    });
+    const workspaceService = new CodingWorkspaceService({
+      getSetting: () => undefined,
+      getService: (type: string) =>
+        type === "ORCHESTRATOR_TASK_SERVICE" ? taskService : undefined,
+    } as unknown as IAgentRuntime);
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+      { CODING_WORKSPACE_SERVICE: workspaceService },
+    );
+
+    const result = await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          taskId: "task-existing",
+          agents:
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(acp.spawnSession).not.toHaveBeenCalled();
+    const data = result?.data as
+      | { lanes?: Array<Record<string, unknown>> }
+      | undefined;
+    expect(data?.lanes?.[0]).toMatchObject({
+      taskId: "task-existing",
+      branchName: expect.any(String),
+    });
+  });
+
+  it("surfaces missing durable task service from the active-session reuse contract", async () => {
+    const runtime = {
+      getSetting: vi.fn(() => undefined),
+      getService: vi.fn(() => undefined),
+    } as unknown as IAgentRuntime;
+    const workspaceService = new CodingWorkspaceService(runtime);
+
+    await expect(
+      workspaceService.findActiveSessionForTask({ taskId: "task-missing" }),
+    ).rejects.toMatchObject({
+      code: "ORCHESTRATOR_TASK_SERVICE_UNAVAILABLE",
+    });
   });
 
   it("does not let content agents duplicate each planned lane", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
@@ -1,0 +1,595 @@
+/**
+ * Lane planner tests pin the deterministic decomposition contract and the
+ * TASKS create integration gate. The action tests use a structural ACP fake so
+ * they verify metadata and spawn shape without starting real coding CLIs.
+ */
+
+import type {
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tasksAction } from "../actions/tasks.ts";
+import {
+  createDeterministicLanePlan,
+  LanePlannerService,
+  scopeSetsOverlap,
+} from "../services/lane-planner.ts";
+
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const MSG = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+
+function makeMessage(
+  text: string,
+  extraContent: Record<string, unknown> = {},
+): Memory {
+  return {
+    id: MSG,
+    entityId: AGENT_ID,
+    roomId: ROOM,
+    content: { text, source: "test", ...extraContent },
+  } as unknown as Memory;
+}
+
+function makeAcp() {
+  let seq = 0;
+  const sessions = new Map<string, Record<string, unknown>>();
+  const spawnSession = vi.fn(async (opts: Record<string, unknown>) => {
+    seq += 1;
+    const sessionId = `sess-${seq}`;
+    const session = {
+      sessionId,
+      id: sessionId,
+      agentType: opts.agentType ?? "codex",
+      name: `Agent ${seq}`,
+      workdir: opts.workdir ?? process.cwd(),
+      status: "ready",
+      createdAt: new Date(0),
+      lastActivityAt: new Date(0),
+      metadata: opts.metadata,
+    };
+    sessions.set(sessionId, session);
+    return session;
+  });
+  return {
+    spawnSession,
+    sendPrompt: vi.fn(async () => ({
+      stopReason: "end_turn",
+      finalText: "done",
+    })),
+    sendToSession: vi.fn(async () => ({
+      stopReason: "end_turn",
+      finalText: "done",
+    })),
+    stopSession: vi.fn(async (sessionId: string) => {
+      const session = sessions.get(sessionId);
+      if (session) session.status = "stopped";
+    }),
+    getSession: vi.fn(async (sessionId: string) => sessions.get(sessionId)),
+    listSessions: vi.fn(async () => [...sessions.values()]),
+    resolveAgentType: vi.fn(async () => "codex"),
+    emitSessionEvent: vi.fn(),
+  };
+}
+
+function makeTaskService() {
+  let seq = 0;
+  return {
+    createTask: vi.fn(async (input: Record<string, unknown>) => {
+      seq += 1;
+      return { id: `task-${seq}`, ...input };
+    }),
+    attachSession: vi.fn(async () => undefined),
+  };
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function makeRuntime(
+  settings: Record<string, string | undefined>,
+  acp = makeAcp(),
+  taskService = makeTaskService(),
+): IAgentRuntime & {
+  acp: ReturnType<typeof makeAcp>;
+  taskService: ReturnType<typeof makeTaskService>;
+} {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Tester" },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    getSetting: (key: string) => settings[key],
+    getService: (type: string) => {
+      if (type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE") {
+        return acp;
+      }
+      if (type === "ORCHESTRATOR_TASK_SERVICE") return taskService;
+      return undefined;
+    },
+    createRoom: vi.fn(async () => undefined),
+    ensureWorldExists: vi.fn(async () => undefined),
+    useModel: vi.fn(async () => "{}"),
+  } as unknown as IAgentRuntime & {
+    acp: ReturnType<typeof makeAcp>;
+    taskService: ReturnType<typeof makeTaskService>;
+  };
+}
+
+async function runCreate(runtime: IAgentRuntime, message: Memory) {
+  const callback = vi.fn(async () => []) as unknown as HandlerCallback;
+  return tasksAction.handler(
+    runtime,
+    message,
+    {} as State,
+    { parameters: { action: "create" } },
+    callback,
+  );
+}
+
+describe("LanePlannerService deterministic planning", () => {
+  it("decomposes explicit scoped tasks into mutually exclusive lanes", () => {
+    const plan = createDeterministicLanePlan({
+      task: "parent",
+      tasks: [
+        "Update plugins/plugin-agent-orchestrator/src/services/a.ts",
+        "Update packages/core/src/runtime.ts",
+      ],
+      waveId: "wave-1",
+    });
+
+    expect(plan.waveId).toBe("wave-1");
+    expect(plan.lanes).toHaveLength(2);
+    expect(plan.lanes[0]?.scopePaths).toEqual([
+      "plugins/plugin-agent-orchestrator/src/services/a.ts",
+    ]);
+    expect(plan.lanes[0]?.forbiddenPaths).toEqual([
+      "packages/core/src/runtime.ts",
+    ]);
+    expect(plan.lanes[0]?.collisions).toContainEqual({
+      source: "sibling",
+      id: "sibling-1",
+      paths: ["packages/core/src/runtime.ts"],
+    });
+    expect(
+      scopeSetsOverlap(
+        plan.lanes[0]?.scopePaths ?? [],
+        plan.lanes[1]?.scopePaths ?? [],
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects overlapping sibling scopes", () => {
+    expect(() =>
+      createDeterministicLanePlan({
+        task: "parent",
+        tasks: [
+          "Update plugins/plugin-agent-orchestrator/src/services",
+          "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+        ],
+      }),
+    ).toThrow(/overlap/i);
+  });
+
+  it("rejects requested tasks above the deterministic lane cap", () => {
+    expect(() =>
+      createDeterministicLanePlan({
+        task: "parent",
+        tasks: Array.from(
+          { length: 7 },
+          (_, index) => `Update packages/core/src/lane-${index}.ts`,
+        ),
+      }),
+    ).toThrow(/at most 6 lanes; received 7/i);
+  });
+
+  it("annotates open PR collisions from an injected provider", async () => {
+    const service = new LanePlannerService(makeRuntime({}), {
+      listOpenPrCollisions: async () => [
+        {
+          id: "pr-12",
+          title: "touch same service",
+          url: "https://github.com/elizaOS/eliza/pull/12",
+          paths: [
+            "plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+          ],
+        },
+      ],
+    });
+
+    const plan = await service.plan({
+      task: "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+      waveId: "wave-2",
+    });
+
+    expect(plan.lanes[0]?.collisions).toContainEqual({
+      source: "open-pr",
+      id: "pr-12",
+      title: "touch same service",
+      url: "https://github.com/elizaOS/eliza/pull/12",
+      paths: ["plugins/plugin-agent-orchestrator/src/services/lane-planner.ts"],
+    });
+  });
+
+  it("emits only the coding backend routing difficulty tags", () => {
+    const hardPlan = createDeterministicLanePlan({
+      task: "Update packages/core/src/schema.ts for an auth migration",
+    });
+    const moderatePlan = createDeterministicLanePlan({
+      task: "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+      difficultyTag: "standard",
+    });
+    const mappedHardPlan = createDeterministicLanePlan({
+      task: "Update packages/core/src/runtime.ts",
+      difficultyTag: "complex",
+    });
+
+    expect(hardPlan.lanes[0]?.difficultyTag).toBe("hard");
+    expect(moderatePlan.lanes[0]?.difficultyTag).toBe("moderate");
+    expect(mappedHardPlan.lanes[0]?.difficultyTag).toBe("hard");
+    expect(
+      [hardPlan, moderatePlan, mappedHardPlan].flatMap((plan) =>
+        plan.lanes.map((lane) => lane.difficultyTag),
+      ),
+    ).toEqual(expect.arrayContaining(["hard", "moderate"]));
+    expect(
+      [hardPlan, moderatePlan, mappedHardPlan].some((plan) =>
+        plan.lanes.some((lane) =>
+          ["complex", "standard"].includes(lane.difficultyTag),
+        ),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("TASKS create lane planner integration", () => {
+  const priorSmithers = process.env.ELIZA_ORCHESTRATOR_SMITHERS;
+
+  beforeEach(() => {
+    process.env.ELIZA_ORCHESTRATOR_SMITHERS = "0";
+  });
+
+  afterEach(() => {
+    if (priorSmithers === undefined)
+      delete process.env.ELIZA_ORCHESTRATOR_SMITHERS;
+    else process.env.ELIZA_ORCHESTRATOR_SMITHERS = priorSmithers;
+    vi.restoreAllMocks();
+  });
+
+  it("leaves create behavior unaltered when the gate is off", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime({}, acp, taskService);
+
+    await runCreate(
+      runtime,
+      makeMessage(
+        "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+      ),
+    );
+
+    expect(acp.spawnSession).toHaveBeenCalledTimes(1);
+    expect(taskService.createTask).toHaveBeenCalledTimes(1);
+    const spawnMetadata = acp.spawnSession.mock.calls[0]?.[0]?.metadata;
+    expect(spawnMetadata).not.toHaveProperty("lane");
+    expect(taskService.createTask.mock.calls[0]?.[0]).not.toHaveProperty(
+      "metadata",
+    );
+  });
+
+  it("spawns one durable create path per lane when the gate is on", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    const result = await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          agents: [
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+            "Update packages/core/src/runtime.ts",
+          ].join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(acp.spawnSession).toHaveBeenCalledTimes(2);
+    expect(taskService.createTask).toHaveBeenCalledTimes(2);
+    const firstMeta = acp.spawnSession.mock.calls[0]?.[0]?.metadata as Record<
+      string,
+      unknown
+    >;
+    const secondTask = taskService.createTask.mock.calls[1]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(firstMeta.waveId).toEqual(expect.any(String));
+    expect(firstMeta.lane).toMatchObject({
+      id: "lane-1",
+      scopePaths: [
+        "plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+      ],
+      forbiddenPaths: ["packages/core/src/runtime.ts"],
+    });
+    expect(secondTask.metadata).toMatchObject({
+      waveId: firstMeta.waveId,
+      lane: {
+        id: "lane-2",
+        scopePaths: ["packages/core/src/runtime.ts"],
+        forbiddenPaths: [
+          "plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+        ],
+      },
+    });
+  });
+
+  it("starts lane 2 before lane 1 finishes", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+    const lane2Started = deferred();
+    const events: string[] = [];
+    const serialFallback = setTimeout(() => lane2Started.resolve(), 100);
+
+    acp.sendPrompt.mockImplementation(async (sessionId: string) => {
+      events.push(`${sessionId}:start`);
+      if (sessionId === "sess-1") {
+        await lane2Started.promise;
+        events.push(`${sessionId}:finish`);
+        return { stopReason: "end_turn", finalText: "done" };
+      }
+      lane2Started.resolve();
+      events.push(`${sessionId}:finish`);
+      return { stopReason: "end_turn", finalText: "done" };
+    });
+
+    await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          agents: [
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+            "Update packages/core/src/runtime.ts",
+          ].join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+    clearTimeout(serialFallback);
+
+    expect(events.indexOf("sess-2:start")).toBeGreaterThan(-1);
+    expect(events.indexOf("sess-2:start")).toBeLessThan(
+      events.indexOf("sess-1:finish"),
+    );
+    expect(acp.spawnSession).toHaveBeenCalledTimes(2);
+    expect(taskService.createTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let content agents duplicate each planned lane", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+    const agents = [
+      "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+      "Update packages/core/src/runtime.ts",
+    ].join(" | ");
+
+    await tasksAction.handler(
+      runtime,
+      makeMessage("split work", { agents }),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          agents: undefined,
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(acp.spawnSession).toHaveBeenCalledTimes(2);
+    expect(acp.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(taskService.createTask).toHaveBeenCalledTimes(2);
+    for (const call of acp.sendPrompt.mock.calls) {
+      expect(call[1]).toContain("Lane scope:");
+      expect(call[1]).not.toContain("Update packages/core/src/runtime.ts |");
+    }
+  });
+
+  it("preserves legacy create behavior for a single unscoped gated task", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    await runCreate(runtime, makeMessage("fix the bug"));
+
+    expect(acp.spawnSession).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt.mock.calls[0]?.[1]).toContain(
+      "--- User Task ---\nfix the bug",
+    );
+    expect(acp.sendPrompt.mock.calls[0]?.[1]).not.toContain("Lane scope:");
+    expect(acp.spawnSession.mock.calls[0]?.[0]?.metadata).not.toHaveProperty(
+      "lane",
+    );
+    expect(taskService.createTask.mock.calls[0]?.[0]).not.toHaveProperty(
+      "metadata",
+    );
+  });
+
+  it("falls back to legacy single-task behavior when planning fails", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    await tasksAction.handler(
+      runtime,
+      makeMessage("split unscoped work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          agents: "fix the bug | add tests",
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(acp.spawnSession).toHaveBeenCalledTimes(2);
+    const spawnMetadata = acp.spawnSession.mock.calls[0]?.[0]?.metadata;
+    expect(spawnMetadata).not.toHaveProperty("lane");
+    expect(taskService.createTask.mock.calls[0]?.[0]).not.toHaveProperty(
+      "metadata",
+    );
+  });
+
+  it("preserves the legacy too-many-agents error when requests exceed both caps", async () => {
+    const acp = makeAcp();
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    const result = await tasksAction.handler(
+      runtime,
+      makeMessage("split too much work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          agents: Array.from(
+            { length: 9 },
+            (_, index) => `Update packages/core/src/too-many-${index}.ts`,
+          ).join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("TOO_MANY_AGENTS");
+    expect(acp.spawnSession).not.toHaveBeenCalled();
+    expect(taskService.createTask).not.toHaveBeenCalled();
+  });
+
+  it("propagates a lane execution throw after lane 1 without replaying the original request", async () => {
+    const acp = makeAcp();
+    let resolveCalls = 0;
+    acp.resolveAgentType.mockImplementation(async () => {
+      resolveCalls += 1;
+      if (resolveCalls === 2) {
+        throw new Error("lane 2 backend resolution exploded");
+      }
+      return "codex";
+    });
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    await expect(
+      tasksAction.handler(
+        runtime,
+        makeMessage("split work"),
+        {} as State,
+        {
+          parameters: {
+            action: "create",
+            agents: [
+              "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+              "Update packages/core/src/runtime.ts",
+            ].join(" | "),
+          },
+        },
+        vi.fn(async () => []) as unknown as HandlerCallback,
+      ),
+    ).rejects.toThrow("lane 2 backend resolution exploded");
+
+    expect(acp.spawnSession).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(taskService.createTask).toHaveBeenCalledTimes(1);
+    expect(resolveCalls).toBe(2);
+  });
+
+  it("returns an ordinary failed lane result without replaying the original request", async () => {
+    const acp = makeAcp();
+    acp.sendPrompt
+      .mockResolvedValueOnce({
+        stopReason: "end_turn",
+        finalText: "done",
+      })
+      .mockRejectedValueOnce(new Error("lane 2 prompt failed"));
+    const taskService = makeTaskService();
+    const runtime = makeRuntime(
+      { ELIZA_ORCHESTRATOR_LANE_PLANNER: "1" },
+      acp,
+      taskService,
+    );
+
+    const result = await tasksAction.handler(
+      runtime,
+      makeMessage("split work"),
+      {} as State,
+      {
+        parameters: {
+          action: "create",
+          agents: [
+            "Update plugins/plugin-agent-orchestrator/src/services/lane-planner.ts",
+            "Update packages/core/src/runtime.ts",
+          ].join(" | "),
+        },
+      },
+      vi.fn(async () => []) as unknown as HandlerCallback,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(acp.spawnSession).toHaveBeenCalledTimes(2);
+    expect(acp.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(taskService.createTask).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -34,6 +34,7 @@ import { resolveCodingBackendLogged } from "../services/coding-backend-routing.j
 import {
   collisionProviderFromWorkspaceService,
   LanePlannerService,
+  laneReadiness,
   shouldUseLanePlanner,
 } from "../services/lane-planner.js";
 import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
@@ -1117,6 +1118,10 @@ async function runCreate(
     plan = await planner.plan({
       task: pickString(params, content, "task") ?? text,
       tasks,
+      dependencies: readLaneDependencies(params, content),
+      maxParallel: readPositiveInteger(
+        params.maxParallel ?? content.maxParallel,
+      ),
       title: pickString(params, content, "title"),
       goal: pickString(params, content, "goal"),
       acceptanceCriteria: pickStringArrayFromInputs(
@@ -1129,6 +1134,20 @@ async function runCreate(
       workdir: explicitWorkdir,
     });
   } catch (error) {
+    if (
+      error instanceof ElizaError &&
+      (String(error.code).startsWith("LANE_DEPENDENCY_") ||
+        error.code === "LANE_PLAN_DEADLOCK")
+    ) {
+      const msg = failureMessage(error);
+      await callbackText(callback, msg);
+      return {
+        success: false,
+        error: error.code,
+        text: msg,
+        continueChain: false,
+      };
+    }
     logger(runtime).warn(
       `[TASKS:create] lane planner failed, falling back to legacy single-task behavior: ${
         error instanceof Error ? error.message : String(error)
@@ -1149,61 +1168,19 @@ async function runCreate(
         callback,
       );
     }
-    return runCreateLegacy(
-      runtime,
-      message,
-      state,
-      {
-        ...params,
-        task: lane.initialPrompt,
-        agents: undefined,
-        title: lane.title,
-        goal: lane.initialPrompt,
-        taskComplexity: lane.difficultyTag,
-        acceptanceCriteria: lane.acceptanceCriteria,
-        metadata: {
-          ...(objectValue(params.metadata) ?? {}),
-          ...laneMetadata(plan, lane),
-        },
-      },
-      laneExecutionContent(content),
-      callback,
-    );
   }
 
-  const laneRuns = plan.lanes.map((lane) =>
-    runCreateLegacy(
-      runtime,
-      message,
-      state,
-      {
-        ...params,
-        task: lane.initialPrompt,
-        agents: undefined,
-        title: lane.title,
-        goal: lane.initialPrompt,
-        taskComplexity: lane.difficultyTag,
-        acceptanceCriteria: lane.acceptanceCriteria,
-        metadata: {
-          ...(objectValue(params.metadata) ?? {}),
-          ...laneMetadata(plan, lane),
-        },
-      },
-      laneExecutionContent(content),
-      callback,
-    ),
+  const laneOutcome = await runLanePlan(
+    runtime,
+    message,
+    state,
+    params,
+    content,
+    callback,
+    plan,
   );
-  const laneResults = await Promise.allSettled(laneRuns);
-  const successfulResults: ActionResult[] = [];
-  for (const result of laneResults) {
-    if (result.status === "rejected") {
-      throw result.reason;
-    }
-    successfulResults.push(result.value);
-  }
-  for (const result of successfulResults) {
-    if (!result.success) return result;
-  }
+  if (!laneOutcome.success) return laneOutcome.result;
+  const successfulResults = laneOutcome.results;
   return {
     success: true,
     text: `Created ${successfulResults.length} task-agent lanes.`,
@@ -1215,11 +1192,158 @@ async function runCreate(
         taskId: successfulResults[index]?.data?.taskId,
         scopePaths: lane.scopePaths,
         forbiddenPaths: lane.forbiddenPaths,
+        branchName: lane.branchName,
+        dependencies: lane.dependencies,
         collisions: lane.collisions,
       })),
       suppressActionResultClipboard: true,
     },
   };
+}
+
+/** Execute a lane plan with dependency-aware admission. maxParallel only gates
+ * currently running lanes; ready backlog stays queued until predecessors finish
+ * instead of being dropped when capacity is saturated. */
+async function runLanePlan(
+  runtime: IAgentRuntime,
+  message: Memory,
+  state: State | undefined,
+  params: Record<string, unknown>,
+  content: Record<string, unknown>,
+  callback: HandlerCallback | undefined,
+  plan: Awaited<ReturnType<LanePlannerService["plan"]>>,
+): Promise<
+  | { success: true; results: ActionResult[] }
+  | { success: false; result: ActionResult }
+> {
+  const pending = new Map(
+    plan.lanes.map((lane, index) => [lane.id, { lane, index }]),
+  );
+  const completed = new Set<string>();
+  const failed = new Set<string>();
+  const results = new Array<ActionResult>(plan.lanes.length);
+  const active = new Set<Promise<void>>();
+  let dependencyFailure: ActionResult | undefined;
+  const workspaceService = getCodingWorkspaceService(runtime);
+  const reuseTaskId =
+    pickString(params, content, "taskId") ??
+    pickString(params, content, "threadId");
+  const launch = (lane: (typeof plan.lanes)[number], index: number) => {
+    const run = (async () => {
+      if (workspaceService && reuseTaskId) {
+        const activeSession = await workspaceService.findActiveSessionForTask({
+          taskId: reuseTaskId,
+        });
+        if (activeSession) {
+          results[index] = {
+            success: true,
+            text: `Reused active task-agent session ${activeSession.sessionId}.`,
+            data: {
+              taskId: activeSession.taskId,
+              agents: [
+                {
+                  id: activeSession.sessionId,
+                  sessionId: activeSession.sessionId,
+                  agentType: activeSession.agentType,
+                  workdir: activeSession.workdir,
+                  status: activeSession.status,
+                  label: lane.title,
+                  reused: true,
+                },
+              ],
+              suppressActionResultClipboard: true,
+            },
+          };
+          completed.add(lane.id);
+          return;
+        }
+      }
+      results[index] = await runCreateLegacy(
+        runtime,
+        message,
+        state,
+        {
+          ...params,
+          task: lane.initialPrompt,
+          agents: undefined,
+          title: lane.title,
+          goal: lane.initialPrompt,
+          taskComplexity: lane.difficultyTag,
+          acceptanceCriteria: [...lane.acceptanceCriteria],
+          branchName: lane.branchName,
+          metadata: {
+            ...(objectValue(params.metadata) ?? {}),
+            ...laneMetadata(plan, lane),
+          },
+        },
+        laneExecutionContent(content),
+        callback,
+      );
+    })()
+      .then((result) => {
+        const actionResult = result ?? results[index];
+        if (!actionResult) {
+          throw new ElizaError("Lane did not produce an action result", {
+            code: "LANE_RESULT_MISSING",
+            context: { laneId: lane.id },
+            severity: "ephemeral",
+          });
+        }
+        if (actionResult.success) completed.add(lane.id);
+        else failed.add(lane.id);
+      })
+      .finally(() => {
+        active.delete(run);
+      });
+    active.add(run);
+  };
+
+  while (pending.size > 0 || active.size > 0) {
+    let launched = false;
+    for (const [id, entry] of [...pending]) {
+      if (active.size >= plan.maxParallel) break;
+      const readiness = laneReadiness(entry.lane, completed, failed);
+      const failedBlocker = readiness.blockers.find((blocker) =>
+        blocker.endsWith(": failed"),
+      );
+      if (failedBlocker) {
+        dependencyFailure = {
+          success: false,
+          error: "LANE_DEPENDENCY_FAILED",
+          text: `Lane ${entry.lane.id} blocked by ${failedBlocker}.`,
+        };
+        pending.clear();
+        break;
+      }
+      if (!readiness.ready) continue;
+      pending.delete(id);
+      launch(entry.lane, entry.index);
+      launched = true;
+    }
+    if (dependencyFailure) {
+      // Already-launched independent lanes remain owned by this action. Wait for
+      // them to settle so failures cannot escape as unobserved background work.
+      if (active.size > 0) await Promise.allSettled([...active]);
+      return { success: false, result: dependencyFailure };
+    }
+    if (active.size === 0 && !launched) {
+      const blocked = [...pending.values()].map(({ lane }) => ({
+        laneId: lane.id,
+        blockers: laneReadiness(lane, completed, failed).blockers,
+      }));
+      throw new ElizaError("No lane is ready to launch", {
+        code: "LANE_PLAN_DEADLOCK",
+        context: { blocked },
+        severity: "ephemeral",
+      });
+    }
+    if (active.size > 0) await Promise.race(active);
+  }
+
+  for (const result of results) {
+    if (!result.success) return { success: false, result };
+  }
+  return { success: true, results };
 }
 
 function pickStringArrayFromInputs(
@@ -1235,6 +1359,37 @@ function pickStringArrayFromInputs(
     .filter((item) => item.length > 0);
 }
 
+/** Read planner-supplied lane dependency edges from a strict object:
+ * `{ "lane-2": ["lane-1"] }`. Other shapes are ignored so natural-language
+ * content cannot accidentally invent graph edges. */
+function readLaneDependencies(
+  params: Record<string, unknown>,
+  content: Record<string, unknown>,
+): Record<string, string[]> | undefined {
+  const raw = objectValue(params.dependencies ?? content.dependencies);
+  if (!raw) return undefined;
+  const deps: Record<string, string[]> = {};
+  for (const [laneId, value] of Object.entries(raw)) {
+    if (!Array.isArray(value)) continue;
+    deps[laneId] = value.filter(
+      (item): item is string =>
+        typeof item === "string" && item.trim().length > 0,
+    );
+  }
+  return deps;
+}
+
+/** Parse numeric planner parameters only when they are explicit positive
+ * integers; malformed values fall back to the planner default. */
+function readPositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value !== "string") return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 function laneExecutionContent(
   content: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -1248,6 +1403,8 @@ function laneMetadata(
   lane: {
     id: string;
     title: string;
+    branchName: string;
+    dependencies: string[];
     scopePaths: string[];
     forbiddenPaths: string[];
     collisions: unknown[];
@@ -1259,6 +1416,8 @@ function laneMetadata(
     lane: {
       id: lane.id,
       title: lane.title,
+      branchName: lane.branchName,
+      dependencies: [...lane.dependencies],
       scopePaths: lane.scopePaths,
       forbiddenPaths: lane.forbiddenPaths,
       collisions: lane.collisions,
@@ -3642,9 +3801,24 @@ export const tasksAction: Action & {
     },
     {
       name: "agents",
-      description: "Pipe-delimited multi-agent task list for action=create.",
+      description:
+        "Pipe-delimited multi-agent task list for action=create. When lane planner is enabled, each part becomes lane-N in order.",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "dependencies",
+      description:
+        'Lane dependency graph for gated action=create, shaped as {"lane-2":["lane-1"]}. References must use generated lane ids.',
+      required: false,
+      schema: { type: "object" as const },
+    },
+    {
+      name: "maxParallel",
+      description:
+        "Maximum concurrently launched lanes for gated action=create; ready backlog remains queued until dependencies and capacity allow launch.",
+      required: false,
+      schema: { type: "integer" as const, minimum: 1 },
     },
     {
       name: "repo",

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -4,6 +4,7 @@
  * runners enforce access, routing, lifecycle, and session-event invariants.
  */
 
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import type {
   Action,
@@ -30,6 +31,11 @@ import {
 } from "../services/acceptance-criteria.js";
 import { augmentTaskWithDeployGuidance } from "../services/app-deploy-guidance.js";
 import { resolveCodingBackendLogged } from "../services/coding-backend-routing.js";
+import {
+  collisionProviderFromWorkspaceService,
+  LanePlannerService,
+  shouldUseLanePlanner,
+} from "../services/lane-planner.js";
 import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import type { OrchestratorTaskStatus } from "../services/orchestrator-task-types.js";
@@ -730,7 +736,7 @@ async function runPromptAndClose(
   }
 }
 
-async function runCreate(
+async function runCreateLegacy(
   runtime: IAgentRuntime,
   message: Memory,
   state: State | undefined,
@@ -1006,6 +1012,14 @@ async function runCreate(
           : {}),
         ...(taskRoomId ? { taskRoomId } : {}),
         acceptanceCriteria,
+        ...(objectValue(extraMetadata.lane)
+          ? {
+              metadata: {
+                waveId: extraMetadata.waveId,
+                lane: extraMetadata.lane,
+              },
+            }
+          : {}),
       });
       threadId = detail?.id ?? null;
     }
@@ -1078,6 +1092,136 @@ async function runCreate(
   };
 }
 
+async function runCreate(
+  runtime: IAgentRuntime,
+  message: Memory,
+  state: State | undefined,
+  params: Record<string, unknown>,
+  content: Record<string, unknown>,
+  callback: HandlerCallback | undefined,
+): Promise<ActionResult> {
+  if (!shouldUseLanePlanner(runtime)) {
+    return runCreateLegacy(runtime, message, state, params, content, callback);
+  }
+
+  let plan: Awaited<ReturnType<LanePlannerService["plan"]>>;
+  try {
+    const text = messageText(message);
+    const tasks = taskParts(params, content, text);
+    const waveId = randomUUID();
+    const explicitWorkdir = pickString(params, content, "workdir");
+    const planner = new LanePlannerService(
+      runtime,
+      collisionProviderFromWorkspaceService(getCodingWorkspaceService(runtime)),
+    );
+    plan = await planner.plan({
+      task: pickString(params, content, "task") ?? text,
+      tasks,
+      title: pickString(params, content, "title"),
+      goal: pickString(params, content, "goal"),
+      acceptanceCriteria: pickStringArrayFromInputs(
+        params,
+        content,
+        "acceptanceCriteria",
+      ),
+      difficultyTag: pickString(params, content, "taskComplexity"),
+      waveId,
+      workdir: explicitWorkdir,
+    });
+  } catch (error) {
+    logger(runtime).warn(
+      `[TASKS:create] lane planner failed, falling back to legacy single-task behavior: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return runCreateLegacy(runtime, message, state, params, content, callback);
+  }
+
+  if (plan.lanes.length <= 1) {
+    const lane = plan.lanes[0];
+    if (!lane || lane.scopePaths.length === 0) {
+      return runCreateLegacy(
+        runtime,
+        message,
+        state,
+        params,
+        content,
+        callback,
+      );
+    }
+    return runCreateLegacy(
+      runtime,
+      message,
+      state,
+      {
+        ...params,
+        task: lane.initialPrompt,
+        agents: undefined,
+        title: lane.title,
+        goal: lane.initialPrompt,
+        taskComplexity: lane.difficultyTag,
+        acceptanceCriteria: lane.acceptanceCriteria,
+        metadata: {
+          ...(objectValue(params.metadata) ?? {}),
+          ...laneMetadata(plan, lane),
+        },
+      },
+      laneExecutionContent(content),
+      callback,
+    );
+  }
+
+  const laneRuns = plan.lanes.map((lane) =>
+    runCreateLegacy(
+      runtime,
+      message,
+      state,
+      {
+        ...params,
+        task: lane.initialPrompt,
+        agents: undefined,
+        title: lane.title,
+        goal: lane.initialPrompt,
+        taskComplexity: lane.difficultyTag,
+        acceptanceCriteria: lane.acceptanceCriteria,
+        metadata: {
+          ...(objectValue(params.metadata) ?? {}),
+          ...laneMetadata(plan, lane),
+        },
+      },
+      laneExecutionContent(content),
+      callback,
+    ),
+  );
+  const laneResults = await Promise.allSettled(laneRuns);
+  const successfulResults: ActionResult[] = [];
+  for (const result of laneResults) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
+    successfulResults.push(result.value);
+  }
+  for (const result of successfulResults) {
+    if (!result.success) return result;
+  }
+  return {
+    success: true,
+    text: `Created ${successfulResults.length} task-agent lanes.`,
+    data: {
+      waveId: plan.waveId,
+      lanes: plan.lanes.map((lane, index) => ({
+        id: lane.id,
+        title: lane.title,
+        taskId: successfulResults[index]?.data?.taskId,
+        scopePaths: lane.scopePaths,
+        forbiddenPaths: lane.forbiddenPaths,
+        collisions: lane.collisions,
+      })),
+      suppressActionResultClipboard: true,
+    },
+  };
+}
+
 function pickStringArrayFromInputs(
   params: Record<string, unknown>,
   content: Record<string, unknown>,
@@ -1089,6 +1233,38 @@ function pickStringArrayFromInputs(
     .filter((item): item is string => typeof item === "string")
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
+}
+
+function laneExecutionContent(
+  content: Record<string, unknown>,
+): Record<string, unknown> {
+  const rest = { ...content };
+  delete rest.agents;
+  return rest;
+}
+
+function laneMetadata(
+  plan: { waveId: string },
+  lane: {
+    id: string;
+    title: string;
+    scopePaths: string[];
+    forbiddenPaths: string[];
+    collisions: unknown[];
+    difficultyTag: string;
+  },
+): Record<string, unknown> {
+  return {
+    waveId: plan.waveId,
+    lane: {
+      id: lane.id,
+      title: lane.title,
+      scopePaths: lane.scopePaths,
+      forbiddenPaths: lane.forbiddenPaths,
+      collisions: lane.collisions,
+      difficultyTag: lane.difficultyTag,
+    },
+  };
 }
 
 // ── action: spawn_agent (SPAWN_AGENT) ───────────────────────────────────────

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -35,6 +35,7 @@ import {
 // `/api/coding-agents/*` surface 404s on the node bundle.
 export { codingAgentRouteRegistration } from "./register-routes.js";
 export {
+  cloneLanePlan,
   collisionProviderFromWorkspaceService,
   createDeterministicLanePlan,
   type ExternalCollision,
@@ -44,9 +45,13 @@ export {
   type LanePlan,
   type LanePlannerInput,
   LanePlannerService,
+  type LaneReadiness,
   type LaneSpec,
+  laneReadiness,
+  sanitizeLaneBranchName,
   scopeSetsOverlap,
   shouldUseLanePlanner,
+  validateLaneDependencyGraph,
 } from "./services/lane-planner.js";
 // Shared relay sanitizer (issue elizaOS/eliza#11578). Re-exported from the
 // package root so packages/agent's swarm-synthesis path can strip captured

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -34,6 +34,20 @@ import {
 // side-effect of evaluating that module. Without this the entire
 // `/api/coding-agents/*` surface 404s on the node bundle.
 export { codingAgentRouteRegistration } from "./register-routes.js";
+export {
+  collisionProviderFromWorkspaceService,
+  createDeterministicLanePlan,
+  type ExternalCollision,
+  extractScopePaths,
+  type LaneCollision,
+  type LaneCollisionProvider,
+  type LanePlan,
+  type LanePlannerInput,
+  LanePlannerService,
+  type LaneSpec,
+  scopeSetsOverlap,
+  shouldUseLanePlanner,
+} from "./services/lane-planner.js";
 // Shared relay sanitizer (issue elizaOS/eliza#11578). Re-exported from the
 // package root so packages/agent's swarm-synthesis path can strip captured
 // tool-output envelopes with the SAME implementation the sub-agent router uses.

--- a/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
@@ -6,13 +6,16 @@
  * failure.
  */
 
-import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime, ModelType } from "@elizaos/core";
 import { staticAcceptanceCriteria } from "./acceptance-criteria.js";
 import { parseJsonObjectResponse } from "./json-model-output.js";
+import { assertSafeGitRef } from "./repo-input.js";
 
 export const LANE_PLANNER_SETTING = "ELIZA_ORCHESTRATOR_LANE_PLANNER";
 const LANE_PLANNER_REFINE_SETTING = "ELIZA_ORCHESTRATOR_LANE_PLANNER_REFINE";
 const MAX_LANES = 6;
+const DEFAULT_MAX_PARALLEL_LANES = 2;
+const MAX_BRANCH_NAME_CHARS = 80;
 
 export interface LaneCollision {
   source: "open-pr" | "sibling";
@@ -25,6 +28,8 @@ export interface LaneCollision {
 export interface LaneSpec {
   id: string;
   title: string;
+  branchName: string;
+  dependencies: string[];
   scopePaths: string[];
   forbiddenPaths: string[];
   collisions: LaneCollision[];
@@ -35,6 +40,7 @@ export interface LaneSpec {
 
 export interface LanePlan {
   waveId: string;
+  maxParallel: number;
   lanes: LaneSpec[];
 }
 
@@ -63,11 +69,18 @@ type WorkspaceCollisionReader = {
 export interface LanePlannerInput {
   task: string;
   tasks?: string[];
+  dependencies?: Record<string, string[]>;
+  maxParallel?: number;
   title?: string;
   goal?: string;
   acceptanceCriteria?: string[];
   difficultyTag?: string;
   waveId?: string;
+}
+
+export interface LaneReadiness {
+  ready: boolean;
+  blockers: string[];
 }
 
 function isEnabledValue(value: unknown): boolean {
@@ -114,6 +127,26 @@ function normalizePath(raw: string): string | undefined {
 
 function uniqueSorted(values: readonly string[]): string[] {
   return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+/** Clone a plan for callers so exported planner data cannot be mutated through
+ * object references and later reused as if it were authoritative state. */
+export function cloneLanePlan(plan: LanePlan): LanePlan {
+  return {
+    waveId: plan.waveId,
+    maxParallel: plan.maxParallel,
+    lanes: plan.lanes.map((lane) => ({
+      ...lane,
+      dependencies: [...lane.dependencies],
+      scopePaths: [...lane.scopePaths],
+      forbiddenPaths: [...lane.forbiddenPaths],
+      collisions: lane.collisions.map((collision) => ({
+        ...collision,
+        paths: [...collision.paths],
+      })),
+      acceptanceCriteria: [...lane.acceptanceCriteria],
+    })),
+  };
 }
 
 export function extractScopePaths(text: string): string[] {
@@ -166,6 +199,137 @@ function difficultyFor(task: string, explicit: string | undefined): string {
   return "moderate";
 }
 
+/** Convert a lane title into a bounded git branch ref segment, leaving only the
+ * conservative character set accepted by the workspace git-ref validator. */
+export function sanitizeLaneBranchName(
+  title: string,
+  used: ReadonlySet<string> = new Set(),
+  prefix = "eliza/lane",
+): string {
+  const baseSlug =
+    title
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._/-]+/g, "-")
+      .replace(/\/{2,}/g, "/")
+      .replace(/^[^a-z0-9]+/g, "")
+      .replace(/[^a-z0-9]+$/g, "")
+      .slice(0, MAX_BRANCH_NAME_CHARS) || "task";
+  const cleanPrefix = prefix
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, "-")
+    .replace(/\/{2,}/g, "/")
+    .replace(/^[^a-z0-9]+/g, "")
+    .replace(/[^a-z0-9]+$/g, "");
+  const root = `${cleanPrefix || "eliza/lane"}/${baseSlug}`;
+  let candidate = root.slice(0, MAX_BRANCH_NAME_CHARS);
+  let suffix = 2;
+  while (used.has(candidate)) {
+    const suffixText = `-${suffix}`;
+    candidate = `${root.slice(0, MAX_BRANCH_NAME_CHARS - suffixText.length)}${suffixText}`;
+    suffix += 1;
+  }
+  return assertSafeGitRef(candidate, "lane branchName");
+}
+
+/** Bound planner concurrency to the number of planned lanes, with a conservative
+ * default that still allows independent lanes to overlap. */
+function normalizeMaxParallel(
+  value: number | undefined,
+  laneCount: number,
+): number {
+  if (!Number.isFinite(value) || value === undefined) {
+    return Math.min(DEFAULT_MAX_PARALLEL_LANES, Math.max(1, laneCount));
+  }
+  return Math.max(1, Math.min(Math.floor(value), Math.max(1, laneCount)));
+}
+
+/** Normalize user/planner dependency input into stable lane-id edges before
+ * graph validation. */
+function normalizeDependencies(
+  raw: Record<string, string[]> | undefined,
+): Map<string, string[]> {
+  const normalized = new Map<string, string[]>();
+  if (!raw) return normalized;
+  for (const [id, deps] of Object.entries(raw)) {
+    normalized.set(
+      id.trim(),
+      uniqueSorted(
+        deps.map((dep) => dep.trim()).filter((dep) => dep.length > 0),
+      ),
+    );
+  }
+  return normalized;
+}
+
+/** Validate lane dependency edges as a graph before any sub-agent launches.
+ * Unknown references and cycles are rejected explicitly instead of being read
+ * later as "not ready" forever. */
+export function validateLaneDependencyGraph(
+  laneIds: readonly string[],
+  dependencies: ReadonlyMap<string, readonly string[]>,
+): void {
+  const known = new Set(laneIds);
+  for (const [id, deps] of dependencies) {
+    if (!known.has(id)) {
+      throw new ElizaError(`Lane dependency references unknown lane ${id}`, {
+        code: "LANE_DEPENDENCY_UNKNOWN_LANE",
+        context: { laneId: id },
+        severity: "ephemeral",
+      });
+    }
+    for (const dep of deps) {
+      if (!known.has(dep)) {
+        throw new ElizaError(`Lane ${id} depends on unknown lane ${dep}`, {
+          code: "LANE_DEPENDENCY_UNKNOWN_REF",
+          context: { laneId: id, dependencyId: dep },
+          severity: "ephemeral",
+        });
+      }
+    }
+  }
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (id: string, path: string[]): void => {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      throw new ElizaError(
+        `Lane dependency cycle: ${[...path, id].join(" -> ")}`,
+        {
+          code: "LANE_DEPENDENCY_CYCLE",
+          context: { laneId: id, path: [...path, id] },
+          severity: "ephemeral",
+        },
+      );
+    }
+    visiting.add(id);
+    for (const dep of dependencies.get(id) ?? []) visit(dep, [...path, id]);
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const id of laneIds) visit(id, []);
+}
+
+/** Semantic readiness for a lane: dependencies must be completed, while
+ * externally blocked or failed dependencies surface as named blockers instead
+ * of being inferred from a coarse task status string. */
+export function laneReadiness(
+  lane: Pick<LaneSpec, "id" | "dependencies">,
+  completed: ReadonlySet<string>,
+  failed: ReadonlySet<string> = new Set(),
+  blocked: ReadonlyMap<string, string> = new Map(),
+): LaneReadiness {
+  const blockers: string[] = [];
+  for (const dep of lane.dependencies) {
+    const blockReason = blocked.get(dep);
+    if (blockReason) blockers.push(`${dep}: ${blockReason}`);
+    else if (failed.has(dep)) blockers.push(`${dep}: failed`);
+    else if (!completed.has(dep)) blockers.push(`${dep}: dependency pending`);
+  }
+  return { ready: blockers.length === 0, blockers };
+}
+
 function lanePrompt(args: {
   parentTask: string;
   laneTask: string;
@@ -173,9 +337,12 @@ function lanePrompt(args: {
   forbidden: string[];
   collisions: LaneCollision[];
   criteria: string[];
+  branchName: string;
 }): string {
   const lines = [
     args.laneTask,
+    "",
+    `Suggested branch: ${args.branchName}`,
     "",
     "Lane scope:",
     ...args.scopes.map((path) => `- ${path}`),
@@ -214,6 +381,8 @@ function buildLane(
   index: number,
   siblingScopes: readonly string[][],
   externalCollisions: readonly ExternalCollision[],
+  dependencies: readonly string[],
+  branchName: string,
 ): LaneSpec {
   const scopes = extractScopePaths(laneTask);
   const forbidden = uniqueSorted(
@@ -242,6 +411,8 @@ function buildLane(
   return {
     id: `lane-${index + 1}`,
     title: (input.title ?? laneTask).slice(0, 80),
+    branchName,
+    dependencies: [...dependencies],
     scopePaths: scopes,
     forbiddenPaths: forbidden,
     collisions,
@@ -254,6 +425,7 @@ function buildLane(
       forbidden,
       collisions,
       criteria,
+      branchName,
     }),
   };
 }
@@ -275,6 +447,9 @@ export function createDeterministicLanePlan(
   }
   const tasks = candidates.length > 0 ? candidates : [input.task];
   const scopeSets = tasks.map((task) => extractScopePaths(task));
+  const laneIds = tasks.map((_, index) => `lane-${index + 1}`);
+  const dependencies = normalizeDependencies(input.dependencies);
+  validateLaneDependencyGraph(laneIds, dependencies);
   if (tasks.length > 1) {
     if (scopeSets.some((scopes) => scopes.length === 0)) {
       throw new Error(
@@ -289,11 +464,26 @@ export function createDeterministicLanePlan(
       }
     }
   }
+  const usedBranches = new Set<string>();
   return {
     waveId: input.waveId ?? "wave",
-    lanes: tasks.map((task, index) =>
-      buildLane(input, task, index, scopeSets, externalCollisions),
-    ),
+    maxParallel: normalizeMaxParallel(input.maxParallel, tasks.length),
+    lanes: tasks.map((task, index) => {
+      const branchName = sanitizeLaneBranchName(
+        input.title ?? task,
+        usedBranches,
+      );
+      usedBranches.add(branchName);
+      return buildLane(
+        input,
+        task,
+        index,
+        scopeSets,
+        externalCollisions,
+        dependencies.get(laneIds[index] ?? "") ?? [],
+        branchName,
+      );
+    }),
   };
 }
 
@@ -314,7 +504,7 @@ function applyRefinement(plan: LanePlan, raw: string): LanePlan {
     const record = lane as Record<string, unknown>;
     if (typeof record.id === "string") byId.set(record.id, record);
   }
-  return {
+  return cloneLanePlan({
     ...plan,
     lanes: plan.lanes.map((lane) => {
       const refined = byId.get(lane.id);
@@ -340,7 +530,7 @@ function applyRefinement(plan: LanePlan, raw: string): LanePlan {
           criteria.length > 0 ? criteria : lane.acceptanceCriteria,
       };
     }),
-  };
+  });
 }
 
 export class LanePlannerService {
@@ -359,9 +549,23 @@ export class LanePlannerService {
           workdir: input.workdir,
           repo: input.repo,
         });
-      } catch {
+      } catch (error) {
         // error-policy:J4 optional collision annotation degrades to no external
-        // collisions; lane execution still carries sibling forbidden paths.
+        // collisions; lane execution still carries sibling forbidden paths. The
+        // remote input failure is still reported as an ElizaError at the
+        // boundary so operators can observe the degraded planner context.
+        this.runtime.reportError?.(
+          "LanePlannerService.collisionProvider",
+          new ElizaError("Lane collision provider failed", {
+            code: "LANE_COLLISION_PROVIDER_FAILED",
+            context: {
+              workdir: input.workdir,
+              repo: input.repo,
+            },
+            cause: error,
+            severity: "ephemeral",
+          }),
+        );
         collisions = [];
       }
     }
@@ -369,7 +573,7 @@ export class LanePlannerService {
     if (
       !isEnabledValue(readSetting(this.runtime, LANE_PLANNER_REFINE_SETTING))
     ) {
-      return deterministic;
+      return cloneLanePlan(deterministic);
     }
     try {
       if (typeof this.runtime.useModel !== "function") return deterministic;
@@ -377,11 +581,13 @@ export class LanePlannerService {
         prompt: refinePrompt(deterministic),
         stopSequences: [],
       });
-      return applyRefinement(deterministic, String(result ?? ""));
+      return cloneLanePlan(
+        applyRefinement(deterministic, String(result ?? "")),
+      );
     } catch {
       // error-policy:J4 optional TEXT_SMALL refinement is advisory only; the
       // deterministic plan is the designed fallback.
-      return deterministic;
+      return cloneLanePlan(deterministic);
     }
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
@@ -1,0 +1,387 @@
+/**
+ * Lane planner for splitting a single orchestrator coding request into
+ * independent Smithers runs. The pure planner is intentionally conservative:
+ * it only emits multiple lanes when scopes can be made mutually exclusive, and
+ * the integration layer falls back to the legacy one-task path on any boundary
+ * failure.
+ */
+
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import { staticAcceptanceCriteria } from "./acceptance-criteria.js";
+import { parseJsonObjectResponse } from "./json-model-output.js";
+
+export const LANE_PLANNER_SETTING = "ELIZA_ORCHESTRATOR_LANE_PLANNER";
+const LANE_PLANNER_REFINE_SETTING = "ELIZA_ORCHESTRATOR_LANE_PLANNER_REFINE";
+const MAX_LANES = 6;
+
+export interface LaneCollision {
+  source: "open-pr" | "sibling";
+  id: string;
+  paths: string[];
+  title?: string;
+  url?: string;
+}
+
+export interface LaneSpec {
+  id: string;
+  title: string;
+  scopePaths: string[];
+  forbiddenPaths: string[];
+  collisions: LaneCollision[];
+  difficultyTag: string;
+  acceptanceCriteria: string[];
+  initialPrompt: string;
+}
+
+export interface LanePlan {
+  waveId: string;
+  lanes: LaneSpec[];
+}
+
+export interface ExternalCollision {
+  id: string;
+  paths: string[];
+  title?: string;
+  url?: string;
+}
+
+export interface LaneCollisionProvider {
+  listOpenPrCollisions(input: {
+    workdir?: string;
+    repo?: string;
+  }): Promise<ExternalCollision[]>;
+}
+
+type WorkspaceCollisionReader = {
+  listOpenPrCollisions?: LaneCollisionProvider["listOpenPrCollisions"];
+  listOpenPullRequestChangedFiles?: (input: {
+    workdir?: string;
+    repo?: string;
+  }) => Promise<ExternalCollision[]>;
+};
+
+export interface LanePlannerInput {
+  task: string;
+  tasks?: string[];
+  title?: string;
+  goal?: string;
+  acceptanceCriteria?: string[];
+  difficultyTag?: string;
+  waveId?: string;
+}
+
+function isEnabledValue(value: unknown): boolean {
+  if (typeof value !== "string") return value === true;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function readSetting(runtime: IAgentRuntime | undefined, key: string): unknown {
+  return runtime?.getSetting?.(key) ?? process.env[key];
+}
+
+export function shouldUseLanePlanner(runtime?: IAgentRuntime): boolean {
+  return isEnabledValue(readSetting(runtime, LANE_PLANNER_SETTING));
+}
+
+export function collisionProviderFromWorkspaceService(
+  service: unknown,
+): LaneCollisionProvider | undefined {
+  if (!service || typeof service !== "object") return undefined;
+  const reader = service as WorkspaceCollisionReader;
+  if (typeof reader.listOpenPrCollisions === "function") {
+    return { listOpenPrCollisions: reader.listOpenPrCollisions.bind(reader) };
+  }
+  if (typeof reader.listOpenPullRequestChangedFiles === "function") {
+    return {
+      listOpenPrCollisions: reader.listOpenPullRequestChangedFiles.bind(reader),
+    };
+  }
+  return undefined;
+}
+
+function normalizePath(raw: string): string | undefined {
+  const trimmed = raw
+    .trim()
+    .replace(/^['"`([{<]+/, "")
+    .replace(/['"`)\]}>.,;:]+$/, "");
+  if (!trimmed || trimmed === "." || trimmed === "/") return undefined;
+  if (trimmed.includes("..")) return undefined;
+  if (/^(?:https?:|file:)/i.test(trimmed)) return undefined;
+  const cleaned = trimmed.replace(/^\.\/+/, "").replace(/\/{2,}/g, "/");
+  if (!/[/.]/.test(cleaned)) return undefined;
+  return cleaned.replace(/\/$/, "");
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+export function extractScopePaths(text: string): string[] {
+  const matches = text.match(
+    /(?:^|[\s(["'`])((?:packages|plugins|src|scripts|docs|tests|test|app|apps|public|server|client|components|lib|services|api|\.\/)[A-Za-z0-9_./-]*|[A-Za-z0-9_-]+\/[A-Za-z0-9_./-]+\.[A-Za-z0-9_-]+)/g,
+  );
+  if (!matches) return [];
+  return uniqueSorted(
+    matches
+      .map((match) => normalizePath(match.trim()))
+      .filter((path): path is string => Boolean(path)),
+  );
+}
+
+function pathOverlaps(a: string, b: string): boolean {
+  if (a === b) return true;
+  const left = a.endsWith("/") ? a : `${a}/`;
+  const right = b.endsWith("/") ? b : `${b}/`;
+  return left.startsWith(right) || right.startsWith(left);
+}
+
+export function scopeSetsOverlap(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return left.some((a) => right.some((b) => pathOverlaps(a, b)));
+}
+
+function splitTaskText(task: string): string[] {
+  return task
+    .split(
+      /\n+|(?:^|\s)(?:and|then|also)\s+(?=(?:update|fix|add|build|create|refactor|test|document|wire|implement)\b)/i,
+    )
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function difficultyFor(task: string, explicit: string | undefined): string {
+  const tag = explicit?.trim().toLowerCase();
+  if (tag === "simple" || tag === "moderate" || tag === "hard") return tag;
+  if (tag === "standard") return "moderate";
+  if (tag === "complex") return "hard";
+  const text = task.toLowerCase();
+  if (
+    /\b(schema|migration|auth|security|cross-package|architecture)\b/.test(text)
+  ) {
+    return "hard";
+  }
+  if (/\b(test|docs?|copy|style|lint)\b/.test(text)) return "simple";
+  return "moderate";
+}
+
+function lanePrompt(args: {
+  parentTask: string;
+  laneTask: string;
+  scopes: string[];
+  forbidden: string[];
+  collisions: LaneCollision[];
+  criteria: string[];
+}): string {
+  const lines = [
+    args.laneTask,
+    "",
+    "Lane scope:",
+    ...args.scopes.map((path) => `- ${path}`),
+    "",
+    "Do not edit outside this lane's scope. Forbidden sibling paths:",
+    ...(args.forbidden.length > 0
+      ? args.forbidden.map((path) => `- ${path}`)
+      : ["- none"]),
+  ];
+  if (args.collisions.length > 0) {
+    lines.push(
+      "",
+      "Potential open PR or sibling lane collisions to inspect before editing:",
+      ...args.collisions.map(
+        (collision) =>
+          `- ${collision.id}: ${collision.paths.join(", ")}${
+            collision.url ? ` (${collision.url})` : ""
+          }`,
+      ),
+    );
+  }
+  if (args.criteria.length > 0) {
+    lines.push(
+      "",
+      "Acceptance criteria seed:",
+      ...args.criteria.map((criterion) => `- ${criterion}`),
+    );
+  }
+  lines.push("", "Parent request:", args.parentTask);
+  return lines.join("\n");
+}
+
+function buildLane(
+  input: LanePlannerInput,
+  laneTask: string,
+  index: number,
+  siblingScopes: readonly string[][],
+  externalCollisions: readonly ExternalCollision[],
+): LaneSpec {
+  const scopes = extractScopePaths(laneTask);
+  const forbidden = uniqueSorted(
+    siblingScopes.filter((_, siblingIndex) => siblingIndex !== index).flat(),
+  );
+  const collisions: LaneCollision[] = [
+    ...externalCollisions
+      .filter((collision) => scopeSetsOverlap(scopes, collision.paths))
+      .map((collision) => ({
+        source: "open-pr" as const,
+        id: collision.id,
+        paths: uniqueSorted(collision.paths),
+        ...(collision.title ? { title: collision.title } : {}),
+        ...(collision.url ? { url: collision.url } : {}),
+      })),
+    ...forbidden.map((path) => ({
+      source: "sibling" as const,
+      id: `sibling-${index + 1}`,
+      paths: [path],
+    })),
+  ];
+  const criteria =
+    input.acceptanceCriteria && input.acceptanceCriteria.length > 0
+      ? input.acceptanceCriteria
+      : staticAcceptanceCriteria(laneTask);
+  return {
+    id: `lane-${index + 1}`,
+    title: (input.title ?? laneTask).slice(0, 80),
+    scopePaths: scopes,
+    forbiddenPaths: forbidden,
+    collisions,
+    difficultyTag: difficultyFor(laneTask, input.difficultyTag),
+    acceptanceCriteria: criteria,
+    initialPrompt: lanePrompt({
+      parentTask: input.task,
+      laneTask,
+      scopes,
+      forbidden,
+      collisions,
+      criteria,
+    }),
+  };
+}
+
+export function createDeterministicLanePlan(
+  input: LanePlannerInput,
+  externalCollisions: readonly ExternalCollision[] = [],
+): LanePlan {
+  const requestedTasks = input.tasks?.length
+    ? input.tasks
+    : splitTaskText(input.task);
+  const candidates = requestedTasks
+    .map((task) => task.trim())
+    .filter((task) => task.length > 0);
+  if (candidates.length > MAX_LANES) {
+    throw new Error(
+      `Lane planner accepts at most ${MAX_LANES} lanes; received ${candidates.length}`,
+    );
+  }
+  const tasks = candidates.length > 0 ? candidates : [input.task];
+  const scopeSets = tasks.map((task) => extractScopePaths(task));
+  if (tasks.length > 1) {
+    if (scopeSets.some((scopes) => scopes.length === 0)) {
+      throw new Error(
+        "Cannot split lanes without explicit non-overlapping scopes",
+      );
+    }
+    for (let i = 0; i < scopeSets.length; i += 1) {
+      for (let j = i + 1; j < scopeSets.length; j += 1) {
+        if (scopeSetsOverlap(scopeSets[i], scopeSets[j])) {
+          throw new Error("Lane scopes overlap");
+        }
+      }
+    }
+  }
+  return {
+    waveId: input.waveId ?? "wave",
+    lanes: tasks.map((task, index) =>
+      buildLane(input, task, index, scopeSets, externalCollisions),
+    ),
+  };
+}
+
+function refinePrompt(plan: LanePlan): string {
+  return [
+    "Refine these coding-agent lanes without changing scopePaths or lane count.",
+    'Return JSON only: {"lanes":[{"id":"lane-1","title":"...","initialPrompt":"...","acceptanceCriteria":["..."]}]}',
+    JSON.stringify(plan),
+  ].join("\n\n");
+}
+
+function applyRefinement(plan: LanePlan, raw: string): LanePlan {
+  const parsed = parseJsonObjectResponse<{ lanes?: unknown }>(raw);
+  if (!parsed || !Array.isArray(parsed.lanes)) return plan;
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const lane of parsed.lanes) {
+    if (!lane || typeof lane !== "object") continue;
+    const record = lane as Record<string, unknown>;
+    if (typeof record.id === "string") byId.set(record.id, record);
+  }
+  return {
+    ...plan,
+    lanes: plan.lanes.map((lane) => {
+      const refined = byId.get(lane.id);
+      if (!refined) return lane;
+      const criteria = Array.isArray(refined.acceptanceCriteria)
+        ? refined.acceptanceCriteria.filter(
+            (item): item is string =>
+              typeof item === "string" && item.trim().length > 0,
+          )
+        : lane.acceptanceCriteria;
+      return {
+        ...lane,
+        title:
+          typeof refined.title === "string" && refined.title.trim()
+            ? refined.title.trim().slice(0, 80)
+            : lane.title,
+        initialPrompt:
+          typeof refined.initialPrompt === "string" &&
+          refined.initialPrompt.trim()
+            ? refined.initialPrompt.trim()
+            : lane.initialPrompt,
+        acceptanceCriteria:
+          criteria.length > 0 ? criteria : lane.acceptanceCriteria,
+      };
+    }),
+  };
+}
+
+export class LanePlannerService {
+  constructor(
+    private readonly runtime: IAgentRuntime,
+    private readonly collisionProvider?: LaneCollisionProvider,
+  ) {}
+
+  async plan(
+    input: LanePlannerInput & { workdir?: string; repo?: string },
+  ): Promise<LanePlan> {
+    let collisions: ExternalCollision[] = [];
+    if (this.collisionProvider) {
+      try {
+        collisions = await this.collisionProvider.listOpenPrCollisions({
+          workdir: input.workdir,
+          repo: input.repo,
+        });
+      } catch {
+        // error-policy:J4 optional collision annotation degrades to no external
+        // collisions; lane execution still carries sibling forbidden paths.
+        collisions = [];
+      }
+    }
+    const deterministic = createDeterministicLanePlan(input, collisions);
+    if (
+      !isEnabledValue(readSetting(this.runtime, LANE_PLANNER_REFINE_SETTING))
+    ) {
+      return deterministic;
+    }
+    try {
+      if (typeof this.runtime.useModel !== "function") return deterministic;
+      const result = await this.runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt: refinePrompt(deterministic),
+        stopSequences: [],
+      });
+      return applyRefinement(deterministic, String(result ?? ""));
+    } catch {
+      // error-policy:J4 optional TEXT_SMALL refinement is advisory only; the
+      // deterministic plan is the designed fallback.
+      return deterministic;
+    }
+  }
+}

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -79,6 +79,10 @@ import {
   reviewDiff,
   summarizeDiffGate,
 } from "./diff-review-gate.js";
+import type {
+  OrchestratorTaskDocument,
+  OrchestratorTaskSession,
+} from "./orchestrator-task-types.js";
 import {
   assertSafeGitRef,
   assertSafeGitRemote,
@@ -124,6 +128,31 @@ import type {
 type WorkspaceEventCallback = (event: WorkspaceEvent) => void;
 type ScratchRetentionPolicy = "ephemeral" | "pending_decision" | "persistent";
 type ScratchTerminalEvent = "stopped" | "task_complete" | "error";
+type TaskReaderService = {
+  getTask?: (taskId: string) => Promise<OrchestratorTaskDocument | null>;
+  listTasks?: (filter?: {
+    search?: string;
+    includeArchived?: boolean;
+    limit?: number;
+  }) => Promise<Array<{ id: string }>>;
+};
+
+const TERMINAL_REUSE_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "stopped",
+  "completed",
+  "done",
+  "error",
+  "errored",
+  "cancelled",
+]);
+
+export interface ActiveTaskSessionReuse {
+  taskId: string;
+  sessionId: string;
+  agentType: string;
+  workdir: string;
+  status: string;
+}
 
 export interface ScratchWorkspaceRecord {
   sessionId: string;
@@ -134,6 +163,14 @@ export interface ScratchWorkspaceRecord {
   terminalAt: number;
   terminalEvent: ScratchTerminalEvent;
   expiresAt?: number;
+}
+
+function newestReusableSession(
+  sessions: readonly OrchestratorTaskSession[],
+): OrchestratorTaskSession | undefined {
+  return sessions
+    .filter((session) => !TERMINAL_REUSE_SESSION_STATUSES.has(session.status))
+    .sort((a, b) => b.lastActivityAt - a.lastActivityAt)[0];
 }
 
 /**
@@ -359,6 +396,53 @@ export class CodingWorkspaceService {
     if (service) {
       await service.stop();
     }
+  }
+
+  /**
+   * Find the newest non-terminal session for a durable task so planner lanes
+   * can reuse an already-running worker instead of spawning a duplicate. The
+   * workspace service owns this lookup contract because callers already depend
+   * on it for workspace/session reuse, while the durable task service remains
+   * the source of truth for task documents.
+   */
+  async findActiveSessionForTask(input: {
+    taskId?: string;
+    title?: string;
+  }): Promise<ActiveTaskSessionReuse | null> {
+    const reader = this.runtime.getService?.("ORCHESTRATOR_TASK_SERVICE") as
+      | TaskReaderService
+      | null
+      | undefined;
+    if (!reader) {
+      throw new ElizaError("Orchestrator task service is unavailable", {
+        code: "ORCHESTRATOR_TASK_SERVICE_UNAVAILABLE",
+        context: input,
+        severity: "ephemeral",
+      });
+    }
+    const taskId =
+      input.taskId ??
+      (input.title && typeof reader.listTasks === "function"
+        ? (
+            await reader.listTasks({
+              search: input.title,
+              includeArchived: false,
+              limit: 1,
+            })
+          )[0]?.id
+        : undefined);
+    if (!taskId || typeof reader.getTask !== "function") return null;
+    const doc = await reader.getTask(taskId);
+    if (!doc) return null;
+    const session = newestReusableSession(doc.sessions);
+    if (!session) return null;
+    return {
+      taskId,
+      sessionId: session.sessionId,
+      agentType: session.framework,
+      workdir: session.workdir,
+      status: session.status,
+    };
   }
 
   private async initialize(): Promise<void> {


### PR DESCRIPTION
# Relates to

W1 of #16443.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync. The exact unrelated local dependency/typecheck blockers are recorded below.
- [x] A reviewer can confirm the change from the focused automated evidence below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync. Local workspace dependency blockers are documented under **Known gaps / failures**.

# Risks

Low to medium. The integration is default OFF behind `ELIZA_ORCHESTRATOR_LANE_PLANNER`. When disabled, `TASKS create` immediately uses the unchanged legacy path. When enabled, only create requests with explicit, mutually exclusive scoped subtasks become concurrent lane task runs. Planning and collision-discovery failures degrade to the legacy path before execution starts.

# Background

## What does this PR do?

Adds W1's `LanePlannerService` to `plugin-agent-orchestrator`:

- pure deterministic decomposition and overlap rejection
- structured `LaneSpec` values with scope, forbidden paths, open-PR/sibling collision annotations, routing-compatible difficulty tag, acceptance criteria seed, and initial prompt
- sibling scope unioning into every lane's forbidden paths
- optional defensive `TEXT_SMALL` refinement behind a separate setting
- one minted wave id stamped into ACP session and durable task metadata
- one existing `runCreateLegacy`/Smithers path per lane, launched concurrently
- an injected collision-provider adapter that reuses workspace-service plumbing without adding a GitHub client, task store, or runner
- exact legacy fallback for planner failures and unscoped single-task plans

## What kind of change is this?

Feature, non-breaking and default OFF.

# Documentation changes needed?

No user-facing documentation change is required for this independently landable W1. The setting is exported in code and defaults OFF while the broader #16443 orchestration stack is assembled.

# Testing

## Where should a reviewer start?

- `plugins/plugin-agent-orchestrator/src/services/lane-planner.ts`
- `plugins/plugin-agent-orchestrator/src/actions/tasks.ts`
- `plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts`

## Detailed testing steps

```bash
cd /tmp
bun test /path/to/eliza/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
```

Result after rebase: **14 pass, 0 fail, 57 expectations**.

Covered behaviors include decomposition, overlap/cap rejection, PR collision annotation, difficulty-tag contract, gate OFF/ON, concurrent lane startup, one durable create path per lane, metadata wave stamping, unscoped legacy behavior, planning fallback, content-agent de-duplication, and no legacy replay after execution begins.

```bash
bunx biome check \
  plugins/plugin-agent-orchestrator/src/services/lane-planner.ts \
  plugins/plugin-agent-orchestrator/src/actions/tasks.ts \
  plugins/plugin-agent-orchestrator/src/index.ts \
  plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
```

Result: **Checked 4 files. No fixes applied.**

Codex reviewed the uncommitted patch repeatedly. All reported findings were fixed, including content-agent duplication, unscoped prompt safety, lane-cap truncation, execution replay, concurrent execution, and settled-result type narrowing.

# Evidence Gate

- [x] Before full-page screenshots: N/A - server-only orchestrator service/action change with no UI surface.
- [x] After full-page screenshots: N/A - server-only orchestrator service/action change with no UI surface.
- [x] Walkthrough video: N/A - no frontend or interactive UI flow changed.
- [x] Backend logs: N/A - no configured live orchestrator service exists in this isolated worktree; focused action integration tests exercise the complete changed path.
- [x] Frontend logs: N/A - no frontend code, request, or browser state changed.
- [x] Real-LLM trajectory: N/A - deterministic lane planning is the production default and optional model refinement is separately gated OFF; no live runtime credentials are configured in this isolated worktree.
- [x] Domain artifacts: N/A - no DB schema, memory, scheduled task, wallet, generated binary, audio, or other persistent domain artifact changed.

# Evidence Details

## Real LLM-call trajectory

N/A - optional refinement is defensive and separately disabled by default. Deterministic and malformed/failure behavior is covered by focused tests.

## Backend + frontend logs

N/A - server-only library/action change; no live server or frontend is configured in this worktree.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun install --frozen-lockfile --offline` could not complete because 29 packages were absent from the local Bun cache. No lockfile was changed.
- Package typecheck is blocked by pre-existing/current-worktree dependency issues (`reset-soonest` contract mismatch, missing `fast-redact` declarations, missing `drizzle-orm`, `coding-agent-adapters`, and local `git-workspace-service` declaration resolution). The one changed-code TypeScript issue found by Codex was fixed before commit.
- Root `bun test` can exit with Bun's known `WriteFailed` while emitting forced multi-file coverage. Running the authoritative test file from `/tmp` passes 14/14.

No self-merge requested.
