### PR TITLE
fix(ci): fail closed on broken packaged launchers

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -253,10 +253,15 @@ jobs:
         id: snapcraft
 
       - name: Test snap
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.npm_version }}
         run: |
+          set -euo pipefail
           sudo snap install ${{ steps.snapcraft.outputs.snap }} --dangerous
           snap list elizaos-app
-          elizaos-app --version || echo "Version check completed"
+          node packages/scripts/verify-packaged-cli.mjs \
+            --expected "$EXPECTED_VERSION" \
+            -- elizaos-app
 
       - name: Publish to Snap Store
         if: success() && needs.prepare.outputs.snap_store_ready == 'true'
@@ -330,11 +335,16 @@ jobs:
           cp ../*.deb ../*.changes deb-output/ 2>/dev/null || cp ../*.deb deb-output/
 
       - name: Test .deb package
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.npm_version }}
         run: |
+          set -euo pipefail
           debs=(deb-output/*.deb)
           sudo dpkg -i "${debs[@]}" || sudo apt-get -f install -y
           which elizaos-app
-          elizaos-app --version || echo "Version check completed"
+          node packages/scripts/verify-packaged-cli.mjs \
+            --expected "$EXPECTED_VERSION" \
+            -- elizaos-app
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -445,9 +455,14 @@ jobs:
 
       - name: Test Flatpak
         working-directory: packages/app-core/packaging/flatpak
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.npm_version }}
         run: |
+          set -euo pipefail
           flatpak --user install -y elizaos-app.flatpak
-          flatpak run ai.elizaos.App --version || echo "Version check completed"
+          node ../../../scripts/verify-packaged-cli.mjs \
+            --expected "$EXPECTED_VERSION" \
+            -- flatpak run ai.elizaos.App
 
       - name: Upload Flatpak bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/snap-build-test.yml
+++ b/.github/workflows/snap-build-test.yml
@@ -120,15 +120,14 @@ jobs:
 
       - name: Install and test snap
         run: |
+          set -euo pipefail
           sudo snap install ${{ steps.snapcraft.outputs.snap }} --dangerous
           echo "=== Installed snap ==="
           snap list elizaos-app
-
-          echo "=== Version check ==="
-          elizaos-app --version || echo "Version check completed (exit $?)"
-
-          echo "=== Help check ==="
-          elizaos-app --help 2>&1 | head -20 || echo "Help check completed (exit $?)"
+          EXPECTED_VERSION="$(node -p "require('./package.json').version")"
+          node packages/scripts/verify-packaged-cli.mjs \
+            --expected "$EXPECTED_VERSION" \
+            -- elizaos-app
 
       - name: Upload snap artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/test-flatpak.yml
+++ b/.github/workflows/test-flatpak.yml
@@ -78,9 +78,12 @@ jobs:
       - name: Install and test
         working-directory: packages/app-core/packaging/flatpak
         run: |
+          set -euo pipefail
           flatpak --user install -y elizaos-app.flatpak
-          flatpak run ai.elizaos.App --version || echo "Version check completed"
-          flatpak run ai.elizaos.App --help || echo "Help check completed"
+          EXPECTED_VERSION="$(node -p "require('../../../../package.json').version")"
+          node ../../../scripts/verify-packaged-cli.mjs \
+            --expected "$EXPECTED_VERSION" \
+            -- flatpak run ai.elizaos.App
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/packages/scripts/__tests__/verify-packaged-cli.test.ts
+++ b/packages/scripts/__tests__/verify-packaged-cli.test.ts
@@ -24,6 +24,7 @@ interface LauncherOptions {
   help?: string;
   helpExit?: number;
   requiredPrefix?: string;
+  stderrWarning?: string;
   version?: string;
   versionExit?: number;
 }
@@ -40,11 +41,14 @@ function launcher({
   help = "Usage: eliza [options]\n\nOptions:\n  --help  Show help\n",
   helpExit = 0,
   requiredPrefix,
+  stderrWarning,
   version = "2.0.0",
   versionExit = 0,
 }: LauncherOptions = {}): string {
   return fixture(`
 const args = process.argv.slice(2);
+const stderrWarning = ${stderrWarning === undefined ? "undefined" : JSON.stringify(stderrWarning)};
+if (stderrWarning !== undefined) process.stderr.write(stderrWarning);
 const requiredPrefix = ${requiredPrefix === undefined ? "undefined" : JSON.stringify(requiredPrefix)};
 if (requiredPrefix !== undefined && args.shift() !== requiredPrefix) process.exit(64);
 const flag = args.shift();
@@ -113,6 +117,17 @@ describe("packaged CLI verification", () => {
     expect(() => verify(launcher({ versionExit: 1 }))).toThrow("exited 1");
     expect(() => verify(launcher({ version: "1.9.9" }))).toThrow(
       "version mismatch",
+    );
+  });
+
+  test("compares the version against stdout only, keeping stderr for diagnostics", () => {
+    const stderrWarning =
+      "(node:1) ExperimentalWarning: Type stripping is enabled\n";
+    expect(verify(launcher({ stderrWarning }))).toMatch(
+      /(?:Options|Commands):/,
+    );
+    expect(() => verify(launcher({ stderrWarning, version: "1.9.9" }))).toThrow(
+      /version mismatch.*ExperimentalWarning/s,
     );
   });
 

--- a/packages/scripts/__tests__/verify-packaged-cli.test.ts
+++ b/packages/scripts/__tests__/verify-packaged-cli.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Exercises packaged-launcher verification through real child processes and
+ * locks release workflows to unmasked checks before publication.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  parseArguments,
+  runCommand,
+  verifyPackagedCli,
+} from "../verify-packaged-cli.mjs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const verifierPath = fileURLToPath(
+  new URL("../verify-packaged-cli.mjs", import.meta.url),
+);
+const temporaryDirectories: string[] = [];
+
+interface LauncherOptions {
+  help?: string;
+  helpExit?: number;
+  requiredPrefix?: string;
+  version?: string;
+  versionExit?: number;
+}
+
+function fixture(source: string): string {
+  const directory = mkdtempSync(join(tmpdir(), "eliza-packaged-cli-"));
+  temporaryDirectories.push(directory);
+  const executable = join(directory, "launcher.mjs");
+  writeFileSync(executable, source);
+  return executable;
+}
+
+function launcher({
+  help = "Usage: eliza [options]\n\nOptions:\n  --help  Show help\n",
+  helpExit = 0,
+  requiredPrefix,
+  version = "2.0.0",
+  versionExit = 0,
+}: LauncherOptions = {}): string {
+  return fixture(`
+const args = process.argv.slice(2);
+const requiredPrefix = ${requiredPrefix === undefined ? "undefined" : JSON.stringify(requiredPrefix)};
+if (requiredPrefix !== undefined && args.shift() !== requiredPrefix) process.exit(64);
+const flag = args.shift();
+if (args.length > 0) process.exit(64);
+if (flag === "--version") {
+  process.stdout.write(${JSON.stringify(`${version}\n`)});
+  process.exit(${versionExit});
+}
+if (flag === "--help") {
+  process.stdout.write(${JSON.stringify(help)});
+  process.exit(${helpExit});
+}
+process.exit(64);
+`);
+}
+
+function verify(
+  executable: string,
+  {
+    commandArgs = [],
+    expectedVersion = "2.0.0",
+    timeoutMs = 2_000,
+  }: {
+    commandArgs?: string[];
+    expectedVersion?: string;
+    timeoutMs?: number;
+  } = {},
+): string {
+  return verifyPackagedCli(
+    process.execPath,
+    [executable, ...commandArgs],
+    expectedVersion,
+    { timeoutMs },
+  );
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("packaged CLI verification", () => {
+  test.each([
+    ["one-line", "Usage: eliza [options]\n\nOptions:\n  --help  Show help\n"],
+    [
+      "multiline",
+      "Usage:\n  eliza [options]\n\nCommands:\n  serve  Start API\n",
+    ],
+  ])("accepts %s usage with the exact version and populated help", (_kind, help) => {
+    expect(verify(launcher({ help }))).toMatch(/(?:Options|Commands):/);
+  });
+
+  test("rejects a command that cannot start", () => {
+    const directory = mkdtempSync(join(tmpdir(), "eliza-missing-launcher-"));
+    temporaryDirectories.push(directory);
+
+    expect(() =>
+      verifyPackagedCli(join(directory, "missing"), [], "2.0.0", {
+        timeoutMs: 500,
+      }),
+    ).toThrow("Could not start");
+  });
+
+  test("rejects a missing runtime dependency and the wrong version", () => {
+    expect(() => verify(launcher({ versionExit: 1 }))).toThrow("exited 1");
+    expect(() => verify(launcher({ version: "1.9.9" }))).toThrow(
+      "version mismatch",
+    );
+  });
+
+  test("rejects failed or structurally empty help", () => {
+    expect(() => verify(launcher({ helpExit: 2 }))).toThrow("exited 2");
+    for (const help of [
+      "installed\n",
+      "Usage:\n",
+      "Usage: eliza\n\nOptions:\n",
+    ]) {
+      expect(() => verify(launcher({ help }))).toThrow(
+        "usable Usage and Commands/Options sections",
+      );
+    }
+  });
+
+  test("hard-kills a launcher that never returns", () => {
+    const executable = fixture("setInterval(() => {}, 60_000);\n");
+    const startedAt = Date.now();
+
+    expect(() =>
+      runCommand(process.execPath, [executable, "--version"], {
+        timeoutMs: 100,
+      }),
+    ).toThrow("timed out after 100ms");
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  test("exercises wrapper arguments through the command-line boundary", () => {
+    const executable = launcher({ requiredPrefix: "wrapped" });
+    const argv = [
+      "--expected",
+      "2.0.0",
+      "--",
+      process.execPath,
+      executable,
+      "wrapped",
+    ];
+
+    expect(parseArguments(argv)).toEqual({
+      command: process.execPath,
+      commandArgs: [executable, "wrapped"],
+      expectedVersion: "2.0.0",
+    });
+
+    const success = spawnSync(process.execPath, [verifierPath, ...argv], {
+      encoding: "utf8",
+    });
+    expect(success.status).toBe(0);
+    expect(success.stdout).toContain("Verified packaged CLI 2.0.0");
+
+    const failure = spawnSync(
+      process.execPath,
+      [
+        verifierPath,
+        "--expected",
+        "9.9.9",
+        "--",
+        process.execPath,
+        executable,
+        "wrapped",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(failure.status).toBe(1);
+    expect(failure.stderr).toContain("version mismatch");
+  });
+
+  test("rejects malformed verifier arguments and timeouts", () => {
+    expect(() => parseArguments([])).toThrow("before the packaged command");
+    expect(() => parseArguments(["--", "command"])).toThrow(
+      "non-empty --expected",
+    );
+    expect(() => parseArguments(["--expected", "2.0.0", "--"])).toThrow(
+      "packaged command",
+    );
+    expect(() =>
+      parseArguments(["--unexpected", "value", "--", "command"]),
+    ).toThrow("Unknown verifier argument");
+    expect(() =>
+      parseArguments([
+        "--expected",
+        "2.0.0",
+        "--expected",
+        "2.0.1",
+        "--",
+        "command",
+      ]),
+    ).toThrow("only be provided once");
+    expect(() => runCommand(process.execPath, [], { timeoutMs: 0 })).toThrow(
+      "positive integer",
+    );
+  });
+});
+
+interface WorkflowStep {
+  "continue-on-error"?: boolean | string;
+  env?: Record<string, string>;
+  name?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function workflow(path: string): Workflow {
+  return Bun.YAML.parse(
+    readFileSync(new URL(path, repoRoot), "utf8"),
+  ) as Workflow;
+}
+
+function workflowStep(
+  path: string,
+  job: string,
+  stepName: string,
+): WorkflowStep {
+  const step = workflow(path).jobs?.[job]?.steps?.find(
+    (candidate) => candidate.name === stepName,
+  );
+  if (!step) {
+    throw new Error(`Missing ${path} ${job} step ${stepName}`);
+  }
+  return step;
+}
+
+function stepIndex(path: string, job: string, stepName: string): number {
+  const index = workflow(path).jobs?.[job]?.steps?.findIndex(
+    (candidate) => candidate.name === stepName,
+  );
+  if (index === undefined || index < 0) {
+    throw new Error(`Missing ${path} ${job} step ${stepName}`);
+  }
+  return index;
+}
+
+function expectFailClosedSmoke(
+  path: string,
+  job: string,
+  stepName: string,
+  terminalCommand: RegExp,
+): WorkflowStep {
+  const step = workflowStep(path, job, stepName);
+  if (!step.run) {
+    throw new Error(`Missing run body for ${path} ${job} step ${stepName}`);
+  }
+
+  expect(step.run).toContain("set -euo pipefail");
+  expect(step.run).toContain("verify-packaged-cli.mjs");
+  expect(step.run.trimEnd()).toMatch(terminalCommand);
+  expect(step["continue-on-error"]).toBeUndefined();
+  return step;
+}
+
+function expectStepBefore(
+  path: string,
+  job: string,
+  first: string,
+  second: string,
+): void {
+  expect(stepIndex(path, job, first)).toBeLessThan(
+    stepIndex(path, job, second),
+  );
+}
+
+describe("package workflows", () => {
+  test("Snap and Flatpak validation use terminal fail-closed checks", () => {
+    const snap = expectFailClosedSmoke(
+      ".github/workflows/snap-build-test.yml",
+      "build-snap",
+      "Install and test snap",
+      /-- elizaos-app$/,
+    );
+    const flatpak = expectFailClosedSmoke(
+      ".github/workflows/test-flatpak.yml",
+      "build",
+      "Install and test",
+      /-- flatpak run ai\.elizaos\.App$/,
+    );
+
+    expect(snap.run).toContain("require('./package.json').version");
+    expect(flatpak.run).toContain(
+      "require('../../../../package.json').version",
+    );
+  });
+
+  test("aggregate publish jobs verify installed launchers before publishing", () => {
+    const path = ".github/workflows/publish-packages.yml";
+    const checks = [
+      {
+        job: "publish-snap",
+        publication: "Publish to Snap Store",
+        smoke: "Test snap",
+        terminalCommand: /-- elizaos-app$/,
+      },
+      {
+        job: "build-deb",
+        publication: "Attach .deb to GitHub Release",
+        smoke: "Test .deb package",
+        terminalCommand: /-- elizaos-app$/,
+      },
+      {
+        job: "build-flatpak",
+        publication: "Attach Flatpak to GitHub Release",
+        smoke: "Test Flatpak",
+        terminalCommand: /-- flatpak run ai\.elizaos\.App$/,
+      },
+    ];
+
+    for (const { job, publication, smoke, terminalCommand } of checks) {
+      const step = expectFailClosedSmoke(path, job, smoke, terminalCommand);
+      expect(step.env?.EXPECTED_VERSION).toBe(
+        "$" + "{{ needs.prepare.outputs.npm_version }}",
+      );
+      expectStepBefore(path, job, smoke, publication);
+    }
+  });
+});

--- a/packages/scripts/verify-packaged-cli.mjs
+++ b/packages/scripts/verify-packaged-cli.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Verifies that an installed elizaOS launcher executes, reports the exact
+ * packaged release, and exposes usable Commander help. Package workflows run
+ * this process-level check before accepting or publishing an artifact.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const COMMAND_TIMEOUT_MS = 30_000;
+const OUTPUT_LIMIT_BYTES = 4 * 1024 * 1024;
+
+export function parseArguments(argv) {
+  const separator = argv.indexOf("--");
+  if (separator < 0) {
+    throw new Error("Expected `--` before the packaged command");
+  }
+
+  const verifierArgs = argv.slice(0, separator);
+  let expectedVersion;
+  for (let index = 0; index < verifierArgs.length; index += 2) {
+    const argument = verifierArgs[index];
+    const value = verifierArgs[index + 1];
+    if (argument !== "--expected") {
+      throw new Error(`Unknown verifier argument: ${String(argument)}`);
+    }
+    if (expectedVersion !== undefined) {
+      throw new Error("--expected may only be provided once");
+    }
+    if (!value?.trim()) {
+      throw new Error("Expected a non-empty --expected version");
+    }
+    expectedVersion = value.trim();
+  }
+
+  const command = argv[separator + 1];
+  if (!expectedVersion) {
+    throw new Error("Expected a non-empty --expected version");
+  }
+  if (!command) {
+    throw new Error("Expected a packaged command after `--`");
+  }
+
+  return {
+    command,
+    commandArgs: argv.slice(separator + 2),
+    expectedVersion,
+  };
+}
+
+export function runCommand(
+  command,
+  args,
+  { timeoutMs = COMMAND_TIMEOUT_MS } = {},
+) {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("Command timeout must be a positive integer");
+  }
+
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+    killSignal: "SIGKILL",
+    maxBuffer: OUTPUT_LIMIT_BYTES,
+    timeout: timeoutMs,
+  });
+
+  if (result.error) {
+    if (result.error.code === "ETIMEDOUT") {
+      throw new Error(
+        `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+        { cause: result.error },
+      );
+    }
+    throw new Error(`Could not start ${command}: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+
+  const output = `${result.stdout}${result.stderr}`;
+  if (result.status !== 0) {
+    const outcome = result.signal
+      ? `terminated by ${result.signal}`
+      : `exited ${String(result.status)}`;
+    throw new Error(`${command} ${args.join(" ")} ${outcome}\n${output}`);
+  }
+
+  return output.trim();
+}
+
+export function verifyPackagedCli(
+  command,
+  commandArgs,
+  expectedVersion,
+  options,
+) {
+  const versionOutput = runCommand(
+    command,
+    [...commandArgs, "--version"],
+    options,
+  );
+  if (versionOutput !== expectedVersion) {
+    throw new Error(
+      `Packaged CLI version mismatch: expected ${expectedVersion}, received ${JSON.stringify(versionOutput)}`,
+    );
+  }
+
+  const helpOutput = runCommand(
+    command,
+    [...commandArgs, "--help"],
+    options,
+  ).replaceAll("\r\n", "\n");
+  const hasUsage = /(^|\n)Usage:\s*(?:\S[^\n]*|\n[ \t]+\S)/m.test(helpOutput);
+  const hasPopulatedSection =
+    /(^|\n)(?:Commands|Options):[ \t]*\n[ \t]+\S/m.test(helpOutput);
+  if (!hasUsage || !hasPopulatedSection) {
+    throw new Error(
+      "Packaged CLI help did not contain usable Usage and Commands/Options sections",
+    );
+  }
+
+  return helpOutput;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const { command, commandArgs, expectedVersion } = parseArguments(argv);
+  const helpOutput = verifyPackagedCli(command, commandArgs, expectedVersion);
+  process.stdout.write(
+    `Verified packaged CLI ${expectedVersion}\n${helpOutput}\n`,
+  );
+}
+
+const isMain = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+if (isMain) main();

--- a/packages/scripts/verify-packaged-cli.mjs
+++ b/packages/scripts/verify-packaged-cli.mjs
@@ -86,7 +86,9 @@ export function runCommand(
     throw new Error(`${command} ${args.join(" ")} ${outcome}\n${output}`);
   }
 
-  return output.trim();
+  // `stdout` is the verified contract value; the combined `output` exists
+  // solely for diagnostics, so stderr warnings never corrupt a comparison.
+  return { output: output.trim(), stdout: result.stdout.trim() };
 }
 
 export function verifyPackagedCli(
@@ -95,14 +97,18 @@ export function verifyPackagedCli(
   expectedVersion,
   options,
 ) {
-  const versionOutput = runCommand(
+  const versionResult = runCommand(
     command,
     [...commandArgs, "--version"],
     options,
   );
-  if (versionOutput !== expectedVersion) {
+  if (versionResult.stdout !== expectedVersion) {
+    const diagnostics =
+      versionResult.output === versionResult.stdout
+        ? ""
+        : `\nCombined output:\n${versionResult.output}`;
     throw new Error(
-      `Packaged CLI version mismatch: expected ${expectedVersion}, received ${JSON.stringify(versionOutput)}`,
+      `Packaged CLI version mismatch: expected ${expectedVersion}, received ${JSON.stringify(versionResult.stdout)}${diagnostics}`,
     );
   }
 
@@ -110,7 +116,7 @@ export function verifyPackagedCli(
     command,
     [...commandArgs, "--help"],
     options,
-  ).replaceAll("\r\n", "\n");
+  ).stdout.replaceAll("\r\n", "\n");
   const hasUsage = /(^|\n)Usage:\s*(?:\S[^\n]*|\n[ \t]+\S)/m.test(helpOutput);
   const hasPopulatedSection =
     /(^|\n)(?:Commands|Options):[ \t]*\n[ \t]+\S/m.test(helpOutput);


### PR DESCRIPTION
Fixes #16268

Replaces closed composite PR #16269 with only the package-launcher verification contract. Store screenshot and unrelated packaging metadata changes are deliberately excluded.

## Problem

Five Snap, Debian, and Flatpak smoke steps converted failed `--version` or `--help` commands into green diagnostics. A package with a missing runtime dependency, wrong version, empty help, or a hanging launcher could therefore proceed to publication.

## Change

- Add one bounded process verifier for exact version plus populated Commander help.
- Use it in all Snap, Debian, and Flatpak smoke steps before publication or artifact attachment.
- Hard-kill commands that exceed the timeout and cap captured output.
- Compare `--version` against trimmed stdout only, so a launcher emitting a harmless stderr warning next to the correct version is not failed spuriously; the combined stdout+stderr is kept solely for diagnostics in the mismatch error (reviewer-identified fix, commit 19e1f8f).
- Cover startup failure, dependency failure, version mismatch, malformed help, hangs, wrapper arguments, CLI exit behavior, workflow masking, and publication order with real Node child processes and parsed workflow YAML.

## Exact-head verification

- 11 tests, 52 assertions (adds the stdout-vs-stderr regression case; it fails against the pre-fix verifier).
- Biome and Node syntax check on the two changed files: passed at `19e1f8f2`.
- Changed-source line coverage at `42e6c8fc`: 94.64%; error-policy, script, test-integrity, test-realness audits and `git diff --check`: passed at `42e6c8fc`.

## Exact-head installed-package runs

Both workflows were dispatched against `42e6c8fc77989ccae3ae885a5f2519ecd91ae355` and manually reviewed.

- [Snap run 29467460045](https://github.com/elizaOS/eliza/actions/runs/29467460045) built and installed `elizaos-app 2.0.4` on amd64 and arm64. The verifier genuinely ran `elizaos-app --version` on both installed snaps and failed closed on `ERR_MODULE_NOT_FOUND` for `zod` imported by `packages/shared/src/config/config-catalog.ts`: [amd64 transcript](https://github.com/elizaOS/eliza/actions/runs/29467460045/job/87523533197#step:10:1), [arm64 transcript](https://github.com/elizaOS/eliza/actions/runs/29467460045/job/87523533203#step:10:1). Help validation was not reached because version startup failed. Both artifact uploads were skipped; the run has zero artifacts.
- [Flatpak run 29467460934](https://github.com/elizaOS/eliza/actions/runs/29467460934) failed before build or install because all three AppStream screenshot URLs returned 404: [validator transcript](https://github.com/elizaOS/eliza/actions/runs/29467460934/job/87523531150#step:4:1). Bundle creation, installation, launcher verification, and artifact upload were skipped. The metadata defect is tracked in #16465.

These are negative installed-package results: the Snap verifier wiring is proven to fail closed on a real broken runtime, but neither a usable Snap launcher nor any Flatpak launcher is proven.

## Red Snap/Flatpak lanes are the gate working, not PR defects

The failing Snap builds on this PR are the fail-closed gate doing exactly what it was built to do: develop's packaged runtime closure is genuinely broken (`ERR_MODULE_NOT_FOUND` for `zod` in the installed snap), which is tracked in #16446 and #16755. Do not read those red lanes as defects introduced by this PR — before this PR the same broken package would have passed green and shipped.

## Draft blocker

This stays draft until #16446/#16755 repair the packaged runtime closure, #16465 repairs Flatpak metadata, and fresh exact-head Snap and Flatpak dispatches complete real installation plus version/help verification. No package artifacts were uploaded by the failed runs.

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - workflow and command-line verification only; no rendered application source changes.`

<!-- evidence-row:after-screenshots -->
`N/A - workflow and command-line verification only; no rendered application source changes.`

<!-- evidence-row:walkthrough-video -->
`N/A - no interactive UI flow; installed-package transcripts are the executable walkthrough.`

<!-- evidence-row:backend-logs -->
`N/A - no backend service path changes.`

<!-- evidence-row:frontend-logs -->
`N/A - no frontend runtime or network path changes.`

<!-- evidence-row:llm-trajectory -->
`N/A - no action, provider, prompt, planner, or model behavior changes.`

<!-- evidence-row:domain-artifacts -->
[Snap installed-launcher transcripts](https://github.com/elizaOS/eliza/actions/runs/29467460045) and [Flatpak pre-install transcript](https://github.com/elizaOS/eliza/actions/runs/29467460934), manually reviewed as negative evidence. Both runs failed and uploaded zero artifacts; this does not prove a usable packaged launcher.
