### PR TITLE
fix(voice): opt Deepgram Flux out of model improvement

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/provider-socket-factory.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/provider-socket-factory.test.ts
@@ -116,7 +116,7 @@ describe("createWorkerDeepgramFluxFactory", () => {
     stubFetch();
     const factory = createWorkerDeepgramFluxFactory();
     const _socket = factory({
-      url: "wss://api.deepgram.com/v1/listen?encoding=linear16&channels=1&model=flux",
+      url: "wss://api.deepgram.com/v1/listen?encoding=linear16&channels=1&model=flux&mip_opt_out=true",
       headers: { Authorization: "Token dg" },
     }) as unknown as {
       addEventListener(t: string, l: (e: unknown) => void): void;
@@ -130,6 +130,7 @@ describe("createWorkerDeepgramFluxFactory", () => {
     // channels stripped; the mono-inferring params preserved.
     expect(upgrade.httpUrl).not.toContain("channels=");
     expect(upgrade.httpUrl).toContain("encoding=linear16");
+    expect(upgrade.httpUrl).toContain("mip_opt_out=true");
     expect(upgrade.headers.Authorization).toBe("Token dg");
     expect(upgrade.headers.Upgrade).toBe("websocket");
   });

--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
@@ -126,6 +126,7 @@ describe("Deepgram Flux realtime adapter", () => {
     expect(url.searchParams.get("eager_eot_threshold")).toBe("0.4");
     expect(url.searchParams.get("eot_threshold")).toBe("0.9");
     expect(url.searchParams.get("eot_timeout_ms")).toBe("1500");
+    expect(url.searchParams.get("mip_opt_out")).toBe("true");
   });
 
   it("passes the server-side API key by Authorization header and never in the query URL", () => {
@@ -134,6 +135,9 @@ describe("Deepgram Flux realtime adapter", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0].headers.Authorization).toBe("Token dg-secret");
     expect(requests[0].url).not.toContain("dg-secret");
+    expect(new URL(requests[0].url).searchParams.get("mip_opt_out")).toBe(
+      "true",
+    );
     expect(socket.binaryType).toBe("arraybuffer");
   });
 

--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
@@ -4,7 +4,8 @@
  * module owns only Flux connection setup, chunk validation, protocol event
  * mapping, and deterministic cleanup. Deepgram's semantic turn detector is the
  * only turn boundary source here, so callers must not layer local VAD decisions
- * onto these events.
+ * onto these events. Every provider URL opts out of Deepgram's Model Improvement
+ * Partnership; the privacy invariant is intentionally not runtime-configurable.
  */
 
 export const DEEPGRAM_FLUX_LISTEN_URL = "wss://api.deepgram.com/v2/listen";
@@ -19,6 +20,7 @@ const DEFAULT_EAGER_EOT_THRESHOLD = 0.35;
 const DEFAULT_EOT_THRESHOLD = 0.8;
 const DEFAULT_EOT_TIMEOUT_MS = 5_000;
 const DEFAULT_CLOSE_CODE = 1000;
+const DEFAULT_MIP_OPT_OUT = true;
 
 export type DeepgramFluxMetricName =
   | "deepgram_flux_connected"
@@ -53,6 +55,7 @@ export type DeepgramFluxConfig = {
   eagerEotThreshold: number;
   eotThreshold: number;
   eotTimeoutMs: number;
+  mipOptOut: true;
 };
 
 export type DeepgramFluxTransportRequest = {
@@ -223,6 +226,7 @@ export function resolveDeepgramFluxConfig(
       500,
       10_000,
     ),
+    mipOptOut: DEFAULT_MIP_OPT_OUT,
   };
 }
 
@@ -235,6 +239,7 @@ export function buildDeepgramFluxListenUrl(config: DeepgramFluxConfig): string {
   url.searchParams.set("eager_eot_threshold", String(config.eagerEotThreshold));
   url.searchParams.set("eot_threshold", String(config.eotThreshold));
   url.searchParams.set("eot_timeout_ms", String(config.eotTimeoutMs));
+  url.searchParams.set("mip_opt_out", String(config.mipOptOut));
   return url.toString();
 }
 


### PR DESCRIPTION
Refs #16431. The issue remains open for provider-account, retention, and live-request evidence.

## Problem

Production Deepgram Flux WebSocket URLs did not set `mip_opt_out=true`. Deepgram documents that flag as the request-level control excluding data from its Model Improvement Partnership, and the Flux API supports it. The stale ambient aggregate depended on this privacy fix without actually containing it.

## Change

- Add `mip_opt_out=true` to every Deepgram Flux listen URL.
- Make the privacy property non-configurable at runtime, so neither client input nor an accidental server option can disable it.
- Prove the Cloudflare Worker WebSocket normalization boundary preserves the parameter while stripping only `channels`.
- Extend the production adapter test to inspect the final request URL and confirm the API key remains header-only.

Primary documentation: [Deepgram Model Improvement Partnership](https://developers.deepgram.com/docs/the-deepgram-model-improvement-partnership-program) and [Flux listen API](https://developers.deepgram.com/reference/speech-to-text/listen-flux?explorer=true).

## Verification

- Focused Flux adapter + Worker socket suites — 21 passed, 75 assertions.
- Combined changed-boundary coverage — 97.28% lines; Worker socket factory 100%, Flux adapter 94.56%.
- Biome on all three changed files — passed.
- Error-policy ratchet and `git diff --check` — passed.
- Cloud API package typecheck remains blocked by unchanged current-`develop` errors: Stripe API-version literal mismatch, duplicate Drizzle package identities, and missing generated i18n keyword modules. None references a changed file.

## Required external evidence before merge

- Redacted real Flux connection request proving `mip_opt_out=true` reached Deepgram.
- Deepgram account/DPA retention attestation.
- Cartesia training opt-out / zero-data-retention attestation for the other voice provider boundary.

This PR remains draft until those external controls are reviewed. It intentionally does not carry the stale ambient branch's session backend, UI, or harness aggregate.

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - server-side provider URL policy has no rendered UI surface.`

<!-- evidence-row:after-screenshots -->
`N/A - server-side provider URL policy has no rendered UI surface.`

<!-- evidence-row:walkthrough-video -->
`N/A - the relevant proof is the real provider request and account policy evidence listed above.`

<!-- evidence-row:backend-logs -->
`N/A - unavailable while this PR is draft; it remains blocked until a redacted exact-head real Deepgram Flux request proves mip_opt_out=true at the provider boundary.`

<!-- evidence-row:frontend-logs -->
`N/A - no frontend code or browser network path changes.`

<!-- evidence-row:llm-trajectory -->
`N/A - STT transport policy only; no LLM prompt, action, provider-model, or response behavior changes.`

<!-- evidence-row:domain-artifacts -->
`N/A - unavailable while this PR is draft; Deepgram DPA/retention and Cartesia training/ZDR account attestations are required before readiness.`

## Risk

Low. The change adds one documented query parameter and pins it through the Worker boundary. There is no runtime override or client-controlled configuration path.
