### PR TITLE
feat(app-core): add public account pool status

### DIFF
--- a/packages/app-core/src/api/account-pool-status-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { getPublicAccountPoolStatus } = vi.hoisted(() => ({
   getPublicAccountPoolStatus: vi.fn(),
 }));
-vi.mock("../services/account-pool-status", () => ({
+vi.mock("../services/account-pool-status.js", () => ({
   getPublicAccountPoolStatus,
 }));
 

--- a/packages/app-core/src/api/account-pool-status-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import type http from "node:http";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getPublicAccountPoolStatus } = vi.hoisted(() => ({
   getPublicAccountPoolStatus: vi.fn(),
@@ -29,9 +29,38 @@ function response(): http.ServerResponse & {
   return res;
 }
 
-beforeEach(() => vi.clearAllMocks());
+const previousPublicStatus =
+  process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED = "1";
+});
+
+afterEach(() => {
+  if (previousPublicStatus === undefined) {
+    delete process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED;
+  } else {
+    process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED = previousPublicStatus;
+  }
+});
 
 describe("GET /api/pool/status", () => {
+  it("returns 404 unless public status is explicitly enabled", async () => {
+    delete process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED;
+    const res = response();
+    await expect(
+      handleAccountPoolStatusRoute(
+        {} as http.IncomingMessage,
+        res,
+        "GET",
+        "/api/pool/status",
+      ),
+    ).resolves.toBe(true);
+    expect(res.statusCode).toBe(404);
+    expect(getPublicAccountPoolStatus).not.toHaveBeenCalled();
+  });
+
   it("serves the public-safe service result", async () => {
     getPublicAccountPoolStatus.mockResolvedValue({ pool: { accounts: 2 } });
     const res = response();

--- a/packages/app-core/src/api/account-pool-status-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.test.ts
@@ -1,0 +1,71 @@
+import { EventEmitter } from "node:events";
+import type http from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getPublicAccountPoolStatus } = vi.hoisted(() => ({
+  getPublicAccountPoolStatus: vi.fn(),
+}));
+vi.mock("../services/account-pool-status", () => ({
+  getPublicAccountPoolStatus,
+}));
+
+import { handleAccountPoolStatusRoute } from "./account-pool-status-routes";
+
+function response(): http.ServerResponse & {
+  body: string;
+  statusCode: number;
+} {
+  const res = new EventEmitter() as http.ServerResponse & {
+    body: string;
+    statusCode: number;
+  };
+  res.body = "";
+  res.statusCode = 200;
+  res.setHeader = vi.fn() as unknown as typeof res.setHeader;
+  res.end = vi.fn((chunk?: string) => {
+    res.body += chunk ?? "";
+    return res;
+  }) as unknown as typeof res.end;
+  return res;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/pool/status", () => {
+  it("serves the public-safe service result", async () => {
+    getPublicAccountPoolStatus.mockResolvedValue({ pool: { accounts: 2 } });
+    const res = response();
+    await expect(
+      handleAccountPoolStatusRoute(
+        {} as http.IncomingMessage,
+        res,
+        "GET",
+        "/api/pool/status",
+      ),
+    ).resolves.toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ pool: { accounts: 2 } });
+  });
+
+  it("rejects non-GET methods and returns 503 with retry-after on refresh failure", async () => {
+    const methodRes = response();
+    await handleAccountPoolStatusRoute(
+      {} as http.IncomingMessage,
+      methodRes,
+      "POST",
+      "/api/pool/status",
+    );
+    expect(methodRes.statusCode).toBe(405);
+
+    getPublicAccountPoolStatus.mockRejectedValue(new Error("unavailable"));
+    const errorRes = response();
+    await handleAccountPoolStatusRoute(
+      {} as http.IncomingMessage,
+      errorRes,
+      "GET",
+      "/api/pool/status",
+    );
+    expect(errorRes.statusCode).toBe(503);
+    expect(errorRes.setHeader).toHaveBeenCalledWith("retry-after", "60");
+  });
+});

--- a/packages/app-core/src/api/account-pool-status-routes.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.ts
@@ -1,0 +1,40 @@
+/**
+ * Public account-pool status route.
+ *
+ * The route is intentionally read-only and unauthenticated, but all response
+ * fields come from the account-pool status service's allowlisted serializer so
+ * private pool metadata, consumer labels, keys, and exact reset timestamps stay
+ * server-side.
+ */
+import type http from "node:http";
+import {
+  getPublicAccountPoolStatus,
+  type PublicPoolStatus,
+} from "../services/account-pool-status.js";
+import { sendJson, sendJsonError } from "./response.js";
+
+const STATUS_PATH = "/api/pool/status";
+const RETRY_AFTER_SECONDS = 60;
+
+export async function handleAccountPoolStatusRoute(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse,
+  method: string,
+  pathname: string,
+): Promise<boolean> {
+  if (pathname !== STATUS_PATH) return false;
+  if (method !== "GET") {
+    res.setHeader("allow", "GET");
+    sendJsonError(res, 405, "method not allowed");
+    return true;
+  }
+  try {
+    const status: PublicPoolStatus = await getPublicAccountPoolStatus();
+    res.setHeader("cache-control", "public, max-age=60");
+    sendJson(res, 200, status);
+  } catch {
+    res.setHeader("retry-after", String(RETRY_AFTER_SECONDS));
+    sendJsonError(res, 503, "pool status temporarily unavailable");
+  }
+  return true;
+}

--- a/packages/app-core/src/api/account-pool-status-routes.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.ts
@@ -7,6 +7,7 @@
  * server-side.
  */
 import type http from "node:http";
+import { logger } from "@elizaos/core";
 import {
   getPublicAccountPoolStatus,
   type PublicPoolStatus,
@@ -16,6 +17,14 @@ import { sendJson, sendJsonError } from "./response.js";
 const STATUS_PATH = "/api/pool/status";
 const RETRY_AFTER_SECONDS = 60;
 
+function publicPoolStatusEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const value =
+    env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
 export async function handleAccountPoolStatusRoute(
   _req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -23,6 +32,11 @@ export async function handleAccountPoolStatusRoute(
   pathname: string,
 ): Promise<boolean> {
   if (pathname !== STATUS_PATH) return false;
+  if (!publicPoolStatusEnabled()) {
+    res.setHeader("cache-control", "no-store");
+    sendJsonError(res, 404, "not found");
+    return true;
+  }
   if (method !== "GET") {
     res.setHeader("allow", "GET");
     sendJsonError(res, 405, "method not allowed");
@@ -32,7 +46,12 @@ export async function handleAccountPoolStatusRoute(
     const status: PublicPoolStatus = await getPublicAccountPoolStatus();
     res.setHeader("cache-control", "public, max-age=60");
     sendJson(res, 200, status);
-  } catch {
+  } catch (error) {
+    // error-policy:J1 HTTP boundary translation: the public response remains
+    // generic while the server retains an actionable diagnostic.
+    logger.error(
+      `[account-pool-status] refresh failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+    );
     res.setHeader("retry-after", String(RETRY_AFTER_SECONDS));
     sendJsonError(res, 503, "pool status temporarily unavailable");
   }

--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -102,6 +102,12 @@ describe("compat route auth policy table", () => {
       id: "pool.status",
       tier: "public",
     });
+    expect(
+      resolveCompatRouteAuthPolicy("POST", "/api/pool/status"),
+    ).toMatchObject({
+      id: "pool.status",
+      tier: "public",
+    });
   });
 
   it("fails closed for undeclared app-core-managed routes", async () => {
@@ -157,19 +163,21 @@ describe("compat route auth policy table", () => {
     expect(res.status()).toBe(200);
   });
 
-  it("allows public account-pool status without a session", async () => {
-    const req = fakeReq({ method: "GET", pathname: "/api/pool/status" });
-    const res = fakeRes();
+  it("allows public account-pool status methods through to the route handler", async () => {
+    for (const method of ["GET", "POST"]) {
+      const req = fakeReq({ method, pathname: "/api/pool/status" });
+      const res = fakeRes();
 
-    await expect(
-      enforceCompatRouteAuthPolicy(
-        req,
-        res.res,
-        STATE,
-        "GET",
-        "/api/pool/status",
-      ),
-    ).resolves.toBe("allowed");
-    expect(res.status()).toBe(200);
+      await expect(
+        enforceCompatRouteAuthPolicy(
+          req,
+          res.res,
+          STATE,
+          method,
+          "/api/pool/status",
+        ),
+      ).resolves.toBe("allowed");
+      expect(res.status()).toBe(200);
+    }
   });
 });

--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -96,6 +96,12 @@ describe("compat route auth policy table", () => {
       id: "tts.elevenlabs-passthrough",
       tier: "public",
     });
+    expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/pool/status"),
+    ).toMatchObject({
+      id: "pool.status",
+      tier: "public",
+    });
   });
 
   it("fails closed for undeclared app-core-managed routes", async () => {
@@ -146,6 +152,22 @@ describe("compat route auth policy table", () => {
         STATE,
         "GET",
         "/api/i18n/locale",
+      ),
+    ).resolves.toBe("allowed");
+    expect(res.status()).toBe(200);
+  });
+
+  it("allows public account-pool status without a session", async () => {
+    const req = fakeReq({ method: "GET", pathname: "/api/pool/status" });
+    const res = fakeRes();
+
+    await expect(
+      enforceCompatRouteAuthPolicy(
+        req,
+        res.res,
+        STATE,
+        "GET",
+        "/api/pool/status",
       ),
     ).resolves.toBe("allowed");
     expect(res.status()).toBe(200);

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -48,6 +48,15 @@ const publicExact = (
   matcher: { kind: "exact", path },
 });
 
+const publicExactAnyMethod = (
+  id: string,
+  path: string,
+): CompatRouteAuthPolicy => ({
+  id,
+  tier: "public",
+  matcher: { kind: "exact", path },
+});
+
 const sessionExact = (
   id: string,
   method: keyof typeof METHODS,
@@ -113,7 +122,9 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   publicExact("auth.pair", "POST", "/api/auth/pair"),
   publicExact("embed.auth", "POST", "/api/embed/auth"),
   publicExact("tts.elevenlabs-passthrough", "POST", "/api/tts/elevenlabs"),
-  publicExact("pool.status", "GET", "/api/pool/status"),
+  // The handler itself rejects non-GET methods with 405 + Allow. Keep every
+  // method public at the auth gate so unsupported methods can reach it.
+  publicExactAnyMethod("pool.status", "/api/pool/status"),
 
   sessionExact("runtime.mode", "GET", "/api/runtime/mode"),
   sessionExact("cloud.status", "GET", "/api/cloud/status"),

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -113,6 +113,7 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   publicExact("auth.pair", "POST", "/api/auth/pair"),
   publicExact("embed.auth", "POST", "/api/embed/auth"),
   publicExact("tts.elevenlabs-passthrough", "POST", "/api/tts/elevenlabs"),
+  publicExact("pool.status", "GET", "/api/pool/status"),
 
   sessionExact("runtime.mode", "GET", "/api/runtime/mode"),
   sessionExact("cloud.status", "GET", "/api/cloud/status"),
@@ -207,6 +208,7 @@ const COMPAT_MANAGED_PREFIXES = [
   "/api/local-inference/",
   "/api/voice/",
   "/api/plugins",
+  "/api/pool",
   "/api/runtime/",
   "/api/secrets/",
   "/api/sensitive-requests",

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -49,6 +49,7 @@ import {
 // that adds rate limiting, audit logging, and a forced confirmation delay.
 import { type AgentRuntime, logger, resolveStateDir } from "@elizaos/core";
 import { resolveLinkedAccountsInConfig } from "@elizaos/shared/contracts/first-run-options";
+import { handleAccountPoolStatusRoute } from "./account-pool-status-routes";
 import {
   ensureCompatSensitiveRouteAuthorized,
   ensureRouteAuthorized,
@@ -830,6 +831,12 @@ const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
     id: "sensitive-request",
     handler: ({ req, res, state }) =>
       handleSensitiveRequestRoutes(req, res, state),
+  },
+  {
+    // Public-safe anonymous capacity status for the first-class account pool.
+    id: "account-pool-status",
+    handler: ({ req, res, method, url }) =>
+      handleAccountPoolStatusRoute(req, res, method, url.pathname),
   },
   {
     id: "credential-tunnel",

--- a/packages/app-core/src/services/account-pool-consumer-metering.test.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.test.ts
@@ -15,6 +15,7 @@ import {
   createAccountPoolConsumerKey,
   createAnthropicSseUsageMeter,
   extractAnthropicUsageFromJson,
+  getAccountPoolConsumerUsageSummary,
   queryAccountPoolConsumerUsage,
   recordAccountPoolConsumerUsage,
 } from "./account-pool-consumer-metering.js";
@@ -314,5 +315,13 @@ describe("quota and totals", () => {
     expect(usage.totals.requests).toBe(50);
     expect(usage.totals.tokens).toBe(150);
     expect(usage.records).toHaveLength(50);
+
+    const summary = await getAccountPoolConsumerUsageSummary();
+    expect(summary.totals).toMatchObject({ requests: 50, tokens: 150 });
+    expect(summary.byConsumer[created.consumer.id]).toMatchObject({
+      requests: 50,
+      tokens: 150,
+    });
+    expect(summary.records).toEqual([]);
   });
 });

--- a/packages/app-core/src/services/account-pool-consumer-metering.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.ts
@@ -1040,6 +1040,23 @@ export function createAnthropicSseUsageMeter(
   return Object.assign(stream, { finalizeUsage });
 }
 
+export async function getAccountPoolConsumerUsageSummary(): Promise<AccountPoolConsumerUsageBreakdown> {
+  const stored = readTotalsFile();
+  return {
+    totals: { ...stored.totals },
+    byDay: Object.fromEntries(
+      Object.entries(stored.byDay).map(([day, bucket]) => [day, { ...bucket }]),
+    ),
+    byConsumer: Object.fromEntries(
+      Object.entries(stored.byConsumer).map(([id, bucket]) => [
+        id,
+        { ...bucket },
+      ]),
+    ),
+    records: [],
+  };
+}
+
 export async function queryAccountPoolConsumerUsage(
   query: AccountPoolConsumerUsageQuery = {},
 ): Promise<AccountPoolConsumerUsageBreakdown> {

--- a/packages/app-core/src/services/account-pool-status.test.ts
+++ b/packages/app-core/src/services/account-pool-status.test.ts
@@ -143,10 +143,16 @@ describe("public account-pool status", () => {
       ...unknownBase,
       id: "unknown-account-id",
     };
+    const unavailable: LinkedAccountConfig = {
+      ...fixtureAccount(now, 0),
+      id: "unavailable-account-id",
+      health: "needs-reauth",
+    };
     const pool = new AccountPool({
       readAccounts: () => ({
         "anthropic-subscription:private-account-id": known,
         "anthropic-subscription:unknown-account-id": unknown,
+        "anthropic-subscription:unavailable-account-id": unavailable,
       }),
       writeAccount: async () => {},
     });

--- a/packages/app-core/src/services/account-pool-status.test.ts
+++ b/packages/app-core/src/services/account-pool-status.test.ts
@@ -125,6 +125,36 @@ describe("public account-pool status", () => {
     walk(status);
   });
 
+  it("excludes accounts with unknown usage from capacity denominators", async () => {
+    const now = Date.UTC(2026, 6, 16, 4);
+    const dir = mkdtempSync(path.join(tmpdir(), "eliza-pool-status-"));
+    cleanup.push(dir);
+    const known = fixtureAccount(now, 25);
+    const { usage: _usage, ...unknownBase } = fixtureAccount(now, 0);
+    const unknown: LinkedAccountConfig = {
+      ...unknownBase,
+      id: "unknown-account-id",
+    };
+    const pool = new AccountPool({
+      readAccounts: () => ({
+        "anthropic-subscription:private-account-id": known,
+        "anthropic-subscription:unknown-account-id": unknown,
+      }),
+      writeAccount: async () => {},
+    });
+    __resetAccountPoolStatusForTests({
+      pool,
+      now: () => now,
+      stateDir: () => dir,
+      queryConsumerUsage: async () => usageBreakdown("2026-07-16"),
+    });
+
+    const status = await getPublicAccountPoolStatus();
+    expect(status.pool.accounts).toBe(2);
+    expect(status.fable).toMatchObject({ leftPct: 75, ofPct: 100 });
+    expect(status.allModels).toEqual({ leftPct: 75, ofPct: 100 });
+  });
+
   it("persists snapshots and projects burn only after a same-window sample", async () => {
     let now = Date.UTC(2026, 6, 16, 4);
     let weeklyPct = 20;

--- a/packages/app-core/src/services/account-pool-status.test.ts
+++ b/packages/app-core/src/services/account-pool-status.test.ts
@@ -1,0 +1,172 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { LinkedAccountConfig } from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { AccountPool } from "./account-pool";
+import type { AccountPoolConsumerUsageBreakdown } from "./account-pool-consumer-metering";
+import {
+  __resetAccountPoolStatusForTests,
+  getPublicAccountPoolStatus,
+} from "./account-pool-status";
+
+const totals = {
+  requests: 4,
+  tokens: 120,
+  input_tokens: 80,
+  output_tokens: 40,
+  cache_read_input_tokens: 5,
+  cache_creation_input_tokens: 2,
+  errors: 1,
+  latencyMs: 900,
+};
+
+function usageBreakdown(day: string): AccountPoolConsumerUsageBreakdown {
+  return {
+    totals,
+    byDay: { [day]: totals },
+    byConsumer: { "consumer-private-id": totals },
+    records: [],
+  };
+}
+
+function fixtureAccount(
+  now: number,
+  weeklyPct: number,
+  resetAt = now + 48 * 60 * 60_000,
+): LinkedAccountConfig {
+  return {
+    id: "private-account-id",
+    providerId: "anthropic-subscription",
+    label: "owner-private@example.test",
+    source: "oauth",
+    enabled: true,
+    priority: 77,
+    createdAt: 1,
+    health: "ok",
+    usage: {
+      sessionPct: 12,
+      weeklyPct,
+      refreshedAt: now,
+      sessionResetsAt: now + 5 * 60 * 60_000,
+      weeklyResetsAt: resetAt,
+    } as unknown as LinkedAccountConfig["usage"],
+  };
+}
+
+const cleanup: string[] = [];
+afterEach(() => {
+  __resetAccountPoolStatusForTests();
+  for (const dir of cleanup.splice(0))
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("public account-pool status", () => {
+  it("returns an allowlisted anonymous shape and no private pool or consumer data", async () => {
+    const now = Date.UTC(2026, 6, 16, 4);
+    const dir = mkdtempSync(path.join(tmpdir(), "eliza-pool-status-"));
+    cleanup.push(dir);
+    const account = fixtureAccount(now, 25);
+    const pool = new AccountPool({
+      readAccounts: () => ({
+        "anthropic-subscription:private-account-id": account,
+      }),
+      writeAccount: async () => {},
+    });
+    __resetAccountPoolStatusForTests({
+      pool,
+      now: () => now,
+      stateDir: () => dir,
+      queryConsumerUsage: async () => usageBreakdown("2026-07-16"),
+    });
+
+    const status = await getPublicAccountPoolStatus();
+    expect(status).toMatchObject({
+      pool: { accounts: 1, capacityPct: 100, selectableAccounts: 1 },
+      fable: { leftPct: 75, ofPct: 100, source: "all-model weekly fallback" },
+      publicEdge: { today: { requests: 4, tokens: 120 } },
+      urgency: { burnRatePctPerHour: null, projectedDepletionIn: null },
+    });
+    expect(status.perAccount[0]).toMatchObject({
+      name: "account-1",
+      weeklyUsedPct: 25,
+      weeklyHeadroomPct: 75,
+      burnRatePctPerHour: null,
+      exhaustionMessage: "at current burn: estimating",
+    });
+
+    const json = JSON.stringify(status);
+    for (const secret of [
+      "private-account-id",
+      "owner-private@example.test",
+      "consumer-private-id",
+    ]) {
+      expect(json).not.toContain(secret);
+    }
+    const forbiddenKeys = new Set([
+      "id",
+      "email",
+      "label",
+      "priority",
+      "lease",
+      "consumerId",
+      "key",
+      "keyPrefix",
+      "resetAt",
+      "resetsAt",
+    ]);
+    const walk = (value: unknown): void => {
+      if (!value || typeof value !== "object") return;
+      for (const [key, child] of Object.entries(value)) {
+        expect(forbiddenKeys.has(key), `private field ${key}`).toBe(false);
+        walk(child);
+      }
+    };
+    walk(status);
+  });
+
+  it("persists snapshots and projects burn only after a same-window sample", async () => {
+    let now = Date.UTC(2026, 6, 16, 4);
+    let weeklyPct = 20;
+    const resetAt = now + 48 * 60 * 60_000;
+    const dir = mkdtempSync(path.join(tmpdir(), "eliza-pool-status-"));
+    cleanup.push(dir);
+    const pool = new AccountPool({
+      readAccounts: () => ({
+        "anthropic-subscription:private-account-id": fixtureAccount(
+          now,
+          weeklyPct,
+          resetAt,
+        ),
+      }),
+      writeAccount: async () => {},
+    });
+    __resetAccountPoolStatusForTests({
+      pool,
+      now: () => now,
+      stateDir: () => dir,
+      cacheTtlMs: 0,
+      queryConsumerUsage: async () => usageBreakdown("2026-07-16"),
+    });
+
+    expect(
+      (await getPublicAccountPoolStatus()).urgency.burnRatePctPerHour,
+    ).toBeNull();
+    now += 60 * 60_000;
+    weeklyPct = 30;
+    const projected = await getPublicAccountPoolStatus();
+    expect(projected.perAccount[0]?.burnRatePctPerHour).toBe(10);
+    expect(projected.perAccount[0]?.burnSampleHours).toBe(1);
+    expect(projected.urgency.burnRatePctPerHour).toBe(10);
+    expect(projected.urgency.projectedDepletionIn).not.toBeNull();
+
+    const snapshots = readFileSync(
+      path.join(dir, "account-pool", "public-status-snapshots.jsonl"),
+      "utf8",
+    )
+      .trim()
+      .split("\n");
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots.join("\n")).not.toContain("private-account-id");
+  });
+});

--- a/packages/app-core/src/services/account-pool-status.test.ts
+++ b/packages/app-core/src/services/account-pool-status.test.ts
@@ -85,7 +85,11 @@ describe("public account-pool status", () => {
       pool: { accounts: 1, capacityPct: 100, selectableAccounts: 1 },
       fable: { leftPct: 75, ofPct: 100, source: "all-model weekly fallback" },
       publicEdge: { today: { requests: 4, tokens: 120 } },
-      urgency: { burnRatePctPerHour: null, projectedDepletionIn: null },
+      urgency: {
+        burnRatePctPerHour: null,
+        projectedDepletionIn: null,
+        nextRefill: { account: "account-1", capacityAddedPct: 25 },
+      },
     });
     expect(status.perAccount[0]).toMatchObject({
       name: "account-1",

--- a/packages/app-core/src/services/account-pool-status.test.ts
+++ b/packages/app-core/src/services/account-pool-status.test.ts
@@ -49,7 +49,7 @@ function fixtureAccount(
       weeklyPct,
       refreshedAt: now,
       sessionResetsAt: now + 5 * 60 * 60_000,
-      weeklyResetsAt: resetAt,
+      resetsAt: resetAt,
     } as unknown as LinkedAccountConfig["usage"],
   };
 }

--- a/packages/app-core/src/services/account-pool-status.test.ts
+++ b/packages/app-core/src/services/account-pool-status.test.ts
@@ -130,6 +130,10 @@ describe("public account-pool status", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "eliza-pool-status-"));
     cleanup.push(dir);
     const known = fixtureAccount(now, 25);
+    known.usage = {
+      ...known.usage,
+      weeklyModelBuckets: { Fable: { pct: 25 } },
+    } as LinkedAccountConfig["usage"];
     const { usage: _usage, ...unknownBase } = fixtureAccount(now, 0);
     const unknown: LinkedAccountConfig = {
       ...unknownBase,
@@ -153,6 +157,7 @@ describe("public account-pool status", () => {
     expect(status.pool.accounts).toBe(2);
     expect(status.fable).toMatchObject({ leftPct: 75, ofPct: 100 });
     expect(status.allModels).toEqual({ leftPct: 75, ofPct: 100 });
+    expect(status.perAccount[0]?.weeklyResetIn).not.toBeNull();
   });
 
   it("persists snapshots and projects burn only after a same-window sample", async () => {

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -304,9 +304,12 @@ function readSnapshots(): StatusSnapshot[] {
                 : null,
           })),
       });
-    } catch {
+    } catch (error) {
       // error-policy:J3 persisted snapshots are local diagnostic input; a bad
       // line is invalid history, not a reason to fail the public status route.
+      logger.warn(
+        `[account-pool-status] skipping invalid snapshot line: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
   return snapshots;

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -24,6 +24,7 @@ import {
   type AccountPool,
   getDefaultAccountPool,
   isAccountSelectableNow,
+  selectionForProvider,
 } from "./account-pool.js";
 import {
   type AccountPoolConsumerUsageBreakdown,
@@ -545,13 +546,24 @@ function buildStatus(
   snapshots: readonly StatusSnapshot[],
 ): InternalPoolStatus {
   const now = nowMs();
+  const configured = selectionForProvider(PROVIDER_ID);
+  const configuredIds = configured.accountIds
+    ? new Set(configured.accountIds)
+    : null;
   const accounts = pool
     .list(PROVIDER_ID)
-    .filter((account) => account.enabled !== false);
+    .filter((account) => account.enabled !== false)
+    .filter(
+      (account) => configuredIds === null || configuredIds.has(account.id),
+    );
   if (accounts.length === 0) {
     throw new Error("no enabled public pool accounts");
   }
-  const selection = pool.selectionState(PROVIDER_ID, "reset-soonest");
+  const selection = pool.selectionState(
+    PROVIDER_ID,
+    configured.strategy ?? "drain-soonest-reset",
+    configured.accountIds ? { accountIds: configured.accountIds } : undefined,
+  );
   let fableLeft = 0;
   let allLeft = 0;
   let fableKnownAccounts = 0;

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -1,0 +1,761 @@
+/**
+ * Public-safe account-pool status snapshots for anonymous capacity reporting.
+ *
+ * This service reads the default account-pool metadata and consumer metering
+ * totals, derives aggregate burn/projection signals, and persists only the
+ * anonymized fields needed to compare future snapshots within the same reset
+ * window. The HTTP route must serialize through the allowlist here; raw
+ * account, consumer, key, and lease records never cross this boundary.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { logger, resolveStateDir } from "@elizaos/core";
+import type { LinkedAccountConfig } from "@elizaos/shared/contracts/service-routing";
+import {
+  type AccountPool,
+  getDefaultAccountPool,
+  isAccountSelectableNow,
+} from "./account-pool.js";
+import {
+  type AccountPoolConsumerUsageBreakdown,
+  type AccountPoolConsumerUsageTotals,
+  queryAccountPoolConsumerUsage,
+} from "./account-pool-consumer-metering.js";
+
+type PublicAccountState = "serving" | "draining" | "exhausted";
+type CapacityState = "EXHAUSTED" | "BURNING HOT" | "OK" | "FRESH";
+
+interface WeeklyModelBucketCompat {
+  pct?: unknown;
+  utilization?: unknown;
+  resetsAt?: unknown;
+}
+
+type UsageCompat = NonNullable<LinkedAccountConfig["usage"]> & {
+  sessionResetsAt?: unknown;
+  weeklyResetsAt?: unknown;
+  weeklyModelBuckets?: Record<string, WeeklyModelBucketCompat>;
+};
+
+export interface PublicPoolModelBucket {
+  usedPct: number;
+}
+
+export type PublicPoolModelBuckets =
+  | {
+      available: true;
+      fable: PublicPoolModelBucket | null;
+      sonnet: PublicPoolModelBucket | null;
+    }
+  | {
+      available: false;
+      note: string;
+    };
+
+interface InternalPoolModelBucket extends PublicPoolModelBucket {
+  resetAt: number | null;
+}
+
+type InternalPoolModelBuckets =
+  | {
+      available: true;
+      fable: InternalPoolModelBucket | null;
+      sonnet: InternalPoolModelBucket | null;
+    }
+  | {
+      available: false;
+      note: string;
+    };
+
+interface InternalPoolStatusAccount {
+  name: string;
+  accountState: PublicAccountState;
+  sessionUsedPct: number | null;
+  sessionHeadroomPct: number | null;
+  sessionResetAt: number | null;
+  sessionResetIn: string | null;
+  weeklyUsedPct: number | null;
+  weeklyHeadroomPct: number | null;
+  weeklyResetAt: number | null;
+  weeklyResetIn: string | null;
+  fableUsedPct: number | null;
+  modelBuckets: InternalPoolModelBuckets;
+  burnRatePctPerHour: number | null;
+  burnSampleHours: number | null;
+  projectedExhaustionIn: string | null;
+  projectedBeforeReset: boolean | null;
+  state: CapacityState;
+  exhaustionMessage: string;
+}
+
+export interface PublicPoolStatusAccount {
+  name: string;
+  accountState: PublicAccountState;
+  sessionUsedPct: number | null;
+  sessionHeadroomPct: number | null;
+  sessionResetIn: string | null;
+  weeklyUsedPct: number | null;
+  weeklyHeadroomPct: number | null;
+  weeklyResetIn: string | null;
+  fableUsedPct: number | null;
+  modelBuckets: PublicPoolModelBuckets;
+  burnRatePctPerHour: number | null;
+  burnSampleHours: number | null;
+  projectedExhaustionIn: string | null;
+  projectedBeforeReset: boolean | null;
+  state: CapacityState;
+  exhaustionMessage: string;
+}
+
+export interface PublicPoolStatus {
+  updatedAt: string;
+  usageRefreshedAt: string | null;
+  pool: {
+    accounts: number;
+    capacityPct: number;
+    selectableAccounts: number;
+  };
+  fable: {
+    leftPct: number;
+    ofPct: number;
+    source: "fable weekly bucket" | "all-model weekly fallback";
+  };
+  allModels: {
+    leftPct: number;
+    ofPct: number;
+  };
+  perAccount: PublicPoolStatusAccount[];
+  publicEdge: {
+    today: PublicPoolConsumerTotals;
+    allTime: PublicPoolConsumerTotals;
+  };
+  urgency: {
+    burnRatePctPerHour: number | null;
+    projectedDepletionIn: string | null;
+    depletionMessage: string;
+    nextRefill: {
+      account: string;
+      in: string;
+      capacityAddedPct: number;
+    } | null;
+  };
+  health: {
+    snapshotAgeSeconds: number;
+    snapshotAge: string;
+    stale: boolean;
+  };
+}
+
+interface InternalPoolStatus extends Omit<PublicPoolStatus, "perAccount"> {
+  perAccount: InternalPoolStatusAccount[];
+}
+
+export interface PublicPoolConsumerTotals {
+  requests: number;
+  tokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  errors: number;
+  latencyMs: number;
+}
+
+interface StatusSnapshotAccount {
+  name: string;
+  weeklyUsedPct: number | null;
+  fableUsedPct: number | null;
+  weeklyResetAt: number | null;
+}
+
+interface StatusSnapshot {
+  ts: number;
+  accounts: StatusSnapshotAccount[];
+}
+
+interface AccountPoolStatusDeps {
+  pool?: AccountPool;
+  queryConsumerUsage?: typeof queryAccountPoolConsumerUsage;
+  now?: () => number;
+  stateDir?: () => string;
+  cacheTtlMs?: number;
+  snapshotMaxLines?: number;
+}
+
+interface BurnEstimate {
+  ratePctPerHour: number | null;
+  sampleHours: number | null;
+}
+
+const STATUS_TTL_MS = 60_000;
+const SNAPSHOT_MAX_LINES = 2_000;
+const SNAPSHOT_RESET_TOLERANCE_MS = 5 * 60_000;
+const STORE_DIR = "account-pool";
+const SNAPSHOTS_FILE = "public-status-snapshots.jsonl";
+const PROVIDER_ID = "anthropic-subscription";
+
+let cache: { at: number; status: InternalPoolStatus } | null = null;
+let inflight: Promise<InternalPoolStatus> | null = null;
+let depsOverride: AccountPoolStatusDeps = {};
+
+function nowMs(): number {
+  return depsOverride.now?.() ?? Date.now();
+}
+
+function stateDir(): string {
+  return depsOverride.stateDir?.() ?? resolveStateDir();
+}
+
+function snapshotFile(): string {
+  return path.join(stateDir(), STORE_DIR, SNAPSHOTS_FILE);
+}
+
+function cacheTtlMs(): number {
+  return depsOverride.cacheTtlMs ?? STATUS_TTL_MS;
+}
+
+function snapshotMaxLines(): number {
+  return depsOverride.snapshotMaxLines ?? SNAPSHOT_MAX_LINES;
+}
+
+function ensureDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+function atomicWriteText(filePath: string, value: string): void {
+  ensureDir(filePath);
+  const tmp = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${randomBytes(8).toString(
+      "hex",
+    )}.tmp`,
+  );
+  writeFileSync(tmp, value, { encoding: "utf8", mode: 0o600 });
+  renameSync(tmp, filePath);
+}
+
+function clampPct(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.min(100, value))
+    : null;
+}
+
+function round2(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function durationText(ms: number | null): string | null {
+  if (typeof ms !== "number" || !Number.isFinite(ms)) return null;
+  if (ms <= 0) return "now";
+  const minutes = Math.max(1, Math.round(ms / 60_000));
+  const days = Math.floor(minutes / 1_440);
+  const hours = Math.floor((minutes % 1_440) / 60);
+  const mins = minutes % 60;
+  if (days > 0) return `~${days}d ${hours}h`;
+  if (hours > 0) return `~${hours}h ${mins}m`;
+  return `~${mins}m`;
+}
+
+function resetText(ms: number | null): string | null {
+  const duration = durationText(ms);
+  if (!duration) return null;
+  if (duration === "now") return "reset due";
+  return `resets in ${duration.replace(/^~/, "")}`;
+}
+
+function compactAge(ms: number): string {
+  if (ms < 60_000) return "<1m";
+  return durationText(ms)?.replace(/^~/, "") ?? "unknown";
+}
+
+function readSnapshots(): StatusSnapshot[] {
+  const file = snapshotFile();
+  if (!existsSync(file)) return [];
+  const snapshots: StatusSnapshot[] = [];
+  const raw = readFileSync(file, "utf8");
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as StatusSnapshot;
+      if (typeof parsed.ts !== "number" || !Array.isArray(parsed.accounts)) {
+        continue;
+      }
+      snapshots.push({
+        ts: parsed.ts,
+        accounts: parsed.accounts
+          .filter((account) => typeof account.name === "string")
+          .map((account) => ({
+            name: account.name,
+            weeklyUsedPct: clampPct(account.weeklyUsedPct),
+            fableUsedPct: clampPct(account.fableUsedPct),
+            weeklyResetAt:
+              typeof account.weeklyResetAt === "number"
+                ? account.weeklyResetAt
+                : null,
+          })),
+      });
+    } catch {
+      // error-policy:J3 persisted snapshots are local diagnostic input; a bad
+      // line is invalid history, not a reason to fail the public status route.
+    }
+  }
+  return snapshots;
+}
+
+function appendSnapshot(status: InternalPoolStatus): void {
+  const snapshot: StatusSnapshot = {
+    ts: nowMs(),
+    accounts: status.perAccount.map((account) => ({
+      name: account.name,
+      weeklyUsedPct: account.weeklyUsedPct,
+      fableUsedPct: account.fableUsedPct,
+      weeklyResetAt: account.weeklyResetAt,
+    })),
+  };
+  const file = snapshotFile();
+  ensureDir(file);
+  appendFileSync(file, `${JSON.stringify(snapshot)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  const lines = readFileSync(file, "utf8").split("\n").filter(Boolean);
+  const max = snapshotMaxLines();
+  if (lines.length > max) {
+    atomicWriteText(file, `${lines.slice(-max).join("\n")}\n`);
+  }
+}
+
+function getModelBuckets(usage: UsageCompat): InternalPoolModelBuckets {
+  const source = usage.weeklyModelBuckets ?? {};
+  let fable: InternalPoolModelBucket | null = null;
+  let sonnet: InternalPoolModelBucket | null = null;
+  for (const [key, value] of Object.entries(source)) {
+    const usedPct = clampPct(value?.pct ?? value?.utilization);
+    if (usedPct === null) continue;
+    const bucket: InternalPoolModelBucket = {
+      usedPct: round2(usedPct),
+      resetAt: typeof value.resetsAt === "number" ? value.resetsAt : null,
+    };
+    if (/fable/i.test(key)) fable = bucket;
+    if (/sonnet/i.test(key)) sonnet = bucket;
+  }
+  if (fable || sonnet) return { available: true, fable, sonnet };
+  return {
+    available: false,
+    note: "per-model buckets pending account usage support",
+  };
+}
+
+function calculateBurn(
+  row: InternalPoolStatusAccount,
+  snapshots: readonly StatusSnapshot[],
+  now: number,
+): BurnEstimate {
+  if (row.fableUsedPct === null || row.weeklyResetAt === null) {
+    return { ratePctPerHour: null, sampleHours: null };
+  }
+  const candidates: { ts: number; used: number }[] = [];
+  for (const snapshot of snapshots) {
+    const old = snapshot.accounts.find((account) => account.name === row.name);
+    if (!old || snapshot.ts >= now) continue;
+    if (
+      old.weeklyResetAt === null ||
+      Math.abs(old.weeklyResetAt - row.weeklyResetAt) >
+        SNAPSHOT_RESET_TOLERANCE_MS
+    ) {
+      continue;
+    }
+    if (old.fableUsedPct === null || old.fableUsedPct > row.fableUsedPct) {
+      continue;
+    }
+    candidates.push({ ts: snapshot.ts, used: old.fableUsedPct });
+  }
+  if (candidates.length === 0) {
+    return { ratePctPerHour: null, sampleHours: null };
+  }
+  candidates.sort((a, b) => a.ts - b.ts);
+  const oldest = candidates[0];
+  const hours = (now - oldest.ts) / 3_600_000;
+  if (!oldest || hours <= 0) {
+    return { ratePctPerHour: null, sampleHours: null };
+  }
+  return {
+    ratePctPerHour: Math.max(0, (row.fableUsedPct - oldest.used) / hours),
+    sampleHours: hours,
+  };
+}
+
+function applyUrgency(
+  status: InternalPoolStatus,
+  snapshots: readonly StatusSnapshot[],
+): void {
+  const now = nowMs();
+  let totalRate = 0;
+  let knownRates = 0;
+  for (const row of status.perAccount) {
+    const burn = calculateBurn(row, snapshots, now);
+    const rate = burn.ratePctPerHour;
+    row.burnRatePctPerHour = rate === null ? null : round2(rate);
+    row.burnSampleHours =
+      burn.sampleHours === null ? null : round2(burn.sampleHours);
+    const resetMs = row.weeklyResetAt === null ? null : row.weeklyResetAt - now;
+    row.weeklyResetIn = resetText(resetMs);
+    row.sessionResetIn =
+      row.sessionResetAt === null ? null : resetText(row.sessionResetAt - now);
+    const exhaustMs =
+      row.fableUsedPct !== null && rate !== null && rate > 0
+        ? ((100 - row.fableUsedPct) / rate) * 3_600_000
+        : null;
+    row.projectedExhaustionIn = durationText(exhaustMs);
+    row.projectedBeforeReset =
+      exhaustMs !== null && resetMs !== null ? exhaustMs < resetMs : null;
+    if (row.fableUsedPct !== null && row.fableUsedPct >= 100) {
+      row.state = "EXHAUSTED";
+    } else if (row.projectedBeforeReset === true) {
+      row.state = "BURNING HOT";
+    } else if (row.fableUsedPct !== null && row.fableUsedPct <= 5) {
+      row.state = "FRESH";
+    } else {
+      row.state = "OK";
+    }
+    if (rate === null) {
+      row.exhaustionMessage = "at current burn: estimating";
+    } else if (rate === 0 || row.projectedBeforeReset === false) {
+      row.exhaustionMessage = "at current burn: will not run out before reset";
+    } else {
+      row.exhaustionMessage = `at current burn: runs out in ${durationText(
+        exhaustMs,
+      )}`;
+    }
+    if (rate !== null) {
+      totalRate += rate;
+      knownRates += 1;
+    }
+  }
+  const rank: Record<CapacityState, number> = {
+    EXHAUSTED: 0,
+    "BURNING HOT": 1,
+    OK: 2,
+    FRESH: 3,
+  };
+  status.perAccount.sort((a, b) => {
+    if (rank[a.state] !== rank[b.state]) return rank[a.state] - rank[b.state];
+    return (b.fableUsedPct ?? -1) - (a.fableUsedPct ?? -1);
+  });
+  const next = status.perAccount
+    .filter((account) => account.weeklyResetAt !== null)
+    .filter((account) => (account.weeklyResetAt ?? 0) > now)
+    .sort((a, b) => (a.weeklyResetAt ?? 0) - (b.weeklyResetAt ?? 0))[0];
+  const poolMs =
+    totalRate > 0 ? (status.fable.leftPct / totalRate) * 3_600_000 : null;
+  status.urgency = {
+    burnRatePctPerHour: knownRates > 0 ? round2(totalRate) : null,
+    projectedDepletionIn: durationText(poolMs),
+    depletionMessage:
+      knownRates === 0
+        ? "pool-wide burn: estimating"
+        : totalRate === 0
+          ? "pool-wide burn is currently flat"
+          : `pool-wide capacity at current burn: ${durationText(poolMs)}`,
+    nextRefill:
+      next && next.weeklyResetAt !== null
+        ? {
+            account: next.name,
+            in: durationText(next.weeklyResetAt - now) ?? "unknown",
+            capacityAddedPct: 100,
+          }
+        : null,
+  };
+}
+
+function consumerTotals(
+  totals: AccountPoolConsumerUsageTotals["totals"],
+): PublicPoolConsumerTotals {
+  return {
+    requests: totals.requests,
+    tokens: totals.tokens,
+    inputTokens: totals.input_tokens,
+    outputTokens: totals.output_tokens,
+    cacheReadInputTokens: totals.cache_read_input_tokens,
+    cacheCreationInputTokens: totals.cache_creation_input_tokens,
+    errors: totals.errors,
+    latencyMs: totals.latencyMs,
+  };
+}
+
+function currentDayStamp(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+function publicEdgeUsage(
+  usage: AccountPoolConsumerUsageBreakdown,
+  now: number,
+): PublicPoolStatus["publicEdge"] {
+  const today =
+    usage.byDay[currentDayStamp(now)] ??
+    ({
+      requests: 0,
+      tokens: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      errors: 0,
+      latencyMs: 0,
+    } satisfies AccountPoolConsumerUsageTotals["totals"]);
+  return {
+    today: consumerTotals(today),
+    allTime: consumerTotals(usage.totals),
+  };
+}
+
+function buildStatus(
+  pool: AccountPool,
+  consumerUsage: AccountPoolConsumerUsageBreakdown,
+  snapshots: readonly StatusSnapshot[],
+): InternalPoolStatus {
+  const now = nowMs();
+  const accounts = pool
+    .list(PROVIDER_ID)
+    .filter((account) => account.enabled !== false);
+  if (accounts.length === 0) {
+    throw new Error("no enabled public pool accounts");
+  }
+  const selection = pool.selectionState(PROVIDER_ID, "reset-soonest");
+  let fableLeft = 0;
+  let allLeft = 0;
+  let fableFromBucket = true;
+  let lastRefreshed = 0;
+  const rows: InternalPoolStatusAccount[] = accounts.map((account, index) => {
+    const usage = (account.usage ?? { refreshedAt: 0 }) as UsageCompat;
+    if (typeof usage.refreshedAt === "number") {
+      lastRefreshed = Math.max(lastRefreshed, usage.refreshedAt);
+    }
+    const weeklyAll = clampPct(usage.weeklyPct);
+    const sessionPct = clampPct(usage.sessionPct);
+    const modelBuckets = getModelBuckets(usage);
+    const fableUsed =
+      modelBuckets.available && modelBuckets.fable
+        ? modelBuckets.fable.usedPct
+        : weeklyAll;
+    if (!(modelBuckets.available && modelBuckets.fable)) {
+      fableFromBucket = false;
+    }
+    if (fableUsed !== null) fableLeft += 100 - fableUsed;
+    if (weeklyAll !== null) allLeft += 100 - weeklyAll;
+    const weeklyResetAt =
+      modelBuckets.available && modelBuckets.fable
+        ? modelBuckets.fable.resetAt
+        : typeof usage.weeklyResetsAt === "number"
+          ? usage.weeklyResetsAt
+          : null;
+    const exhausted = fableUsed !== null && fableUsed >= 100;
+    const serving =
+      selection.activeAccountId === account.id &&
+      isAccountSelectableNow(account, now);
+    return {
+      name: `account-${index + 1}`,
+      accountState: exhausted ? "exhausted" : serving ? "serving" : "draining",
+      sessionUsedPct: sessionPct === null ? null : round2(sessionPct),
+      sessionHeadroomPct: sessionPct === null ? null : round2(100 - sessionPct),
+      sessionResetAt:
+        typeof usage.sessionResetsAt === "number"
+          ? usage.sessionResetsAt
+          : null,
+      sessionResetIn: null,
+      weeklyUsedPct: weeklyAll === null ? null : round2(weeklyAll),
+      weeklyHeadroomPct: weeklyAll === null ? null : round2(100 - weeklyAll),
+      weeklyResetAt,
+      weeklyResetIn: null,
+      fableUsedPct: fableUsed === null ? null : round2(fableUsed),
+      modelBuckets,
+      burnRatePctPerHour: null,
+      burnSampleHours: null,
+      projectedExhaustionIn: null,
+      projectedBeforeReset: null,
+      state: "OK",
+      exhaustionMessage: "at current burn: estimating",
+    };
+  });
+  const status: InternalPoolStatus = {
+    updatedAt: new Date(now).toISOString(),
+    usageRefreshedAt: lastRefreshed
+      ? new Date(lastRefreshed).toISOString()
+      : null,
+    pool: {
+      accounts: accounts.length,
+      capacityPct: accounts.length * 100,
+      selectableAccounts: accounts.filter((account) =>
+        isAccountSelectableNow(account, now),
+      ).length,
+    },
+    fable: {
+      leftPct: round2(fableLeft),
+      ofPct: accounts.length * 100,
+      source: fableFromBucket
+        ? "fable weekly bucket"
+        : "all-model weekly fallback",
+    },
+    allModels: {
+      leftPct: round2(allLeft),
+      ofPct: accounts.length * 100,
+    },
+    perAccount: rows,
+    publicEdge: publicEdgeUsage(consumerUsage, now),
+    urgency: {
+      burnRatePctPerHour: null,
+      projectedDepletionIn: null,
+      depletionMessage: "pool-wide burn: estimating",
+      nextRefill: null,
+    },
+    health: {
+      snapshotAgeSeconds: 0,
+      snapshotAge: "<1m",
+      stale: false,
+    },
+  };
+  applyUrgency(status, snapshots);
+  return status;
+}
+
+function withHealth(
+  status: InternalPoolStatus,
+  stale: boolean,
+): InternalPoolStatus {
+  const now = nowMs();
+  const ageSeconds = Math.max(0, Math.round((now - (cache?.at ?? now)) / 1000));
+  return {
+    ...status,
+    health: {
+      snapshotAgeSeconds: ageSeconds,
+      snapshotAge: compactAge(ageSeconds * 1000),
+      stale,
+    },
+  };
+}
+
+function publicModelBuckets(
+  buckets: InternalPoolModelBuckets,
+): PublicPoolModelBuckets {
+  if (!buckets.available) {
+    return { available: false, note: buckets.note };
+  }
+  return {
+    available: true,
+    fable: buckets.fable ? { usedPct: buckets.fable.usedPct } : null,
+    sonnet: buckets.sonnet ? { usedPct: buckets.sonnet.usedPct } : null,
+  };
+}
+
+export function serializePublicPoolStatus(
+  status: InternalPoolStatus,
+): PublicPoolStatus {
+  return {
+    updatedAt: status.updatedAt,
+    usageRefreshedAt: status.usageRefreshedAt,
+    pool: {
+      accounts: status.pool.accounts,
+      capacityPct: status.pool.capacityPct,
+      selectableAccounts: status.pool.selectableAccounts,
+    },
+    fable: {
+      leftPct: status.fable.leftPct,
+      ofPct: status.fable.ofPct,
+      source: status.fable.source,
+    },
+    allModels: {
+      leftPct: status.allModels.leftPct,
+      ofPct: status.allModels.ofPct,
+    },
+    perAccount: status.perAccount.map((account) => ({
+      name: account.name,
+      accountState: account.accountState,
+      sessionUsedPct: account.sessionUsedPct,
+      sessionHeadroomPct: account.sessionHeadroomPct,
+      sessionResetIn: account.sessionResetIn,
+      weeklyUsedPct: account.weeklyUsedPct,
+      weeklyHeadroomPct: account.weeklyHeadroomPct,
+      weeklyResetIn: account.weeklyResetIn,
+      fableUsedPct: account.fableUsedPct,
+      modelBuckets: publicModelBuckets(account.modelBuckets),
+      burnRatePctPerHour: account.burnRatePctPerHour,
+      burnSampleHours: account.burnSampleHours,
+      projectedExhaustionIn: account.projectedExhaustionIn,
+      projectedBeforeReset: account.projectedBeforeReset,
+      state: account.state,
+      exhaustionMessage: account.exhaustionMessage,
+    })),
+    publicEdge: {
+      today: { ...status.publicEdge.today },
+      allTime: { ...status.publicEdge.allTime },
+    },
+    urgency: {
+      burnRatePctPerHour: status.urgency.burnRatePctPerHour,
+      projectedDepletionIn: status.urgency.projectedDepletionIn,
+      depletionMessage: status.urgency.depletionMessage,
+      nextRefill: status.urgency.nextRefill
+        ? {
+            account: status.urgency.nextRefill.account,
+            in: status.urgency.nextRefill.in,
+            capacityAddedPct: status.urgency.nextRefill.capacityAddedPct,
+          }
+        : null,
+    },
+    health: {
+      snapshotAgeSeconds: status.health.snapshotAgeSeconds,
+      snapshotAge: status.health.snapshotAge,
+      stale: status.health.stale,
+    },
+  };
+}
+
+export async function getPublicAccountPoolStatus(): Promise<PublicPoolStatus> {
+  const now = nowMs();
+  if (cache && now - cache.at < cacheTtlMs()) {
+    return serializePublicPoolStatus(withHealth(cache.status, false));
+  }
+  if (!inflight) {
+    inflight = (async () => {
+      const history = readSnapshots();
+      const pool = depsOverride.pool ?? getDefaultAccountPool();
+      const usage = await (
+        depsOverride.queryConsumerUsage ?? queryAccountPoolConsumerUsage
+      )();
+      const status = buildStatus(pool, usage, history);
+      cache = { at: nowMs(), status };
+      appendSnapshot(status);
+      return status;
+    })()
+      .catch((error) => {
+        logger.warn(
+          `[AccountPoolStatus] status refresh failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        if (cache) return withHealth(cache.status, true);
+        throw error;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return serializePublicPoolStatus(await inflight);
+}
+
+export function __resetAccountPoolStatusForTests(
+  deps: AccountPoolStatusDeps = {},
+): void {
+  depsOverride = deps;
+  cache = null;
+  inflight = null;
+}

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -559,9 +559,11 @@ function buildStatus(
     const weeklyResetAt =
       modelBuckets.available && modelBuckets.fable
         ? modelBuckets.fable.resetAt
-        : typeof usage.weeklyResetsAt === "number"
-          ? usage.weeklyResetsAt
-          : null;
+        : typeof usage.resetsAt === "number"
+          ? usage.resetsAt
+          : typeof usage.weeklyResetsAt === "number"
+            ? usage.weeklyResetsAt
+            : null;
     const exhausted = fableUsed !== null && fableUsed >= 100;
     const serving =
       selection.activeAccountId === account.id &&

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -8,7 +8,7 @@
  * account, consumer, key, and lease records never cross this boundary.
  */
 
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
@@ -77,6 +77,8 @@ type InternalPoolModelBuckets =
     };
 
 interface InternalPoolStatusAccount {
+  /** Stable local identity for persisted burn snapshots. Never serialized. */
+  snapshotKey: string;
   name: string;
   accountState: PublicAccountState;
   sessionUsedPct: number | null;
@@ -171,6 +173,7 @@ export interface PublicPoolConsumerTotals {
 }
 
 interface StatusSnapshotAccount {
+  snapshotKey: string;
   name: string;
   weeklyUsedPct: number | null;
   fableUsedPct: number | null;
@@ -254,6 +257,12 @@ function round2(value: number): number {
   return Number(value.toFixed(2));
 }
 
+function snapshotKey(account: LinkedAccountConfig): string {
+  return createHash("sha256")
+    .update(`${account.providerId}:${account.id}`, "utf8")
+    .digest("hex");
+}
+
 function durationText(ms: number | null): string | null {
   if (typeof ms !== "number" || !Number.isFinite(ms)) return null;
   if (ms <= 0) return "now";
@@ -293,8 +302,13 @@ function readSnapshots(): StatusSnapshot[] {
       snapshots.push({
         ts: parsed.ts,
         accounts: parsed.accounts
-          .filter((account) => typeof account.name === "string")
+          .filter(
+            (account) =>
+              typeof account.name === "string" &&
+              typeof account.snapshotKey === "string",
+          )
           .map((account) => ({
+            snapshotKey: account.snapshotKey,
             name: account.name,
             weeklyUsedPct: clampPct(account.weeklyUsedPct),
             fableUsedPct: clampPct(account.fableUsedPct),
@@ -319,6 +333,7 @@ function appendSnapshot(status: InternalPoolStatus): void {
   const snapshot: StatusSnapshot = {
     ts: nowMs(),
     accounts: status.perAccount.map((account) => ({
+      snapshotKey: account.snapshotKey,
       name: account.name,
       weeklyUsedPct: account.weeklyUsedPct,
       fableUsedPct: account.fableUsedPct,
@@ -369,7 +384,9 @@ function calculateBurn(
   }
   const candidates: { ts: number; used: number }[] = [];
   for (const snapshot of snapshots) {
-    const old = snapshot.accounts.find((account) => account.name === row.name);
+    const old = snapshot.accounts.find(
+      (account) => account.snapshotKey === row.snapshotKey,
+    );
     if (!old || snapshot.ts >= now) continue;
     if (
       old.weeklyResetAt === null ||
@@ -537,6 +554,8 @@ function buildStatus(
   const selection = pool.selectionState(PROVIDER_ID, "reset-soonest");
   let fableLeft = 0;
   let allLeft = 0;
+  let fableKnownAccounts = 0;
+  let allModelsKnownAccounts = 0;
   let fableFromBucket = true;
   let lastRefreshed = 0;
   const rows: InternalPoolStatusAccount[] = accounts.map((account, index) => {
@@ -554,8 +573,14 @@ function buildStatus(
     if (!(modelBuckets.available && modelBuckets.fable)) {
       fableFromBucket = false;
     }
-    if (fableUsed !== null) fableLeft += 100 - fableUsed;
-    if (weeklyAll !== null) allLeft += 100 - weeklyAll;
+    if (fableUsed !== null) {
+      fableLeft += 100 - fableUsed;
+      fableKnownAccounts += 1;
+    }
+    if (weeklyAll !== null) {
+      allLeft += 100 - weeklyAll;
+      allModelsKnownAccounts += 1;
+    }
     const weeklyResetAt =
       modelBuckets.available && modelBuckets.fable
         ? modelBuckets.fable.resetAt
@@ -569,6 +594,7 @@ function buildStatus(
       selection.activeAccountId === account.id &&
       isAccountSelectableNow(account, now);
     return {
+      snapshotKey: snapshotKey(account),
       name: `account-${index + 1}`,
       accountState: exhausted ? "exhausted" : serving ? "serving" : "draining",
       sessionUsedPct: sessionPct === null ? null : round2(sessionPct),
@@ -606,14 +632,14 @@ function buildStatus(
     },
     fable: {
       leftPct: round2(fableLeft),
-      ofPct: accounts.length * 100,
+      ofPct: fableKnownAccounts * 100,
       source: fableFromBucket
         ? "fable weekly bucket"
         : "all-model weekly fallback",
     },
     allModels: {
       leftPct: round2(allLeft),
-      ofPct: accounts.length * 100,
+      ofPct: allModelsKnownAccounts * 100,
     },
     perAccount: rows,
     publicEdge: publicEdgeUsage(consumerUsage, now),

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -494,7 +494,9 @@ function applyUrgency(
         ? {
             account: next.name,
             in: durationText(next.weeklyResetAt - now) ?? "unknown",
-            capacityAddedPct: 100,
+            capacityAddedPct: round2(
+              next.fableUsedPct ?? next.weeklyUsedPct ?? 0,
+            ),
           }
         : null,
   };

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -558,9 +558,10 @@ function buildStatus(
     .filter((account) => account.enabled !== false)
     .filter(
       (account) => configuredIds === null || configuredIds.has(account.id),
-    );
+    )
+    .filter((account) => isAccountSelectableNow(account, now));
   if (accounts.length === 0) {
-    throw new Error("no enabled public pool accounts");
+    throw new Error("no selectable public pool accounts");
   }
   const selection = pool.selectionState(
     PROVIDER_ID,

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -593,14 +593,16 @@ function buildStatus(
       allLeft += 100 - weeklyAll;
       allModelsKnownAccounts += 1;
     }
+    const fallbackWeeklyResetAt =
+      typeof usage.resetsAt === "number"
+        ? usage.resetsAt
+        : typeof usage.weeklyResetsAt === "number"
+          ? usage.weeklyResetsAt
+          : null;
     const weeklyResetAt =
       modelBuckets.available && modelBuckets.fable
-        ? modelBuckets.fable.resetAt
-        : typeof usage.resetsAt === "number"
-          ? usage.resetsAt
-          : typeof usage.weeklyResetsAt === "number"
-            ? usage.weeklyResetsAt
-            : null;
+        ? (modelBuckets.fable.resetAt ?? fallbackWeeklyResetAt)
+        : fallbackWeeklyResetAt;
     const exhausted = fableUsed !== null && fableUsed >= 100;
     const serving =
       selection.activeAccountId === account.id &&

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -29,7 +29,8 @@ import {
 import {
   type AccountPoolConsumerUsageBreakdown,
   type AccountPoolConsumerUsageTotals,
-  queryAccountPoolConsumerUsage,
+  getAccountPoolConsumerUsageSummary,
+  type queryAccountPoolConsumerUsage,
 } from "./account-pool-consumer-metering.js";
 
 type PublicAccountState = "serving" | "draining" | "exhausted";
@@ -774,7 +775,7 @@ export async function getPublicAccountPoolStatus(): Promise<PublicPoolStatus> {
       const history = readSnapshots();
       const pool = depsOverride.pool ?? getDefaultAccountPool();
       const usage = await (
-        depsOverride.queryConsumerUsage ?? queryAccountPoolConsumerUsage
+        depsOverride.queryConsumerUsage ?? getAccountPoolConsumerUsageSummary
       )();
       const status = buildStatus(pool, usage, history);
       cache = { at: nowMs(), status };

--- a/packages/app-core/src/services/account-pool.test.ts
+++ b/packages/app-core/src/services/account-pool.test.ts
@@ -690,6 +690,30 @@ describe("AccountPool reset-soonest selection", () => {
     ).toEqual(state);
   });
 
+  it("selectionState honors configured account-id pins", () => {
+    const accounts = {
+      "anthropic-subscription:soon": account("anthropic-subscription", {
+        id: "soon",
+        usage: { sessionPct: 10, resetsAt: now + 3_600_000, refreshedAt: now },
+      }),
+      "anthropic-subscription:pinned": account("anthropic-subscription", {
+        id: "pinned",
+        usage: {
+          sessionPct: 10,
+          resetsAt: now + 50 * 3_600_000,
+          refreshedAt: now,
+        },
+      }),
+    };
+    expect(
+      poolOf(accounts).selectionState(
+        "anthropic-subscription",
+        "reset-soonest",
+        { accountIds: ["pinned"] },
+      ),
+    ).toEqual({ activeAccountId: "pinned", reason: "only-eligible" });
+  });
+
   it("selectionState falls back to least-recently-throttled when resets unknown", () => {
     const accounts = {
       "anthropic-subscription:stale": account("anthropic-subscription", {

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -330,10 +330,13 @@ export class AccountPool {
   selectionState(
     providerId: PoolProviderId,
     strategy: Strategy = "priority",
-    opts?: { model?: string },
+    opts?: { model?: string; accountIds?: string[] },
   ): { activeAccountId: string | null; reason: string | null } {
     const all = this.deps.readAccounts();
-    const eligible = this.filterEligible(all, { providerId });
+    const eligible = this.filterEligible(all, {
+      providerId,
+      accountIds: opts?.accountIds,
+    });
     if (eligible.length === 0) return { activeAccountId: null, reason: null };
     if (eligible.length === 1) {
       return {


### PR DESCRIPTION
## Summary

- add public `GET /api/pool/status` through the app-core compat route chain and explicit public auth policy
- expose aggregate capacity, anonymized `account-N` rows, model-aware headroom, relative refill windows, burn rate, projected depletion, and aggregate consumer usage
- persist bounded anonymous snapshots for same-reset-window burn estimates, with atomic trim rewrites, cache TTL, and in-flight dedup
- fail honestly with `null` / `estimating` when weekly reset or history is insufficient
- assert a strict privacy boundary recursively: no account/consumer IDs, emails, labels, priorities, leases, keys/prefixes, or exact reset timestamps

## Stack

This is stacked on #16461, which is stacked on #16355. It is designed to consume the split session/weekly/model reset fields from #16398 when that PR lands. Without #16398, weekly headroom is still shown, but reset-window projections remain honestly unavailable rather than treating the 5-hour session reset as a weekly refill.

Companion observability UI is #16399. Consumer-key admin UI remains a follow-up; #16461 already provides create/list/rotate/disable APIs and one-time plaintext key return.

## Validation

- `bunx vitest run packages/app-core/src/services/account-pool-status.test.ts packages/app-core/src/api/account-pool-status-routes.test.ts packages/app-core/src/api/route-auth-policy.test.ts --config vitest.config.ts` (11 passed)
- `bunx biome check` on all changed files (clean)
- package typecheck inspected for changed-file diagnostics (none; workspace has unrelated pre-existing missing generated/dependency diagnostics in this sparse worktree)
- Codex review run twice. First review found session-reset/weekly-reset conflation, fixed by refusing the old `usage.resetsAt` fallback. Second review suggested restoring that fallback based on the old contract comment, intentionally not applied because current probe tests explicitly establish `resetsAt` as the 5-hour primary reset; #16398 supplies the real weekly/model timestamps.

## Review / merge

Auth-adjacent public route. Human review required. **Do not auto-merge.**

Evidence: `local-evidence` (API/unit tests; no UI screenshot surface in this PR).

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (public pool status route + service), no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:backend-logs -->
- [x] [16477-vitest-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16477-vitest-tests.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM-facing behavior change; status endpoint is read-only aggregation, covered by unit tests

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - privacy-boundary and projection behavior pinned by the vitest suites in backend-logs row

<!-- evidence refresh 2026-07-16T09:10Z -->
