### PR TITLE
fix: harden reconciliation, model caching, and training probes

### DIFF
--- a/packages/cloud/api/v1/models/route.test.ts
+++ b/packages/cloud/api/v1/models/route.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as modelCatalogActual from "@/lib/services/model-catalog";
+import * as loggerActual from "@/lib/utils/logger";
+
+const getCurrentUser = mock(async () => null);
+const getAiProviderConfigurationError = mock(
+  () => "No AI provider is configured",
+);
+const hasAnyAiProviderConfigured = mock(() => true);
+const getCachedMergedModelCatalog = mock(
+  async (): Promise<Array<{ id: string; object: string }>> => [
+    { id: "openai/gpt-5-mini", object: "model" },
+  ],
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  getCurrentUser,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  getAiProviderConfigurationError,
+  hasAnyAiProviderConfigured,
+}));
+
+mock.module("@/lib/services/model-catalog", () => ({
+  ...modelCatalogActual,
+  getCachedMergedModelCatalog,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/services/model-catalog", () => modelCatalogActual);
+  mock.module("@/lib/utils/logger", () => loggerActual);
+});
+
+describe("GET /api/v1/models cache policy", () => {
+  beforeEach(() => {
+    getCurrentUser.mockClear();
+    getCurrentUser.mockResolvedValue(null);
+    getAiProviderConfigurationError.mockClear();
+    getAiProviderConfigurationError.mockReturnValue(
+      "No AI provider is configured",
+    );
+    hasAnyAiProviderConfigured.mockClear();
+    hasAnyAiProviderConfigured.mockReturnValue(true);
+    getCachedMergedModelCatalog.mockClear();
+    getCachedMergedModelCatalog.mockResolvedValue([
+      { id: "openai/gpt-5-mini", object: "model" },
+    ]);
+  });
+
+  test("successful catalogs remain publicly cacheable", async () => {
+    const response = await app.request("/");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, s-maxage=3600, stale-while-revalidate=7200",
+    );
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [{ id: "openai/gpt-5-mini", object: "model" }],
+    });
+  });
+
+  test("a rejected best-effort auth probe does not fail or uncache the catalog", async () => {
+    getCurrentUser.mockRejectedValueOnce(new Error("session unavailable"));
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, s-maxage=3600, stale-while-revalidate=7200",
+    );
+    expect(getCachedMergedModelCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  test("catalog failures cannot inherit the public cache policy", async () => {
+    getCachedMergedModelCatalog.mockRejectedValueOnce(
+      new Error("catalog unavailable"),
+    );
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).not.toContain("s-maxage");
+  });
+
+  test("configuration errors are explicitly non-cacheable", async () => {
+    hasAnyAiProviderConfigured.mockReturnValueOnce(false);
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).not.toContain("s-maxage");
+    expect(getCachedMergedModelCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/models/route.ts
+++ b/packages/cloud/api/v1/models/route.ts
@@ -23,6 +23,7 @@ app.get("/", async (c) => {
     await getCurrentUser(c).catch(() => null);
 
     if (!hasAnyAiProviderConfigured()) {
+      c.header("Cache-Control", "no-store");
       return c.json(
         {
           error: {
@@ -34,17 +35,19 @@ app.get("/", async (c) => {
       );
     }
 
+    const data = await getCachedMergedModelCatalog();
     c.header(
       "Cache-Control",
       "public, s-maxage=3600, stale-while-revalidate=7200",
     );
     return c.json({
       object: "list",
-      data: await getCachedMergedModelCatalog(),
+      data,
     });
   } catch (error) {
     // error-policy:J1 route boundary — every catch in v1/models/* translates a thrown error into a structured HTTP failure via failureResponse (never a fabricated 200/empty catalog).
     logger.error("Error fetching models:", error);
+    c.header("Cache-Control", "no-store");
     return failureResponse(c, error);
   }
 });

--- a/packages/training/scripts/training/instrumentation.py
+++ b/packages/training/scripts/training/instrumentation.py
@@ -175,17 +175,34 @@ def _git_head() -> dict[str, Any]:
     """
     if not shutil.which("git"):
         return {"available": False, "reason": "git not on PATH"}
-    out = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        check=False, capture_output=True, text=True, timeout=5,
-    )
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return {"available": False, "reason": "git rev-parse timed out after 5 seconds"}
     if out.returncode != 0:
         return {"available": False, "reason": out.stderr.strip() or f"exit={out.returncode}"}
     head = out.stdout.strip()
-    dirty = subprocess.run(
-        ["git", "status", "--porcelain"],
-        check=False, capture_output=True, text=True, timeout=5,
-    )
+    try:
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "available": True,
+            "head": head,
+            "dirty": None,
+            "dirty_reason": "git status timed out after 5 seconds",
+        }
     return {
         "available": True,
         "head": head,

--- a/packages/training/scripts/training/instrumentation.py
+++ b/packages/training/scripts/training/instrumentation.py
@@ -29,6 +29,7 @@ import logging
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import time
 from collections.abc import Iterable, Mapping
@@ -167,7 +168,40 @@ def _hash_paths(paths: Iterable[Path | str] | None) -> dict[str, str]:
     return out
 
 
-def _git_head() -> dict[str, Any]:
+def _run_git(
+    args: list[str], *, timeout_seconds: float
+) -> subprocess.CompletedProcess[str]:
+    """Run a bounded Git probe and tear down its whole POSIX process group.
+
+    ``git status`` may start submodule/fsmonitor children. ``subprocess.run``
+    kills only the direct process on timeout, leaving those descendants alive
+    with inherited pipes. Training runs are Linux-based, so start a fresh
+    session there and terminate the group before re-raising the timeout. Other
+    platforms retain the direct-process fallback.
+    """
+    process = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        else:
+            process.kill()
+        process.communicate()
+        raise
+    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
+
+def _git_head(*, timeout_seconds: float = 5) -> dict[str, Any]:
     """Capture the training commit for the reproducibility manifest.
 
     Best-effort: outside a git checkout (or with git absent) the head is
@@ -175,38 +209,67 @@ def _git_head() -> dict[str, Any]:
     """
     if not shutil.which("git"):
         return {"available": False, "reason": "git not on PATH"}
+    timeout_label = f"{timeout_seconds:g} seconds"
     try:
-        out = subprocess.run(
+        out = _run_git(
             ["git", "rev-parse", "HEAD"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=5,
+            timeout_seconds=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
-        return {"available": False, "reason": "git rev-parse timed out after 5 seconds"}
+        return {
+            "available": False,
+            "reason": f"git rev-parse timed out after {timeout_label}",
+        }
+    except OSError as error:
+        return {
+            "available": False,
+            "reason": f"git rev-parse failed to start: {error}",
+        }
     if out.returncode != 0:
-        return {"available": False, "reason": out.stderr.strip() or f"exit={out.returncode}"}
+        detail = out.stderr.strip() or f"exit={out.returncode}"
+        return {"available": False, "reason": f"git rev-parse failed: {detail}"}
     head = out.stdout.strip()
     try:
-        dirty = subprocess.run(
-            ["git", "status", "--porcelain"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=5,
+        dirty = _run_git(
+            [
+                "git",
+                # A hard timeout must not strand .git/index.lock.
+                "--no-optional-locks",
+                # This is best-effort metadata. Do not invoke a configured
+                # fsmonitor hook/daemon that could outlive a timed-out probe.
+                "-c",
+                "core.fsmonitor=false",
+                "status",
+                "--porcelain",
+            ],
+            timeout_seconds=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
         return {
             "available": True,
             "head": head,
             "dirty": None,
-            "dirty_reason": "git status timed out after 5 seconds",
+            "dirty_reason": f"git status timed out after {timeout_label}",
+        }
+    except OSError as error:
+        return {
+            "available": True,
+            "head": head,
+            "dirty": None,
+            "dirty_reason": f"git status failed to start: {error}",
+        }
+    if dirty.returncode != 0:
+        detail = dirty.stderr.strip() or f"exit={dirty.returncode}"
+        return {
+            "available": True,
+            "head": head,
+            "dirty": None,
+            "dirty_reason": f"git status failed: {detail}",
         }
     return {
         "available": True,
         "head": head,
-        "dirty": bool(dirty.stdout.strip()) if dirty.returncode == 0 else None,
+        "dirty": bool(dirty.stdout.strip()),
     }
 
 

--- a/packages/training/scripts/training/test_instrumentation.py
+++ b/packages/training/scripts/training/test_instrumentation.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import subprocess
 from pathlib import Path
 
 from scripts.training import instrumentation
-from scripts.training.instrumentation import _hash_paths, log_environment
+from scripts.training.instrumentation import _git_head, _hash_paths, log_environment
 
 
 def _read_env(out_dir: Path) -> dict:
@@ -54,6 +55,40 @@ def test_log_environment_captures_git_head(tmp_path, monkeypatch):
         "available": True,
         "head": "abc123def456",
         "dirty": False,
+    }
+
+
+def test_git_head_preserves_commit_when_dirty_probe_times_out(monkeypatch):
+    calls = 0
+
+    def run(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return subprocess.CompletedProcess(args[0], 0, stdout="abc123\n", stderr="")
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(instrumentation.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(instrumentation.subprocess, "run", run)
+
+    assert _git_head() == {
+        "available": True,
+        "head": "abc123",
+        "dirty": None,
+        "dirty_reason": "git status timed out after 5 seconds",
+    }
+
+
+def test_git_head_reports_unavailable_when_head_probe_times_out(monkeypatch):
+    def run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(instrumentation.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(instrumentation.subprocess, "run", run)
+
+    assert _git_head() == {
+        "available": False,
+        "reason": "git rev-parse timed out after 5 seconds",
     }
 
 

--- a/packages/training/scripts/training/test_instrumentation.py
+++ b/packages/training/scripts/training/test_instrumentation.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 from scripts.training import instrumentation
@@ -60,16 +63,18 @@ def test_log_environment_captures_git_head(tmp_path, monkeypatch):
 
 def test_git_head_preserves_commit_when_dirty_probe_times_out(monkeypatch):
     calls = 0
+    status_command = None
 
     def run(*args, **kwargs):
-        nonlocal calls
+        nonlocal calls, status_command
         calls += 1
         if calls == 1:
             return subprocess.CompletedProcess(args[0], 0, stdout="abc123\n", stderr="")
-        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+        status_command = args[0]
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout_seconds"])
 
     monkeypatch.setattr(instrumentation.shutil, "which", lambda _name: "/usr/bin/git")
-    monkeypatch.setattr(instrumentation.subprocess, "run", run)
+    monkeypatch.setattr(instrumentation, "_run_git", run)
 
     assert _git_head() == {
         "available": True,
@@ -77,19 +82,95 @@ def test_git_head_preserves_commit_when_dirty_probe_times_out(monkeypatch):
         "dirty": None,
         "dirty_reason": "git status timed out after 5 seconds",
     }
+    assert status_command[:2] == ["git", "--no-optional-locks"]
 
 
 def test_git_head_reports_unavailable_when_head_probe_times_out(monkeypatch):
     def run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout_seconds"])
 
     monkeypatch.setattr(instrumentation.shutil, "which", lambda _name: "/usr/bin/git")
-    monkeypatch.setattr(instrumentation.subprocess, "run", run)
+    monkeypatch.setattr(instrumentation, "_run_git", run)
 
     assert _git_head() == {
         "available": False,
         "reason": "git rev-parse timed out after 5 seconds",
     }
+
+
+def test_git_head_reports_nonzero_dirty_probe_without_fabricating_clean(monkeypatch):
+    calls = 0
+
+    def run(*args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return subprocess.CompletedProcess(args[0], 0, stdout="abc123\n", stderr="")
+        return subprocess.CompletedProcess(
+            args[0], 128, stdout="", stderr="fatal: index is corrupt\n"
+        )
+
+    monkeypatch.setattr(instrumentation.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(instrumentation, "_run_git", run)
+
+    assert _git_head() == {
+        "available": True,
+        "head": "abc123",
+        "dirty": None,
+        "dirty_reason": "git status failed: fatal: index is corrupt",
+    }
+
+
+def test_git_head_preserves_head_when_real_status_subprocess_is_slow(
+    tmp_path, monkeypatch
+):
+    """Exercise the failing status process boundary, not a mocked run call."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    leaked_child_marker = tmp_path / "git-child-survived"
+    child = tmp_path / "git-child.py"
+    child.write_text(
+        (
+            "import pathlib\n"
+            "import sys\n"
+            "import time\n"
+            "time.sleep(1)\n"
+            "pathlib.Path(sys.argv[1]).write_text('leaked', encoding='utf-8')\n"
+        ),
+        encoding="utf-8",
+    )
+    fake_git = bin_dir / "git"
+    fake_git.write_text(
+        (
+            f"#!{sys.executable}\n"
+            "import subprocess\n"
+            "import sys\n"
+            "import time\n"
+            "if 'rev-parse' in sys.argv:\n"
+            "    print('abc123')\n"
+            "else:\n"
+            f"    subprocess.Popen([{sys.executable!r}, {str(child)!r}, {str(leaked_child_marker)!r}])\n"
+            "    time.sleep(10)\n"
+        ),
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    started = time.monotonic()
+    result = _git_head(timeout_seconds=0.5)
+    elapsed = time.monotonic() - started
+
+    assert result == {
+        "available": True,
+        "head": "abc123",
+        "dirty": None,
+        "dirty_reason": "git status timed out after 0.5 seconds",
+    }
+    assert elapsed < 2, "slow provenance probe should be terminated at its deadline"
+    if os.name == "posix":
+        time.sleep(0.75)
+        assert not leaked_child_marker.exists(), "timed-out Git child survived"
 
 
 def test_log_environment_hashes_tokenizer_and_base_checkpoint(tmp_path, monkeypatch):

--- a/packages/ui/src/hooks/useAccounts.test.tsx
+++ b/packages/ui/src/hooks/useAccounts.test.tsx
@@ -23,8 +23,12 @@ const client = vi.hoisted(() => ({
   refreshAccountUsage: vi.fn(),
   patchProviderStrategy: vi.fn(),
 }));
+const loggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock("../api", () => ({ client }));
+vi.mock("@elizaos/logger", () => ({
+  logger: { warn: loggerWarn },
+}));
 vi.mock("../state", () => ({
   useAppSelector: (
     selector: (state: {
@@ -266,6 +270,38 @@ describe("useAccounts", () => {
     expect(result.current.error).toBeNull();
     expect(notices).not.toHaveBeenCalledWith(
       "Failed to load accounts: transport down",
+      "error",
+      6000,
+    );
+  });
+
+  it("reports reconciliation failure while preserving the primary probe rejection", async () => {
+    const probeError = new Error("usage probe failed");
+    const reconcileError = new Error("account list unavailable");
+    client.listAccounts
+      .mockResolvedValueOnce(initial)
+      .mockRejectedValueOnce(reconcileError);
+    client.refreshAccountUsage.mockRejectedValueOnce(probeError);
+    const notices = vi.fn();
+    const { result } = renderHook(() =>
+      useAccounts({ pollMs: 0, setActionNotice: notices }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(
+      act(() => result.current.refreshUsage("openai-api", "primary")),
+    ).rejects.toBe(probeError);
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      {
+        error: reconcileError,
+        providerId: "openai-api",
+        accountId: "primary",
+      },
+      "[useAccounts] post-probe reconciliation failed",
+    );
+    expect(notices).toHaveBeenCalledWith(
+      "Failed to refresh usage: usage probe failed",
       "error",
       6000,
     );

--- a/packages/ui/src/hooks/useAccounts.ts
+++ b/packages/ui/src/hooks/useAccounts.ts
@@ -9,6 +9,7 @@
  * `setActionNotice` so the parent settings panel can surface them.
  */
 
+import { logger } from "@elizaos/logger";
 import type {
   LinkedAccountConfig,
   LinkedAccountProviderId,
@@ -339,9 +340,9 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
           // error-policy:J7 diagnostics-must-not-kill-the-loop. Preserve and
           // rethrow the primary usage failure; the regular list poll retries
           // reconciliation without replacing the actionable probe notice.
-          console.warn(
+          logger.warn(
+            { error: reconcileError, providerId, accountId },
             "[useAccounts] post-probe reconciliation failed",
-            reconcileError,
           );
         }
         throw err;


### PR DESCRIPTION
## Summary

- preserve primary account usage failures while reporting secondary reconciliation failures through structured diagnostics
- prevent `/api/v1/models` error responses from inheriting public CDN caching
- bound training Git provenance probes, terminate timed-out process trees, and preserve explicit unknown-dirty provenance
- add regression coverage for each failure mode

This branch is rooted directly on the latest `develop` and intentionally excludes the unrelated large history on the original working branch.

## Verification

- `bun run lint`
- `bun run build`
- `bun run typecheck` — 340/340 tasks successful
- focused account reconciliation tests
- focused model route and model catalog cache tests
- Python instrumentation compile and subprocess regression tests
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - no rendered UI source or visual behavior changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no rendered UI source or visual behavior changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - changes are non-rendered hook diagnostics, API cache headers, and training instrumentation`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no deployed backend was mutated; API failure behavior is covered by the focused route tests above`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs `N/A - no rendered frontend flow changed; hook behavior is covered by the focused tests above`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model invocation, prompt, or generated response behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no database, wallet, device, generated file, or other domain output changed`.

@wakesync for visibility.