### PR TITLE
feat(app): redesign ChatOverlay as a liquid-glass system surface

### DIFF
--- a/packages/ui/src/components/shell/CHAT_OVERLAY_DESIGN_SPEC.md
+++ b/packages/ui/src/components/shell/CHAT_OVERLAY_DESIGN_SPEC.md
@@ -1,0 +1,131 @@
+# ChatOverlay — liquid-glass system surface (design spec)
+
+The design spec for `ContinuousChatOverlay.tsx` as a **liquid-glass system
+surface**: hierarchy, materials, contrast, motion, focus, scrolling, resize,
+reduced-motion, and keyboard/touch. The detent/gesture state machine — the
+resting states, transition table, and gesture vocabulary — is the companion
+[`__e2e__/CHAT_SHEET_STATE_MATRIX.md`](./__e2e__/CHAT_SHEET_STATE_MATRIX.md);
+this document owns the surface's **look and feel** and references the matrix for
+behavior rather than restating it.
+
+Binding rule across every dimension: **presentation never stands in for typed
+state.** The overlay's openness is one ordered `ChatMode` machine
+(`pill → input → half → full`, with `maximized` the full-bleed variant of
+`full`); `data-detent` / `data-chat-state` / `data-maximized` mirror it for
+tests. Transcript length / message count is content to render, never a signal
+for which detent or material to show.
+
+## Hierarchy
+
+One always-present, bottom-anchored element that **never remounts** across
+`pill ↔ input ↔ half ↔ full ↔ maximized` — every transition is
+transform / opacity / height only (compositor-friendly). Its container is
+`pointer-events-none` so the view/wallpaper behind stays live; only the composer
+and the open sheet capture input. The composer never moves — the transcript
+grows **up** out of it inside the same panel.
+
+- **PILL / INPUT** (rest): just the composer bar (+ grabber). The chat column is
+  pinned to `max-w-3xl` in every state and never reflows.
+- **HALF / FULL**: the thread reveals above the composer; the status header
+  appears at/over the HALF height.
+- **MAXIMIZED**: edge-to-edge full-bleed; only the glass (width, side inset,
+  corner radius, height cap — driven by the `fullBleedT` motion value 0→1)
+  grows to the screen edges. The reading column stays pinned; the grabber is
+  replaced by a top restore strip.
+
+No chrome/signage: no message counter, no "new chat", no tab strip. Controls
+dissolve into the glass; status is a soft breath of light, not a branded alert.
+
+## Materials — liquid glass, sourced from the token system
+
+The frosted panel is a **system surface**: its material comes from the shared
+glass tokens (`glass/tokens.ts`), not a hand-rolled inline recipe. The overlay
+imports the exact same constants the `sheet` recipe uses, so token and surface
+can never drift:
+
+- **Fill** — `GLASS_SHEET_FILL` = `color-mix(in srgb, var(--card) 62%, transparent)`.
+  A mostly-translucent dark card so the live view behind reads as a soft, bright
+  frost, not a gray near-opaque slab.
+- **Backdrop** — `GLASS_SHEET_BACKDROP_FILTER` = `blur(30px)`. A heavy **neutral**
+  blur: it keeps text legible while letting the backdrop's color and light
+  through. **No `saturate`** — saturate muddies the warm/orange field to brown
+  (measured, not taste); the whole liquid-glass system is neutral white/black
+  only. **No refraction** — a panel this size would visibly warp the text behind
+  it (refraction is reserved for the small notification cards).
+- **Edge** — the shared `LIQUID_GLASS_EDGE_SHADOW` bevel (bright top-left rim over
+  a soft bottom-right shade) + `LIQUID_GLASS_SHEEN` specular highlight. Depth is
+  inset light, never an outer drop shadow (the shell's flat surface system).
+
+Per-platform tiers are owned by `glass/useNativeGlass.ts`: `native` (real
+`UIGlassEffect` on iOS 26+, Material panel on Android 12+, element transparent),
+`css-refraction` (Chromium), `css-frosted` (universal). The tier changes only
+which layer paints the material — never geometry. Full-bleed is opaque
+(`var(--bg)`, no blur): nothing to see through, so the blur would be wasted
+battery. The `no-backdrop-blur-gate` test keeps blur confined to this named set
+of glass surfaces (#9141 battery).
+
+## Contrast (WCAG-AA)
+
+Self-contained contrast: the overlay ships its own dark, neutral token block
+(`CHAT_PANEL_THEME`: `--card #181a20`, `--txt #f4f5f7`, `--muted` 0.68,
+`--muted-strong` 0.86) scoped on the fieldset, so text stays legible over any
+substrate (bright view, dark view, warm "good evening" field) and the chat never
+reads as a transparent orange overlay. Body/muted text clears the AA 4.5:1 floor
+over the panel fill; helper text never uses opacity-suffixed muted classes
+(`text-muted/70` etc.) — the bar #16418 set. Icon hit targets are 44×44.
+
+## Motion + reduced-motion
+
+Springs: `SHEET_SPRING` (height) `{320, 34, 0.9}`; `OPEN_SPRING` (pill→input
+"liquid glass" open, springier) `{300, 26, 0.85}`. Open/close motion is
+opacity/translate only — animating blur/filter or scaling the transcript
+repaints too much and janks. Maximize is a **discrete** state (shape springs to
+full-bleed when the over-pull crosses `MAXIMIZE_COMMIT_T`, back below
+`MAXIMIZE_RELEASE_T` — hysteresis), not a finger-tracked lerp of the shape. Each
+detent crossing fires one light haptic.
+
+`useReducedMotion()` gates every animation: each reduced-motion path snaps the
+motion value instantly (height set directly instead of animated, first-run
+backdrop straight to `off`, `fullBleedT`/`openProgress` set not sprung, overlay
+fade duration → 0). Pulse indicators use `motion-reduce:animate-none`.
+
+## Focus management
+
+Focus == INPUT intent only. Focusing the composer records the pre-focus state;
+typing a **non-empty draft** (a typed-state signal, `draft.trim().length > 0`)
+expands to HALF when a thread exists. Keyboard-dismiss (tap grabber / scrim /
+outside) returns to the pre-focus state: collapsed-before-focus → INPUT,
+open-before-focus → its detent. Every collapse to INPUT/PILL blurs the composer
+so the keyboard drops. `Escape` in the transcript collapses the sheet.
+
+## Scrolling
+
+Bottom-follow is delegated to the shadcn `MessageScroller` primitive
+(`components/ui/message-scroller.tsx`): it sticks to the bottom **only when the
+user is already at the bottom**, so streamed/incoming content never yanks the
+viewport when the reader has scrolled up. First-run starts at the top (`start`);
+normal chat pins the latest line near the composer (`end`). The only forced
+scroll is after an explicit send (`scrollToEnd`). The viewport is
+`touch-pan-y overscroll-contain` with a closed horizontal axis; infinite upward
+history loads via a top sentinel with the reader's anchor preserved.
+
+## Resize / detents / keyboard / touch
+
+Owned by [`CHAT_SHEET_STATE_MATRIX.md`](./__e2e__/CHAT_SHEET_STATE_MATRIX.md).
+Load-bearing invariants: FULL is a ceiling you over-pull past (top always
+maximizes); only FULL may carry `maximized`, every other landing clears it;
+`openProgress` always settles to 0 (pill) or 1 (anything else), never mid-morph;
+1:1 finger tracking at both extremes; travel past the full-bleed ceiling is
+consumed, not banked. Keyboard-intrusion resizes the panel to the true visual
+viewport and applies the native keyboard lift the visual viewport may under-report.
+
+## State coverage
+
+`empty` (fresh/cleared thread), `loading` (`chat-thread-loading` spinner while
+`visibleMessages.length === 0 && conversationLoading`), `error` (send-blocked /
+model-unavailable composer states, image read errors), `connected` (live
+transcript + turn-status), and `offline` (provisioning / no-provider recovery
+gate) each render distinguishably. Loading is never rendered as a broken empty
+box; empty is never rendered as loading. Long / adversarial content wraps within
+the pinned reading column and scrolls; the composer placeholder never wraps past
+two lines.

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -69,6 +69,10 @@ import type {
 import { reportComposerActivity } from "../../chat/report-composer-activity";
 import { CHAT_PREFILL_EVENT, ELIZA_BACK_INTENT_EVENT } from "../../events";
 import {
+  GLASS_SHEET_BACKDROP_FILTER,
+  GLASS_SHEET_FILL,
+} from "../../glass/tokens";
+import {
   LAYOUT_SHIFT_INTENT_ATTR,
   LAYOUT_SHIFT_INTENT_TRANSIENT,
 } from "../../hooks/useLayoutShiftMonitor";
@@ -232,6 +236,18 @@ describe("ContinuousChatOverlay", () => {
     });
     expect(screen.getByLabelText("send")).toBeTruthy();
     expect(screen.queryByLabelText("talk")).toBeNull();
+  });
+
+  it("renders the frosted sheet from the glass token system (no saturate)", () => {
+    // The chat sheet is a liquid-glass SYSTEM surface: its inset material comes
+    // from GLASS_SHEET_* tokens, not a hand-rolled inline recipe. The backdrop
+    // filter is a neutral blur with NO saturate — saturate muddies the warm
+    // field to brown, which the whole liquid-glass system forbids.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const surface = screen.getByTestId("chat-sheet-surface");
+    expect(surface.style.backdropFilter).toBe(GLASS_SHEET_BACKDROP_FILTER);
+    expect(surface.style.backdropFilter).not.toMatch(/saturate|brightness/);
+    expect(surface.style.backgroundColor).toBe(GLASS_SHEET_FILL);
   });
 
   it("reports typing start and pause from the real composer draft", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -62,6 +62,10 @@ import {
   TOUCH_TAP_MOVE_SLOP as OUTSIDE_SHEET_TAP_SLOP,
   useRafCoalescer,
 } from "../../gestures";
+import {
+  GLASS_SHEET_BACKDROP_FILTER,
+  GLASS_SHEET_FILL,
+} from "../../glass/tokens";
 import { useConversationRenderWindow } from "../../hooks/useConversationRenderWindow";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
@@ -5014,27 +5018,31 @@ export function ContinuousChatOverlay({
               // sheet radius squares off as it maximizes and rounds back as it
               // de-maximizes, in lockstep with the side/bottom insets.
               borderRadius: morphRadius,
-              // REAL frosted glass on the inset sheet: a mostly-translucent dark
-              // fill over a strong backdrop blur, so the live view behind reads
-              // as a soft, bright frost — not the grayish near-opaque slab a high
-              // fill produced. The heavy blur (30px) + light saturate is what
-              // keeps text readable while letting the backdrop's color and light
-              // through: nothing sharp bleeds, but the panel is unmistakably
-              // glass, not a gray card. `--card` / `--bg` are scoped by
-              // CHAT_PANEL_THEME on the fieldset, not the orange app theme behind.
-              // Full-bleed stays fully opaque (it covers the whole screen — there
-              // is nothing to see through, and the blur would be wasted battery).
+              // REAL frosted glass on the inset sheet, sourced from the glass
+              // token system (`glass/tokens.ts`) so the chat sheet is a genuine
+              // liquid-glass SYSTEM surface, not a hand-rolled recipe that drifts
+              // from the token: `GLASS_SHEET_FILL` is a mostly-translucent dark
+              // card fill so the live view behind reads as a soft, bright frost
+              // (not a gray near-opaque slab), and `GLASS_SHEET_BACKDROP_FILTER`
+              // is a heavy neutral blur with NO saturate — the blur keeps text
+              // readable while letting the backdrop's color and light through,
+              // and saturate is omitted because it muddies the warm field to
+              // brown (the whole liquid-glass system is neutral white/black
+              // only). `--card` / `--bg` are scoped by CHAT_PANEL_THEME on the
+              // fieldset, not the orange app theme behind. Full-bleed stays fully
+              // opaque (it covers the whole screen — there is nothing to see
+              // through, and the blur would be wasted battery).
               backgroundColor: firstRunOpen
                 ? "transparent"
                 : fullBleed
                   ? "var(--bg)"
-                  : "color-mix(in srgb, var(--card) 62%, transparent)",
+                  : GLASS_SHEET_FILL,
               backdropFilter: fullBleed
                 ? undefined
-                : "blur(30px) saturate(1.4)",
+                : GLASS_SHEET_BACKDROP_FILTER,
               WebkitBackdropFilter: fullBleed
                 ? undefined
-                : "blur(30px) saturate(1.4)",
+                : GLASS_SHEET_BACKDROP_FILTER,
               // Liquid-glass bevel: a bright top-left rim over a soft
               // bottom-right shade so the frosted edge catches light like a real
               // glass slab. Only on the inset sheet — full-bleed has no edge to

--- a/packages/ui/src/glass/glass.test.tsx
+++ b/packages/ui/src/glass/glass.test.tsx
@@ -12,7 +12,12 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GlassStyles, GlassSurface } from "./GlassSurface";
 import { resetGlassBridgeForTests } from "./native-bridge";
-import { GLASS_RECIPES, type GlassVariant } from "./tokens";
+import {
+  GLASS_RECIPES,
+  GLASS_SHEET_BACKDROP_FILTER,
+  GLASS_SHEET_FILL,
+  type GlassVariant,
+} from "./tokens";
 
 type CapGlobal = { Capacitor?: unknown };
 
@@ -84,6 +89,23 @@ describe("glass tokens", () => {
   it("keeps the sheet saturate-free (saturate reads brown over the warm theme)", () => {
     expect(GLASS_RECIPES.sheet.backdropFilter).not.toMatch(/saturate/);
     expect(GLASS_RECIPES.sheet.refraction).toBeNull();
+  });
+
+  it("exposes the chat-sheet material as tokens the overlay consumes", () => {
+    // ContinuousChatOverlay renders its frosted panel from these exact tokens
+    // (not a hand-rolled inline recipe), so the chat sheet is a genuine
+    // liquid-glass SYSTEM surface. If either drifts, the overlay drifts with it.
+    expect(GLASS_SHEET_FILL).toBe(
+      "color-mix(in srgb, var(--card) 62%, transparent)",
+    );
+    // Neutral blur only — no saturate (brown over the warm field), no refraction.
+    expect(GLASS_SHEET_BACKDROP_FILTER).toBe("blur(30px)");
+    expect(GLASS_SHEET_BACKDROP_FILTER).not.toMatch(/saturate|brightness/);
+    // The recipe is wired to the same constants, so token and surface agree.
+    expect(GLASS_RECIPES.sheet.background).toBe(GLASS_SHEET_FILL);
+    expect(GLASS_RECIPES.sheet.backdropFilter).toBe(
+      GLASS_SHEET_BACKDROP_FILTER,
+    );
   });
 
   it("gives refraction only to small surfaces (card, menu)", () => {

--- a/packages/ui/src/glass/index.ts
+++ b/packages/ui/src/glass/index.ts
@@ -17,6 +17,7 @@ export {
   GLASS_MENU_FILL,
   GLASS_PILL_FILL,
   GLASS_RECIPES,
+  GLASS_SHEET_BACKDROP_FILTER,
   GLASS_SHEET_FILL,
   type GlassRecipe,
   type GlassVariant,

--- a/packages/ui/src/glass/tokens.ts
+++ b/packages/ui/src/glass/tokens.ts
@@ -56,9 +56,26 @@ export interface GlassRecipe {
   radius: string;
 }
 
-/** Fill used by the chat sheet: theme-aware card at 86%. */
+/**
+ * Fill for the chat sheet — the single source of truth for the frosted panel
+ * material `ContinuousChatOverlay` renders. A mostly-translucent theme-aware
+ * card at 62%: the live view behind reads as a soft, bright frost rather than
+ * the grayish near-opaque slab a high fill produced. Paired with
+ * {@link GLASS_SHEET_BACKDROP_FILTER}; the overlay imports both, so the chat
+ * sheet is a genuine liquid-glass SYSTEM surface instead of a hand-rolled
+ * recipe that drifts from the token.
+ */
 export const GLASS_SHEET_FILL =
-  "color-mix(in srgb, var(--card) 86%, transparent)";
+  "color-mix(in srgb, var(--card) 62%, transparent)";
+/**
+ * Backdrop filter for the chat sheet: a heavy neutral blur with NO saturate.
+ * The blur keeps text legible while letting the backdrop's color and light
+ * through; saturate is omitted because it muddies the warm/orange field to
+ * brown (measured, not taste — the whole liquid-glass system is neutral
+ * white/black only). No refraction: a panel this size would visibly warp the
+ * text behind it. Shared by the recipe and the overlay so the two never drift.
+ */
+export const GLASS_SHEET_BACKDROP_FILTER = "blur(30px)";
 /** Fill used by floating cards (notifications). */
 export const GLASS_CARD_FILL = "rgb(12 12 14 / 34%)";
 /** Darker menu fill so labels stay readable over any wallpaper. */
@@ -71,8 +88,7 @@ export const GLASS_PILL_FILL = "rgb(20 20 24 / 30%)";
 export const GLASS_RECIPES: Record<GlassVariant, GlassRecipe> = {
   sheet: {
     background: GLASS_SHEET_FILL,
-    // No saturate: over the orange-accented theme, saturate() muddies to brown.
-    backdropFilter: "blur(20px)",
+    backdropFilter: GLASS_SHEET_BACKDROP_FILTER,
     refraction: null,
     rim: false,
     edgeShadow: LIQUID_GLASS_EDGE_SHADOW,


### PR DESCRIPTION
## Summary

Closes #16439 (one of five focused cards replacing the closed monolith #16200).

Makes the ChatOverlay's frosted sheet a genuine **liquid-glass system surface**.
The chat sheet was the last hand-rolled glass in the overlay: an inline fill +
`backdrop-filter` recipe that diverged from the canonical `sheet` glass token and,
with `saturate(1.4)`, violated the liquid-glass system's own unit-tested rule that
the sheet stays saturate-free (saturate muddies the warm/orange field to brown —
the whole system is neutral white/black only).

This PR sources the sheet's fill and backdrop from `GLASS_SHEET_FILL` +
`GLASS_SHEET_BACKDROP_FILTER` in `glass/tokens.ts` so token and surface can never
drift, drops the saturate, and adds a focused design spec. All
chat/attachments/voice/permissions/a11y semantics and the typed `ChatMode` detent
state machine are unchanged; **no transcript-length heuristic stands in for typed
state.**

## Current develop → delta

Most of the liquid-glass redesign the card describes already merged on `develop`
(the 62% translucent card fill, the 30px blur, the edge-shadow bevel + specular
sheen, the per-platform native-glass tiers, the WCAG-AA `CHAT_PANEL_THEME` block
from #16418, and the minimal no-chrome hierarchy from #16367). This PR implements
only the remaining **delta**:

| Area | Before (develop) | After |
| --- | --- | --- |
| Sheet fill | inline `color-mix(... var(--card) 62% ...)` | `GLASS_SHEET_FILL` token (single source of truth) |
| Sheet backdrop | inline `blur(30px) saturate(1.4)` | `GLASS_SHEET_BACKDROP_FILTER` token = `blur(30px)` (no saturate) |
| `GLASS_RECIPES.sheet` | `blur(20px)`, fill 86% | wired to the same two constants (kept in sync; no component renders `variant="sheet"`, so inert visually) |
| Design spec | none | `CHAT_OVERLAY_DESIGN_SPEC.md` |

Net user-visible change: the chat sheet's backdrop loses `saturate(1.4)`, so the
frost reads neutral instead of warm/brown-tinted over the orange ember field.

## Design spec (concise; full copy in `packages/ui/src/components/shell/CHAT_OVERLAY_DESIGN_SPEC.md`)

- **Hierarchy** — one always-present, bottom-anchored element that never remounts
  across `pill ↔ input ↔ half ↔ full ↔ maximized`; every transition is
  transform/opacity/height only. Container is `pointer-events-none` so the view
  behind stays live. No chrome: no message counter, tab strip, or branded alert.
- **Materials** — frosted panel sourced from the shared glass tokens. Fill
  `GLASS_SHEET_FILL` (translucent card, reads as bright frost not a gray slab);
  backdrop `GLASS_SHEET_BACKDROP_FILTER` = neutral `blur(30px)`, **no saturate, no
  refraction**; edge = shared `LIQUID_GLASS_EDGE_SHADOW` bevel + `LIQUID_GLASS_SHEEN`
  specular. Full-bleed is opaque (nothing to see through). Per-platform tier owned
  by `useNativeGlass.ts`; the `no-backdrop-blur-gate` keeps blur confined to the
  named glass surfaces (#9141 battery).
- **Contrast (WCAG-AA)** — self-contained dark neutral token block
  (`CHAT_PANEL_THEME`); body/muted text clears 4.5:1 over the panel fill; no
  opacity-suffixed muted classes (#16418 bar). Icon hit targets 44×44. (OCR of the
  open sheet below reads the whole transcript cleanly over the frost.)
- **Motion + reduced-motion** — `SHEET_SPRING` {320,34,0.9} height, `OPEN_SPRING`
  {300,26,0.85} open; opacity/translate only (no animated blur). Maximize is a
  discrete hysteresis state, not a finger-tracked shape lerp. `useReducedMotion()`
  snaps every animated value instantly.
- **Focus** — focus == INPUT intent only; a non-empty typed draft
  (`draft.trim().length > 0`, a typed-state signal) expands to HALF when a thread
  exists; keyboard-dismiss returns to the pre-focus detent; `Escape` collapses.
- **Scrolling** — bottom-follow delegated to the `MessageScroller` primitive
  (sticks only when already at bottom); `touch-pan-y overscroll-contain`, closed
  horizontal axis; upward history via a top sentinel preserving the anchor.
- **Resize/detents/keyboard/touch** — owned by `__e2e__/CHAT_SHEET_STATE_MATRIX.md`.
  FULL is a ceiling you over-pull past to maximize; only FULL may carry
  `maximized`; `openProgress` always settles to 0 or 1; 1:1 finger tracking at
  both extremes.
- **State coverage** — `empty` / `loading` / `error` / `connected` / `offline`
  each render distinguishably; loading is never a broken empty box; long/adversarial
  content wraps within the pinned reading column and scrolls.

## Tests

- `glass.test.tsx` — asserts the chat-sheet material tokens exist, are neutral
  (no saturate/brightness), and that `GLASS_RECIPES.sheet` is wired to the same
  constants (token/surface can't drift).
- `ContinuousChatOverlay.test.tsx` — renders the overlay and asserts the
  `chat-sheet-surface` node reads its `backdropFilter`/`backgroundColor` from the
  tokens, with no saturate. Full touched suites: 190 overlay tests + the glass
  suite pass locally.

## Verification

- CI `aesthetic-audit` lane (full `audit:app`, desktop + mobile, all views): **pass**
  — no touched/reachable page left needs-work/broken. `ocr-content-audit`: pass.
- Evidence below is captured from a real headless-Chromium render of
  `ContinuousChatOverlay` (the chat-sheet e2e fixture) over the warm `/chat`
  backdrop — the exact substrate where saturate-vs-neutral shows — plus the
  desktop + mobile `builtin-chat` page captures from the audit run.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] **Before** (develop material `blur(30px) saturate(1.4)`), open sheet over the warm field, desktop:
  ![before-half](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-before-desktop-half.jpg)
  ![before-full](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-before-desktop-full.jpg)
<!-- evidence-row:after-screenshots -->
- [x] **After** (neutral `blur(30px)`), rest + open over the field (desktop) and full-page desktop + mobile chat:
  ![after-rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-after-desktop-rest.jpg)
  ![after-half](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-after-desktop-half.jpg)
  ![after-full](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-after-desktop-full.jpg)
  ![after-desktop-page](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-after-desktop-page.jpg)
  ![after-mobile-page](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-after-mobile-page.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Mobile walkthrough of the sheet drag matrix (pill → input → half → full → maximize → collapse):
  https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - client-only presentation change; the chat sheet material (CSS fill + backdrop-filter tokens) has no server code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend render log (real Chromium): computed sheet fill reads `color(srgb 0.094 0.102 0.125 / 0.62)` = `#181a20 @ 62%` (neutral, not the orange app theme), borderless glass, **zero page errors** across the render + drag matrix:
  https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-frontend.log
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed; this is a presentation-material change only.`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no memories/DB rows/scheduled tasks/on-chain output produced; presentation-only change.`
<!-- evidence-row:ocr-review -->
- [x] OCR text readout of the open sheet (after) — the full transcript reads cleanly over the neutral frost (WCAG-AA legibility): OCR report
  https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16489-ocr.txt
