### PR TITLE
fix(core): never ship tool-invocation dialects as the recovered evaluator answer

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -875,4 +875,39 @@ describe("native tool dialects never recover as the user-facing answer", () => {
 		expect(result.messageToUser ?? "").not.toContain("GET_WEATHER");
 		expect(result.messageToUser ?? "").not.toContain("location");
 	});
+
+	it("does not deliver a call:NAME{...} invocation with non-JSON args (live 2026-07-16 leak)", async () => {
+		// gemma emitted this exact dialect as its whole reply — unquoted keys, so
+		// the JSON-object screen can never see it. It shipped to Discord verbatim,
+		// four turns in a row.
+		const result = await runWithModelText(
+			"call:WEB_SEARCH{numResults:6,query:best restaurants near 25 Nassau Ave Brooklyn NY 11222}",
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser ?? "").toBe("");
+	});
+
+	it("does not deliver a mid-text invocation of a tool the trajectory carries", async () => {
+		const result = await runWithModelText(
+			"Let me check that again. SHELL{cmd: df -h}",
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser ?? "").toBe("");
+	});
+
+	it("still recovers genuine prose after a successful tool result", async () => {
+		const result = await runWithModelText(
+			"You have 165G available on / and plenty of headroom on /home.",
+		);
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("165G available");
+	});
+
+	it("still recovers prose that merely MENTIONS a trajectory tool without invoking it", async () => {
+		const result = await runWithModelText(
+			"I used SHELL to check the disk — you have 165G free, so no cleanup needed.",
+		);
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("165G free");
+	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -529,7 +529,10 @@ function recoverEvaluatorTextOutput(
 	const text = rawText(raw).trim();
 	if (!text) return output;
 
-	if (containsToolAttemptObject(text)) {
+	if (
+		containsToolAttemptObject(text) ||
+		invokesTrajectoryTool(text, trajectory)
+	) {
 		return {
 			success: false,
 			decision: "CONTINUE",
@@ -611,6 +614,31 @@ function hasSuccessfulToolResult(trajectory: PlannerTrajectory): boolean {
 	return trajectory.steps.some((step) => step.result?.success === true);
 }
 
+/**
+ * True when the recovered text invokes a tool this trajectory actually
+ * carries — the model wanted ANOTHER tool call, not a user reply. Grounded in
+ * the turn's real tool surface (step tool names) rather than a syntax
+ * dictionary, because models drift into invocation dialects the JSON screen
+ * above cannot parse (observed live: gemma emitting
+ * `call:WEB_SEARCH{numResults:6,query:…}` with unquoted keys — JSON.parse
+ * throws, the guard passed it, and the invocation shipped to Discord as the
+ * final answer, repeatedly).
+ */
+function invokesTrajectoryTool(
+	text: string,
+	trajectory: PlannerTrajectory,
+): boolean {
+	for (const step of trajectory.steps) {
+		const name = step.toolCall?.name?.trim();
+		if (!name) continue;
+		const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		if (new RegExp(`(?:^|[^A-Za-z0-9_])${escaped}\\s*[({]`, "i").test(text)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function containsToolAttemptObject(text: string): boolean {
 	for (const objectText of extractJsonObjects(text)) {
 		try {
@@ -660,6 +688,17 @@ function looksLikeUserFacingAnswer(text: string): boolean {
 		return false;
 	}
 	if (/^\s*[A-Z][A-Z0-9_]{2,}\s*\n\s*\{/.test(text)) {
+		return false;
+	}
+	// A reply that OPENS with an invocation DSL ("call:WEB_SEARCH{…}",
+	// "invoke: shell(…)") is machine syntax regardless of dialect — the
+	// argument block is rarely valid JSON, so the key-based guard above
+	// cannot see it.
+	if (
+		/^\s*(?:call|invoke|use|run)\s*:\s*[A-Za-z][A-Za-z0-9_.-]*\s*[({]/i.test(
+			text,
+		)
+	) {
 		return false;
 	}
 	if (


### PR DESCRIPTION
## What

The evaluator's prose-recovery path (`recoverEvaluatorTextOutput`) salvages a user-facing reply when the model answers the evaluation stage with unstructured text after a successful tool run. Its tool-attempt screen only recognized **JSON-object dialects** (`extractJsonObjects` → `JSON.parse` → name+params keys). A model asking for ANOTHER tool call in a non-JSON dialect walked straight through and its invocation syntax shipped as the final answer.

Observed live (2026-07-16): after a **successful** WEB_SEARCH with results in hand, gemma answered the evaluation stage with exactly `call:WEB_SEARCH{numResults:6,query:best restaurants near 25 Nassau Ave Brooklyn NY 11222}` — unquoted keys, invisible to JSON.parse — and that line went to Discord verbatim, four turns in a row.

Two structural screens, grounded rather than dialect-enumerating:
- recovery now **CONTINUEs when the recovered text invokes a tool the trajectory actually carries** (step tool names — the turn's real tool surface), whatever syntax surrounds it;
- `looksLikeUserFacingAnswer` rejects replies that **open with an invocation DSL** (`call:`/`invoke:`/`use:`/`run:` + name + argument block) — the shape class the JSON-key screen structurally cannot match, sitting beside the existing XML-dialect and ALL_CAPS-name screens.

## Evidence

| Type | Evidence |
|---|---|
| LLM trajectory | Full stage-by-stage record of the live leak (tj-2623accca9e290) + post-fix live replay of the exact prompt: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/eval-leak-incident.txt |
| Tests | 4 new fences in `evaluator.test.ts`'s delivery-guard suite: the live leak verbatim, a mid-text invocation of a trajectory tool, and two false-positive controls (genuine prose still recovers; prose that merely mentions a tool name still recovers). Falsified both ways — the identical input FINISHes-and-leaks on the previous code. 32/32 evaluator suite; evaluator.ts at 84.8% lines from its own changed suite. |
| Backend logs | The trajectory record above is the backend evidence; the recovery path logs no additional lines. |
| Screenshots / video | N/A - runtime evaluator change; user-visible effect is reply content, shown verbatim in the incident transcript. |

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend evaluator change; the before state is the verbatim Discord leak transcript in the llm-trajectory row.`

<!-- evidence-row:after-screenshots -->
`N/A - backend evaluator change; the after state is the one-message live replay in the llm-trajectory row.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the incident + replay transcript.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/eval-leak-incident.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/eval-leak-incident.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/eval-leak-incident.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
