### PR TITLE
fix(ui): stabilize notification shade and continuous chat interactions

### DIFF
--- a/packages/agent/src/api/__tests__/ws-event-replay.test.ts
+++ b/packages/agent/src/api/__tests__/ws-event-replay.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_REPLAY_LIMIT,
   eventSequence,
+  markReplayEvent,
   parseEventCursor,
   type ReplayableEvent,
   selectReplayEvents,
@@ -54,6 +55,14 @@ describe("eventSequence", () => {
 
   it("returns null for an unparseable eventId", () => {
     expect(eventSequence({ eventId: "no-digits-here" })).toBeNull();
+  });
+});
+
+describe("markReplayEvent", () => {
+  it("labels a copy without contaminating the live buffered envelope", () => {
+    const live = { eventId: "evt-7", bufferSeq: 7, payload: { value: 1 } };
+    expect(markReplayEvent(live)).toEqual({ ...live, replayed: true });
+    expect(live).not.toHaveProperty("replayed");
   });
 });
 

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -478,6 +478,7 @@ import {
 } from "./wallet-rpc.ts";
 import {
   DEFAULT_REPLAY_LIMIT,
+  markReplayEvent,
   parseEventCursor,
   selectReplayEvents,
 } from "./ws-event-replay.ts";
@@ -4821,7 +4822,7 @@ export async function startApiServer(opts?: {
           DEFAULT_REPLAY_LIMIT,
         );
         for (const event of replay) {
-          ws.send(JSON.stringify(event));
+          ws.send(JSON.stringify(markReplayEvent(event)));
         }
       } catch (err) {
         logger.error(

--- a/packages/agent/src/api/ws-event-replay.ts
+++ b/packages/agent/src/api/ws-event-replay.ts
@@ -30,6 +30,13 @@ export interface ReplayableEvent {
   bufferSeq?: number;
 }
 
+/** Label a replay copy without mutating the canonical buffered envelope. */
+export function markReplayEvent<T extends ReplayableEvent>(
+  event: T,
+): T & { replayed: true } {
+  return { ...event, replayed: true };
+}
+
 /**
  * Resolve the monotonic sequence of a buffered envelope.
  *

--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -1007,17 +1007,30 @@ function buildCapacitorPluginsIfNeeded(childEnv) {
 function startVite() {
   const childEnv = createDevChildEnv(process.env);
 
-  const viteCmd = hasBun ? "bun" : "npx";
+  // Vite's WebSocket proxy depends on Node's HTTP upgrade semantics. Under
+  // Bun, `/ws` remains pending even while ordinary HTTP proxying succeeds,
+  // silently disconnecting live notifications and chat events in the UI.
+  const viteCmd = which("node");
+  if (!viteCmd) {
+    throw new Error("Node.js 24+ is required to run the Vite dev server.");
+  }
+  const viteCli = path.join(
+    cwd,
+    appDir,
+    "node_modules",
+    "vite",
+    "bin",
+    "vite.js",
+  );
+  if (!existsSync(viteCli)) {
+    throw new Error(`Vite CLI not found at ${viteCli}. Run bun install first.`);
+  }
   const viteForce =
     process.env.ELIZA_VITE_FORCE === "1" ||
     process.env.ELIZA_VITE_FORCE === "1";
-  const viteArgs = hasBun
-    ? viteForce
-      ? ["--bun", "vite", "--force", "--port", String(UI_PORT)]
-      : ["--bun", "vite", "--port", String(UI_PORT)]
-    : viteForce
-      ? ["vite", "--force", "--port", String(UI_PORT)]
-      : ["vite", "--port", String(UI_PORT)];
+  const viteArgs = viteForce
+    ? [viteCli, "--force", "--port", String(UI_PORT)]
+    : [viteCli, "--port", String(UI_PORT)];
   if (viteForce) {
     console.log(
       `  ${green(logPrefix)} ${dim("Vite --force (ELIZA_VITE_FORCE=1): re-optimizing deps.")}`,

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -313,6 +313,10 @@
       overflow: hidden;
       background: var(--launch-bg, #000000);
       color: #ffffff;
+      /* This surface paints before the bundled Poppins face is declared. An
+         OS-resident stack keeps the centered brand row fixed while app CSS
+         loads and React takes ownership of the root. */
+      font-family: Arial, system-ui, sans-serif;
     }
 
     .eliza-preboot-shell__content {
@@ -396,7 +400,7 @@
       <div class="eliza-preboot-shell__content">
         <div class="eliza-preboot-shell__brand" aria-hidden="true">
           <img class="eliza-preboot-shell__mark" src="%BASE_URL%brand/logos/logo_white_nobg.svg" alt="" />
-          <span class="eliza-preboot-shell__name">elizaOS</span>
+          <span class="eliza-preboot-shell__name">__APP_NAME__</span>
         </div>
         <p class="eliza-preboot-shell__status">Booting up</p>
       </div>

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -322,7 +322,7 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 1.25rem;
+      gap: 1rem;
       padding: 0 1.5rem;
       text-align: center;
     }
@@ -348,22 +348,42 @@
     }
 
     .eliza-preboot-shell__status {
+      --eliza-preboot-shimmer-spread: calc(2.5ch + 32px);
       margin: 0;
-      min-height: 1.25rem;
-      font-size: 0.875rem;
-      line-height: 1.25rem;
-      opacity: 0.8;
-      animation: eliza-preboot-status-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+      min-height: 1.5rem;
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 1.5rem;
+      letter-spacing: 0.01em;
+      color: rgba(255, 255, 255, 0.6);
+      background-image: linear-gradient(
+        110deg,
+        currentColor calc(50% - var(--eliza-preboot-shimmer-spread)),
+        rgba(255, 255, 255, 1) 50%,
+        currentColor calc(50% + var(--eliza-preboot-shimmer-spread))
+      );
+      background-repeat: no-repeat;
+      background-size: calc(200% + var(--eliza-preboot-shimmer-spread) * 2) 100%;
+      background-position: 0 0;
+      background-clip: text;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      animation: eliza-preboot-status-shimmer 1.8s linear infinite;
     }
 
-    @keyframes eliza-preboot-status-pulse {
-      50% {
-        opacity: 0.5;
+    @keyframes eliza-preboot-status-shimmer {
+      from {
+        background-position: 100% 0;
+      }
+      to {
+        background-position: 0 0;
       }
     }
 
     @media (prefers-reduced-motion: reduce) {
       .eliza-preboot-shell__status {
+        background-image: none;
+        -webkit-text-fill-color: currentColor;
         animation: none;
       }
     }
@@ -378,7 +398,7 @@
           <img class="eliza-preboot-shell__mark" src="%BASE_URL%brand/logos/logo_white_nobg.svg" alt="" />
           <span class="eliza-preboot-shell__name">elizaOS</span>
         </div>
-        <p class="eliza-preboot-shell__status">Booting up&hellip;</p>
+        <p class="eliza-preboot-shell__status">Booting up</p>
       </div>
     </div>
   </div>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.0-beta.2",
   "type": "module",
   "scripts": {
-    "dev": "bun --bun vite",
-    "dev:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 bun --bun vite",
+    "dev": "node ./node_modules/vite/bin/vite.js",
+    "dev:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node ./node_modules/vite/bin/vite.js",
     "preview": "bun --bun vite preview",
     "design-review": "node --import tsx test/design-review/run-design-review.ts",
     "lint": "bunx @biomejs/biome check --write src scripts vite.config.ts vitest.config.ts vitest.e2e.config.ts playwright.dev-smoke.config.ts playwright.ui-smoke.config.ts playwright.ui-packaged.config.ts playwright.electrobun.packaged.config.ts playwright.web-views.config.ts playwright.android.config.ts test/android package.json capacitor.config.ts",

--- a/packages/app/scripts/dev-shared.mjs
+++ b/packages/app/scripts/dev-shared.mjs
@@ -28,7 +28,8 @@ console.log(
     `[dev:shared] registry=${registryPath}`,
 );
 
-const child = spawn("bun", ["--bun", "vite"], {
+const viteCli = path.join(appDir, "node_modules", "vite", "bin", "vite.js");
+const child = spawn(process.execPath, [viteCli], {
   cwd: appDir,
   env,
   stdio: "inherit",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -81,6 +81,7 @@ import { RenderTelemetryProfiler } from "@elizaos/ui/cloud-ui/runtime/render-tel
 import { AppWindowRenderer } from "@elizaos/ui/components/apps/AppWindowRenderer";
 import { ShellModalityProvider } from "@elizaos/ui/components/ShellModalityProvider";
 import { ShellRoleProvider } from "@elizaos/ui/components/ShellRoleProvider";
+import { StartupLoading } from "@elizaos/ui/components/shell/StartupShell";
 import type {
   BrandingConfig,
   CodingAgentTasksPanelProps,
@@ -3076,7 +3077,9 @@ function mountReactApp(): void {
   createRoot(rootEl).render(
     <ErrorBoundary>
       <StrictMode>
-        <Suspense fallback={null}>
+        <Suspense
+          fallback={<StartupLoading phase="loading-ui" status="Booting up" />}
+        >
           <RenderTelemetryProfiler id="AppRoot">
             {mainTree}
           </RenderTelemetryProfiler>

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -190,7 +190,18 @@ describe("brand surfaces", () => {
     const html = read("index.html");
     expect(html).toContain('class="eliza-preboot-shell__mark"');
     expect(html).toContain('class="eliza-preboot-shell__status"');
-    expect(html).toContain("Booting up&hellip;");
+    expect(html).toContain(
+      '<p class="eliza-preboot-shell__status">Booting up</p>',
+    );
+    expect(html).toContain(
+      "animation: eliza-preboot-status-shimmer 1.8s linear infinite",
+    );
+    expect(html).toContain("font-size: 1rem");
+    expect(html).toContain("color: rgba(255, 255, 255, 0.6)");
+    expect(html).toContain("-webkit-text-fill-color: transparent");
+    expect(html).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.eliza-preboot-shell__status\s*\{[\s\S]*?animation: none/,
+    );
   });
 
   it("preboot logo uses a base-aware brand path so it resolves on deep web routes and native builds", () => {

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -189,6 +189,9 @@ describe("brand surfaces", () => {
   it("keeps the branded preboot status visible until React takes over", () => {
     const html = read("index.html");
     expect(html).toContain('class="eliza-preboot-shell__mark"');
+    expect(html).toContain(
+      '<span class="eliza-preboot-shell__name">__APP_NAME__</span>',
+    );
     expect(html).toContain('class="eliza-preboot-shell__status"');
     expect(html).toContain(
       '<p class="eliza-preboot-shell__status">Booting up</p>',
@@ -196,11 +199,20 @@ describe("brand surfaces", () => {
     expect(html).toContain(
       "animation: eliza-preboot-status-shimmer 1.8s linear infinite",
     );
+    expect(html).toMatch(
+      /\.eliza-preboot-shell\s*\{[^}]*font-family:\s*Arial, system-ui, sans-serif/s,
+    );
     expect(html).toContain("font-size: 1rem");
     expect(html).toContain("color: rgba(255, 255, 255, 0.6)");
     expect(html).toContain("-webkit-text-fill-color: transparent");
+    expect(html).not.toMatch(
+      /\.eliza-preboot-shell__(?:content|brand|mark|name)\s*\{[^}]*\b(?:animation|transition)\s*:/s,
+    );
     expect(html).toMatch(
       /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.eliza-preboot-shell__status\s*\{[\s\S]*?animation: none/,
+    );
+    expect(read("src/main.tsx")).toContain(
+      '<StartupLoading phase="loading-ui" status="Booting up" />',
     );
   });
 

--- a/packages/app/test/ui-smoke/chat-message-actions.spec.ts
+++ b/packages/app/test/ui-smoke/chat-message-actions.spec.ts
@@ -1,9 +1,11 @@
-// Browser-level evidence for #10713: the real app chat overlay exposes a
-// click-to-reveal per-message action row. The component-level tests prove the
-// exact callbacks; this smoke records the shipped UI at desktop + mobile sizes.
+/**
+ * Browser-level proof for the continuous chat overlay's per-message actions.
+ * The checks cover rendered geometry as well as behavior because virtualized
+ * transcript containment can clip an otherwise visible, interactive element.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
   openAppPath,
@@ -156,6 +158,55 @@ async function screenshot(page: Page, name: string): Promise<void> {
   });
 }
 
+function messageRowFor(page: Page, text: string): Locator {
+  return page
+    .getByText(text, { exact: true })
+    .locator("xpath=ancestor::*[@data-testid='thread-line'][1]");
+}
+
+async function expectFullyPaintableActionSurface(row: Locator): Promise<void> {
+  const actions = row.getByTestId("thread-line-actions");
+  const surface = row.getByTestId("thread-line-action-surface");
+  await expect(actions).toHaveAttribute("aria-hidden", "false");
+  await expect(surface).toBeVisible();
+
+  await expect
+    .poll(
+      () =>
+        surface.evaluate((element) => {
+          const surfaceRect = element.getBoundingClientRect();
+          const item = element.closest('[data-slot="message-scroller-item"]');
+          if (!(item instanceof HTMLElement)) {
+            throw new Error(
+              "Message action surface is outside a scroller item",
+            );
+          }
+          const itemRect = item.getBoundingClientRect();
+          const centerElement = document.elementFromPoint(
+            surfaceRect.left + surfaceRect.width / 2,
+            surfaceRect.top + surfaceRect.height / 2,
+          );
+          return {
+            hasSize: surfaceRect.width > 0 && surfaceRect.height > 0,
+            fullyInside:
+              surfaceRect.top >= itemRect.top - 0.5 &&
+              surfaceRect.right <= itemRect.right + 0.5 &&
+              surfaceRect.bottom <= itemRect.bottom + 0.5 &&
+              surfaceRect.left >= itemRect.left - 0.5,
+            centerHitsSurface: Boolean(
+              centerElement && element.contains(centerElement),
+            ),
+          };
+        }),
+      { timeout: 2_000 },
+    )
+    .toEqual({
+      hasSize: true,
+      fullyInside: true,
+      centerHitsSurface: true,
+    });
+}
+
 for (const viewport of [
   { name: "desktop", size: { width: 1280, height: 900 } },
   { name: "mobile", size: { width: 390, height: 844 } },
@@ -179,20 +230,21 @@ for (const viewport of [
     await openThread(page);
     await screenshot(page, `${viewport.name}-chat-open`);
 
-    await page.getByText(ASSISTANT_TEXT).click();
-    await expect(page.getByTestId("thread-line-actions")).toBeVisible();
-    await expect(page.getByTestId("thread-line-copy")).toBeVisible();
-    await expect(page.getByTestId("thread-line-speak")).toBeVisible();
-    await expect(page.getByTestId("thread-line-edit")).toHaveCount(0);
+    const assistantRow = messageRowFor(page, ASSISTANT_TEXT);
+    await assistantRow.getByText(ASSISTANT_TEXT, { exact: true }).click();
+    await expectFullyPaintableActionSurface(assistantRow);
+    await expect(assistantRow.getByTestId("thread-line-copy")).toBeVisible();
+    await expect(assistantRow.getByTestId("thread-line-speak")).toBeVisible();
+    await expect(assistantRow.getByTestId("thread-line-edit")).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: /copy conversation/i }),
     ).toHaveCount(0);
     await screenshot(page, `${viewport.name}-assistant-actions`);
 
-    await page.getByTestId("thread-line-copy").click();
-    await expect(page.getByTestId("thread-line-copy")).toHaveAttribute(
+    await assistantRow.getByTestId("thread-line-copy").click();
+    await expect(assistantRow.getByTestId("thread-line-copy")).toHaveAttribute(
       "aria-label",
-      "Copied",
+      "Copied!",
       {
         timeout: 5_000,
       },
@@ -206,27 +258,33 @@ for (const viewport of [
     expect(copiedClipboardText).toBe(ASSISTANT_TEXT);
     await screenshot(page, `${viewport.name}-assistant-copied`);
 
-    await page.getByTestId("thread-line-speak").click();
-    await expect(page.getByTestId("thread-line-speak")).toBeVisible();
+    await assistantRow.getByTestId("thread-line-speak").click();
+    await expect(assistantRow.getByTestId("thread-line-speak")).toBeVisible();
     await screenshot(page, `${viewport.name}-assistant-play`);
 
-    const userBubble = page.getByText(USER_TEXT);
+    const userRow = messageRowFor(page, USER_TEXT);
+    const userBubble = userRow.getByText(USER_TEXT, { exact: true });
     await userBubble.click();
-    if ((await page.getByTestId("thread-line-copy").count()) === 0) {
+    if (
+      (await userRow
+        .getByTestId("thread-line-actions")
+        .getAttribute("aria-hidden")) !== "false"
+    ) {
       await userBubble.click();
     }
-    await expect(page.getByTestId("thread-line-copy")).toBeVisible();
-    await expect(page.getByTestId("thread-line-edit")).toBeVisible();
-    await expect(page.getByTestId("thread-line-speak")).toHaveCount(0);
+    await expectFullyPaintableActionSurface(userRow);
+    await expect(userRow.getByTestId("thread-line-copy")).toBeVisible();
+    await expect(userRow.getByTestId("thread-line-edit")).toBeVisible();
+    await expect(userRow.getByTestId("thread-line-speak")).toHaveCount(0);
     await screenshot(page, `${viewport.name}-user-actions`);
 
-    await page.getByTestId("thread-line-edit").click();
-    const editor = page.getByTestId("thread-line-edit-input");
+    await userRow.getByTestId("thread-line-edit").click();
+    const editor = userRow.getByTestId("thread-line-edit-input");
     await expect(editor).toBeVisible();
     await expect(editor).toHaveValue(USER_TEXT);
     await editor.fill(EDITED_TEXT);
     await screenshot(page, `${viewport.name}-user-editing`);
-    await page.getByTestId("thread-line-edit-save").click();
+    await userRow.getByTestId("thread-line-edit-save").click();
 
     await expect.poll(() => streamCalls.length, { timeout: 15_000 }).toBe(1);
     expect(JSON.stringify(streamCalls[0])).toContain(EDITED_TEXT);

--- a/packages/app/test/ui-smoke/chat-message-actions.spec.ts
+++ b/packages/app/test/ui-smoke/chat-message-actions.spec.ts
@@ -28,9 +28,10 @@ const OUT_DIR = path.join(
 
 type StreamCall = Record<string, unknown>;
 
-async function installMessageActionConversationRoutes(
-  page: Page,
-): Promise<{ streamCalls: StreamCall[] }> {
+async function installMessageActionConversationRoutes(page: Page): Promise<{
+  streamCalls: StreamCall[];
+  truncateCalls: StreamCall[];
+}> {
   const now = Date.now();
   const conversation = {
     id: CONVERSATION_ID,
@@ -58,6 +59,7 @@ async function installMessageActionConversationRoutes(
     },
   ];
   const streamCalls: StreamCall[] = [];
+  const truncateCalls: StreamCall[] = [];
 
   await page.route("**/api/conversations", async (route) => {
     if (route.request().method() === "GET") {
@@ -110,6 +112,18 @@ async function installMessageActionConversationRoutes(
   );
 
   await page.route(
+    `**/api/conversations/${CONVERSATION_ID}/messages/truncate`,
+    async (route) => {
+      truncateCalls.push(JSON.parse(route.request().postData() ?? "{}"));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, deletedCount: 2 }),
+      });
+    },
+  );
+
+  await page.route(
     `**/api/conversations/${CONVERSATION_ID}/messages/stream`,
     async (route) => {
       streamCalls.push(JSON.parse(route.request().postData() ?? "{}"));
@@ -135,7 +149,7 @@ async function installMessageActionConversationRoutes(
     },
   );
 
-  return { streamCalls };
+  return { streamCalls, truncateCalls };
 }
 
 async function openThread(page: Page): Promise<void> {
@@ -175,13 +189,15 @@ async function expectFullyPaintableActionSurface(row: Locator): Promise<void> {
       () =>
         surface.evaluate((element) => {
           const surfaceRect = element.getBoundingClientRect();
-          const item = element.closest('[data-slot="message-scroller-item"]');
-          if (!(item instanceof HTMLElement)) {
+          const viewport = element.closest(
+            '[data-slot="message-scroller-viewport"]',
+          );
+          if (!(viewport instanceof HTMLElement)) {
             throw new Error(
-              "Message action surface is outside a scroller item",
+              "Message action surface is outside the scroller viewport",
             );
           }
-          const itemRect = item.getBoundingClientRect();
+          const viewportRect = viewport.getBoundingClientRect();
           const centerElement = document.elementFromPoint(
             surfaceRect.left + surfaceRect.width / 2,
             surfaceRect.top + surfaceRect.height / 2,
@@ -189,10 +205,10 @@ async function expectFullyPaintableActionSurface(row: Locator): Promise<void> {
           return {
             hasSize: surfaceRect.width > 0 && surfaceRect.height > 0,
             fullyInside:
-              surfaceRect.top >= itemRect.top - 0.5 &&
-              surfaceRect.right <= itemRect.right + 0.5 &&
-              surfaceRect.bottom <= itemRect.bottom + 0.5 &&
-              surfaceRect.left >= itemRect.left - 0.5,
+              surfaceRect.top >= viewportRect.top - 0.5 &&
+              surfaceRect.right <= viewportRect.right + 0.5 &&
+              surfaceRect.bottom <= viewportRect.bottom + 0.5 &&
+              surfaceRect.left >= viewportRect.left - 0.5,
             centerHitsSurface: Boolean(
               centerElement && element.contains(centerElement),
             ),
@@ -224,7 +240,8 @@ for (const viewport of [
     await page.setViewportSize(viewport.size);
     await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
     await installDefaultAppRoutes(page);
-    const { streamCalls } = await installMessageActionConversationRoutes(page);
+    const { streamCalls, truncateCalls } =
+      await installMessageActionConversationRoutes(page);
 
     await openAppPath(page, "/chat");
     await openThread(page);
@@ -233,9 +250,11 @@ for (const viewport of [
     const assistantRow = messageRowFor(page, ASSISTANT_TEXT);
     await assistantRow.getByText(ASSISTANT_TEXT, { exact: true }).click();
     await expectFullyPaintableActionSurface(assistantRow);
+    await expect(assistantRow.getByTestId("thread-line-reply")).toBeVisible();
     await expect(assistantRow.getByTestId("thread-line-copy")).toBeVisible();
     await expect(assistantRow.getByTestId("thread-line-speak")).toBeVisible();
     await expect(assistantRow.getByTestId("thread-line-edit")).toHaveCount(0);
+    await expect(assistantRow.getByTestId("thread-line-delete")).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: /copy conversation/i }),
     ).toHaveCount(0);
@@ -262,6 +281,11 @@ for (const viewport of [
     await expect(assistantRow.getByTestId("thread-line-speak")).toBeVisible();
     await screenshot(page, `${viewport.name}-assistant-play`);
 
+    await assistantRow.getByTestId("thread-line-reply").click();
+    await expect(page.getByTestId("chat-reply-pill")).toBeVisible();
+    await page.getByTestId("chat-reply-pill-cancel").click();
+    await expect(page.getByTestId("chat-reply-pill")).toHaveCount(0);
+
     const userRow = messageRowFor(page, USER_TEXT);
     const userBubble = userRow.getByText(USER_TEXT, { exact: true });
     await userBubble.click();
@@ -273,9 +297,11 @@ for (const viewport of [
       await userBubble.click();
     }
     await expectFullyPaintableActionSurface(userRow);
+    await expect(userRow.getByTestId("thread-line-reply")).toBeVisible();
     await expect(userRow.getByTestId("thread-line-copy")).toBeVisible();
     await expect(userRow.getByTestId("thread-line-edit")).toBeVisible();
     await expect(userRow.getByTestId("thread-line-speak")).toHaveCount(0);
+    await expect(userRow.getByTestId("thread-line-delete")).toHaveCount(0);
     await screenshot(page, `${viewport.name}-user-actions`);
 
     await userRow.getByTestId("thread-line-edit").click();
@@ -284,9 +310,12 @@ for (const viewport of [
     await expect(editor).toHaveValue(USER_TEXT);
     await editor.fill(EDITED_TEXT);
     await screenshot(page, `${viewport.name}-user-editing`);
-    await userRow.getByTestId("thread-line-edit-save").click();
+    await page.getByTestId("thread-line-edit-save").click();
 
     await expect.poll(() => streamCalls.length, { timeout: 15_000 }).toBe(1);
+    expect(truncateCalls).toEqual([
+      { messageId: "seed-user-action-row", inclusive: true },
+    ]);
     expect(JSON.stringify(streamCalls[0])).toContain(EDITED_TEXT);
     expect(pageErrors, "no uncaught page errors").toEqual([]);
 
@@ -296,295 +325,3 @@ for (const viewport of [
     });
   });
 }
-
-// ── Persistent message delete (#13533) ──────────────────────────────────────
-// The delete affordance is part of the SAME click-to-reveal glass action row
-// (thread-line-delete). These tests drive it end to end in a real browser: a
-// reveal → delete removes the row AND the server DELETE fires; a reload proves
-// the removal is server truth (the store no longer serves the message), not a
-// client-only hide; the failure leg (server 500) rolls the row back WITH a
-// visible error notice — never a silent success.
-
-const DELETE_CONVERSATION_ID = "delete-message-conversation";
-const DELETE_ROOM_ID = "delete-message-room";
-const DELETE_KEEP_TEXT = "Keep this reply — it must survive the delete.";
-const DELETE_TARGET_TEXT = "Delete this reply — the trash control removes it.";
-
-interface DeleteMessage {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-  source: string;
-  roomId: string;
-  timestamp: number;
-}
-
-interface DeleteStore {
-  messages: DeleteMessage[];
-  deleted: string[];
-  /** When true the DELETE route answers 500 so the client rolls back. */
-  failDelete: boolean;
-}
-
-function makeDeleteStore(): DeleteStore {
-  const now = Date.now();
-  return {
-    messages: [
-      {
-        id: "seed-keep",
-        role: "assistant",
-        text: DELETE_KEEP_TEXT,
-        source: "eliza",
-        roomId: DELETE_ROOM_ID,
-        timestamp: now - 6_000,
-      },
-      {
-        id: "seed-delete-target",
-        role: "assistant",
-        text: DELETE_TARGET_TEXT,
-        source: "eliza",
-        roomId: DELETE_ROOM_ID,
-        timestamp: now - 3_000,
-      },
-    ],
-    deleted: [],
-    failDelete: false,
-  };
-}
-
-async function installDeleteConversationRoutes(
-  page: Page,
-  store: DeleteStore,
-): Promise<void> {
-  const now = Date.now();
-  const conversation = {
-    id: DELETE_CONVERSATION_ID,
-    roomId: DELETE_ROOM_ID,
-    title: "Delete message",
-    createdAt: new Date(now - 60_000).toISOString(),
-    updatedAt: new Date(now).toISOString(),
-  };
-
-  await page.route("**/api/conversations", async (route) => {
-    if (route.request().method() === "GET") {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ conversations: [conversation] }),
-      });
-      return;
-    }
-    await route.fallback();
-  });
-
-  await page.route(
-    `**/api/conversations/${DELETE_CONVERSATION_ID}`,
-    async (route) => {
-      const method = route.request().method();
-      if (method === "GET" || method === "PATCH") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ conversation }),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
-
-  // DELETE one message: /api/conversations/:id/messages/:messageId. Registered
-  // BEFORE the list GET so the more-specific path wins.
-  await page.route(
-    `**/api/conversations/${DELETE_CONVERSATION_ID}/messages/*`,
-    async (route) => {
-      if (route.request().method() !== "DELETE") {
-        await route.fallback();
-        return;
-      }
-      const messageId = new URL(route.request().url()).pathname
-        .split("/")
-        .pop();
-      if (store.failDelete) {
-        // Server-truth failure → the client must roll the row back + notice.
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ error: "delete failed" }),
-        });
-        return;
-      }
-      if (messageId) {
-        store.deleted.push(messageId);
-        store.messages = store.messages.filter((m) => m.id !== messageId);
-      }
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ ok: true, deletedCount: 1 }),
-      });
-    },
-  );
-
-  await page.route(
-    `**/api/conversations/${DELETE_CONVERSATION_ID}/messages`,
-    async (route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ messages: store.messages }),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
-
-  await page.route(
-    `**/api/conversations/${DELETE_CONVERSATION_ID}/greeting**`,
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ text: "Ready.", localInference: null }),
-      });
-    },
-  );
-}
-
-/**
- * Open the thread and wait for a stable message to render. `waitFor` defaults to
- * the always-present KEEP message so this works both before AND after a delete
- * (the target message is gone after deletion + reload).
- */
-async function openDeleteThread(
-  page: Page,
-  waitFor: string = DELETE_KEEP_TEXT,
-): Promise<void> {
-  const overlay = page.getByTestId("continuous-chat-overlay");
-  await expect(overlay).toBeVisible({ timeout: 60_000 });
-  await page.getByTestId("chat-sheet-grabber").click();
-  await expect(overlay).toHaveAttribute("data-open", "true", {
-    timeout: 15_000,
-  });
-  await expect(page.getByText(waitFor)).toBeVisible({
-    timeout: 15_000,
-  });
-}
-
-/** Reveal the glass action row for a message, then click its delete control. */
-async function revealAndDelete(page: Page, messageText: string): Promise<void> {
-  const bubble = page.getByText(messageText);
-  await bubble.click();
-  // The action row reveal is a single click; a stray first click that only
-  // focuses can need a second (mirrors the copy/edit reveal above).
-  if ((await page.getByTestId("thread-line-delete").count()) === 0) {
-    await bubble.click();
-  }
-  await expect(page.getByTestId("thread-line-delete")).toBeVisible({
-    timeout: 10_000,
-  });
-  await page.getByTestId("thread-line-delete").click();
-}
-
-test("desktop: delete removes the message, the server DELETE fires, and it stays gone after reload", async ({
-  page,
-}) => {
-  const pageErrors: string[] = [];
-  page.on("pageerror", (err) => pageErrors.push(err.message));
-
-  const store = makeDeleteStore();
-  await page.setViewportSize({ width: 1280, height: 900 });
-  await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
-  await installDefaultAppRoutes(page);
-  await installDeleteConversationRoutes(page, store);
-
-  await openAppPath(page, "/chat");
-  await openDeleteThread(page);
-
-  await revealAndDelete(page, DELETE_TARGET_TEXT);
-
-  // The row leaves the transcript; the kept message survives.
-  await expect(page.getByText(DELETE_TARGET_TEXT)).toHaveCount(0, {
-    timeout: 10_000,
-  });
-  await expect(page.getByText(DELETE_KEEP_TEXT)).toBeVisible();
-  // The server DELETE actually fired for the target id (not a client-only hide).
-  await expect
-    .poll(() => store.deleted, { timeout: 10_000 })
-    .toContain("seed-delete-target");
-
-  // PERSISTENCE: reload the page. The store no longer serves the message, so a
-  // fresh mount rehydrates WITHOUT it — server truth, not a client hide.
-  await openAppPath(page, "/chat");
-  await openDeleteThread(page);
-  await expect(page.getByText(DELETE_KEEP_TEXT)).toBeVisible({
-    timeout: 15_000,
-  });
-  await expect(page.getByText(DELETE_TARGET_TEXT)).toHaveCount(0);
-
-  expect(pageErrors, "no uncaught page errors").toEqual([]);
-});
-
-test("mobile: tap-reveal delete removes the message and fires the server DELETE", async ({
-  page,
-}) => {
-  const pageErrors: string[] = [];
-  page.on("pageerror", (err) => pageErrors.push(err.message));
-
-  const store = makeDeleteStore();
-  await page.setViewportSize({ width: 390, height: 844 });
-  await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
-  await installDefaultAppRoutes(page);
-  await installDeleteConversationRoutes(page, store);
-
-  await openAppPath(page, "/chat");
-  await openDeleteThread(page);
-
-  await revealAndDelete(page, DELETE_TARGET_TEXT);
-
-  await expect(page.getByText(DELETE_TARGET_TEXT)).toHaveCount(0, {
-    timeout: 10_000,
-  });
-  await expect(page.getByText(DELETE_KEEP_TEXT)).toBeVisible();
-  await expect
-    .poll(() => store.deleted, { timeout: 10_000 })
-    .toContain("seed-delete-target");
-
-  expect(pageErrors, "no uncaught page errors").toEqual([]);
-});
-
-test("failure: a 500 on DELETE rolls the message back and shows an error notice (no silent success)", async ({
-  page,
-}) => {
-  const pageErrors: string[] = [];
-  page.on("pageerror", (err) => pageErrors.push(err.message));
-
-  const store = makeDeleteStore();
-  store.failDelete = true;
-  await page.setViewportSize({ width: 1280, height: 900 });
-  await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
-  await installDefaultAppRoutes(page);
-  await installDeleteConversationRoutes(page, store);
-
-  await openAppPath(page, "/chat");
-  await openDeleteThread(page);
-
-  await revealAndDelete(page, DELETE_TARGET_TEXT);
-
-  // ROLLBACK: after the server 500 the optimistically-removed message returns
-  // (the pipeline is not left in a locally-hidden-but-still-persisted state).
-  await expect(page.getByText(DELETE_TARGET_TEXT)).toBeVisible({
-    timeout: 10_000,
-  });
-  // A visible error notice — the three-state rule: the failure surfaces, it is
-  // not a silent success.
-  await expect(page.getByText(/failed to delete message/i)).toBeVisible({
-    timeout: 10_000,
-  });
-  // The store never recorded a successful delete.
-  expect(store.deleted).not.toContain("seed-delete-target");
-
-  expect(pageErrors, "no uncaught page errors").toEqual([]);
-});

--- a/packages/app/test/ui-smoke/chat-thread-gestures.spec.ts
+++ b/packages/app/test/ui-smoke/chat-thread-gestures.spec.ts
@@ -113,6 +113,29 @@ async function installConversationRoutes(page: Page): Promise<void> {
     },
   );
 
+  await page.route("**/api/conversations/messages/search**", async (route) => {
+    const query = new URL(route.request().url()).searchParams.get("q") ?? "";
+    const results = query.toLowerCase().includes("oldest")
+      ? [
+          {
+            messageId: "g-first",
+            conversationId: CONVERSATION_ID,
+            roomId: ROOM_ID,
+            role: "assistant",
+            text: FIRST_TEXT,
+            snippet: FIRST_TEXT,
+            createdAt: NOW - 40_000,
+            score: 10,
+          },
+        ]
+      : [];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ results, count: results.length }),
+    });
+  });
+
   await page.route(
     `**/api/conversations/${CONVERSATION_ID}/greeting**`,
     async (route) => {
@@ -460,5 +483,18 @@ test("header controls: no header nav (search in composer + menu), maximize remov
   await expect(page.getByTestId("chat-message-search")).toBeVisible({
     timeout: 10_000,
   });
+
+  // Selecting an older result must use MessageScroller's coordinated jump.
+  // That keeps the row inside the real viewport after the search layer closes
+  // and makes the short white highlight visible instead of bottom-follow
+  // immediately reclaiming the scroll position.
+  await page.getByTestId("message-search-input").fill("oldest visible turn");
+  await page.getByTestId("message-search-result").click();
+  await expect(page.getByTestId("chat-message-search")).toHaveCount(0);
+  const target = page.locator("#chat-message-g-first");
+  await expect(target).toBeInViewport();
+  await expect(
+    target.locator('[data-chat-search-highlight="true"]'),
+  ).toBeVisible();
   await expectNoPageDiagnostics(page, testInfo.title);
 });

--- a/packages/app/test/ui-smoke/chat-thread-gestures.spec.ts
+++ b/packages/app/test/ui-smoke/chat-thread-gestures.spec.ts
@@ -484,6 +484,15 @@ test("header controls: no header nav (search in composer + menu), maximize remov
     timeout: 10_000,
   });
 
+  // A long results list owns trackpad/touch scrolling. Before the scroll-region
+  // boundary was explicit, this wheel bubbled into the sheet detent controller
+  // and collapsed search instead of moving through the results.
+  const searchScroller = page.getByTestId("message-search-scroll");
+  await searchScroller.hover();
+  await page.mouse.wheel(0, -180);
+  await expect(sheet).toHaveAttribute("data-detent", "full");
+  await expect(page.getByTestId("chat-message-search")).toBeVisible();
+
   // Selecting an older result must use MessageScroller's coordinated jump.
   // That keeps the row inside the real viewport after the search layer closes
   // and makes the short white highlight visible instead of bottom-follow

--- a/packages/app/test/ui-smoke/gesture-matrix.spec.ts
+++ b/packages/app/test/ui-smoke/gesture-matrix.spec.ts
@@ -417,10 +417,15 @@ test("dashboard notification center: row tap marks read in place, hover-X dismis
   ).toHaveCount(0, { timeout: 10_000 });
   await expect(center.getByTestId("notification-row")).toHaveCount(7);
 
-  // (d) There is no bulk clear-all trash button any more — rows are dismissed
-  // one at a time. The right-click contextual menu is a second per-row path:
-  // open it on a remaining row and dismiss from it.
-  await expect(center.getByTestId("notifications-clear-all")).toHaveCount(0);
+  // (d) The bulk command keeps one stable DOM node so a pull can reveal it
+  // continuously, but its rested slot is fully collapsed and inert. The
+  // right-click contextual menu remains a second per-row dismissal path.
+  const clearAll = center.getByTestId("notifications-clear-all");
+  await expect(clearAll).toHaveCount(1);
+  await expect(clearAll.locator("..")).toHaveCSS("opacity", "0");
+  await expect(clearAll.locator("..")).toHaveCSS("height", "0px");
+  await expect(clearAll.locator("..")).toHaveAttribute("aria-hidden", "true");
+  await expect(clearAll.locator("..")).toHaveAttribute("inert", "");
   // Right-click the row button; the contextmenu bubbles to the row li, which
   // opens the menu.
   const menuTarget = center

--- a/packages/app/test/ui-smoke/transcript-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/transcript-realaudio.spec.ts
@@ -559,11 +559,7 @@ async function startTranscriptionViaSlash(page: Page): Promise<void> {
   await expect(
     page.getByTestId("chat-composer-transcription-stop"),
   ).toHaveAttribute("aria-label", "stop transcription", { timeout: 15_000 });
-  await expect(page.getByTestId("chat-composer-action")).toHaveAttribute(
-    "aria-label",
-    "send transcription",
-    { timeout: 15_000 },
-  );
+  await expect(page.getByTestId("chat-composer-action")).toHaveCount(0);
 }
 
 async function finalizeTranscriptionViaComposerStop(page: Page): Promise<void> {

--- a/packages/app/test/ui-smoke/transcript-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/transcript-realaudio.spec.ts
@@ -539,7 +539,7 @@ function trackAsrPosts(page: Page): { count: () => number } {
   return { count: () => posted };
 }
 
-async function toggleTranscriptionViaSlash(page: Page): Promise<void> {
+async function startTranscriptionViaSlash(page: Page): Promise<void> {
   const composer = page.getByTestId("chat-composer-textarea");
   await composer.fill("/transcribe");
   await expect(page.getByTestId("slash-command-menu")).toBeVisible({
@@ -549,31 +549,38 @@ async function toggleTranscriptionViaSlash(page: Page): Promise<void> {
   await expect(page.getByTestId("slash-command-menu")).toBeHidden({
     timeout: 15_000,
   });
-  await expect(composer).toHaveValue("", { timeout: 15_000 });
-}
-
-async function startTranscriptionViaSlash(page: Page): Promise<void> {
-  await toggleTranscriptionViaSlash(page);
+  await expect(composer).toHaveCount(0, { timeout: 15_000 });
   await expect(page.getByTestId("chat-transcribing-badge")).toBeVisible({
     timeout: 15_000,
   });
-  await expect(page.getByTestId("chat-composer-mic")).toHaveAttribute(
+  await expect(page.getByTestId("chat-composer-mic-activity")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    page.getByTestId("chat-composer-transcription-stop"),
+  ).toHaveAttribute("aria-label", "stop transcription", { timeout: 15_000 });
+  await expect(page.getByTestId("chat-composer-action")).toHaveAttribute(
     "aria-label",
-    "stop transcription and mic",
+    "send transcription",
     { timeout: 15_000 },
   );
 }
 
-async function finalizeTranscriptionViaSlash(page: Page): Promise<void> {
-  await toggleTranscriptionViaSlash(page);
+async function finalizeTranscriptionViaComposerStop(page: Page): Promise<void> {
+  const stop = page.getByTestId("chat-composer-transcription-stop");
+  await expect(stop).toHaveAttribute("aria-label", "stop transcription", {
+    timeout: 15_000,
+  });
+  await stop.click();
+  await expect(page.getByTestId("chat-composer-mic-activity")).toHaveCount(0, {
+    timeout: 15_000,
+  });
   await expect(page.getByTestId("chat-transcribing-badge")).toHaveCount(0, {
     timeout: 15_000,
   });
-  await expect(page.getByTestId("chat-composer-mic")).toHaveAttribute(
-    "aria-label",
-    "end conversation",
-    { timeout: 15_000 },
-  );
+  await expect(page.getByTestId("chat-composer-textarea")).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 async function dispatchTranscriptionAgentAction(
@@ -591,14 +598,14 @@ async function dispatchTranscriptionAgentAction(
 
 async function startTranscriptionViaAgentAction(page: Page): Promise<void> {
   await dispatchTranscriptionAgentAction(page, "start");
-  // The agent-action bridge flips the shell controller directly; unlike the
-  // slash-command path it may not expand the sheet far enough to render the
-  // visible badge, so the mic control state is the durable proof.
-  await expect(page.getByTestId("chat-composer-mic")).toHaveAttribute(
-    "aria-label",
-    "stop transcription and mic",
-    { timeout: 15_000 },
-  );
+  // The agent-action bridge flips the shell controller directly. The dedicated
+  // composer activity and Stop control are durable even at a short sheet detent.
+  await expect(page.getByTestId("chat-composer-mic-activity")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    page.getByTestId("chat-composer-transcription-stop"),
+  ).toHaveAttribute("aria-label", "stop transcription", { timeout: 15_000 });
 }
 
 async function finalizeTranscriptionViaAgentAction(page: Page): Promise<void> {
@@ -606,11 +613,12 @@ async function finalizeTranscriptionViaAgentAction(page: Page): Promise<void> {
   await expect(page.getByTestId("chat-transcribing-badge")).toHaveCount(0, {
     timeout: 15_000,
   });
-  await expect(page.getByTestId("chat-composer-mic")).toHaveAttribute(
-    "aria-label",
-    "end conversation",
-    { timeout: 15_000 },
-  );
+  await expect(page.getByTestId("chat-composer-mic-activity")).toHaveCount(0, {
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId("chat-composer-textarea")).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 /**
@@ -729,10 +737,9 @@ async function openTranscriptViewer(page: Page): Promise<Locator> {
 
 /**
  * Drive the REAL transcript-capture chain from the chat overlay: tap mic ->
- * /transcribe -> (real audio captured + POSTed) -> /transcribe again to
- * finalize -> the transcript chip lands in the composer -> send -> the
- * transcript ATTACHMENT tile renders in the thread. Returns once the tile is
- * visible.
+ * /transcribe -> real audio captured + POSTed -> composer Stop finalizes ->
+ * the transcript chip lands in the composer -> send -> the transcript
+ * ATTACHMENT tile renders in the thread. Returns once the tile is visible.
  */
 async function captureTranscriptToAttachment(
   page: Page,
@@ -756,7 +763,7 @@ async function captureTranscriptToAttachment(
 
   await expect.poll(() => asr.count(), { timeout: 30_000 }).toBeGreaterThan(0);
 
-  await finalizeTranscriptionViaSlash(page);
+  await finalizeTranscriptionViaComposerStop(page);
   await expect
     .poll(
       () => probes.createBodies.find((b) => b.audioBase64Length > 1000) ?? null,
@@ -859,7 +866,7 @@ async function captureTranscriptRecordViaControlPath(
   if (controlPath === "agent-action") {
     await finalizeTranscriptionViaAgentAction(page);
   } else {
-    await finalizeTranscriptionViaSlash(page);
+    await finalizeTranscriptionViaComposerStop(page);
   }
 
   await expect
@@ -883,7 +890,7 @@ test.beforeEach(async ({ page }) => {
   await installDefaultAppRoutes(page);
 });
 
-test("REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/transcripts, keeps the mic active, and drops a transcript attachment", async ({
+test("REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/transcripts, uses dedicated capture controls, and drops a transcript attachment", async ({
   page,
 }) => {
   const probes = freshProbes();
@@ -903,17 +910,10 @@ test("REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/t
     timeout: 15_000,
   });
 
-  // (LINKAGE b) /transcribe -> transcription mode. The mic STAYS active
-  // (transcript is an additive layer; the mic is the parent).
+  // (LINKAGE b) /transcribe transfers capture ownership from conversation mode
+  // to the dedicated transcription composer.
   await startTranscriptionViaSlash(page);
-  // The mic button is still the active mic control while transcribing.
-  await expect(mic).toHaveAttribute(
-    "aria-label",
-    "stop transcription and mic",
-    {
-      timeout: 15_000,
-    },
-  );
+  await expect(mic).toHaveCount(0);
 
   // (REAL AUDIO) The transcription re-listen loop opens the REAL local-ASR
   // recorder against the fake device, WAV-encodes the injected audio, and POSTs
@@ -929,10 +929,10 @@ test("REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/t
     "the captured WAV POSTed to ASR must be a non-trivial recording",
   ).toBeGreaterThan(1000);
 
-  // (REAL AUDIO + ATTACHMENT) Run /transcribe again to FINALIZE. The shell POSTs
-  // the segments + the REAL captured audio (audioBase64) to /api/transcripts and
-  // drops a `Transcript ….md` chip into the composer.
-  await finalizeTranscriptionViaSlash(page);
+  // (REAL AUDIO + ATTACHMENT) Stop finalizes the session. The shell POSTs the
+  // segments + REAL captured audio (audioBase64) to /api/transcripts and returns
+  // the finished payload to the editable composer.
+  await finalizeTranscriptionViaComposerStop(page);
   await expect
     .poll(
       () => probes.createBodies.find((b) => b.audioBase64Length > 1000) ?? null,
@@ -948,11 +948,14 @@ test("REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/t
   );
   expect(realCreate?.segmentCount ?? 0).toBeGreaterThan(0);
 
-  // (LINKAGE c) Transcript OFF leaves the mic ON. After finalize,
-  // transcriptionMode is false and the hands-free parent loop resumes.
-  await expect(mic).toHaveAttribute("aria-label", "end conversation", {
-    timeout: 15_000,
-  });
+  // (LINKAGE c) Finalization does not silently resume the prior conversation
+  // mode. The pending transcript owns the ordinary Send slot instead.
+  await expect(mic).toHaveCount(0);
+  await expect(page.getByTestId("chat-composer-action")).toHaveAttribute(
+    "aria-label",
+    "send",
+    { timeout: 15_000 },
+  );
 
   // The finished transcript becomes a composer attachment chip (document kind).
   await expect(page.getByText(/^Transcript .*\.md$/).first()).toBeVisible({
@@ -961,15 +964,12 @@ test("REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/t
 
   // (ATTACHMENT) Type a caption (so the tile-bearing user turn has text and isn't
   // dropped by the overlay's empty-turn filter), then send via the textarea Enter
-  // key — robust against the trailing-button morph (mic<->send) while the
-  // hands-free re-listen loop runs.
+  // key; the dedicated transcription flow leaves no hands-free re-listen loop.
   await page.getByTestId("chat-composer-textarea").fill(TRANSCRIPT_CAPTION);
   await page.getByTestId("chat-composer-textarea").press("Enter");
 
-  // (LINKAGE d) The mic is the master voice control: tapping it turns BOTH the
-  // mic and transcript fully off. stopVoiceAndSettle taps the mic and asserts
-  // the mic returns to "talk", stopping the re-listen loop so the thread
-  // settles for the tile click below.
+  // (LINKAGE d) Voice remains off after the transcript send. This helper also
+  // waits through the in-flight response until the idle "talk" control returns.
   await stopVoiceAndSettle(page);
   // Let the turn finish (clean stream done) so the assistant bubble stops
   // animating and the thread goes static, then the persisted history (carrying

--- a/packages/app/test/ui-smoke/voice-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/voice-realaudio.spec.ts
@@ -556,13 +556,17 @@ test("REAL audio: transcription start during spoken local TTS barges in and sile
   // clip is still playing; the shell's recording-driven barge-in effect must
   // silence the in-flight Web Audio source immediately.
   await dispatchVoiceControl(page, "start");
-  await expect(mic).toHaveAttribute(
-    "aria-label",
-    "stop transcription and mic",
-    {
-      timeout: 15_000,
-    },
-  );
+  await expect(page.getByTestId("chat-composer-mic")).toHaveCount(0, {
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId("chat-composer-mic-activity")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    page.getByTestId("chat-composer-transcription-stop"),
+  ).toHaveAttribute("aria-label", "stop transcription", {
+    timeout: 15_000,
+  });
   await expect
     .poll(
       async () => {

--- a/packages/shared/src/api/agent-api-types.ts
+++ b/packages/shared/src/api/agent-api-types.ts
@@ -44,6 +44,12 @@ export interface StreamEventEnvelope {
    * for backward compatibility with envelopes that predate the cursor.
    */
   bufferSeq?: number;
+  /**
+   * Set only on envelopes resent from the server's connection replay buffer.
+   * Consumers may rebuild idempotent state from these frames, but must not
+   * repeat one-shot effects such as notifications, sounds, or navigation.
+   */
+  replayed?: boolean;
   stream?: string;
   sessionKey?: string;
   agentId?: string;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -18,12 +18,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const oauthState = vi.hoisted(() => ({
   popup: null as Window | null,
   pkceError: null as Error | null,
+  preOpenCalls: 0,
   storeVerifier: true,
 }));
 
 vi.mock("../../../../state/cloud-login-launch", () => ({
-  preOpenCloudLoginWindow: () => oauthState.popup,
   canNavigateSameTabForBlockedPopup: () => true,
+  preOpenCloudLoginWindow: () => {
+    oauthState.preOpenCalls += 1;
+    return oauthState.popup;
+  },
+  shouldReuseCurrentCloudLoginWindow: (returnTo: string | null) =>
+    returnTo === "/auth/cli-login" ||
+    returnTo?.startsWith("/auth/cli-login?") === true,
 }));
 
 vi.mock("@stwd/sdk", () => ({
@@ -102,9 +109,9 @@ vi.mock("../../lib/steward-oauth-url", async () => {
 
 import StewardLoginSection from "./steward-login-section";
 
-function renderSection() {
+function renderSection(initialEntry = "/login") {
   return render(
-    <MemoryRouter initialEntries={["/login"]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <StewardLoginSection />
     </MemoryRouter>,
   );
@@ -123,6 +130,7 @@ describe("StewardLoginSection OAuth launch", () => {
   beforeEach(() => {
     oauthState.popup = makePopup();
     oauthState.pkceError = null;
+    oauthState.preOpenCalls = 0;
     oauthState.storeVerifier = true;
   });
 
@@ -142,6 +150,15 @@ describe("StewardLoginSection OAuth launch", () => {
       ),
     );
     expect(oauthState.popup?.opener).toBeNull();
+    expect(oauthState.preOpenCalls).toBe(1);
+  });
+
+  it("reuses the device-login surface instead of opening a nested popup", async () => {
+    renderSection("/login?returnTo=%2Fauth%2Fcli-login%3Fsession%3Dsession-1");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+
+    expect(oauthState.preOpenCalls).toBe(0);
   });
 
   it("closes the popup when browser storage cannot save the verifier", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -41,6 +41,7 @@ import { Input } from "../../../../components/ui/input";
 import {
   canNavigateSameTabForBlockedPopup,
   preOpenCloudLoginWindow,
+  shouldReuseCurrentCloudLoginWindow,
 } from "../../../../state/cloud-login-launch";
 import { navigatePreOpenedWindow } from "../../../../utils/openExternalUrl";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
@@ -592,7 +593,11 @@ export default function StewardLoginSection() {
     // PKCE challenge is asynchronous, so opening after it resolves is blocked
     // by browsers. Touch-primary browsers intentionally return null here and
     // continue in the current tab.
-    const authWindow = preOpenCloudLoginWindow();
+    const authWindow = shouldReuseCurrentCloudLoginWindow(
+      searchParams.get("returnTo"),
+    )
+      ? null
+      : preOpenCloudLoginWindow();
     setLoading(provider);
     setError(null);
     const host = window.location.hostname.toLowerCase();

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
@@ -69,6 +69,42 @@ describe("MessageSearchPanel", () => {
     expect(screen.getByText(/Agent ·/)).toBeTruthy();
   });
 
+  it("owns scrolling for long keyboard-anchored result lists", async () => {
+    const search = vi.fn(async () =>
+      Array.from({ length: 18 }, (_, index) =>
+        result({
+          messageId: `m${index}`,
+          snippet: `result ${index}`,
+        }),
+      ),
+    );
+    render(
+      <MessageSearchPanel
+        search={search}
+        onJump={vi.fn()}
+        onClose={vi.fn()}
+        layout="keyboard-anchored"
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("message-search-input"), {
+      target: { value: "history" },
+    });
+    await waitFor(() =>
+      expect(screen.getAllByTestId("message-search-result")).toHaveLength(18),
+    );
+
+    const scroller = screen.getByTestId("message-search-scroll");
+    const list = screen.getByTestId("message-search-results");
+    expect(scroller.hasAttribute("data-chat-sheet-scroll-region")).toBe(true);
+    expect(scroller.className).toContain("touch-pan-y");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller.className).not.toContain("justify-end");
+    // Auto margin bottom-aligns a short list, but collapses to zero once the
+    // list overflows so its first result remains reachable by native scrolling.
+    expect(list.className).toContain("mt-auto");
+  });
+
   it("jumps to a result and closes", async () => {
     const onJump = vi.fn();
     const onClose = vi.fn();

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -100,8 +100,10 @@ export function MessageSearchPanel({
 
   const handleJump = useCallback(
     (result: ConversationMessageSearchResult) => {
-      onJump(result);
+      // Remove the keyboard-anchored search layer before the destination row
+      // scrolls, so focus restoration cannot move the sheet during the jump.
       onClose();
+      onJump(result);
     },
     [onJump, onClose],
   );

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -133,7 +133,7 @@ export function MessageSearchPanel({
       // away when the results list above it is long.
       className={
         keyboardAnchored
-          ? "shrink-0 border-white/15 bg-white/[0.08] text-white shadow-sm placeholder:text-white/45"
+          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl placeholder:text-white/45"
           : undefined
       }
     />
@@ -187,7 +187,7 @@ export function MessageSearchPanel({
               variant="ghost"
               className={
                 keyboardAnchored
-                  ? "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-lg border border-transparent bg-white/[0.04] px-3 py-2 text-left font-normal hover:border-white/10 hover:bg-white/[0.08]"
+                  ? "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-xl border border-white/10 bg-[rgba(12,16,18,0.86)] px-3 py-2 text-left font-normal shadow-[0_10px_28px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-xl hover:border-white/20 hover:bg-[rgba(18,22,24,0.92)]"
                   : "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-md px-2 py-1.5 text-left font-normal hover:bg-muted/60"
               }
             >

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -180,7 +180,14 @@ export function MessageSearchPanel({
 
   const resultsListEl =
     results.length > 0 ? (
-      <ul data-testid="message-search-results" className="flex flex-col gap-1">
+      <ul
+        data-testid="message-search-results"
+        className={
+          keyboardAnchored
+            ? "mt-auto flex flex-col gap-1"
+            : "flex flex-col gap-1"
+        }
+      >
         {results.map((result) => (
           <li key={result.messageId}>
             <Button
@@ -223,7 +230,8 @@ export function MessageSearchPanel({
       >
         <div
           data-testid="message-search-scroll"
-          className="scroll-fade flex min-h-0 flex-1 flex-col justify-end gap-1 overflow-y-auto overscroll-contain [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+          data-chat-sheet-scroll-region
+          className="scroll-fade flex min-h-0 flex-1 touch-pan-y flex-col gap-1 overflow-y-auto overscroll-contain [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
         >
           {resultsListEl}
         </div>

--- a/packages/ui/src/components/composites/chat/chat-attachment-strip.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-attachment-strip.stories.tsx
@@ -61,6 +61,54 @@ export const CustomRemoveLabel: Story = {
   },
 };
 
+export const MixedMedia: Story = {
+  args: {
+    items: [
+      sampleItems[0],
+      {
+        id: "att-audio",
+        name: "interview-recording.wav",
+        alt: "Interview recording",
+        src: "data:audio/wav;base64,",
+        kind: "audio",
+      },
+      {
+        id: "att-video",
+        name: "walkthrough.mp4",
+        alt: "Product walkthrough",
+        src: "data:video/mp4;base64,",
+        kind: "video",
+      },
+      {
+        id: "att-document",
+        name: "project-brief.pdf",
+        alt: "Project brief",
+        src: "data:application/pdf;base64,",
+        kind: "document",
+      },
+    ],
+  },
+};
+
+export const Overflowing: Story = {
+  args: {
+    items: [
+      ...sampleItems,
+      ...sampleItems.map((item) => ({
+        ...item,
+        id: `${item.id}-copy`,
+      })),
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
 export const Empty: Story = {
   args: { items: [] },
 };

--- a/packages/ui/src/components/composites/chat/chat-attachment-strip.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-attachment-strip.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Verifies the pending-attachment strip's compact geometry, horizontal scroll
+ * treatment, media variants, and remove-control contract in the real shared
+ * primitive composition.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChatAttachmentStrip } from "./chat-attachment-strip";
+import type { ChatAttachmentItem } from "./chat-types";
+
+const items: ChatAttachmentItem[] = [
+  {
+    id: "image-1",
+    name: "forest.png",
+    alt: "A misty forest",
+    src: "data:image/png;base64,forest",
+    kind: "image",
+  },
+  {
+    id: "audio-1",
+    name: "memo.wav",
+    alt: "Voice memo",
+    src: "data:audio/wav;base64,memo",
+    kind: "audio",
+  },
+];
+
+afterEach(cleanup);
+
+describe("ChatAttachmentStrip", () => {
+  it("renders nothing without pending attachments", () => {
+    const { container } = render(
+      <ChatAttachmentStrip items={[]} onRemove={vi.fn()} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("uses the compact attachment primitives in a fading horizontal scroller", () => {
+    const { container } = render(
+      <ChatAttachmentStrip items={items} onRemove={vi.fn()} />,
+    );
+
+    const group = container.querySelector('[data-slot="attachment-group"]');
+    expect(group).not.toBeNull();
+    expect(group?.hasAttribute("data-scroll-cert-scroller")).toBe(true);
+    expect(group?.className).toContain("scroll-fade-x");
+    expect(group?.className).toContain("overflow-x-auto");
+
+    const attachments = container.querySelectorAll('[data-slot="attachment"]');
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0]?.getAttribute("data-size")).toBe("xs");
+    expect(attachments[0]?.className).toContain("h-16");
+    expect(attachments[0]?.className).toContain("w-16");
+
+    expect(screen.getByAltText("A misty forest")).toBeTruthy();
+    expect(screen.getByTitle("memo.wav").textContent).toBe("memo.wav");
+  });
+
+  it("preserves the remove callback, custom label, and coarse-pointer hit floor", () => {
+    const onRemove = vi.fn();
+    render(
+      <ChatAttachmentStrip
+        items={items}
+        onRemove={onRemove}
+        removeLabel={(item) => `Discard ${item.name}`}
+      />,
+    );
+
+    const remove = screen.getByRole("button", { name: "Discard memo.wav" });
+    expect(remove.className).toContain("pointer-coarse:min-h-touch");
+    expect(remove.className).toContain("pointer-coarse:min-w-touch");
+    fireEvent.click(remove);
+
+    expect(onRemove).toHaveBeenCalledWith("audio-1", 1);
+  });
+
+  it("retains game-modal pointer ownership and surface remove styling", () => {
+    const { container } = render(
+      <ChatAttachmentStrip
+        items={[items[0]]}
+        onRemove={vi.fn()}
+        variant="game-modal"
+      />,
+    );
+
+    const group = container.querySelector('[data-slot="attachment-group"]');
+    expect(group?.getAttribute("data-no-camera-drag")).toBe("true");
+    expect(group?.className).toContain("pointer-events-auto");
+    expect(screen.getByRole("button").className).toContain(
+      "bg-destructive-subtle",
+    );
+  });
+});

--- a/packages/ui/src/components/composites/chat/chat-attachment-strip.tsx
+++ b/packages/ui/src/components/composites/chat/chat-attachment-strip.tsx
@@ -5,7 +5,14 @@
  */
 import { FileText, Film, Music } from "lucide-react";
 import type * as React from "react";
-import { Button } from "../../ui/button";
+import {
+  Attachment,
+  AttachmentAction,
+  AttachmentActions,
+  AttachmentGroup,
+  AttachmentMedia,
+  AttachmentTitle,
+} from "../../ui/attachment";
 import type { ChatAttachmentItem, ChatVariant } from "./chat-types";
 
 export interface ChatAttachmentStripProps {
@@ -23,12 +30,15 @@ function NonImageTile({
   const Icon =
     item.kind === "audio" ? Music : item.kind === "video" ? Film : FileText;
   return (
-    <div className="flex h-16 w-16 flex-col items-center justify-center gap-1 rounded-sm border border-border bg-bg/40 px-1 text-center">
-      <Icon className="h-5 w-5 text-muted" />
-      <span className="w-full truncate text-2xs text-muted" title={item.name}>
+    <AttachmentMedia className="h-16 w-16 flex-col gap-1 rounded-sm border border-border bg-bg/40 px-1 text-center">
+      <Icon className="size-5 text-muted" />
+      <AttachmentTitle
+        className="w-full text-2xs font-normal text-muted"
+        title={item.name}
+      >
         {item.name}
-      </span>
-    </div>
+      </AttachmentTitle>
+    </AttachmentMedia>
   );
 }
 
@@ -43,38 +53,46 @@ export function ChatAttachmentStrip({
   }
 
   return (
-    <div
-      className={`relative flex flex-wrap gap-2 py-1 ${
+    <AttachmentGroup
+      className={`relative w-full gap-2 px-1.5 py-1.5 [--scroll-fade-size:1.5rem] ${
         variant === "game-modal" ? "pointer-events-auto" : ""
       }`}
       data-no-camera-drag={variant === "game-modal" || undefined}
+      data-scroll-cert-scroller
       style={{ zIndex: 1 }}
     >
       {items.map((item, index) => (
-        <div key={item.id} className="relative h-16 w-16 shrink-0 group">
+        <Attachment
+          key={item.id}
+          size="xs"
+          className="group h-16 w-16 min-w-16 overflow-visible rounded-sm border-0 bg-transparent p-0 has-data-[slot=attachment-media]:p-0"
+        >
           {!item.kind || item.kind === "image" ? (
-            <img
-              src={item.src}
-              alt={item.alt}
-              className="h-16 w-16 rounded-sm border border-border object-cover"
-            />
+            <AttachmentMedia
+              variant="image"
+              className="h-16 w-16 rounded-sm border border-border bg-bg/40"
+            >
+              <img src={item.src} alt={item.alt} />
+            </AttachmentMedia>
           ) : (
             <NonImageTile item={item} />
           )}
-          <Button
-            variant={
-              variant === "game-modal" ? "surfaceDestructive" : "destructive"
-            }
-            size="icon"
-            title={removeLabel(item)}
-            aria-label={removeLabel(item)}
-            onClick={() => onRemove(item.id, index)}
-            className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-sm text-2xs opacity-100 transition-opacity  sm:opacity-0 sm:group-hover:opacity-100"
-          >
-            ×
-          </Button>
-        </div>
+          <AttachmentActions className="absolute -right-1.5 -top-1.5">
+            <AttachmentAction
+              variant={
+                variant === "game-modal" ? "surfaceDestructive" : "destructive"
+              }
+              size="icon"
+              title={removeLabel(item)}
+              aria-label={removeLabel(item)}
+              onClick={() => onRemove(item.id, index)}
+              className="h-4 w-4 rounded-sm text-2xs opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+            >
+              ×
+            </AttachmentAction>
+          </AttachmentActions>
+        </Attachment>
       ))}
-    </div>
+    </AttachmentGroup>
   );
 }

--- a/packages/ui/src/components/composites/chat/chat-message-actions.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.stories.tsx
@@ -17,23 +17,19 @@ const meta = {
     ),
   ],
   argTypes: {
-    canDelete: { control: "boolean" },
     canEdit: { control: "boolean" },
     canPlay: { control: "boolean" },
     copied: { control: "boolean" },
     labels: { control: "object" },
     onCopy: { action: "copy" },
-    onDelete: { action: "delete" },
     onEdit: { action: "edit" },
     onPlay: { action: "play" },
   },
   args: {
-    canDelete: false,
     canEdit: false,
     canPlay: false,
     copied: false,
     onCopy: () => {},
-    onDelete: () => {},
     onEdit: () => {},
     onPlay: () => {},
   },
@@ -52,7 +48,6 @@ export const Copied: Story = {
 
 export const AllActions: Story = {
   args: {
-    canDelete: true,
     canEdit: true,
     canPlay: true,
   },
@@ -66,7 +61,6 @@ export const PlayableOnly: Story = {
 
 export const CustomLabels: Story = {
   args: {
-    canDelete: true,
     canEdit: true,
     canPlay: true,
     labels: {
@@ -75,7 +69,6 @@ export const CustomLabels: Story = {
       copiedAria: "Message copied to clipboard",
       play: "Play audio",
       edit: "Edit this message",
-      delete: "Remove message",
     },
   },
 };

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 //
-// The desktop hover action rail's Copy button fires `onCopy` (which the
-// ChatView wires to the clipboard helper) and reflects the copied state in its
-// label. This closes the coverage gap called out in #9148 — the overlay copy
-// was tested but the desktop ChatMessageActions copy was not.
+/**
+ * Behavior and material checks for the shared per-message action plate. The
+ * real controls render directly so callback, confirmation, neutral glass, and
+ * the absence of a destructive message action stay locked together.
+ */
 
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -37,34 +38,31 @@ describe("ChatMessageActions copy", () => {
     expect(screen.getByRole("button", { name: "Copy text" })).toBeTruthy();
   });
 
-  it("invokes onDelete when the delete button is enabled and clicked", async () => {
-    const onDelete = vi.fn();
-    render(<ChatMessageActions canDelete onDelete={onDelete} />);
-    await userEvent.click(
-      screen.getByRole("button", { name: "Delete message" }),
-    );
-    expect(onDelete).toHaveBeenCalledTimes(1);
-  });
-
-  it("renders glass-row actions as unframed icons", () => {
+  it("renders every action on one neutral liquid-glass plate", () => {
     render(
       <ChatMessageActions
         appearance="glass-row"
-        canDelete
         canEdit
+        canPlay
         canReply
         onCopy={vi.fn()}
-        onDelete={vi.fn()}
         onEdit={vi.fn()}
+        onPlay={vi.fn()}
         onReply={vi.fn()}
       />,
     );
 
+    const surface = screen.getByTestId("thread-line-action-surface");
+    expect(surface.className).toContain("bg-black/55");
+    expect(surface.className).toContain("border-white/25");
+    expect(surface.style.backgroundImage).toContain("radial-gradient");
+    expect(surface.style.backdropFilter).toContain("blur");
+
     for (const button of screen.getAllByRole("button")) {
       expect(button.className).toContain("bg-transparent");
-      expect(button.className).toContain("rounded-none");
-      expect(button.className).not.toContain("bg-white/10");
       expect(button.className).not.toContain("rounded-full");
+      expect(button.className).not.toContain("text-[rgb(255");
     }
+    expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
   });
 });

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -22,10 +22,15 @@ describe("ChatMessageActions copy", () => {
   });
 
   it("reflects the copied state in the button label", () => {
-    render(<ChatMessageActions copied onCopy={vi.fn()} />);
-    expect(
-      screen.getByRole("button", { name: "Copied to clipboard" }),
-    ).toBeTruthy();
+    render(
+      <ChatMessageActions appearance="glass-row" copied onCopy={vi.fn()} />,
+    );
+    const copy = screen.getByRole("button", { name: "Copied!" });
+    expect(copy).toBeTruthy();
+    expect(copy.className.split(" ")).toContain("bg-transparent");
+    expect(copy.className.split(" ")).not.toContain("bg-white/10");
+    expect(copy.className.split(" ")).toContain("hover:bg-white/10");
+    expect(screen.getByTestId("copy-status-icon").dataset.state).toBe("copied");
   });
 
   it("uses provided copy labels when supplied", () => {

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -67,6 +67,7 @@ describe("ChatMessageActions copy", () => {
     for (const button of screen.getAllByRole("button")) {
       expect(button.className).toContain("bg-transparent");
       expect(button.className).toContain("rounded-none");
+      expect(button.className).toContain("h-5");
       expect(button.className).toContain("hover:bg-transparent");
       expect(button.className).toContain("pointer-coarse:h-11");
       expect(button.className).not.toContain("text-[rgb(255");

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 //
 /**
- * Behavior and material checks for the shared per-message action plate. The
- * real controls render directly so callback, confirmation, neutral glass, and
- * the absence of a destructive message action stay locked together.
+ * Behavior and presentation checks for shared per-message actions. The real
+ * controls render directly so callback, confirmation, panel glass, bare
+ * overlay icons, and the absence of destructive actions stay locked together.
  */
 
 import { cleanup, render, screen } from "@testing-library/react";
@@ -29,7 +29,7 @@ describe("ChatMessageActions copy", () => {
     expect(copy).toBeTruthy();
     expect(copy.className.split(" ")).toContain("bg-transparent");
     expect(copy.className.split(" ")).not.toContain("bg-white/10");
-    expect(copy.className.split(" ")).toContain("hover:bg-white/10");
+    expect(copy.className.split(" ")).toContain("hover:bg-transparent");
     expect(screen.getByTestId("copy-status-icon").dataset.state).toBe("copied");
   });
 
@@ -43,7 +43,7 @@ describe("ChatMessageActions copy", () => {
     expect(screen.getByRole("button", { name: "Copy text" })).toBeTruthy();
   });
 
-  it("renders every action on one neutral liquid-glass plate", () => {
+  it("renders overlay actions as a bare icon lane", () => {
     render(
       <ChatMessageActions
         appearance="glass-row"
@@ -58,16 +58,28 @@ describe("ChatMessageActions copy", () => {
     );
 
     const surface = screen.getByTestId("thread-line-action-surface");
+    expect(surface.className).not.toContain("bg-black/55");
+    expect(surface.className).not.toContain("border-white/25");
+    expect(surface.className).not.toContain("rounded-xl");
+    expect(surface.style.backgroundImage).toBe("");
+    expect(surface.style.backdropFilter).toBe("");
+
+    for (const button of screen.getAllByRole("button")) {
+      expect(button.className).toContain("bg-transparent");
+      expect(button.className).toContain("rounded-none");
+      expect(button.className).toContain("hover:bg-transparent");
+      expect(button.className).toContain("pointer-coarse:h-11");
+      expect(button.className).not.toContain("text-[rgb(255");
+    }
+    expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
+  });
+
+  it("keeps panel actions on the neutral glass surface", () => {
+    render(<ChatMessageActions canReply onCopy={vi.fn()} onReply={vi.fn()} />);
+    const surface = screen.getByTestId("chat-message-actions");
     expect(surface.className).toContain("bg-black/55");
     expect(surface.className).toContain("border-white/25");
     expect(surface.style.backgroundImage).toContain("radial-gradient");
     expect(surface.style.backdropFilter).toContain("blur");
-
-    for (const button of screen.getAllByRole("button")) {
-      expect(button.className).toContain("bg-transparent");
-      expect(button.className).not.toContain("rounded-full");
-      expect(button.className).not.toContain("text-[rgb(255");
-    }
-    expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
   });
 });

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -103,10 +103,10 @@ function MessageActionButton({
         onClick();
       }}
       className={cn(
-        "h-6 w-6 bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
+        "bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
         bare
-          ? "rounded-none hover:bg-transparent active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55"
-          : "rounded-lg transition-[background-color,color,transform] hover:bg-white/10 active:bg-white/10",
+          ? "h-5 w-5 rounded-none hover:bg-transparent active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55"
+          : "h-6 w-6 rounded-lg transition-[background-color,color,transform] hover:bg-white/10 active:bg-white/10",
         active &&
           (bare ? "text-white" : "bg-white/10 text-white hover:bg-white/15"),
       )}

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -32,6 +32,8 @@ export interface ChatMessageActionsProps {
   onReply?: () => void;
   /** True while THIS message's audio is playing — flips play → stop (glass-row). */
   playing?: boolean;
+  /** Quiet live state placed after the icon controls in the same action rail. */
+  trailingAccessory?: React.ReactNode;
 }
 
 /**
@@ -101,7 +103,7 @@ function MessageActionButton({
         onClick();
       }}
       className={cn(
-        "h-7 w-7 bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
+        "h-6 w-6 bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
         bare
           ? "rounded-none hover:bg-transparent active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55"
           : "rounded-lg transition-[background-color,color,transform] hover:bg-white/10 active:bg-white/10",
@@ -126,6 +128,7 @@ export function ChatMessageActions({
   onPlay,
   onReply,
   playing = false,
+  trailingAccessory,
 }: ChatMessageActionsProps) {
   const reduceMotion = useReducedMotion() ?? false;
   const copyLabel = labels.copy ?? "Copy message";
@@ -228,6 +231,15 @@ export function ChatMessageActions({
           onClick={onEdit}
           bare={glassRow}
         />
+      ) : null}
+
+      {trailingAccessory ? (
+        <div
+          data-testid="thread-line-action-accessory"
+          className="ml-1 min-w-0 shrink-0"
+        >
+          {trailingAccessory}
+        </div>
       ) : null}
     </ChatMessageActionSurface>
   );

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -1,31 +1,24 @@
 /**
- * Per-message action controls (copy / play / edit / delete), in the two chromes
- * the chat surfaces use: `rail` — the hover `PagePanel.ActionRail` overlaying a
- * panel bubble (ChatView / detached windows) — and `glass-row` — the continuous
- * overlay's tap-revealed row of unframed icon buttons beneath a glass bubble
- * (#10713). Each control is opt-in via its `can*` flag; copy shows a transient
- * confirmed state; play toggles to stop on the bubble that is speaking
- * (`playing`, glass-row only). Wired by ChatMessage.
+ * Per-message reply, copy, playback, and edit controls. Both panel chat and the
+ * continuous overlay use the same neutral liquid-glass plate so revealing a
+ * row never swaps between unrelated button treatments. Individual controls
+ * stay visually unframed at rest; copy and playback use a quiet selected state.
+ * Wired by ChatMessage.
  */
-import {
-  Check,
-  Copy,
-  Pencil,
-  Reply,
-  Square,
-  Trash2,
-  Volume2,
-} from "lucide-react";
+import { Check, Copy, Pencil, Reply, Square, Volume2 } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "../../../lib/utils";
+import {
+  LIQUID_GLASS_BLUR,
+  LIQUID_GLASS_EDGE_SHADOW,
+  LIQUID_GLASS_SHEEN,
+} from "../../shell/liquid-glass";
 import { Button } from "../../ui/button";
-import { PagePanel } from "../page-panel";
 import type { ChatMessageLabels } from "./chat-types";
 
 export interface ChatMessageActionsProps {
   appearance?: "rail" | "glass-row";
-  canDelete?: boolean;
   canEdit?: boolean;
   canPlay?: boolean;
   /** Show the Reply control — set the composer to reply to this message. */
@@ -33,7 +26,6 @@ export interface ChatMessageActionsProps {
   copied?: boolean;
   labels?: ChatMessageLabels;
   onCopy?: () => void;
-  onDelete?: () => void;
   onEdit?: () => void;
   onPlay?: () => void;
   onReply?: () => void;
@@ -42,12 +34,39 @@ export interface ChatMessageActionsProps {
 }
 
 /**
- * One unframed icon-only control in the glass action row. The invisible square
- * remains a full hit target, while only icon color changes on hover or active
- * state. `stopPropagation` keeps a tap from re-toggling the row or ending text
- * selection.
+ * Shared glass material for message actions and the inline editor controls.
+ * It reuses the notification-center sheen, blur, and inset edge stack so chat
+ * controls read as part of the shell rather than a row of independent bubbles.
  */
-function GlassActionButton({
+export function ChatMessageActionSurface({
+  className,
+  style,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-xl border border-white/25 bg-black/55 p-0.5 text-white transition-colors duration-150",
+        className,
+      )}
+      style={{
+        backgroundImage: LIQUID_GLASS_SHEEN,
+        boxShadow: LIQUID_GLASS_EDGE_SHADOW,
+        WebkitBackdropFilter: LIQUID_GLASS_BLUR,
+        backdropFilter: LIQUID_GLASS_BLUR,
+        ...style,
+      }}
+      {...props}
+    />
+  );
+}
+
+/**
+ * One icon control inside the shared plate. The full square remains the hit
+ * target while its resting state has no fill; taps stop at the control so the
+ * parent message does not re-toggle its reveal state.
+ */
+function MessageActionButton({
   label,
   icon,
   onClick,
@@ -72,8 +91,8 @@ function GlassActionButton({
         onClick();
       }}
       className={cn(
-        "h-7 w-7 rounded-none bg-transparent p-0 text-white/70 transition-colors hover:bg-transparent hover:text-white",
-        active && "text-[rgb(255,148,84)] hover:text-[rgb(255,148,84)]",
+        "h-7 w-7 rounded-lg bg-transparent p-0 text-white/65 transition-[background-color,color,transform] duration-150 hover:bg-white/10 hover:text-white active:scale-95",
+        active && "bg-white/10 text-white hover:bg-white/15",
       )}
     >
       {icon}
@@ -83,14 +102,12 @@ function GlassActionButton({
 
 export function ChatMessageActions({
   appearance = "rail",
-  canDelete = false,
   canEdit = false,
   canPlay = false,
   canReply = false,
   copied = false,
   labels = {},
   onCopy,
-  onDelete,
   onEdit,
   onPlay,
   onReply,
@@ -100,137 +117,73 @@ export function ChatMessageActions({
   const copiedLabel = labels.copied ?? "Copied!";
   const copiedAriaLabel = labels.copiedAria ?? "Copied to clipboard";
   const replyLabel = labels.reply ?? "Reply";
-
-  if (appearance === "glass-row") {
-    return (
-      <>
-        {canReply && onReply ? (
-          <GlassActionButton
-            label={replyLabel}
-            testId="thread-line-reply"
-            icon={<Reply className="h-3.5 w-3.5" />}
-            onClick={onReply}
-          />
-        ) : null}
-        {onCopy ? (
-          <GlassActionButton
-            label={copied ? "Copied" : "Copy"}
-            testId="thread-line-copy"
-            icon={
-              copied ? (
-                <Check className="h-3.5 w-3.5" />
-              ) : (
-                <Copy className="h-3.5 w-3.5" />
-              )
-            }
-            onClick={onCopy}
-            active={copied}
-          />
-        ) : null}
-        {canPlay && onPlay ? (
-          <GlassActionButton
-            label={playing ? "Stop" : "Play audio"}
-            testId="thread-line-speak"
-            icon={
-              playing ? (
-                <Square className="h-3.5 w-3.5" />
-              ) : (
-                <Volume2 className="h-3.5 w-3.5" />
-              )
-            }
-            onClick={onPlay}
-            active={playing}
-          />
-        ) : null}
-        {canEdit && onEdit ? (
-          <GlassActionButton
-            label="Edit"
-            testId="thread-line-edit"
-            icon={<Pencil className="h-3.5 w-3.5" />}
-            onClick={onEdit}
-          />
-        ) : null}
-        {canDelete && onDelete ? (
-          <GlassActionButton
-            label={labels.delete ?? "Delete"}
-            testId="thread-line-delete"
-            icon={<Trash2 className="h-3.5 w-3.5" />}
-            onClick={onDelete}
-          />
-        ) : null}
-      </>
-    );
-  }
+  const editLabel = labels.edit ?? "Edit message";
+  const playLabel = labels.play ?? "Play message";
+  const glassRow = appearance === "glass-row";
 
   return (
-    <PagePanel.ActionRail className="top-1 rounded-sm p-1">
+    <ChatMessageActionSurface
+      data-testid={
+        glassRow ? "thread-line-action-surface" : "chat-message-actions"
+      }
+    >
       {canReply && onReply ? (
-        <Button
-          variant="surface"
-          size="icon"
+        <MessageActionButton
+          label={replyLabel}
+          testId={glassRow ? "thread-line-reply" : "chat-message-reply"}
+          icon={<Reply className="h-3.5 w-3.5" />}
           onClick={onReply}
-          className="h-8 w-8 rounded-sm"
-          title={replyLabel}
-          aria-label={replyLabel}
-          data-testid="chat-message-reply"
-        >
-          <Reply className="h-3.5 w-3.5" />
-        </Button>
+        />
       ) : null}
 
-      <Button
-        variant="surface"
-        size="icon"
-        onClick={onCopy}
-        className="h-8 w-8 rounded-sm"
-        title={copied ? copiedLabel : copyLabel}
-        aria-label={copied ? copiedAriaLabel : copyLabel}
-      >
-        {copied ? (
-          <Check className="h-3.5 w-3.5 text-ok" />
-        ) : (
-          <Copy className="h-3.5 w-3.5" />
-        )}
-      </Button>
+      {onCopy ? (
+        <MessageActionButton
+          label={
+            copied
+              ? glassRow
+                ? copiedLabel
+                : copiedAriaLabel
+              : glassRow
+                ? (labels.copy ?? "Copy")
+                : copyLabel
+          }
+          testId={glassRow ? "thread-line-copy" : undefined}
+          icon={
+            copied ? (
+              <Check className="h-3.5 w-3.5" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )
+          }
+          onClick={onCopy}
+          active={copied}
+        />
+      ) : null}
 
-      {canPlay ? (
-        <Button
-          variant="surface"
-          size="icon"
+      {canPlay && onPlay ? (
+        <MessageActionButton
+          label={playing ? "Stop" : glassRow ? "Play audio" : playLabel}
+          testId={glassRow ? "thread-line-speak" : undefined}
+          icon={
+            playing ? (
+              <Square className="h-3.5 w-3.5" />
+            ) : (
+              <Volume2 className="h-3.5 w-3.5" />
+            )
+          }
           onClick={onPlay}
-          className="h-8 w-8 rounded-sm"
-          title={labels.play ?? "Play message"}
-          aria-label={labels.play ?? "Play message"}
-        >
-          <Volume2 className="h-3.5 w-3.5" />
-        </Button>
+          active={playing}
+        />
       ) : null}
 
-      {canEdit ? (
-        <Button
-          variant="surface"
-          size="icon"
+      {canEdit && onEdit ? (
+        <MessageActionButton
+          label={glassRow ? (labels.edit ?? "Edit") : editLabel}
+          testId={glassRow ? "thread-line-edit" : undefined}
+          icon={<Pencil className="h-3.5 w-3.5" />}
           onClick={onEdit}
-          className="h-8 w-8 rounded-sm"
-          title={labels.edit ?? "Edit message"}
-          aria-label={labels.edit ?? "Edit message"}
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </Button>
+        />
       ) : null}
-
-      {canDelete ? (
-        <Button
-          variant="surfaceDestructive"
-          size="icon"
-          onClick={onDelete}
-          className="h-8 w-8 rounded-sm"
-          title={labels.delete ?? "Delete message"}
-          aria-label={labels.delete ?? "Delete message"}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </Button>
-      ) : null}
-    </PagePanel.ActionRail>
+    </ChatMessageActionSurface>
   );
 }

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -6,6 +6,7 @@
  * Wired by ChatMessage.
  */
 import { Check, Copy, Pencil, Reply, Square, Volume2 } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import type * as React from "react";
 
 import { cn } from "../../../lib/utils";
@@ -113,6 +114,7 @@ export function ChatMessageActions({
   onReply,
   playing = false,
 }: ChatMessageActionsProps) {
+  const reduceMotion = useReducedMotion() ?? false;
   const copyLabel = labels.copy ?? "Copy message";
   const copiedLabel = labels.copied ?? "Copied!";
   const copiedAriaLabel = labels.copiedAria ?? "Copied to clipboard";
@@ -149,14 +151,39 @@ export function ChatMessageActions({
           }
           testId={glassRow ? "thread-line-copy" : undefined}
           icon={
-            copied ? (
-              <Check className="h-3.5 w-3.5" />
-            ) : (
-              <Copy className="h-3.5 w-3.5" />
-            )
+            <span className="relative flex h-3.5 w-3.5 items-center justify-center">
+              <AnimatePresence initial={false}>
+                <motion.span
+                  key={copied ? "copied" : "copy"}
+                  data-testid="copy-status-icon"
+                  data-state={copied ? "copied" : "idle"}
+                  initial={
+                    reduceMotion
+                      ? false
+                      : { opacity: 0, rotate: copied ? -8 : 8, scale: 0.76 }
+                  }
+                  animate={{ opacity: 1, rotate: 0, scale: 1 }}
+                  exit={
+                    reduceMotion
+                      ? { opacity: 0 }
+                      : { opacity: 0, rotate: copied ? 8 : -8, scale: 0.76 }
+                  }
+                  transition={{
+                    duration: reduceMotion ? 0.08 : 0.16,
+                    ease: [0.16, 1, 0.3, 1],
+                  }}
+                  className="absolute inset-0 flex items-center justify-center"
+                >
+                  {copied ? (
+                    <Check className="h-3.5 w-3.5" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </motion.span>
+              </AnimatePresence>
+            </span>
           }
           onClick={onCopy}
-          active={copied}
         />
       ) : null}
 

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -1,8 +1,8 @@
 /**
- * Per-message reply, copy, playback, and edit controls. Both panel chat and the
- * continuous overlay use the same neutral liquid-glass plate so revealing a
- * row never swaps between unrelated button treatments. Individual controls
- * stay visually unframed at rest; copy and playback use a quiet selected state.
+ * Per-message reply, copy, playback, and edit controls. Panel chat groups the
+ * controls on a neutral liquid-glass plate; the continuous overlay renders a
+ * bare icon lane beneath each message so hover and touch affordances stay
+ * visually quiet. Copy and playback retain their compact state transitions.
  * Wired by ChatMessage.
  */
 import { Check, Copy, Pencil, Reply, Square, Volume2 } from "lucide-react";
@@ -35,49 +35,58 @@ export interface ChatMessageActionsProps {
 }
 
 /**
- * Shared glass material for message actions and the inline editor controls.
- * It reuses the notification-center sheen, blur, and inset edge stack so chat
- * controls read as part of the shell rather than a row of independent bubbles.
+ * Shared action container for the material panel and the overlay's bare lane.
+ * Inline editor controls retain the notification-center glass stack, while
+ * message actions can opt out without duplicating their interaction wiring.
  */
 export function ChatMessageActionSurface({
+  bare = false,
   className,
   style,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: React.HTMLAttributes<HTMLDivElement> & { bare?: boolean }) {
   return (
     <div
       className={cn(
-        "inline-flex items-center gap-0.5 rounded-xl border border-white/25 bg-black/55 p-0.5 text-white transition-colors duration-150",
+        "inline-flex items-center text-white",
+        bare
+          ? "gap-0.5"
+          : "gap-0.5 rounded-xl border border-white/25 bg-black/55 p-0.5 transition-colors duration-150",
         className,
       )}
-      style={{
-        backgroundImage: LIQUID_GLASS_SHEEN,
-        boxShadow: LIQUID_GLASS_EDGE_SHADOW,
-        WebkitBackdropFilter: LIQUID_GLASS_BLUR,
-        backdropFilter: LIQUID_GLASS_BLUR,
-        ...style,
-      }}
+      style={
+        bare
+          ? style
+          : {
+              backgroundImage: LIQUID_GLASS_SHEEN,
+              boxShadow: LIQUID_GLASS_EDGE_SHADOW,
+              WebkitBackdropFilter: LIQUID_GLASS_BLUR,
+              backdropFilter: LIQUID_GLASS_BLUR,
+              ...style,
+            }
+      }
       {...props}
     />
   );
 }
 
 /**
- * One icon control inside the shared plate. The full square remains the hit
- * target while its resting state has no fill; taps stop at the control so the
- * parent message does not re-toggle its reveal state.
+ * One icon control with a full hit target and an unframed resting state. Taps
+ * stop at the control so the parent message does not re-toggle its reveal.
  */
 function MessageActionButton({
   label,
   icon,
   onClick,
   active,
+  bare,
   testId,
 }: {
   label: string;
   icon: React.ReactNode;
   onClick: () => void;
   active?: boolean;
+  bare?: boolean;
   testId?: string;
 }) {
   return (
@@ -92,8 +101,12 @@ function MessageActionButton({
         onClick();
       }}
       className={cn(
-        "h-7 w-7 rounded-lg bg-transparent p-0 text-white/65 transition-[background-color,color,transform] duration-150 hover:bg-white/10 hover:text-white active:scale-95",
-        active && "bg-white/10 text-white hover:bg-white/15",
+        "h-7 w-7 bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
+        bare
+          ? "rounded-none hover:bg-transparent active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55"
+          : "rounded-lg transition-[background-color,color,transform] hover:bg-white/10 active:bg-white/10",
+        active &&
+          (bare ? "text-white" : "bg-white/10 text-white hover:bg-white/15"),
       )}
     >
       {icon}
@@ -125,6 +138,7 @@ export function ChatMessageActions({
 
   return (
     <ChatMessageActionSurface
+      bare={glassRow}
       data-testid={
         glassRow ? "thread-line-action-surface" : "chat-message-actions"
       }
@@ -135,6 +149,7 @@ export function ChatMessageActions({
           testId={glassRow ? "thread-line-reply" : "chat-message-reply"}
           icon={<Reply className="h-3.5 w-3.5" />}
           onClick={onReply}
+          bare={glassRow}
         />
       ) : null}
 
@@ -184,6 +199,7 @@ export function ChatMessageActions({
             </span>
           }
           onClick={onCopy}
+          bare={glassRow}
         />
       ) : null}
 
@@ -200,6 +216,7 @@ export function ChatMessageActions({
           }
           onClick={onPlay}
           active={playing}
+          bare={glassRow}
         />
       ) : null}
 
@@ -209,6 +226,7 @@ export function ChatMessageActions({
           testId={glassRow ? "thread-line-edit" : undefined}
           icon={<Pencil className="h-3.5 w-3.5" />}
           onClick={onEdit}
+          bare={glassRow}
         />
       ) : null}
     </ChatMessageActionSurface>

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -43,7 +43,7 @@ function makeMessage(
 }
 
 describe("ChatMessage desktop hover action plate", () => {
-  it("reveals the overlay's bare actions on hover without changing row flow", () => {
+  it("reveals the overlay's bare actions into a compact animated lane", () => {
     render(
       <ChatMessage
         appearance="glass"
@@ -61,14 +61,16 @@ describe("ChatMessage desktop hover action plate", () => {
 
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.className).toContain("absolute");
-    expect(content?.className).toContain("pb-6");
+    expect(content?.className).toContain("pb-0");
     expect(content?.className).toContain("pointer-coarse:pb-11");
-    expect(message.className).toContain("mb-0.5");
+    expect(content?.className).toContain("transition-[padding-bottom]");
+    expect(message.className).toContain("mb-0");
     expect(surface.className).not.toContain("bg-black/55");
 
     fireEvent.mouseEnter(message);
     expect(actions.getAttribute("aria-hidden")).toBe("false");
     expect(actions.hasAttribute("inert")).toBe(false);
+    expect(actions.parentElement?.className).toContain("pb-6");
 
     fireEvent.mouseLeave(message);
     expect(actions.getAttribute("aria-hidden")).toBe("true");
@@ -149,6 +151,6 @@ describe("ChatMessage desktop hover action plate", () => {
     expect(bubble?.classList.contains("rounded-br-md")).toBe(true);
     expect(bubble?.classList.contains("border-white/15")).toBe(true);
     expect(bubble?.classList.contains("px-3.5")).toBe(true);
-    expect(bubble?.classList.contains("py-2")).toBe(true);
+    expect(bubble?.classList.contains("py-1")).toBe(true);
   });
 });

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 
 /**
- * Desktop hover coverage for the per-message delete control. The test runs in
- * its own file because ChatMessage caches the hover MediaQueryList at module
- * scope, so a sibling touch-suite install would otherwise poison the device
- * branch under test.
+ * Desktop hover coverage for the per-message action plate. The test runs in its
+ * own file because ChatMessage caches the hover MediaQueryList at module scope,
+ * so a sibling touch-suite install would otherwise poison this device branch.
  */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -43,30 +42,36 @@ function makeMessage(
   };
 }
 
-function deleteControl(): HTMLElement | null {
-  return screen.queryByRole("button", { name: "Delete message" });
-}
-
-describe("ChatMessage desktop hover-chrome delete control (#13533)", () => {
-  it("reveals the delete control on desktop hover when the surface wires onDelete", () => {
+describe("ChatMessage desktop hover action plate", () => {
+  it("fades and settles the neutral action plate without a delete control", () => {
     render(
       <ChatMessage
         message={makeMessage()}
         onCopy={vi.fn()}
-        onDelete={vi.fn()}
+        onReply={vi.fn()}
+        onSpeak={vi.fn()}
       />,
     );
     const message = screen.getByTestId("chat-message");
     const rail = screen.getByTestId("chat-message-action-rail");
+    const surface = screen.getByTestId("chat-message-actions");
 
-    expect(deleteControl()).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
+    expect(surface.className).toContain("bg-black/55");
+    expect(rail.className).toContain("transition-[opacity,transform]");
     expect(rail.className).toContain("pointer-events-none");
     expect(rail.className).toContain("opacity-0");
+    expect(rail.className).toContain("translate-y-1");
+    expect(rail.className).toContain("scale-[0.98]");
+    expect(rail.hasAttribute("inert")).toBe(true);
 
     fireEvent.mouseEnter(message);
 
     expect(rail.className).not.toContain("pointer-events-none");
     expect(rail.className).toContain("opacity-100");
+    expect(rail.className).toContain("translate-y-0");
+    expect(rail.className).toContain("scale-100");
+    expect(rail.hasAttribute("inert")).toBe(false);
 
     fireEvent.mouseLeave(message);
 
@@ -74,27 +79,9 @@ describe("ChatMessage desktop hover-chrome delete control (#13533)", () => {
     expect(rail.className).toContain("opacity-0");
   });
 
-  it("omits the delete control when the surface wires no onDelete", () => {
-    render(<ChatMessage message={makeMessage()} onCopy={vi.fn()} />);
-    expect(deleteControl()).toBeNull();
-  });
-
-  it("omits the delete control on an optimistic (temp-) turn even with onDelete wired", () => {
-    render(
-      <ChatMessage
-        message={makeMessage({ id: "temp-123" })}
-        onCopy={vi.fn()}
-        onDelete={vi.fn()}
-      />,
-    );
-    // A temp turn has no persisted memory row to delete; ChatMessage's canDelete
-    // guard excludes `temp-` ids so the control never appears on it.
-    expect(deleteControl()).toBeNull();
-  });
-
   it("renders a frosted first-run greeting with no action rail", () => {
     // The onboarding greeting is seeded wallpaper prose with a CTA beneath it;
-    // reply / copy / delete / play are meaningless on it and the hover rail read
+    // reply / copy / play are meaningless on it and the hover rail read
     // as a bug during first-run. Even with every action handler wired, a
     // `first_run` source turn must render no rail.
     render(
@@ -102,7 +89,6 @@ describe("ChatMessage desktop hover-chrome delete control (#13533)", () => {
         message={makeMessage({ source: "first_run" })}
         appearance="glass"
         onCopy={vi.fn()}
-        onDelete={vi.fn()}
         onReply={vi.fn()}
         onSpeak={vi.fn()}
       />,
@@ -116,7 +102,6 @@ describe("ChatMessage desktop hover-chrome delete control (#13533)", () => {
     expect(bubble?.classList.contains("rounded-bl-md")).toBe(true);
     expect(bubble?.classList.contains("bg-black/35")).toBe(true);
     expect(screen.queryByTestId("chat-message-action-rail")).toBeNull();
-    expect(deleteControl()).toBeNull();
     expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
   });
 

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -43,7 +43,7 @@ function makeMessage(
 }
 
 describe("ChatMessage desktop hover action plate", () => {
-  it("reveals the overlay's bare actions into a compact animated lane", () => {
+  it("reveals the overlay's bare actions without changing row flow", () => {
     render(
       <ChatMessage
         appearance="glass"
@@ -58,23 +58,25 @@ describe("ChatMessage desktop hover action plate", () => {
     const actions = screen.getByTestId("thread-line-actions");
     const surface = screen.getByTestId("thread-line-action-surface");
     const content = actions.parentElement;
+    const restingContentClass = content?.className;
 
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.className).toContain("absolute");
-    expect(content?.className).toContain("pb-0");
-    expect(content?.className).toContain("pointer-coarse:pb-11");
-    expect(content?.className).toContain("transition-[padding-bottom]");
+    expect(content?.className).toContain("pb-5");
+    expect(content?.className).toContain("pointer-coarse:pb-9");
+    expect(actions.className).toContain("pointer-coarse:-bottom-1");
     expect(message.className).toContain("mb-0");
     expect(surface.className).not.toContain("bg-black/55");
 
     fireEvent.mouseEnter(message);
     expect(actions.getAttribute("aria-hidden")).toBe("false");
     expect(actions.hasAttribute("inert")).toBe(false);
-    expect(actions.parentElement?.className).toContain("pb-6");
+    expect(actions.parentElement?.className).toBe(restingContentClass);
 
     fireEvent.mouseLeave(message);
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.hasAttribute("inert")).toBe(true);
+    expect(actions.parentElement?.className).toBe(restingContentClass);
   });
 
   it("fades and settles the neutral action plate without a delete control", () => {
@@ -151,6 +153,6 @@ describe("ChatMessage desktop hover action plate", () => {
     expect(bubble?.classList.contains("rounded-br-md")).toBe(true);
     expect(bubble?.classList.contains("border-white/15")).toBe(true);
     expect(bubble?.classList.contains("px-3.5")).toBe(true);
-    expect(bubble?.classList.contains("py-1")).toBe(true);
+    expect(bubble?.classList.contains("py-[3px]")).toBe(true);
   });
 });

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -61,7 +61,7 @@ describe("ChatMessage desktop hover action plate", () => {
 
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.className).toContain("absolute");
-    expect(content?.className).toContain("pb-7");
+    expect(content?.className).toContain("pb-6");
     expect(content?.className).toContain("pointer-coarse:pb-11");
     expect(message.className).toContain("mb-0.5");
     expect(surface.className).not.toContain("bg-black/55");

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -61,8 +61,9 @@ describe("ChatMessage desktop hover action plate", () => {
 
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.className).toContain("absolute");
-    expect(content?.className).toContain("pb-8");
-    expect(content?.className).toContain("pointer-coarse:pb-12");
+    expect(content?.className).toContain("pb-7");
+    expect(content?.className).toContain("pointer-coarse:pb-11");
+    expect(message.className).toContain("mb-0.5");
     expect(surface.className).not.toContain("bg-black/55");
 
     fireEvent.mouseEnter(message);

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -43,6 +43,37 @@ function makeMessage(
 }
 
 describe("ChatMessage desktop hover action plate", () => {
+  it("reveals the overlay's bare actions on hover without changing row flow", () => {
+    render(
+      <ChatMessage
+        appearance="glass"
+        message={makeMessage()}
+        onCopy={vi.fn()}
+        onReply={vi.fn()}
+        onSpeak={vi.fn()}
+      />,
+    );
+
+    const message = screen.getByTestId("thread-line");
+    const actions = screen.getByTestId("thread-line-actions");
+    const surface = screen.getByTestId("thread-line-action-surface");
+    const content = actions.parentElement;
+
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+    expect(actions.className).toContain("absolute");
+    expect(content?.className).toContain("pb-8");
+    expect(content?.className).toContain("pointer-coarse:pb-12");
+    expect(surface.className).not.toContain("bg-black/55");
+
+    fireEvent.mouseEnter(message);
+    expect(actions.getAttribute("aria-hidden")).toBe("false");
+    expect(actions.hasAttribute("inert")).toBe(false);
+
+    fireEvent.mouseLeave(message);
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+    expect(actions.hasAttribute("inert")).toBe(true);
+  });
+
   it("fades and settles the neutral action plate without a delete control", () => {
     render(
       <ChatMessage

--- a/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
@@ -1,6 +1,6 @@
-// @vitest-environment jsdom
-
 /**
+ * @vitest-environment jsdom
+ *
  * Glass-message inline editing keeps the overlay's action lane visually bare
  * while preserving labelled touch targets, cancel restoration, and save wiring.
  */

--- a/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+/**
+ * Glass-message inline editing keeps the overlay's action lane visually bare
+ * while preserving labelled touch targets, cancel restoration, and save wiring.
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ChatMessage } from "./chat-message";
+
+beforeAll(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("hover: hover"),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterEach(cleanup);
+
+function openEditor(onEdit = vi.fn().mockResolvedValue(true)) {
+  render(
+    <ChatMessage
+      appearance="glass"
+      message={{ id: "message-1", role: "user", text: "Original message" }}
+      onCopy={vi.fn()}
+      onReply={vi.fn()}
+      onEdit={onEdit}
+    />,
+  );
+
+  fireEvent.mouseEnter(screen.getByTestId("thread-line"));
+  fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+  return onEdit;
+}
+
+describe("ChatMessage glass inline edit controls", () => {
+  it("uses two bare labelled icons instead of the old Cancel and Send plate", () => {
+    openEditor();
+
+    const controls = screen.getByTestId("thread-line-edit-controls");
+    const cancel = screen.getByTestId("thread-line-edit-cancel");
+    const save = screen.getByTestId("thread-line-edit-save");
+
+    expect(controls.className).not.toContain("rounded-xl");
+    expect(controls.className).not.toContain("border-white");
+    expect(cancel.getAttribute("aria-label")).toBe("Cancel");
+    expect(save.getAttribute("aria-label")).toBe("Send");
+    expect(cancel.textContent).toBe("");
+    expect(save.textContent).toBe("");
+    expect(cancel.className).toContain("pointer-coarse:h-11");
+    expect(save.className).toContain("pointer-coarse:h-11");
+  });
+
+  it("restores the message action icons after Cancel", () => {
+    openEditor();
+
+    fireEvent.click(screen.getByTestId("thread-line-edit-cancel"));
+
+    expect(screen.queryByLabelText("Edit message")).toBeNull();
+    expect(
+      screen.getByTestId("thread-line-actions").getAttribute("aria-hidden"),
+    ).toBe("false");
+    expect(screen.getByRole("button", { name: "Copy" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reply" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
+  });
+
+  it("submits the edited text from the icon-only Save control", async () => {
+    const onEdit = openEditor();
+    const input = screen.getByLabelText("Edit message");
+
+    fireEvent.change(input, { target: { value: "Cleaner edited message" } });
+    fireEvent.click(screen.getByTestId("thread-line-edit-save"));
+
+    await waitFor(() => {
+      expect(onEdit).toHaveBeenCalledWith(
+        "message-1",
+        "Cleaner edited message",
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/composites/chat/chat-message.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.stories.tsx
@@ -79,7 +79,6 @@ export const Editable: Story = {
       fromUserName: "nubscarson",
     },
     onEdit: () => true,
-    onDelete: () => {},
   },
 };
 

--- a/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 // Touch tap-vs-scroll discrimination for the composite ChatMessage's
-// tap-to-reveal action rail (copy/edit/play/delete). On non-hover devices the
+// tap-to-reveal action rail (reply/copy/edit/play). On non-hover devices the
 // whole <article> toggles the rail on touchend; without move-slop tracking a
 // flick-scroll over the transcript toggled the rail on whichever message the
 // finger started on. The fix mirrors the shell ThreadLine: finger travel past

--- a/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
@@ -71,6 +71,36 @@ function touchPoint(clientX: number, clientY: number) {
 }
 
 describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
+  it("toggles the overlay's reserved action lane on touch-style taps", () => {
+    render(
+      <ChatMessage
+        appearance="glass"
+        message={makeMessage()}
+        onCopy={vi.fn()}
+        onReply={vi.fn()}
+      />,
+    );
+
+    const actions = screen.getByTestId("thread-line-actions");
+    const bubble = screen.getByRole("button", {
+      name: "Show message actions",
+    });
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+    expect(actions.className).toContain("absolute");
+    expect(actions.parentElement?.className).toContain("pointer-coarse:pb-12");
+
+    fireEvent.click(bubble);
+    expect(actions.getAttribute("aria-hidden")).toBe("false");
+    expect(
+      screen.getByRole("button", { name: "Hide message actions" }),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hide message actions" }),
+    );
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("a clean tap toggles the action rail on and off", () => {
     render(<ChatMessage message={makeMessage()} onCopy={vi.fn()} />);
     const article = getArticle();

--- a/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
@@ -87,7 +87,8 @@ describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
     });
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.className).toContain("absolute");
-    expect(actions.parentElement?.className).toContain("pointer-coarse:pb-11");
+    expect(actions.parentElement?.className).toContain("pointer-coarse:pb-9");
+    expect(actions.className).toContain("pointer-coarse:-bottom-1");
 
     fireEvent.click(bubble);
     expect(actions.getAttribute("aria-hidden")).toBe("false");

--- a/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
@@ -87,7 +87,7 @@ describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
     });
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.className).toContain("absolute");
-    expect(actions.parentElement?.className).toContain("pointer-coarse:pb-12");
+    expect(actions.parentElement?.className).toContain("pointer-coarse:pb-11");
 
     fireEvent.click(bubble);
     expect(actions.getAttribute("aria-hidden")).toBe("false");

--- a/packages/ui/src/components/composites/chat/chat-message.timestamp.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.timestamp.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Verifies that compact message times share the glass action lane for both
+ * speakers and inherit its reveal without changing the row's reserved flow.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { ChatMessage } from "./chat-message";
+import type { ChatMessageData } from "./chat-types";
+
+const NOW = new Date("2026-07-15T16:00:00.000Z");
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+beforeAll(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function makeMessage(
+  role: "user" | "assistant",
+  timestamp: number,
+): ChatMessageData {
+  return {
+    id: `${role}-message`,
+    role,
+    text: role === "user" ? "Please keep this compact." : "Absolutely.",
+    timestamp,
+  };
+}
+
+describe("ChatMessage glass timestamp", () => {
+  it.each([
+    ["assistant", "left-0"],
+    ["user", "right-0"],
+  ] as const)("renders for the %s lane without reveal reflow", (role, edge) => {
+    const timestamp = NOW.getTime() - 5 * MINUTE_MS;
+    render(
+      <ChatMessage
+        appearance="glass"
+        message={makeMessage(role, timestamp)}
+        onCopy={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByTestId("thread-line");
+    const actions = screen.getByTestId("thread-line-actions");
+    const content = actions.parentElement;
+    const restingContentClass = content?.className;
+    const time = screen.getByTestId("thread-line-timestamp");
+
+    expect(time.textContent).toBe("5m");
+    expect(time.getAttribute("dateTime")).toBe(
+      new Date(timestamp).toISOString(),
+    );
+    expect(time.getAttribute("title")).toBe(
+      new Date(timestamp).toLocaleString(),
+    );
+    expect(time.className).toContain("min-w-[3ch]");
+    expect(actions.className).toContain(edge);
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+
+    fireEvent.mouseEnter(row);
+
+    expect(actions.getAttribute("aria-hidden")).toBe("false");
+    expect(actions.parentElement?.className).toBe(restingContentClass);
+  });
+
+  it.each([
+    [59_999, "now"],
+    [MINUTE_MS, "1m"],
+    [HOUR_MS - 1, "59m"],
+    [HOUR_MS, "1h"],
+    [DAY_MS - 1, "23h"],
+    [DAY_MS, "1d"],
+    [7 * DAY_MS - 1, "6d"],
+    [7 * DAY_MS, new Date(NOW.getTime() - 7 * DAY_MS).toLocaleDateString()],
+  ])("uses the compact relative label at %dms", (age, label) => {
+    render(
+      <ChatMessage
+        appearance="glass"
+        message={makeMessage("assistant", NOW.getTime() - age)}
+        onCopy={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("thread-line-timestamp").textContent).toBe(label);
+  });
+
+  it("omits the time leaf when a generic message has no transport timestamp", () => {
+    render(
+      <ChatMessage
+        appearance="glass"
+        message={{ id: "no-time", role: "assistant", text: "Hello." }}
+        onCopy={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("thread-line-timestamp")).toBeNull();
+  });
+
+  it("keeps the live action accessory beside the timestamp", () => {
+    render(
+      <ChatMessage
+        actionAccessory={<span data-testid="live-status">Working</span>}
+        appearance="glass"
+        message={makeMessage("assistant", NOW.getTime() - 5 * MINUTE_MS)}
+        onCopy={vi.fn()}
+      />,
+    );
+
+    const accessory = screen.getByTestId("thread-line-action-accessory");
+    const liveStatus = screen.getByTestId("live-status");
+    const timestamp = screen.getByTestId("thread-line-timestamp");
+    expect(
+      liveStatus.compareDocumentPosition(timestamp) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(accessory.contains(timestamp)).toBe(true);
+    expect(accessory.contains(liveStatus)).toBe(true);
+  });
+});

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -990,7 +990,7 @@ export const ChatMessage = memo(function ChatMessage({
             the turn's side (#10713). */}
         <MessageRowContent
           className={cn(
-            "flex flex-col gap-1",
+            "flex flex-col",
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser
@@ -1042,33 +1042,48 @@ export const ChatMessage = memo(function ChatMessage({
             </ChatBubble>
           )}
           {hasActions ? (
-            <MessageRowFooter
+            <motion.div
               data-testid="thread-line-actions"
               aria-hidden={!actionsVisible || isEditing}
               inert={!actionsVisible || isEditing}
-              className={cn(
-                "absolute top-full z-20 mt-1 flex items-center px-0 text-white/70",
-                ACTION_REVEAL_MOTION,
-                isUser ? "right-0 origin-top-right" : "left-0 origin-top-left",
+              initial={false}
+              animate={
                 actionsVisible && !isEditing
-                  ? ACTION_REVEAL_VISIBLE
-                  : ACTION_REVEAL_HIDDEN,
+                  ? { height: "auto", opacity: 1, y: 0, scale: 1 }
+                  : {
+                      height: 0,
+                      opacity: 0,
+                      y: reduceMotion ? 0 : 4,
+                      scale: reduceMotion ? 1 : 0.98,
+                    }
+              }
+              transition={{
+                duration: reduceMotion ? 0.1 : 0.2,
+                ease: GLASS_EASE,
+              }}
+              className={cn(
+                "min-w-0 overflow-hidden",
+                isUser
+                  ? "self-end origin-top-right"
+                  : "self-start origin-top-left",
               )}
             >
-              <ChatMessageActions
-                appearance="glass-row"
-                canEdit={canEdit}
-                canPlay={canPlay}
-                canReply={canReply}
-                copied={copied}
-                labels={labels}
-                onCopy={canRowCopy ? handleCopy : undefined}
-                onEdit={handleStartEditing}
-                onPlay={() => onSpeak?.(message.id, message.text)}
-                onReply={handleReply}
-                playing={playing}
-              />
-            </MessageRowFooter>
+              <MessageRowFooter className="flex items-center px-0 pt-1 text-white/70">
+                <ChatMessageActions
+                  appearance="glass-row"
+                  canEdit={canEdit}
+                  canPlay={canPlay}
+                  canReply={canReply}
+                  copied={copied}
+                  labels={labels}
+                  onCopy={canRowCopy ? handleCopy : undefined}
+                  onEdit={handleStartEditing}
+                  onPlay={() => onSpeak?.(message.id, message.text)}
+                  onReply={handleReply}
+                  playing={playing}
+                />
+              </MessageRowFooter>
+            </motion.div>
           ) : null}
           {/* Retry a recoverable failure by re-sending the preceding user turn.
               Always visible on the failed turn (not gated behind the reveal
@@ -1083,7 +1098,7 @@ export const ChatMessage = memo(function ChatMessage({
                 e.stopPropagation();
                 onRetry?.(message.id);
               }}
-              className="h-auto gap-1.5 rounded-full bg-white/10 px-3 py-1 text-[13px] font-medium text-white/80 transition-colors hover:bg-white/20"
+              className="mt-1 h-auto gap-1.5 rounded-full bg-white/10 px-3 py-1 text-[13px] font-medium text-white/80 transition-colors hover:bg-white/20"
             >
               <RotateCcw className="h-3.5 w-3.5" aria-hidden />
               Retry

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1045,7 +1045,7 @@ export const ChatMessage = memo(function ChatMessage({
         initial={initial}
         animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
         transition={transition}
-        className="mb-1.5"
+        className="mb-0.5"
         onMouseEnter={
           supportsHover && hasActions ? () => setShowActions(true) : undefined
         }
@@ -1068,7 +1068,7 @@ export const ChatMessage = memo(function ChatMessage({
         <MessageRowContent
           className={cn(
             "relative flex flex-col",
-            hasActions && "pb-8 pointer-coarse:pb-12",
+            hasActions && "pb-7 pointer-coarse:pb-11",
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -17,7 +17,7 @@
  * deliberately excluded from that check (see `enterOnMount`).
  * Presentation only — actions are delegated to callbacks.
  */
-import { RotateCcw, Sparkles, X } from "lucide-react";
+import { Check, LoaderCircle, RotateCcw, Sparkles, X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type * as React from "react";
 import {
@@ -750,37 +750,82 @@ export const ChatMessage = memo(function ChatMessage({
     savingEdit || !draftText.trim() || draftText.trim() === message.text.trim();
   const inlineEditControls = (
     <ChatMessageActionSurface
+      bare={glass}
       data-testid={
         glass ? "thread-line-edit-controls" : "chat-message-edit-controls"
       }
       className={cn(
-        "gap-0 px-1.5 py-0.5",
+        glass ? "gap-0.5" : "gap-0 px-1.5 py-0.5",
         !glass && "absolute right-0 top-full z-30 mt-1",
       )}
     >
-      <Button
-        unstyled
-        data-testid={glass ? "thread-line-edit-cancel" : undefined}
-        onClick={handleCancelEditing}
-        disabled={savingEdit}
-        className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
-      >
-        {labels.cancel ?? "Cancel"}
-      </Button>
-      <span aria-hidden className="mx-0.5 h-3.5 w-px bg-white/15" />
-      <Button
-        unstyled
-        data-testid={glass ? "thread-line-edit-save" : undefined}
-        onClick={() => void handleSaveEdit()}
-        disabled={editSaveDisabled}
-        className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
-      >
-        {savingEdit
-          ? (labels.saving ?? "Saving...")
-          : glass
-            ? (labels.send ?? "Send")
-            : (labels.saveAndResend ?? "Save and resend")}
-      </Button>
+      {glass ? (
+        <>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={labels.cancel ?? "Cancel"}
+            title={labels.cancel ?? "Cancel"}
+            data-testid="thread-line-edit-cancel"
+            onClick={(event) => {
+              event.stopPropagation();
+              handleCancelEditing();
+            }}
+            disabled={savingEdit}
+            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={
+              savingEdit
+                ? (labels.saving ?? "Saving...")
+                : (labels.send ?? "Send")
+            }
+            title={savingEdit ? undefined : (labels.send ?? "Send")}
+            data-testid="thread-line-edit-save"
+            onClick={(event) => {
+              event.stopPropagation();
+              void handleSaveEdit();
+            }}
+            disabled={editSaveDisabled}
+            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+          >
+            {savingEdit ? (
+              <LoaderCircle
+                aria-hidden="true"
+                className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none"
+              />
+            ) : (
+              <Check className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </>
+      ) : (
+        <>
+          <Button
+            unstyled
+            onClick={handleCancelEditing}
+            disabled={savingEdit}
+            className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+          >
+            {labels.cancel ?? "Cancel"}
+          </Button>
+          <span aria-hidden className="mx-0.5 h-3.5 w-px bg-white/15" />
+          <Button
+            unstyled
+            onClick={() => void handleSaveEdit()}
+            disabled={editSaveDisabled}
+            className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+          >
+            {savingEdit
+              ? (labels.saving ?? "Saving...")
+              : (labels.saveAndResend ?? "Save and resend")}
+          </Button>
+        </>
+      )}
     </ChatMessageActionSurface>
   );
 

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1018,6 +1018,9 @@ export const ChatMessage = memo(function ChatMessage({
         "w-fit max-w-full rounded-2xl rounded-bl-md border border-white/20 bg-black/35 px-4 py-3.5 backdrop-blur-md sm:px-5 sm:py-4",
       // Ordinary assistant replies use shadcn's full-width ghost treatment.
       isFlatAssistant && "w-full px-0 py-1",
+      // Match the flat assistant's compact vertical rhythm in the overlay.
+      // The panel chrome keeps its roomier shared bubble padding.
+      isUser && "py-1",
       // Suggestion treatment (#8792): dashed accent edge + faint accent tint so
       // a proactive offer reads as a suggestion, not a normal reply. Placed
       // last so it wins over the glass hairline.
@@ -1036,7 +1039,7 @@ export const ChatMessage = memo(function ChatMessage({
         initial={initial}
         animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
         transition={transition}
-        className="mb-0.5"
+        className="mb-0"
         onMouseEnter={
           supportsHover && hasActions ? () => setShowActions(true) : undefined
         }
@@ -1058,8 +1061,11 @@ export const ChatMessage = memo(function ChatMessage({
       >
         <MessageRowContent
           className={cn(
-            "relative flex flex-col",
-            hasActionLane && "pb-6 pointer-coarse:pb-11",
+            "relative flex flex-col transition-[padding-bottom] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-100",
+            hasActionLane &&
+              (accessoryVisible
+                ? "pb-6 pointer-coarse:pb-11"
+                : "pb-0 pointer-coarse:pb-11"),
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -3,10 +3,11 @@
  * `panel` — avatar/name grouping, theme-token bubble, hover action rail,
  * touch tap-reveal (ChatView + detached windows via ChatTranscript) — and
  * `glass` — the continuous overlay's floating dark-glass row: motion
- * entrance/exit, press-and-hold copy, click-to-reveal action row beneath the
- * bubble, Retry pill on recoverable failures, and the suggestion affordance in
- * glass trim. Reveal/edit/copy state, eligibility rules, and the suggestion
- * detection are shared; only the chrome branches.
+ * entrance/exit, press-and-hold copy, click-to-reveal action plate, Retry on
+ * recoverable failures, and the suggestion affordance in glass trim.
+ * Reveal/edit/copy state, eligibility rules, and the suggestion detection are
+ * shared; only the chrome branches. Editing replaces the message text in place
+ * and pins the bubble's measured width so the transcript does not reflow.
  *
  * Memoized with a custom equality check so streamed-token re-renders stay
  * cheap; volatile per-row values (turn status, reasoning suppression) flow
@@ -46,7 +47,10 @@ import {
 } from "../../ui/message";
 import { Textarea } from "../../ui/textarea";
 import { ChatBubble, GLASS_EASE } from "./chat-bubble";
-import { ChatMessageActions } from "./chat-message-actions";
+import {
+  ChatMessageActionSurface,
+  ChatMessageActions,
+} from "./chat-message-actions";
 import { ChatVoiceSpeakerBadge } from "./chat-source";
 import {
   normalizeChatSourceKey,
@@ -80,7 +84,6 @@ export interface ChatMessageProps {
   labels?: ChatMessageLabels;
   message: ChatMessageData;
   onCopy?: (text: string) => void;
-  onDelete?: (messageId: string) => void;
   onEdit?: (messageId: string, text: string) => Promise<boolean> | boolean;
   onSpeak?: (messageId: string, text: string) => void;
   /**
@@ -101,9 +104,8 @@ export interface ChatMessageProps {
   /** Collapse glass motion to quick fades (OS reduce-motion). */
   reduceMotion?: boolean;
   /**
-   * Dismiss a proactive suggestion (#8792). Distinct from `onDelete` so the
-   * suggestion's one-tap dismiss works without enabling delete on every
-   * ordinary message. Only rendered on suggestion bubbles.
+   * Dismiss a proactive suggestion (#8792). This is intentionally separate
+   * from ordinary message actions and only renders on suggestion bubbles.
    */
   onDismissSuggestion?: (messageId: string) => void;
   /** Accept ("Do it") a proactive suggestion (#8792) — sends the implied action. */
@@ -125,6 +127,12 @@ export interface ChatMessageProps {
 }
 
 const HOVER_MEDIA_QUERY = "(hover: hover) and (pointer: fine)";
+const ACTION_REVEAL_MOTION =
+  "transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-opacity motion-reduce:duration-100";
+const ACTION_REVEAL_VISIBLE =
+  "pointer-events-auto translate-y-0 scale-100 opacity-100";
+const ACTION_REVEAL_HIDDEN =
+  "pointer-events-none translate-y-1 scale-[0.98] opacity-0";
 // Tap-to-reveal move slop (the shared TOUCH_TAP_MOVE_SLOP): finger travel past
 // this between touchstart and touchend means the gesture was a transcript
 // scroll, not a tap, so it must not toggle the action rail.
@@ -400,7 +408,6 @@ function arePropsEqual(
     prev.playing === next.playing &&
     prev.labels === next.labels &&
     prev.onCopy === next.onCopy &&
-    prev.onDelete === next.onDelete &&
     prev.onDismissSuggestion === next.onDismissSuggestion &&
     prev.onAcceptSuggestion === next.onAcceptSuggestion &&
     prev.onEdit === next.onEdit &&
@@ -465,7 +472,6 @@ export const ChatMessage = memo(function ChatMessage({
   onCopy,
   onSpeak,
   onEdit,
-  onDelete,
   onDismissSuggestion,
   onAcceptSuggestion,
   onLongPressCopy,
@@ -486,6 +492,7 @@ export const ChatMessage = memo(function ChatMessage({
   const [showActions, setShowActions] = useState(false);
   const supportsHover = useSupportsHover();
   const [isEditing, setIsEditing] = useState(false);
+  const [editBubbleWidth, setEditBubbleWidth] = useState<number | null>(null);
   const [draftText, setDraftText] = useState(message.text);
   const [savingEdit, setSavingEdit] = useState(false);
   const articleRef = useRef<HTMLElement | null>(null);
@@ -498,8 +505,8 @@ export const ChatMessage = memo(function ChatMessage({
   // First-run onboarding turns render chromeless: agent prose floats as plain
   // wallpaper text with its CTA button directly beneath. Computed up here (not
   // at first use) so the message-action capabilities below can suppress the
-  // hover/tap rail — replying to / copying / deleting the seeded greeting is
-  // meaningless, and the rail contradicts the chromeless intent.
+  // hover/tap rail — replying to or copying the seeded greeting is meaningless,
+  // and the rail contradicts the chromeless intent.
   const isFirstRun = !isUser && message.source === "first_run";
   const canEdit =
     isUser &&
@@ -511,14 +518,6 @@ export const ChatMessage = memo(function ChatMessage({
   const canPlay = Boolean(
     !isUser && !isFirstRun && typeof onSpeak === "function" && trimmedText,
   );
-  // Persistent delete (#13533): available on any real turn when the surface
-  // wires onDelete. An optimistic (temp-) turn has no persisted row to delete;
-  // a proactive suggestion uses its own dismiss affordance (below), not delete;
-  // a first-run greeting is chromeless (no rail at all).
-  const canDelete =
-    typeof onDelete === "function" &&
-    !message.id.startsWith("temp-") &&
-    !isFirstRun;
   const normalizedSource = normalizeChatSourceKey(message.source) ?? undefined;
   // Reply targets the persisted message by id, so an optimistic (temp-) turn,
   // which has no server row yet, has nothing to reply to. A proactive
@@ -593,16 +592,23 @@ export const ChatMessage = memo(function ChatMessage({
 
   const handleStartEditing = useCallback(() => {
     if (!canEdit || savingEdit) return;
+    const bubble = articleRef.current?.querySelector<HTMLElement>(
+      '[data-chat-message-bubble="true"]',
+    );
+    const measuredWidth = bubble?.getBoundingClientRect().width ?? 0;
+    setEditBubbleWidth(measuredWidth > 0 ? measuredWidth : null);
     setDraftText(message.text);
+    setShowActions(false);
     setIsEditing(true);
   }, [canEdit, message.text, savingEdit]);
 
   const handleCancelEditing = useCallback(() => {
     if (savingEdit) return;
     setDraftText(message.text);
+    setEditBubbleWidth(null);
     setIsEditing(false);
-    if (glass) setShowActions(false);
-  }, [message.text, savingEdit, glass]);
+    setShowActions(false);
+  }, [message.text, savingEdit]);
 
   const handleSaveEdit = useCallback(async () => {
     if (!onEdit) return;
@@ -610,8 +616,9 @@ export const ChatMessage = memo(function ChatMessage({
     if (!nextText) return;
     if (nextText === message.text.trim()) {
       setDraftText(message.text);
+      setEditBubbleWidth(null);
       setIsEditing(false);
-      if (glass) setShowActions(false);
+      setShowActions(false);
       return;
     }
 
@@ -619,13 +626,14 @@ export const ChatMessage = memo(function ChatMessage({
     try {
       const saved = await onEdit(message.id, nextText);
       if (saved !== false) {
+        setEditBubbleWidth(null);
         setIsEditing(false);
-        if (glass) setShowActions(false);
+        setShowActions(false);
       }
     } finally {
       setSavingEdit(false);
     }
-  }, [draftText, message.id, message.text, onEdit, glass]);
+  }, [draftText, message.id, message.text, onEdit]);
 
   const handleTapStart = useCallback((event: TouchEvent<HTMLElement>) => {
     const touch = event.touches[0];
@@ -710,7 +718,10 @@ export const ChatMessage = memo(function ChatMessage({
       }
       if (!articleRef.current?.contains(target)) {
         setShowActions(false);
-        if (glass) setIsEditing(false);
+        if (glass) {
+          setEditBubbleWidth(null);
+          setIsEditing(false);
+        }
       }
     };
 
@@ -731,6 +742,67 @@ export const ChatMessage = memo(function ChatMessage({
       target.scrollIntoView({ behavior: "smooth", block: "center" });
     },
     [replyTargetId],
+  );
+
+  const editSaveDisabled =
+    savingEdit || !draftText.trim() || draftText.trim() === message.text.trim();
+  const inlineEditor = (
+    <div
+      data-testid={
+        glass ? "thread-line-inline-editor" : "chat-message-inline-editor"
+      }
+      className="relative min-w-0"
+    >
+      <Textarea
+        ref={editTextareaRef}
+        aria-label={labels.edit ?? "Edit message"}
+        data-testid={
+          glass ? "thread-line-edit-input" : "chat-message-edit-input"
+        }
+        value={draftText}
+        onChange={(event) => setDraftText(event.target.value)}
+        onKeyDown={handleEditKeyDown}
+        rows={Math.min(6, Math.max(1, draftText.split("\n").length))}
+        className={cn(
+          "field-sizing-content min-h-0 max-h-40 w-full resize-none overflow-y-auto rounded-none border-0 bg-transparent p-0 shadow-none outline-none transition-opacity duration-200 disabled:cursor-default",
+          glass
+            ? "text-[14px] leading-relaxed text-white caret-white"
+            : "text-[15px] leading-[1.7] text-txt-strong caret-txt-strong",
+        )}
+        style={{ fontFamily: "var(--font-chat)" }}
+        disabled={savingEdit}
+      />
+      <ChatMessageActionSurface
+        data-testid={
+          glass ? "thread-line-edit-controls" : "chat-message-edit-controls"
+        }
+        className="absolute right-0 top-full z-30 mt-1 gap-0 px-1.5 py-1"
+      >
+        <Button
+          unstyled
+          data-testid={glass ? "thread-line-edit-cancel" : undefined}
+          onClick={handleCancelEditing}
+          disabled={savingEdit}
+          className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+        >
+          {labels.cancel ?? "Cancel"}
+        </Button>
+        <span aria-hidden className="mx-0.5 h-3.5 w-px bg-white/15" />
+        <Button
+          unstyled
+          data-testid={glass ? "thread-line-edit-save" : undefined}
+          onClick={() => void handleSaveEdit()}
+          disabled={editSaveDisabled}
+          className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+        >
+          {savingEdit
+            ? (labels.saving ?? "Saving...")
+            : glass
+              ? (labels.send ?? "Send")
+              : (labels.saveAndResend ?? "Save and resend")}
+        </Button>
+      </ChatMessageActionSurface>
+    </div>
   );
 
   // ── Glass chrome (the continuous overlay's floating row) ──────────────────
@@ -766,13 +838,10 @@ export const ChatMessage = memo(function ChatMessage({
     }
 
     const canRowCopy = !isFirstRun && !!onCopy && trimmedText.length > 0;
-    // Suggestions carry their own dismiss affordance, not the delete control.
-    const canRowDelete = canDelete && !isSuggestion;
     // A first-run greeting is chromeless — no rail, no tap-to-reveal. Every
     // capability above already excludes it, so hasActions is false and the
     // bubble stays a plain, non-interactive container.
-    const hasActions =
-      canRowCopy || canPlay || canEdit || canRowDelete || canReply;
+    const hasActions = canRowCopy || canPlay || canEdit || canReply;
     // An assistant turn carrying an inline choice/form/followups widget must
     // stay a plain container — see messageHasInteractiveWidget.
     const hasInteractiveWidget =
@@ -809,40 +878,7 @@ export const ChatMessage = memo(function ChatMessage({
 
     const bubbleContent =
       isUser && isEditing ? (
-        <div className="flex flex-col gap-2">
-          <Textarea
-            ref={editTextareaRef}
-            aria-label="Edit message"
-            data-testid="thread-line-edit-input"
-            value={draftText}
-            onChange={(e) => setDraftText(e.target.value)}
-            onKeyDown={handleEditKeyDown}
-            rows={Math.min(6, Math.max(1, draftText.split("\n").length))}
-            className="min-h-0 w-full resize-none rounded-lg border-0 bg-white/10 px-2.5 py-1.5 text-[14px] text-white outline-none [overflow-wrap:anywhere]"
-            disabled={savingEdit}
-          />
-          <div className="flex items-center justify-end gap-1.5">
-            <Button
-              variant="ghost"
-              size="sm"
-              data-testid="thread-line-edit-cancel"
-              onClick={handleCancelEditing}
-              className="h-auto rounded-full bg-white/10 px-3 py-1 text-[13px] font-medium text-white/80 transition-colors hover:bg-white/20"
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              data-testid="thread-line-edit-save"
-              onClick={() => void handleSaveEdit()}
-              className="h-auto rounded-full bg-[rgb(255,88,0)] px-3 py-1 text-[13px] font-medium text-white transition-colors hover:bg-[rgb(214,74,0)]"
-            >
-              Send
-            </Button>
-          </div>
-        </div>
+        inlineEditor
       ) : (
         <>
           {isSuggestion ? (
@@ -977,6 +1013,12 @@ export const ChatMessage = memo(function ChatMessage({
               onClick={handleBubbleClick}
               onKeyDown={handleBubbleKeyDown}
               className={bubbleExtraClassName}
+              style={
+                isEditing && editBubbleWidth
+                  ? { width: editBubbleWidth, maxWidth: "100%" }
+                  : undefined
+              }
+              data-chat-message-bubble="true"
               data-proactive-suggestion={isSuggestion ? "true" : undefined}
             >
               {bubbleContent}
@@ -988,29 +1030,39 @@ export const ChatMessage = memo(function ChatMessage({
               tone={isUser ? "user" : "assistant"}
               {...(holdHandlers ?? {})}
               className={bubbleExtraClassName}
+              style={
+                isEditing && editBubbleWidth
+                  ? { width: editBubbleWidth, maxWidth: "100%" }
+                  : undefined
+              }
+              data-chat-message-bubble="true"
               data-proactive-suggestion={isSuggestion ? "true" : undefined}
             >
               {bubbleContent}
             </ChatBubble>
           )}
-          {actionsVisible && !isEditing && hasActions ? (
+          {hasActions ? (
             <MessageRowFooter
               data-testid="thread-line-actions"
+              aria-hidden={!actionsVisible || isEditing}
+              inert={!actionsVisible || isEditing}
               className={cn(
-                "flex items-center gap-1.5 px-0 text-white/70",
-                isUser ? "pr-1" : "pl-1",
+                "absolute top-full z-20 mt-1 flex items-center px-0 text-white/70",
+                ACTION_REVEAL_MOTION,
+                isUser ? "right-0 origin-top-right" : "left-0 origin-top-left",
+                actionsVisible && !isEditing
+                  ? ACTION_REVEAL_VISIBLE
+                  : ACTION_REVEAL_HIDDEN,
               )}
             >
               <ChatMessageActions
                 appearance="glass-row"
-                canDelete={canRowDelete}
                 canEdit={canEdit}
                 canPlay={canPlay}
                 canReply={canReply}
                 copied={copied}
                 labels={labels}
                 onCopy={canRowCopy ? handleCopy : undefined}
-                onDelete={() => onDelete?.(message.id)}
                 onEdit={handleStartEditing}
                 onPlay={() => onSpeak?.(message.id, message.text)}
                 onReply={handleReply}
@@ -1143,7 +1195,13 @@ export const ChatMessage = memo(function ChatMessage({
             isSuggestion &&
               "border border-dashed border-accent/45 bg-accent/[0.06]",
           )}
-          style={{ fontFamily: "var(--font-chat)" }}
+          style={{
+            fontFamily: "var(--font-chat)",
+            ...(isEditing && editBubbleWidth
+              ? { width: editBubbleWidth, maxWidth: "100%" }
+              : {}),
+          }}
+          data-chat-message-bubble="true"
           data-proactive-suggestion={isSuggestion ? "true" : undefined}
         >
           {isSuggestion && !isEditing ? (
@@ -1189,50 +1247,11 @@ export const ChatMessage = memo(function ChatMessage({
               {replyReferenceLabel}
             </a>
           ) : null}
-          {isEditing ? (
-            <div className="space-y-3">
-              <Textarea
-                ref={editTextareaRef}
-                value={draftText}
-                onChange={(event) => setDraftText(event.target.value)}
-                onKeyDown={handleEditKeyDown}
-                className="min-h-[110px] w-full rounded-sm border border-border bg-card px-3 py-2.5 text-[15px] leading-[1.7] text-txt outline-none   "
-                style={{ fontFamily: "var(--font-chat)" }}
-                aria-label={labels.edit ?? "Edit message"}
-                disabled={savingEdit}
-              />
-              <div className="flex items-center justify-end gap-2">
-                <Button
-                  variant="surface"
-                  size="sm"
-                  onClick={handleCancelEditing}
-                  disabled={savingEdit}
-                  className="h-8 rounded-sm px-3 text-xs"
-                >
-                  {labels.cancel ?? "Cancel"}
-                </Button>
-                <Button
-                  variant="surfaceAccent"
-                  size="sm"
-                  onClick={() => void handleSaveEdit()}
-                  disabled={
-                    savingEdit ||
-                    !draftText.trim() ||
-                    draftText.trim() === message.text.trim()
-                  }
-                  className="h-8 rounded-sm px-3 text-xs disabled:border-border/20 disabled:bg-bg-accent disabled:text-muted-strong"
-                >
-                  {savingEdit
-                    ? (labels.saving ?? "Saving...")
-                    : (labels.saveAndResend ?? "Save and resend")}
-                </Button>
-              </div>
-            </div>
-          ) : (
-            (renderContent?.(message, renderContext) ??
-            children ??
-            message.text)
-          )}
+          {isEditing
+            ? inlineEditor
+            : (renderContent?.(message, renderContext) ??
+              children ??
+              message.text)}
 
           {!isUser && message.interrupted ? (
             <div className="mt-2 border-t border-danger/30 pt-2">
@@ -1242,11 +1261,14 @@ export const ChatMessage = memo(function ChatMessage({
             </div>
           ) : null}
 
-          {!isEditing && !isFirstRun ? (
+          {!isFirstRun ? (
             <div
               data-testid="chat-message-action-rail"
+              aria-hidden={!actionsVisible || isEditing}
+              inert={!actionsVisible || isEditing}
               className={cn(
-                "absolute top-0 flex items-center gap-1 transition-opacity duration-200",
+                "absolute top-0 z-20 flex items-center",
+                ACTION_REVEAL_MOTION,
                 // Below the `sm` breakpoint (narrow phones) anchor the
                 // action rail to the bubble's top-right corner so it can
                 // never overflow the viewport. From `sm` up the rail
@@ -1254,22 +1276,20 @@ export const ChatMessage = memo(function ChatMessage({
                 // bubbles, right of left-aligned bot bubbles) where there
                 // is enough horizontal room.
                 isRightAligned
-                  ? "right-1 sm:right-auto sm:left-0 sm:-translate-x-full"
-                  : "right-1 sm:right-0 sm:translate-x-full",
-                actionsVisible
-                  ? "opacity-100"
-                  : "pointer-events-none opacity-0",
+                  ? "right-1 origin-top-right sm:right-auto sm:left-0 sm:-translate-x-full"
+                  : "right-1 origin-top-right sm:right-0 sm:translate-x-full sm:origin-top-left",
+                actionsVisible && !isEditing
+                  ? ACTION_REVEAL_VISIBLE
+                  : ACTION_REVEAL_HIDDEN,
               )}
             >
               <ChatMessageActions
-                canDelete={canDelete}
                 canEdit={canEdit}
                 canPlay={canPlay}
                 canReply={canReply}
                 copied={copied}
                 labels={labels}
                 onCopy={handleCopy}
-                onDelete={() => onDelete?.(message.id)}
                 onEdit={handleStartEditing}
                 onPlay={() => onSpeak?.(message.id, message.text)}
                 onReply={handleReply}

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -753,7 +753,7 @@ export const ChatMessage = memo(function ChatMessage({
         glass ? "thread-line-edit-controls" : "chat-message-edit-controls"
       }
       className={cn(
-        "gap-0 px-1.5 py-1",
+        "gap-0 px-1.5 py-0.5",
         !glass && "absolute right-0 top-full z-30 mt-1",
       )}
     >

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -18,7 +18,7 @@
  * Presentation only — actions are delegated to callbacks.
  */
 import { Check, LoaderCircle, RotateCcw, Sparkles, X } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { motion } from "motion/react";
 import type * as React from "react";
 import {
   type KeyboardEvent,
@@ -70,6 +70,12 @@ export type ChatMessageAppearance = "panel" | "glass";
 const MotionMessageRow = motion.create(MessageRow);
 
 export interface ChatMessageProps {
+  /**
+   * Live, non-message state that shares the glass action lane. The continuous
+   * overlay uses this for the active turn label so status never consumes a
+   * second transcript row.
+   */
+  actionAccessory?: React.ReactNode;
   agentName?: string;
   /** Chrome: theme-token `panel` (default) or the overlay's floating `glass`. */
   appearance?: ChatMessageAppearance;
@@ -403,6 +409,7 @@ function arePropsEqual(
 ): boolean {
   const sharedEqual =
     prev.isGrouped === next.isGrouped &&
+    prev.actionAccessory === next.actionAccessory &&
     prev.agentName === next.agentName &&
     prev.appearance === next.appearance &&
     prev.reduceMotion === next.reduceMotion &&
@@ -464,6 +471,7 @@ function arePropsEqual(
 
 export const ChatMessage = memo(function ChatMessage({
   message,
+  actionAccessory,
   appearance = "panel",
   isGrouped = false,
   agentName = "Agent",
@@ -487,9 +495,6 @@ export const ChatMessage = memo(function ChatMessage({
 }: ChatMessageProps) {
   const glass = appearance === "glass";
   const [copied, flashCopied] = useCopiedFlash(glass ? 1100 : 2000);
-  // The press-and-hold "Copied" chip (glass) — separate from the action-row
-  // copy state so a hold-flash never lights the row button and vice versa.
-  const [holdCopied, flashHoldCopied] = useCopiedFlash(1100);
   const [showActions, setShowActions] = useState(false);
   const supportsHover = useSupportsHover();
   const [isEditing, setIsEditing] = useState(false);
@@ -571,14 +576,14 @@ export const ChatMessage = memo(function ChatMessage({
 
   const handleReply = useCallback(() => {
     onReply?.(message);
-    // Collapse the tap-revealed rail (touch/glass) after arming the reply so the
-    // focus returns to the composer, not a lingering action row.
+    // Collapse the tap-revealed rail after arming the reply so touch users see
+    // the new context lane instead of a stale action row.
     if (glass || !supportsHover) setShowActions(false);
   }, [message, onReply, glass, supportsHover]);
 
   // Press-and-hold to copy an assistant answer (glass) — the only extraction
-  // affordance on touch. A still hold past COPY_HOLD_MS copies + flashes
-  // "Copied"; real finger travel cancels (shared usePointerPressAndHold).
+  // affordance on touch. A still hold past COPY_HOLD_MS copies silently; real
+  // finger travel cancels (shared usePointerPressAndHold).
   const canHoldCopy =
     glass && isAssistant && !!onLongPressCopy && trimmedText.length > 0;
   const holdBinding = usePointerPressAndHold<HTMLDivElement>({
@@ -587,7 +592,6 @@ export const ChatMessage = memo(function ChatMessage({
     canBegin: (e) => !isNestedInteractiveTarget(e.currentTarget, e.target),
     onHold: () => {
       onLongPressCopy?.(message.text);
-      flashHoldCopied();
     },
   });
   const holdHandlers = canHoldCopy ? holdBinding : null;
@@ -896,7 +900,9 @@ export const ChatMessage = memo(function ChatMessage({
     // capability above already excludes it, so hasActions is false and the
     // bubble stays a plain, non-interactive container.
     const hasActions = canRowCopy || canPlay || canEdit || canReply;
-    const accessoryVisible = actionsVisible || isEditing;
+    const hasActionLane = hasActions || Boolean(actionAccessory);
+    const accessoryVisible =
+      actionsVisible || isEditing || Boolean(actionAccessory);
     if (isEditing) accessoryModeRef.current = "edit";
     else if (actionsVisible) accessoryModeRef.current = "actions";
     // Retain the last visible contents while the shared slot collapses so its
@@ -998,21 +1004,6 @@ export const ChatMessage = memo(function ChatMessage({
               children ??
               message.text}
           </div>
-          <AnimatePresence>
-            {holdCopied ? (
-              <motion.span
-                key="copied"
-                data-testid="thread-line-copied"
-                initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: reduceMotion ? 0 : 0.18 }}
-                className="pointer-events-none absolute -top-2 right-2 rounded-full bg-white/90 px-2 py-0.5 text-[11px] font-medium text-black"
-              >
-                Copied
-              </motion.span>
-            ) : null}
-          </AnimatePresence>
         </>
       );
 
@@ -1068,7 +1059,7 @@ export const ChatMessage = memo(function ChatMessage({
         <MessageRowContent
           className={cn(
             "relative flex flex-col",
-            hasActions && "pb-7 pointer-coarse:pb-11",
+            hasActionLane && "pb-6 pointer-coarse:pb-11",
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser
@@ -1119,7 +1110,7 @@ export const ChatMessage = memo(function ChatMessage({
               {bubbleContent}
             </ChatBubble>
           )}
-          {hasActions ? (
+          {hasActionLane ? (
             <motion.div
               data-testid="thread-line-actions"
               aria-hidden={!accessoryVisible}
@@ -1168,6 +1159,7 @@ export const ChatMessage = memo(function ChatMessage({
                       onPlay={() => onSpeak?.(message.id, message.text)}
                       onReply={handleReply}
                       playing={playing}
+                      trailingAccessory={actionAccessory}
                     />
                   )}
                 </motion.div>

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -412,7 +412,6 @@ function arePropsEqual(
     prev.renderContent === next.renderContent &&
     // renderContext is rebuilt per parent render; compare its fields so only
     // the row whose volatile values changed re-renders.
-    prev.renderContext?.turnStatus === next.renderContext?.turnStatus &&
     prev.renderContext?.suppressReasoning ===
       next.renderContext?.suppressReasoning &&
     prev.userMessagesOnRight === next.userMessagesOnRight &&

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1156,8 +1156,10 @@ export const ChatMessage = memo(function ChatMessage({
                 ease: GLASS_EASE,
               }}
               className={cn(
-                "absolute bottom-0 z-10 min-w-0 pointer-coarse:-bottom-1",
-                isUser ? "right-0 origin-top-right" : "left-0 origin-top-left",
+                "absolute z-10 min-w-0",
+                isUser
+                  ? "-bottom-0.5 right-0 origin-top-right pointer-coarse:-bottom-1.5"
+                  : "bottom-0 left-0 origin-top-left pointer-coarse:-bottom-1",
               )}
             >
               <MessageRowFooter className="flex items-center p-0 text-white/70">

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1158,7 +1158,7 @@ export const ChatMessage = memo(function ChatMessage({
               className={cn(
                 "absolute z-10 min-w-0",
                 isUser
-                  ? "-bottom-0.5 right-0 origin-top-right pointer-coarse:-bottom-1.5"
+                  ? "-bottom-1 right-0 origin-top-right pointer-coarse:-bottom-2"
                   : "bottom-0 left-0 origin-top-left pointer-coarse:-bottom-1",
               )}
             >

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -3,8 +3,9 @@
  * `panel` — avatar/name grouping, theme-token bubble, hover action rail,
  * touch tap-reveal (ChatView + detached windows via ChatTranscript) — and
  * `glass` — the continuous overlay's floating dark-glass row: motion
- * entrance/exit, press-and-hold copy, click-to-reveal action plate, Retry on
- * recoverable failures, and the suggestion affordance in glass trim.
+ * entrance/exit, press-and-hold copy, hover/focus or touch-revealed bare
+ * actions, Retry on recoverable failures, and the suggestion affordance in
+ * glass trim.
  * Reveal/edit/copy state, eligibility rules, and the suggestion detection are
  * shared; only the chrome branches. Editing replaces the message text in place
  * and pins the bubble's measured width so the transcript does not reflow.
@@ -880,6 +881,7 @@ export const ChatMessage = memo(function ChatMessage({
     };
     const handleBubbleClick = (e: MouseEvent<HTMLDivElement>) => {
       if (!bubbleInteractive) return;
+      if (supportsHover) return;
       if (isNestedInteractiveTarget(e.currentTarget, e.target)) return;
       toggleRevealed();
     };
@@ -999,12 +1001,29 @@ export const ChatMessage = memo(function ChatMessage({
         animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
         transition={transition}
         className="mb-1.5"
+        onMouseEnter={
+          supportsHover && hasActions ? () => setShowActions(true) : undefined
+        }
+        onMouseLeave={
+          supportsHover && hasActions ? () => setShowActions(false) : undefined
+        }
+        onFocusCapture={
+          supportsHover && hasActions ? () => setShowActions(true) : undefined
+        }
+        onBlurCapture={
+          supportsHover && hasActions
+            ? (event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) {
+                  setShowActions(false);
+                }
+              }
+            : undefined
+        }
       >
-        {/* Bubble + its click-to-reveal action row stack vertically, aligned to
-            the turn's side (#10713). */}
         <MessageRowContent
           className={cn(
-            "flex flex-col",
+            "relative flex flex-col",
+            hasActions && "pb-8 pointer-coarse:pb-12",
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser
@@ -1063,9 +1082,8 @@ export const ChatMessage = memo(function ChatMessage({
               initial={false}
               animate={
                 accessoryVisible
-                  ? { height: "auto", opacity: 1, y: 0, scale: 1 }
+                  ? { opacity: 1, y: 0, scale: 1 }
                   : {
-                      height: 0,
                       opacity: 0,
                       y: reduceMotion ? 0 : 4,
                       scale: reduceMotion ? 1 : 0.98,
@@ -1076,13 +1094,11 @@ export const ChatMessage = memo(function ChatMessage({
                 ease: GLASS_EASE,
               }}
               className={cn(
-                "min-w-0 overflow-hidden",
-                isUser
-                  ? "self-end origin-top-right"
-                  : "self-start origin-top-left",
+                "absolute bottom-0 z-10 min-w-0",
+                isUser ? "right-0 origin-top-right" : "left-0 origin-top-left",
               )}
             >
-              <MessageRowFooter className="flex items-center px-0 pt-1 text-white/70">
+              <MessageRowFooter className="flex items-center p-0 text-white/70">
                 <motion.div
                   key={accessoryMode}
                   initial={reduceMotion ? false : { opacity: 0, y: 2 }}

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -608,8 +608,8 @@ export const ChatMessage = memo(function ChatMessage({
     setDraftText(message.text);
     setEditBubbleWidth(null);
     setIsEditing(false);
-    setShowActions(false);
-  }, [message.text, savingEdit]);
+    setShowActions(glass);
+  }, [glass, message.text, savingEdit]);
 
   const handleSaveEdit = useCallback(async () => {
     if (!onEdit) return;

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -498,6 +498,7 @@ export const ChatMessage = memo(function ChatMessage({
   const articleRef = useRef<HTMLElement | null>(null);
   const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const tapStartRef = useRef<{ x: number; y: number } | null>(null);
+  const accessoryModeRef = useRef<"actions" | "edit">("actions");
   const isUser = message.role === "user";
   const isAssistant = message.role === "assistant";
   const isRightAligned = isUser ? userMessagesOnRight : !userMessagesOnRight;
@@ -746,6 +747,42 @@ export const ChatMessage = memo(function ChatMessage({
 
   const editSaveDisabled =
     savingEdit || !draftText.trim() || draftText.trim() === message.text.trim();
+  const inlineEditControls = (
+    <ChatMessageActionSurface
+      data-testid={
+        glass ? "thread-line-edit-controls" : "chat-message-edit-controls"
+      }
+      className={cn(
+        "gap-0 px-1.5 py-1",
+        !glass && "absolute right-0 top-full z-30 mt-1",
+      )}
+    >
+      <Button
+        unstyled
+        data-testid={glass ? "thread-line-edit-cancel" : undefined}
+        onClick={handleCancelEditing}
+        disabled={savingEdit}
+        className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+      >
+        {labels.cancel ?? "Cancel"}
+      </Button>
+      <span aria-hidden className="mx-0.5 h-3.5 w-px bg-white/15" />
+      <Button
+        unstyled
+        data-testid={glass ? "thread-line-edit-save" : undefined}
+        onClick={() => void handleSaveEdit()}
+        disabled={editSaveDisabled}
+        className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+      >
+        {savingEdit
+          ? (labels.saving ?? "Saving...")
+          : glass
+            ? (labels.send ?? "Send")
+            : (labels.saveAndResend ?? "Save and resend")}
+      </Button>
+    </ChatMessageActionSurface>
+  );
+
   const inlineEditor = (
     <div
       data-testid={
@@ -772,36 +809,7 @@ export const ChatMessage = memo(function ChatMessage({
         style={{ fontFamily: "var(--font-chat)" }}
         disabled={savingEdit}
       />
-      <ChatMessageActionSurface
-        data-testid={
-          glass ? "thread-line-edit-controls" : "chat-message-edit-controls"
-        }
-        className="absolute right-0 top-full z-30 mt-1 gap-0 px-1.5 py-1"
-      >
-        <Button
-          unstyled
-          data-testid={glass ? "thread-line-edit-cancel" : undefined}
-          onClick={handleCancelEditing}
-          disabled={savingEdit}
-          className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
-        >
-          {labels.cancel ?? "Cancel"}
-        </Button>
-        <span aria-hidden className="mx-0.5 h-3.5 w-px bg-white/15" />
-        <Button
-          unstyled
-          data-testid={glass ? "thread-line-edit-save" : undefined}
-          onClick={() => void handleSaveEdit()}
-          disabled={editSaveDisabled}
-          className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
-        >
-          {savingEdit
-            ? (labels.saving ?? "Saving...")
-            : glass
-              ? (labels.send ?? "Send")
-              : (labels.saveAndResend ?? "Save and resend")}
-        </Button>
-      </ChatMessageActionSurface>
+      {glass ? null : inlineEditControls}
     </div>
   );
 
@@ -842,6 +850,12 @@ export const ChatMessage = memo(function ChatMessage({
     // capability above already excludes it, so hasActions is false and the
     // bubble stays a plain, non-interactive container.
     const hasActions = canRowCopy || canPlay || canEdit || canReply;
+    const accessoryVisible = actionsVisible || isEditing;
+    if (isEditing) accessoryModeRef.current = "edit";
+    else if (actionsVisible) accessoryModeRef.current = "actions";
+    // Retain the last visible contents while the shared slot collapses so its
+    // exit never flashes the other control set on the final frame.
+    const accessoryMode = accessoryModeRef.current;
     // An assistant turn carrying an inline choice/form/followups widget must
     // stay a plain container — see messageHasInteractiveWidget.
     const hasInteractiveWidget =
@@ -1044,11 +1058,11 @@ export const ChatMessage = memo(function ChatMessage({
           {hasActions ? (
             <motion.div
               data-testid="thread-line-actions"
-              aria-hidden={!actionsVisible || isEditing}
-              inert={!actionsVisible || isEditing}
+              aria-hidden={!accessoryVisible}
+              inert={!accessoryVisible}
               initial={false}
               animate={
-                actionsVisible && !isEditing
+                accessoryVisible
                   ? { height: "auto", opacity: 1, y: 0, scale: 1 }
                   : {
                       height: 0,
@@ -1069,19 +1083,33 @@ export const ChatMessage = memo(function ChatMessage({
               )}
             >
               <MessageRowFooter className="flex items-center px-0 pt-1 text-white/70">
-                <ChatMessageActions
-                  appearance="glass-row"
-                  canEdit={canEdit}
-                  canPlay={canPlay}
-                  canReply={canReply}
-                  copied={copied}
-                  labels={labels}
-                  onCopy={canRowCopy ? handleCopy : undefined}
-                  onEdit={handleStartEditing}
-                  onPlay={() => onSpeak?.(message.id, message.text)}
-                  onReply={handleReply}
-                  playing={playing}
-                />
+                <motion.div
+                  key={accessoryMode}
+                  initial={reduceMotion ? false : { opacity: 0, y: 2 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: reduceMotion ? 0.08 : 0.14,
+                    ease: GLASS_EASE,
+                  }}
+                >
+                  {accessoryMode === "edit" ? (
+                    inlineEditControls
+                  ) : (
+                    <ChatMessageActions
+                      appearance="glass-row"
+                      canEdit={canEdit}
+                      canPlay={canPlay}
+                      canReply={canReply}
+                      copied={copied}
+                      labels={labels}
+                      onCopy={canRowCopy ? handleCopy : undefined}
+                      onEdit={handleStartEditing}
+                      onPlay={() => onSpeak?.(message.id, message.text)}
+                      onReply={handleReply}
+                      playing={playing}
+                    />
+                  )}
+                </motion.div>
               </MessageRowFooter>
             </motion.div>
           ) : null}

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -40,6 +40,7 @@ import { cn } from "../../../lib/utils";
 import { findChoiceRegions } from "../../chat/message-choice-parser";
 import { findFollowupsRegions } from "../../chat/message-followups-parser";
 import { findFormRegions } from "../../chat/message-form-parser";
+import { RelativeTime } from "../../shell/RelativeTime";
 import { Button } from "../../ui/button";
 import {
   Message as MessageRow,
@@ -445,6 +446,7 @@ function arePropsEqual(
     a.id === b.id &&
     a.role === b.role &&
     a.text === b.text &&
+    a.timestamp === b.timestamp &&
     a.source === b.source &&
     a.interrupted === b.interrupted &&
     a.from === b.from &&
@@ -903,6 +905,23 @@ export const ChatMessage = memo(function ChatMessage({
     const hasActionLane = hasActions || Boolean(actionAccessory);
     const accessoryVisible =
       actionsVisible || isEditing || Boolean(actionAccessory);
+    const timestampAccessory =
+      typeof message.timestamp === "number" &&
+      Number.isFinite(message.timestamp) ? (
+        <RelativeTime
+          ts={message.timestamp}
+          short
+          data-testid="thread-line-timestamp"
+          className="inline-block min-w-[3ch] whitespace-nowrap text-left text-[11px] tabular-nums text-white/45"
+        />
+      ) : null;
+    const trailingAccessory =
+      timestampAccessory || actionAccessory ? (
+        <div className="flex min-w-0 items-center gap-1.5">
+          {actionAccessory}
+          {timestampAccessory}
+        </div>
+      ) : undefined;
     if (isEditing) accessoryModeRef.current = "edit";
     else if (actionsVisible) accessoryModeRef.current = "actions";
     // Retain the last visible contents while the shared slot collapses so its
@@ -1018,9 +1037,9 @@ export const ChatMessage = memo(function ChatMessage({
         "w-fit max-w-full rounded-2xl rounded-bl-md border border-white/20 bg-black/35 px-4 py-3.5 backdrop-blur-md sm:px-5 sm:py-4",
       // Ordinary assistant replies use shadcn's full-width ghost treatment.
       isFlatAssistant && "w-full px-0 py-1",
-      // Match the flat assistant's compact vertical rhythm in the overlay.
-      // The panel chrome keeps its roomier shared bubble padding.
-      isUser && "py-1",
+      // Measure the overlay's rhythm from the text edge: the user bubble's 1px
+      // border plus 3px padding equals the flat assistant's 4px padding.
+      isUser && "py-[3px]",
       // Suggestion treatment (#8792): dashed accent edge + faint accent tint so
       // a proactive offer reads as a suggestion, not a normal reply. Placed
       // last so it wins over the glass hairline.
@@ -1061,11 +1080,12 @@ export const ChatMessage = memo(function ChatMessage({
       >
         <MessageRowContent
           className={cn(
-            "relative flex flex-col transition-[padding-bottom] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-100",
-            hasActionLane &&
-              (accessoryVisible
-                ? "pb-6 pointer-coarse:pb-11"
-                : "pb-0 pointer-coarse:pb-11"),
+            "relative flex flex-col",
+            // Fine pointers reserve the exact 20px rail height, so revealing
+            // actions never reflows the transcript. Coarse pointers retain
+            // 44px hit targets but overlap four pixels at each edge of a 36px
+            // lane, keeping touch access generous without opening a large gap.
+            hasActionLane && "pb-5 pointer-coarse:pb-9",
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser
@@ -1136,7 +1156,7 @@ export const ChatMessage = memo(function ChatMessage({
                 ease: GLASS_EASE,
               }}
               className={cn(
-                "absolute bottom-0 z-10 min-w-0",
+                "absolute bottom-0 z-10 min-w-0 pointer-coarse:-bottom-1",
                 isUser ? "right-0 origin-top-right" : "left-0 origin-top-left",
               )}
             >
@@ -1165,7 +1185,7 @@ export const ChatMessage = memo(function ChatMessage({
                       onPlay={() => onSpeak?.(message.id, message.text)}
                       onReply={handleReply}
                       playing={playing}
-                      trailingAccessory={actionAccessory}
+                      trailingAccessory={trailingAccessory}
                     />
                   )}
                 </motion.div>

--- a/packages/ui/src/components/composites/chat/chat-transcript.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.stories.tsx
@@ -90,7 +90,6 @@ const meta = {
     userMessagesOnRight: true,
     variant: "default",
     onCopy: () => {},
-    onDelete: () => {},
     onEdit: () => true,
     onSpeak: () => {},
   },

--- a/packages/ui/src/components/composites/chat/chat-transcript.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.tsx
@@ -24,7 +24,6 @@ export interface ChatTranscriptProps {
   labels?: ChatMessageLabels;
   messages: ChatMessageData[];
   onCopy?: (text: string) => void;
-  onDelete?: (messageId: string) => void;
   /** Dismiss a proactive suggestion bubble (#8792). */
   onDismissSuggestion?: (messageId: string) => void;
   /** Accept ("Do it") a proactive suggestion bubble (#8792). */
@@ -141,7 +140,6 @@ export const ChatTranscript = memo(function ChatTranscript({
   labels,
   messages,
   onCopy,
-  onDelete,
   onDismissSuggestion,
   onAcceptSuggestion,
   onEdit,
@@ -272,7 +270,6 @@ export const ChatTranscript = memo(function ChatTranscript({
             agentName={agentName}
             labels={labels}
             onCopy={onCopy}
-            onDelete={onDelete}
             onDismissSuggestion={onDismissSuggestion}
             onAcceptSuggestion={onAcceptSuggestion}
             onEdit={onEdit}

--- a/packages/ui/src/components/composites/chat/chat-types.ts
+++ b/packages/ui/src/components/composites/chat/chat-types.ts
@@ -7,7 +7,6 @@
 
 import type {
   ChatFailureKind,
-  ChatTurnStatus,
   ConversationSecretRequest,
   MessageAttachment,
 } from "../../../api/client-types-chat";
@@ -139,8 +138,6 @@ export interface ChatMessageData {
  * re-render EVERY row; these fields are compared per-row by the memo instead).
  */
 export interface ChatMessageRenderContext {
-  /** Live phase status for the one in-flight (empty assistant) turn. */
-  turnStatus?: ChatTurnStatus | null;
   /** Hide reasoning while this turn is still streaming. */
   suppressReasoning?: boolean;
 }

--- a/packages/ui/src/components/composites/chat/chat-types.ts
+++ b/packages/ui/src/components/composites/chat/chat-types.ts
@@ -111,6 +111,8 @@ export interface ChatMessageData {
   role: string;
   source?: string;
   text: string;
+  /** Message creation time as epoch milliseconds, when the transport supplies it. */
+  timestamp?: number;
   /** Voice speaker attribution when this message arrived via voice (R10 §4.1). */
   voiceSpeaker?: ChatVoiceSpeaker;
   /**

--- a/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
+++ b/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
@@ -216,9 +216,8 @@ export function formatElapsed(seconds: number): string {
 /**
  * The Codex-style working indicator — a spinner glyph, the debounced phase label
  * (a word for every phase, including `thinking`), and a live elapsed-seconds
- * clock — WITHOUT a bubble/motion wrapper; the overlay wraps it in its own glass
- * chrome. When `showLabel` is false (the in-flight assistant bubble) it degrades
- * to the bare breathing dots so the streamed text fills in where the dots were.
+ * clock — without a bubble/motion wrapper. The compact `showLabel={false}` form
+ * is a text-only shimmer used by the continuous overlay's stable work-status row.
  *
  * Mirrors ChatVoiceStatusBar's a11y (`role="status"` + `aria-live="polite"`).
  * Honors reduced motion (no spin/pulse). Degrades to plain dots when no status

--- a/packages/ui/src/components/conversations/ConversationsSidebar.jump.test.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.jump.test.tsx
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 
 /**
- * Jump-to-message coverage for the keyword-search panel (#9955). When a search
- * hit is OLDER than the loaded recent window, its anchor element is absent after
- * selecting the conversation; the sidebar must then load the window CENTERED on
- * the target (`loadConversationMessagesAround`) and only THEN scroll it into
- * view. These tests drive the real ConversationsSidebar → MessageSearchPanel →
- * jumpToMessage path with mocked app state + client.
+ * Jump-to-message coverage for the keyword-search panel (#9955). An absent DOM
+ * anchor can mean either a loaded message outside the bounded render window or
+ * an older message that needs a centered fetch, so the sidebar must reveal,
+ * recheck, and only then load around the target. These tests drive the real
+ * ConversationsSidebar → MessageSearchPanel → jumpToMessage path with mocked
+ * app state and client boundaries.
  */
 
 import {
@@ -152,17 +152,17 @@ describe("ConversationsSidebar jump-to-message (#9955)", () => {
     appMock.value = makeAppState();
   });
 
-  it("emits the render-window reveal after the around-load so a windowed transcript mounts the pivot", async () => {
-    // A windowed ChatView/overlay slices the centered around-load's pivot out of
-    // the render window unless it is told to reveal (#15281). The sidebar must
-    // fire CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT after a successful around-load.
+  it("reveals the loaded render window before falling back to an around-load", async () => {
+    // A missing DOM anchor can be a loaded turn outside the bounded render
+    // window. Reveal first; only a second miss earns a centered network fetch.
     const scroll = scrollSpy();
-    const revealEvents: number[] = [];
-    const off = onViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT, () =>
-      revealEvents.push(Date.now()),
-    );
+    const order: string[] = [];
+    const off = onViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT, () => {
+      order.push("reveal");
+    });
     const loadConversationMessagesAround = vi.fn(
       async (_conversationId: string, messageId: string) => {
+        order.push("around");
         const el = document.createElement("div");
         el.id = getChatMessageAnchorId(messageId);
         document.body.appendChild(el);
@@ -181,7 +181,27 @@ describe("ConversationsSidebar jump-to-message (#9955)", () => {
       TARGET_CONVERSATION_ID,
       OLD_MESSAGE_ID,
     );
-    expect(revealEvents).toHaveLength(1);
+    expect(order).toEqual(["reveal", "around"]);
+    off();
+  });
+
+  it("scrolls a windowed-out loaded hit without an around request", async () => {
+    const scroll = scrollSpy();
+    const loadConversationMessagesAround = vi.fn(async () => false);
+    const off = onViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT, () => {
+      const el = document.createElement("div");
+      el.id = getChatMessageAnchorId(OLD_MESSAGE_ID);
+      document.body.appendChild(el);
+    });
+    appMock.value = makeAppState({ loadConversationMessagesAround });
+
+    render(<ConversationsSidebar />);
+    await openSearchAndJump();
+
+    await waitFor(() => expect(scroll).toHaveBeenCalledTimes(1), {
+      timeout: 3000,
+    });
+    expect(loadConversationMessagesAround).not.toHaveBeenCalled();
     off();
   });
 

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -531,18 +531,21 @@ export function ConversationsSidebar({
         await handleSelectConversation(result.conversationId);
         let el = await waitForAnchor(anchorId, 20);
         if (!el) {
-          // The hit is older than the loaded recent window (#9955): load the
-          // window CENTERED on it, then reveal the transcript's full loaded set
-          // so the centered pivot is not sliced out of the render window
-          // (#15281) — without the reveal, a windowed ChatView/overlay drops the
-          // anchor and the jump silently no-ops. waitForAnchor's 20-frame budget
-          // covers the reveal re-render.
+          // The transcript deliberately mounts only its newest window. Reveal
+          // already-loaded history before fetching so a merely windowed-out hit
+          // stays local and cannot fail with the network.
+          emitViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT);
+          el = await waitForAnchor(anchorId, 2);
+        }
+        if (!el) {
+          // The target genuinely predates loaded state. The reveal flag above
+          // follows the centered window's renderable count when the fetch lands,
+          // so no second event or extra layout transition is needed.
           const loaded = await loadConversationMessagesAround(
             result.conversationId,
             result.messageId,
           );
           if (loaded) {
-            emitViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT);
             el = await waitForAnchor(anchorId, 20);
           }
         }

--- a/packages/ui/src/components/pages/ChatView.edit-message.test.tsx
+++ b/packages/ui/src/components/pages/ChatView.edit-message.test.tsx
@@ -128,7 +128,7 @@ describe("chat transcript edit-and-resend (useChatSend.handleChatEdit)", () => {
     ]);
     const { result } = renderHook(() => useChatSend(deps));
 
-    const { getByLabelText, getByRole } = render(
+    const { getByLabelText, getByRole, getByTestId, getByText } = render(
       <ChatMessage
         message={original}
         agentName="Eliza"
@@ -136,13 +136,39 @@ describe("chat transcript edit-and-resend (useChatSend.handleChatEdit)", () => {
       />,
     );
 
+    const bubble = getByText("original question").closest<HTMLElement>(
+      '[data-chat-message-bubble="true"]',
+    );
+    if (!bubble) throw new Error("message bubble not found");
+    vi.spyOn(bubble, "getBoundingClientRect").mockReturnValue({
+      bottom: 42,
+      height: 42,
+      left: 20,
+      right: 280,
+      top: 0,
+      width: 260,
+      x: 20,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
     // Open the edit UI via the action rail's "Edit message" button.
     act(() => {
       fireEvent.click(getByLabelText("Edit message"));
     });
 
     // Change the text and Save (the button is "Save and resend").
-    const editArea = getByLabelText("Edit message") as HTMLTextAreaElement;
+    const editArea = getByTestId(
+      "chat-message-edit-input",
+    ) as HTMLTextAreaElement;
+    expect(editArea.closest('[data-chat-message-bubble="true"]')).toBe(bubble);
+    expect(bubble.style.width).toBe("260px");
+    expect(editArea.className).toContain("bg-transparent");
+    expect(editArea.className).toContain("min-h-0");
+    const editControls = getByTestId("chat-message-edit-controls");
+    expect(editControls.className).toContain("absolute");
+    expect(editControls.className).toContain("top-full");
+    expect(editControls.style.backgroundImage).toContain("radial-gradient");
     act(() => {
       fireEvent.change(editArea, { target: { value: "edited question" } });
     });

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -200,7 +200,6 @@ export function ChatView({
     handleChatStop: s.handleChatStop,
     interruptActiveChatPipeline: s.interruptActiveChatPipeline,
     handleChatEdit: s.handleChatEdit,
-    handleChatDelete: s.handleChatDelete,
     elizaCloudConnected: s.elizaCloudConnected,
     elizaCloudVoiceProxyAvailable: s.elizaCloudVoiceProxyAvailable,
     elizaCloudHasPersistedKey: s.elizaCloudHasPersistedKey,
@@ -229,7 +228,6 @@ export function ChatView({
     handleChatStop,
     interruptActiveChatPipeline,
     handleChatEdit,
-    handleChatDelete,
     elizaCloudConnected,
     elizaCloudVoiceProxyAvailable,
     elizaCloudHasPersistedKey,
@@ -708,7 +706,6 @@ export function ChatView({
   const chatMessageLabels = useMemo(
     () => ({
       cancel: t("common.cancel"),
-      delete: t("aria.deleteMessage"),
       edit: t("aria.editMessage"),
       play: t("aria.playMessage"),
       responseInterrupted: t("chatmessage.ResponseInterrupte"),
@@ -753,15 +750,6 @@ export function ChatView({
       void copyToClipboard(text);
     },
     [copyToClipboard],
-  );
-  // Persistent per-message delete (#13533): the server DELETE + optimistic
-  // removal with rollback lives in handleChatDelete. Distinct from
-  // handleDismissSuggestion, which is a local-only (#8792) removal.
-  const handleDeleteMessage = useCallback(
-    (messageId: string) => {
-      void handleChatDelete(messageId);
-    },
-    [handleChatDelete],
   );
   // Reply arms the composer: set the shared reply target so the next turn
   // carries replyToMessageId (→ REPLY_CONTEXT) and the pill renders above the
@@ -810,7 +798,6 @@ export function ChatView({
           onEdit={handleEditMessage}
           onSpeak={handleSpeakMessage}
           onCopy={handleCopyMessageText}
-          onDelete={handleDeleteMessage}
           onReply={handleReplyMessage}
           onDismissSuggestion={handleDismissSuggestion}
           onAcceptSuggestion={handleAcceptSuggestion}

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -751,13 +751,19 @@ export function ChatView({
     },
     [copyToClipboard],
   );
-  // Reply arms the composer: set the shared reply target so the next turn
-  // carries replyToMessageId (→ REPLY_CONTEXT) and the pill renders above the
-  // input. Focus the composer so the user can type the reply immediately.
+  // Reply arms the composer so the next turn carries replyToMessageId (→
+  // REPLY_CONTEXT). Fine pointers keep the desktop one-click-to-type flow;
+  // touch pointers stay put so arming context never raises the mobile keyboard.
   const handleReplyMessage = useCallback(
     (message: ChatMessageData) => {
       setChatReplyTarget(buildReplyTargetFromMessage(message, agentName));
-      textareaRef.current?.focus();
+      if (
+        typeof window === "undefined" ||
+        typeof window.matchMedia !== "function" ||
+        window.matchMedia("(hover: hover) and (pointer: fine)").matches
+      ) {
+        textareaRef.current?.focus();
+      }
     },
     [setChatReplyTarget, agentName],
   );

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
@@ -82,7 +82,6 @@ function makeController(
     handsFree: false,
     toggleHandsFree: vi.fn(),
     toggleTranscriptionMode: vi.fn(),
-    stopTranscriptionAndMic: vi.fn(),
     setDictationSink: vi.fn(),
     setTranscriptSessionSink: vi.fn(),
     setComposerHasDraft: vi.fn(),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.morph.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.morph.test.tsx
@@ -67,7 +67,6 @@ function makeController(
     handsFree: false,
     toggleHandsFree: vi.fn(),
     toggleTranscriptionMode: vi.fn(),
-    stopTranscriptionAndMic: vi.fn(),
     setDictationSink: vi.fn(),
     setTranscriptSessionSink: vi.fn(),
     setComposerHasDraft: vi.fn(),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx
@@ -75,7 +75,6 @@ function makeController(
     handsFree: false,
     toggleHandsFree: vi.fn(),
     toggleTranscriptionMode: vi.fn(),
-    stopTranscriptionAndMic: vi.fn(),
     setDictationSink: vi.fn(),
     setTranscriptSessionSink: vi.fn(),
     setComposerHasDraft: vi.fn(),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
@@ -92,7 +92,6 @@ function makeController(
     toggleHandsFree: () => {},
     transcriptionMode: false,
     toggleTranscriptionMode: () => {},
-    stopTranscriptionAndMic: () => {},
     setDictationSink: () => {},
     setTranscriptSessionSink: () => {},
     setComposerHasDraft: () => {},

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3444,12 +3444,15 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
 
     // Panel is closed at rest.
     expect(screen.queryByTestId("chat-message-search")).toBeNull();
-    // "+" → "Search chat…" reveals the search panel over the transcript.
+    // "+" → "Search chat…" reveals search on the sheet's existing liquid-glass
+    // surface without stacking a second black backdrop blur over it.
     openSearchFromComposerMenu();
     const searchLayer = screen.getByTestId("chat-message-search");
-    expect(searchLayer.className).toContain("bg-black/20");
-    expect(searchLayer.className).not.toContain("bg-scrim");
+    expect(searchLayer.className).not.toContain("backdrop-blur");
+    expect(searchLayer.className).not.toContain("bg-black");
     expect(screen.getByTestId("message-search-panel")).toBeTruthy();
+    expect(thread().getAttribute("aria-hidden")).toBe("true");
+    expect(thread().tabIndex).toBe(-1);
   });
 
   it("drives the header search → query → jump path against the real search API shape (#14330)", async () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -4061,7 +4061,29 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     fireEvent.change(input, { target: { value: "changed" } });
     fireEvent.keyDown(input, { key: "Escape" });
     expect(screen.queryByTestId("thread-line-edit-input")).toBeNull();
+    expect(
+      screen.getByTestId("thread-line-actions").getAttribute("aria-hidden"),
+    ).toBe("false");
+    expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
+    expect(screen.getByTestId("thread-line-edit")).toBeTruthy();
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it("returns to the three message actions when Cancel closes an edit", () => {
+    openThreadWith({
+      messages: [{ id: "u", role: "user", content: "keep me", createdAt: 1 }],
+      send: vi.fn(),
+    });
+    fireEvent.click(bubbleFor("keep me"));
+    fireEvent.click(screen.getByTestId("thread-line-edit"));
+    fireEvent.click(screen.getByTestId("thread-line-edit-cancel"));
+
+    expect(screen.queryByTestId("thread-line-edit-input")).toBeNull();
+    expect(
+      screen.getByTestId("thread-line-actions").getAttribute("aria-hidden"),
+    ).toBe("false");
+    expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
+    expect(screen.getByTestId("thread-line-edit")).toBeTruthy();
   });
 });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2916,7 +2916,7 @@ describe("ContinuousChatOverlay", () => {
 
   // ── Rich turn-status indicator (#8813) ──────────────────────────────────
   describe("turn status indicator", () => {
-    it("labels the thinking phase in the standalone status row", () => {
+    it("renders the standalone thinking phase as chromeless shimmer", () => {
       render(
         <ContinuousChatOverlay
           controller={makeController({
@@ -2931,12 +2931,13 @@ describe("ContinuousChatOverlay", () => {
       expect(indicator.getAttribute("data-status-kind")).toBe("thinking");
       expect(indicator.getAttribute("role")).toBe("status");
       expect(indicator.getAttribute("aria-live")).toBe("polite");
-      // The standalone status row carries a word for every phase (including
-      // thinking) beside a spinner — the bare-dots variant is the in-bubble one.
-      expect(screen.getByTestId("turn-status-label").textContent).toContain(
-        "Thinking",
-      );
-      expect(screen.getByTestId("turn-status-spinner")).toBeTruthy();
+      const label = screen.getByTestId("turn-status-label");
+      expect(label.textContent).toContain("Thinking");
+      expect(label.className).toContain("shimmer");
+      expect(screen.queryByTestId("turn-status-spinner")).toBeNull();
+      const row = screen.getByTestId("turn-status-row");
+      expect(row.className).not.toContain("rounded");
+      expect(row.className).not.toContain("border");
     });
 
     it("humanizes the action name for a running_action phase", () => {
@@ -2955,7 +2956,7 @@ describe("ContinuousChatOverlay", () => {
       );
     });
 
-    it("shows one shimmering status marker inside the in-flight assistant row", () => {
+    it("keeps one shimmer row while the empty assistant placeholder arrives", () => {
       render(
         <ContinuousChatOverlay
           controller={makeController({
@@ -2971,10 +2972,15 @@ describe("ContinuousChatOverlay", () => {
         />,
       );
       fireEvent.focus(screen.getByLabelText("message"));
-      // Exactly one indicator (no double-up between the bubble + standalone row).
+      // The transport placeholder stays non-visual; the original status row
+      // remains mounted, so there is no bubble swap before the first token.
       const indicators = screen.getAllByTestId("turn-status-indicator");
       expect(indicators).toHaveLength(1);
       expect(indicators[0].getAttribute("data-status-kind")).toBe("waking");
+      expect(
+        screen.getByTestId("turn-status-row").contains(indicators[0]),
+      ).toBe(true);
+      expect(indicators[0].closest('[data-testid="thread-line"]')).toBeNull();
       const label = screen.getByTestId("turn-status-label");
       expect(label.textContent).toBe("Waking the agent");
       expect(label.className).toContain("shimmer");

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2316,7 +2316,7 @@ describe("ContinuousChatOverlay", () => {
     expect(normal.closest('[data-failure="no_provider"]')).toBeNull();
   });
 
-  it("press-and-hold copies an assistant message and flashes confirmation", () => {
+  it("press-and-hold copies an assistant message without a popup", () => {
     vi.useFakeTimers();
     try {
       vi.mocked(copyTextToClipboard).mockClear();
@@ -2344,7 +2344,7 @@ describe("ContinuousChatOverlay", () => {
         vi.advanceTimersByTime(450); // past the hold threshold
       });
       expect(copyTextToClipboard).toHaveBeenCalledWith("the answer is 42");
-      expect(screen.getByTestId("thread-line-copied")).toBeTruthy();
+      expect(screen.queryByText("Copied")).toBeNull();
     } finally {
       vi.useRealTimers();
     }
@@ -2555,16 +2555,17 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.getByTestId("chat-composer-textarea")).toBeTruthy();
   });
 
-  it("shows the transcribe (mic-glyph) button beside the voice control at rest — ChatGPT arrangement", () => {
-    // Resting composer: BOTH controls are always available — the mic glyph
-    // starts a transcription/dictation session, the waveform glyph next to it
-    // is the spoken conversation. (Previously transcribe only appeared once a
-    // voice session was already live.)
+  it("keeps spoken conversation before the rightmost transcription mic at rest", () => {
+    // Resting composer: both controls stay available, with spoken conversation
+    // first and dictation rightmost so that mic can morph directly into Stop.
     render(<ContinuousChatOverlay controller={makeController()} />);
-    expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
+    const voice = screen.getByTestId("chat-composer-mic");
     const transcribe = screen.getByTestId("chat-composer-transcribe");
-    expect(transcribe).toBeTruthy();
     expect(transcribe.getAttribute("aria-label")).toBe("start transcription");
+    expect(
+      voice.compareDocumentPosition(transcribe) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("resting transcribe tap starts a transcription session", () => {
@@ -2609,7 +2610,7 @@ describe("ContinuousChatOverlay", () => {
     ).toBe("start transcription");
   });
 
-  it("keeps chat actions and replaces the mic slot with transcription stop", () => {
+  it("gives active transcription the full lane plus one Stop control", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
@@ -2625,11 +2626,17 @@ describe("ContinuousChatOverlay", () => {
     fireEvent.pointerMove(grabber, { clientY: 280, pointerId: 1 });
     fireEvent.pointerUp(grabber, { clientY: 280, pointerId: 1 });
     expect(screen.getByTestId("chat-transcribing-badge")).toBeTruthy();
-    expect(screen.getByTestId("chat-composer-plus")).toBeTruthy();
+    expect(screen.queryByTestId("chat-composer-plus")).toBeNull();
     expect(screen.queryByTestId("chat-composer-textarea")).toBeNull();
     expect(screen.getByTestId("chat-composer-mic-activity")).toBeTruthy();
     expect(screen.queryByTestId("chat-composer-mic")).toBeNull();
     expect(screen.queryByTestId("chat-composer-transcribe")).toBeNull();
+    expect(screen.queryByTestId("chat-composer-action")).toBeNull();
+    expect(
+      screen
+        .getByTestId("chat-composer-mic-activity")
+        .querySelectorAll("span[style]").length,
+    ).toBe(15);
 
     const stopTranscription = screen.getByTestId(
       "chat-composer-transcription-stop",
@@ -2645,12 +2652,6 @@ describe("ContinuousChatOverlay", () => {
         .contains(stopTranscription),
     ).toBe(true);
     expect(screen.queryByTestId("chat-composer-transcribe-status")).toBeNull();
-
-    const sendTranscription = screen.getByTestId("chat-composer-action");
-    expect(sendTranscription.getAttribute("aria-label")).toBe(
-      "send transcription (agent stopped)",
-    );
-    expect(sendTranscription.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("Stop drains a completed transcript into the existing draft without sending", async () => {
@@ -2714,7 +2715,7 @@ describe("ContinuousChatOverlay", () => {
     ).toBe("notes so far captured words");
   });
 
-  it("Send drains and submits the combined draft and transcript exactly once", async () => {
+  it("Stop preserves the collapsed detent and does not focus the restored draft", async () => {
     let sink:
       | ((
           segments: TranscriptSegment[],
@@ -2722,7 +2723,6 @@ describe("ContinuousChatOverlay", () => {
           audioWav: Uint8Array | null,
         ) => void)
       | null = null;
-    const send = vi.fn();
     const toggleTranscriptionMode = vi.fn(async () => {
       sink?.(
         [
@@ -2730,7 +2730,7 @@ describe("ContinuousChatOverlay", () => {
             id: "s1",
             startMs: 0,
             endMs: 900,
-            text: "captured words",
+            text: "quietly restored",
             words: [],
           },
         ],
@@ -2742,33 +2742,30 @@ describe("ContinuousChatOverlay", () => {
       sink = nextSink;
     });
     const inactiveController = makeController({
-      send,
       setTranscriptSessionSink,
       toggleTranscriptionMode,
     });
     const { rerender } = render(
-      <ContinuousChatOverlay controller={inactiveController} />,
-    );
-    fireEvent.change(screen.getByLabelText("message"), {
-      target: { value: "notes so far" },
-    });
-    rerender(
       <ContinuousChatOverlay
         controller={makeController({
           transcriptionMode: true,
-          send,
           setTranscriptSessionSink,
           toggleTranscriptionMode,
         })}
       />,
     );
+    const sheet = screen.getByTestId("chat-sheet");
+    expect(sheet.getAttribute("data-detent")).toBe("collapsed");
 
     await act(async () => {
-      fireEvent.click(screen.getByTestId("chat-composer-action"));
+      fireEvent.click(screen.getByTestId("chat-composer-transcription-stop"));
     });
     expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith("notes so far captured words");
+    rerender(<ContinuousChatOverlay controller={inactiveController} />);
+    const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+    expect(input.value).toBe("quietly restored");
+    expect(sheet.getAttribute("data-detent")).toBe("collapsed");
+    expect(document.activeElement).not.toBe(input);
   });
 
   it("an empty finalization never sends and ignores a second in-flight tap", async () => {
@@ -2800,9 +2797,11 @@ describe("ContinuousChatOverlay", () => {
         })}
       />,
     );
-    const sendTranscription = screen.getByTestId("chat-composer-action");
-    fireEvent.click(sendTranscription);
-    fireEvent.click(sendTranscription);
+    const stopTranscription = screen.getByTestId(
+      "chat-composer-transcription-stop",
+    );
+    fireEvent.click(stopTranscription);
+    fireEvent.click(stopTranscription);
     expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
     expect(send).not.toHaveBeenCalled();
     expect(
@@ -2815,76 +2814,11 @@ describe("ContinuousChatOverlay", () => {
         .getByTestId("chat-composer-transcription-stop")
         .getAttribute("aria-label"),
     ).toBe("finishing transcription");
-    expect(sendTranscription.getAttribute("aria-label")).toBe(
-      "send transcription (finishing)",
-    );
+    expect(screen.queryByTestId("chat-composer-action")).toBeNull();
 
     await act(async () => {
       releaseDrain?.();
     });
-  });
-
-  it("falls back to an editable draft when the agent stops during Send finalization", async () => {
-    let sink:
-      | ((
-          segments: TranscriptSegment[],
-          startedAt: number,
-          audioWav: Uint8Array | null,
-        ) => void)
-      | null = null;
-    let completeDrain: (() => void) | null = null;
-    const send = vi.fn();
-    const toggleTranscriptionMode = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          completeDrain = () => {
-            sink?.(
-              [
-                {
-                  id: "s1",
-                  startMs: 0,
-                  endMs: 900,
-                  text: "keep these words",
-                  words: [],
-                },
-              ],
-              1_700_000_000_000,
-              null,
-            );
-            resolve();
-          };
-        }),
-    );
-    const setTranscriptSessionSink = (nextSink: typeof sink) => {
-      sink = nextSink;
-    };
-    const activeController = makeController({
-      transcriptionMode: true,
-      send,
-      setTranscriptSessionSink,
-      toggleTranscriptionMode,
-    });
-    const stoppedController = makeController({
-      canSend: false,
-      send,
-      setTranscriptSessionSink,
-      toggleTranscriptionMode,
-    });
-    const { rerender } = render(
-      <ContinuousChatOverlay controller={activeController} />,
-    );
-
-    fireEvent.click(screen.getByTestId("chat-composer-action"));
-    rerender(<ContinuousChatOverlay controller={stoppedController} />);
-    await act(async () => {
-      completeDrain?.();
-    });
-
-    expect(send).not.toHaveBeenCalled();
-    expect(
-      (screen.getByLabelText("message") as HTMLTextAreaElement).value,
-    ).toBe("keep these words");
-    expect(screen.getByLabelText("send (agent stopped)")).toBeTruthy();
   });
 
   it("the audio-unlock chip works while the sheet is open (not swallowed as an outside tap)", () => {
@@ -3055,7 +2989,7 @@ describe("ContinuousChatOverlay", () => {
     expect(controller.send).not.toHaveBeenCalled();
   });
 
-  it("keeps the oversized-recording warning visible when Send delivers the transcript", async () => {
+  it("keeps the oversized-recording warning visible when Stop restores the transcript", async () => {
     let sink:
       | ((
           segments: TranscriptSegment[],
@@ -3098,11 +3032,10 @@ describe("ContinuousChatOverlay", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByTestId("chat-composer-action"));
+      fireEvent.click(screen.getByTestId("chat-composer-transcription-stop"));
     });
 
-    expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith("keep the transcript");
+    expect(send).not.toHaveBeenCalled();
     expect(screen.queryByText(/^Recording .*\.wav$/)).toBeNull();
     expect(screen.getByRole("alert").textContent).toContain(
       "Recording too large to attach",
@@ -3185,7 +3118,7 @@ describe("ContinuousChatOverlay", () => {
 
   // ── Rich turn-status indicator (#8813) ──────────────────────────────────
   describe("turn status indicator", () => {
-    it("renders the standalone thinking phase as chromeless shimmer", () => {
+    it("renders the thinking phase as a chromeless action-lane shimmer", () => {
       render(
         <ContinuousChatOverlay
           controller={makeController({
@@ -3204,9 +3137,12 @@ describe("ContinuousChatOverlay", () => {
       expect(label.textContent).toContain("Thinking");
       expect(label.className).toContain("shimmer");
       expect(screen.queryByTestId("turn-status-spinner")).toBeNull();
-      const row = screen.getByTestId("turn-status-row");
-      expect(row.className).not.toContain("rounded");
-      expect(row.className).not.toContain("border");
+      const accessory = screen.getByTestId("turn-status-accessory");
+      expect(accessory.className).not.toContain("rounded");
+      expect(accessory.className).not.toContain("border");
+      expect(
+        accessory.closest('[data-testid="thread-line-actions"]'),
+      ).toBeTruthy();
     });
 
     it("humanizes the action name for a running_action phase", () => {
@@ -3225,7 +3161,7 @@ describe("ContinuousChatOverlay", () => {
       );
     });
 
-    it("keeps one shimmer row while the empty assistant placeholder arrives", () => {
+    it("keeps one action-lane shimmer while the empty assistant placeholder arrives", () => {
       render(
         <ContinuousChatOverlay
           controller={makeController({
@@ -3241,15 +3177,17 @@ describe("ContinuousChatOverlay", () => {
         />,
       );
       fireEvent.focus(screen.getByLabelText("message"));
-      // The transport placeholder stays non-visual; the original status row
-      // remains mounted, so there is no bubble swap before the first token.
+      // The transport placeholder stays non-visual; status stays on the latest
+      // real message's action lane, so there is no bubble swap before token one.
       const indicators = screen.getAllByTestId("turn-status-indicator");
       expect(indicators).toHaveLength(1);
       expect(indicators[0].getAttribute("data-status-kind")).toBe("waking");
       expect(
-        screen.getByTestId("turn-status-row").contains(indicators[0]),
+        screen.getByTestId("turn-status-accessory").contains(indicators[0]),
       ).toBe(true);
-      expect(indicators[0].closest('[data-testid="thread-line"]')).toBeNull();
+      expect(
+        indicators[0].closest('[data-testid="thread-line"]')?.textContent,
+      ).toContain("do it");
       const label = screen.getByTestId("turn-status-label");
       expect(label.textContent).toBe("Waking the agent");
       expect(label.className).toContain("shimmer");
@@ -4136,18 +4074,28 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     ).toBeNull();
   });
 
-  it("keeps reply state inside the bounded thread and clears it when the sheet closes", async () => {
-    openThreadWith({
-      messages: [
-        {
-          id: "reply-source",
-          role: "assistant",
-          content: "Reply without moving the sheet",
-          createdAt: 1,
-        },
-      ],
-    });
+  it("reserves an animated reply lane without focusing and clears it when the sheet closes", async () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages: [
+            {
+              id: "reply-source",
+              role: "assistant",
+              content: "Reply without moving the sheet",
+              createdAt: 1,
+            },
+          ],
+        })}
+      />,
+    );
     const sheet = screen.getByTestId("chat-sheet");
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    fireEvent.pointerDown(grabber, { clientY: 420, pointerId: 1 });
+    fireEvent.pointerMove(grabber, { clientY: 280, pointerId: 1 });
+    fireEvent.pointerUp(grabber, { clientY: 280, pointerId: 1 });
+    const input = screen.getByLabelText("message");
+    expect(document.activeElement).not.toBe(input);
     const detentBeforeReply = sheet.getAttribute("data-detent");
 
     revealActionsFor("Reply without moving the sheet");
@@ -4155,10 +4103,14 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
 
     const replyPill = screen.getByTestId("chat-reply-pill");
     expect(screen.getByTestId("chat-thread").contains(replyPill)).toBe(true);
-    expect(replyPill.parentElement?.className).toContain("absolute");
+    const replyLane = screen.getByTestId("chat-reply-lane");
+    expect(replyLane.className).toContain("shrink-0");
+    expect(replyLane.className).toContain("overflow-hidden");
+    expect(replyLane.className).not.toContain("absolute");
     expect(sheet.getAttribute("data-detent")).toBe(detentBeforeReply);
+    expect(document.activeElement).not.toBe(input);
 
-    fireEvent.keyDown(screen.getByLabelText("message"), { key: "Escape" });
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(sheet.getAttribute("data-variant")).toBe("closed");
     await waitFor(() => {
       expect(screen.queryByTestId("chat-reply-pill")).toBeNull();

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3843,14 +3843,14 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       speak,
       speaking: false,
     });
-    // The plate stays mounted so hide can animate; inert + opacity keep it out
-    // of interaction until the bubble is clicked.
+    // The plate stays mounted so height and opacity can settle together; inert
+    // keeps its hidden controls out of interaction until the bubble is clicked.
     const actions = screen.getByTestId("thread-line-actions");
     expect(actions.getAttribute("aria-hidden")).toBe("true");
-    expect(actions.className).toContain("opacity-0");
+    expect(actions.hasAttribute("inert")).toBe(true);
     fireEvent.click(bubbleFor("the answer"));
     expect(actions.getAttribute("aria-hidden")).toBe("false");
-    expect(actions.className).toContain("opacity-100");
+    expect(actions.hasAttribute("inert")).toBe(false);
     expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
     expect(screen.getByTestId("thread-line-speak")).toBeTruthy();
     // Assistant has no edit affordance.
@@ -3988,10 +3988,10 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     });
     fireEvent.click(bubbleFor("tap away"));
     const actions = screen.getByTestId("thread-line-actions");
-    expect(actions.className).toContain("opacity-100");
+    expect(actions.getAttribute("aria-hidden")).toBe("false");
     fireEvent.pointerDown(document.body);
     expect(actions.getAttribute("aria-hidden")).toBe("true");
-    expect(actions.className).toContain("opacity-0");
+    expect(actions.hasAttribute("inert")).toBe(true);
   });
 
   it("Escape cancels the inline editor without resending", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3843,10 +3843,14 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       speak,
       speaking: false,
     });
-    // No row until the bubble is clicked.
-    expect(screen.queryByTestId("thread-line-actions")).toBeNull();
+    // The plate stays mounted so hide can animate; inert + opacity keep it out
+    // of interaction until the bubble is clicked.
+    const actions = screen.getByTestId("thread-line-actions");
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+    expect(actions.className).toContain("opacity-0");
     fireEvent.click(bubbleFor("the answer"));
-    expect(screen.getByTestId("thread-line-actions")).toBeTruthy();
+    expect(actions.getAttribute("aria-hidden")).toBe("false");
+    expect(actions.className).toContain("opacity-100");
     expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
     expect(screen.getByTestId("thread-line-speak")).toBeTruthy();
     // Assistant has no edit affordance.
@@ -3983,9 +3987,11 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       speak: vi.fn(),
     });
     fireEvent.click(bubbleFor("tap away"));
-    expect(screen.getByTestId("thread-line-actions")).toBeTruthy();
+    const actions = screen.getByTestId("thread-line-actions");
+    expect(actions.className).toContain("opacity-100");
     fireEvent.pointerDown(document.body);
-    expect(screen.queryByTestId("thread-line-actions")).toBeNull();
+    expect(actions.getAttribute("aria-hidden")).toBe("true");
+    expect(actions.className).toContain("opacity-0");
   });
 
   it("Escape cancels the inline editor without resending", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3945,11 +3945,23 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     expect(copyTextToClipboard).toHaveBeenCalledWith("copy this text");
   });
 
-  it("reveals Copy + Edit on a user message and resends the edited text", () => {
+  it("edits a user message in place without creating a duplicate turn", async () => {
     const send = vi.fn();
+    const stopSpeaking = vi.fn();
+    const handleChatEdit = vi.fn().mockResolvedValue(true);
+    const noop = () => {};
+    __setAppValueForTests(
+      new Proxy({} as never, {
+        get(_target, prop) {
+          if (prop === "handleChatEdit") return handleChatEdit;
+          return noop;
+        },
+      }),
+    );
     openThreadWith({
       messages: [{ id: "u", role: "user", content: "helo wrld", createdAt: 1 }],
       send,
+      stopSpeaking,
     });
     fireEvent.click(bubbleFor("helo wrld"));
     expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
@@ -3958,13 +3970,22 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     expect(screen.queryByTestId("thread-line-speak")).toBeNull();
 
     fireEvent.click(screen.getByTestId("thread-line-edit"));
+    expect(
+      screen.getByTestId("thread-line-actions").getAttribute("aria-hidden"),
+    ).toBe("false");
+    expect(screen.getByTestId("thread-line-edit-controls")).toBeTruthy();
+    expect(screen.queryByTestId("thread-line-action-surface")).toBeNull();
     const input = screen.getByTestId(
       "thread-line-edit-input",
     ) as HTMLTextAreaElement;
     expect(input.value).toBe("helo wrld");
     fireEvent.change(input, { target: { value: "hello world" } });
     fireEvent.click(screen.getByTestId("thread-line-edit-save"));
-    expect(send).toHaveBeenCalledWith("hello world");
+    await waitFor(() => {
+      expect(handleChatEdit).toHaveBeenCalledWith("u", "hello world");
+    });
+    expect(stopSpeaking).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("does not offer Edit on an optimistic temp- user turn", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1862,10 +1862,28 @@ describe("ContinuousChatOverlay", () => {
     expect(log?.getAttribute("tabindex")).toBe("-1");
   });
 
-  it("shows the attach (+) control", () => {
+  it("keeps the chat-actions menu focused on search and upload", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
-    expect(screen.getByTestId("chat-composer-plus")).toBeTruthy();
+    const plus = screen.getByTestId("chat-composer-plus");
+    expect(plus).toBeTruthy();
     expect(screen.getByLabelText("chat actions")).toBeTruthy();
+
+    fireEvent.pointerDown(plus, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerUp(plus, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+
+    expect(screen.getByText("Search chat…")).toBeTruthy();
+    expect(screen.getByText("Upload file")).toBeTruthy();
+    expect(screen.queryByText("Enable camera")).toBeNull();
+    expect(screen.queryByText("Transcribe")).toBeNull();
+    expect(screen.queryByText("Stop transcribing")).toBeNull();
   });
 
   it("attaches an image and enables an image-only send", async () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -90,6 +90,7 @@ import {
 } from "../../state/useStreamingText";
 import { setViewChatBinding } from "../../state/view-chat-binding";
 import { copyTextToClipboard } from "../../utils/clipboard";
+import { getChatMessageAnchorId } from "../composites/chat/chat-message";
 import { ContinuousChatOverlay } from "./ContinuousChatOverlay";
 import type { ShellMessage } from "./shell-state";
 import {
@@ -3587,25 +3588,107 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     );
     expect(bubble).toBeTruthy();
 
-    // Selecting the hit closes search, jumps to the real row, and highlights
-    // inside the bubble so message-scroller paint containment cannot clip it.
+    // Selecting the hit closes search and hands the jump to MessageScroller's
+    // coordinated state machine. The raw DOM fallback must stay unused for a
+    // flat registered row, or bottom-follow can overwrite the jump on resize.
     fireEvent.click(result);
     expect(selectSpy).toHaveBeenCalledWith("b");
     expect(aroundSpy).not.toHaveBeenCalled();
     await waitFor(() =>
-      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
-        block: "center",
-        behavior: "smooth",
-      }),
-    );
-    await waitFor(() =>
       expect(bubble?.getAttribute("data-chat-search-highlight")).toBe("true"),
     );
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
     expect(bubble?.style.outline).toContain("rgba(255, 255, 255, 0.96)");
     expect(bubble?.style.outlineOffset).toBe("-2px");
     await waitFor(() =>
       expect(screen.queryByTestId("chat-message-search")).toBeNull(),
     );
+  });
+
+  it("reveals an already-loaded windowed result before falling back to the network", async () => {
+    const targetId = "loaded-but-windowed";
+    const selectSpy = vi.fn<(id: string) => Promise<void>>(async () => {});
+    const aroundSpy = vi.fn(async () => false);
+    const noop = () => {};
+    __setAppValueForTests(
+      new Proxy({} as never, {
+        get(_target, prop) {
+          if (prop === "handleSelectConversation") return selectSpy;
+          if (prop === "loadConversationMessagesAround") return aroundSpy;
+          if (prop === "t") return (key: string) => key;
+          if (prop === "uiLanguage") return "en";
+          if (prop === "navigation") {
+            return { scheduleAfterTabCommit: (fn: () => void) => fn() };
+          }
+          return noop;
+        },
+      }),
+    );
+
+    const loadedMessages: ShellMessage[] = Array.from(
+      { length: 81 },
+      (_, index) => ({
+        id: index === 0 ? targetId : `loaded-message-${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        content:
+          index === 0
+            ? "This loaded result sits just outside the mounted window."
+            : `Loaded message ${index}`,
+        createdAt: index + 1,
+      }),
+    );
+    vi.mocked(client.searchConversationMessages).mockResolvedValue({
+      results: [
+        {
+          messageId: targetId,
+          conversationId: "b",
+          roomId: "room-b",
+          role: "user",
+          text: loadedMessages[0]?.content ?? "",
+          snippet: loadedMessages[0]?.content ?? "",
+          createdAt: 1,
+          score: 8,
+        },
+      ],
+      count: 1,
+    });
+
+    const conversationNav = buildConversationNav(CONVERSATIONS, "b", vi.fn());
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages: loadedMessages,
+          conversationNav,
+        } as unknown as Partial<ShellController>)}
+      />,
+    );
+    openSheet();
+    expect(
+      document.getElementById(getChatMessageAnchorId(targetId)),
+    ).toBeNull();
+
+    openSearchFromComposerMenu();
+    fireEvent.change(screen.getByTestId("message-search-input"), {
+      target: { value: "outside mounted window" },
+    });
+    const result = await waitFor(() =>
+      screen.getByTestId("message-search-result"),
+    );
+    fireEvent.click(result);
+
+    const anchor = await waitFor(() => {
+      const element = document.getElementById(getChatMessageAnchorId(targetId));
+      expect(element).toBeTruthy();
+      return element as HTMLElement;
+    });
+    const bubble = anchor.querySelector<HTMLElement>(
+      '[data-chat-message-bubble="true"]',
+    );
+    await waitFor(() =>
+      expect(bubble?.getAttribute("data-chat-search-highlight")).toBe("true"),
+    );
+    expect(selectSpy).toHaveBeenCalledWith("b");
+    expect(aroundSpy).not.toHaveBeenCalled();
   });
 
   it("renders a distinguishable error state when the search API rejects (#14330)", async () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -110,7 +110,6 @@ afterEach(() => {
   vi.mocked(reportComposerActivity).mockClear();
   vi.mocked(client.searchConversationMessages).mockReset();
   vi.mocked(Element.prototype.scrollIntoView).mockClear();
-  document.getElementById("chat-message-m-hit")?.remove();
   // Search-jump tests seed the AppContext store with spies; clear it so the
   // inert test-fallback proxy backs every other test again.
   __setAppValueForTests(null);
@@ -3461,12 +3460,7 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     // inert test-fallback proxy (noop for everything else the overlay reads via
     // other selectors) so only the jump collaborators are observable.
     const selectSpy = vi.fn<(id: string) => Promise<void>>(async () => {});
-    const aroundSpy = vi.fn(async () => {
-      const anchor = document.createElement("div");
-      anchor.id = "chat-message-m-hit";
-      document.body.appendChild(anchor);
-      return true;
-    });
+    const aroundSpy = vi.fn(async () => true);
     const noop = () => {};
     __setAppValueForTests(
       new Proxy({} as never, {
@@ -3486,8 +3480,8 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     // The panel renders exactly what the server route returns; use its real
     // response shape (ranked hits with snippet/role/createdAt).
     const hit: ConversationMessageSearchResult = {
-      messageId: "m-hit",
-      conversationId: "conv-42",
+      messageId: "a",
+      conversationId: "b",
       roomId: "room-1",
       role: "assistant",
       text: "the quarterly budget review is on friday",
@@ -3519,20 +3513,31 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     );
     expect(result.textContent).toContain("budget");
 
-    // Selecting the hit jumps to its conversation (the real jump plumbing) and
-    // then loads the centered around-window because this fixture starts with no
-    // DOM anchor for the hit.
-    fireEvent.click(result);
-    expect(selectSpy).toHaveBeenCalledWith("conv-42");
-    await waitFor(() =>
-      expect(aroundSpy).toHaveBeenCalledWith("conv-42", "m-hit"),
+    // The rendered glass row itself owns the canonical anchor. This catches the
+    // production bug the old fixture hid by appending a fake body-level div.
+    const anchor = document.getElementById("chat-message-a");
+    expect(anchor?.getAttribute("data-slot")).toBe("message-scroller-item");
+    const bubble = anchor?.querySelector<HTMLElement>(
+      '[data-chat-message-bubble="true"]',
     );
+    expect(bubble).toBeTruthy();
+
+    // Selecting the hit closes search, jumps to the real row, and highlights
+    // inside the bubble so message-scroller paint containment cannot clip it.
+    fireEvent.click(result);
+    expect(selectSpy).toHaveBeenCalledWith("b");
+    expect(aroundSpy).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
         block: "center",
         behavior: "smooth",
       }),
     );
+    await waitFor(() =>
+      expect(bubble?.getAttribute("data-chat-search-highlight")).toBe("true"),
+    );
+    expect(bubble?.style.outline).toContain("var(--accent)");
+    expect(bubble?.style.outlineOffset).toBe("-2px");
     await waitFor(() =>
       expect(screen.queryByTestId("chat-message-search")).toBeNull(),
     );

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -910,6 +910,7 @@ describe("ContinuousChatOverlay", () => {
       expect(waveform.className).toContain("animate-pulse");
       expect(waveform.className).toContain("motion-reduce:animate-none");
       expect(waveform.className).toContain("text-accent");
+      expect(waveform.className).toContain("hover:text-accent");
     });
 
     it("keeps the pulsing waveform neutral during push-to-talk recording", () => {
@@ -2608,7 +2609,7 @@ describe("ContinuousChatOverlay", () => {
     ).toBe("start transcription");
   });
 
-  it("replaces the composer with dedicated neutral transcription controls", () => {
+  it("keeps chat actions and replaces the mic slot with transcription stop", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
@@ -2624,7 +2625,7 @@ describe("ContinuousChatOverlay", () => {
     fireEvent.pointerMove(grabber, { clientY: 280, pointerId: 1 });
     fireEvent.pointerUp(grabber, { clientY: 280, pointerId: 1 });
     expect(screen.getByTestId("chat-transcribing-badge")).toBeTruthy();
-    expect(screen.queryByTestId("chat-composer-plus")).toBeNull();
+    expect(screen.getByTestId("chat-composer-plus")).toBeTruthy();
     expect(screen.queryByTestId("chat-composer-textarea")).toBeNull();
     expect(screen.getByTestId("chat-composer-mic-activity")).toBeTruthy();
     expect(screen.queryByTestId("chat-composer-mic")).toBeNull();
@@ -2638,10 +2639,12 @@ describe("ContinuousChatOverlay", () => {
     );
     // A stopped agent blocks delivery, not finalization back into the draft.
     expect(stopTranscription.getAttribute("aria-disabled")).toBe("false");
-
-    const micStatus = screen.getByTestId("chat-composer-transcribe-status");
-    expect(micStatus.className).toContain("text-white/80");
-    expect(micStatus.className).not.toContain("text-accent");
+    expect(
+      screen
+        .getByTestId("chat-composer-trailing-controls")
+        .contains(stopTranscription),
+    ).toBe(true);
+    expect(screen.queryByTestId("chat-composer-transcribe-status")).toBeNull();
 
     const sendTranscription = screen.getByTestId("chat-composer-action");
     expect(sendTranscription.getAttribute("aria-label")).toBe(
@@ -2807,13 +2810,6 @@ describe("ContinuousChatOverlay", () => {
         .getByTestId("chat-composer-mic-activity")
         .getAttribute("aria-label"),
     ).toBe("Finishing transcription");
-    const micStatus = screen.getByTestId("chat-composer-transcribe-status");
-    expect(micStatus.getAttribute("aria-label")).toBe(
-      "Finishing transcription",
-    );
-    expect(micStatus.querySelector("svg")?.getAttribute("class")).not.toContain(
-      "animate-pulse",
-    );
     expect(
       screen
         .getByTestId("chat-composer-transcription-stop")
@@ -4159,6 +4155,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
 
     const replyPill = screen.getByTestId("chat-reply-pill");
     expect(screen.getByTestId("chat-thread").contains(replyPill)).toBe(true);
+    expect(replyPill.parentElement?.className).toContain("absolute");
     expect(sheet.getAttribute("data-detent")).toBe(detentBeforeReply);
 
     fireEvent.keyDown(screen.getByLabelText("message"), { key: "Escape" });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2014,6 +2014,23 @@ describe("ContinuousChatOverlay", () => {
     expect(input.className).not.toContain("basis-full");
   });
 
+  it("keeps long-draft scrolling inside the composer without stepping the sheet", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    const input = screen.getByTestId("chat-composer-textarea");
+
+    fireEvent.focus(input);
+    expect(sheet.getAttribute("data-detent")).toBe("half");
+    expect(input.hasAttribute("data-chat-sheet-scroll-region")).toBe(true);
+    expect(input.className).toContain("chat-composer-scrollbar");
+    expect(input.className).toContain("overflow-y-auto");
+    expect(input.className).toContain("overscroll-contain");
+    expect(input.className).not.toContain("scrollbar-hide");
+
+    fireEvent.wheel(input, { deltaY: 120 });
+    expect(sheet.getAttribute("data-detent")).toBe("half");
+  });
+
   it("renders no prompt-suggestion chips while the strip is flagged off", () => {
     render(
       <ContinuousChatOverlay

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2025,10 +2025,27 @@ describe("ContinuousChatOverlay", () => {
     expect(input.className).toContain("chat-composer-scrollbar");
     expect(input.className).toContain("overflow-y-auto");
     expect(input.className).toContain("overscroll-contain");
+    expect(input.className).toContain("pr-3");
     expect(input.className).not.toContain("scrollbar-hide");
 
     fireEvent.wheel(input, { deltaY: 120 });
     expect(sheet.getAttribute("data-detent")).toBe("half");
+
+    Object.defineProperties(input, {
+      clientHeight: { configurable: true, value: 136 },
+      scrollHeight: { configurable: true, value: 500 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    });
+    fireEvent.scroll(input);
+    expect(input.getAttribute("data-scroll-fade")).toBe("bottom");
+
+    input.scrollTop = 100;
+    fireEvent.scroll(input);
+    expect(input.getAttribute("data-scroll-fade")).toBe("both");
+
+    input.scrollTop = 364;
+    fireEvent.scroll(input);
+    expect(input.getAttribute("data-scroll-fade")).toBe("top");
   });
 
   it("renders no prompt-suggestion chips while the strip is flagged off", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1965,7 +1965,11 @@ describe("ContinuousChatOverlay", () => {
 
     // Once the read resolves, a thumbnail + send control appear.
     await screen.findByLabelText("send");
-    expect(screen.getByLabelText(/remove pic\.png/)).toBeTruthy();
+    expect(
+      document.querySelector('[data-slot="attachment-group"]'),
+    ).toBeTruthy();
+    expect(document.querySelector('[data-slot="attachment"]')).toBeTruthy();
+    expect(screen.getByLabelText(/remove pic\.png/i)).toBeTruthy();
 
     fireEvent.click(screen.getByLabelText("send"));
     expect(controller.send).toHaveBeenCalledWith(

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1792,7 +1792,9 @@ describe("ContinuousChatOverlay", () => {
       .getByText("fix my typo")
       .closest('[data-testid="thread-line"]')
       ?.querySelector("div.select-text") as HTMLElement;
-    fireEvent.click(bubble);
+    const row = bubble.closest('[data-testid="thread-line"]');
+    if (!row) throw new Error("message row not found");
+    fireEvent.mouseEnter(row);
     fireEvent.click(screen.getByTestId("thread-line-edit"));
     const editInput = screen.getByTestId("thread-line-edit-input");
 
@@ -3866,8 +3868,8 @@ describe("ContinuousChatOverlay — streaming + thinking render (#10712)", () =>
   });
 });
 
-// Per-message click-to-reveal action row (#10713): assistant → Copy + Play,
-// user → Copy + Edit-and-resend, temp turns are not editable.
+// Per-message hover/touch action row (#10713): assistant → Copy + Play, user →
+// Copy + Edit-and-resend, and optimistic turns stay non-editable.
 describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
   function openThreadWith(overrides: Partial<ShellController>) {
     render(
@@ -3886,6 +3888,12 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       ?.querySelector("div.select-text") as HTMLElement;
   }
 
+  function revealActionsFor(text: string): void {
+    const row = bubbleFor(text).closest('[data-testid="thread-line"]');
+    if (!row) throw new Error(`message row not found for: ${text}`);
+    fireEvent.mouseEnter(row);
+  }
+
   it("reveals Copy + Play on an assistant message and no top-menu copy button", () => {
     const speak = vi.fn();
     openThreadWith({
@@ -3895,12 +3903,12 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       speak,
       speaking: false,
     });
-    // The plate stays mounted so height and opacity can settle together; inert
-    // keeps its hidden controls out of interaction until the bubble is clicked.
+    // The bare lane stays mounted in its reserved slot; inert keeps hidden
+    // controls out of interaction until the row is hovered or touch-revealed.
     const actions = screen.getByTestId("thread-line-actions");
     expect(actions.getAttribute("aria-hidden")).toBe("true");
     expect(actions.hasAttribute("inert")).toBe(true);
-    fireEvent.click(bubbleFor("the answer"));
+    revealActionsFor("the answer");
     expect(actions.getAttribute("aria-hidden")).toBe("false");
     expect(actions.hasAttribute("inert")).toBe(false);
     expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
@@ -3922,7 +3930,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       speak,
       speaking: false,
     });
-    fireEvent.click(bubbleFor("read me aloud"));
+    revealActionsFor("read me aloud");
     fireEvent.click(screen.getByTestId("thread-line-speak"));
     expect(speak).toHaveBeenCalledWith("read me aloud");
   });
@@ -3938,7 +3946,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       stopSpeaking,
       speaking: true,
     });
-    fireEvent.click(bubbleFor("now playing"));
+    revealActionsFor("now playing");
     const play = screen.getByTestId("thread-line-speak");
     // The agent is globally speaking, but nothing has been Played from THIS
     // bubble, so it still offers Play (not a spurious Stop — the old bug).
@@ -3966,8 +3974,8 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     });
     // Reveal both action rows. With the global `speaking` flag set but nothing
     // Played yet, NEITHER bubble claims Stop (the old bug lit every bubble).
-    fireEvent.click(bubbleFor("first answer"));
-    fireEvent.click(bubbleFor("second answer"));
+    revealActionsFor("first answer");
+    revealActionsFor("second answer");
     expect(
       screen
         .getAllByTestId("thread-line-speak")
@@ -3992,7 +4000,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       ],
       speak: vi.fn(),
     });
-    fireEvent.click(bubbleFor("copy this text"));
+    revealActionsFor("copy this text");
     fireEvent.click(screen.getByTestId("thread-line-copy"));
     expect(copyTextToClipboard).toHaveBeenCalledWith("copy this text");
   });
@@ -4015,7 +4023,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       send,
       stopSpeaking,
     });
-    fireEvent.click(bubbleFor("helo wrld"));
+    revealActionsFor("helo wrld");
     expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
     expect(screen.getByTestId("thread-line-edit")).toBeTruthy();
     // User turns have no play control.
@@ -4047,7 +4055,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       ],
       send: vi.fn(),
     });
-    fireEvent.click(bubbleFor("pending turn"));
+    revealActionsFor("pending turn");
     expect(screen.getByTestId("thread-line-copy")).toBeTruthy();
     expect(screen.queryByTestId("thread-line-edit")).toBeNull();
   });
@@ -4059,7 +4067,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       ],
       speak: vi.fn(),
     });
-    fireEvent.click(bubbleFor("tap away"));
+    revealActionsFor("tap away");
     const actions = screen.getByTestId("thread-line-actions");
     expect(actions.getAttribute("aria-hidden")).toBe("false");
     fireEvent.pointerDown(document.body);
@@ -4073,7 +4081,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       messages: [{ id: "u", role: "user", content: "keep me", createdAt: 1 }],
       send,
     });
-    fireEvent.click(bubbleFor("keep me"));
+    revealActionsFor("keep me");
     fireEvent.click(screen.getByTestId("thread-line-edit"));
     const input = screen.getByTestId("thread-line-edit-input");
     fireEvent.change(input, { target: { value: "changed" } });
@@ -4092,7 +4100,7 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
       messages: [{ id: "u", role: "user", content: "keep me", createdAt: 1 }],
       send: vi.fn(),
     });
-    fireEvent.click(bubbleFor("keep me"));
+    revealActionsFor("keep me");
     fireEvent.click(screen.getByTestId("thread-line-edit"));
     fireEvent.click(screen.getByTestId("thread-line-edit-cancel"));
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -58,6 +58,8 @@ vi.mock("../../chat/report-composer-activity", () => ({
   reportComposerActivity: vi.fn(),
 }));
 
+import { MAX_CHAT_MEDIA_RAW_BYTES } from "@elizaos/shared";
+import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import * as React from "react";
 import { client } from "../../api/client";
 import type {
@@ -128,6 +130,7 @@ function makeController(
     responding: false,
     turnStatus: null,
     recording: false,
+    analyser: null,
     transcript: "",
     transcriptionMode: false,
     // Required ShellController surface the overlay reads unconditionally — the
@@ -141,8 +144,6 @@ function makeController(
     handsFree: false,
     toggleHandsFree: vi.fn(),
     toggleTranscriptionMode: vi.fn(),
-    // A mic tap while transcribing routes through this master voice control.
-    stopTranscriptionAndMic: vi.fn(),
     setDictationSink: vi.fn(),
     setTranscriptSessionSink: vi.fn(),
     setComposerHasDraft: vi.fn(),
@@ -889,9 +890,8 @@ describe("ContinuousChatOverlay", () => {
     expect(grabber.className).toContain("before:bottom-0");
   });
 
-  // #14331: the waveform pulses whenever capture is hot, but only turns orange
-  // when its own conversation mode is active. Transcription belongs to the
-  // adjacent mic and must not recolor this separate control.
+  // #14331: the waveform reflects only spoken-conversation capture. Dedicated
+  // transcription replaces it with the neutral activity presentation below.
   describe("waveform + pill pulse while capture is hot (#14331)", () => {
     it("does not pulse the mic while idle (neutral resting, no motion)", () => {
       render(<ContinuousChatOverlay controller={makeController()} />);
@@ -912,11 +912,12 @@ describe("ContinuousChatOverlay", () => {
       expect(waveform.className).toContain("text-accent");
     });
 
-    it.each([
-      ["recording", { recording: true }],
-      ["transcribing", { transcriptionMode: true }],
-    ] as const)("keeps the pulsing waveform neutral while %s", (_label, override) => {
-      render(<ContinuousChatOverlay controller={makeController(override)} />);
+    it("keeps the pulsing waveform neutral during push-to-talk recording", () => {
+      render(
+        <ContinuousChatOverlay
+          controller={makeController({ recording: true })}
+        />,
+      );
       const waveform = screen.getByTestId("chat-composer-mic");
       expect(waveform.className).toContain("animate-pulse");
       expect(waveform.className).not.toContain("text-accent");
@@ -2598,7 +2599,8 @@ describe("ContinuousChatOverlay", () => {
         } as unknown as Partial<ShellController>)}
       />,
     );
-    // Both controls present in voice mode; the mic stays the master control.
+    // Idle dictation and spoken-conversation controls remain independently
+    // available when neither mode owns capture.
     expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
     expect(screen.getByTestId("chat-composer-transcribe")).toBeTruthy();
     expect(
@@ -2606,95 +2608,287 @@ describe("ContinuousChatOverlay", () => {
     ).toBe("start transcription");
   });
 
-  it("shows the transcribe button (as stop) while transcribing, alongside the status badge (#10699)", () => {
+  it("replaces the composer with dedicated neutral transcription controls", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
           transcriptionMode: true,
-        } as unknown as Partial<ShellController>)}
-      />,
-    );
-    fireEvent.focus(screen.getByLabelText("message"));
-    expect(screen.getByTestId("chat-transcribing-badge")).toBeTruthy();
-    const transcribe = screen.getByTestId("chat-composer-transcribe");
-    expect(transcribe).toBeTruthy();
-    expect(transcribe.getAttribute("aria-label")).toBe("stop transcription");
-  });
-
-  it("clicking the transcribe button toggles transcription mode (#10699)", () => {
-    const toggleTranscriptionMode = vi.fn();
-    render(
-      <ContinuousChatOverlay
-        controller={makeController({
-          handsFree: true,
-          recording: true,
-          toggleTranscriptionMode,
-        } as unknown as Partial<ShellController>)}
-      />,
-    );
-    fireEvent.click(screen.getByTestId("chat-composer-transcribe"));
-    expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps the waveform pressed but visually neutral while the mic transcribes", () => {
-    render(
-      <ContinuousChatOverlay
-        controller={makeController({
-          transcriptionMode: true,
-          toggleTranscriptionMode: vi.fn(),
-        } as unknown as Partial<ShellController>)}
-      />,
-    );
-    const waveform = screen.getByTestId("chat-composer-mic");
-    expect(waveform.getAttribute("aria-pressed")).toBe("true");
-    expect(waveform.className).toContain("animate-pulse");
-    expect(waveform.className).toContain("text-muted-strong");
-    expect(waveform.className).not.toContain("text-accent");
-  });
-
-  it("a mic tap while transcribing ends transcription, never starts a conversation", () => {
-    const stopTranscriptionAndMic = vi.fn();
-    const toggleHandsFree = vi.fn();
-    render(
-      <ContinuousChatOverlay
-        controller={makeController({
-          transcriptionMode: true,
-          stopTranscriptionAndMic,
-          toggleHandsFree,
-        } as unknown as Partial<ShellController>)}
-      />,
-    );
-    fireEvent.click(screen.getByTestId("chat-composer-mic"));
-    // The mic is the master voice control: a tap ends transcription AND the mic
-    // (stopTranscriptionAndMic → finished transcript drops into the composer);
-    // it must NOT open a hands-free conversation.
-    expect(stopTranscriptionAndMic).toHaveBeenCalledTimes(1);
-    expect(toggleHandsFree).not.toHaveBeenCalled();
-  });
-
-  it("a mic tap ends transcription even while a reply is in flight (#9880 inline reply)", () => {
-    // A wake-word inline reply during transcription flips `responding` true
-    // while `handsFree` is false (the transcript layer paused it). The mic —
-    // labeled "stop transcription" — must still turn the session off; gating
-    // the OFF path on `responding` left a lit, dead mic button until the reply
-    // finished.
-    const stopTranscriptionAndMic = vi.fn();
-    const toggleHandsFree = vi.fn();
-    render(
-      <ContinuousChatOverlay
-        controller={makeController({
-          transcriptionMode: true,
-          recording: true,
           responding: true,
-          handsFree: false,
-          stopTranscriptionAndMic,
-          toggleHandsFree,
+          canSend: false,
         } as unknown as Partial<ShellController>)}
       />,
     );
-    fireEvent.click(screen.getByTestId("chat-composer-mic"));
-    expect(stopTranscriptionAndMic).toHaveBeenCalledTimes(1);
-    expect(toggleHandsFree).not.toHaveBeenCalled();
+
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    fireEvent.pointerDown(grabber, { clientY: 420, pointerId: 1 });
+    fireEvent.pointerMove(grabber, { clientY: 280, pointerId: 1 });
+    fireEvent.pointerUp(grabber, { clientY: 280, pointerId: 1 });
+    expect(screen.getByTestId("chat-transcribing-badge")).toBeTruthy();
+    expect(screen.queryByTestId("chat-composer-plus")).toBeNull();
+    expect(screen.queryByTestId("chat-composer-textarea")).toBeNull();
+    expect(screen.getByTestId("chat-composer-mic-activity")).toBeTruthy();
+    expect(screen.queryByTestId("chat-composer-mic")).toBeNull();
+    expect(screen.queryByTestId("chat-composer-transcribe")).toBeNull();
+
+    const stopTranscription = screen.getByTestId(
+      "chat-composer-transcription-stop",
+    );
+    expect(stopTranscription.getAttribute("aria-label")).toBe(
+      "stop transcription",
+    );
+    // A stopped agent blocks delivery, not finalization back into the draft.
+    expect(stopTranscription.getAttribute("aria-disabled")).toBe("false");
+
+    const micStatus = screen.getByTestId("chat-composer-transcribe-status");
+    expect(micStatus.className).toContain("text-white/80");
+    expect(micStatus.className).not.toContain("text-accent");
+
+    const sendTranscription = screen.getByTestId("chat-composer-action");
+    expect(sendTranscription.getAttribute("aria-label")).toBe(
+      "send transcription (agent stopped)",
+    );
+    expect(sendTranscription.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("Stop drains a completed transcript into the existing draft without sending", async () => {
+    let sink:
+      | ((
+          segments: TranscriptSegment[],
+          startedAt: number,
+          audioWav: Uint8Array | null,
+        ) => void)
+      | null = null;
+    const send = vi.fn();
+    const toggleTranscriptionMode = vi.fn(async () => {
+      sink?.(
+        [
+          {
+            id: "s1",
+            startMs: 0,
+            endMs: 900,
+            text: "captured words",
+            words: [],
+          },
+        ],
+        1_700_000_000_000,
+        null,
+      );
+    });
+    const setTranscriptSessionSink = vi.fn((nextSink: typeof sink) => {
+      sink = nextSink;
+    });
+    const inactiveController = makeController({
+      send,
+      setTranscriptSessionSink,
+      toggleTranscriptionMode,
+    });
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={inactiveController} />,
+    );
+    fireEvent.change(screen.getByLabelText("message"), {
+      target: { value: "notes so far" },
+    });
+    rerender(
+      <ContinuousChatOverlay
+        controller={makeController({
+          send,
+          transcriptionMode: true,
+          setTranscriptSessionSink,
+          toggleTranscriptionMode,
+        })}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("chat-composer-transcription-stop"));
+    });
+    expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
+
+    rerender(<ContinuousChatOverlay controller={inactiveController} />);
+    expect(
+      (screen.getByLabelText("message") as HTMLTextAreaElement).value,
+    ).toBe("notes so far captured words");
+  });
+
+  it("Send drains and submits the combined draft and transcript exactly once", async () => {
+    let sink:
+      | ((
+          segments: TranscriptSegment[],
+          startedAt: number,
+          audioWav: Uint8Array | null,
+        ) => void)
+      | null = null;
+    const send = vi.fn();
+    const toggleTranscriptionMode = vi.fn(async () => {
+      sink?.(
+        [
+          {
+            id: "s1",
+            startMs: 0,
+            endMs: 900,
+            text: "captured words",
+            words: [],
+          },
+        ],
+        1_700_000_000_000,
+        null,
+      );
+    });
+    const setTranscriptSessionSink = vi.fn((nextSink: typeof sink) => {
+      sink = nextSink;
+    });
+    const inactiveController = makeController({
+      send,
+      setTranscriptSessionSink,
+      toggleTranscriptionMode,
+    });
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={inactiveController} />,
+    );
+    fireEvent.change(screen.getByLabelText("message"), {
+      target: { value: "notes so far" },
+    });
+    rerender(
+      <ContinuousChatOverlay
+        controller={makeController({
+          transcriptionMode: true,
+          send,
+          setTranscriptSessionSink,
+          toggleTranscriptionMode,
+        })}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("chat-composer-action"));
+    });
+    expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("notes so far captured words");
+  });
+
+  it("an empty finalization never sends and ignores a second in-flight tap", async () => {
+    let sink:
+      | ((
+          segments: TranscriptSegment[],
+          startedAt: number,
+          audioWav: Uint8Array | null,
+        ) => void)
+      | null = null;
+    let releaseDrain: (() => void) | null = null;
+    const send = vi.fn();
+    const toggleTranscriptionMode = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          sink?.([], 1_700_000_000_000, null);
+          releaseDrain = resolve;
+        }),
+    );
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          transcriptionMode: true,
+          send,
+          setTranscriptSessionSink: (nextSink: typeof sink) => {
+            sink = nextSink;
+          },
+          toggleTranscriptionMode,
+        })}
+      />,
+    );
+    const sendTranscription = screen.getByTestId("chat-composer-action");
+    fireEvent.click(sendTranscription);
+    fireEvent.click(sendTranscription);
+    expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
+    expect(
+      screen
+        .getByTestId("chat-composer-mic-activity")
+        .getAttribute("aria-label"),
+    ).toBe("Finishing transcription");
+    const micStatus = screen.getByTestId("chat-composer-transcribe-status");
+    expect(micStatus.getAttribute("aria-label")).toBe(
+      "Finishing transcription",
+    );
+    expect(micStatus.querySelector("svg")?.getAttribute("class")).not.toContain(
+      "animate-pulse",
+    );
+    expect(
+      screen
+        .getByTestId("chat-composer-transcription-stop")
+        .getAttribute("aria-label"),
+    ).toBe("finishing transcription");
+    expect(sendTranscription.getAttribute("aria-label")).toBe(
+      "send transcription (finishing)",
+    );
+
+    await act(async () => {
+      releaseDrain?.();
+    });
+  });
+
+  it("falls back to an editable draft when the agent stops during Send finalization", async () => {
+    let sink:
+      | ((
+          segments: TranscriptSegment[],
+          startedAt: number,
+          audioWav: Uint8Array | null,
+        ) => void)
+      | null = null;
+    let completeDrain: (() => void) | null = null;
+    const send = vi.fn();
+    const toggleTranscriptionMode = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completeDrain = () => {
+            sink?.(
+              [
+                {
+                  id: "s1",
+                  startMs: 0,
+                  endMs: 900,
+                  text: "keep these words",
+                  words: [],
+                },
+              ],
+              1_700_000_000_000,
+              null,
+            );
+            resolve();
+          };
+        }),
+    );
+    const setTranscriptSessionSink = (nextSink: typeof sink) => {
+      sink = nextSink;
+    };
+    const activeController = makeController({
+      transcriptionMode: true,
+      send,
+      setTranscriptSessionSink,
+      toggleTranscriptionMode,
+    });
+    const stoppedController = makeController({
+      canSend: false,
+      send,
+      setTranscriptSessionSink,
+      toggleTranscriptionMode,
+    });
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={activeController} />,
+    );
+
+    fireEvent.click(screen.getByTestId("chat-composer-action"));
+    rerender(<ContinuousChatOverlay controller={stoppedController} />);
+    await act(async () => {
+      completeDrain?.();
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(
+      (screen.getByLabelText("message") as HTMLTextAreaElement).value,
+    ).toBe("keep these words");
+    expect(screen.getByLabelText("send (agent stopped)")).toBeTruthy();
   });
 
   it("the audio-unlock chip works while the sheet is open (not swallowed as an outside tap)", () => {
@@ -2726,36 +2920,6 @@ describe("ContinuousChatOverlay", () => {
     expect(unlockAudio).toHaveBeenCalledTimes(1);
     // The sheet must stay open — the chip tap is not an outside collapse.
     expect(sheet.getAttribute("data-variant")).toBe("open");
-  });
-
-  it("does not enter push-to-talk on a long press while transcribing", () => {
-    vi.useFakeTimers();
-    try {
-      const stopTranscriptionAndMic = vi.fn();
-      const startRecording = vi.fn();
-      render(
-        <ContinuousChatOverlay
-          controller={makeController({
-            transcriptionMode: true,
-            stopTranscriptionAndMic,
-            startRecording,
-          } as unknown as Partial<ShellController>)}
-        />,
-      );
-
-      const mic = screen.getByTestId("chat-composer-mic");
-      fireEvent.pointerDown(mic, { button: 0, pointerId: 1 });
-      act(() => {
-        vi.advanceTimersByTime(250);
-      });
-      fireEvent.pointerUp(mic, { button: 0, pointerId: 1 });
-      fireEvent.click(mic);
-
-      expect(startRecording).not.toHaveBeenCalled();
-      expect(stopTranscriptionAndMic).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("push-to-talk dictates into the composer on release; the label matches (never 'send')", () => {
@@ -2893,6 +3057,61 @@ describe("ContinuousChatOverlay", () => {
     ).toBe("just words");
     expect(screen.queryByText(/^Recording .*\.wav$/)).toBeNull();
     expect(controller.send).not.toHaveBeenCalled();
+  });
+
+  it("keeps the oversized-recording warning visible when Send delivers the transcript", async () => {
+    let sink:
+      | ((
+          segments: TranscriptSegment[],
+          startedAt: number,
+          audioWav: Uint8Array | null,
+        ) => void)
+      | null = null;
+    const oversizedAudio = new Uint8Array([82, 73, 70, 70]);
+    Object.defineProperty(oversizedAudio, "byteLength", {
+      value: MAX_CHAT_MEDIA_RAW_BYTES + 1,
+    });
+    const send = vi.fn();
+    const toggleTranscriptionMode = vi.fn(() => {
+      sink?.(
+        [
+          {
+            id: "s1",
+            startMs: 0,
+            endMs: 900,
+            text: "keep the transcript",
+            words: [],
+          },
+        ],
+        1_700_000_000_000,
+        oversizedAudio,
+      );
+    });
+
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          transcriptionMode: true,
+          send,
+          setTranscriptSessionSink: (nextSink) => {
+            sink = nextSink;
+          },
+          toggleTranscriptionMode,
+        })}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("chat-composer-action"));
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("keep the transcript");
+    expect(screen.queryByText(/^Recording .*\.wav$/)).toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Recording too large to attach",
+    );
+    expect(screen.getByRole("alert").textContent).toContain("transcript kept");
   });
 
   // ── SheetGrabber inert-while-pilled (the symmetric half of the PillHandle

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -593,6 +593,109 @@ describe("ContinuousChatOverlay", () => {
     }
   });
 
+  it("keeps the resting home clearance fixed while the chat sheet is dragged open", async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let panelHeight = 76;
+    const resizeCallbacks: ResizeObserverCallback[] = [];
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect");
+    class TestResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback);
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+
+    try {
+      vi.stubGlobal("ResizeObserver", TestResizeObserver);
+      rectSpy.mockImplementation(function (this: HTMLElement) {
+        const height =
+          this.getAttribute("data-testid") === "chat-sheet" ? panelHeight : 0;
+        return {
+          width: 360,
+          height,
+          x: 0,
+          y: 0,
+          top: 0,
+          right: 360,
+          bottom: height,
+          left: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      });
+      document.documentElement.style.removeProperty(
+        "--eliza-continuous-chat-clearance",
+      );
+
+      render(<ContinuousChatOverlay controller={makeController()} />);
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--eliza-continuous-chat-clearance",
+        ),
+      ).toBe("76px");
+
+      const grabber = screen.getByTestId("chat-sheet-grabber");
+      fireEvent.pointerDown(grabber, {
+        clientY: 420,
+        pointerId: 1,
+        pointerType: "mouse",
+      });
+      fireEvent.pointerMove(grabber, {
+        clientY: 380,
+        pointerId: 1,
+        pointerType: "mouse",
+      });
+      // Live drag samples are coalesced to the display clock. Let that frame
+      // apply while the pointer remains held, then emulate the panel observer
+      // seeing the expanded preview height.
+      await act(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => resolve());
+          }),
+      );
+      panelHeight = 180;
+      const notifyResize = resizeCallbacks[0];
+      if (!notifyResize) throw new Error("chat panel was not observed");
+      act(() => notifyResize([], {} as ResizeObserver));
+
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--eliza-continuous-chat-clearance",
+        ),
+      ).toBe("76px");
+
+      // Change the eventual resting footprint while the preview is frozen,
+      // then cancel the pointer so the sheet settles back to INPUT without a
+      // tap/open decision. The settle completion must perform a fresh
+      // measurement even though the observer's last live-drag delivery was
+      // intentionally ignored.
+      panelHeight = 92;
+      fireEvent.pointerCancel(grabber, {
+        clientY: 380,
+        pointerId: 1,
+        pointerType: "mouse",
+      });
+      await waitFor(
+        () => {
+          expect(
+            document.documentElement.style.getPropertyValue(
+              "--eliza-continuous-chat-clearance",
+            ),
+          ).toBe("92px");
+        },
+        { timeout: 2_000 },
+      );
+    } finally {
+      rectSpy.mockRestore();
+      vi.stubGlobal("ResizeObserver", originalResizeObserver);
+      document.documentElement.style.removeProperty(
+        "--eliza-continuous-chat-clearance",
+      );
+    }
+  });
+
   it("recomputes the resting composer after portrait-landscape rotation", async () => {
     const originalInnerWidth = Object.getOwnPropertyDescriptor(
       window,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3449,7 +3449,7 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     openSearchFromComposerMenu();
     const searchLayer = screen.getByTestId("chat-message-search");
     expect(searchLayer.className).not.toContain("backdrop-blur");
-    expect(searchLayer.className).toContain("bg-black/20");
+    expect(searchLayer.className).not.toContain("bg-black");
     expect(screen.getByTestId("message-search-panel")).toBeTruthy();
     expect(thread().getAttribute("aria-hidden")).toBe("true");
     expect(thread().tabIndex).toBe(-1);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -4188,6 +4188,59 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     ).toEqual(["Stop", "Play audio"]);
   });
 
+  it("keeps the Speaking status on the older message that started playback", () => {
+    const speak = vi.fn();
+    const messages: ShellMessage[] = [
+      {
+        id: "older-assistant",
+        role: "assistant",
+        content: "older answer",
+        createdAt: 1,
+      },
+      {
+        id: "newer-assistant",
+        role: "assistant",
+        content: "newer answer",
+        createdAt: 2,
+      },
+    ];
+    const { rerender } = render(
+      <ContinuousChatOverlay
+        controller={makeController({ messages, speak, speaking: false })}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+    revealActionsFor("older answer");
+    const olderRow = screen
+      .getByText("older answer")
+      .closest('[data-testid="thread-line"]');
+    if (!olderRow) throw new Error("older message row not found");
+    fireEvent.click(
+      olderRow.querySelector(
+        '[data-testid="thread-line-speak"]',
+      ) as HTMLElement,
+    );
+
+    rerender(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages,
+          speak,
+          speaking: true,
+          responding: true,
+          turnStatus: { kind: "speaking" },
+        })}
+      />,
+    );
+
+    const statusRow = screen
+      .getByTestId("turn-status-accessory")
+      .closest('[data-testid="thread-line"]');
+    expect(statusRow).toBe(olderRow);
+    expect(statusRow?.textContent).toContain("Speaking");
+    expect(statusRow?.textContent).not.toContain("newer answer");
+  });
+
   it("row Copy writes the message text to the clipboard", () => {
     vi.mocked(copyTextToClipboard).mockClear();
     openThreadWith({

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3449,7 +3449,7 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     openSearchFromComposerMenu();
     const searchLayer = screen.getByTestId("chat-message-search");
     expect(searchLayer.className).not.toContain("backdrop-blur");
-    expect(searchLayer.className).not.toContain("bg-black");
+    expect(searchLayer.className).toContain("bg-black/20");
     expect(screen.getByTestId("message-search-panel")).toBeTruthy();
     expect(thread().getAttribute("aria-hidden")).toBe("true");
     expect(thread().tabIndex).toBe(-1);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3520,6 +3520,30 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     expect(thread().tabIndex).toBe(-1);
   });
 
+  it("keeps search-result scrolling from stepping or closing the chat sheet", () => {
+    const { controller } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    openSheet();
+    openSearchFromComposerMenu();
+
+    const sheet = screen.getByTestId("chat-sheet");
+    const searchScroller = screen.getByTestId("message-search-scroll");
+    expect(sheet.getAttribute("data-detent")).toBe("full");
+
+    // This bubbles through the fieldset's trackpad-detent handler. The search
+    // viewport must claim it before that handler interprets it as a sheet pull.
+    fireEvent.wheel(searchScroller, { deltaY: -120 });
+
+    // The pinned input is a sibling of the scroll viewport. Its wheel gesture
+    // still belongs to the open search mode and must never resize the sheet.
+    fireEvent.wheel(screen.getByTestId("message-search-input"), {
+      deltaY: -120,
+    });
+
+    expect(sheet.getAttribute("data-detent")).toBe("full");
+    expect(screen.getByTestId("chat-message-search")).toBeTruthy();
+  });
+
   it("drives the header search → query → jump path against the real search API shape (#14330)", async () => {
     // Real jump plumbing: the overlay pulls handleSelectConversation from the
     // AppContext store, so seed it with a spy the jump must call. Mirror the

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -3601,7 +3601,7 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     await waitFor(() =>
       expect(bubble?.getAttribute("data-chat-search-highlight")).toBe("true"),
     );
-    expect(bubble?.style.outline).toContain("var(--accent)");
+    expect(bubble?.style.outline).toContain("rgba(255, 255, 255, 0.96)");
     expect(bubble?.style.outlineOffset).toBe("-2px");
     await waitFor(() =>
       expect(screen.queryByTestId("chat-message-search")).toBeNull(),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1889,6 +1889,67 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.queryByText("Stop transcribing")).toBeNull();
   });
 
+  it.each([
+    "half",
+    "full",
+  ] as const)("keeps the %s sheet open while the portaled Upload action opens the file picker", (detent) => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+
+    fireEvent.focus(input);
+    expect(sheet.getAttribute("data-detent")).toBe("half");
+    if (detent === "full") {
+      fireEvent.pointerDown(grabber, { clientY: 420, pointerId: 10 });
+      fireEvent.pointerMove(grabber, { clientY: 280, pointerId: 10 });
+      fireEvent.pointerUp(grabber, { clientY: 280, pointerId: 10 });
+      expect(sheet.getAttribute("data-detent")).toBe("full");
+    }
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const openPicker = vi
+      .spyOn(fileInput, "click")
+      .mockImplementation(() => {});
+    fireEvent.pointerDown(screen.getByTestId("chat-composer-plus"), {
+      button: 0,
+      pointerId: 11,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerUp(screen.getByTestId("chat-composer-plus"), {
+      button: 0,
+      pointerId: 11,
+      pointerType: "mouse",
+    });
+    const upload = screen.getByText("Upload file").closest('[role="menuitem"]');
+    if (!(upload instanceof HTMLElement)) {
+      throw new Error("Upload menu item not found");
+    }
+
+    // Drive the complete pointer sequence: the regression lived in the
+    // document capture handlers and a synthetic click alone could not see it.
+    fireEvent.pointerDown(upload, {
+      button: 0,
+      clientX: 40,
+      clientY: 40,
+      pointerId: 12,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerUp(upload, {
+      button: 0,
+      clientX: 40,
+      clientY: 40,
+      pointerId: 12,
+      pointerType: "mouse",
+    });
+    fireEvent.click(upload);
+
+    expect(openPicker).toHaveBeenCalledTimes(1);
+    expect(sheet.getAttribute("data-detent")).toBe(detent);
+  });
+
   it("attaches an image and enables an image-only send", async () => {
     const controller = makeController({ messages: [] });
     render(<ContinuousChatOverlay controller={controller} />);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -4140,6 +4140,34 @@ describe("ContinuousChatOverlay — per-message action row (#10713)", () => {
     ).toBeNull();
   });
 
+  it("keeps reply state inside the bounded thread and clears it when the sheet closes", async () => {
+    openThreadWith({
+      messages: [
+        {
+          id: "reply-source",
+          role: "assistant",
+          content: "Reply without moving the sheet",
+          createdAt: 1,
+        },
+      ],
+    });
+    const sheet = screen.getByTestId("chat-sheet");
+    const detentBeforeReply = sheet.getAttribute("data-detent");
+
+    revealActionsFor("Reply without moving the sheet");
+    fireEvent.click(screen.getByTestId("thread-line-reply"));
+
+    const replyPill = screen.getByTestId("chat-reply-pill");
+    expect(screen.getByTestId("chat-thread").contains(replyPill)).toBe(true);
+    expect(sheet.getAttribute("data-detent")).toBe(detentBeforeReply);
+
+    fireEvent.keyDown(screen.getByLabelText("message"), { key: "Escape" });
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+    await waitFor(() => {
+      expect(screen.queryByTestId("chat-reply-pill")).toBeNull();
+    });
+  });
+
   it("Play speaks the assistant message via the controller", () => {
     const speak = vi.fn();
     openThreadWith({

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1638,8 +1638,10 @@ export function ContinuousChatOverlay({
   // space the collapsed composer occupies. Without this the var was never set —
   // every surface rode the 5.25rem fallback, which a multi-line draft or pending
   // attachments overgrow, letting the composer cover content. Only measured
-  // while collapsed: an expanded/full sheet covers the screen, so its height
-  // must NOT become the reserved clearance.
+  // while collapsed and settled: an expanded/full sheet covers the screen, and
+  // a direct pull grows this same panel before the open mode commits. Neither
+  // transient height may become reserved clearance or the home content behind
+  // the sheet will reflow under the user's finger.
   React.useEffect(() => {
     if (
       typeof window === "undefined" ||
@@ -1649,9 +1651,17 @@ export function ContinuousChatOverlay({
     }
     const panel = getPanelElement();
     const root = document.documentElement;
-    if (sheetOpen) return; // Keep the last resting value while the sheet is open.
+    // Re-entering this effect when the release spring clears `isDragging`
+    // guarantees one final measurement even when ResizeObserver delivered its
+    // last size notification while the transient-height guard was still armed.
+    if (sheetOpen || isDragging) return;
     if (!panel) return;
     const publish = () => {
+      // `draggingRef` owns direct manipulation; `isDraggingRef` stays armed
+      // through the release spring. Freeze the last resting footprint for both
+      // phases so opening chat never feeds its live panel height back into the
+      // home layout that sits behind it.
+      if (draggingRef.current || isDraggingRef.current) return;
       const h = panel.getBoundingClientRect().height;
       // Cap it: a mid-collapse frame can report the open panel height, and
       // reserving that in the home/launcher layout clips the top apps off-screen.
@@ -1665,7 +1675,7 @@ export function ContinuousChatOverlay({
     const ro = new ResizeObserver(publish);
     ro.observe(panel);
     return () => ro.disconnect();
-  }, [sheetOpen, getPanelElement]);
+  }, [sheetOpen, isDragging, getPanelElement]);
   // The composer content (textarea + thread). Held so we can imperatively clear
   // its `inert` (set while pilled) the instant the pill is tapped open, before
   // React re-renders — iOS only raises the keyboard for a focus() that lands on

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5473,17 +5473,12 @@ export function ContinuousChatOverlay({
                   <div
                     data-testid="chat-message-search"
                     data-keyboard-open={keyboardLiftActive ? "true" : undefined}
-                    // Bottom-anchored, NON-scrolling flex column. The panel
-                    // itself owns scrolling in its results region and pins its
-                    // search input to the bottom (`keyboard-anchored` layout),
-                    // so the input the user types into always sits right above
-                    // a raised soft keyboard — the whole overlay is already
-                    // lifted by `effectiveKeyboardInset`, so the panel bottom IS
-                    // the top of the keyboard. Making THIS wrapper scroll (the
-                    // old `overflow-y-auto`) let the input scroll away under the
-                    // keyboard on iOS; keep it `overflow-hidden` and let the
-                    // inner results list be the only scroll region.
-                    className="absolute inset-0 z-30 flex flex-col overflow-hidden bg-black/20 px-4 pb-3 pt-2 backdrop-blur-md"
+                    // The sheet already owns the glass surface. Search reuses
+                    // that single layer while the transcript beneath is hidden
+                    // and inert, avoiding the opaque double-blur slab that a
+                    // second backdrop produced. Only the inner results list
+                    // scrolls, keeping the input pinned above the keyboard.
+                    className="absolute inset-0 z-30 flex flex-col overflow-hidden px-4 pb-3 pt-2"
                   >
                     <MessageSearchPanel
                       search={runMessageSearch}
@@ -5502,7 +5497,7 @@ export function ContinuousChatOverlay({
                   <MessageScroller>
                     <motion.div
                       className="flex min-h-0 w-full flex-1 flex-col"
-                      style={{ opacity: threadContentOpacity }}
+                      style={{ opacity: searchOpen ? 0 : threadContentOpacity }}
                     >
                       <MessageScrollerViewport
                         id="continuous-thread"
@@ -5510,8 +5505,8 @@ export function ContinuousChatOverlay({
                         ref={threadRef}
                         preserveScrollOnPrepend={false}
                         aria-label="conversation history"
-                        aria-hidden={!sheetOpen ? true : undefined}
-                        tabIndex={sheetOpen ? 0 : -1}
+                        aria-hidden={!sheetOpen || searchOpen ? true : undefined}
+                        tabIndex={sheetOpen && !searchOpen ? 0 : -1}
                         onKeyDown={(e) => {
                           if (e.key === "Escape") {
                             e.preventDefault();

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -2035,21 +2035,62 @@ export function ContinuousChatOverlay({
       }),
     [],
   );
-  const scrollAndFlashSearchAnchor = React.useCallback((el: HTMLElement) => {
-    el.scrollIntoView({ block: "center", behavior: "smooth" });
-    el.style.transition = "outline-color 0.5s ease-out";
-    el.style.outline = "2px solid var(--primary)";
-    el.style.outlineOffset = "2px";
-    el.style.borderRadius = "8px";
-    window.setTimeout(() => {
-      el.style.outline = "2px solid transparent";
-    }, 1200);
-    window.setTimeout(() => {
-      el.style.removeProperty("outline");
-      el.style.removeProperty("outline-offset");
-      el.style.removeProperty("transition");
-    }, 1800);
+  const activeSearchHighlightRef = React.useRef<{
+    element: HTMLElement;
+    fadeTimer: number;
+    cleanupTimer: number;
+    outline: string;
+    outlineOffset: string;
+    transition: string;
+  } | null>(null);
+  const clearSearchHighlight = React.useCallback(() => {
+    const active = activeSearchHighlightRef.current;
+    if (!active) return;
+    window.clearTimeout(active.fadeTimer);
+    window.clearTimeout(active.cleanupTimer);
+    active.element.style.outline = active.outline;
+    active.element.style.outlineOffset = active.outlineOffset;
+    active.element.style.transition = active.transition;
+    active.element.removeAttribute("data-chat-search-highlight");
+    activeSearchHighlightRef.current = null;
   }, []);
+  React.useEffect(() => clearSearchHighlight, [clearSearchHighlight]);
+  const scrollAndFlashSearchAnchor = React.useCallback(
+    (el: HTMLElement) => {
+      clearSearchHighlight();
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      // Message-scroller rows use paint containment for long-thread performance,
+      // so an outward row outline is clipped. Paint the accent inside the actual
+      // bubble instead; this stays visible without disturbing its liquid-glass
+      // shadow or layout.
+      const bubble =
+        el.querySelector<HTMLElement>('[data-chat-message-bubble="true"]') ??
+        el;
+      const previous = {
+        outline: bubble.style.outline,
+        outlineOffset: bubble.style.outlineOffset,
+        transition: bubble.style.transition,
+      };
+      bubble.setAttribute("data-chat-search-highlight", "true");
+      bubble.style.outline = "2px solid var(--accent)";
+      bubble.style.outlineOffset = "-2px";
+      bubble.style.transition =
+        "outline-color 650ms cubic-bezier(0.22, 1, 0.36, 1)";
+      const fadeTimer = window.setTimeout(() => {
+        bubble.style.outline = "2px solid transparent";
+      }, 1050);
+      const cleanupTimer = window.setTimeout(() => {
+        clearSearchHighlight();
+      }, 1750);
+      activeSearchHighlightRef.current = {
+        element: bubble,
+        fadeTimer,
+        cleanupTimer,
+        ...previous,
+      };
+    },
+    [clearSearchHighlight],
+  );
   const handleSearchJump = React.useCallback(
     (result: ConversationMessageSearchResult) => {
       const anchorId = getChatMessageAnchorId(result.messageId);
@@ -2166,7 +2207,12 @@ export function ContinuousChatOverlay({
             }
           : undefined;
       return (
-        <MessageScrollerItem key={m.id} messageId={m.id} className="w-full">
+        <MessageScrollerItem
+          key={m.id}
+          id={getChatMessageAnchorId(m.id)}
+          messageId={m.id}
+          className="w-full"
+        >
           <ChatMessage
             actionAccessory={
               responding && m.id === turnStatusAnchorId ? (
@@ -5505,7 +5551,9 @@ export function ContinuousChatOverlay({
                         ref={threadRef}
                         preserveScrollOnPrepend={false}
                         aria-label="conversation history"
-                        aria-hidden={!sheetOpen || searchOpen ? true : undefined}
+                        aria-hidden={
+                          !sheetOpen || searchOpen ? true : undefined
+                        }
                         tabIndex={sheetOpen && !searchOpen ? 0 : -1}
                         onKeyDown={(e) => {
                           if (e.key === "Escape") {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -2058,7 +2058,7 @@ export function ContinuousChatOverlay({
       clearSearchHighlight();
       el.scrollIntoView({ block: "center", behavior: "smooth" });
       // Message-scroller rows use paint containment for long-thread performance,
-      // so an outward row outline is clipped. Paint the accent inside the actual
+      // so an outward row outline is clipped. Paint the flash inside the actual
       // bubble instead; this stays visible without disturbing its liquid-glass
       // shadow or layout.
       const bubble =
@@ -2070,7 +2070,7 @@ export function ContinuousChatOverlay({
         transition: bubble.style.transition,
       };
       bubble.setAttribute("data-chat-search-highlight", "true");
-      bubble.style.outline = "2px solid var(--accent)";
+      bubble.style.outline = "2px solid rgba(255, 255, 255, 0.96)";
       bubble.style.outlineOffset = "-2px";
       bubble.style.transition =
         "outline-color 650ms cubic-bezier(0.22, 1, 0.36, 1)";

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5478,7 +5478,7 @@ export function ContinuousChatOverlay({
                     // and inert, avoiding the opaque double-blur slab that a
                     // second backdrop produced. Only the inner results list
                     // scrolls, keeping the input pinned above the keyboard.
-                    className="absolute inset-0 z-30 flex flex-col overflow-hidden bg-black/20 px-4 pb-3 pt-2"
+                    className="absolute inset-0 z-30 flex flex-col overflow-hidden px-4 pb-3 pt-2"
                   >
                     <MessageSearchPanel
                       search={runMessageSearch}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3443,7 +3443,10 @@ export function ContinuousChatOverlay({
   const wheelStepDecayRef = React.useRef<number | null>(null);
   const onSheetWheel = React.useCallback(
     (e: React.WheelEvent) => {
-      if (firstRunOpen || draggingRef.current) return;
+      // Search is a modal interaction inside the full-height sheet. Every wheel
+      // gesture belongs to its query/results surface, including gestures that
+      // begin over the pinned input rather than the scrolling result viewport.
+      if (firstRunOpen || draggingRef.current || searchOpen) return;
       if (
         e.target instanceof Element &&
         e.target.closest("#continuous-thread, [data-chat-sheet-scroll-region]")
@@ -3482,6 +3485,7 @@ export function ContinuousChatOverlay({
     },
     [
       firstRunOpen,
+      searchOpen,
       pilled,
       sheetOpen,
       expanded,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -769,9 +769,9 @@ function MessageScrollerSendFollow({ request }: { request: number }) {
 }
 
 /**
- * The rich, phase-aware status row shown while the assistant works (#8813),
- * replacing the bare typing dots in the pre-placeholder gap. Wraps the
- * canonical TurnStatus in its own glass bubble + fade so it reads as a turn.
+ * The phase-aware status row shown while the assistant works (#8813). It stays
+ * chromeless so the temporary lifecycle state cannot be mistaken for a message;
+ * the same compact shimmer is used before and after the placeholder arrives.
  */
 function TurnStatusIndicator({
   status,
@@ -780,29 +780,18 @@ function TurnStatusIndicator({
   status: ChatTurnStatus | null;
   reduce?: boolean;
 }): React.JSX.Element {
-  const speaking = status?.kind === "speaking";
   return (
     <motion.div
-      className="mb-2.5 flex w-full justify-start"
-      // Fade in/out so the row dissolves with the reply rather than popping.
+      className="mb-2 flex w-full justify-start py-1"
+      data-testid="turn-status-row"
+      // A pure opacity dissolve avoids adding another moving surface while the
+      // real assistant turn mounts and begins streaming beneath it.
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: reduce ? 0 : 0.45, ease: OVERLAY_EASE }}
     >
-      <div
-        className={cn(
-          "rounded-2xl rounded-bl-md border px-3.5 py-2",
-          WALLPAPER_FLOAT_SHADOW,
-          // Orange (the accent) ONLY for spoken replies; every other phase is
-          // neutral white glass. No blue anywhere.
-          // #10698: no own scrim — the shared panel glass carries the contrast;
-          // keep only the tone border (orange when speaking) + WALLPAPER_FLOAT_SHADOW.
-          speaking ? "border-accent/45" : "border-border",
-        )}
-      >
-        <TurnStatus status={status} />
-      </div>
+      <TurnStatus status={status} showLabel={false} />
     </motion.div>
   );
 }
@@ -829,12 +818,14 @@ function ThreadLineText({ content }: { content: string }): React.ReactNode {
 
 /**
  * The overlay's message BODY — everything rendered inside the canonical
- * ChatMessage glass row: the no-provider recovery gate, the in-flight breathing
- * dots (TurnStatus), a user turn's slash-bolded text, and a settled assistant
- * turn's inline widgets + attachments + secret request + reasoning. Kept
- * structurally identical to the ChatView (MessageContent) paths for the
- * affordances the render-parity contract pins; the row chrome (bubble,
- * tap-reveal actions, copy-hold, retry, suggestion) lives in ChatMessage.
+ * ChatMessage glass row: the no-provider recovery gate, a user turn's
+ * slash-bolded text, and a settled assistant turn's inline widgets + attachments
+ * + secret request + reasoning. Transient work state lives in one stable row
+ * after the transcript, so an empty transport placeholder never paints a second
+ * status surface. Its settled content stays structurally identical to ChatView's
+ * MessageContent paths for the affordances the render-parity contract pins; row
+ * chrome (bubble, tap-reveal actions, copy-hold, retry, suggestion) lives in
+ * ChatMessage.
  * `onOpenSettings` reaches only the no-provider gate.
  */
 function renderOverlayMessageBody(
@@ -879,15 +870,7 @@ function renderOverlayMessageBody(
   }
 
   if (!isUser && !message.text.trim() && !message.attachments?.length) {
-    // The in-flight assistant turn: dots INSIDE the bubble, anchored where the
-    // streamed text fills in — then the text replaces them. Labels stay in the
-    // standalone status row so the bubble never flashes "Running …" text.
-    return (
-      <>
-        <TurnStatus status={ctx?.turnStatus ?? null} showLabel={false} />
-        {attachmentsNode}
-      </>
-    );
+    return null;
   }
 
   if (isUser) {
@@ -1980,7 +1963,7 @@ export function ContinuousChatOverlay({
   }, []);
   // The single, stable body renderer handed to every row (see
   // renderOverlayMessageBody). Stable identity keeps ChatMessage's memo intact;
-  // per-row volatile values (turnStatus/suppressReasoning) flow via renderContext.
+  // per-row reasoning suppression flows through renderContext.
   const renderRowBody = React.useCallback(
     (m: ChatMessageData, ctx: ChatMessageRenderContext | undefined) =>
       renderOverlayMessageBody(m, ctx, openSettings),
@@ -2005,13 +1988,24 @@ export function ContinuousChatOverlay({
     (m: ShellMessage, index: number) => {
       const isLastAssistant =
         index === visibleMessages.length - 1 && m.role === "assistant";
-      const isInFlight = isLastAssistant && !m.content.trim();
-      // Only the last assistant turn reads volatile status; every settled row
-      // gets no renderContext so its memo identity is unchanged.
+      const message = shellToChatMessageData(m);
+      const isInFlight =
+        isLastAssistant &&
+        !message.text.trim() &&
+        !message.attachments?.length &&
+        !message.failureKind &&
+        !message.reasoning?.trim() &&
+        !message.secretRequest &&
+        !message.toolEvents?.length;
+      // The server's empty assistant placeholder is deliberately not a visual
+      // turn. Keeping the single status row mounted across this transport state
+      // prevents a Thinking/Replying bubble swap before the first token lands.
+      if (isInFlight) return null;
+      // Only the last assistant turn reads volatile reasoning suppression;
+      // every settled row gets no renderContext so its memo identity is stable.
       const renderContext: ChatMessageRenderContext | undefined =
         isLastAssistant
           ? {
-              turnStatus: isInFlight ? turnStatus : null,
               suppressReasoning: responding,
             }
           : undefined;
@@ -2021,7 +2015,7 @@ export function ContinuousChatOverlay({
             appearance="glass"
             enterOnMount={m.id.startsWith("temp-")}
             agentName={agentName}
-            message={shellToChatMessageData(m)}
+            message={message}
             reduceMotion={reduce}
             onCopy={handleCopyMessage}
             onLongPressCopy={handleLongPressCopy}
@@ -2053,7 +2047,6 @@ export function ContinuousChatOverlay({
       speaking,
       playingMessageId,
       responding,
-      turnStatus,
       renderRowBody,
       handleAcceptSuggestion,
       handleDismissSuggestion,
@@ -5463,10 +5456,7 @@ export function ContinuousChatOverlay({
                                   );
                                 });
                               })()
-                            : // Flat transcript (no topic tags) — unchanged behavior.
-                              // Only the LAST, content-less assistant turn (the
-                              // in-flight one) reads turnStatus — every settled bubble
-                              // gets undefined so its memo identity is unchanged.
+                            : // Flat transcript (no topic tags) renders below.
                               null}
                           {hasTopics
                             ? null
@@ -5474,18 +5464,12 @@ export function ContinuousChatOverlay({
                                 renderThreadLine(m, i),
                               )}
                           <AnimatePresence>
-                            {/* Rich status row (#8813): what the agent is doing —
-                          thinking / running an action / waking / speaking — for
-                          the brief window where we're responding but the assistant
-                          placeholder turn isn't in the thread yet. Once the
-                          in-flight assistant bubble exists it carries the same
-                          status row inline (anchored where the reply fills in),
-                          so don't double up. */}
-                            {responding &&
-                            !(
-                              visibleMessages.at(-1)?.role === "assistant" &&
-                              !visibleMessages.at(-1)?.content.trim()
-                            ) ? (
+                            {/* One persistent inline status (#8813) spans the
+                          whole active turn. The server's empty assistant
+                          placeholder never replaces it, so rapid Thinking →
+                          Replying phases update one shimmer instead of flashing
+                          between temporary message bubbles. */}
+                            {responding ? (
                               <MessageScrollerItem
                                 key="turn-status"
                                 className="w-full"

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5478,7 +5478,7 @@ export function ContinuousChatOverlay({
                     // and inert, avoiding the opaque double-blur slab that a
                     // second backdrop produced. Only the inner results list
                     // scrolls, keeping the input pinned above the keyboard.
-                    className="absolute inset-0 z-30 flex flex-col overflow-hidden px-4 pb-3 pt-2"
+                    className="absolute inset-0 z-30 flex flex-col overflow-hidden bg-black/20 px-4 pb-3 pt-2"
                   >
                     <MessageSearchPanel
                       search={runMessageSearch}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -568,6 +568,90 @@ function SoftButton({
   );
 }
 
+const COMPOSER_MIC_BARS = [
+  { id: "outer-left", height: 10 },
+  { id: "mid-left", height: 16 },
+  { id: "inner-left", height: 22 },
+  { id: "center", height: 28 },
+  { id: "inner-right", height: 22 },
+  { id: "mid-right", height: 16 },
+  { id: "outer-right", height: 10 },
+] as const;
+
+// Audio-frame writes stay imperative so live microphone activity never
+// rerenders the chat tree while transcription owns the composer's text lane.
+function ComposerMicActivity({
+  analyser,
+  finishing,
+  reduceMotion,
+  transcript,
+}: {
+  analyser: AnalyserNode | null;
+  finishing: boolean;
+  reduceMotion: boolean;
+  transcript: string;
+}): React.JSX.Element {
+  const barsRef = React.useRef<Array<HTMLSpanElement | null>>([]);
+
+  React.useEffect(() => {
+    if (!analyser || finishing || reduceMotion) return;
+    const samples = new Uint8Array(analyser.fftSize);
+    let frame = 0;
+    const renderFrame = () => {
+      analyser.getByteTimeDomainData(samples);
+      let energy = 0;
+      for (const sample of samples) {
+        const normalized = (sample - 128) / 128;
+        energy += normalized * normalized;
+      }
+      const rms = Math.sqrt(energy / Math.max(samples.length, 1));
+      const activity = Math.min(1, Math.max(0.14, rms * 5));
+      barsRef.current.forEach((bar, index) => {
+        if (!bar) return;
+        const centerWeight = 1 - Math.abs(index - 3) * 0.1;
+        bar.style.transform = `scaleY(${Math.max(0.18, activity * centerWeight)})`;
+      });
+      frame = window.requestAnimationFrame(renderFrame);
+    };
+    frame = window.requestAnimationFrame(renderFrame);
+    return () => window.cancelAnimationFrame(frame);
+  }, [analyser, finishing, reduceMotion]);
+
+  return (
+    <div
+      role="status"
+      aria-label={
+        finishing ? "Finishing transcription" : "Live microphone activity"
+      }
+      data-testid="chat-composer-mic-activity"
+      className="flex min-h-8 min-w-0 flex-1 items-center justify-center gap-1.5 px-3 text-txt"
+    >
+      <span className="sr-only" aria-live="polite">
+        {finishing
+          ? "Finishing transcription"
+          : transcript.trim() || "Listening"}
+      </span>
+      {COMPOSER_MIC_BARS.map(({ id, height }, index) => (
+        <span
+          // The fixed seven-bar geometry is presentation-only and never reorders.
+          key={id}
+          ref={(node) => {
+            barsRef.current[index] = node;
+          }}
+          aria-hidden="true"
+          className={cn(
+            "w-1 origin-center rounded-full bg-current shadow-[0_0_9px_rgba(255,255,255,0.38)] transition-transform duration-75",
+            !finishing &&
+              !analyser &&
+              "animate-pulse motion-reduce:animate-none",
+          )}
+          style={{ height, transform: "scaleY(0.32)" }}
+        />
+      ))}
+    </div>
+  );
+}
+
 /** Inert conversation-nav fallback for minimal mock controllers. */
 const EMPTY_CONVERSATION_NAV: ConversationNav = {
   hasPrev: false,
@@ -1059,13 +1143,14 @@ export function ContinuousChatOverlay({
     send,
     canSend,
     recording,
+    analyser,
+    transcript,
     startRecording,
     stopRecording,
     handsFree,
     toggleHandsFree,
     transcriptionMode,
     toggleTranscriptionMode,
-    stopTranscriptionAndMic,
     setDictationSink,
     setTranscriptSessionSink,
     setComposerHasDraft,
@@ -1254,6 +1339,19 @@ export function ContinuousChatOverlay({
   // without subscribing (dictation append), same pattern as messagesRef above.
   const draftRef = React.useRef(draft);
   draftRef.current = draft;
+  const pendingImagesRef = React.useRef(pendingImages);
+  pendingImagesRef.current = pendingImages;
+  // Session completion is normally delivered back into the editable draft.
+  // The transcription Send control changes that disposition for exactly one
+  // drain/finalize cycle without teaching the voice engine about composer UI.
+  const transcriptionDeliveryRef = React.useRef<"draft" | "send">("draft");
+  // Finalization drains the capture asynchronously. An immediate ref closes
+  // the same-frame double-tap gap before React can paint the disabled controls.
+  const transcriptionFinishingRef = React.useRef(false);
+  const [transcriptionFinishing, setTranscriptionFinishing] =
+    React.useState(false);
+  const transcriptionComposerActive =
+    transcriptionMode || transcriptionFinishing;
   // Live handle to the active conversation id for the send path's draft clear,
   // so submitText keeps its stable identity.
   const activeConversationIdRef = React.useRef(activeConversationId);
@@ -2184,6 +2282,31 @@ export function ContinuousChatOverlay({
     [canSend, firstRunOpen, send, setDraft, setPendingImages, viewChatBinding],
   );
 
+  const finishTranscription = React.useCallback(
+    async (delivery: "draft" | "send") => {
+      if (transcriptionFinishingRef.current) return;
+      transcriptionFinishingRef.current = true;
+      setTranscriptionFinishing(true);
+      transcriptionDeliveryRef.current = delivery;
+      try {
+        await toggleTranscriptionMode();
+      } finally {
+        // An empty/error session never reaches the sink. Reset here as well so
+        // its delivery intent cannot leak into a later recording.
+        transcriptionDeliveryRef.current = "draft";
+        transcriptionFinishingRef.current = false;
+        setTranscriptionFinishing(false);
+        // The textarea remounts only after the finishing guard drops. Restore
+        // focus on the next frame so Stop opens the editable result and Send
+        // leaves the composer ready for the next turn.
+        if (typeof window !== "undefined") {
+          window.requestAnimationFrame(() => inputRef.current?.focus());
+        }
+      }
+    },
+    [toggleTranscriptionMode],
+  );
+
   const addImageFiles = React.useCallback(
     (files: FileList | File[]) => {
       void intakeAttachmentFiles(files)
@@ -2262,20 +2385,6 @@ export function ContinuousChatOverlay({
       voiceCaptureDebug("mic:noop", { reason: "suppress-click" });
       return;
     }
-    // While transcribing, the mic is the master voice control: a tap turns the
-    // mic OFF, which also ends transcription (mic = parent — turning off the mic
-    // turns off transcript). This is distinct from the transcript button, which
-    // turns transcript off but LEAVES THE MIC ON. The finished transcript still
-    // drops into the composer as an attachment. This OFF path is checked FIRST
-    // — never gated on `responding`: a wake-word inline reply (#9880) flips
-    // `responding` true while `handsFree` stays false mid-transcription, and
-    // gating it left a lit, dead "stop transcription" mic until the reply
-    // finished.
-    if (transcriptionMode) {
-      voiceCaptureDebug("mic:branch", { action: "stop-transcription" });
-      stopTranscriptionAndMic();
-      return;
-    }
     // Voice can't be turned ON while a reply is in flight (it's gated until the
     // turn finishes), but an active hands-free session can always be turned OFF.
     if (responding && !handsFree) {
@@ -2291,7 +2400,6 @@ export function ContinuousChatOverlay({
     handsFree,
     toggleHandsFree,
     transcriptionMode,
-    stopTranscriptionAndMic,
     shouldSuppressClick,
   ]);
 
@@ -3521,30 +3629,29 @@ export function ContinuousChatOverlay({
     return () => setDictationSink(null);
   }, [setDictationSink, setDraft, expand]);
 
-  // A completed transcription SESSION works like ChatGPT dictation: the full
-  // transcript is INSERTED AS TEXT at the end of the composer draft — never
-  // auto-sent, never a document chip the user has to open. The captured audio
-  // becomes a pending AUDIO ATTACHMENT (the sharable artifact: sending it
-  // routes the WAV through the content-addressed media store, so the thread
-  // carries a playable, downloadable /api/media/<sha256>.wav recording). The
-  // session is also archived (Transcript record + audio) for the Transcripts
-  // view, best-effort and silent.
+  // A completed transcription session has one drain path. Stop returns its text
+  // and optional recording to the editable composer; Send delivers that exact
+  // combined payload directly, avoiding a render-timing race between draining
+  // the capture and submitting the draft. Both paths still archive the session.
   React.useEffect(() => {
     setTranscriptSessionSink((segments, startedAtMs, audioWav) => {
       if (segments.length === 0) return;
+      const delivery = transcriptionDeliveryRef.current;
+      transcriptionDeliveryRef.current = "draft";
       const text = transcriptPlainText(segments);
       const stamp = new Date(startedAtMs)
         .toISOString()
         .slice(0, 16)
         .replace("T", " ");
-      if (text) {
-        // Append at the END of whatever is already typed (through the live
-        // ref — the shared context setter takes a plain string), mirroring the
-        // push-to-talk dictation sink above.
-        const current = draftRef.current;
-        setDraft(current ? `${current} ${text}` : text);
-      }
+      const currentDraft = draftRef.current;
+      const combinedText = text
+        ? currentDraft
+          ? `${currentDraft} ${text}`
+          : text
+        : currentDraft;
       const hasAudio = Boolean(audioWav && audioWav.byteLength > 0);
+      let recordingAttachment: ImageAttachment | null = null;
+      let recordingError: string | null = null;
       if (audioWav && hasAudio) {
         // Enforce the SAME per-file media size cap the attach/paste/drop paths
         // go through (intakeAttachmentFiles → perFileByteCap): a several-minute
@@ -3553,23 +3660,38 @@ export function ContinuousChatOverlay({
         // cap, drop just the audio artifact — the transcript TEXT inserted above
         // is the primary output and always lands — and say so inline.
         if (audioWav.byteLength > MAX_CHAT_MEDIA_RAW_BYTES) {
-          setImageError(
-            `Recording too large to attach (max ${bytesToMb(
-              MAX_CHAT_MEDIA_RAW_BYTES,
-            )}MB) — transcript kept.`,
-          );
+          recordingError = `Recording too large to attach (max ${bytesToMb(
+            MAX_CHAT_MEDIA_RAW_BYTES,
+          )}MB) — transcript kept.`;
         } else {
-          const recording: ImageAttachment = {
+          recordingAttachment = {
             data: wavBytesToBase64(audioWav),
             mimeType: "audio/wav",
             name: `Recording ${stamp}.wav`,
           };
-          setPendingImages((prev) =>
-            [...prev, recording].slice(0, MAX_CHAT_IMAGES),
-          );
         }
       }
-      if (text || hasAudio) {
+      const combinedImages = recordingAttachment
+        ? [...pendingImagesRef.current, recordingAttachment].slice(
+            0,
+            MAX_CHAT_IMAGES,
+          )
+        : pendingImagesRef.current;
+      // Agent availability can change while the microphone drains. Never discard
+      // the finished session because Send was valid at pointer-down but no longer
+      // valid when the final ASR payload arrives; preserve it as an editable draft.
+      const deliverImmediately =
+        delivery === "send" && canSend && !firstRunOpen;
+      if (deliverImmediately) {
+        submitText(combinedText, combinedImages);
+      } else {
+        if (text) setDraft(combinedText);
+        if (recordingAttachment) setPendingImages(combinedImages);
+      }
+      // submitText clears attachment errors as part of a successful send. Apply
+      // this notice afterwards so a sent transcript never silently omits its WAV.
+      if (recordingError) setImageError(recordingError);
+      if (!deliverImmediately && (text || hasAudio)) {
         expand();
         inputRef.current?.focus();
       }
@@ -3584,12 +3706,25 @@ export function ContinuousChatOverlay({
               }
             : {}),
         })
-        .catch(() => {
-          /* archival is best-effort; a failed save just skips the record */
+        .catch((err: unknown) => {
+          // error-policy:J7 transcript archival must not break composer delivery;
+          // the failed diagnostic artifact remains observable to developers.
+          logger.warn(
+            { err },
+            "[ContinuousChatOverlay] transcript archive failed",
+          );
         });
     });
     return () => setTranscriptSessionSink(null);
-  }, [setTranscriptSessionSink, setDraft, setPendingImages, expand]);
+  }, [
+    setTranscriptSessionSink,
+    setDraft,
+    setPendingImages,
+    submitText,
+    expand,
+    canSend,
+    firstRunOpen,
+  ]);
 
   // Tell the controller whether a draft is pending so the hands-free always-on
   // loop pauses while the user is typing (or editing a PTT dictation) and
@@ -5245,12 +5380,14 @@ export function ContinuousChatOverlay({
                     Upload live in the composer "+" menu, while Home lives in
                     the launcher. This bar exists only to reserve the safe-area
                     top inset at full-bleed and host the transcription badge. */}
-                {transcriptionMode ? (
+                {transcriptionComposerActive ? (
                   <div
                     data-testid="chat-transcribing-badge"
-                    className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full bg-accent/15 px-2.5 py-0.5 text-[11px] font-medium text-accent"
+                    className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full bg-white/10 px-2.5 py-0.5 text-[11px] font-medium text-white/75"
                   >
-                    Transcribing — say “exit transcription mode” to stop
+                    {transcriptionFinishing
+                      ? "Finishing transcription…"
+                      : "Transcribing — say “exit transcription mode” to stop"}
                   </div>
                 ) : null}
               </motion.div>
@@ -5650,7 +5787,7 @@ export function ContinuousChatOverlay({
               ) : null}
               {/* Inline slash-command autocomplete, floating just above the
                     input row. */}
-              {slashProp && !slashDismissed ? (
+              {!transcriptionComposerActive && slashProp && !slashDismissed ? (
                 <SlashCommandMenu
                   state={slashMenu}
                   loading={isSlashDraft && slash.loading}
@@ -5662,142 +5799,169 @@ export function ContinuousChatOverlay({
                   in-app conversation, never connector actions on a
                   Discord/Telegram room. Search is agent-driveable; Upload is a
                   pure client affordance. */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-lg"
-                    aria-label="chat actions"
-                    disabled={firstRunOpen}
-                    data-testid="chat-composer-plus"
-                    // Same 40px box / 20px mark / padded-back-to-44px hit zone
-                    // as the SoftButton controls, so the row reads as one family.
-                    className="relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"
-                  >
-                    <Glyph d={PLUS_GLYPH} className="size-5" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="top"
-                  align="start"
-                  sideOffset={10}
-                  // Above the shell overlay (z 9000); mirrors the config-select
-                  // floating layer so the menu never hides behind the glass.
-                  style={{ zIndex: 12000 }}
-                  // Unified liquid-glass menu chrome (glass/tokens.ts `menu`
-                  // variant) instead of the flat opaque card.
-                  glass
-                  className="min-w-[13rem]"
-                >
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                    onSelect={() => openSearch()}
-                  >
-                    <Search
-                      className="h-4 w-4 shrink-0 text-muted"
-                      aria-hidden
-                    />
-                    Search chat…
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                    disabled={pendingImages.length >= MAX_CHAT_IMAGES}
-                    onSelect={() => fileInputRef.current?.click()}
-                  >
-                    <Paperclip
-                      className="h-4 w-4 shrink-0 text-muted"
-                      aria-hidden
-                    />
-                    Upload file
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <Textarea
-                ref={inputRef}
-                rows={1}
-                value={draft}
-                // Onboarding is sign-in-first: lock the composer until the user
-                // signs in, so they can't type into a chat that isn't ready yet.
-                disabled={firstRunOpen}
-                onChange={(e) => {
-                  const nextDraft = e.target.value;
-                  if (
-                    draft.trim().length > 0 &&
-                    nextDraft.trim().length === 0
-                  ) {
-                    reportComposerActivity({
-                      activity: "draft_abandoned",
-                      surface: COMPOSER_ACTIVITY_SURFACE,
-                      conversationId: activeConversationIdRef.current,
-                      draftLength: 0,
-                      reason: "cleared",
-                    });
+              {transcriptionComposerActive ? (
+                <SoftButton
+                  glyph={STOP_GLYPH}
+                  label={
+                    transcriptionFinishing
+                      ? "finishing transcription"
+                      : "stop transcription"
                   }
-                  setDraft(nextDraft);
-                  // Mirror the live draft to the active view (Help search etc.).
-                  viewChatBinding?.onQuery?.(nextDraft);
-                  if (nextDraft.trim().length > 0) expand();
-                }}
-                onFocus={() => {
-                  // Widen out of the short-landscape compact affordance (#14173)
-                  // on focus, before the first keystroke.
-                  setComposerFocused(true);
-                  // A pill-open focus only raises the keyboard; it must not
-                  // expand a history thread (see suppressExpandOnFocusRef).
-                  if (suppressExpandOnFocusRef.current) {
-                    suppressExpandOnFocusRef.current = false;
-                  } else {
-                    expand();
+                  disabled={firstRunOpen || transcriptionFinishing}
+                  onPointerDown={(event) => event.preventDefault()}
+                  onClick={() => void finishTranscription("draft")}
+                  testId="chat-composer-transcription-stop"
+                />
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-lg"
+                      aria-label="chat actions"
+                      disabled={firstRunOpen}
+                      data-testid="chat-composer-plus"
+                      // Same 40px box / 20px mark / padded-back-to-44px hit zone
+                      // as the SoftButton controls, so the row reads as one family.
+                      className="relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"
+                    >
+                      <Glyph d={PLUS_GLYPH} className="size-5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    side="top"
+                    align="start"
+                    sideOffset={10}
+                    // Above the shell overlay (z 9000); mirrors the config-select
+                    // floating layer so the menu never hides behind the glass.
+                    style={{ zIndex: 12000 }}
+                    // Unified liquid-glass menu chrome (glass/tokens.ts `menu`
+                    // variant) instead of the flat opaque card.
+                    glass
+                    className="min-w-[13rem]"
+                  >
+                    <DropdownMenuItem
+                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                      onSelect={() => openSearch()}
+                    >
+                      <Search
+                        className="h-4 w-4 shrink-0 text-muted"
+                        aria-hidden
+                      />
+                      Search chat…
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                      disabled={pendingImages.length >= MAX_CHAT_IMAGES}
+                      onSelect={() => fileInputRef.current?.click()}
+                    >
+                      <Paperclip
+                        className="h-4 w-4 shrink-0 text-muted"
+                        aria-hidden
+                      />
+                      Upload file
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {transcriptionComposerActive ? (
+                <ComposerMicActivity
+                  analyser={analyser}
+                  finishing={transcriptionFinishing}
+                  reduceMotion={reduce}
+                  transcript={transcript}
+                />
+              ) : (
+                <Textarea
+                  ref={inputRef}
+                  rows={1}
+                  value={draft}
+                  // Onboarding is sign-in-first: lock the composer until the user
+                  // signs in, so they can't type into a chat that isn't ready yet.
+                  disabled={firstRunOpen}
+                  onChange={(e) => {
+                    const nextDraft = e.target.value;
+                    if (
+                      draft.trim().length > 0 &&
+                      nextDraft.trim().length === 0
+                    ) {
+                      reportComposerActivity({
+                        activity: "draft_abandoned",
+                        surface: COMPOSER_ACTIVITY_SURFACE,
+                        conversationId: activeConversationIdRef.current,
+                        draftLength: 0,
+                        reason: "cleared",
+                      });
+                    }
+                    setDraft(nextDraft);
+                    // Mirror the live draft to the active view (Help search etc.).
+                    viewChatBinding?.onQuery?.(nextDraft);
+                    if (nextDraft.trim().length > 0) expand();
+                  }}
+                  onFocus={() => {
+                    // Widen out of the short-landscape compact affordance (#14173)
+                    // on focus, before the first keystroke.
+                    setComposerFocused(true);
+                    // A pill-open focus only raises the keyboard; it must not
+                    // expand a history thread (see suppressExpandOnFocusRef).
+                    if (suppressExpandOnFocusRef.current) {
+                      suppressExpandOnFocusRef.current = false;
+                    } else {
+                      expand();
+                    }
+                  }}
+                  onBlur={() => setComposerFocused(false)}
+                  onPaste={handleComposerPaste}
+                  onKeyDown={handleComposerKeyDown}
+                  // The composer is LOCKED during onboarding: first-run is
+                  // sign-in-first, so the input is disabled (see `disabled` above)
+                  // until the user signs in.
+                  // (This surface's strings are plain literals by design — see
+                  // the imageError note above.)
+                  placeholder={
+                    compactLanding
+                      ? "Ask"
+                      : firstRunOpen
+                        ? "Sign in to start chatting"
+                        : noProviderConfigured
+                          ? "Connect a model provider in Settings to chat"
+                          : modelBlocksSend
+                            ? modelStatus?.kind === "downloading"
+                              ? `Downloading ${modelStatus.modelName ?? "your model"} — you can keep typing`
+                              : `Getting ${modelStatus?.modelName ?? "your model"} ready — you can keep typing`
+                            : booting
+                              ? `Ask ${agentName} — waking up…`
+                              : (viewChatBinding?.placeholder ??
+                                `Ask ${agentName}`)
                   }
-                }}
-                onBlur={() => setComposerFocused(false)}
-                onPaste={handleComposerPaste}
-                onKeyDown={handleComposerKeyDown}
-                // The composer is LOCKED during onboarding: first-run is
-                // sign-in-first, so the input is disabled (see `disabled` above)
-                // until the user signs in.
-                // (This surface's strings are plain literals by design — see
-                // the imageError note above.)
-                placeholder={
-                  compactLanding
-                    ? "Ask"
-                    : firstRunOpen
-                      ? "Sign in to start chatting"
-                      : noProviderConfigured
-                        ? "Connect a model provider in Settings to chat"
-                        : modelBlocksSend
-                          ? modelStatus?.kind === "downloading"
-                            ? `Downloading ${modelStatus.modelName ?? "your model"} — you can keep typing`
-                            : `Getting ${modelStatus?.modelName ?? "your model"} ready — you can keep typing`
-                          : booting
-                            ? `Ask ${agentName} — waking up…`
-                            : (viewChatBinding?.placeholder ??
-                              `Ask ${agentName}`)
-                }
-                aria-label="message"
-                data-testid="chat-composer-textarea"
-                data-chat-sheet-scroll-region
-                data-scroll-fade={composerScrollFade}
-                onScroll={(event) =>
-                  updateComposerScrollFade(event.currentTarget)
-                }
-                aria-describedby={
-                  booting && !noProviderConfigured && !firstRunOpen
-                    ? "cc-booting-hint"
-                    : undefined
-                }
-                // Combobox semantics (role + aria-*) are applied as one spread,
-                // and only when a slash catalog is wired in — a plain message
-                // box otherwise.
-                {...comboboxAria}
-                // The floating composer is the primary chat affordance on the
-                // ambient home surface, so its placeholder must stay readable
-                // even when the glass pill sits over dark wallpaper. During
-                // onboarding `disabled:opacity-100` prevents the browser from
-                // dimming the locked cue.
-                className="chat-composer-scrollbar max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center overflow-y-auto overscroll-contain border-none bg-transparent py-1 pr-3 pl-1.5 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
-              />
-              {booting && !noProviderConfigured && !firstRunOpen ? (
+                  aria-label="message"
+                  data-testid="chat-composer-textarea"
+                  data-chat-sheet-scroll-region
+                  data-scroll-fade={composerScrollFade}
+                  onScroll={(event) =>
+                    updateComposerScrollFade(event.currentTarget)
+                  }
+                  aria-describedby={
+                    booting && !noProviderConfigured && !firstRunOpen
+                      ? "cc-booting-hint"
+                      : undefined
+                  }
+                  // Combobox semantics (role + aria-*) are applied as one spread,
+                  // and only when a slash catalog is wired in — a plain message
+                  // box otherwise.
+                  {...comboboxAria}
+                  // The floating composer is the primary chat affordance on the
+                  // ambient home surface, so its placeholder must stay readable
+                  // even when the glass pill sits over dark wallpaper. During
+                  // onboarding `disabled:opacity-100` prevents the browser from
+                  // dimming the locked cue.
+                  className="chat-composer-scrollbar max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center overflow-y-auto overscroll-contain border-none bg-transparent py-1 pr-3 pl-1.5 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
+                />
+              )}
+              {!transcriptionComposerActive &&
+              booting &&
+              !noProviderConfigured &&
+              !firstRunOpen ? (
                 <span id="cc-booting-hint" className="sr-only">
                   {agentName} is waking up — you can type now; your message
                   sends and the reply arrives in a moment.
@@ -5805,125 +5969,115 @@ export function ContinuousChatOverlay({
               ) : null}
               {/* Trailing controls. */}
               <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
-                {/* Transcription start/stop — ChatGPT-style dictation, always
-                sitting next to the voice control (mic glyph = "transcribe my
-                speech into the box"; the waveform next door is the spoken
-                conversation). Tap to start; tap again (or say "exit
-                transcription mode") to stop — the full transcript lands at the
-                END of the draft and the recording attaches as a sharable audio
-                artifact (see the transcript-session sink). The voice button
-                stays the master control (a tap there ends transcription AND the
-                mic); this one LEAVES THE MIC ON, matching
-                toggleTranscriptionMode's off-path (#10699). Hidden when a
-                send/stop control is showing (a draft or a streaming reply). */}
-                {!((hasDraft || hasImages) && !recording) &&
-                !(!recording && responding) ? (
-                  <SoftButton
-                    icon={Mic}
-                    label={
-                      transcriptionMode
-                        ? "stop transcription"
-                        : "start transcription"
-                    }
-                    disabled={firstRunOpen}
-                    active={transcriptionMode}
-                    pulse={transcriptionMode}
-                    onPointerDown={(e) => e.preventDefault()}
-                    onClick={toggleTranscriptionMode}
-                    testId="chat-composer-transcribe"
-                  />
-                ) : null}
-                {/* One trailing control, ChatGPT-style: mic when there's nothing
-                to send (or while recording, to stop), swapping to send once the
-                user starts typing or attaches an image. It morphs IN PLACE (one
-                persistent <div>, no `key`): React reconciles the SoftButton's
-                glyph/label/handlers without a remount, so there's no scale/fade
-                pop on every keystroke that crosses the draft boundary. */}
-                <div className="shrink-0">
-                  {(hasDraft || hasImages) && !recording ? (
+                {transcriptionComposerActive ? (
+                  <>
+                    {/* Stop owns session finalization; this neutral status is a
+                    live capture cue, not a second toggle for the same mic. */}
+                    <div
+                      role="status"
+                      aria-label={
+                        transcriptionFinishing
+                          ? "Finishing transcription"
+                          : "Transcribing"
+                      }
+                      data-testid="chat-composer-transcribe-status"
+                      className="relative grid h-10 w-10 shrink-0 place-items-center text-white/80 drop-shadow-[0_0_8px_rgba(255,255,255,0.62)] [&_svg]:size-5"
+                    >
+                      <Mic
+                        aria-hidden="true"
+                        className={cn(
+                          !transcriptionFinishing &&
+                            "animate-pulse motion-reduce:animate-none",
+                        )}
+                      />
+                    </div>
                     <SoftButton
                       icon={SendHorizontal}
                       label={
-                        !canSend
-                          ? "send (agent stopped)"
-                          : responding
-                            ? "send another"
-                            : "send"
+                        transcriptionFinishing
+                          ? "send transcription (finishing)"
+                          : canSend
+                            ? "send transcription"
+                            : "send transcription (agent stopped)"
                       }
-                      // Onboarding is sign-in-first; if a synthetic draft exists
-                      // anyway, send stays locked with the rest of the composer.
-                      disabled={firstRunOpen || !canSend}
-                      // Keep focus in the textarea on tap: without this the
-                      // button steals focus, the textarea blurs, the keyboard
-                      // retracts and the composer relayouts between pointerdown
-                      // and click — so the first tap only dismissed the keyboard
-                      // and a second tap was needed to actually send. Chromium
-                      // still dispatches click after a preventDefaulted
-                      // pointerdown, so onClick fires on the first tap and the
-                      // keyboard stays up for the next message.
-                      onPointerDown={(e) => e.preventDefault()}
-                      onClick={submit}
+                      disabled={
+                        firstRunOpen || !canSend || transcriptionFinishing
+                      }
+                      onPointerDown={(event) => event.preventDefault()}
+                      onClick={() => void finishTranscription("send")}
                       testId="chat-composer-action"
                     />
-                  ) : !recording && responding ? (
-                    // While a reply is streaming and nothing is typed, the mic becomes a
-                    // stop control so the user can interrupt a runaway generation.
-                    <SoftButton
-                      glyph={STOP_GLYPH}
-                      label="stop generating"
-                      onClick={() => stop()}
-                      testId="chat-composer-stop"
-                    />
-                  ) : (
-                    // VOICE — the spoken-conversation control (waveform glyph;
-                    // the mic glyph lives on the transcribe/dictate button
-                    // beside it). Tap = hands-free conversation; hold =
-                    // push-to-talk dictation; while transcribing a tap is the
-                    // master off (ends transcription AND the mic).
-                    <SoftButton
-                      icon={AudioLines}
-                      label={
-                        pttHolding
-                          ? // Press-and-hold dictates into the composer draft; a
-                            // release drops the transcript into the text box and
-                            // does NOT send (usePushToTalk onHoldEnd). Label the
-                            // real behavior.
-                            "release to insert"
-                          : transcriptionMode
-                            ? // Distinct from the transcribe button's "stop
-                              // transcription" (which leaves the mic on): the
-                              // voice control is the MASTER off — a tap ends
-                              // transcription AND the mic — so a screen reader
-                              // can tell the two adjacent controls apart.
-                              "stop transcription and mic"
-                            : handsFree
-                              ? "end conversation"
-                              : recording
-                                ? "stop listening"
-                                : "talk"
-                      }
-                      // Voice input is free text too — locked with the rest of
-                      // the composer while onboarding is choice-driven.
-                      disabled={firstRunOpen}
-                      // The adjacent mic owns transcription. Keep this waveform
-                      // neutral when that separate control starts recording;
-                      // orange active state belongs only to conversation mode
-                      // initiated by this waveform (or its push-to-talk hold).
-                      active={handsFree || pttHolding}
-                      // Recording can also be owned by the adjacent transcription
-                      // control. Report the live voice state without coloring this
-                      // separate waveform control as active.
-                      pressed={recording || handsFree || transcriptionMode}
-                      pulse={recording || handsFree || transcriptionMode}
-                      onClick={handleMicClick}
-                      onPointerDown={micHoldHandlers.onPointerDown}
-                      onPointerUp={micHoldHandlers.onPointerUp}
-                      onPointerCancel={micHoldHandlers.onPointerCancel}
-                      onPointerLeave={micHoldHandlers.onPointerLeave}
-                      testId="chat-composer-mic"
-                    />
-                  )}
-                </div>
+                  </>
+                ) : (
+                  <>
+                    {/* Dictation and spoken conversation are separate controls.
+                    Starting dictation temporarily replaces this whole layout so
+                    the waveform never reflects or owns transcript capture. */}
+                    {!((hasDraft || hasImages) && !recording) &&
+                    !(!recording && responding) ? (
+                      <SoftButton
+                        icon={Mic}
+                        label="start transcription"
+                        disabled={firstRunOpen}
+                        onPointerDown={(event) => event.preventDefault()}
+                        onClick={toggleTranscriptionMode}
+                        testId="chat-composer-transcribe"
+                      />
+                    ) : null}
+                    {/* The rightmost slot morphs in place across send, generation
+                    stop, and voice so ordinary composer changes never pop it. */}
+                    <div className="shrink-0">
+                      {(hasDraft || hasImages) && !recording ? (
+                        <SoftButton
+                          icon={SendHorizontal}
+                          label={
+                            !canSend
+                              ? "send (agent stopped)"
+                              : responding
+                                ? "send another"
+                                : "send"
+                          }
+                          disabled={firstRunOpen || !canSend}
+                          onPointerDown={(event) => event.preventDefault()}
+                          onClick={submit}
+                          testId="chat-composer-action"
+                        />
+                      ) : !recording && responding ? (
+                        <SoftButton
+                          glyph={STOP_GLYPH}
+                          label="stop generating"
+                          onClick={() => stop()}
+                          testId="chat-composer-stop"
+                        />
+                      ) : (
+                        // Tap starts hands-free conversation; hold inserts
+                        // push-to-talk dictation into the editable draft.
+                        <SoftButton
+                          icon={AudioLines}
+                          label={
+                            pttHolding
+                              ? "release to insert"
+                              : handsFree
+                                ? "end conversation"
+                                : recording
+                                  ? "stop listening"
+                                  : "talk"
+                          }
+                          disabled={firstRunOpen}
+                          active={handsFree || pttHolding}
+                          pressed={recording || handsFree}
+                          pulse={recording || handsFree}
+                          onClick={handleMicClick}
+                          onPointerDown={micHoldHandlers.onPointerDown}
+                          onPointerUp={micHoldHandlers.onPointerUp}
+                          onPointerCancel={micHoldHandlers.onPointerCancel}
+                          onPointerLeave={micHoldHandlers.onPointerLeave}
+                          testId="chat-composer-mic"
+                        />
+                      )}
+                    </div>
+                  </>
+                )}
               </div>
             </motion.div>
           </motion.div>

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1399,6 +1399,16 @@ export function ContinuousChatOverlay({
   const pilled = effectiveMode === "pill";
   const sheetOpen = effectiveMode === "half" || effectiveMode === "full";
   const expanded = effectiveMode === "full";
+  const previousSheetOpenRef = React.useRef(sheetOpen);
+  React.useLayoutEffect(() => {
+    const wasOpen = previousSheetOpenRef.current;
+    previousSheetOpenRef.current = sheetOpen;
+    // A reply belongs to the visible thread it references. Clear it on the
+    // shared open → closed edge so every dismissal path has identical behavior.
+    if (wasOpen && !sheetOpen && chatReplyTarget) {
+      setChatReplyTarget(null);
+    }
+  }, [chatReplyTarget, setChatReplyTarget, sheetOpen]);
   // Free-drag rest height (px): when set, the sheet rests exactly where the user
   // released a deliberate drag instead of snapping to a detent. Cleared whenever
   // a detent is taken (tap/flick/focus/collapse) so the detents stay the
@@ -5480,7 +5490,7 @@ export function ContinuousChatOverlay({
                   <MessageScrollerSendFollow request={scrollToEndRequest} />
                   <MessageScroller>
                     <motion.div
-                      className="flex size-full min-h-0 flex-col"
+                      className="flex min-h-0 w-full flex-1 flex-col"
                       style={{ opacity: threadContentOpacity }}
                     >
                       <MessageScrollerViewport
@@ -5625,6 +5635,30 @@ export function ContinuousChatOverlay({
                         </MessageScrollerContent>
                       </MessageScrollerViewport>
                     </motion.div>
+                    {/* Reply stays inside the motion-bounded thread. Arming it can
+                        reduce the transcript viewport, but never changes the sheet
+                        detent or pushes the whole bottom-anchored panel upward. */}
+                    <AnimatePresence initial={false}>
+                      {chatReplyTarget ? (
+                        <motion.div
+                          key="chat-reply-target"
+                          initial={reduce ? false : { opacity: 0, y: 4 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={reduce ? undefined : { opacity: 0, y: 4 }}
+                          transition={{
+                            duration: reduce ? 0 : 0.18,
+                            ease: "easeOut",
+                          }}
+                          className="relative z-10 shrink-0 px-3 pb-2"
+                        >
+                          <ChatReplyPill
+                            appearance="glass"
+                            target={chatReplyTarget}
+                            onCancel={() => setChatReplyTarget(null)}
+                          />
+                        </motion.div>
+                      ) : null}
+                    </AnimatePresence>
                   </MessageScroller>
                 </MessageScrollerProvider>
               </motion.div>
@@ -5636,16 +5670,6 @@ export function ContinuousChatOverlay({
                 (or a credit/retry state is live), so this is inert in the common
                 case. Full chat-column width, styled to sit in the sheet. */}
             <AgentProvisioningWidget spanClassName="relative z-10 mx-auto w-full max-w-3xl shrink-0 px-3 pt-2" />
-            {/* Reply target pill, just above the input (glass chrome). */}
-            {chatReplyTarget ? (
-              <div className="relative z-10 shrink-0 px-3 pt-2">
-                <ChatReplyPill
-                  appearance="glass"
-                  target={chatReplyTarget}
-                  onCancel={() => setChatReplyTarget(null)}
-                />
-              </div>
-            ) : null}
             {/* Pending image attachments + any read error, just above the input. */}
             {hasImages || imageError ? (
               <div className="relative z-10 flex shrink-0 flex-col gap-1.5 px-3 pt-2">

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1552,6 +1552,27 @@ export function ContinuousChatOverlay({
   const [pttHolding, setPttHolding] = React.useState(false);
   const [imageError, setImageError] = React.useState<string | null>(null);
   const inputRef = React.useRef<HTMLTextAreaElement>(null);
+  const [composerScrollFade, setComposerScrollFade] = React.useState<
+    "none" | "top" | "bottom" | "both"
+  >("none");
+  const updateComposerScrollFade = React.useCallback(
+    (target: HTMLTextAreaElement) => {
+      const hasOverflow = target.scrollHeight - target.clientHeight > 1;
+      const hasContentAbove = hasOverflow && target.scrollTop > 1;
+      const hasContentBelow =
+        hasOverflow &&
+        target.scrollTop + target.clientHeight < target.scrollHeight - 1;
+      const next = hasContentAbove
+        ? hasContentBelow
+          ? "both"
+          : "top"
+        : hasContentBelow
+          ? "bottom"
+          : "none";
+      setComposerScrollFade((current) => (current === next ? current : next));
+    },
+    [],
+  );
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const panelRef = React.useRef<HTMLFieldSetElement>(null);
@@ -3172,8 +3193,8 @@ export function ContinuousChatOverlay({
   // the pointer drag. Wheel events accumulate with a short decay and step once
   // per threshold with a cooldown, so a single physical swipe moves ONE detent
   // (no accidental multi-jumps). Scoped to the sheet chrome: events that
-  // originate inside the transcript scroller belong to transcript scrolling
-  // and are ignored here, so reading history never resizes the sheet.
+  // originate inside an owned scroll region belong to that region and are
+  // ignored here, so reading history or a long draft never resizes the sheet.
   const wheelStepAccRef = React.useRef(0);
   const wheelStepCooldownRef = React.useRef(0);
   const wheelStepDecayRef = React.useRef<number | null>(null);
@@ -3969,13 +3990,14 @@ export function ContinuousChatOverlay({
   // Auto-grow the composer with multi-line input: snap to the content height
   // (capped by `max-h` in CSS, which then scrolls). Runs on every draft change
   // so it also springs back to one line after a send clears the draft.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: draft is the trigger; the body reads the textarea ref
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draft is the trigger; the body reads and measures the textarea ref
   React.useLayoutEffect(() => {
     const el = inputRef.current;
     if (!el) return;
     el.style.height = "auto";
     el.style.height = `${el.scrollHeight}px`;
-  }, [draft]);
+    updateComposerScrollFade(el);
+  }, [draft, updateComposerScrollFade]);
 
   // Open the input back out of the collapsed pill (tap or keyboard-activate).
   // A tap routes through the gesture's `onDrag(0)` first, which sets
@@ -5779,6 +5801,10 @@ export function ContinuousChatOverlay({
                 aria-label="message"
                 data-testid="chat-composer-textarea"
                 data-chat-sheet-scroll-region
+                data-scroll-fade={composerScrollFade}
+                onScroll={(event) =>
+                  updateComposerScrollFade(event.currentTarget)
+                }
                 aria-describedby={
                   booting && !noProviderConfigured && !firstRunOpen
                     ? "cc-booting-hint"
@@ -5793,7 +5819,7 @@ export function ContinuousChatOverlay({
                 // even when the glass pill sits over dark wallpaper. During
                 // onboarding `disabled:opacity-100` prevents the browser from
                 // dimming the locked cue.
-                className="chat-composer-scrollbar max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center overflow-y-auto overscroll-contain border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
+                className="chat-composer-scrollbar max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center overflow-y-auto overscroll-contain border-none bg-transparent py-1 pr-3 pl-1.5 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
               />
               {booting && !noProviderConfigured && !firstRunOpen ? (
                 <span id="cc-booting-hint" className="sr-only">

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -7,8 +7,6 @@ import { MAX_CHAT_MEDIA_RAW_BYTES } from "@elizaos/shared";
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
 import {
   AudioLines,
-  Camera,
-  Captions,
   FileText,
   Film,
   Loader2,
@@ -5201,10 +5199,11 @@ export function ContinuousChatOverlay({
             {/* Sheet header — shown at the HALF detent and up (not just FULL).
               One infinite thread (#13531): no maximize/minimize (that's a
               vertical pull now) and no clear/new-chat (the thread never resets).
-              It carries NO buttons — search/upload/camera/transcribe moved to the
-              composer "+" menu and Home lives in the launcher — so the chat stops
-              acting like a second app nav bar. The bar remains only to reserve
-              the safe-area top inset at full-bleed and host the transcribe badge. */}
+              It carries NO buttons — thread search and upload live in the
+              composer "+" menu and Home lives in the launcher — so the chat
+              stops acting like a second app nav bar. The bar remains only to
+              reserve the safe-area top inset at full-bleed and host the
+              transcribe badge. */}
             {threadPresented ? (
               <motion.div
                 data-testid="chat-sheet-header"
@@ -5242,11 +5241,10 @@ export function ContinuousChatOverlay({
                   "mx-auto w-full max-w-3xl",
                 )}
               >
-                {/* The header carries no nav/search buttons — Search, Upload,
-                    Enable camera, and Transcribe all live in the composer "+"
-                    menu now, and Home lives in the launcher. This bar exists
-                    only to reserve the safe-area top inset at full-bleed and to
-                    host the transcription status badge. */}
+                {/* The header carries no nav/search buttons — thread Search and
+                    Upload live in the composer "+" menu, while Home lives in
+                    the launcher. This bar exists only to reserve the safe-area
+                    top inset at full-bleed and host the transcription badge. */}
                 {transcriptionMode ? (
                   <div
                     data-testid="chat-transcribing-badge"
@@ -5660,12 +5658,10 @@ export function ContinuousChatOverlay({
                   onPick={pickSlashItem}
                 />
               ) : null}
-              {/* The "+" opens the chat-actions menu. Every item acts on THIS
-                  in-app conversation only — they are surface-local affordances
-                  (search this thread, attach to this turn, point the agent's
-                  camera/transcription at this chat), never connector actions on a
-                  Discord/Telegram room. Search + Transcribe + camera are things
-                  the agent can also drive; Upload is a pure client affordance. */}
+              {/* The "+" opens surface-local Search and Upload actions for this
+                  in-app conversation, never connector actions on a
+                  Discord/Telegram room. Search is agent-driveable; Upload is a
+                  pure client affordance. */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -5713,26 +5709,6 @@ export function ContinuousChatOverlay({
                       aria-hidden
                     />
                     Upload file
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                    onSelect={() => send("Turn on the camera so you can see.")}
-                  >
-                    <Camera
-                      className="h-4 w-4 shrink-0 text-muted"
-                      aria-hidden
-                    />
-                    Enable camera
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                    onSelect={() => toggleTranscriptionMode()}
-                  >
-                    <Captions
-                      className="h-4 w-4 shrink-0 text-muted"
-                      aria-hidden
-                    />
-                    {transcriptionMode ? "Stop transcribing" : "Transcribe"}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -874,6 +874,30 @@ function MessageScrollerSendFollow({ request }: { request: number }) {
   return null;
 }
 
+type ScrollToTranscriptMessage = ReturnType<
+  typeof useMessageScroller
+>["scrollToMessage"];
+
+/** Exposes the scroller's coordinated jump API to search result handling. */
+function MessageScrollerSearchBridge({
+  scrollToMessageRef,
+}: {
+  scrollToMessageRef: React.MutableRefObject<ScrollToTranscriptMessage | null>;
+}) {
+  const { scrollToMessage } = useMessageScroller();
+
+  React.useLayoutEffect(() => {
+    scrollToMessageRef.current = scrollToMessage;
+    return () => {
+      if (scrollToMessageRef.current === scrollToMessage) {
+        scrollToMessageRef.current = null;
+      }
+    };
+  }, [scrollToMessage, scrollToMessageRef]);
+
+  return null;
+}
+
 /**
  * The phase-aware status accessory shown while the assistant works (#8813).
  * It stays chromeless inside the latest message's action lane so temporary
@@ -2053,10 +2077,25 @@ export function ContinuousChatOverlay({
     activeSearchHighlightRef.current = null;
   }, []);
   React.useEffect(() => clearSearchHighlight, [clearSearchHighlight]);
+  const searchScrollToMessageRef =
+    React.useRef<ScrollToTranscriptMessage | null>(null);
   const scrollAndFlashSearchAnchor = React.useCallback(
-    (el: HTMLElement) => {
+    (el: HTMLElement, messageId: string) => {
       clearSearchHighlight();
-      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      // MessageScroller owns bottom-follow and resize reconciliation. Using its
+      // jump API moves that state machine into settling-jump mode so closing the
+      // search panel cannot immediately pull the transcript back to the end.
+      const scrolled = searchScrollToMessageRef.current?.(messageId, {
+        align: "center",
+        // Land before painting the short highlight. A smooth scroll can spend
+        // the highlight's entire lifetime outside the viewport on long threads.
+        behavior: "auto",
+      });
+      // Topic-group rows register a group id rather than each nested message;
+      // retain a DOM fallback for those anchors only.
+      if (!scrolled) {
+        el.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
       // Message-scroller rows use paint containment for long-thread performance,
       // so an outward row outline is clipped. Paint the flash inside the actual
       // bubble instead; this stays visible without disturbing its liquid-glass
@@ -2098,20 +2137,27 @@ export function ContinuousChatOverlay({
         await handleSelectConversation(result.conversationId);
         let el = await waitForSearchAnchor(anchorId, 20);
         if (!el) {
-          // The hit predates the loaded recent window: load a window CENTERED on
-          // it, then reveal the full loaded set so the centered pivot is not
-          // sliced out of the render window (#15281) — without the reveal a
-          // windowed transcript drops the anchor and the jump silently no-ops.
+          // An absent DOM anchor does not prove the message is absent from
+          // state: the transcript deliberately mounts only its newest window.
+          // Reveal loaded history before touching the network so a windowed-out
+          // hit remains a local, immediate jump.
+          renderWindow.revealFullWindow();
+          el = await waitForSearchAnchor(anchorId, 2);
+        }
+        if (!el) {
+          // The hit genuinely predates the loaded history. Fetch a window
+          // centered on it; the reveal flag above tracks the new renderable
+          // count when that state lands, so the pivot mounts without a second
+          // state transition.
           const loaded = await loadConversationMessagesAround(
             result.conversationId,
             result.messageId,
           );
           if (loaded) {
-            renderWindow.revealFullWindow();
             el = await waitForSearchAnchor(anchorId, 20);
           }
         }
-        if (el) scrollAndFlashSearchAnchor(el);
+        if (el) scrollAndFlashSearchAnchor(el, result.messageId);
       })();
     },
     [
@@ -5544,6 +5590,9 @@ export function ContinuousChatOverlay({
                   defaultScrollPosition={firstRunOpen ? "start" : "end"}
                 >
                   <MessageScrollerSendFollow request={scrollToEndRequest} />
+                  <MessageScrollerSearchBridge
+                    scrollToMessageRef={searchScrollToMessageRef}
+                  />
                   <MessageScroller>
                     <motion.div
                       className="flex min-h-0 w-full flex-1 flex-col"

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1088,24 +1088,16 @@ export function ContinuousChatOverlay({
   // cancel/switch controls; the placeholder tells the user they can keep typing.
   const modelStatus = controller.modelStatus;
   const modelBlocksSend = modelStatus?.blocksSend ?? false;
-  // App-level chat handlers shared with the desktop chat surface. The first-run
-  // transcript's CHOICE widgets still use the action funnel inside their own
-  // renderer; this overlay-level selection only needs message-management
-  // handlers.
-  const {
-    handleChatDelete,
-    handleSelectConversation,
-    loadConversationMessagesAround,
-  } = useAppSelectorShallow((s) => ({
-    // Persistent per-message delete (#13533): server DELETE + optimistic
-    // removal with rollback. Inert no-op in stories/tests with no AppContext.
-    handleChatDelete: s.handleChatDelete,
-    // Search-jump (#14279): select the hit's conversation, then (if the hit is
-    // older than the loaded recent window) load a window centered on it before
-    // scrolling. Inert no-ops in stories/tests with no AppContext.
-    handleSelectConversation: s.handleSelectConversation,
-    loadConversationMessagesAround: s.loadConversationMessagesAround,
-  }));
+  // Search-jump needs the app-level conversation selectors; turn controls stay
+  // local to this overlay or flow through the controller.
+  const { handleSelectConversation, loadConversationMessagesAround } =
+    useAppSelectorShallow((s) => ({
+      // Search-jump (#14279): select the hit's conversation, then (if the hit is
+      // older than the loaded recent window) load a window centered on it before
+      // scrolling. Inert no-ops in stories/tests with no AppContext.
+      handleSelectConversation: s.handleSelectConversation,
+      loadConversationMessagesAround: s.loadConversationMessagesAround,
+    }));
   // Defensive default so a minimal mock controller (stories/tests) that predates
   // the swipe-nav surface still renders without crashing.
   const conversationNav = controller.conversationNav ?? EMPTY_CONVERSATION_NAV;
@@ -1175,18 +1167,6 @@ export function ContinuousChatOverlay({
       return true;
     },
     [send],
-  );
-
-  // Persistent per-message delete from the glass row (#13533). Routes through
-  // the app-level handler so the server DELETE + optimistic removal + rollback
-  // are identical to the panel (ChatView) surface; the shell transcript mirrors
-  // conversationMessages, so the row disappears optimistically and re-appears
-  // if the DELETE fails.
-  const handleDeleteMessage = React.useCallback(
-    (id: string) => {
-      void handleChatDelete?.(id);
-    },
-    [handleChatDelete],
   );
 
   // Retry a failed/interrupted assistant turn by re-sending its preceding user
@@ -2021,7 +2001,6 @@ export function ContinuousChatOverlay({
             onLongPressCopy={handleLongPressCopy}
             onSpeak={handleSpeakMessage}
             onEdit={handleEditResend}
-            onDelete={handleDeleteMessage}
             onReply={handleReplyMessage}
             onRetry={handleRetry}
             playing={speaking && playingMessageId === m.id}
@@ -2041,7 +2020,6 @@ export function ContinuousChatOverlay({
       handleLongPressCopy,
       handleSpeakMessage,
       handleEditResend,
-      handleDeleteMessage,
       handleReplyMessage,
       handleRetry,
       speaking,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -545,7 +545,9 @@ function SoftButton({
         // 2.5.5) is preserved by the invisible `before` overlay that pads the
         // pointer zone back out past the visible box.
         "relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent [&_svg]:size-5",
-        active ? "text-accent" : "text-muted-strong hover:text-txt",
+        active
+          ? "text-accent hover:text-accent"
+          : "text-muted-strong hover:text-txt",
         // Pulse the accent glyph while capture is hot; reduced-motion falls back
         // to the static accent without adding background or border chrome.
         pulse && "animate-pulse motion-reduce:animate-none",
@@ -5635,9 +5637,9 @@ export function ContinuousChatOverlay({
                         </MessageScrollerContent>
                       </MessageScrollerViewport>
                     </motion.div>
-                    {/* Reply stays inside the motion-bounded thread. Arming it can
-                        reduce the transcript viewport, but never changes the sheet
-                        detent or pushes the whole bottom-anchored panel upward. */}
+                    {/* Reply overlays the motion-bounded thread instead of joining
+                        its flex flow, so arming it cannot move the transcript,
+                        composer, or bottom-anchored sheet. */}
                     <AnimatePresence initial={false}>
                       {chatReplyTarget ? (
                         <motion.div
@@ -5649,7 +5651,7 @@ export function ContinuousChatOverlay({
                             duration: reduce ? 0 : 0.18,
                             ease: "easeOut",
                           }}
-                          className="relative z-10 shrink-0 px-3 pb-2"
+                          className="absolute inset-x-0 bottom-0 z-10 px-3 pb-2"
                         >
                           <ChatReplyPill
                             appearance="glass"
@@ -5823,71 +5825,56 @@ export function ContinuousChatOverlay({
                   in-app conversation, never connector actions on a
                   Discord/Telegram room. Search is agent-driveable; Upload is a
                   pure client affordance. */}
-              {transcriptionComposerActive ? (
-                <SoftButton
-                  glyph={STOP_GLYPH}
-                  label={
-                    transcriptionFinishing
-                      ? "finishing transcription"
-                      : "stop transcription"
-                  }
-                  disabled={firstRunOpen || transcriptionFinishing}
-                  onPointerDown={(event) => event.preventDefault()}
-                  onClick={() => void finishTranscription("draft")}
-                  testId="chat-composer-transcription-stop"
-                />
-              ) : (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-lg"
-                      aria-label="chat actions"
-                      disabled={firstRunOpen}
-                      data-testid="chat-composer-plus"
-                      // Same 40px box / 20px mark / padded-back-to-44px hit zone
-                      // as the SoftButton controls, so the row reads as one family.
-                      className="relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"
-                    >
-                      <Glyph d={PLUS_GLYPH} className="size-5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    side="top"
-                    align="start"
-                    sideOffset={10}
-                    // Above the shell overlay (z 9000); mirrors the config-select
-                    // floating layer so the menu never hides behind the glass.
-                    style={{ zIndex: 12000 }}
-                    // Unified liquid-glass menu chrome (glass/tokens.ts `menu`
-                    // variant) instead of the flat opaque card.
-                    glass
-                    className="min-w-[13rem]"
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-lg"
+                    aria-label="chat actions"
+                    disabled={firstRunOpen}
+                    data-testid="chat-composer-plus"
+                    // Same 40px box / 20px mark / padded-back-to-44px hit zone
+                    // as the SoftButton controls, so the row reads as one family.
+                    className="relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"
                   >
-                    <DropdownMenuItem
-                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                      onSelect={() => openSearch()}
-                    >
-                      <Search
-                        className="h-4 w-4 shrink-0 text-muted"
-                        aria-hidden
-                      />
-                      Search chat…
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                      disabled={pendingImages.length >= MAX_CHAT_IMAGES}
-                      onSelect={() => fileInputRef.current?.click()}
-                    >
-                      <Paperclip
-                        className="h-4 w-4 shrink-0 text-muted"
-                        aria-hidden
-                      />
-                      Upload file
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+                    <Glyph d={PLUS_GLYPH} className="size-5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="top"
+                  align="start"
+                  sideOffset={10}
+                  // Above the shell overlay (z 9000); mirrors the config-select
+                  // floating layer so the menu never hides behind the glass.
+                  style={{ zIndex: 12000 }}
+                  // Unified liquid-glass menu chrome (glass/tokens.ts `menu`
+                  // variant) instead of the flat opaque card.
+                  glass
+                  className="min-w-[13rem]"
+                >
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                    onSelect={() => openSearch()}
+                  >
+                    <Search
+                      className="h-4 w-4 shrink-0 text-muted"
+                      aria-hidden
+                    />
+                    Search chat…
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                    disabled={pendingImages.length >= MAX_CHAT_IMAGES}
+                    onSelect={() => fileInputRef.current?.click()}
+                  >
+                    <Paperclip
+                      className="h-4 w-4 shrink-0 text-muted"
+                      aria-hidden
+                    />
+                    Upload file
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               {transcriptionComposerActive ? (
                 <ComposerMicActivity
                   analyser={analyser}
@@ -5992,29 +5979,26 @@ export function ContinuousChatOverlay({
                 </span>
               ) : null}
               {/* Trailing controls. */}
-              <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
+              <div
+                data-testid="chat-composer-trailing-controls"
+                className="flex shrink-0 items-center gap-1.5 sm:gap-2"
+              >
                 {transcriptionComposerActive ? (
                   <>
-                    {/* Stop owns session finalization; this neutral status is a
-                    live capture cue, not a second toggle for the same mic. */}
-                    <div
-                      role="status"
-                      aria-label={
+                    {/* Dictation owns the mic slot while live: the same place
+                        that starts capture becomes its single stop control. */}
+                    <SoftButton
+                      glyph={STOP_GLYPH}
+                      label={
                         transcriptionFinishing
-                          ? "Finishing transcription"
-                          : "Transcribing"
+                          ? "finishing transcription"
+                          : "stop transcription"
                       }
-                      data-testid="chat-composer-transcribe-status"
-                      className="relative grid h-10 w-10 shrink-0 place-items-center text-white/80 drop-shadow-[0_0_8px_rgba(255,255,255,0.62)] [&_svg]:size-5"
-                    >
-                      <Mic
-                        aria-hidden="true"
-                        className={cn(
-                          !transcriptionFinishing &&
-                            "animate-pulse motion-reduce:animate-none",
-                        )}
-                      />
-                    </div>
+                      disabled={firstRunOpen || transcriptionFinishing}
+                      onPointerDown={(event) => event.preventDefault()}
+                      onClick={() => void finishTranscription("draft")}
+                      testId="chat-composer-transcription-stop"
+                    />
                     <SoftButton
                       icon={SendHorizontal}
                       label={

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1034,6 +1034,7 @@ function shellToChatMessageData(m: ShellMessage): ChatMessageData {
     id: m.id,
     role: m.role,
     text: m.content,
+    timestamp: m.createdAt,
     ...(m.source ? { source: m.source } : {}),
     ...(m.failureKind ? { failureKind: m.failureKind } : {}),
     ...(m.reasoning ? { reasoning: m.reasoning } : {}),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1884,6 +1884,9 @@ export function ContinuousChatOverlay({
   ]);
   const turnStatusAnchorId = React.useMemo(() => {
     if (!responding) return null;
+    // Manual playback belongs to the message that started it. Automatic voice
+    // replies have no source id and continue to use the latest visible turn.
+    if (speaking && playingMessageId) return playingMessageId;
     for (let index = visibleMessages.length - 1; index >= 0; index -= 1) {
       const candidate = visibleMessages[index];
       if (!candidate) continue;
@@ -1898,7 +1901,7 @@ export function ContinuousChatOverlay({
       if (!isEmptyAssistantPlaceholder) return candidate.id;
     }
     return null;
-  }, [responding, visibleMessages]);
+  }, [playingMessageId, responding, speaking, visibleMessages]);
   const lastId = visibleMessages.at(-1)?.id ?? null;
   const lastContent = visibleMessages.at(-1)?.content ?? "";
   // The thread body is mounted while the sheet is open OR during an upward

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3182,7 +3182,7 @@ export function ContinuousChatOverlay({
       if (firstRunOpen || draggingRef.current) return;
       if (
         e.target instanceof Element &&
-        e.target.closest("#continuous-thread")
+        e.target.closest("#continuous-thread, [data-chat-sheet-scroll-region]")
       ) {
         return;
       }
@@ -5778,6 +5778,7 @@ export function ContinuousChatOverlay({
                 }
                 aria-label="message"
                 data-testid="chat-composer-textarea"
+                data-chat-sheet-scroll-region
                 aria-describedby={
                   booting && !noProviderConfigured && !firstRunOpen
                     ? "cc-booting-hint"
@@ -5792,7 +5793,7 @@ export function ContinuousChatOverlay({
                 // even when the glass pill sits over dark wallpaper. During
                 // onboarding `disabled:opacity-100` prevents the browser from
                 // dimming the locked cue.
-                className="scrollbar-hide max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
+                className="chat-composer-scrollbar max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center overflow-y-auto overscroll-contain border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
               />
               {booting && !noProviderConfigured && !firstRunOpen ? (
                 <span id="cc-booting-hint" className="sr-only">

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -572,11 +572,19 @@ function SoftButton({
 
 const COMPOSER_MIC_BARS = [
   { id: "outer-left", height: 10 },
+  { id: "far-left", height: 13 },
+  { id: "mid-far-left", height: 17 },
   { id: "mid-left", height: 16 },
+  { id: "near-left", height: 21 },
   { id: "inner-left", height: 22 },
+  { id: "center-left", height: 26 },
   { id: "center", height: 28 },
+  { id: "center-right", height: 26 },
   { id: "inner-right", height: 22 },
+  { id: "near-right", height: 21 },
   { id: "mid-right", height: 16 },
+  { id: "mid-far-right", height: 17 },
+  { id: "far-right", height: 13 },
   { id: "outer-right", height: 10 },
 ] as const;
 
@@ -601,16 +609,28 @@ function ComposerMicActivity({
     let frame = 0;
     const renderFrame = () => {
       analyser.getByteTimeDomainData(samples);
-      let energy = 0;
-      for (const sample of samples) {
-        const normalized = (sample - 128) / 128;
-        energy += normalized * normalized;
-      }
-      const rms = Math.sqrt(energy / Math.max(samples.length, 1));
-      const activity = Math.min(1, Math.max(0.14, rms * 5));
       barsRef.current.forEach((bar, index) => {
         if (!bar) return;
-        const centerWeight = 1 - Math.abs(index - 3) * 0.1;
+        const segmentStart = Math.floor(
+          (index * samples.length) / COMPOSER_MIC_BARS.length,
+        );
+        const segmentEnd = Math.max(
+          segmentStart + 1,
+          Math.floor(((index + 1) * samples.length) / COMPOSER_MIC_BARS.length),
+        );
+        let energy = 0;
+        for (
+          let sampleIndex = segmentStart;
+          sampleIndex < segmentEnd;
+          sampleIndex += 1
+        ) {
+          const normalized = ((samples[sampleIndex] ?? 128) - 128) / 128;
+          energy += normalized * normalized;
+        }
+        const rms = Math.sqrt(energy / (segmentEnd - segmentStart));
+        const activity = Math.min(1, Math.max(0.16, rms * 5.5));
+        const center = (COMPOSER_MIC_BARS.length - 1) / 2;
+        const centerWeight = 1 - Math.abs(index - center) * 0.035;
         bar.style.transform = `scaleY(${Math.max(0.18, activity * centerWeight)})`;
       });
       frame = window.requestAnimationFrame(renderFrame);
@@ -626,23 +646,27 @@ function ComposerMicActivity({
         finishing ? "Finishing transcription" : "Live microphone activity"
       }
       data-testid="chat-composer-mic-activity"
-      className="flex min-h-8 min-w-0 flex-1 items-center justify-center gap-1.5 px-3 text-txt"
+      className="relative flex min-h-10 min-w-0 flex-1 items-center justify-between gap-1 px-2 text-white/85"
     >
       <span className="sr-only" aria-live="polite">
         {finishing
           ? "Finishing transcription"
           : transcript.trim() || "Listening"}
       </span>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-2 top-1/2 h-px -translate-y-1/2 bg-gradient-to-r from-transparent via-white/15 to-transparent"
+      />
       {COMPOSER_MIC_BARS.map(({ id, height }, index) => (
         <span
-          // The fixed seven-bar geometry is presentation-only and never reorders.
+          // Stable bar ids keep imperative analyser writes independent of React.
           key={id}
           ref={(node) => {
             barsRef.current[index] = node;
           }}
           aria-hidden="true"
           className={cn(
-            "w-1 origin-center rounded-full bg-current shadow-[0_0_9px_rgba(255,255,255,0.38)] transition-transform duration-75",
+            "relative z-10 w-0.5 origin-center rounded-full bg-current shadow-[0_0_9px_rgba(255,255,255,0.4)] transition-transform duration-75 sm:w-1",
             !finishing &&
               !analyser &&
               "animate-pulse motion-reduce:animate-none",
@@ -853,9 +877,9 @@ function MessageScrollerSendFollow({ request }: { request: number }) {
 }
 
 /**
- * The phase-aware status row shown while the assistant works (#8813). It stays
- * chromeless so the temporary lifecycle state cannot be mistaken for a message;
- * the same compact shimmer is used before and after the placeholder arrives.
+ * The phase-aware status accessory shown while the assistant works (#8813).
+ * It stays chromeless inside the latest message's action lane so temporary
+ * lifecycle state cannot be mistaken for another transcript row.
  */
 function TurnStatusIndicator({
   status,
@@ -866,8 +890,8 @@ function TurnStatusIndicator({
 }): React.JSX.Element {
   return (
     <motion.div
-      className="mb-2 flex w-full justify-start py-1"
-      data-testid="turn-status-row"
+      className="flex min-w-0 shrink-0 items-center whitespace-nowrap"
+      data-testid="turn-status-accessory"
       // A pure opacity dissolve avoids adding another moving surface while the
       // real assistant turn mounts and begins streaming beneath it.
       initial={{ opacity: 0 }}
@@ -1343,10 +1367,6 @@ export function ContinuousChatOverlay({
   draftRef.current = draft;
   const pendingImagesRef = React.useRef(pendingImages);
   pendingImagesRef.current = pendingImages;
-  // Session completion is normally delivered back into the editable draft.
-  // The transcription Send control changes that disposition for exactly one
-  // drain/finalize cycle without teaching the voice engine about composer UI.
-  const transcriptionDeliveryRef = React.useRef<"draft" | "send">("draft");
   // Finalization drains the capture asynchronously. An immediate ref closes
   // the same-frame double-tap gap before React can paint the disabled controls.
   const transcriptionFinishingRef = React.useRef(false);
@@ -1862,6 +1882,23 @@ export function ContinuousChatOverlay({
     renderableMessages,
     renderWindow.windowSize,
   ]);
+  const turnStatusAnchorId = React.useMemo(() => {
+    if (!responding) return null;
+    for (let index = visibleMessages.length - 1; index >= 0; index -= 1) {
+      const candidate = visibleMessages[index];
+      if (!candidate) continue;
+      const isEmptyAssistantPlaceholder =
+        candidate.role === "assistant" &&
+        !candidate.content.trim() &&
+        !candidate.attachments?.length &&
+        !candidate.failureKind &&
+        !candidate.reasoning?.trim() &&
+        !candidate.secretRequest &&
+        !candidate.toolEvents?.length;
+      if (!isEmptyAssistantPlaceholder) return candidate.id;
+    }
+    return null;
+  }, [responding, visibleMessages]);
   const lastId = visibleMessages.at(-1)?.id ?? null;
   const lastContent = visibleMessages.at(-1)?.content ?? "";
   // The thread body is mounted while the sheet is open OR during an upward
@@ -2086,13 +2123,13 @@ export function ContinuousChatOverlay({
   );
   // Reply arms the shared composer reply target so the next send() stamps
   // replyToMessageId (attached at the sendChatText chokepoint → REPLY_CONTEXT)
-  // and the pill renders above the input. Opens the sheet so the reply is typed
-  // against the visible thread, not the bare collapsed bar.
+  // and the pill renders above the input. Arming a reply must not focus the
+  // composer: on touch devices that would raise the keyboard and move the
+  // entire sheet before the user has chosen to type.
   const handleReplyMessage = React.useCallback(
     (message: ChatMessageData) => {
       setChatReplyTarget(buildReplyTargetFromMessage(message, agentName));
       setMode((m) => (m === "half" || m === "full" ? m : "half"));
-      inputRef.current?.focus();
     },
     [setChatReplyTarget, agentName],
   );
@@ -2113,8 +2150,8 @@ export function ContinuousChatOverlay({
         !message.secretRequest &&
         !message.toolEvents?.length;
       // The server's empty assistant placeholder is deliberately not a visual
-      // turn. Keeping the single status row mounted across this transport state
-      // prevents a Thinking/Replying bubble swap before the first token lands.
+      // turn. The status remains attached to the latest real message's action
+      // lane, preventing a Thinking/Replying bubble swap before the first token.
       if (isInFlight) return null;
       // Only the last assistant turn reads volatile reasoning suppression;
       // every settled row gets no renderContext so its memo identity is stable.
@@ -2127,6 +2164,11 @@ export function ContinuousChatOverlay({
       return (
         <MessageScrollerItem key={m.id} messageId={m.id} className="w-full">
           <ChatMessage
+            actionAccessory={
+              responding && m.id === turnStatusAnchorId ? (
+                <TurnStatusIndicator status={turnStatus} reduce={reduce} />
+              ) : undefined
+            }
             appearance="glass"
             enterOnMount={m.id.startsWith("temp-")}
             agentName={agentName}
@@ -2149,6 +2191,8 @@ export function ContinuousChatOverlay({
     },
     [
       visibleMessages.length,
+      turnStatusAnchorId,
+      turnStatus,
       agentName,
       reduce,
       handleCopyMessage,
@@ -2294,30 +2338,17 @@ export function ContinuousChatOverlay({
     [canSend, firstRunOpen, send, setDraft, setPendingImages, viewChatBinding],
   );
 
-  const finishTranscription = React.useCallback(
-    async (delivery: "draft" | "send") => {
-      if (transcriptionFinishingRef.current) return;
-      transcriptionFinishingRef.current = true;
-      setTranscriptionFinishing(true);
-      transcriptionDeliveryRef.current = delivery;
-      try {
-        await toggleTranscriptionMode();
-      } finally {
-        // An empty/error session never reaches the sink. Reset here as well so
-        // its delivery intent cannot leak into a later recording.
-        transcriptionDeliveryRef.current = "draft";
-        transcriptionFinishingRef.current = false;
-        setTranscriptionFinishing(false);
-        // The textarea remounts only after the finishing guard drops. Restore
-        // focus on the next frame so Stop opens the editable result and Send
-        // leaves the composer ready for the next turn.
-        if (typeof window !== "undefined") {
-          window.requestAnimationFrame(() => inputRef.current?.focus());
-        }
-      }
-    },
-    [toggleTranscriptionMode],
-  );
+  const finishTranscription = React.useCallback(async () => {
+    if (transcriptionFinishingRef.current) return;
+    transcriptionFinishingRef.current = true;
+    setTranscriptionFinishing(true);
+    try {
+      await toggleTranscriptionMode();
+    } finally {
+      transcriptionFinishingRef.current = false;
+      setTranscriptionFinishing(false);
+    }
+  }, [toggleTranscriptionMode]);
 
   const addImageFiles = React.useCallback(
     (files: FileList | File[]) => {
@@ -3641,15 +3672,12 @@ export function ContinuousChatOverlay({
     return () => setDictationSink(null);
   }, [setDictationSink, setDraft, expand]);
 
-  // A completed transcription session has one drain path. Stop returns its text
-  // and optional recording to the editable composer; Send delivers that exact
-  // combined payload directly, avoiding a render-timing race between draining
-  // the capture and submitting the draft. Both paths still archive the session.
+  // A completed transcription session has one drain path: it restores text and
+  // optional audio to the editable composer without changing the sheet detent.
+  // The user explicitly chooses when to focus, review, or send the result.
   React.useEffect(() => {
     setTranscriptSessionSink((segments, startedAtMs, audioWav) => {
       if (segments.length === 0) return;
-      const delivery = transcriptionDeliveryRef.current;
-      transcriptionDeliveryRef.current = "draft";
       const text = transcriptPlainText(segments);
       const stamp = new Date(startedAtMs)
         .toISOString()
@@ -3689,24 +3717,9 @@ export function ContinuousChatOverlay({
             MAX_CHAT_IMAGES,
           )
         : pendingImagesRef.current;
-      // Agent availability can change while the microphone drains. Never discard
-      // the finished session because Send was valid at pointer-down but no longer
-      // valid when the final ASR payload arrives; preserve it as an editable draft.
-      const deliverImmediately =
-        delivery === "send" && canSend && !firstRunOpen;
-      if (deliverImmediately) {
-        submitText(combinedText, combinedImages);
-      } else {
-        if (text) setDraft(combinedText);
-        if (recordingAttachment) setPendingImages(combinedImages);
-      }
-      // submitText clears attachment errors as part of a successful send. Apply
-      // this notice afterwards so a sent transcript never silently omits its WAV.
+      if (text) setDraft(combinedText);
+      if (recordingAttachment) setPendingImages(combinedImages);
       if (recordingError) setImageError(recordingError);
-      if (!deliverImmediately && (text || hasAudio)) {
-        expand();
-        inputRef.current?.focus();
-      }
       void client
         .createTranscript({
           segments,
@@ -3728,15 +3741,7 @@ export function ContinuousChatOverlay({
         });
     });
     return () => setTranscriptSessionSink(null);
-  }, [
-    setTranscriptSessionSink,
-    setDraft,
-    setPendingImages,
-    submitText,
-    expand,
-    canSend,
-    firstRunOpen,
-  ]);
+  }, [setTranscriptSessionSink, setDraft, setPendingImages]);
 
   // Tell the controller whether a draft is pending so the hands-free always-on
   // loop pauses while the user is typing (or editing a PTT dictation) and
@@ -5616,48 +5621,38 @@ export function ContinuousChatOverlay({
                             : visibleMessages.map((m, i) =>
                                 renderThreadLine(m, i),
                               )}
-                          <AnimatePresence>
-                            {/* One persistent inline status (#8813) spans the
-                          whole active turn. The server's empty assistant
-                          placeholder never replaces it, so rapid Thinking →
-                          Replying phases update one shimmer instead of flashing
-                          between temporary message bubbles. */}
-                            {responding ? (
-                              <MessageScrollerItem
-                                key="turn-status"
-                                className="w-full"
-                              >
-                                <TurnStatusIndicator
-                                  status={turnStatus}
-                                  reduce={reduce}
-                                />
-                              </MessageScrollerItem>
-                            ) : null}
-                          </AnimatePresence>
                         </MessageScrollerContent>
                       </MessageScrollerViewport>
                     </motion.div>
-                    {/* Reply overlays the motion-bounded thread instead of joining
-                        its flex flow, so arming it cannot move the transcript,
-                        composer, or bottom-anchored sheet. */}
+                    {/* Reply gets a dedicated lane below the viewport. Its measured
+                        height eases into the fixed scroller, so the latest message
+                        and its actions glide clear instead of being covered or
+                        making the bottom-anchored sheet itself jump. */}
                     <AnimatePresence initial={false}>
                       {chatReplyTarget ? (
                         <motion.div
                           key="chat-reply-target"
-                          initial={reduce ? false : { opacity: 0, y: 4 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={reduce ? undefined : { opacity: 0, y: 4 }}
+                          data-testid="chat-reply-lane"
+                          initial={
+                            reduce ? false : { height: 0, opacity: 0, y: 5 }
+                          }
+                          animate={{ height: "auto", opacity: 1, y: 0 }}
+                          exit={
+                            reduce ? undefined : { height: 0, opacity: 0, y: 5 }
+                          }
                           transition={{
-                            duration: reduce ? 0 : 0.18,
-                            ease: "easeOut",
+                            duration: reduce ? 0 : 0.32,
+                            ease: OVERLAY_EASE,
                           }}
-                          className="absolute inset-x-0 bottom-0 z-10 px-3 pb-2"
+                          className="z-10 shrink-0 overflow-hidden"
                         >
-                          <ChatReplyPill
-                            appearance="glass"
-                            target={chatReplyTarget}
-                            onCancel={() => setChatReplyTarget(null)}
-                          />
+                          <div className="px-3 pb-2 pt-1">
+                            <ChatReplyPill
+                              appearance="glass"
+                              target={chatReplyTarget}
+                              onCancel={() => setChatReplyTarget(null)}
+                            />
+                          </div>
                         </motion.div>
                       ) : null}
                     </AnimatePresence>
@@ -5825,56 +5820,58 @@ export function ContinuousChatOverlay({
                   in-app conversation, never connector actions on a
                   Discord/Telegram room. Search is agent-driveable; Upload is a
                   pure client affordance. */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-lg"
-                    aria-label="chat actions"
-                    disabled={firstRunOpen}
-                    data-testid="chat-composer-plus"
-                    // Same 40px box / 20px mark / padded-back-to-44px hit zone
-                    // as the SoftButton controls, so the row reads as one family.
-                    className="relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"
+              {!transcriptionComposerActive ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-lg"
+                      aria-label="chat actions"
+                      disabled={firstRunOpen}
+                      data-testid="chat-composer-plus"
+                      // Same 40px box / 20px mark / padded-back-to-44px hit zone
+                      // as the SoftButton controls, so the row reads as one family.
+                      className="relative grid h-10 w-10 shrink-0 place-items-center bg-transparent p-0 text-muted-strong transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-transparent hover:text-txt data-[state=open]:text-txt [&_svg]:size-5"
+                    >
+                      <Glyph d={PLUS_GLYPH} className="size-5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    side="top"
+                    align="start"
+                    sideOffset={10}
+                    // Above the shell overlay (z 9000); mirrors the config-select
+                    // floating layer so the menu never hides behind the glass.
+                    style={{ zIndex: 12000 }}
+                    // Unified liquid-glass menu chrome (glass/tokens.ts `menu`
+                    // variant) instead of the flat opaque card.
+                    glass
+                    className="min-w-[13rem]"
                   >
-                    <Glyph d={PLUS_GLYPH} className="size-5" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="top"
-                  align="start"
-                  sideOffset={10}
-                  // Above the shell overlay (z 9000); mirrors the config-select
-                  // floating layer so the menu never hides behind the glass.
-                  style={{ zIndex: 12000 }}
-                  // Unified liquid-glass menu chrome (glass/tokens.ts `menu`
-                  // variant) instead of the flat opaque card.
-                  glass
-                  className="min-w-[13rem]"
-                >
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                    onSelect={() => openSearch()}
-                  >
-                    <Search
-                      className="h-4 w-4 shrink-0 text-muted"
-                      aria-hidden
-                    />
-                    Search chat…
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                    disabled={pendingImages.length >= MAX_CHAT_IMAGES}
-                    onSelect={() => fileInputRef.current?.click()}
-                  >
-                    <Paperclip
-                      className="h-4 w-4 shrink-0 text-muted"
-                      aria-hidden
-                    />
-                    Upload file
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    <DropdownMenuItem
+                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                      onSelect={() => openSearch()}
+                    >
+                      <Search
+                        className="h-4 w-4 shrink-0 text-muted"
+                        aria-hidden
+                      />
+                      Search chat…
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                      disabled={pendingImages.length >= MAX_CHAT_IMAGES}
+                      onSelect={() => fileInputRef.current?.click()}
+                    >
+                      <Paperclip
+                        className="h-4 w-4 shrink-0 text-muted"
+                        aria-hidden
+                      />
+                      Upload file
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : null}
               {transcriptionComposerActive ? (
                 <ComposerMicActivity
                   analyser={analyser}
@@ -5984,56 +5981,24 @@ export function ContinuousChatOverlay({
                 className="flex shrink-0 items-center gap-1.5 sm:gap-2"
               >
                 {transcriptionComposerActive ? (
-                  <>
-                    {/* Dictation owns the mic slot while live: the same place
-                        that starts capture becomes its single stop control. */}
-                    <SoftButton
-                      glyph={STOP_GLYPH}
-                      label={
-                        transcriptionFinishing
-                          ? "finishing transcription"
-                          : "stop transcription"
-                      }
-                      disabled={firstRunOpen || transcriptionFinishing}
-                      onPointerDown={(event) => event.preventDefault()}
-                      onClick={() => void finishTranscription("draft")}
-                      testId="chat-composer-transcription-stop"
-                    />
-                    <SoftButton
-                      icon={SendHorizontal}
-                      label={
-                        transcriptionFinishing
-                          ? "send transcription (finishing)"
-                          : canSend
-                            ? "send transcription"
-                            : "send transcription (agent stopped)"
-                      }
-                      disabled={
-                        firstRunOpen || !canSend || transcriptionFinishing
-                      }
-                      onPointerDown={(event) => event.preventDefault()}
-                      onClick={() => void finishTranscription("send")}
-                      testId="chat-composer-action"
-                    />
-                  </>
+                  /* The rightmost transcription mic becomes Stop. Activity owns
+                     every other composer pixel until capture finishes. */
+                  <SoftButton
+                    glyph={STOP_GLYPH}
+                    label={
+                      transcriptionFinishing
+                        ? "finishing transcription"
+                        : "stop transcription"
+                    }
+                    disabled={firstRunOpen || transcriptionFinishing}
+                    onPointerDown={(event) => event.preventDefault()}
+                    onClick={() => void finishTranscription()}
+                    testId="chat-composer-transcription-stop"
+                  />
                 ) : (
                   <>
-                    {/* Dictation and spoken conversation are separate controls.
-                    Starting dictation temporarily replaces this whole layout so
-                    the waveform never reflects or owns transcript capture. */}
-                    {!((hasDraft || hasImages) && !recording) &&
-                    !(!recording && responding) ? (
-                      <SoftButton
-                        icon={Mic}
-                        label="start transcription"
-                        disabled={firstRunOpen}
-                        onPointerDown={(event) => event.preventDefault()}
-                        onClick={toggleTranscriptionMode}
-                        testId="chat-composer-transcribe"
-                      />
-                    ) : null}
-                    {/* The rightmost slot morphs in place across send, generation
-                    stop, and voice so ordinary composer changes never pop it. */}
+                    {/* The left trailing slot morphs across send, generation stop,
+                    and spoken conversation without reshuffling the row. */}
                     <div className="shrink-0">
                       {(hasDraft || hasImages) && !recording ? (
                         <SoftButton
@@ -6084,6 +6049,19 @@ export function ContinuousChatOverlay({
                         />
                       )}
                     </div>
+                    {/* Dictation stays rightmost so starting it can morph this mic
+                    directly into the active Stop control. */}
+                    {!((hasDraft || hasImages) && !recording) &&
+                    !(!recording && responding) ? (
+                      <SoftButton
+                        icon={Mic}
+                        label="start transcription"
+                        disabled={firstRunOpen}
+                        onPointerDown={(event) => event.preventDefault()}
+                        onClick={toggleTranscriptionMode}
+                        testId="chat-composer-transcribe"
+                      />
+                    ) : null}
                   </>
                 )}
               </div>

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3965,6 +3965,12 @@ export function ContinuousChatOverlay({
   // stays OUTSIDE.
   const isOverlayControlTarget = React.useCallback(
     (target: EventTarget | null): boolean => {
+      if (
+        target instanceof Element &&
+        target.closest("[data-chat-overlay-control]")
+      ) {
+        return true;
+      }
       if (!(target instanceof Node) || !overlayRef.current?.contains(target)) {
         return false;
       }
@@ -5884,6 +5890,7 @@ export function ContinuousChatOverlay({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent
+                    data-chat-overlay-control
                     side="top"
                     align="start"
                     sideOffset={10}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1090,14 +1090,20 @@ export function ContinuousChatOverlay({
   const modelBlocksSend = modelStatus?.blocksSend ?? false;
   // Search-jump needs the app-level conversation selectors; turn controls stay
   // local to this overlay or flow through the controller.
-  const { handleSelectConversation, loadConversationMessagesAround } =
-    useAppSelectorShallow((s) => ({
-      // Search-jump (#14279): select the hit's conversation, then (if the hit is
-      // older than the loaded recent window) load a window centered on it before
-      // scrolling. Inert no-ops in stories/tests with no AppContext.
-      handleSelectConversation: s.handleSelectConversation,
-      loadConversationMessagesAround: s.loadConversationMessagesAround,
-    }));
+  const {
+    handleChatEdit,
+    handleSelectConversation,
+    loadConversationMessagesAround,
+  } = useAppSelectorShallow((s) => ({
+    // Editing a persisted turn must truncate and replace the original branch;
+    // sending the corrected text as a fresh turn leaves the typo in history.
+    handleChatEdit: s.handleChatEdit,
+    // Search-jump (#14279): select the hit's conversation, then (if the hit is
+    // older than the loaded recent window) load a window centered on it before
+    // scrolling. Inert no-ops in stories/tests with no AppContext.
+    handleSelectConversation: s.handleSelectConversation,
+    loadConversationMessagesAround: s.loadConversationMessagesAround,
+  }));
   // Defensive default so a minimal mock controller (stories/tests) that predates
   // the swipe-nav surface still renders without crashing.
   const conversationNav = controller.conversationNav ?? EMPTY_CONVERSATION_NAV;
@@ -1157,21 +1163,21 @@ export function ContinuousChatOverlay({
     [speaking, playingMessageId, speak, stopSpeaking],
   );
 
-  // Save an edited user message and resend it as a new turn (#10713) — the same
-  // send path a typed turn uses, so the agent sees the corrected text. Adapts
-  // the row's (id, text) → bool save contract onto the overlay's text-only
-  // send; returning true tells the row the edit committed.
-  const handleEditResend = React.useCallback(
-    (_id: string, text: string): boolean => {
-      send(text);
-      return true;
+  // Editing rewinds the persisted branch at the selected user turn, replaces
+  // its text, and resends through the canonical AppContext transaction. Stop
+  // playback first so stale audio never continues over the corrected branch.
+  const handleEditMessage = React.useCallback(
+    async (id: string, text: string): Promise<boolean> => {
+      stopSpeaking?.();
+      setPlayingMessageId(null);
+      return handleChatEdit(id, text);
     },
-    [send],
+    [handleChatEdit, stopSpeaking],
   );
 
   // Retry a failed/interrupted assistant turn by re-sending its preceding user
-  // turn — the SAME send() path the edit-resend action uses. (The ShellController
-  // exposes no handleChatRetry, so the overlay owns the walk-back locally; a
+  // turn. The ShellController exposes no handleChatRetry, so the overlay owns
+  // the walk-back locally; a
   // truncating in-place retry would require a controller method we don't have.)
   // Reads the live message list through a ref so the callback keeps a stable
   // identity and the memoized ThreadLine isn't re-rendered on every tick.
@@ -1198,8 +1204,8 @@ export function ContinuousChatOverlay({
   // Proactive suggestions (#8792) — same semantics as the composite ChatView:
   // dismiss removes the bubble from the live transcript only (the server-side
   // per-surface cooldown keeps the same offer from immediately re-appearing);
-  // accept ("Do it") sends the implied action as a real turn through the SAME
-  // send() path an edit-resend uses, then clears the bubble.
+  // accept ("Do it") sends the implied action as a real turn through the normal
+  // composer path, then clears the bubble.
   const {
     removeConversationMessage,
     conversationMessages,
@@ -2000,7 +2006,7 @@ export function ContinuousChatOverlay({
             onCopy={handleCopyMessage}
             onLongPressCopy={handleLongPressCopy}
             onSpeak={handleSpeakMessage}
-            onEdit={handleEditResend}
+            onEdit={handleEditMessage}
             onReply={handleReplyMessage}
             onRetry={handleRetry}
             playing={speaking && playingMessageId === m.id}
@@ -2019,7 +2025,7 @@ export function ContinuousChatOverlay({
       handleCopyMessage,
       handleLongPressCopy,
       handleSpeakMessage,
-      handleEditResend,
+      handleEditMessage,
       handleReplyMessage,
       handleRetry,
       speaking,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -7,11 +7,8 @@ import { MAX_CHAT_MEDIA_RAW_BYTES } from "@elizaos/shared";
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
 import {
   AudioLines,
-  FileText,
-  Film,
   Loader2,
   Mic,
-  Music,
   Paperclip,
   Search,
   SendHorizontal,
@@ -111,6 +108,7 @@ import { parseFormSubmitDisplay } from "../chat/message-parser-helpers";
 import { MessageSearchPanel } from "../chat/message-search/MessageSearchPanel";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { AgentProvisioningWidget } from "../chat/widgets/agent-provisioning";
+import { ChatAttachmentStrip } from "../composites/chat/chat-attachment-strip";
 import {
   buildReplyTargetFromMessage,
   ChatMessage,
@@ -5724,60 +5722,17 @@ export function ContinuousChatOverlay({
             {hasImages || imageError ? (
               <div className="relative z-10 flex shrink-0 flex-col gap-1.5 px-3 pt-2">
                 {hasImages ? (
-                  <div className="flex flex-wrap gap-2">
-                    {pendingImages.map((img, i) => {
-                      const kind = chatUploadKind(img.mimeType);
-                      const removeButton = (
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          aria-label={`remove ${img.name}`}
-                          onClick={() => removeImage(i)}
-                          // Small visual disc, but a 44px-class hit zone via the
-                          // invisible `before` overlay so it's thumb-tappable
-                          // without crowding the tile.
-                          className="absolute -right-1.5 -top-1.5 z-30 grid h-5 w-5 place-items-center rounded-full border border-border-strong bg-scrim p-0 text-xs text-txt transition-colors before:absolute before:-inset-3 before:content-[''] hover:bg-bg"
-                        >
-                          ×
-                        </Button>
-                      );
-                      const tileKey = `${img.name}-${img.mimeType}-${img.data.length}`;
-                      if (kind === "image") {
-                        return (
-                          <div
-                            key={tileKey}
-                            className="group relative h-14 w-14 shrink-0"
-                          >
-                            <img
-                              src={`data:${img.mimeType};base64,${img.data}`}
-                              alt={img.name}
-                              className="h-14 w-14 rounded-lg border border-border-strong object-cover"
-                            />
-                            {removeButton}
-                          </div>
-                        );
-                      }
-                      const KindIcon =
-                        kind === "audio"
-                          ? Music
-                          : kind === "video"
-                            ? Film
-                            : FileText;
-                      return (
-                        <div
-                          key={tileKey}
-                          className="group relative flex h-14 min-w-[3.5rem] max-w-[10rem] shrink-0 items-center gap-2 rounded-lg border border-border-strong bg-surface px-2.5 text-txt"
-                          title={img.name}
-                        >
-                          <KindIcon className="h-5 w-5 shrink-0 text-muted-strong" />
-                          <span className="min-w-0 truncate text-xs-tight leading-tight">
-                            {img.name}
-                          </span>
-                          {removeButton}
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <ChatAttachmentStrip
+                    items={pendingImages.map((img, index) => ({
+                      id: `${img.name}-${img.mimeType}-${img.data.length}-${index}`,
+                      alt: img.name,
+                      name: img.name,
+                      src: `data:${img.mimeType};base64,${img.data}`,
+                      kind: chatUploadKind(img.mimeType),
+                    }))}
+                    removeLabel={(item) => `Remove ${item.name}`}
+                    onRemove={(_id, index) => removeImage(index)}
+                  />
                 ) : null}
                 {imageError ? (
                   <p

--- a/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
@@ -24,12 +24,16 @@ const originalMatchMedia = window.matchMedia;
 
 function mockDesktopPagingMedia({
   finePointer,
+  desktopViewport = true,
 }: {
   finePointer: boolean;
+  desktopViewport?: boolean;
 }): void {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches:
       finePointer &&
+      desktopViewport &&
+      query.includes("(min-width: 768px)") &&
       query.includes("(hover: hover)") &&
       query.includes("(pointer: fine)"),
     media: query,
@@ -189,8 +193,8 @@ describe("HomeLauncherSurface", () => {
     expect(screen.queryByTestId("rail-pager-edge-next")).toBeNull();
   });
 
-  it("shows rail edge buttons on any fine-pointer window — the gate has no min-width clause", () => {
-    mockDesktopPagingMedia({ finePointer: true });
+  it("hides rail edge buttons in the mobile layout even with a fine pointer", () => {
+    mockDesktopPagingMedia({ finePointer: true, desktopViewport: false });
     render(
       <HomeLauncherSurface
         home={<div>home</div>}
@@ -198,12 +202,9 @@ describe("HomeLauncherSurface", () => {
       />,
     );
 
-    // Fine pointer + hover is sufficient: a sub-1024px window still gets the
-    // `>` control (there are no page dots in production, so without it a
-    // narrow fine-pointer window would have no paging affordance at all).
-    expect(screen.queryByTestId("rail-pager-edge-next")).not.toBeNull();
+    expect(screen.queryByTestId("rail-pager-edge-next")).toBeNull();
     expect(window.matchMedia).toHaveBeenCalledWith(
-      expect.not.stringContaining("min-width"),
+      expect.stringContaining("min-width: 768px"),
     );
   });
 

--- a/packages/ui/src/components/shell/HomeLauncherSurface.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.tsx
@@ -158,11 +158,12 @@ export function HomeLauncherSurface({
           {launcher}
         </div>
       </div>
-      {/* Web/desktop `< >` edge buttons for the home↔launcher rail (hidden on
-          touch). PagerEdgeButtons self-hides each chevron at the rail's
-          first/last page, so the `>` (Launcher) hides on the launcher half and
-          the `<` (Home) hides on the home half. These drive goPrev/goNext
-          directly, so paging works even where touch swipes don't apply. */}
+      {/* Desktop `< >` edge buttons for the home↔launcher rail (hidden in the
+          compact mobile layout and on touch devices). PagerEdgeButtons
+          self-hides each chevron at the rail's first/last page, so the `>`
+          (Launcher) hides on the launcher half and the `<` (Home) hides on the
+          home half. These drive goPrev/goNext directly, so desktop paging
+          remains available alongside pointer dragging. */}
       <PagerEdgeButtons
         idPrefix="rail"
         canPrev={pager.canPrev}

--- a/packages/ui/src/components/shell/HomeScreen.flicker.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.flicker.test.tsx
@@ -89,6 +89,11 @@ describe("HomeScreen entrance flicker lock (#9304)", () => {
 
     // First mount: the entrance class is present (animation plays once).
     expect(classOnAnyBlock(container)).toBe(true);
+    expect(
+      container
+        .querySelector("[data-home-below-notifications]")
+        ?.getAttribute("data-eliza-layout-shift-intent"),
+    ).toBe("transient");
     sample(); // opacity 0 (fade start)
 
     // Advance past the mount window so the once-guard strips the class.
@@ -96,6 +101,11 @@ describe("HomeScreen entrance flicker lock (#9304)", () => {
       vi.advanceTimersByTime(750);
     });
     expect(classOnAnyBlock(container)).toBe(false); // entrance done, class gone
+    expect(
+      container
+        .querySelector("[data-home-below-notifications]")
+        ?.hasAttribute("data-eliza-layout-shift-intent"),
+    ).toBe(false);
     sample(); // opacity settled at 1
 
     // A later re-render (e.g. a prop / resize-driven update) must NOT re-add the

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -417,7 +417,7 @@ describe("HomeScreen", () => {
     fireEvent.pointerDown(tile, { ...pointer, clientY: 620 });
     fireEvent.pointerMove(tile, { ...pointer, clientY: 760 });
     fireEvent.pointerUp(tile, { ...pointer, clientY: 760 });
-    fireEvent.click(tile);
+    fireEvent.click(tile, { detail: 1 });
 
     expect(onOpenTile).not.toHaveBeenCalled();
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -183,6 +183,90 @@ describe("HomeScreen", () => {
     expect(screen.queryByTestId("notification-group-label")).toBeNull();
   });
 
+  it("lets an expanded inbox consume the live composer-safe column", () => {
+    __ingestNotificationForTests(makeNotification());
+    render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
+
+    const home = screen.getByTestId("home-screen");
+    const column = screen.getByTestId("home-content-column");
+    const list = screen.getByTestId("home-notification-list");
+    const secondaryRegion = column.querySelector<HTMLElement>(
+      "[data-home-below-notifications]",
+    );
+    const secondaryRegionInner = column.querySelector<HTMLElement>(
+      "[data-home-below-notifications-inner]",
+    );
+    const css = home.querySelector("style")?.textContent ?? "";
+
+    expect(home.className).toContain("--eliza-continuous-chat-clearance");
+    expect(home.className).toContain("--safe-area-bottom");
+    expect(secondaryRegion).toBeTruthy();
+    expect(secondaryRegionInner?.className).toContain("min-h-0");
+    expect(secondaryRegionInner?.className).toContain("overflow-hidden");
+    expect(
+      secondaryRegion?.contains(screen.getByTestId("home-widget-host")),
+    ).toBe(true);
+    expect(secondaryRegion?.contains(screen.getByTestId("home-tiles"))).toBe(
+      true,
+    );
+    expect(css).toContain(
+      '[data-shade-preview="expanding"][data-shade-dragging]',
+    );
+    expect(css).toContain(
+      '[data-shade-mode="expanded"]:not([data-shade-settling])',
+    );
+    expect(css).toContain("grid-template-rows: 0fr");
+    expect(css).toContain("visibility: hidden");
+    expect(css).toContain("--eliza-home-notification-settle-duration");
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 91,
+      clientX: 100,
+      clientY: 100,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 91,
+      clientX: 100,
+      clientY: 130,
+    });
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(true);
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 91,
+      clientX: 100,
+      clientY: 130,
+    });
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(
+      screen
+        .getByTestId("home-notification-center")
+        .hasAttribute("data-notification-shade-cancelling"),
+    ).toBe(true);
+    expect(
+      column.style.getPropertyValue(
+        "--eliza-home-notification-settle-duration",
+      ),
+    ).toMatch(/^\d+ms$/);
+    act(() => vi.advanceTimersByTime(700));
+    expect(list.hasAttribute("data-shade-preview")).toBe(false);
+
+    fireEvent.wheel(list, { deltaY: -(PULL_COMMIT_PX + 10) });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    expect(
+      column.style.getPropertyValue(
+        "--eliza-home-notification-settle-duration",
+      ),
+    ).toBe("460ms");
+  });
+
   it("keeps widget taps inert and expands a populated shade from a widget-area pull", () => {
     __ingestNotificationForTests(
       makeNotification({ title: "Priority alert", priority: "urgent" }),

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -263,9 +263,32 @@ describe("HomeScreen", () => {
       touches: [{ clientX: 202, clientY: 300 }],
     });
     fireEvent.touchEnd(home, { touches: [] });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(500));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
+  });
+
+  it("reveals the empty state from a mouse pull on the lower home background", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    const home = screen.getByTestId("home-screen");
+    const list = screen.getByTestId("home-notification-list");
+    const pointer = {
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "mouse",
+      clientX: 200,
+    } as const;
+
+    fireEvent.pointerDown(home, { ...pointer, clientY: 620 });
+    fireEvent.pointerMove(home, { ...pointer, clientY: 760 });
+    fireEvent.pointerUp(home, { ...pointer, clientY: 760 });
+    fireEvent.click(home);
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(screen.getByTestId("notifications-empty").textContent).toBe(
+      "No Notifications",
+    );
   });
 
   it("reveals and closes the empty state from a trackpad swipe on the home background", () => {
@@ -289,28 +312,87 @@ describe("HomeScreen", () => {
     act(() => vi.advanceTimersByTime(500));
     fireEvent.wheel(home, { deltaY: PULL_COMMIT_PX + 10 });
     fireEvent.wheel(home, { deltaY: PULL_COMMIT_PX + 10 });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(500));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
   });
 
-  it("does not steal an empty-inbox gesture that begins on a home control", () => {
+  it("turns a vertical mouse drag on a lower home control into a pull without firing its click", () => {
+    __setHydratedForTests(true);
+    const onOpenTile = vi.fn();
+    render(<HomeScreen onOpenTile={onOpenTile} showNativeOsTiles />);
+    const tile = screen.getByTestId("home-tile-camera");
+    const list = screen.getByTestId("home-notification-list");
+    const pointer = {
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: "mouse",
+      clientX: 200,
+    } as const;
+
+    fireEvent.pointerDown(tile, { ...pointer, clientY: 620 });
+    fireEvent.pointerMove(tile, { ...pointer, clientY: 760 });
+    fireEvent.pointerUp(tile, { ...pointer, clientY: 760 });
+    fireEvent.click(tile);
+
+    expect(onOpenTile).not.toHaveBeenCalled();
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("yields a horizontal mouse drag on a lower home control without opening the shade", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
+    const tile = screen.getByTestId("home-tile-camera");
+    const list = screen.getByTestId("home-notification-list");
+    const pointer = {
+      isPrimary: true,
+      pointerId: 9,
+      pointerType: "mouse",
+      clientY: 620,
+    } as const;
+
+    fireEvent.pointerDown(tile, { ...pointer, clientX: 260 });
+    fireEvent.pointerMove(tile, {
+      ...pointer,
+      clientX: 120,
+      clientY: 624,
+    });
+    fireEvent.pointerUp(tile, {
+      ...pointer,
+      clientX: 120,
+      clientY: 624,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
+  });
+
+  it("turns a vertical touch drag begun on a lower home control into a pull", () => {
     __setHydratedForTests(true);
     render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
     const tile = screen.getByTestId("home-tile-camera");
     const list = screen.getByTestId("home-notification-list");
 
     fireEvent.touchStart(tile, {
-      touches: [{ clientX: 200, clientY: 300 }],
+      touches: [{ clientX: 200, clientY: 620 }],
     });
     fireEvent.touchMove(tile, {
-      touches: [{ clientX: 202, clientY: 440 }],
+      touches: [{ clientX: 202, clientY: 760 }],
     });
     fireEvent.touchEnd(tile, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("lets an empty-inbox trackpad pull begin on a lower home control", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
+    const tile = screen.getByTestId("home-tile-camera");
+    const list = screen.getByTestId("home-notification-list");
+
     fireEvent.wheel(tile, { deltaY: -(PULL_COMMIT_PX + 10) });
 
-    expect(list.getAttribute("data-shade-mode")).toBe("rested");
-    expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("tapping an inline row follows its safe deep link directly", () => {

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -281,11 +281,9 @@ export function HomeScreen({
             it fades in (Apple-style) on first appearance. */}
           <div
             className={cn(
-              enterClass,
               "mt-4",
               hasNotifications && "flex min-h-0 flex-1 flex-col",
             )}
-            style={{ animationDelay: "90ms" }}
           >
             <NotificationsHomeCenter
               emptyGestureTargetRef={homeScreenRef}

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -293,6 +293,14 @@ export function HomeScreen({
 
           <div
             data-home-below-notifications=""
+            // Widget declarations resolve during the staged first-mount fade.
+            // Both children are still fully transparent when this box acquires
+            // its final height, but Chromium attributes that invisible resize
+            // as CLS. Scope the existing transient-motion marker to the same
+            // once-only entrance window; later widget changes remain measured.
+            data-eliza-layout-shift-intent={
+              enterClass ? "transient" : undefined
+            }
             className={hasNotifications ? undefined : "flex-1"}
           >
             <div

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -26,14 +26,44 @@ import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
 // A gentle staggered fade-up as the home settles in - iOS-style, calm, and
 // fully stilled under prefers-reduced-motion. Each block carries a small
 // animation-delay (set inline) so the cards/tiles cascade in.
-const HOME_ENTER_CSS = `
+const HOME_SCREEN_CSS = `
 @keyframes home-enter {
   from { opacity: 0; transform: translateY(10px); }
   to   { opacity: 1; transform: none; }
 }
 .home-enter { animation: home-enter 460ms cubic-bezier(0.22,1,0.36,1) both; }
+
+/* Direct expansion previews and the committed shade own the full region below
+   the editorial header. Folding the secondary content through a grid track
+   lets the inbox grow to the live safe-bottom boundary without duplicating the
+   floating composer's clearance. A cancelled preview or committed close drops
+   these selectors at release so the same track reverses on the shade clock. */
+[data-home-below-notifications] {
+  display: grid;
+  grid-template-rows: 1fr;
+  min-height: 0;
+  transition:
+    grid-template-rows var(--eliza-home-notification-settle-duration, 460ms) cubic-bezier(0.25,0.1,0.25,1),
+    opacity 220ms ease-out;
+}
+[data-home-below-notifications-inner] {
+  min-height: 0;
+  overflow: hidden;
+}
+[data-testid="home-content-column"]:has(
+  [data-testid="home-notification-list"][data-shade-preview="expanding"][data-shade-dragging]
+) [data-home-below-notifications],
+[data-testid="home-content-column"]:has(
+  [data-testid="home-notification-list"][data-shade-mode="expanded"]:not([data-shade-settling])
+) [data-home-below-notifications] {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
 @media (prefers-reduced-motion: reduce) {
   .home-enter { animation: none; }
+  [data-home-below-notifications] { transition: none; }
 }
 `;
 
@@ -175,6 +205,7 @@ export function HomeScreen({
   // Dev/test-only: observe home layout shifts on the shared telemetry channel.
   useHomeLayoutShiftObserver();
   const homeScreenRef = useRef<HTMLDivElement>(null);
+  const homeContentColumnRef = useRef<HTMLDivElement>(null);
 
   // When the inbox has notifications it becomes the home's primary content and
   // grows to fill the column down to the chat; the ranked widget host then sits
@@ -216,7 +247,7 @@ export function HomeScreen({
           "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1.5rem)]",
         )}
       >
-        <style>{HOME_ENTER_CSS}</style>
+        <style>{HOME_SCREEN_CSS}</style>
         {/* The content column owns the definite FULL height of the scroller
           (`h-full`) so flex children such as the notification inbox receive a
           bounded height and scroll internally instead of growing behind the
@@ -230,6 +261,7 @@ export function HomeScreen({
           as calm airiness rather than a broken gap; the AOSP tiles settle at
           the BOTTOM. */}
         <div
+          ref={homeContentColumnRef}
           data-testid="home-content-column"
           className="mx-auto flex h-full w-full max-w-2xl flex-col"
         >
@@ -255,73 +287,83 @@ export function HomeScreen({
             )}
             style={{ animationDelay: "90ms" }}
           >
-            <NotificationsHomeCenter emptyGestureTargetRef={homeScreenRef} />
-          </div>
-
-          {/* The prioritized data widgets (#9143). With notifications present
-            they keep a modest height beneath the inbox, leaving a clear gesture
-            area above the chat instead of letting notifications consume every
-            remaining pixel. With
-            an EMPTY inbox this reclaims the `flex-1` breathing region and centres
-            its content, so a quiet home reads as calm airiness rather than a
-            broken gap. A little padding sets the stack apart as its own section. */}
-          <div
-            className={cn(
-              enterClass,
-              "flex min-h-32 flex-col py-6",
-              !hasNotifications && "flex-1 justify-center",
-            )}
-            style={{ animationDelay: "110ms" }}
-          >
-            <WidgetHost
-              slot="home"
-              layout="grid"
-              events={events}
-              clearEvents={clearEvents}
+            <NotificationsHomeCenter
+              emptyGestureTargetRef={homeScreenRef}
+              shadeLayoutTargetRef={homeContentColumnRef}
             />
           </div>
 
-          {tiles.length > 0 ? (
-            <nav
-              aria-label="Apps"
-              data-testid="home-tiles"
-              className={cn(enterClass, "pt-2")}
-              style={{ animationDelay: "150ms" }}
+          <div
+            data-home-below-notifications=""
+            className={hasNotifications ? undefined : "flex-1"}
+          >
+            <div
+              data-home-below-notifications-inner=""
+              className="flex min-h-0 flex-col overflow-hidden"
             >
-              <div className="grid grid-cols-4 gap-3">
-                {tiles.map((tile) => {
-                  const Icon = tile.icon;
-                  return (
-                    <Button
-                      key={tile.id}
-                      data-testid={`home-tile-${tile.id}`}
-                      onClick={() => onOpenTile(tile.target)}
-                      variant="ghost"
-                      className={cn(
-                        // Naked tile: icon + label sit directly on the ambient
-                        // orange field - no fill, no border.
-                        "flex h-auto flex-col items-center gap-1.5 whitespace-normal rounded-2xl px-1 py-3.5",
-                        WALLPAPER_TEXT.base,
-                        WALLPAPER_FLOAT_SHADOW,
-                        // Tactile press: a quick scale-down on tap (stilled for
-                        // reduce-motion users), plus a faint white wash on hover.
-                        "transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:active:scale-100",
-                        "hover:bg-white/8",
-                      )}
-                    >
-                      <Icon
-                        className="h-[22px] w-[22px] text-white"
-                        aria-hidden
-                      />
-                      <span className="max-w-full truncate text-[11px] font-medium text-white">
-                        {tile.label}
-                      </span>
-                    </Button>
-                  );
-                })}
+              {/* The prioritized data widgets (#9143) yield their region while
+                the notification shade is expanded. A quiet inbox instead lets
+                this block absorb the column's breathing room and centre its
+                content. */}
+              <div
+                className={cn(
+                  enterClass,
+                  "flex min-h-32 flex-col py-6",
+                  !hasNotifications && "flex-1 justify-center",
+                )}
+                style={{ animationDelay: "110ms" }}
+              >
+                <WidgetHost
+                  slot="home"
+                  layout="grid"
+                  events={events}
+                  clearEvents={clearEvents}
+                />
               </div>
-            </nav>
-          ) : null}
+
+              {tiles.length > 0 ? (
+                <nav
+                  aria-label="Apps"
+                  data-testid="home-tiles"
+                  className={cn(enterClass, "pt-2")}
+                  style={{ animationDelay: "150ms" }}
+                >
+                  <div className="grid grid-cols-4 gap-3">
+                    {tiles.map((tile) => {
+                      const Icon = tile.icon;
+                      return (
+                        <Button
+                          key={tile.id}
+                          data-testid={`home-tile-${tile.id}`}
+                          onClick={() => onOpenTile(tile.target)}
+                          variant="ghost"
+                          className={cn(
+                            // Naked tile: icon + label sit directly on the ambient
+                            // orange field - no fill, no border.
+                            "flex h-auto flex-col items-center gap-1.5 whitespace-normal rounded-2xl px-1 py-3.5",
+                            WALLPAPER_TEXT.base,
+                            WALLPAPER_FLOAT_SHADOW,
+                            // Tactile press: a quick scale-down on tap (stilled for
+                            // reduce-motion users), plus a faint white wash on hover.
+                            "transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:active:scale-100",
+                            "hover:bg-white/8",
+                          )}
+                        >
+                          <Icon
+                            className="h-[22px] w-[22px] text-white"
+                            aria-hidden
+                          />
+                          <span className="max-w-full truncate text-[11px] font-medium text-white">
+                            {tile.label}
+                          </span>
+                        </Button>
+                      );
+                    })}
+                  </div>
+                </nav>
+              ) : null}
+            </div>
+          </div>
         </div>
       </div>
     </>

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
@@ -114,6 +114,9 @@ function expandShade(): void {
   fireEvent.wheel(screen.getByTestId("home-notification-list"), {
     deltaY: -(PULL_COMMIT_PX + 10),
   });
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
 }
 
 describe("NotificationsHomeCenter render count (#14559)", () => {
@@ -218,6 +221,9 @@ describe("NotificationsHomeCenter render count (#14559)", () => {
     });
     // A peek tap fans the producer stack and enters the expanded shade.
     fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(30);
     expect(rowRenders).toBeGreaterThanOrEqual(30);
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1434,6 +1434,8 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     );
     const clear = screen.getByTestId("notification-stack-clear");
     expect(clear.dataset.confirming).toBeUndefined();
+    expect(clear.className).toContain("w-8");
+    expect(clear.textContent).not.toContain("Clear all");
     fireEvent.click(clear);
     expect(clear.dataset.confirming).toBe("true");
     expect(__getStateForTests().notifications).toHaveLength(3);
@@ -2002,6 +2004,25 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const clear = screen.getByTestId("notifications-clear-all");
     expect(clear.className).toContain("h-8");
     expect(clear.className).not.toContain("min-h-touch");
+    expect(clear.className).toContain("eliza-notif-clear-all");
+    expect(clear.closest("li")?.className).toContain("justify-end");
+    expect(clear.closest("li")?.className).toContain("px-2");
+    const clearCss = clear
+      .closest("section")
+      ?.querySelector("style")?.textContent;
+    expect(clearCss).toContain(".eliza-notif-clear-all {");
+    expect(clearCss).toContain("@media (hover: none), (pointer: coarse)");
+    expect(clearCss).toContain("@media (hover: hover) and (pointer: fine)");
+    expect(clearCss).toContain(
+      ".eliza-notif-clear-all:not([data-confirming]):focus-visible",
+    );
+    const restingLabel = clear.querySelector(
+      "[data-notification-clear-resting-label]",
+    );
+    expect(restingLabel?.textContent).toBe("Clear all");
+    expect(
+      clear.querySelector("[data-notification-clear-resting-icon]"),
+    ).toBeTruthy();
     expect(clear.dataset.confirming).toBeUndefined();
     fireEvent.click(clear);
     expect(clear.dataset.confirming).toBe("true");
@@ -2244,8 +2265,22 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(list.getAttribute("data-shade-preview")).toBe("expanding");
     expect(list.hasAttribute("data-shade-dragging")).toBe(true);
-    expect(list.parentElement?.querySelector("style")?.textContent).toContain(
+    const css = list.parentElement?.querySelector("style")?.textContent ?? "";
+    expect(css).toContain(
       ".eliza-notif-scroll[data-shade-preview][data-shade-dragging]",
+    );
+    const releaseRule = css.match(
+      /\.eliza-notif-scroll\[data-shade-release-settling\]\s*\{([^}]*)\}/,
+    )?.[1];
+    expect(releaseRule).toContain("animation: none");
+    expect(releaseRule).toContain("--scroll-fade-t: 1.25rem");
+    expect(releaseRule).toContain("--scroll-fade-b: 1.5rem");
+    expect(releaseRule).not.toContain("mask-image: none");
+    const rowAnimationGuard = css
+      .match(/[^{}]+\{\s*animation: none !important;\s*\}/g)
+      ?.find((rule) => rule.includes("data-shade-release-settling"));
+    expect(rowAnimationGuard).toContain(
+      '.eliza-notif-scroll[data-shade-mode="expanded"] .eliza-notif-row',
     );
     expect(groupContent?.style.transform).toBe(expectedTransform);
     expect(clearSlot?.style.transform).toBe(expectedTransform);
@@ -2266,6 +2301,43 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     act(() => vi.advanceTimersByTime(700));
     expect(list.hasAttribute("data-shade-release-settling")).toBe(false);
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      "0px",
+    );
+  });
+
+  it("finishes a deep-pull release transaction before an outside close", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 170,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 170,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(true);
+    fireEvent.click(document.body);
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(false);
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
     expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
       "0px",
     );

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -281,7 +281,7 @@ describe("interrupt priority projection", () => {
       "4",
     );
     expect(screen.getByTestId("notification-stack").style.paddingBottom).toBe(
-      "24px",
+      "16px",
     );
 
     fireEvent.pointerDown(list, {
@@ -295,7 +295,7 @@ describe("interrupt priority projection", () => {
       pointerType: "mouse",
       pointerId: 31,
       clientX: 10,
-      clientY: 78,
+      clientY: 40,
     });
 
     expect(screen.getByTestId("notification-row")).toBe(topRow);
@@ -308,13 +308,13 @@ describe("interrupt priority projection", () => {
     const previewTail = Number.parseFloat(
       screen.getByTestId("notification-stack").style.paddingBottom,
     );
-    expect(previewTail).toBe(24);
+    expect(previewTail).toBe(16);
 
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
       pointerId: 31,
       clientX: 10,
-      clientY: 78,
+      clientY: 40,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
@@ -322,7 +322,7 @@ describe("interrupt priority projection", () => {
     expandShade();
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
     expect(screen.getByTestId("notification-stack").style.paddingBottom).toBe(
-      "24px",
+      "16px",
     );
     collapseShade();
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
@@ -348,7 +348,7 @@ describe("interrupt priority projection", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack").style.paddingBottom).toBe(
-      "17px",
+      "9px",
     );
     expect(screen.getByTestId("notification-source-count").textContent).toBe(
       "2",
@@ -430,7 +430,7 @@ describe("interrupt priority projection", () => {
       touches: [{ clientX: 10, clientY: 10 }],
     });
     fireEvent.touchMove(list, {
-      touches: [{ clientX: 12, clientY: 75 }],
+      touches: [{ clientX: 12, clientY: 40 }],
     });
     fireEvent.touchEnd(list, { touches: [] });
     fireEvent.click(screen.getByTestId("notification-row"));
@@ -528,7 +528,7 @@ describe("interrupt priority projection", () => {
       pointerType: "mouse",
       pointerId: 32,
       clientX: 10,
-      clientY: 70,
+      clientY: 40,
     });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
 
@@ -536,7 +536,7 @@ describe("interrupt priority projection", () => {
       pointerType: "mouse",
       pointerId: 32,
       clientX: 10,
-      clientY: 70,
+      clientY: 40,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
@@ -1097,7 +1097,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(peeks[1].style.opacity).toBe("1");
     expect(peeks[0].style.transform).toBe("translateY(7px) scale(0.985)");
     expect(peeks[1].style.transform).toBe("translateY(14px) scale(0.97)");
-    expect(stack.style.paddingBottom).toBe("24px");
+    expect(stack.style.paddingBottom).toBe("16px");
     // The producer tile is vertically centered and carries the stack total.
     const sourceIcon = screen.getByTestId("notification-source-icon");
     expect(sourceIcon.className).toContain("h-10");
@@ -1190,7 +1190,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     );
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
-    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(groupContent.style.paddingBottom).toBe("16px");
     expect(closingPeeks).toHaveLength(2);
     expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
     const enteringRows = screen
@@ -1248,7 +1248,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
-    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(groupContent.style.paddingBottom).toBe("16px");
     expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
     expect(enteringControls.getAttribute("aria-hidden")).toBe("true");
     expect(enteringControls.hasAttribute("inert")).toBe(true);
@@ -1608,7 +1608,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(collapseFooter.className).toContain("shrink-0");
     expect(collapseFooter.className).not.toContain("absolute");
     expect(list.className).toContain("flex-[0_1_auto]");
-    expect(list.className).toContain("pb-2");
+    expect(list.className).toContain("pb-1");
     expect(list.className).toContain("scroll-fade");
     expect(list.className).toContain("scroll-fade-b-[1.5rem]");
     collapse.focus();
@@ -1777,6 +1777,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientY: 20,
     });
     expect(list.getAttribute("data-shade-dragging")).toBeNull();
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
   });
@@ -2056,6 +2058,49 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
   });
 
+  it("keeps an owned pull open when preview insertion changes scrollTop", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(list, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 70,
+    });
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+
+    list.scrollTop = 36;
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 170,
+    });
+    expect(list.scrollTop).toBe(0);
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 170,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
   it("reveals hidden notification groups continuously before release", () => {
     __ingestNotificationForTests(
       makeNotification({
@@ -2184,10 +2229,30 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const collapse = screen.getByTestId("notifications-collapse-footer");
 
     expect(list.style.transform).toBe("");
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      `${overpull}px`,
+    );
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(true);
+    expect(list.parentElement?.querySelector("style")?.textContent).toContain(
+      ".eliza-notif-scroll[data-shade-preview][data-shade-dragging]",
+    );
     expect(groupContent?.style.transform).toBe(expectedTransform);
     expect(clearSlot?.style.transform).toBe(expectedTransform);
     expect(count.style.transform).toBe(expectedTransform);
-    expect(collapse.style.transform).toBe(`translateY(${overpull}px)`);
+    expect(collapse.style.transform).toBe("translateY(0px)");
+
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 108,
+      clientX: 10,
+      clientY: 142,
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      "0px",
+    );
   });
 
   it("a short pull springs back without toggling", () => {
@@ -2379,7 +2444,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       false,
     );
-    act(() => vi.advanceTimersByTime(219));
+    act(() => vi.advanceTimersByTime(459));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -2447,6 +2512,159 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
+  });
+
+  it("keeps an owned touch pull after preview scroll anchoring", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(list, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    fireEvent.touchStart(list, {
+      touches: [{ identifier: 7, clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 7, clientX: 10, clientY: 70 }],
+    });
+    list.scrollTop = 36;
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 7, clientX: 10, clientY: 170 }],
+    });
+    expect(list.scrollTop).toBe(0);
+    fireEvent.touchEnd(list, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("retains a native pull when a notification arrives mid-gesture", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.touchStart(list, {
+      touches: [{ identifier: 11, clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 11, clientX: 10, clientY: 70 }],
+    });
+    __ingestNotificationForTests(
+      makeNotification({ priority: "low", source: "live-arrival" }),
+    );
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 11, clientX: 10, clientY: 170 }],
+    });
+    fireEvent.touchEnd(list, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("keeps a lower-surface mouse pull after the surface scrollTop shifts", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const surface = screen.getByTestId("home-gesture-surface");
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(surface, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    fireEvent.pointerDown(surface, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 12,
+      clientX: 180,
+      clientY: 300,
+    });
+    fireEvent.pointerMove(surface, {
+      pointerType: "mouse",
+      pointerId: 12,
+      clientX: 180,
+      clientY: 360,
+    });
+    surface.scrollTop = 36;
+    fireEvent.pointerMove(surface, {
+      pointerType: "mouse",
+      pointerId: 12,
+      clientX: 180,
+      clientY: 460,
+    });
+    expect(surface.scrollTop).toBe(0);
+    fireEvent.pointerUp(surface, {
+      pointerType: "mouse",
+      pointerId: 12,
+      clientX: 180,
+      clientY: 460,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("rebases lower-surface touch travel at the top and retains ownership", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const surface = screen.getByTestId("home-gesture-surface");
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(surface, "scrollTop", {
+      configurable: true,
+      value: 120,
+      writable: true,
+    });
+
+    fireEvent.touchStart(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 200 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 300 }],
+    });
+    surface.scrollTop = 0;
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 400 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 430 }],
+    });
+    fireEvent.touchEnd(surface, { touches: [] });
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+
+    fireEvent.touchStart(surface, {
+      touches: [{ identifier: 9, clientX: 180, clientY: 300 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 9, clientX: 180, clientY: 380 }],
+    });
+    surface.scrollTop = 24;
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 9, clientX: 180, clientY: 470 }],
+    });
+    expect(surface.scrollTop).toBe(0);
+    fireEvent.touchEnd(surface, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("a continuous drag that scrolls the expanded list back to the top does NOT collapse (re-base at the crossing)", () => {
@@ -2763,7 +2981,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
 
-    act(() => vi.advanceTimersByTime(219));
+    act(() => vi.advanceTimersByTime(459));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -2799,7 +3017,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
 
-    act(() => vi.advanceTimersByTime(219));
+    act(() => vi.advanceTimersByTime(459));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1159,6 +1159,8 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expandShade();
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
+    const collapseFooter = screen.getByTestId("notifications-collapse-footer");
+    expect(collapseFooter.style.opacity).toBe("1");
     // Tapping the peeked card below the top one fans the stack out.
     const openingPeek = screen.getAllByTestId("notification-stack-peek")[0];
     openingPeek.focus();
@@ -1213,10 +1215,21 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
         screen.getAllByTestId("notification-row")[0],
       ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(screen.queryByTestId("notifications-collapse")).toBeNull();
+    expect(screen.getByTestId("notifications-collapse-footer")).toBe(
+      collapseFooter,
+    );
+    expect(collapseFooter.style.opacity).toBe("0");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+    expect(collapseFooter.hasAttribute("inert")).toBe(true);
     fireEvent.click(screen.getByTestId("notification-stack-collapse"), {
       detail: 0,
     });
+    expect(screen.getByTestId("notifications-collapse-footer")).toBe(
+      collapseFooter,
+    );
+    expect(collapseFooter.style.opacity).toBe("1");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+    expect(collapseFooter.hasAttribute("inert")).toBe(true);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
@@ -1249,6 +1262,12 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
     expect(screen.queryByTestId("notification-stack-collapse")).toBeNull();
     expect(document.activeElement).toBe(screen.getByTestId("notification-row"));
+    expect(screen.getByTestId("notifications-collapse-footer")).toBe(
+      collapseFooter,
+    );
+    expect(collapseFooter.style.opacity).toBe("1");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+    expect(collapseFooter.hasAttribute("inert")).toBe(false);
     expect(screen.getByTestId("notifications-collapse").textContent).toContain(
       "Collapse",
     );
@@ -2570,6 +2589,39 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("collapses a fanned shade from empty space below its cards", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    act(() => vi.advanceTimersByTime(40));
+    const center = screen.getByTestId("home-notification-center");
+    const group = center.querySelector(
+      "[data-notification-group]",
+    ) as HTMLElement;
+    vi.spyOn(group, "getBoundingClientRect").mockReturnValue({
+      x: 20,
+      y: 100,
+      top: 100,
+      right: 300,
+      bottom: 300,
+      left: 20,
+      width: 280,
+      height: 200,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.click(center, { clientY: 240 });
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+    expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
+
+    fireEvent.click(center, { clientY: 360 });
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    finishShadeCollapse();
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
   });
 
   it("ignores empty-region drags while the shade close is settling", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -61,6 +61,7 @@ import {
 } from "./NotificationsHomeCenter";
 import {
   notificationGroupContainerOffset,
+  notificationPullOvershootOffset,
   PULL_TRAVEL_PX,
 } from "./notification-shade-presentation";
 
@@ -152,7 +153,7 @@ function collapseShade(): HTMLElement {
 }
 
 function finishShadeCollapse(): void {
-  act(() => vi.advanceTimersByTime(400));
+  act(() => vi.advanceTimersByTime(500));
 }
 
 function finishStackFold(): void {
@@ -539,7 +540,7 @@ describe("interrupt priority projection", () => {
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
-    act(() => vi.advanceTimersByTime(340));
+    act(() => vi.advanceTimersByTime(500));
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(0);
   });
 });
@@ -587,15 +588,21 @@ describe("dampenPull", () => {
     expect(dampenPull(96)).toBe(PULL_TRAVEL_PX);
     expect(dampenPull(124)).toBeCloseTo(97.8);
   });
+
+  it("preserves resisted travel as signed visual overshoot", () => {
+    const overpull = dampenPull(124);
+
+    expect(notificationPullOvershootOffset(PULL_TRAVEL_PX)).toBe(0);
+    expect(notificationPullOvershootOffset(overpull)).toBeCloseTo(9.8);
+    expect(notificationPullOvershootOffset(-overpull)).toBeCloseTo(-9.8);
+  });
 });
 
 describe("notificationPullRevealProgress", () => {
   it("tracks full detent travel while staggering later groups", () => {
     expect(notificationPullRevealProgress(0, 0)).toBe(0);
     expect(notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 0)).toBe(0.5);
-    expect(
-      notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 2),
-    ).toBeLessThan(
+    expect(notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 2)).toBeLessThan(
       0.5,
     );
     expect(notificationPullRevealProgress(PULL_TRAVEL_PX, 4)).toBe(1);
@@ -689,8 +696,9 @@ describe("NotificationsHomeCenter", () => {
       clientX: 10,
       clientY: 300,
     });
+    act(() => vi.advanceTimersByTime(16));
     expect(empty.style.opacity).toBe(restingEmptyStyle.opacity);
-    expect(empty.style.transform).toBe(restingEmptyStyle.transform);
+    expect(empty.style.transform).not.toBe(restingEmptyStyle.transform);
     expect(list.style.transform).toBe("");
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -701,7 +709,7 @@ describe("NotificationsHomeCenter", () => {
 
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getByTestId("notifications-empty").style.opacity).toBe("1");
-    expect(empty.style.transform).toBe(restingEmptyStyle.transform);
+    expect(empty.style.transform).toBe("translate3d(0, 0px, 0)");
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
 
     fireEvent.click(document.body);
@@ -2096,7 +2104,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(revealedGroups).toHaveLength(2);
     for (const group of revealedGroups) {
-      const opacity = Number.parseFloat((group as HTMLElement).style.opacity);
+      const content = group.querySelector<HTMLElement>(
+        "[data-notification-group-content]",
+      );
+      const opacity = Number.parseFloat(content?.style.opacity ?? "");
       expect(opacity).toBeGreaterThan(0);
       expect(opacity).toBeLessThan(1);
     }
@@ -2131,10 +2142,52 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(collapseReveal).toBeGreaterThan(0);
     expect(collapseReveal).toBeLessThan(1);
     for (const group of revealedGroups) {
-      const opacity = Number.parseFloat((group as HTMLElement).style.opacity);
+      const content = group.querySelector<HTMLElement>(
+        "[data-notification-group-content]",
+      );
+      const opacity = Number.parseFloat(content?.style.opacity ?? "");
       expect(opacity).toBeGreaterThan(0);
       expect(opacity).toBeLessThan(1);
     }
+  });
+
+  it("keeps resisted overpull on stable shade contents without translating the scroller", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", source: "files" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 108,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 108,
+      clientX: 10,
+      clientY: 142,
+    });
+    act(() => vi.advanceTimersByTime(20));
+
+    const overpull = notificationPullOvershootOffset(dampenPull(132));
+    const expectedTransform = `translate3d(0, ${overpull}px, 0)`;
+    const groupContent = list.querySelector<HTMLElement>(
+      "[data-notification-group-content]",
+    );
+    const clearSlot = list.querySelector<HTMLElement>(
+      "[data-notification-clear-slot]",
+    );
+    const count = screen.getByTestId("notifications-count");
+    const collapse = screen.getByTestId("notifications-collapse-footer");
+
+    expect(list.style.transform).toBe("");
+    expect(groupContent?.style.transform).toBe(expectedTransform);
+    expect(clearSlot?.style.transform).toBe(expectedTransform);
+    expect(count.style.transform).toBe(expectedTransform);
+    expect(collapse.style.transform).toBe(`translateY(${overpull}px)`);
   });
 
   it("a short pull springs back without toggling", () => {
@@ -2193,12 +2246,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(list.getAttribute("data-shade-preview")).toBe("expanding");
     expect(
-      previewGroups.every(
-        (group) =>
+      previewGroups.every((group) => {
+        const content = group.querySelector<HTMLElement>(
+          "[data-notification-group-content]",
+        );
+        return (
           group.isConnected &&
-          group.classList.contains("eliza-notif-shade-transition") &&
-          group.style.opacity === "0",
-      ),
+          content?.classList.contains("eliza-notif-shade-transition") &&
+          content.style.opacity === "0"
+        );
+      }),
     ).toBe(true);
     expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
@@ -2206,7 +2263,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(previewGroups.every((group) => group.isConnected)).toBe(true);
     expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
-    act(() => vi.advanceTimersByTime(239));
+    act(() => vi.advanceTimersByTime(393));
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       true,
     );
@@ -2221,7 +2278,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(1);
   });
 
-  it("keeps the same preview nodes mounted when an active pull crosses zero", () => {
+  it("keeps the same preview nodes mounted through zero and a committed settle", () => {
     __ingestNotificationForTests(
       makeNotification({ priority: "urgent", source: "mail" }),
     );
@@ -2247,6 +2304,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       "[data-notification-pull-reveal]",
     );
     expect(preview).toBeTruthy();
+    const previewContent = preview?.querySelector<HTMLElement>(
+      "[data-notification-group-content]",
+    );
+    expect(previewContent).toBeTruthy();
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
@@ -2257,7 +2318,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     act(() => vi.advanceTimersByTime(20));
     expect(list.getAttribute("data-shade-dragging")).not.toBeNull();
     expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
-    expect(preview?.style.opacity).toBe("0");
+    expect(previewContent?.style.opacity).toBe("0");
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
@@ -2267,7 +2328,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     act(() => vi.advanceTimersByTime(20));
     expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
-    expect(Number.parseFloat(preview?.style.opacity ?? "0")).toBeGreaterThan(0);
+    expect(
+      Number.parseFloat(previewContent?.style.opacity ?? "0"),
+    ).toBeGreaterThan(0);
 
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -2275,9 +2338,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 10,
       clientY: 80,
     });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(preview?.isConnected).toBe(true);
-    act(() => vi.advanceTimersByTime(340));
-    expect(preview?.isConnected).toBe(false);
+    expect(preview?.hasAttribute("data-notification-pull-reveal")).toBe(false);
+    expect(previewContent?.style.opacity).toBe("1");
+    act(() => vi.advanceTimersByTime(460));
+    expect(preview?.isConnected).toBe(true);
   });
 
   it("clears a cancelled-pull settle before starting a committed collapse", () => {
@@ -2361,7 +2427,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
-    act(() => vi.advanceTimersByTime(340));
+    act(() => vi.advanceTimersByTime(460));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2213,6 +2213,15 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       pointerType: "mouse",
       pointerId: 108,
       clientX: 10,
+      clientY: 80,
+    });
+    // Establish the React drag state before the deep move. Subsequent frames
+    // update the runway imperatively, which is the real-browser path that can
+    // otherwise leave stale padding behind on release.
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 108,
+      clientX: 10,
       clientY: 142,
     });
     act(() => vi.advanceTimersByTime(20));
@@ -2251,7 +2260,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(list.hasAttribute("data-shade-dragging")).toBe(false);
     expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
-      "0px",
+      "",
     );
   });
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1902,8 +1902,15 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     render(<NotificationsHomeCenter />);
     const priorityRow = screen.getByTestId("notification-row");
     fireEvent.click(priorityRow);
+    act(() => vi.advanceTimersByTime(40));
     const controls = screen.getByTestId("notification-stack-controls");
     const quietRow = screen.getByText("Calendar summary").closest("li");
+    const stackRows = document.querySelector(
+      "[data-notification-stack-rows]",
+    ) as HTMLElement;
+    const sourceCount = screen.getByTestId("notification-source-count");
+    expect(stackRows.style.rowGap).toBe("6px");
+    expect(sourceCount.style.opacity).toBe("0");
 
     fireEvent.click(document.body);
 
@@ -1914,6 +1921,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(controls.style.height).toBe("0px");
     expect(quietRow?.style.opacity).toBe("0");
     expect(quietRow?.style.gridTemplateRows).toBe("0fr");
+    expect(stackRows.style.rowGap).toBe("0px");
+    expect(sourceCount.style.opacity).toBe("1");
     finishShadeCollapse();
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2465,6 +2465,11 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       true,
     );
     expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    const shadeCss = center.querySelector("style")?.textContent ?? "";
+    const previewRowAnimationGuard = shadeCss.match(
+      /\.eliza-notif-scroll \[data-notification-pull-reveal\] \.eliza-notif-row,[^{]+\{([^}]*)\}/,
+    )?.[1];
+    expect(previewRowAnimationGuard).toContain("animation: none !important");
     expect(
       previewGroups.every((group) => {
         const content = group.querySelector<HTMLElement>(

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -62,6 +62,7 @@ import {
 import {
   notificationGroupContainerOffset,
   notificationPullOvershootOffset,
+  notificationPullPresentation,
   PULL_TRAVEL_PX,
 } from "./notification-shade-presentation";
 
@@ -631,6 +632,28 @@ describe("dampenPull", () => {
     expect(notificationPullOvershootOffset(PULL_TRAVEL_PX)).toBe(0);
     expect(notificationPullOvershootOffset(overpull)).toBeCloseTo(9.8, 1);
     expect(notificationPullOvershootOffset(-overpull)).toBeCloseTo(-9.8, 1);
+  });
+
+  it("fades the count before upward overpull reaches its clipping boundary", () => {
+    const atCloseDetent = notificationPullPresentation(
+      -PULL_TRAVEL_PX,
+      true,
+      false,
+    );
+    const midwayThroughBoundaryFade = notificationPullPresentation(
+      -(PULL_TRAVEL_PX + 16),
+      true,
+      false,
+    );
+    const pastBoundaryFade = notificationPullPresentation(
+      -(PULL_TRAVEL_PX + 24),
+      true,
+      false,
+    );
+
+    expect(atCloseDetent.notificationCountVisibility).toBe(1);
+    expect(midwayThroughBoundaryFade.notificationCountVisibility).toBe(0.5);
+    expect(pastBoundaryFade.notificationCountVisibility).toBe(0);
   });
 });
 
@@ -1803,7 +1826,11 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
 
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
-    expect(screen.getByTestId("notifications-count").style.opacity).toBe("1");
+    const overpullCountOpacity = Number.parseFloat(
+      screen.getByTestId("notifications-count").style.opacity,
+    );
+    expect(overpullCountOpacity).toBeGreaterThan(0);
+    expect(overpullCountOpacity).toBeLessThan(1);
     const peeks = screen.getAllByTestId("notification-stack-peek");
     expect(peeks[0].style.opacity).toBe("1");
     expect(peeks[1].style.opacity).toBe("1");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -586,15 +586,16 @@ describe("dampenPull", () => {
     expect(dampenPull(48)).toBe(40);
     expect(dampenPull(52)).toBe(PULL_COMMIT_PX);
     expect(dampenPull(96)).toBe(PULL_TRAVEL_PX);
-    expect(dampenPull(124)).toBeCloseTo(97.8);
+    expect(dampenPull(124)).toBeCloseTo(97.8, 1);
+    expect(dampenPull(2_000)).toBeLessThanOrEqual(PULL_TRAVEL_PX + 32);
   });
 
   it("preserves resisted travel as signed visual overshoot", () => {
     const overpull = dampenPull(124);
 
     expect(notificationPullOvershootOffset(PULL_TRAVEL_PX)).toBe(0);
-    expect(notificationPullOvershootOffset(overpull)).toBeCloseTo(9.8);
-    expect(notificationPullOvershootOffset(-overpull)).toBeCloseTo(-9.8);
+    expect(notificationPullOvershootOffset(overpull)).toBeCloseTo(9.8, 1);
+    expect(notificationPullOvershootOffset(-overpull)).toBeCloseTo(-9.8, 1);
   });
 });
 
@@ -2259,8 +2260,14 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(true);
     expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
-      "",
+      "0px",
+    );
+    act(() => vi.advanceTimersByTime(700));
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(false);
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      "0px",
     );
   });
 
@@ -2543,14 +2550,19 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       changedTouches: [{ identifier: 15, clientX: 180, clientY: 620 }],
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
-    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(true);
     expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
-      "",
+      "0px",
     );
     expect(collapseFooter.style.transform).toBe("translateY(0px)");
 
     fireEvent.click(screen.getByTestId("notifications-collapse"));
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
+
+    act(() => vi.advanceTimersByTime(700));
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(false);
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
 
     fireEvent.click(screen.getByTestId("notifications-collapse"));
     expect(list.hasAttribute("data-shade-settling")).toBe(true);
@@ -2738,12 +2750,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       changedTouches: [{ identifier: 14, clientX: 180, clientY: 620 }],
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(true);
     expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
-      "",
+      "0px",
     );
     expect(
       screen.getByTestId("notifications-collapse-footer").style.transform,
     ).toBe("translateY(0px)");
+
+    act(() => vi.advanceTimersByTime(700));
+    expect(list.hasAttribute("data-shade-release-settling")).toBe(false);
 
     fireEvent.click(surface, { clientY: 620 });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -395,7 +395,7 @@ describe("interrupt priority projection", () => {
       value: 240,
       writable: true,
     });
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
 
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(list.scrollTop).toBe(0);
@@ -469,13 +469,13 @@ describe("interrupt priority projection", () => {
       touches: [{ clientX: 12, clientY: 40 }],
     });
     fireEvent.touchEnd(list, { touches: [] });
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
     expect(__getStateForTests().notifications).toHaveLength(2);
 
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
   });
@@ -1702,7 +1702,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
   });
 
-  it("opens from the notification total without treating a pointer drag as a click", () => {
+  it("suppresses a drag release click without blocking keyboard activation", () => {
     seedTriage();
     render(<NotificationsHomeCenter />);
     const list = screen.getByTestId("home-notification-list");
@@ -1733,9 +1733,32 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 10,
       clientY: 30,
     });
-    fireEvent.click(countButton);
+    fireEvent.click(countButton, { detail: 1 });
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+
+    fireEvent.pointerDown(countButton, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 83,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(countButton, {
+      pointerType: "mouse",
+      pointerId: 83,
+      clientX: 10,
+      clientY: 30,
+    });
+    fireEvent.pointerUp(countButton, {
+      pointerType: "mouse",
+      pointerId: 83,
+      clientX: 10,
+      clientY: 30,
+    });
+    fireEvent.click(countButton, { detail: 0 });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("animates groups that mount when the notification total opens the shade", () => {
@@ -2672,8 +2695,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     // The list consumes the first post-drag synthetic click. The next click is
     // the intentional activation and must start on its own transition clock.
-    fireEvent.click(screen.getByTestId("notification-row"));
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       false,
     );
@@ -2728,7 +2751,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(collapseFooter.style.transform).toBe("translateY(0px)");
 
-    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    fireEvent.click(screen.getByTestId("notifications-collapse"), {
+      detail: 1,
+    });
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
 
     act(() => vi.advanceTimersByTime(700));

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2544,6 +2544,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      "",
+    );
+    expect(collapseFooter.style.transform).toBe("translateY(0px)");
 
     fireEvent.click(screen.getByTestId("notifications-collapse"));
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
@@ -2734,6 +2738,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       changedTouches: [{ identifier: 14, clientX: 180, clientY: 620 }],
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      "",
+    );
+    expect(
+      screen.getByTestId("notifications-collapse-footer").style.transform,
+    ).toBe("translateY(0px)");
 
     fireEvent.click(surface, { clientY: 620 });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2523,6 +2523,35 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
   });
 
+  it("keeps preview Collapse inert and ignores its deep-pull release click", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.touchStart(list, {
+      touches: [{ identifier: 15, clientX: 180, clientY: 120 }],
+    });
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 15, clientX: 180, clientY: 620 }],
+    });
+    const collapseFooter = screen.getByTestId("notifications-collapse-footer");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => vi.advanceTimersByTime(700));
+    fireEvent.touchEnd(list, {
+      touches: [],
+      changedTouches: [{ identifier: 15, clientX: 180, clientY: 620 }],
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+  });
+
   it("keeps an owned touch pull after preview scroll anchoring", () => {
     seedTriage();
     render(<NotificationsHomeCenter />);

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -67,6 +67,40 @@ import {
 
 let seq = 0;
 let restoreMatchMediaForTest: (() => void) | null = null;
+const FINE_POINTER_QUERY = "(hover: hover) and (pointer: fine)";
+
+function staticMediaQuery(media: string, matches: boolean): MediaQueryList {
+  return {
+    matches,
+    media,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MediaQueryList;
+}
+
+function installPointerCapability(finePointer: boolean): void {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "matchMedia",
+  );
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) =>
+      staticMediaQuery(query, query === FINE_POINTER_QUERY && finePointer),
+  });
+  restoreMatchMediaForTest = () => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, "matchMedia", originalDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
+    }
+    restoreMatchMediaForTest = null;
+  };
+}
 
 function installReducedMotionController(initialMatches = false): {
   setMatches: (matches: boolean) => void;
@@ -99,7 +133,8 @@ function installReducedMotionController(initialMatches = false): {
   } as unknown as MediaQueryList;
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
-    value: () => mediaQuery,
+    value: (query: string) =>
+      query === media ? mediaQuery : staticMediaQuery(query, false),
   });
   restoreMatchMediaForTest = () => {
     if (originalDescriptor) {
@@ -1997,7 +2032,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
   });
 
-  it("requires X then Clear before clearing the expanded inbox", () => {
+  it("asks for an explicit second-click confirmation on fine pointers", () => {
+    installPointerCapability(true);
     seedTriage();
     render(<NotificationsHomeCenter />);
     expandShade();
@@ -2011,7 +2047,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       .closest("section")
       ?.querySelector("style")?.textContent;
     expect(clearCss).toContain(".eliza-notif-clear-all {");
-    expect(clearCss).toContain("@media (hover: none), (pointer: coarse)");
+    expect(clearCss).not.toContain("@media (hover: none), (pointer: coarse)");
     expect(clearCss).toContain("@media (hover: hover) and (pointer: fine)");
     expect(clearCss).toContain(
       ".eliza-notif-clear-all:not([data-confirming]):focus-visible",
@@ -2026,7 +2062,39 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(clear.dataset.confirming).toBeUndefined();
     fireEvent.click(clear);
     expect(clear.dataset.confirming).toBe("true");
+    expect(clear.getAttribute("aria-label")).toBe(
+      "Confirm clear all notifications",
+    );
+    expect(
+      clear.querySelector("[data-notification-clear-confirming-label]")
+        ?.textContent,
+    ).toBe("Confirm?");
     expect(__getStateForTests().notifications).toHaveLength(3);
+    fireEvent.click(clear);
+    expect(__getStateForTests().notifications).toHaveLength(0);
+  });
+
+  it("keeps the coarse-pointer X then Clear all two-tap flow", () => {
+    installPointerCapability(false);
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    expandShade();
+    const clear = screen.getByTestId("notifications-clear-all");
+    expect(clear.dataset.confirming).toBeUndefined();
+    expect(clear.getAttribute("aria-label")).toBe("Clear all notifications");
+
+    fireEvent.click(clear);
+
+    expect(clear.dataset.confirming).toBe("true");
+    expect(clear.getAttribute("aria-label")).toBe(
+      "Confirm clear all notifications",
+    );
+    expect(
+      clear.querySelector("[data-notification-clear-confirming-label]")
+        ?.textContent,
+    ).toBe("Clear all");
+    expect(__getStateForTests().notifications).toHaveLength(3);
+
     fireEvent.click(clear);
     expect(__getStateForTests().notifications).toHaveLength(0);
   });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -903,6 +903,7 @@ describe("NotificationsHomeCenter", () => {
     expandShade();
     const clear = screen.getByTestId("notifications-clear-all");
     expect(clear.parentElement?.className).not.toContain("sticky");
+    expect(clear.parentElement?.className).toContain("px-2");
     expect(clear.parentElement).toBe(
       screen.getByTestId("home-notification-list").firstElementChild,
     );
@@ -931,6 +932,11 @@ describe("NotificationsHomeCenter", () => {
     expect(css).toContain(".eliza-notif-glass");
     expect(css).toContain("backdrop-filter");
     expect(css).toContain("box-shadow");
+    const focusedGlassRule = css.match(
+      /\.eliza-notif-glass:focus-within\s*\{([^}]*)\}/,
+    )?.[1];
+    expect(focusedGlassRule).toContain("box-shadow:");
+    expect(focusedGlassRule).toContain("!important");
     expect(css).toContain(".eliza-notif-row-inner[data-swipe-dragging]");
     expect(surface.getAttribute("data-swipe-dragging")).toBeNull();
   });
@@ -1167,6 +1173,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     fireEvent.click(openingPeek, { detail: 0 });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     const enteringControls = screen.getByTestId("notification-stack-controls");
+    expect(enteringControls.className).toContain("px-2");
     const groupContent = document.querySelector(
       "[data-notification-group-content]",
     ) as HTMLElement;

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2676,6 +2676,43 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
+  it("keeps a deep lower-surface touch pull open through its synthetic release click", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const surface = screen.getByTestId("home-gesture-surface");
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.touchStart(surface, {
+      touches: [{ identifier: 14, clientX: 180, clientY: 220 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 14, clientX: 180, clientY: 620 }],
+    });
+    // A slow hold must not let the release-click guard expire before touchend.
+    act(() => vi.advanceTimersByTime(700));
+    fireEvent.touchEnd(surface, {
+      touches: [],
+      changedTouches: [{ identifier: 14, clientX: 180, clientY: 620 }],
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+
+    fireEvent.click(surface, { clientY: 620 });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+
+    fireEvent.click(surface, { clientY: 620 });
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+  });
+
   it("a continuous drag that scrolls the expanded list back to the top does NOT collapse (re-base at the crossing)", () => {
     seedTriage();
     render(<NotificationsHomeCenter />);

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -59,6 +59,7 @@ import {
   PULL_COMMIT_PX,
   STACK_FOLD_SETTLE_MS,
 } from "./NotificationsHomeCenter";
+import { NOTIFICATION_ROW_SETTLE_MS } from "./notification-shade-content";
 import {
   notificationGroupContainerOffset,
   notificationPullOvershootOffset,
@@ -68,7 +69,6 @@ import {
 
 let seq = 0;
 let restoreMatchMediaForTest: (() => void) | null = null;
-const FINE_POINTER_QUERY = "(hover: hover) and (pointer: fine)";
 
 function staticMediaQuery(media: string, matches: boolean): MediaQueryList {
   return {
@@ -81,26 +81,6 @@ function staticMediaQuery(media: string, matches: boolean): MediaQueryList {
     removeListener: vi.fn(),
     dispatchEvent: vi.fn(),
   } as unknown as MediaQueryList;
-}
-
-function installPointerCapability(finePointer: boolean): void {
-  const originalDescriptor = Object.getOwnPropertyDescriptor(
-    window,
-    "matchMedia",
-  );
-  Object.defineProperty(window, "matchMedia", {
-    configurable: true,
-    value: (query: string) =>
-      staticMediaQuery(query, query === FINE_POINTER_QUERY && finePointer),
-  });
-  restoreMatchMediaForTest = () => {
-    if (originalDescriptor) {
-      Object.defineProperty(window, "matchMedia", originalDescriptor);
-    } else {
-      Reflect.deleteProperty(window, "matchMedia");
-    }
-    restoreMatchMediaForTest = null;
-  };
 }
 
 function installReducedMotionController(initialMatches = false): {
@@ -475,6 +455,7 @@ describe("interrupt priority projection", () => {
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
     expect(__getStateForTests().notifications).toHaveLength(2);
 
+    act(() => vi.advanceTimersByTime(180));
     fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
@@ -641,12 +622,12 @@ describe("dampenPull", () => {
       false,
     );
     const midwayThroughBoundaryFade = notificationPullPresentation(
-      -(PULL_TRAVEL_PX + 16),
+      -(PULL_TRAVEL_PX + 4),
       true,
       false,
     );
     const pastBoundaryFade = notificationPullPresentation(
-      -(PULL_TRAVEL_PX + 24),
+      -(PULL_TRAVEL_PX + 8),
       true,
       false,
     );
@@ -962,13 +943,18 @@ describe("NotificationsHomeCenter", () => {
     expect(screen.queryByText("Dismiss me")).toBeNull();
   });
 
-  it("shows the non-sticky clear command only at the top of the expanded shade", () => {
+  it("keeps the clear command mounted while its shade slot reveals", () => {
     __ingestNotificationForTests(makeNotification());
     __ingestNotificationForTests(makeNotification());
     render(<NotificationsHomeCenter />);
-    expect(screen.queryByTestId("notifications-clear-all")).toBeNull();
+    const restingClear = screen.getByTestId("notifications-clear-all");
+    expect(restingClear.closest("li")?.style.opacity).toBe("0");
+    expect(restingClear.closest("li")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
     expandShade();
     const clear = screen.getByTestId("notifications-clear-all");
+    expect(clear).toBe(restingClear);
     expect(clear.parentElement?.className).not.toContain("sticky");
     expect(clear.parentElement?.className).toContain("px-2");
     expect(clear.parentElement).toBe(
@@ -1292,9 +1278,9 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getByTestId("notifications-collapse-footer")).toBe(
       collapseFooter,
     );
-    expect(collapseFooter.style.opacity).toBe("0");
-    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
-    expect(collapseFooter.hasAttribute("inert")).toBe(true);
+    expect(collapseFooter.style.opacity).toBe("1");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+    expect(collapseFooter.hasAttribute("inert")).toBe(false);
     fireEvent.click(screen.getByTestId("notification-stack-collapse"), {
       detail: 0,
     });
@@ -1302,8 +1288,8 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       collapseFooter,
     );
     expect(collapseFooter.style.opacity).toBe("1");
-    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
-    expect(collapseFooter.hasAttribute("inert")).toBe(true);
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+    expect(collapseFooter.hasAttribute("inert")).toBe(false);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
@@ -1557,11 +1543,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getByText("Quiet")).toBeTruthy();
   });
 
-  it("SWIPE-dismissing the stack top promotes the next card WITHOUT its fling-out state (keyed remount)", () => {
-    // The single-child stacked top card must be keyed by id: on swipe-dismiss
-    // the promoted card would otherwise reconcile into the outgoing card's slot
-    // and inherit its `dismissing` transform (translateX 120%) — painting the
-    // arriving card invisible/off-screen.
+  it("reveals and smoothly promotes the next real card when swiping a stack top", () => {
     vi.useFakeTimers();
     try {
       __ingestNotificationForTests(
@@ -1573,8 +1555,12 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       render(<NotificationsHomeCenter />);
       expandShade();
       const swipe = screen.getByTestId("notification-row-swipe");
-      // Drag the top card right past SWIPE_DISMISS_PX (88) and release → the
-      // outgoing card gets `translateX(120%)`, then the store removes it (180ms).
+      const peek = screen.getByTestId("notification-stack-peek");
+      expect(
+        peek
+          .querySelector("[data-notification-stack-preview-title]")
+          ?.getAttribute("data-notification-stack-preview-title"),
+      ).toBe("Below");
       const step = (type: string, x: number) =>
         (
           fireEvent as unknown as Record<
@@ -1590,12 +1576,22 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       step("pointerDown", 20);
       step("pointerMove", 80);
       step("pointerMove", 150);
+      expect(swipe.style.transform).toContain("translateX(130px)");
+      expect(peek.style.transform).toContain("translateY(7px)");
       step("pointerUp", 150);
+      expect(swipe.style.transform).toContain("translateX(120%)");
+      expect(peek.getAttribute("data-swipe-promoting")).toBe("");
+      expect(peek.style.transform).toContain("translateY(0px) scale(1)");
+
       act(() => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(NOTIFICATION_ROW_SETTLE_MS);
       });
-      // The promoted "Below" card is fully visible: no residual fling-out
-      // transform, full opacity — the key forced a fresh mount.
+      expect(screen.getByTestId("notification-row").textContent).toContain(
+        "On top",
+      );
+      act(() => {
+        vi.advanceTimersByTime(24);
+      });
       const promoted = screen.getByTestId("notification-row-swipe");
       expect(screen.getByTestId("notification-row").textContent).toContain(
         "Below",
@@ -1604,6 +1600,55 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       expect(
         promoted.style.opacity === "" || promoted.style.opacity === "1",
       ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("smoothly closes the vacated gap after dismissing a fanned stack row", () => {
+    vi.useFakeTimers();
+    try {
+      __ingestNotificationForTests(
+        makeNotification({ title: "Below", priority: "high" }),
+      );
+      __ingestNotificationForTests(
+        makeNotification({ title: "On top", priority: "urgent" }),
+      );
+      render(<NotificationsHomeCenter />);
+      expandShade();
+      fireEvent.click(screen.getByTestId("notification-row"));
+      const rows = screen.getAllByTestId("notification-row-swipe");
+      expect(rows).toHaveLength(2);
+      const outgoing = rows[0] as HTMLElement;
+      const item = outgoing.closest("li") as HTMLElement;
+      const step = (type: string, x: number) =>
+        (
+          fireEvent as unknown as Record<
+            string,
+            (element: Element, init: unknown) => void
+          >
+        )[type](outgoing, {
+          clientX: x,
+          clientY: 22,
+          pointerId: 4,
+          pointerType: "touch",
+        });
+
+      step("pointerDown", 150);
+      step("pointerMove", 30);
+      step("pointerUp", 30);
+      expect(outgoing.style.transform).toContain("translateX(-120%)");
+      expect(item.getAttribute("data-swipe-collapsing")).toBe("");
+      expect(item.style.gridTemplateRows).toBe("0fr");
+      expect(item.style.marginBottom).toBe("-6px");
+
+      act(() => {
+        vi.advanceTimersByTime(NOTIFICATION_ROW_SETTLE_MS + 24);
+      });
+      expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+      expect(screen.getByTestId("notification-row").textContent).toContain(
+        "Below",
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -1852,8 +1897,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const overpullCountOpacity = Number.parseFloat(
       screen.getByTestId("notifications-count").style.opacity,
     );
-    expect(overpullCountOpacity).toBeGreaterThan(0);
-    expect(overpullCountOpacity).toBeLessThan(1);
+    expect(overpullCountOpacity).toBe(0);
     const peeks = screen.getAllByTestId("notification-stack-peek");
     expect(peeks[0].style.opacity).toBe("1");
     expect(peeks[1].style.opacity).toBe("1");
@@ -2082,8 +2126,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
   });
 
-  it("asks for an explicit second-click confirmation on fine pointers", () => {
-    installPointerCapability(true);
+  it("requires X, Clear all, and Confirm? clicks before bulk clearing", () => {
     seedTriage();
     render(<NotificationsHomeCenter />);
     expandShade();
@@ -2097,21 +2140,29 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       .closest("section")
       ?.querySelector("style")?.textContent;
     expect(clearCss).toContain(".eliza-notif-clear-all {");
-    expect(clearCss).not.toContain("@media (hover: none), (pointer: coarse)");
-    expect(clearCss).toContain("@media (hover: hover) and (pointer: fine)");
-    expect(clearCss).toContain(
-      ".eliza-notif-clear-all:not([data-confirming]):focus-visible",
+    expect(clearCss).not.toContain(
+      ".eliza-notif-clear-all:not([data-confirming]):hover",
     );
-    const restingLabel = clear.querySelector(
-      "[data-notification-clear-resting-label]",
-    );
-    expect(restingLabel?.textContent).toBe("Clear all");
-    expect(
-      clear.querySelector("[data-notification-clear-resting-icon]"),
-    ).toBeTruthy();
     expect(clear.dataset.confirming).toBeUndefined();
+    expect(clear.dataset.clearStage).toBe("0");
+
     fireEvent.click(clear);
+
     expect(clear.dataset.confirming).toBe("true");
+    expect(clear.dataset.clearStage).toBe("1");
+    expect(clear.getAttribute("aria-label")).toBe(
+      "Continue clearing all notifications",
+    );
+    expect(
+      clear.querySelector("[data-notification-clear-arming-label]")
+        ?.textContent,
+    ).toBe("Clear all");
+    expect(__getStateForTests().notifications).toHaveLength(3);
+
+    fireEvent.click(clear);
+
+    expect(clear.dataset.confirming).toBe("true");
+    expect(clear.dataset.clearStage).toBe("2");
     expect(clear.getAttribute("aria-label")).toBe(
       "Confirm clear all notifications",
     );
@@ -2119,30 +2170,6 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clear.querySelector("[data-notification-clear-confirming-label]")
         ?.textContent,
     ).toBe("Confirm?");
-    expect(__getStateForTests().notifications).toHaveLength(3);
-    fireEvent.click(clear);
-    expect(__getStateForTests().notifications).toHaveLength(0);
-  });
-
-  it("keeps the coarse-pointer X then Clear all two-tap flow", () => {
-    installPointerCapability(false);
-    seedTriage();
-    render(<NotificationsHomeCenter />);
-    expandShade();
-    const clear = screen.getByTestId("notifications-clear-all");
-    expect(clear.dataset.confirming).toBeUndefined();
-    expect(clear.getAttribute("aria-label")).toBe("Clear all notifications");
-
-    fireEvent.click(clear);
-
-    expect(clear.dataset.confirming).toBe("true");
-    expect(clear.getAttribute("aria-label")).toBe(
-      "Confirm clear all notifications",
-    );
-    expect(
-      clear.querySelector("[data-notification-clear-confirming-label]")
-        ?.textContent,
-    ).toBe("Clear all");
     expect(__getStateForTests().notifications).toHaveLength(3);
 
     fireEvent.click(clear);
@@ -2484,6 +2511,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     render(<NotificationsHomeCenter />);
     const list = screen.getByTestId("home-notification-list");
+    const restingClear = screen.getByTestId("notifications-clear-all");
+    expect(restingClear.closest("li")?.style.opacity).toBe("0");
     fireEvent.pointerDown(list, {
       pointerType: "mouse",
       isPrimary: true,
@@ -2501,7 +2530,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       list.querySelectorAll<HTMLElement>("[data-notification-pull-reveal]"),
     );
     expect(previewGroups).toHaveLength(2);
-    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-clear-all")).toBe(restingClear);
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -2548,7 +2577,11 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
     expect(previewGroups.every((group) => !group.isConnected)).toBe(true);
-    expect(screen.queryByTestId("notifications-clear-all")).toBeNull();
+    expect(screen.getByTestId("notifications-clear-all")).toBe(restingClear);
+    expect(restingClear.closest("li")?.style.opacity).toBe("0");
+    expect(restingClear.closest("li")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(1);
   });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -5,7 +5,7 @@
 // Pins the shade spec: priority-only triage, liquid-glass Z-stacked groups
 // with no headers/dividers, DIRECTIONAL pull/wheel expand-collapse (down
 // expands, up collapses — never a toggle, so trailing trackpad momentum can't
-// snap the shade back shut), a passive notification total, direct-tap
+// snap the shade back shut), an interactive notification total, direct-tap
 // activation, and swipe-to-dismiss.
 
 import {
@@ -57,9 +57,66 @@ import {
   notificationPullRevealProgress,
   orderDashboardNotifications,
   PULL_COMMIT_PX,
+  STACK_FOLD_SETTLE_MS,
 } from "./NotificationsHomeCenter";
+import {
+  notificationGroupContainerOffset,
+  PULL_TRAVEL_PX,
+} from "./notification-shade-presentation";
 
 let seq = 0;
+let restoreMatchMediaForTest: (() => void) | null = null;
+
+function installReducedMotionController(initialMatches = false): {
+  setMatches: (matches: boolean) => void;
+} {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "matchMedia",
+  );
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialMatches;
+  const media = "(prefers-reduced-motion: reduce)";
+  const mediaQuery = {
+    get matches() {
+      return matches;
+    },
+    media,
+    onchange: null,
+    addEventListener: (
+      _type: string,
+      listener: (event: MediaQueryListEvent) => void,
+    ) => listeners.add(listener),
+    removeEventListener: (
+      _type: string,
+      listener: (event: MediaQueryListEvent) => void,
+    ) => listeners.delete(listener),
+    addListener: (listener: (event: MediaQueryListEvent) => void) =>
+      listeners.add(listener),
+    removeListener: (listener: (event: MediaQueryListEvent) => void) =>
+      listeners.delete(listener),
+  } as unknown as MediaQueryList;
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => mediaQuery,
+  });
+  restoreMatchMediaForTest = () => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, "matchMedia", originalDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
+    }
+    restoreMatchMediaForTest = null;
+  };
+  return {
+    setMatches: (nextMatches: boolean) => {
+      matches = nextMatches;
+      const event = { matches, media } as MediaQueryListEvent;
+      for (const listener of listeners) listener(event);
+    },
+  };
+}
+
 function makeNotification(
   overrides: Partial<AgentNotification> = {},
 ): AgentNotification {
@@ -82,6 +139,7 @@ function makeNotification(
 function expandShade(): HTMLElement {
   const list = screen.getByTestId("home-notification-list");
   fireEvent.wheel(list, { deltaY: -(PULL_COMMIT_PX + 10) });
+  act(() => vi.advanceTimersByTime(40));
   return list;
 }
 
@@ -94,7 +152,11 @@ function collapseShade(): HTMLElement {
 }
 
 function finishShadeCollapse(): void {
-  act(() => vi.advanceTimersByTime(250));
+  act(() => vi.advanceTimersByTime(400));
+}
+
+function finishStackFold(): void {
+  act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS + 40));
 }
 
 function setOverflowingListGeometry(list: HTMLElement): void {
@@ -123,6 +185,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  restoreMatchMediaForTest?.();
   vi.clearAllTimers();
   vi.useRealTimers();
   __resetNotificationStoreForTests();
@@ -309,12 +372,27 @@ describe("interrupt priority projection", () => {
     expect(navigateDeepLink).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId("notification-stack-collapse"));
-    finishShadeCollapse();
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(2);
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS - 1));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    act(() => vi.advanceTimersByTime(1));
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    act(() => vi.advanceTimersByTime(40));
     expect(
       screen
         .getByTestId("home-notification-list")
         .getAttribute("data-shade-mode"),
     ).toBe("rested");
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
 
@@ -460,6 +538,8 @@ describe("interrupt priority projection", () => {
       clientY: 70,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
+    act(() => vi.advanceTimersByTime(340));
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(0);
   });
 });
@@ -499,23 +579,26 @@ describe("notification producer grouping", () => {
 });
 
 describe("dampenPull", () => {
-  it("has a slop dead zone, applies deliberate resistance, and clamps", () => {
+  it("tracks directly between detents and resists only after the endpoint", () => {
     expect(dampenPull(0)).toBe(0);
     expect(dampenPull(8)).toBe(0); // inside the dead zone
-    expect(dampenPull(48)).toBe(20); // (48-8) × 0.5
-    expect(dampenPull(104)).toBe(PULL_COMMIT_PX);
-    expect(dampenPull(10_000)).toBe(88); // clamped rubber band
+    expect(dampenPull(48)).toBe(40);
+    expect(dampenPull(52)).toBe(PULL_COMMIT_PX);
+    expect(dampenPull(96)).toBe(PULL_TRAVEL_PX);
+    expect(dampenPull(124)).toBeCloseTo(97.8);
   });
 });
 
 describe("notificationPullRevealProgress", () => {
-  it("tracks pull travel, staggers later groups, and finishes by commit", () => {
+  it("tracks full detent travel while staggering later groups", () => {
     expect(notificationPullRevealProgress(0, 0)).toBe(0);
-    expect(notificationPullRevealProgress(PULL_COMMIT_PX / 2, 0)).toBe(0.5);
-    expect(notificationPullRevealProgress(PULL_COMMIT_PX / 2, 2)).toBeLessThan(
+    expect(notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 0)).toBe(0.5);
+    expect(
+      notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 2),
+    ).toBeLessThan(
       0.5,
     );
-    expect(notificationPullRevealProgress(PULL_COMMIT_PX, 4)).toBe(1);
+    expect(notificationPullRevealProgress(PULL_TRAVEL_PX, 4)).toBe(1);
   });
 });
 
@@ -987,7 +1070,10 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       // Peeks are TAPPABLE (tap fans the stack) and remain crisp.
       expect(peek.tagName).toBe("BUTTON");
       expect(peek.style.filter).toBe("");
-      expect(peek.style.bottom).toBe("24px");
+      expect(peek.className).toContain("inset-0");
+      expect(peek.closest("[data-notif-row]")).toBe(
+        rows[0]?.closest("[data-notif-row]"),
+      );
     }
     // Deeper cards sit lower in Z and protrude further.
     expect(Number(peeks[0].style.zIndex)).toBeGreaterThan(
@@ -1074,8 +1160,37 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
     // Tapping the peeked card below the top one fans the stack out.
-    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    const openingPeek = screen.getAllByTestId("notification-stack-peek")[0];
+    openingPeek.focus();
+    fireEvent.click(openingPeek, { detail: 0 });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    const enteringControls = screen.getByTestId("notification-stack-controls");
+    const groupContent = document.querySelector(
+      "[data-notification-group-content]",
+    ) as HTMLElement;
+    const closingPeeks = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-notification-stack-peek]"),
+    );
+    expect(enteringControls.style.height).toBe("0px");
+    expect(enteringControls.style.opacity).toBe("0");
+    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(closingPeeks).toHaveLength(2);
+    expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
+    const enteringRows = screen
+      .getAllByTestId("notification-row")
+      .slice(1)
+      .map((row) => row.closest("[data-notif-row]") as HTMLElement);
+    expect(enteringRows.every((row) => row.style.opacity === "0")).toBe(true);
+
+    act(() => vi.advanceTimersByTime(40));
+    expect(enteringControls.style.height).toBe("36px");
+    expect(enteringControls.style.opacity).toBe("1");
+    expect(enteringRows.every((row) => row.style.opacity === "1")).toBe(true);
+    expect(groupContent.style.paddingBottom).toBe("16px");
+    expect(closingPeeks.every((peek) => peek.style.opacity === "0")).toBe(true);
+    expect(document.activeElement).toBe(
+      screen.getByTestId("notification-stack-collapse"),
+    );
     expect(screen.queryByTestId("notification-stack")).toBeNull();
     expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
     // Priority order inside the fanned group: urgent first.
@@ -1099,10 +1214,41 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
-    fireEvent.click(screen.getByTestId("notification-stack-collapse"));
+    fireEvent.click(screen.getByTestId("notification-stack-collapse"), {
+      detail: 0,
+    });
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    expect(enteringControls.style.height).toBe("0px");
+    expect(enteringControls.style.opacity).toBe("0");
+    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
+    expect(enteringControls.getAttribute("aria-hidden")).toBe("true");
+    expect(enteringControls.hasAttribute("inert")).toBe(true);
+    expect(
+      closingPeeks.every(
+        (peek) =>
+          peek.getAttribute("aria-hidden") === "true" &&
+          peek.getAttribute("tabindex") === "-1" &&
+          peek.hasAttribute("disabled"),
+      ),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("notification-stack-collapse")
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(document.activeElement).toBe(
+      screen.getAllByTestId("notification-row")[0],
+    );
+    act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS - 1));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    act(() => vi.advanceTimersByTime(40));
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
     expect(screen.queryByTestId("notification-stack-collapse")).toBeNull();
+    expect(document.activeElement).toBe(screen.getByTestId("notification-row"));
     expect(screen.getByTestId("notifications-collapse").textContent).toContain(
       "Collapse",
     );
@@ -1133,6 +1279,106 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
+  });
+
+  it("does not let an older fold auto-close a stack opened during its settle", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "A older", source: "calendar" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "A newest", source: "calendar" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "B older", source: "mail" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "B newest", source: "mail" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const groupA = screen
+      .getByText("A newest")
+      .closest<HTMLElement>("[data-notification-group]");
+    const groupB = screen
+      .getByText("B newest")
+      .closest<HTMLElement>("[data-notification-group]");
+    expect(groupA).toBeTruthy();
+    expect(groupB).toBeTruthy();
+
+    fireEvent.click(
+      groupA?.querySelector<HTMLElement>(
+        '[data-testid="notification-row"]',
+      ) as HTMLElement,
+    );
+    act(() => vi.advanceTimersByTime(40));
+    fireEvent.click(
+      groupA?.querySelector<HTMLElement>(
+        '[data-testid="notification-stack-collapse"]',
+      ) as HTMLElement,
+    );
+    fireEvent.click(
+      groupB?.querySelector<HTMLElement>(
+        '[data-testid="notification-row"]',
+      ) as HTMLElement,
+    );
+    act(() => vi.advanceTimersByTime(40));
+    expect(screen.getAllByTestId("notification-stack-controls")).toHaveLength(
+      2,
+    );
+
+    finishStackFold();
+    expect(screen.getAllByTestId("notification-stack-controls")).toHaveLength(
+      1,
+    );
+    expect(
+      groupB?.querySelector('[data-testid="notification-stack-controls"]'),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+    finishShadeCollapse();
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+  });
+
+  it("finishes an in-flight fold immediately when reduced motion turns on", () => {
+    const motionPreference = installReducedMotionController();
+    __ingestNotificationForTests(makeNotification({ title: "A" }));
+    __ingestNotificationForTests(makeNotification({ title: "B" }));
+    __ingestNotificationForTests(makeNotification({ title: "C" }));
+    render(<NotificationsHomeCenter />);
+    expandShade();
+    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    act(() => vi.advanceTimersByTime(40));
+    fireEvent.click(screen.getByTestId("notification-stack-collapse"));
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+
+    act(() => motionPreference.setMatches(true));
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeNull();
+    expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+
+    act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS + 250));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
   });
 
   it("requires X then Clear before removing only that producer stack", () => {
@@ -1331,7 +1577,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.className).toContain("pb-2");
     expect(list.className).toContain("scroll-fade");
     expect(list.className).toContain("scroll-fade-b-[1.5rem]");
-    fireEvent.click(collapse);
+    collapse.focus();
+    fireEvent.click(collapse, { detail: 0 });
     // The total crossfades in while expanded rows settle, so release does not
     // leave an empty beat before the rested count appears.
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("1");
@@ -1342,11 +1589,22 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       priorityRow.closest<HTMLElement>("[data-notification-group]")?.style
         .opacity,
     ).not.toBe("0");
+    expect(document.activeElement).toBe(
+      screen.getByTestId("notifications-count-button"),
+    );
+    expect(
+      screen
+        .getByTestId("notifications-count-button")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
     finishShadeCollapse();
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("1");
+    expect(document.activeElement).toBe(
+      screen.getByTestId("notifications-count-button"),
+    );
   });
 
   it("opens from the notification total without treating a pointer drag as a click", () => {
@@ -1383,6 +1641,33 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     fireEvent.click(countButton);
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("animates groups that mount when the notification total opens the shade", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", title: "Quiet thing" }),
+    );
+    render(<NotificationsHomeCenter />);
+
+    const countButton = screen.getByTestId("notifications-count-button");
+    countButton.focus();
+    fireEvent.click(countButton, { detail: 0 });
+    const groupContent = document.querySelector(
+      "[data-notification-group-content]",
+    ) as HTMLElement;
+    expect(groupContent.style.opacity).toBe("0");
+    expect(groupContent.style.transform).toContain("-8px");
+    expect(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    ).toBe("0");
+
+    act(() => vi.advanceTimersByTime(40));
+    expect(groupContent.style.opacity).toBe("1");
+    expect(groupContent.style.transform).toContain("0px");
+    expect(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    ).toBe("1");
+    expect(document.activeElement).toBe(screen.getByTestId("notification-row"));
   });
 
   it("keeps the priority row mounted while an outside tap fades quiet groups", () => {
@@ -1506,23 +1791,50 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       pointerType: "mouse",
       pointerId: 83,
       clientX: 12,
-      clientY: 92,
+      clientY: 116,
     });
 
-    const filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
-    const agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
+    let filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
+    let agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
     expect(filesOpacity).toBeGreaterThan(0);
     expect(filesOpacity).toBeLessThan(1);
     expect(agentOpacity).toBeLessThan(filesOpacity);
-    const countOpacity = Number.parseFloat(
+    let countOpacity = Number.parseFloat(
       screen.getByTestId("notifications-count").style.opacity,
     );
-    const collapseOpacity = Number.parseFloat(
+    let collapseOpacity = Number.parseFloat(
       screen.getByTestId("notifications-collapse-footer").style.opacity,
     );
     expect(countOpacity).toBeGreaterThan(0);
     expect(countOpacity).toBeLessThan(1);
-    expect(collapseOpacity).toBeCloseTo(1 - countOpacity);
+    expect(collapseOpacity).toBeGreaterThan(0);
+    expect(collapseOpacity).toBeLessThan(1);
+    expect(countOpacity).toBeLessThan(filesOpacity);
+    expect(screen.getByTestId("notifications-count").style.clipPath).toBe("");
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 83,
+      clientX: 12,
+      clientY: 92,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
+    agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
+    countOpacity = Number.parseFloat(
+      screen.getByTestId("notifications-count").style.opacity,
+    );
+    collapseOpacity = Number.parseFloat(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    );
+    expect(filesOpacity).toBeGreaterThan(0);
+    expect(filesOpacity).toBeLessThan(1);
+    expect(agentOpacity).toBeGreaterThan(0);
+    expect(agentOpacity).toBeLessThan(filesOpacity);
+    expect(countOpacity).toBeGreaterThan(0);
+    expect(countOpacity).toBeLessThan(1);
+    expect(collapseOpacity).toBeGreaterThan(0);
+    expect(collapseOpacity).toBeLessThan(1);
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
@@ -1530,6 +1842,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 12,
       clientY: 160,
     });
+    act(() => vi.advanceTimersByTime(20));
     expect(filesGroup?.style.opacity).toBe("1");
     expect(agentGroup?.style.opacity).toBe("1");
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
@@ -1743,15 +2056,6 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(countOpacity).toBeGreaterThan(0);
     expect(countOpacity).toBeLessThan(1);
-    const clear = screen.getByTestId("notifications-clear-all");
-    const clearReveal = clear.closest("li") as HTMLElement;
-    expect(Number.parseFloat(clearReveal.style.opacity)).toBeGreaterThan(0);
-    expect(Number.parseFloat(clearReveal.style.opacity)).toBeLessThan(1);
-    const collapseReveal = Number.parseFloat(
-      screen.getByTestId("notifications-collapse-footer").style.opacity,
-    );
-    expect(collapseReveal).toBeGreaterThan(0);
-    expect(collapseReveal).toBeLessThan(1);
     const revealedGroups = list.querySelectorAll(
       ":scope > [data-notification-pull-reveal]",
     );
@@ -1761,10 +2065,65 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       expect(opacity).toBeGreaterThan(0);
       expect(opacity).toBeLessThan(1);
     }
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 10,
+      clientX: 10,
+      clientY: 80,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    expect(
+      Number.parseFloat(
+        screen.getByTestId("notifications-count").style.opacity,
+      ),
+    ).toBeGreaterThan(0);
+    const expectedCountOffset = notificationGroupContainerOffset(
+      dampenPull(70),
+      false,
+      false,
+    );
+    expect(screen.getByTestId("notifications-count").style.transform).toBe(
+      `translate3d(0, ${expectedCountOffset}px, 0)`,
+    );
+    const clear = screen.getByTestId("notifications-clear-all");
+    const clearReveal = clear.closest("li") as HTMLElement;
+    expect(Number.parseFloat(clearReveal.style.opacity)).toBeGreaterThan(0);
+    expect(Number.parseFloat(clearReveal.style.opacity)).toBeLessThan(1);
+    const collapseReveal = Number.parseFloat(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    );
+    expect(collapseReveal).toBeGreaterThan(0);
+    expect(collapseReveal).toBeLessThan(1);
+    for (const group of revealedGroups) {
+      const opacity = Number.parseFloat((group as HTMLElement).style.opacity);
+      expect(opacity).toBeGreaterThan(0);
+      expect(opacity).toBeLessThan(1);
+    }
   });
 
   it("a short pull springs back without toggling", () => {
-    seedTriage();
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "urgent",
+        source: "mail",
+        title: "Urgent mail",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "normal",
+        source: "files",
+        title: "Files updated",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "low",
+        source: "agent",
+        title: "Agent summary",
+      }),
+    );
     render(<NotificationsHomeCenter />);
     const list = screen.getByTestId("home-notification-list");
     fireEvent.pointerDown(list, {
@@ -1780,6 +2139,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 10,
       clientY: 40, // 30px raw → dampened 11px < commit
     });
+    const previewGroups = Array.from(
+      list.querySelectorAll<HTMLElement>("[data-notification-pull-reveal]"),
+    );
+    expect(previewGroups).toHaveLength(2);
+    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
       pointerId: 9,
@@ -1787,8 +2152,182 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientY: 40,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    const center = screen.getByTestId("home-notification-center");
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    expect(
+      previewGroups.every(
+        (group) =>
+          group.isConnected &&
+          group.classList.contains("eliza-notif-shade-transition") &&
+          group.style.opacity === "0",
+      ),
+    ).toBe(true);
+    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
+    act(() => vi.advanceTimersByTime(100));
+    expect(previewGroups.every((group) => group.isConnected)).toBe(true);
+    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
+    act(() => vi.advanceTimersByTime(239));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+    expect(previewGroups.every((group) => group.isConnected)).toBe(true);
+    act(() => vi.advanceTimersByTime(1));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    expect(previewGroups.every((group) => !group.isConnected)).toBe(true);
+    expect(screen.queryByTestId("notifications-clear-all")).toBeNull();
+    expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(1);
-    expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
+  });
+
+  it("keeps the same preview nodes mounted when an active pull crosses zero", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "urgent", source: "mail" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", source: "files" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 80,
+    });
+    const preview = list.querySelector<HTMLElement>(
+      "[data-notification-pull-reveal]",
+    );
+    expect(preview).toBeTruthy();
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    expect(list.getAttribute("data-shade-dragging")).not.toBeNull();
+    expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
+    expect(preview?.style.opacity).toBe("0");
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 80,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
+    expect(Number.parseFloat(preview?.style.opacity ?? "0")).toBeGreaterThan(0);
+
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 80,
+    });
+    expect(preview?.isConnected).toBe(true);
+    act(() => vi.advanceTimersByTime(340));
+    expect(preview?.isConnected).toBe(false);
+  });
+
+  it("clears a cancelled-pull settle before starting a committed collapse", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 110,
+      clientX: 10,
+      clientY: 160,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 110,
+      clientX: 10,
+      clientY: 130,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 110,
+      clientX: 10,
+      clientY: 130,
+    });
+    const center = screen.getByTestId("home-notification-center");
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    act(() => vi.advanceTimersByTime(219));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    act(() => vi.advanceTimersByTime(1));
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("clears a cancelled-pull settle before a stack opens", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "urgent", source: "calendar" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", source: "calendar" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 111,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 111,
+      clientX: 10,
+      clientY: 40,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 111,
+      clientX: 10,
+      clientY: 40,
+    });
+    const center = screen.getByTestId("home-notification-center");
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+
+    // The list consumes the first post-drag synthetic click. The next click is
+    // the intentional activation and must start on its own transition clock.
+    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
+    act(() => vi.advanceTimersByTime(340));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("a touch pull-down expands the shade (native non-passive listener path)", () => {
@@ -1837,11 +2376,32 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
   });
 
   it("trackpad fingers-down (wheel deltaY < 0) at the top expands the rested shade", () => {
-    seedTriage();
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "urgent",
+        source: "urgent-source",
+        title: "Urgent thing",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "normal",
+        source: "normal-source",
+        title: "Normal thing",
+      }),
+    );
     render(<NotificationsHomeCenter />);
     const list = screen.getByTestId("home-notification-list");
     fireEvent.wheel(list, { deltaY: -(PULL_COMMIT_PX + 10) });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    const quietGroup = screen
+      .getByText("Normal thing")
+      .closest("[data-notification-group-content]") as HTMLElement;
+    expect(quietGroup.style.opacity).toBe("0");
+    expect(quietGroup.style.transform).toContain("-8px");
+    act(() => vi.advanceTimersByTime(40));
+    expect(quietGroup.style.opacity).toBe("1");
+    expect(quietGroup.style.transform).toContain("0px");
   });
 
   it("the wheel gesture is DIRECTIONAL: trailing same-direction momentum never collapses what it just expanded", () => {
@@ -1980,6 +2540,136 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("an upward mouse drag on the empty notification region collapses the shade", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+
+    fireEvent.pointerDown(center, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 41,
+      clientX: 150,
+      clientY: 420,
+    });
+    fireEvent.pointerMove(center, {
+      pointerType: "mouse",
+      pointerId: 41,
+      clientX: 152,
+      clientY: 280,
+    });
+    fireEvent.pointerUp(center, {
+      pointerType: "mouse",
+      pointerId: 41,
+      clientX: 152,
+      clientY: 280,
+    });
+
+    finishShadeCollapse();
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("ignores empty-region drags while the shade close is settling", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+
+    // Neither an aborted nudge nor a commit-distance swipe may start a second
+    // transition while the committed close owns the presentation clock.
+    fireEvent.pointerDown(center, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 42,
+      clientX: 150,
+      clientY: 420,
+    });
+    fireEvent.pointerMove(center, {
+      pointerType: "mouse",
+      pointerId: 42,
+      clientX: 150,
+      clientY: 390,
+    });
+    fireEvent.pointerUp(center, {
+      pointerType: "mouse",
+      pointerId: 42,
+      clientX: 150,
+      clientY: 390,
+    });
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+
+    fireEvent.pointerDown(center, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 43,
+      clientX: 150,
+      clientY: 420,
+    });
+    fireEvent.pointerMove(center, {
+      pointerType: "mouse",
+      pointerId: 43,
+      clientX: 150,
+      clientY: 280,
+    });
+    fireEvent.pointerUp(center, {
+      pointerType: "mouse",
+      pointerId: 43,
+      clientX: 150,
+      clientY: 280,
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+
+    act(() => vi.advanceTimersByTime(219));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    act(() => vi.advanceTimersByTime(1));
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+  });
+
+  it("ignores empty-region touch swipes while the shade close is settling", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+
+    fireEvent.touchStart(center, {
+      touches: [{ clientX: 150, clientY: 420 }],
+    });
+    fireEvent.touchMove(center, {
+      touches: [{ clientX: 150, clientY: 280 }],
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    fireEvent.touchEnd(center, { touches: [] });
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+
+    act(() => vi.advanceTimersByTime(219));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    act(() => vi.advanceTimersByTime(1));
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
   });
 
   it("a bottom-edge touch drag closes an overflowing expanded shade", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2273,9 +2273,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       /\.eliza-notif-scroll\[data-shade-release-settling\]\s*\{([^}]*)\}/,
     )?.[1];
     expect(releaseRule).toContain("animation: none");
-    expect(releaseRule).toContain("--scroll-fade-t: 1.25rem");
-    expect(releaseRule).toContain("--scroll-fade-b: 1.5rem");
-    expect(releaseRule).not.toContain("mask-image: none");
+    expect(releaseRule).toContain("-webkit-mask-image: none");
+    expect(releaseRule).toContain("mask-image: none");
     const rowAnimationGuard = css
       .match(/[^{}]+\{\s*animation: none !important;\s*\}/g)
       ?.find((rule) => rule.includes("data-shade-release-settling"));

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -839,18 +839,14 @@ export function NotificationsHomeCenter({
     // first scrolled the list up to its top doesn't arrive already maxed.
     anchorY: number | null;
   } | null>(null);
-  const emptyPointerPull = useRef<{
-    id: number;
-    startX: number;
-    startY: number;
-    axis: "none" | "x" | "y";
-  } | null>(null);
   // A touch drag can end in `pointercancel` before the row sees enough pointer
   // movement to suppress the browser's synthetic click. The list owns the
   // vertical shade gesture, so it also blocks that one immediate follow-up
   // click; the next intentional tap remains available.
   const suppressNotificationClick = useRef(false);
   const suppressNotificationClickTimer = useRef<number | null>(null);
+  const suppressBackgroundClick = useRef(false);
+  const suppressBackgroundClickTimer = useRef<number | null>(null);
   // Wheel accumulation toward a shade commit: one direction at a time; a
   // direction flip abandons the previous run.
   const wheelPull = useRef<{ dir: 1 | -1; px: number }>({ dir: 1, px: 0 });
@@ -1248,6 +1244,10 @@ export function NotificationsHomeCenter({
   useEffect(() => {
     if (!shadeExpanded) return;
     const collapseOnOutsideClick = (event: MouseEvent) => {
+      // A background drag may end over a tile that synthesizes a click. The
+      // drag already decided the shade state; do not reinterpret that release
+      // as a separate outside-tap collapse before the surface can consume it.
+      if (suppressBackgroundClick.current) return;
       const target = event.target;
       const center = centerRef.current;
       if (target instanceof Node && center && !center.contains(target)) {
@@ -1328,6 +1328,20 @@ export function NotificationsHomeCenter({
     setShade,
     setShadeSettleDuration,
   ]);
+
+  const abortPointerPull = useCallback(() => {
+    const px = pullPxRef.current;
+    if (px !== 0) {
+      flushPullPresentation();
+      if (!reduceMotion) {
+        beginPullCancellation(
+          px > 0 ? "expand" : "collapse",
+          PULL_CANCEL_SETTLE_MS,
+        );
+      }
+    }
+    setPullPx(0);
+  }, [beginPullCancellation, flushPullPresentation, reduceMotion, setPullPx]);
 
   // Shared wheel accumulator for both the list and, while empty, the wider
   // home background. Returns whether the shade consumed this delta so the
@@ -1422,12 +1436,7 @@ export function NotificationsHomeCenter({
     };
     const onTouchStart = (e: TouchEvent) => {
       const t = e.touches[0];
-      const target = e.target;
-      if (
-        e.touches.length !== 1 ||
-        !t ||
-        (usesEmptyBackground && isInteractiveGestureTarget(target))
-      ) {
+      if (e.touches.length !== 1 || !t) {
         abortTouchPull();
         return;
       }
@@ -1572,7 +1581,6 @@ export function NotificationsHomeCenter({
       // surface. The home listener only fills the otherwise dead background.
       if (
         !usesEmptyBackground ||
-        isInteractiveGestureTarget(target) ||
         (target instanceof Node && list.contains(target))
       ) {
         return;
@@ -1844,6 +1852,124 @@ export function NotificationsHomeCenter({
     shadeExpanded,
   ]);
 
+  useEffect(() => {
+    const surface = emptyGestureTargetRef?.current ?? centerRef.current;
+    const list = scrollRef.current;
+    if (!surface || !list || !surfaceReady) return;
+
+    let gesture: {
+      id: number;
+      startX: number;
+      startY: number;
+      axis: "none" | "x" | "y";
+    } | null = null;
+    const armClickSuppression = () => {
+      suppressBackgroundClick.current = true;
+      if (suppressBackgroundClickTimer.current !== null) {
+        window.clearTimeout(suppressBackgroundClickTimer.current);
+      }
+      suppressBackgroundClickTimer.current = window.setTimeout(() => {
+        suppressBackgroundClick.current = false;
+        suppressBackgroundClickTimer.current = null;
+      }, 500);
+    };
+    const onClick = (event: MouseEvent) => {
+      if (!suppressBackgroundClick.current) return;
+      suppressBackgroundClick.current = false;
+      if (suppressBackgroundClickTimer.current !== null) {
+        window.clearTimeout(suppressBackgroundClickTimer.current);
+        suppressBackgroundClickTimer.current = null;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        event.pointerType !== "mouse" ||
+        !event.isPrimary ||
+        (target instanceof Node && list.contains(target))
+      ) {
+        return;
+      }
+      const { canExpand, canCollapse } = shadeGestureRef.current;
+      if (!canExpand && !canCollapse) return;
+      gesture = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        axis: "none",
+      };
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      const current = gesture;
+      if (!current || current.id !== event.pointerId) return;
+      const dx = event.clientX - current.startX;
+      const dy = event.clientY - current.startY;
+      if (
+        current.axis === "none" &&
+        (Math.abs(dx) > PULL_SLOP_PX || Math.abs(dy) > PULL_SLOP_PX)
+      ) {
+        current.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+        if (current.axis === "x") {
+          gesture = null;
+          return;
+        }
+        surface.setPointerCapture?.(event.pointerId);
+        armClickSuppression();
+      }
+      if (current.axis !== "y") return;
+      event.preventDefault();
+      const { canExpand, canCollapse } = shadeGestureRef.current;
+      if (dy > 0 && canExpand && surface.scrollTop <= 0) {
+        setPullPx(dy > PULL_SLOP_PX ? dampenPull(dy) : 0, dy <= PULL_SLOP_PX);
+      } else if (dy < 0 && canCollapse) {
+        setPullPx(
+          dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0,
+          dy >= -PULL_SLOP_PX,
+        );
+      } else if (pullPxRef.current !== 0) {
+        setPullPx(0, true);
+      }
+    };
+    const onPointerEnd = (event: PointerEvent) => {
+      const current = gesture;
+      if (!current || current.id !== event.pointerId) return;
+      onPointerMove(event);
+      if (!gesture) return;
+      if (current.axis === "y") {
+        armClickSuppression();
+      }
+      gesture = null;
+      commitPull();
+    };
+    const onPointerCancel = (event: PointerEvent) => {
+      if (gesture?.id !== event.pointerId) return;
+      gesture = null;
+      abortPointerPull();
+    };
+
+    surface.addEventListener("pointerdown", onPointerDown);
+    surface.addEventListener("pointermove", onPointerMove, { passive: false });
+    surface.addEventListener("pointerup", onPointerEnd);
+    surface.addEventListener("pointercancel", onPointerCancel);
+    surface.addEventListener("click", onClick, true);
+    return () => {
+      surface.removeEventListener("pointerdown", onPointerDown);
+      surface.removeEventListener("pointermove", onPointerMove);
+      surface.removeEventListener("pointerup", onPointerEnd);
+      surface.removeEventListener("pointercancel", onPointerCancel);
+      surface.removeEventListener("click", onClick, true);
+    };
+  }, [
+    abortPointerPull,
+    commitPull,
+    emptyGestureTargetRef,
+    setPullPx,
+    surfaceReady,
+  ]);
+
   // Clear timers that may outlive a single gesture.
   useEffect(
     () => () => {
@@ -1858,6 +1984,9 @@ export function NotificationsHomeCenter({
       stackFoldTimers.current.clear();
       if (suppressNotificationClickTimer.current !== null) {
         window.clearTimeout(suppressNotificationClickTimer.current);
+      }
+      if (suppressBackgroundClickTimer.current !== null) {
+        window.clearTimeout(suppressBackgroundClickTimer.current);
       }
     },
     [],
@@ -2050,19 +2179,6 @@ export function NotificationsHomeCenter({
     hasNotifications &&
     expandedStacks.size === 0 &&
     !shadeOpenedByStack;
-  const abortPointerPull = () => {
-    const px = pullPxRef.current;
-    if (px !== 0) {
-      flushPullPresentation();
-      if (!reduceMotion) {
-        beginPullCancellation(
-          px > 0 ? "expand" : "collapse",
-          PULL_CANCEL_SETTLE_MS,
-        );
-      }
-    }
-    setPullPx(0);
-  };
   const onListPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType !== "mouse" || !e.isPrimary) return;
     const el = scrollRef.current;
@@ -2134,63 +2250,6 @@ export function NotificationsHomeCenter({
     pointerPull.current = null;
     abortPointerPull();
   };
-  const onEmptyPointerDown = (e: React.PointerEvent) => {
-    const list = scrollRef.current;
-    if (
-      e.pointerType !== "mouse" ||
-      !e.isPrimary ||
-      !canCollapse ||
-      !list ||
-      (e.target instanceof Node && list.contains(e.target)) ||
-      isInteractiveGestureTarget(e.target)
-    ) {
-      return;
-    }
-    emptyPointerPull.current = {
-      id: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      axis: "none",
-    };
-  };
-  const onEmptyPointerMove = (e: React.PointerEvent) => {
-    const gesture = emptyPointerPull.current;
-    if (!gesture || gesture.id !== e.pointerId) return;
-    if (!shadeGestureRef.current.canCollapse) {
-      emptyPointerPull.current = null;
-      if (pullPxRef.current !== 0) setPullPx(0);
-      return;
-    }
-    const dx = e.clientX - gesture.startX;
-    const dy = e.clientY - gesture.startY;
-    if (
-      gesture.axis === "none" &&
-      (Math.abs(dx) > PULL_SLOP_PX || Math.abs(dy) > PULL_SLOP_PX)
-    ) {
-      gesture.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
-      if (gesture.axis === "y") {
-        e.currentTarget.setPointerCapture?.(e.pointerId);
-      }
-    }
-    if (gesture.axis === "x") {
-      emptyPointerPull.current = null;
-      return;
-    }
-    if (gesture.axis !== "y") return;
-    setPullPx(dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0, dy >= -PULL_SLOP_PX);
-  };
-  const onEmptyPointerEnd = (e: React.PointerEvent) => {
-    const gesture = emptyPointerPull.current;
-    if (!gesture || gesture.id !== e.pointerId) return;
-    onEmptyPointerMove(e);
-    emptyPointerPull.current = null;
-    commitPull();
-  };
-  const onEmptyPointerCancel = (e: React.PointerEvent) => {
-    if (emptyPointerPull.current?.id !== e.pointerId) return;
-    emptyPointerPull.current = null;
-    abortPointerPull();
-  };
   const onListClickCapture = (e: React.MouseEvent) => {
     if (!suppressNotificationClick.current) return;
     suppressNotificationClick.current = false;
@@ -2247,10 +2306,6 @@ export function NotificationsHomeCenter({
       data-notification-shade-cancelling={
         pullCancellingDirection ? "" : undefined
       }
-      onPointerDown={onEmptyPointerDown}
-      onPointerMove={onEmptyPointerMove}
-      onPointerUp={onEmptyPointerEnd}
-      onPointerCancel={onEmptyPointerCancel}
       // No card chrome on the CONTAINER: the inbox has no fill and no border of
       // its own — the glass lives on each notification card. It sits inline on
       // the home field directly under the time/weather header.

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -66,7 +66,6 @@ import {
   shouldCommitMomentumDetent,
   useRafCoalescer,
 } from "../../gestures";
-import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { cn } from "../../lib/utils";
 import {
   isSafeDeepLink,
@@ -83,6 +82,7 @@ import {
   ClearConfirmationContent,
   groupDashboardNotifications,
   isInterruptPriority,
+  NOTIFICATION_ROW_SETTLE_MS,
   NotificationRow,
   orderDashboardNotifications,
 } from "./notification-shade-content";
@@ -216,7 +216,7 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 2;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
-const FINE_POINTER_CLEAR_CONFIRM_QUERY = "(hover: hover) and (pointer: fine)";
+const POST_DRAG_CLICK_SUPPRESSION_MS = 180;
 const SHADE_SETTLE_MS = 460;
 const SHADE_MIN_SETTLE_MS = 320;
 const SHADE_MAX_SETTLE_MS = 600;
@@ -232,7 +232,6 @@ const SHADE_MIN_VELOCITY_SAMPLE_MS = 16;
 // geometry must settle on one clock or a cancelled pull overshoots before the
 // slower slot catches up, making the count reverse direction at the edge.
 const NOTIFICATION_COUNT_RESTORE_MS = SHADE_SETTLE_MS;
-const NOTIFICATION_ROW_SETTLE_MS = 220;
 /** The stack fan has enough travel to read clearly without feeling delayed. */
 export const STACK_FAN_SETTLE_MS = 300;
 const STACK_FAN_LAYOUT_TRANSITION = {
@@ -338,6 +337,11 @@ const NOTIF_SCROLL_CSS = `
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
+.eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass:hover,
+.eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass:hover,
+.eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek:hover {
+  background-color: rgb(38 38 42);
+}
 /* Directional specular rim tracing every rounded corner (mask-composite ring)
    — replaces the old one-sided inset hairline that read as a vertical line. */
 ${liquidGlassRimCss(".eliza-notif-glass")}
@@ -397,30 +401,6 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 }
 .eliza-notif-clear-all[data-confirming] {
   width: 4rem;
-}
-.eliza-notif-clear-all:not([data-confirming]):focus-visible {
-  width: 3.5rem;
-}
-.eliza-notif-clear-all:not([data-confirming]):focus-visible [data-notification-clear-resting-label] {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-}
-.eliza-notif-clear-all:not([data-confirming]):focus-visible [data-notification-clear-resting-icon] {
-  opacity: 0;
-  transform: scale(0.75);
-}
-@media (hover: hover) and (pointer: fine) {
-  .eliza-notif-clear-all:not([data-confirming]):hover {
-    width: 3.5rem;
-  }
-  .eliza-notif-clear-all:not([data-confirming]):hover [data-notification-clear-resting-label] {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  .eliza-notif-clear-all:not([data-confirming]):hover [data-notification-clear-resting-icon] {
-    opacity: 0;
-    transform: scale(0.75);
-  }
 }
 /* A view-timeline animation reattaches from its entry keyframe when a transient
    drag marker disappears. Preview groups retain their own marker through a
@@ -494,6 +474,33 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 }
 .eliza-notif-row-inner[data-swipe-dragging] {
   transition: none;
+}
+.eliza-notif-row[data-swipe-collapsing] {
+  overflow: hidden;
+  transition:
+    grid-template-rows ${NOTIFICATION_ROW_SETTLE_MS}ms cubic-bezier(0.22,1,0.36,1),
+    margin-bottom ${NOTIFICATION_ROW_SETTLE_MS}ms cubic-bezier(0.22,1,0.36,1);
+}
+/* Folded cards keep real notification faces under the front card. Generated
+   labels make that content visible during a swipe without introducing a
+   second copy into the accessibility tree or message-search surface. */
+[data-notification-stack-preview-title]::before {
+  content: attr(data-notification-stack-preview-title);
+}
+[data-notification-stack-preview-body]::before {
+  content: attr(data-notification-stack-preview-body);
+}
+[data-notification-stack-preview-time]::before {
+  content: attr(data-notification-stack-preview-time);
+}
+[data-notification-stack-preview-source-initial]::before {
+  content: attr(data-notification-stack-preview-source-initial);
+}
+[data-notification-stack-preview-count]::before {
+  content: attr(data-notification-stack-preview-count);
+}
+.eliza-notif-stack-peek[data-swipe-promoting] {
+  --eliza-notif-geometry-duration: ${NOTIFICATION_ROW_SETTLE_MS}ms;
 }
 @supports (animation-timeline: view()) {
   @media (prefers-reduced-motion: no-preference) {
@@ -594,7 +601,6 @@ export function NotificationsHomeCenter({
   const { notifications, hydrated, hydrationStatus } = useNotifications();
   const inboxEmpty = notifications.length === 0;
   const reduceMotion = usePrefersReducedMotion();
-  const finePointer = useMediaQuery(FINE_POINTER_CLEAR_CONFIRM_QUERY);
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
   const [shadeExpanded, setShadeExpanded] = useState(false);
@@ -631,7 +637,7 @@ export function NotificationsHomeCenter({
   const [confirmingGroupKey, setConfirmingGroupKey] = useState<string | null>(
     null,
   );
-  const [confirmingClearAll, setConfirmingClearAll] = useState(false);
+  const [clearAllStage, setClearAllStage] = useState<0 | 1 | 2>(0);
   const [shadeClosing, setShadeClosing] = useState(false);
   const [pullCancellingDirection, setPullCancellingDirection] = useState<
     "expand" | "collapse" | null
@@ -718,7 +724,7 @@ export function NotificationsHomeCenter({
         return next;
       });
       setConfirmingGroupKey(null);
-      setConfirmingClearAll(false);
+      setClearAllStage(0);
       setShadeExpanded(true);
     },
     [cancelPullCancellation, cancelStackFold, reduceMotion, shadeExpanded],
@@ -741,7 +747,7 @@ export function NotificationsHomeCenter({
         return next;
       });
       setConfirmingGroupKey((current) => (current === key ? null : current));
-      setConfirmingClearAll(false);
+      setClearAllStage(0);
     },
     [cancelPullCancellation, cancelStackFold],
   );
@@ -1032,7 +1038,7 @@ export function NotificationsHomeCenter({
     suppressNotificationClickTimer.current = window.setTimeout(() => {
       suppressNotificationClick.current = false;
       suppressNotificationClickTimer.current = null;
-    }, 500);
+    }, POST_DRAG_CLICK_SUPPRESSION_MS);
   }, []);
 
   const armBackgroundClickSuppression = useCallback(() => {
@@ -1043,7 +1049,7 @@ export function NotificationsHomeCenter({
     suppressBackgroundClickTimer.current = window.setTimeout(() => {
       suppressBackgroundClick.current = false;
       suppressBackgroundClickTimer.current = null;
-    }, 500);
+    }, POST_DRAG_CLICK_SUPPRESSION_MS);
   }, []);
 
   const setPullPx = useCallback(
@@ -1124,7 +1130,7 @@ export function NotificationsHomeCenter({
   }, []);
 
   const cancelClearConfirmation = useCallback(() => {
-    setConfirmingClearAll(false);
+    setClearAllStage(0);
     setConfirmingGroupKey(null);
   }, []);
 
@@ -1155,7 +1161,7 @@ export function NotificationsHomeCenter({
       cancelPullCancellation();
       setShadeClosing(false);
       setShadeExpanded(expanded);
-      setConfirmingClearAll(false);
+      setClearAllStage(0);
       setConfirmingGroupKey(null);
       setShadeOpenedByStack(false);
       if (expanded) {
@@ -1352,7 +1358,7 @@ export function NotificationsHomeCenter({
         return next;
       });
       setConfirmingGroupKey((current) => (current === key ? null : current));
-      setConfirmingClearAll(false);
+      setClearAllStage(0);
       // A stack that opened the shade also closes it, but both layers share
       // this fold clock. Sequencing the shade afterward creates a visible
       // second tail even when the stack itself has already reached rest.
@@ -1387,8 +1393,7 @@ export function NotificationsHomeCenter({
     for (const key of closingStacks) completeStackFold(key);
   }, [closingStacks, completeStackFold, reduceMotion]);
 
-  const hasClearConfirmation =
-    confirmingClearAll || confirmingGroupKey !== null;
+  const hasClearConfirmation = clearAllStage > 0 || confirmingGroupKey !== null;
   useEffect(() => {
     if (!hasClearConfirmation) return;
     const timeout = window.setTimeout(
@@ -2262,7 +2267,7 @@ export function NotificationsHomeCenter({
   const clearProducer = useCallback(
     (key: string, ids: readonly string[]) => {
       if (confirmingGroupKey !== key) {
-        setConfirmingClearAll(false);
+        setClearAllStage(0);
         setConfirmingGroupKey(key);
         return;
       }
@@ -2273,18 +2278,22 @@ export function NotificationsHomeCenter({
     [confirmingGroupKey, foldStack],
   );
   const clearAll = useCallback(() => {
-    if (!confirmingClearAll) {
+    if (clearAllStage === 0) {
       setConfirmingGroupKey(null);
-      setConfirmingClearAll(true);
+      setClearAllStage(1);
       return;
     }
-    setConfirmingClearAll(false);
+    if (clearAllStage === 1) {
+      setClearAllStage(2);
+      return;
+    }
+    setClearAllStage(0);
     setConfirmingGroupKey(null);
     cancelAllStackFolds();
     setOpeningStacks(new Set());
     setExpandedStacks(new Set());
     void clearNotifications();
-  }, [cancelAllStackFolds, confirmingClearAll]);
+  }, [cancelAllStackFolds, clearAllStage]);
 
   // An emptied-out inbox resets the shade so the next arrival starts rested.
   // `pullPx` is cleared too: if the inbox empties mid-pull the touch effect
@@ -2298,7 +2307,7 @@ export function NotificationsHomeCenter({
       setOpeningStacks(new Set());
       setExpandedStacks(new Set());
       setConfirmingGroupKey(null);
-      setConfirmingClearAll(false);
+      setClearAllStage(0);
       cancelPullCancellation();
       setPullPx(0);
     }
@@ -2423,26 +2432,15 @@ export function NotificationsHomeCenter({
     expandedStacks.size > 0 && closingStacks.size === 0
       ? STACK_FAN_LAYOUT_TRANSITION
       : STACK_FOLD_LAYOUT_TRANSITION;
-  const allExpandedStacksAreClosing =
-    expandedStacks.size > 0 &&
-    expandedStacks.size === closingStacks.size &&
-    Array.from(expandedStacks).every((key) => closingStacks.has(key));
-  // The footer stays in flow while a stack fans so its text can crossfade
-  // instead of changing both the list geometry and DOM ownership in one frame.
-  const stackCollapseControlVisibility =
-    expandedStacks.size === 0 || allExpandedStacksAreClosing ? 1 : 0;
   const collapseControlPresentationVisibility =
-    collapseControlVisibility *
-    shadeOpenProgress *
-    stackCollapseControlVisibility;
+    collapseControlVisibility * shadeOpenProgress;
   const collapseControlInteractive =
     shadeExpanded &&
     !shadeClosing &&
     !isPulling &&
     !pullReleaseSettling &&
     pullCancellingDirection === null &&
-    collapseControlPresentationVisibility === 1 &&
-    expandedStacks.size === 0;
+    collapseControlPresentationVisibility === 1;
   const showCollapseControl =
     (shadeExpanded || previewingExpansion) && hasNotifications;
   const onListPointerDown = (e: React.PointerEvent) => {
@@ -2638,30 +2636,32 @@ export function NotificationsHomeCenter({
             }}
             className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-2"
           >
-            {shadeExpanded || previewingExpansion ? (
-              <button
-                type="button"
-                data-testid="notifications-clear-all"
-                data-confirming={confirmingClearAll ? "true" : undefined}
-                data-notif-control=""
-                aria-label={
-                  confirmingClearAll
-                    ? "Confirm clear all notifications"
+            <button
+              type="button"
+              data-testid="notifications-clear-all"
+              data-confirming={clearAllStage > 0 ? "true" : undefined}
+              data-clear-stage={clearAllStage}
+              data-notif-control=""
+              aria-label={
+                clearAllStage === 2
+                  ? "Confirm clear all notifications"
+                  : clearAllStage === 1
+                    ? "Continue clearing all notifications"
                     : "Clear all notifications"
-                }
-                onClick={clearAll}
-                className={cn(
-                  "eliza-notif-clear-all eliza-notif-control-transition h-8 shrink-0 overflow-hidden whitespace-nowrap text-xs font-medium text-white/60 transition-[width,color] duration-200 ease-out hover:text-white/90 focus-visible:text-white/90",
-                  confirmingClearAll && "text-white",
-                )}
-              >
-                <ClearConfirmationContent
-                  confirmingLabel={finePointer ? "Confirm?" : "Clear all"}
-                  confirming={confirmingClearAll}
-                  restingLabel="Clear all"
-                />
-              </button>
-            ) : null}
+              }
+              onClick={clearAll}
+              className={cn(
+                "eliza-notif-clear-all eliza-notif-control-transition h-8 shrink-0 overflow-hidden whitespace-nowrap text-xs font-medium text-white/60 transition-[width,color] duration-200 ease-out hover:text-white/90 focus-visible:text-white/90",
+                clearAllStage > 0 && "text-white",
+              )}
+            >
+              <ClearConfirmationContent
+                armingLabel="Clear all"
+                confirmingLabel="Confirm?"
+                confirming={clearAllStage > 0}
+                stage={clearAllStage}
+              />
+            </button>
           </li>
         ) : null}
         {!hasNotifications ? (
@@ -2963,6 +2963,7 @@ export function NotificationsHomeCenter({
                               openOffsetsPx: stackPeekOpenOffsets.get(
                                 group.key,
                               ),
+                              previewRows: peeks,
                               testIdVisible: !fanned || shadeCloseProgress > 0,
                               totalCount: allGroupRows.length,
                               visibility: stackPeekVisibility,

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -17,7 +17,7 @@
  * Two shade modes:
  *
  *  - RESTED is triage: interrupt-tier (`high`/`urgent`) producer stacks remain
- *    visible above the passive total while quieter notifications stay folded
+ *    visible above the interactive total while quieter notifications stay folded
  *    behind the same producer's visible stack depth.
  *  - EXPANDED shows every priority and preserves each producer stack until the
  *    user fans that group out in place; the list is height-capped and scrolls
@@ -29,9 +29,9 @@
  * same-direction gesture in the state it already produced is a no-op — this is
  * what makes trackpad momentum safe (the old toggle re-fired on trailing
  * momentum deltas and snapped the shade shut moments after opening it). The
- * footer is a passive total (for example, "3 Notifications"), never a control;
- * it belongs only to the closed shade, fading away during expansion and back
- * in during collapse. Pull/push gestures exclusively own the transition.
+ * footer total (for example, "3 Notifications") opens the shade directly and
+ * fades away during expansion, then returns during collapse. Pull/push gestures
+ * provide the same directional transition from the surrounding surface.
  *
  * The pull/wheel gesture NEVER fans a stack, and a drag that starts on a stack
  * still belongs to the shade. Tapping a peek fans that producer group and
@@ -57,6 +57,14 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  getMomentumReleaseVelocity,
+  getVelocityAwareSettleDuration,
+  MOMENTUM_RELEASE_WINDOW_MS,
+  type MomentumSample,
+  shouldCommitMomentumDetent,
+  useRafCoalescer,
+} from "../../gestures";
 import { cn } from "../../lib/utils";
 import {
   isSafeDeepLink,
@@ -107,6 +115,7 @@ import {
   notificationPullRevealStyle,
   PULL_COMMIT_PX,
   PULL_SLOP_PX,
+  PULL_TRAVEL_PX,
   visibleNotificationGroups,
 } from "./notification-shade-presentation";
 
@@ -150,6 +159,17 @@ function isInteractiveGestureTarget(target: EventTarget | null): boolean {
   );
 }
 
+function touchWithIdentifier(
+  touches: TouchList,
+  identifier: number,
+): Touch | undefined {
+  for (let index = 0; index < touches.length; index += 1) {
+    const touch = touches[index];
+    if (touch?.identifier === identifier) return touch;
+  }
+  return undefined;
+}
+
 /**
  * Per-event cap (px) on a wheel delta's contribution toward the COLLAPSE
  * commit. Collapse shares its direction with ordinary downward scrolling, so
@@ -174,13 +194,43 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 10;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
-const SHADE_CLOSE_FADE_MS = 220;
-const NOTIFICATION_COUNT_RESTORE_MS = 140;
+const SHADE_SETTLE_MS = 340;
+const SHADE_MIN_SETTLE_MS = 260;
+const SHADE_MAX_SETTLE_MS = 440;
+const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.22;
+const SHADE_EASING = "cubic-bezier(0.25,0.1,0.25,1)";
+const PULL_CANCEL_SETTLE_MS = SHADE_SETTLE_MS;
+const SHADE_MIN_FLICK_DISTANCE_PX = 22;
+const SHADE_FLICK_VELOCITY_PX_PER_MS = 0.45;
+const SHADE_MIN_VELOCITY_SAMPLE_MS = 16;
+// The count and clear slots trade the same 40px of list flow space. Their
+// geometry must settle on one clock or a cancelled pull overshoots before the
+// slower slot catches up, making the count reverse direction at the edge.
+const NOTIFICATION_COUNT_RESTORE_MS = SHADE_SETTLE_MS;
 const NOTIFICATION_ROW_SETTLE_MS = 220;
-const STACK_LAYOUT_TRANSITION = {
-  duration: 0.34,
-  ease: [0.22, 1, 0.36, 1],
+/** The stack fan has enough travel to read clearly without feeling delayed. */
+export const STACK_FAN_SETTLE_MS = 300;
+const STACK_FAN_LAYOUT_TRANSITION = {
+  duration: STACK_FAN_SETTLE_MS / 1_000,
+  ease: [0.25, 0.1, 0.25, 1],
 } as const;
+/**
+ * A fold retains the fanned DOM until its rows have reached the stack. Sharing
+ * this clock with the layout settle prevents sibling groups from snapping into
+ * their new positions before the disappearing cards finish converging.
+ */
+export const STACK_FOLD_SETTLE_MS = 340;
+const STACK_FOLD_COMPACTION_BUFFER_MS = 34;
+const STACK_FOLD_LAYOUT_TRANSITION = {
+  duration: STACK_FOLD_SETTLE_MS / 1_000,
+  ease: [0.25, 0.1, 0.25, 1],
+} as const;
+
+interface PendingStackFold {
+  timer: number;
+  mayRestoreRestedShade: boolean;
+  shadeCloseStarted: boolean;
+}
 
 /**
  * Scroll + glass polish for the shade, in one inline block (house pattern —
@@ -199,9 +249,8 @@ const STACK_LAYOUT_TRANSITION = {
  *  - Rows hidden by the closed shade track pull distance with opacity and
  *    vertical settling, so the user's finger reveals content before release.
  *
- * Reduced motion keeps the direct-manipulation transitions that preserve
- * spatial continuity, while omitting scroll-edge decoration and scale-heavy
- * effects.
+ * Reduced motion still tracks direct manipulation under the pointer, but
+ * removes every automated settle and decorative transition.
  */
 const NOTIF_SCROLL_CSS = `
 /* Apple-style entrance: the whole inbox fades + rises a touch the moment it
@@ -232,11 +281,11 @@ const NOTIF_SCROLL_CSS = `
 }
 /* A dense expanded inbox cannot afford one live backdrop-refraction graph per
    card. Keep the full material for the small rested triage; while previewing
-   or expanded, the same sheen/rim sits on an opaque translucent fill so drag
+   or expanded, the same sheen/rim sits on a solid fill so drag
    and scroll stay compositor-cheap even at the 100-row render cap. */
 .eliza-notif-scroll[data-shade-preview] .eliza-notif-glass,
 .eliza-notif-scroll[data-shade-mode="expanded"] .eliza-notif-glass {
-  background-color: rgb(22 22 25 / 88%);
+  background-color: rgb(22 22 25);
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
@@ -251,6 +300,7 @@ const NOTIF_SCROLL_CSS = `
 /* A collapsed stack is a set of physical cards, not translucent glass panes.
    Keep its front card and peeks solid through every shade/pager material
    override so the wallpaper and adjacent rows cannot show through. */
+.eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass,
 .eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass,
 .eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek {
   background-color: rgb(28 28 30);
@@ -270,19 +320,39 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-shade-transition {
   transform-origin: top center;
   transition:
-    grid-template-rows ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    height ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    margin-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    padding-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    opacity ${SHADE_CLOSE_FADE_MS}ms ease-out,
-    transform ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1);
+    grid-template-rows var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    height var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    margin-bottom var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    padding-bottom var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    row-gap var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING} var(--eliza-notif-opacity-delay, 0ms),
+    transform var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
+}
+/* Rows, peeks, controls, and the count badge share the stack's full settle so
+   the physical layers crossfade while they converge instead of swapping near
+   the endpoint. */
+[data-notification-stack-fanned]:not([data-notification-stack-closing]) .eliza-notif-shade-transition {
+  --eliza-notif-geometry-duration: ${STACK_FAN_SETTLE_MS}ms;
+  transition-timing-function: ${SHADE_EASING};
+}
+[data-notification-stack-closing] .eliza-notif-shade-transition {
+  --eliza-notif-geometry-duration: ${STACK_FOLD_SETTLE_MS}ms;
+  transition-timing-function: ${SHADE_EASING};
+}
+[data-notification-stack-fanned]:not([data-notification-stack-closing]) :is([data-notification-stack-peek], [data-notification-source-count], [data-notification-stack-controls], [data-notification-disposable-row]) {
+  --eliza-notif-opacity-duration: ${STACK_FAN_SETTLE_MS}ms;
+  --eliza-notif-opacity-delay: 0ms;
+}
+[data-notification-stack-closing] :is([data-notification-stack-peek], [data-notification-source-count], [data-notification-stack-controls], [data-notification-disposable-row]) {
+  --eliza-notif-opacity-duration: ${STACK_FOLD_SETTLE_MS}ms;
+  --eliza-notif-opacity-delay: 0ms;
 }
 .eliza-notif-count-transition {
   transition:
-    height ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    margin-bottom ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    opacity ${NOTIFICATION_COUNT_RESTORE_MS}ms ease-out;
+    height var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms) ${SHADE_EASING},
+    margin-bottom var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms) ${SHADE_EASING},
+    opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms)) ${SHADE_EASING} var(--eliza-notif-opacity-delay, 0ms),
+    transform var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms) ${SHADE_EASING};
 }
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-shade-transition,
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
@@ -297,7 +367,19 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   animation: none;
 }
 .eliza-notif-scroll {
+  isolation: isolate;
   scrollbar-width: none;
+}
+/* Count and card shells become independent compositor layers while they trade
+   flow space. Keep cards above the count so its label fades behind their
+   material instead of painting through it during either shade direction. */
+.eliza-notif-scroll [data-notification-count-slot] {
+  position: relative;
+  z-index: 0;
+}
+.eliza-notif-scroll [data-notification-group] {
+  position: relative;
+  z-index: 1;
 }
 .eliza-notif-scroll::-webkit-scrollbar { display: none; }
 @keyframes eliza-notif-fade-in {
@@ -332,47 +414,52 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .eliza-notif-row { animation: none; }
-  .eliza-notif-center-in {
-    animation: eliza-notif-fade-in 240ms ease-out both !important;
-  }
-  .eliza-notif-row-inner {
-    transition:
-      transform ${NOTIFICATION_ROW_SETTLE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      opacity ${NOTIFICATION_ROW_SETTLE_MS}ms linear !important;
-  }
-  .eliza-notif-row-inner[data-swipe-dragging] {
+  .eliza-notif-center,
+  .eliza-notif-center *,
+  .eliza-notif-center *::before,
+  .eliza-notif-center *::after {
+    animation: none !important;
     transition: none !important;
-  }
-  .eliza-notif-shade-transition {
-    transition:
-      grid-template-rows ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      height ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      margin-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      padding-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      opacity ${SHADE_CLOSE_FADE_MS}ms ease-out,
-      transform ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1) !important;
-  }
-  .eliza-notif-scroll[data-shade-dragging] .eliza-notif-shade-transition {
-    transition: none !important;
-  }
-  .eliza-notif-count-transition {
-    transition:
-      height ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      margin-bottom ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      opacity ${NOTIFICATION_COUNT_RESTORE_MS}ms ease-out !important;
-  }
-  .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
-    transition: none !important;
-  }
-  .eliza-notif-control-transition {
-    transition-duration: 220ms !important;
   }
 }
 `;
 
 let notificationsHomeCenterRenderObserverForTests: (() => void) | null = null;
+
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return false;
+    }
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(mediaQuery.matches);
+    update();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", update);
+      return () => mediaQuery.removeEventListener("change", update);
+    }
+
+    mediaQuery.addListener(update);
+    return () => mediaQuery.removeListener(update);
+  }, []);
+
+  return prefersReducedMotion;
+}
 
 export function __setNotificationsHomeCenterRenderObserverForTests(
   observer: (() => void) | null,
@@ -397,24 +484,114 @@ export function NotificationsHomeCenter({
 } = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
+  const reduceMotion = usePrefersReducedMotion();
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
   const [shadeExpanded, setShadeExpanded] = useState(false);
+  const [shadeOpenProgress, setShadeOpenProgress] = useState(1);
   // Per-producer stack expansion (iOS-shade idiom). Tapping a peek fans that
   // stack and enters the expanded shade; folding the shade resets every stack.
   const [expandedStacks, setExpandedStacks] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  const [openingStacks, setOpeningStacks] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [closingStacks, setClosingStacks] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [stackPeekOpenOffsets, setStackPeekOpenOffsets] = useState<
+    ReadonlyMap<string, readonly number[]>
+  >(() => new Map());
+  const stackGeometryRevision = useMemo(
+    () =>
+      notifications
+        .map(
+          (notification) =>
+            `${notification.id}\u0000${notification.title}\u0000${notification.body ?? ""}`,
+        )
+        .join("\u0001"),
+    [notifications],
+  );
+  const expandedStacksRef = useRef(expandedStacks);
+  expandedStacksRef.current = expandedStacks;
   const [shadeOpenedByStack, setShadeOpenedByStack] = useState(false);
+  const shadeOpenedByStackRef = useRef(shadeOpenedByStack);
+  shadeOpenedByStackRef.current = shadeOpenedByStack;
   const [confirmingGroupKey, setConfirmingGroupKey] = useState<string | null>(
     null,
   );
   const [confirmingClearAll, setConfirmingClearAll] = useState(false);
   const [shadeClosing, setShadeClosing] = useState(false);
+  const [pullCancellingDirection, setPullCancellingDirection] = useState<
+    "expand" | "collapse" | null
+  >(null);
   const shadeCloseTimer = useRef<number | null>(null);
+  const pullCancelTimer = useRef<number | null>(null);
+  const stackFoldTimers = useRef(new Map<string, PendingStackFold>());
+  const centerRef = useRef<HTMLElement | null>(null);
+  const pendingShadeFocusRef = useRef(false);
+  const pendingStackFocusRef = useRef<string | null>(null);
+  const pendingCollapsedStackFocusRef = useRef<string | null>(null);
+  const pendingRestedCountFocusRef = useRef(false);
+  const cancelPullCancellation = useCallback(() => {
+    if (pullCancelTimer.current !== null) {
+      window.clearTimeout(pullCancelTimer.current);
+      pullCancelTimer.current = null;
+    }
+    setPullCancellingDirection(null);
+  }, []);
+  const cancelStackFold = useCallback((key: string) => {
+    const pending = stackFoldTimers.current.get(key);
+    if (pending) {
+      window.clearTimeout(pending.timer);
+      stackFoldTimers.current.delete(key);
+    }
+    setClosingStacks((prev) => {
+      if (!prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
+  const cancelAllStackFolds = useCallback(() => {
+    for (const pending of stackFoldTimers.current.values()) {
+      window.clearTimeout(pending.timer);
+    }
+    stackFoldTimers.current.clear();
+    setClosingStacks((prev) => (prev.size === 0 ? prev : new Set()));
+  }, []);
   const expandStack = useCallback(
-    (key: string) => {
-      if (!shadeExpanded) setShadeOpenedByStack(true);
+    (key: string, moveFocus: boolean) => {
+      if (shadeCloseTimer.current !== null) {
+        // A newly fanned producer supersedes an auto-restore started by an
+        // older fold. Reverse the shared shade settle and let the live stack
+        // projection decide whether a later fold should restore rest.
+        window.clearTimeout(shadeCloseTimer.current);
+        shadeCloseTimer.current = null;
+        setShadeClosing(false);
+        for (const pending of stackFoldTimers.current.values()) {
+          pending.shadeCloseStarted = false;
+        }
+      }
+      cancelPullCancellation();
+      cancelStackFold(key);
+      centerRef.current?.style.setProperty(
+        "--eliza-notif-settle-duration",
+        `${STACK_FAN_SETTLE_MS}ms`,
+      );
+      if (moveFocus) pendingStackFocusRef.current = key;
+      if (!shadeExpanded) {
+        setShadeOpenedByStack(true);
+        setShadeOpenProgress(reduceMotion ? 1 : 0);
+      }
+      if (!reduceMotion) {
+        setOpeningStacks((prev) => {
+          const next = new Set(prev);
+          next.add(key);
+          return next;
+        });
+      }
       setExpandedStacks((prev) => {
         if (prev.has(key)) return prev;
         const next = new Set(prev);
@@ -425,18 +602,213 @@ export function NotificationsHomeCenter({
       setConfirmingClearAll(false);
       setShadeExpanded(true);
     },
-    [shadeExpanded],
+    [cancelPullCancellation, cancelStackFold, reduceMotion, shadeExpanded],
   );
-  const collapseStack = useCallback((key: string) => {
-    setExpandedStacks((prev) => {
-      if (!prev.has(key)) return prev;
-      const next = new Set(prev);
-      next.delete(key);
-      return next;
+  const collapseStack = useCallback(
+    (key: string, moveFocus = false) => {
+      cancelPullCancellation();
+      cancelStackFold(key);
+      if (moveFocus) pendingCollapsedStackFocusRef.current = key;
+      setOpeningStacks((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setExpandedStacks((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setConfirmingGroupKey((current) => (current === key ? null : current));
+      setConfirmingClearAll(false);
+    },
+    [cancelPullCancellation, cancelStackFold],
+  );
+
+  useLayoutEffect(() => {
+    const shouldOpenShade =
+      shadeExpanded && shadeOpenProgress === 0 && !reduceMotion;
+    const shouldFanStacks = openingStacks.size > 0 && !reduceMotion;
+    if (!shouldOpenShade && !shouldFanStacks) return;
+
+    // Snapshot the mounted origin once, then launch both targets on the next
+    // frame. This preserves a real CSS transition without two idle frames or
+    // two separate React commits when a stack also opens the shade.
+    centerRef.current?.getBoundingClientRect();
+    const targetFrame = window.requestAnimationFrame(() => {
+      if (shouldOpenShade) setShadeOpenProgress(1);
+      if (shouldFanStacks) setOpeningStacks(new Set());
     });
-    setConfirmingGroupKey((current) => (current === key ? null : current));
-    setConfirmingClearAll(false);
-  }, []);
+    return () => window.cancelAnimationFrame(targetFrame);
+  }, [openingStacks, reduceMotion, shadeExpanded, shadeOpenProgress]);
+
+  useLayoutEffect(() => {
+    if (!reduceMotion) return;
+    if (shadeOpenProgress !== 1) setShadeOpenProgress(1);
+    if (openingStacks.size > 0) setOpeningStacks(new Set());
+  }, [openingStacks.size, reduceMotion, shadeOpenProgress]);
+
+  useLayoutEffect(() => {
+    const center = centerRef.current;
+    if (!center || expandedStacks.size === 0 || stackGeometryRevision === "") {
+      return;
+    }
+
+    let disposed = false;
+    let measureFrame: number | null = null;
+    const stackRows = () =>
+      center.querySelectorAll<HTMLElement>(
+        "[data-notification-group-key][data-notification-stack-fanned] [data-notification-stack-rows]",
+      );
+    const measure = () => {
+      measureFrame = null;
+      if (disposed) return;
+      const measured = new Map<string, readonly number[]>();
+      for (const rowList of stackRows()) {
+        const group = rowList.closest<HTMLElement>(
+          "[data-notification-group-key]",
+        );
+        const key = group?.dataset.notificationGroupKey;
+        if (!key) continue;
+        const rows = Array.from(rowList.children).filter(
+          (child): child is HTMLElement =>
+            child instanceof HTMLElement &&
+            child.hasAttribute("data-notif-row"),
+        );
+        if (rows.length < 2) continue;
+
+        let offsetPx = 0;
+        const offsets: number[] = [];
+        for (
+          let rowIndex = 0;
+          rowIndex < Math.min(rows.length - 1, MAX_VISIBLE_STACK_LAYERS - 1);
+          rowIndex += 1
+        ) {
+          const rowContent = rows[rowIndex]?.querySelector<HTMLElement>(
+            '[data-testid="notification-row"]',
+          );
+          if (!rowContent) break;
+          // The content button retains its natural size while the outer grid
+          // row fans from 0fr. Measuring it avoids sampling an intermediate
+          // transition height and keeps variable-height rows spatially exact.
+          const renderedHeightPx = rowContent.getBoundingClientRect().height;
+          const rowHeightPx =
+            renderedHeightPx > 0 ? renderedHeightPx : rowContent.scrollHeight;
+          if (rowHeightPx <= 0) break;
+          offsetPx += rowHeightPx + 6;
+          offsets.push(offsetPx);
+        }
+        if (offsets.length > 0) measured.set(key, offsets);
+      }
+
+      setStackPeekOpenOffsets((previous) => {
+        let changed = previous.size !== measured.size;
+        if (!changed) {
+          for (const [key, offsets] of measured) {
+            const prior = previous.get(key);
+            if (
+              prior?.length !== offsets.length ||
+              offsets.some((offset, index) => prior[index] !== offset)
+            ) {
+              changed = true;
+              break;
+            }
+          }
+        }
+        return changed ? measured : previous;
+      });
+    };
+    const scheduleMeasure = () => {
+      if (disposed) return;
+      if (measureFrame !== null) window.cancelAnimationFrame(measureFrame);
+      measureFrame = window.requestAnimationFrame(measure);
+    };
+
+    measure();
+    const resizeObserver =
+      typeof ResizeObserver === "function"
+        ? new ResizeObserver(scheduleMeasure)
+        : null;
+    for (const rowList of stackRows()) {
+      for (const row of Array.from(rowList.children)) {
+        const rowContent = row.querySelector<HTMLElement>(
+          '[data-testid="notification-row"]',
+        );
+        if (rowContent) resizeObserver?.observe(rowContent);
+      }
+    }
+    window.addEventListener("resize", scheduleMeasure);
+    void document.fonts?.ready.then(scheduleMeasure);
+    return () => {
+      disposed = true;
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleMeasure);
+      if (measureFrame !== null) window.cancelAnimationFrame(measureFrame);
+    };
+  }, [expandedStacks, stackGeometryRevision]);
+
+  useLayoutEffect(() => {
+    if (
+      !pendingShadeFocusRef.current ||
+      !shadeExpanded ||
+      shadeOpenProgress !== 1
+    ) {
+      return;
+    }
+    const firstRow = centerRef.current?.querySelector<HTMLElement>(
+      '[data-testid="notification-row"]',
+    );
+    if (!firstRow) return;
+    pendingShadeFocusRef.current = false;
+    firstRow.focus();
+  }, [shadeExpanded, shadeOpenProgress]);
+
+  useLayoutEffect(() => {
+    const key = pendingStackFocusRef.current;
+    if (!key || openingStacks.has(key) || !expandedStacks.has(key)) return;
+    const group = Array.from(
+      centerRef.current?.querySelectorAll<HTMLElement>(
+        "[data-notification-group-key]",
+      ) ?? [],
+    ).find((candidate) => candidate.dataset.notificationGroupKey === key);
+    const collapseControl = group?.querySelector<HTMLElement>(
+      '[data-testid="notification-stack-collapse"]',
+    );
+    if (!collapseControl) return;
+    pendingStackFocusRef.current = null;
+    collapseControl.focus();
+  }, [expandedStacks, openingStacks]);
+
+  useLayoutEffect(() => {
+    const key = pendingCollapsedStackFocusRef.current;
+    if (!key || (expandedStacks.has(key) && !closingStacks.has(key))) {
+      return;
+    }
+    const group = Array.from(
+      centerRef.current?.querySelectorAll<HTMLElement>(
+        "[data-notification-group-key]",
+      ) ?? [],
+    ).find((candidate) => candidate.dataset.notificationGroupKey === key);
+    pendingCollapsedStackFocusRef.current = null;
+    group
+      ?.querySelector<HTMLElement>('[data-testid="notification-row"]')
+      ?.focus();
+  }, [closingStacks, expandedStacks]);
+
+  useLayoutEffect(() => {
+    if (
+      !pendingRestedCountFocusRef.current ||
+      (shadeExpanded && !shadeClosing)
+    ) {
+      return;
+    }
+    pendingRestedCountFocusRef.current = false;
+    centerRef.current
+      ?.querySelector<HTMLElement>('[data-testid="notifications-count-button"]')
+      ?.focus();
+  }, [shadeClosing, shadeExpanded]);
   // Dampened live pull (px), SIGNED: positive is a downward pull (expand),
   // negative an upward push (collapse). React mounts the preview once when a
   // gesture starts; pointer moves update existing styles directly so a
@@ -446,12 +818,15 @@ export function NotificationsHomeCenter({
   >(null);
   const pullDirectionRef = useRef<"expand" | "collapse" | null>(null);
   const pullPxRef = useRef(0);
-  const pullPresentationFrame = useRef<number | null>(null);
+  const pullMomentumRef = useRef<{
+    direction: "expand" | "collapse";
+    startedAtMs: number;
+    samples: MomentumSample[];
+  } | null>(null);
   // No list-level clock tick here (binding pattern, spec §C.4): relative
   // timestamps live in the `<RelativeTime>` leaf inside each row, which owns the
   // shared visibility-gated ticker. The minute roll re-renders those text nodes
   // only - not this list, not the rows, not the glass surface.
-  const centerRef = useRef<HTMLElement | null>(null);
   const scrollRef = useRef<HTMLUListElement | null>(null);
   const pullVisibleGroupsRef = useRef<HTMLElement[] | undefined>(undefined);
   const pointerPull = useRef<{
@@ -463,6 +838,12 @@ export function NotificationsHomeCenter({
     // pull is measured from here, not from the gesture start, so a drag that
     // first scrolled the list up to its top doesn't arrive already maxed.
     anchorY: number | null;
+  } | null>(null);
+  const emptyPointerPull = useRef<{
+    id: number;
+    startX: number;
+    startY: number;
+    axis: "none" | "x" | "y";
   } | null>(null);
   // A touch drag can end in `pointercancel` before the row sees enough pointer
   // movement to suppress the browser's synthetic click. The list owns the
@@ -493,6 +874,33 @@ export function NotificationsHomeCenter({
     closing: shadeClosing,
   };
 
+  const applyPullPresentation = useCallback((px: number) => {
+    applyNotificationPullPresentation(
+      centerRef.current,
+      px,
+      shadePresentationRef.current.expanded,
+      shadePresentationRef.current.closing,
+      pullVisibleGroupsRef.current,
+    );
+  }, []);
+  const {
+    schedule: schedulePullPresentation,
+    flush: flushScheduledPullPresentation,
+    cancel: cancelScheduledPullPresentation,
+  } = useRafCoalescer(applyPullPresentation);
+
+  const setShadeSettleDuration = useCallback((durationMs: number) => {
+    centerRef.current?.style.setProperty(
+      "--eliza-notif-settle-duration",
+      `${durationMs}ms`,
+    );
+  }, []);
+
+  const flushPullPresentation = useCallback(() => {
+    flushScheduledPullPresentation();
+    centerRef.current?.getBoundingClientRect();
+  }, [flushScheduledPullPresentation]);
+
   const armNotificationClickSuppression = useCallback(() => {
     suppressNotificationClick.current = true;
     if (suppressNotificationClickTimer.current !== null) {
@@ -504,67 +912,137 @@ export function NotificationsHomeCenter({
     }, 500);
   }, []);
 
-  const setPullPx = useCallback((px: number) => {
-    pullPxRef.current = px;
-    const nextDirection = px > 0 ? "expand" : px < 0 ? "collapse" : null;
-    const directionChanged = pullDirectionRef.current !== nextDirection;
-    if (directionChanged) {
-      pullDirectionRef.current = nextDirection;
-      pullVisibleGroupsRef.current = nextDirection
-        ? visibleNotificationGroups(centerRef.current, scrollRef.current)
-        : undefined;
-      setPullDirection(nextDirection);
-    }
-    // The zero state is rendered declaratively after the dragging marker is
-    // removed, allowing the release transition to run. Non-zero movement is
-    // direct manipulation and must update in the current input event.
-    const applyCurrentPull = () => {
-      pullPresentationFrame.current = null;
-      applyNotificationPullPresentation(
-        centerRef.current,
-        pullPxRef.current,
-        shadePresentationRef.current.expanded,
-        shadePresentationRef.current.closing,
-        pullVisibleGroupsRef.current,
-      );
-    };
-    if (!nextDirection) {
-      if (pullPresentationFrame.current !== null) {
-        window.cancelAnimationFrame(pullPresentationFrame.current);
-        pullPresentationFrame.current = null;
+  const setPullPx = useCallback(
+    (px: number, preserveDirectionAtZero = false) => {
+      pullPxRef.current = px;
+      const nextDirection =
+        px > 0
+          ? "expand"
+          : px < 0
+            ? "collapse"
+            : preserveDirectionAtZero
+              ? pullDirectionRef.current
+              : null;
+      const directionChanged = pullDirectionRef.current !== nextDirection;
+      if (nextDirection) {
+        const now = performance.now();
+        let momentum = pullMomentumRef.current;
+        if (!momentum || momentum.direction !== nextDirection) {
+          momentum = {
+            direction: nextDirection,
+            startedAtMs: now,
+            samples: [{ positionPx: 0, timeMs: now }],
+          };
+          pullMomentumRef.current = momentum;
+        }
+        momentum.samples.push({ positionPx: px, timeMs: now });
+        const cutoff = now - MOMENTUM_RELEASE_WINDOW_MS;
+        while (
+          momentum.samples.length > 2 &&
+          (momentum.samples[1]?.timeMs ?? now) < cutoff
+        ) {
+          momentum.samples.shift();
+        }
+      } else {
+        pullMomentumRef.current = null;
       }
-    } else if (directionChanged) {
-      applyCurrentPull();
-    } else if (pullPresentationFrame.current === null) {
-      pullPresentationFrame.current =
-        window.requestAnimationFrame(applyCurrentPull);
-    }
-  }, []);
+      if (directionChanged) {
+        pullDirectionRef.current = nextDirection;
+        pullVisibleGroupsRef.current = nextDirection
+          ? visibleNotificationGroups(centerRef.current, scrollRef.current)
+          : undefined;
+        setPullDirection(nextDirection);
+      }
+      // The zero state is rendered declaratively after the dragging marker is
+      // removed, allowing the release transition to run. Non-zero movement is
+      // direct manipulation and must update in the current input event.
+      if (!nextDirection) {
+        cancelScheduledPullPresentation();
+      } else if (directionChanged) {
+        cancelScheduledPullPresentation();
+        applyPullPresentation(px);
+      } else {
+        schedulePullPresentation(px);
+      }
+    },
+    [
+      applyPullPresentation,
+      cancelScheduledPullPresentation,
+      schedulePullPresentation,
+    ],
+  );
 
   const cancelClearConfirmation = useCallback(() => {
     setConfirmingClearAll(false);
     setConfirmingGroupKey(null);
   }, []);
 
-  const setShade = useCallback((expanded: boolean) => {
-    if (shadeCloseTimer.current) {
-      window.clearTimeout(shadeCloseTimer.current);
-      shadeCloseTimer.current = null;
+  const beginPullCancellation = useCallback(
+    (direction: "expand" | "collapse", settleMs: number) => {
+      if (pullCancelTimer.current !== null) {
+        window.clearTimeout(pullCancelTimer.current);
+      }
+      setShadeSettleDuration(settleMs);
+      // The cancelling direction keeps the preview DOM mounted until every
+      // surface reaches its zero-opacity/zero-layout endpoint. Removing it at
+      // pointer-up would make quiet groups disappear while the count eases.
+      setPullCancellingDirection(direction);
+      pullCancelTimer.current = window.setTimeout(() => {
+        pullCancelTimer.current = null;
+        setPullCancellingDirection(null);
+      }, settleMs + STACK_FOLD_COMPACTION_BUFFER_MS);
+    },
+    [setShadeSettleDuration],
+  );
+
+  const setShade = useCallback(
+    (expanded: boolean) => {
+      if (shadeCloseTimer.current) {
+        window.clearTimeout(shadeCloseTimer.current);
+        shadeCloseTimer.current = null;
+      }
+      cancelPullCancellation();
+      setShadeClosing(false);
+      setShadeExpanded(expanded);
+      setConfirmingClearAll(false);
+      setConfirmingGroupKey(null);
+      setShadeOpenedByStack(false);
+      if (expanded) {
+        pendingRestedCountFocusRef.current = false;
+      } else {
+        cancelAllStackFolds();
+        pendingShadeFocusRef.current = false;
+        pendingStackFocusRef.current = null;
+        // Folding the shade folds every fanned stack with it so the next open
+        // starts from a predictable grouped inbox.
+        setExpandedStacks(new Set());
+        setOpeningStacks(new Set());
+        setShadeOpenProgress(1);
+      }
+      // Collapse completion is deterministic even when a smooth scroll was
+      // interrupted. Expansion resets after the expanded rows mount below.
+      if (!expanded && scrollRef.current) scrollRef.current.scrollTop = 0;
+    },
+    [cancelAllStackFolds, cancelPullCancellation],
+  );
+
+  const beginProgrammaticShadeOpen = useCallback(() => {
+    setShadeSettleDuration(SHADE_SETTLE_MS);
+    if (reduceMotion) {
+      setShadeOpenProgress(1);
+    } else {
+      setShadeOpenProgress(0);
     }
-    setShadeClosing(false);
-    setShadeExpanded(expanded);
-    setConfirmingClearAll(false);
-    setConfirmingGroupKey(null);
-    setShadeOpenedByStack(false);
-    if (!expanded) {
-      // Folding the shade folds every fanned stack with it so the next open
-      // starts from a predictable grouped inbox.
-      setExpandedStacks(new Set());
-    }
-    // Collapse completion is deterministic even when a smooth scroll was
-    // interrupted. Expansion resets after the expanded rows mount below.
-    if (!expanded && scrollRef.current) scrollRef.current.scrollTop = 0;
-  }, []);
+    setShade(true);
+  }, [reduceMotion, setShade, setShadeSettleDuration]);
+
+  const openShadeFromControl = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      pendingShadeFocusRef.current = event.detail === 0;
+      beginProgrammaticShadeOpen();
+    },
+    [beginProgrammaticShadeOpen],
+  );
 
   // Every expansion path must reveal the shade's first row and clear control.
   // Stack taps call expandStack directly (not setShade), and mounting their
@@ -577,6 +1055,9 @@ export function NotificationsHomeCenter({
   }, [shadeExpanded]);
 
   useLayoutEffect(() => {
+    // Settled renders are fully declarative. Direct writes are reserved for an
+    // active drag/close so they cannot overwrite click-entry interpolation.
+    if (!pullDirection && !shadeClosing) return;
     if (pullDirection) {
       pullVisibleGroupsRef.current = visibleNotificationGroups(
         centerRef.current,
@@ -592,50 +1073,152 @@ export function NotificationsHomeCenter({
     );
   });
 
-  const requestShadeCollapse = useCallback(() => {
-    if (!shadeExpanded || shadeClosing) return;
-    const draggedFullyClosed = pullPxRef.current <= -PULL_COMMIT_PX;
-    cancelClearConfirmation();
-    const list = scrollRef.current;
-    if (list && list.scrollTop > 0) {
-      list.scrollTo?.({ top: 0, behavior: "smooth" });
-    }
-    wheelCommitLockUntil.current = Date.now() + WHEEL_COMMIT_LOCK_MS;
-    // End direct manipulation before starting the close settle. Leaving a
-    // non-zero pull marks the shade as dragging, which intentionally disables
-    // child transitions and turns the committed close into a delayed snap.
-    setPullPx(0);
-    // A completed direct gesture has already faded the disposable cards to
-    // zero. Remove their layout immediately instead of making the user wait
-    // through a second, invisible close animation.
-    if (draggedFullyClosed) {
-      setShade(false);
-      return;
-    }
-    setShadeClosing(true);
-    shadeCloseTimer.current = window.setTimeout(() => {
-      shadeCloseTimer.current = null;
-      setShade(false);
-    }, SHADE_CLOSE_FADE_MS);
-  }, [
-    cancelClearConfirmation,
-    setPullPx,
-    setShade,
-    shadeClosing,
-    shadeExpanded,
-  ]);
+  const requestShadeCollapse = useCallback(
+    (settleMs = SHADE_SETTLE_MS) => {
+      if (!shadeExpanded || shadeClosing) return;
+      cancelPullCancellation();
+      cancelClearConfirmation();
+      const list = scrollRef.current;
+      if (list && list.scrollTop > 0) {
+        list.scrollTo?.({
+          top: 0,
+          behavior: reduceMotion ? "auto" : "smooth",
+        });
+      }
+      wheelCommitLockUntil.current = Date.now() + WHEEL_COMMIT_LOCK_MS;
+      // A release can arrive before the last coalesced pointer frame. Paint the
+      // latest direct-manipulation value synchronously and flush its style so
+      // the retained close transition always starts from what the finger did.
+      if (pullPxRef.current !== 0) {
+        flushPullPresentation();
+      }
+      // End direct manipulation before starting the close settle. Leaving a
+      // non-zero pull marks the shade as dragging, which intentionally disables
+      // child transitions and turns the committed close into a delayed snap.
+      setPullPx(0);
+      if (reduceMotion) {
+        setShade(false);
+        return;
+      }
+      // Fanned stacks own longer geometry than the ordinary shade. Retaining
+      // their keyed rows through that endpoint prevents pointer-up from
+      // compacting a still-visible stack into one card.
+      const retainsFannedStacks = expandedStacksRef.current.size > 0;
+      const retainedSettleMs = Math.max(
+        settleMs,
+        retainsFannedStacks ? STACK_FOLD_SETTLE_MS : 0,
+      );
+      setShadeSettleDuration(retainedSettleMs);
+      setShadeClosing(true);
+      shadeCloseTimer.current = window.setTimeout(
+        () => {
+          shadeCloseTimer.current = null;
+          setShade(false);
+        },
+        retainedSettleMs +
+          (retainsFannedStacks ? STACK_FOLD_COMPACTION_BUFFER_MS : 0),
+      );
+    },
+    [
+      cancelClearConfirmation,
+      cancelPullCancellation,
+      flushPullPresentation,
+      reduceMotion,
+      setPullPx,
+      setShade,
+      setShadeSettleDuration,
+      shadeClosing,
+      shadeExpanded,
+    ],
+  );
+
+  useLayoutEffect(() => {
+    if (reduceMotion && shadeClosing) setShade(false);
+  }, [reduceMotion, setShade, shadeClosing]);
+
+  const completeStackFold = useCallback(
+    (key: string) => {
+      const pending = stackFoldTimers.current.get(key);
+      if (!pending) return;
+      window.clearTimeout(pending.timer);
+      stackFoldTimers.current.delete(key);
+      // Another producer can fan while this stack is converging. Restore the
+      // rested shade only when the live projection still makes this the final
+      // expanded stack; the intent captured at click time is not authoritative.
+      const restoresRestedShade =
+        pending.mayRestoreRestedShade &&
+        shadeOpenedByStackRef.current &&
+        expandedStacksRef.current.size === 1 &&
+        expandedStacksRef.current.has(key);
+      collapseStack(key);
+      if (restoresRestedShade && !pending.shadeCloseStarted) {
+        requestShadeCollapse(STACK_FOLD_SETTLE_MS);
+      }
+    },
+    [collapseStack, requestShadeCollapse],
+  );
 
   const foldStack = useCallback(
-    (key: string) => {
+    (key: string, moveFocus = false) => {
+      if (!expandedStacks.has(key) || stackFoldTimers.current.has(key)) return;
       const restoresRestedShade =
         shadeOpenedByStack &&
         expandedStacks.size === 1 &&
         expandedStacks.has(key);
-      collapseStack(key);
-      if (restoresRestedShade) requestShadeCollapse();
+      if (reduceMotion) {
+        collapseStack(key, moveFocus);
+        if (restoresRestedShade) requestShadeCollapse();
+        return;
+      }
+
+      cancelPullCancellation();
+      if (moveFocus) pendingCollapsedStackFocusRef.current = key;
+      setOpeningStacks((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setClosingStacks((prev) => {
+        const next = new Set(prev);
+        next.add(key);
+        return next;
+      });
+      setConfirmingGroupKey((current) => (current === key ? null : current));
+      setConfirmingClearAll(false);
+      // A stack that opened the shade also closes it, but both layers share
+      // this fold clock. Sequencing the shade afterward creates a visible
+      // second tail even when the stack itself has already reached rest.
+      const pending: PendingStackFold = {
+        timer: 0,
+        mayRestoreRestedShade: shadeOpenedByStack,
+        shadeCloseStarted: restoresRestedShade && !shadeClosing,
+      };
+      pending.timer = window.setTimeout(
+        () => completeStackFold(key),
+        STACK_FOLD_SETTLE_MS + STACK_FOLD_COMPACTION_BUFFER_MS,
+      );
+      stackFoldTimers.current.set(key, pending);
+      if (pending.shadeCloseStarted) {
+        requestShadeCollapse(STACK_FOLD_SETTLE_MS);
+      }
     },
-    [collapseStack, expandedStacks, requestShadeCollapse, shadeOpenedByStack],
+    [
+      cancelPullCancellation,
+      collapseStack,
+      completeStackFold,
+      expandedStacks,
+      reduceMotion,
+      requestShadeCollapse,
+      shadeClosing,
+      shadeOpenedByStack,
+    ],
   );
+
+  useLayoutEffect(() => {
+    if (!reduceMotion || closingStacks.size === 0) return;
+    for (const key of closingStacks) completeStackFold(key);
+  }, [closingStacks, completeStackFold, reduceMotion]);
 
   const hasClearConfirmation =
     confirmingClearAll || confirmingGroupKey !== null;
@@ -681,15 +1264,70 @@ export function NotificationsHomeCenter({
     const { canExpand, canCollapse } = shadeGestureRef.current;
     const commitPx =
       notifications.length === 0 ? EMPTY_PULL_COMMIT_PX : PULL_COMMIT_PX;
+    const canMove = (px > 0 && canExpand) || (px < 0 && canCollapse);
+    const now = performance.now();
+    const momentum = pullMomentumRef.current;
+    const sampleDurationMs = momentum ? now - momentum.startedAtMs : 0;
+    const fallbackVelocity =
+      momentum && sampleDurationMs >= SHADE_MIN_VELOCITY_SAMPLE_MS
+        ? px / sampleDurationMs
+        : 0;
+    const releaseVelocity = momentum
+      ? sampleDurationMs >= SHADE_MIN_VELOCITY_SAMPLE_MS
+        ? getMomentumReleaseVelocity({
+            samples: momentum.samples,
+            endPositionPx: px,
+            endTimeMs: now,
+            fallbackVelocityPxPerMs: fallbackVelocity,
+          })
+        : 0
+      : fallbackVelocity;
+    const shouldCommit =
+      canMove &&
+      shouldCommitMomentumDetent({
+        displacementPx: px,
+        releaseVelocityPxPerMs: releaseVelocity,
+        distanceThresholdPx: commitPx,
+        minimumFlickDistancePx:
+          notifications.length === 0
+            ? EMPTY_PULL_COMMIT_PX / 2
+            : SHADE_MIN_FLICK_DISTANCE_PX,
+        flickVelocityThresholdPxPerMs: SHADE_FLICK_VELOCITY_PX_PER_MS,
+      });
+    const remainingDistancePx = shouldCommit
+      ? Math.max(0, PULL_TRAVEL_PX - Math.abs(px))
+      : Math.abs(px);
+    const settleMs = getVelocityAwareSettleDuration({
+      velocityPxPerMs: releaseVelocity,
+      remainingDistancePx,
+      fallbackDurationMs: PULL_CANCEL_SETTLE_MS,
+      minimumDurationMs: SHADE_MIN_SETTLE_MS,
+      maximumDurationMs: SHADE_MAX_SETTLE_MS,
+      minimumSpeedPxPerMs: SHADE_MIN_SETTLE_SPEED_PX_PER_MS,
+    });
+
+    if (px !== 0) flushPullPresentation();
+    setShadeSettleDuration(settleMs);
     // Directional: a downward pull only expands, an upward push only
     // collapses. A gesture in the direction of the current state is a no-op.
-    if (px >= commitPx && canExpand) setShade(true);
-    else if (px <= -commitPx && canCollapse) {
-      requestShadeCollapse();
+    if (shouldCommit && px > 0 && canExpand) setShade(true);
+    else if (shouldCommit && px < 0 && canCollapse) {
+      requestShadeCollapse(settleMs);
       return;
+    } else if (px !== 0 && !reduceMotion && canMove) {
+      beginPullCancellation(px > 0 ? "expand" : "collapse", settleMs);
     }
     setPullPx(0);
-  }, [notifications.length, requestShadeCollapse, setPullPx, setShade]);
+  }, [
+    beginPullCancellation,
+    flushPullPresentation,
+    notifications.length,
+    reduceMotion,
+    requestShadeCollapse,
+    setPullPx,
+    setShade,
+    setShadeSettleDuration,
+  ]);
 
   // Shared wheel accumulator for both the list and, while empty, the wider
   // home background. Returns whether the shade consumed this delta so the
@@ -731,12 +1369,12 @@ export function NotificationsHomeCenter({
         if (empty) {
           wheelCommitLockUntil.current = Date.now() + WHEEL_COMMIT_LOCK_MS;
         }
-        if (dir === 1) setShade(true);
+        if (dir === 1) beginProgrammaticShadeOpen();
         else requestShadeCollapse();
       }
       return true;
     },
-    [notifications.length, requestShadeCollapse, setShade],
+    [beginProgrammaticShadeOpen, notifications.length, requestShadeCollapse],
   );
 
   const onListWheel = useCallback(
@@ -765,25 +1403,39 @@ export function NotificationsHomeCenter({
         ? emptyGestureTargetRef.current
         : list;
     const usesEmptyBackground = gestureTarget !== list;
-    let start: { x: number; y: number } | null = null;
+    let start: { identifier: number; x: number; y: number } | null = null;
     // clientY where the drag first reached the top; the pull is measured from
     // here so a continuous drag that scrolled the list up to its top doesn't
     // jump the shade by the pre-top travel and instantly commit.
     let expandAnchorY: number | null = null;
     let collapseAnchorY: number | null = null;
     let closeFromBottomEdge = false;
+    const resetTouchState = () => {
+      start = null;
+      expandAnchorY = null;
+      collapseAnchorY = null;
+      closeFromBottomEdge = false;
+    };
+    const abortTouchPull = () => {
+      resetTouchState();
+      setPullPx(0);
+    };
     const onTouchStart = (e: TouchEvent) => {
       const t = e.touches[0];
       const target = e.target;
-      if (usesEmptyBackground && isInteractiveGestureTarget(target)) {
-        start = null;
-        expandAnchorY = null;
-        collapseAnchorY = null;
-        closeFromBottomEdge = false;
+      if (
+        e.touches.length !== 1 ||
+        !t ||
+        (usesEmptyBackground && isInteractiveGestureTarget(target))
+      ) {
+        abortTouchPull();
         return;
       }
-      start =
-        e.touches.length === 1 && t ? { x: t.clientX, y: t.clientY } : null;
+      start = {
+        identifier: t.identifier,
+        x: t.clientX,
+        y: t.clientY,
+      };
       // Already at the top → anchor at the touch start so the whole drag counts
       // as pull. Started scrolled down → leave null; the move handler anchors at
       // the instant scrollTop first reaches 0 (the top crossing).
@@ -815,17 +1467,13 @@ export function NotificationsHomeCenter({
           ? start.y
           : null;
     };
-    const onTouchMove = (e: TouchEvent) => {
-      const t = e.touches[0];
+    const updateTouchPosition = (t: Touch, event?: TouchEvent) => {
       if (!start || !t) return;
       const dx = t.clientX - start.x;
       const dy = t.clientY - start.y;
       // A horizontal gesture belongs to the row swipe; hand it off for good.
       if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > PULL_SLOP_PX) {
-        start = null;
-        expandAnchorY = null;
-        collapseAnchorY = null;
-        closeFromBottomEdge = false;
+        abortTouchPull();
         return;
       }
       if (Math.abs(dy) > PULL_SLOP_PX && Math.abs(dy) >= Math.abs(dx)) {
@@ -835,7 +1483,7 @@ export function NotificationsHomeCenter({
         // Claim the bottom-edge close from its first vertical pixel so the
         // native scroller never moves underneath the gesture before the slop
         // threshold is crossed.
-        e.preventDefault();
+        event?.preventDefault();
       }
       const { canExpand, canCollapse } = shadeGestureRef.current;
       if (dy < -PULL_SLOP_PX) {
@@ -859,14 +1507,14 @@ export function NotificationsHomeCenter({
           if (collapseAnchorY === null) collapseAnchorY = t.clientY;
           const push = collapseAnchorY - t.clientY;
           if (push > PULL_SLOP_PX) {
-            e.preventDefault();
+            event?.preventDefault();
             setPullPx(-dampenPull(push));
           } else if (pullPxRef.current !== 0) {
-            setPullPx(0);
+            setPullPx(0, true);
           }
         } else {
           collapseAnchorY = null;
-          if (pullPxRef.current !== 0) setPullPx(0);
+          if (pullPxRef.current !== 0) setPullPx(0, true);
         }
         return;
       }
@@ -874,36 +1522,49 @@ export function NotificationsHomeCenter({
         if (expandAnchorY === null) expandAnchorY = t.clientY;
         const pull = t.clientY - expandAnchorY;
         if (pull > PULL_SLOP_PX) {
-          e.preventDefault();
+          event?.preventDefault();
           setPullPx(dampenPull(pull));
         } else if (pullPxRef.current !== 0) {
           // Finger reversed back above the anchor — the pull is withdrawn, so
           // the release must not commit from the stale peak (parity with the
           // pointer path).
-          setPullPx(0);
+          setPullPx(0, true);
         }
       } else if (expandAnchorY !== null) {
         // Scrolled back down into content — abandon the pull and re-anchor.
         expandAnchorY = null;
-        if (pullPxRef.current !== 0) setPullPx(0);
+        if (pullPxRef.current !== 0) setPullPx(0, true);
       }
     };
-    const onTouchEnd = () => {
-      start = null;
-      expandAnchorY = null;
-      collapseAnchorY = null;
-      closeFromBottomEdge = false;
+    const onTouchMove = (event: TouchEvent) => {
+      if (!start) return;
+      if (event.touches.length !== 1) {
+        abortTouchPull();
+        return;
+      }
+      const touch = touchWithIdentifier(event.touches, start.identifier);
+      if (touch) updateTouchPosition(touch, event);
+      else abortTouchPull();
+    };
+    const onTouchEnd = (event: TouchEvent) => {
+      if (!start) return;
+      const finalTouch = touchWithIdentifier(
+        event.changedTouches,
+        start.identifier,
+      );
+      if (!finalTouch && event.changedTouches.length > 0) {
+        abortTouchPull();
+        return;
+      }
+      if (finalTouch) updateTouchPosition(finalTouch);
+      resetTouchState();
       commitPull();
     };
     const onTouchCancel = () => {
       // An OS-cancelled gesture (incoming call, edge-gesture takeover, palm
       // rejection) ABORTS: snap back to rest, never change the shade from a
       // gesture the user never completed.
-      start = null;
-      expandAnchorY = null;
-      collapseAnchorY = null;
-      closeFromBottomEdge = false;
-      setPullPx(0);
+      abortTouchPull();
     };
     const onEmptyBackgroundWheel = (e: WheelEvent) => {
       const target = e.target;
@@ -958,7 +1619,7 @@ export function NotificationsHomeCenter({
     const surface = emptyGestureTargetRef?.current;
     const list = scrollRef.current;
     if (!hasNotifications || !surface || !list || surface === list) return;
-    let start: { x: number; y: number } | null = null;
+    let start: { identifier: number; x: number; y: number } | null = null;
     let axis: "none" | "x" | "y" = "none";
     let ownsPull = false;
 
@@ -967,21 +1628,30 @@ export function NotificationsHomeCenter({
       axis = "none";
       ownsPull = false;
     };
+    const abort = () => {
+      reset();
+      setPullPx(0);
+    };
     const onTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
       const target = event.target;
-      start =
-        event.touches.length === 1 &&
-        touch &&
-        !isInteractiveGestureTarget(target) &&
-        !(target instanceof Node && list.contains(target))
-          ? { x: touch.clientX, y: touch.clientY }
-          : null;
-      axis = "none";
-      ownsPull = false;
+      if (
+        event.touches.length !== 1 ||
+        !touch ||
+        isInteractiveGestureTarget(target) ||
+        (target instanceof Node && list.contains(target))
+      ) {
+        abort();
+        return;
+      }
+      reset();
+      start = {
+        identifier: touch.identifier,
+        x: touch.clientX,
+        y: touch.clientY,
+      };
     };
-    const onTouchMove = (event: TouchEvent) => {
-      const touch = event.touches[0];
+    const updateTouchPosition = (touch: Touch, event?: TouchEvent) => {
       if (!start || !touch) return;
       const dx = touch.clientX - start.x;
       const dy = touch.clientY - start.y;
@@ -1003,21 +1673,39 @@ export function NotificationsHomeCenter({
         shadeGestureRef.current.canExpand
       ) {
         ownsPull = true;
-        event.preventDefault();
+        event?.preventDefault();
         setPullPx(dampenPull(dy));
       } else if (ownsPull && pullPxRef.current !== 0) {
-        setPullPx(0);
+        setPullPx(0, true);
       }
     };
-    const onTouchEnd = () => {
+    const onTouchMove = (event: TouchEvent) => {
+      if (!start) return;
+      if (event.touches.length !== 1) {
+        abort();
+        return;
+      }
+      const touch = touchWithIdentifier(event.touches, start.identifier);
+      if (touch) updateTouchPosition(touch, event);
+      else abort();
+    };
+    const onTouchEnd = (event: TouchEvent) => {
+      if (!start) return;
+      const finalTouch = touchWithIdentifier(
+        event.changedTouches,
+        start.identifier,
+      );
+      if (!finalTouch && event.changedTouches.length > 0) {
+        abort();
+        return;
+      }
+      if (finalTouch) updateTouchPosition(finalTouch);
       const shouldCommit = ownsPull;
       reset();
       if (shouldCommit) commitPull();
     };
     const onTouchCancel = () => {
-      const shouldResetPull = ownsPull;
-      reset();
-      if (shouldResetPull) setPullPx(0);
+      abort();
     };
     const onWheel = (event: WheelEvent) => {
       const target = event.target;
@@ -1061,24 +1749,41 @@ export function NotificationsHomeCenter({
     const surface = emptyGestureTargetRef?.current;
     const center = centerRef.current;
     const list = scrollRef.current;
-    if (!shadeExpanded || !surface || !center || !list) return;
-    let start: { x: number; y: number } | null = null;
+    if (!shadeExpanded || shadeClosing || !surface || !center || !list) return;
+    let start: { identifier: number; x: number; y: number } | null = null;
+
+    const abort = () => {
+      start = null;
+      setPullPx(0);
+    };
 
     const onTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
       const target = event.target;
-      start =
-        event.touches.length === 1 &&
-        touch &&
-        target instanceof Node &&
-        !list.contains(target) &&
-        !isInteractiveGestureTarget(target)
-          ? { x: touch.clientX, y: touch.clientY }
-          : null;
+      if (
+        event.touches.length !== 1 ||
+        !touch ||
+        !shadeGestureRef.current.canCollapse ||
+        !(target instanceof Node) ||
+        list.contains(target) ||
+        isInteractiveGestureTarget(target)
+      ) {
+        abort();
+        return;
+      }
+      start = {
+        identifier: touch.identifier,
+        x: touch.clientX,
+        y: touch.clientY,
+      };
     };
-    const onTouchMove = (event: TouchEvent) => {
-      const touch = event.touches[0];
+    const updateTouchPosition = (touch: Touch, event?: TouchEvent) => {
       if (!start || !touch) return;
+      if (!shadeGestureRef.current.canCollapse) {
+        start = null;
+        if (pullPxRef.current !== 0) setPullPx(0);
+        return;
+      }
       const dx = touch.clientX - start.x;
       const dy = touch.clientY - start.y;
       if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > PULL_SLOP_PX) {
@@ -1086,21 +1791,39 @@ export function NotificationsHomeCenter({
         setPullPx(0);
         return;
       }
-      if (dy < 0 && Math.abs(dy) >= Math.abs(dx)) event.preventDefault();
+      if (dy < 0 && Math.abs(dy) >= Math.abs(dx)) event?.preventDefault();
       if (dy < -PULL_SLOP_PX) {
         setPullPx(-dampenPull(-dy));
       } else if (pullPxRef.current !== 0) {
-        setPullPx(0);
+        setPullPx(0, true);
       }
     };
-    const onTouchEnd = () => {
+    const onTouchMove = (event: TouchEvent) => {
       if (!start) return;
+      if (event.touches.length !== 1) {
+        abort();
+        return;
+      }
+      const touch = touchWithIdentifier(event.touches, start.identifier);
+      if (touch) updateTouchPosition(touch, event);
+      else abort();
+    };
+    const onTouchEnd = (event: TouchEvent) => {
+      if (!start) return;
+      const finalTouch = touchWithIdentifier(
+        event.changedTouches,
+        start.identifier,
+      );
+      if (!finalTouch && event.changedTouches.length > 0) {
+        abort();
+        return;
+      }
+      if (finalTouch) updateTouchPosition(finalTouch);
       start = null;
       commitPull();
     };
     const onTouchCancel = () => {
-      start = null;
-      setPullPx(0);
+      abort();
     };
 
     surface.addEventListener("touchstart", onTouchStart, { passive: true });
@@ -1113,18 +1836,28 @@ export function NotificationsHomeCenter({
       surface.removeEventListener("touchend", onTouchEnd);
       surface.removeEventListener("touchcancel", onTouchCancel);
     };
-  }, [commitPull, emptyGestureTargetRef, setPullPx, shadeExpanded]);
+  }, [
+    commitPull,
+    emptyGestureTargetRef,
+    setPullPx,
+    shadeClosing,
+    shadeExpanded,
+  ]);
 
   // Clear timers that may outlive a single gesture.
   useEffect(
     () => () => {
       if (wheelDecayTimer.current) window.clearTimeout(wheelDecayTimer.current);
       if (shadeCloseTimer.current) window.clearTimeout(shadeCloseTimer.current);
+      if (pullCancelTimer.current !== null) {
+        window.clearTimeout(pullCancelTimer.current);
+      }
+      for (const pending of stackFoldTimers.current.values()) {
+        window.clearTimeout(pending.timer);
+      }
+      stackFoldTimers.current.clear();
       if (suppressNotificationClickTimer.current !== null) {
         window.clearTimeout(suppressNotificationClickTimer.current);
-      }
-      if (pullPresentationFrame.current !== null) {
-        window.cancelAnimationFrame(pullPresentationFrame.current);
       }
     },
     [],
@@ -1164,9 +1897,11 @@ export function NotificationsHomeCenter({
     }
     setConfirmingClearAll(false);
     setConfirmingGroupKey(null);
+    cancelAllStackFolds();
+    setOpeningStacks(new Set());
     setExpandedStacks(new Set());
     void clearNotifications();
-  }, [confirmingClearAll]);
+  }, [cancelAllStackFolds, confirmingClearAll]);
 
   // An emptied-out inbox resets the shade so the next arrival starts rested.
   // `pullPx` is cleared too: if the inbox empties mid-pull the touch effect
@@ -1174,14 +1909,22 @@ export function NotificationsHomeCenter({
   // the next arrival's first paint.
   useEffect(() => {
     if (notifications.length === 0) {
+      cancelAllStackFolds();
       setShadeExpanded(false);
       setShadeOpenedByStack(false);
+      setOpeningStacks(new Set());
       setExpandedStacks(new Set());
       setConfirmingGroupKey(null);
       setConfirmingClearAll(false);
+      cancelPullCancellation();
       setPullPx(0);
     }
-  }, [notifications.length, setPullPx]);
+  }, [
+    cancelAllStackFolds,
+    cancelPullCancellation,
+    notifications.length,
+    setPullPx,
+  ]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible
@@ -1237,7 +1980,7 @@ export function NotificationsHomeCenter({
       <section
         aria-label="Notifications"
         data-testid="home-notification-center"
-        className="relative flex min-h-20 flex-none items-center px-1.5 py-1 text-white"
+        className="eliza-notif-center relative flex min-h-20 flex-none items-center px-1.5 py-1 text-white"
       >
         <style>{NOTIF_SCROLL_CSS}</style>
         <LiquidGlassRefractionDefs />
@@ -1272,19 +2015,23 @@ export function NotificationsHomeCenter({
   const pullPx = pullPxRef.current;
   const isPulling = pullDirection !== null;
   const canExpand = !shadeExpanded;
-  const previewingExpansion = canExpand && pullDirection === "expand";
+  const canCollapse = shadeExpanded && !shadeClosing;
+  const previewingExpansion =
+    canExpand &&
+    (pullDirection === "expand" || pullCancellingDirection === "expand");
   const groups = shadeExpanded
     ? expandedGroups
     : previewingExpansion
       ? previewGroups
       : restedGroups;
-  shadeGestureRef.current = { canExpand, canCollapse: shadeExpanded };
+  shadeGestureRef.current = { canExpand, canCollapse };
   const {
     shadeCloseProgress,
     committedCloseProgress,
     disposableContentVisibility,
     pullContentVisibility,
     notificationCountVisibility,
+    notificationCountOffset,
     notificationCountLayoutVisibility,
     emptyStateVisibility,
     collapseControlVisibility,
@@ -1292,11 +2039,30 @@ export function NotificationsHomeCenter({
     clearControlLayoutVisibility,
   } = notificationPullPresentation(pullPx, shadeExpanded, shadeClosing);
   const disposableLayoutVisibility = 1 - committedCloseProgress;
+  const stackLayoutTransition =
+    expandedStacks.size > 0 && closingStacks.size === 0
+      ? STACK_FAN_LAYOUT_TRANSITION
+      : STACK_FOLD_LAYOUT_TRANSITION;
+  const collapseControlPresentationVisibility =
+    collapseControlVisibility * shadeOpenProgress;
   const showCollapseControl =
     (shadeExpanded || previewingExpansion) &&
     hasNotifications &&
     expandedStacks.size === 0 &&
     !shadeOpenedByStack;
+  const abortPointerPull = () => {
+    const px = pullPxRef.current;
+    if (px !== 0) {
+      flushPullPresentation();
+      if (!reduceMotion) {
+        beginPullCancellation(
+          px > 0 ? "expand" : "collapse",
+          PULL_CANCEL_SETTLE_MS,
+        );
+      }
+    }
+    setPullPx(0);
+  };
   const onListPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType !== "mouse" || !e.isPrimary) return;
     const el = scrollRef.current;
@@ -1332,25 +2098,98 @@ export function NotificationsHomeCenter({
       // Upward drag: the collapse gesture. A mouse drag never scrolls the
       // list, so it is measured from the gesture start — no top-crossing to
       // re-anchor at, and no scroll position to respect.
-      if (canCollapse) setPullPx(dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0);
-      else if (pullPxRef.current !== 0) setPullPx(0);
+      if (canCollapse) {
+        setPullPx(
+          dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0,
+          dy >= -PULL_SLOP_PX,
+        );
+      } else if (pullPxRef.current !== 0) setPullPx(0, true);
       return;
     }
     // Downward drag: the expand gesture, only from the list top.
     if (el.scrollTop <= 0 && mayExpand) {
       if (g.anchorY === null) g.anchorY = e.clientY;
       const pull = e.clientY - g.anchorY;
-      setPullPx(pull > PULL_SLOP_PX ? dampenPull(pull) : 0);
+      setPullPx(
+        pull > PULL_SLOP_PX ? dampenPull(pull) : 0,
+        pull <= PULL_SLOP_PX,
+      );
     } else if (g.anchorY !== null) {
       g.anchorY = null;
-      if (pullPxRef.current !== 0) setPullPx(0);
+      if (pullPxRef.current !== 0) setPullPx(0, true);
     }
   };
   const onListPointerEnd = (e: React.PointerEvent) => {
     const g = pointerPull.current;
     if (!g || g.id !== e.pointerId) return;
+    // Pointerup can carry the final coalesced position. Applying it before the
+    // release decision preserves a last-moment reversal or flick instead of
+    // committing from the previous frame's stale sample.
+    onListPointerMove(e);
     pointerPull.current = null;
     commitPull();
+  };
+  const onListPointerCancel = (e: React.PointerEvent) => {
+    if (pointerPull.current?.id !== e.pointerId) return;
+    pointerPull.current = null;
+    abortPointerPull();
+  };
+  const onEmptyPointerDown = (e: React.PointerEvent) => {
+    const list = scrollRef.current;
+    if (
+      e.pointerType !== "mouse" ||
+      !e.isPrimary ||
+      !canCollapse ||
+      !list ||
+      (e.target instanceof Node && list.contains(e.target)) ||
+      isInteractiveGestureTarget(e.target)
+    ) {
+      return;
+    }
+    emptyPointerPull.current = {
+      id: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      axis: "none",
+    };
+  };
+  const onEmptyPointerMove = (e: React.PointerEvent) => {
+    const gesture = emptyPointerPull.current;
+    if (!gesture || gesture.id !== e.pointerId) return;
+    if (!shadeGestureRef.current.canCollapse) {
+      emptyPointerPull.current = null;
+      if (pullPxRef.current !== 0) setPullPx(0);
+      return;
+    }
+    const dx = e.clientX - gesture.startX;
+    const dy = e.clientY - gesture.startY;
+    if (
+      gesture.axis === "none" &&
+      (Math.abs(dx) > PULL_SLOP_PX || Math.abs(dy) > PULL_SLOP_PX)
+    ) {
+      gesture.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+      if (gesture.axis === "y") {
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+      }
+    }
+    if (gesture.axis === "x") {
+      emptyPointerPull.current = null;
+      return;
+    }
+    if (gesture.axis !== "y") return;
+    setPullPx(dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0, dy >= -PULL_SLOP_PX);
+  };
+  const onEmptyPointerEnd = (e: React.PointerEvent) => {
+    const gesture = emptyPointerPull.current;
+    if (!gesture || gesture.id !== e.pointerId) return;
+    onEmptyPointerMove(e);
+    emptyPointerPull.current = null;
+    commitPull();
+  };
+  const onEmptyPointerCancel = (e: React.PointerEvent) => {
+    if (emptyPointerPull.current?.id !== e.pointerId) return;
+    emptyPointerPull.current = null;
+    abortPointerPull();
   };
   const onListClickCapture = (e: React.MouseEvent) => {
     if (!suppressNotificationClick.current) return;
@@ -1374,18 +2213,19 @@ export function NotificationsHomeCenter({
         height: `${notificationCountLayoutVisibility * 32}px`,
         marginBottom: `${(notificationCountLayoutVisibility - 1) * 8}px`,
         opacity: notificationCountVisibility,
+        transform: `translate3d(0, ${notificationCountOffset}px, 0)`,
         transition: isPulling ? "none" : undefined,
       }}
-      className="eliza-notif-count-transition flex shrink-0 items-center justify-center overflow-hidden px-3 text-2xs font-medium text-white/50"
+      className="eliza-notif-count-transition flex shrink-0 items-center justify-center px-3 text-2xs font-medium text-white/50"
     >
       <button
         type="button"
         data-testid="notifications-count-button"
         data-notif-control=""
         aria-label={`Show all ${notifications.length} notification${notifications.length === 1 ? "" : "s"}`}
-        aria-expanded={shadeExpanded}
-        onClick={() => setShade(true)}
-        className="flex h-full w-full items-center justify-center gap-1 text-inherit transition-colors hover:text-white/70"
+        aria-expanded={shadeExpanded && !shadeClosing}
+        onClick={openShadeFromControl}
+        className="flex h-8 w-full shrink-0 items-center justify-center gap-1 text-inherit transition-colors hover:text-white/70"
       >
         {notifications.length === 1
           ? "1 Notification"
@@ -1403,6 +2243,14 @@ export function NotificationsHomeCenter({
       ref={centerRef}
       aria-label="Notifications"
       data-testid="home-notification-center"
+      data-notification-reduced-motion={reduceMotion ? "" : undefined}
+      data-notification-shade-cancelling={
+        pullCancellingDirection ? "" : undefined
+      }
+      onPointerDown={onEmptyPointerDown}
+      onPointerMove={onEmptyPointerMove}
+      onPointerUp={onEmptyPointerEnd}
+      onPointerCancel={onEmptyPointerCancel}
       // No card chrome on the CONTAINER: the inbox has no fill and no border of
       // its own — the glass lives on each notification card. It sits inline on
       // the home field directly under the time/weather header.
@@ -1411,7 +2259,7 @@ export function NotificationsHomeCenter({
       // `min-h-0 flex-1` lets a populated inbox fill the home column down to the
       // chat when the parent grows it.
       className={cn(
-        "relative flex min-h-0 flex-1 flex-col overflow-hidden text-white",
+        "eliza-notif-center relative flex min-h-0 flex-1 flex-col overflow-hidden text-white",
         hasNotifications && "eliza-notif-center-in",
         !hasNotifications && "min-h-14 flex-none",
       )}
@@ -1427,7 +2275,7 @@ export function NotificationsHomeCenter({
         onPointerDown={onListPointerDown}
         onPointerMove={onListPointerMove}
         onPointerUp={onListPointerEnd}
-        onPointerCancel={onListPointerEnd}
+        onPointerCancel={onListPointerCancel}
         onClickCapture={onListClickCapture}
         onWheel={onListWheel}
         data-testid="home-notification-list"
@@ -1504,7 +2352,13 @@ export function NotificationsHomeCenter({
           const groupWasRested = restedGroupKeys.has(group.key);
           const pullRevealed = previewingExpansion && !groupWasRested;
           const revealProgress = pullRevealed
-            ? notificationPullRevealProgress(pullPx, groupIndex)
+            ? notificationGroupPullVisibility(
+                pullPx,
+                groupIndex,
+                shadeExpanded,
+                shadeClosing,
+                true,
+              )
             : 1;
           const closeVisibility = notificationGroupPullVisibility(
             pullPx,
@@ -1512,6 +2366,12 @@ export function NotificationsHomeCenter({
             shadeExpanded,
             shadeClosing,
             false,
+          );
+          const shadeOpenVisibility =
+            shadeExpanded && !groupWasRested ? shadeOpenProgress : 1;
+          const groupVisibility = Math.min(
+            closeVisibility,
+            shadeOpenVisibility,
           );
           const groupContainerOffset = notificationGroupContainerOffset(
             pullPx,
@@ -1522,6 +2382,9 @@ export function NotificationsHomeCenter({
           // Every presentation shares one shell, so the top NotificationRow
           // stays under the same parent/key while a fanned stack closes.
           const fanned = stackExpanded && group.rows.length > 1;
+          const stackClosing = closingStacks.has(group.key);
+          const stackFanProgress =
+            openingStacks.has(group.key) || stackClosing ? 0 : 1;
           // A rested priority card keeps the visual depth of every folded
           // sibling from the same producer, including quiet rows. The content
           // remains priority-only; the peeks communicate that tapping fans a
@@ -1532,10 +2395,7 @@ export function NotificationsHomeCenter({
           const stacked = !fanned && collapsedStackRows.length > 1;
           // Resting peeks remain mounted invisibly behind a fan so full cards
           // can fold back into them without a last-frame pop.
-          const peeks = (fanned ? restedStackRows : collapsedStackRows).slice(
-            1,
-            MAX_VISIBLE_STACK_LAYERS,
-          );
+          const peeks = collapsedStackRows.slice(1, MAX_VISIBLE_STACK_LAYERS);
           const expandedStackTailPx =
             peeks.length * STACK_PEEK_OFFSET_PX +
             (peeks.length > 0 ? STACK_BOTTOM_CLEARANCE_PX : 0);
@@ -1556,28 +2416,56 @@ export function NotificationsHomeCenter({
           const stackTailPx =
             restedStackTailPx +
             (expandedStackTailPx - restedStackTailPx) * stackTailRevealProgress;
+          const fannedOpenPaddingPx =
+            expandedStackTailPx + (16 - expandedStackTailPx) * stackFanProgress;
           const rows = fanned
             ? group.rows
             : [group.rows[0] as AgentNotification];
           const collapsedGroupHasMore = !fanned && allGroupRows.length > 1;
+          const stackPeekMode = fanned
+            ? "close"
+            : groupWasRested
+              ? "static"
+              : "disposable";
+          const stackPeekVisibility = fanned
+            ? Math.max(
+                groupWasRested ? shadeCloseProgress : 0,
+                1 - stackFanProgress,
+              )
+            : stackPeekMode === "disposable"
+              ? pullContentVisibility
+              : 1;
+          const stackPeekExpansionProgress = fanned
+            ? Math.min(stackFanProgress, 1 - shadeCloseProgress)
+            : 0;
+          // CSS owns the retained fold from start to finish. Motion layout is
+          // suspended for that interval so the zero-geometry DOM compaction
+          // cannot launch a second settle after the visible fold is complete.
           const groupElement = (
             <motion.li
               key={group.key}
               layout={
-                shadeExpanded && !isPulling && !shadeClosing
+                !reduceMotion &&
+                !isPulling &&
+                !pullCancellingDirection &&
+                !shadeClosing &&
+                !stackClosing
                   ? "position"
                   : false
               }
-              transition={{ layout: STACK_LAYOUT_TRANSITION }}
+              transition={{ layout: stackLayoutTransition }}
               data-notification-group=""
+              data-notification-group-key={group.key}
               data-notification-group-index={groupIndex}
+              data-notification-stack-fanned={fanned ? "" : undefined}
+              data-notification-stack-closing={stackClosing ? "" : undefined}
               data-rested-notification-group={groupWasRested ? "" : undefined}
               data-notification-pull-reveal={pullRevealed ? "" : undefined}
               inert={pullRevealed ? true : undefined}
               className={cn(
                 "relative flex flex-col",
-                pullRevealed && "eliza-notif-pull-reveal pointer-events-none",
-                fanned && "pb-2",
+                pullRevealed &&
+                  "eliza-notif-pull-reveal eliza-notif-shade-transition pointer-events-none",
               )}
               style={
                 pullRevealed || groupContainerOffset !== 0
@@ -1594,40 +2482,47 @@ export function NotificationsHomeCenter({
               <div
                 data-notification-group-content=""
                 data-notification-stacked={stacked ? "" : undefined}
+                data-notification-stack-material={
+                  allGroupRows.length > 1 ? "" : undefined
+                }
                 data-notification-rested-tail-px={restedStackTailPx}
                 data-notification-expanded-tail-px={expandedStackTailPx}
                 data-testid={stacked ? "notification-stack" : undefined}
                 className="eliza-notif-shade-transition relative flex flex-col"
                 style={{
                   paddingBottom: fanned
-                    ? disposableLayoutVisibility * 8 +
+                    ? fannedOpenPaddingPx * disposableLayoutVisibility +
                       shadeCloseProgress * restedStackTailPx
                     : stacked
                       ? stackTailPx
                       : 0,
-                  opacity: groupWasRested ? 1 : closeVisibility,
+                  opacity: groupWasRested ? 1 : groupVisibility,
                   transform: groupWasRested
                     ? undefined
                     : `translate3d(0, ${notificationGroupPullOffset(
                         pullPx,
                         shadeExpanded,
                         shadeClosing,
-                        closeVisibility,
+                        groupVisibility,
                       )}px, 0)`,
-                  transition: isPulling
-                    ? "none"
-                    : `padding-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1), opacity ${SHADE_CLOSE_FADE_MS}ms ease-out, transform ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1)`,
+                  transition: isPulling ? "none" : undefined,
                 }}
               >
                 {fanned ? (
                   <div
                     data-testid="notification-stack-controls"
                     data-notification-stack-controls=""
+                    aria-hidden={stackClosing ? true : undefined}
+                    inert={stackClosing ? true : undefined}
                     className="eliza-notif-shade-transition flex items-center justify-between gap-3 overflow-hidden px-2"
                     style={{
-                      height: disposableLayoutVisibility * 36,
-                      opacity: disposableContentVisibility,
-                      transform: `translate3d(0, ${(1 - disposableContentVisibility) * -6}px, 0)`,
+                      height:
+                        stackFanProgress * disposableLayoutVisibility * 36,
+                      opacity: stackFanProgress * disposableContentVisibility,
+                      transform: `translate3d(0, ${
+                        (1 - stackFanProgress * disposableContentVisibility) *
+                        -6
+                      }px, 0)`,
                     }}
                   >
                     <span className="truncate text-xs font-semibold text-white/55">
@@ -1638,7 +2533,10 @@ export function NotificationsHomeCenter({
                         type="button"
                         data-testid="notification-stack-collapse"
                         data-notif-control=""
-                        onClick={() => foldStack(group.key)}
+                        disabled={stackClosing}
+                        onClick={(event) =>
+                          foldStack(group.key, event.detail === 0)
+                        }
                         className="h-8 px-2 text-xs font-medium text-white/60 transition-colors hover:text-white/90"
                       >
                         Show Less
@@ -1675,17 +2573,15 @@ export function NotificationsHomeCenter({
                     </span>
                   </div>
                 ) : null}
-                <motion.ul
-                  layout={
-                    shadeExpanded && !isPulling && !shadeClosing
-                      ? "position"
-                      : false
-                  }
-                  transition={{ layout: STACK_LAYOUT_TRANSITION }}
+                <ul
+                  data-notification-stack-rows=""
                   className={cn(
                     "relative z-[2] flex flex-col",
-                    fanned && "gap-1.5",
+                    fanned && "eliza-notif-shade-transition",
                   )}
+                  style={
+                    fanned ? { rowGap: `${stackFanProgress * 6}px` } : undefined
+                  }
                 >
                   {rows.map((notification, rowIndex) => (
                     <NotificationRow
@@ -1697,13 +2593,38 @@ export function NotificationsHomeCenter({
                           : undefined
                       }
                       stackCount={
-                        rowIndex === 0 && collapsedGroupHasMore
+                        rowIndex === 0 && allGroupRows.length > 1
                           ? allGroupRows.length
+                          : undefined
+                      }
+                      stackCountVisibility={
+                        rowIndex === 0 && allGroupRows.length > 1
+                          ? fanned
+                            ? 1 - stackFanProgress
+                            : 1
+                          : undefined
+                      }
+                      stackPeeks={
+                        rowIndex === 0 && peeks.length > 0
+                          ? {
+                              count: peeks.length,
+                              disabled: stackClosing,
+                              expansionProgress: stackPeekExpansionProgress,
+                              fanned,
+                              groupLabel: group.label,
+                              mode: stackPeekMode,
+                              openOffsetsPx: stackPeekOpenOffsets.get(
+                                group.key,
+                              ),
+                              testIdVisible: !fanned || shadeCloseProgress > 0,
+                              totalCount: allGroupRows.length,
+                              visibility: stackPeekVisibility,
+                            }
                           : undefined
                       }
                       shadeVisibility={
                         fanned && rowIndex > 0
-                          ? disposableLayoutVisibility
+                          ? stackFanProgress * disposableLayoutVisibility
                           : undefined
                       }
                       onExpandStack={expandStack}
@@ -1711,52 +2632,7 @@ export function NotificationsHomeCenter({
                       onDismiss={dismissNotification}
                     />
                   ))}
-                </motion.ul>
-                {peeks.map((peek, i) => {
-                  const peekMode = fanned
-                    ? "close"
-                    : groupWasRested
-                      ? "static"
-                      : "disposable";
-                  const peekCloseVisibility = fanned
-                    ? shadeCloseProgress
-                    : peekMode === "disposable"
-                      ? pullContentVisibility
-                      : 1;
-                  return (
-                    <button
-                      key={peek.id}
-                      type="button"
-                      data-testid={
-                        !fanned || shadeCloseProgress > 0
-                          ? "notification-stack-peek"
-                          : undefined
-                      }
-                      data-notif-control=""
-                      data-notification-stack-peek=""
-                      data-notification-peek-mode={peekMode}
-                      tabIndex={peekCloseVisibility < 1 ? -1 : undefined}
-                      aria-hidden={peekCloseVisibility === 0 ? true : undefined}
-                      aria-label={`Show all ${allGroupRows.length} ${group.label} notifications`}
-                      onClick={() => expandStack(group.key)}
-                      className={cn(
-                        "eliza-notif-glass eliza-notif-stack-peek eliza-notif-shade-transition absolute inset-x-0 top-0 rounded-2xl",
-                        fanned && "pointer-events-none",
-                      )}
-                      style={{
-                        bottom: fanned ? restedStackTailPx : stackTailPx,
-                        zIndex: 1 - i,
-                        opacity: peekCloseVisibility,
-                        transform: `translateY(${(i + 1) * STACK_PEEK_OFFSET_PX}px) scale(${
-                          1 - (i + 1) * 0.015
-                        })`,
-                        transition: isPulling
-                          ? "none"
-                          : `bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1), opacity ${SHADE_CLOSE_FADE_MS}ms ease-out`,
-                      }}
-                    />
-                  );
-                })}
+                </ul>
               </div>
             </motion.li>
           );
@@ -1769,18 +2645,26 @@ export function NotificationsHomeCenter({
         <div
           data-testid="notifications-collapse-footer"
           data-notification-collapse-footer=""
-          aria-hidden={collapseControlVisibility === 0 ? true : undefined}
-          inert={collapseControlVisibility < 1 ? true : undefined}
+          aria-hidden={
+            collapseControlPresentationVisibility === 0 ? true : undefined
+          }
+          inert={collapseControlPresentationVisibility < 1 ? true : undefined}
           style={{
-            opacity: collapseControlVisibility,
-            transform: `translateY(${(1 - collapseControlVisibility) * 4}px)`,
+            opacity: collapseControlPresentationVisibility,
+            transform: `translateY(${
+              (1 - collapseControlPresentationVisibility) * 4
+            }px)`,
+            transition: isPulling ? "none" : undefined,
           }}
           className="eliza-notif-shade-transition pointer-events-none flex shrink-0 justify-center px-3"
         >
           <button
             type="button"
             data-testid="notifications-collapse"
-            onClick={requestShadeCollapse}
+            onClick={(event) => {
+              pendingRestedCountFocusRef.current = event.detail === 0;
+              requestShadeCollapse();
+            }}
             className="pointer-events-auto flex min-h-touch items-center justify-center gap-1 px-2 text-2xs font-medium text-white/55 transition-colors hover:text-white/90"
           >
             Collapse

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -293,6 +293,11 @@ const NOTIF_SCROLL_CSS = `
   backdrop-filter: ${LIQUID_GLASS_BLUR};
   transition: background-color 150ms linear;
 }
+/* The global focus reset removes box shadows, but this inset edge is part of
+   the glass material rather than a focus ring and must survive card focus. */
+.eliza-notif-glass:focus-within {
+  box-shadow: ${LIQUID_GLASS_EDGE_SHADOW} !important;
+}
 /* Chromium honors url(#…) on backdrop-filter → refract the background at the
    rim (the "liquid" cue). WebKit can't, so it keeps the frosted blur above. */
 @supports (backdrop-filter: url(#x)) or (-webkit-backdrop-filter: url(#x)) {
@@ -2406,7 +2411,7 @@ export function NotificationsHomeCenter({
               opacity: clearControlVisibility,
               transform: `translate3d(0, ${(1 - clearControlVisibility) * -8}px, 0)`,
             }}
-            className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-1"
+            className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-2"
           >
             {shadeExpanded || previewingExpansion ? (
               <button

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -386,9 +386,59 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
   transition: none;
 }
+/* Bulk clear keeps its right edge aligned with each producer's X. Touch-first
+   surfaces expose the command label at rest; precise pointers retain the
+   compact X and reveal the same label leftward on hover or keyboard focus. */
+.eliza-notif-clear-all {
+  width: 2rem;
+}
+.eliza-notif-clear-all[data-confirming] {
+  width: 3rem;
+}
+.eliza-notif-clear-all:not([data-confirming]):focus-visible {
+  width: 3.5rem;
+}
+.eliza-notif-clear-all:not([data-confirming]):focus-visible [data-notification-clear-resting-label] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+.eliza-notif-clear-all:not([data-confirming]):focus-visible [data-notification-clear-resting-icon] {
+  opacity: 0;
+  transform: scale(0.75);
+}
+@media (hover: none), (pointer: coarse) {
+  .eliza-notif-clear-all:not([data-confirming]) {
+    width: 3.5rem;
+  }
+  .eliza-notif-clear-all:not([data-confirming]) [data-notification-clear-resting-label] {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  .eliza-notif-clear-all:not([data-confirming]) [data-notification-clear-resting-icon] {
+    opacity: 0;
+    transform: scale(0.75);
+  }
+}
+@media (hover: hover) and (pointer: fine) {
+  .eliza-notif-clear-all:not([data-confirming]):hover {
+    width: 3.5rem;
+  }
+  .eliza-notif-clear-all:not([data-confirming]):hover [data-notification-clear-resting-label] {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  .eliza-notif-clear-all:not([data-confirming]):hover [data-notification-clear-resting-icon] {
+    opacity: 0;
+    transform: scale(0.75);
+  }
+}
+/* A view-timeline animation reattaches from its entry keyframe when a transient
+   release marker disappears. Keep it suspended for the expanded projection so
+   that handoff cannot reapply opacity/scale to otherwise-settled glass cards. */
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-row,
 .eliza-notif-scroll[data-shade-settling] .eliza-notif-row,
-.eliza-notif-scroll[data-shade-release-settling] .eliza-notif-row {
+.eliza-notif-scroll[data-shade-release-settling] .eliza-notif-row,
+.eliza-notif-scroll[data-shade-mode="expanded"] .eliza-notif-row {
   animation: none !important;
 }
 .eliza-notif-scroll .eliza-notif-row.eliza-notif-pull-reveal,
@@ -420,12 +470,14 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   mask-image: none;
   transition: none;
 }
-/* A released deep pull keeps the same unmasked runway until every translated
-   card reaches rest. Restoring the edge mask earlier clips the returning cards
-   while their container is still settling. */
+/* A released deep pull keeps a static feather at both scrollport edges while
+   translated cards return through the retained runway. The scroll-linked mask
+   normally removes its top fade at scrollTop=0; freezing it here prevents the
+   returning cards from ending at the center's hard overflow clip. */
 .eliza-notif-scroll[data-shade-release-settling] {
-  -webkit-mask-image: none;
-  mask-image: none;
+  animation: none;
+  --scroll-fade-t: 1.25rem;
+  --scroll-fade-b: 1.5rem;
 }
 /* Count and card shells become independent compositor layers while they trade
    flow space. Keep cards above the count so its label fades behind their
@@ -532,12 +584,19 @@ export function __setNotificationsHomeCenterRenderObserverForTests(
  */
 export function NotificationsHomeCenter({
   emptyGestureTargetRef,
+  shadeLayoutTargetRef,
 }: {
   /**
    * Larger background surface that may start the pull only while the inbox is
    * empty. Populated shades continue to own their list gestures directly.
    */
   emptyGestureTargetRef?: RefObject<HTMLElement | null>;
+  /**
+   * Home column whose secondary region shares the shade's geometry clock.
+   * Keeping this explicit avoids querying through component ownership while
+   * velocity-aware releases still settle as one layout transaction.
+   */
+  shadeLayoutTargetRef?: RefObject<HTMLElement | null>;
 } = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
@@ -952,12 +1011,20 @@ export function NotificationsHomeCenter({
     cancel: cancelScheduledPullPresentation,
   } = useRafCoalescer(applyPullPresentation);
 
-  const setShadeSettleDuration = useCallback((durationMs: number) => {
-    centerRef.current?.style.setProperty(
-      "--eliza-notif-settle-duration",
-      `${durationMs}ms`,
-    );
-  }, []);
+  const setShadeSettleDuration = useCallback(
+    (durationMs: number) => {
+      const duration = `${durationMs}ms`;
+      centerRef.current?.style.setProperty(
+        "--eliza-notif-settle-duration",
+        duration,
+      );
+      shadeLayoutTargetRef?.current?.style.setProperty(
+        "--eliza-home-notification-settle-duration",
+        duration,
+      );
+    },
+    [shadeLayoutTargetRef],
+  );
 
   const flushPullPresentation = useCallback(() => {
     flushScheduledPullPresentation();
@@ -1181,8 +1248,10 @@ export function NotificationsHomeCenter({
     (settleMs = SHADE_SETTLE_MS) => {
       if (!shadeExpanded || shadeClosing) return;
       cancelPullCancellation();
+      cancelPullReleaseSettle();
       cancelClearConfirmation();
       const list = scrollRef.current;
+      list?.style.setProperty("--eliza-notif-pull-overshoot", "0px");
       if (list && list.scrollTop > 0) {
         list.scrollTo?.({
           top: 0,
@@ -1226,6 +1295,7 @@ export function NotificationsHomeCenter({
     [
       cancelClearConfirmation,
       cancelPullCancellation,
+      cancelPullReleaseSettle,
       flushPullPresentation,
       reduceMotion,
       setPullPx,
@@ -2585,11 +2655,14 @@ export function NotificationsHomeCenter({
                 }
                 onClick={clearAll}
                 className={cn(
-                  "eliza-notif-control-transition h-8 overflow-hidden text-xs font-medium text-white/60 transition-[width,color] duration-200 ease-out hover:text-white/90",
-                  confirmingClearAll ? "w-12 text-white" : "w-8",
+                  "eliza-notif-clear-all eliza-notif-control-transition h-8 shrink-0 overflow-hidden whitespace-nowrap text-xs font-medium text-white/60 transition-[width,color] duration-200 ease-out hover:text-white/90 focus-visible:text-white/90",
+                  confirmingClearAll && "text-white",
                 )}
               >
-                <ClearConfirmationContent confirming={confirmingClearAll} />
+                <ClearConfirmationContent
+                  confirming={confirmingClearAll}
+                  restingLabel="Clear all"
+                />
               </button>
             ) : null}
           </li>

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1102,7 +1102,13 @@ export function NotificationsHomeCenter({
   useLayoutEffect(() => {
     // Settled renders are fully declarative. Direct writes are reserved for an
     // active drag/close so they cannot overwrite click-entry interpolation.
-    if (!pullDirection && !shadeClosing) return;
+    if (!pullDirection && !shadeClosing) {
+      // Later drag frames mutate this custom property without a React render.
+      // Clear that imperative value after the dragging marker is removed so
+      // the enabled padding transition settles the footer back into place.
+      scrollRef.current?.style.removeProperty("--eliza-notif-pull-overshoot");
+      return;
+    }
     if (pullDirection) {
       if (pullDirection === "expand" && !shadeExpanded && scrollRef.current) {
         scrollRef.current.scrollTop = 0;
@@ -2433,7 +2439,6 @@ export function NotificationsHomeCenter({
         style={
           {
             "--eliza-notif-base-padding": showCollapseControl ? "4px" : "40px",
-            "--eliza-notif-pull-overshoot": `${Math.max(0, pullOvershootOffset)}px`,
           } as CSSProperties
         }
         className={cn(

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1316,8 +1316,16 @@ export function NotificationsHomeCenter({
       // A background drag may end over a tile that synthesizes a click. The
       // drag already decided the shade state; do not reinterpret that release
       // as a separate outside-tap collapse before the surface can consume it.
-      if (suppressBackgroundClick.current) return;
       const target = event.target;
+      const gestureSurface =
+        emptyGestureTargetRef?.current ?? centerRef.current;
+      if (
+        suppressBackgroundClick.current &&
+        target instanceof Node &&
+        gestureSurface?.contains(target)
+      ) {
+        return;
+      }
       const center = centerRef.current;
       if (target instanceof Node && center && !center.contains(target)) {
         requestShadeCollapse();
@@ -1326,7 +1334,7 @@ export function NotificationsHomeCenter({
     document.addEventListener("click", collapseOnOutsideClick, true);
     return () =>
       document.removeEventListener("click", collapseOnOutsideClick, true);
-  }, [requestShadeCollapse, shadeExpanded]);
+  }, [emptyGestureTargetRef, requestShadeCollapse, shadeExpanded]);
 
   const commitPull = useCallback(() => {
     const px = pullPxRef.current;
@@ -1376,8 +1384,10 @@ export function NotificationsHomeCenter({
     setShadeSettleDuration(settleMs);
     // Directional: a downward pull only expands, an upward push only
     // collapses. A gesture in the direction of the current state is a no-op.
-    if (shouldCommit && px > 0 && canExpand) setShade(true);
-    else if (shouldCommit && px < 0 && canCollapse) {
+    if (shouldCommit && px > 0 && canExpand) {
+      armBackgroundClickSuppression();
+      setShade(true);
+    } else if (shouldCommit && px < 0 && canCollapse) {
       requestShadeCollapse(settleMs);
       return;
     } else if (px !== 0 && !reduceMotion && canMove) {
@@ -1385,6 +1395,7 @@ export function NotificationsHomeCenter({
     }
     setPullPx(0);
   }, [
+    armBackgroundClickSuppression,
     beginPullCancellation,
     flushPullPresentation,
     inboxEmpty,
@@ -1959,6 +1970,11 @@ export function NotificationsHomeCenter({
           window.clearTimeout(suppressBackgroundClickTimer.current);
           suppressBackgroundClickTimer.current = null;
         }
+        suppressNotificationClick.current = false;
+        if (suppressNotificationClickTimer.current !== null) {
+          window.clearTimeout(suppressNotificationClickTimer.current);
+          suppressNotificationClickTimer.current = null;
+        }
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
@@ -2281,7 +2297,12 @@ export function NotificationsHomeCenter({
     shadeOpenProgress *
     stackCollapseControlVisibility;
   const collapseControlInteractive =
-    collapseControlPresentationVisibility === 1 && expandedStacks.size === 0;
+    shadeExpanded &&
+    !shadeClosing &&
+    !isPulling &&
+    pullCancellingDirection === null &&
+    collapseControlPresentationVisibility === 1 &&
+    expandedStacks.size === 0;
   const showCollapseControl =
     (shadeExpanded || previewingExpansion) && hasNotifications;
   const onListPointerDown = (e: React.PointerEvent) => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -957,6 +957,17 @@ export function NotificationsHomeCenter({
     }, 500);
   }, []);
 
+  const armBackgroundClickSuppression = useCallback(() => {
+    suppressBackgroundClick.current = true;
+    if (suppressBackgroundClickTimer.current !== null) {
+      window.clearTimeout(suppressBackgroundClickTimer.current);
+    }
+    suppressBackgroundClickTimer.current = window.setTimeout(() => {
+      suppressBackgroundClick.current = false;
+      suppressBackgroundClickTimer.current = null;
+    }, 500);
+  }, []);
+
   const setPullPx = useCallback(
     (px: number, preserveDirectionAtZero = false) => {
       pullPxRef.current = px;
@@ -1746,6 +1757,7 @@ export function NotificationsHomeCenter({
         const pull = touch.clientY - expandAnchorY;
         if (pull > PULL_SLOP_PX) {
           ownsPull = true;
+          armBackgroundClickSuppression();
           event?.preventDefault();
           if (surface.scrollTop !== 0) surface.scrollTop = 0;
           setPullPx(dampenPull(pull));
@@ -1779,7 +1791,13 @@ export function NotificationsHomeCenter({
       if (finalTouch) updateTouchPosition(finalTouch);
       const shouldCommit = ownsPull;
       reset();
-      if (shouldCommit) commitPull();
+      if (shouldCommit) {
+        // Touch browsers synthesize a click after release. Refresh suppression
+        // here so a deliberate slow pull cannot expire the move-time guard and
+        // immediately look like an outside-tap collapse.
+        armBackgroundClickSuppression();
+        commitPull();
+      }
     };
     const onTouchCancel = () => {
       abort();
@@ -1811,6 +1829,7 @@ export function NotificationsHomeCenter({
       surface.removeEventListener("wheel", onWheel);
     };
   }, [
+    armBackgroundClickSuppression,
     commitPull,
     emptyGestureTargetRef,
     handleWheelDelta,
@@ -1933,16 +1952,6 @@ export function NotificationsHomeCenter({
       axis: "none" | "x" | "y";
       ownsPull: boolean;
     } | null = null;
-    const armClickSuppression = () => {
-      suppressBackgroundClick.current = true;
-      if (suppressBackgroundClickTimer.current !== null) {
-        window.clearTimeout(suppressBackgroundClickTimer.current);
-      }
-      suppressBackgroundClickTimer.current = window.setTimeout(() => {
-        suppressBackgroundClick.current = false;
-        suppressBackgroundClickTimer.current = null;
-      }, 500);
-    };
     const onClick = (event: MouseEvent) => {
       if (suppressBackgroundClick.current) {
         suppressBackgroundClick.current = false;
@@ -2003,7 +2012,7 @@ export function NotificationsHomeCenter({
           return;
         }
         surface.setPointerCapture?.(event.pointerId);
-        armClickSuppression();
+        armBackgroundClickSuppression();
       }
       if (current.axis !== "y") return;
       event.preventDefault();
@@ -2027,7 +2036,7 @@ export function NotificationsHomeCenter({
       onPointerMove(event);
       if (!gesture) return;
       if (current.axis === "y") {
-        armClickSuppression();
+        armBackgroundClickSuppression();
       }
       gesture = null;
       commitPull();
@@ -2052,6 +2061,7 @@ export function NotificationsHomeCenter({
     };
   }, [
     abortPointerPull,
+    armBackgroundClickSuppression,
     commitPull,
     emptyGestureTargetRef,
     requestShadeCollapse,

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -66,6 +66,7 @@ import {
   shouldCommitMomentumDetent,
   useRafCoalescer,
 } from "../../gestures";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { cn } from "../../lib/utils";
 import {
   isSafeDeepLink,
@@ -215,6 +216,7 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 2;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
+const FINE_POINTER_CLEAR_CONFIRM_QUERY = "(hover: hover) and (pointer: fine)";
 const SHADE_SETTLE_MS = 460;
 const SHADE_MIN_SETTLE_MS = 320;
 const SHADE_MAX_SETTLE_MS = 600;
@@ -387,13 +389,14 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   transition: none;
 }
 /* Bulk clear keeps its right edge aligned with each producer's X. Touch-first
-   surfaces expose the command label at rest; precise pointers retain the
-   compact X and reveal the same label leftward on hover or keyboard focus. */
+   surfaces reveal the destructive command after the first tap; precise
+   pointers can preview it leftward on hover or keyboard focus before the
+   first click advances to the explicit confirmation. */
 .eliza-notif-clear-all {
   width: 2rem;
 }
 .eliza-notif-clear-all[data-confirming] {
-  width: 3rem;
+  width: 4rem;
 }
 .eliza-notif-clear-all:not([data-confirming]):focus-visible {
   width: 3.5rem;
@@ -405,19 +408,6 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-clear-all:not([data-confirming]):focus-visible [data-notification-clear-resting-icon] {
   opacity: 0;
   transform: scale(0.75);
-}
-@media (hover: none), (pointer: coarse) {
-  .eliza-notif-clear-all:not([data-confirming]) {
-    width: 3.5rem;
-  }
-  .eliza-notif-clear-all:not([data-confirming]) [data-notification-clear-resting-label] {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  .eliza-notif-clear-all:not([data-confirming]) [data-notification-clear-resting-icon] {
-    opacity: 0;
-    transform: scale(0.75);
-  }
 }
 @media (hover: hover) and (pointer: fine) {
   .eliza-notif-clear-all:not([data-confirming]):hover {
@@ -601,6 +591,7 @@ export function NotificationsHomeCenter({
   const { notifications, hydrated, hydrationStatus } = useNotifications();
   const inboxEmpty = notifications.length === 0;
   const reduceMotion = usePrefersReducedMotion();
+  const finePointer = useMediaQuery(FINE_POINTER_CLEAR_CONFIRM_QUERY);
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
   const [shadeExpanded, setShadeExpanded] = useState(false);
@@ -2659,6 +2650,7 @@ export function NotificationsHomeCenter({
                 )}
               >
                 <ClearConfirmationContent
+                  confirmingLabel={finePointer ? "Confirm?" : "Clear all"}
                   confirming={confirmingClearAll}
                   restingLabel="Clear all"
                 />

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -111,6 +111,7 @@ import {
   notificationGroupContainerOffset,
   notificationGroupPullOffset,
   notificationGroupPullVisibility,
+  notificationPullOvershootOffset,
   notificationPullPresentation,
   notificationPullRevealProgress,
   notificationPullRevealStyle,
@@ -386,7 +387,8 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   transition: none;
 }
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-row,
-.eliza-notif-scroll[data-shade-settling] .eliza-notif-row {
+.eliza-notif-scroll[data-shade-settling] .eliza-notif-row,
+.eliza-notif-scroll[data-shade-release-settling] .eliza-notif-row {
   animation: none !important;
 }
 .eliza-notif-scroll .eliza-notif-row.eliza-notif-pull-reveal,
@@ -417,6 +419,13 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   -webkit-mask-image: none;
   mask-image: none;
   transition: none;
+}
+/* A released deep pull keeps the same unmasked runway until every translated
+   card reaches rest. Restoring the edge mask earlier clips the returning cards
+   while their container is still settling. */
+.eliza-notif-scroll[data-shade-release-settling] {
+  -webkit-mask-image: none;
+  mask-image: none;
 }
 /* Count and card shells become independent compositor layers while they trade
    flow space. Keep cards above the count so its label fades behind their
@@ -575,8 +584,10 @@ export function NotificationsHomeCenter({
   const [pullCancellingDirection, setPullCancellingDirection] = useState<
     "expand" | "collapse" | null
   >(null);
+  const [pullReleaseSettling, setPullReleaseSettling] = useState(false);
   const shadeCloseTimer = useRef<number | null>(null);
   const pullCancelTimer = useRef<number | null>(null);
+  const pullReleaseTimer = useRef<number | null>(null);
   const stackFoldTimers = useRef(new Map<string, PendingStackFold>());
   const centerRef = useRef<HTMLElement | null>(null);
   const pendingShadeFocusRef = useRef(false);
@@ -589,6 +600,13 @@ export function NotificationsHomeCenter({
       pullCancelTimer.current = null;
     }
     setPullCancellingDirection(null);
+  }, []);
+  const cancelPullReleaseSettle = useCallback(() => {
+    if (pullReleaseTimer.current !== null) {
+      window.clearTimeout(pullReleaseTimer.current);
+      pullReleaseTimer.current = null;
+    }
+    setPullReleaseSettling(false);
   }, []);
   const cancelStackFold = useCallback((key: string) => {
     const pending = stackFoldTimers.current.get(key);
@@ -1014,12 +1032,8 @@ export function NotificationsHomeCenter({
       // direct manipulation and must update in the current input event.
       if (!nextDirection) {
         cancelScheduledPullPresentation();
-        // Drag frames write overshoot padding directly onto the scrollport.
-        // Release must remove it in the same input event: touch and pointer
-        // commits can batch the declarative render, leaving the expanded cards
-        // with stale runway that strands the Collapse footer below them.
-        scrollRef.current?.style.removeProperty("--eliza-notif-pull-overshoot");
       } else if (directionChanged) {
+        cancelPullReleaseSettle();
         cancelScheduledPullPresentation();
         applyPullPresentation(px);
       } else {
@@ -1028,10 +1042,26 @@ export function NotificationsHomeCenter({
     },
     [
       applyPullPresentation,
+      cancelPullReleaseSettle,
       cancelScheduledPullPresentation,
       schedulePullPresentation,
     ],
   );
+
+  const beginPullReleaseSettle = useCallback((settleMs: number) => {
+    if (pullReleaseTimer.current !== null) {
+      window.clearTimeout(pullReleaseTimer.current);
+    }
+    setPullReleaseSettling(true);
+    pullReleaseTimer.current = window.setTimeout(() => {
+      pullReleaseTimer.current = null;
+      scrollRef.current?.style.setProperty(
+        "--eliza-notif-pull-overshoot",
+        "0px",
+      );
+      setPullReleaseSettling(false);
+    }, settleMs + STACK_FOLD_COMPACTION_BUFFER_MS);
+  }, []);
 
   const cancelClearConfirmation = useCallback(() => {
     setConfirmingClearAll(false);
@@ -1119,10 +1149,14 @@ export function NotificationsHomeCenter({
     // Settled renders are fully declarative. Direct writes are reserved for an
     // active drag/close so they cannot overwrite click-entry interpolation.
     if (!pullDirection && !shadeClosing) {
-      // Later drag frames mutate this custom property without a React render.
-      // Clear that imperative value after the dragging marker is removed so
-      // the enabled padding transition settles the footer back into place.
-      scrollRef.current?.style.removeProperty("--eliza-notif-pull-overshoot");
+      const list = scrollRef.current;
+      if (list) {
+        // The drag leaves its positive runway in place through the React commit
+        // that removes `data-shade-dragging`. Flush that retained start before
+        // targeting zero so padding and card transforms share one transition.
+        if (pullReleaseSettling) list.getBoundingClientRect();
+        list.style.setProperty("--eliza-notif-pull-overshoot", "0px");
+      }
       return;
     }
     if (pullDirection) {
@@ -1387,6 +1421,17 @@ export function NotificationsHomeCenter({
 
     if (px !== 0) flushPullPresentation();
     setShadeSettleDuration(settleMs);
+    const hasPositiveRunway =
+      px > 0 && notificationPullOvershootOffset(px) > 0 && canExpand;
+    if (!reduceMotion && hasPositiveRunway) {
+      beginPullReleaseSettle(settleMs);
+    } else {
+      cancelPullReleaseSettle();
+      scrollRef.current?.style.setProperty(
+        "--eliza-notif-pull-overshoot",
+        "0px",
+      );
+    }
     // Directional: a downward pull only expands, an upward push only
     // collapses. A gesture in the direction of the current state is a no-op.
     if (shouldCommit && px > 0 && canExpand) {
@@ -1401,7 +1446,9 @@ export function NotificationsHomeCenter({
     setPullPx(0);
   }, [
     armBackgroundClickSuppression,
+    beginPullReleaseSettle,
     beginPullCancellation,
+    cancelPullReleaseSettle,
     flushPullPresentation,
     inboxEmpty,
     reduceMotion,
@@ -1422,8 +1469,24 @@ export function NotificationsHomeCenter({
         );
       }
     }
+    if (!reduceMotion && px > 0 && notificationPullOvershootOffset(px) > 0) {
+      beginPullReleaseSettle(PULL_CANCEL_SETTLE_MS);
+    } else {
+      cancelPullReleaseSettle();
+      scrollRef.current?.style.setProperty(
+        "--eliza-notif-pull-overshoot",
+        "0px",
+      );
+    }
     setPullPx(0);
-  }, [beginPullCancellation, flushPullPresentation, reduceMotion, setPullPx]);
+  }, [
+    beginPullCancellation,
+    beginPullReleaseSettle,
+    cancelPullReleaseSettle,
+    flushPullPresentation,
+    reduceMotion,
+    setPullPx,
+  ]);
 
   // Shared wheel accumulator for both the list and, while empty, the wider
   // home background. Returns whether the shade consumed this delta so the
@@ -1514,7 +1577,7 @@ export function NotificationsHomeCenter({
     };
     const abortTouchPull = () => {
       resetTouchState();
-      setPullPx(0);
+      abortPointerPull();
     };
     const onTouchStart = (e: TouchEvent) => {
       const t = e.touches[0];
@@ -1696,6 +1759,7 @@ export function NotificationsHomeCenter({
       gestureTarget.removeEventListener("wheel", onEmptyBackgroundWheel);
     };
   }, [
+    abortPointerPull,
     armNotificationClickSuppression,
     commitPull,
     emptyGestureTargetRef,
@@ -1726,7 +1790,7 @@ export function NotificationsHomeCenter({
     };
     const abort = () => {
       reset();
-      setPullPx(0);
+      abortPointerPull();
     };
     const onTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
@@ -1845,6 +1909,7 @@ export function NotificationsHomeCenter({
       surface.removeEventListener("wheel", onWheel);
     };
   }, [
+    abortPointerPull,
     armBackgroundClickSuppression,
     commitPull,
     emptyGestureTargetRef,
@@ -2098,6 +2163,9 @@ export function NotificationsHomeCenter({
       if (pullCancelTimer.current !== null) {
         window.clearTimeout(pullCancelTimer.current);
       }
+      if (pullReleaseTimer.current !== null) {
+        window.clearTimeout(pullReleaseTimer.current);
+      }
       for (const pending of stackFoldTimers.current.values()) {
         window.clearTimeout(pending.timer);
       }
@@ -2305,6 +2373,7 @@ export function NotificationsHomeCenter({
     shadeExpanded &&
     !shadeClosing &&
     !isPulling &&
+    !pullReleaseSettling &&
     pullCancellingDirection === null &&
     collapseControlPresentationVisibility === 1 &&
     expandedStacks.size === 0;
@@ -2472,6 +2541,7 @@ export function NotificationsHomeCenter({
         data-shade-preview={previewingExpansion ? "expanding" : undefined}
         data-shade-dragging={isPulling ? "" : undefined}
         data-shade-settling={shadeClosing ? "" : undefined}
+        data-shade-release-settling={pullReleaseSettling ? "" : undefined}
         style={
           {
             "--eliza-notif-base-padding": showCollapseControl ? "4px" : "40px",
@@ -2667,6 +2737,7 @@ export function NotificationsHomeCenter({
               layout={
                 !reduceMotion &&
                 !isPulling &&
+                !pullReleaseSettling &&
                 !pullCancellingDirection &&
                 !shadeClosing &&
                 !stackClosing

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -159,6 +159,28 @@ function isInteractiveGestureTarget(target: EventTarget | null): boolean {
   );
 }
 
+function isClickBelowNotificationCards(
+  target: EventTarget | null,
+  clientY: number,
+  center: HTMLElement,
+): boolean {
+  if (!(target instanceof Node) || !center.contains(target)) return false;
+  if (
+    target instanceof Element &&
+    target.closest("[data-notification-group]")
+  ) {
+    return false;
+  }
+  if (isInteractiveGestureTarget(target)) return false;
+  const groups = center.querySelectorAll<HTMLElement>(
+    "[data-notification-group]",
+  );
+  const lastGroup = groups.item(groups.length - 1);
+  if (!lastGroup) return false;
+  const bounds = lastGroup.getBoundingClientRect();
+  return bounds.height > 0 && clientY > bounds.bottom;
+}
+
 function touchWithIdentifier(
   touches: TouchList,
   identifier: number,
@@ -1874,15 +1896,30 @@ export function NotificationsHomeCenter({
       }, 500);
     };
     const onClick = (event: MouseEvent) => {
-      if (!suppressBackgroundClick.current) return;
-      suppressBackgroundClick.current = false;
-      if (suppressBackgroundClickTimer.current !== null) {
-        window.clearTimeout(suppressBackgroundClickTimer.current);
-        suppressBackgroundClickTimer.current = null;
+      if (suppressBackgroundClick.current) {
+        suppressBackgroundClick.current = false;
+        if (suppressBackgroundClickTimer.current !== null) {
+          window.clearTimeout(suppressBackgroundClickTimer.current);
+          suppressBackgroundClickTimer.current = null;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        return;
       }
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
+      // The list's capture handler owns its post-drag synthetic click. A plain
+      // background tap below the final card, however, should feel like the
+      // full-screen shade surface and close from anywhere in that empty band.
+      if (suppressNotificationClick.current) return;
+      const center = centerRef.current;
+      if (
+        shadePresentationRef.current.expanded &&
+        !shadePresentationRef.current.closing &&
+        center &&
+        isClickBelowNotificationCards(event.target, event.clientY, center)
+      ) {
+        requestShadeCollapse();
+      }
     };
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target;
@@ -1966,6 +2003,7 @@ export function NotificationsHomeCenter({
     abortPointerPull,
     commitPull,
     emptyGestureTargetRef,
+    requestShadeCollapse,
     setPullPx,
     surfaceReady,
   ]);
@@ -2172,13 +2210,22 @@ export function NotificationsHomeCenter({
     expandedStacks.size > 0 && closingStacks.size === 0
       ? STACK_FAN_LAYOUT_TRANSITION
       : STACK_FOLD_LAYOUT_TRANSITION;
+  const allExpandedStacksAreClosing =
+    expandedStacks.size > 0 &&
+    expandedStacks.size === closingStacks.size &&
+    Array.from(expandedStacks).every((key) => closingStacks.has(key));
+  // The footer stays in flow while a stack fans so its text can crossfade
+  // instead of changing both the list geometry and DOM ownership in one frame.
+  const stackCollapseControlVisibility =
+    expandedStacks.size === 0 || allExpandedStacksAreClosing ? 1 : 0;
   const collapseControlPresentationVisibility =
-    collapseControlVisibility * shadeOpenProgress;
+    collapseControlVisibility *
+    shadeOpenProgress *
+    stackCollapseControlVisibility;
+  const collapseControlInteractive =
+    collapseControlPresentationVisibility === 1 && expandedStacks.size === 0;
   const showCollapseControl =
-    (shadeExpanded || previewingExpansion) &&
-    hasNotifications &&
-    expandedStacks.size === 0 &&
-    !shadeOpenedByStack;
+    (shadeExpanded || previewingExpansion) && hasNotifications;
   const onListPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType !== "mouse" || !e.isPrimary) return;
     const el = scrollRef.current;
@@ -2700,16 +2747,18 @@ export function NotificationsHomeCenter({
         <div
           data-testid="notifications-collapse-footer"
           data-notification-collapse-footer=""
-          aria-hidden={
-            collapseControlPresentationVisibility === 0 ? true : undefined
-          }
-          inert={collapseControlPresentationVisibility < 1 ? true : undefined}
+          aria-hidden={!collapseControlInteractive ? true : undefined}
+          inert={!collapseControlInteractive ? true : undefined}
           style={{
             opacity: collapseControlPresentationVisibility,
             transform: `translateY(${
               (1 - collapseControlPresentationVisibility) * 4
             }px)`,
-            transition: isPulling ? "none" : undefined,
+            transition: isPulling
+              ? "none"
+              : closingStacks.size > 0
+                ? `opacity ${STACK_FOLD_SETTLE_MS}ms ${SHADE_EASING}, transform ${STACK_FOLD_SETTLE_MS}ms ${SHADE_EASING}`
+                : undefined,
           }}
           className="eliza-notif-shade-transition pointer-events-none flex shrink-0 justify-center px-3"
         >
@@ -2720,7 +2769,12 @@ export function NotificationsHomeCenter({
               pendingRestedCountFocusRef.current = event.detail === 0;
               requestShadeCollapse();
             }}
-            className="pointer-events-auto flex min-h-touch items-center justify-center gap-1 px-2 text-2xs font-medium text-white/55 transition-colors hover:text-white/90"
+            className={cn(
+              "flex min-h-touch items-center justify-center gap-1 px-2 text-2xs font-medium text-white/55 transition-colors hover:text-white/90",
+              collapseControlInteractive
+                ? "pointer-events-auto"
+                : "pointer-events-none",
+            )}
           >
             Collapse
             <ChevronUp aria-hidden className="h-3 w-3 shrink-0" />

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -203,9 +203,6 @@ function touchWithIdentifier(
  */
 const WHEEL_COLLAPSE_STEP_PX = PULL_COMMIT_PX / 2;
 
-/** Ignore trackpad rebound while the committed shade settle is running. */
-const WHEEL_COMMIT_LOCK_MS = 280;
-
 /** iOS-style visual depth: one, two, or three cards, never more. */
 const MAX_VISIBLE_STACK_LAYERS = 3;
 
@@ -216,11 +213,13 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 10;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
-const SHADE_SETTLE_MS = 340;
-const SHADE_MIN_SETTLE_MS = 260;
-const SHADE_MAX_SETTLE_MS = 440;
-const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.22;
+const SHADE_SETTLE_MS = 460;
+const SHADE_MIN_SETTLE_MS = 320;
+const SHADE_MAX_SETTLE_MS = 600;
+const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.15;
 const SHADE_EASING = "cubic-bezier(0.25,0.1,0.25,1)";
+/** Ignore trackpad rebound while the committed shade settle is running. */
+const WHEEL_COMMIT_LOCK_MS = SHADE_SETTLE_MS;
 const PULL_CANCEL_SETTLE_MS = SHADE_SETTLE_MS;
 const SHADE_MIN_FLICK_DISTANCE_PX = 22;
 const SHADE_FLICK_VELOCITY_PX_PER_MS = 0.45;
@@ -1321,9 +1320,8 @@ export function NotificationsHomeCenter({
             : SHADE_MIN_FLICK_DISTANCE_PX,
         flickVelocityThresholdPxPerMs: SHADE_FLICK_VELOCITY_PX_PER_MS,
       });
-    const remainingDistancePx = shouldCommit
-      ? Math.max(0, PULL_TRAVEL_PX - Math.abs(px))
-      : Math.abs(px);
+    const targetPullPx = shouldCommit ? Math.sign(px) * PULL_TRAVEL_PX : 0;
+    const remainingDistancePx = Math.abs(targetPullPx - px);
     const settleMs = getVelocityAwareSettleDuration({
       velocityPxPerMs: releaseVelocity,
       remainingDistancePx,
@@ -2204,6 +2202,7 @@ export function NotificationsHomeCenter({
     pullContentVisibility,
     notificationCountVisibility,
     notificationCountOffset,
+    pullOvershootOffset,
     notificationCountLayoutVisibility,
     emptyStateVisibility,
     collapseControlVisibility,
@@ -2324,7 +2323,9 @@ export function NotificationsHomeCenter({
         height: `${notificationCountLayoutVisibility * 32}px`,
         marginBottom: `${(notificationCountLayoutVisibility - 1) * 8}px`,
         opacity: notificationCountVisibility,
-        transform: `translate3d(0, ${notificationCountOffset}px, 0)`,
+        transform: `translate3d(0, ${
+          notificationCountOffset + pullOvershootOffset
+        }px, 0)`,
         transition: isPulling ? "none" : undefined,
       }}
       className="eliza-notif-count-transition flex shrink-0 items-center justify-center px-3 text-2xs font-medium text-white/50"
@@ -2409,7 +2410,9 @@ export function NotificationsHomeCenter({
               height: clearControlLayoutVisibility * 32,
               marginBottom: (clearControlLayoutVisibility - 1) * 8,
               opacity: clearControlVisibility,
-              transform: `translate3d(0, ${(1 - clearControlVisibility) * -8}px, 0)`,
+              transform: `translate3d(0, ${
+                (1 - clearControlVisibility) * -8 + pullOvershootOffset
+              }px, 0)`,
             }}
             className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-2"
           >
@@ -2445,7 +2448,10 @@ export function NotificationsHomeCenter({
             }
             inert={!shadeExpanded && !previewingExpansion ? true : undefined}
             style={{
-              ...notificationPullRevealStyle(emptyStateVisibility),
+              ...notificationPullRevealStyle(
+                emptyStateVisibility,
+                pullOvershootOffset,
+              ),
               transition: isPulling ? "none" : undefined,
             }}
             className="eliza-notif-pull-reveal eliza-notif-shade-transition flex min-h-14 items-center justify-center px-3 py-3 text-2xs font-medium text-white/45"
@@ -2485,6 +2491,27 @@ export function NotificationsHomeCenter({
             shadeExpanded,
             shadeClosing,
           );
+          const groupContentVisibility = pullRevealed
+            ? revealProgress
+            : groupWasRested
+              ? 1
+              : groupVisibility;
+          const groupContentPullOffset = pullRevealed
+            ? (1 - revealProgress) * -8
+            : groupWasRested
+              ? 0
+              : notificationGroupPullOffset(
+                  pullPx,
+                  shadeExpanded,
+                  shadeClosing,
+                  groupVisibility,
+                );
+          // Framer Motion owns the outer group's layout transform. Keeping the
+          // finger-tracked transform on this stable child lets a committed
+          // preview continue into its CSS settle without either system
+          // replacing the other's transform at pointer-up.
+          const groupContentOffset =
+            groupContainerOffset + groupContentPullOffset + pullOvershootOffset;
           const stackExpanded = expandedStacks.has(group.key);
           // Every presentation shares one shell, so the top NotificationRow
           // stays under the same parent/key while a fanned stack closes.
@@ -2574,17 +2601,6 @@ export function NotificationsHomeCenter({
                 pullRevealed &&
                   "eliza-notif-pull-reveal eliza-notif-shade-transition pointer-events-none",
               )}
-              style={
-                pullRevealed || groupContainerOffset !== 0
-                  ? {
-                      opacity: pullRevealed ? revealProgress : undefined,
-                      transform: `translate3d(0, ${
-                        groupContainerOffset +
-                        (pullRevealed ? (1 - revealProgress) * -8 : 0)
-                      }px, 0)`,
-                    }
-                  : undefined
-              }
             >
               <div
                 data-notification-group-content=""
@@ -2603,15 +2619,8 @@ export function NotificationsHomeCenter({
                     : stacked
                       ? stackTailPx
                       : 0,
-                  opacity: groupWasRested ? 1 : groupVisibility,
-                  transform: groupWasRested
-                    ? undefined
-                    : `translate3d(0, ${notificationGroupPullOffset(
-                        pullPx,
-                        shadeExpanded,
-                        shadeClosing,
-                        groupVisibility,
-                      )}px, 0)`,
+                  opacity: groupContentVisibility,
+                  transform: `translate3d(0, ${groupContentOffset}px, 0)`,
                   transition: isPulling ? "none" : undefined,
                 }}
               >
@@ -2761,7 +2770,8 @@ export function NotificationsHomeCenter({
           style={{
             opacity: collapseControlPresentationVisibility,
             transform: `translateY(${
-              (1 - collapseControlPresentationVisibility) * 4
+              (1 - collapseControlPresentationVisibility) * 4 +
+              pullOvershootOffset
             }px)`,
             transition: isPulling
               ? "none"

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -337,16 +337,21 @@ const NOTIF_SCROLL_CSS = `
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
-.eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass:hover,
-.eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass:hover,
-.eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek:hover {
-  background-color: rgb(38 38 42);
-}
 /* Directional specular rim tracing every rounded corner (mask-composite ring)
    — replaces the old one-sided inset hairline that read as a vertical line. */
 ${liquidGlassRimCss(".eliza-notif-glass")}
-.eliza-notif-glass:hover {
-  background-color: rgb(38 38 42 / 42%);
+/* Touch browsers can leave :hover latched on the release target until React's
+   settled projection replaces it. Only precise pointers get a hover material,
+   so every physical card keeps one fill throughout a touch release. */
+@media (hover: hover) and (pointer: fine) {
+  .eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass:hover,
+  .eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass:hover,
+  .eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek:hover {
+    background-color: rgb(38 38 42);
+  }
+  .eliza-notif-glass:hover {
+    background-color: rgb(38 38 42 / 42%);
+  }
 }
 .eliza-notif-pull-reveal {
   transform-origin: top center;

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -453,7 +453,7 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
    while that projection is mounted so Chromium cannot turn the insertion into
    a positive scrollTop and revoke a gesture the user already owns. The live
    overshoot padding keeps translated cards inside the scrollport; the edge mask
-   returns on release, when card opacity owns the close transition. */
+   returns after the release runway has settled. */
 .eliza-notif-scroll[data-shade-preview],
 .eliza-notif-scroll[data-shade-mode="expanded"] {
   padding-bottom: calc(
@@ -470,14 +470,13 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   mask-image: none;
   transition: none;
 }
-/* A released deep pull keeps a static feather at both scrollport edges while
-   translated cards return through the retained runway. The scroll-linked mask
-   normally removes its top fade at scrollTop=0; freezing it here prevents the
-   returning cards from ending at the center's hard overflow clip. */
+/* The retained overshoot padding is the release runway. Keep the edge mask off
+   until the cards finish crossing it; otherwise the mask darkens the lowest
+   physical stack layers and then brightens them as they settle upward. */
 .eliza-notif-scroll[data-shade-release-settling] {
   animation: none;
-  --scroll-fade-t: 1.25rem;
-  --scroll-fade-b: 1.5rem;
+  -webkit-mask-image: none;
+  mask-image: none;
 }
 /* Count and card shells become independent compositor layers while they trade
    flow space. Keep cards above the count so its label fades behind their

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -2687,7 +2687,11 @@ export function NotificationsHomeCenter({
                     fanned && "eliza-notif-shade-transition",
                   )}
                   style={
-                    fanned ? { rowGap: `${stackFanProgress * 6}px` } : undefined
+                    fanned
+                      ? {
+                          rowGap: `${stackFanProgress * disposableLayoutVisibility * 6}px`,
+                        }
+                      : undefined
                   }
                 >
                   {rows.map((notification, rowIndex) => (
@@ -2707,7 +2711,7 @@ export function NotificationsHomeCenter({
                       stackCountVisibility={
                         rowIndex === 0 && allGroupRows.length > 1
                           ? fanned
-                            ? 1 - stackFanProgress
+                            ? Math.max(1 - stackFanProgress, shadeCloseProgress)
                             : 1
                           : undefined
                       }

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -49,6 +49,7 @@ import type { AgentNotification } from "@elizaos/core";
 import { ChevronDown, ChevronUp, RefreshCw } from "lucide-react";
 import { motion } from "motion/react";
 import {
+  type CSSProperties,
   type RefObject,
   useCallback,
   useEffect,
@@ -210,7 +211,7 @@ const MAX_VISIBLE_STACK_LAYERS = 3;
 const STACK_PEEK_OFFSET_PX = 7;
 
 /** Clear space after the final peek before the next notification group. */
-const STACK_BOTTOM_CLEARANCE_PX = 10;
+const STACK_BOTTOM_CLEARANCE_PX = 2;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
 const SHADE_SETTLE_MS = 460;
@@ -396,6 +397,27 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   isolation: isolate;
   scrollbar-width: none;
 }
+/* Pull previews insert rows above the resting count. Disable scroll anchoring
+   while that projection is mounted so Chromium cannot turn the insertion into
+   a positive scrollTop and revoke a gesture the user already owns. The live
+   overshoot padding keeps translated cards inside the scrollport; the edge mask
+   returns on release, when card opacity owns the close transition. */
+.eliza-notif-scroll[data-shade-preview],
+.eliza-notif-scroll[data-shade-mode="expanded"] {
+  padding-bottom: calc(
+    var(--eliza-notif-base-padding, 0px) +
+    var(--eliza-notif-pull-overshoot, 0px)
+  );
+  transition: padding-bottom var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
+}
+.eliza-notif-scroll[data-shade-preview] {
+  overflow-anchor: none;
+}
+.eliza-notif-scroll[data-shade-preview][data-shade-dragging] {
+  -webkit-mask-image: none;
+  mask-image: none;
+  transition: none;
+}
 /* Count and card shells become independent compositor layers while they trade
    flow space. Keep cards above the count so its label fades behind their
    material instead of painting through it during either shade direction. */
@@ -510,6 +532,7 @@ export function NotificationsHomeCenter({
 } = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
+  const inboxEmpty = notifications.length === 0;
   const reduceMotion = usePrefersReducedMotion();
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
@@ -1081,6 +1104,9 @@ export function NotificationsHomeCenter({
     // active drag/close so they cannot overwrite click-entry interpolation.
     if (!pullDirection && !shadeClosing) return;
     if (pullDirection) {
+      if (pullDirection === "expand" && !shadeExpanded && scrollRef.current) {
+        scrollRef.current.scrollTop = 0;
+      }
       pullVisibleGroupsRef.current = visibleNotificationGroups(
         centerRef.current,
         scrollRef.current,
@@ -1288,8 +1314,7 @@ export function NotificationsHomeCenter({
   const commitPull = useCallback(() => {
     const px = pullPxRef.current;
     const { canExpand, canCollapse } = shadeGestureRef.current;
-    const commitPx =
-      notifications.length === 0 ? EMPTY_PULL_COMMIT_PX : PULL_COMMIT_PX;
+    const commitPx = inboxEmpty ? EMPTY_PULL_COMMIT_PX : PULL_COMMIT_PX;
     const canMove = (px > 0 && canExpand) || (px < 0 && canCollapse);
     const now = performance.now();
     const momentum = pullMomentumRef.current;
@@ -1314,10 +1339,9 @@ export function NotificationsHomeCenter({
         displacementPx: px,
         releaseVelocityPxPerMs: releaseVelocity,
         distanceThresholdPx: commitPx,
-        minimumFlickDistancePx:
-          notifications.length === 0
-            ? EMPTY_PULL_COMMIT_PX / 2
-            : SHADE_MIN_FLICK_DISTANCE_PX,
+        minimumFlickDistancePx: inboxEmpty
+          ? EMPTY_PULL_COMMIT_PX / 2
+          : SHADE_MIN_FLICK_DISTANCE_PX,
         flickVelocityThresholdPxPerMs: SHADE_FLICK_VELOCITY_PX_PER_MS,
       });
     const targetPullPx = shouldCommit ? Math.sign(px) * PULL_TRAVEL_PX : 0;
@@ -1346,7 +1370,7 @@ export function NotificationsHomeCenter({
   }, [
     beginPullCancellation,
     flushPullPresentation,
-    notifications.length,
+    inboxEmpty,
     reduceMotion,
     requestShadeCollapse,
     setPullPx,
@@ -1373,7 +1397,7 @@ export function NotificationsHomeCenter({
   // native background listener can suppress browser overscroll.
   const handleWheelDelta = useCallback(
     (deltaY: number, scrollTop: number): boolean => {
-      const empty = notifications.length === 0;
+      const empty = inboxEmpty;
       if (Date.now() < wheelCommitLockUntil.current) return true;
       // Away from the top the scroller owns every wheel event.
       if (scrollTop > 0) {
@@ -1413,7 +1437,7 @@ export function NotificationsHomeCenter({
       }
       return true;
     },
-    [beginProgrammaticShadeOpen, notifications.length, requestShadeCollapse],
+    [beginProgrammaticShadeOpen, inboxEmpty, requestShadeCollapse],
   );
 
   const onListWheel = useCallback(
@@ -1432,7 +1456,7 @@ export function NotificationsHomeCenter({
   // ordinary scrolling (see reference: pan-y pull gestures are dead on arrival
   // without this). `surfaceReady` re-runs the bind when hydration establishes a
   // genuinely empty inbox or when a notification arrives before hydration.
-  const hasNotifications = notifications.length > 0;
+  const hasNotifications = !inboxEmpty;
   const surfaceReady = hydrated || hasNotifications;
   useEffect(() => {
     const list = scrollRef.current;
@@ -1552,11 +1576,15 @@ export function NotificationsHomeCenter({
         }
         return;
       }
-      if (gestureTarget.scrollTop <= 0 && canExpand) {
+      if (
+        canExpand &&
+        (expandAnchorY !== null || gestureTarget.scrollTop <= 0)
+      ) {
         if (expandAnchorY === null) expandAnchorY = t.clientY;
         const pull = t.clientY - expandAnchorY;
         if (pull > PULL_SLOP_PX) {
           event?.preventDefault();
+          if (gestureTarget.scrollTop !== 0) gestureTarget.scrollTop = 0;
           setPullPx(dampenPull(pull));
         } else if (pullPxRef.current !== 0) {
           // Finger reversed back above the anchor — the pull is withdrawn, so
@@ -1653,11 +1681,13 @@ export function NotificationsHomeCenter({
     const list = scrollRef.current;
     if (!hasNotifications || !surface || !list || surface === list) return;
     let start: { identifier: number; x: number; y: number } | null = null;
+    let expandAnchorY: number | null = null;
     let axis: "none" | "x" | "y" = "none";
     let ownsPull = false;
 
     const reset = () => {
       start = null;
+      expandAnchorY = null;
       axis = "none";
       ownsPull = false;
     };
@@ -1683,6 +1713,7 @@ export function NotificationsHomeCenter({
         x: touch.clientX,
         y: touch.clientY,
       };
+      expandAnchorY = surface.scrollTop <= 0 ? touch.clientY : null;
     };
     const updateTouchPosition = (touch: Touch, event?: TouchEvent) => {
       if (!start || !touch) return;
@@ -1702,12 +1733,19 @@ export function NotificationsHomeCenter({
       if (
         axis === "y" &&
         dy > PULL_SLOP_PX &&
-        surface.scrollTop <= 0 &&
+        (expandAnchorY !== null || surface.scrollTop <= 0) &&
         shadeGestureRef.current.canExpand
       ) {
-        ownsPull = true;
-        event?.preventDefault();
-        setPullPx(dampenPull(dy));
+        if (expandAnchorY === null) expandAnchorY = touch.clientY;
+        const pull = touch.clientY - expandAnchorY;
+        if (pull > PULL_SLOP_PX) {
+          ownsPull = true;
+          event?.preventDefault();
+          if (surface.scrollTop !== 0) surface.scrollTop = 0;
+          setPullPx(dampenPull(pull));
+        } else if (ownsPull && pullPxRef.current !== 0) {
+          setPullPx(0, true);
+        }
       } else if (ownsPull && pullPxRef.current !== 0) {
         setPullPx(0, true);
       }
@@ -1887,6 +1925,7 @@ export function NotificationsHomeCenter({
       startX: number;
       startY: number;
       axis: "none" | "x" | "y";
+      ownsPull: boolean;
     } | null = null;
     const armClickSuppression = () => {
       suppressBackgroundClick.current = true;
@@ -1940,6 +1979,7 @@ export function NotificationsHomeCenter({
         startX: event.clientX,
         startY: event.clientY,
         axis: "none",
+        ownsPull: false,
       };
     };
     const onPointerMove = (event: PointerEvent) => {
@@ -1962,7 +2002,9 @@ export function NotificationsHomeCenter({
       if (current.axis !== "y") return;
       event.preventDefault();
       const { canExpand, canCollapse } = shadeGestureRef.current;
-      if (dy > 0 && canExpand && surface.scrollTop <= 0) {
+      if (dy > 0 && canExpand && (current.ownsPull || surface.scrollTop <= 0)) {
+        current.ownsPull = true;
+        if (surface.scrollTop !== 0) surface.scrollTop = 0;
         setPullPx(dy > PULL_SLOP_PX ? dampenPull(dy) : 0, dy <= PULL_SLOP_PX);
       } else if (dy < 0 && canCollapse) {
         setPullPx(
@@ -2078,7 +2120,7 @@ export function NotificationsHomeCenter({
   // unbinds before touchend, so a stale translateY would otherwise ride into
   // the next arrival's first paint.
   useEffect(() => {
-    if (notifications.length === 0) {
+    if (inboxEmpty) {
       cancelAllStackFolds();
       setShadeExpanded(false);
       setShadeOpenedByStack(false);
@@ -2089,12 +2131,7 @@ export function NotificationsHomeCenter({
       cancelPullCancellation();
       setPullPx(0);
     }
-  }, [
-    cancelAllStackFolds,
-    cancelPullCancellation,
-    notifications.length,
-    setPullPx,
-  ]);
+  }, [cancelAllStackFolds, cancelPullCancellation, inboxEmpty, setPullPx]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible
@@ -2203,6 +2240,7 @@ export function NotificationsHomeCenter({
     notificationCountVisibility,
     notificationCountOffset,
     pullOvershootOffset,
+    collapseControlOvershootOffset,
     notificationCountLayoutVisibility,
     emptyStateVisibility,
     collapseControlVisibility,
@@ -2274,9 +2312,10 @@ export function NotificationsHomeCenter({
       return;
     }
     // Downward drag: the expand gesture, only from the list top.
-    if (el.scrollTop <= 0 && mayExpand) {
+    if (mayExpand && (g.anchorY !== null || el.scrollTop <= 0)) {
       if (g.anchorY === null) g.anchorY = e.clientY;
       const pull = e.clientY - g.anchorY;
+      if (pull > PULL_SLOP_PX && el.scrollTop !== 0) el.scrollTop = 0;
       setPullPx(
         pull > PULL_SLOP_PX ? dampenPull(pull) : 0,
         pull <= PULL_SLOP_PX,
@@ -2391,11 +2430,17 @@ export function NotificationsHomeCenter({
         data-shade-preview={previewingExpansion ? "expanding" : undefined}
         data-shade-dragging={isPulling ? "" : undefined}
         data-shade-settling={shadeClosing ? "" : undefined}
+        style={
+          {
+            "--eliza-notif-base-padding": showCollapseControl ? "4px" : "40px",
+            "--eliza-notif-pull-overshoot": `${Math.max(0, pullOvershootOffset)}px`,
+          } as CSSProperties
+        }
         className={cn(
           // select-none: a mouse pull-drag must read as a gesture, not a text
           // selection sweep across the cards (platform-shade idiom).
           "eliza-notif-scroll relative flex min-h-0 touch-pan-y select-none flex-col gap-2 overflow-y-auto overflow-x-hidden overscroll-y-contain px-1.5 pt-1",
-          showCollapseControl ? "flex-[0_1_auto] pb-2" : "flex-1 pb-10",
+          showCollapseControl ? "flex-[0_1_auto] pb-1" : "flex-1 pb-10",
           hasNotifications &&
             "scroll-fade scroll-fade-t-[1.25rem] scroll-fade-b-[1.5rem]",
           shadeClosing && "pointer-events-none",
@@ -2771,7 +2816,7 @@ export function NotificationsHomeCenter({
             opacity: collapseControlPresentationVisibility,
             transform: `translateY(${
               (1 - collapseControlPresentationVisibility) * 4 +
-              pullOvershootOffset
+              collapseControlOvershootOffset
             }px)`,
             transition: isPulling
               ? "none"

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1014,6 +1014,11 @@ export function NotificationsHomeCenter({
       // direct manipulation and must update in the current input event.
       if (!nextDirection) {
         cancelScheduledPullPresentation();
+        // Drag frames write overshoot padding directly onto the scrollport.
+        // Release must remove it in the same input event: touch and pointer
+        // commits can batch the declarative render, leaving the expanded cards
+        // with stale runway that strands the Collapse footer below them.
+        scrollRef.current?.style.removeProperty("--eliza-notif-pull-overshoot");
       } else if (directionChanged) {
         cancelScheduledPullPresentation();
         applyPullPresentation(px);

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -2097,7 +2097,10 @@ export function NotificationsHomeCenter({
       ownsPull: boolean;
     } | null = null;
     const onClick = (event: MouseEvent) => {
-      if (suppressBackgroundClick.current) {
+      // Browser-synthesized release clicks carry pointer click detail. A
+      // keyboard activation has detail 0 and is a distinct user action, so a
+      // preceding drag must never make the shade temporarily keyboard-dead.
+      if (suppressBackgroundClick.current && event.detail !== 0) {
         suppressBackgroundClick.current = false;
         if (suppressBackgroundClickTimer.current !== null) {
           window.clearTimeout(suppressBackgroundClickTimer.current);
@@ -2515,7 +2518,7 @@ export function NotificationsHomeCenter({
     abortPointerPull();
   };
   const onListClickCapture = (e: React.MouseEvent) => {
-    if (!suppressNotificationClick.current) return;
+    if (!suppressNotificationClick.current || e.detail === 0) return;
     suppressNotificationClick.current = false;
     if (suppressNotificationClickTimer.current !== null) {
       window.clearTimeout(suppressNotificationClickTimer.current);

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -423,8 +423,11 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   }
 }
 /* A view-timeline animation reattaches from its entry keyframe when a transient
-   release marker disappears. Keep it suspended for the expanded projection so
-   that handoff cannot reapply opacity/scale to otherwise-settled glass cards. */
+   drag marker disappears. Preview groups retain their own marker through a
+   cancelled settle, so their parent opacity can finish cleanly before unmount;
+   expanded and committed-release projections likewise keep one presentation
+   owner until their handoff completes. */
+.eliza-notif-scroll [data-notification-pull-reveal] .eliza-notif-row,
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-row,
 .eliza-notif-scroll[data-shade-settling] .eliza-notif-row,
 .eliza-notif-scroll[data-shade-release-settling] .eliza-notif-row,

--- a/packages/ui/src/components/shell/PagerEdgeButtons.test.tsx
+++ b/packages/ui/src/components/shell/PagerEdgeButtons.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 //
-// #10717: the web/desktop `< >` pager edge buttons — fine-pointer gated
-// (never on touch/coarse pointers, but at ANY viewport width), self-hiding at
-// the first/last page, click → goPrev/goNext.
+// #10717: the web/desktop `< >` pager edge buttons — desktop-width and
+// fine-pointer gated, self-hiding at the first/last page, click →
+// goPrev/goNext.
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,10 +11,18 @@ import {
   PagerEdgeButtons,
 } from "./PagerEdgeButtons";
 
-function mockPointerCapability({ finePointer }: { finePointer: boolean }) {
+function mockPointerCapability({
+  finePointer,
+  desktopViewport = true,
+}: {
+  finePointer: boolean;
+  desktopViewport?: boolean;
+}) {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches:
       finePointer &&
+      desktopViewport &&
+      query.includes("(min-width: 768px)") &&
       query.includes("(hover: hover)") &&
       query.includes("(pointer: fine)"),
     media: query,
@@ -42,18 +50,15 @@ describe("PagerEdgeButtons (#10717)", () => {
     expect(queryByTestId("pager-edge-next")).toBeNull();
   });
 
-  it("gates on pointer capability only — no min-width clause, so a narrow fine-pointer window still gets a paging control", () => {
-    mockPointerCapability({ finePointer: true });
+  it("renders nothing in a mobile-width viewport even when the pointer is fine", () => {
+    mockPointerCapability({ finePointer: true, desktopViewport: false });
     const { queryByTestId } = render(
       <PagerEdgeButtons canPrev canNext goPrev={vi.fn()} goNext={vi.fn()} />,
     );
-    // The buttons render from the pointer-capability match alone; the media
-    // gate never consults the viewport width (below 1024px there are no page
-    // dots in production, so these arrows are the only paging control).
-    expect(queryByTestId("pager-edge-prev")).not.toBeNull();
-    expect(queryByTestId("pager-edge-next")).not.toBeNull();
+    expect(queryByTestId("pager-edge-prev")).toBeNull();
+    expect(queryByTestId("pager-edge-next")).toBeNull();
     expect(window.matchMedia).toHaveBeenCalledWith(
-      expect.not.stringContaining("min-width"),
+      expect.stringContaining("min-width: 768px"),
     );
   });
 
@@ -115,7 +120,7 @@ describe("PagerEdgeButtons (#10717)", () => {
 describe("FINE_POINTER_EDGE_BUTTON_QUERY complement contract", () => {
   it("is the exact fine-pointer query FirstSessionSwipeHint inverts", () => {
     expect(FINE_POINTER_EDGE_BUTTON_QUERY).toBe(
-      "(hover: hover) and (pointer: fine)",
+      "(min-width: 768px) and (hover: hover) and (pointer: fine)",
     );
   });
 

--- a/packages/ui/src/components/shell/PagerEdgeButtons.tsx
+++ b/packages/ui/src/components/shell/PagerEdgeButtons.tsx
@@ -10,12 +10,11 @@ import { Button } from "../ui/button";
 
 /**
  * Web/desktop `<` `>` edge buttons for a horizontal pager (#10717). Rendered
- * ONLY on fine-pointer / hover-capable devices, so they never appear on
- * touch/coarse phones/tablets where the swipe gesture is the sole navigation.
- * There is deliberately NO width gate: page dots are off in production, so a
- * fine-pointer window below desktop width (a narrow browser window, a small
- * desktop shell) still needs a visible paging control alongside the drag
- * gesture.
+ * ONLY on desktop-width, fine-pointer / hover-capable devices, so they never
+ * appear in the compact mobile layout or on touch/coarse phones and tablets.
+ * Compact layouts keep the swipe gesture as their sole navigation even when a
+ * mouse happens to be attached or browser device emulation reports a fine
+ * pointer.
  *
  * Icon-only (no card chrome), neutral resting → neutral hover (no orange→black,
  * no blue), positioned on the vertical center of the left/right edges. Each
@@ -27,7 +26,7 @@ import { Button } from "../ui/button";
  * complements — every device gets exactly one of them, never both.
  */
 export const FINE_POINTER_EDGE_BUTTON_QUERY =
-  "(hover: hover) and (pointer: fine)";
+  "(min-width: 768px) and (hover: hover) and (pointer: fine)";
 
 export function PagerEdgeButtons({
   canPrev,

--- a/packages/ui/src/components/shell/RelativeTime.tsx
+++ b/packages/ui/src/components/shell/RelativeTime.tsx
@@ -50,9 +50,9 @@ export interface RelativeTimeProps {
  * (and only it) re-renders when the minute rolls over; the formatted string is
  * derived from the wall clock at render time.
  *
- * Memoized on `(ts, className, testid)`: a parent re-render with the same props
- * does not re-render the leaf, and a tick re-renders the leaf without touching
- * the parent - the two directions of the binding pattern.
+ * Memoized on its display props: a parent re-render with the same values does
+ * not re-render the leaf, and a tick re-renders the leaf without touching the
+ * parent - the two directions of the binding pattern.
  */
 function RelativeTimeImpl({
   ts,
@@ -69,10 +69,16 @@ function RelativeTimeImpl({
 
   const date = ts instanceof Date ? ts : new Date(ts);
   const iso = Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+  const label = short ? formatRelativeTimeShort(ts) : formatRelativeTime(ts, t);
 
   return (
-    <time className={className} dateTime={iso} data-testid={testId}>
-      {short ? formatRelativeTimeShort(ts) : formatRelativeTime(ts, t)}
+    <time
+      className={className}
+      dateTime={iso}
+      data-testid={testId}
+      title={short && iso ? date.toLocaleString() : undefined}
+    >
+      {label}
     </time>
   );
 }

--- a/packages/ui/src/components/shell/StartupShell.test.tsx
+++ b/packages/ui/src/components/shell/StartupShell.test.tsx
@@ -87,6 +87,17 @@ describe("StartupShell — delayed loading splash", () => {
     // Visual contract preserved: phase + role attributes still present.
     expect(splash?.getAttribute("data-startup-phase")).toBe("starting-backend");
     expect(splash?.getAttribute("role")).toBe("status");
+    const status = screen.getByText("Starting");
+    expect(status.classList.contains("shimmer")).toBe(true);
+    expect(status.classList.contains("text-base")).toBe(true);
+    expect(status.classList.contains("font-medium")).toBe(true);
+    expect(status.classList.contains("text-white/60")).toBe(true);
+    expect(status.className).toContain("[--shimmer-color:rgba(255,255,255,1)]");
+    expect(status.className).toContain("[--shimmer-duration:1.8s]");
+    expect(status.classList.contains("motion-reduce:shimmer-none")).toBe(true);
+    expect(status.classList.contains("motion-reduce:animate-none")).toBe(true);
+    expect(status.classList.contains("opacity-80")).toBe(false);
+    expect(status.classList.contains("animate-pulse")).toBe(false);
     // first-paint telemetry fires only when the splash actually paints.
     expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
   });

--- a/packages/ui/src/components/shell/StartupShell.test.tsx
+++ b/packages/ui/src/components/shell/StartupShell.test.tsx
@@ -1,16 +1,16 @@
 // @vitest-environment jsdom
 //
-// StartupShell's view gating (loading vs failure vs pairing vs bootstrap) and
-// its splash-delay + first-paint telemetry mark. Child surfaces are stubbed so
-// only the shell's own gating runs; the telemetry module is real.
+// StartupShell's view gating (loading vs failure vs pairing vs bootstrap),
+// stable loading lockup, and first-paint telemetry mark. Child surfaces are
+// stubbed so only the shell's own gating runs; the telemetry module is real.
 
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetStartupTraceForTests,
   hasStartupMark,
 } from "../../state/startup-telemetry";
-import { STARTUP_SPLASH_DELAY_MS, StartupShell } from "./StartupShell";
+import { StartupShell } from "./StartupShell";
 import type { StartupShellView } from "./startup-shell-types";
 
 // The child surfaces pull in heavy trees (branding, platform, bootstrap flow);
@@ -44,49 +44,28 @@ function queryLoading() {
   return screen.queryByTestId("startup-shell-loading");
 }
 
-// Timer callbacks call setState; flush them through act() so React commits the
-// re-render before the assertion reads the DOM.
-function advance(ms: number) {
-  act(() => {
-    vi.advanceTimersByTime(ms);
-  });
-}
-
 beforeEach(() => {
-  vi.useFakeTimers();
   __resetStartupTraceForTests();
 });
 
 afterEach(() => {
   cleanup();
-  vi.runOnlyPendingTimers();
-  vi.useRealTimers();
 });
 
-describe("StartupShell — delayed loading splash", () => {
-  it("does NOT render the splash before the delay threshold elapses", () => {
+describe("StartupShell — stable loading splash", () => {
+  it("renders immediately with a static lockup and shimmer-only status", () => {
     render(<StartupShell view={loadingView} onRetry={vi.fn()} />);
-
-    // Immediately after mount: nothing painted, no first-paint mark.
-    expect(queryLoading()).toBeNull();
-    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
-
-    // Advance to just before the threshold — still hidden.
-    advance(STARTUP_SPLASH_DELAY_MS - 1);
-    expect(queryLoading()).toBeNull();
-    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
-  });
-
-  it("renders the splash once the delay threshold is crossed", () => {
-    render(<StartupShell view={loadingView} onRetry={vi.fn()} />);
-
-    advance(STARTUP_SPLASH_DELAY_MS);
 
     const splash = queryLoading();
     expect(splash).not.toBeNull();
     // Visual contract preserved: phase + role attributes still present.
     expect(splash?.getAttribute("data-startup-phase")).toBe("starting-backend");
     expect(splash?.getAttribute("role")).toBe("status");
+    expect(splash?.style.fontFamily).toBe("Arial, system-ui, sans-serif");
+    const lockup = screen.getByTestId("startup-brand-lockup");
+    expect(lockup.className).not.toMatch(/(?:animate-|transition)/);
+    const brandName = screen.getByText("elizaOS");
+    expect(brandName.className).not.toMatch(/(?:shimmer|animate-|transition)/);
     const status = screen.getByText("Starting");
     expect(status.classList.contains("shimmer")).toBe(true);
     expect(status.classList.contains("text-base")).toBe(true);
@@ -98,49 +77,37 @@ describe("StartupShell — delayed loading splash", () => {
     expect(status.classList.contains("motion-reduce:animate-none")).toBe(true);
     expect(status.classList.contains("opacity-80")).toBe(false);
     expect(status.classList.contains("animate-pulse")).toBe(false);
-    // first-paint telemetry fires only when the splash actually paints.
+    // First-paint telemetry fires with the first visible React lockup.
     expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
   });
 
-  it("NEVER renders the splash when the view becomes ready before the threshold (fast cached boot)", () => {
+  it("hands an already-visible loading lockup directly to the ready app", () => {
     const { rerender } = render(
       <StartupShell view={loadingView} onRetry={vi.fn()} />,
     );
 
-    // App becomes ready well before the delay elapses.
-    advance(STARTUP_SPLASH_DELAY_MS - 50);
+    expect(queryLoading()).not.toBeNull();
     rerender(<StartupShell view={{ kind: "none" }} onRetry={vi.fn()} />);
 
-    // Even after the original timer would have fired, no flash.
-    advance(500);
     expect(queryLoading()).toBeNull();
-    // The startup shell never painted, so no first-paint mark was recorded.
-    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
   });
 
-  it("still shows the splash if a fast flicker returns to loading and then persists", () => {
+  it("does not introduce a blank interval when loading resumes", () => {
     const onRetry = vi.fn();
     const { rerender } = render(
       <StartupShell view={loadingView} onRetry={onRetry} />,
     );
 
-    // Brief flip to ready then back to loading — the delay timer restarts.
-    advance(STARTUP_SPLASH_DELAY_MS - 20);
     rerender(<StartupShell view={{ kind: "none" }} onRetry={onRetry} />);
     expect(queryLoading()).toBeNull();
 
     rerender(<StartupShell view={loadingView} onRetry={onRetry} />);
-    // Only 100ms of continuous loading — still hidden (timer restarted).
-    advance(100);
-    expect(queryLoading()).toBeNull();
-
-    // Cross the full threshold from the restart — now it paints.
-    advance(STARTUP_SPLASH_DELAY_MS);
     expect(queryLoading()).not.toBeNull();
   });
 });
 
-describe("StartupShell — non-loading views render immediately (no delay)", () => {
+describe("StartupShell — non-loading views", () => {
   it("renders the error view immediately and marks first-paint", () => {
     render(
       <StartupShell

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -59,6 +59,10 @@ function brandName(): string {
   return getBootConfig().branding?.appName ?? "elizaOS";
 }
 
+function startupStatusLabel(status: string): string {
+  return status.replace(/(?:\.{3}|…)\s*$/u, "").trim();
+}
+
 // Host-overridable brand glyph (whitelabel seam); falls back to the elizaOS mark.
 function BrandMark(props: { className?: string }) {
   const Mark = getBootConfig().brandMark ?? ElizaMark;
@@ -137,7 +141,7 @@ function StartupLoading(props: { phase: string; status: string }) {
       className={`fixed inset-0 flex items-center justify-center overflow-hidden ${LAUNCH_SURFACE}`}
       style={{ fontFamily: FONT }}
     >
-      <div className="relative z-10 flex w-full max-w-[24rem] flex-col items-center gap-5 px-6 text-center">
+      <div className="relative z-10 flex w-full max-w-[24rem] flex-col items-center gap-4 px-6 text-center">
         <div className="flex items-center justify-center gap-3">
           <BrandMark className="h-12 w-12" />
           <span className="text-4xl font-medium leading-none tracking-normal">
@@ -145,11 +149,8 @@ function StartupLoading(props: { phase: string; status: string }) {
           </span>
         </div>
 
-        <p
-          style={{ fontFamily: FONT }}
-          className="min-h-5 text-sm opacity-80 animate-pulse motion-reduce:animate-none"
-        >
-          {props.status}
+        <p className="min-h-6 text-base font-medium leading-6 tracking-[0.01em] text-white/60 shimmer [--shimmer-color:rgba(255,255,255,1)] [--shimmer-duration:1.8s] [--shimmer-spread:calc(2.5ch+32px)] motion-reduce:shimmer-none motion-reduce:animate-none">
+          {startupStatusLabel(props.status)}
         </p>
       </div>
     </div>

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -2,7 +2,7 @@
  * Composes the startup shell around boot, retry, pairing, and handoff states
  * before the app is ready.
  */
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect } from "react";
 import { getBootConfig } from "../../config/boot-config-store";
 import { markStartup } from "../../state/startup-telemetry";
 import { ElizaMark } from "../brand/eliza-mark";
@@ -11,7 +11,9 @@ import { PairingView } from "./PairingView";
 import { StartupFailureView } from "./StartupFailureView";
 import type { StartupShellProps } from "./startup-shell-types";
 
-const FONT = "'Poppins', Arial, system-ui, sans-serif";
+// The startup surface can paint before the bundled Poppins face is ready. An
+// OS-resident stack keeps the centered brand row fixed through that handoff.
+const FONT = "Arial, system-ui, sans-serif";
 
 // Launch surface for the startup splash + loading: it must match the default
 // HOME background base (#000000 = DEFAULT_BACKGROUND_COLOR, the black field
@@ -24,36 +26,6 @@ const FONT = "'Poppins', Arial, system-ui, sans-serif";
 // elizaOS defaults.
 const LAUNCH_SURFACE =
   "bg-[var(--launch-bg,#000000)] text-[var(--accent-foreground,#fff)]";
-
-// A fast, already-cached boot flips the view through the loading state for only
-// a few milliseconds before the app is ready. Painting the full-screen orange
-// splash for those few ms and then ripping it away reads as a jarring flash. So
-// the splash is gated behind a short delay: it renders ONLY once the loading
-// state has persisted this long. A boot that becomes ready first never paints
-// it. Error / pairing / bootstrap views are NOT gated — they are terminal or
-// interactive states the user is meant to see immediately, not fast-flash cases.
-// NOTE: during the ≤220ms null-render window the shell paints nothing — the
-// host's FOUC guard painting `--launch-bg` is what keeps the screen non-blank.
-export const STARTUP_SPLASH_DELAY_MS = 220;
-
-/**
- * True only after `active` has stayed `true` continuously for `delayMs`.
- * Flips back to `false` the instant `active` goes `false`. The timer lives in
- * an effect (never at render time) so the render path stays deterministic and
- * the `audit:ui-determinism` gate stays green.
- */
-function useDelayElapsed(active: boolean, delayMs: number): boolean {
-  const [elapsed, setElapsed] = useState(false);
-  useEffect(() => {
-    if (!active) {
-      setElapsed(false);
-      return;
-    }
-    const timer = setTimeout(() => setElapsed(true), delayMs);
-    return () => clearTimeout(timer);
-  }, [active, delayMs]);
-  return elapsed;
-}
 
 function brandName(): string {
   return getBootConfig().branding?.appName ?? "elizaOS";
@@ -70,17 +42,9 @@ function BrandMark(props: { className?: string }) {
 }
 
 export function StartupShell({ view, onRetry }: StartupShellProps) {
-  // The loading splash is delay-gated (see STARTUP_SPLASH_DELAY_MS): it renders
-  // only once the loading state has persisted past the threshold, so a fast
-  // cached boot that becomes ready first never flashes it.
-  const splashElapsed = useDelayElapsed(
-    view.kind === "loading",
-    STARTUP_SPLASH_DELAY_MS,
-  );
-
-  // Unconditional mount checkpoint: unlike the gated first-paint mark below,
-  // this fires as soon as the shell mounts (any view, including a fast boot
-  // that never paints the splash), so the boot-trace harness
+  // Unconditional mount checkpoint: unlike the visible-paint mark below, this
+  // fires as soon as the shell mounts (including a ready boot that never needs
+  // the React splash), so the boot-trace harness
   // (capture-startup-trace.mjs) always has a reachable renderer-only mark.
   // markStartup dedupes by name, so re-renders keep it single.
   useEffect(() => {
@@ -88,16 +52,11 @@ export function StartupShell({ view, onRetry }: StartupShellProps) {
   }, [view.kind]);
 
   // Renderer cold-start checkpoint (#9565): "first paint" of the startup front
-  // door = the moment visible startup UI actually renders. Error / pairing /
-  // bootstrap paint immediately; the loading splash paints only once the delay
-  // gate opens; the "none" (ready) branch renders null and must NOT count as a
-  // startup-shell paint (nothing painted). markStartup dedupes by name, so the
-  // first real paint wins.
-  const painting =
-    view.kind === "error" ||
-    view.kind === "pairing" ||
-    view.kind === "bootstrap" ||
-    (view.kind === "loading" && splashElapsed);
+  // door = the moment visible startup UI actually renders. Loading paints
+  // immediately because it replaces the host's identical preboot lockup; a
+  // delay would erase that lockup and expose a blank frame between renderers.
+  // The "none" (ready) branch renders null and must not count as a paint.
+  const painting = view.kind !== "none";
   useEffect(() => {
     if (painting) {
       markStartup("startup-shell:first-paint", { view: view.kind });
@@ -121,16 +80,19 @@ export function StartupShell({ view, onRetry }: StartupShellProps) {
   }
 
   if (view.kind === "loading") {
-    return splashElapsed ? (
-      <StartupLoading phase={view.phase} status={view.status} />
-    ) : null;
+    return <StartupLoading phase={view.phase} status={view.status} />;
   }
 
   // kind === "none": app is ready, the startup shell renders nothing.
   return null;
 }
 
-function StartupLoading(props: { phase: string; status: string }) {
+/**
+ * Branded loading lockup shared by the app's root Suspense handoff and the
+ * startup state machine so replacing the static preboot DOM never blanks or
+ * changes geometry while lazy UI chunks resolve.
+ */
+export function StartupLoading(props: { phase: string; status: string }) {
   return (
     <div
       data-testid="startup-shell-loading"
@@ -142,7 +104,10 @@ function StartupLoading(props: { phase: string; status: string }) {
       style={{ fontFamily: FONT }}
     >
       <div className="relative z-10 flex w-full max-w-[24rem] flex-col items-center gap-4 px-6 text-center">
-        <div className="flex items-center justify-center gap-3">
+        <div
+          data-testid="startup-brand-lockup"
+          className="flex items-center justify-center gap-3"
+        >
           <BrandMark className="h-12 w-12" />
           <span className="text-4xl font-medium leading-none tracking-normal">
             {brandName()}

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -1,8 +1,9 @@
 /**
  * Browser regression run + screenshots for the notification shade, desktop +
- * mobile: rested Z-stacks, the pull-gesture expand/collapse (real mouse drag
- * and wheel — the paths jsdom cannot exercise against real layout),
- * per-stack fan/fold controls, and swipe-to-dismiss. No app server:
+ * mobile: rested Z-stacks, real-layout pull expansion, directional wheel
+ * behavior, per-stack fan/fold controls, explicit shade collapse, and
+ * swipe-to-dismiss. It saves full-page screenshots plus walkthrough video.
+ * No app server:
  * bundles the fixture with esbuild (core/node builtins stubbed dead-in-browser)
  * and drives it in headless chromium.
  *
@@ -174,7 +175,11 @@ for (const [name, width, height] of [
   ["mobile", 390, 844],
 ]) {
   console.log(`\n── ${name} (${width}x${height}) ──`);
-  const page = await browser.newPage({ viewport: { width, height } });
+  const context = await browser.newContext({
+    viewport: { width, height },
+    recordVideo: { dir: outDir, size: { width, height } },
+  });
+  const page = await context.newPage();
   // Headless: still the entrance + scroll-driven (`animation-timeline: view()`)
   // effects for deterministic pixels and to dodge the headless-shell compositor
   // crash driving view-timeline rows while the scroller transforms. Headful
@@ -213,9 +218,9 @@ for (const [name, width, height] of [
     ),
   );
   check(
-    "two glass peeks",
+    "two producer stacks retain their glass peeks",
     (await page.locator('[data-testid="notification-stack-peek"]').count()) ===
-      2,
+      4,
   );
   check(
     "no group header eyebrows / stack counts",
@@ -249,9 +254,9 @@ for (const [name, width, height] of [
       };
     });
   check(
-    "cards are liquid glass (backdrop blur + inset edge)",
-    glass.blur.includes("blur") && glass.shadow.includes("inset"),
-    glass.blur,
+    "stacked cards retain the liquid-glass inset edge",
+    glass.shadow.includes("inset"),
+    glass.shadow,
   );
   await page.screenshot({
     path: join(outDir, `notifications-${name}-rested.png`),
@@ -328,6 +333,15 @@ for (const [name, width, height] of [
     .locator('[data-testid="notification-stack-collapse"]')
     .first()
     .click();
+  await page.waitForFunction(
+    ({ rowSelector, peekSelector }) =>
+      document.querySelectorAll(rowSelector).length === 5 &&
+      document.querySelectorAll(peekSelector).length === 2,
+    {
+      rowSelector: ROW,
+      peekSelector: '[data-testid="notification-stack-peek"]',
+    },
+  );
   check(
     "Show Less folds the producer back into a stack",
     (await page.locator(ROW).count()) === 5 &&
@@ -373,11 +387,14 @@ for (const [name, width, height] of [
   });
   console.log(`  📸 notifications-${name}-after-swipe.png`);
 
-  // 5. DIRECTIONAL COLLAPSE: fingers-up (positive wheel deltas) at the top
-  //    compresses the shade back to triage; fingers-down (negative) while
-  //    expanded is a no-op — the gesture is directional, so trailing trackpad
-  //    momentum can never snap the shade shut right after opening it.
+  // 5. DIRECTIONAL SETTLE: fingers-down (negative wheel deltas) while expanded
+  //    is a no-op, so trailing trackpad momentum cannot snap the shade shut.
+  //    Fold the producer stacks before exercising the global Collapse control,
+  //    matching the control hierarchy a person sees on screen.
   const listBox = await page.locator(LIST).boundingBox();
+  await page.locator(LIST).evaluate((list) => {
+    list.scrollTop = 0;
+  });
   await page.mouse.move(
     listBox.x + listBox.width / 2,
     listBox.y + listBox.height / 3,
@@ -388,19 +405,24 @@ for (const [name, width, height] of [
     "fingers-down while expanded does NOT collapse (momentum-proof)",
     (await shadeMode(page)) === "expanded",
   );
-  // Collapse contributions are per-event capped, so it takes a sustained
-  // fingers-up run (several events) to commit.
-  for (let i = 0; i < 4; i++) {
-    await page.mouse.wheel(0, 30);
-    await page.waitForTimeout(30);
+  while (
+    (await page.locator('[data-testid="notification-stack-collapse"]').count()) >
+    0
+  ) {
+    await page
+      .locator('[data-testid="notification-stack-collapse"]')
+      .first()
+      .click();
+    await page.waitForTimeout(500);
   }
+  await page.locator('[data-testid="notifications-collapse"]').click();
   await page.waitForFunction(
     (sel) =>
       document.querySelector(sel)?.getAttribute("data-shade-mode") === "rested",
     LIST,
   );
   check(
-    "fingers-up at the top collapses back to triage",
+    "the explicit collapse control returns to triage",
     (await shadeMode(page)) === "rested",
   );
 
@@ -408,7 +430,12 @@ for (const [name, width, height] of [
     console.log(`  page errors:`, errors);
     failures += 1;
   }
+  const video = page.video();
   await page.close();
+  await context.close();
+  if (video) {
+    await video.saveAs(join(outDir, `notifications-${name}-walkthrough.webm`));
+  }
 }
 if (HEADFUL) {
   console.log("HEADFUL: holding the window open 8s for live inspection…");

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -264,6 +264,59 @@ for (const [name, width, height] of [
   });
   console.log(`  📸 notifications-${name}-rested.png`);
 
+  // A partial horizontal swipe exposes the actual next notification rather
+  // than a blank decorative plate. Release below threshold restores the stack
+  // without changing inbox state.
+  const restedSwipe = page
+    .locator('[data-testid="notification-row-swipe"]')
+    .first();
+  const restedSwipeBox = await restedSwipe.boundingBox();
+  const underlyingPeek = page
+    .locator('[data-testid="notification-stack-peek"]')
+    .first();
+  await page.mouse.move(
+    restedSwipeBox.x + 40,
+    restedSwipeBox.y + restedSwipeBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    restedSwipeBox.x + 124,
+    restedSwipeBox.y + restedSwipeBox.height / 2,
+    { steps: 8 },
+  );
+  const underCard = await underlyingPeek.evaluate((peek) => {
+    const title = peek.querySelector(
+      "[data-notification-stack-preview-title]",
+    );
+    return {
+      title: title?.getAttribute("data-notification-stack-preview-title"),
+      renderedTitle: title ? getComputedStyle(title, "::before").content : "",
+    };
+  });
+  check(
+    "partial stack swipe reveals the next notification face",
+    underCard.title === "PR #42 approved" &&
+      underCard.renderedTitle.includes("PR #42 approved"),
+    JSON.stringify(underCard),
+  );
+  await page.screenshot({
+    path: join(outDir, `notifications-${name}-during-stack-swipe.png`),
+    fullPage: true,
+  });
+  console.log(`  📸 notifications-${name}-during-stack-swipe.png`);
+  await page.mouse.up();
+  await page.waitForFunction(
+    (selector) =>
+      !document.querySelector(selector)?.getAttribute("style")?.includes(
+        "translateX",
+      ),
+    '[data-testid="notification-row-swipe"]',
+  );
+  check(
+    "cancelled stack swipe restores the original inbox",
+    (await page.locator(ROW).count()) === 2,
+  );
+
   // 2. PULL TO EXPAND: a real mouse drag down from the list top reveals every
   //    priority tier — but the Z-stacks PERSIST (per-stack fan-out below).
   await pullDown(page);
@@ -281,6 +334,53 @@ for (const [name, width, height] of [
       1 &&
       (await page.locator('[data-testid="notifications-collapse"]').count()) ===
         1,
+  );
+  const clearAllControl = page.locator(
+    '[data-testid="notifications-clear-all"]',
+  );
+  const clearAllRestBox = await clearAllControl.boundingBox();
+  await clearAllControl.hover();
+  await page.waitForTimeout(220);
+  const clearAllHoverBox = await clearAllControl.boundingBox();
+  check(
+    "Clear All stays an X on hover",
+    Math.abs(clearAllRestBox.width - clearAllHoverBox.width) <= 1 &&
+      (await clearAllControl.getAttribute("data-clear-stage")) === "0",
+  );
+  await clearAllControl.click();
+  await page.waitForTimeout(220);
+  const firstClearStage = {
+    stage: await clearAllControl.getAttribute("data-clear-stage"),
+    label: await clearAllControl.getAttribute("aria-label"),
+  };
+  check(
+    "first Clear All click reveals Clear all",
+    firstClearStage.stage === "1" &&
+      firstClearStage.label === "Continue clearing all notifications",
+    JSON.stringify(firstClearStage),
+  );
+  await clearAllControl.click();
+  await page.waitForTimeout(220);
+  const secondClearStage = {
+    stage: await clearAllControl.getAttribute("data-clear-stage"),
+    label: await clearAllControl.getAttribute("aria-label"),
+  };
+  check(
+    "second Clear All click requires Confirm?",
+    secondClearStage.stage === "2" &&
+      secondClearStage.label === "Confirm clear all notifications",
+    JSON.stringify(secondClearStage),
+  );
+  await page.evaluate(() => {
+    document.body.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true }),
+    );
+  });
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-testid="notifications-clear-all"]')
+        ?.getAttribute("data-clear-stage") === "0",
   );
   check(
     "stacks persist through the shade expand",
@@ -328,6 +428,10 @@ for (const [name, width, height] of [
         0 &&
       (await page.locator('[data-testid="notification-stack-clear"]').count()) >
         0,
+  );
+  check(
+    "global Collapse remains visible with fanned stacks",
+    await page.locator('[data-testid="notifications-collapse"]').isVisible(),
   );
   await page
     .locator('[data-testid="notification-stack-collapse"]')
@@ -389,8 +493,8 @@ for (const [name, width, height] of [
 
   // 5. DIRECTIONAL SETTLE: fingers-down (negative wheel deltas) while expanded
   //    is a no-op, so trailing trackpad momentum cannot snap the shade shut.
-  //    Fold the producer stacks before exercising the global Collapse control,
-  //    matching the control hierarchy a person sees on screen.
+  //    The global Collapse control remains available even when producer stacks
+  //    are fanned and closes the complete notification surface in one action.
   const listBox = await page.locator(LIST).boundingBox();
   await page.locator(LIST).evaluate((list) => {
     list.scrollTop = 0;
@@ -405,16 +509,6 @@ for (const [name, width, height] of [
     "fingers-down while expanded does NOT collapse (momentum-proof)",
     (await shadeMode(page)) === "expanded",
   );
-  while (
-    (await page.locator('[data-testid="notification-stack-collapse"]').count()) >
-    0
-  ) {
-    await page
-      .locator('[data-testid="notification-stack-collapse"]')
-      .first()
-      .click();
-    await page.waitForTimeout(500);
-  }
   await page.locator('[data-testid="notifications-collapse"]').click();
   await page.waitForFunction(
     (sel) =>

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -110,7 +110,7 @@ const MANY_SEED: ShellMessage[] = Array.from({ length: 40 }, (_, i) => {
     content:
       role === "user"
         ? `message number ${i + 1} — a question that takes a full line to read`
-        : `reply ${i + 1}: here is a deliberately long answer so the transcript grows well past the tallest sheet detent and the scroll container has real overflow to scroll through on every viewport.`,
+        : `reply ${i + 1}: here is a deliberately long answer so the transcript grows well past the tallest sheet detent and the scroll container has real overflow to scroll through on every viewport. The extra detail ensures a full render window still exercises scrolling at the tallest mobile detent.`,
     createdAt: i + 1,
   } as ShellMessage;
 });

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -28,55 +28,86 @@ declare global {
 
 let nextId = 100;
 const uid = () => `m${nextId++}`;
+const FIXTURE_NOW = Date.now();
 
 const SEED: ShellMessage[] = [
-  { id: "m1", role: "user", content: "what's the plan for today?", createdAt: 1 },
+  {
+    id: "m1",
+    role: "user",
+    content: "what's the plan for today?",
+    createdAt: FIXTURE_NOW - 12 * 60_000,
+  },
   {
     id: "m2",
     role: "assistant",
     content:
       "Three things: ship the chat-sheet redesign, review the screenshots, then wire the drag e2e. Want me to start on the first?",
-    createdAt: 2,
+    createdAt: FIXTURE_NOW - 11 * 60_000,
   },
-  { id: "m3", role: "user", content: "yes, and keep the input fixed", createdAt: 3 },
+  {
+    id: "m3",
+    role: "user",
+    content: "yes, and keep the input fixed",
+    createdAt: FIXTURE_NOW - 10 * 60_000,
+  },
   {
     id: "m4",
     role: "assistant",
     content:
       "Done — the composer stays pinned at the bottom; the history pulls up over it and you pull the grabber back down to close.",
-    createdAt: 4,
+    createdAt: FIXTURE_NOW - 9 * 60_000,
   },
-  { id: "m5", role: "user", content: "nice. show me the open state", createdAt: 5 },
+  {
+    id: "m5",
+    role: "user",
+    content: "nice. show me the open state",
+    createdAt: FIXTURE_NOW - 8 * 60_000,
+  },
   {
     id: "m6",
     role: "assistant",
     content:
       "Pull up anywhere on the sheet (or just start typing) and it springs open into the full transcript.",
-    createdAt: 6,
+    createdAt: FIXTURE_NOW - 7 * 60_000,
   },
-  { id: "m7", role: "user", content: "what closes it?", createdAt: 7 },
+  {
+    id: "m7",
+    role: "user",
+    content: "what closes it?",
+    createdAt: FIXTURE_NOW - 6 * 60_000,
+  },
   {
     id: "m8",
     role: "assistant",
     content:
       "Drag the grabber at the top back down, or press Escape. Clicking the view behind does nothing — it stays open until you pull it down.",
-    createdAt: 8,
+    createdAt: FIXTURE_NOW - 5 * 60_000,
   },
-  { id: "m9", role: "user", content: "and the input?", createdAt: 9 },
+  {
+    id: "m9",
+    role: "user",
+    content: "and the input?",
+    createdAt: FIXTURE_NOW - 4 * 60_000,
+  },
   {
     id: "m10",
     role: "assistant",
     content:
       "The composer is pinned at the very bottom and never moves; the history slides up over it. The latest line always sits just above the input.",
-    createdAt: 10,
+    createdAt: FIXTURE_NOW - 3 * 60_000,
   },
-  { id: "m11", role: "user", content: "great, this scrolls now right?", createdAt: 11 },
+  {
+    id: "m11",
+    role: "user",
+    content: "great, this scrolls now right?",
+    createdAt: FIXTURE_NOW - 2 * 60_000,
+  },
   {
     id: "m12",
     role: "assistant",
     content:
       "Yes — once the transcript is taller than the open sheet it scrolls, and the newest line stays pinned at the bottom. This thread is intentionally long so the open state has history to scroll through.",
-    createdAt: 12,
+    createdAt: FIXTURE_NOW - 60_000,
   },
 ];
 
@@ -111,7 +142,7 @@ const MANY_SEED: ShellMessage[] = Array.from({ length: 40 }, (_, i) => {
       role === "user"
         ? `message number ${i + 1} — a question that takes a full line to read`
         : `reply ${i + 1}: here is a deliberately long answer so the transcript grows well past the tallest sheet detent and the scroll container has real overflow to scroll through on every viewport. The extra detail ensures a full render window still exercises scrolling at the tallest mobile detent.`,
-    createdAt: i + 1,
+    createdAt: FIXTURE_NOW - (40 - i) * 60_000,
   } as ShellMessage;
 });
 const FEW_SEED: ShellMessage[] = [

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -12,6 +12,10 @@ import { ContinuousChatOverlay } from "../ContinuousChatOverlay";
 import type { ShellMessage } from "../shell-state";
 import type { CaptureIntent, ShellController } from "../useShellController";
 
+type TranscriptSessionSink = NonNullable<
+  Parameters<ShellController["setTranscriptSessionSink"]>[0]
+>;
+
 declare global {
   interface Window {
     __appendAssistant?: (content: string) => void;
@@ -321,8 +325,14 @@ function Harness(): React.JSX.Element {
   // Capture intent of the active mic session — mirrors the real controller:
   // PTT press → "dictate" (transcript fills the composer draft, no send);
   // hands-free tap → "converse" (final transcript sends a VOICE_DM).
-  const captureIntentRef = React.useRef<CaptureIntent>("converse");
+  const captureIntentRef = React.useRef<CaptureIntent>(
+    initialTranscribing ? "transcription" : "converse",
+  );
   const dictationSinkRef = React.useRef<((text: string) => void) | null>(null);
+  const transcriptSessionSinkRef = React.useRef<TranscriptSessionSink | null>(
+    null,
+  );
+  const transcriptFinalsRef = React.useRef<string[]>([]);
 
   const startRecording = React.useCallback(
     (intent: CaptureIntent = "converse") => {
@@ -373,7 +383,12 @@ function Harness(): React.JSX.Element {
     },
     [],
   );
-  const setTranscriptSessionSink = React.useCallback(() => {}, []);
+  const setTranscriptSessionSink = React.useCallback(
+    (sink: TranscriptSessionSink | null) => {
+      transcriptSessionSinkRef.current = sink;
+    },
+    [],
+  );
   // Test hooks for BIDIRECTIONAL voice (asserted by the e2e): a final transcript
   // either fills the composer draft (dictate) or sends a VOICE_DM (converse),
   // routed by the active capture intent — exactly the two real directions.
@@ -382,13 +397,16 @@ function Harness(): React.JSX.Element {
     window.__emitVoiceFinal = (t) => {
       if (captureIntentRef.current === "dictate") {
         dictationSinkRef.current?.(t);
+        setRecording(false);
+        setPhase("summoned");
       } else if (captureIntentRef.current === "transcription") {
+        transcriptFinalsRef.current.push(t);
         setTranscript(t);
       } else {
         send(t, { channelType: "VOICE_DM" });
+        setRecording(false);
+        setPhase("summoned");
       }
-      setRecording(false);
-      setPhase("summoned");
     };
     return () => {
       window.__emitDictation = undefined;
@@ -401,6 +419,45 @@ function Harness(): React.JSX.Element {
       return !m;
     });
   }, []);
+
+  const toggleTranscriptionMode = React.useCallback(() => {
+    const next = !transcriptionMode;
+    console.log(`[fixture] toggleTranscriptionMode -> ${next}`);
+    setTranscriptionMode(next);
+    setRecording(next);
+    setPhase(next ? "listening" : "summoned");
+    if (next) {
+      captureIntentRef.current = "transcription";
+      transcriptFinalsRef.current = [];
+      setTranscript("");
+    } else {
+      const finals =
+        transcriptFinalsRef.current.length > 0
+          ? transcriptFinalsRef.current
+          : transcript.trim()
+            ? [transcript.trim()]
+            : [];
+      transcriptFinalsRef.current = [];
+      if (finals.length > 0) {
+        console.log(
+          `[fixture] finalizeTranscriptSession segments=${finals.length}`,
+        );
+        transcriptSessionSinkRef.current?.(
+          finals.map((text, index) => ({
+            id: `fixture-transcript-${index}`,
+            startMs: index * 1_000,
+            endMs: (index + 1) * 1_000,
+            text,
+            words: [],
+          })),
+          Date.now(),
+          null,
+        );
+      }
+      captureIntentRef.current = "converse";
+      setTranscript("");
+    }
+  }, [transcript, transcriptionMode]);
 
   const controller: ShellController = {
     phase,
@@ -442,20 +499,7 @@ function Harness(): React.JSX.Element {
     agentVoiceMuted,
     needsAudioUnlock,
     transcriptionMode,
-    toggleTranscriptionMode: () => {
-      setTranscriptionMode((t) => {
-        console.log(`[fixture] toggleTranscriptionMode -> ${!t}`);
-        return !t;
-      });
-    },
-    // Mic tap while transcribing: master voice control — everything off.
-    stopTranscriptionAndMic: () => {
-      console.log("[fixture] stopTranscriptionAndMic");
-      setTranscriptionMode(false);
-      setRecording(false);
-      setTranscript("");
-      setPhase("summoned");
-    },
+    toggleTranscriptionMode,
     // The overlay reads `modelStatus.kind` unconditionally; "ready" keeps the
     // local-model status strip dormant in the fixture.
     modelStatus: {

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
@@ -51,6 +51,25 @@ if (params.has("notificationOverflow")) {
   for (const notification of notifications) {
     __ingestNotificationForTests(notification, notifications.length);
   }
+} else if (params.has("notificationMaterialMotion")) {
+  __resetNotificationStoreForTests();
+  const now = Date.now();
+  const notifications: AgentNotification[] = Array.from(
+    { length: 6 },
+    (_, index) => ({
+      id: `notif-material-motion-${index}`,
+      title: `Material motion ${index + 1}`,
+      body: "Two physical stacks expose the lower backplates during release",
+      category: "system",
+      priority: index < 3 ? "high" : "normal",
+      source: index < 3 ? "trigger" : "system",
+      createdAt: now - index * 1_000,
+      readAt: null,
+    }),
+  );
+  for (const notification of notifications) {
+    __ingestNotificationForTests(notification, notifications.length);
+  }
 } else if (params.has("notificationMotion")) {
   __resetNotificationStoreForTests();
   const now = Date.now();

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
@@ -8,6 +8,7 @@
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import type { AgentNotification } from "@elizaos/core";
 
 import {
   installHomeWidgetFetchMock,
@@ -16,19 +17,63 @@ import {
 } from "../../../widgets/__fixtures__/home-widget-mock-data";
 import { ShaderBackground } from "../../../backgrounds/ShaderBackground";
 import { LauncherSurface } from "../../pages/LauncherSurface";
+import {
+  __ingestNotificationForTests,
+  __resetNotificationStoreForTests,
+} from "../../../state/notifications/notification-store";
 import { HomeLauncherSurface } from "../HomeLauncherSurface";
 import { HomeScreen, type HomeTileTarget } from "../HomeScreen";
-
-// Inject the home-widget data BEFORE the React tree renders so every widget's
-// mount-time fetch + the WidgetHost's plugin resolution see populated data.
-seedHomeWidgetAppStore();
-seedHomeWidgetNotifications();
-installHomeWidgetFetchMock();
 
 const params =
   typeof location !== "undefined"
     ? new URLSearchParams(location.search)
     : new URLSearchParams();
+
+// Inject the home-widget data BEFORE the React tree renders so every widget's
+// mount-time fetch + the WidgetHost's plugin resolution see populated data.
+seedHomeWidgetAppStore();
+if (params.has("notificationMotion")) {
+  __resetNotificationStoreForTests();
+  const now = Date.now();
+  const notifications: AgentNotification[] = [
+    {
+      id: "notif-motion-1",
+      title: "Motion one",
+      body: "First folded notification",
+      category: "system",
+      priority: "normal",
+      source: "system",
+      createdAt: now,
+      readAt: null,
+    },
+    {
+      id: "notif-motion-2",
+      title: "Motion two",
+      body: "Second folded notification",
+      category: "system",
+      priority: "normal",
+      source: "system",
+      createdAt: now - 1_000,
+      readAt: null,
+    },
+    {
+      id: "notif-motion-3",
+      title: "Motion three",
+      body: "Third folded notification",
+      category: "system",
+      priority: "normal",
+      source: "system",
+      createdAt: now - 2_000,
+      readAt: null,
+    },
+  ];
+  for (const notification of notifications) {
+    __ingestNotificationForTests(notification, notifications.length);
+  }
+} else {
+  seedHomeWidgetNotifications();
+}
+installHomeWidgetFetchMock();
 const showNativeOsTiles = params.has("native");
 
 function Harness(): React.JSX.Element {

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
@@ -32,7 +32,26 @@ const params =
 // Inject the home-widget data BEFORE the React tree renders so every widget's
 // mount-time fetch + the WidgetHost's plugin resolution see populated data.
 seedHomeWidgetAppStore();
-if (params.has("notificationMotion")) {
+if (params.has("notificationOverflow")) {
+  __resetNotificationStoreForTests();
+  const now = Date.now();
+  const notifications: AgentNotification[] = Array.from(
+    { length: 14 },
+    (_, index) => ({
+      id: `notif-overflow-${index}`,
+      title: `Overflow notification ${index + 1}`,
+      body: "Enough independent groups to require an internal shade scroll",
+      category: "system",
+      priority: "normal",
+      source: `overflow-source-${index}`,
+      createdAt: now - index * 1_000,
+      readAt: null,
+    }),
+  );
+  for (const notification of notifications) {
+    __ingestNotificationForTests(notification, notifications.length);
+  }
+} else if (params.has("notificationMotion")) {
   __resetNotificationStoreForTests();
   const now = Date.now();
   const notifications: AgentNotification[] = [

--- a/packages/ui/src/components/shell/__e2e__/notifications-center-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/notifications-center-fixture.tsx
@@ -1,8 +1,8 @@
 /**
  * Fixture for the notification-shade browser regression run: seeds the store
  * with a spread that exercises every shade surface — a multi-row interrupt
- * group (renders as the rested Z-stack), a solo interrupt row, and
- * sub-interrupt rows (hidden at rest until a pull, including the
+ * producer and a mixed-priority system producer (both render as rested
+ * Z-stacks), plus sub-interrupt rows hidden at rest until a pull, including the
  * onboarding "Take the tour" row the capture asserts appears after the pull
  * gesture expands the shade).
  */
@@ -38,7 +38,8 @@ const SEED_SET: Array<Partial<AgentNotification>> = [
     priority: "high",
     source: "github",
   },
-  // A solo interrupt row in its own group → renders flat next to the stack.
+  // The system producer mixes one interrupt row with quieter rows; its rested
+  // stack count still communicates the full producer backlog.
   {
     title: "Disk almost full",
     body: "The agent workspace volume is at 94% capacity.",

--- a/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
@@ -171,7 +171,6 @@ function Harness(): React.JSX.Element {
     micPermission: "unknown",
     recheckMicPermission: async () => "unknown",
     toggleTranscriptionMode: () => {},
-    stopTranscriptionAndMic: () => {},
     setDictationSink: () => {},
     setTranscriptSessionSink: () => {},
     setComposerHasDraft: () => {},

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -513,6 +513,88 @@ async function runDragSuite(p, pointer, tag) {
   assert(near(await sheetHeight(p), 0, 6), `[${pointer}] COLLAPSED thread height ≈ 0px`);
   await snap(p, `${tag}-collapsed`);
 
+  // The home layout reserves only the RESTING composer footprint. The chat
+  // panel itself grows during a held pull before the open detent commits, so a
+  // ResizeObserver must not feed that preview height back into the root
+  // clearance and shift the home/notification content behind the finger.
+  const restingClearance = await p.evaluate(() =>
+    document.documentElement.style.getPropertyValue(
+      "--eliza-continuous-chat-clearance",
+    ),
+  );
+  assert(
+    restingClearance.endsWith("px"),
+    `[${pointer}] resting composer publishes a concrete home clearance (${restingClearance})`,
+  );
+  await gesture(p, 44, { pointer, slow: true, hold: true, steps: 8 });
+  await p.waitForTimeout(100);
+  const heldPullClearance = await p.evaluate(() =>
+    document.documentElement.style.getPropertyValue(
+      "--eliza-continuous-chat-clearance",
+    ),
+  );
+  assert(
+    heldPullClearance === restingClearance,
+    `[${pointer}] held chat pull leaves home clearance fixed (${heldPullClearance} === ${restingClearance})`,
+  );
+  // Grow the eventual resting footprint while the observer is frozen. This
+  // deterministic layout mutation stands in for a composer gaining a draft or
+  // attachment mid-gesture without focusing it (focus would open the chat for
+  // a different reason).
+  await p.evaluate(() => {
+    const panel = document.querySelector('[data-testid="chat-sheet"]');
+    if (panel instanceof HTMLElement) panel.style.paddingBottom = "24px";
+  });
+  await p.waitForTimeout(100);
+  const heldChangedClearance = await p.evaluate(() =>
+    document.documentElement.style.getPropertyValue(
+      "--eliza-continuous-chat-clearance",
+    ),
+  );
+  assert(
+    heldChangedClearance === restingClearance,
+    `[${pointer}] footprint change stays frozen while held (${heldChangedClearance} === ${restingClearance})`,
+  );
+  await release(p, pointer, 44);
+  await p.waitForFunction(
+    (previousClearance) => {
+      const panel = document.querySelector('[data-testid="chat-sheet"]');
+      if (!(panel instanceof HTMLElement)) return false;
+      const clearance = document.documentElement.style.getPropertyValue(
+        "--eliza-continuous-chat-clearance",
+      );
+      return (
+        clearance !== previousClearance &&
+        clearance === `${Math.ceil(panel.getBoundingClientRect().height)}px`
+      );
+    },
+    restingClearance,
+    { timeout: 2_000 },
+  );
+  const settledClearance = await p.evaluate(() =>
+    document.documentElement.style.getPropertyValue(
+      "--eliza-continuous-chat-clearance",
+    ),
+  );
+  assert(
+    settledClearance !== restingClearance,
+    `[${pointer}] release republishes the changed resting footprint (${restingClearance} → ${settledClearance})`,
+  );
+  assert(
+    (await detent(p)) === "collapsed",
+    `[${pointer}] clearance probe settles back to COLLAPSED`,
+  );
+  await p.evaluate((clearance) => {
+    const panel = document.querySelector('[data-testid="chat-sheet"]');
+    if (panel instanceof HTMLElement) panel.style.removeProperty("padding-bottom");
+    // Restore the fixture's baseline directly after the thaw assertion so this
+    // instrumentation cannot influence the rest of the detent matrix.
+    document.documentElement.style.setProperty(
+      "--eliza-continuous-chat-clearance",
+      clearance,
+    );
+  }, restingClearance);
+
   // FLICK up → HALF (fast deliberate pull crosses the velocity threshold → snap to a detent)
   await gesture(p, 160, { pointer, slow: false, steps: 1 });
   await p.waitForTimeout(SETTLE);

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -3491,36 +3491,35 @@ try {
     await p.close();
   }
 
-  // ── STREAMING: the in-flight assistant turn keeps the approved shimmering
-  // status marker inside its own bubble, where streamed text replaces it.
+  // ── STREAMING: one approved shimmer row spans the turn while the empty
+  // assistant transport placeholder stays non-visual.
   {
     const p = await ctrl();
     attachConsole(p, sink);
     await gotoFixture(p, `${url}?streaming`);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(500);
-    // Open the thread so the in-flight assistant bubble is on screen.
+    // Open the thread so the in-flight status is on screen.
     await gesture(p, 400, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
-    const statusInBubble = p
-      .locator(
-        '[data-testid="thread-line"][data-role="assistant"] [data-testid="turn-status-indicator"]',
-      );
+    const inlineStatus = p
+      .getByTestId("turn-status-row")
+      .getByTestId("turn-status-indicator");
     assert(
-      (await statusInBubble.count()) >= 1,
-      "STREAMING: status marker is anchored inside the in-flight assistant bubble",
+      (await inlineStatus.count()) === 1,
+      "STREAMING: exactly one standalone status shimmer spans the active turn",
     );
     assert(
-      await statusInBubble
+      await inlineStatus
         .getByTestId("turn-status-label")
         .evaluate((el) => el.className.includes("shimmer")),
-      "STREAMING: in-bubble status uses the approved shimmer treatment",
+      "STREAMING: inline status uses the approved shimmer treatment",
     );
     assert(
       (await p.getByTestId("typing-dots").count()) === 0,
       "STREAMING: legacy typing dots stay removed",
     );
-    await snap(p, "state-streaming-dots-in-bubble");
+    await snap(p, "state-streaming-inline-status");
     await p.close();
   }
 

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -2211,6 +2211,18 @@ try {
     await snap(p, "state-plus-menu-glass");
     await p.keyboard.press("Escape");
     assert((await p.getByTestId("chat-composer-mic").count()) === 1, "EMPTY: mic button shown (no draft)");
+    const [voiceBox, transcriptionBox] = await Promise.all([
+      p.getByTestId("chat-composer-mic").boundingBox(),
+      p.getByTestId("chat-composer-transcribe").boundingBox(),
+    ]);
+    assert(
+      Boolean(
+        voiceBox &&
+          transcriptionBox &&
+          voiceBox.x < transcriptionBox.x,
+      ),
+      "EMPTY: spoken conversation sits before the rightmost transcription mic",
+    );
     await snap(p, "state-empty");
     await p.close();
   }
@@ -2337,9 +2349,112 @@ try {
     await p.close();
   }
 
-  // Transcription owns the text lane even while an inline reply is in flight:
-  // activity replaces the textarea, the mic slot becomes Stop, and the chat
-  // actions control stays put so starting capture does not reshuffle the row.
+  // Reply is an armed context state, not a request to begin typing. A measured
+  // lane eases into the bounded scroller so the latest message glides clear of
+  // the pill while the sheet, composer, and visual viewport stay fixed.
+  {
+    const p = await ctrl();
+    attachConsole(p, sink);
+    await gotoFixture(p);
+    await p.waitForSelector('[data-testid="chat-sheet"]');
+    await p.getByTestId("chat-sheet-grabber").focus();
+    await p.keyboard.press("ArrowUp");
+    await p.waitForTimeout(450);
+
+    const sampleReplyGeometry = () =>
+      p.evaluate(() => {
+        const rect = (testId) => {
+          const box = document
+            .querySelector(`[data-testid="${testId}"]`)
+            ?.getBoundingClientRect();
+          return box
+            ? { top: box.top, height: box.height, bottom: box.bottom }
+            : null;
+        };
+        return {
+          sheet: rect("chat-sheet"),
+          composer: rect("chat-composer-row"),
+          thread: rect("chat-thread"),
+          viewport: rect("chat-thread-scroll"),
+        };
+      });
+    const message = p.getByTestId("thread-line").last();
+    await message
+      .getByRole("button", { name: "Show message actions" })
+      .click();
+    await message
+      .getByTestId("thread-line-actions")
+      .waitFor({ state: "visible" });
+    const beforeReply = await sampleReplyGeometry();
+    await message.getByTestId("thread-line-reply").click();
+    await p.getByTestId("chat-reply-pill").waitFor();
+    await p.waitForTimeout(420);
+    const afterReply = await sampleReplyGeometry();
+
+    assert(
+      await p
+        .getByTestId("chat-reply-lane")
+        .evaluate(
+          (lane) =>
+            getComputedStyle(lane).position !== "absolute" &&
+            lane.getBoundingClientRect().height > 0,
+        ),
+      "REPLY: context pill reserves a visible lane below the transcript",
+    );
+    for (const key of ["sheet", "composer", "thread"]) {
+      const before = beforeReply[key];
+      const after = afterReply[key];
+      assert(
+        Boolean(
+          before &&
+            after &&
+            near(before.top, after.top, 1) &&
+            near(before.height, after.height, 1),
+        ),
+        `REPLY: outer ${key} geometry stays fixed while its inner viewport yields room`,
+      );
+    }
+    assert(
+      Boolean(
+        beforeReply.viewport &&
+          afterReply.viewport &&
+          near(beforeReply.viewport.top, afterReply.viewport.top, 1) &&
+          afterReply.viewport.height < beforeReply.viewport.height,
+      ),
+      "REPLY: transcript viewport yields the pill's space without moving its top edge",
+    );
+    const pillBox = await p
+      .getByTestId("chat-reply-pill")
+      .evaluate((element) => element.getBoundingClientRect().toJSON());
+    const latestActionsBox = await message
+      .getByTestId("thread-line-reply")
+      .evaluate((element) => element.getBoundingClientRect().toJSON());
+    assert(
+      latestActionsBox.bottom <= pillBox.top + 1,
+      "REPLY: context lane never covers the latest message actions",
+    );
+    assert(
+      await p.evaluate(
+        () =>
+          document.activeElement?.getAttribute("data-testid") !==
+          "chat-composer-textarea",
+      ),
+      "REPLY: arming context does not focus input or raise the keyboard",
+    );
+    await snap(p, "state-reply-context-no-shift");
+    await p.getByTestId("chat-sheet-grabber").focus();
+    await p.keyboard.press("Escape");
+    await p.waitForTimeout(500);
+    assert(
+      (await p.getByTestId("chat-reply-pill").count()) === 0 &&
+        (await variant(p)) === "closed",
+      "REPLY: closing the sheet clears its reply context",
+    );
+    await p.close();
+  }
+
+  // Transcription owns the whole composer lane even while a reply is in flight:
+  // activity replaces text/+ and the rightmost mic becomes the sole Stop.
   {
     const p = await ctrl();
     attachConsole(p, sink);
@@ -2350,12 +2465,28 @@ try {
       '[data-testid="chat-composer-transcription-stop"]',
     );
     await p.waitForTimeout(500);
+    const detentBeforeStop = await detent(p);
     assert(
       (await p.getByTestId("chat-composer-mic").count()) === 0 &&
         (await p.getByTestId("chat-composer-mic-activity").count()) === 1 &&
-        (await p.getByTestId("chat-composer-plus").count()) === 1 &&
+        (await p.getByTestId("chat-composer-plus").count()) === 0 &&
+        (await p.getByTestId("chat-composer-action").count()) === 0 &&
         (await p.getByTestId("chat-composer-transcription-stop").count()) === 1,
-      "TRANSCRIBING+REPLY: activity replaces text and Stop replaces the mic in place",
+      "TRANSCRIBING+REPLY: wide activity plus one Stop owns the composer",
+    );
+    const [activityBox, rowBox, stopBox] = await Promise.all([
+      p.getByTestId("chat-composer-mic-activity").boundingBox(),
+      p.getByTestId("chat-composer-row").boundingBox(),
+      p.getByTestId("chat-composer-transcription-stop").boundingBox(),
+    ]);
+    assert(
+      Boolean(
+        activityBox &&
+          rowBox &&
+          stopBox &&
+          activityBox.width >= rowBox.width - stopBox.width - 40,
+      ),
+      "TRANSCRIBING+REPLY: live activity spans the available composer width",
     );
     assert(
       (await p.getByTestId("chat-composer-transcribe-status").count()) === 0,
@@ -2381,6 +2512,10 @@ try {
       "TRANSCRIBING+REPLY: Stop preserves the transcript without sending it",
     );
     assert(
+      (await detent(p)) === detentBeforeStop,
+      "TRANSCRIBING+REPLY: Stop preserves the resting chat detent",
+    );
+    assert(
       (await p.getByTestId("chat-composer-mic-activity").count()) === 0 &&
         (await p.getByTestId("chat-composer-textarea").count()) === 1 &&
         (await p.getByTestId("chat-composer-action").count()) === 1 &&
@@ -2391,47 +2526,6 @@ try {
       (await p.getByTestId("chat-composer-textarea").inputValue()) ===
         "tell me the plan for…",
       "TRANSCRIBING+REPLY: finalized words remain intact in the composer",
-    );
-    await p.close();
-  }
-
-  // Send uses the same drain sink as Stop, then submits the finalized text once.
-  // This fixture path guards the ordering between session teardown and delivery:
-  // teardown must not replace the send-triggered responding state or lose text.
-  {
-    const p = await ctrl();
-    attachConsole(p, sink);
-    const logs = [];
-    p.on("console", (m) => logs.push(m.text()));
-    await gotoFixture(
-      p,
-      `${url}?transcribing&recording&phase=listening&transcript=send%20this%20transcript`,
-    );
-    await p.waitForSelector('[data-testid="chat-composer-action"]');
-    assert(
-      (await p
-        .getByTestId("chat-composer-action")
-        .getAttribute("aria-label")) === "send transcription",
-      "TRANSCRIBING+SEND: dedicated Send control is available during capture",
-    );
-    await p.getByTestId("chat-composer-action").click();
-    await p.waitForTimeout(300);
-    assert(
-      logs.some((t) =>
-        t.includes("[fixture] finalizeTranscriptSession segments=1"),
-      ),
-      "TRANSCRIBING+SEND: Send drains the captured session through the composer sink",
-    );
-    assert(
-      logs.filter((t) =>
-        t.includes('[fixture] send: "send this transcript"'),
-      ).length === 1,
-      "TRANSCRIBING+SEND: finalized transcript submits exactly once",
-    );
-    assert(
-      (await p.getByTestId("chat-composer-mic-activity").count()) === 0 &&
-        (await p.getByTestId("chat-composer-textarea").inputValue()) === "",
-      "TRANSCRIBING+SEND: capture exits and leaves no duplicate draft behind",
     );
     await p.close();
   }
@@ -3560,8 +3654,8 @@ try {
     await p.close();
   }
 
-  // ── STREAMING: one approved shimmer row spans the turn while the empty
-  // assistant transport placeholder stays non-visual.
+  // ── STREAMING: one approved shimmer shares the latest message's action lane
+  // while the empty assistant transport placeholder stays non-visual.
   {
     const p = await ctrl();
     attachConsole(p, sink);
@@ -3572,11 +3666,20 @@ try {
     await gesture(p, 400, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     const inlineStatus = p
-      .getByTestId("turn-status-row")
+      .getByTestId("turn-status-accessory")
       .getByTestId("turn-status-indicator");
     assert(
       (await inlineStatus.count()) === 1,
-      "STREAMING: exactly one standalone status shimmer spans the active turn",
+      "STREAMING: exactly one action-lane status shimmer spans the active turn",
+    );
+    assert(
+      await p
+        .getByTestId("turn-status-accessory")
+        .evaluate(
+          (element) =>
+            element.closest('[data-testid="thread-line-actions"]') !== null,
+        ),
+      "STREAMING: status stays on the same row as Copy and Reply",
     );
     assert(
       await inlineStatus

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -2195,6 +2195,12 @@ try {
     assert(await p.getByTestId("chat-composer-plus").isVisible(), "EMPTY: chat actions (+) button shown");
     await p.getByTestId("chat-composer-plus").click();
     assert(await p.getByText("Upload file", { exact: true }).isVisible(), "EMPTY: upload lives in the chat-actions menu");
+    assert(
+      (await p.getByText("Enable camera", { exact: true }).count()) === 0 &&
+        (await p.getByText("Transcribe", { exact: true }).count()) === 0 &&
+        (await p.getByText("Stop transcribing", { exact: true }).count()) === 0,
+      "EMPTY: deferred camera and transcription actions stay out of the + menu",
+    );
     // The + menu is the first migrated liquid-glass menu surface: assert the
     // glass class is live (GlassStyles mounted by the fixture shell) and
     // capture the open-menu state for visual evidence.

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -2337,9 +2337,9 @@ try {
     await p.close();
   }
 
-  // Transcription owns the whole composer even while an inline reply is in
-  // flight: Stop/activity/neutral mic/Send replace the attachment, textarea,
-  // and spoken-conversation controls until finalization completes.
+  // Transcription owns the text lane even while an inline reply is in flight:
+  // activity replaces the textarea, the mic slot becomes Stop, and the chat
+  // actions control stays put so starting capture does not reshuffle the row.
   {
     const p = await ctrl();
     attachConsole(p, sink);
@@ -2353,17 +2353,13 @@ try {
     assert(
       (await p.getByTestId("chat-composer-mic").count()) === 0 &&
         (await p.getByTestId("chat-composer-mic-activity").count()) === 1 &&
-        (await p.getByTestId("chat-composer-transcribe-status").count()) === 1,
-      "TRANSCRIBING+REPLY: dedicated activity replaces the voice waveform",
+        (await p.getByTestId("chat-composer-plus").count()) === 1 &&
+        (await p.getByTestId("chat-composer-transcription-stop").count()) === 1,
+      "TRANSCRIBING+REPLY: activity replaces text and Stop replaces the mic in place",
     );
-    const statusClass =
-      (await p
-        .getByTestId("chat-composer-transcribe-status")
-        .getAttribute("class")) ?? "";
     assert(
-      statusClass.includes("text-white/80") &&
-        !statusClass.includes("text-accent"),
-      "TRANSCRIBING+REPLY: live mic status is neutral white, never accent orange",
+      (await p.getByTestId("chat-composer-transcribe-status").count()) === 0,
+      "TRANSCRIBING+REPLY: no duplicate live-mic status control remains",
     );
     await snap(p, "state-transcribing-inline-reply");
     await p.getByTestId("chat-composer-transcription-stop").click();

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -2337,38 +2337,105 @@ try {
     await p.close();
   }
 
-  // TRANSCRIBING while an inline reply is in flight (regression, #9880 path):
-  // the voice control is the MASTER off — labeled "stop transcription and mic"
-  // (distinct from the transcribe button's "stop transcription", which leaves
-  // the mic on) — and must END the session on tap even while `responding` is
-  // true; the OFF path was gated on the reply finishing, leaving a lit, dead
-  // mic button.
+  // Transcription owns the whole composer even while an inline reply is in
+  // flight: Stop/activity/neutral mic/Send replace the attachment, textarea,
+  // and spoken-conversation controls until finalization completes.
   {
     const p = await ctrl();
     attachConsole(p, sink);
     const logs = [];
     p.on("console", (m) => logs.push(m.text()));
     await gotoFixture(p, `${url}?transcribing&recording&speaking&phase=listening`);
-    await p.waitForSelector('[data-testid="chat-composer-mic"]');
+    await p.waitForSelector(
+      '[data-testid="chat-composer-transcription-stop"]',
+    );
     await p.waitForTimeout(500);
     assert(
-      (await p.getByTestId("chat-composer-mic").getAttribute("aria-label")) ===
-        "stop transcription and mic",
-      "TRANSCRIBING+REPLY: voice control reads 'stop transcription and mic'",
+      (await p.getByTestId("chat-composer-mic").count()) === 0 &&
+        (await p.getByTestId("chat-composer-mic-activity").count()) === 1 &&
+        (await p.getByTestId("chat-composer-transcribe-status").count()) === 1,
+      "TRANSCRIBING+REPLY: dedicated activity replaces the voice waveform",
+    );
+    const statusClass =
+      (await p
+        .getByTestId("chat-composer-transcribe-status")
+        .getAttribute("class")) ?? "";
+    assert(
+      statusClass.includes("text-white/80") &&
+        !statusClass.includes("text-accent"),
+      "TRANSCRIBING+REPLY: live mic status is neutral white, never accent orange",
     );
     await snap(p, "state-transcribing-inline-reply");
-    await p.getByTestId("chat-composer-mic").click();
+    await p.getByTestId("chat-composer-transcription-stop").click();
     await p.waitForTimeout(300);
     assert(
-      logs.some((t) => t.includes("[fixture] stopTranscriptionAndMic")),
-      "TRANSCRIBING+REPLY: mic tap ends transcription even mid-reply (not gated on responding)",
+      logs.some((t) =>
+        t.includes("[fixture] toggleTranscriptionMode -> false"),
+      ),
+      "TRANSCRIBING+REPLY: Stop finalizes transcription even mid-reply",
     );
-    // With the mic off and the (fixture-constant) reply still in flight the
-    // trailing control morphs mic → stop, exactly like the plain speaking state.
     assert(
-      (await p.getByTestId("chat-composer-mic").count()) === 0 &&
-        (await p.getByTestId("chat-composer-stop").count()) === 1,
-      "TRANSCRIBING+REPLY: after the tap the trailing control is the stop (mic off)",
+      logs.some((t) =>
+        t.includes("[fixture] finalizeTranscriptSession segments=1"),
+      ),
+      "TRANSCRIBING+REPLY: Stop drains the captured session through the composer sink",
+    );
+    assert(
+      !logs.some((t) => t.includes("[fixture] send:")),
+      "TRANSCRIBING+REPLY: Stop preserves the transcript without sending it",
+    );
+    assert(
+      (await p.getByTestId("chat-composer-mic-activity").count()) === 0 &&
+        (await p.getByTestId("chat-composer-textarea").count()) === 1 &&
+        (await p.getByTestId("chat-composer-action").count()) === 1 &&
+        (await p.getByTestId("chat-composer-stop").count()) === 0,
+      "TRANSCRIBING+REPLY: Stop restores the transcript as an editable draft",
+    );
+    assert(
+      (await p.getByTestId("chat-composer-textarea").inputValue()) ===
+        "tell me the plan for…",
+      "TRANSCRIBING+REPLY: finalized words remain intact in the composer",
+    );
+    await p.close();
+  }
+
+  // Send uses the same drain sink as Stop, then submits the finalized text once.
+  // This fixture path guards the ordering between session teardown and delivery:
+  // teardown must not replace the send-triggered responding state or lose text.
+  {
+    const p = await ctrl();
+    attachConsole(p, sink);
+    const logs = [];
+    p.on("console", (m) => logs.push(m.text()));
+    await gotoFixture(
+      p,
+      `${url}?transcribing&recording&phase=listening&transcript=send%20this%20transcript`,
+    );
+    await p.waitForSelector('[data-testid="chat-composer-action"]');
+    assert(
+      (await p
+        .getByTestId("chat-composer-action")
+        .getAttribute("aria-label")) === "send transcription",
+      "TRANSCRIBING+SEND: dedicated Send control is available during capture",
+    );
+    await p.getByTestId("chat-composer-action").click();
+    await p.waitForTimeout(300);
+    assert(
+      logs.some((t) =>
+        t.includes("[fixture] finalizeTranscriptSession segments=1"),
+      ),
+      "TRANSCRIBING+SEND: Send drains the captured session through the composer sink",
+    );
+    assert(
+      logs.filter((t) =>
+        t.includes('[fixture] send: "send this transcript"'),
+      ).length === 1,
+      "TRANSCRIBING+SEND: finalized transcript submits exactly once",
+    );
+    assert(
+      (await p.getByTestId("chat-composer-mic-activity").count()) === 0 &&
+        (await p.getByTestId("chat-composer-textarea").inputValue()) === "",
+      "TRANSCRIBING+SEND: capture exits and leaves no duplicate draft behind",
     );
     await p.close();
   }

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -191,9 +191,17 @@ const stubElizaCore = {
 // `color-mix(..., var(--brand-white))`, and an undefined var resolves to black —
 // unreadable on the dark ember field, tripping the foreground-contrast gate. The
 // fixture loads no app CSS, so the handful of brand vars the home widgets read
-// must be declared inline.
+// must be declared inline. The standalone esbuild page also bypasses Tailwind's
+// `@utility` transform; mirror the production scroll-fade mask so Chromium can
+// exercise its release handoff instead of treating the class as unstyled.
 const headHtml = `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-<style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#000000;--brand-orange:#ff6a1f}</style>`;
+<style>
+:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#000000;--brand-orange:#ff6a1f}
+.scroll-fade{
+  mask-image:linear-gradient(to bottom,transparent 0,#000 1.25rem,#000 calc(100% - 1.5rem),transparent 100%);
+  -webkit-mask-image:linear-gradient(to bottom,transparent 0,#000 1.25rem,#000 calc(100% - 1.5rem),transparent 100%);
+}
+</style>`;
 const url = await writeFixturePage({
   entry: join(here, "home-screen-fixture.tsx"),
   outDir,
@@ -2254,7 +2262,7 @@ try {
   // Reload into a clean shade before the deep-pull marker trace. Keeping this
   // proof isolated prevents its release-click suppression from changing the
   // interaction sequence exercised above.
-  await notificationMotion.goto(`${url}?notificationMotion`);
+  await notificationMotion.goto(`${url}?notificationMaterialMotion`);
   await notificationCenter.waitFor({ state: "visible", timeout: 5000 });
   await waitForHomeEnterSettled(notificationMotion);
   await notificationMotion.evaluate(() => {
@@ -2267,10 +2275,35 @@ try {
       const row = document.querySelector(".eliza-notif-row");
       const glass = row?.querySelector(".eliza-notif-glass");
       const rowStyle = row ? getComputedStyle(row) : null;
+      const groupContents = Array.from(
+        document.querySelectorAll("[data-notification-group-content]"),
+      );
+      const stackPeeks = Array.from(
+        document.querySelectorAll("[data-notification-stack-peek]"),
+      );
+      const listStyle = list ? getComputedStyle(list) : null;
       window.__ELIZA_NOTIFICATION_DEEP_PULL_TRACE__.push({
         t: performance.now() - startedAt,
         mode: list?.getAttribute("data-shade-mode"),
+        dragging: list?.hasAttribute("data-shade-dragging"),
         releaseSettling: list?.hasAttribute("data-shade-release-settling"),
+        maskImage: listStyle?.maskImage ?? null,
+        webkitMaskImage: listStyle?.webkitMaskImage ?? null,
+        groupOpacities: groupContents.map((group) =>
+          Number.parseFloat(getComputedStyle(group).opacity),
+        ),
+        peekOpacities: stackPeeks.map((peek) =>
+          Number.parseFloat(getComputedStyle(peek).opacity),
+        ),
+        peekColors: stackPeeks.map(
+          (peek) => getComputedStyle(peek).backgroundColor,
+        ),
+        peekImages: stackPeeks.map(
+          (peek) => getComputedStyle(peek).backgroundImage,
+        ),
+        peekShadows: stackPeeks.map(
+          (peek) => getComputedStyle(peek).boxShadow,
+        ),
         row: rowStyle
           ? {
               animationName: rowStyle.animationName,
@@ -2300,8 +2333,17 @@ try {
   const expandedDeepPullFrames = deepPullTrace.filter(
     (sample) => sample.mode === "expanded" && sample.row,
   );
+  const heldDeepPullFrames = deepPullTrace.filter(
+    (sample) =>
+      sample.mode === "rested" &&
+      sample.dragging &&
+      sample.groupOpacities.length > 0,
+  );
   const settledDeepPullFrames = expandedDeepPullFrames.filter(
     (sample) => !sample.releaseSettling,
+  );
+  const releasingDeepPullFrames = expandedDeepPullFrames.filter(
+    (sample) => sample.releaseSettling,
   );
   const expandedGlassColors = new Set(
     expandedDeepPullFrames
@@ -2312,6 +2354,50 @@ try {
     expandedDeepPullFrames.some((sample) => sample.releaseSettling) &&
       settledDeepPullFrames.length > 0,
     "deep pull trace spans the release marker handoff",
+  );
+  assert(
+    heldDeepPullFrames.some(
+      (sample) =>
+        sample.groupOpacities.every((opacity) => opacity >= 0.99) &&
+        sample.groupOpacities.length === 2 &&
+        sample.peekOpacities.length === 4 &&
+        sample.peekOpacities.every((opacity) => opacity >= 0.99),
+    ),
+    "held deep pull advances both mounted stacks and all four backplates to full opacity",
+  );
+  const expandedPeekColors = new Set(
+    expandedDeepPullFrames.flatMap((sample) => sample.peekColors),
+  );
+  const expandedPeekImages = new Set(
+    expandedDeepPullFrames.flatMap((sample) => sample.peekImages),
+  );
+  const expandedPeekShadows = new Set(
+    expandedDeepPullFrames.flatMap((sample) => sample.peekShadows),
+  );
+  assert(
+    expandedDeepPullFrames.every(
+      (sample) =>
+        sample.groupOpacities.length === 2 &&
+        sample.groupOpacities.every((opacity) => opacity >= 0.99) &&
+        sample.peekOpacities.length === 4 &&
+        sample.peekOpacities.every((opacity) => opacity >= 0.99),
+    ) &&
+      expandedPeekColors.size === 1 &&
+      expandedPeekImages.size === 1 &&
+      expandedPeekShadows.size === 1,
+    `deep-pull release keeps every stack backplate at one opacity and material (${JSON.stringify({ expandedPeekColors: [...expandedPeekColors], expandedPeekImages: [...expandedPeekImages], expandedPeekShadows: [...expandedPeekShadows], firstFrames: expandedDeepPullFrames.slice(0, 4) })})`,
+  );
+  assert(
+    releasingDeepPullFrames.length > 0 &&
+      releasingDeepPullFrames.every(
+        (sample) =>
+          sample.maskImage === "none" && sample.webkitMaskImage === "none",
+      ) &&
+      settledDeepPullFrames.some(
+        (sample) =>
+          sample.maskImage !== "none" && sample.webkitMaskImage !== "none",
+      ),
+    `release runway stays unmasked until both stacks settle (${JSON.stringify({ releasing: releasingDeepPullFrames.slice(0, 3), settled: settledDeepPullFrames.slice(0, 2) })})`,
   );
   assert(
     expandedDeepPullFrames.every(

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -1611,7 +1611,7 @@ try {
       mountedFanFrames[0]?.controls.opacity <= 0.05 &&
       mountedFanFrames[0]?.peeks.length === 2 &&
       mountedFanFrames[0]?.peeks.every((opacity) => opacity >= 0.98) &&
-      mountedFanFrames[0]?.group.paddingBottom >= 23,
+      mountedFanFrames[0]?.group.paddingBottom >= 15,
     "stack fan mounts controls and rows from collapsed geometry",
   );
   console.log(

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -745,10 +745,24 @@ try {
       (await countButton.textContent())?.includes("1 Notification"),
       "the rested count control reflects the seeded notification",
     );
+    const restedClearState = await center
+      .getByTestId("notifications-clear-all")
+      .evaluate((button) => {
+        const slot = button.closest("[data-notification-clear-slot]");
+        return {
+          opacity: slot ? getComputedStyle(slot).opacity : null,
+          height: slot ? getComputedStyle(slot).height : null,
+          ariaHidden: slot?.getAttribute("aria-hidden"),
+          inert: slot?.hasAttribute("inert"),
+        };
+      });
     assert(
-      (await center.getByTestId("notifications-clear-all").count()) === 0 &&
+      restedClearState.opacity === "0" &&
+        restedClearState.height === "0px" &&
+        restedClearState.ariaHidden === "true" &&
+        restedClearState.inert === true &&
         (await center.getByTestId("notifications-collapse").count()) === 0,
-      "expanded-only controls stay hidden at rest",
+      "expanded controls remain mounted but fully inert and hidden at rest",
     );
 
     const countSlot = center.getByTestId("notifications-count");
@@ -823,10 +837,24 @@ try {
         '[data-testid="home-notification-list"][data-shade-mode="rested"]',
       )
       .waitFor({ state: "visible", timeout: 5000 });
+    const collapsedClearState = await center
+      .getByTestId("notifications-clear-all")
+      .evaluate((button) => {
+        const slot = button.closest("[data-notification-clear-slot]");
+        return {
+          opacity: slot ? getComputedStyle(slot).opacity : null,
+          height: slot ? getComputedStyle(slot).height : null,
+          ariaHidden: slot?.getAttribute("aria-hidden"),
+          inert: slot?.hasAttribute("inert"),
+        };
+      });
     assert(
-      (await center.getByTestId("notifications-clear-all").count()) === 0 &&
+      collapsedClearState.opacity === "0" &&
+        collapsedClearState.height === "0px" &&
+        collapsedClearState.ariaHidden === "true" &&
+        collapsedClearState.inert === true &&
         (await center.getByTestId("notifications-collapse").count()) === 0,
-      "collapse returns the notification center to its rested controls",
+      "collapse restores the mounted clear control to its inert rested state",
     );
   }
   // No general quick-access tiles anymore - Launcher is the adjacent
@@ -2069,9 +2097,10 @@ try {
   );
   assert(
     cancelTrace.at(-1)?.quietOpacity === null &&
-      cancelTrace.at(-1)?.clearMounted === false &&
+      cancelTrace.at(-1)?.clearMounted === true &&
+      cancelTrace.at(-1)?.clearOpacity === 0 &&
       cancelTrace.at(-1)?.collapseMounted === false,
-    "cancelled pull unmounts preview-only surfaces only after the settle completes",
+    "cancelled pull hides its stable clear slot and unmounts preview-only surfaces after settling",
   );
 
   await notificationMotion.emulateMedia({ reducedMotion: "reduce" });
@@ -2288,6 +2317,20 @@ try {
     clearControls: document.querySelectorAll(
       '[data-testid="notifications-clear-all"]',
     ).length,
+    clearOpacity: (() => {
+      const slot = document.querySelector("[data-notification-clear-slot]");
+      return slot ? getComputedStyle(slot).opacity : null;
+    })(),
+    clearHeight: (() => {
+      const slot = document.querySelector("[data-notification-clear-slot]");
+      return slot ? getComputedStyle(slot).height : null;
+    })(),
+    clearHidden: document
+      .querySelector("[data-notification-clear-slot]")
+      ?.getAttribute("aria-hidden"),
+    clearInert: document
+      .querySelector("[data-notification-clear-slot]")
+      ?.hasAttribute("inert"),
     collapseControls: document.querySelectorAll(
       '[data-testid="notifications-collapse"]',
     ).length,
@@ -2296,7 +2339,11 @@ try {
     reducedCancel.mode === "rested" &&
       reducedCancel.cancelling === false &&
       reducedCancel.previewGroups === 0 &&
-      reducedCancel.clearControls === 0 &&
+      reducedCancel.clearControls === 1 &&
+      reducedCancel.clearOpacity === "0" &&
+      reducedCancel.clearHeight === "0px" &&
+      reducedCancel.clearHidden === "true" &&
+      reducedCancel.clearInert === true &&
       reducedCancel.collapseControls === 0,
     `reduced-motion short pull resets preview DOM immediately (${JSON.stringify(reducedCancel)})`,
   );
@@ -2636,8 +2683,8 @@ try {
       const clear = document.querySelector(
         '[data-testid="notifications-clear-all"]',
       );
-      const clearLabel = clear?.querySelector(
-        "[data-notification-clear-resting-label]",
+      const clearArmingLabel = clear?.querySelector(
+        "[data-notification-clear-arming-label]",
       );
       const clearConfirmingLabel = clear?.querySelector(
         "[data-notification-clear-confirming-label]",
@@ -2650,7 +2697,7 @@ try {
         !(list instanceof HTMLElement) ||
         !(secondary instanceof HTMLElement) ||
         !(clear instanceof HTMLElement) ||
-        !(clearLabel instanceof HTMLElement) ||
+        !(clearArmingLabel instanceof HTMLElement) ||
         !(clearConfirmingLabel instanceof HTMLElement) ||
         !(clearIcon instanceof SVGElement)
       ) {
@@ -2686,12 +2733,14 @@ try {
         clear: {
           ...rect(clear),
           confirming: clear.hasAttribute("data-confirming"),
+          stage: clear.getAttribute("data-clear-stage"),
+          armingLabel: clearArmingLabel.textContent,
+          armingLabelOpacity: Number.parseFloat(
+            getComputedStyle(clearArmingLabel).opacity,
+          ),
           confirmingLabel: clearConfirmingLabel.textContent,
           confirmingLabelOpacity: Number.parseFloat(
             getComputedStyle(clearConfirmingLabel).opacity,
-          ),
-          labelOpacity: Number.parseFloat(
-            getComputedStyle(clearLabel).opacity,
           ),
           iconOpacity: Number.parseFloat(getComputedStyle(clearIcon).opacity),
         },
@@ -2731,9 +2780,11 @@ try {
     );
     assert(
       initialExpandedGeometry.clear.width <= 33 &&
-        initialExpandedGeometry.clear.labelOpacity <= 0.01 &&
+        initialExpandedGeometry.clear.armingLabelOpacity <= 0.01 &&
+        initialExpandedGeometry.clear.confirmingLabelOpacity <= 0.01 &&
         initialExpandedGeometry.clear.iconOpacity >= 0.99 &&
-        !initialExpandedGeometry.clear.confirming,
+        !initialExpandedGeometry.clear.confirming &&
+        initialExpandedGeometry.clear.stage === "0",
       `coarse-pointer clear control rests as a compact X (${JSON.stringify(initialExpandedGeometry.clear)})`,
     );
   }
@@ -2746,10 +2797,23 @@ try {
   const armedCoarseClearGeometry = await readExpandedGeometry();
   assert(
     armedCoarseClearGeometry?.clear.confirming === true &&
-      armedCoarseClearGeometry.clear.confirmingLabel === "Clear all" &&
-      armedCoarseClearGeometry.clear.confirmingLabelOpacity >= 0.99 &&
+      armedCoarseClearGeometry.clear.stage === "1" &&
+      armedCoarseClearGeometry.clear.armingLabel === "Clear all" &&
+      armedCoarseClearGeometry.clear.armingLabelOpacity >= 0.99 &&
       armedCoarseClearGeometry.clear.width >= 63,
-    `coarse-pointer first tap reveals “Clear all” without adding a third step (${JSON.stringify(armedCoarseClearGeometry?.clear)})`,
+    `coarse-pointer first tap reveals Clear all (${JSON.stringify(armedCoarseClearGeometry?.clear)})`,
+  );
+  await touchTap(
+    notificationGeometry,
+    '[data-testid="notifications-clear-all"]',
+  );
+  await notificationGeometry.waitForTimeout(220);
+  const confirmingCoarseClearGeometry = await readExpandedGeometry();
+  assert(
+    confirmingCoarseClearGeometry?.clear.stage === "2" &&
+      confirmingCoarseClearGeometry.clear.confirmingLabel === "Confirm?" &&
+      confirmingCoarseClearGeometry.clear.confirmingLabelOpacity >= 0.99,
+    `coarse-pointer second tap advances to Confirm? (${JSON.stringify(confirmingCoarseClearGeometry?.clear)})`,
   );
   await notificationGeometry.evaluate(() => {
     document.body.dispatchEvent(
@@ -2965,24 +3029,13 @@ try {
     );
     await desktop.waitForTimeout(520);
     const clear = center.getByTestId("notifications-clear-all");
-    const readClearGeometry = () =>
+    const readClearState = () =>
       clear.evaluate((button) => {
-        const label = button.querySelector(
-          "[data-notification-clear-resting-label]",
-        );
-        const icon = button.querySelector(
-          "[data-notification-clear-resting-icon]",
-        );
         const slot = button.closest("[data-notification-clear-slot]");
         const row = document.querySelector(
           '[data-testid="notification-row"]',
         );
-        if (
-          !(label instanceof HTMLElement) ||
-          !(icon instanceof SVGElement) ||
-          !(slot instanceof HTMLElement) ||
-          !(row instanceof HTMLElement)
-        ) {
+        if (!(slot instanceof HTMLElement) || !(row instanceof HTMLElement)) {
           return null;
         }
         const rect = (element) => {
@@ -2998,40 +3051,40 @@ try {
           button: rect(button),
           slot: rect(slot),
           row: rect(row),
-          labelOpacity: Number.parseFloat(getComputedStyle(label).opacity),
-          iconOpacity: Number.parseFloat(getComputedStyle(icon).opacity),
+          stage: button.getAttribute("data-clear-stage"),
         };
       });
-    const clearRest = await readClearGeometry();
+    const clearRest = await readClearState();
     await clear.hover();
     await desktop.waitForTimeout(220);
-    const clearHover = await readClearGeometry();
+    const clearHover = await readClearState();
     await desktop.mouse.move(0, 0);
     await desktop.waitForTimeout(220);
-    const clearReturned = await readClearGeometry();
+    const clearReturned = await readClearState();
     assert(
       clearRest !== null &&
         clearHover !== null &&
         clearReturned !== null &&
         clearRest.button.width <= 33 &&
-        clearHover.button.width >= 55 &&
-        clearHover.labelOpacity >= 0.99 &&
-        clearHover.iconOpacity <= 0.01 &&
+        clearHover.button.width <= 33 &&
         Math.abs(clearRest.button.right - clearHover.button.right) <= 1 &&
         Math.abs(clearRest.slot.width - clearHover.slot.width) <= 1 &&
         Math.abs(clearRest.row.top - clearHover.row.top) <= 1 &&
-        clearReturned.button.width <= 33,
-      `desktop clear reveals leftward without shifting its slot or cards (${JSON.stringify({ clearRest, clearHover, clearReturned })})`,
+        clearReturned.button.width <= 33 &&
+        clearRest.stage === "0" &&
+        clearHover.stage === "0",
+      `desktop clear stays an X on hover without shifting its slot or cards (${JSON.stringify({ clearRest, clearHover, clearReturned })})`,
     );
     await clear.click();
     await desktop.waitForTimeout(220);
-    const desktopConfirmation = await clear.evaluate((button) => {
+    const desktopArming = await clear.evaluate((button) => {
       const label = button.querySelector(
-        "[data-notification-clear-confirming-label]",
+        "[data-notification-clear-arming-label]",
       );
       return {
         ariaLabel: button.getAttribute("aria-label"),
         confirming: button.hasAttribute("data-confirming"),
+        stage: button.getAttribute("data-clear-stage"),
         label: label?.textContent,
         labelOpacity:
           label instanceof HTMLElement
@@ -3040,12 +3093,28 @@ try {
       };
     });
     assert(
-      desktopConfirmation.confirming &&
+      desktopArming.confirming &&
+        desktopArming.stage === "1" &&
+        desktopArming.label === "Clear all" &&
+        desktopArming.labelOpacity >= 0.99 &&
+        desktopArming.ariaLabel === "Continue clearing all notifications",
+      `desktop first click changes X to Clear all (${JSON.stringify(desktopArming)})`,
+    );
+    await clear.click();
+    await desktop.waitForTimeout(220);
+    const desktopConfirmation = await clear.evaluate((button) => ({
+      ariaLabel: button.getAttribute("aria-label"),
+      stage: button.getAttribute("data-clear-stage"),
+      label: button.querySelector(
+        "[data-notification-clear-confirming-label]",
+      )?.textContent,
+    }));
+    assert(
+      desktopConfirmation.stage === "2" &&
         desktopConfirmation.label === "Confirm?" &&
-        desktopConfirmation.labelOpacity >= 0.99 &&
         desktopConfirmation.ariaLabel ===
           "Confirm clear all notifications",
-      `desktop first click changes Clear all to an explicit Confirm? step (${JSON.stringify(desktopConfirmation)})`,
+      `desktop second click advances Clear all to Confirm? (${JSON.stringify(desktopConfirmation)})`,
     );
     await desktop.evaluate(() => {
       document.body.dispatchEvent(

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -27,6 +27,7 @@ import {
   summarizeStability,
 } from "../../../testing/layout-stability.ts";
 import {
+  touchDragHold,
   touchLongPress,
   touchSwipe,
   touchTap,
@@ -720,6 +721,54 @@ try {
       "expanded-only controls stay hidden at rest",
     );
 
+    const countSlot = center.getByTestId("notifications-count");
+    const restedCountBox = await countSlot.boundingBox();
+    if (!restedCountBox) throw new Error("missing notification count bounds");
+    const partialPull = await touchDragHold(
+      mobile,
+      '[data-testid="home-notification-list"]',
+      0,
+      48,
+      { steps: 6, stepDelayMs: 16 },
+    );
+    await mobile.evaluate(
+      () => new Promise((resolve) => requestAnimationFrame(resolve)),
+    );
+    const heldCountBox = await countSlot.boundingBox();
+    if (!heldCountBox) throw new Error("missing pulled count bounds");
+    const heldCountTravel = heldCountBox.y - restedCountBox.y;
+    assert(
+      heldCountTravel > 1 && heldCountTravel < 28,
+      `a partial pull moves the count continuously instead of inserting a 40px row (${heldCountTravel.toFixed(2)}px)`,
+    );
+
+    await partialPull.release();
+    const releaseTrace = await mobile.evaluate(async (restedTop) => {
+      const samples = [];
+      const startedAt = performance.now();
+      // Keep sampling through the gesture's click-suppression window so the
+      // next tap is a distinct user action as well as a settled-state check.
+      while (performance.now() - startedAt < 560) {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        const count = document.querySelector(
+          '[data-testid="notifications-count"]',
+        );
+        if (!(count instanceof HTMLElement)) break;
+        samples.push(count.getBoundingClientRect().top - restedTop);
+      }
+      return samples;
+    }, restedCountBox.y);
+    const releasePeak = Math.max(...releaseTrace);
+    const releaseFinal = releaseTrace.at(-1) ?? Number.POSITIVE_INFINITY;
+    assert(
+      releasePeak <= heldCountTravel + 1.5,
+      `a cancelled pull returns without bouncing farther from rest (${releasePeak.toFixed(2)}px peak)`,
+    );
+    assert(
+      Math.abs(releaseFinal) < 0.75,
+      `the notification count settles back at rest (${releaseFinal.toFixed(2)}px)`,
+    );
+
     await touchTap(mobile, '[data-testid="notifications-count-button"]');
     await center
       .locator(
@@ -731,6 +780,12 @@ try {
         (await center.getByTestId("notifications-collapse").count()) === 1,
       "opening the shade reveals clear and collapse controls",
     );
+    await mobile.waitForFunction(() => {
+      const footer = document.querySelector(
+        '[data-testid="notifications-collapse-footer"]',
+      );
+      return footer instanceof HTMLElement && !footer.hasAttribute("inert");
+    });
 
     await touchTap(mobile, '[data-testid="notifications-collapse"]');
     await center
@@ -1039,6 +1094,1163 @@ try {
     await rename(videoPath, stableVideoPath);
     console.log(`  🎥 ${stableVideoPath}`);
   }
+
+  // A dedicated three-row quiet stack exercises the transitions that cannot
+  // exist in the default urgent-row fixture: click-open insertion, producer
+  // fan-out, empty-region collapse/close-race handling, and a cancelled pull
+  // settle.
+  const notificationMotionContext = await browser.newContext({
+    viewport: { width: 402, height: 874 },
+    deviceScaleFactor: 2,
+    hasTouch: true,
+    isMobile: true,
+  });
+  const notificationMotion = await notificationMotionContext.newPage();
+  notificationMotion.on("pageerror", (e) => sink.errors.push(String(e)));
+  await installCoarsePointerMedia(notificationMotion);
+  await notificationMotion.goto(`${url}?notificationMotion`);
+  const notificationCenter = notificationMotion.getByTestId(
+    "home-notification-center",
+  );
+  await notificationCenter.waitFor({ state: "visible", timeout: 5000 });
+  await waitForHomeEnterSettled(notificationMotion);
+  assert(
+    (await notificationCenter.getByTestId("notification-row").count()) === 0,
+    "quiet notification stack starts folded behind the total",
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_OPEN_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      const count = document.querySelector('[data-testid="notifications-count"]');
+      const groupLayer = group?.closest("[data-notification-group]");
+      const clear = document.querySelector("[data-notification-clear-slot]");
+      window.__ELIZA_NOTIFICATION_OPEN_TRACE__.push({
+        t: performance.now() - startedAt,
+        group: group
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(group).opacity),
+              top: group.getBoundingClientRect().top,
+              duration: getComputedStyle(group).transitionDuration,
+              zIndex: groupLayer
+                ? getComputedStyle(groupLayer).zIndex
+                : null,
+            }
+          : null,
+        count: count
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(count).opacity),
+              height: count.getBoundingClientRect().height,
+              duration: getComputedStyle(count).transitionDuration,
+              zIndex: getComputedStyle(count).zIndex,
+            }
+          : null,
+        clear: clear
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(clear).opacity),
+              height: clear.getBoundingClientRect().height,
+              duration: getComputedStyle(clear).transitionDuration,
+            }
+          : null,
+      });
+      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+    };
+    const countButton = document.querySelector(
+      '[data-testid="notifications-count-button"]',
+    );
+    if (!(countButton instanceof HTMLButtonElement)) {
+      throw new Error("missing notification count button");
+    }
+    countButton.click();
+    requestAnimationFrame(sample);
+  });
+  await notificationMotion.waitForTimeout(460);
+  const openTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_OPEN_TRACE__,
+  );
+  const mountedOpenFrames = openTrace.filter((sample) => sample.group);
+  const openIntermediateOpacity = new Set(
+    mountedOpenFrames
+      .map((sample) => sample.group.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const openIntermediateCountHeights = new Set(
+    mountedOpenFrames
+      .map((sample) => sample.count.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  const openIntermediateClearHeights = new Set(
+    mountedOpenFrames
+      .map((sample) => sample.clear.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  assert(
+    mountedOpenFrames[0]?.group.opacity <= 0.05,
+    `click-open mounts at the transition origin (${mountedOpenFrames[0]?.group.opacity ?? "missing"})`,
+  );
+  console.log(
+    `  [notification click-open] distinct intermediate frames=${openIntermediateOpacity.size}`,
+  );
+  assert(
+    openIntermediateOpacity.size >= 2 &&
+      openIntermediateCountHeights.size >= 2 &&
+      openIntermediateClearHeights.size >= 2,
+    `click-open produces intermediate group/count/clear frames (${openIntermediateOpacity.size}/${openIntermediateCountHeights.size}/${openIntermediateClearHeights.size})`,
+  );
+  assert(
+    mountedOpenFrames[0]?.group.duration.includes("0.22s") &&
+      mountedOpenFrames[0]?.count.duration.includes("0.22s") &&
+      mountedOpenFrames[0]?.clear.duration.includes("0.22s"),
+    `click-open uses one 220ms group/count/clear settle (${JSON.stringify(mountedOpenFrames[0] ?? null)})`,
+  );
+  assert(
+    mountedOpenFrames.every(
+      (sample) => sample.group.zIndex === "1" && sample.count.zIndex === "0",
+    ),
+    "click-open keeps notification cards above the fading count label",
+  );
+  assert(
+    mountedOpenFrames.every(
+      (sample, index) =>
+        index === 0 ||
+        sample.group.opacity + 0.02 >=
+          mountedOpenFrames[index - 1].group.opacity,
+    ),
+    "click-open opacity advances monotonically",
+  );
+  assert(
+    mountedOpenFrames.at(-1)?.group.opacity >= 0.98 &&
+      mountedOpenFrames.at(-1)?.count.height < 0.75 &&
+      mountedOpenFrames.at(-1)?.clear.height > 31,
+    "click-open settles with the group visible and count/clear slots exchanged",
+  );
+
+  const notificationCenterBox = await notificationCenter.boundingBox();
+  const notificationListBox = await notificationCenter
+    .getByTestId("home-notification-list")
+    .boundingBox();
+  if (!notificationCenterBox || !notificationListBox) {
+    throw new Error("missing notification motion geometry");
+  }
+  const emptyLaneX = notificationCenterBox.x + notificationCenterBox.width / 2;
+  const emptyLaneStartY =
+    notificationCenterBox.y + notificationCenterBox.height - 60;
+  assert(
+    emptyLaneStartY > notificationListBox.y + notificationListBox.height + 8,
+    "mouse collapse starts below the notification list",
+  );
+  const emptyLaneHitsList = await notificationMotion.evaluate(
+    ({ x, y }) => {
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const target = document.elementFromPoint(x, y);
+      return Boolean(list && target && list.contains(target));
+    },
+    { x: emptyLaneX, y: emptyLaneStartY },
+  );
+  assert(!emptyLaneHitsList, "empty-region drag hit-tests outside the list");
+
+  const emptyTouchLaneSelector =
+    '[data-testid="notification-empty-touch-lane"]';
+  await notificationMotion.evaluate(
+    ({ x, y }) => {
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      if (!(center instanceof HTMLElement)) {
+        throw new Error("missing notification touch-lane center");
+      }
+      const bounds = center.getBoundingClientRect();
+      const target = document.createElement("div");
+      target.dataset.testid = "notification-empty-touch-lane";
+      Object.assign(target.style, {
+        position: "absolute",
+        left: `${x - bounds.left - 12}px`,
+        top: `${y - bounds.top - 12}px`,
+        width: "24px",
+        height: "24px",
+        zIndex: "50",
+      });
+      center.append(target);
+    },
+    { x: emptyLaneX, y: emptyLaneStartY },
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_CLOSE_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const count = document.querySelector(
+        '[data-testid="notifications-count"]',
+      );
+      const clear = document.querySelector("[data-notification-clear-slot]");
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      const groupLayer = group?.closest("[data-notification-group]");
+      window.__ELIZA_NOTIFICATION_CLOSE_TRACE__.push({
+        t: performance.now() - startedAt,
+        mode: list?.getAttribute("data-shade-mode"),
+        count: count
+          ? {
+              top: count.getBoundingClientRect().top,
+              height: count.getBoundingClientRect().height,
+              opacity: Number.parseFloat(getComputedStyle(count).opacity),
+              duration: getComputedStyle(count).transitionDuration,
+              zIndex: getComputedStyle(count).zIndex,
+            }
+          : null,
+        clear: clear
+          ? {
+              height: clear.getBoundingClientRect().height,
+              opacity: Number.parseFloat(getComputedStyle(clear).opacity),
+              duration: getComputedStyle(clear).transitionDuration,
+            }
+          : null,
+        group: group
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(group).opacity),
+              duration: getComputedStyle(group).transitionDuration,
+              zIndex: groupLayer
+                ? getComputedStyle(groupLayer).zIndex
+                : null,
+            }
+          : null,
+      });
+      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  });
+
+  await notificationCenter.getByTestId("notifications-collapse").click();
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-settling")) !== null,
+    "notification shade exposes its committed close settle",
+  );
+  const closeRaceState = await notificationMotion.evaluate(
+    ({ x, y }) => {
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const target = document.elementFromPoint(x, y);
+      if (!(center instanceof HTMLElement) || !(target instanceof Element)) {
+        throw new Error("missing notification close-race target");
+      }
+      const dispatchGesture = (pointerId, endY) => {
+        target.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            cancelable: true,
+            pointerType: "mouse",
+            pointerId,
+            isPrimary: true,
+            buttons: 1,
+            clientX: x,
+            clientY: y,
+          }),
+        );
+        target.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            pointerType: "mouse",
+            pointerId,
+            isPrimary: true,
+            buttons: 1,
+            clientX: x,
+            clientY: endY,
+          }),
+        );
+        target.dispatchEvent(
+          new PointerEvent("pointerup", {
+            bubbles: true,
+            cancelable: true,
+            pointerType: "mouse",
+            pointerId,
+            isPrimary: true,
+            clientX: x,
+            clientY: endY,
+          }),
+        );
+      };
+      dispatchGesture(71, y - 30);
+      dispatchGesture(72, y - 160);
+      return {
+        mode: list?.getAttribute("data-shade-mode"),
+        settling: list?.hasAttribute("data-shade-settling"),
+        dragging: list?.hasAttribute("data-shade-dragging"),
+        cancelling: center.hasAttribute(
+          "data-notification-shade-cancelling",
+        ),
+      };
+    },
+    { x: emptyLaneX, y: emptyLaneStartY },
+  );
+  assert(
+    closeRaceState.mode === "expanded" &&
+      closeRaceState.settling &&
+      !closeRaceState.dragging &&
+      !closeRaceState.cancelling,
+    `empty-region swipes cannot interrupt a committed close (${JSON.stringify(closeRaceState)})`,
+  );
+  await notificationMotion.waitForTimeout(460);
+  const closeTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_CLOSE_TRACE__,
+  );
+  const mountedCloseFrames = closeTrace.filter(
+    (sample) => sample.count && sample.clear && sample.group,
+  );
+  const closeIntermediateCountHeights = new Set(
+    closeTrace
+      .map((sample) => sample.count?.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  const closeIntermediateClearHeights = new Set(
+    mountedCloseFrames
+      .map((sample) => sample.clear.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  const closeIntermediateGroupOpacity = new Set(
+    mountedCloseFrames
+      .map((sample) => sample.group.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const visibleCloseCountFrames = closeTrace.filter(
+    (sample) => sample.count && sample.count.height > 0.75,
+  );
+  const closeCountTops = visibleCloseCountFrames.map(
+    (sample) => sample.count.top,
+  );
+  const closeMaxUpwardStep = Math.max(
+    0,
+    ...closeCountTops.slice(1).map((top, index) => closeCountTops[index] - top),
+  );
+  const closeMaxDownwardStep = Math.max(
+    0,
+    ...closeCountTops.slice(1).map((top, index) => top - closeCountTops[index]),
+  );
+  const closeFinalTop = closeCountTops.at(-1) ?? Number.POSITIVE_INFINITY;
+  const closeMinTop = Math.min(...closeCountTops);
+  console.log(
+    `  [notification click-close] intermediate=${closeIntermediateCountHeights.size}/${closeIntermediateClearHeights.size}/${closeIntermediateGroupOpacity.size} max-up=${closeMaxUpwardStep.toFixed(2)}px max-down=${closeMaxDownwardStep.toFixed(2)}px`,
+  );
+  assert(
+    closeIntermediateCountHeights.size >= 2 &&
+      closeIntermediateClearHeights.size >= 2 &&
+      closeIntermediateGroupOpacity.size >= 2,
+    `click-close produces intermediate count/clear/group frames (${closeIntermediateCountHeights.size}/${closeIntermediateClearHeights.size}/${closeIntermediateGroupOpacity.size})`,
+  );
+  assert(
+    mountedCloseFrames[0]?.count.duration.includes("0.22s") &&
+      mountedCloseFrames[0]?.clear.duration.includes("0.22s") &&
+      mountedCloseFrames[0]?.group.duration.includes("0.22s"),
+    `click-close uses one 220ms count/clear/group settle (${JSON.stringify(mountedCloseFrames[0] ?? null)})`,
+  );
+  assert(
+    mountedCloseFrames.every(
+      (sample) => sample.group.zIndex === "1" && sample.count.zIndex === "0",
+    ),
+    "click-close keeps notification cards above the fading count label",
+  );
+  assert(
+    closeMaxUpwardStep < 12 &&
+      closeMaxDownwardStep < 1.5 &&
+      closeFinalTop - closeMinTop < 1,
+    `notification count reaches its rested top monotonically without a jump or bounce (${JSON.stringify({ closeMaxUpwardStep, closeMaxDownwardStep, closeFinalTop, closeMinTop })})`,
+  );
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "the original close clock completes after rejected empty-region swipes",
+  );
+  await notificationCenter.getByTestId("notifications-count-button").click();
+  await notificationMotion.waitForTimeout(300);
+
+  await notificationMotion.mouse.move(emptyLaneX, emptyLaneStartY);
+  await notificationMotion.mouse.down();
+  await notificationMotion.mouse.move(emptyLaneX, emptyLaneStartY - 160, {
+    steps: 12,
+  });
+  await notificationMotion.mouse.up();
+  await notificationMotion.waitForTimeout(280);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "mouse swipe-up from the empty notification region collapses the shade",
+  );
+  await notificationCenter.getByTestId("notifications-count-button").click();
+  await notificationMotion.waitForTimeout(300);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "expanded",
+    "notification shade reopens before the real-touch collapse",
+  );
+
+  await touchSwipe(
+    notificationMotion,
+    emptyTouchLaneSelector,
+    0,
+    -160,
+    { steps: 12, stepDelayMs: 12 },
+  );
+  await notificationMotion.waitForTimeout(280);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "real CDP touch swipe-up from the empty notification region collapses the shade",
+  );
+  await notificationCenter.getByTestId("notifications-count-button").click();
+  await notificationMotion.waitForTimeout(300);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "expanded",
+    "notification shade reopens before the stack fan trace",
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_FAN_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const controls = document.querySelector(
+        '[data-testid="notification-stack-controls"]',
+      );
+      const rows = Array.from(
+        document.querySelectorAll("[data-notification-disposable-row]"),
+      );
+      const peeks = Array.from(
+        document.querySelectorAll("[data-notification-stack-peek]"),
+      );
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      window.__ELIZA_NOTIFICATION_FAN_TRACE__.push({
+        t: performance.now() - startedAt,
+        group: group
+          ? {
+              height: group.getBoundingClientRect().height,
+              paddingBottom: Number.parseFloat(
+                getComputedStyle(group).paddingBottom,
+              ),
+            }
+          : null,
+        controls: controls
+          ? {
+              height: controls.getBoundingClientRect().height,
+              opacity: Number.parseFloat(getComputedStyle(controls).opacity),
+              duration: getComputedStyle(controls).transitionDuration,
+            }
+          : null,
+        rows: rows.map((row) => ({
+          height: row.getBoundingClientRect().height,
+          opacity: Number.parseFloat(getComputedStyle(row).opacity),
+        })),
+        peeks: peeks.map((peek) =>
+          Number.parseFloat(getComputedStyle(peek).opacity),
+        ),
+      });
+      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+    };
+    const stackButton = document.querySelector(
+      '[data-testid="notification-row"]',
+    );
+    if (!(stackButton instanceof HTMLButtonElement)) {
+      throw new Error("missing notification stack button");
+    }
+    stackButton.click();
+    requestAnimationFrame(sample);
+  });
+  await notificationMotion.waitForTimeout(460);
+  const fanTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_FAN_TRACE__,
+  );
+  const mountedFanFrames = fanTrace.filter((sample) => sample.controls);
+  const fanIntermediateOpacity = new Set(
+    mountedFanFrames
+      .map((sample) => sample.controls.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const fanIntermediateRowOpacity = new Set(
+    mountedFanFrames
+      .flatMap((sample) => sample.rows.map((row) => row.opacity))
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const fanIntermediatePeekOpacity = new Set(
+    mountedFanFrames
+      .flatMap((sample) => sample.peeks)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  assert(
+    mountedFanFrames[0]?.controls.height < 1 &&
+      mountedFanFrames[0]?.controls.opacity <= 0.05 &&
+      mountedFanFrames[0]?.peeks.length === 2 &&
+      mountedFanFrames[0]?.peeks.every((opacity) => opacity >= 0.98) &&
+      mountedFanFrames[0]?.group.paddingBottom >= 23,
+    "stack fan mounts controls and rows from collapsed geometry",
+  );
+  console.log(
+    `  [notification stack fan] distinct intermediate frames=${fanIntermediateOpacity.size}`,
+  );
+  assert(
+    fanIntermediateOpacity.size >= 2 &&
+      fanIntermediateRowOpacity.size >= 2 &&
+      fanIntermediatePeekOpacity.size >= 2,
+    `stack fan produces intermediate control/row/peek frames (${fanIntermediateOpacity.size}/${fanIntermediateRowOpacity.size}/${fanIntermediatePeekOpacity.size})`,
+  );
+  assert(
+    mountedFanFrames[0]?.controls.duration.includes("0.3s"),
+    `stack fan uses the balanced 300ms settle (${mountedFanFrames[0]?.controls.duration ?? "missing"})`,
+  );
+  assert(
+    mountedFanFrames.every(
+      (sample, index) =>
+        index === 0 ||
+        sample.controls.opacity + 0.02 >=
+          mountedFanFrames[index - 1].controls.opacity,
+    ) &&
+      mountedFanFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.group.height + 1 >= mountedFanFrames[index - 1].group.height,
+      ) &&
+      mountedFanFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.peeks.every(
+            (opacity, peekIndex) =>
+              opacity <=
+              (mountedFanFrames[index - 1].peeks[peekIndex] ?? opacity) + 0.02,
+          ),
+      ),
+    "stack fan geometry advances monotonically while its peeks fade",
+  );
+  assert(
+    mountedFanFrames.at(-1)?.controls.height > 35 &&
+      mountedFanFrames.at(-1)?.controls.opacity >= 0.98 &&
+      mountedFanFrames.at(-1)?.rows.length === 2 &&
+      mountedFanFrames.at(-1)?.peeks.length === 2 &&
+      mountedFanFrames.at(-1)?.peeks.every((opacity) => opacity <= 0.02) &&
+      Math.abs(mountedFanFrames.at(-1)?.group.paddingBottom - 16) < 0.75,
+    "stack fan settles with controls and both folded rows visible",
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_FOLD_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const controls = document.querySelector(
+        '[data-testid="notification-stack-controls"]',
+      );
+      const rows = Array.from(
+        document.querySelectorAll("[data-notification-disposable-row]"),
+      );
+      const peeks = Array.from(
+        document.querySelectorAll("[data-notification-stack-peek]"),
+      );
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      const frontRow = group?.querySelector("[data-notif-row]");
+      const restControl =
+        document.querySelector('[data-testid="notifications-count"]') ??
+        document.querySelector("[data-notification-collapse-footer]");
+      const groupRect = group?.getBoundingClientRect();
+      const frontRowRect = frontRow?.getBoundingClientRect();
+      const groupShell = group?.closest("[data-notification-group]");
+      const runningAnimations = (
+        groupShell?.getAnimations({ subtree: true }) ?? []
+      )
+        .filter((animation) => {
+          if (animation.playState !== "running") return false;
+          const duration = animation.effect?.getComputedTiming().duration;
+          return (
+            typeof duration === "number" &&
+            duration > 16 &&
+            ("transitionProperty" in animation ||
+              !("animationName" in animation))
+          );
+        })
+        .map((animation) => {
+          const target =
+            animation.effect instanceof KeyframeEffect
+              ? animation.effect.target
+              : null;
+          return {
+            type: animation.constructor.name,
+            property:
+              "transitionProperty" in animation
+                ? animation.transitionProperty
+                : null,
+            target:
+              target instanceof Element
+                ? target.getAttribute("data-testid") || target.className
+                : null,
+          };
+        });
+      window.__ELIZA_NOTIFICATION_FOLD_TRACE__.push({
+        t: performance.now() - startedAt,
+        group: groupRect
+          ? { top: groupRect.top, height: groupRect.height }
+          : null,
+        frontRow: frontRowRect
+          ? { top: frontRowRect.top, height: frontRowRect.height }
+          : null,
+        restControlTop: restControl?.getBoundingClientRect().top ?? null,
+        runningAnimations,
+        controls: controls
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(controls).opacity),
+              duration: getComputedStyle(controls).transitionDuration,
+              timing: getComputedStyle(controls).transitionTimingFunction,
+            }
+          : null,
+        rows: rows.map((row) =>
+          Number.parseFloat(getComputedStyle(row).opacity),
+        ),
+        peeks: peeks.map((peek) =>
+          Number.parseFloat(getComputedStyle(peek).opacity),
+        ),
+        peekTops: peeks.map((peek) => peek.getBoundingClientRect().top),
+      });
+      if (performance.now() - startedAt < 760) requestAnimationFrame(sample);
+    };
+    const showLess = document.querySelector(
+      '[data-testid="notification-stack-collapse"]',
+    );
+    if (!(showLess instanceof HTMLButtonElement)) {
+      throw new Error("missing Show Less control");
+    }
+    showLess.click();
+    requestAnimationFrame(sample);
+  });
+  await notificationMotion.waitForTimeout(800);
+  const foldTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_FOLD_TRACE__,
+  );
+  const mountedFoldFrames = foldTrace.filter((sample) => sample.controls);
+  const foldIntermediateControlOpacity = new Set(
+    mountedFoldFrames
+      .map((sample) => sample.controls.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const foldIntermediateRowOpacity = new Set(
+    mountedFoldFrames
+      .flatMap((sample) => sample.rows)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const foldIntermediatePeekOpacity = new Set(
+    mountedFoldFrames
+      .flatMap((sample) => sample.peeks)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  assert(
+    mountedFoldFrames[0]?.controls.duration.includes("0.34s"),
+    `stack fold uses the 340ms settle (${mountedFoldFrames[0]?.controls.duration ?? "missing"})`,
+  );
+  const foldTimingFunctions = new Set(
+    (mountedFoldFrames[0]?.controls.timing ?? "")
+      .split(",")
+      .map((timing) => timing.trim())
+      .filter(Boolean),
+  );
+  assert(
+    foldTimingFunctions.size === 1 && foldTimingFunctions.has("ease"),
+    `stack fold geometry and opacity share one ease curve (${mountedFoldFrames[0]?.controls.timing ?? "missing"})`,
+  );
+  assert(
+    foldIntermediateControlOpacity.size >= 3 &&
+      foldIntermediateRowOpacity.size >= 3 &&
+      foldIntermediatePeekOpacity.size >= 3,
+    `stack fold produces intermediate control/row/peek frames (${foldIntermediateControlOpacity.size}/${foldIntermediateRowOpacity.size}/${foldIntermediatePeekOpacity.size})`,
+  );
+  assert(
+    mountedFoldFrames.every(
+      (sample, index) =>
+        index === 0 ||
+        sample.controls.opacity <=
+          mountedFoldFrames[index - 1].controls.opacity + 0.02,
+    ) &&
+      mountedFoldFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.group.height <= mountedFoldFrames[index - 1].group.height + 1,
+      ) &&
+      mountedFoldFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.peeks.every(
+            (opacity, peekIndex) =>
+              opacity + 0.02 >=
+              (mountedFoldFrames[index - 1].peeks[peekIndex] ?? opacity),
+          ),
+      ),
+    "stack fold geometry converges monotonically while its peeks return",
+  );
+  const settledFoldFrames = foldTrace.filter(
+    (sample) =>
+      sample.t >= 380 &&
+      !sample.controls &&
+      sample.group &&
+      sample.frontRow &&
+      sample.restControlTop !== null &&
+      sample.peekTops.length === 2,
+  );
+  const settledFoldAnchor = settledFoldFrames[0];
+  const foldTailDrift = settledFoldAnchor
+    ? Math.max(
+        ...settledFoldFrames.flatMap((sample) => [
+          Math.abs(sample.group.top - settledFoldAnchor.group.top),
+          Math.abs(sample.group.height - settledFoldAnchor.group.height),
+          Math.abs(sample.frontRow.top - settledFoldAnchor.frontRow.top),
+          Math.abs(sample.frontRow.height - settledFoldAnchor.frontRow.height),
+          Math.abs(
+            sample.restControlTop - settledFoldAnchor.restControlTop,
+          ),
+          ...sample.peekTops.map((top, index) =>
+            Math.abs(top - settledFoldAnchor.peekTops[index]),
+          ),
+        ]),
+      )
+    : Number.POSITIVE_INFINITY;
+  console.log(
+    `  [notification stack fold tail] frames=${settledFoldFrames.length} max-drift=${foldTailDrift.toFixed(2)}px`,
+  );
+  assert(
+    settledFoldFrames.length >= 20 &&
+      foldTailDrift <= 0.5 &&
+      settledFoldFrames.every(
+        (sample) => sample.runningAnimations.length === 0,
+      ),
+    `stack fold has no second-phase animation or layout tail after its 340ms settle (${settledFoldFrames.length} frames, ${foldTailDrift.toFixed(2)}px drift, ${JSON.stringify(settledFoldFrames.find((sample) => sample.runningAnimations.length > 0)?.runningAnimations ?? [])})`,
+  );
+  assert(
+    (await notificationCenter
+      .getByTestId("notification-stack-collapse")
+      .count()) === 0 &&
+      (await notificationCenter.getByTestId("notification-stack").count()) ===
+        1 &&
+      (await notificationCenter
+        .getByTestId("notification-stack-peek")
+        .count()) === 2,
+    "stack fold settles as one front card with two physical peeks",
+  );
+  await notificationCenter.getByTestId("notifications-collapse").click();
+  await notificationMotion.waitForTimeout(280);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "stack fold and collapse controls restore the rested shade",
+  );
+
+  const restedCountTop = (
+    await notificationCenter.getByTestId("notifications-count").boundingBox()
+  )?.y;
+  if (restedCountTop === undefined) {
+    throw new Error("missing cancelled-pull geometry");
+  }
+  const cancelledTouchPull = await touchDragHold(
+    notificationMotion,
+    '[data-testid="home-notification-list"]',
+    0,
+    48,
+    { steps: 6, stepDelayMs: 16 },
+  );
+  await notificationMotion.waitForTimeout(32);
+  const heldCountTop = (
+    await notificationCenter.getByTestId("notifications-count").boundingBox()
+  )?.y;
+  await notificationMotion.evaluate((restTop) => {
+    window.__ELIZA_NOTIFICATION_CANCEL_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const count = document.querySelector('[data-testid="notifications-count"]');
+      const quietGroup = document.querySelector(
+        "[data-notification-pull-reveal]",
+      );
+      const clearSlot = document.querySelector(
+        "[data-notification-clear-slot]",
+      );
+      const clearButton = document.querySelector(
+        '[data-testid="notifications-clear-all"]',
+      );
+      const collapseFooter = document.querySelector(
+        "[data-notification-collapse-footer]",
+      );
+      if (count) {
+        window.__ELIZA_NOTIFICATION_CANCEL_TRACE__.push({
+          t: performance.now() - startedAt,
+          offset: count.getBoundingClientRect().top - restTop,
+          quietOpacity: quietGroup
+            ? Number.parseFloat(getComputedStyle(quietGroup).opacity)
+            : null,
+          clearMounted: Boolean(clearButton),
+          clearOpacity: clearSlot
+            ? Number.parseFloat(getComputedStyle(clearSlot).opacity)
+            : null,
+          collapseMounted: Boolean(collapseFooter),
+          collapseOpacity: collapseFooter
+            ? Number.parseFloat(getComputedStyle(collapseFooter).opacity)
+            : null,
+        });
+      }
+      if (performance.now() - startedAt < 430) requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  }, restedCountTop);
+  const heldDirectManipulation = await notificationMotion.evaluate(() => {
+    const quietGroup = document.querySelector(
+      "[data-notification-pull-reveal]",
+    );
+    const collapseFooter = document.querySelector(
+      "[data-notification-collapse-footer]",
+    );
+    return {
+      quietDuration: quietGroup
+        ? getComputedStyle(quietGroup).transitionDuration
+        : "missing",
+      collapseDuration: collapseFooter
+        ? getComputedStyle(collapseFooter).transitionDuration
+        : "missing",
+    };
+  });
+  assert(
+    heldDirectManipulation.quietDuration === "0s" &&
+      heldDirectManipulation.collapseDuration === "0s",
+    `active pull surfaces track the pointer without easing (${JSON.stringify(heldDirectManipulation)})`,
+  );
+  await cancelledTouchPull.release();
+  const cancelStyle = await notificationMotion.evaluate(() => {
+    const center = document.querySelector(
+      '[data-testid="home-notification-center"]',
+    );
+    const count = document.querySelector('[data-testid="notifications-count"]');
+    const quietGroup = document.querySelector(
+      "[data-notification-pull-reveal]",
+    );
+    const clearButton = document.querySelector(
+      '[data-testid="notifications-clear-all"]',
+    );
+    const collapseFooter = document.querySelector(
+      "[data-notification-collapse-footer]",
+    );
+    return {
+      active: center?.hasAttribute("data-notification-shade-cancelling"),
+      duration: count ? getComputedStyle(count).transitionDuration : "",
+      quietMounted: Boolean(quietGroup),
+      quietDuration: quietGroup
+        ? getComputedStyle(quietGroup).transitionDuration
+        : "",
+      clearMounted: Boolean(clearButton),
+      collapseMounted: Boolean(collapseFooter),
+      collapseDuration: collapseFooter
+        ? getComputedStyle(collapseFooter).transitionDuration
+        : "",
+    };
+  });
+  await notificationMotion.waitForTimeout(450);
+  const cancelTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_CANCEL_TRACE__,
+  );
+  const heldOffset = (heldCountTop ?? restedCountTop) - restedCountTop;
+  const cancelAt100 = cancelTrace.find((sample) => sample.t >= 100);
+  assert(
+    cancelStyle.active &&
+      cancelStyle.duration.includes("0.34s") &&
+      cancelStyle.quietMounted &&
+      cancelStyle.quietDuration.includes("0.34s") &&
+      cancelStyle.clearMounted &&
+      cancelStyle.collapseMounted &&
+      cancelStyle.collapseDuration.includes("0.34s"),
+    `cancelled pull keeps every preview surface on the softer 340ms settle (${JSON.stringify(cancelStyle)})`,
+  );
+  assert(
+    Math.abs(cancelAt100?.offset ?? 0) > Math.abs(heldOffset) * 0.1,
+    "cancelled pull remains visibly in flight after 100ms",
+  );
+  assert(
+    (cancelAt100?.quietOpacity ?? 0) > 0.01 &&
+      cancelAt100?.clearMounted === true &&
+      (cancelAt100?.clearOpacity ?? 0) > 0.01 &&
+      cancelAt100?.collapseMounted === true &&
+      (cancelAt100?.collapseOpacity ?? 0) > 0.01,
+    "quiet group, clear control, and collapse footer remain visibly in flight after 100ms",
+  );
+  assert(
+    Math.abs(cancelTrace.at(-1)?.offset ?? Number.POSITIVE_INFINITY) < 0.75,
+    "cancelled pull settles exactly back at rest",
+  );
+  assert(
+    cancelTrace.at(-1)?.quietOpacity === null &&
+      cancelTrace.at(-1)?.clearMounted === false &&
+      cancelTrace.at(-1)?.collapseMounted === false,
+    "cancelled pull unmounts preview-only surfaces only after the settle completes",
+  );
+
+  await notificationMotion.emulateMedia({ reducedMotion: "reduce" });
+  await notificationMotion.waitForFunction(() =>
+    document
+      .querySelector('[data-testid="home-notification-center"]')
+      ?.hasAttribute("data-notification-reduced-motion"),
+  );
+  const reducedCountButton = notificationCenter.getByTestId(
+    "notifications-count-button",
+  );
+  await reducedCountButton.focus();
+  await notificationMotion.keyboard.press("Enter");
+  const reducedOpen = await notificationMotion.evaluate(() => {
+    const center = document.querySelector(
+      '[data-testid="home-notification-center"]',
+    );
+    const list = document.querySelector(
+      '[data-testid="home-notification-list"]',
+    );
+    const group = document.querySelector(
+      "[data-notification-group-content]",
+    );
+    const count = document.querySelector('[data-testid="notifications-count"]');
+    return {
+      mode: list?.getAttribute("data-shade-mode"),
+      groupOpacity: group
+        ? Number.parseFloat(getComputedStyle(group).opacity)
+        : -1,
+      groupDuration: group ? getComputedStyle(group).transitionDuration : "",
+      countHeight: count?.getBoundingClientRect().height ?? -1,
+      countDuration: count ? getComputedStyle(count).transitionDuration : "",
+      activeTestId: document.activeElement?.getAttribute("data-testid"),
+      materialRunningAnimations:
+        center instanceof Element
+          ? center
+              .getAnimations({ subtree: true })
+              .filter((animation) => {
+                const duration = animation.effect?.getComputedTiming().duration;
+                return (
+                  animation.playState === "running" &&
+                  typeof duration === "number" &&
+                  duration > 16
+                );
+              })
+              .map((animation) => {
+                const effect = animation.effect;
+                const target =
+                  effect instanceof KeyframeEffect ? effect.target : null;
+                return {
+                  duration: effect?.getComputedTiming().duration,
+                  name:
+                    "animationName" in animation
+                      ? animation.animationName
+                      : undefined,
+                  property:
+                    "transitionProperty" in animation
+                      ? animation.transitionProperty
+                      : undefined,
+                  target:
+                    target instanceof Element
+                      ? target.getAttribute("data-testid") || target.className
+                      : null,
+                };
+              })
+          : [],
+    };
+  });
+  assert(
+    reducedOpen.mode === "expanded" &&
+      reducedOpen.groupOpacity >= 0.98 &&
+      reducedOpen.countHeight < 0.75 &&
+      reducedOpen.groupDuration === "0s" &&
+      reducedOpen.countDuration === "0s" &&
+      reducedOpen.activeTestId === "notification-row" &&
+      reducedOpen.materialRunningAnimations.length === 0,
+    `reduced-motion click-open is immediate and hands keyboard focus to the first row (${JSON.stringify(reducedOpen)})`,
+  );
+  await notificationMotion.keyboard.press("Enter");
+  const reducedFan = await notificationMotion.evaluate(() => {
+    const center = document.querySelector(
+      '[data-testid="home-notification-center"]',
+    );
+    const controls = document.querySelector(
+      '[data-testid="notification-stack-controls"]',
+    );
+    const peeks = Array.from(
+      document.querySelectorAll("[data-notification-stack-peek]"),
+    );
+    return {
+      controlsHeight: controls?.getBoundingClientRect().height ?? -1,
+      controlsOpacity: controls
+        ? Number.parseFloat(getComputedStyle(controls).opacity)
+        : -1,
+      controlsDuration: controls
+        ? getComputedStyle(controls).transitionDuration
+        : "",
+      peekOpacities: peeks.map((peek) =>
+        Number.parseFloat(getComputedStyle(peek).opacity),
+      ),
+      activeTestId: document.activeElement?.getAttribute("data-testid"),
+      materialRunningAnimations:
+        center instanceof Element
+          ? center
+              .getAnimations({ subtree: true })
+              .filter((animation) => {
+                const duration = animation.effect?.getComputedTiming().duration;
+                return (
+                  animation.playState === "running" &&
+                  typeof duration === "number" &&
+                  duration > 16
+                );
+              })
+              .map((animation) => {
+                const effect = animation.effect;
+                const target =
+                  effect instanceof KeyframeEffect ? effect.target : null;
+                return {
+                  duration: effect?.getComputedTiming().duration,
+                  name:
+                    "animationName" in animation
+                      ? animation.animationName
+                      : undefined,
+                  property:
+                    "transitionProperty" in animation
+                      ? animation.transitionProperty
+                      : undefined,
+                  target:
+                    target instanceof Element
+                      ? target.getAttribute("data-testid") || target.className
+                      : null,
+                };
+              })
+          : [],
+    };
+  });
+  assert(
+    reducedFan.controlsHeight > 35 &&
+      reducedFan.controlsOpacity >= 0.98 &&
+      reducedFan.controlsDuration === "0s" &&
+      reducedFan.peekOpacities.length === 2 &&
+      reducedFan.peekOpacities.every((opacity) => opacity <= 0.02) &&
+      reducedFan.activeTestId === "notification-stack-collapse" &&
+      reducedFan.materialRunningAnimations.length === 0,
+    `reduced-motion stack fan is immediate and hands focus to Show Less (${JSON.stringify(reducedFan)})`,
+  );
+  await notificationMotion.keyboard.press("Enter");
+  const reducedFold = await notificationMotion.evaluate(() => ({
+    mode: document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode"),
+    stackControls: document.querySelectorAll(
+      '[data-testid="notification-stack-controls"]',
+    ).length,
+    activeTestId: document.activeElement?.getAttribute("data-testid"),
+  }));
+  assert(
+    reducedFold.mode === "expanded" &&
+      reducedFold.stackControls === 0 &&
+      reducedFold.activeTestId === "notification-row",
+    `reduced-motion stack fold immediately returns focus to its top row (${JSON.stringify(reducedFold)})`,
+  );
+  const reducedCollapse = notificationCenter.getByTestId(
+    "notifications-collapse",
+  );
+  await reducedCollapse.focus();
+  await notificationMotion.keyboard.press("Enter");
+  const reducedClose = await notificationMotion.evaluate(() => {
+    const list = document.querySelector(
+      '[data-testid="home-notification-list"]',
+    );
+    const count = document.querySelector('[data-testid="notifications-count"]');
+    const countButton = document.querySelector(
+      '[data-testid="notifications-count-button"]',
+    );
+    return {
+      mode: list?.getAttribute("data-shade-mode"),
+      countHeight: count?.getBoundingClientRect().height ?? -1,
+      expanded: countButton?.getAttribute("aria-expanded"),
+      collapseControls: document.querySelectorAll(
+        '[data-testid="notifications-collapse"]',
+      ).length,
+      activeTestId: document.activeElement?.getAttribute("data-testid"),
+    };
+  });
+  assert(
+    reducedClose.mode === "rested" &&
+      reducedClose.countHeight > 31 &&
+      reducedClose.expanded === "false" &&
+      reducedClose.collapseControls === 0 &&
+      reducedClose.activeTestId === "notifications-count-button",
+    `reduced-motion collapse commits DOM, ARIA, and reverse focus immediately (${JSON.stringify(reducedClose)})`,
+  );
+  await touchSwipe(
+    notificationMotion,
+    '[data-testid="home-notification-list"]',
+    0,
+    48,
+    {
+    steps: 6,
+      stepDelayMs: 8,
+    },
+  );
+  const reducedCancel = await notificationMotion.evaluate(() => ({
+    mode: document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode"),
+    cancelling: document
+      .querySelector('[data-testid="home-notification-center"]')
+      ?.hasAttribute("data-notification-shade-cancelling"),
+    previewGroups: document.querySelectorAll(
+      "[data-notification-pull-reveal]",
+    ).length,
+    clearControls: document.querySelectorAll(
+      '[data-testid="notifications-clear-all"]',
+    ).length,
+    collapseControls: document.querySelectorAll(
+      '[data-testid="notifications-collapse"]',
+    ).length,
+  }));
+  assert(
+    reducedCancel.mode === "rested" &&
+      reducedCancel.cancelling === false &&
+      reducedCancel.previewGroups === 0 &&
+      reducedCancel.clearControls === 0 &&
+      reducedCancel.collapseControls === 0,
+    `reduced-motion short pull resets preview DOM immediately (${JSON.stringify(reducedCancel)})`,
+  );
+  await notificationMotion.emulateMedia({ reducedMotion: "no-preference" });
+  await notificationMotion.waitForFunction(
+    () =>
+      !document
+        .querySelector('[data-testid="home-notification-center"]')
+        ?.hasAttribute("data-notification-reduced-motion"),
+  );
+  await notificationMotion.close();
+  await notificationMotionContext.close();
 
   // Measure the rail in a dedicated non-recording context. Video encoding is
   // intentionally excluded from the frame budget: the product never performs

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -52,6 +52,28 @@ const DROPPED_FRAME_EPSILON_MS = 0.5;
 const MIN_FRAME_SAMPLES = 30;
 const RAIL_SWIPE_ATTEMPTS = 3;
 const RAIL_SWIPE_CYCLES_PER_ATTEMPT = 3;
+const NOTIFICATION_SHADE_SETTLE_MS = 460;
+const NOTIFICATION_SHADE_MAX_SETTLE_MS = 600;
+const NOTIFICATION_SHADE_EASING =
+  "cubic-bezier(0.25, 0.1, 0.25, 1)";
+
+function splitTopLevelCssList(value) {
+  const items = [];
+  let current = "";
+  let depth = 0;
+  for (const character of value) {
+    if (character === "(") depth += 1;
+    if (character === ")") depth = Math.max(0, depth - 1);
+    if (character === "," && depth === 0) {
+      if (current.trim()) items.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  if (current.trim()) items.push(current.trim());
+  return items;
+}
 
 const here = dirname(fileURLToPath(import.meta.url));
 const outDir = join(here, "output-home");
@@ -1127,7 +1149,7 @@ try {
     "quiet notification stack starts folded behind the total",
   );
 
-  await notificationMotion.evaluate(() => {
+  await notificationMotion.evaluate((settleMs) => {
     window.__ELIZA_NOTIFICATION_OPEN_TRACE__ = [];
     const startedAt = performance.now();
     const sample = () => {
@@ -1165,7 +1187,7 @@ try {
             }
           : null,
       });
-      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+      if (performance.now() - startedAt < settleMs) requestAnimationFrame(sample);
     };
     const countButton = document.querySelector(
       '[data-testid="notifications-count-button"]',
@@ -1175,8 +1197,8 @@ try {
     }
     countButton.click();
     requestAnimationFrame(sample);
-  });
-  await notificationMotion.waitForTimeout(460);
+  }, NOTIFICATION_SHADE_SETTLE_MS);
+  await notificationMotion.waitForTimeout(NOTIFICATION_SHADE_SETTLE_MS);
   const openTrace = await notificationMotion.evaluate(
     () => window.__ELIZA_NOTIFICATION_OPEN_TRACE__,
   );
@@ -1213,10 +1235,10 @@ try {
     `click-open produces intermediate group/count/clear frames (${openIntermediateOpacity.size}/${openIntermediateCountHeights.size}/${openIntermediateClearHeights.size})`,
   );
   assert(
-    mountedOpenFrames[0]?.group.duration.includes("0.22s") &&
-      mountedOpenFrames[0]?.count.duration.includes("0.22s") &&
-      mountedOpenFrames[0]?.clear.duration.includes("0.22s"),
-    `click-open uses one 220ms group/count/clear settle (${JSON.stringify(mountedOpenFrames[0] ?? null)})`,
+    mountedOpenFrames[0]?.group.duration.includes("0.46s") &&
+      mountedOpenFrames[0]?.count.duration.includes("0.46s") &&
+      mountedOpenFrames[0]?.clear.duration.includes("0.46s"),
+    `click-open uses one 460ms group/count/clear settle (${JSON.stringify(mountedOpenFrames[0] ?? null)})`,
   );
   assert(
     mountedOpenFrames.every(
@@ -1292,7 +1314,7 @@ try {
     { x: emptyLaneX, y: emptyLaneStartY },
   );
 
-  await notificationMotion.evaluate(() => {
+  await notificationMotion.evaluate((settleMs) => {
     window.__ELIZA_NOTIFICATION_CLOSE_TRACE__ = [];
     const startedAt = performance.now();
     const sample = () => {
@@ -1336,10 +1358,10 @@ try {
             }
           : null,
       });
-      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+      if (performance.now() - startedAt < settleMs) requestAnimationFrame(sample);
     };
     requestAnimationFrame(sample);
-  });
+  }, NOTIFICATION_SHADE_SETTLE_MS);
 
   await notificationCenter.getByTestId("notifications-collapse").click();
   assert(
@@ -1417,7 +1439,7 @@ try {
       !closeRaceState.cancelling,
     `empty-region swipes cannot interrupt a committed close (${JSON.stringify(closeRaceState)})`,
   );
-  await notificationMotion.waitForTimeout(460);
+  await notificationMotion.waitForTimeout(NOTIFICATION_SHADE_SETTLE_MS);
   const closeTrace = await notificationMotion.evaluate(
     () => window.__ELIZA_NOTIFICATION_CLOSE_TRACE__,
   );
@@ -1468,10 +1490,10 @@ try {
     `click-close produces intermediate count/clear/group frames (${closeIntermediateCountHeights.size}/${closeIntermediateClearHeights.size}/${closeIntermediateGroupOpacity.size})`,
   );
   assert(
-    mountedCloseFrames[0]?.count.duration.includes("0.22s") &&
-      mountedCloseFrames[0]?.clear.duration.includes("0.22s") &&
-      mountedCloseFrames[0]?.group.duration.includes("0.22s"),
-    `click-close uses one 220ms count/clear/group settle (${JSON.stringify(mountedCloseFrames[0] ?? null)})`,
+    mountedCloseFrames[0]?.count.duration.includes("0.46s") &&
+      mountedCloseFrames[0]?.clear.duration.includes("0.46s") &&
+      mountedCloseFrames[0]?.group.duration.includes("0.46s"),
+    `click-close uses one 460ms count/clear/group settle (${JSON.stringify(mountedCloseFrames[0] ?? null)})`,
   );
   assert(
     mountedCloseFrames.every(
@@ -1501,7 +1523,11 @@ try {
     steps: 12,
   });
   await notificationMotion.mouse.up();
-  await notificationMotion.waitForTimeout(280);
+  await notificationMotion.waitForFunction(() =>
+    document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode") === "rested",
+  );
   assert(
     (await notificationCenter
       .getByTestId("home-notification-list")
@@ -1524,7 +1550,11 @@ try {
     -160,
     { steps: 12, stepDelayMs: 12 },
   );
-  await notificationMotion.waitForTimeout(280);
+  await notificationMotion.waitForFunction(() =>
+    document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode") === "rested",
+  );
   assert(
     (await notificationCenter
       .getByTestId("home-notification-list")
@@ -1786,13 +1816,11 @@ try {
     `stack fold uses the 340ms settle (${mountedFoldFrames[0]?.controls.duration ?? "missing"})`,
   );
   const foldTimingFunctions = new Set(
-    (mountedFoldFrames[0]?.controls.timing ?? "")
-      .split(",")
-      .map((timing) => timing.trim())
-      .filter(Boolean),
+    splitTopLevelCssList(mountedFoldFrames[0]?.controls.timing ?? ""),
   );
   assert(
-    foldTimingFunctions.size === 1 && foldTimingFunctions.has("ease"),
+    foldTimingFunctions.size === 1 &&
+      foldTimingFunctions.has(NOTIFICATION_SHADE_EASING),
     `stack fold geometry and opacity share one ease curve (${mountedFoldFrames[0]?.controls.timing ?? "missing"})`,
   );
   assert(
@@ -1873,7 +1901,11 @@ try {
     "stack fold settles as one front card with two physical peeks",
   );
   await notificationCenter.getByTestId("notifications-collapse").click();
-  await notificationMotion.waitForTimeout(280);
+  await notificationMotion.waitForFunction(() =>
+    document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode") === "rested",
+  );
   assert(
     (await notificationCenter
       .getByTestId("home-notification-list")
@@ -1898,7 +1930,7 @@ try {
   const heldCountTop = (
     await notificationCenter.getByTestId("notifications-count").boundingBox()
   )?.y;
-  await notificationMotion.evaluate((restTop) => {
+  await notificationMotion.evaluate(({ restTop, settleMaxMs }) => {
     window.__ELIZA_NOTIFICATION_CANCEL_TRACE__ = [];
     const startedAt = performance.now();
     const sample = () => {
@@ -1932,10 +1964,14 @@ try {
             : null,
         });
       }
-      if (performance.now() - startedAt < 430) requestAnimationFrame(sample);
+      if (performance.now() - startedAt < settleMaxMs)
+        requestAnimationFrame(sample);
     };
     requestAnimationFrame(sample);
-  }, restedCountTop);
+  }, {
+    restTop: restedCountTop,
+    settleMaxMs: NOTIFICATION_SHADE_MAX_SETTLE_MS,
+  });
   const heldDirectManipulation = await notificationMotion.evaluate(() => {
     const quietGroup = document.querySelector(
       "[data-notification-pull-reveal]",
@@ -1986,21 +2022,34 @@ try {
         : "",
     };
   });
-  await notificationMotion.waitForTimeout(450);
+  await notificationMotion.waitForFunction(() =>
+    !document
+      .querySelector('[data-testid="home-notification-center"]')
+      ?.hasAttribute("data-notification-shade-cancelling"),
+  );
   const cancelTrace = await notificationMotion.evaluate(
     () => window.__ELIZA_NOTIFICATION_CANCEL_TRACE__,
   );
   const heldOffset = (heldCountTop ?? restedCountTop) - restedCountTop;
   const cancelAt100 = cancelTrace.find((sample) => sample.t >= 100);
+  const cancelDurations = [
+    cancelStyle.duration,
+    cancelStyle.quietDuration,
+    cancelStyle.collapseDuration,
+  ].map((duration) => Number.parseFloat(duration.split(",")[0] ?? ""));
+  const cancelDurationSpread =
+    Math.max(...cancelDurations) - Math.min(...cancelDurations);
   assert(
     cancelStyle.active &&
-      cancelStyle.duration.includes("0.34s") &&
       cancelStyle.quietMounted &&
-      cancelStyle.quietDuration.includes("0.34s") &&
       cancelStyle.clearMounted &&
       cancelStyle.collapseMounted &&
-      cancelStyle.collapseDuration.includes("0.34s"),
-    `cancelled pull keeps every preview surface on the softer 340ms settle (${JSON.stringify(cancelStyle)})`,
+      cancelDurations.every(Number.isFinite) &&
+      Math.min(...cancelDurations) >= 0.32 &&
+      Math.max(...cancelDurations) <=
+        NOTIFICATION_SHADE_MAX_SETTLE_MS / 1_000 &&
+      cancelDurationSpread < 0.001,
+    `cancelled pull keeps every preview surface on one velocity-aware settle (${JSON.stringify({ cancelStyle, cancelDurations })})`,
   );
   assert(
     Math.abs(cancelAt100?.offset ?? 0) > Math.abs(heldOffset) * 0.1,

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -2590,6 +2590,9 @@ try {
       const clearLabel = clear?.querySelector(
         "[data-notification-clear-resting-label]",
       );
+      const clearConfirmingLabel = clear?.querySelector(
+        "[data-notification-clear-confirming-label]",
+      );
       const clearIcon = clear?.querySelector("svg");
       if (
         !(home instanceof HTMLElement) ||
@@ -2599,6 +2602,7 @@ try {
         !(secondary instanceof HTMLElement) ||
         !(clear instanceof HTMLElement) ||
         !(clearLabel instanceof HTMLElement) ||
+        !(clearConfirmingLabel instanceof HTMLElement) ||
         !(clearIcon instanceof SVGElement)
       ) {
         return null;
@@ -2632,6 +2636,11 @@ try {
         ),
         clear: {
           ...rect(clear),
+          confirming: clear.hasAttribute("data-confirming"),
+          confirmingLabel: clearConfirmingLabel.textContent,
+          confirmingLabelOpacity: Number.parseFloat(
+            getComputedStyle(clearConfirmingLabel).opacity,
+          ),
           labelOpacity: Number.parseFloat(
             getComputedStyle(clearLabel).opacity,
           ),
@@ -2672,12 +2681,38 @@ try {
       `overflowing expanded notifications scroll inside their available region (${JSON.stringify(initialExpandedGeometry.list)})`,
     );
     assert(
-      initialExpandedGeometry.clear.width >= 55 &&
-        initialExpandedGeometry.clear.labelOpacity >= 0.99 &&
-        initialExpandedGeometry.clear.iconOpacity <= 0.01,
-      `coarse-pointer clear control visibly rests as “Clear all” (${JSON.stringify(initialExpandedGeometry.clear)})`,
+      initialExpandedGeometry.clear.width <= 33 &&
+        initialExpandedGeometry.clear.labelOpacity <= 0.01 &&
+        initialExpandedGeometry.clear.iconOpacity >= 0.99 &&
+        !initialExpandedGeometry.clear.confirming,
+      `coarse-pointer clear control rests as a compact X (${JSON.stringify(initialExpandedGeometry.clear)})`,
     );
   }
+
+  await touchTap(
+    notificationGeometry,
+    '[data-testid="notifications-clear-all"]',
+  );
+  await notificationGeometry.waitForTimeout(220);
+  const armedCoarseClearGeometry = await readExpandedGeometry();
+  assert(
+    armedCoarseClearGeometry?.clear.confirming === true &&
+      armedCoarseClearGeometry.clear.confirmingLabel === "Clear all" &&
+      armedCoarseClearGeometry.clear.confirmingLabelOpacity >= 0.99 &&
+      armedCoarseClearGeometry.clear.width >= 63,
+    `coarse-pointer first tap reveals “Clear all” without adding a third step (${JSON.stringify(armedCoarseClearGeometry?.clear)})`,
+  );
+  await notificationGeometry.evaluate(() => {
+    document.body.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true }),
+    );
+  });
+  await notificationGeometry.waitForFunction(
+    () =>
+      !document
+        .querySelector('[data-testid="notifications-clear-all"]')
+        ?.hasAttribute("data-confirming"),
+  );
 
   await notificationGeometry.evaluate(
     () =>
@@ -2938,6 +2973,41 @@ try {
         Math.abs(clearRest.row.top - clearHover.row.top) <= 1 &&
         clearReturned.button.width <= 33,
       `desktop clear reveals leftward without shifting its slot or cards (${JSON.stringify({ clearRest, clearHover, clearReturned })})`,
+    );
+    await clear.click();
+    await desktop.waitForTimeout(220);
+    const desktopConfirmation = await clear.evaluate((button) => {
+      const label = button.querySelector(
+        "[data-notification-clear-confirming-label]",
+      );
+      return {
+        ariaLabel: button.getAttribute("aria-label"),
+        confirming: button.hasAttribute("data-confirming"),
+        label: label?.textContent,
+        labelOpacity:
+          label instanceof HTMLElement
+            ? Number.parseFloat(getComputedStyle(label).opacity)
+            : 0,
+      };
+    });
+    assert(
+      desktopConfirmation.confirming &&
+        desktopConfirmation.label === "Confirm?" &&
+        desktopConfirmation.labelOpacity >= 0.99 &&
+        desktopConfirmation.ariaLabel ===
+          "Confirm clear all notifications",
+      `desktop first click changes Clear all to an explicit Confirm? step (${JSON.stringify(desktopConfirmation)})`,
+    );
+    await desktop.evaluate(() => {
+      document.body.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true }),
+      );
+    });
+    await desktop.waitForFunction(
+      () =>
+        !document
+          .querySelector('[data-testid="notifications-clear-all"]')
+          ?.hasAttribute("data-confirming"),
     );
     await center.getByTestId("notifications-collapse").click();
     await center

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -1483,6 +1483,7 @@ try {
       .getAttribute("data-shade-mode")) === "rested",
     "the original close clock completes after rejected empty-region swipes",
   );
+
   await notificationCenter.getByTestId("notifications-count-button").click();
   await notificationMotion.waitForTimeout(300);
 
@@ -2249,8 +2250,443 @@ try {
         .querySelector('[data-testid="home-notification-center"]')
         ?.hasAttribute("data-notification-reduced-motion"),
   );
+
+  // Reload into a clean shade before the deep-pull marker trace. Keeping this
+  // proof isolated prevents its release-click suppression from changing the
+  // interaction sequence exercised above.
+  await notificationMotion.goto(`${url}?notificationMotion`);
+  await notificationCenter.waitFor({ state: "visible", timeout: 5000 });
+  await waitForHomeEnterSettled(notificationMotion);
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_DEEP_PULL_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const row = document.querySelector(".eliza-notif-row");
+      const glass = row?.querySelector(".eliza-notif-glass");
+      const rowStyle = row ? getComputedStyle(row) : null;
+      window.__ELIZA_NOTIFICATION_DEEP_PULL_TRACE__.push({
+        t: performance.now() - startedAt,
+        mode: list?.getAttribute("data-shade-mode"),
+        releaseSettling: list?.hasAttribute("data-shade-release-settling"),
+        row: rowStyle
+          ? {
+              animationName: rowStyle.animationName,
+              opacity: Number.parseFloat(rowStyle.opacity),
+              transform: rowStyle.transform,
+              backgroundColor: glass
+                ? getComputedStyle(glass).backgroundColor
+                : null,
+            }
+          : null,
+      });
+      if (performance.now() - startedAt < 1_000) requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  });
+  await touchSwipe(
+    notificationMotion,
+    '[data-testid="home-notification-list"]',
+    0,
+    420,
+    { steps: 12, stepDelayMs: 12 },
+  );
+  await notificationMotion.waitForTimeout(700);
+  const deepPullTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_DEEP_PULL_TRACE__,
+  );
+  const expandedDeepPullFrames = deepPullTrace.filter(
+    (sample) => sample.mode === "expanded" && sample.row,
+  );
+  const settledDeepPullFrames = expandedDeepPullFrames.filter(
+    (sample) => !sample.releaseSettling,
+  );
+  const expandedGlassColors = new Set(
+    expandedDeepPullFrames
+      .map((sample) => sample.row.backgroundColor)
+      .filter(Boolean),
+  );
+  assert(
+    expandedDeepPullFrames.some((sample) => sample.releaseSettling) &&
+      settledDeepPullFrames.length > 0,
+    "deep pull trace spans the release marker handoff",
+  );
+  assert(
+    expandedDeepPullFrames.every(
+      (sample) => sample.row.animationName === "none",
+    ),
+    "expanded notification rows never reactivate their view-timeline animation",
+  );
+  assert(
+    settledDeepPullFrames.every(
+      (sample) =>
+        sample.row.opacity >= 0.99 &&
+        (sample.row.transform === "none" ||
+          sample.row.transform === "matrix(1, 0, 0, 1, 0, 0)"),
+    ) && expandedGlassColors.size === 1,
+    `deep-pull marker clear preserves settled row opacity/transform/material (${JSON.stringify({ settledDeepPullFrames: settledDeepPullFrames.slice(-3), expandedGlassColors: [...expandedGlassColors] })})`,
+  );
   await notificationMotion.close();
   await notificationMotionContext.close();
+
+  // A short mobile viewport with enough independent producers to overflow
+  // proves the expanded shade consumes the column's live safe-bottom region.
+  // The home column owns the composer clearance, so the notification center
+  // must follow that boundary rather than introducing its own viewport cap.
+  const notificationGeometryContext = await browser.newContext({
+    viewport: { width: 393, height: 852 },
+    deviceScaleFactor: 2,
+    hasTouch: true,
+    isMobile: true,
+  });
+  const notificationGeometry = await notificationGeometryContext.newPage();
+  notificationGeometry.on("pageerror", (e) => sink.errors.push(String(e)));
+  await installCoarsePointerMedia(notificationGeometry);
+  await notificationGeometry.goto(`${url}?notificationOverflow`);
+  await notificationGeometry
+    .getByTestId("home-notification-center")
+    .waitFor({ state: "visible", timeout: 5000 });
+  await waitForHomeEnterSettled(notificationGeometry);
+
+  const readShadeLayoutGeometry = () =>
+    notificationGeometry.evaluate(() => {
+      const column = document.querySelector(
+        '[data-testid="home-content-column"]',
+      );
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const secondary = document.querySelector(
+        "[data-home-below-notifications]",
+      );
+      if (
+        !(column instanceof HTMLElement) ||
+        !(center instanceof HTMLElement) ||
+        !(list instanceof HTMLElement) ||
+        !(secondary instanceof HTMLElement)
+      ) {
+        return null;
+      }
+      return {
+        mode: list.getAttribute("data-shade-mode"),
+        preview: list.getAttribute("data-shade-preview"),
+        dragging: list.hasAttribute("data-shade-dragging"),
+        settling: list.hasAttribute("data-shade-settling"),
+        cancelling: center.hasAttribute(
+          "data-notification-shade-cancelling",
+        ),
+        columnBottom: column.getBoundingClientRect().bottom,
+        centerBottom: center.getBoundingClientRect().bottom,
+        secondary: {
+          height: secondary.getBoundingClientRect().height,
+          visibility: getComputedStyle(secondary).visibility,
+          transitionDuration: getComputedStyle(secondary).transitionDuration,
+        },
+        layoutDuration: column.style.getPropertyValue(
+          "--eliza-home-notification-settle-duration",
+        ),
+      };
+    });
+
+  // Holding a sub-threshold pull proves the preview receives the expanded
+  // runway before commit. Releasing it must reverse the same grid track while
+  // preview DOM is still mounted, with no second layout tail after cancellation.
+  const previewRestGeometry = await readShadeLayoutGeometry();
+  const previewListBox = await notificationGeometry
+    .getByTestId("home-notification-list")
+    .boundingBox();
+  assert(previewListBox !== null, "preview list geometry is measurable");
+  if (previewListBox) {
+    const previewX = previewListBox.x + previewListBox.width / 2;
+    const previewY = previewListBox.y + previewListBox.height / 2;
+    await notificationGeometry.mouse.move(previewX, previewY);
+    await notificationGeometry.mouse.down();
+    for (let step = 1; step <= 5; step += 1) {
+      await notificationGeometry.mouse.move(
+        previewX,
+        previewY + (30 * step) / 5,
+      );
+      await notificationGeometry.waitForTimeout(25);
+    }
+    await notificationGeometry.waitForTimeout(360);
+    const heldPreviewGeometry = await readShadeLayoutGeometry();
+    assert(
+      previewRestGeometry !== null &&
+        heldPreviewGeometry !== null &&
+        heldPreviewGeometry.preview === "expanding" &&
+        heldPreviewGeometry.dragging &&
+        heldPreviewGeometry.secondary.height <= 1 &&
+        heldPreviewGeometry.secondary.visibility === "hidden" &&
+        Math.abs(
+          heldPreviewGeometry.centerBottom - heldPreviewGeometry.columnBottom,
+        ) <= 2,
+      `active pull preview reaches the composer-safe boundary (${JSON.stringify({ previewRestGeometry, heldPreviewGeometry })})`,
+    );
+
+    await notificationGeometry.mouse.up();
+    const cancelStartGeometry = await readShadeLayoutGeometry();
+    await notificationGeometry.waitForTimeout(100);
+    const cancelMidGeometry = await readShadeLayoutGeometry();
+    const cancelDurationMs = Number.parseFloat(
+      cancelStartGeometry?.layoutDuration ?? "460",
+    );
+    await notificationGeometry.waitForTimeout(
+      Math.max(0, cancelDurationMs + 60 - 100),
+    );
+    const cancelSettledGeometry = await readShadeLayoutGeometry();
+    await notificationGeometry.waitForTimeout(220);
+    const cancelTailGeometry = await readShadeLayoutGeometry();
+    assert(
+      previewRestGeometry !== null &&
+        heldPreviewGeometry !== null &&
+        cancelStartGeometry !== null &&
+        cancelMidGeometry !== null &&
+        cancelSettledGeometry !== null &&
+        cancelTailGeometry !== null &&
+        cancelStartGeometry.mode === "rested" &&
+        cancelStartGeometry.preview === "expanding" &&
+        !cancelStartGeometry.dragging &&
+        cancelStartGeometry.cancelling &&
+        cancelMidGeometry.secondary.height >
+          heldPreviewGeometry.secondary.height + 1 &&
+        cancelSettledGeometry.preview === null &&
+        !cancelSettledGeometry.cancelling &&
+        Math.abs(
+          cancelSettledGeometry.secondary.height -
+            previewRestGeometry.secondary.height,
+        ) <= 1 &&
+        Math.abs(
+          cancelTailGeometry.secondary.height -
+            cancelSettledGeometry.secondary.height,
+        ) <= 1 &&
+        Math.abs(
+          cancelTailGeometry.centerBottom -
+            cancelSettledGeometry.centerBottom,
+        ) <= 1,
+      `cancelled pull reverses its layout on one settle clock (${JSON.stringify({ cancelStartGeometry, cancelMidGeometry, cancelSettledGeometry, cancelTailGeometry })})`,
+    );
+  }
+
+  await notificationGeometry
+    .getByTestId("notifications-count-button")
+    .click();
+  await notificationGeometry.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-testid="home-notification-list"]')
+        ?.getAttribute("data-shade-mode") === "expanded",
+  );
+  await notificationGeometry.waitForTimeout(520);
+
+  const readExpandedGeometry = () =>
+    notificationGeometry.evaluate(() => {
+      const home = document.querySelector('[data-testid="home-screen"]');
+      const column = document.querySelector(
+        '[data-testid="home-content-column"]',
+      );
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const secondary = document.querySelector(
+        "[data-home-below-notifications]",
+      );
+      const clear = document.querySelector(
+        '[data-testid="notifications-clear-all"]',
+      );
+      const clearLabel = clear?.querySelector(
+        "[data-notification-clear-resting-label]",
+      );
+      const clearIcon = clear?.querySelector("svg");
+      if (
+        !(home instanceof HTMLElement) ||
+        !(column instanceof HTMLElement) ||
+        !(center instanceof HTMLElement) ||
+        !(list instanceof HTMLElement) ||
+        !(secondary instanceof HTMLElement) ||
+        !(clear instanceof HTMLElement) ||
+        !(clearLabel instanceof HTMLElement) ||
+        !(clearIcon instanceof SVGElement)
+      ) {
+        return null;
+      }
+      const rect = (element) => {
+        const bounds = element.getBoundingClientRect();
+        return {
+          top: bounds.top,
+          right: bounds.right,
+          bottom: bounds.bottom,
+          left: bounds.left,
+          width: bounds.width,
+          height: bounds.height,
+        };
+      };
+      return {
+        home: rect(home),
+        column: rect(column),
+        center: rect(center),
+        list: {
+          ...rect(list),
+          clientHeight: list.clientHeight,
+          scrollHeight: list.scrollHeight,
+        },
+        secondary: {
+          ...rect(secondary),
+          visibility: getComputedStyle(secondary).visibility,
+        },
+        homePaddingBottom: Number.parseFloat(
+          getComputedStyle(home).paddingBottom,
+        ),
+        clear: {
+          ...rect(clear),
+          labelOpacity: Number.parseFloat(
+            getComputedStyle(clearLabel).opacity,
+          ),
+          iconOpacity: Number.parseFloat(getComputedStyle(clearIcon).opacity),
+        },
+      };
+    });
+
+  const initialExpandedGeometry = await readExpandedGeometry();
+  assert(
+    initialExpandedGeometry !== null,
+    "expanded overflow geometry is measurable",
+  );
+  if (initialExpandedGeometry) {
+    assert(
+      initialExpandedGeometry.secondary.height <= 1 &&
+        initialExpandedGeometry.secondary.visibility === "hidden",
+      `expanded shade folds secondary home content (${JSON.stringify(initialExpandedGeometry.secondary)})`,
+    );
+    assert(
+      Math.abs(
+        initialExpandedGeometry.center.bottom -
+          initialExpandedGeometry.column.bottom,
+      ) <= 2,
+      `expanded notification center reaches the composer-safe column bottom (${JSON.stringify({ centerBottom: initialExpandedGeometry.center.bottom, columnBottom: initialExpandedGeometry.column.bottom })})`,
+    );
+    assert(
+      Math.abs(
+        initialExpandedGeometry.column.bottom -
+          (initialExpandedGeometry.home.bottom -
+            initialExpandedGeometry.homePaddingBottom),
+      ) <= 2,
+      `home column ends at the live bottom clearance (${JSON.stringify({ homeBottom: initialExpandedGeometry.home.bottom, paddingBottom: initialExpandedGeometry.homePaddingBottom, columnBottom: initialExpandedGeometry.column.bottom })})`,
+    );
+    assert(
+      initialExpandedGeometry.list.scrollHeight >
+        initialExpandedGeometry.list.clientHeight + 2,
+      `overflowing expanded notifications scroll inside their available region (${JSON.stringify(initialExpandedGeometry.list)})`,
+    );
+    assert(
+      initialExpandedGeometry.clear.width >= 55 &&
+        initialExpandedGeometry.clear.labelOpacity >= 0.99 &&
+        initialExpandedGeometry.clear.iconOpacity <= 0.01,
+      `coarse-pointer clear control visibly rests as “Clear all” (${JSON.stringify(initialExpandedGeometry.clear)})`,
+    );
+  }
+
+  await notificationGeometry.evaluate(
+    () =>
+      document.documentElement.style.setProperty(
+        "--eliza-continuous-chat-clearance",
+        "7rem",
+      ),
+  );
+  await notificationGeometry.evaluate(
+    () =>
+      new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      ),
+  );
+  const adjustedExpandedGeometry = await readExpandedGeometry();
+  if (initialExpandedGeometry && adjustedExpandedGeometry) {
+    const expectedClearanceDelta = (7 - 5.25) * 16;
+    assert(
+      Math.abs(
+        initialExpandedGeometry.column.bottom -
+          adjustedExpandedGeometry.column.bottom -
+          expectedClearanceDelta,
+      ) <= 2 &&
+        Math.abs(
+          adjustedExpandedGeometry.center.bottom -
+            adjustedExpandedGeometry.column.bottom,
+        ) <= 2,
+      `expanded shade follows a live composer-clearance change (${JSON.stringify({ before: initialExpandedGeometry.column.bottom, after: adjustedExpandedGeometry.column.bottom, expectedClearanceDelta })})`,
+    );
+  }
+
+  const closeStartExpandedGeometry = await readShadeLayoutGeometry();
+  await notificationGeometry.getByTestId("notifications-collapse").click();
+  const closeStartGeometry = await readShadeLayoutGeometry();
+  await notificationGeometry.waitForTimeout(120);
+  const closeMidGeometry = await readShadeLayoutGeometry();
+  const closeDurationMs = Number.parseFloat(
+    closeStartGeometry?.layoutDuration ?? "460",
+  );
+  await notificationGeometry.waitForTimeout(
+    Math.max(0, closeDurationMs + 60 - 120),
+  );
+  const closeSettledGeometry = await readShadeLayoutGeometry();
+  await notificationGeometry.waitForTimeout(220);
+  const closeTailGeometry = await readShadeLayoutGeometry();
+  assert(
+    closeStartExpandedGeometry !== null &&
+      closeStartGeometry !== null &&
+      closeMidGeometry !== null &&
+      closeSettledGeometry !== null &&
+      closeTailGeometry !== null &&
+      closeStartGeometry.mode === "expanded" &&
+      closeStartGeometry.settling &&
+      closeMidGeometry.secondary.height >
+        closeStartGeometry.secondary.height + 1 &&
+      closeMidGeometry.centerBottom <
+        closeStartExpandedGeometry.centerBottom - 1 &&
+      closeSettledGeometry.mode === "rested" &&
+      !closeSettledGeometry.settling &&
+      Math.abs(
+        closeTailGeometry.secondary.height -
+          closeSettledGeometry.secondary.height,
+      ) <= 1 &&
+      Math.abs(
+        closeTailGeometry.centerBottom - closeSettledGeometry.centerBottom,
+      ) <= 1,
+    `committed close restores secondary content on the shade clock with no layout tail (${JSON.stringify({ closeStartGeometry, closeMidGeometry, closeSettledGeometry, closeTailGeometry })})`,
+  );
+
+  await notificationGeometry.goto(`${url}?notificationMotion`);
+  await notificationGeometry
+    .getByTestId("home-notification-center")
+    .waitFor({ state: "visible", timeout: 5000 });
+  await waitForHomeEnterSettled(notificationGeometry);
+  await notificationGeometry
+    .getByTestId("notifications-count-button")
+    .click();
+  await notificationGeometry.waitForTimeout(520);
+  const shortListGeometry = await notificationGeometry.evaluate(() => {
+    const list = document.querySelector(
+      '[data-testid="home-notification-list"]',
+    );
+    if (!(list instanceof HTMLElement)) return null;
+    return {
+      clientHeight: list.clientHeight,
+      scrollHeight: list.scrollHeight,
+    };
+  });
+  assert(
+    shortListGeometry !== null &&
+      shortListGeometry.scrollHeight <= shortListGeometry.clientHeight + 1,
+    `short expanded notification content does not create a false scroll range (${JSON.stringify(shortListGeometry)})`,
+  );
+  await notificationGeometry.close();
+  await notificationGeometryContext.close();
 
   // Measure the rail in a dedicated non-recording context. Video encoding is
   // intentionally excluded from the frame budget: the product never performs
@@ -2356,6 +2792,66 @@ try {
       (await center.getByTestId("notifications-clear-all").count()) === 1 &&
         (await center.getByTestId("notifications-collapse").count()) === 1,
       "desktop opens the same clear and collapse controls",
+    );
+    await desktop.waitForTimeout(520);
+    const clear = center.getByTestId("notifications-clear-all");
+    const readClearGeometry = () =>
+      clear.evaluate((button) => {
+        const label = button.querySelector(
+          "[data-notification-clear-resting-label]",
+        );
+        const icon = button.querySelector(
+          "[data-notification-clear-resting-icon]",
+        );
+        const slot = button.closest("[data-notification-clear-slot]");
+        const row = document.querySelector(
+          '[data-testid="notification-row"]',
+        );
+        if (
+          !(label instanceof HTMLElement) ||
+          !(icon instanceof SVGElement) ||
+          !(slot instanceof HTMLElement) ||
+          !(row instanceof HTMLElement)
+        ) {
+          return null;
+        }
+        const rect = (element) => {
+          const bounds = element.getBoundingClientRect();
+          return {
+            top: bounds.top,
+            right: bounds.right,
+            width: bounds.width,
+            height: bounds.height,
+          };
+        };
+        return {
+          button: rect(button),
+          slot: rect(slot),
+          row: rect(row),
+          labelOpacity: Number.parseFloat(getComputedStyle(label).opacity),
+          iconOpacity: Number.parseFloat(getComputedStyle(icon).opacity),
+        };
+      });
+    const clearRest = await readClearGeometry();
+    await clear.hover();
+    await desktop.waitForTimeout(220);
+    const clearHover = await readClearGeometry();
+    await desktop.mouse.move(0, 0);
+    await desktop.waitForTimeout(220);
+    const clearReturned = await readClearGeometry();
+    assert(
+      clearRest !== null &&
+        clearHover !== null &&
+        clearReturned !== null &&
+        clearRest.button.width <= 33 &&
+        clearHover.button.width >= 55 &&
+        clearHover.labelOpacity >= 0.99 &&
+        clearHover.iconOpacity <= 0.01 &&
+        Math.abs(clearRest.button.right - clearHover.button.right) <= 1 &&
+        Math.abs(clearRest.slot.width - clearHover.slot.width) <= 1 &&
+        Math.abs(clearRest.row.top - clearHover.row.top) <= 1 &&
+        clearReturned.button.width <= 33,
+      `desktop clear reveals leftward without shifting its slot or cards (${JSON.stringify({ clearRest, clearHover, clearReturned })})`,
     );
     await center.getByTestId("notifications-collapse").click();
     await center

--- a/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
@@ -209,7 +209,6 @@ function Harness(): React.JSX.Element {
     captureVision: () => {},
     visionCapturing: false,
     toggleTranscriptionMode: () => {},
-    stopTranscriptionAndMic: () => {},
     modelStatus: {
       kind: "ready",
       blocksSend: false,

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -989,45 +989,31 @@ describe("useShellController — voice capture routing", () => {
     expect(appMock.value.sendChatText).not.toHaveBeenCalled();
   });
 
-  it("transcript button OFF leaves the mic ON (resumes the paused hands-free loop)", async () => {
+  it("transcription exit leaves spoken conversation off", async () => {
     const { result } = renderHook(() => useShellController());
     // Mic on (hands-free) is the base state.
     await act(async () => result.current.toggleHandsFree());
     expect(result.current.handsFree).toBe(true);
 
-    // Transcript ON pauses the reply loop but the mic stays on (transcribing).
+    // Transcription takes sole ownership of the physical microphone.
     await act(async () => result.current.toggleTranscriptionMode());
     expect(result.current.transcriptionMode).toBe(true);
     expect(result.current.handsFree).toBe(false);
 
-    // Transcript OFF (the transcript button) must LEAVE THE MIC ON — the
-    // hands-free loop it paused resumes; it does not kill the mic.
+    // Exiting does not resurrect the separate spoken-conversation mode.
     await act(async () => result.current.toggleTranscriptionMode());
-    expect(result.current.transcriptionMode).toBe(false);
-    expect(result.current.handsFree).toBe(true);
-  });
-
-  it("the mic button while transcribing turns the mic AND transcript fully off", async () => {
-    const { result } = renderHook(() => useShellController());
-    await act(async () => result.current.toggleHandsFree());
-    await act(async () => result.current.toggleTranscriptionMode());
-    expect(result.current.transcriptionMode).toBe(true);
-
-    // stopTranscriptionAndMic is the mic button's action: mic = parent, so
-    // turning the mic off turns transcript off too — nothing resumes.
-    await act(async () => result.current.stopTranscriptionAndMic());
     expect(result.current.transcriptionMode).toBe(false);
     expect(result.current.handsFree).toBe(false);
   });
 
-  it("transcript OFF does not resume the mic when it was started from cold (no prior mic)", async () => {
+  it("transcription started from cold also exits with voice off", async () => {
     const { result } = renderHook(() => useShellController());
     // Enter transcription with the mic NOT already on (e.g. a server command).
     await act(async () => result.current.toggleTranscriptionMode());
     expect(result.current.transcriptionMode).toBe(true);
     expect(result.current.handsFree).toBe(false);
 
-    // Turning it off leaves the mic off — there was no mic loop to resume.
+    // Exit is deterministic regardless of the state that preceded capture.
     await act(async () => result.current.toggleTranscriptionMode());
     expect(result.current.transcriptionMode).toBe(false);
     expect(result.current.handsFree).toBe(false);

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -94,9 +94,11 @@ export function groupDashboardNotifications(
 }
 
 export function ClearConfirmationContent({
+  confirmingLabel = "Clear",
   confirming,
   restingLabel,
 }: {
+  confirmingLabel?: string;
   confirming: boolean;
   restingLabel?: string;
 }): JSX.Element {
@@ -125,6 +127,7 @@ export function ClearConfirmationContent({
       </span>
       <span
         aria-hidden={!confirming}
+        data-notification-clear-confirming-label=""
         className={cn(
           "eliza-notif-control-transition absolute transition-[opacity,transform] duration-200 ease-out",
           confirming
@@ -132,7 +135,7 @@ export function ClearConfirmationContent({
             : "translate-y-0.5 scale-95 opacity-0",
         )}
       >
-        Clear
+        {confirmingLabel}
       </span>
     </span>
   );

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -18,6 +18,7 @@ import { notificationPullRevealStyle } from "./notification-shade-presentation";
 import { RelativeTime } from "./RelativeTime";
 
 const SWIPE_DISMISS_PX = 88;
+const STACK_PEEK_LAYERS = ["near", "far"] as const;
 
 /** Stable shade order: priority, recency, then id as a total tiebreak. */
 export function orderDashboardNotifications(
@@ -123,9 +124,11 @@ export function ClearConfirmationContent({
 
 function NotificationSourceIcon({
   count,
+  countVisibility = 1,
   source,
 }: {
   count?: number;
+  countVisibility?: number;
   source: string;
 }): JSX.Element {
   const meta = getChatSourceMeta(source);
@@ -157,8 +160,10 @@ function NotificationSourceIcon({
       {count && count > 1 ? (
         <span
           data-testid="notification-source-count"
+          data-notification-source-count=""
           aria-hidden
-          className="absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-[11px] font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
+          style={{ opacity: countVisibility }}
+          className="eliza-notif-shade-transition absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-[11px] font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
         >
           {count > 99 ? "99+" : count}
         </span>
@@ -171,9 +176,22 @@ export interface NotificationRowProps {
   notification: AgentNotification;
   stackKey?: string;
   stackCount?: number;
+  stackCountVisibility?: number;
+  stackPeeks?: {
+    count: number;
+    disabled: boolean;
+    expansionProgress: number;
+    fanned: boolean;
+    groupLabel: string;
+    mode: "close" | "static" | "disposable";
+    openOffsetsPx?: readonly number[];
+    testIdVisible: boolean;
+    totalCount: number;
+    visibility: number;
+  };
   pullRevealProgress?: number;
   shadeVisibility?: number;
-  onExpandStack?: (key: string) => void;
+  onExpandStack?: (key: string, moveFocus: boolean) => void;
   onOpen: (notification: AgentNotification) => void;
   onDismiss: (id: string) => void;
 }
@@ -192,6 +210,21 @@ export function rowPropsEqual(
     a.source === b.source &&
     previous.stackKey === next.stackKey &&
     previous.stackCount === next.stackCount &&
+    previous.stackCountVisibility === next.stackCountVisibility &&
+    previous.stackPeeks?.count === next.stackPeeks?.count &&
+    previous.stackPeeks?.disabled === next.stackPeeks?.disabled &&
+    previous.stackPeeks?.expansionProgress ===
+      next.stackPeeks?.expansionProgress &&
+    previous.stackPeeks?.fanned === next.stackPeeks?.fanned &&
+    previous.stackPeeks?.groupLabel === next.stackPeeks?.groupLabel &&
+    previous.stackPeeks?.mode === next.stackPeeks?.mode &&
+    previous.stackPeeks?.openOffsetsPx?.[0] ===
+      next.stackPeeks?.openOffsetsPx?.[0] &&
+    previous.stackPeeks?.openOffsetsPx?.[1] ===
+      next.stackPeeks?.openOffsetsPx?.[1] &&
+    previous.stackPeeks?.testIdVisible === next.stackPeeks?.testIdVisible &&
+    previous.stackPeeks?.totalCount === next.stackPeeks?.totalCount &&
+    previous.stackPeeks?.visibility === next.stackPeeks?.visibility &&
     previous.pullRevealProgress === next.pullRevealProgress &&
     previous.shadeVisibility === next.shadeVisibility &&
     previous.onExpandStack === next.onExpandStack &&
@@ -213,6 +246,8 @@ export const NotificationRow = memo(function NotificationRow({
   notification,
   stackKey,
   stackCount,
+  stackCountVisibility,
+  stackPeeks,
   pullRevealProgress,
   shadeVisibility,
   onExpandStack,
@@ -291,7 +326,7 @@ export const NotificationRow = memo(function NotificationRow({
   return (
     <li
       className={cn(
-        "eliza-notif-row relative",
+        "eliza-notif-row relative isolate",
         pullRevealProgress !== undefined &&
           "eliza-notif-pull-reveal pointer-events-none",
         shadeVisibility !== undefined && "eliza-notif-shade-transition grid",
@@ -337,7 +372,7 @@ export const NotificationRow = memo(function NotificationRow({
         onPointerMove={onPointerMove}
         onPointerUp={onPointerEnd}
         onPointerCancel={onPointerEnd}
-        className="eliza-notif-row-inner eliza-notif-glass group relative flex min-h-0 flex-col overflow-hidden rounded-2xl"
+        className="eliza-notif-row-inner eliza-notif-glass group relative z-[2] flex min-h-0 flex-col overflow-hidden rounded-2xl"
       >
         <button
           type="button"
@@ -355,14 +390,16 @@ export const NotificationRow = memo(function NotificationRow({
               event.preventDefault();
               return;
             }
-            if (stackKey && onExpandStack) onExpandStack(stackKey);
-            else onOpen(notification);
+            if (stackKey && onExpandStack) {
+              onExpandStack(stackKey, event.detail === 0);
+            } else onOpen(notification);
           }}
           className="flex min-h-touch min-w-0 items-center gap-3 rounded-2xl px-3 py-2 text-left active:scale-[0.99] motion-reduce:active:scale-100"
         >
           <NotificationSourceIcon
             source={notification.source}
             count={stackCount}
+            countVisibility={stackCountVisibility}
           />
           <span className="flex min-w-0 flex-1 flex-col gap-0.5">
             <span className="flex items-baseline gap-1.5">
@@ -384,6 +421,56 @@ export const NotificationRow = memo(function NotificationRow({
           </span>
         </button>
       </div>
+      {stackPeeks
+        ? STACK_PEEK_LAYERS.slice(0, stackPeeks.count).map((layer, index) => {
+            const collapsedOffsetPx = (index + 1) * 7;
+            const openOffsetPx =
+              stackPeeks.openOffsetsPx?.[index] ?? (index + 1) * 44;
+            const offsetPx =
+              collapsedOffsetPx +
+              (openOffsetPx - collapsedOffsetPx) * stackPeeks.expansionProgress;
+            return (
+              <button
+                key={`${notification.id}-stack-peek-${layer}`}
+                type="button"
+                data-testid={
+                  stackPeeks.testIdVisible
+                    ? "notification-stack-peek"
+                    : undefined
+                }
+                data-notif-control=""
+                data-notification-stack-peek=""
+                data-notification-peek-mode={stackPeeks.mode}
+                disabled={stackPeeks.disabled}
+                tabIndex={
+                  stackPeeks.disabled || stackPeeks.visibility < 1
+                    ? -1
+                    : undefined
+                }
+                aria-hidden={
+                  stackPeeks.disabled || stackPeeks.visibility === 0
+                    ? true
+                    : undefined
+                }
+                aria-label={`Show all ${stackPeeks.totalCount} ${stackPeeks.groupLabel} notifications`}
+                onClick={(event) => {
+                  if (stackKey && onExpandStack) {
+                    onExpandStack(stackKey, event.detail === 0);
+                  }
+                }}
+                className={cn(
+                  "eliza-notif-glass eliza-notif-stack-peek eliza-notif-shade-transition absolute inset-0 rounded-2xl",
+                  stackPeeks.fanned && "pointer-events-none",
+                )}
+                style={{
+                  zIndex: 1 - index,
+                  opacity: stackPeeks.visibility,
+                  transform: `translateY(${offsetPx}px) scale(${1 - (index + 1) * 0.015})`,
+                }}
+              />
+            );
+          })
+        : null}
     </li>
   );
 }, rowPropsEqual);

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -95,18 +95,34 @@ export function groupDashboardNotifications(
 
 export function ClearConfirmationContent({
   confirming,
+  restingLabel,
 }: {
   confirming: boolean;
+  restingLabel?: string;
 }): JSX.Element {
   return (
     <span className="relative flex h-full w-full items-center justify-center">
-      <X
-        aria-hidden
+      <span
         className={cn(
-          "eliza-notif-control-transition absolute h-3.5 w-3.5 transition-[opacity,transform] duration-200 ease-out",
+          "eliza-notif-control-transition absolute flex items-center justify-center transition-[opacity,transform] duration-200 ease-out",
           confirming ? "scale-75 opacity-0" : "scale-100 opacity-100",
         )}
-      />
+      >
+        <X
+          aria-hidden
+          data-notification-clear-resting-icon={restingLabel ? "" : undefined}
+          className="eliza-notif-control-transition h-3.5 w-3.5 shrink-0 transition-[opacity,transform] duration-200 ease-out"
+        />
+        {restingLabel ? (
+          <span
+            data-notification-clear-resting-label=""
+            aria-hidden
+            className="eliza-notif-control-transition absolute translate-y-0.5 scale-95 whitespace-nowrap opacity-0 transition-[opacity,transform] duration-200 ease-out"
+          >
+            {restingLabel}
+          </span>
+        ) : null}
+      </span>
       <span
         aria-hidden={!confirming}
         className={cn(

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -6,8 +6,17 @@
 import type { AgentNotification, NotificationCategory } from "@elizaos/core";
 import { tierForPriority } from "@elizaos/core";
 import { X } from "lucide-react";
-import { type JSX, memo, useCallback, useRef, useState } from "react";
+import {
+  type JSX,
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useSharedNow } from "../../hooks/useSharedNow";
 import { cn } from "../../lib/utils";
+import { formatRelativeTimeShort } from "../../utils/format";
 import { NOTIFICATION_PRIORITY_RANK } from "../../widgets/home-priority";
 import {
   getChatSourceMeta,
@@ -18,6 +27,8 @@ import { notificationPullRevealStyle } from "./notification-shade-presentation";
 import { RelativeTime } from "./RelativeTime";
 
 const SWIPE_DISMISS_PX = 88;
+export const NOTIFICATION_ROW_SETTLE_MS = 220;
+const NOTIFICATION_ROW_DISMISS_COMMIT_MS = NOTIFICATION_ROW_SETTLE_MS + 24;
 const STACK_PEEK_LAYERS = ["near", "far"] as const;
 
 /** Stable shade order: priority, recency, then id as a total tiebreak. */
@@ -94,43 +105,50 @@ export function groupDashboardNotifications(
 }
 
 export function ClearConfirmationContent({
+  armingLabel,
   confirmingLabel = "Clear",
   confirming,
-  restingLabel,
+  stage,
 }: {
+  armingLabel?: string;
   confirmingLabel?: string;
   confirming: boolean;
-  restingLabel?: string;
+  stage?: 0 | 1 | 2;
 }): JSX.Element {
+  const resolvedStage = stage ?? (confirming ? 2 : 0);
   return (
     <span className="relative flex h-full w-full items-center justify-center">
       <span
         className={cn(
           "eliza-notif-control-transition absolute flex items-center justify-center transition-[opacity,transform] duration-200 ease-out",
-          confirming ? "scale-75 opacity-0" : "scale-100 opacity-100",
+          resolvedStage === 0 ? "scale-100 opacity-100" : "scale-75 opacity-0",
         )}
       >
         <X
           aria-hidden
-          data-notification-clear-resting-icon={restingLabel ? "" : undefined}
           className="eliza-notif-control-transition h-3.5 w-3.5 shrink-0 transition-[opacity,transform] duration-200 ease-out"
         />
-        {restingLabel ? (
-          <span
-            data-notification-clear-resting-label=""
-            aria-hidden
-            className="eliza-notif-control-transition absolute translate-y-0.5 scale-95 whitespace-nowrap opacity-0 transition-[opacity,transform] duration-200 ease-out"
-          >
-            {restingLabel}
-          </span>
-        ) : null}
       </span>
+      {armingLabel ? (
+        <span
+          aria-hidden={resolvedStage !== 1}
+          data-notification-clear-arming-label=""
+          className={cn(
+            "eliza-notif-control-transition absolute transition-[opacity,transform] duration-200 ease-out",
+            resolvedStage === 1
+              ? "translate-y-0 scale-100 opacity-100"
+              : "translate-y-0.5 scale-95 opacity-0",
+          )}
+        >
+          {armingLabel}
+        </span>
+      ) : null}
       <span
-        aria-hidden={!confirming}
+        aria-hidden={resolvedStage !== 2}
         data-notification-clear-confirming-label=""
         className={cn(
           "eliza-notif-control-transition absolute transition-[opacity,transform] duration-200 ease-out",
-          confirming
+          resolvedStage === 2
             ? "translate-y-0 scale-100 opacity-100"
             : "translate-y-0.5 scale-95 opacity-0",
         )}
@@ -144,10 +162,12 @@ export function ClearConfirmationContent({
 function NotificationSourceIcon({
   count,
   countVisibility = 1,
+  decorative = false,
   source,
 }: {
   count?: number;
   countVisibility?: number;
+  decorative?: boolean;
   source: string;
 }): JSX.Element {
   const meta = getChatSourceMeta(source);
@@ -155,15 +175,18 @@ function NotificationSourceIcon({
   const registered = hasChatSourceMeta(source);
   return (
     <span
-      data-testid="notification-source-icon"
+      data-testid={decorative ? undefined : "notification-source-icon"}
       data-source={normalizeChatSourceKey(source) ?? undefined}
       role="img"
+      aria-hidden={decorative ? true : undefined}
       aria-label={
-        count && count > 1
-          ? `${meta.label}, ${count} notifications`
-          : meta.label
+        decorative
+          ? undefined
+          : count && count > 1
+            ? `${meta.label}, ${count} notifications`
+            : meta.label
       }
-      title={meta.label}
+      title={decorative ? undefined : meta.label}
       className={cn(
         "relative flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] border border-white/15 bg-black/30",
         registered && meta.iconClassName,
@@ -171,6 +194,13 @@ function NotificationSourceIcon({
     >
       {registered ? (
         <Icon className="h-5 w-5" />
+      ) : decorative ? (
+        <span
+          data-notification-stack-preview-source-initial={
+            meta.label.trim().charAt(0).toUpperCase() || "E"
+          }
+          className="text-sm font-semibold text-white/85"
+        />
       ) : (
         <span aria-hidden className="text-sm font-semibold text-white/85">
           {meta.label.trim().charAt(0).toUpperCase() || "E"}
@@ -178,16 +208,70 @@ function NotificationSourceIcon({
       )}
       {count && count > 1 ? (
         <span
-          data-testid="notification-source-count"
+          data-testid={decorative ? undefined : "notification-source-count"}
           data-notification-source-count=""
+          data-notification-stack-preview-count={
+            decorative ? (count > 99 ? "99+" : count) : undefined
+          }
           aria-hidden
           style={{ opacity: countVisibility }}
           className="eliza-notif-shade-transition absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-[11px] font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
         >
-          {count > 99 ? "99+" : count}
+          {decorative ? null : count > 99 ? "99+" : count}
         </span>
       ) : null}
     </span>
+  );
+}
+
+function NotificationStackPreviewContent({
+  notification,
+  stackCount,
+}: {
+  notification: AgentNotification;
+  stackCount?: number;
+}): JSX.Element {
+  return (
+    <span
+      aria-hidden
+      data-notification-stack-preview-content=""
+      className="pointer-events-none flex min-h-touch min-w-0 items-center gap-3 px-3 py-2 text-left"
+    >
+      <NotificationSourceIcon
+        source={notification.source}
+        count={stackCount}
+        decorative
+      />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="flex items-baseline gap-1.5">
+          <span
+            data-notification-stack-preview-title={notification.title}
+            className="truncate text-sm font-semibold text-white"
+          />
+          <NotificationStackPreviewTime ts={notification.createdAt} />
+        </span>
+        {notification.body ? (
+          <span
+            data-notification-stack-preview-body={notification.body}
+            className="line-clamp-2 text-xs leading-snug text-white/60"
+          />
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
+function NotificationStackPreviewTime({
+  ts,
+}: {
+  ts: AgentNotification["createdAt"];
+}): JSX.Element {
+  void useSharedNow();
+  return (
+    <time
+      data-notification-stack-preview-time={formatRelativeTimeShort(ts)}
+      className="ml-auto shrink-0 pl-2 text-2xs tabular-nums text-white/60"
+    />
   );
 }
 
@@ -204,6 +288,7 @@ export interface NotificationRowProps {
     groupLabel: string;
     mode: "close" | "static" | "disposable";
     openOffsetsPx?: readonly number[];
+    previewRows: readonly AgentNotification[];
     testIdVisible: boolean;
     totalCount: number;
     visibility: number;
@@ -241,6 +326,26 @@ export function rowPropsEqual(
       next.stackPeeks?.openOffsetsPx?.[0] &&
     previous.stackPeeks?.openOffsetsPx?.[1] ===
       next.stackPeeks?.openOffsetsPx?.[1] &&
+    previous.stackPeeks?.previewRows?.[0]?.id ===
+      next.stackPeeks?.previewRows?.[0]?.id &&
+    previous.stackPeeks?.previewRows?.[0]?.title ===
+      next.stackPeeks?.previewRows?.[0]?.title &&
+    previous.stackPeeks?.previewRows?.[0]?.body ===
+      next.stackPeeks?.previewRows?.[0]?.body &&
+    previous.stackPeeks?.previewRows?.[0]?.source ===
+      next.stackPeeks?.previewRows?.[0]?.source &&
+    previous.stackPeeks?.previewRows?.[0]?.createdAt ===
+      next.stackPeeks?.previewRows?.[0]?.createdAt &&
+    previous.stackPeeks?.previewRows?.[1]?.id ===
+      next.stackPeeks?.previewRows?.[1]?.id &&
+    previous.stackPeeks?.previewRows?.[1]?.title ===
+      next.stackPeeks?.previewRows?.[1]?.title &&
+    previous.stackPeeks?.previewRows?.[1]?.body ===
+      next.stackPeeks?.previewRows?.[1]?.body &&
+    previous.stackPeeks?.previewRows?.[1]?.source ===
+      next.stackPeeks?.previewRows?.[1]?.source &&
+    previous.stackPeeks?.previewRows?.[1]?.createdAt ===
+      next.stackPeeks?.previewRows?.[1]?.createdAt &&
     previous.stackPeeks?.testIdVisible === next.stackPeeks?.testIdVisible &&
     previous.stackPeeks?.totalCount === next.stackPeeks?.totalCount &&
     previous.stackPeeks?.visibility === next.stackPeeks?.visibility &&
@@ -282,7 +387,17 @@ export const NotificationRow = memo(function NotificationRow({
     startY: number;
     axis: "none" | "x" | "y";
   } | null>(null);
+  const dismissTimer = useRef<number | null>(null);
   const suppressClick = useRef(false);
+
+  useEffect(
+    () => () => {
+      if (dismissTimer.current !== null) {
+        window.clearTimeout(dismissTimer.current);
+      }
+    },
+    [],
+  );
 
   const clearGesture = useCallback(() => {
     gesture.current = null;
@@ -292,7 +407,10 @@ export const NotificationRow = memo(function NotificationRow({
     (direction: "left" | "right") => {
       suppressClick.current = true;
       setDismissing(direction);
-      window.setTimeout(() => onDismiss(notification.id), 180);
+      dismissTimer.current = window.setTimeout(
+        () => onDismiss(notification.id),
+        NOTIFICATION_ROW_DISMISS_COMMIT_MS,
+      );
     },
     [notification.id, onDismiss],
   );
@@ -342,10 +460,28 @@ export const NotificationRow = memo(function NotificationRow({
   );
 
   const dragging = swipeX !== 0 && !dismissing;
+  const promotingStack = Boolean(
+    dismissing && stackPeeks && !stackPeeks.fanned,
+  );
+  const collapsingDismissedRow = Boolean(
+    dismissing && (!stackPeeks || stackPeeks.fanned),
+  );
+  const collapsingFannedRow = Boolean(
+    dismissing && (stackPeeks?.fanned || shadeVisibility !== undefined),
+  );
+  const rowPresentationStyle =
+    pullRevealProgress !== undefined
+      ? notificationPullRevealStyle(pullRevealProgress)
+      : shadeVisibility !== undefined
+        ? {
+            opacity: shadeVisibility,
+            transform: `translate3d(0, ${(1 - shadeVisibility) * -8}px, 0)`,
+          }
+        : undefined;
   return (
     <li
       className={cn(
-        "eliza-notif-row relative isolate",
+        "eliza-notif-row relative isolate grid",
         pullRevealProgress !== undefined &&
           "eliza-notif-pull-reveal pointer-events-none",
         shadeVisibility !== undefined && "eliza-notif-shade-transition grid",
@@ -356,23 +492,18 @@ export const NotificationRow = memo(function NotificationRow({
       data-notification-disposable-row={
         shadeVisibility !== undefined ? "" : undefined
       }
+      data-swipe-collapsing={collapsingDismissedRow ? "" : undefined}
       aria-hidden={shadeVisibility === 0 ? true : undefined}
       inert={
         pullRevealProgress !== undefined || shadeVisibility === 0
           ? true
           : undefined
       }
-      style={
-        pullRevealProgress !== undefined
-          ? notificationPullRevealStyle(pullRevealProgress)
-          : shadeVisibility !== undefined
-            ? {
-                gridTemplateRows: `${shadeVisibility}fr`,
-                opacity: shadeVisibility,
-                transform: `translate3d(0, ${(1 - shadeVisibility) * -8}px, 0)`,
-              }
-            : undefined
-      }
+      style={{
+        ...rowPresentationStyle,
+        gridTemplateRows: `${(shadeVisibility ?? 1) * (collapsingDismissedRow ? 0 : 1)}fr`,
+        marginBottom: collapsingFannedRow ? -6 : 0,
+      }}
       data-notif-row
     >
       <div
@@ -384,8 +515,9 @@ export const NotificationRow = memo(function NotificationRow({
             : swipeX
               ? `translateX(${swipeX}px)`
               : undefined,
-          opacity: dismissing ? 0 : Math.max(0, 1 - Math.abs(swipeX) / 220),
+          opacity: dismissing ? 0 : 1,
           touchAction: "pan-y",
+          willChange: dragging || dismissing ? "transform, opacity" : undefined,
         }}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
@@ -442,7 +574,7 @@ export const NotificationRow = memo(function NotificationRow({
       </div>
       {stackPeeks
         ? STACK_PEEK_LAYERS.slice(0, stackPeeks.count).map((layer, index) => {
-            const collapsedOffsetPx = (index + 1) * 7;
+            const collapsedOffsetPx = (promotingStack ? index : index + 1) * 7;
             const openOffsetPx =
               stackPeeks.openOffsetsPx?.[index] ?? (index + 1) * 44;
             const offsetPx =
@@ -460,14 +592,18 @@ export const NotificationRow = memo(function NotificationRow({
                 data-notif-control=""
                 data-notification-stack-peek=""
                 data-notification-peek-mode={stackPeeks.mode}
-                disabled={stackPeeks.disabled}
+                disabled={stackPeeks.disabled || promotingStack}
                 tabIndex={
-                  stackPeeks.disabled || stackPeeks.visibility < 1
+                  stackPeeks.disabled ||
+                  promotingStack ||
+                  stackPeeks.visibility < 1
                     ? -1
                     : undefined
                 }
                 aria-hidden={
-                  stackPeeks.disabled || stackPeeks.visibility === 0
+                  stackPeeks.disabled ||
+                  promotingStack ||
+                  stackPeeks.visibility === 0
                     ? true
                     : undefined
                 }
@@ -481,12 +617,24 @@ export const NotificationRow = memo(function NotificationRow({
                   "eliza-notif-glass eliza-notif-stack-peek eliza-notif-shade-transition absolute inset-0 rounded-2xl",
                   stackPeeks.fanned && "pointer-events-none",
                 )}
+                data-swipe-promoting={promotingStack ? "" : undefined}
                 style={{
                   zIndex: 1 - index,
                   opacity: stackPeeks.visibility,
-                  transform: `translateY(${offsetPx}px) scale(${1 - (index + 1) * 0.015})`,
+                  transform: `translateY(${offsetPx}px) scale(${1 - (promotingStack ? index : index + 1) * 0.015})`,
                 }}
-              />
+              >
+                {stackPeeks.previewRows?.[index] ? (
+                  <NotificationStackPreviewContent
+                    notification={stackPeeks.previewRows[index]}
+                    stackCount={
+                      index === 0 && stackPeeks.totalCount > 2
+                        ? stackPeeks.totalCount - 1
+                        : undefined
+                    }
+                  />
+                ) : null}
+              </button>
             );
           })
         : null}

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -4,7 +4,7 @@
  * groups remains smooth while React remains authoritative for settled states.
  */
 import type { CSSProperties } from "react";
-import { rubberBand } from "../../gestures/recognizers";
+import { sqrtRubberBand } from "../../gestures/recognizers";
 
 /** Full visual travel between the shade's rested and expanded detents. */
 export const PULL_TRAVEL_PX = 88;
@@ -15,9 +15,15 @@ export const PULL_COMMIT_PX = PULL_TRAVEL_PX / 2;
 /** Dead zone before a vertical drag starts reading as a pull. */
 export const PULL_SLOP_PX = 8;
 
+/** Extreme pulls retain elastic give without moving cards beyond the shade. */
+const PULL_MAX_OVERSHOOT_PX = 32;
+
 /** Track the finger directly between detents, resisting only past the end. */
 export function dampenPull(rawDy: number): number {
-  return rubberBand(Math.max(0, rawDy - PULL_SLOP_PX), PULL_TRAVEL_PX, 0.35);
+  const travel = Math.max(0, rawDy - PULL_SLOP_PX);
+  if (travel <= PULL_TRAVEL_PX) return travel;
+  const overshoot = sqrtRubberBand(travel - PULL_TRAVEL_PX, 1.85);
+  return PULL_TRAVEL_PX + Math.min(PULL_MAX_OVERSHOOT_PX, overshoot);
 }
 
 /** Preserve the resisted travel past either detent as visible elastic give. */

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -71,12 +71,26 @@ export function notificationPullPresentation(
   const pullContentVisibility = shadeExpanded
     ? disposableContentVisibility
     : pullRevealProgress;
+  const pullOvershootOffset = notificationPullOvershootOffset(pullPx);
+  const countCloseOvershootProgress = Math.min(
+    1,
+    Math.max(
+      0,
+      (-pullOvershootOffset - PULL_MAX_OVERSHOOT_PX / 4) /
+        (PULL_MAX_OVERSHOOT_PX / 2),
+    ),
+  );
+  const countCloseBoundaryVisibility =
+    1 -
+    countCloseOvershootProgress ** 2 * (3 - 2 * countCloseOvershootProgress);
   // The count follows the same continuous travel as the cards but stays much
   // dimmer while their surfaces overlap. This reads as a fade beneath the
-  // stack without either a hard clipping edge or legible text through glass.
-  const notificationCountVisibility = shadeExpanded
-    ? shadeCloseProgress ** 3
-    : (1 - pullRevealProgress) ** 3;
+  // stack without either legible text through glass or a hard clipping edge.
+  // Once upward elastic travel carries it toward the scrollport boundary, a
+  // smooth end fade completes before the final quarter of resisted movement.
+  const notificationCountVisibility =
+    (shadeExpanded ? shadeCloseProgress ** 3 : (1 - pullRevealProgress) ** 3) *
+    countCloseBoundaryVisibility;
   const clearControlVisibility = shadeExpanded
     ? disposableContentVisibility
     : pullPx > 0
@@ -91,8 +105,6 @@ export function notificationPullPresentation(
     shadeExpanded,
     shadeClosing,
   );
-  const pullOvershootOffset = notificationPullOvershootOffset(pullPx);
-
   return {
     shadeCloseProgress,
     committedCloseProgress,

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -4,16 +4,20 @@
  * groups remains smooth while React remains authoritative for settled states.
  */
 import type { CSSProperties } from "react";
+import { rubberBand } from "../../gestures/recognizers";
 
-/** Dampened pull travel that commits a shade mode change on release. */
-export const PULL_COMMIT_PX = 48;
+/** Full visual travel between the shade's rested and expanded detents. */
+export const PULL_TRAVEL_PX = 88;
+
+/** A slow drag commits at the same halfway point as the home pager. */
+export const PULL_COMMIT_PX = PULL_TRAVEL_PX / 2;
 
 /** Dead zone before a vertical drag starts reading as a pull. */
 export const PULL_SLOP_PX = 8;
 
-/** Rubber-band raw overscroll into the travel rendered by the shade. */
+/** Track the finger directly between detents, resisting only past the end. */
 export function dampenPull(rawDy: number): number {
-  return Math.min(Math.max(0, rawDy - PULL_SLOP_PX) * 0.5, 88);
+  return rubberBand(Math.max(0, rawDy - PULL_SLOP_PX), PULL_TRAVEL_PX, 0.35);
 }
 
 /** Convert live pull travel into a staggered reveal for hidden groups. */
@@ -21,7 +25,7 @@ export function notificationPullRevealProgress(
   pullPx: number,
   groupIndex: number,
 ): number {
-  const progress = Math.min(1, Math.max(0, pullPx / PULL_COMMIT_PX));
+  const progress = Math.min(1, Math.max(0, pullPx / PULL_TRAVEL_PX));
   const stagger = Math.min(Math.max(groupIndex, 0), 4) * 0.06;
   return Math.min(1, Math.max(0, (progress - stagger) / (1 - stagger)));
 }
@@ -48,17 +52,30 @@ export function notificationPullPresentation(
     committedCloseProgress,
   );
   const disposableContentVisibility = 1 - shadeCloseProgress;
+  const pullRevealProgress = notificationPullRevealProgress(pullPx, 0);
   const pullContentVisibility = shadeExpanded
     ? disposableContentVisibility
-    : notificationPullRevealProgress(pullPx, 0);
+    : pullRevealProgress;
+  // The count follows the same continuous travel as the cards but stays much
+  // dimmer while their surfaces overlap. This reads as a fade beneath the
+  // stack without either a hard clipping edge or legible text through glass.
   const notificationCountVisibility = shadeExpanded
-    ? shadeCloseProgress
-    : 1 - notificationPullRevealProgress(pullPx, 0);
+    ? shadeCloseProgress ** 3
+    : (1 - pullRevealProgress) ** 3;
   const clearControlVisibility = shadeExpanded
     ? disposableContentVisibility
     : pullPx > 0
-      ? notificationPullRevealProgress(pullPx, 0)
+      ? pullRevealProgress
       : 0;
+  // The clear-control slot reserves its full row as soon as a drag starts so
+  // notification groups can mount without reflowing under the finger. The
+  // count follows that slot in document flow, so it needs the same inverse
+  // offset as the groups or its first drag frame jumps by the full 40px row.
+  const notificationCountOffset = notificationGroupContainerOffset(
+    pullPx,
+    shadeExpanded,
+    shadeClosing,
+  );
 
   return {
     shadeCloseProgress,
@@ -66,16 +83,19 @@ export function notificationPullPresentation(
     disposableContentVisibility,
     pullContentVisibility,
     notificationCountVisibility,
+    notificationCountOffset,
     notificationCountLayoutVisibility:
       shadeExpanded && pullPx < 0 && !shadeClosing
         ? 1
-        : notificationCountVisibility,
+        : shadeExpanded
+          ? shadeCloseProgress
+          : 1 - pullRevealProgress,
     emptyStateVisibility: shadeExpanded
       ? disposableContentVisibility
       : notificationPullRevealProgress(pullPx, 0),
     collapseControlVisibility: shadeExpanded
       ? disposableContentVisibility
-      : notificationPullRevealProgress(pullPx, 0),
+      : pullRevealProgress,
     clearControlVisibility,
     clearControlLayoutVisibility: shadeExpanded
       ? shadeClosing || pullPx < 0
@@ -127,7 +147,7 @@ export function notificationGroupPullVisibility(
   }
   if (shadeClosing) return 0;
   if (shadeExpanded && pullPx < 0) {
-    return notificationPullRevealProgress(PULL_COMMIT_PX + pullPx, groupIndex);
+    return notificationPullRevealProgress(PULL_TRAVEL_PX + pullPx, groupIndex);
   }
   return 1;
 }
@@ -143,19 +163,20 @@ export function applyNotificationPullPresentation(
   shadeClosing: boolean,
   visibleGroups?: readonly HTMLElement[],
 ): void {
+  const count = root?.querySelector<HTMLElement>(
+    "[data-notification-count-slot]",
+  );
   if (!root) return;
   const presentation = notificationPullPresentation(
     pullPx,
     shadeExpanded,
     shadeClosing,
   );
-  const count = root.querySelector<HTMLElement>(
-    "[data-notification-count-slot]",
-  );
   if (count) {
     count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
     count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
     count.style.opacity = String(presentation.notificationCountVisibility);
+    count.style.transform = `translate3d(0, ${presentation.notificationCountOffset}px, 0)`;
   }
   const clearSlot = root.querySelector<HTMLElement>(
     "[data-notification-clear-slot]",
@@ -238,11 +259,6 @@ export function applyNotificationPullPresentation(
         const tailPx =
           restedTailPx + (expandedTailPx - restedTailPx) * tailProgress;
         content.style.paddingBottom = `${tailPx}px`;
-        for (const peek of content.querySelectorAll<HTMLElement>(
-          "[data-notification-stack-peek]",
-        )) {
-          peek.style.bottom = `${tailPx}px`;
-        }
       }
     }
     const controls = group.querySelector<HTMLElement>(

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -95,6 +95,7 @@ export function notificationPullPresentation(
     notificationCountVisibility,
     notificationCountOffset,
     pullOvershootOffset,
+    collapseControlOvershootOffset: Math.min(0, pullOvershootOffset),
     notificationCountLayoutVisibility:
       shadeExpanded && pullPx < 0 && !shadeClosing
         ? 1
@@ -183,6 +184,13 @@ export function applyNotificationPullPresentation(
     shadeExpanded,
     shadeClosing,
   );
+  const scrollport = root.querySelector<HTMLElement>(
+    "[data-testid='home-notification-list']",
+  );
+  scrollport?.style.setProperty(
+    "--eliza-notif-pull-overshoot",
+    `${Math.max(0, presentation.pullOvershootOffset)}px`,
+  );
   if (count) {
     count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
     count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
@@ -220,7 +228,7 @@ export function applyNotificationPullPresentation(
     collapse.style.opacity = String(presentation.collapseControlVisibility);
     collapse.style.transform = `translateY(${
       (1 - presentation.collapseControlVisibility) * 4 +
-      presentation.pullOvershootOffset
+      presentation.collapseControlOvershootOffset
     }px)`;
   }
   const groups =

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -20,6 +20,12 @@ export function dampenPull(rawDy: number): number {
   return rubberBand(Math.max(0, rawDy - PULL_SLOP_PX), PULL_TRAVEL_PX, 0.35);
 }
 
+/** Preserve the resisted travel past either detent as visible elastic give. */
+export function notificationPullOvershootOffset(pullPx: number): number {
+  const overshoot = Math.max(0, Math.abs(pullPx) - PULL_TRAVEL_PX);
+  return Math.sign(pullPx) * overshoot;
+}
+
 /** Convert live pull travel into a staggered reveal for hidden groups. */
 export function notificationPullRevealProgress(
   pullPx: number,
@@ -30,10 +36,13 @@ export function notificationPullRevealProgress(
   return Math.min(1, Math.max(0, (progress - stagger) / (1 - stagger)));
 }
 
-export function notificationPullRevealStyle(progress: number): CSSProperties {
+export function notificationPullRevealStyle(
+  progress: number,
+  offsetPx = 0,
+): CSSProperties {
   return {
     opacity: progress,
-    transform: `translate3d(0, ${(1 - progress) * -8}px, 0)`,
+    transform: `translate3d(0, ${(1 - progress) * -8 + offsetPx}px, 0)`,
   };
 }
 
@@ -76,6 +85,7 @@ export function notificationPullPresentation(
     shadeExpanded,
     shadeClosing,
   );
+  const pullOvershootOffset = notificationPullOvershootOffset(pullPx);
 
   return {
     shadeCloseProgress,
@@ -84,6 +94,7 @@ export function notificationPullPresentation(
     pullContentVisibility,
     notificationCountVisibility,
     notificationCountOffset,
+    pullOvershootOffset,
     notificationCountLayoutVisibility:
       shadeExpanded && pullPx < 0 && !shadeClosing
         ? 1
@@ -176,7 +187,9 @@ export function applyNotificationPullPresentation(
     count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
     count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
     count.style.opacity = String(presentation.notificationCountVisibility);
-    count.style.transform = `translate3d(0, ${presentation.notificationCountOffset}px, 0)`;
+    count.style.transform = `translate3d(0, ${
+      presentation.notificationCountOffset + presentation.pullOvershootOffset
+    }px, 0)`;
   }
   const clearSlot = root.querySelector<HTMLElement>(
     "[data-notification-clear-slot]",
@@ -185,13 +198,19 @@ export function applyNotificationPullPresentation(
     clearSlot.style.height = `${presentation.clearControlLayoutVisibility * 32}px`;
     clearSlot.style.marginBottom = `${(presentation.clearControlLayoutVisibility - 1) * 8}px`;
     clearSlot.style.opacity = String(presentation.clearControlVisibility);
-    clearSlot.style.transform = `translate3d(0, ${(1 - presentation.clearControlVisibility) * -8}px, 0)`;
+    clearSlot.style.transform = `translate3d(0, ${
+      (1 - presentation.clearControlVisibility) * -8 +
+      presentation.pullOvershootOffset
+    }px, 0)`;
   }
   const empty = root.querySelector<HTMLElement>("[data-notification-empty]");
   if (empty) {
     Object.assign(
       empty.style,
-      notificationPullRevealStyle(presentation.emptyStateVisibility),
+      notificationPullRevealStyle(
+        presentation.emptyStateVisibility,
+        presentation.pullOvershootOffset,
+      ),
     );
   }
   const collapse = root.querySelector<HTMLElement>(
@@ -199,7 +218,10 @@ export function applyNotificationPullPresentation(
   );
   if (collapse) {
     collapse.style.opacity = String(presentation.collapseControlVisibility);
-    collapse.style.transform = `translateY(${(1 - presentation.collapseControlVisibility) * 4}px)`;
+    collapse.style.transform = `translateY(${
+      (1 - presentation.collapseControlVisibility) * 4 +
+      presentation.pullOvershootOffset
+    }px)`;
   }
   const groups =
     visibleGroups ??
@@ -219,41 +241,36 @@ export function applyNotificationPullPresentation(
       shadeExpanded,
       shadeClosing,
     );
-    group.style.transform = `translate3d(0, ${
-      containerOffset + (pullRevealed ? (1 - groupVisibility) * -8 : 0)
-    }px, 0)`;
-    if (pullRevealed) group.style.opacity = String(groupVisibility);
-    if (
-      !pullRevealed &&
-      !group.hasAttribute("data-rested-notification-group")
-    ) {
-      const content = group.querySelector<HTMLElement>(
-        ":scope > [data-notification-group-content]",
-      );
-      if (content) {
-        content.style.opacity = String(groupVisibility);
-        content.style.transform = `translate3d(0, ${notificationGroupPullOffset(
-          pullPx,
-          shadeExpanded,
-          shadeClosing,
-          groupVisibility,
-        )}px, 0)`;
-      }
+    const rested = group.hasAttribute("data-rested-notification-group");
+    const content = group.querySelector<HTMLElement>(
+      ":scope > [data-notification-group-content]",
+    );
+    if (content) {
+      const contentVisibility = pullRevealed || !rested ? groupVisibility : 1;
+      const contentPullOffset = pullRevealed
+        ? (1 - groupVisibility) * -8
+        : rested
+          ? 0
+          : notificationGroupPullOffset(
+              pullPx,
+              shadeExpanded,
+              shadeClosing,
+              groupVisibility,
+            );
+      content.style.opacity = String(contentVisibility);
+      content.style.transform = `translate3d(0, ${
+        containerOffset + contentPullOffset + presentation.pullOvershootOffset
+      }px, 0)`;
     }
     if (!shadeExpanded && pullPx > 0) {
-      const content = group.querySelector<HTMLElement>(
-        ":scope > [data-notification-group-content][data-notification-stacked]",
-      );
-      if (content) {
+      if (content?.hasAttribute("data-notification-stacked")) {
         const restedTailPx = Number(
           content.dataset.notificationRestedTailPx ?? 0,
         );
         const expandedTailPx = Number(
           content.dataset.notificationExpandedTailPx ?? restedTailPx,
         );
-        const tailProgress = group.hasAttribute(
-          "data-rested-notification-group",
-        )
+        const tailProgress = rested
           ? notificationPullRevealProgress(pullPx, groupIndex)
           : 1;
         const tailPx =

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -74,11 +74,7 @@ export function notificationPullPresentation(
   const pullOvershootOffset = notificationPullOvershootOffset(pullPx);
   const countCloseOvershootProgress = Math.min(
     1,
-    Math.max(
-      0,
-      (-pullOvershootOffset - PULL_MAX_OVERSHOOT_PX / 4) /
-        (PULL_MAX_OVERSHOOT_PX / 2),
-    ),
+    Math.max(0, -pullOvershootOffset / (PULL_MAX_OVERSHOOT_PX / 4)),
   );
   const countCloseBoundaryVisibility =
     1 -

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -11,10 +11,7 @@
 import { useEffect } from "react";
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { useAppSelector } from "../../state";
-import {
-  initNotifications,
-  seedDevNotificationsIfEmpty,
-} from "../../state/notifications/notification-store";
+import { initNotifications } from "../../state/notifications/notification-store";
 import { initPushRegistration } from "../../state/notifications/push-registration";
 import { goHome } from "../../state/shell-surface-store";
 
@@ -27,14 +24,6 @@ export function NotificationsShellBoot(): null {
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();
-    // Dev builds only: paint the demo spread when the inbox is empty so the
-    // inline home notification surface is visible by default while developing.
-    // Prod bundles compile `import.meta.env.DEV` to false, so this is stripped.
-    try {
-      if (import.meta.env?.DEV) void seedDevNotificationsIfEmpty();
-    } catch {
-      // `import.meta.env` unavailable (non-Vite host) — treat as non-dev.
-    }
   }, []);
 
   // Route every "open notifications" entry point to the dashboard: the combined

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -208,19 +208,16 @@ export interface ShellController {
    *  phrase ("exit transcription mode"), then the session becomes a Transcript. */
   transcriptionMode: boolean;
   /** Toggle transcription mode on/off. Enabling opens a long-running capture
-   *  that suppresses replies; disabling stops it and RESUMES the hands-free mic
-   *  loop it paused (transcript off leaves the mic on — they are linked). */
+   *  that suppresses replies; disabling finalizes the session and leaves the
+   *  separate hands-free conversation mode off. */
   toggleTranscriptionMode: () => void | Promise<void>;
-  /** End transcription AND turn the mic fully off (the mic button's action while
-   *  transcribing — turning off the mic turns off transcript). */
-  stopTranscriptionAndMic: () => void | Promise<void>;
   /** Register where push-to-talk dictation drops its final transcript (the
    *  overlay wires this to its composer draft). Pass null to clear. */
   setDictationSink: (sink: ((text: string) => void) | null) => void;
   /** Register where a completed transcription SESSION is delivered (its segments,
    *  the absolute session-start ms, and the concatenated session WAV when audio
-   *  was retained). The overlay wires this to create the Transcript record (+
-   *  audio) + drop a chat link-widget. Pass null to clear. */
+   *  was retained). The overlay routes that payload to its editable draft or
+   *  immediate Send action and archives the Transcript record. Pass null to clear. */
   setTranscriptSessionSink: (
     sink:
       | ((
@@ -606,12 +603,6 @@ export function useShellController(): ShellController {
   const [transcriptionMode, setTranscriptionMode] = React.useState(false);
   const transcriptionModeRef = React.useRef(false);
   transcriptionModeRef.current = transcriptionMode;
-  // Whether the hands-free mic loop was running when transcription was entered.
-  // The mic and transcript are LINKED but not identical: the transcript button
-  // (and a spoken/server "stop") pauses the hands-free reply loop on enter and
-  // RESUMES it on exit, so turning transcript off leaves the mic on. Only the
-  // mic button turns the mic (and thus transcript) fully off.
-  const resumeHandsFreeAfterTranscriptRef = React.useRef(false);
   // Set when a wake-triggered inline reply is sent during transcription, so the
   // assistant's answer is folded into the transcript once it arrives (#9880).
   const recordReplyIntoTranscriptRef = React.useRef(false);
@@ -1011,13 +1002,6 @@ export function useShellController(): ShellController {
               transcriptionModeRef.current = false;
               finalizeTranscriptSession();
               stopCapture();
-              // A spoken "stop transcription" turns transcript OFF but leaves
-              // the mic ON — resume the hands-free loop it paused on enter.
-              if (resumeHandsFreeAfterTranscriptRef.current) {
-                resumeHandsFreeAfterTranscriptRef.current = false;
-                setHandsFree(true);
-                handsFreeRef.current = true;
-              }
               return;
             }
             // Wake word DURING transcription → one inline reply, parallel-chat
@@ -1619,13 +1603,9 @@ export function useShellController(): ShellController {
     }, [stopCapture]),
   });
 
-  // Toggle transcription mode (long-form, record-only — the agent never replies
-  // to a transcribed turn). It is an ADDITIVE voice layer: the mic stays on and
-  // the composer keeps working; enabling it just pauses the hands-free REPLY
-  // loop and opens a long-running capture that accumulates every utterance
-  // silently. Turning it off (this toggle, the mic button, or a spoken exit
-  // phrase) finalizes the session, which drops the transcript into the composer
-  // as an attachment the user sends with their next message.
+  // Transcription is a dedicated record-only capture, not a state layered over
+  // spoken conversation. Entering it shuts down hands-free ownership; leaving
+  // it finalizes the session without rearming any voice mode.
   const toggleTranscriptionMode = React.useCallback(async () => {
     if (transcriptionModeRef.current) {
       setTranscriptionMode(false);
@@ -1633,24 +1613,14 @@ export function useShellController(): ShellController {
       if (captureRef.current) await stopCaptureAndDrain();
       // Close the recording session → Transcript record + chat link-widget.
       finalizeTranscriptSession();
-      // Turning transcript OFF must leave the mic ON: resume the hands-free
-      // listen loop the transcription layer paused on enter. (Only the mic
-      // button — handleMicClick → stopTranscriptionAndMic — turns the mic off.)
-      if (resumeHandsFreeAfterTranscriptRef.current) {
-        resumeHandsFreeAfterTranscriptRef.current = false;
-        setHandsFree(true);
-        handsFreeRef.current = true;
-      }
     } else {
-      // Remember the mic state so we can restore it on exit, then pause the
-      // hands-free REPLY loop while transcription records silently. The mic
-      // itself stays on (transcription capture) — pressing transcript never
-      // disables the mic.
-      resumeHandsFreeAfterTranscriptRef.current = handsFreeRef.current;
-      if (handsFreeRef.current) {
-        setHandsFree(false);
-        handsFreeRef.current = false;
+      // Persist the pre-conversation preference so neither the current loop nor
+      // a later remount interprets transcript completion as always-on voice.
+      if (handsFreeRef.current || loadContinuousChatMode() === "always-on") {
+        saveContinuousChatMode(priorContinuousModeRef.current);
       }
+      setHandsFree(false);
+      handsFreeRef.current = false;
       setTranscriptionMode(true);
       transcriptionModeRef.current = true;
       setIsOpen(true);
@@ -1668,21 +1638,6 @@ export function useShellController(): ShellController {
     finalizeTranscriptSession,
   ]);
 
-  // The mic button while transcribing: turn the mic (and thus transcript) fully
-  // OFF. Distinct from `toggleTranscriptionMode`'s off-path, which leaves the
-  // mic listening — "turning off the mic turns off transcript" (mic = parent).
-  const stopTranscriptionAndMic = React.useCallback(async () => {
-    setTranscriptionMode(false);
-    transcriptionModeRef.current = false;
-    if (captureRef.current) await stopCaptureAndDrain();
-    finalizeTranscriptSession();
-    resumeHandsFreeAfterTranscriptRef.current = false;
-    // Turn the mic fully off like a hands-free tap-off: persist the prior
-    // non-always-on mode so the auto-engage loop does NOT re-open the mic.
-    saveContinuousChatMode(priorContinuousModeRef.current);
-    setHandsFree(false);
-    handsFreeRef.current = false;
-  }, [stopCaptureAndDrain, finalizeTranscriptSession]);
   // Keep the forward ref current so the converse capture loop (defined above)
   // can flip into transcription on a spoken start phrase.
   toggleTranscriptionModeRef.current = toggleTranscriptionMode;
@@ -1935,7 +1890,6 @@ export function useShellController(): ShellController {
     recheckMicPermission,
     transcriptionMode,
     toggleTranscriptionMode,
-    stopTranscriptionAndMic,
     setDictationSink,
     setTranscriptSessionSink,
     setComposerHasDraft,

--- a/packages/ui/src/gestures/index.ts
+++ b/packages/ui/src/gestures/index.ts
@@ -1,9 +1,10 @@
 /**
- * Barrel for the pointer-gesture utilities (recognizers, press-and-hold, click
- * suppression, raf coalescing).
+ * Barrel for the pointer-gesture utilities (recognizers, momentum, press-and-
+ * hold, click suppression, raf coalescing).
  */
 export * from "./constants";
 export * from "./lost-capture";
+export * from "./momentum";
 export * from "./recognizers";
 export * from "./useClickSuppression";
 export * from "./usePointerPressAndHold";

--- a/packages/ui/src/gestures/momentum.test.ts
+++ b/packages/ui/src/gestures/momentum.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure contract coverage for the shared one-dimensional release, settle, and
+ * detent math used by pointer-driven surfaces.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  getMomentumReleaseVelocity,
+  getVelocityAwareSettleDuration,
+  shouldCommitMomentumDetent,
+} from "./momentum";
+
+describe("getMomentumReleaseVelocity", () => {
+  it("uses the trailing samples rather than the whole-gesture fallback", () => {
+    expect(
+      getMomentumReleaseVelocity({
+        samples: [
+          { positionPx: 20, timeMs: 40 },
+          { positionPx: 44, timeMs: 60 },
+        ],
+        endPositionPx: 80,
+        endTimeMs: 80,
+        fallbackVelocityPxPerMs: 0.2,
+      }),
+    ).toBe(1.5);
+  });
+
+  it("falls back when the trailing window cannot carry direction", () => {
+    expect(
+      getMomentumReleaseVelocity({
+        samples: [{ positionPx: 80, timeMs: 80 }],
+        endPositionPx: 80,
+        endTimeMs: 80,
+        fallbackVelocityPxPerMs: 0.35,
+      }),
+    ).toBe(0.35);
+    expect(
+      getMomentumReleaseVelocity({
+        samples: [
+          { positionPx: 80, timeMs: 60 },
+          { positionPx: 90, timeMs: 70 },
+        ],
+        endPositionPx: 80,
+        endTimeMs: 80,
+        fallbackVelocityPxPerMs: -0.2,
+      }),
+    ).toBe(-0.2);
+  });
+});
+
+describe("getVelocityAwareSettleDuration", () => {
+  it("preserves the pager's 320–600 ms velocity curve", () => {
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 1.8,
+        remainingDistancePx: 260,
+        fallbackDurationMs: 460,
+      }),
+    ).toBe(320);
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 0.18,
+        remainingDistancePx: 260,
+        fallbackDurationMs: 460,
+      }),
+    ).toBe(433);
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 0.1,
+        remainingDistancePx: 500,
+        fallbackDurationMs: 460,
+      }),
+    ).toBe(600);
+  });
+
+  it("bounds the fallback when release velocity is unavailable", () => {
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 0,
+        remainingDistancePx: 260,
+        fallbackDurationMs: 700,
+      }),
+    ).toBe(600);
+  });
+});
+
+describe("shouldCommitMomentumDetent", () => {
+  const base = {
+    distanceThresholdPx: 200,
+    minimumFlickDistancePx: 48,
+    flickVelocityThresholdPxPerMs: 0.45,
+  };
+
+  it("commits at the distance threshold regardless of release speed", () => {
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: -200,
+        releaseVelocityPxPerMs: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("commits a short flick only when velocity follows the drag direction", () => {
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: -64,
+        releaseVelocityPxPerMs: -0.5,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: -64,
+        releaseVelocityPxPerMs: 0.5,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects flicks below the travel floor or outside release-axis ownership", () => {
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: 47,
+        releaseVelocityPxPerMs: 1,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: 64,
+        releaseVelocityPxPerMs: 1,
+        isFlickAxisDominant: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/gestures/momentum.ts
+++ b/packages/ui/src/gestures/momentum.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure one-dimensional momentum math for drag surfaces that settle onto a
+ * detent. The defaults preserve the home pager's release sampling and settle
+ * tuning while allowing vertical and horizontal consumers to share the same
+ * motion model without sharing pointer-event state.
+ */
+
+/** A position sample captured during the trailing edge of a drag. */
+export interface MomentumSample {
+  positionPx: number;
+  timeMs: number;
+}
+
+/** The pager samples only the final 100 ms so release intent wins over the
+ * whole-gesture average. Callers use this while retaining samples. */
+export const MOMENTUM_RELEASE_WINDOW_MS = 100;
+
+/** The home pager's velocity-aware settle band and speed floor. */
+export const MOMENTUM_MIN_SETTLE_MS = 320;
+export const MOMENTUM_MAX_SETTLE_MS = 600;
+export const MOMENTUM_MIN_SETTLE_SPEED_PX_PER_MS = 0.6;
+
+interface ReleaseVelocityOptions {
+  samples: readonly MomentumSample[];
+  endPositionPx: number;
+  endTimeMs: number;
+  fallbackVelocityPxPerMs: number;
+}
+
+/**
+ * Estimates how fast the pointer left the surface from its trailing samples.
+ * Samples are expected to have already been retained within
+ * {@link MOMENTUM_RELEASE_WINDOW_MS}; a whole-gesture average is the fallback
+ * for tap-flicks and degenerate windows.
+ */
+export function getMomentumReleaseVelocity({
+  samples,
+  endPositionPx,
+  endTimeMs,
+  fallbackVelocityPxPerMs,
+}: ReleaseVelocityOptions): number {
+  if (samples.length < 2) return fallbackVelocityPxPerMs;
+
+  const oldest = samples[0];
+  const elapsedMs = endTimeMs - oldest.timeMs;
+  if (elapsedMs <= 0) return fallbackVelocityPxPerMs;
+
+  const velocityPxPerMs = (endPositionPx - oldest.positionPx) / elapsedMs;
+  return velocityPxPerMs === 0 ? fallbackVelocityPxPerMs : velocityPxPerMs;
+}
+
+interface VelocityAwareSettleOptions {
+  velocityPxPerMs: number;
+  remainingDistancePx: number;
+  fallbackDurationMs: number;
+  minimumDurationMs?: number;
+  maximumDurationMs?: number;
+  minimumSpeedPxPerMs?: number;
+}
+
+/**
+ * Converts release speed and remaining travel into a bounded settle duration.
+ * Fast releases land at the short end of the band; a near-still release uses
+ * the caller's bounded fallback rather than manufacturing directional intent.
+ */
+export function getVelocityAwareSettleDuration({
+  velocityPxPerMs,
+  remainingDistancePx,
+  fallbackDurationMs,
+  minimumDurationMs = MOMENTUM_MIN_SETTLE_MS,
+  maximumDurationMs = MOMENTUM_MAX_SETTLE_MS,
+  minimumSpeedPxPerMs = MOMENTUM_MIN_SETTLE_SPEED_PX_PER_MS,
+}: VelocityAwareSettleOptions): number {
+  const clampDuration = (durationMs: number) =>
+    Math.max(
+      minimumDurationMs,
+      Math.min(maximumDurationMs, Math.round(durationMs)),
+    );
+  const remaining = Math.abs(remainingDistancePx);
+  const speed = Math.abs(velocityPxPerMs);
+
+  if (remaining < 1 || speed < 0.01) {
+    return clampDuration(fallbackDurationMs);
+  }
+
+  return clampDuration(remaining / Math.max(minimumSpeedPxPerMs, speed));
+}
+
+interface MomentumDetentOptions {
+  displacementPx: number;
+  releaseVelocityPxPerMs: number;
+  distanceThresholdPx: number;
+  minimumFlickDistancePx: number;
+  flickVelocityThresholdPxPerMs: number;
+  /** Axis ownership is determined by the pointer recognizer; only the
+   * short-distance flick escape hatch requires it again at release. */
+  isFlickAxisDominant?: boolean;
+}
+
+/**
+ * Resolves a detent commit from distance or a same-direction release flick.
+ * Reversing velocity never commits the original drag direction, which keeps a
+ * drag-out-then-fling-back gesture on its current detent.
+ */
+export function shouldCommitMomentumDetent({
+  displacementPx,
+  releaseVelocityPxPerMs,
+  distanceThresholdPx,
+  minimumFlickDistancePx,
+  flickVelocityThresholdPxPerMs,
+  isFlickAxisDominant = true,
+}: MomentumDetentOptions): boolean {
+  if (Math.abs(displacementPx) >= distanceThresholdPx) return true;
+
+  return (
+    isFlickAxisDominant &&
+    Math.abs(displacementPx) >= minimumFlickDistancePx &&
+    Math.abs(releaseVelocityPxPerMs) >= flickVelocityThresholdPxPerMs &&
+    Math.sign(releaseVelocityPxPerMs) === Math.sign(displacementPx)
+  );
+}

--- a/packages/ui/src/state/cloud-login-launch.test.ts
+++ b/packages/ui/src/state/cloud-login-launch.test.ts
@@ -76,6 +76,7 @@ function makePopup(closed: boolean): Window {
 afterEach(() => {
   delete globalWithPlatform.Capacitor;
   delete windowWithElectrobun.__electrobunWindowId;
+  window.name = "";
   vi.restoreAllMocks();
   restoreDescriptor("location", originalLocationDescriptor);
   restoreDescriptor("matchMedia", originalMatchMediaDescriptor);
@@ -167,6 +168,14 @@ describe("buildSameTabCloudLoginPath", () => {
 });
 
 describe("preOpenCloudLoginWindow", () => {
+  it("reuses the existing cloud auth popup instead of blanking it", () => {
+    window.name = CLOUD_LOGIN_POPUP_NAME;
+    const openSpy = vi.spyOn(window, "open");
+
+    expect(preOpenCloudLoginWindow()).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
   it("skips the popup attempt on touch-primary hosted web (redirect-first)", () => {
     stubMatchMedia(true);
     const openSpy = vi.spyOn(window, "open");

--- a/packages/ui/src/state/cloud-login-launch.test.ts
+++ b/packages/ui/src/state/cloud-login-launch.test.ts
@@ -17,6 +17,7 @@ import {
   isTouchPrimaryWebBrowser,
   preOpenCloudLoginWindow,
   resolveCloudSignInPageUrl,
+  shouldReuseCurrentCloudLoginWindow,
   shouldUseSameTabCloudLogin,
 } from "./cloud-login-launch";
 
@@ -188,6 +189,27 @@ describe("preOpenCloudLoginWindow", () => {
     const openSpy = vi.spyOn(window, "open").mockReturnValue(popup);
     expect(preOpenCloudLoginWindow()).toBe(popup);
     expect(openSpy).toHaveBeenCalledWith("about:blank", CLOUD_LOGIN_POPUP_NAME);
+  });
+});
+
+describe("shouldReuseCurrentCloudLoginWindow", () => {
+  it("reuses the current surface for CLI device-login callbacks", () => {
+    expect(shouldReuseCurrentCloudLoginWindow("/auth/cli-login")).toBe(true);
+    expect(
+      shouldReuseCurrentCloudLoginWindow(
+        "/auth/cli-login?session=session-1&returnTo=http%3A%2F%2Flocalhost%3A2138",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps direct login destinations on the normal popup path", () => {
+    expect(shouldReuseCurrentCloudLoginWindow("/dashboard")).toBe(false);
+    expect(
+      shouldReuseCurrentCloudLoginWindow(
+        "https://example.test/auth/cli-login?session=session-1",
+      ),
+    ).toBe(false);
+    expect(shouldReuseCurrentCloudLoginWindow(null)).toBe(false);
   });
 });
 

--- a/packages/ui/src/state/cloud-login-launch.ts
+++ b/packages/ui/src/state/cloud-login-launch.ts
@@ -81,6 +81,14 @@ export function hasSameOriginStewardLogin(): boolean {
  * a popup/tab the flow would immediately abandon.
  */
 export function preOpenCloudLoginWindow(): Window | null {
+  // The hosted login page may already be running inside the named window that
+  // onboarding pre-opened. Calling window.open("about:blank", sameName) from
+  // there replaces the login page before the async PKCE work can navigate it,
+  // stranding the flow on a blank tab. Reuse that window as the current-tab
+  // OAuth surface instead; returning null selects the safe same-tab branch.
+  if (typeof window !== "undefined" && window.name === CLOUD_LOGIN_POPUP_NAME) {
+    return null;
+  }
   if (
     isPlainWebPlatform() &&
     hasSameOriginStewardLogin() &&

--- a/packages/ui/src/state/cloud-login-launch.ts
+++ b/packages/ui/src/state/cloud-login-launch.ts
@@ -100,6 +100,21 @@ export function preOpenCloudLoginWindow(): Window | null {
 }
 
 /**
+ * Device-login already owns a dedicated browser surface. Its cross-origin
+ * redirect applies COOP, which may clear both window.name and window.opener;
+ * the encoded return target is the durable signal that OAuth must reuse the
+ * current surface instead of opening a nested popup.
+ */
+export function shouldReuseCurrentCloudLoginWindow(
+  returnTo: string | null,
+): boolean {
+  return (
+    returnTo === "/auth/cli-login" ||
+    returnTo?.startsWith("/auth/cli-login?") === true
+  );
+}
+
+/**
  * Whether the cloud sign-in should navigate THIS tab to the same-origin
  * `/login` page instead of driving the popup device-code flow. True on plain
  * web with a same-origin Steward login when the popup handle is dead (blocked

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -373,6 +373,135 @@ describe("notification-store", () => {
     });
   });
 
+  it("reconciles a ready empty inbox after the WebSocket reconnects", async () => {
+    const restored = makeNotification({
+      id: "restored-after-reconnect",
+      title: "Take the tour",
+    });
+    listNotifications
+      .mockResolvedValueOnce({ notifications: [], unreadCount: 0 })
+      .mockResolvedValueOnce({ notifications: [restored], unreadCount: 1 });
+
+    initNotifications();
+    await flushDelivery();
+    expect(__getStateForTests()).toMatchObject({
+      notifications: [],
+      hydrated: true,
+      hydrationStatus: "ready",
+    });
+
+    const reconnectHandler = onWsEvent.mock.calls.find(
+      ([event]) => event === "ws-reconnected",
+    )?.[1] as () => void;
+    reconnectHandler();
+    await flushDelivery();
+
+    expect(listNotifications).toHaveBeenCalledTimes(2);
+    expect(__getStateForTests()).toMatchObject({
+      notifications: [restored],
+      unreadCount: 1,
+      hydrated: true,
+      hydrationStatus: "ready",
+      hydrationError: null,
+    });
+  });
+
+  it("removes locally stale rows when the reconnect snapshot no longer contains them", async () => {
+    const stale = makeNotification({ id: "removed-on-server" });
+    listNotifications
+      .mockResolvedValueOnce({ notifications: [stale], unreadCount: 1 })
+      .mockResolvedValueOnce({ notifications: [], unreadCount: 0 });
+
+    initNotifications();
+    await flushDelivery();
+    expect(__getStateForTests().notifications).toEqual([stale]);
+
+    const reconnectHandler = onWsEvent.mock.calls.find(
+      ([event]) => event === "ws-reconnected",
+    )?.[1] as () => void;
+    reconnectHandler();
+    await flushDelivery();
+
+    expect(__getStateForTests()).toMatchObject({
+      notifications: [],
+      unreadCount: 0,
+      hydrated: true,
+      hydrationStatus: "ready",
+    });
+  });
+
+  it("preserves a live arrival while a reconnect snapshot is in flight", async () => {
+    const persisted = makeNotification({
+      id: "persisted-during-reconnect",
+      createdAt: 10,
+    });
+    const live = makeNotification({
+      id: "live-during-reconnect",
+      createdAt: 20,
+    });
+    let resolveReconnect!: (value: {
+      notifications: AgentNotification[];
+      unreadCount: number;
+    }) => void;
+    const reconnectResponse = new Promise<{
+      notifications: AgentNotification[];
+      unreadCount: number;
+    }>((resolve) => {
+      resolveReconnect = resolve;
+    });
+    listNotifications
+      .mockResolvedValueOnce({ notifications: [], unreadCount: 0 })
+      .mockReturnValueOnce(reconnectResponse);
+
+    initNotifications();
+    await flushDelivery();
+    const reconnectHandler = onWsEvent.mock.calls.find(
+      ([event]) => event === "ws-reconnected",
+    )?.[1] as () => void;
+    reconnectHandler();
+    await flushDelivery();
+
+    const notificationHandler = onWsEvent.mock.calls.find(
+      ([event]) => event === "agent_event",
+    )?.[1] as (data: Record<string, unknown>) => void;
+    notificationHandler({
+      stream: "notification",
+      payload: { notification: live, unreadCount: 1 },
+    });
+    resolveReconnect({ notifications: [persisted], unreadCount: 2 });
+    await flushDelivery();
+
+    expect(
+      __getStateForTests().notifications.map((notification) => notification.id),
+    ).toEqual([live.id, persisted.id]);
+    expect(__getStateForTests().unreadCount).toBe(1);
+  });
+
+  it("does not start a parallel hydrate while a retry timer is armed", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    listNotifications
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValueOnce({ notifications: [], unreadCount: 0 });
+
+    initNotifications();
+    await flushDelivery();
+    expect(__getStateForTests().hydrationStatus).toBe("retrying");
+    expect(listNotifications).toHaveBeenCalledTimes(1);
+
+    const reconnectHandler = onWsEvent.mock.calls.find(
+      ([event]) => event === "ws-reconnected",
+    )?.[1] as () => void;
+    reconnectHandler();
+    await flushDelivery();
+    expect(listNotifications).toHaveBeenCalledTimes(1);
+
+    await vi.runOnlyPendingTimersAsync();
+    await flushDelivery();
+    expect(listNotifications).toHaveBeenCalledTimes(2);
+    expect(__getStateForTests().hydrationStatus).toBe("ready");
+  });
+
   it("WS handler ignores non-notification streams", async () => {
     initNotifications();
     const handler = onWsEvent.mock.calls[0][1] as (

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -534,6 +534,28 @@ describe("notification-store", () => {
     expect(pushNotificationBanner.mock.calls[0][0].title).toBe("From WS");
   });
 
+  it("ignores replayed notification history and leaves hydration authoritative", async () => {
+    initNotifications();
+    await flushDelivery();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      d: Record<string, unknown>,
+    ) => void;
+    handler({
+      replayed: true,
+      stream: "notification",
+      payload: {
+        type: "notification",
+        notification: makeNotification({ title: "Historical" }),
+        unreadCount: 99,
+      },
+    });
+    await flushDelivery();
+    expect(__getStateForTests().notifications).toHaveLength(0);
+    expect(__getStateForTests().unreadCount).toBe(0);
+    expect(pushNotificationBanner).not.toHaveBeenCalled();
+    expect(showNativeNotification).not.toHaveBeenCalled();
+  });
+
   it("WS handler drops a payload missing id or title (validated, not cast)", async () => {
     initNotifications();
     const handler = onWsEvent.mock.calls[0][1] as (

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -14,7 +14,6 @@ const markNotificationReadApi = vi.fn();
 const markAllNotificationsReadApi = vi.fn();
 const removeNotificationApi = vi.fn();
 const clearNotificationsApi = vi.fn();
-const seedDevNotificationsApi = vi.fn();
 const onWsEvent = vi.fn();
 const connectWs = vi.fn();
 
@@ -27,8 +26,6 @@ vi.mock("../../api/client", () => ({
       markAllNotificationsReadApi(...args),
     removeNotification: (...args: unknown[]) => removeNotificationApi(...args),
     clearNotifications: (...args: unknown[]) => clearNotificationsApi(...args),
-    seedDevNotifications: (...args: unknown[]) =>
-      seedDevNotificationsApi(...args),
     onWsEvent: (...args: unknown[]) => onWsEvent(...args),
     connectWs: () => connectWs(),
   },
@@ -69,7 +66,6 @@ import {
   markNotificationRead,
   removeNotification,
   removeNotifications,
-  seedDevNotificationsIfEmpty,
 } from "./notification-store";
 
 function makeNotification(
@@ -108,10 +104,6 @@ describe("notification-store", () => {
     markAllNotificationsReadApi.mockReset().mockResolvedValue({ changed: 0 });
     removeNotificationApi.mockReset().mockResolvedValue({ ok: true });
     clearNotificationsApi.mockReset().mockResolvedValue({ ok: true });
-    seedDevNotificationsApi.mockReset().mockResolvedValue({
-      count: 0,
-      notifications: [],
-    });
     onWsEvent.mockReset().mockReturnValue(() => {});
     connectWs.mockReset();
     // Defaults model the plain web platform: no desktop bridge (null), no
@@ -829,47 +821,6 @@ describe("notification-store", () => {
     expect(__getStateForTests().notifications.every((n) => !n.readAt)).toBe(
       true,
     );
-  });
-
-  describe("seedDevNotificationsIfEmpty (dev default-active)", () => {
-    it("seeds the demo spread when the inbox hydrates empty", async () => {
-      const seeded = [
-        makeNotification({ id: "s1", priority: "urgent" }),
-        makeNotification({ id: "s2", priority: "normal", readAt: Date.now() }),
-      ];
-      seedDevNotificationsApi.mockResolvedValueOnce({
-        count: 2,
-        notifications: seeded,
-      });
-      await seedDevNotificationsIfEmpty();
-      expect(seedDevNotificationsApi).toHaveBeenCalledTimes(1);
-      expect(__getStateForTests().notifications).toHaveLength(2);
-      // Unread count is derived from the seeded rows (one is pre-read).
-      expect(__getStateForTests().unreadCount).toBe(1);
-    });
-
-    it("never seeds over a real inbox", async () => {
-      listNotifications.mockResolvedValueOnce({
-        notifications: [makeNotification({ id: "real" })],
-        unreadCount: 1,
-      });
-      await seedDevNotificationsIfEmpty();
-      expect(seedDevNotificationsApi).not.toHaveBeenCalled();
-      expect(__getStateForTests().notifications).toHaveLength(1);
-      expect(__getStateForTests().notifications[0]?.id).toBe("real");
-    });
-
-    it("runs at most once per session", async () => {
-      await seedDevNotificationsIfEmpty();
-      await seedDevNotificationsIfEmpty();
-      expect(seedDevNotificationsApi).toHaveBeenCalledTimes(1);
-    });
-
-    it("stays data-driven when the seed route 404s (no throw)", async () => {
-      seedDevNotificationsApi.mockRejectedValueOnce(new Error("404"));
-      await expect(seedDevNotificationsIfEmpty()).resolves.toBeUndefined();
-      expect(__getStateForTests().notifications).toHaveLength(0);
-    });
   });
 });
 

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -16,6 +16,7 @@ const removeNotificationApi = vi.fn();
 const clearNotificationsApi = vi.fn();
 const seedDevNotificationsApi = vi.fn();
 const onWsEvent = vi.fn();
+const connectWs = vi.fn();
 
 vi.mock("../../api/client", () => ({
   client: {
@@ -29,6 +30,7 @@ vi.mock("../../api/client", () => ({
     seedDevNotifications: (...args: unknown[]) =>
       seedDevNotificationsApi(...args),
     onWsEvent: (...args: unknown[]) => onWsEvent(...args),
+    connectWs: () => connectWs(),
   },
 }));
 
@@ -111,6 +113,7 @@ describe("notification-store", () => {
       notifications: [],
     });
     onWsEvent.mockReset().mockReturnValue(() => {});
+    connectWs.mockReset();
     // Defaults model the plain web platform: no desktop bridge (null), no
     // Capacitor channel ("none"), web Notification unavailable (false).
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
@@ -269,6 +272,7 @@ describe("notification-store", () => {
     expect(onWsEvent).toHaveBeenCalledTimes(2);
     expect(onWsEvent.mock.calls[0][0]).toBe("agent_event");
     expect(onWsEvent.mock.calls[1][0]).toBe("ws-reconnected");
+    expect(connectWs).toHaveBeenCalledTimes(1);
     expect(listNotifications).toHaveBeenCalledTimes(1);
     await Promise.resolve();
   });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -244,6 +244,7 @@ function ingest(
 }
 
 interface WsAgentEvent {
+  replayed?: boolean;
   stream?: string;
   payload?: unknown;
 }
@@ -330,6 +331,10 @@ function validateWsNotification(value: unknown): AgentNotification | null {
 
 function handleWsAgentEvent(data: Record<string, unknown>): void {
   const event = data as WsAgentEvent;
+  // HTTP hydration/reconciliation is the canonical inbox snapshot. Buffered
+  // socket history exists for idempotent stream consumers and must never be
+  // mistaken for a fresh arrival that replays banners or stale unread state.
+  if (event.replayed === true) return;
   if (event.stream !== "notification") return;
   const payload =
     event.payload && typeof event.payload === "object"

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -399,14 +399,21 @@ function hydrationErrorMessage(error: unknown): string {
     : "Notification inbox hydration failed";
 }
 
-async function runHydrationAttempt(generation: number): Promise<void> {
-  const attempt = state.hydrationAttempts + 1;
+async function runHydrationAttempt(
+  generation: number,
+  preserveReadyState = false,
+): Promise<void> {
+  const backgroundReconciliation =
+    preserveReadyState && state.hydrated && state.hydrationStatus === "ready";
+  const attempt = backgroundReconciliation ? 1 : state.hydrationAttempts + 1;
   const liveRevisionAtStart = liveEventRevision;
-  setState({
-    hydrated: false,
-    hydrationStatus: attempt === 1 ? "loading" : "retrying",
-    hydrationAttempts: attempt,
-  });
+  if (!backgroundReconciliation) {
+    setState({
+      hydrated: false,
+      hydrationStatus: attempt === 1 ? "loading" : "retrying",
+      hydrationAttempts: attempt,
+    });
+  }
   try {
     const res = await client.listNotifications({ limit: 100 });
     if (generation !== hydrationGeneration) return;
@@ -414,7 +421,10 @@ async function runHydrationAttempt(generation: number): Promise<void> {
       clearTimeout(hydrationRetryTimer);
       hydrationRetryTimer = null;
     }
-    const notifications = mergeHydratedNotifications(res.notifications);
+    const notifications =
+      liveEventRevision === liveRevisionAtStart
+        ? res.notifications
+        : mergeHydratedNotifications(res.notifications);
     const hydrationStatus =
       res.serviceStatus === "disabled" ? "disabled" : "ready";
     setState({
@@ -437,6 +447,13 @@ async function runHydrationAttempt(generation: number): Promise<void> {
     // error-policy:J1 transport boundary — bounded background retries keep the
     // live subscription active while surfacing terminal failure in store state.
     if (generation !== hydrationGeneration) return;
+    if (backgroundReconciliation && isRetryableHydrationError(err)) {
+      logger.warn(
+        { err },
+        "[notification-store] inbox reconciliation failed; preserving hydrated state",
+      );
+      return;
+    }
     const message = hydrationErrorMessage(err);
     const retryable =
       isRetryableHydrationError(err) && attempt < HYDRATION_MAX_ATTEMPTS;
@@ -469,7 +486,9 @@ async function runHydrationAttempt(generation: number): Promise<void> {
   }
 }
 
-function requestHydration(): Promise<void> {
+function requestHydration(
+  options: { preserveReadyState?: boolean } = {},
+): Promise<void> {
   if (!notificationProbesEnabled()) {
     // No session yet on the shared Cloud app — skip the protected fetch (it
     // would 401 and Chromium logs the console error) and re-arm once, so the
@@ -487,7 +506,10 @@ function requestHydration(): Promise<void> {
   if (hydrationInFlight) return hydrationInFlight;
   if (state.hydrationStatus === "failed") return Promise.resolve();
   const generation = hydrationGeneration;
-  const run = runHydrationAttempt(generation);
+  const run = runHydrationAttempt(
+    generation,
+    options.preserveReadyState ?? false,
+  );
   let tracked: Promise<void>;
   tracked = run.finally(() => {
     if (hydrationInFlight === tracked) hydrationInFlight = null;
@@ -508,6 +530,20 @@ export function retryNotificationHydration(): Promise<void> {
   return requestHydration();
 }
 
+/** Reconcile lifecycle gaps without blanking a successfully-hydrated inbox. */
+function reconcileNotificationHydration(): Promise<void> {
+  if (state.hydrationStatus === "failed") {
+    return retryNotificationHydration();
+  }
+  if (
+    state.hydrationStatus === "loading" ||
+    state.hydrationStatus === "retrying"
+  ) {
+    return hydrationInFlight ?? Promise.resolve();
+  }
+  return requestHydration({ preserveReadyState: true });
+}
+
 /** Idempotent boot: hydrate the inbox and subscribe to live notifications. */
 export function initNotifications(): void {
   if (initialized) return;
@@ -515,18 +551,18 @@ export function initNotifications(): void {
   notificationCleanups.push(
     client.onWsEvent("agent_event", handleWsAgentEvent),
     client.onWsEvent("ws-reconnected", () => {
-      void retryNotificationHydration();
+      void reconcileNotificationHydration();
     }),
   );
   if (typeof window !== "undefined") {
-    const retryOnline = () => void retryNotificationHydration();
+    const retryOnline = () => void reconcileNotificationHydration();
     window.addEventListener("online", retryOnline);
     notificationCleanups.push(() =>
       window.removeEventListener("online", retryOnline),
     );
   }
   if (typeof document !== "undefined") {
-    const retryOnResume = () => void retryNotificationHydration();
+    const retryOnResume = () => void reconcileNotificationHydration();
     document.addEventListener(APP_RESUME_EVENT, retryOnResume);
     notificationCleanups.push(() =>
       document.removeEventListener(APP_RESUME_EVENT, retryOnResume),

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -580,38 +580,6 @@ export function initNotifications(): void {
   void requestHydration();
 }
 
-let devSeedAttempted = false;
-
-/**
- * Dev-only: populate the demo spread when the inbox is empty so the home
- * notification surface is visible by default while developing. The boot wiring
- * calls this only in dev builds (`import.meta.env.DEV`); the server's
- * `/dev/seed` route is itself non-production (404s in prod), so this stays a
- * no-op outside dev. Runs at most once per session and never seeds over a real
- * inbox — production is strictly data-driven.
- */
-export async function seedDevNotificationsIfEmpty(): Promise<void> {
-  if (devSeedAttempted) return;
-  devSeedAttempted = true;
-  // Hydrate first so we only seed a genuinely-empty inbox, never over real rows.
-  if (!state.hydrated) await requestHydration();
-  if (state.hydrationStatus !== "ready" || state.hydrationError !== null) {
-    return;
-  }
-  if (state.notifications.length > 0) return;
-  try {
-    const res = await client.seedDevNotifications();
-    setState({
-      notifications: res.notifications,
-      unreadCount: countUnread(res.notifications),
-      hydrated: true,
-    });
-  } catch {
-    // Prod 404s the seed route (or it is otherwise unavailable) — stay
-    // data-driven; a dev seed failure must never break boot.
-  }
-}
-
 // ── Mutations (optimistic; backed by the HTTP API) ──────────────────────────
 
 /**
@@ -741,7 +709,6 @@ export function __resetNotificationStoreForTests(): void {
     hydrationError: null,
   };
   initialized = false;
-  devSeedAttempted = false;
   ephemeralNotificationIds.clear();
   listeners.clear();
 }

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -568,6 +568,10 @@ export function initNotifications(): void {
       document.removeEventListener(APP_RESUME_EVENT, retryOnResume),
     );
   }
+  // This store owns a realtime dependency even when first-run startup never
+  // reaches the broader shell hydration phase. Subscribing before connect
+  // ensures the first notification frame cannot race past the inbox handler.
+  client.connectWs();
   void requestHydration();
 }
 

--- a/packages/ui/src/state/parsers.test.ts
+++ b/packages/ui/src/state/parsers.test.ts
@@ -235,11 +235,13 @@ describe("parseStreamEventEnvelopeEvent", () => {
       ...valid,
       runId: "r1",
       seq: 4,
+      replayed: true,
       agentId: "a1",
       stream: 99, // wrong type → ignored
     });
     expect(env?.runId).toBe("r1");
     expect(env?.seq).toBe(4);
+    expect(env?.replayed).toBe(true);
     expect(env?.agentId).toBe("a1");
     expect(env?.stream).toBeUndefined();
   });

--- a/packages/ui/src/state/parsers.ts
+++ b/packages/ui/src/state/parsers.ts
@@ -143,6 +143,7 @@ export function parseStreamEventEnvelopeEvent(
   };
   if (typeof data.runId === "string") envelope.runId = data.runId;
   if (typeof data.seq === "number") envelope.seq = data.seq;
+  if (data.replayed === true) envelope.replayed = true;
   if (typeof data.stream === "string") envelope.stream = data.stream;
   if (typeof data.sessionKey === "string")
     envelope.sessionKey = data.sessionKey;

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -457,6 +457,55 @@ body.pwa-standalone textarea {
   background-clip: padding-box;
 }
 
+.chat-composer-scrollbar[data-scroll-fade="top"] {
+  -webkit-mask-image:
+    linear-gradient(to bottom, transparent 0, black 16px, black 100%),
+    linear-gradient(to right, transparent calc(100% - 8px), black 0);
+  mask-image:
+    linear-gradient(to bottom, transparent 0, black 16px, black 100%),
+    linear-gradient(to right, transparent calc(100% - 8px), black 0);
+}
+
+.chat-composer-scrollbar[data-scroll-fade="bottom"] {
+  -webkit-mask-image:
+    linear-gradient(
+      to bottom,
+      black 0,
+      black calc(100% - 16px),
+      transparent 100%
+    ),
+    linear-gradient(to right, transparent calc(100% - 8px), black 0);
+  mask-image:
+    linear-gradient(
+      to bottom,
+      black 0,
+      black calc(100% - 16px),
+      transparent 100%
+    ),
+    linear-gradient(to right, transparent calc(100% - 8px), black 0);
+}
+
+.chat-composer-scrollbar[data-scroll-fade="both"] {
+  -webkit-mask-image:
+    linear-gradient(
+      to bottom,
+      transparent 0,
+      black 16px,
+      black calc(100% - 16px),
+      transparent 100%
+    ),
+    linear-gradient(to right, transparent calc(100% - 8px), black 0);
+  mask-image:
+    linear-gradient(
+      to bottom,
+      transparent 0,
+      black 16px,
+      black calc(100% - 16px),
+      transparent 100%
+    ),
+    linear-gradient(to right, transparent calc(100% - 8px), black 0);
+}
+
 /* Keyboard shortcuts styling */
 kbd {
   font-family: var(--mono);

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -431,6 +431,32 @@ body.pwa-standalone textarea {
   background: transparent;
 }
 
+.chat-composer-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb-mid) transparent;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-thumb {
+  border: 1px solid transparent;
+  background: var(--scrollbar-thumb-mid);
+  background-clip: padding-box;
+  border-radius: 9999px;
+  box-shadow: none;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover-mid);
+  background-clip: padding-box;
+}
+
 /* Keyboard shortcuts styling */
 kbd {
   font-family: var(--mono);

--- a/packages/ui/stories/src/lab/mock-chat.ts
+++ b/packages/ui/stories/src/lab/mock-chat.ts
@@ -285,7 +285,6 @@ export function useMockChat(config: MockChatConfig): MockChat {
       needsAudioUnlock: false,
       transcriptionMode: config.transcribing,
       toggleTranscriptionMode: () => {},
-      stopTranscriptionAndMic: () => {},
       modelStatus: {
         kind: "ready",
         blocksSend: false,


### PR DESCRIPTION
Closes #16460

## Summary

This is a cohesive interaction and visual-stability pass across the home notification shade, continuous chat sheet, startup/auth surfaces, and local development runtime.

- Gives the notification shade shared momentum physics, endpoint resistance, stable detents, coordinated card/count/control fades, clean stack expansion/collapse, desktop clear-all confirmation, and isolated chat-vs-home gestures.
- Makes notification boot/reconnect snapshots authoritative while preserving concurrent arrivals, and tags replayed WebSocket events so one-shot UI effects are not repeated.
- Reworks chat actions, inline editing, replies, playback state, timestamps, transcription, long-draft scrolling, search, upload, and pending attachments so controls stay scoped to the correct message without unintended row or sheet movement.
- Makes message-search jumps deterministic by revealing already-loaded history before fetching and routing the jump through the canonical message scroller; the target lands in view with a neutral white highlight.
- Keeps the startup logo/name static while only status text shimmers, hides desktop pager arrows on mobile, reuses canonical cloud/device login launch surfaces, and runs the local Vite server under Node so HTTP upgrade/WebSocket proxying remains connected.

## Root causes

Notification drag physics, settle state, opacity, mounting, and glass presentation were driven by partially independent transitions. Chat action/reply/transcription controls participated in message and composer layout. Search fetched before revealing bounded history while bottom-follow could override imperative scrolling. Snapshot/replay handling could conflate reconnect state with new arrivals. The pre-React startup lockup and mounted shell used different geometry, and Bun-hosted Vite did not reliably preserve proxy upgrades.

## User impact

Notification pulls and stacks now track, settle, expand, collapse, and clear as one coherent surface. Chat controls stay minimal and stable. Older search hits reliably scroll into view. Voice/transcription and attachment workflows no longer unexpectedly open or collapse the sheet. Startup/auth transitions no longer morph or fork into duplicate UI, and mobile keeps swipe navigation without desktop arrows.

## Verification

Passed:

- Focused UI/component suites: 182/182
- Chat-thread gesture Playwright: 6/6
- Desktop/mobile chat-message-actions Playwright: 2/2
- Fresh app aesthetic audit: 246/246 captures passed; 227 good, 17 manually reviewed needs-eyeball, 0 needs-work, 0 broken
- UI package typecheck, Biome, diff checks, and dist-path consumer typecheck
- Branch-scoped error-policy, voice-policy, view-action, alias-env, build-dependency, compiler-model, secret-leak, and test-realness guards
- Full Turbo typecheck + lint: 573/573 tasks
- Rebased onto current `origin/develop`: 0 commits behind

The fresh manual visual pass found no regression in the changed chat/home shell across mobile portrait, mobile landscape, desktop landscape, and iPad portrait. The remaining needs-eyeball items are pre-existing responsive polish/overflow cases in unrelated Skills, Logs, and tall plugin views; they are not introduced by the develop-relative diff.

## Inherited develop blockers

`bun run verify` currently stops on two repository-wide checks whose failures reproduce from current `origin/develop` and are not introduced by this diff:

- `audit:type-safety-ratchet`: the fixed baseline drifted upstream; this branch contributes zero counted fallback expressions.
- `audit:scripts`: upstream orphan `packages/scripts/aggregate-scenario-reports.mjs` is not referenced by a package script.

The transcript real-audio spec reaches and passes the updated active-transcription assertion; four later pre-existing fixture/document failures remain (three fake-WAV ASR posts and one missing document-open-transcript path).

## Evidence still required before ready-for-review

- Before/after desktop and mobile screenshots plus MP4 walkthrough
- Frontend console/network and backend reconnect logs
- Real voice/transcription audio evidence

N/A: model trajectories, schema migrations, wallet/on-chain artifacts, and scheduled-task artifacts; this PR does not change prompt/action/provider/model behavior.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16496-before-notification-text-bleed.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16496-after-desktop-mobile-contact-sheet.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16496-full-ui-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [16496-backend-ws-replay.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16496-backend-ws-replay.log)

<!-- evidence-row:frontend-logs -->
- [x] [16496-frontend-playwright.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16496-frontend-playwright.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - UI interaction and realtime transport behavior only; no schema or domain artifact is produced.

<!-- evidence-row:ocr-review -->
- [x] [16496-ocr-manual-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16496-ocr-manual-review.md)
