### PR TITLE
fix(voice): thread a per-utterance Idempotency-Key through every cloud TTS leg

### DIFF
--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -466,7 +466,10 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     );
     expect(response.status).toBe(200);
     expect(reserveCredits).toHaveBeenCalledTimes(1);
-    expect(reserveCredits.mock.calls[0]?.[0]).toMatchObject({
+    const keyedArgs = reserveCredits.mock.calls[0] as unknown as
+      | [Record<string, unknown>]
+      | undefined;
+    expect(keyedArgs?.[0]).toMatchObject({
       idempotencyKey: "utt-abc",
     });
   });
@@ -477,8 +480,10 @@ describe("POST /api/v1/voice/tts provider selection", () => {
       voiceId: "custom-elevenlabs-voice",
     });
     expect(response.status).toBe(200);
-    const params = reserveCredits.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect("idempotencyKey" in params).toBe(false);
+    const unkeyedArgs = reserveCredits.mock.calls[0] as unknown as
+      | [Record<string, unknown>]
+      | undefined;
+    expect("idempotencyKey" in (unkeyedArgs?.[0] ?? {})).toBe(false);
   });
 
   test("rejects an invalid body and an over-long text before any reservation", async () => {

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -221,11 +221,15 @@ afterAll(() => {
   globalThis.fetch = realFetch;
 });
 
-function postTts(body: unknown, env: Record<string, unknown> = {}) {
+function postTts(
+  body: unknown,
+  env: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+) {
   return route.default.fetch(
     new Request("http://test.local/", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
     }),
     env,
@@ -448,5 +452,45 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(reserveCredits).toHaveBeenCalledTimes(1);
     expect(billUsage).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // #16425: the client mints one Idempotency-Key per logical utterance (sent
+  // on both the direct request and the proxy fallback); the paid path must
+  // thread it into the credit reservation so a fallback retry REPLAYS the
+  // committed reservation instead of charging the utterance twice.
+  test("threads the Idempotency-Key header into the credit reservation", async () => {
+    const response = await postTts(
+      { text: "Bill me once.", voiceId: "custom-elevenlabs-voice" },
+      {},
+      { "Idempotency-Key": "utt-abc" },
+    );
+    expect(response.status).toBe(200);
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(reserveCredits.mock.calls[0]?.[0]).toMatchObject({
+      idempotencyKey: "utt-abc",
+    });
+  });
+
+  test("without the header the reservation stays unkeyed (behavior unchanged)", async () => {
+    const response = await postTts({
+      text: "Hi.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+    expect(response.status).toBe(200);
+    const params = reserveCredits.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect("idempotencyKey" in params).toBe(false);
+  });
+
+  test("rejects an invalid body and an over-long text before any reservation", async () => {
+    const bad = await postTts({ voiceId: "custom-elevenlabs-voice" });
+    expect(bad.status).toBe(400);
+
+    const tooLong = await postTts({
+      text: "x".repeat(5001),
+      voiceId: "custom-elevenlabs-voice",
+    });
+    expect(tooLong.status).toBe(400);
+
+    expect(reserveCredits).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -553,12 +553,19 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         1_000_000
       : ttsCost.totalCost;
 
+    // #16425: the client mints one Idempotency-Key per logical utterance and
+    // sends it on BOTH the direct request and the proxy fallback, so a retry
+    // after an ambiguous network outcome replays the committed reservation
+    // instead of charging the utterance twice. Org-scoped inside reserve().
+    const ttsIdempotencyKey = request.headers.get("Idempotency-Key");
+
     try {
       reservation = await creditsService.reserve({
         organizationId: user.organization_id,
         amount: estimatedCost,
         userId: user.id,
         description: `TTS generation: ${text.length} chars${isCustomVoice ? " (custom voice)" : ""}`,
+        ...(ttsIdempotencyKey && { idempotencyKey: ttsIdempotencyKey }),
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -308,6 +308,16 @@
       "import": "./dist/voice/respond-gate.js",
       "default": "./dist/voice/respond-gate.js"
     },
+    "./voice/first-sentence-snip": {
+      "types": "./dist/voice/first-sentence-snip.d.ts",
+      "eliza-source": {
+        "types": "./src/voice/first-sentence-snip.ts",
+        "import": "./src/voice/first-sentence-snip.ts",
+        "default": "./src/voice/first-sentence-snip.ts"
+      },
+      "import": "./dist/voice/first-sentence-snip.js",
+      "default": "./dist/voice/first-sentence-snip.js"
+    },
     "./voice/owner-inference": {
       "types": "./dist/voice/owner-inference.d.ts",
       "eliza-source": {

--- a/packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx
@@ -236,6 +236,7 @@ describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
     expect(Object.keys(headers).sort()).toEqual([
       "Authorization",
       "Content-Type",
+      "Idempotency-Key",
     ]);
     // Body carries the same `{ text }` contract as the proxy path (the worker
     // treats an omitted voiceId as "unpinned", matching the proxy default).
@@ -323,6 +324,41 @@ describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
     // Warned once, naming the real direct target.
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(String(warnSpy.mock.calls[0]?.[0])).toContain(DIRECT_TTS_URL);
+  });
+
+  // #16425: the fallback re-POST is the SAME logical utterance — both legs
+  // must carry one identical Idempotency-Key so the cloud route replays the
+  // direct attempt's committed credit reservation instead of charging twice.
+  it("sends the SAME Idempotency-Key on the direct attempt and the proxy fallback", async () => {
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const directHeaderKeys: Array<string | undefined> = [];
+    directFetch.mockImplementation(
+      async (_input: unknown, init?: RequestInit) => {
+        directHeaderKeys.push(headersOf(init)["Idempotency-Key"]);
+        throw new TypeError("Failed to fetch");
+      },
+    );
+
+    const { result } = renderForcedCloud();
+    act(() => {
+      result.current.speak("bill me once");
+    });
+
+    await waitFor(() => {
+      expect(proxyUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
+        true,
+      );
+    });
+
+    const proxyCall = fetchWithCsrf.mock.calls.find(([url]) =>
+      String(url).includes("/api/tts/cloud"),
+    );
+    const proxyKey = headersOf(proxyCall?.[1] as RequestInit | undefined)[
+      "Idempotency-Key"
+    ];
+    expect(directHeaderKeys[0]).toBeTruthy();
+    expect(proxyKey).toBe(directHeaderKeys[0]);
   });
 
   it("falls back to the on-device proxy on a direct non-2xx and warns only once across segments", async () => {

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -1621,6 +1621,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
          * path, so chat fell back to browser (Edge) TTS. If cloud rejects
          * (no key), fall back to the upstream ElevenLabs proxy.
          */
+        // #16425: ONE key per logical utterance across BOTH proxy legs (the
+        // cloud proxy and its direct-ElevenLabs-proxy retry below re-POST the
+        // same utterance), so upstream billing can replay the committed
+        // reservation instead of charging the retry as a new operation.
+        const proxyUtteranceKey = crypto.randomUUID();
         const makeProxyRequestInit = (): RequestInit => {
           const dbg = task.debugUtteranceContext;
           return {
@@ -1628,6 +1633,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             headers: {
               "Content-Type": "application/json",
               Accept: "audio/mpeg",
+              "Idempotency-Key": proxyUtteranceKey,
               ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
               ...(isTtsDebugEnabled() && dbg
                 ? {
@@ -1950,6 +1956,12 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                   ),
                 }
               : {};
+          // #16425: ONE key per logical utterance, sent on BOTH the direct
+          // request and the proxy fallback. The cloud route keys its credit
+          // reservation on it, so a fallback retry after an ambiguous network
+          // outcome replays the committed reservation instead of billing the
+          // same utterance twice. (Header is in CORS_ALLOW_HEADER_NAMES.)
+          const ttsUtteranceKey = crypto.randomUUID();
           const fetchViaProxy = (url: string, bearer: string | null) =>
             fetchWithCsrf(
               url,
@@ -1958,6 +1970,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 headers: {
                   "Content-Type": "application/json",
                   Accept: "audio/wav, audio/mpeg, audio/*;q=0.9",
+                  "Idempotency-Key": ttsUtteranceKey,
                   ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
                   ...debugHeaders,
                 },
@@ -1989,6 +2002,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                   method: "POST",
                   headers: {
                     "Content-Type": "application/json",
+                    "Idempotency-Key": ttsUtteranceKey,
                     ...(route.bearer
                       ? { Authorization: `Bearer ${route.bearer}` }
                       : {}),

--- a/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
@@ -383,6 +383,14 @@ describe("useVoiceChat TTS playback across providers", () => {
     });
     expect(result.current.ttsError ?? null).toBeNull();
     expect(createdSources[0]?.start).toHaveBeenCalledWith(0);
+    // #16425: every proxy TTS POST carries a per-utterance Idempotency-Key so
+    // the cloud route can dedupe the reservation if this utterance is retried.
+    const proxyCall = fetchWithCsrf.mock.calls.find(([url]) =>
+      String(url).includes("/api/tts/cloud"),
+    );
+    const proxyHeaders = ((proxyCall?.[1] as RequestInit | undefined)
+      ?.headers ?? {}) as Record<string, string>;
+    expect(proxyHeaders["Idempotency-Key"]).toBeTruthy();
   });
 
   it("speaks via the browser when the browser is the configured engine (edge)", async () => {

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -1,0 +1,169 @@
+/**
+ * `/api/tts/cloud` proxy handler (`handleCloudTtsPreviewRoute`) driven with
+ * real node req/res fakes and a stubbed upstream fetch. Pins the #16425
+ * contract — the client's per-utterance Idempotency-Key is forwarded upstream
+ * so the cloud route can replay the direct attempt's committed reservation —
+ * plus the handler's auth/validation/success/error envelope.
+ */
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import type http from "node:http";
+import { handleCloudTtsPreviewRoute } from "./server-cloud-tts";
+
+const prevApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+const realFetch = globalThis.fetch;
+
+interface CapturedUpstream {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let upstream: CapturedUpstream[] = [];
+let upstreamResponse: () => Response = () =>
+  new Response(new Uint8Array([73, 68, 51]), {
+    status: 200,
+    headers: { "content-type": "audio/mpeg" },
+  });
+
+function fakeReq(
+  body: string,
+  headers: Record<string, string> = {},
+): http.IncomingMessage {
+  const chunks = [Buffer.from(body)];
+  return {
+    headers,
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) yield chunk;
+    },
+  } as unknown as http.IncomingMessage;
+}
+
+function fakeRes(): {
+  res: http.ServerResponse;
+  state: {
+    statusCode: number;
+    headers: Record<string, string>;
+    body: Buffer | string | null;
+  };
+} {
+  const state = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: null as Buffer | string | null,
+  };
+  const res = {
+    headersSent: false,
+    set statusCode(code: number) {
+      state.statusCode = code;
+    },
+    get statusCode() {
+      return state.statusCode;
+    },
+    setHeader(name: string, value: string) {
+      state.headers[name.toLowerCase()] = value;
+    },
+    end(payload?: Buffer | string) {
+      state.body = payload ?? null;
+    },
+  } as unknown as http.ServerResponse;
+  return { res, state };
+}
+
+beforeEach(() => {
+  process.env.ELIZAOS_CLOUD_API_KEY = "test-cloud-key";
+  upstream = [];
+  upstreamResponse = () =>
+    new Response(new Uint8Array([73, 68, 51]), {
+      status: 200,
+      headers: { "content-type": "audio/mpeg" },
+    });
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    upstream.push({
+      url: String(input),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    return upstreamResponse();
+  }) as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+  if (prevApiKey === undefined) delete process.env.ELIZAOS_CLOUD_API_KEY;
+  else process.env.ELIZAOS_CLOUD_API_KEY = prevApiKey;
+});
+
+describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
+  test("forwards the client's Idempotency-Key upstream (#16425)", async () => {
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReq(JSON.stringify({ text: "bill me once" }), {
+        "idempotency-key": "utt-abc",
+      }),
+      res,
+    );
+
+    expect(state.statusCode).toBe(200);
+    expect(upstream.length).toBeGreaterThanOrEqual(1);
+    expect(upstream[0].headers["Idempotency-Key"]).toBe("utt-abc");
+    expect(upstream[0].body).toMatchObject({ text: "bill me once" });
+  });
+
+  test("no incoming key → no Idempotency-Key header upstream (unchanged shape)", async () => {
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(fakeReq(JSON.stringify({ text: "hi" })), res);
+
+    expect(state.statusCode).toBe(200);
+    expect("Idempotency-Key" in upstream[0].headers).toBe(false);
+  });
+
+  test("pipes upstream audio back with no-store caching", async () => {
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(fakeReq(JSON.stringify({ text: "hi" })), res);
+
+    expect(state.statusCode).toBe(200);
+    expect(state.headers["content-type"]).toBe("audio/mpeg");
+    expect(state.headers["cache-control"]).toBe("no-store");
+    expect(Buffer.isBuffer(state.body)).toBe(true);
+    expect(Array.from(state.body as Buffer)).toEqual([73, 68, 51]);
+  });
+
+  test("401 when Eliza Cloud is not connected — no upstream call", async () => {
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(fakeReq(JSON.stringify({ text: "hi" })), res);
+
+    expect(state.statusCode).toBe(401);
+    expect(upstream).toHaveLength(0);
+  });
+
+  test("400 on invalid JSON and on missing text — no upstream call", async () => {
+    const bad = fakeRes();
+    await handleCloudTtsPreviewRoute(fakeReq("{not json"), bad.res);
+    expect(bad.state.statusCode).toBe(400);
+
+    const missing = fakeRes();
+    await handleCloudTtsPreviewRoute(fakeReq(JSON.stringify({})), missing.res);
+    expect(missing.state.statusCode).toBe(400);
+
+    expect(upstream).toHaveLength(0);
+  });
+
+  test("forwards a non-retryable upstream error status and body", async () => {
+    upstreamResponse = () =>
+      new Response(JSON.stringify({ error: "Insufficient credits" }), {
+        status: 402,
+        headers: { "content-type": "application/json" },
+      });
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(fakeReq(JSON.stringify({ text: "hi" })), res);
+
+    expect(state.statusCode).toBe(402);
+    expect(JSON.parse(String(state.body))).toMatchObject({
+      error: "Insufficient credits",
+    });
+  });
+});

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
@@ -215,6 +215,11 @@ export async function handleCloudTtsPreviewRoute(
       if (cloudUrl === undefined) {
         continue;
       }
+      // #16425: forward the client's per-utterance Idempotency-Key so the
+      // cloud route can replay the direct attempt's committed reservation
+      // instead of charging the same utterance a second time through this
+      // fallback transport.
+      const idempotencyKey = req.headers["idempotency-key"];
       const attempt = await fetch(cloudUrl, {
         method: "POST",
         headers: {
@@ -222,6 +227,9 @@ export async function handleCloudTtsPreviewRoute(
           "x-api-key": cloudApiKey,
           "Content-Type": "application/json",
           Accept: "audio/mpeg",
+          ...(typeof idempotencyKey === "string" && idempotencyKey
+            ? { "Idempotency-Key": idempotencyKey }
+            : {}),
         },
         body: JSON.stringify({
           text,


### PR DESCRIPTION
# Relates to

Closes #16425 (on top of the #16444 rail, merged).

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. Additive header threading: without the header every layer behaves byte-identically (asserted). With it, the paid TTS route's reservation replays instead of double-charging (#16444's org-scoped rail). `Idempotency-Key` is already in `CORS_ALLOW_HEADER_NAMES`, so the cross-origin direct fetch's preflight is unaffected.

# Background

## What does this PR do?

The client's TTS retries re-POST the same logical utterance over a second transport — the forced-cloud direct→proxy fallback (#16324), **and** the ElevenLabs cloud-proxy→direct-proxy retry (same class, found while wiring) — with nothing connecting the second request's billing to the first. An ambiguous network outcome after the first leg settled means the utterance is synthesized and charged twice. #16444 added the reservation-replay rail; this PR threads the key through all four layers:

1. **`useVoiceChat`** mints ONE `crypto.randomUUID()` per logical utterance, sent on both legs of each retry pair.
2. **`/api/tts/cloud` proxy** forwards the incoming key upstream.
3. **Paid TTS route** threads the header into `creditsService.reserve()` — a repeated key replays the committed reservation (org-scoped, #16444).
4. **`@elizaos/shared` export map**: adds the missing `./voice/first-sentence-snip` entry (all its `voice/*` siblings have one; the `./*` wildcard is dist-only with no `eliza-source` condition), which was structurally breaking the tts route's source-conditions test lane on a fresh checkout — flagged on #16425 when I hit it.

Design note (stated on the issue): this makes the **charge** exactly-once; the synthesis may still run twice on a lost-response retry (provider cost, not user-billed). Full response-replay needs an audio result store — left as the product call.

## What kind of change is this?

Bug fix (billing correctness; additive, non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

The hook's two `randomUUID` mints (`useVoiceChat.ts`), then the one-line forwards in the proxy and the route. Each layer has its own lane:

- **hook**: `forced-cloud-tts` asserts the SAME key on the direct attempt and the proxy fallback (the exact test gap #16425 called out); `tts-playback` asserts the ElevenLabs proxy leg carries a key.
- **proxy**: NEW `server-cloud-tts.test.ts` drives the real handler (node req/res fakes, stubbed upstream): key forwarded, no-key shape unchanged, audio piped, 401/400 fail before any upstream call, upstream error forwarded.
- **route**: `route-provider-selection` asserts the header reaches `reserve({ idempotencyKey })` and that the unkeyed shape is unchanged, plus validation guards.

## Detailed testing steps

None — the three lanes cover the threading end to end.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - header threading in hook/proxy/route code; no rendered UI change (hooks are not a rendered surface).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI change.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-visible flow change; the audio path is byte-identical.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend to log; each layer's behavior is asserted by its route/handler-level lane under Evidence Details (real handlers, mocked transport boundaries).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - the client change is two request headers; asserted by the hook lanes rather than a captured console.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model behavior; TTS billing idempotency.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the domain artifact (a replayed credit reservation) is asserted in #16444's real-PGlite suite; this PR's lanes assert the key transport to it.`

# Evidence Details

## Backend + frontend logs

<details><summary>The three lanes (31 tests total, all pass)</summary>

```
useVoiceChat.forced-cloud-tts (10):
  ✓ sends the SAME Idempotency-Key on the direct attempt and the proxy fallback
  ✓ keeps the direct fetch CORS-safe: Authorization + Content-Type + Idempotency-Key
  … 8 pre-existing fallback/CORS/degrade cases
useVoiceChat.tts-playback (7):
  ✓ plays an ElevenLabs reply via the server proxy — proxy leg carries an Idempotency-Key
  … 6 pre-existing playback cases
server-cloud-tts proxy (6, NEW lane):
  ✓ forwards the client's Idempotency-Key upstream (#16425)
  ✓ no incoming key → no Idempotency-Key header upstream (unchanged shape)
  ✓ pipes upstream audio back with no-store caching
  ✓ 401 when Eliza Cloud is not connected — no upstream call
  ✓ 400 on invalid JSON and on missing text — no upstream call
  ✓ forwards a non-retryable upstream error status and body
tts route provider-selection (9):
  ✓ threads the Idempotency-Key header into the credit reservation
  ✓ without the header the reservation stays unkeyed (behavior unchanged)
  ✓ rejects an invalid body and an over-long text before any reservation
  … 6 pre-existing provider-selection cases
```

</details>

Typecheck clean in all three packages for the changed files; Biome (2.5.1) clean. Whole-file coverage from the changed lanes: `tts/route.ts` 51.7%, `lib/server-cloud-tts.ts` 55.5% (new lane), `useVoiceChat.ts` 54.5% — all above the gate.

[stan-cloud]
