### PR TITLE
fix(coding-tools): stop projecting a sub-agent's cat/grep output as a resource summary

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1054,6 +1054,49 @@ describeIfPosix("shellAction", () => {
     }
   });
 
+  it("does not project a message-intent resource summary for a coding sub-agent", async () => {
+    // The sub-agent's message text is its brief + the coding preamble ("make
+    // real changes on disk"), which false-matched disk+memory intent. A `cat`
+    // of a df-shaped source line must NOT surface as the tool's userFacingText
+    // on the sub-agent path — the sub-agent synthesizes its own deliverable.
+    const previousMode = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "shell-subagent-resource-"),
+    );
+    // A real df-shaped mount line, so only the sub-agent exemption (not the
+    // field-shape validation) can suppress the projection here.
+    await fs.writeFile(
+      path.join(tempDir, "notes.txt"),
+      "/dev/root 95G 48G 47G 51% /\n",
+      "utf8",
+    );
+    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "true";
+
+    try {
+      const { runtime } = await makeRuntime();
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          "11111111-aaaa-bbbb-cccc-616161616161",
+          "You are Eliza Code, you make real changes on disk; memory available: add multiple claude subscriptions with round robin, check disk space and free RAM",
+        ),
+        undefined,
+        { command: "cat notes.txt", cwd: tempDir },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.userFacingText ?? "").not.toContain("Root disk:");
+      expect(result.userFacingText ?? "").not.toContain("Free RAM:");
+    } finally {
+      if (previousMode === undefined) {
+        delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+      } else {
+        process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = previousMode;
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not treat later output section markers as cleanup candidates", () => {
     const stdout = [
       "Filesystem      Size  Used Avail Use% Mounted on",
@@ -1079,6 +1122,44 @@ describeIfPosix("shellAction", () => {
     );
     expect(result).not.toContain("Biggest cleanup candidate:");
     expect(result).not.toContain("memory ---");
+  });
+
+  it("does not project a `cat`'d source file as a disk summary (live 2026-07-16 leak)", () => {
+    // A sub-agent investigating the account pool `cat`'d a source file whose
+    // lines ended in `/` with ≥6 whitespace tokens; the old positional match
+    // read arbitrary tokens as df columns and produced
+    // "Root disk: records used, `LinkedAccountConfig` available.", which the
+    // orchestrator then relayed as the deliverable. The message text matches
+    // both disk+memory intent (the coding-agent preamble says "on disk"), so
+    // the gate is not what protects here — the field-shape validation is.
+    const stdout = [
+      "// Users link multiple accounts; the LinkedAccountConfig store",
+      "// tracks how many records used LinkedAccountConfig available /",
+      "export const strategies = ['round-robin', 'priority'] // rotation /",
+      "Mem: the in-memory cache holds tokens per accountId /",
+    ].join("\n");
+
+    const result = localResourceUserFacingText({
+      message: makeMessage(
+        "11111111-aaaa-bbbb-cccc-595959595959",
+        "You are Eliza Code. You make real changes on disk. Memory available for the task: add multiple claude subscriptions with round robin mode",
+      ),
+      stdout,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores an ls-style line ending in / even when disk intent is present", () => {
+    const result = localResourceUserFacingText({
+      message: makeMessage(
+        "11111111-aaaa-bbbb-cccc-606060606060",
+        "check disk space and free RAM on this server, cleanup candidates and memory availability",
+      ),
+      stdout:
+        "drwxr-xr-x  5 user group 4096 records LinkedAccountConfig available /",
+    });
+    expect(result).toBeUndefined();
   });
 
   it("returns command_failed when the command exits non-zero", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -936,17 +936,40 @@ function memoryUserFacingText(stdout: string): string | undefined {
   const total = parts[1];
   const free = parts[3];
   const available = parts[6];
-  if (!total || !free) return undefined;
-  return `Free RAM: ${free} MB (${available ?? "unknown"} MB available) of ${total} MB total.`;
+  // `free -m` reports integer MB in these columns; a line that merely starts
+  // with "mem:" (a code comment, a log prefix) is not `free` output.
+  if (!total || !free || !/^\d+$/u.test(total) || !/^\d+$/u.test(free)) {
+    return undefined;
+  }
+  const availableText =
+    available && /^\d+$/u.test(available) ? available : "unknown";
+  return `Free RAM: ${free} MB (${availableText} MB available) of ${total} MB total.`;
 }
+
+// A df use-percent field is one to three digits then `%`.
+const DF_USE_PERCENT_RE = /^\d{1,3}%$/u;
+// A df size field is a number with an optional binary/decimal unit suffix
+// (`47G`, `100M`, `1.5T`, `512K`, or a bare byte count).
+const DF_SIZE_RE = /^\d+(?:[.,]\d+)?[KMGTPE]?i?B?$/u;
 
 function rootDiskSummary(stdout: string): string | undefined {
   for (const line of stdout.split(/\r?\n/u)) {
     const parts = line.trim().split(/\s+/u);
+    // A `df` mount row ends in `/` and carries Filesystem, Size, Used, Avail,
+    // and Use% columns. Position alone is not enough: an arbitrary line ending
+    // in `/` (e.g. a `cat`'d source file) matched the shape and produced
+    // "Root disk: records used, LinkedAccountConfig available." Validate the
+    // Avail and Use% columns actually look like df output so a non-df line
+    // never masquerades as a disk summary.
     if (parts.length < 6 || parts.at(-1) !== "/") continue;
     const available = parts[3];
     const usedPercent = parts[4];
-    if (available && usedPercent) {
+    if (
+      available &&
+      usedPercent &&
+      DF_SIZE_RE.test(available) &&
+      DF_USE_PERCENT_RE.test(usedPercent)
+    ) {
       return `Root disk: ${usedPercent} used, ${available} available.`;
     }
   }
@@ -1447,14 +1470,26 @@ export const shellAction: Action = {
       sandbox_backend: result.sandbox,
       signal,
     });
+    // The crypto / disk / memory / status projections are CHAT conveniences
+    // keyed on the *message text*, and the coding sub-agent's message text is
+    // its task brief plus the "you make real changes on disk" preamble — which
+    // false-matched disk+memory intent and stamped an exploratory `cat`'s output
+    // as "Root disk: records used, LinkedAccountConfig available.", which the
+    // orchestrator then relayed as the deliverable. The sub-agent synthesizes
+    // its own final answer, so these message-intent projections are skipped for
+    // it exactly like the command rewrites above. `safeSmallStdout` stays: it is
+    // command-shape based (bounded `ls`/`grep` output), which the sub-agent
+    // relies on for small verbatim results.
     const userFacingText =
-      cryptoSpotUserFacingText({
-        message,
-        command,
-        stdout: result.stdout,
-      }) ??
-      localResourceUserFacingText({ message, stdout: result.stdout }) ??
-      localStatusUserFacingText({ message, stdout: result.stdout }) ??
+      (codingSubAgentShell
+        ? undefined
+        : (cryptoSpotUserFacingText({
+            message,
+            command,
+            stdout: result.stdout,
+          }) ??
+          localResourceUserFacingText({ message, stdout: result.stdout }) ??
+          localStatusUserFacingText({ message, stdout: result.stdout }))) ??
       safeSmallStdoutUserFacingText({
         command,
         stdout: result.stdout,


### PR DESCRIPTION
## What

A coding sub-agent investigating the account-pool code `cat`'d a source file, and its **deliverable to the user** came back as:

> `Root disk: records used, \`LinkedAccountConfig\` available.`

— a meaningless fragment instead of an answer. The sub-agent had actually done the work correctly; the fragment came from a `df`/disk "user-facing" projection wrongly stamped `verifiedUserFacing: true` on an **intermediate** SHELL step, which the orchestrator then surfaced as the deliverable, discarding the sub-agent's real synthesized reply.

## The error, concretely

From the sub-agent's own trajectory (`tj-ae625806809626`): it ran **5 real SHELL/FILE tool calls** and its final answer (~1987 chars) was correct — it described the rotation strategies (`priority` / `round-robin` / `least-used` / `quota-aware`) and the `PATCH /api/providers/:providerId/strategy` mechanism. But one intermediate `cat` step carried:

```
result.userFacingText     = "Root disk: records used, `LinkedAccountConfig` available."
result.verifiedUserFacing = true
```

**How a `cat` of source became a "disk summary":** `rootDiskSummary()` scanned stdout for a line ending in `/` with ≥6 tokens and read them **positionally** as `df` columns (`available = token[3]`, `usedPercent = token[4]`) with zero validation. A code line ending in `/` matched: `token[3]="LinkedAccountConfig"`, `token[4]="records"`. The message-intent gate also fired because the coding sub-agent's message text includes its system preamble ("you make real changes **on disk** … memory available"), which false-matched disk+memory inspection intent.

## The fix — two independent structural guards

1. **Field-shape validation.** `rootDiskSummary` / `memoryUserFacingText` now require the columns to actually look like `df`/`free` output (Use% = `NN%`, sizes/MB numeric). A non-`df` line can no longer masquerade as a disk/RAM summary.
2. **Sub-agent exemption.** The crypto/disk/memory/status projections are CHAT conveniences keyed on message text; they are now skipped on the coding sub-agent path (`ELIZA_PLANNER_FULL_ACTION_SURFACE`), exactly like the command rewrites already are. `safeSmallStdout` (bounded `ls`/`grep` output) stays active for sub-agents.

## Evidence

| Type | Evidence |
|---|---|
| LLM trajectory + logs | Full incident writeup with the real trajectory excerpts (the 5 tool calls, the sub-agent's actual 1987-char answer, the poisoned SHELL step's `userFacingText`/`verifiedUserFacing`), the fix code, the falsification, and the post-fix live re-run: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/relay-leak-detailed.txt |
| Backend logs | Single-log line ordering proving the fix landed: garbage relay @382764 (pre-fix) < restart-ready @390532 < clean relay @391910 (post-fix). Same file above. |
| Tests | `bash.test.ts`: the exact `cat`'d-source leak → `undefined`, an `ls`-style line under disk intent → `undefined`, the sub-agent exemption over a **real df-shaped** source line → no projection; control: the genuine `df`+`free` path still summarizes. Falsified both ways (fails on the pre-fix positional match). Full plugin suite 206 green. |
| Screenshots / video | N/A - backend coding-tools change; the user-visible effect is the relayed message content, shown verbatim in the trajectory row. |

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend tool-output change; the before state is the verbatim "Root disk: records used..." relay in the llm-trajectory row.`

<!-- evidence-row:after-screenshots -->
`N/A - backend tool-output change; the after state is the coherent post-fix relay in the llm-trajectory row.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the incident + post-fix re-run in the llm-trajectory row.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/relay-leak-detailed.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/relay-leak-detailed.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/relay-leak-detailed.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
