### PR TITLE
fix(discord): respond to an explicit @mention even when co-mentioned with other users

### DIFF
--- a/plugins/plugin-discord/__tests__/connector-loop.harness.test.ts
+++ b/plugins/plugin-discord/__tests__/connector-loop.harness.test.ts
@@ -80,6 +80,10 @@ async function driveDiscordTurn(options: {
 	inboundText: string;
 	fixtures?: LlmProxyFixture[];
 	channelKind?: "guild" | "dm";
+	// Extra user ids to include in `message.mentions.users` alongside the
+	// author — used to reproduce a co-mention (`@other @bot`) where the bot is
+	// not the first-mentioned user.
+	coMentionedUserIds?: string[];
 }): Promise<{ sent: SentMessage[]; channelId: string }> {
 	const channelKind = options.channelKind ?? "guild";
 	// Heuristic (non-strict) proxy: the reply turn makes several model calls;
@@ -195,7 +199,20 @@ async function driveDiscordTurn(options: {
 		embeds: [],
 		stickers: { size: 0 },
 		attachments: { size: 0 },
-		mentions: { users: new Map(), repliedUser: undefined },
+		mentions: {
+			// The bot is @mentioned but listed AFTER the co-mentioned users, so
+			// `isDiscordUserAddressed` (first-mention) is false — the case where
+			// the bot must still respond because it is explicitly tagged.
+			users: new Map<string, { id: string }>([
+				...(options.coMentionedUserIds ?? []).map(
+					(id) => [id, { id }] as const,
+				),
+				...(options.coMentionedUserIds?.length
+					? ([[botMemberId, { id: botMemberId }]] as const)
+					: []),
+			]),
+			repliedUser: undefined,
+		},
 		react: async () => undefined,
 		reactions: { resolve: () => null },
 	} as never;
@@ -246,6 +263,35 @@ async function driveDiscordTurn(options: {
 }
 
 describe("discord connector loop (keyless harness)", () => {
+	it("responds when explicitly @mentioned among other users (co-mention, bot not first)", async () => {
+		// Live 2026-07-16: `@ruby @osiris @remilio` in a multi-bot channel was
+		// dropped by the "targets another mentioned user" gate because the bot
+		// was not the FIRST mention. An explicit tag of the bot must still get a
+		// reply even when other users are co-mentioned.
+		const { sent, channelId } = await driveDiscordTurn({
+			inboundText: "<@2000000000000000001> <@bot> talk to them",
+			coMentionedUserIds: ["2000000000000000001"],
+			fixtures: [
+				{
+					name: "co-mention-reply",
+					match: { modelType: ModelType.RESPONSE_HANDLER },
+					response: {
+						contexts: ["simple"],
+						intents: [],
+						replyText: "On it.",
+						candidateActionNames: [],
+					},
+				},
+			],
+		});
+
+		expect(
+			sent.length,
+			"an explicit co-mention still delivers a reply",
+		).toBeGreaterThan(0);
+		expect(sent[0]?.channelId).toBe(channelId);
+	}, 120_000);
+
 	it("drives a synthetic Discord message through the mock LLM to a delivered reply", async () => {
 		const { sent, channelId } = await driveDiscordTurn({
 			inboundText: "Hello agent, please reply.",

--- a/plugins/plugin-discord/__tests__/messages-regression-lane.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-regression-lane.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Composes the MessageManager-focused suites for changes to the monolithic
+ * `messages.ts` (the inbound `handleMessage` path). The changed-file coverage
+ * gate runs only tests present in a PR diff, so this lane keeps message-handler
+ * changes attached to the existing behavioral matrix until the handler is
+ * decomposed into independently covered units. Mirrors the core and discord
+ * service regression lanes.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import "./dm-gate-handle-message.test.ts";
+import "./dm-policy.test.ts";
+import "./dm-widget-components.test.ts";
+import "./generation-abort.test.ts";
+import "./generation-timeout-dispatch.test.ts";
+import "./generation-timeout.test.ts";
+import "./messages-component-delivery.test.ts";
+import "./messages-url.test.ts";
+import "./numeric-fact-dedup.test.ts";
+
+describe("messages regression lane composition", () => {
+	it("imports every default-lane suite that drives ../messages", () => {
+		const here = path.dirname(fileURLToPath(import.meta.url));
+		const selfSource = readFileSync(fileURLToPath(import.meta.url), "utf8");
+		const imported = [...selfSource.matchAll(/import "\.\/([^"]+)";/g)]
+			.map((match) => match[1])
+			.sort();
+		const suites = readdirSync(here)
+			.filter(
+				(name) =>
+					name.endsWith(".test.ts") &&
+					!name.endsWith(".harness.test.ts") &&
+					name !== path.basename(fileURLToPath(import.meta.url)) &&
+					// Static or dynamic reference to the module under test, with or
+					// without the `.ts` extension (`from "../messages"`,
+					// `from "../messages.ts"`, `import("../messages")`).
+					/["'(]\.\.\/messages(?:\.ts)?["')]/.test(
+						readFileSync(path.join(here, name), "utf8"),
+					),
+			)
+			.sort();
+		expect(imported).toEqual(suites);
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -834,14 +834,25 @@ export class MessageManager {
 			!!message.mentions.repliedUser?.id &&
 			message.mentions.repliedUser.id !== clientUser?.id &&
 			message.mentions.repliedUser.id !== message.author.id;
+		// `isBotAddressed` marks the PRIMARY addressee (first mention / reply-to)
+		// so the bot does not butt into a message aimed at someone else. But an
+		// explicit @mention of the bot — even alongside or after other mentions
+		// (`@ruby @osiris @remilio`) — is a deliberate call to THIS bot and must
+		// get a response. Treat any explicit platform mention as directly
+		// addressed for the respond/ignore decision, while leaving
+		// `isDiscordUserAddressed`'s first-mention semantics (and its tests)
+		// untouched.
+		const isBotDirectlyAddressed = isBotAddressed || isBotPlatformMentioned;
 		const isInThread = message.channel.isThread();
 		const isDM = message.channel.type === DiscordChannelType.DM;
 		const strictModeEnabled =
 			this.discordSettings.shouldRespondOnlyToMentions === true;
 		const replyToMode = normalizeReplyToMode(this.discordSettings.replyToMode);
 		const outboundReplyToMessageId =
-			!isDM && replyToMode !== "off" && isBotAddressed ? message.id : undefined;
-		const strictModeShouldProcess = isDM || isBotAddressed;
+			!isDM && replyToMode !== "off" && isBotDirectlyAddressed
+				? message.id
+				: undefined;
+		const strictModeShouldProcess = isDM || isBotDirectlyAddressed;
 
 		const userName = message.author.bot
 			? `${message.author.username}#${message.author.discriminator}`
@@ -920,7 +931,9 @@ export class MessageManager {
 			// same message. Only short-circuit these messages when the bot is not
 			// also clearly addressed.
 			const ignoresOtherTarget =
-				!isDM && !isBotAddressed && (mentionedOtherUsers || isReplyToOtherUser);
+				!isDM &&
+				!isBotDirectlyAddressed &&
+				(mentionedOtherUsers || isReplyToOtherUser);
 
 			// Use the service's buildMemoryFromMessage method with pre-processed content
 			const newMessage = await this.discordService.buildMemoryFromMessage(
@@ -931,17 +944,16 @@ export class MessageManager {
 					extraContent: {
 						currentMessageText,
 						mentionContext: {
-							isMention: isBotPlatformMentioned && isBotAddressed,
+							isMention: isBotPlatformMentioned,
 							isReply: isReplyToBot,
 							isThread: isInThread,
-							mentionType:
-								isBotPlatformMentioned && isBotAddressed
-									? "platform_mention"
-									: isReplyToBot
-										? "reply"
-										: isInThread
-											? "thread"
-											: "none",
+							mentionType: isBotPlatformMentioned
+								? "platform_mention"
+								: isReplyToBot
+									? "reply"
+									: isInThread
+										? "thread"
+										: "none",
 						},
 					},
 					extraMetadata: compactJsonObject(


### PR DESCRIPTION
## What

A user @mentions the bot **alongside other users** ("@Other1 @Other2 @AgentBot help") and the bot stays silent — a common multi-participant / multi-bot channel pattern.

The addressing gate treats the **first** `@mention` as the primary addressee (`isDiscordUserAddressed` → first-mention, in `addressing.ts`) so the bot does not butt into a message aimed at someone else. But when the bot is explicitly `@mentioned` and merely isn't listed first, `ignoresOtherTarget` (`messages.ts`) dropped the turn as "targets another mentioned user." An explicit tag of the bot is a deliberate call to it and should get a reply.

## Fix

Introduce one signal — `isBotDirectlyAddressed = isBotAddressed || isBotPlatformMentioned` — and thread it through the four decision points (the ignore gate, the mention context handed to the model, strict-mode processing, and reply threading). This leaves `isDiscordUserAddressed`'s first-mention semantics (and its unit tests) **untouched** — the "who is the primary addressee" meaning is unchanged; the connector just additionally treats an explicit platform `@mention` as "respond to me."

The "don't butt in" behavior is preserved: it only ever applied when the bot was **not** mentioned (reply-chains to others, other-user mentions without the bot) — those paths are unchanged, because `isBotPlatformMentioned` is true only when the bot's own id is in `message.mentions.users`.

## Evidence

| Type | Evidence |
|---|---|
| Backend logs | Live multi-bot channel, redacted: an explicit three-way @mention now returns a reply; a co-mentioned bot's unaddressed chatter still returns IGNORE. https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-comention.txt |
| Tests | `connector-loop.harness.test.ts` gains a case driving the REAL `MessageManager.handleMessage`: a guild message co-mentioning `[otherUser, bot]` (bot not first) still delivers a reply. Falsified both ways — it fails on the pre-fix gate. Full plugin-discord suite 492 green. |
| Screenshots / video | N/A - connector routing change with no UI surface; the log transcript above is the user-visible proof. |

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend Discord connector change; the user-visible before/after is message content, shown in the backend-logs row.`

<!-- evidence-row:after-screenshots -->
`N/A - backend Discord connector change; the user-visible before/after is message content, shown in the backend-logs row.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live log transcript under backend-logs.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-comention.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-comention.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-comention.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
