### PR TITLE
fix(discord): deliver button-tap replies via the interaction token so group-DM buttons work

### DIFF
--- a/plugins/plugin-discord/__tests__/interaction-dispatch-coverage.test.ts
+++ b/plugins/plugin-discord/__tests__/interaction-dispatch-coverage.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Behavioral coverage for the non-button branches of
+ * `handleInteractionCreate` and the guild sync builders in
+ * `discord-interactions.ts` — slash commands emit `SLASH_COMMAND`, modal
+ * submits emit `MODAL_SUBMIT`, a non-codec component is acknowledged
+ * (`deferUpdate`) without a dispatch, and `buildStandardizedRooms` /
+ * `buildStandardizedUsers` map a fake guild's channels/members into the
+ * runtime's room/entity records. Only discord.js SDK objects are stubbed —
+ * no bot token, no network. Complements `interaction-replay-render.test.ts`
+ * (the codec-button branch).
+ */
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildStandardizedRooms,
+	buildStandardizedUsers,
+	handleInteractionCreate,
+} from "../discord-interactions";
+
+const noop = () => {};
+const BOT_ID = "888000000000000000";
+const GUILD_ID = "700000000000000000";
+
+function makeService(overrides: Record<string, unknown> = {}) {
+	const emitEvent = vi.fn();
+	const service = {
+		accountId: "default",
+		client: { user: { id: BOT_ID }, users: { fetch: vi.fn() } },
+		slashCommands: [],
+		resolveDiscordEntityId: vi.fn(
+			(id: string) =>
+				`00000000-0000-0000-0000-${id.slice(-12).padStart(12, "0")}`,
+		),
+		getChannelType: vi.fn(async () => "GROUP"),
+		registerSlashCommands: vi.fn(),
+		refreshOwnerDiscordUserIds: vi.fn(),
+		discordSettings: {},
+		runtime: {
+			agentId: "00000000-0000-0000-0000-0000000000aa",
+			emitEvent,
+			ensureConnection: vi.fn(async () => {}),
+			getSetting: () => undefined,
+			logger: { info: noop, warn: noop, debug: noop, error: noop },
+		},
+		...overrides,
+	};
+	return { service, emitEvent };
+}
+
+function baseInteraction(kind: "command" | "modal" | "component") {
+	return {
+		id: "interaction-1",
+		user: {
+			id: "user-1",
+			username: "alice",
+			displayName: "Alice",
+			discriminator: "0",
+			bot: false,
+		},
+		guild: null,
+		channel: { id: "chan-1" },
+		channelId: "chan-1",
+		commandName: "help",
+		commandType: 1,
+		customId: "raw-noncodec-button",
+		inGuild: () => false,
+		isCommand: () => kind === "command",
+		isModalSubmit: () => kind === "modal",
+		isMessageComponent: () => kind === "component",
+		isButton: () => kind === "component",
+		isStringSelectMenu: () => false,
+		deferUpdate: vi.fn(async () => {}),
+	};
+}
+
+describe("handleInteractionCreate dispatch branches", () => {
+	it("emits SLASH_COMMAND for a command interaction", async () => {
+		const { service, emitEvent } = makeService();
+		await handleInteractionCreate(
+			service as never,
+			baseInteraction("command") as never,
+		);
+		const events = emitEvent.mock.calls.map((c) => c[0]);
+		expect(events).toContain("DISCORD_SLASH_COMMAND");
+	});
+
+	it("emits MODAL_SUBMIT for a modal submit interaction", async () => {
+		const { service, emitEvent } = makeService();
+		await handleInteractionCreate(
+			service as never,
+			baseInteraction("modal") as never,
+		);
+		const events = emitEvent.mock.calls.map((c) => c[0]);
+		expect(events).toContain("DISCORD_MODAL_SUBMIT");
+	});
+
+	it("acknowledges a non-codec component without dispatching a turn", async () => {
+		const { service, emitEvent } = makeService();
+		const interaction = baseInteraction("component");
+		await handleInteractionCreate(service as never, interaction as never);
+		// A raw (non-codec) button carries no submit semantics — it is only
+		// deferUpdate'd to clear the client loading state.
+		expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+		expect(emitEvent).not.toHaveBeenCalled();
+	});
+
+	it("resolves the guild channel type + server id for an in-guild command", async () => {
+		const { service, emitEvent } = makeService();
+		const interaction = {
+			...baseInteraction("command"),
+			guild: {
+				id: GUILD_ID,
+				name: "Test Guild",
+				ownerId: "111111111111111111",
+				fetch: vi.fn(async function fetchGuild() {
+					return interaction.guild;
+				}),
+			},
+			channel: { id: "chan-1", name: "general" },
+			inGuild: () => true,
+		};
+		await handleInteractionCreate(service as never, interaction as never);
+		expect(interaction.guild.fetch).toHaveBeenCalled();
+		expect(service.getChannelType).toHaveBeenCalled();
+		expect(emitEvent.mock.calls.map((c) => c[0])).toContain(
+			"DISCORD_SLASH_COMMAND",
+		);
+	});
+});
+
+describe("guild sync builders", () => {
+	function member(id: string, username: string, bot: boolean) {
+		return {
+			id,
+			displayName: username,
+			user: {
+				id,
+				username,
+				bot,
+				discriminator: "0",
+				globalName: null,
+				displayAvatarURL: () => `https://cdn.discord.test/${id}.png`,
+			},
+		};
+	}
+
+	function makeGuild() {
+		return {
+			id: GUILD_ID,
+			name: "Test Guild",
+			memberCount: 3,
+			channels: {
+				cache: new Map<string, { id: string; name: string; type: number }>([
+					[
+						"c-text",
+						{
+							id: "c-text",
+							name: "general",
+							type: DiscordChannelType.GuildText,
+						},
+					],
+					[
+						"c-voice",
+						{
+							id: "c-voice",
+							name: "Voice",
+							type: DiscordChannelType.GuildVoice,
+						},
+					],
+					[
+						"c-cat",
+						{
+							id: "c-cat",
+							name: "Category",
+							type: DiscordChannelType.GuildCategory,
+						},
+					],
+				]),
+			},
+			members: {
+				fetch: vi.fn(),
+				cache: new Map([
+					[BOT_ID, member(BOT_ID, "bot", true)],
+					["m-1", member("m-1", "human", false)],
+				]),
+			},
+		};
+	}
+
+	it("maps text/voice channels into rooms and skips categories", async () => {
+		const { service } = makeService();
+		const rooms = await buildStandardizedRooms(
+			service as never,
+			makeGuild() as never,
+			"00000000-0000-0000-0000-000000000fff" as never,
+		);
+		expect(rooms.length).toBe(2);
+		expect(rooms.every((room) => typeof room.id === "string")).toBe(true);
+	});
+
+	it("maps guild members into entities", async () => {
+		const { service } = makeService();
+		const entities = await buildStandardizedUsers(
+			service as never,
+			makeGuild() as never,
+		);
+		expect(entities.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("uses the optimized cache path for a large guild (>1000 members)", async () => {
+		const { service } = makeService();
+		const guild = { ...makeGuild(), memberCount: 5000 };
+		const entities = await buildStandardizedUsers(
+			service as never,
+			guild as never,
+		);
+		// The bot itself is excluded; the one human member survives.
+		expect(entities.flatMap((entity) => entity.names)).toContain("human");
+	});
+});

--- a/plugins/plugin-discord/__tests__/interaction-replay-render.test.ts
+++ b/plugins/plugin-discord/__tests__/interaction-replay-render.test.ts
@@ -5,10 +5,16 @@
  * replay callback rendered without the app-origin resolver, so a `[TASK:…]`
  * reply produced after a choice tap silently lost its "Open task" button.
  *
+ * Also guards the group-DM delivery fix: a user-installed app is not a channel
+ * member in a group DM / DM-with-others, so `channel.send` is unavailable and
+ * the button reply must ride the interaction token via `followUp`. The reply is
+ * delivered through `followUp` on every surface, falling back to `channel.send`
+ * only if the interaction delivery fails.
+ *
  * Drives the REAL `handleInteractionCreate` codec-button branch with a fake
  * discord.js interaction + a fake message service whose handler replies with a
- * task card; asserts the captured `channel.send` carries the link button. Only
- * the discord.js SDK objects are stubbed — no bot token, no network.
+ * task card. Only the discord.js SDK objects are stubbed — no bot token, no
+ * network.
  */
 import { encodeReplyCallback } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -22,15 +28,22 @@ interface CapturedSend {
 	components?: Array<{ toJSON(): { type: number; components: unknown[] } }>;
 }
 
-function makeService(appUrl: string | undefined) {
+function makeService(
+	appUrl: string | undefined,
+	options: { channelSendable?: boolean } = {},
+) {
 	const sends: CapturedSend[] = [];
-	const channel = {
-		id: "chan-1",
-		send: vi.fn(async (opts: CapturedSend) => {
-			sends.push(opts);
-			return { id: `sent-${sends.length}` };
-		}),
-	};
+	const channel = options.channelSendable
+		? {
+				id: "chan-1",
+				send: vi.fn(async (opts: CapturedSend) => {
+					sends.push(opts);
+					return { id: `sent-${sends.length}` };
+				}),
+			}
+		: // Group DM: the user-installed bot is not a member, so there is no
+			// usable `channel.send`.
+			{ id: "chan-1" };
 	// The fake message service replays the tapped choice value back into the
 	// agent loop and, like a real turn, answers with a task-card reply.
 	const messageService = {
@@ -71,7 +84,7 @@ function makeService(appUrl: string | undefined) {
 	return { service, channel, sends, messageService };
 }
 
-function makeCodecButtonInteraction(channel: unknown) {
+function makeCodecButtonInteraction(channel: unknown, follows: CapturedSend[]) {
 	const codecId = encodeReplyCallback("yes", { maxBytes: 100 });
 	if (!codecId) throw new Error("codec id should encode");
 	return {
@@ -96,18 +109,28 @@ function makeCodecButtonInteraction(channel: unknown) {
 		replied: false,
 		deferred: false,
 		deferUpdate: vi.fn(async () => {}),
+		// The interaction token delivery path — works in servers, group DMs, and
+		// DMs-with-others alike.
+		followUp: vi.fn(async (opts: CapturedSend) => {
+			follows.push(opts);
+			return { id: `follow-${follows.length}` };
+		}),
 	};
 }
 
 describe("#14527 button-tap replay renders link-out blocks natively", () => {
 	it("attaches an Open task link button to a post-tap task reply", async () => {
-		const { service, channel, sends } = makeService("https://app.test");
-		const interaction = makeCodecButtonInteraction(channel);
+		const { service, channel } = makeService("https://app.test", {
+			channelSendable: true,
+		});
+		const follows: CapturedSend[] = [];
+		const interaction = makeCodecButtonInteraction(channel, follows);
 
 		await handleInteractionCreate(service as never, interaction as never);
 
-		expect(channel.send).toHaveBeenCalledTimes(1);
-		const built = sends[0]?.components;
+		// Delivered through the interaction token, not channel.send.
+		expect(interaction.followUp).toHaveBeenCalledTimes(1);
+		const built = follows[0]?.components;
 		expect(built).toBeDefined();
 		expect(built).toHaveLength(1);
 		const row = built?.[0].toJSON();
@@ -119,19 +142,43 @@ describe("#14527 button-tap replay renders link-out blocks natively", () => {
 		expect(button.style).toBe(5);
 		expect(button.url).toBe(`https://app.test/orchestrator?taskId=${TASK_ID}`);
 		// Prose keeps the title; the raw marker is stripped.
-		expect(sends[0]?.content).toContain("Opening your task.");
-		expect(sends[0]?.content).not.toContain("[TASK:");
+		expect(follows[0]?.content).toContain("Opening your task.");
+		expect(follows[0]?.content).not.toContain("[TASK:");
 	});
 
 	it("degrades the same reply to prose when no app origin is configured", async () => {
-		const { service, channel, sends } = makeService(undefined);
-		const interaction = makeCodecButtonInteraction(channel);
+		const { service, channel } = makeService(undefined, {
+			channelSendable: true,
+		});
+		const follows: CapturedSend[] = [];
+		const interaction = makeCodecButtonInteraction(channel, follows);
 
 		await handleInteractionCreate(service as never, interaction as never);
 
-		expect(channel.send).toHaveBeenCalledTimes(1);
+		expect(interaction.followUp).toHaveBeenCalledTimes(1);
 		// No resolver URL: no fabricated dead button, and the title survives as prose.
-		expect(sends[0]?.components ?? []).toHaveLength(0);
-		expect(sends[0]?.content).toContain("Ship the release");
+		expect(follows[0]?.components ?? []).toHaveLength(0);
+		expect(follows[0]?.content).toContain("Ship the release");
+	});
+
+	it("delivers via followUp in a group DM where channel.send is unavailable", async () => {
+		// The live 2026-07-16 bug: a group-DM button tap ran the turn but the
+		// reply used channel.send (the bot is not a member) and vanished.
+		const { service, channel } = makeService("https://app.test", {
+			channelSendable: false,
+		});
+		const follows: CapturedSend[] = [];
+		const interaction = makeCodecButtonInteraction(channel, follows);
+
+		await handleInteractionCreate(service as never, interaction as never);
+
+		expect(interaction.followUp).toHaveBeenCalledTimes(1);
+		expect(follows[0]?.content).toContain("Opening your task.");
+		expect(follows[0]?.components).toHaveLength(1);
+		// No channel.send exists on the group-DM channel; delivery still landed.
+		expect(
+			(channel as { send?: unknown }).send,
+			"a group-DM channel has no send method",
+		).toBeUndefined();
 	});
 });

--- a/plugins/plugin-discord/discord-interactions.ts
+++ b/plugins/plugin-discord/discord-interactions.ts
@@ -37,6 +37,7 @@ import {
 	buildDiscordWorldMetadata,
 } from "./identity";
 import { buildDiscordReplyPayload } from "./interactions";
+import { chunkDiscordText } from "./messaging";
 import { generateInviteUrl } from "./permissions";
 import { syncDiscordClientProfile } from "./profileSync";
 import type { DiscordService } from "./service";
@@ -48,7 +49,11 @@ import {
 	type DiscordSlashCommand,
 	type DiscordSlashCommandPayload,
 } from "./types";
-import { getMessageService, sendMessageInChunks } from "./utils";
+import {
+	buildDiscordComponents,
+	getMessageService,
+	sendMessageInChunks,
+} from "./utils";
 
 /**
  * Subset of DiscordService fields needed by interaction handling.
@@ -256,20 +261,60 @@ export async function handleInteractionCreate(
 				createdAt: Date.now(),
 			};
 			const callback: HandlerCallback = async (content) => {
-				const channel = interaction.channel as TextChannel | null;
-				if (!content.text || !channel || typeof channel.send !== "function") {
+				const render = buildDiscordReplyPayload(service.runtime, content);
+				const components =
+					render.components.length > 0
+						? buildDiscordComponents(render.components)
+						: undefined;
+				const chunks = render.text.trim() ? chunkDiscordText(render.text) : [];
+				// A user-installed app in a group DM / DM-with-others is NOT a
+				// channel member, so `channel.send` is unavailable — the button
+				// reply must ride the interaction token via followUp (the button
+				// was already deferUpdate'd above, so followUp posts a new
+				// message). Buttons attach to the LAST chunk. Fall back to
+				// channel.send only when there is no usable interaction (should
+				// not happen for a component interaction).
+				if (chunks.length === 0 && !components) {
 					return [];
 				}
-				const render = buildDiscordReplyPayload(service.runtime, content);
-				await sendMessageInChunks(
-					channel,
-					render.text,
-					"",
-					[],
-					render.components.length > 0 ? render.components : undefined,
-					service.runtime,
-				);
-				return [];
+				const lastIndex = Math.max(0, chunks.length - 1);
+				try {
+					if (chunks.length === 0 && components) {
+						await interaction.followUp({ content: "​", components });
+					}
+					for (let i = 0; i < chunks.length; i++) {
+						await interaction.followUp({
+							content: chunks[i],
+							...(components && i === lastIndex ? { components } : {}),
+						});
+					}
+					return [];
+				} catch (error) {
+					// error-policy:J1 interaction delivery failed (token expired or
+					// missing) — fall back to a channel send where the bot can.
+					const channel = interaction.channel as TextChannel | null;
+					if (channel && typeof channel.send === "function") {
+						await sendMessageInChunks(
+							channel,
+							render.text,
+							"",
+							[],
+							render.components.length > 0 ? render.components : undefined,
+							service.runtime,
+						);
+					} else {
+						service.runtime.logger.warn(
+							{
+								src: "plugin:discord",
+								agentId: service.runtime.agentId,
+								customId: interaction.customId,
+								error: error instanceof Error ? error.message : String(error),
+							},
+							"Button-reply delivery failed and no channel send is available",
+						);
+					}
+					return [];
+				}
 			};
 			const messageService = getMessageService(service.runtime);
 			if (messageService) {


### PR DESCRIPTION
## What

A user-installed app in a **group DM / DM-with-others** is not a channel member, so when a user tapped an in-chat button the codec-button replay callback delivered via `channel.send` — unavailable there — and the reply (generated by a full agent turn) **silently vanished**. The button rendered and the tap ran a turn, but nothing came back ("clicked the button, nothing happened").

## Fix

The button-tap reply now delivers through the **interaction token** (`interaction.followUp` — the button was already `deferUpdate`'d), which works on every surface (server, group chat, DM-with-others), falling back to `channel.send` only if the interaction delivery itself fails. Buttons ride the last chunk of a split reply.

## Coverage

`discord-interactions.ts` was significantly under-tested (~30% even across the whole suite). This PR adds `interaction-dispatch-coverage.test.ts` covering the previously-untested `handleInteractionCreate` branches (slash-command emit, modal-submit emit, non-codec component ack, in-guild channel-type resolution) and the `buildStandardizedRooms` / `buildStandardizedUsers` guild-sync builders — lifting the file over the changed-file coverage floor (~30% → 53%).

## Evidence

| Type | Evidence |
|---|---|
| Backend logs | Live group chat, redacted: a codec button tap is received (`custom_id=ia1:*`) → a turn runs → the reply is delivered via the interaction token; two consecutive taps each produced a distinct reply. https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-groupdm-buttons.txt |
| Tests | `interaction-replay-render.test.ts` asserts delivery via `followUp`, incl. a group-DM case where `channel.send` does not exist (reply still lands, falsified both ways). `interaction-dispatch-coverage.test.ts` (new) covers the dispatch + guild-sync branches. Full plugin-discord suite 548 green, typecheck clean. |
| Screenshots / video | N/A - connector delivery change; the user-visible effect (button responds) is covered by the log transcript + tests. |

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend connector delivery change; before/after is message behavior, shown in backend-logs.`

<!-- evidence-row:after-screenshots -->
`N/A - backend connector delivery change; before/after is message behavior, shown in backend-logs.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live log transcript under backend-logs.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-groupdm-buttons.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
`N/A - connector delivery change, not a model-behavior change; the turn a button triggers is an ordinary agent turn. Backend-logs shows the tap→reply.`

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/discord-groupdm-buttons.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
