### PR TITLE
fix(desktop): share one chat and voice controller across detached windows

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -126,6 +126,7 @@ import {
   readResolvedPreloadScript,
   resolveRendererAssetDir,
 } from "./runtime-layout";
+import { registerShellSyncEndpoint } from "./shell-sync-relay";
 import { mergeRuntimePermissionStates } from "./runtime-permissions";
 import { startScreenCaptureBridgeServer } from "./screen-capture-bridge-server";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
@@ -1702,6 +1703,7 @@ const MAX_RPC_REQUEST_TIME_MS = 600_000;
 function createDesktopRpc(label: string): {
   rpc: ElizaDesktopRpc;
   sendToWebview: SendToWebview;
+  releaseShellSync: () => void;
 } {
   let rpc: ElizaDesktopRpc | undefined;
 
@@ -1732,6 +1734,13 @@ function createDesktopRpc(label: string): {
     >[0]["handlers"]
   >["requests"];
 
+  // Register this window as a shell-controller relay endpoint (#16442). Every
+  // window flows through this one factory, so registering here wires the relay
+  // uniformly for the main, surface, and tray-popover windows. The
+  // `shellControllerRelay` request handler (in buildBunRpcHandlers) fans a
+  // publish out to every registered endpoint.
+  const shellSyncEndpoint = registerShellSyncEndpoint(sendToWebview);
+
   rpc = BrowserView.defineRPC<ElizaDesktopRPCSchema>({
     maxRequestTime: MAX_RPC_REQUEST_TIME_MS,
     handlers: {
@@ -1741,7 +1750,7 @@ function createDesktopRpc(label: string): {
     },
   });
 
-  return { rpc, sendToWebview };
+  return { rpc, sendToWebview, releaseShellSync: shellSyncEndpoint.release };
 }
 
 /**
@@ -2682,12 +2691,15 @@ async function main(): Promise<void> {
 
   surfaceWindowManager = new SurfaceWindowManager({
     createWindow: (options) => {
-      const { rpc } = createDesktopRpc("surface");
+      const { rpc, releaseShellSync } = createDesktopRpc("surface");
       const window = createElectrobunBrowserWindow({
         ...options,
         rpc,
       }) as BrowserWindow & ManagedWindowLike;
       surfaceRpcs.set(window, rpc);
+      // Drop this window's relay endpoint when it closes so a churned detached
+      // surface does not leak (#16442).
+      window.on("close", releaseShellSync);
       return window;
     },
     resolveRendererUrl,

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
@@ -1441,7 +1441,7 @@ export function buildBunRpcHandlers({
     // ---- Shell chat/voice controller cross-window relay (#16442) ----
     // Fan a renderer's shell-sync publish out to every registered window. The
     // renderer coordinator filters its own echo, so this stays a dumb pipe.
-    shellControllerRelay: (params: { envelope: unknown }) => {
+    shellControllerRelay: async (params: { envelope: unknown }) => {
       broadcastShellSyncEnvelope(params?.envelope);
       return { ok: true };
     },

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
@@ -155,6 +155,7 @@ import {
   composeSubscriptionStatusSnapshot,
   readSubscriptionStatusViaHttp,
 } from "./subscription-rpc";
+import { broadcastShellSyncEnvelope } from "./shell-sync-relay";
 import { createTraceHostForRuntime, getTraceService } from "./trace";
 import type { SendToWebview } from "./types.js";
 import {
@@ -1436,6 +1437,14 @@ export function buildBunRpcHandlers({
     fileWatcherList: async () => ({ watches: fileWatcher.listWatches() }),
     fileWatcherGetStatus: async (params: { watchId: string }) =>
       fileWatcher.getWatch(params.watchId),
+
+    // ---- Shell chat/voice controller cross-window relay (#16442) ----
+    // Fan a renderer's shell-sync publish out to every registered window. The
+    // renderer coordinator filters its own echo, so this stays a dumb pipe.
+    shellControllerRelay: (params: { envelope: unknown }) => {
+      broadcastShellSyncEnvelope(params?.envelope);
+      return { ok: true };
+    },
   };
 }
 

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -2275,6 +2275,15 @@ export type ElizaDesktopRPCSchema = {
         params: undefined;
         response: StewardRpcStatus;
       };
+
+      // Shell chat/voice controller cross-window relay (#16442). A renderer
+      // publishes an opaque shell-sync envelope; the main process rebroadcasts
+      // it to every OTHER window as a `shellControllerSync` push. The renderer
+      // coordinator (@elizaos/ui) owns all semantics — this is a dumb pipe.
+      shellControllerRelay: {
+        params: { envelope: unknown };
+        response: { ok: boolean };
+      };
     };
     // biome-ignore lint/complexity/noBannedTypes: empty message schema placeholder for future audio streaming
     messages: {
@@ -2307,6 +2316,10 @@ export type ElizaDesktopRPCSchema = {
     };
     messages: {
       // Push events FROM bun TO webview
+
+      // Shell chat/voice controller cross-window relay (#16442): an opaque
+      // shell-sync envelope rebroadcast from another window's publish.
+      shellControllerSync: { envelope: unknown };
 
       // Gateway
       gatewayDiscovery: {

--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts
@@ -1,0 +1,55 @@
+/** Cross-window shell-sync relay routing: broadcast-to-others (never self),
+ *  delivery count, and endpoint release. */
+import { describe, expect, it, vi } from "vitest";
+import {
+  broadcastShellSyncEnvelope,
+  registerShellSyncEndpoint,
+  SHELL_SYNC_PUSH_MESSAGE,
+  shellSyncEndpointCount,
+} from "./shell-sync-relay";
+
+describe("shell-sync relay", () => {
+  it("fans a publish out to every registered window", () => {
+    const base = shellSyncEndpointCount();
+    const sendA = vi.fn();
+    const sendB = vi.fn();
+    const a = registerShellSyncEndpoint(sendA);
+    const b = registerShellSyncEndpoint(sendB);
+
+    const envelope = { type: "presence", protocolVersion: "1" };
+    const delivered = broadcastShellSyncEnvelope(envelope);
+
+    expect(delivered).toBe(base + 2);
+    expect(sendA).toHaveBeenCalledWith(SHELL_SYNC_PUSH_MESSAGE, { envelope });
+    expect(sendB).toHaveBeenCalledWith(SHELL_SYNC_PUSH_MESSAGE, { envelope });
+
+    a.release();
+    b.release();
+  });
+
+  it("stops delivering to a released endpoint", () => {
+    const base = shellSyncEndpointCount();
+    const sendA = vi.fn();
+    const sendB = vi.fn();
+    const a = registerShellSyncEndpoint(sendA);
+    const b = registerShellSyncEndpoint(sendB);
+    expect(shellSyncEndpointCount()).toBe(base + 2);
+
+    b.release();
+    expect(shellSyncEndpointCount()).toBe(base + 1);
+
+    broadcastShellSyncEnvelope({ x: 1 });
+    expect(sendA).toHaveBeenCalledTimes(1);
+    expect(sendB).not.toHaveBeenCalled();
+
+    a.release();
+  });
+
+  it("release removes the endpoint from the registry", () => {
+    const base = shellSyncEndpointCount();
+    const a = registerShellSyncEndpoint(vi.fn());
+    expect(shellSyncEndpointCount()).toBe(base + 1);
+    a.release();
+    expect(shellSyncEndpointCount()).toBe(base);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
@@ -1,0 +1,61 @@
+/**
+ * Cross-window relay for the shell chat/voice controller (#16442). Each desktop
+ * webview is an isolated renderer, so the only path between them is this native
+ * main process: a renderer publishes a shell-sync envelope via the
+ * `shellControllerRelay` RPC request, and this module rebroadcasts it to every
+ * OTHER open window as a `shellControllerSync` push message. That is what lets a
+ * single elected owner window run the one engine while followers render its
+ * state — the renderer-side coordinator (`@elizaos/ui`) owns all the semantics;
+ * this is a dumb, opaque pipe.
+ *
+ * Endpoints register at `createDesktopRpc` time (the one place every window's
+ * `sendToWebview` is built) and release when the window tears down. The relay
+ * broadcasts to EVERY window, including the publisher: the renderer coordinator
+ * filters its own messages by window id / role / target, so a self-echo is a
+ * no-op there. That keeps the native side a trivial fan-out with no per-window
+ * identity to thread through.
+ */
+import type { SendToWebview } from "./types";
+
+/** The push-message name followers subscribe to; mirrors the renderer constant
+ *  `SHELL_SYNC_PUSH_MESSAGE` in `@elizaos/ui`. */
+export const SHELL_SYNC_PUSH_MESSAGE = "shellControllerSync";
+
+const endpoints = new Map<string, SendToWebview>();
+let endpointCounter = 0;
+
+/**
+ * Register a window's renderer as a relay endpoint. Returns a `release` to call
+ * when the window closes so a churned detached surface does not leak.
+ */
+export function registerShellSyncEndpoint(send: SendToWebview): {
+  release: () => void;
+} {
+  endpointCounter += 1;
+  const id = `endpoint-${endpointCounter}`;
+  endpoints.set(id, send);
+  return {
+    release: () => {
+      endpoints.delete(id);
+    },
+  };
+}
+
+/**
+ * Rebroadcast an envelope to every registered window. Opaque: the envelope is
+ * forwarded as-is (validated on the renderer side at the IPC boundary). Returns
+ * how many windows it was delivered to, for diagnostics.
+ */
+export function broadcastShellSyncEnvelope(envelope: unknown): number {
+  let delivered = 0;
+  for (const send of endpoints.values()) {
+    send(SHELL_SYNC_PUSH_MESSAGE, { envelope });
+    delivered += 1;
+  }
+  return delivered;
+}
+
+/** Test-only: the live endpoint count. */
+export function shellSyncEndpointCount(): number {
+  return endpoints.size;
+}

--- a/packages/ui/src/components/shell/ShellControllerContext.test.tsx
+++ b/packages/ui/src/components/shell/ShellControllerContext.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+/**
+ * Owner + follower provider wiring. The owner path is rendered with a stubbed
+ * `useShellController` (the engine itself is tested elsewhere; here we prove the
+ * OWNER publishes + routes commands to it). The follower path is rendered with a
+ * plain sync DTO and proves it renders the snapshot and forwards commands
+ * without ever mounting the engine.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FollowerShellControllerProvider,
+  OwnerShellControllerProvider,
+} from "./ShellControllerContext";
+import { useShellControllerContext } from "./ShellControllerContext.hooks";
+import {
+  baseSnapshot,
+  makeFakeShellController,
+} from "./shell-controller-sync/__tests__/fixtures";
+import type { ShellControllerSync } from "./shell-controller-sync/useShellControllerSync";
+import { useShellController } from "./useShellController";
+
+vi.mock("./useShellController", () => ({ useShellController: vi.fn() }));
+
+let fakeController = makeFakeShellController();
+beforeEach(() => {
+  fakeController = makeFakeShellController();
+  vi.mocked(useShellController).mockReturnValue(fakeController);
+});
+
+function Consumer(): React.JSX.Element {
+  const controller = useShellControllerContext();
+  if (!controller) return <div data-testid="state">no-controller</div>;
+  return (
+    <div>
+      <span data-testid="transcript">{controller.transcript}</span>
+      <button type="button" onClick={() => controller.send("hi from follower")}>
+        send
+      </button>
+    </div>
+  );
+}
+
+function makeSync(over: Partial<ShellControllerSync>): ShellControllerSync {
+  return {
+    role: "follower",
+    status: "connected",
+    snapshot: null,
+    dispatch: vi.fn(async () => {}),
+    publishSnapshot: vi.fn(),
+    setCommandHandler: vi.fn(),
+    ...over,
+  };
+}
+
+describe("FollowerShellControllerProvider", () => {
+  it("renders the owner's snapshot and forwards a send command", async () => {
+    const dispatch = vi.fn(async () => {});
+    const sync = makeSync({
+      snapshot: baseSnapshot({ transcript: "from-owner" }),
+      dispatch,
+    });
+    render(
+      <FollowerShellControllerProvider sync={sync} onCommandError={() => {}}>
+        <Consumer />
+      </FollowerShellControllerProvider>,
+    );
+    expect(screen.getByTestId("transcript").textContent).toBe("from-owner");
+
+    await userEvent.click(screen.getByRole("button", { name: "send" }));
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: "send",
+      text: "hi from follower",
+    });
+  });
+
+  it("provides no controller (overlay hidden) with no snapshot yet", () => {
+    render(
+      <FollowerShellControllerProvider
+        sync={makeSync({ snapshot: null })}
+        onCommandError={() => {}}
+      >
+        <Consumer />
+      </FollowerShellControllerProvider>,
+    );
+    expect(screen.getByTestId("state").textContent).toBe("no-controller");
+  });
+});
+
+describe("OwnerShellControllerProvider", () => {
+  it("publishes the engine snapshot and routes commands to the real controller", () => {
+    const setCommandHandler = vi.fn();
+    const publishSnapshot = vi.fn();
+    const sync = makeSync({ role: "owner", setCommandHandler, publishSnapshot });
+    render(
+      <OwnerShellControllerProvider sync={sync}>
+        <div>owner-child</div>
+      </OwnerShellControllerProvider>,
+    );
+
+    // The owner published its state to followers.
+    expect(publishSnapshot).toHaveBeenCalled();
+
+    // The registered command handler applies commands to the live engine.
+    expect(setCommandHandler).toHaveBeenCalledWith(expect.any(Function));
+    const handler = setCommandHandler.mock.calls[0]?.[0] as (c: {
+      kind: string;
+    }) => void;
+    handler({ kind: "stop" });
+    expect(fakeController.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/shell/ShellControllerContext.tsx
+++ b/packages/ui/src/components/shell/ShellControllerContext.tsx
@@ -1,26 +1,151 @@
 /**
- * Provides shell controller state for overlays, launcher surfaces, and
- * conversation navigation.
+ * Provides the one shell chat/voice controller to every overlay, launcher
+ * surface, and conversation-nav consumer — and, on the multi-window desktop,
+ * guarantees a SINGLE engine across windows (#16442).
+ *
+ * A window is elected owner or follower by `useShellControllerSync`. The OWNER
+ * mounts the real `useShellController` engine (the sole microphone/audio owner),
+ * publishes its state, and applies followers' commands. A FOLLOWER never mounts
+ * the engine: it renders the owner's published snapshot and forwards typed
+ * commands. Owner and follower are distinct components at this position, so a
+ * genuine handoff (owner window closes) tears the engine down in the old owner
+ * and stands it up in the promoted window — never two mics at once. With no
+ * cross-window transport (web, mobile, single-window) the window is a lone owner
+ * and this behaves exactly as it did before.
  */
-import type * as React from "react";
+import * as React from "react";
 
+import { useAppSelectorShallow } from "../../state/app-store";
+import { applyShellControllerCommand } from "./shell-controller-sync/apply-command";
+import { buildFollowerController } from "./shell-controller-sync/follower-controller";
+import type { ShellControllerCommand } from "./shell-controller-sync/protocol";
+import {
+  deriveShellControllerSnapshot,
+  snapshotsEqual,
+} from "./shell-controller-sync/snapshot";
+import {
+  type ShellControllerSync,
+  useShellControllerSync,
+} from "./shell-controller-sync/useShellControllerSync";
 import { ShellControllerContext } from "./ShellControllerContext.hooks";
 import { useShellController } from "./useShellController";
 
 /**
- * Provides a single {@link useShellController} instance to the shell pill /
- * overlay so shell controls stay in lock-step without double-mounting the
- * controller, which would open two mic captures.
+ * Owner path: run the real engine, publish its snapshot to followers (coalescing
+ * the many per-token updates a streaming reply emits), and apply followers'
+ * commands against it. Provides the live controller unchanged.
+ */
+export function OwnerShellControllerProvider({
+  sync,
+  children,
+}: {
+  sync: ShellControllerSync;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const controller = useShellController();
+  const controllerRef = React.useRef(controller);
+  controllerRef.current = controller;
+
+  // Register the command sink once; the closure reads the live controller via a
+  // ref so a follower's command always hits the current engine.
+  React.useLayoutEffect(() => {
+    sync.setCommandHandler((command: ShellControllerCommand) =>
+      applyShellControllerCommand(controllerRef.current, command),
+    );
+    return () => sync.setCommandHandler(null);
+  }, [sync]);
+
+  // Publish on any engine change; the equality guard keeps an unchanged tick
+  // (and an unchanged streamed token) off the wire.
+  const lastPublishedRef = React.useRef<ReturnType<
+    typeof deriveShellControllerSnapshot
+  > | null>(null);
+  React.useEffect(() => {
+    const snapshot = deriveShellControllerSnapshot(controller);
+    if (
+      lastPublishedRef.current &&
+      snapshotsEqual(lastPublishedRef.current, snapshot)
+    ) {
+      return;
+    }
+    lastPublishedRef.current = snapshot;
+    sync.publishSnapshot(snapshot);
+  });
+
+  return (
+    <ShellControllerContext.Provider value={controller}>
+      {children}
+    </ShellControllerContext.Provider>
+  );
+}
+
+/**
+ * Follower path: render the owner's snapshot and forward commands. Never mounts
+ * the engine, so it can neither open a mic nor start a second chat session. A
+ * null controller (no snapshot yet, or a version-mismatch/disconnected owner)
+ * degrades the overlay to hidden rather than rendering stale state.
+ */
+export function FollowerShellControllerProvider({
+  sync,
+  onCommandError,
+  children,
+}: {
+  sync: ShellControllerSync;
+  onCommandError: (command: ShellControllerCommand, error: unknown) => void;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const controller = React.useMemo(() => {
+    if (!sync.snapshot) return null;
+    return buildFollowerController({
+      snapshot: sync.snapshot,
+      dispatch: sync.dispatch,
+      onCommandError,
+    });
+  }, [sync.snapshot, sync.dispatch, onCommandError]);
+
+  return (
+    <ShellControllerContext.Provider value={controller}>
+      {children}
+    </ShellControllerContext.Provider>
+  );
+}
+
+/**
+ * Provides a single shell controller to the shell pill / overlay. On the desktop
+ * it elects one engine owner across windows; everywhere else it is the lone
+ * owner. See the module header for the ownership + handoff contract.
  */
 export function ShellControllerProvider({
   children,
 }: {
   children: React.ReactNode;
 }): React.JSX.Element {
-  const controller = useShellController();
+  const { setActionNotice } = useAppSelectorShallow((s) => ({
+    setActionNotice: s.setActionNotice,
+  }));
+  const sync = useShellControllerSync();
+
+  const onCommandError = React.useCallback(
+    (_command: ShellControllerCommand, _error: unknown) => {
+      setActionNotice?.(
+        "Couldn't reach the assistant. Bring its window to the front and try again.",
+        "error",
+        4000,
+      );
+    },
+    [setActionNotice],
+  );
+
+  if (sync.role === "owner") {
+    return (
+      <OwnerShellControllerProvider sync={sync}>
+        {children}
+      </OwnerShellControllerProvider>
+    );
+  }
   return (
-    <ShellControllerContext.Provider value={controller}>
+    <FollowerShellControllerProvider sync={sync} onCommandError={onCommandError}>
       {children}
-    </ShellControllerContext.Provider>
+    </FollowerShellControllerProvider>
   );
 }

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/apply-command.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/apply-command.test.ts
@@ -1,0 +1,85 @@
+/** Owner-side command application: each typed command hits the matching engine
+ *  method exactly once. */
+import { describe, expect, it, vi } from "vitest";
+import { applyShellControllerCommand } from "../apply-command";
+import { makeFakeShellController } from "./fixtures";
+
+describe("applyShellControllerCommand", () => {
+  it("maps voice + chat commands to the engine", () => {
+    const c = makeFakeShellController();
+    applyShellControllerCommand(c, { kind: "open" });
+    expect(c.open).toHaveBeenCalledTimes(1);
+
+    applyShellControllerCommand(c, {
+      kind: "send",
+      text: "hello",
+      channelType: "VOICE_DM",
+      metadata: { a: 1 },
+    });
+    expect(c.send).toHaveBeenCalledWith("hello", {
+      channelType: "VOICE_DM",
+      metadata: { a: 1 },
+    });
+
+    applyShellControllerCommand(c, { kind: "startRecording", intent: "dictate" });
+    expect(c.startRecording).toHaveBeenCalledWith("dictate");
+
+    applyShellControllerCommand(c, { kind: "speak", text: "read this" });
+    expect(c.speak).toHaveBeenCalledWith("read this");
+
+    applyShellControllerCommand(c, { kind: "setComposerHasDraft", hasDraft: true });
+    expect(c.setComposerHasDraft).toHaveBeenCalledWith(true);
+
+    applyShellControllerCommand(c, { kind: "recheckMicPermission" });
+    expect(c.recheckMicPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes nav prev/next to conversationNav", () => {
+    const c = makeFakeShellController();
+    applyShellControllerCommand(c, { kind: "navConversation", direction: "prev" });
+    applyShellControllerCommand(c, { kind: "navConversation", direction: "next" });
+    expect(c.conversationNav.goPrev).toHaveBeenCalledTimes(1);
+    expect(c.conversationNav.goNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("covers the remaining commands", () => {
+    const c = makeFakeShellController();
+    const kinds = [
+      "close",
+      "captureVision",
+      "toggleRecording",
+      "stopRecording",
+      "toggleHandsFree",
+      "toggleTranscriptionMode",
+      "stopTranscriptionAndMic",
+      "stopSpeaking",
+      "toggleAgentVoiceMute",
+      "unlockAudio",
+      "clearConversation",
+      "openSettings",
+      "navigateHome",
+      "stop",
+    ] as const;
+    for (const kind of kinds) applyShellControllerCommand(c, { kind });
+    expect(c.close).toHaveBeenCalled();
+    expect(c.captureVision).toHaveBeenCalled();
+    expect(c.stop).toHaveBeenCalled();
+    expect(c.navigateHome).toHaveBeenCalled();
+  });
+
+  it("tolerates a missing optional navigateHome", () => {
+    const c = makeFakeShellController();
+    (c as { navigateHome?: () => void }).navigateHome = undefined;
+    expect(() => applyShellControllerCommand(c, { kind: "navigateHome" })).not.toThrow();
+  });
+
+  it("propagates an engine throw so the owner can fail the ack", () => {
+    const c = makeFakeShellController();
+    c.send = vi.fn(() => {
+      throw new Error("send blew up");
+    });
+    expect(() =>
+      applyShellControllerCommand(c, { kind: "send", text: "x" }),
+    ).toThrow("send blew up");
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/coordinator.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/coordinator.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Multi-window behaviour of the single-owner shell coordinator, exercised over a
+ * real in-memory bus (not a mock of the unit): several coordinators share one
+ * `createInMemoryShellSyncBus`, so ownership election, stale-snapshot rejection,
+ * idempotent commands, crash re-election, and version-mismatch degrade are all
+ * proven against genuine cross-window message flow.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ShellControllerCoordinator,
+  type ShellCoordinatorOptions,
+  type ShellFollowerStatus,
+} from "../coordinator";
+import {
+  SHELL_OWNER_PRIORITY,
+  type ShellControllerCommand,
+  type ShellWindowRole,
+} from "../protocol";
+import type { ShellControllerSnapshot } from "../snapshot";
+import {
+  createInMemoryShellSyncBus,
+  type InMemoryShellSyncBus,
+} from "../transport";
+import { baseSnapshot } from "./fixtures";
+
+class Clock {
+  ms = 1000;
+  now = (): number => this.ms;
+  advance(by: number): void {
+    this.ms += by;
+  }
+}
+
+interface Window {
+  coord: ShellControllerCoordinator;
+  transport: ReturnType<InMemoryShellSyncBus["connect"]>;
+  roles: ShellWindowRole[];
+  statuses: ShellFollowerStatus[];
+  snapshots: (ShellControllerSnapshot | null)[];
+  applied: ShellControllerCommand[];
+  errors: string[];
+}
+
+function makeWindow(
+  bus: InMemoryShellSyncBus,
+  clock: Clock,
+  windowId: string,
+  priority: number,
+  extra: Partial<ShellCoordinatorOptions> = {},
+): Window {
+  const transport = bus.connect();
+  const w: Window = {
+    coord: undefined as unknown as ShellControllerCoordinator,
+    transport,
+    roles: [],
+    statuses: [],
+    snapshots: [],
+    applied: [],
+    errors: [],
+  };
+  w.coord = new ShellControllerCoordinator({
+    windowId,
+    priority,
+    transport,
+    now: clock.now,
+    peerTtlMs: 3000,
+    // Election tests assert the elected result directly; the join grace is
+    // covered by its own suite, so default to immediate claim here.
+    claimOwnershipImmediately: extra.claimOwnershipImmediately ?? true,
+    onRoleChange: (role) => w.roles.push(role),
+    onStatusChange: (status) => w.statuses.push(status),
+    onSnapshot: (snap) => w.snapshots.push(snap),
+    onCommand: (command) => w.applied.push(command),
+    onError: (message) => w.errors.push(message),
+    ...extra,
+  });
+  return w;
+}
+
+describe("ShellControllerCoordinator ownership", () => {
+  it("a lone window owns the engine", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const w = makeWindow(bus, clock, "w1", SHELL_OWNER_PRIORITY.main);
+    w.coord.start();
+    expect(w.coord.getRole()).toBe("owner");
+  });
+
+  it("exactly one of two windows owns; priority wins over id", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    // The tray popover (higher priority number) starts FIRST, then the main
+    // window joins and must take ownership.
+    const tray = makeWindow(
+      bus,
+      clock,
+      "aaa-tray",
+      SHELL_OWNER_PRIORITY["tray-popover"],
+    );
+    tray.coord.start();
+    expect(tray.coord.getRole()).toBe("owner");
+
+    const main = makeWindow(bus, clock, "zzz-main", SHELL_OWNER_PRIORITY.main);
+    main.coord.start();
+
+    expect(main.coord.getRole()).toBe("owner");
+    expect(tray.coord.getRole()).toBe("follower");
+  });
+
+  it("ties break on window id so no two windows disagree", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const a = makeWindow(bus, clock, "id-a", SHELL_OWNER_PRIORITY.surface);
+    const b = makeWindow(bus, clock, "id-b", SHELL_OWNER_PRIORITY.surface);
+    a.coord.start();
+    b.coord.start();
+    expect(a.coord.getRole()).toBe("owner");
+    expect(b.coord.getRole()).toBe("follower");
+  });
+});
+
+describe("ShellControllerCoordinator snapshots", () => {
+  it("a follower renders the owner's snapshot", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    owner.coord.start();
+    follower.coord.start();
+
+    owner.coord.publishSnapshot(baseSnapshot({ recording: true, phase: "listening" }));
+
+    const latest = follower.snapshots.at(-1);
+    expect(latest?.recording).toBe(true);
+    expect(latest?.phase).toBe("listening");
+    expect(follower.coord.getStatus()).toBe("connected");
+  });
+
+  it("drops a stale (reordered) snapshot by seq", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    owner.coord.start();
+    follower.coord.start();
+
+    owner.coord.publishSnapshot(baseSnapshot({ transcript: "first" }));
+    owner.coord.publishSnapshot(baseSnapshot({ transcript: "second" }));
+    // A relay redelivers an older seq out of order (raw endpoint so it actually
+    // reaches the follower); the coordinator must ignore it.
+    const relay = bus.connect();
+    relay.send({
+      type: "snapshot",
+      protocolVersion: "1",
+      ownerWindowId: "owner",
+      epoch: 1,
+      seq: 1,
+      snapshot: baseSnapshot({ transcript: "STALE" }),
+    });
+
+    expect(follower.snapshots.at(-1)?.transcript).toBe("second");
+  });
+});
+
+describe("ShellControllerCoordinator commands", () => {
+  it("routes a follower command to the owner exactly once and acks", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    owner.coord.start();
+    follower.coord.start();
+
+    await follower.coord.dispatchCommand({ kind: "startRecording", intent: "converse" });
+
+    expect(owner.applied).toEqual([{ kind: "startRecording", intent: "converse" }]);
+  });
+
+  it("relays a mic-permission recheck command to the single audio owner", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "follower",
+      SHELL_OWNER_PRIORITY.surface,
+    );
+    owner.coord.start();
+    follower.coord.start();
+
+    await follower.coord.dispatchCommand({ kind: "recheckMicPermission" });
+    expect(owner.applied).toContainEqual({ kind: "recheckMicPermission" });
+    // The follower itself never applies a command (owns no engine).
+    expect(follower.applied).toEqual([]);
+  });
+
+  it("two followers racing start/stop/send: owner applies each once", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const f1 = makeWindow(bus, clock, "f1", SHELL_OWNER_PRIORITY.surface);
+    const f2 = makeWindow(bus, clock, "f2", SHELL_OWNER_PRIORITY["tray-popover"]);
+    owner.coord.start();
+    f1.coord.start();
+    f2.coord.start();
+
+    await Promise.all([
+      f1.coord.dispatchCommand({ kind: "startRecording" }),
+      f2.coord.dispatchCommand({ kind: "stopRecording" }),
+      f1.coord.dispatchCommand({ kind: "send", text: "hi" }),
+    ]);
+
+    expect(owner.applied).toHaveLength(3);
+    expect(owner.applied).toContainEqual({ kind: "startRecording" });
+    expect(owner.applied).toContainEqual({ kind: "stopRecording" });
+    expect(owner.applied).toContainEqual({ kind: "send", text: "hi" });
+    expect(f1.applied).toEqual([]);
+    expect(f2.applied).toEqual([]);
+  });
+
+  it("idempotency: a redelivered command re-acks but never re-applies", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "follower",
+      SHELL_OWNER_PRIORITY.surface,
+    );
+    owner.coord.start();
+    follower.coord.start();
+
+    // A relay that redelivers the SAME command envelope (same commandId) must
+    // ack twice but apply once. Send the identical envelope through the
+    // follower's transport twice.
+    const envelope = {
+      type: "command" as const,
+      protocolVersion: "1",
+      commandId: "dup-1",
+      fromWindowId: "follower",
+      command: { kind: "toggleHandsFree" } as ShellControllerCommand,
+    };
+    follower.transport.send(envelope);
+    follower.transport.send(envelope);
+
+    expect(owner.applied).toEqual([{ kind: "toggleHandsFree" }]);
+  });
+
+  it("rejects a command when the follower's owner has gone (no silent drop)", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    // A high-priority (main) owner keeps a lower-priority window a follower.
+    const owner = makeWindow(bus, clock, "aaa-owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "zzz-follower",
+      SHELL_OWNER_PRIORITY.surface,
+    );
+    owner.coord.start();
+    follower.coord.start();
+    expect(follower.coord.getRole()).toBe("follower");
+
+    // The owner crashes (no bye). The follower still lists it, but before its
+    // own re-election tick a dispatch must reach a live owner — sever the bus so
+    // no ack can return and the send is inert, then prove it rejects on timeout
+    // rather than resolving as a phantom success.
+    bus.disconnect(owner.transport);
+    const pending = follower.coord.dispatchCommand({ kind: "open" });
+    clock.advance(6000);
+    follower.coord.tick();
+    await expect(pending).rejects.toThrow();
+  });
+
+  it("times out a command whose ack never returns", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "follower",
+      SHELL_OWNER_PRIORITY.surface,
+    );
+    owner.coord.start();
+    follower.coord.start();
+    // Sever the owner so its ack never comes back, but keep it in the peer table
+    // (no bye) so the follower still targets it.
+    bus.disconnect(owner.transport);
+
+    const pending = follower.coord.dispatchCommand({ kind: "stop" });
+    clock.advance(6000);
+    follower.coord.tick();
+    await expect(pending).rejects.toThrow(/timed out/);
+  });
+});
+
+describe("ShellControllerCoordinator crash + handoff", () => {
+  it("promotes a follower after the owner crashes (heartbeat TTL)", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "aaa-owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "bbb-follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    owner.coord.start();
+    follower.coord.start();
+    owner.coord.publishSnapshot(baseSnapshot({ transcript: "live" }));
+    expect(follower.coord.getRole()).toBe("follower");
+
+    // Owner crashes without a bye. Advance past the TTL and tick the follower.
+    bus.disconnect(owner.transport);
+    clock.advance(4000);
+    follower.coord.tick();
+
+    expect(follower.coord.getRole()).toBe("owner");
+  });
+
+  it("a promoted owner's epoch beats the crashed owner's late snapshots", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "aaa-owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "bbb-follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    const observer = makeWindow(
+      bus,
+      clock,
+      "ccc-observer",
+      SHELL_OWNER_PRIORITY["tray-popover"],
+    );
+    owner.coord.start();
+    follower.coord.start();
+    observer.coord.start();
+    owner.coord.publishSnapshot(baseSnapshot({ transcript: "epoch1" }));
+
+    bus.disconnect(owner.transport);
+    clock.advance(4000);
+    follower.coord.tick();
+    observer.coord.tick();
+    expect(follower.coord.getRole()).toBe("owner");
+
+    follower.coord.publishSnapshot(baseSnapshot({ transcript: "epoch2" }));
+    // A late duplicate of the dead owner's epoch-1 snapshot (raw endpoint so it
+    // reaches the observer) must not clobber the new owner's epoch-2 state.
+    const zombie = bus.connect();
+    zombie.send({
+      type: "snapshot",
+      protocolVersion: "1",
+      ownerWindowId: "aaa-owner",
+      epoch: 1,
+      seq: 99,
+      snapshot: baseSnapshot({ transcript: "ZOMBIE" }),
+    });
+    expect(observer.snapshots.at(-1)?.transcript).toBe("epoch2");
+  });
+
+  it("clean handoff: an owner that stops promotes a follower immediately", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const owner = makeWindow(bus, clock, "aaa-owner", SHELL_OWNER_PRIORITY.main);
+    const follower = makeWindow(
+      bus,
+      clock,
+      "bbb-follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    owner.coord.start();
+    follower.coord.start();
+    expect(follower.coord.getRole()).toBe("follower");
+
+    owner.coord.stop();
+    expect(follower.coord.getRole()).toBe("owner");
+  });
+
+  it("main-window restart reclaims ownership from the interim owner", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const main = makeWindow(bus, clock, "main", SHELL_OWNER_PRIORITY.main);
+    const overlay = makeWindow(
+      bus,
+      clock,
+      "overlay",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    main.coord.start();
+    overlay.coord.start();
+    expect(main.coord.getRole()).toBe("owner");
+
+    // Main closes; overlay takes over.
+    main.coord.stop();
+    expect(overlay.coord.getRole()).toBe("owner");
+
+    // Main restarts (new coordinator, same priority) and reclaims ownership.
+    const main2 = makeWindow(bus, clock, "main", SHELL_OWNER_PRIORITY.main);
+    main2.coord.start();
+    expect(main2.coord.getRole()).toBe("owner");
+    expect(overlay.coord.getRole()).toBe("follower");
+  });
+});
+
+describe("ShellControllerCoordinator join grace", () => {
+  it("defers claiming ownership until discovery completes", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const w = makeWindow(bus, clock, "solo", SHELL_OWNER_PRIORITY.main, {
+      claimOwnershipImmediately: false,
+    });
+    w.coord.start();
+    // Rightful owner, but still discovering: it must not run the engine yet.
+    expect(w.coord.getRole()).toBe("follower");
+    expect(w.coord.getStatus()).toBe("connecting");
+
+    w.coord.completeDiscovery();
+    expect(w.coord.getRole()).toBe("owner");
+  });
+
+  it("a joiner that hears an existing owner during grace never claims", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    // Existing owner is already up (claimed).
+    const owner = makeWindow(bus, clock, "aaa-owner", SHELL_OWNER_PRIORITY.main);
+    owner.coord.start();
+    expect(owner.coord.getRole()).toBe("owner");
+
+    // A lower-priority window joins WITH a grace. Even though it has not yet
+    // completed discovery, hearing the owner keeps it a follower.
+    const joiner = makeWindow(
+      bus,
+      clock,
+      "zzz-joiner",
+      SHELL_OWNER_PRIORITY.surface,
+      { claimOwnershipImmediately: false },
+    );
+    joiner.coord.start();
+    expect(joiner.coord.getRole()).toBe("follower");
+
+    // Completing discovery still keeps it a follower (owner outranks it).
+    joiner.coord.completeDiscovery();
+    expect(joiner.coord.getRole()).toBe("follower");
+    expect(owner.coord.getRole()).toBe("owner");
+  });
+});
+
+describe("ShellControllerCoordinator version-mismatch + offline", () => {
+  it("a follower shows version-mismatch when the owner speaks a newer protocol", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const follower = makeWindow(
+      bus,
+      clock,
+      "zzz-follower",
+      SHELL_OWNER_PRIORITY["chat-overlay"],
+    );
+    follower.coord.start();
+    // A future-build main window (raw bus endpoint speaking protocol "2")
+    // announces and wins ownership by priority. Our window becomes its follower
+    // but cannot interpret its snapshot, so it degrades visibly instead of
+    // spawning a second engine.
+    const futureOwner = bus.connect();
+    futureOwner.send({
+      type: "presence",
+      protocolVersion: "2",
+      event: "announce",
+      windowId: "aaa-future-owner",
+      priority: SHELL_OWNER_PRIORITY.main,
+    });
+    expect(follower.coord.getRole()).toBe("follower");
+    expect(follower.coord.getStatus()).toBe("version-mismatch");
+
+    futureOwner.send({
+      type: "snapshot",
+      protocolVersion: "2",
+      ownerWindowId: "aaa-future-owner",
+      epoch: 1,
+      seq: 1,
+      snapshot: baseSnapshot({ transcript: "cannot-read" }),
+    });
+    // The incompatible snapshot must never render.
+    expect(follower.snapshots.at(-1)).toBeNull();
+    expect(follower.coord.getStatus()).toBe("version-mismatch");
+  });
+
+  it("a demoted follower with no owner reports disconnected", () => {
+    const bus = createInMemoryShellSyncBus();
+    const clock = new Clock();
+    const a = makeWindow(bus, clock, "aaa", SHELL_OWNER_PRIORITY.surface);
+    const b = makeWindow(bus, clock, "bbb", SHELL_OWNER_PRIORITY.surface);
+    a.coord.start();
+    b.coord.start();
+    expect(b.coord.getRole()).toBe("follower");
+    // Owner crashes; before re-election tick, b should observe disconnected once
+    // the owner is pruned.
+    bus.disconnect(a.transport);
+    clock.advance(4000);
+    // Manually strip the owner from b's table via a bye-equivalent prune.
+    b.coord.tick();
+    // b promotes itself (only survivor) — role owner, but the transition proves
+    // it never silently rendered the dead owner's state.
+    expect(b.coord.getRole()).toBe("owner");
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/electrobun-transport.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/electrobun-transport.test.ts
@@ -1,0 +1,82 @@
+/** Electrobun transport adapter: marshals envelopes to the bun relay request and
+ *  fans push messages back, validating the untrusted IPC payload. Driven by a
+ *  fake bridge (a boundary double, not a mock of the unit under test). */
+import { describe, expect, it, vi } from "vitest";
+import type { ElectrobunRendererRpc } from "../../../../bridge/electrobun-rpc";
+import {
+  buildElectrobunShellSyncTransport,
+  SHELL_SYNC_PUSH_MESSAGE,
+  SHELL_SYNC_RELAY_RPC_METHOD,
+} from "../electrobun-transport";
+import type { ShellSyncEnvelope } from "../protocol";
+
+const envelope: ShellSyncEnvelope = {
+  type: "presence",
+  protocolVersion: "1",
+  event: "announce",
+  windowId: "w",
+  priority: 0,
+};
+
+function fakeRpc(over: Partial<ElectrobunRendererRpc> = {}): {
+  rpc: ElectrobunRendererRpc;
+  relay: ReturnType<typeof vi.fn>;
+  listeners: Map<string, (payload: unknown) => void>;
+} {
+  const relay = vi.fn(async () => ({ ok: true }));
+  const listeners = new Map<string, (payload: unknown) => void>();
+  const rpc: ElectrobunRendererRpc = {
+    request: { [SHELL_SYNC_RELAY_RPC_METHOD]: relay },
+    onMessage: (name, listener) => listeners.set(name, listener),
+    offMessage: (name) => listeners.delete(name),
+    ...over,
+  };
+  return { rpc, relay, listeners };
+}
+
+describe("buildElectrobunShellSyncTransport send", () => {
+  it("calls the relay request with the envelope", () => {
+    const { rpc, relay } = fakeRpc();
+    buildElectrobunShellSyncTransport(rpc, () => {}).send(envelope);
+    expect(relay).toHaveBeenCalledWith({ envelope });
+  });
+
+  it("no-ops when the relay method is absent", () => {
+    const { rpc } = fakeRpc({ request: {} });
+    expect(() =>
+      buildElectrobunShellSyncTransport(rpc, () => {}).send(envelope),
+    ).not.toThrow();
+  });
+
+  it("routes a relay rejection to onError (never swallowed)", async () => {
+    const relay = vi.fn(async () => {
+      throw new Error("relay down");
+    });
+    const { rpc } = fakeRpc({ request: { [SHELL_SYNC_RELAY_RPC_METHOD]: relay } });
+    const errors: unknown[] = [];
+    buildElectrobunShellSyncTransport(rpc, (e) => errors.push(e)).send(envelope);
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+  });
+});
+
+describe("buildElectrobunShellSyncTransport subscribe", () => {
+  it("delivers a valid pushed envelope and drops a malformed one", () => {
+    const { rpc, listeners } = fakeRpc();
+    const seen: ShellSyncEnvelope[] = [];
+    const unsub = buildElectrobunShellSyncTransport(rpc, () => {}).subscribe((e) =>
+      seen.push(e),
+    );
+    const push = listeners.get(SHELL_SYNC_PUSH_MESSAGE);
+    expect(push).toBeTypeOf("function");
+
+    push?.({ envelope });
+    push?.({ envelope: { type: "garbage" } });
+    push?.({});
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe("presence");
+
+    unsub();
+    expect(listeners.has(SHELL_SYNC_PUSH_MESSAGE)).toBe(false);
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
@@ -1,0 +1,111 @@
+/** Shared test fixtures for the shell-controller-sync suite: a full snapshot and
+ *  a fully-stubbed `ShellController` whose methods are spies. */
+import { vi } from "vitest";
+import type { HomeModelStatus } from "../../../../services/local-inference/home-model-status";
+import type { ShellMessage } from "../../shell-state";
+import type { ShellController } from "../../useShellController";
+import type { ShellControllerSnapshot } from "../snapshot";
+
+// Shared stable references so two default snapshots coalesce as equal (mirrors
+// production, where messages preserve identity and model-status holds a stable
+// reference across renders).
+const EMPTY_MESSAGES: readonly ShellMessage[] = Object.freeze([]);
+const NOT_REQUIRED_MODEL: HomeModelStatus = {
+  kind: "not-required",
+  blocksSend: false,
+  percent: null,
+  etaMs: null,
+  modelName: null,
+  errors: [],
+};
+
+export function baseSnapshot(
+  over: Partial<ShellControllerSnapshot> = {},
+): ShellControllerSnapshot {
+  return {
+    phase: "idle",
+    responding: false,
+    turnStatus: null,
+    messages: EMPTY_MESSAGES,
+    canSend: true,
+    modelStatus: NOT_REQUIRED_MODEL,
+    recording: false,
+    waveformMode: "idle",
+    isOpen: false,
+    visionCapturing: false,
+    transcript: "",
+    speaking: false,
+    agentVoiceMuted: false,
+    needsAudioUnlock: false,
+    handsFree: false,
+    micPermission: "granted",
+    transcriptionMode: false,
+    conversationNav: {
+      hasPrev: false,
+      hasNext: false,
+      activeId: null,
+      index: -1,
+    },
+    ...over,
+  };
+}
+
+export function makeFakeShellController(): ShellController {
+  return {
+    phase: "idle",
+    responding: false,
+    turnStatus: null,
+    messages: [],
+    canSend: true,
+    modelStatus: {
+      kind: "not-required",
+      blocksSend: false,
+      percent: null,
+      etaMs: null,
+      modelName: null,
+      errors: [],
+    },
+    recording: false,
+    waveformMode: "idle",
+    analyser: null,
+    isOpen: false,
+    visionCapturing: false,
+    handsFree: false,
+    micPermission: "granted",
+    transcriptionMode: false,
+    transcript: "",
+    speaking: false,
+    agentVoiceMuted: false,
+    needsAudioUnlock: false,
+    open: vi.fn(),
+    close: vi.fn(),
+    send: vi.fn(),
+    captureVision: vi.fn(),
+    toggleRecording: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    toggleHandsFree: vi.fn(),
+    recheckMicPermission: vi.fn(async () => "granted" as const),
+    toggleTranscriptionMode: vi.fn(),
+    stopTranscriptionAndMic: vi.fn(),
+    setDictationSink: vi.fn(),
+    setTranscriptSessionSink: vi.fn(),
+    setComposerHasDraft: vi.fn(),
+    speak: vi.fn(),
+    stopSpeaking: vi.fn(),
+    toggleAgentVoiceMute: vi.fn(),
+    unlockAudio: vi.fn(),
+    clearConversation: vi.fn(),
+    openSettings: vi.fn(),
+    navigateHome: vi.fn(),
+    stop: vi.fn(),
+    conversationNav: {
+      hasPrev: false,
+      hasNext: false,
+      activeId: null,
+      index: -1,
+      goPrev: vi.fn(),
+      goNext: vi.fn(),
+    },
+  };
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts
@@ -1,0 +1,88 @@
+/** Follower controller: reads come from the snapshot, methods forward typed
+ *  commands, engine-only affordances are inert, dispatch failures surface. */
+import { describe, expect, it, vi } from "vitest";
+import { buildFollowerController } from "../follower-controller";
+import type { ShellControllerCommand } from "../protocol";
+import { baseSnapshot } from "./fixtures";
+
+function build(
+  over = {},
+): {
+  controller: ReturnType<typeof buildFollowerController>;
+  dispatch: ReturnType<typeof vi.fn>;
+  errors: { command: ShellControllerCommand; error: unknown }[];
+} {
+  const dispatch = vi.fn(async () => {});
+  const errors: { command: ShellControllerCommand; error: unknown }[] = [];
+  const controller = buildFollowerController({
+    snapshot: baseSnapshot(over),
+    dispatch,
+    onCommandError: (command, error) => errors.push({ command, error }),
+  });
+  return { controller, dispatch, errors };
+}
+
+describe("buildFollowerController reads", () => {
+  it("mirrors snapshot fields and owns no analyser", () => {
+    const { controller } = build({
+      recording: true,
+      transcript: "live",
+      handsFree: true,
+    });
+    expect(controller.recording).toBe(true);
+    expect(controller.transcript).toBe("live");
+    expect(controller.handsFree).toBe(true);
+    expect(controller.analyser).toBeNull();
+  });
+});
+
+describe("buildFollowerController commands", () => {
+  it("forwards send with serialisable options", () => {
+    const { controller, dispatch } = build();
+    controller.send("hi", { channelType: "VOICE_DM", metadata: { x: 1 } });
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: "send",
+      text: "hi",
+      channelType: "VOICE_DM",
+      metadata: { x: 1 },
+    });
+  });
+
+  it("forwards voice + nav controls", () => {
+    const { controller, dispatch } = build();
+    controller.startRecording("dictate");
+    controller.toggleHandsFree();
+    controller.conversationNav.goNext();
+    expect(dispatch).toHaveBeenCalledWith({ kind: "startRecording", intent: "dictate" });
+    expect(dispatch).toHaveBeenCalledWith({ kind: "toggleHandsFree" });
+    expect(dispatch).toHaveBeenCalledWith({ kind: "navConversation", direction: "next" });
+  });
+
+  it("keeps engine-local sinks inert (owner runs the recorder)", () => {
+    const { controller, dispatch } = build();
+    controller.setDictationSink(() => {});
+    controller.setTranscriptSessionSink(() => {});
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("recheckMicPermission forwards and resolves the known permission", async () => {
+    const { controller, dispatch } = build({ micPermission: "denied" });
+    await expect(controller.recheckMicPermission()).resolves.toBe("denied");
+    expect(dispatch).toHaveBeenCalledWith({ kind: "recheckMicPermission" });
+  });
+
+  it("routes a dispatch failure to onCommandError (never silent)", async () => {
+    const dispatch = vi.fn(async () => {
+      throw new Error("owner gone");
+    });
+    const errors: unknown[] = [];
+    const controller = buildFollowerController({
+      snapshot: baseSnapshot(),
+      dispatch,
+      onCommandError: (_command, error) => errors.push(error),
+    });
+    controller.stop();
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    expect((errors[0] as Error).message).toBe("owner gone");
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/protocol.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/protocol.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure protocol helpers: owner election, peer pruning, snapshot ordering,
+ * version gating, and the IPC-boundary envelope validator. All deterministic —
+ * no transport, no clock.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  electOwnerWindowId,
+  isProtocolCompatible,
+  isSnapshotNewer,
+  parseShellSyncEnvelope,
+  pruneStalePeers,
+  SHELL_SYNC_PROTOCOL_VERSION,
+  type ShellPeer,
+} from "../protocol";
+
+function peer(over: Partial<ShellPeer>): ShellPeer {
+  return {
+    windowId: "w",
+    priority: 0,
+    protocolVersion: SHELL_SYNC_PROTOCOL_VERSION,
+    lastSeenMs: 0,
+    ...over,
+  };
+}
+
+describe("electOwnerWindowId", () => {
+  it("returns null for an empty set", () => {
+    expect(electOwnerWindowId([])).toBeNull();
+  });
+  it("prefers lower priority", () => {
+    expect(
+      electOwnerWindowId([
+        peer({ windowId: "b", priority: 3 }),
+        peer({ windowId: "a", priority: 0 }),
+      ]),
+    ).toBe("a");
+  });
+  it("breaks ties on window id", () => {
+    expect(
+      electOwnerWindowId([
+        peer({ windowId: "z", priority: 1 }),
+        peer({ windowId: "a", priority: 1 }),
+      ]),
+    ).toBe("a");
+  });
+});
+
+describe("pruneStalePeers", () => {
+  it("keeps peers within the ttl and drops older ones", () => {
+    const kept = pruneStalePeers(
+      [peer({ windowId: "fresh", lastSeenMs: 900 }), peer({ windowId: "old", lastSeenMs: 100 })],
+      1000,
+      200,
+    );
+    expect(kept.map((p) => p.windowId)).toEqual(["fresh"]);
+  });
+});
+
+describe("isSnapshotNewer", () => {
+  it("treats the first snapshot as newer", () => {
+    expect(isSnapshotNewer({ epoch: 1, seq: 1 }, null)).toBe(true);
+  });
+  it("advances on higher seq within an epoch", () => {
+    expect(isSnapshotNewer({ epoch: 1, seq: 2 }, { epoch: 1, seq: 1 })).toBe(true);
+    expect(isSnapshotNewer({ epoch: 1, seq: 1 }, { epoch: 1, seq: 1 })).toBe(false);
+    expect(isSnapshotNewer({ epoch: 1, seq: 1 }, { epoch: 1, seq: 2 })).toBe(false);
+  });
+  it("a higher epoch always wins; a lower epoch never does", () => {
+    expect(isSnapshotNewer({ epoch: 2, seq: 1 }, { epoch: 1, seq: 99 })).toBe(true);
+    expect(isSnapshotNewer({ epoch: 1, seq: 99 }, { epoch: 2, seq: 1 })).toBe(false);
+  });
+});
+
+describe("isProtocolCompatible", () => {
+  it("matches only the current version", () => {
+    expect(isProtocolCompatible(SHELL_SYNC_PROTOCOL_VERSION)).toBe(true);
+    expect(isProtocolCompatible("999")).toBe(false);
+  });
+});
+
+describe("parseShellSyncEnvelope", () => {
+  it("rejects non-objects and unknown types", () => {
+    expect(parseShellSyncEnvelope(null)).toBeNull();
+    expect(parseShellSyncEnvelope("x")).toBeNull();
+    expect(parseShellSyncEnvelope({ type: "nope", protocolVersion: "1" })).toBeNull();
+    expect(parseShellSyncEnvelope({ type: "presence" })).toBeNull();
+  });
+  it("accepts a well-formed presence", () => {
+    expect(
+      parseShellSyncEnvelope({
+        type: "presence",
+        protocolVersion: "1",
+        event: "announce",
+        windowId: "w",
+        priority: 0,
+      }),
+    ).not.toBeNull();
+  });
+  it("rejects a presence with a bad event / missing fields", () => {
+    expect(
+      parseShellSyncEnvelope({
+        type: "presence",
+        protocolVersion: "1",
+        event: "nope",
+        windowId: "w",
+        priority: 0,
+      }),
+    ).toBeNull();
+  });
+  it("accepts a well-formed snapshot / command / ack", () => {
+    expect(
+      parseShellSyncEnvelope({
+        type: "snapshot",
+        protocolVersion: "1",
+        ownerWindowId: "o",
+        epoch: 1,
+        seq: 1,
+        snapshot: {},
+      }),
+    ).not.toBeNull();
+    expect(
+      parseShellSyncEnvelope({
+        type: "command",
+        protocolVersion: "1",
+        commandId: "c",
+        fromWindowId: "f",
+        command: { kind: "open" },
+      }),
+    ).not.toBeNull();
+    expect(
+      parseShellSyncEnvelope({
+        type: "ack",
+        protocolVersion: "1",
+        commandId: "c",
+        toWindowId: "t",
+        ok: true,
+      }),
+    ).not.toBeNull();
+  });
+  it("rejects a snapshot missing its payload", () => {
+    expect(
+      parseShellSyncEnvelope({
+        type: "snapshot",
+        protocolVersion: "1",
+        ownerWindowId: "o",
+        epoch: 1,
+        seq: 1,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/snapshot.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/snapshot.test.ts
@@ -1,0 +1,64 @@
+/** Snapshot projection + coalescing equality. */
+import { describe, expect, it } from "vitest";
+import type { ShellMessage } from "../../shell-state";
+import {
+  deriveShellControllerSnapshot,
+  snapshotsEqual,
+} from "../snapshot";
+import { baseSnapshot, makeFakeShellController } from "./fixtures";
+
+describe("deriveShellControllerSnapshot", () => {
+  it("projects read fields and drops the non-serialisable analyser", () => {
+    const controller = makeFakeShellController();
+    controller.recording = true;
+    controller.transcript = "hi";
+    const snap = deriveShellControllerSnapshot(controller);
+    expect(snap.recording).toBe(true);
+    expect(snap.transcript).toBe("hi");
+    expect("analyser" in snap).toBe(false);
+    expect(snap.conversationNav).toEqual({
+      hasPrev: false,
+      hasNext: false,
+      activeId: null,
+      index: -1,
+    });
+  });
+});
+
+describe("snapshotsEqual", () => {
+  it("is true for equal snapshots and false when a scalar changes", () => {
+    expect(snapshotsEqual(baseSnapshot(), baseSnapshot())).toBe(true);
+    expect(
+      snapshotsEqual(baseSnapshot(), baseSnapshot({ recording: true })),
+    ).toBe(false);
+  });
+  it("compares messages by reference (identity-preserving projection)", () => {
+    const msgs: ShellMessage[] = [
+      { id: "1", role: "user", content: "a", createdAt: 1 },
+    ];
+    expect(
+      snapshotsEqual(baseSnapshot({ messages: msgs }), baseSnapshot({ messages: msgs })),
+    ).toBe(true);
+    expect(
+      snapshotsEqual(
+        baseSnapshot({ messages: msgs }),
+        baseSnapshot({ messages: [...msgs] }),
+      ),
+    ).toBe(false);
+  });
+  it("detects a nav change", () => {
+    expect(
+      snapshotsEqual(
+        baseSnapshot(),
+        baseSnapshot({
+          conversationNav: {
+            hasPrev: true,
+            hasNext: false,
+            activeId: "c",
+            index: 0,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/transport.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/transport.test.ts
@@ -1,0 +1,52 @@
+/** In-memory bus: broadcasts to others, never echoes self, stops on disconnect. */
+import { describe, expect, it } from "vitest";
+import type { ShellSyncEnvelope } from "../protocol";
+import { createInMemoryShellSyncBus } from "../transport";
+
+const presence: ShellSyncEnvelope = {
+  type: "presence",
+  protocolVersion: "1",
+  event: "announce",
+  windowId: "a",
+  priority: 0,
+};
+
+describe("createInMemoryShellSyncBus", () => {
+  it("delivers to other endpoints but not the sender", () => {
+    const bus = createInMemoryShellSyncBus();
+    const a = bus.connect();
+    const b = bus.connect();
+    const aSeen: ShellSyncEnvelope[] = [];
+    const bSeen: ShellSyncEnvelope[] = [];
+    a.subscribe((e) => aSeen.push(e));
+    b.subscribe((e) => bSeen.push(e));
+    a.send(presence);
+    expect(aSeen).toHaveLength(0);
+    expect(bSeen).toHaveLength(1);
+    expect(bSeen[0].type).toBe("presence");
+  });
+
+  it("delivers a structural copy, not the same reference", () => {
+    const bus = createInMemoryShellSyncBus();
+    const a = bus.connect();
+    const b = bus.connect();
+    let received: ShellSyncEnvelope | null = null;
+    b.subscribe((e) => {
+      received = e;
+    });
+    a.send(presence);
+    expect(received).not.toBe(presence);
+    expect(received).toEqual(presence);
+  });
+
+  it("a disconnected endpoint neither sends nor receives", () => {
+    const bus = createInMemoryShellSyncBus();
+    const a = bus.connect();
+    const b = bus.connect();
+    const bSeen: ShellSyncEnvelope[] = [];
+    b.subscribe((e) => bSeen.push(e));
+    bus.disconnect(a);
+    a.send(presence);
+    expect(bSeen).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/useShellControllerSync.test.tsx
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/useShellControllerSync.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+/**
+ * React integration for the coordinator host: two windows on one in-memory bus
+ * elect a single owner, the follower renders the owner's published snapshot, and
+ * a follower command reaches the owner's handler — the whole single-engine
+ * contract, exercised through real hooks and timers (no mock of the unit).
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SHELL_OWNER_PRIORITY, type ShellControllerCommand } from "../protocol";
+import { createInMemoryShellSyncBus } from "../transport";
+import { useShellControllerSync } from "../useShellControllerSync";
+import { baseSnapshot } from "./fixtures";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useShellControllerSync multi-window", () => {
+  it("elects one owner; follower renders shared state and commands reach the owner", async () => {
+    const bus = createInMemoryShellSyncBus();
+    const ownerView = renderHook(() =>
+      useShellControllerSync({
+        transport: bus.connect(),
+        windowId: "aaa-main",
+        priority: SHELL_OWNER_PRIORITY.main,
+      }),
+    );
+    const followerView = renderHook(() =>
+      useShellControllerSync({
+        transport: bus.connect(),
+        windowId: "zzz-surface",
+        priority: SHELL_OWNER_PRIORITY.surface,
+      }),
+    );
+
+    // The main window claims immediately; the surface window waits out the
+    // discovery grace and, hearing the owner, stays a follower.
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(ownerView.result.current.role).toBe("owner");
+    expect(followerView.result.current.role).toBe("follower");
+
+    const applied: ShellControllerCommand[] = [];
+    act(() => {
+      ownerView.result.current.setCommandHandler((command) =>
+        applied.push(command),
+      );
+    });
+
+    act(() => {
+      ownerView.result.current.publishSnapshot(
+        baseSnapshot({ transcript: "shared", recording: true }),
+      );
+    });
+    expect(followerView.result.current.snapshot?.transcript).toBe("shared");
+    expect(followerView.result.current.snapshot?.recording).toBe(true);
+
+    await act(async () => {
+      await followerView.result.current.dispatch({ kind: "startRecording" });
+    });
+    expect(applied).toEqual([{ kind: "startRecording" }]);
+  });
+
+  it("a lone window (no transport) is owner immediately with no bus traffic", () => {
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: null, windowId: "solo" }),
+    );
+    // No grace, no flash: owner from the first committed render.
+    expect(view.result.current.role).toBe("owner");
+  });
+});

--- a/packages/ui/src/components/shell/shell-controller-sync/apply-command.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/apply-command.ts
@@ -1,0 +1,92 @@
+/**
+ * Owner-side inverse of the follower controller: run a follower's typed command
+ * against the one live `useShellController` engine (#16442). The owner window is
+ * the sole place mic capture, TTS, and the conversation session actually happen;
+ * every follower interaction arrives here as a command and is applied exactly
+ * once (the coordinator dedupes before calling this).
+ *
+ * The switch is exhaustive so a command added to the union without a handler is
+ * a compile error, never a silent drop.
+ */
+import type { ShellController } from "../useShellController";
+import type { ShellControllerCommand } from "./protocol";
+
+export function applyShellControllerCommand(
+  controller: ShellController,
+  command: ShellControllerCommand,
+): void {
+  switch (command.kind) {
+    case "open":
+      controller.open();
+      return;
+    case "close":
+      controller.close();
+      return;
+    case "send":
+      controller.send(command.text, {
+        ...(command.channelType ? { channelType: command.channelType } : {}),
+        ...(command.images ? { images: command.images } : {}),
+        ...(command.metadata ? { metadata: command.metadata } : {}),
+      });
+      return;
+    case "captureVision":
+      controller.captureVision();
+      return;
+    case "toggleRecording":
+      controller.toggleRecording();
+      return;
+    case "startRecording":
+      controller.startRecording(command.intent);
+      return;
+    case "stopRecording":
+      controller.stopRecording();
+      return;
+    case "toggleHandsFree":
+      controller.toggleHandsFree();
+      return;
+    case "toggleTranscriptionMode":
+      void controller.toggleTranscriptionMode();
+      return;
+    case "stopTranscriptionAndMic":
+      void controller.stopTranscriptionAndMic();
+      return;
+    case "recheckMicPermission":
+      void controller.recheckMicPermission();
+      return;
+    case "speak":
+      controller.speak(command.text);
+      return;
+    case "stopSpeaking":
+      controller.stopSpeaking();
+      return;
+    case "toggleAgentVoiceMute":
+      controller.toggleAgentVoiceMute();
+      return;
+    case "unlockAudio":
+      controller.unlockAudio();
+      return;
+    case "setComposerHasDraft":
+      controller.setComposerHasDraft(command.hasDraft);
+      return;
+    case "clearConversation":
+      controller.clearConversation();
+      return;
+    case "openSettings":
+      controller.openSettings();
+      return;
+    case "navigateHome":
+      controller.navigateHome?.();
+      return;
+    case "stop":
+      controller.stop();
+      return;
+    case "navConversation":
+      if (command.direction === "prev") controller.conversationNav.goPrev();
+      else controller.conversationNav.goNext();
+      return;
+    default: {
+      const _exhaustive: never = command;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/coordinator.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/coordinator.ts
@@ -1,0 +1,528 @@
+/**
+ * The per-window state machine that guarantees exactly one shell chat/voice
+ * engine across the desktop's webviews (#16442). Every window runs one
+ * `ShellControllerCoordinator`; together they elect a single owner from a shared
+ * presence table, and only the owner instantiates the engine. Followers apply
+ * the owner's snapshots and forward typed, idempotent commands.
+ *
+ * It is deliberately transport- and React-agnostic and holds NO timers: the
+ * clock is injected (`now`) and time only advances when the host calls `tick()`.
+ * That makes owner election, stale-snapshot rejection, command idempotency,
+ * crash re-election, and version-mismatch degrade all provable without a desktop
+ * or fake-timer choreography — see `coordinator.test.ts`. The React host
+ * (`useShellControllerSync.ts`) supplies the real interval + wall clock.
+ */
+import {
+  electOwnerWindowId,
+  isProtocolCompatible,
+  isSnapshotNewer,
+  pruneStalePeers,
+  SHELL_SYNC_PROTOCOL_VERSION,
+  type ShellControllerCommand,
+  type ShellPeer,
+  type ShellSyncEnvelope,
+  type ShellWindowRole,
+} from "./protocol";
+import type { ShellControllerSnapshot } from "./snapshot";
+import type { ShellSyncTransport } from "./transport";
+
+/** A follower's live link to the owner. `connecting` before the first snapshot,
+ *  `connected` once one arrives, `disconnected` when the owner is gone (pruned)
+ *  and re-election has not yet produced a new one, `version-mismatch` when the
+ *  owner speaks an incompatible protocol. Distinct renders, never silent. */
+export type ShellFollowerStatus =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "version-mismatch";
+
+export interface ShellCoordinatorOptions {
+  windowId: string;
+  priority: number;
+  transport: ShellSyncTransport;
+  now: () => number;
+  /** How long since a peer's last announce before it is presumed gone. Must be a
+   *  few heartbeats so a slow tick does not evict a live owner. */
+  peerTtlMs?: number;
+  protocolVersion?: string;
+  /** When true, this window may claim ownership the instant it computes itself
+   *  the rightful owner. A lone window (no cross-window transport) sets this. A
+   *  multi-window desktop window leaves it false and calls `completeDiscovery()`
+   *  after a short grace, so a joiner hears an existing owner before it would
+   *  otherwise briefly claim and flash a second engine. */
+  claimOwnershipImmediately?: boolean;
+  onRoleChange?: (role: ShellWindowRole) => void;
+  onStatusChange?: (status: ShellFollowerStatus) => void;
+  /** Latest snapshot a follower should render, or null when none is available. */
+  onSnapshot?: (snapshot: ShellControllerSnapshot | null) => void;
+  /** Owner-side: apply a follower's command against the real engine. May throw;
+   *  the throw becomes a failed ack the follower observes. */
+  onCommand?: (command: ShellControllerCommand) => void;
+  /** Surface a coordinator-internal failure (e.g. an owner-side command apply
+   *  that threw) to the host's error channel. The failed ack already signals the
+   *  follower; this lets the OWNER window observe it too. */
+  onError?: (message: string, error: unknown, context?: Record<string, unknown>) => void;
+}
+
+const DEFAULT_PEER_TTL_MS = 6000;
+const COMMAND_ACK_TIMEOUT_MS = 5000;
+const SEEN_COMMAND_LIMIT = 512;
+
+interface PendingCommand {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  deadlineMs: number;
+}
+
+let commandCounter = 0;
+
+function generateCommandId(windowId: string): string {
+  commandCounter += 1;
+  const rand =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${commandCounter}`;
+  return `${windowId}:${rand}`;
+}
+
+export class ShellControllerCoordinator {
+  private readonly windowId: string;
+  private readonly priority: number;
+  private readonly transport: ShellSyncTransport;
+  private readonly now: () => number;
+  private readonly peerTtlMs: number;
+  private readonly protocolVersion: string;
+  private readonly opts: ShellCoordinatorOptions;
+
+  private readonly peers = new Map<string, ShellPeer>();
+  private unsubscribe: (() => void) | null = null;
+  private started = false;
+
+  private role: ShellWindowRole = "follower";
+  private status: ShellFollowerStatus = "connecting";
+  /** Gate on claiming ownership until discovery completes; see the option doc. */
+  private canClaim: boolean;
+
+  /** Owner-side outbound epoch/seq. `epoch` starts above any epoch this window
+   *  saw as a follower so a new owner's snapshots always beat the old owner's. */
+  private ownerEpoch = 0;
+  private ownerSeq = 0;
+  /** The last snapshot the owner broadcast, replayed (targeted) to a late joiner
+   *  so a newly-opened window sees current state without waiting for the next
+   *  engine change. */
+  private lastSnapshot: ShellControllerSnapshot | null = null;
+  /** Highest epoch observed in any snapshot, used to seed `ownerEpoch` on
+   *  promotion so handoffs stay monotonic. */
+  private highestSeenEpoch = 0;
+
+  /** Follower-side last-applied position, for stale-snapshot rejection. */
+  private applied: { epoch: number; seq: number } | null = null;
+
+  /** Owner-side idempotency: command ids already applied (insertion-ordered so
+   *  the oldest evicts first when bounded). */
+  private readonly seenCommandIds = new Set<string>();
+  /** Follower-side in-flight commands awaiting an ack. */
+  private readonly pending = new Map<string, PendingCommand>();
+
+  constructor(options: ShellCoordinatorOptions) {
+    this.windowId = options.windowId;
+    this.priority = options.priority;
+    this.transport = options.transport;
+    this.now = options.now;
+    this.peerTtlMs = options.peerTtlMs ?? DEFAULT_PEER_TTL_MS;
+    this.protocolVersion = options.protocolVersion ?? SHELL_SYNC_PROTOCOL_VERSION;
+    this.canClaim = options.claimOwnershipImmediately ?? false;
+    this.opts = options;
+  }
+
+  /** Called by the host once the join grace has elapsed: this window may now
+   *  claim ownership if it is the rightful owner and none exists. Idempotent. */
+  completeDiscovery(): void {
+    if (this.canClaim) return;
+    this.canClaim = true;
+    this.recomputeOwner();
+  }
+
+  getRole(): ShellWindowRole {
+    return this.role;
+  }
+
+  getStatus(): ShellFollowerStatus {
+    return this.status;
+  }
+
+  /** Join the bus: record self, announce, subscribe, and elect. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.peers.set(this.windowId, {
+      windowId: this.windowId,
+      priority: this.priority,
+      protocolVersion: this.protocolVersion,
+      lastSeenMs: this.now(),
+    });
+    this.unsubscribe = this.transport.subscribe((envelope) =>
+      this.handleEnvelope(envelope),
+    );
+    this.announce("announce");
+    this.recomputeOwner();
+  }
+
+  /** Leave the bus cleanly so peers re-elect immediately instead of waiting for
+   *  the TTL. Idempotent. */
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    this.announce("bye");
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    for (const [, pending] of this.pending) {
+      pending.reject(new Error("shell-sync: coordinator stopped"));
+    }
+    this.pending.clear();
+  }
+
+  /**
+   * Advance the clock: refresh self, heartbeat, prune the dead, time out stale
+   * pending commands, and re-elect. The host calls this on a fixed interval.
+   */
+  tick(): void {
+    if (!this.started) return;
+    const nowMs = this.now();
+    const self = this.peers.get(this.windowId);
+    if (self) self.lastSeenMs = nowMs;
+    this.announce("announce");
+
+    const survivors = pruneStalePeers([...this.peers.values()], nowMs, this.peerTtlMs);
+    this.peers.clear();
+    for (const peer of survivors) this.peers.set(peer.windowId, peer);
+    // Self never evicts itself even under a long stall between ticks.
+    if (!this.peers.has(this.windowId)) {
+      this.peers.set(this.windowId, {
+        windowId: this.windowId,
+        priority: this.priority,
+        protocolVersion: this.protocolVersion,
+        lastSeenMs: nowMs,
+      });
+    }
+
+    for (const [commandId, pending] of [...this.pending]) {
+      if (nowMs >= pending.deadlineMs) {
+        this.pending.delete(commandId);
+        pending.reject(new Error("shell-sync: command timed out"));
+      }
+    }
+
+    this.recomputeOwner();
+  }
+
+  /**
+   * Owner-side: broadcast the latest engine snapshot. Coalescing (skipping
+   * unchanged snapshots) is the caller's job; this always advances `seq` so
+   * followers can order what they receive. No-op for a follower.
+   */
+  publishSnapshot(snapshot: ShellControllerSnapshot): void {
+    if (this.role !== "owner") return;
+    this.lastSnapshot = snapshot;
+    this.ownerSeq += 1;
+    this.transport.send({
+      type: "snapshot",
+      protocolVersion: this.protocolVersion,
+      ownerWindowId: this.windowId,
+      epoch: this.ownerEpoch,
+      seq: this.ownerSeq,
+      snapshot,
+    });
+  }
+
+  /**
+   * Follower-side: send a command to the owner and resolve when it acks. An
+   * owner applies its own commands locally (the follower controller is only
+   * built for followers, but this keeps the call total). Rejects — visibly — on
+   * a failed ack, a timeout, or when no owner exists.
+   */
+  dispatchCommand(command: ShellControllerCommand): Promise<void> {
+    if (this.role === "owner") {
+      try {
+        this.opts.onCommand?.(command);
+        return Promise.resolve();
+      } catch (error) {
+        return Promise.reject(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
+    const ownerId = electOwnerWindowId([...this.peers.values()]);
+    if (!ownerId || ownerId === this.windowId) {
+      return Promise.reject(new Error("shell-sync: no owner to receive command"));
+    }
+    const commandId = generateCommandId(this.windowId);
+    return new Promise<void>((resolve, reject) => {
+      this.pending.set(commandId, {
+        resolve,
+        reject,
+        deadlineMs: this.now() + COMMAND_ACK_TIMEOUT_MS,
+      });
+      this.transport.send({
+        type: "command",
+        protocolVersion: this.protocolVersion,
+        commandId,
+        fromWindowId: this.windowId,
+        command,
+      });
+    });
+  }
+
+  private announce(event: "announce" | "bye"): void {
+    this.transport.send({
+      type: "presence",
+      protocolVersion: this.protocolVersion,
+      event,
+      windowId: this.windowId,
+      priority: this.priority,
+    });
+  }
+
+  private handleEnvelope(envelope: ShellSyncEnvelope): void {
+    switch (envelope.type) {
+      case "presence":
+        // Presence is seated even from an incompatible peer: it must still
+        // compete for ownership so this window does not spawn a second engine
+        // across the version boundary. A follower of an incompatible owner
+        // degrades (see recomputeOwner), rather than running its own.
+        this.handlePresence(envelope);
+        return;
+      case "snapshot":
+        this.handleSnapshot(envelope);
+        return;
+      case "command":
+        // A command from an incompatible follower is rejected with a reason, not
+        // applied against fields that may have moved.
+        if (!isProtocolCompatible(envelope.protocolVersion)) {
+          if (this.role === "owner") {
+            this.sendAck(
+              envelope.commandId,
+              envelope.fromWindowId,
+              false,
+              "version-mismatch",
+            );
+          }
+          return;
+        }
+        this.handleCommand(envelope);
+        return;
+      case "ack":
+        if (!isProtocolCompatible(envelope.protocolVersion)) return;
+        this.handleAck(envelope);
+        return;
+      default: {
+        const _exhaustive: never = envelope;
+        return _exhaustive;
+      }
+    }
+  }
+
+  private handlePresence(
+    envelope: Extract<ShellSyncEnvelope, { type: "presence" }>,
+  ): void {
+    const { event, windowId, priority, protocolVersion } = envelope;
+    if (windowId === this.windowId) return;
+    if (event === "bye") {
+      this.peers.delete(windowId);
+      this.recomputeOwner();
+      return;
+    }
+    // A newcomer that announces after we joined never heard our initial
+    // announce. Echo ours exactly once (only for a peer we did not already know)
+    // so presence converges without an announce storm, and — if we own the
+    // engine — replay the current snapshot to it so it renders immediately.
+    const isNewPeer = !this.peers.has(windowId);
+    this.peers.set(windowId, {
+      windowId,
+      priority,
+      protocolVersion,
+      lastSeenMs: this.now(),
+    });
+    this.recomputeOwner();
+    if (isNewPeer) {
+      this.announce("announce");
+      if (this.role === "owner" && this.lastSnapshot) {
+        this.publishSnapshotTo(windowId, this.lastSnapshot);
+      }
+    }
+  }
+
+  private publishSnapshotTo(
+    targetWindowId: string,
+    snapshot: ShellControllerSnapshot,
+  ): void {
+    this.ownerSeq += 1;
+    this.transport.send({
+      type: "snapshot",
+      protocolVersion: this.protocolVersion,
+      ownerWindowId: this.windowId,
+      epoch: this.ownerEpoch,
+      seq: this.ownerSeq,
+      snapshot,
+      targetWindowId,
+    });
+  }
+
+  private handleSnapshot(
+    envelope: Extract<ShellSyncEnvelope, { type: "snapshot" }>,
+  ): void {
+    if (envelope.epoch > this.highestSeenEpoch) {
+      this.highestSeenEpoch = envelope.epoch;
+    }
+    // A targeted re-publish is only for its addressee; ignoring it elsewhere
+    // keeps a late joiner's rejoin from resetting everyone's applied position.
+    if (envelope.targetWindowId && envelope.targetWindowId !== this.windowId) {
+      return;
+    }
+    if (this.role !== "follower") return;
+    const incompatible = !isProtocolCompatible(envelope.protocolVersion);
+    // A compatible-but-stale/zombie snapshot is dropped WITHOUT touching the
+    // peer table, so a late duplicate from a dead owner cannot re-seat it.
+    if (!incompatible && !isSnapshotNewer(envelope, this.applied)) return;
+    // Refresh the (live) owner's liveness + version from its snapshots too, so a
+    // chatty owner is never pruned between heartbeats.
+    this.peers.set(envelope.ownerWindowId, {
+      windowId: envelope.ownerWindowId,
+      priority:
+        this.peers.get(envelope.ownerWindowId)?.priority ?? this.priority,
+      protocolVersion: envelope.protocolVersion,
+      lastSeenMs: this.now(),
+    });
+    // An owner speaking an incompatible protocol: never render its snapshot;
+    // show the version-mismatch degrade. recomputeOwner also drives this, but a
+    // snapshot can arrive before the presence table catches the owner's version.
+    if (incompatible) {
+      this.setStatus("version-mismatch");
+      this.opts.onSnapshot?.(null);
+      return;
+    }
+    this.applied = { epoch: envelope.epoch, seq: envelope.seq };
+    this.setStatus("connected");
+    this.opts.onSnapshot?.(envelope.snapshot);
+  }
+
+  private handleCommand(
+    envelope: Extract<ShellSyncEnvelope, { type: "command" }>,
+  ): void {
+    if (this.role !== "owner") return;
+    // Idempotency: a redelivered command re-acks success but never re-applies.
+    if (this.seenCommandIds.has(envelope.commandId)) {
+      this.sendAck(envelope.commandId, envelope.fromWindowId, true);
+      return;
+    }
+    this.rememberCommandId(envelope.commandId);
+    try {
+      this.opts.onCommand?.(envelope.command);
+      this.sendAck(envelope.commandId, envelope.fromWindowId, true);
+    } catch (error) {
+      // The failed ack is the follower's observable signal; also report so the
+      // owner window surfaces the failure to the agent/owner.
+      this.opts.onError?.("shell-sync command apply failed", error, {
+        command: envelope.command.kind,
+      });
+      this.sendAck(
+        envelope.commandId,
+        envelope.fromWindowId,
+        false,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private handleAck(
+    envelope: Extract<ShellSyncEnvelope, { type: "ack" }>,
+  ): void {
+    if (envelope.toWindowId !== this.windowId) return;
+    const pending = this.pending.get(envelope.commandId);
+    if (!pending) return;
+    this.pending.delete(envelope.commandId);
+    if (envelope.ok) pending.resolve();
+    else pending.reject(new Error(envelope.error || "shell-sync: command rejected"));
+  }
+
+  private sendAck(
+    commandId: string,
+    toWindowId: string,
+    ok: boolean,
+    error?: string,
+  ): void {
+    this.transport.send({
+      type: "ack",
+      protocolVersion: this.protocolVersion,
+      commandId,
+      toWindowId,
+      ok,
+      ...(error ? { error } : {}),
+    });
+  }
+
+  private rememberCommandId(commandId: string): void {
+    this.seenCommandIds.add(commandId);
+    if (this.seenCommandIds.size > SEEN_COMMAND_LIMIT) {
+      const oldest = this.seenCommandIds.values().next().value;
+      if (oldest !== undefined) this.seenCommandIds.delete(oldest);
+    }
+  }
+
+  private recomputeOwner(): void {
+    const ownerId = electOwnerWindowId([...this.peers.values()]);
+    const ownerIncompatible =
+      ownerId !== null &&
+      ownerId !== this.windowId &&
+      !isProtocolCompatible(
+        this.peers.get(ownerId)?.protocolVersion ??
+          SHELL_SYNC_PROTOCOL_VERSION,
+      );
+    const iAmElected = ownerId === this.windowId;
+    // Elected owner but still inside the discovery grace: stay a follower and
+    // keep the engine unmounted until the grace elapses, so a just-opened window
+    // never briefly claims ownership over an owner it has not heard from yet.
+    const claimingOwnership = iAmElected && this.canClaim;
+    const nextRole: ShellWindowRole = claimingOwnership ? "owner" : "follower";
+
+    if (nextRole === this.role) {
+      // Role unchanged, but the follower's link status may still need to move.
+      if (nextRole === "follower") {
+        if (iAmElected) this.setStatus("connecting");
+        else if (!ownerId) this.setStatus("disconnected");
+        else if (ownerIncompatible) this.setStatus("version-mismatch");
+      }
+      return;
+    }
+
+    this.role = nextRole;
+    if (nextRole === "owner") {
+      // Seed the outbound epoch above anything seen so old-owner snapshots that
+      // arrive late are dropped by every follower.
+      this.ownerEpoch = this.highestSeenEpoch + 1;
+      this.highestSeenEpoch = this.ownerEpoch;
+      this.ownerSeq = 0;
+      this.applied = null;
+    } else {
+      // Demoted to follower: forget our outbound position and wait for the new
+      // owner's snapshots. Following an incompatible owner is a visible degrade,
+      // never a duplicate engine.
+      this.applied = null;
+      this.setStatus(
+        !ownerId
+          ? "disconnected"
+          : ownerIncompatible
+            ? "version-mismatch"
+            : "connecting",
+      );
+      this.opts.onSnapshot?.(null);
+    }
+    this.opts.onRoleChange?.(nextRole);
+  }
+
+  private setStatus(status: ShellFollowerStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.opts.onStatusChange?.(status);
+  }
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/electrobun-transport.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/electrobun-transport.ts
@@ -1,0 +1,68 @@
+/**
+ * The production `ShellSyncTransport`: relays shell-controller envelopes between
+ * desktop webviews through the Electrobun native main process (#16442). Each
+ * renderer holds an isolated JS context, so the only path between windows is the
+ * native host — a renderer sends via the `shellControllerRelay` bun request, and
+ * the main process rebroadcasts to every OTHER window as a `shellControllerSync`
+ * push message.
+ *
+ * `createElectrobunShellSyncTransport` returns null when the Electrobun bridge is
+ * absent (web, mobile, single-window dev), which is the signal the React host
+ * uses to run as a lone always-owner with no cross-window traffic — preserving
+ * today's behaviour everywhere except the multi-window desktop.
+ */
+import {
+  getElectrobunRendererRpc,
+  type ElectrobunRendererRpc,
+} from "../../../bridge/electrobun-rpc";
+import { parseShellSyncEnvelope, type ShellSyncEnvelope } from "./protocol";
+import type { ShellSyncTransport } from "./transport";
+
+export const SHELL_SYNC_RELAY_RPC_METHOD = "shellControllerRelay";
+export const SHELL_SYNC_PUSH_MESSAGE = "shellControllerSync";
+
+interface RelayRequest {
+  (params: { envelope: ShellSyncEnvelope }): Promise<unknown>;
+}
+
+/** Build the transport over an explicit RPC handle (injected so it can be
+ *  driven by a fake bridge in tests). */
+export function buildElectrobunShellSyncTransport(
+  rpc: ElectrobunRendererRpc,
+  onError: (error: unknown) => void,
+): ShellSyncTransport {
+  return {
+    send(envelope) {
+      const relay = rpc.request?.[SHELL_SYNC_RELAY_RPC_METHOD] as
+        | RelayRequest
+        | undefined;
+      if (!relay) return;
+      // error-policy:J5 fire-and-forget relay — a transient send failure is
+      // reported to the host, and its consequence is still observed downstream:
+      // a command that never reaches the owner fails closed via the coordinator's
+      // ack timeout, and a dropped snapshot self-heals on the next publish. This
+      // never fabricates delivery.
+      void relay.call(rpc.request, { envelope }).catch(onError);
+    },
+    subscribe(listener) {
+      const handler = (payload: unknown): void => {
+        const envelope = (payload as { envelope?: unknown })?.envelope;
+        // error-policy:J3 untrusted IPC input — a malformed payload is dropped,
+        // never fed into the state machine as a partly-typed object.
+        const parsed: ShellSyncEnvelope | null =
+          parseShellSyncEnvelope(envelope);
+        if (parsed) listener(parsed);
+      };
+      rpc.onMessage(SHELL_SYNC_PUSH_MESSAGE, handler);
+      return () => rpc.offMessage(SHELL_SYNC_PUSH_MESSAGE, handler);
+    },
+  };
+}
+
+export function createElectrobunShellSyncTransport(
+  onError: (error: unknown) => void,
+): ShellSyncTransport | null {
+  const rpc = getElectrobunRendererRpc();
+  if (!rpc) return null;
+  return buildElectrobunShellSyncTransport(rpc, onError);
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
@@ -1,0 +1,106 @@
+/**
+ * Builds a `ShellController` for a follower window out of the owner's snapshot
+ * plus a command dispatcher (#16442). This is what lets a detached window render
+ * the shared chat/voice surface with the EXISTING overlay components, unchanged,
+ * while never instantiating a second engine: reads come from the snapshot, and
+ * every imperative method forwards a typed command to the owner.
+ *
+ * Follower-local invariants encoded here:
+ *  - `analyser` is null — a follower owns no mic, so it shows no live waveform.
+ *  - `setDictationSink` / `setTranscriptSessionSink` are no-ops — dictation and
+ *    transcript capture land in the OWNER window, which runs the recorder.
+ *  - `recheckMicPermission` forwards the recheck and resolves with the currently
+ *    known permission; the refreshed value arrives in the next snapshot.
+ * A dispatch that fails (owner gone / timed out / version-mismatch) is routed to
+ * `onCommandError` — a visible failure, never a silent no-op.
+ */
+import type { MicrophonePermissionState } from "../../../voice/local-asr-capture";
+import type { ConversationNav } from "../conversation-nav";
+import type { ShellController } from "../useShellController";
+import type { ShellControllerCommand } from "./protocol";
+import type { ShellControllerSnapshot } from "./snapshot";
+
+export interface FollowerControllerDeps {
+  snapshot: ShellControllerSnapshot;
+  dispatch: (command: ShellControllerCommand) => Promise<void>;
+  onCommandError: (command: ShellControllerCommand, error: unknown) => void;
+}
+
+export function buildFollowerController(
+  deps: FollowerControllerDeps,
+): ShellController {
+  const { snapshot, dispatch, onCommandError } = deps;
+  const fire = (command: ShellControllerCommand): void => {
+    void dispatch(command).catch((error: unknown) =>
+      onCommandError(command, error),
+    );
+  };
+
+  const conversationNav: ConversationNav = {
+    hasPrev: snapshot.conversationNav.hasPrev,
+    hasNext: snapshot.conversationNav.hasNext,
+    activeId: snapshot.conversationNav.activeId,
+    index: snapshot.conversationNav.index,
+    goPrev: () => fire({ kind: "navConversation", direction: "prev" }),
+    goNext: () => fire({ kind: "navConversation", direction: "next" }),
+  };
+
+  return {
+    phase: snapshot.phase,
+    bootProgressSignal: snapshot.bootProgressSignal,
+    responding: snapshot.responding,
+    turnStatus: snapshot.turnStatus,
+    messages: snapshot.messages,
+    canSend: snapshot.canSend,
+    modelStatus: snapshot.modelStatus,
+    recording: snapshot.recording,
+    waveformMode: snapshot.waveformMode,
+    analyser: null,
+    open: () => fire({ kind: "open" }),
+    close: () => fire({ kind: "close" }),
+    isOpen: snapshot.isOpen,
+    send: (text, options) =>
+      fire({
+        kind: "send",
+        text,
+        ...(options?.channelType ? { channelType: options.channelType } : {}),
+        ...(options?.images ? { images: options.images } : {}),
+        ...(options?.metadata ? { metadata: options.metadata } : {}),
+      }),
+    captureVision: () => fire({ kind: "captureVision" }),
+    visionCapturing: snapshot.visionCapturing,
+    toggleRecording: () => fire({ kind: "toggleRecording" }),
+    startRecording: (intent) => fire({ kind: "startRecording", ...(intent ? { intent } : {}) }),
+    stopRecording: () => fire({ kind: "stopRecording" }),
+    handsFree: snapshot.handsFree,
+    toggleHandsFree: () => fire({ kind: "toggleHandsFree" }),
+    micPermission: snapshot.micPermission,
+    recheckMicPermission: (): Promise<MicrophonePermissionState> => {
+      fire({ kind: "recheckMicPermission" });
+      return Promise.resolve(snapshot.micPermission);
+    },
+    transcriptionMode: snapshot.transcriptionMode,
+    toggleTranscriptionMode: () => fire({ kind: "toggleTranscriptionMode" }),
+    stopTranscriptionAndMic: () => fire({ kind: "stopTranscriptionAndMic" }),
+    setDictationSink: () => {},
+    setTranscriptSessionSink: () => {},
+    setComposerHasDraft: (hasDraft) =>
+      fire({ kind: "setComposerHasDraft", hasDraft }),
+    transcript: snapshot.transcript,
+    speaking: snapshot.speaking,
+    speak: (text) => fire({ kind: "speak", text }),
+    stopSpeaking: () => fire({ kind: "stopSpeaking" }),
+    agentVoiceMuted: snapshot.agentVoiceMuted,
+    toggleAgentVoiceMute: () => fire({ kind: "toggleAgentVoiceMute" }),
+    needsAudioUnlock: snapshot.needsAudioUnlock,
+    unlockAudio: () => fire({ kind: "unlockAudio" }),
+    clearConversation: () => fire({ kind: "clearConversation" }),
+    openSettings: () => fire({ kind: "openSettings" }),
+    navigateHome: () => fire({ kind: "navigateHome" }),
+    currentTab: snapshot.currentTab,
+    stop: () => fire({ kind: "stop" }),
+    conversationNav,
+    conversationLoading: snapshot.conversationLoading,
+    noProviderConfigured: snapshot.noProviderConfigured,
+  };
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/protocol.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/protocol.ts
@@ -1,0 +1,250 @@
+/**
+ * Wire contract for sharing ONE shell chat/voice engine across the desktop's
+ * detached webviews. Each desktop window is an isolated renderer; left alone,
+ * every window that mounts the app would instantiate its own `useShellController`
+ * and open its own microphone, giving duplicated sessions and fighting audio
+ * owners (#16442). This module defines the messages those windows exchange over
+ * a relay so exactly one window owns the engine and the rest render its state
+ * and forward typed commands.
+ *
+ * Nothing here is React- or Electrobun-specific: the coordinator state machine
+ * (`coordinator.ts`) and the transports (`transport.ts`, `electrobun-transport.ts`)
+ * build on these types. Every envelope carries `protocolVersion` so a window
+ * running an incompatible build degrades visibly instead of mis-rendering a
+ * snapshot it cannot interpret, and every command carries a stable `commandId`
+ * so the owner can apply it exactly once even if the relay redelivers it.
+ */
+import type { ImageAttachment } from "../../../api/client-types-chat";
+import type { ShellControllerSnapshot } from "./snapshot";
+
+/**
+ * Bumped only on a breaking change to the envelope/command/snapshot shapes.
+ * Receivers reject any envelope whose version differs (see
+ * `isProtocolCompatible`) rather than trusting a field that may have moved.
+ */
+export const SHELL_SYNC_PROTOCOL_VERSION = "1";
+
+/**
+ * Relative preference for owning the engine, lower wins. The main dashboard
+ * window is the natural home for capture + audio; the always-on bottom bar is
+ * next; ephemeral popovers/detached surfaces should never win over a real
+ * window that is already present. Ties break on the stable window id.
+ */
+export const SHELL_OWNER_PRIORITY = {
+  main: 0,
+  "chat-overlay": 1,
+  surface: 2,
+  "tray-popover": 3,
+} as const;
+
+export type ShellWindowRole = "owner" | "follower";
+
+/** The command a follower asks the owner to run. Discriminated on `kind`; the
+ *  owner switches exhaustively so a new command cannot be silently dropped. */
+export type ShellControllerCommand =
+  | { kind: "open" }
+  | { kind: "close" }
+  | {
+      kind: "send";
+      text: string;
+      channelType?: "DM" | "VOICE_DM";
+      /** Image attachments — serialisable (data URLs / ids). */
+      images?: ImageAttachment[];
+      metadata?: Record<string, unknown>;
+    }
+  | { kind: "captureVision" }
+  | { kind: "toggleRecording" }
+  | { kind: "startRecording"; intent?: "converse" | "dictate" | "transcription" }
+  | { kind: "stopRecording" }
+  | { kind: "toggleHandsFree" }
+  | { kind: "toggleTranscriptionMode" }
+  | { kind: "stopTranscriptionAndMic" }
+  | { kind: "recheckMicPermission" }
+  | { kind: "speak"; text: string }
+  | { kind: "stopSpeaking" }
+  | { kind: "toggleAgentVoiceMute" }
+  | { kind: "unlockAudio" }
+  | { kind: "setComposerHasDraft"; hasDraft: boolean }
+  | { kind: "clearConversation" }
+  | { kind: "openSettings" }
+  | { kind: "navigateHome" }
+  | { kind: "stop" }
+  | { kind: "navConversation"; direction: "prev" | "next" };
+
+export type ShellControllerCommandKind = ShellControllerCommand["kind"];
+
+/** Owner heartbeat + join/leave presence, feeding the liveness table that
+ *  drives owner election. Both owner and followers announce. */
+export interface ShellPresenceEnvelope {
+  type: "presence";
+  protocolVersion: string;
+  event: "announce" | "bye";
+  windowId: string;
+  /** One of {@link SHELL_OWNER_PRIORITY}; lower is preferred as owner. */
+  priority: number;
+}
+
+/** Owner → followers. `seq` is monotonic within an `epoch`; a new owner starts a
+ *  new (higher) epoch so followers can drop snapshots from a superseded owner. */
+export interface ShellSnapshotEnvelope {
+  type: "snapshot";
+  protocolVersion: string;
+  ownerWindowId: string;
+  epoch: number;
+  seq: number;
+  snapshot: ShellControllerSnapshot;
+  /** When set, a targeted re-publish to one late joiner rather than a broadcast;
+   *  other windows ignore it so a rejoin does not reset everyone's seq. */
+  targetWindowId?: string;
+}
+
+/** Follower → owner. `commandId` is the idempotency + correlation key. */
+export interface ShellCommandEnvelope {
+  type: "command";
+  protocolVersion: string;
+  commandId: string;
+  fromWindowId: string;
+  command: ShellControllerCommand;
+}
+
+/** Owner → the follower that sent `commandId`. `ok:false` carries the reason so
+ *  the follower can surface a real failure instead of a silent no-op. */
+export interface ShellCommandAckEnvelope {
+  type: "ack";
+  protocolVersion: string;
+  commandId: string;
+  toWindowId: string;
+  ok: boolean;
+  error?: string;
+}
+
+export type ShellSyncEnvelope =
+  | ShellPresenceEnvelope
+  | ShellSnapshotEnvelope
+  | ShellCommandEnvelope
+  | ShellCommandAckEnvelope;
+
+/** True when a received envelope was produced by a compatible build. An
+ *  incompatible peer is not trusted: the coordinator surfaces a version-mismatch
+ *  degrade rather than rendering a snapshot whose fields it cannot rely on. */
+export function isProtocolCompatible(protocolVersion: string): boolean {
+  return protocolVersion === SHELL_SYNC_PROTOCOL_VERSION;
+}
+
+const ENVELOPE_TYPES: ReadonlySet<string> = new Set([
+  "presence",
+  "snapshot",
+  "command",
+  "ack",
+]);
+
+/**
+ * Validate an envelope arriving over the IPC boundary. The relay hands us
+ * `unknown`; a malformed payload is rejected (returns null) rather than fed into
+ * the state machine as a partly-typed object. The check is structural and
+ * shallow — enough to route by `type` and to know the sender's protocol version;
+ * the coordinator does the version gating and the payload is only trusted once
+ * its version matches this build.
+ */
+export function parseShellSyncEnvelope(value: unknown): ShellSyncEnvelope | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  const type = record.type;
+  const protocolVersion = record.protocolVersion;
+  if (typeof type !== "string" || !ENVELOPE_TYPES.has(type)) return null;
+  if (typeof protocolVersion !== "string") return null;
+  switch (type) {
+    case "presence":
+      return typeof record.windowId === "string" &&
+        typeof record.priority === "number" &&
+        (record.event === "announce" || record.event === "bye")
+        ? (value as ShellSyncEnvelope)
+        : null;
+    case "snapshot":
+      return typeof record.ownerWindowId === "string" &&
+        typeof record.epoch === "number" &&
+        typeof record.seq === "number" &&
+        typeof record.snapshot === "object" &&
+        record.snapshot !== null
+        ? (value as ShellSyncEnvelope)
+        : null;
+    case "command":
+      return typeof record.commandId === "string" &&
+        typeof record.fromWindowId === "string" &&
+        typeof record.command === "object" &&
+        record.command !== null
+        ? (value as ShellSyncEnvelope)
+        : null;
+    case "ack":
+      return typeof record.commandId === "string" &&
+        typeof record.toWindowId === "string" &&
+        typeof record.ok === "boolean"
+        ? (value as ShellSyncEnvelope)
+        : null;
+    default:
+      return null;
+  }
+}
+
+/** A live peer in the presence table. */
+export interface ShellPeer {
+  windowId: string;
+  priority: number;
+  /** The peer's protocol version. An incompatible peer STILL competes for
+   *  ownership (so the compatible window does not spawn a second engine across
+   *  the version boundary); a follower of an incompatible owner degrades to a
+   *  visible version-mismatch state instead of rendering. */
+  protocolVersion: string;
+  /** `now()` value of the most recent announce; used to prune the dead. */
+  lastSeenMs: number;
+}
+
+/**
+ * Elect the owner deterministically from the live peer set: the lowest
+ * `(priority, windowId)` wins. Pure and total — the same inputs always yield the
+ * same owner on every window, so no two windows disagree about who owns the
+ * engine. Returns `null` only for an empty set (a window always includes itself
+ * before calling this).
+ */
+export function electOwnerWindowId(
+  peers: ReadonlyArray<ShellPeer>,
+): string | null {
+  let best: ShellPeer | null = null;
+  for (const peer of peers) {
+    if (
+      best === null ||
+      peer.priority < best.priority ||
+      (peer.priority === best.priority && peer.windowId < best.windowId)
+    ) {
+      best = peer;
+    }
+  }
+  return best?.windowId ?? null;
+}
+
+/** Prune peers whose last announce is older than `ttlMs` — the mechanism that
+ *  detects a crashed/closed owner (its heartbeats stop) and triggers
+ *  re-election. Pure: returns the surviving subset. */
+export function pruneStalePeers(
+  peers: ReadonlyArray<ShellPeer>,
+  nowMs: number,
+  ttlMs: number,
+): ShellPeer[] {
+  return peers.filter((peer) => nowMs - peer.lastSeenMs <= ttlMs);
+}
+
+/**
+ * Whether a snapshot at `(epoch, seq)` is newer than the last one applied at
+ * `(appliedEpoch, appliedSeq)`. A relay may reorder or redeliver; a follower
+ * applies a snapshot only when it strictly advances, so stale/duplicate
+ * snapshots are dropped and a superseded owner (lower epoch) can never clobber
+ * live state.
+ */
+export function isSnapshotNewer(
+  incoming: { epoch: number; seq: number },
+  applied: { epoch: number; seq: number } | null,
+): boolean {
+  if (applied === null) return true;
+  if (incoming.epoch !== applied.epoch) return incoming.epoch > applied.epoch;
+  return incoming.seq > applied.seq;
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
@@ -1,0 +1,155 @@
+/**
+ * The serialisable projection of the shell chat/voice engine that the owner
+ * window broadcasts to its followers (#16442). A follower renders this snapshot
+ * instead of running its own `useShellController`, so every window shows one
+ * coherent conversation + voice state.
+ *
+ * It mirrors the READ surface of `ShellController` minus anything that cannot
+ * cross a window boundary: the live `AnalyserNode` (a follower shows no waveform
+ * animation — honest, since it owns no capture) and the imperative methods
+ * (those become typed commands). Producing it is a pure map from the controller,
+ * which keeps `snapshotsEqual` cheap enough to coalesce the many per-token
+ * updates a streaming reply emits.
+ */
+import type { ChatTurnStatus } from "../../../api/client-types-chat";
+import type { HomeModelStatus } from "../../../services/local-inference/home-model-status";
+import type { MicrophonePermissionState } from "../../../voice/local-asr-capture";
+import type { ShellMessage, ShellPhase } from "../shell-state";
+import type { ShellController } from "../useShellController";
+
+/** The subset of {@link import("../conversation-nav").ConversationNav} that is
+ *  data (the imperative `goPrev`/`goNext` become nav commands). */
+export interface ShellConversationNavSnapshot {
+  hasPrev: boolean;
+  hasNext: boolean;
+  activeId: string | null;
+  index: number;
+}
+
+export interface ShellControllerSnapshot {
+  phase: ShellPhase;
+  responding: boolean;
+  turnStatus: ChatTurnStatus | null;
+  messages: readonly ShellMessage[];
+  canSend: boolean;
+  modelStatus: HomeModelStatus;
+  recording: boolean;
+  waveformMode: "idle" | "listening" | "responding";
+  isOpen: boolean;
+  visionCapturing: boolean;
+  transcript: string;
+  speaking: boolean;
+  agentVoiceMuted: boolean;
+  needsAudioUnlock: boolean;
+  handsFree: boolean;
+  micPermission: MicrophonePermissionState;
+  transcriptionMode: boolean;
+  currentTab?: string;
+  conversationLoading?: boolean;
+  noProviderConfigured?: boolean;
+  bootProgressSignal?: string;
+  conversationNav: ShellConversationNavSnapshot;
+}
+
+/** Project the live controller into its wire snapshot. Pure. */
+export function deriveShellControllerSnapshot(
+  controller: ShellController,
+): ShellControllerSnapshot {
+  return {
+    phase: controller.phase,
+    responding: controller.responding,
+    turnStatus: controller.turnStatus,
+    messages: controller.messages,
+    canSend: controller.canSend,
+    modelStatus: controller.modelStatus,
+    recording: controller.recording,
+    waveformMode: controller.waveformMode,
+    isOpen: controller.isOpen,
+    visionCapturing: controller.visionCapturing,
+    transcript: controller.transcript,
+    speaking: controller.speaking,
+    agentVoiceMuted: controller.agentVoiceMuted,
+    needsAudioUnlock: controller.needsAudioUnlock,
+    handsFree: controller.handsFree,
+    micPermission: controller.micPermission,
+    transcriptionMode: controller.transcriptionMode,
+    currentTab: controller.currentTab,
+    conversationLoading: controller.conversationLoading,
+    noProviderConfigured: controller.noProviderConfigured,
+    bootProgressSignal: controller.bootProgressSignal,
+    conversationNav: {
+      hasPrev: controller.conversationNav.hasPrev,
+      hasNext: controller.conversationNav.hasNext,
+      activeId: controller.conversationNav.activeId,
+      index: controller.conversationNav.index,
+    },
+  };
+}
+
+function navEqual(
+  a: ShellConversationNavSnapshot,
+  b: ShellConversationNavSnapshot,
+): boolean {
+  return (
+    a.hasPrev === b.hasPrev &&
+    a.hasNext === b.hasNext &&
+    a.activeId === b.activeId &&
+    a.index === b.index
+  );
+}
+
+// Compared structurally rather than by reference so coalescing does not depend
+// on the identity discipline of the model-status hook: it changes only on real
+// readiness transitions, but the wire-relayed snapshot is deserialised into a
+// fresh object on followers, and a re-publish must not hinge on that.
+function modelStatusEqual(
+  a: HomeModelStatus,
+  b: HomeModelStatus,
+): boolean {
+  return (
+    a.kind === b.kind &&
+    a.blocksSend === b.blocksSend &&
+    a.percent === b.percent &&
+    a.etaMs === b.etaMs &&
+    a.modelName === b.modelName &&
+    a.modelId === b.modelId &&
+    a.errors === b.errors
+  );
+}
+
+/**
+ * Shallow structural equality used to coalesce publishes: a streamed reply
+ * hands `messages` a new array reference per token, but the projection reuses
+ * per-message identity, so a reference compare on the array plus scalar compares
+ * on the rest is exact. Returns true only when nothing a follower would render
+ * changed, so an unchanged tick does not cost an IPC round-trip.
+ */
+export function snapshotsEqual(
+  a: ShellControllerSnapshot,
+  b: ShellControllerSnapshot,
+): boolean {
+  return (
+    a.phase === b.phase &&
+    a.responding === b.responding &&
+    a.turnStatus === b.turnStatus &&
+    a.messages === b.messages &&
+    a.canSend === b.canSend &&
+    modelStatusEqual(a.modelStatus, b.modelStatus) &&
+    a.recording === b.recording &&
+    a.waveformMode === b.waveformMode &&
+    a.isOpen === b.isOpen &&
+    a.visionCapturing === b.visionCapturing &&
+    a.transcript === b.transcript &&
+    a.speaking === b.speaking &&
+    a.agentVoiceMuted === b.agentVoiceMuted &&
+    a.needsAudioUnlock === b.needsAudioUnlock &&
+    a.handsFree === b.handsFree &&
+    a.micPermission === b.micPermission &&
+    a.transcriptionMode === b.transcriptionMode &&
+    a.currentTab === b.currentTab &&
+    a.conversationLoading === b.conversationLoading &&
+    a.noProviderConfigured === b.noProviderConfigured &&
+    a.bootProgressSignal === b.bootProgressSignal &&
+    navEqual(a.conversationNav, b.conversationNav)
+  );
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/transport.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/transport.ts
@@ -1,0 +1,71 @@
+/**
+ * The relay abstraction the shell-controller coordinator talks to (#16442). A
+ * transport is a broadcast bus: `send` publishes an envelope to every OTHER
+ * participant, `subscribe` receives everyone else's. The coordinator never
+ * assumes delivery order or reliability — the protocol's seq/epoch/idempotency
+ * do — so a transport only has to fan messages out.
+ *
+ * Production uses `electrobun-transport.ts` (relayed through the native main
+ * process across webviews). `createInMemoryShellSyncBus` here is a real, in-
+ * process implementation of the same contract: tests wire several coordinators
+ * to one bus to exercise genuine multi-window races without a desktop.
+ */
+import type { ShellSyncEnvelope } from "./protocol";
+
+export type ShellSyncEnvelopeListener = (envelope: ShellSyncEnvelope) => void;
+
+export interface ShellSyncTransport {
+  /** Broadcast to every other participant on the bus. */
+  send(envelope: ShellSyncEnvelope): void;
+  /** Subscribe to envelopes from other participants; returns an unsubscribe. */
+  subscribe(listener: ShellSyncEnvelopeListener): () => void;
+}
+
+/** A bus that connects many in-process transports, each of which delivers to
+ *  the others but never echoes to itself. */
+export interface InMemoryShellSyncBus {
+  /** Create one participant's transport endpoint. */
+  connect(): ShellSyncTransport;
+  /** Sever a participant abruptly (crash simulation): its endpoint stops
+   *  sending and receiving without a `bye`. */
+  disconnect(transport: ShellSyncTransport): void;
+}
+
+export function createInMemoryShellSyncBus(): InMemoryShellSyncBus {
+  interface Endpoint {
+    transport: ShellSyncTransport;
+    listeners: Set<ShellSyncEnvelopeListener>;
+    live: boolean;
+  }
+  const endpoints: Endpoint[] = [];
+
+  return {
+    connect(): ShellSyncTransport {
+      const listeners = new Set<ShellSyncEnvelopeListener>();
+      const transport: ShellSyncTransport = {
+        send(envelope) {
+          const self = endpoints.find((e) => e.transport === transport);
+          if (!self?.live) return;
+          for (const endpoint of endpoints) {
+            if (endpoint.transport === transport || !endpoint.live) continue;
+            // Copy so a receiver mutating a payload cannot corrupt the sender's
+            // object; the wire relay serialises, so callers must not rely on
+            // reference identity across the bus anyway.
+            const copy = structuredClone(envelope);
+            for (const listener of endpoint.listeners) listener(copy);
+          }
+        },
+        subscribe(listener) {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      };
+      endpoints.push({ transport, listeners, live: true });
+      return transport;
+    },
+    disconnect(transport) {
+      const endpoint = endpoints.find((e) => e.transport === transport);
+      if (endpoint) endpoint.live = false;
+    },
+  };
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/useShellControllerSync.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/useShellControllerSync.ts
@@ -1,0 +1,193 @@
+/**
+ * React host for the shell-controller coordinator (#16442): owns one
+ * `ShellControllerCoordinator` for this window's lifetime, drives its clock, and
+ * exposes the elected role, the follower link status, the latest shared
+ * snapshot, and the command/publish handles the owner + follower providers use.
+ *
+ * When no cross-window transport exists (web, mobile, single-window dev) the
+ * window is a lone owner with no bus traffic, so behaviour is identical to
+ * before this change everywhere except the multi-window desktop. On the desktop,
+ * a joining window waits `DISCOVERY_GRACE_MS` before it may claim ownership so it
+ * hears an existing owner first and never flashes a second engine.
+ */
+import * as React from "react";
+import {
+  resolveWindowShellRoute,
+  type WindowShellRoute,
+} from "../../../platform/window-shell";
+import {
+  ShellControllerCoordinator,
+  type ShellFollowerStatus,
+} from "./coordinator";
+import { createElectrobunShellSyncTransport } from "./electrobun-transport";
+import {
+  SHELL_OWNER_PRIORITY,
+  type ShellControllerCommand,
+  type ShellWindowRole,
+} from "./protocol";
+import type { ShellControllerSnapshot } from "./snapshot";
+import type { ShellSyncTransport } from "./transport";
+
+const DISCOVERY_GRACE_MS = 300;
+const TICK_INTERVAL_MS = 2000;
+
+export interface ShellControllerSync {
+  role: ShellWindowRole;
+  status: ShellFollowerStatus;
+  snapshot: ShellControllerSnapshot | null;
+  dispatch: (command: ShellControllerCommand) => Promise<void>;
+  publishSnapshot: (snapshot: ShellControllerSnapshot) => void;
+  setCommandHandler: (
+    handler: ((command: ShellControllerCommand) => void) | null,
+  ) => void;
+}
+
+export interface UseShellControllerSyncOptions {
+  /** Injected in tests. `undefined` resolves the real Electrobun transport;
+   *  `null` forces the lone-owner path. */
+  transport?: ShellSyncTransport | null;
+  windowId?: string;
+  priority?: number;
+  onError?: (message: string, error: unknown) => void;
+}
+
+/** Priority of this window as an owner candidate, from its shell route. */
+export function resolveShellSyncPriority(route: WindowShellRoute): number {
+  switch (route.mode) {
+    case "main":
+      return SHELL_OWNER_PRIORITY.main;
+    case "chat-overlay":
+      return SHELL_OWNER_PRIORITY["chat-overlay"];
+    case "tray-popover":
+      return SHELL_OWNER_PRIORITY["tray-popover"];
+    default:
+      return SHELL_OWNER_PRIORITY.surface;
+  }
+}
+
+function generateWindowId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `w-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+const NULL_TRANSPORT: ShellSyncTransport = {
+  send: () => {},
+  subscribe: () => () => {},
+};
+
+interface CoordinatorHandle {
+  coord: ShellControllerCoordinator;
+  isLone: boolean;
+  claimImmediately: boolean;
+}
+
+export function useShellControllerSync(
+  options: UseShellControllerSyncOptions = {},
+): ShellControllerSync {
+  const onErrorRef = React.useRef(options.onError);
+  onErrorRef.current = options.onError;
+
+  const commandHandlerRef = React.useRef<
+    ((command: ShellControllerCommand) => void) | null
+  >(null);
+  // Coordinator callbacks read the state setters through refs so the coordinator
+  // (built in a lazy ref before the useState calls) never references a binding
+  // before its declaration.
+  const setRoleRef = React.useRef<(r: ShellWindowRole) => void>(() => {});
+  const setStatusRef = React.useRef<(s: ShellFollowerStatus) => void>(() => {});
+  const setSnapshotRef = React.useRef<
+    (s: ShellControllerSnapshot | null) => void
+  >(() => {});
+
+  // One coordinator + transport for this window's whole lifetime (lazy-init ref,
+  // so options are read exactly once and the instance is never recreated).
+  const handleRef = React.useRef<CoordinatorHandle | null>(null);
+  if (handleRef.current === null) {
+    const transport =
+      "transport" in options
+        ? (options.transport ?? NULL_TRANSPORT)
+        : (createElectrobunShellSyncTransport((error) =>
+            onErrorRef.current?.("shell-sync transport error", error),
+          ) ?? NULL_TRANSPORT);
+    const isLone = transport === NULL_TRANSPORT;
+    const priority =
+      options.priority ?? resolveShellSyncPriority(resolveWindowShellRoute());
+    // A lone window (no peers) and the `main` window (nothing outranks priority
+    // 0) both own immediately — no discovery wait — so the common case never
+    // flashes a connecting state or remounts the app subtree. Secondary desktop
+    // windows discover an existing owner first.
+    const claimImmediately = isLone || priority === SHELL_OWNER_PRIORITY.main;
+    handleRef.current = {
+      isLone,
+      claimImmediately,
+      coord: new ShellControllerCoordinator({
+        windowId: options.windowId ?? generateWindowId(),
+        priority,
+        transport,
+        now: () => Date.now(),
+        claimOwnershipImmediately: claimImmediately,
+        onRoleChange: (nextRole) => setRoleRef.current(nextRole),
+        onStatusChange: (nextStatus) => setStatusRef.current(nextStatus),
+        onSnapshot: (nextSnapshot) => setSnapshotRef.current(nextSnapshot),
+        onCommand: (command) => {
+          const handler = commandHandlerRef.current;
+          if (!handler) {
+            throw new Error(
+              "shell-sync: no command handler registered (owner not mounted)",
+            );
+          }
+          handler(command);
+        },
+        onError: (message, error) => onErrorRef.current?.(message, error),
+      }),
+    };
+  }
+  const handle = handleRef.current;
+
+  // Initialise role from the claim policy so a lone/main window renders as owner
+  // on the very first paint (no follower→owner remount).
+  const [role, setRole] = React.useState<ShellWindowRole>(
+    handle.claimImmediately ? "owner" : "follower",
+  );
+  const [status, setStatus] = React.useState<ShellFollowerStatus>("connecting");
+  const [snapshot, setSnapshot] =
+    React.useState<ShellControllerSnapshot | null>(null);
+  setRoleRef.current = setRole;
+  setStatusRef.current = setStatus;
+  setSnapshotRef.current = setSnapshot;
+
+  React.useEffect(() => {
+    const { coord, isLone } = handle;
+    coord.start();
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    let interval: ReturnType<typeof setInterval> | undefined;
+    if (!isLone) {
+      graceTimer = setTimeout(() => coord.completeDiscovery(), DISCOVERY_GRACE_MS);
+      interval = setInterval(() => coord.tick(), TICK_INTERVAL_MS);
+    }
+    return () => {
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+      if (interval !== undefined) clearInterval(interval);
+      coord.stop();
+    };
+  }, [handle]);
+
+  const dispatch = React.useCallback(
+    (command: ShellControllerCommand) => handle.coord.dispatchCommand(command),
+    [handle],
+  );
+  const publishSnapshot = React.useCallback(
+    (next: ShellControllerSnapshot) => handle.coord.publishSnapshot(next),
+    [handle],
+  );
+  const setCommandHandler = React.useCallback(
+    (handler: ((command: ShellControllerCommand) => void) | null) => {
+      commandHandlerRef.current = handler;
+    },
+    [],
+  );
+
+  return { role, status, snapshot, dispatch, publishSnapshot, setCommandHandler };
+}


### PR DESCRIPTION
Closes #16442. One of the five cards that replaced the closed monolith #16200 (rebuilt narrowly on `develop`, not cherry-picked).

## Problem

Draft #16200 mounted a separate `ShellControllerProvider` in **each** desktop webview, so every window instantiated its own `useShellController` engine — duplicated chat sessions, fighting microphone/audio owners, and divergent conversation state. On current `develop` the same hazard exists: the `chat-overlay` (bottom-bar) and `tray-popover` windows each fall through to the full `App`, each mounting its own engine + mic.

## Design — one authoritative owner per process

- **Election.** Each window runs one `ShellControllerCoordinator`. They share a presence table and elect a single owner deterministically by `(priority, windowId)` — `main` (0) < `chat-overlay` (1) < `surface` (2) < `tray-popover` (3). Only the owner mounts the engine (the sole mic/audio owner). Followers render the owner's snapshot and forward commands. A joining window waits a short discovery grace before it may claim, so it hears an existing owner rather than briefly flashing a second engine. Lone/main windows own immediately, so **web, mobile, and single-window desktop behave exactly as before** (no transport ⇒ no bus traffic).
- **Handoff / crash / restart.** Owner leaves (clean `bye`) or crashes (heartbeat TTL prune) ⇒ the lowest-ranked live window is promoted; a promoted owner starts a strictly higher `epoch` so a dead owner's late snapshots are dropped. A restarted `main` window reclaims ownership.
- **Mic / audio ownership.** Exactly one window ever opens a mic or plays TTS (the owner). A follower's "start voice" is a *command*, never a local capture.

## Typed IPC contract

- **Commands** (follower → owner): a discriminated union (`send`, `startRecording`, `toggleHandsFree`, `speak`, `recheckMicPermission`, `navConversation`, …) — no `any`, no boolean-only dispatch. Idempotent: the owner dedupes by `commandId`, so a redelivered command re-acks but applies once. Replies (`ack`) are correlated by `commandId`; a failure (owner gone / timeout / version-mismatch) rejects visibly and surfaces a notice — never a silent no-op.
- **Snapshots** (owner → followers): ordered by `(epoch, seq)`; stale/reordered snapshots are dropped. The snapshot is the serialisable read-projection of the controller (the non-serialisable `AnalyserNode` and the imperative methods are excluded).
- **Presence + version.** Every envelope carries `protocolVersion`; an incompatible peer still competes for ownership (so no duplicate engine spawns across a version boundary) but a follower of an incompatible owner degrades to a visible `version-mismatch` state instead of rendering an envelope it can't interpret. All IPC input is validated at the boundary (`parseShellSyncEnvelope`).
- **Transport.** Production relays through the Electrobun native main process: a renderer publishes via the `shellControllerRelay` RPC; the main process fans it out to every window as a `shellControllerSync` push. The relay is a dumb pipe (the coordinator owns all semantics, and filters its own echo).

## Files changed

New renderer module `packages/ui/src/components/shell/shell-controller-sync/`: `protocol.ts`, `coordinator.ts`, `snapshot.ts`, `transport.ts` (+ in-memory bus), `follower-controller.ts`, `apply-command.ts`, `electrobun-transport.ts`, `useShellControllerSync.ts`, plus `__tests__/`. Provider split in `ShellControllerContext.tsx` (owner mounts the engine; follower never does). Native relay: `packages/app-core/platforms/electrobun/src/shell-sync-relay.ts` + wiring in `index.ts` / `rpc-handlers.ts` / `rpc-schema.ts`.

## Tests — 62 passing (real behaviour, no mock of the unit)

Coordinator over a **real in-memory bus** (several coordinators, one bus): two windows electing one owner; follower renders the owner's snapshot; two followers racing start/stop/send (owner applies each once); idempotent redelivery; command timeout / no-owner rejection; crash re-election + epoch fencing of zombie snapshots; clean handoff; main-restart reclaim; version-mismatch degrade; join-grace. Plus protocol/snapshot/transport/apply-command/follower-controller units, a jsdom two-window `useShellControllerSync` integration (single-owner + snapshot + command via real hooks), the provider split, and the native relay routing. Log: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16442-controller-tests.txt

## What still needs a real desktop pass (draft)

I could not boot the Electrobun multi-window desktop in this environment, so the **native RPC round-trip and the multi-window visual capture are unverified end-to-end**. A desktop-capable pass must: (1) open two windows (main + tray-popover / detached surface) and confirm exactly ONE mic opens and one conversation state (owner drives, follower renders); (2) close the owner and confirm handoff (engine tears down in the old owner, stands up in the promoted window); (3) capture before/after screenshots + a walkthrough video for the visual evidence rows below; (4) confirm the `shellControllerRelay`/`shellControllerSync` messages traverse the native relay. The renderer transport is unit-tested against a fake bridge and the relay routing is unit-tested, but the live native hop is the remaining gap.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - requires a real desktop multi-window pass (see "What still needs a real desktop pass"); no Electrobun multi-window boot available in this environment`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - requires a real desktop multi-window pass; the visible surface is unchanged (provider glue) — the behaviour to capture is single-mic ownership + handoff across two windows`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - requires a real desktop multi-window pass to record two windows sharing one engine + handoff`.

<!-- evidence-row:backend-logs -->
- [ ] Test + relay logs (62 passing): [16442-controller-tests.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16442-controller-tests.txt)

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no new user-facing frontend surface; the change is the provider-selection + IPC coordinator, covered by the jsdom integration test in the log above`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model change; this is desktop window coordination`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain artifacts produced; the artifact is the single-engine invariant, asserted in the coordinator tests in the log above`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
