### PR TITLE
feat(native): render typed transcript events consistently across platforms

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -259,6 +259,11 @@
       "import": "./dist/lib/utils.js",
       "default": "./dist/lib/utils.js"
     },
+    "./native-transcript": {
+      "types": "./dist/native-transcript/index.d.ts",
+      "import": "./dist/native-transcript/index.js",
+      "default": "./dist/native-transcript/index.js"
+    },
     "./navigation": {
       "types": "./dist/navigation/index.d.ts",
       "import": "./dist/navigation/index.js",

--- a/packages/ui/src/native-transcript/TranscriptEventView.test.tsx
+++ b/packages/ui/src/native-transcript/TranscriptEventView.test.tsx
@@ -15,10 +15,26 @@ describe("TranscriptEventView", () => {
   it("renders user/agent/tool rows with structural status attributes", () => {
     const events: TranscriptEvent[] = [
       { type: "stt.final", seq: 1, turnId: "t1", text: "hello world" },
-      { type: "agent.text", seq: 2, messageId: "m1", turnId: "t1", text: "Hi there!", final: true },
-      { type: "tool.state", seq: 3, callId: "c1", name: "search", phase: "succeeded", turnId: "t1" },
+      {
+        type: "agent.text",
+        seq: 2,
+        messageId: "m1",
+        turnId: "t1",
+        text: "Hi there!",
+        final: true,
+      },
+      {
+        type: "tool.state",
+        seq: 3,
+        callId: "c1",
+        name: "search",
+        phase: "succeeded",
+        turnId: "t1",
+      },
     ];
-    const { container, getByText } = render(<TranscriptEventView events={events} />);
+    const { container, getByText } = render(
+      <TranscriptEventView events={events} />,
+    );
 
     const user = container.querySelector('[data-role="user"]');
     expect(user?.getAttribute("data-status")).toBe("final");
@@ -26,10 +42,14 @@ describe("TranscriptEventView", () => {
     expect(getByText("hello world").getAttribute("dir")).toBe("auto");
 
     expect(
-      container.querySelector('[data-role="agent"]')?.getAttribute("data-status"),
+      container
+        .querySelector('[data-role="agent"]')
+        ?.getAttribute("data-status"),
     ).toBe("final");
     expect(
-      container.querySelector('[data-role="tool"]')?.getAttribute("data-status"),
+      container
+        .querySelector('[data-role="tool"]')
+        ?.getAttribute("data-status"),
     ).toBe("succeeded");
   });
 
@@ -50,9 +70,17 @@ describe("TranscriptEventView", () => {
 
   it("renders a permission-denied error as a distinct alert row", () => {
     const events: TranscriptEvent[] = [
-      { type: "error", seq: 1, code: "permission-denied", retryable: false, message: "Mic denied" },
+      {
+        type: "error",
+        seq: 1,
+        code: "permission-denied",
+        retryable: false,
+        message: "Mic denied",
+      },
     ];
-    const { container, getByRole } = render(<TranscriptEventView events={events} />);
+    const { container, getByRole } = render(
+      <TranscriptEventView events={events} />,
+    );
     const alert = getByRole("alert");
     expect(alert.getAttribute("data-code")).toBe("permission-denied");
     expect(alert.getAttribute("data-retryable")).toBe("false");
@@ -71,7 +99,13 @@ describe("TranscriptEventView", () => {
   it("exposes live speaking + connection state on the container", () => {
     const events: TranscriptEvent[] = [
       { type: "agent.text", seq: 1, messageId: "m1", text: "hi", final: true },
-      { type: "tts.audio", seq: 2, utteranceId: "u1", phase: "started", messageId: "m1" },
+      {
+        type: "tts.audio",
+        seq: 2,
+        utteranceId: "u1",
+        phase: "started",
+        messageId: "m1",
+      },
       { type: "reconnect", seq: 3, phase: "lost", attempt: 1 },
     ];
     const { container } = render(<TranscriptEventView events={events} />);
@@ -79,7 +113,9 @@ describe("TranscriptEventView", () => {
     expect(root?.getAttribute("data-speaking")).toBe("u1");
     expect(root?.getAttribute("data-connection")).toBe("lost");
     expect(
-      container.querySelector('[data-role="reconnect"]')?.getAttribute("data-phase"),
+      container
+        .querySelector('[data-role="reconnect"]')
+        ?.getAttribute("data-phase"),
     ).toBe("lost");
   });
 });

--- a/packages/ui/src/native-transcript/TranscriptEventView.test.tsx
+++ b/packages/ui/src/native-transcript/TranscriptEventView.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+//
+// Renderer tests: the web/DOM view paints one row per reduced item and exposes
+// transport state via data attributes, all from structural fields. Real jsdom
+// render via @testing-library; the parser + CodeBlock are the production ones.
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { TranscriptEvent } from "./contract";
+import { TranscriptEventView } from "./TranscriptEventView";
+
+afterEach(cleanup);
+
+describe("TranscriptEventView", () => {
+  it("renders user/agent/tool rows with structural status attributes", () => {
+    const events: TranscriptEvent[] = [
+      { type: "stt.final", seq: 1, turnId: "t1", text: "hello world" },
+      { type: "agent.text", seq: 2, messageId: "m1", turnId: "t1", text: "Hi there!", final: true },
+      { type: "tool.state", seq: 3, callId: "c1", name: "search", phase: "succeeded", turnId: "t1" },
+    ];
+    const { container, getByText } = render(<TranscriptEventView events={events} />);
+
+    const user = container.querySelector('[data-role="user"]');
+    expect(user?.getAttribute("data-status")).toBe("final");
+    expect(getByText("hello world")).toBeTruthy();
+    expect(getByText("hello world").getAttribute("dir")).toBe("auto");
+
+    expect(
+      container.querySelector('[data-role="agent"]')?.getAttribute("data-status"),
+    ).toBe("final");
+    expect(
+      container.querySelector('[data-role="tool"]')?.getAttribute("data-status"),
+    ).toBe("succeeded");
+  });
+
+  it("renders agent code segments through the shared CodeBlock primitive", () => {
+    const events: TranscriptEvent[] = [
+      {
+        type: "agent.text",
+        seq: 1,
+        messageId: "m1",
+        text: "Here:\n```js\nconst x = 1;\n```",
+        final: true,
+      },
+    ];
+    const { container } = render(<TranscriptEventView events={events} />);
+    expect(container.querySelector("pre")).toBeTruthy();
+    expect(container.textContent).toContain("const x = 1");
+  });
+
+  it("renders a permission-denied error as a distinct alert row", () => {
+    const events: TranscriptEvent[] = [
+      { type: "error", seq: 1, code: "permission-denied", retryable: false, message: "Mic denied" },
+    ];
+    const { container, getByRole } = render(<TranscriptEventView events={events} />);
+    const alert = getByRole("alert");
+    expect(alert.getAttribute("data-code")).toBe("permission-denied");
+    expect(alert.getAttribute("data-retryable")).toBe("false");
+    expect(container.textContent).toContain("Mic denied");
+  });
+
+  it("carries RTL/Unicode text verbatim and lets the browser bidi-resolve it", () => {
+    const events: TranscriptEvent[] = [
+      { type: "stt.final", seq: 1, turnId: "t1", text: "مرحبا بالعالم" },
+    ];
+    const { getByText } = render(<TranscriptEventView events={events} />);
+    const el = getByText("مرحبا بالعالم");
+    expect(el.getAttribute("dir")).toBe("auto");
+  });
+
+  it("exposes live speaking + connection state on the container", () => {
+    const events: TranscriptEvent[] = [
+      { type: "agent.text", seq: 1, messageId: "m1", text: "hi", final: true },
+      { type: "tts.audio", seq: 2, utteranceId: "u1", phase: "started", messageId: "m1" },
+      { type: "reconnect", seq: 3, phase: "lost", attempt: 1 },
+    ];
+    const { container } = render(<TranscriptEventView events={events} />);
+    const root = container.querySelector('[data-testid="native-transcript"]');
+    expect(root?.getAttribute("data-speaking")).toBe("u1");
+    expect(root?.getAttribute("data-connection")).toBe("lost");
+    expect(
+      container.querySelector('[data-role="reconnect"]')?.getAttribute("data-phase"),
+    ).toBe("lost");
+  });
+});

--- a/packages/ui/src/native-transcript/TranscriptEventView.tsx
+++ b/packages/ui/src/native-transcript/TranscriptEventView.tsx
@@ -1,0 +1,151 @@
+/**
+ * Web/DOM renderer for the `eliza.native-transcript/v1` contract — the browser
+ * shell's implementation of the same render model the iOS/Android shells draw.
+ * It consumes decoded {@link TranscriptEvent}s, folds them with the shared
+ * reducer (`reduce.ts`), and paints one row per {@link TranscriptItem}.
+ *
+ * Every visual decision reads a STRUCTURAL field — `item.kind`, `item.status`,
+ * `speaking`, `connection` — never the transcript text or its length. Agent text
+ * is split with the existing chat parser (`parseSegments`) so prose and code
+ * render exactly as they do in the full chat surface; interactive widgets are a
+ * full-chat concern and are intentionally not surfaced on this transcript rail.
+ * `dir="auto"` lets the browser bidi-resolve each row so Unicode/RTL utterances
+ * render correctly without any text inspection here.
+ */
+
+import { type ReactNode, useMemo } from "react";
+import { parseSegments } from "../components/chat/message-parser-helpers";
+import { CodeBlock } from "../components/ui/code-block";
+import { cn } from "../lib/utils";
+import type {
+  TranscriptEvent,
+  TranscriptItem,
+  TranscriptViewModel,
+} from "./contract";
+import { reduceTranscriptEvents } from "./reduce";
+
+/** Fold a decoded event log into the render model (memoized by identity). */
+export function useTranscriptEvents(
+  events: readonly TranscriptEvent[],
+): TranscriptViewModel {
+  return useMemo(() => reduceTranscriptEvents(events), [events]);
+}
+
+export interface TranscriptEventViewProps {
+  /** The decoded, append-only event log to render. */
+  events: readonly TranscriptEvent[];
+  className?: string;
+}
+
+/** Render agent prose + code via the shared chat parser; drop widget markers. */
+function renderAgentBody(text: string): ReactNode {
+  const segments = parseSegments(text, false);
+  return segments.map((segment, index) => {
+    const key = `${segment.kind}-${index}`;
+    if (segment.kind === "text") {
+      return (
+        <span key={key} dir="auto">
+          {segment.text}
+        </span>
+      );
+    }
+    if (segment.kind === "code") {
+      return (
+        <CodeBlock
+          key={key}
+          value={segment.code}
+          variant={segment.inline ? "inline" : "block"}
+          copyable={!segment.inline}
+        />
+      );
+    }
+    return null;
+  });
+}
+
+function TranscriptRow({ item }: { item: TranscriptItem }): ReactNode {
+  switch (item.kind) {
+    case "user":
+      return (
+        <div
+          className="native-transcript-row"
+          data-role="user"
+          data-status={item.status}
+        >
+          <span dir="auto">{item.text}</span>
+        </div>
+      );
+    case "agent":
+      return (
+        <div
+          className="native-transcript-row"
+          data-role="agent"
+          data-status={item.status}
+        >
+          {renderAgentBody(item.text)}
+        </div>
+      );
+    case "tool":
+      return (
+        <div
+          className="native-transcript-row"
+          data-role="tool"
+          data-status={item.status}
+        >
+          <span>{item.name}</span>
+          {item.detail ? <span dir="auto">{item.detail}</span> : null}
+        </div>
+      );
+    case "error":
+      return (
+        <div
+          className="native-transcript-row"
+          role="alert"
+          data-role="error"
+          data-code={item.code}
+          data-retryable={item.retryable}
+        >
+          <span dir="auto">{item.message ?? item.code}</span>
+        </div>
+      );
+    case "reconnect":
+      return (
+        <div
+          className="native-transcript-row"
+          data-role="reconnect"
+          data-phase={item.phase}
+          data-attempt={item.attempt}
+        />
+      );
+    default: {
+      const _never: never = item;
+      void _never;
+      return null;
+    }
+  }
+}
+
+/**
+ * Render a transcript-event log. Ordering, dedupe, late-event, and cancellation
+ * are decided by the reducer; this component only maps the resulting items to
+ * DOM. The container exposes `data-connection` and `data-speaking` so shells and
+ * tests can read transport state without re-deriving it.
+ */
+export function TranscriptEventView({
+  events,
+  className,
+}: TranscriptEventViewProps): ReactNode {
+  const view = useTranscriptEvents(events);
+  return (
+    <div
+      className={cn("flex flex-col gap-2", className)}
+      data-testid="native-transcript"
+      data-connection={view.connection}
+      data-speaking={view.speaking ? view.speaking.utteranceId : undefined}
+    >
+      {view.items.map((item) => (
+        <TranscriptRow key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/native-transcript/contract.conformance.test.ts
+++ b/packages/ui/src/native-transcript/contract.conformance.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-platform conformance: drives the language-neutral golden fixture
+ * (`fixtures/native-transcript-golden.json`) through the real decoder + reducer
+ * and asserts the reduced view exactly matches each scenario's `expectView`.
+ * This is the same fixture the iOS/Android native decoders must satisfy, so a
+ * failure here is a contract break, not a rendering nit. Deterministic — no
+ * clock, RNG, or I/O beyond reading the fixture file.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { NATIVE_TRANSCRIPT_SCHEMA } from "./contract";
+import { decodeTranscriptStream } from "./decode";
+import { reduceTranscriptEvents } from "./reduce";
+
+interface GoldenScenario {
+  name: string;
+  case?: string;
+  events: unknown[];
+  expectRejectedIndexes: number[];
+  expectView: unknown;
+}
+interface GoldenFixture {
+  schema: string;
+  scenarios: GoldenScenario[];
+}
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL("./fixtures/native-transcript-golden.json", import.meta.url),
+    "utf8",
+  ),
+) as GoldenFixture;
+
+describe("native-transcript golden conformance", () => {
+  it("fixture is tagged with the current schema version", () => {
+    expect(fixture.schema).toBe(NATIVE_TRANSCRIPT_SCHEMA);
+    expect(fixture.scenarios.length).toBeGreaterThan(0);
+  });
+
+  for (const scenario of fixture.scenarios) {
+    it(`${scenario.name} — ${scenario.case ?? ""}`, () => {
+      const decoded = decodeTranscriptStream({
+        schema: NATIVE_TRANSCRIPT_SCHEMA,
+        events: scenario.events,
+      });
+      expect(decoded.rejected.map((r) => r.index)).toEqual(
+        scenario.expectRejectedIndexes,
+      );
+      const view = reduceTranscriptEvents(decoded.events);
+      expect(view).toEqual(scenario.expectView);
+    });
+  }
+});

--- a/packages/ui/src/native-transcript/contract.ts
+++ b/packages/ui/src/native-transcript/contract.ts
@@ -1,0 +1,257 @@
+/**
+ * The one cross-platform transcript-event contract (`eliza.native-transcript/v1`)
+ * rendered identically by the iOS (SwiftUI), Android (Views), desktop, and web
+ * shells. A voice/agent turn is expressed as an append-only log of typed events;
+ * every shell decodes the same bytes (see `fixtures/native-transcript-golden.json`)
+ * and folds them into the same ordered render model.
+ *
+ * Design rules that make cross-bridge rendering deterministic:
+ *   - Behavior derives from STRUCTURAL fields only — the discriminant `type`, the
+ *     `phase`/`status`/`final` flags, the stable ids, and the monotonic `seq`.
+ *     Never from transcript text or its length. (Bucketing state by `text.length`
+ *     is the banned anti-pattern the earlier draft used.)
+ *   - Each event is a self-contained SNAPSHOT of the item it updates, not a delta.
+ *     A partial STT hypothesis and a streamed agent message each carry the full
+ *     text so far, so a bridge that duplicates, reorders, or drops an event never
+ *     has to buffer or re-accumulate — last-write-by-`seq` per item is correct.
+ *   - `seq` is a per-stream, source-assigned, strictly increasing integer. It is
+ *     the authoritative total order and the dedupe key. The reducer (`reduce.ts`)
+ *     is the executable definition of ordering, dedupe, late-event, and
+ *     cancellation-boundary semantics.
+ *
+ * This module is pure type + constant declarations (runtime validation lives in
+ * `decode.ts`) so it is safe to import from any layer, native bridge shim
+ * included.
+ */
+
+/** Versioned schema identifier carried by a transcript-event stream envelope. */
+export const NATIVE_TRANSCRIPT_SCHEMA = "eliza.native-transcript/v1" as const;
+export type NativeTranscriptSchema = typeof NATIVE_TRANSCRIPT_SCHEMA;
+
+/** Per-word timing for a final STT result (ms from the utterance start). */
+export interface TranscriptEventWord {
+  text: string;
+  startMs: number;
+  endMs: number;
+}
+
+// ── Events (the append-only wire log) ──────────────────────────────────
+
+/**
+ * Interim STT hypothesis for a user turn. `text` is the full current hypothesis
+ * (a snapshot, not a delta); a later `stt.final` on the same `turnId` supersedes
+ * every partial.
+ */
+export interface SttPartialEvent {
+  type: "stt.partial";
+  seq: number;
+  turnId: string;
+  text: string;
+  at?: number;
+}
+
+/** Committed STT result for a user turn; terminal for that `turnId`. */
+export interface SttFinalEvent {
+  type: "stt.final";
+  seq: number;
+  turnId: string;
+  text: string;
+  words?: TranscriptEventWord[];
+  at?: number;
+}
+
+/**
+ * Agent response text for one message. `text` is the full text emitted so far;
+ * `final` marks the message complete. `turnId` links the message to the user
+ * turn it answers so a turn-scoped cancellation can reach it.
+ */
+export interface AgentTextEvent {
+  type: "agent.text";
+  seq: number;
+  messageId: string;
+  text: string;
+  final: boolean;
+  turnId?: string;
+  at?: number;
+}
+
+/** Lifecycle phase of a tool/action invocation. */
+export type ToolPhase = "started" | "succeeded" | "failed";
+
+/** Tool/action invocation state update, identified by a stable `callId`. */
+export interface ToolStateEvent {
+  type: "tool.state";
+  seq: number;
+  callId: string;
+  name: string;
+  phase: ToolPhase;
+  detail?: string;
+  turnId?: string;
+  at?: number;
+}
+
+/** Audio-playback phase for one TTS utterance. */
+export type AudioPhase = "started" | "ended";
+
+/**
+ * TTS/audio playback state for one spoken utterance. Playback is transient view
+ * state (a "speaking now" indicator), not a persisted transcript row.
+ */
+export interface TtsAudioEvent {
+  type: "tts.audio";
+  seq: number;
+  utteranceId: string;
+  phase: AudioPhase;
+  messageId?: string;
+  at?: number;
+}
+
+/** Scope of a cancellation boundary. */
+export type CancelScope = "turn" | "all";
+
+/**
+ * A cancellation boundary. `scope: "all"` cancels every in-flight item; `scope:
+ * "turn"` cancels only items linked to `turnId`. The boundary also draws a `seq`
+ * line: a late pre-boundary event for a cancelled item is dropped, while a
+ * post-boundary event (higher `seq`) is a fresh continuation and still applies.
+ */
+export interface CancelEvent {
+  type: "cancel";
+  seq: number;
+  scope: CancelScope;
+  turnId?: string;
+  reason?: string;
+  at?: number;
+}
+
+/** A surfaced error. `retryable` drives whether the shell offers a retry. */
+export interface TranscriptErrorEvent {
+  type: "error";
+  seq: number;
+  code: string;
+  retryable: boolean;
+  message?: string;
+  at?: number;
+}
+
+/** Connection lifecycle phase for a reconnect marker. */
+export type ReconnectPhase = "lost" | "restored";
+
+/** Transport reconnect marker; `lost`/`restored` toggle the connection state. */
+export interface ReconnectEvent {
+  type: "reconnect";
+  seq: number;
+  phase: ReconnectPhase;
+  attempt: number;
+  at?: number;
+}
+
+export type TranscriptEvent =
+  | SttPartialEvent
+  | SttFinalEvent
+  | AgentTextEvent
+  | ToolStateEvent
+  | TtsAudioEvent
+  | CancelEvent
+  | TranscriptErrorEvent
+  | ReconnectEvent;
+
+export type TranscriptEventType = TranscriptEvent["type"];
+
+/** Every recognized event discriminant, for the decoder's known-type gate. */
+export const TRANSCRIPT_EVENT_TYPES: readonly TranscriptEventType[] = [
+  "stt.partial",
+  "stt.final",
+  "agent.text",
+  "tool.state",
+  "tts.audio",
+  "cancel",
+  "error",
+  "reconnect",
+] as const;
+
+/** Stream envelope: the versioned schema tag plus the ordered event log. */
+export interface TranscriptEventStream {
+  schema: NativeTranscriptSchema;
+  events: TranscriptEvent[];
+}
+
+// ── Reduced render model (what every shell draws) ──────────────────────
+
+export type UserTurnStatus = "partial" | "final" | "cancelled";
+export type AgentTurnStatus = "streaming" | "final" | "cancelled";
+export type ToolItemStatus = "running" | "succeeded" | "failed" | "cancelled";
+
+/** A user utterance row, keyed by its `turnId`. */
+export interface UserTranscriptItem {
+  kind: "user";
+  id: string;
+  status: UserTurnStatus;
+  text: string;
+  words: TranscriptEventWord[];
+}
+
+/** An agent message row, keyed by its `messageId`. */
+export interface AgentTranscriptItem {
+  kind: "agent";
+  id: string;
+  status: AgentTurnStatus;
+  text: string;
+  turnId?: string;
+}
+
+/** A tool/action row, keyed by its `callId`. */
+export interface ToolTranscriptItem {
+  kind: "tool";
+  id: string;
+  status: ToolItemStatus;
+  name: string;
+  detail?: string;
+  turnId?: string;
+}
+
+/** An error row; `id` is synthesized from the event `seq` (`error:<seq>`). */
+export interface ErrorTranscriptItem {
+  kind: "error";
+  id: string;
+  code: string;
+  retryable: boolean;
+  message?: string;
+}
+
+/** A reconnect marker row; `id` is synthesized (`reconnect:<seq>`). */
+export interface ReconnectTranscriptItem {
+  kind: "reconnect";
+  id: string;
+  phase: ReconnectPhase;
+  attempt: number;
+}
+
+export type TranscriptItem =
+  | UserTranscriptItem
+  | AgentTranscriptItem
+  | ToolTranscriptItem
+  | ErrorTranscriptItem
+  | ReconnectTranscriptItem;
+
+export type TranscriptItemKind = TranscriptItem["kind"];
+
+/** Transient "audio is playing now" indicator, cleared when playback ends. */
+export interface SpeakingState {
+  utteranceId: string;
+  messageId?: string;
+}
+
+export type ConnectionState = "live" | "lost";
+
+/**
+ * The render model a shell draws. `items` is ordered by each item's first-seen
+ * `seq` (stable across later updates); `speaking` and `connection` are transient
+ * transport state. This is the single shape the golden fixture asserts against.
+ */
+export interface TranscriptViewModel {
+  items: TranscriptItem[];
+  speaking: SpeakingState | null;
+  connection: ConnectionState;
+  lastSeq: number;
+}

--- a/packages/ui/src/native-transcript/decode.test.ts
+++ b/packages/ui/src/native-transcript/decode.test.ts
@@ -28,7 +28,12 @@ describe("decodeTranscriptEvent", () => {
 
   it("rejects a missing, fractional, negative, or unsafe seq", () => {
     for (const seq of [undefined, 1.5, -1, Number.MAX_SAFE_INTEGER + 1, NaN]) {
-      const res = decodeTranscriptEvent({ type: "stt.partial", seq, turnId: "t", text: "" });
+      const res = decodeTranscriptEvent({
+        type: "stt.partial",
+        seq,
+        turnId: "t",
+        text: "",
+      });
       expect(res.ok).toBe(false);
       if (!res.ok) expect(res.error.code).toBe("invalid-seq");
     }
@@ -41,14 +46,32 @@ describe("decodeTranscriptEvent", () => {
   });
 
   it("rejects an invalid optional `at`", () => {
-    const res = decodeTranscriptEvent({ type: "reconnect", seq: 1, phase: "lost", attempt: 0, at: "soon" });
+    const res = decodeTranscriptEvent({
+      type: "reconnect",
+      seq: 1,
+      phase: "lost",
+      attempt: 0,
+      at: "soon",
+    });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.field).toBe("at");
   });
 
   it("accepts an empty stt text but rejects a non-string one", () => {
-    expect(decodeTranscriptEvent({ type: "stt.partial", seq: 1, turnId: "t", text: "" }).ok).toBe(true);
-    const bad = decodeTranscriptEvent({ type: "stt.partial", seq: 1, turnId: "t", text: 5 });
+    expect(
+      decodeTranscriptEvent({
+        type: "stt.partial",
+        seq: 1,
+        turnId: "t",
+        text: "",
+      }).ok,
+    ).toBe(true);
+    const bad = decodeTranscriptEvent({
+      type: "stt.partial",
+      seq: 1,
+      turnId: "t",
+      text: 5,
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("text");
   });
@@ -66,34 +89,82 @@ describe("decodeTranscriptEvent", () => {
   });
 
   it("rejects a non-boolean agent.text final", () => {
-    const res = decodeTranscriptEvent({ type: "agent.text", seq: 1, messageId: "m", text: "hi", final: 1 });
+    const res = decodeTranscriptEvent({
+      type: "agent.text",
+      seq: 1,
+      messageId: "m",
+      text: "hi",
+      final: 1,
+    });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.field).toBe("final");
   });
 
   it("rejects an invalid tool phase and an invalid audio phase", () => {
-    expect(decodeTranscriptEvent({ type: "tool.state", seq: 1, callId: "c", name: "n", phase: "x" }).ok).toBe(false);
-    expect(decodeTranscriptEvent({ type: "tts.audio", seq: 1, utteranceId: "u", phase: "paused" }).ok).toBe(false);
+    expect(
+      decodeTranscriptEvent({
+        type: "tool.state",
+        seq: 1,
+        callId: "c",
+        name: "n",
+        phase: "x",
+      }).ok,
+    ).toBe(false);
+    expect(
+      decodeTranscriptEvent({
+        type: "tts.audio",
+        seq: 1,
+        utteranceId: "u",
+        phase: "paused",
+      }).ok,
+    ).toBe(false);
   });
 
   it("requires turnId for a turn-scoped cancel but not an all-scoped cancel", () => {
-    expect(decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "turn" }).ok).toBe(false);
-    expect(decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "all" }).ok).toBe(true);
-    expect(decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "turn", turnId: "t" }).ok).toBe(true);
+    expect(
+      decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "turn" }).ok,
+    ).toBe(false);
+    expect(
+      decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "all" }).ok,
+    ).toBe(true);
+    expect(
+      decodeTranscriptEvent({
+        type: "cancel",
+        seq: 1,
+        scope: "turn",
+        turnId: "t",
+      }).ok,
+    ).toBe(true);
   });
 
   it("ignores unknown keys (forward compatibility)", () => {
-    const res = decodeTranscriptEvent({ type: "error", seq: 1, code: "e", retryable: true, futureField: {} });
+    const res = decodeTranscriptEvent({
+      type: "error",
+      seq: 1,
+      code: "e",
+      retryable: true,
+      futureField: {},
+    });
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.event).toEqual({ type: "error", seq: 1, code: "e", retryable: true });
+    if (res.ok)
+      expect(res.event).toEqual({
+        type: "error",
+        seq: 1,
+        code: "e",
+        retryable: true,
+      });
   });
 });
 
 describe("decodeTranscriptStream", () => {
   it("throws on an unusable envelope (not-object, wrong schema, non-array events)", () => {
     expect(() => decodeTranscriptStream(null)).toThrow();
-    expect(() => decodeTranscriptStream({ schema: "other", events: [] })).toThrow();
-    expect(() => decodeTranscriptStream({ schema: NATIVE_TRANSCRIPT_SCHEMA, events: {} })).toThrow();
+    expect(() =>
+      decodeTranscriptStream({ schema: "other", events: [] }),
+    ).toThrow();
+    expect(() =>
+      decodeTranscriptStream({ schema: NATIVE_TRANSCRIPT_SCHEMA, events: {} }),
+    ).toThrow();
   });
 
   it("keeps valid events and collects rejected ones with index + reason", () => {

--- a/packages/ui/src/native-transcript/decode.test.ts
+++ b/packages/ui/src/native-transcript/decode.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Boundary-decoder unit tests: every field-level rejection reason, optional-field
+ * validation, forward-compatible unknown-key tolerance, and the stream envelope
+ * guards. Deterministic; no I/O.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NATIVE_TRANSCRIPT_SCHEMA } from "./contract";
+import { decodeTranscriptEvent, decodeTranscriptStream } from "./decode";
+
+describe("decodeTranscriptEvent", () => {
+  it("rejects non-objects with not-an-object", () => {
+    for (const raw of [null, undefined, 42, "x", [], true]) {
+      const res = decodeTranscriptEvent(raw);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.code).toBe("not-an-object");
+    }
+  });
+
+  it("requires a string `type`", () => {
+    const res = decodeTranscriptEvent({ seq: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe("missing-field");
+      expect(res.error.field).toBe("type");
+    }
+  });
+
+  it("rejects a missing, fractional, negative, or unsafe seq", () => {
+    for (const seq of [undefined, 1.5, -1, Number.MAX_SAFE_INTEGER + 1, NaN]) {
+      const res = decodeTranscriptEvent({ type: "stt.partial", seq, turnId: "t", text: "" });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.code).toBe("invalid-seq");
+    }
+  });
+
+  it("rejects an unknown type", () => {
+    const res = decodeTranscriptEvent({ type: "nope", seq: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("unknown-type");
+  });
+
+  it("rejects an invalid optional `at`", () => {
+    const res = decodeTranscriptEvent({ type: "reconnect", seq: 1, phase: "lost", attempt: 0, at: "soon" });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.field).toBe("at");
+  });
+
+  it("accepts an empty stt text but rejects a non-string one", () => {
+    expect(decodeTranscriptEvent({ type: "stt.partial", seq: 1, turnId: "t", text: "" }).ok).toBe(true);
+    const bad = decodeTranscriptEvent({ type: "stt.partial", seq: 1, turnId: "t", text: 5 });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("text");
+  });
+
+  it("rejects malformed stt.final words", () => {
+    const res = decodeTranscriptEvent({
+      type: "stt.final",
+      seq: 1,
+      turnId: "t",
+      text: "hi",
+      words: [{ text: "hi", startMs: "0", endMs: 1 }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.field).toBe("words");
+  });
+
+  it("rejects a non-boolean agent.text final", () => {
+    const res = decodeTranscriptEvent({ type: "agent.text", seq: 1, messageId: "m", text: "hi", final: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.field).toBe("final");
+  });
+
+  it("rejects an invalid tool phase and an invalid audio phase", () => {
+    expect(decodeTranscriptEvent({ type: "tool.state", seq: 1, callId: "c", name: "n", phase: "x" }).ok).toBe(false);
+    expect(decodeTranscriptEvent({ type: "tts.audio", seq: 1, utteranceId: "u", phase: "paused" }).ok).toBe(false);
+  });
+
+  it("requires turnId for a turn-scoped cancel but not an all-scoped cancel", () => {
+    expect(decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "turn" }).ok).toBe(false);
+    expect(decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "all" }).ok).toBe(true);
+    expect(decodeTranscriptEvent({ type: "cancel", seq: 1, scope: "turn", turnId: "t" }).ok).toBe(true);
+  });
+
+  it("ignores unknown keys (forward compatibility)", () => {
+    const res = decodeTranscriptEvent({ type: "error", seq: 1, code: "e", retryable: true, futureField: {} });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.event).toEqual({ type: "error", seq: 1, code: "e", retryable: true });
+  });
+});
+
+describe("decodeTranscriptStream", () => {
+  it("throws on an unusable envelope (not-object, wrong schema, non-array events)", () => {
+    expect(() => decodeTranscriptStream(null)).toThrow();
+    expect(() => decodeTranscriptStream({ schema: "other", events: [] })).toThrow();
+    expect(() => decodeTranscriptStream({ schema: NATIVE_TRANSCRIPT_SCHEMA, events: {} })).toThrow();
+  });
+
+  it("keeps valid events and collects rejected ones with index + reason", () => {
+    const res = decodeTranscriptStream({
+      schema: NATIVE_TRANSCRIPT_SCHEMA,
+      events: [
+        { type: "stt.final", seq: 1, turnId: "t", text: "ok" },
+        { type: "broken" },
+        { type: "agent.text", seq: 3, messageId: "m", text: "hi", final: true },
+      ],
+    });
+    expect(res.events.map((e) => e.seq)).toEqual([1, 3]);
+    expect(res.rejected).toHaveLength(1);
+    expect(res.rejected[0].index).toBe(1);
+  });
+});

--- a/packages/ui/src/native-transcript/decode.ts
+++ b/packages/ui/src/native-transcript/decode.ts
@@ -143,7 +143,11 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
         return fail("invalid-field", "`text` must be a string", "text");
       if (typeof r.final !== "boolean")
         return fail("invalid-field", "`final` must be a boolean", "final");
-      if ("turnId" in r && r.turnId !== undefined && !isNonEmptyString(r.turnId))
+      if (
+        "turnId" in r &&
+        r.turnId !== undefined &&
+        !isNonEmptyString(r.turnId)
+      )
         return fail("invalid-field", "`turnId` must be a string", "turnId");
       return {
         ok: true,
@@ -168,9 +172,17 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
         r.phase !== "failed"
       )
         return fail("invalid-field", "`phase` is not a tool phase", "phase");
-      if ("detail" in r && r.detail !== undefined && typeof r.detail !== "string")
+      if (
+        "detail" in r &&
+        r.detail !== undefined &&
+        typeof r.detail !== "string"
+      )
         return fail("invalid-field", "`detail` must be a string", "detail");
-      if ("turnId" in r && r.turnId !== undefined && !isNonEmptyString(r.turnId))
+      if (
+        "turnId" in r &&
+        r.turnId !== undefined &&
+        !isNonEmptyString(r.turnId)
+      )
         return fail("invalid-field", "`turnId` must be a string", "turnId");
       return {
         ok: true,
@@ -187,7 +199,11 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
     }
     case "tts.audio": {
       if (!isNonEmptyString(r.utteranceId))
-        return fail("missing-field", "`utteranceId` is required", "utteranceId");
+        return fail(
+          "missing-field",
+          "`utteranceId` is required",
+          "utteranceId",
+        );
       if (r.phase !== "started" && r.phase !== "ended")
         return fail("invalid-field", "`phase` is not an audio phase", "phase");
       if (
@@ -195,7 +211,11 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
         r.messageId !== undefined &&
         !isNonEmptyString(r.messageId)
       )
-        return fail("invalid-field", "`messageId` must be a string", "messageId");
+        return fail(
+          "invalid-field",
+          "`messageId` must be a string",
+          "messageId",
+        );
       return {
         ok: true,
         event: {
@@ -212,7 +232,11 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
         return fail("invalid-field", "`scope` must be turn|all", "scope");
       if (r.scope === "turn" && !isNonEmptyString(r.turnId))
         return fail("missing-field", "turn cancel requires `turnId`", "turnId");
-      if ("reason" in r && r.reason !== undefined && typeof r.reason !== "string")
+      if (
+        "reason" in r &&
+        r.reason !== undefined &&
+        typeof r.reason !== "string"
+      )
         return fail("invalid-field", "`reason` must be a string", "reason");
       return {
         ok: true,
@@ -229,7 +253,11 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
       if (!isNonEmptyString(r.code))
         return fail("missing-field", "`code` is required", "code");
       if (typeof r.retryable !== "boolean")
-        return fail("invalid-field", "`retryable` must be a boolean", "retryable");
+        return fail(
+          "invalid-field",
+          "`retryable` must be a boolean",
+          "retryable",
+        );
       if (
         "message" in r &&
         r.message !== undefined &&
@@ -249,10 +277,25 @@ export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
     }
     case "reconnect": {
       if (r.phase !== "lost" && r.phase !== "restored")
-        return fail("invalid-field", "`phase` is not a reconnect phase", "phase");
-      if (typeof r.attempt !== "number" || !Number.isInteger(r.attempt) || r.attempt < 0)
-        return fail("invalid-field", "`attempt` must be a non-negative integer", "attempt");
-      return { ok: true, event: { type, seq, phase: r.phase, attempt: r.attempt } };
+        return fail(
+          "invalid-field",
+          "`phase` is not a reconnect phase",
+          "phase",
+        );
+      if (
+        typeof r.attempt !== "number" ||
+        !Number.isInteger(r.attempt) ||
+        r.attempt < 0
+      )
+        return fail(
+          "invalid-field",
+          "`attempt` must be a non-negative integer",
+          "attempt",
+        );
+      return {
+        ok: true,
+        event: { type, seq, phase: r.phase, attempt: r.attempt },
+      };
     }
     default:
       return fail("unknown-type", `unknown event type: ${type}`, "type");

--- a/packages/ui/src/native-transcript/decode.ts
+++ b/packages/ui/src/native-transcript/decode.ts
@@ -1,0 +1,301 @@
+/**
+ * Boundary decoder for `eliza.native-transcript/v1`. Every field of an untrusted
+ * event is validated here before it reaches the reducer, so `reduce.ts` can trust
+ * its input completely and never re-checks shapes.
+ *
+ * A malformed frame yields an explicit typed failure (`{ ok: false, error }`),
+ * never a fabricated-valid default and never a throw — a single bad frame from
+ * one bridge must not tear down a live session (error-policy J3: untrusted-input
+ * sanitizing produces an explicit "invalid" result). `decodeTranscriptStream`
+ * applies the same rule per event: valid events accumulate, malformed ones are
+ * collected with their index and reason.
+ */
+
+import {
+  NATIVE_TRANSCRIPT_SCHEMA,
+  type TranscriptEvent,
+  type TranscriptEventWord,
+} from "./contract";
+
+/** Machine-readable reason a raw value failed to decode. */
+export type TranscriptDecodeErrorCode =
+  | "not-an-object"
+  | "unknown-type"
+  | "invalid-seq"
+  | "missing-field"
+  | "invalid-field";
+
+export interface TranscriptDecodeError {
+  code: TranscriptDecodeErrorCode;
+  /** The offending field, when the failure is field-specific. */
+  field?: string;
+  message: string;
+}
+
+export type TranscriptDecodeResult =
+  | { ok: true; event: TranscriptEvent }
+  | { ok: false; error: TranscriptDecodeError };
+
+function fail(
+  code: TranscriptDecodeErrorCode,
+  message: string,
+  field?: string,
+): { ok: false; error: TranscriptDecodeError } {
+  return { ok: false, error: { code, field, message } };
+}
+
+/** `seq` must be a finite, non-negative, safe integer (the ordering key). */
+function isValidSeq(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    Number.isSafeInteger(value)
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** `at` is optional display metadata; when present it must be a finite number. */
+function optionalTimestampInvalid(record: Record<string, unknown>): boolean {
+  return "at" in record && !isFiniteNumber(record.at);
+}
+
+function decodeWords(
+  value: unknown,
+): { ok: true; words: TranscriptEventWord[] } | { ok: false } {
+  if (!Array.isArray(value)) return { ok: false };
+  const words: TranscriptEventWord[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") return { ok: false };
+    const w = raw as Record<string, unknown>;
+    if (
+      typeof w.text !== "string" ||
+      !isFiniteNumber(w.startMs) ||
+      !isFiniteNumber(w.endMs)
+    ) {
+      return { ok: false };
+    }
+    words.push({ text: w.text, startMs: w.startMs, endMs: w.endMs });
+  }
+  return { ok: true, words };
+}
+
+/**
+ * Validate one raw value into a typed {@link TranscriptEvent}. Unknown keys are
+ * ignored (forward compatibility); every KNOWN field is type-checked, and an
+ * enum-valued field (`phase`, `scope`) must be one of its allowed members.
+ */
+export function decodeTranscriptEvent(raw: unknown): TranscriptDecodeResult {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return fail("not-an-object", "event must be a non-null object");
+  }
+  const r = raw as Record<string, unknown>;
+  const type = r.type;
+  if (typeof type !== "string") {
+    return fail("missing-field", "event is missing a string `type`", "type");
+  }
+  if (!isValidSeq(r.seq)) {
+    return fail("invalid-seq", "`seq` must be a non-negative integer", "seq");
+  }
+  if (optionalTimestampInvalid(r)) {
+    return fail("invalid-field", "`at` must be a finite number", "at");
+  }
+  const seq = r.seq;
+
+  switch (type) {
+    case "stt.partial": {
+      if (!isNonEmptyString(r.turnId))
+        return fail("missing-field", "`turnId` is required", "turnId");
+      if (typeof r.text !== "string")
+        return fail("invalid-field", "`text` must be a string", "text");
+      return { ok: true, event: { type, seq, turnId: r.turnId, text: r.text } };
+    }
+    case "stt.final": {
+      if (!isNonEmptyString(r.turnId))
+        return fail("missing-field", "`turnId` is required", "turnId");
+      if (typeof r.text !== "string")
+        return fail("invalid-field", "`text` must be a string", "text");
+      let words: TranscriptEventWord[] | undefined;
+      if ("words" in r && r.words !== undefined) {
+        const decoded = decodeWords(r.words);
+        if (!decoded.ok)
+          return fail("invalid-field", "`words` is malformed", "words");
+        words = decoded.words;
+      }
+      return {
+        ok: true,
+        event: words
+          ? { type, seq, turnId: r.turnId, text: r.text, words }
+          : { type, seq, turnId: r.turnId, text: r.text },
+      };
+    }
+    case "agent.text": {
+      if (!isNonEmptyString(r.messageId))
+        return fail("missing-field", "`messageId` is required", "messageId");
+      if (typeof r.text !== "string")
+        return fail("invalid-field", "`text` must be a string", "text");
+      if (typeof r.final !== "boolean")
+        return fail("invalid-field", "`final` must be a boolean", "final");
+      if ("turnId" in r && r.turnId !== undefined && !isNonEmptyString(r.turnId))
+        return fail("invalid-field", "`turnId` must be a string", "turnId");
+      return {
+        ok: true,
+        event: {
+          type,
+          seq,
+          messageId: r.messageId,
+          text: r.text,
+          final: r.final,
+          ...(isNonEmptyString(r.turnId) ? { turnId: r.turnId } : {}),
+        },
+      };
+    }
+    case "tool.state": {
+      if (!isNonEmptyString(r.callId))
+        return fail("missing-field", "`callId` is required", "callId");
+      if (!isNonEmptyString(r.name))
+        return fail("missing-field", "`name` is required", "name");
+      if (
+        r.phase !== "started" &&
+        r.phase !== "succeeded" &&
+        r.phase !== "failed"
+      )
+        return fail("invalid-field", "`phase` is not a tool phase", "phase");
+      if ("detail" in r && r.detail !== undefined && typeof r.detail !== "string")
+        return fail("invalid-field", "`detail` must be a string", "detail");
+      if ("turnId" in r && r.turnId !== undefined && !isNonEmptyString(r.turnId))
+        return fail("invalid-field", "`turnId` must be a string", "turnId");
+      return {
+        ok: true,
+        event: {
+          type,
+          seq,
+          callId: r.callId,
+          name: r.name,
+          phase: r.phase,
+          ...(typeof r.detail === "string" ? { detail: r.detail } : {}),
+          ...(isNonEmptyString(r.turnId) ? { turnId: r.turnId } : {}),
+        },
+      };
+    }
+    case "tts.audio": {
+      if (!isNonEmptyString(r.utteranceId))
+        return fail("missing-field", "`utteranceId` is required", "utteranceId");
+      if (r.phase !== "started" && r.phase !== "ended")
+        return fail("invalid-field", "`phase` is not an audio phase", "phase");
+      if (
+        "messageId" in r &&
+        r.messageId !== undefined &&
+        !isNonEmptyString(r.messageId)
+      )
+        return fail("invalid-field", "`messageId` must be a string", "messageId");
+      return {
+        ok: true,
+        event: {
+          type,
+          seq,
+          utteranceId: r.utteranceId,
+          phase: r.phase,
+          ...(isNonEmptyString(r.messageId) ? { messageId: r.messageId } : {}),
+        },
+      };
+    }
+    case "cancel": {
+      if (r.scope !== "turn" && r.scope !== "all")
+        return fail("invalid-field", "`scope` must be turn|all", "scope");
+      if (r.scope === "turn" && !isNonEmptyString(r.turnId))
+        return fail("missing-field", "turn cancel requires `turnId`", "turnId");
+      if ("reason" in r && r.reason !== undefined && typeof r.reason !== "string")
+        return fail("invalid-field", "`reason` must be a string", "reason");
+      return {
+        ok: true,
+        event: {
+          type,
+          seq,
+          scope: r.scope,
+          ...(isNonEmptyString(r.turnId) ? { turnId: r.turnId } : {}),
+          ...(typeof r.reason === "string" ? { reason: r.reason } : {}),
+        },
+      };
+    }
+    case "error": {
+      if (!isNonEmptyString(r.code))
+        return fail("missing-field", "`code` is required", "code");
+      if (typeof r.retryable !== "boolean")
+        return fail("invalid-field", "`retryable` must be a boolean", "retryable");
+      if (
+        "message" in r &&
+        r.message !== undefined &&
+        typeof r.message !== "string"
+      )
+        return fail("invalid-field", "`message` must be a string", "message");
+      return {
+        ok: true,
+        event: {
+          type,
+          seq,
+          code: r.code,
+          retryable: r.retryable,
+          ...(typeof r.message === "string" ? { message: r.message } : {}),
+        },
+      };
+    }
+    case "reconnect": {
+      if (r.phase !== "lost" && r.phase !== "restored")
+        return fail("invalid-field", "`phase` is not a reconnect phase", "phase");
+      if (typeof r.attempt !== "number" || !Number.isInteger(r.attempt) || r.attempt < 0)
+        return fail("invalid-field", "`attempt` must be a non-negative integer", "attempt");
+      return { ok: true, event: { type, seq, phase: r.phase, attempt: r.attempt } };
+    }
+    default:
+      return fail("unknown-type", `unknown event type: ${type}`, "type");
+  }
+}
+
+export interface TranscriptStreamDecodeResult {
+  /** Events that passed validation, in the order they appeared. */
+  events: TranscriptEvent[];
+  /** Malformed events with their source index and reason (never silently lost). */
+  rejected: { index: number; error: TranscriptDecodeError }[];
+}
+
+/**
+ * Decode a stream envelope `{ schema, events }`. Throws only when the envelope
+ * itself is unusable (not an object, wrong/absent schema tag) — that is a
+ * programming/version error, not untrusted per-event input. Per-event failures
+ * are returned in `rejected`, never thrown, so a mixed batch still yields its
+ * good events.
+ */
+export function decodeTranscriptStream(
+  raw: unknown,
+): TranscriptStreamDecodeResult {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError(
+      "[decodeTranscriptStream] stream must be a { schema, events } object",
+    );
+  }
+  const env = raw as Record<string, unknown>;
+  if (env.schema !== NATIVE_TRANSCRIPT_SCHEMA) {
+    throw new TypeError(
+      `[decodeTranscriptStream] unsupported schema: ${String(env.schema)}`,
+    );
+  }
+  if (!Array.isArray(env.events)) {
+    throw new TypeError("[decodeTranscriptStream] `events` must be an array");
+  }
+  const events: TranscriptEvent[] = [];
+  const rejected: { index: number; error: TranscriptDecodeError }[] = [];
+  env.events.forEach((rawEvent, index) => {
+    const decoded = decodeTranscriptEvent(rawEvent);
+    if (decoded.ok) events.push(decoded.event);
+    else rejected.push({ index, error: decoded.error });
+  });
+  return { events, rejected };
+}

--- a/packages/ui/src/native-transcript/fixtures/native-transcript-golden.json
+++ b/packages/ui/src/native-transcript/fixtures/native-transcript-golden.json
@@ -7,21 +7,89 @@
       "case": "baseline: partial -> final STT, streamed agent text, tool started/succeeded, TTS started/ended",
       "events": [
         { "type": "stt.partial", "seq": 1, "turnId": "t1", "text": "hel" },
-        { "type": "stt.partial", "seq": 2, "turnId": "t1", "text": "hello wor" },
-        { "type": "stt.final", "seq": 3, "turnId": "t1", "text": "hello world" },
-        { "type": "agent.text", "seq": 4, "messageId": "m1", "turnId": "t1", "text": "Hi", "final": false },
-        { "type": "tool.state", "seq": 5, "callId": "c1", "name": "search", "phase": "started", "turnId": "t1" },
-        { "type": "tool.state", "seq": 6, "callId": "c1", "name": "search", "phase": "succeeded", "turnId": "t1" },
-        { "type": "agent.text", "seq": 7, "messageId": "m1", "turnId": "t1", "text": "Hi there!", "final": true },
-        { "type": "tts.audio", "seq": 8, "utteranceId": "u1", "phase": "started", "messageId": "m1" },
-        { "type": "tts.audio", "seq": 9, "utteranceId": "u1", "phase": "ended", "messageId": "m1" }
+        {
+          "type": "stt.partial",
+          "seq": 2,
+          "turnId": "t1",
+          "text": "hello wor"
+        },
+        {
+          "type": "stt.final",
+          "seq": 3,
+          "turnId": "t1",
+          "text": "hello world"
+        },
+        {
+          "type": "agent.text",
+          "seq": 4,
+          "messageId": "m1",
+          "turnId": "t1",
+          "text": "Hi",
+          "final": false
+        },
+        {
+          "type": "tool.state",
+          "seq": 5,
+          "callId": "c1",
+          "name": "search",
+          "phase": "started",
+          "turnId": "t1"
+        },
+        {
+          "type": "tool.state",
+          "seq": 6,
+          "callId": "c1",
+          "name": "search",
+          "phase": "succeeded",
+          "turnId": "t1"
+        },
+        {
+          "type": "agent.text",
+          "seq": 7,
+          "messageId": "m1",
+          "turnId": "t1",
+          "text": "Hi there!",
+          "final": true
+        },
+        {
+          "type": "tts.audio",
+          "seq": 8,
+          "utteranceId": "u1",
+          "phase": "started",
+          "messageId": "m1"
+        },
+        {
+          "type": "tts.audio",
+          "seq": 9,
+          "utteranceId": "u1",
+          "phase": "ended",
+          "messageId": "m1"
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "hello world", "words": [] },
-          { "kind": "agent", "id": "m1", "status": "final", "text": "Hi there!", "turnId": "t1" },
-          { "kind": "tool", "id": "c1", "status": "succeeded", "name": "search", "turnId": "t1" }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "hello world",
+            "words": []
+          },
+          {
+            "kind": "agent",
+            "id": "m1",
+            "status": "final",
+            "text": "Hi there!",
+            "turnId": "t1"
+          },
+          {
+            "kind": "tool",
+            "id": "c1",
+            "status": "succeeded",
+            "name": "search",
+            "turnId": "t1"
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -36,17 +104,41 @@
         { "type": "stt.partial", "turnId": "t1", "text": "no seq" },
         { "type": "stt.partial", "seq": -1, "turnId": "t1", "text": "neg" },
         { "type": "bogus.kind", "seq": 2 },
-        { "type": "tool.state", "seq": 3, "callId": "c1", "name": "x", "phase": "weird" },
-        { "type": "agent.text", "seq": 4, "messageId": "m1", "text": "hi", "final": "yes" },
+        {
+          "type": "tool.state",
+          "seq": 3,
+          "callId": "c1",
+          "name": "x",
+          "phase": "weird"
+        },
+        {
+          "type": "agent.text",
+          "seq": 4,
+          "messageId": "m1",
+          "text": "hi",
+          "final": "yes"
+        },
         { "type": "stt.final", "seq": 5, "turnId": "t1", "text": "done" },
         "not an object",
         { "type": "cancel", "seq": 6, "scope": "turn" },
-        { "type": "agent.text", "seq": 7, "messageId": "m1", "text": "hi", "final": true }
+        {
+          "type": "agent.text",
+          "seq": 7,
+          "messageId": "m1",
+          "text": "hi",
+          "final": true
+        }
       ],
       "expectRejectedIndexes": [1, 2, 3, 4, 5, 7, 8],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "done", "words": [] },
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "done",
+            "words": []
+          },
           { "kind": "agent", "id": "m1", "status": "final", "text": "hi" }
         ],
         "speaking": null,
@@ -60,13 +152,31 @@
       "events": [
         { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hello" },
         { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hello" },
-        { "type": "agent.text", "seq": 2, "messageId": "m1", "text": "hi", "final": true },
-        { "type": "agent.text", "seq": 2, "messageId": "m1", "text": "hi", "final": true }
+        {
+          "type": "agent.text",
+          "seq": 2,
+          "messageId": "m1",
+          "text": "hi",
+          "final": true
+        },
+        {
+          "type": "agent.text",
+          "seq": 2,
+          "messageId": "m1",
+          "text": "hi",
+          "final": true
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "hello", "words": [] },
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "hello",
+            "words": []
+          },
           { "kind": "agent", "id": "m1", "status": "final", "text": "hi" }
         ],
         "speaking": null,
@@ -85,7 +195,13 @@
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "final text", "words": [] }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "final text",
+            "words": []
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -96,13 +212,25 @@
       "name": "reordered-creation-orders-by-seq",
       "case": "reordered: render order follows first-seen seq, not arrival order",
       "events": [
-        { "type": "agent.text", "seq": 5, "messageId": "m2", "text": "second", "final": true },
+        {
+          "type": "agent.text",
+          "seq": 5,
+          "messageId": "m2",
+          "text": "second",
+          "final": true
+        },
         { "type": "stt.final", "seq": 2, "turnId": "t1", "text": "first" }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "first", "words": [] },
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "first",
+            "words": []
+          },
           { "kind": "agent", "id": "m2", "status": "final", "text": "second" }
         ],
         "speaking": null,
@@ -117,17 +245,55 @@
         { "type": "stt.partial", "seq": 1, "turnId": "tA", "text": "A hel" },
         { "type": "stt.partial", "seq": 2, "turnId": "tB", "text": "B wor" },
         { "type": "stt.final", "seq": 3, "turnId": "tA", "text": "A hello" },
-        { "type": "agent.text", "seq": 4, "messageId": "mA", "turnId": "tA", "text": "resA", "final": true },
+        {
+          "type": "agent.text",
+          "seq": 4,
+          "messageId": "mA",
+          "turnId": "tA",
+          "text": "resA",
+          "final": true
+        },
         { "type": "stt.final", "seq": 5, "turnId": "tB", "text": "B world" },
-        { "type": "agent.text", "seq": 6, "messageId": "mB", "turnId": "tB", "text": "resB", "final": true }
+        {
+          "type": "agent.text",
+          "seq": 6,
+          "messageId": "mB",
+          "turnId": "tB",
+          "text": "resB",
+          "final": true
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "tA", "status": "final", "text": "A hello", "words": [] },
-          { "kind": "user", "id": "tB", "status": "final", "text": "B world", "words": [] },
-          { "kind": "agent", "id": "mA", "status": "final", "text": "resA", "turnId": "tA" },
-          { "kind": "agent", "id": "mB", "status": "final", "text": "resB", "turnId": "tB" }
+          {
+            "kind": "user",
+            "id": "tA",
+            "status": "final",
+            "text": "A hello",
+            "words": []
+          },
+          {
+            "kind": "user",
+            "id": "tB",
+            "status": "final",
+            "text": "B world",
+            "words": []
+          },
+          {
+            "kind": "agent",
+            "id": "mA",
+            "status": "final",
+            "text": "resA",
+            "turnId": "tA"
+          },
+          {
+            "kind": "agent",
+            "id": "mB",
+            "status": "final",
+            "text": "resB",
+            "turnId": "tB"
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -149,13 +315,17 @@
     {
       "name": "empty-text-preserved",
       "case": "empty: an empty-text final still produces a row (no length inference)",
-      "events": [
-        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "" }
-      ],
+      "events": [{ "type": "stt.final", "seq": 1, "turnId": "t1", "text": "" }],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "", "words": [] }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "",
+            "words": []
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -166,14 +336,38 @@
       "name": "unicode-rtl",
       "case": "Unicode/RTL: Arabic, Hebrew, CJK, emoji + skin-tone modifier, combining accent carried verbatim",
       "events": [
-        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "مرحبا بالعالم" },
-        { "type": "agent.text", "seq": 2, "messageId": "m1", "turnId": "t1", "text": "שלום 世界 👋🏽 café", "final": true }
+        {
+          "type": "stt.final",
+          "seq": 1,
+          "turnId": "t1",
+          "text": "مرحبا بالعالم"
+        },
+        {
+          "type": "agent.text",
+          "seq": 2,
+          "messageId": "m1",
+          "turnId": "t1",
+          "text": "שלום 世界 👋🏽 café",
+          "final": true
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "مرحبا بالعالم", "words": [] },
-          { "kind": "agent", "id": "m1", "status": "final", "text": "שלום 世界 👋🏽 café", "turnId": "t1" }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "مرحبا بالعالم",
+            "words": []
+          },
+          {
+            "kind": "agent",
+            "id": "m1",
+            "status": "final",
+            "text": "שלום 世界 👋🏽 café",
+            "turnId": "t1"
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -184,12 +378,23 @@
       "name": "long-text",
       "case": "long: a large snapshot is just text; no length-based state bucketing",
       "events": [
-        { "type": "agent.text", "seq": 1, "messageId": "m1", "final": true, "text": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word" }
+        {
+          "type": "agent.text",
+          "seq": 1,
+          "messageId": "m1",
+          "final": true,
+          "text": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word"
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "agent", "id": "m1", "status": "final", "text": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word" }
+          {
+            "kind": "agent",
+            "id": "m1",
+            "status": "final",
+            "text": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word"
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -208,10 +413,32 @@
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "before", "words": [] },
-          { "kind": "reconnect", "id": "reconnect:2", "phase": "lost", "attempt": 1 },
-          { "kind": "reconnect", "id": "reconnect:3", "phase": "restored", "attempt": 1 },
-          { "kind": "user", "id": "t2", "status": "final", "text": "after", "words": [] }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "before",
+            "words": []
+          },
+          {
+            "kind": "reconnect",
+            "id": "reconnect:2",
+            "phase": "lost",
+            "attempt": 1
+          },
+          {
+            "kind": "reconnect",
+            "id": "reconnect:3",
+            "phase": "restored",
+            "attempt": 1
+          },
+          {
+            "kind": "user",
+            "id": "t2",
+            "status": "final",
+            "text": "after",
+            "words": []
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -228,8 +455,19 @@
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "hi", "words": [] },
-          { "kind": "reconnect", "id": "reconnect:2", "phase": "lost", "attempt": 2 }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "hi",
+            "words": []
+          },
+          {
+            "kind": "reconnect",
+            "id": "reconnect:2",
+            "phase": "lost",
+            "attempt": 2
+          }
         ],
         "speaking": null,
         "connection": "lost",
@@ -240,12 +478,24 @@
       "name": "permission-denied-error",
       "case": "permission-denied: surfaced as a non-retryable error row",
       "events": [
-        { "type": "error", "seq": 1, "code": "permission-denied", "retryable": false, "message": "Microphone permission denied" }
+        {
+          "type": "error",
+          "seq": 1,
+          "code": "permission-denied",
+          "retryable": false,
+          "message": "Microphone permission denied"
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "error", "id": "error:1", "code": "permission-denied", "retryable": false, "message": "Microphone permission denied" }
+          {
+            "kind": "error",
+            "id": "error:1",
+            "code": "permission-denied",
+            "retryable": false,
+            "message": "Microphone permission denied"
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -257,19 +507,76 @@
       "case": "cancellation: scope=all cancels in-flight items, drops a pre-boundary straggler, applies a post-boundary continuation",
       "events": [
         { "type": "stt.partial", "seq": 10, "turnId": "t1", "text": "start" },
-        { "type": "agent.text", "seq": 11, "messageId": "m1", "turnId": "t1", "text": "thinking", "final": false },
-        { "type": "tool.state", "seq": 12, "callId": "c1", "name": "search", "phase": "started", "turnId": "t1" },
-        { "type": "tts.audio", "seq": 13, "utteranceId": "u1", "phase": "started", "messageId": "m1" },
-        { "type": "cancel", "seq": 20, "scope": "all", "reason": "user-barge-in" },
-        { "type": "agent.text", "seq": 15, "messageId": "m1", "turnId": "t1", "text": "late chunk", "final": false },
-        { "type": "agent.text", "seq": 25, "messageId": "m1", "turnId": "t1", "text": "post cancel continuation", "final": true }
+        {
+          "type": "agent.text",
+          "seq": 11,
+          "messageId": "m1",
+          "turnId": "t1",
+          "text": "thinking",
+          "final": false
+        },
+        {
+          "type": "tool.state",
+          "seq": 12,
+          "callId": "c1",
+          "name": "search",
+          "phase": "started",
+          "turnId": "t1"
+        },
+        {
+          "type": "tts.audio",
+          "seq": 13,
+          "utteranceId": "u1",
+          "phase": "started",
+          "messageId": "m1"
+        },
+        {
+          "type": "cancel",
+          "seq": 20,
+          "scope": "all",
+          "reason": "user-barge-in"
+        },
+        {
+          "type": "agent.text",
+          "seq": 15,
+          "messageId": "m1",
+          "turnId": "t1",
+          "text": "late chunk",
+          "final": false
+        },
+        {
+          "type": "agent.text",
+          "seq": 25,
+          "messageId": "m1",
+          "turnId": "t1",
+          "text": "post cancel continuation",
+          "final": true
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "cancelled", "text": "start", "words": [] },
-          { "kind": "agent", "id": "m1", "status": "final", "text": "post cancel continuation", "turnId": "t1" },
-          { "kind": "tool", "id": "c1", "status": "cancelled", "name": "search", "turnId": "t1" }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "cancelled",
+            "text": "start",
+            "words": []
+          },
+          {
+            "kind": "agent",
+            "id": "m1",
+            "status": "final",
+            "text": "post cancel continuation",
+            "turnId": "t1"
+          },
+          {
+            "kind": "tool",
+            "id": "c1",
+            "status": "cancelled",
+            "name": "search",
+            "turnId": "t1"
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -280,15 +587,37 @@
       "name": "cancellation-turn-scoped",
       "case": "cancellation: scope=turn only cancels the matching turn; the other turn keeps flowing",
       "events": [
-        { "type": "stt.partial", "seq": 1, "turnId": "tA", "text": "a in flight" },
-        { "type": "stt.partial", "seq": 2, "turnId": "tB", "text": "b in flight" },
+        {
+          "type": "stt.partial",
+          "seq": 1,
+          "turnId": "tA",
+          "text": "a in flight"
+        },
+        {
+          "type": "stt.partial",
+          "seq": 2,
+          "turnId": "tB",
+          "text": "b in flight"
+        },
         { "type": "cancel", "seq": 3, "scope": "turn", "turnId": "tA" }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "tA", "status": "cancelled", "text": "a in flight", "words": [] },
-          { "kind": "user", "id": "tB", "status": "partial", "text": "b in flight", "words": [] }
+          {
+            "kind": "user",
+            "id": "tA",
+            "status": "cancelled",
+            "text": "a in flight",
+            "words": []
+          },
+          {
+            "kind": "user",
+            "id": "tB",
+            "status": "partial",
+            "text": "b in flight",
+            "words": []
+          }
         ],
         "speaking": null,
         "connection": "live",
@@ -299,8 +628,20 @@
       "name": "speaking-active",
       "case": "TTS/audio: playback in progress is transient view state (speaking indicator), not a row",
       "events": [
-        { "type": "agent.text", "seq": 1, "messageId": "m1", "text": "hello", "final": true },
-        { "type": "tts.audio", "seq": 2, "utteranceId": "u1", "phase": "started", "messageId": "m1" }
+        {
+          "type": "agent.text",
+          "seq": 1,
+          "messageId": "m1",
+          "text": "hello",
+          "final": true
+        },
+        {
+          "type": "tts.audio",
+          "seq": 2,
+          "utteranceId": "u1",
+          "phase": "started",
+          "messageId": "m1"
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
@@ -316,12 +657,30 @@
       "name": "stt-final-with-words",
       "case": "word timings: stt.final carries per-word timing that survives decode verbatim",
       "events": [
-        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hi there", "words": [ { "text": "hi", "startMs": 0, "endMs": 200 }, { "text": "there", "startMs": 200, "endMs": 600 } ] }
+        {
+          "type": "stt.final",
+          "seq": 1,
+          "turnId": "t1",
+          "text": "hi there",
+          "words": [
+            { "text": "hi", "startMs": 0, "endMs": 200 },
+            { "text": "there", "startMs": 200, "endMs": 600 }
+          ]
+        }
       ],
       "expectRejectedIndexes": [],
       "expectView": {
         "items": [
-          { "kind": "user", "id": "t1", "status": "final", "text": "hi there", "words": [ { "text": "hi", "startMs": 0, "endMs": 200 }, { "text": "there", "startMs": 200, "endMs": 600 } ] }
+          {
+            "kind": "user",
+            "id": "t1",
+            "status": "final",
+            "text": "hi there",
+            "words": [
+              { "text": "hi", "startMs": 0, "endMs": 200 },
+              { "text": "there", "startMs": 200, "endMs": 600 }
+            ]
+          }
         ],
         "speaking": null,
         "connection": "live",

--- a/packages/ui/src/native-transcript/fixtures/native-transcript-golden.json
+++ b/packages/ui/src/native-transcript/fixtures/native-transcript-golden.json
@@ -1,0 +1,332 @@
+{
+  "schema": "eliza.native-transcript/v1",
+  "note": "Language-neutral golden conformance fixture for eliza.native-transcript/v1. Every shell (web here; iOS/Android native next) must decode these exact events and fold them into `expectView`. `expectRejectedIndexes` lists positions in `events` that MUST fail decode (malformed). Item objects omit optional fields that are absent; a conformant comparison ignores undefined-valued keys.",
+  "scenarios": [
+    {
+      "name": "happy-path-voice-turn",
+      "case": "baseline: partial -> final STT, streamed agent text, tool started/succeeded, TTS started/ended",
+      "events": [
+        { "type": "stt.partial", "seq": 1, "turnId": "t1", "text": "hel" },
+        { "type": "stt.partial", "seq": 2, "turnId": "t1", "text": "hello wor" },
+        { "type": "stt.final", "seq": 3, "turnId": "t1", "text": "hello world" },
+        { "type": "agent.text", "seq": 4, "messageId": "m1", "turnId": "t1", "text": "Hi", "final": false },
+        { "type": "tool.state", "seq": 5, "callId": "c1", "name": "search", "phase": "started", "turnId": "t1" },
+        { "type": "tool.state", "seq": 6, "callId": "c1", "name": "search", "phase": "succeeded", "turnId": "t1" },
+        { "type": "agent.text", "seq": 7, "messageId": "m1", "turnId": "t1", "text": "Hi there!", "final": true },
+        { "type": "tts.audio", "seq": 8, "utteranceId": "u1", "phase": "started", "messageId": "m1" },
+        { "type": "tts.audio", "seq": 9, "utteranceId": "u1", "phase": "ended", "messageId": "m1" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "hello world", "words": [] },
+          { "kind": "agent", "id": "m1", "status": "final", "text": "Hi there!", "turnId": "t1" },
+          { "kind": "tool", "id": "c1", "status": "succeeded", "name": "search", "turnId": "t1" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 9
+      }
+    },
+    {
+      "name": "malformed-events-rejected",
+      "case": "malformed: missing/negative seq, unknown type, bad enum, wrong field type, non-object, missing required id",
+      "events": [
+        { "type": "stt.partial", "seq": 1, "turnId": "t1", "text": "ok" },
+        { "type": "stt.partial", "turnId": "t1", "text": "no seq" },
+        { "type": "stt.partial", "seq": -1, "turnId": "t1", "text": "neg" },
+        { "type": "bogus.kind", "seq": 2 },
+        { "type": "tool.state", "seq": 3, "callId": "c1", "name": "x", "phase": "weird" },
+        { "type": "agent.text", "seq": 4, "messageId": "m1", "text": "hi", "final": "yes" },
+        { "type": "stt.final", "seq": 5, "turnId": "t1", "text": "done" },
+        "not an object",
+        { "type": "cancel", "seq": 6, "scope": "turn" },
+        { "type": "agent.text", "seq": 7, "messageId": "m1", "text": "hi", "final": true }
+      ],
+      "expectRejectedIndexes": [1, 2, 3, 4, 5, 7, 8],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "done", "words": [] },
+          { "kind": "agent", "id": "m1", "status": "final", "text": "hi" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 7
+      }
+    },
+    {
+      "name": "duplicated-events-deduped",
+      "case": "duplicated: identical seq repeated is a no-op",
+      "events": [
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hello" },
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hello" },
+        { "type": "agent.text", "seq": 2, "messageId": "m1", "text": "hi", "final": true },
+        { "type": "agent.text", "seq": 2, "messageId": "m1", "text": "hi", "final": true }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "hello", "words": [] },
+          { "kind": "agent", "id": "m1", "status": "final", "text": "hi" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 2
+      }
+    },
+    {
+      "name": "reordered-late-partial-dropped",
+      "case": "reordered: a partial that arrives after the final (lower seq) never regresses the row",
+      "events": [
+        { "type": "stt.final", "seq": 3, "turnId": "t1", "text": "final text" },
+        { "type": "stt.partial", "seq": 1, "turnId": "t1", "text": "fin" },
+        { "type": "stt.partial", "seq": 2, "turnId": "t1", "text": "final te" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "final text", "words": [] }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 3
+      }
+    },
+    {
+      "name": "reordered-creation-orders-by-seq",
+      "case": "reordered: render order follows first-seen seq, not arrival order",
+      "events": [
+        { "type": "agent.text", "seq": 5, "messageId": "m2", "text": "second", "final": true },
+        { "type": "stt.final", "seq": 2, "turnId": "t1", "text": "first" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "first", "words": [] },
+          { "kind": "agent", "id": "m2", "status": "final", "text": "second" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 5
+      }
+    },
+    {
+      "name": "concurrent-interleaved-turns",
+      "case": "concurrent: two overlapping turns advance independently and stay ordered by first-seen seq",
+      "events": [
+        { "type": "stt.partial", "seq": 1, "turnId": "tA", "text": "A hel" },
+        { "type": "stt.partial", "seq": 2, "turnId": "tB", "text": "B wor" },
+        { "type": "stt.final", "seq": 3, "turnId": "tA", "text": "A hello" },
+        { "type": "agent.text", "seq": 4, "messageId": "mA", "turnId": "tA", "text": "resA", "final": true },
+        { "type": "stt.final", "seq": 5, "turnId": "tB", "text": "B world" },
+        { "type": "agent.text", "seq": 6, "messageId": "mB", "turnId": "tB", "text": "resB", "final": true }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "tA", "status": "final", "text": "A hello", "words": [] },
+          { "kind": "user", "id": "tB", "status": "final", "text": "B world", "words": [] },
+          { "kind": "agent", "id": "mA", "status": "final", "text": "resA", "turnId": "tA" },
+          { "kind": "agent", "id": "mB", "status": "final", "text": "resB", "turnId": "tB" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 6
+      }
+    },
+    {
+      "name": "empty-log",
+      "case": "empty: no events yields the empty designed state, never a fabricated row",
+      "events": [],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 0
+      }
+    },
+    {
+      "name": "empty-text-preserved",
+      "case": "empty: an empty-text final still produces a row (no length inference)",
+      "events": [
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "", "words": [] }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 1
+      }
+    },
+    {
+      "name": "unicode-rtl",
+      "case": "Unicode/RTL: Arabic, Hebrew, CJK, emoji + skin-tone modifier, combining accent carried verbatim",
+      "events": [
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "مرحبا بالعالم" },
+        { "type": "agent.text", "seq": 2, "messageId": "m1", "turnId": "t1", "text": "שלום 世界 👋🏽 café", "final": true }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "مرحبا بالعالم", "words": [] },
+          { "kind": "agent", "id": "m1", "status": "final", "text": "שלום 世界 👋🏽 café", "turnId": "t1" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 2
+      }
+    },
+    {
+      "name": "long-text",
+      "case": "long: a large snapshot is just text; no length-based state bucketing",
+      "events": [
+        { "type": "agent.text", "seq": 1, "messageId": "m1", "final": true, "text": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "agent", "id": "m1", "status": "final", "text": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 1
+      }
+    },
+    {
+      "name": "offline-reconnect-restored",
+      "case": "offline: connection lost then restored; markers ordered, connection ends live",
+      "events": [
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "before" },
+        { "type": "reconnect", "seq": 2, "phase": "lost", "attempt": 1 },
+        { "type": "reconnect", "seq": 3, "phase": "restored", "attempt": 1 },
+        { "type": "stt.final", "seq": 4, "turnId": "t2", "text": "after" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "before", "words": [] },
+          { "kind": "reconnect", "id": "reconnect:2", "phase": "lost", "attempt": 1 },
+          { "kind": "reconnect", "id": "reconnect:3", "phase": "restored", "attempt": 1 },
+          { "kind": "user", "id": "t2", "status": "final", "text": "after", "words": [] }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 4
+      }
+    },
+    {
+      "name": "offline-connection-lost",
+      "case": "offline: a trailing lost marker leaves connection lost",
+      "events": [
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hi" },
+        { "type": "reconnect", "seq": 2, "phase": "lost", "attempt": 2 }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "hi", "words": [] },
+          { "kind": "reconnect", "id": "reconnect:2", "phase": "lost", "attempt": 2 }
+        ],
+        "speaking": null,
+        "connection": "lost",
+        "lastSeq": 2
+      }
+    },
+    {
+      "name": "permission-denied-error",
+      "case": "permission-denied: surfaced as a non-retryable error row",
+      "events": [
+        { "type": "error", "seq": 1, "code": "permission-denied", "retryable": false, "message": "Microphone permission denied" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "error", "id": "error:1", "code": "permission-denied", "retryable": false, "message": "Microphone permission denied" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 1
+      }
+    },
+    {
+      "name": "cancellation-boundary-all",
+      "case": "cancellation: scope=all cancels in-flight items, drops a pre-boundary straggler, applies a post-boundary continuation",
+      "events": [
+        { "type": "stt.partial", "seq": 10, "turnId": "t1", "text": "start" },
+        { "type": "agent.text", "seq": 11, "messageId": "m1", "turnId": "t1", "text": "thinking", "final": false },
+        { "type": "tool.state", "seq": 12, "callId": "c1", "name": "search", "phase": "started", "turnId": "t1" },
+        { "type": "tts.audio", "seq": 13, "utteranceId": "u1", "phase": "started", "messageId": "m1" },
+        { "type": "cancel", "seq": 20, "scope": "all", "reason": "user-barge-in" },
+        { "type": "agent.text", "seq": 15, "messageId": "m1", "turnId": "t1", "text": "late chunk", "final": false },
+        { "type": "agent.text", "seq": 25, "messageId": "m1", "turnId": "t1", "text": "post cancel continuation", "final": true }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "cancelled", "text": "start", "words": [] },
+          { "kind": "agent", "id": "m1", "status": "final", "text": "post cancel continuation", "turnId": "t1" },
+          { "kind": "tool", "id": "c1", "status": "cancelled", "name": "search", "turnId": "t1" }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 25
+      }
+    },
+    {
+      "name": "cancellation-turn-scoped",
+      "case": "cancellation: scope=turn only cancels the matching turn; the other turn keeps flowing",
+      "events": [
+        { "type": "stt.partial", "seq": 1, "turnId": "tA", "text": "a in flight" },
+        { "type": "stt.partial", "seq": 2, "turnId": "tB", "text": "b in flight" },
+        { "type": "cancel", "seq": 3, "scope": "turn", "turnId": "tA" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "tA", "status": "cancelled", "text": "a in flight", "words": [] },
+          { "kind": "user", "id": "tB", "status": "partial", "text": "b in flight", "words": [] }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 3
+      }
+    },
+    {
+      "name": "speaking-active",
+      "case": "TTS/audio: playback in progress is transient view state (speaking indicator), not a row",
+      "events": [
+        { "type": "agent.text", "seq": 1, "messageId": "m1", "text": "hello", "final": true },
+        { "type": "tts.audio", "seq": 2, "utteranceId": "u1", "phase": "started", "messageId": "m1" }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "agent", "id": "m1", "status": "final", "text": "hello" }
+        ],
+        "speaking": { "utteranceId": "u1", "messageId": "m1" },
+        "connection": "live",
+        "lastSeq": 2
+      }
+    },
+    {
+      "name": "stt-final-with-words",
+      "case": "word timings: stt.final carries per-word timing that survives decode verbatim",
+      "events": [
+        { "type": "stt.final", "seq": 1, "turnId": "t1", "text": "hi there", "words": [ { "text": "hi", "startMs": 0, "endMs": 200 }, { "text": "there", "startMs": 200, "endMs": 600 } ] }
+      ],
+      "expectRejectedIndexes": [],
+      "expectView": {
+        "items": [
+          { "kind": "user", "id": "t1", "status": "final", "text": "hi there", "words": [ { "text": "hi", "startMs": 0, "endMs": 200 }, { "text": "there", "startMs": 200, "endMs": 600 } ] }
+        ],
+        "speaking": null,
+        "connection": "live",
+        "lastSeq": 1
+      }
+    }
+  ]
+}

--- a/packages/ui/src/native-transcript/index.test.ts
+++ b/packages/ui/src/native-transcript/index.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Barrel smoke: the public `@elizaos/ui/native-transcript` surface re-exports the
+ * schema constant, decoder, reducer, and renderer that shells import. Guards the
+ * subpath export from silently losing a symbol.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as api from "./index";
+
+describe("native-transcript public surface", () => {
+  it("re-exports the contract, decoder, reducer, and renderer", () => {
+    expect(api.NATIVE_TRANSCRIPT_SCHEMA).toBe("eliza.native-transcript/v1");
+    expect(api.TRANSCRIPT_EVENT_TYPES).toContain("stt.partial");
+    expect(typeof api.decodeTranscriptEvent).toBe("function");
+    expect(typeof api.decodeTranscriptStream).toBe("function");
+    expect(typeof api.applyTranscriptEvent).toBe("function");
+    expect(typeof api.reduceTranscriptEvents).toBe("function");
+    expect(typeof api.toViewModel).toBe("function");
+    expect(typeof api.TranscriptEventView).toBe("function");
+    expect(typeof api.useTranscriptEvents).toBe("function");
+  });
+});

--- a/packages/ui/src/native-transcript/index.ts
+++ b/packages/ui/src/native-transcript/index.ts
@@ -1,0 +1,61 @@
+/**
+ * `eliza.native-transcript/v1` — the one typed transcript-event contract shared
+ * by the iOS, Android, desktop, and web shells. Types + schema (`contract`),
+ * boundary decoder (`decode`), pure reducer (`reduce`), and the web/DOM renderer
+ * (`TranscriptEventView`).
+ */
+
+export {
+  type AgentTextEvent,
+  type AgentTranscriptItem,
+  type AgentTurnStatus,
+  type AudioPhase,
+  type CancelEvent,
+  type CancelScope,
+  type ConnectionState,
+  type ErrorTranscriptItem,
+  NATIVE_TRANSCRIPT_SCHEMA,
+  type NativeTranscriptSchema,
+  type ReconnectEvent,
+  type ReconnectPhase,
+  type ReconnectTranscriptItem,
+  type SpeakingState,
+  type SttFinalEvent,
+  type SttPartialEvent,
+  type ToolItemStatus,
+  type ToolPhase,
+  type ToolStateEvent,
+  type ToolTranscriptItem,
+  TRANSCRIPT_EVENT_TYPES,
+  type TranscriptErrorEvent,
+  type TranscriptEvent,
+  type TranscriptEventStream,
+  type TranscriptEventType,
+  type TranscriptEventWord,
+  type TranscriptItem,
+  type TranscriptItemKind,
+  type TranscriptViewModel,
+  type TtsAudioEvent,
+  type UserTranscriptItem,
+  type UserTurnStatus,
+} from "./contract";
+export {
+  decodeTranscriptEvent,
+  decodeTranscriptStream,
+  type TranscriptDecodeError,
+  type TranscriptDecodeErrorCode,
+  type TranscriptDecodeResult,
+  type TranscriptStreamDecodeResult,
+} from "./decode";
+export {
+  applyTranscriptEvent,
+  initialReducerState,
+  reduceTranscriptEvents,
+  type TranscriptReducerState,
+  toViewModel,
+} from "./reduce";
+export {
+  TranscriptEventView,
+  type TranscriptEventViewProps,
+  useTranscriptEvents,
+} from "./TranscriptEventView";

--- a/packages/ui/src/native-transcript/reduce.test.ts
+++ b/packages/ui/src/native-transcript/reduce.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Reducer unit tests for the structural guarantees that the golden fixture
+ * exercises end-to-end but that are worth pinning in isolation: dedupe is a true
+ * no-op, late updates never regress a row, a partial never downgrades a final,
+ * TTS playback is transient, and a very long snapshot is handled as plain text.
+ * Deterministic; no I/O.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { TranscriptEvent } from "./contract";
+import {
+  applyTranscriptEvent,
+  initialReducerState,
+  reduceTranscriptEvents,
+  toViewModel,
+} from "./reduce";
+
+function reduce(events: TranscriptEvent[]) {
+  return reduceTranscriptEvents(events);
+}
+
+describe("applyTranscriptEvent", () => {
+  it("treats a repeated seq as a no-op (returns the same state reference)", () => {
+    const first = applyTranscriptEvent(initialReducerState(), {
+      type: "stt.final",
+      seq: 1,
+      turnId: "t",
+      text: "hi",
+    });
+    const again = applyTranscriptEvent(first, {
+      type: "stt.partial",
+      seq: 1,
+      turnId: "t",
+      text: "ignored",
+    });
+    expect(again).toBe(first);
+  });
+
+  it("does not let a partial downgrade an already-final row", () => {
+    const view = reduce([
+      { type: "stt.final", seq: 1, turnId: "t", text: "final" },
+      { type: "stt.partial", seq: 2, turnId: "t", text: "later partial" },
+    ]);
+    // A higher-seq partial after a final is unusual but must not un-finalize.
+    expect(view.items).toEqual([
+      { kind: "user", id: "t", status: "final", text: "final", words: [] },
+    ]);
+  });
+
+  it("clears the speaking indicator only when `ended` names the active utterance", () => {
+    const view = reduce([
+      { type: "tts.audio", seq: 1, utteranceId: "u1", phase: "started" },
+      { type: "tts.audio", seq: 2, utteranceId: "u2", phase: "ended" },
+    ]);
+    // u2 ended does not clear u1's playback.
+    expect(view.speaking).toEqual({ utteranceId: "u1" });
+  });
+
+  it("projects an empty accumulator to the designed empty view", () => {
+    expect(toViewModel(initialReducerState())).toEqual({
+      items: [],
+      speaking: null,
+      connection: "live",
+      lastSeq: 0,
+    });
+  });
+
+  it("carries a very long snapshot as plain text with no length bucketing", () => {
+    const long = "speech ".repeat(5000).trim();
+    const view = reduce([
+      { type: "agent.text", seq: 1, messageId: "m", text: long, final: true },
+    ]);
+    expect(view.items).toEqual([
+      { kind: "agent", id: "m", status: "final", text: long },
+    ]);
+  });
+
+  it("advances lastSeq to the max applied seq even for dropped late events", () => {
+    const view = reduce([
+      { type: "stt.final", seq: 9, turnId: "t", text: "done" },
+      { type: "stt.partial", seq: 4, turnId: "t", text: "late" },
+    ]);
+    expect(view.lastSeq).toBe(9);
+  });
+});

--- a/packages/ui/src/native-transcript/reduce.ts
+++ b/packages/ui/src/native-transcript/reduce.ts
@@ -126,18 +126,23 @@ export function applyTranscriptEvent(
   };
 
   switch (event.type) {
-    case "stt.partial":
-      upsert(event.turnId, (prev) => ({
+    case "stt.partial": {
+      // A final/cancelled turn is terminal: a stray later partial is ignored
+      // outright (not even its text is applied), so a committed utterance never
+      // reverts to an interim hypothesis.
+      const prev = entries.get(event.turnId);
+      if (prev && prev.item.kind === "user" && prev.item.status !== "partial") {
+        break;
+      }
+      upsert(event.turnId, (existing) => ({
         kind: "user",
         id: event.turnId,
-        // A partial never downgrades an already-final/cancelled row.
-        status: prev && prev.kind === "user" && prev.status !== "partial"
-          ? prev.status
-          : "partial",
+        status: "partial",
         text: event.text,
-        words: prev && prev.kind === "user" ? prev.words : [],
+        words: existing && existing.kind === "user" ? existing.words : [],
       }));
       break;
+    }
 
     case "stt.final":
       upsert(event.turnId, () => ({

--- a/packages/ui/src/native-transcript/reduce.ts
+++ b/packages/ui/src/native-transcript/reduce.ts
@@ -1,0 +1,274 @@
+/**
+ * Pure fold from the append-only `eliza.native-transcript/v1` event log to the
+ * ordered render model. This reducer IS the contract's behavioral spec — the
+ * golden fixture asserts every shell (web here; iOS/Android native next) folds
+ * to the exact same {@link TranscriptViewModel}.
+ *
+ * The four cross-bridge guarantees, all decided from structural fields only:
+ *   - Dedupe: `seq` is unique per stream, so a repeated `seq` is a no-op.
+ *   - Ordering: an item renders at its first-seen `seq`; later updates to it
+ *     never move it. Render order is therefore stable under reordering.
+ *   - Late events: an item tracks the highest `seq` applied to it (`revSeq`); an
+ *     event with `seq <= revSeq` cannot regress it (a late partial after a final
+ *     is dropped). Creation from any event is by first-seen id.
+ *   - Cancellation boundary: a `cancel` marks matching in-flight items cancelled
+ *     and bumps their `revSeq` to the cancel `seq`, so a pre-boundary straggler
+ *     is dropped while a genuinely newer (post-boundary) event still applies.
+ *
+ * Nothing here inspects transcript text or its length.
+ */
+
+import type {
+  ConnectionState,
+  SpeakingState,
+  TranscriptEvent,
+  TranscriptItem,
+  TranscriptViewModel,
+} from "./contract";
+
+interface ItemEntry {
+  item: TranscriptItem;
+  /** `seq` of the event that created this item; the stable render order. */
+  order: number;
+  /** Highest `seq` applied to this item; guards against late regressions. */
+  revSeq: number;
+}
+
+/**
+ * Internal accumulator. Kept separate from {@link TranscriptViewModel} so the
+ * render model stays free of bookkeeping (dedupe set, per-item order/revSeq) and
+ * native reducers can mirror the same split.
+ */
+export interface TranscriptReducerState {
+  entries: Map<string, ItemEntry>;
+  appliedSeqs: Set<number>;
+  speaking: SpeakingState | null;
+  connection: ConnectionState;
+  lastSeq: number;
+}
+
+export function initialReducerState(): TranscriptReducerState {
+  return {
+    entries: new Map(),
+    appliedSeqs: new Set(),
+    speaking: null,
+    connection: "live",
+    lastSeq: 0,
+  };
+}
+
+/** Whether an item is still in-flight and therefore cancellable. */
+function isInFlight(item: TranscriptItem): boolean {
+  return (
+    (item.kind === "user" && item.status === "partial") ||
+    (item.kind === "agent" && item.status === "streaming") ||
+    (item.kind === "tool" && item.status === "running")
+  );
+}
+
+/** Apply the cancelled status to an in-flight item (terminal for that row). */
+function cancelItem(item: TranscriptItem): TranscriptItem {
+  switch (item.kind) {
+    case "user":
+      return { ...item, status: "cancelled" };
+    case "agent":
+      return { ...item, status: "cancelled" };
+    case "tool":
+      return { ...item, status: "cancelled" };
+    default:
+      return item;
+  }
+}
+
+/** Does this in-flight item belong to `turnId` (for turn-scoped cancel)? */
+function belongsToTurn(item: TranscriptItem, turnId: string): boolean {
+  if (item.kind === "user") return item.id === turnId;
+  if (item.kind === "agent" || item.kind === "tool")
+    return item.turnId === turnId;
+  return false;
+}
+
+/**
+ * Fold one already-decoded event into the state. Callers pass only validated
+ * events (see `decode.ts`); this function trusts the shapes and decides purely
+ * on structural fields.
+ */
+export function applyTranscriptEvent(
+  state: TranscriptReducerState,
+  event: TranscriptEvent,
+): TranscriptReducerState {
+  // Dedupe: a `seq` we have already consumed is a no-op, regardless of type.
+  if (state.appliedSeqs.has(event.seq)) return state;
+
+  const entries = new Map(state.entries);
+  const appliedSeqs = new Set(state.appliedSeqs);
+  appliedSeqs.add(event.seq);
+  let { speaking, connection } = state;
+  const lastSeq = Math.max(state.lastSeq, event.seq);
+
+  /**
+   * Create-or-update the item at `id`. `build(prev)` returns the next item given
+   * the previous one (or undefined on first sight). An update to an existing
+   * item is dropped when the event is not newer than the last applied (`revSeq`)
+   * — this is the late-event guard.
+   */
+  const upsert = (
+    id: string,
+    build: (prev: TranscriptItem | undefined) => TranscriptItem,
+  ): void => {
+    const existing = entries.get(id);
+    if (existing && event.seq <= existing.revSeq) return; // late/stale
+    entries.set(id, {
+      item: build(existing?.item),
+      order: existing?.order ?? event.seq,
+      revSeq: event.seq,
+    });
+  };
+
+  switch (event.type) {
+    case "stt.partial":
+      upsert(event.turnId, (prev) => ({
+        kind: "user",
+        id: event.turnId,
+        // A partial never downgrades an already-final/cancelled row.
+        status: prev && prev.kind === "user" && prev.status !== "partial"
+          ? prev.status
+          : "partial",
+        text: event.text,
+        words: prev && prev.kind === "user" ? prev.words : [],
+      }));
+      break;
+
+    case "stt.final":
+      upsert(event.turnId, () => ({
+        kind: "user",
+        id: event.turnId,
+        status: "final",
+        text: event.text,
+        words: event.words ?? [],
+      }));
+      break;
+
+    case "agent.text":
+      upsert(event.messageId, (prev) => ({
+        kind: "agent",
+        id: event.messageId,
+        status: event.final ? "final" : "streaming",
+        text: event.text,
+        turnId:
+          event.turnId ?? (prev && prev.kind === "agent" ? prev.turnId : undefined),
+      }));
+      break;
+
+    case "tool.state":
+      upsert(event.callId, (prev) => ({
+        kind: "tool",
+        id: event.callId,
+        status:
+          event.phase === "started"
+            ? "running"
+            : event.phase === "succeeded"
+              ? "succeeded"
+              : "failed",
+        name: event.name,
+        detail:
+          event.detail ?? (prev && prev.kind === "tool" ? prev.detail : undefined),
+        turnId:
+          event.turnId ?? (prev && prev.kind === "tool" ? prev.turnId : undefined),
+      }));
+      break;
+
+    case "tts.audio":
+      // Playback is transient view state, not a row. `started` sets the
+      // indicator; `ended` clears it only if it still names this utterance.
+      if (event.phase === "started") {
+        speaking = {
+          utteranceId: event.utteranceId,
+          ...(event.messageId ? { messageId: event.messageId } : {}),
+        };
+      } else if (speaking && speaking.utteranceId === event.utteranceId) {
+        speaking = null;
+      }
+      break;
+
+    case "cancel": {
+      const cancelledMessageIds = new Set<string>();
+      for (const [id, entry] of entries) {
+        if (!isInFlight(entry.item)) continue;
+        if (event.scope === "turn") {
+          if (!event.turnId || !belongsToTurn(entry.item, event.turnId)) continue;
+        }
+        if (entry.item.kind === "agent") cancelledMessageIds.add(entry.item.id);
+        entries.set(id, {
+          item: cancelItem(entry.item),
+          order: entry.order,
+          // The cancel draws the boundary at its own seq: pre-boundary
+          // stragglers are dropped, post-boundary continuations still apply.
+          revSeq: Math.max(entry.revSeq, event.seq),
+        });
+      }
+      if (
+        speaking &&
+        (event.scope === "all" ||
+          (speaking.messageId !== undefined &&
+            cancelledMessageIds.has(speaking.messageId)))
+      ) {
+        speaking = null;
+      }
+      break;
+    }
+
+    case "error":
+      upsert(`error:${event.seq}`, () => ({
+        kind: "error",
+        id: `error:${event.seq}`,
+        code: event.code,
+        retryable: event.retryable,
+        ...(event.message !== undefined ? { message: event.message } : {}),
+      }));
+      break;
+
+    case "reconnect":
+      connection = event.phase === "lost" ? "lost" : "live";
+      upsert(`reconnect:${event.seq}`, () => ({
+        kind: "reconnect",
+        id: `reconnect:${event.seq}`,
+        phase: event.phase,
+        attempt: event.attempt,
+      }));
+      break;
+
+    default: {
+      // Exhaustiveness guard — an unhandled type is impossible after decode.
+      const _never: never = event;
+      void _never;
+      return state;
+    }
+  }
+
+  return { entries, appliedSeqs, speaking, connection, lastSeq };
+}
+
+/** Project the internal accumulator into the render model. */
+export function toViewModel(
+  state: TranscriptReducerState,
+): TranscriptViewModel {
+  const ordered = [...state.entries.values()].sort((a, b) =>
+    a.order !== b.order ? a.order - b.order : a.item.id < b.item.id ? -1 : 1,
+  );
+  return {
+    items: ordered.map((entry) => entry.item),
+    speaking: state.speaking,
+    connection: state.connection,
+    lastSeq: state.lastSeq,
+  };
+}
+
+/** Fold a whole (already-decoded) event sequence into a render model. */
+export function reduceTranscriptEvents(
+  events: readonly TranscriptEvent[],
+): TranscriptViewModel {
+  let state = initialReducerState();
+  for (const event of events) state = applyTranscriptEvent(state, event);
+  return toViewModel(state);
+}

--- a/packages/ui/src/native-transcript/reduce.ts
+++ b/packages/ui/src/native-transcript/reduce.ts
@@ -161,7 +161,8 @@ export function applyTranscriptEvent(
         status: event.final ? "final" : "streaming",
         text: event.text,
         turnId:
-          event.turnId ?? (prev && prev.kind === "agent" ? prev.turnId : undefined),
+          event.turnId ??
+          (prev && prev.kind === "agent" ? prev.turnId : undefined),
       }));
       break;
 
@@ -177,9 +178,11 @@ export function applyTranscriptEvent(
               : "failed",
         name: event.name,
         detail:
-          event.detail ?? (prev && prev.kind === "tool" ? prev.detail : undefined),
+          event.detail ??
+          (prev && prev.kind === "tool" ? prev.detail : undefined),
         turnId:
-          event.turnId ?? (prev && prev.kind === "tool" ? prev.turnId : undefined),
+          event.turnId ??
+          (prev && prev.kind === "tool" ? prev.turnId : undefined),
       }));
       break;
 
@@ -201,7 +204,8 @@ export function applyTranscriptEvent(
       for (const [id, entry] of entries) {
         if (!isInFlight(entry.item)) continue;
         if (event.scope === "turn") {
-          if (!event.turnId || !belongsToTurn(entry.item, event.turnId)) continue;
+          if (!event.turnId || !belongsToTurn(entry.item, event.turnId))
+            continue;
         }
         if (entry.item.kind === "agent") cancelledMessageIds.add(entry.item.id);
         entries.set(id, {


### PR DESCRIPTION
## What

Implements the core of #16440: **one typed, append-only transcript-event contract
(`eliza.native-transcript/v1`)** meant to be rendered identically by the iOS,
Android, desktop, and web shells, plus the web/DOM renderer, a language-neutral
golden fixture, and a full conformance test matrix.

Rebuilt fresh from `develop`. Does **not** cherry-pick the closed monolith #16200,
and deliberately does **not** reintroduce its banned anti-pattern of bucketing
state by `text.length` — every reduction/render decision here is made from
**structural fields only** (the `type` discriminant, `phase`/`status`/`final`
flags, stable ids, and the monotonic `seq`).

## Contract (`packages/ui/src/native-transcript/`)

- `contract.ts` — discriminated-union `TranscriptEvent` (8 types: `stt.partial`,
  `stt.final`, `agent.text`, `tool.state`, `tts.audio`, `cancel`, `error`,
  `reconnect`) + the reduced `TranscriptViewModel` (ordered `TranscriptItem[]` +
  transient `speaking`/`connection`). Each event is a self-contained **snapshot**
  (not a delta), so a bridge that dupes/reorders/drops a frame never buffers.
- `decode.ts` — strict boundary decoder. Every field validated; a malformed frame
  yields a typed `{ ok: false, error }` (never a fabricated default, never a throw
  on per-event input) — error-policy **J3**. `decodeTranscriptStream` keeps good
  events and collects rejected ones with index + reason.
- `reduce.ts` — the pure reducer that IS the behavioral spec: **dedupe** (unique
  `seq` → repeat is a no-op), **stable ordering** (item renders at its first-seen
  `seq`), **late-event** guard (per-item `revSeq`; a late partial after a final is
  dropped), and the **cancellation boundary** (`cancel` marks in-flight items
  cancelled and bumps their `revSeq` to the cancel `seq`, so pre-boundary
  stragglers drop while a post-boundary continuation still applies).
- `TranscriptEventView.tsx` — web/DOM renderer. Reuses the chat `parseSegments`
  pipeline for agent prose+code; renders each row from `item.kind`/`item.status`;
  `dir="auto"` bidi-resolves Unicode/RTL; the error row is a distinct
  `role="alert"` state (J4). No text/length inspection anywhere. Exposed as the
  `@elizaos/ui/native-transcript` subpath.

## Case-matrix conformance

`fixtures/native-transcript-golden.json` is the **language-neutral** golden
fixture (schema-tagged `{ schema, scenarios[] }`) so the iOS/Android native
decoders can load the exact same bytes and assert the same reduced model. The
conformance test decodes + reduces every scenario and deep-equals `expectView`.

Cases covered (golden fixture + focused unit tests): malformed, duplicated,
reordered, concurrent (interleaved turns), empty, Unicode/RTL, long, offline
(reconnect lost/restored), permission-denied (error), and cancellation boundary.

## Test results (web-verified, per-file vitest)

```
bunx vitest run src/native-transcript/    → 4 files, 42 tests passed
  contract.conformance.test.ts  18 passed   (golden matrix: decode + reduce)
  decode.test.ts                            (field-level rejections, stream guards)
  reduce.test.ts                            (dedupe no-op, late guard, terminal turn, long text)
  TranscriptEventView.test.tsx              (jsdom DOM: roles/status/dir/code/alert/speaking)
bunx tsgo --noEmit -p packages/ui          → EXIT 0 (no diagnostics)
```

## Web-verified vs device-gated (explicit)

- **Web-verified here:** contract, decoder, reducer, web renderer, and the full
  conformance matrix — all as fast per-file vitest (results above). Evidence
  screenshots/video are a lightweight standalone render of the component
  (`react-dom/server` → the real `parseSegments`+`CodeBlock`), since the renderer
  is not yet wired into a routed page (that integration is a separate UI task).
- **Device-gated remainder (NOT done here — needs a real iOS-sim / Android-emu
  pass):** the SwiftUI and Android-Views decoders that consume
  `native-transcript-golden.json`. No native transcript decoder is tracked on
  `develop` today (the earlier #16200 native work exists only in gitignored
  generated project dirs), so there was nothing to wire. This PR defines the
  contract + golden fixture so those decoders **can** conform; the fixture is the
  cross-language source of truth. I ran **no** iOS simulator or Android emulator
  and claim **no** native verification.

# Evidence Details

Web renderer of the contract's golden events (user STT right-aligned, agent
message with a lifted `js` code block + copy button, tool status row, RTL Arabic
+ emoji turn, a distinct permission-denied error alert, and the live speaking
indicator).

<!-- evidence-row:before-screenshots -->
N/A - wholly new surface; `TranscriptEventView.tsx` and its entire module are added, so there is no prior UI state to diff.
<!-- evidence-row:after-screenshots -->
Desktop: ![desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16507-transcript-desktop.png)
Mobile: ![mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16507-transcript-mobile.png)
OCR text readout of the rendered pixels (confirms the visible text is real, not overlapping): [16507-transcript-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16507-transcript-ocr.txt)
<!-- evidence-row:walkthrough-video -->
Walkthrough (scroll through all rows): https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16507-transcript-walkthrough.mp4
<!-- evidence-row:backend-logs -->
N/A - no server code touched; this is a pure client-side contract + renderer.
<!-- evidence-row:frontend-logs -->
N/A - the renderer is pure (no network/fetch/state I/O); its DOM behavior is asserted directly in `TranscriptEventView.test.tsx` (jsdom).
<!-- evidence-row:llm-trajectory -->
N/A - no agent/action/provider/prompt/model behavior changed; the contract is transport-agnostic and sits above the model layer.
<!-- evidence-row:domain-artifacts -->
N/A - no persisted domain artifacts (no DB rows/memories/scheduled tasks/on-chain output). The nearest artifact is the reduced `TranscriptViewModel`, whose exact output for all 18 golden scenarios is pinned by `contract.conformance.test.ts`.

Refs #16440. Draft - do not merge.
