### PR TITLE
feat(os): unify chat, voice, and transcription intent routing

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -269,6 +269,11 @@
       "import": "./dist/navigation/index.js",
       "default": "./dist/navigation/index.js"
     },
+    "./os-intent": {
+      "types": "./dist/os-intent/index.d.ts",
+      "import": "./dist/os-intent/index.js",
+      "default": "./dist/os-intent/index.js"
+    },
     "./platform": {
       "types": "./dist/platform/index.d.ts",
       "import": "./dist/platform/index.js",

--- a/packages/ui/src/os-intent/apply-command.test.ts
+++ b/packages/ui/src/os-intent/apply-command.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Executor unit tests: each routed command drives the one controller's matching
+ * method, send forwards its options, and the transcription toggle is idempotent
+ * (never turns a live session off on a redelivered start). The controller is a
+ * spy double of the narrow {@link IntentControllerTarget} surface the executor
+ * touches. Deterministic; no I/O.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyOsIntentCommand,
+  applyOsIntentCommands,
+  type IntentControllerTarget,
+} from "./apply-command";
+
+function spyController(overrides: Partial<IntentControllerTarget> = {}): {
+  controller: IntentControllerTarget;
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  startRecording: ReturnType<typeof vi.fn>;
+  stopRecording: ReturnType<typeof vi.fn>;
+  toggleTranscriptionMode: ReturnType<typeof vi.fn>;
+  stopTranscriptionAndMic: ReturnType<typeof vi.fn>;
+} {
+  const open = vi.fn();
+  const send = vi.fn();
+  const startRecording = vi.fn();
+  const stopRecording = vi.fn();
+  const toggleTranscriptionMode = vi.fn();
+  const stopTranscriptionAndMic = vi.fn();
+  const controller: IntentControllerTarget = {
+    open,
+    send,
+    startRecording,
+    stopRecording,
+    toggleTranscriptionMode,
+    stopTranscriptionAndMic,
+    transcriptionMode: false,
+    ...overrides,
+  };
+  return {
+    controller,
+    open,
+    send,
+    startRecording,
+    stopRecording,
+    toggleTranscriptionMode,
+    stopTranscriptionAndMic,
+  };
+}
+
+describe("applyOsIntentCommand", () => {
+  it("open → controller.open()", () => {
+    const s = spyController();
+    applyOsIntentCommand(s.controller, { kind: "open" });
+    expect(s.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("send → controller.send(text, options)", () => {
+    const s = spyController();
+    applyOsIntentCommand(s.controller, {
+      kind: "send",
+      text: "hi",
+      channelType: "VOICE_DM",
+    });
+    expect(s.send).toHaveBeenCalledWith("hi", { channelType: "VOICE_DM" });
+  });
+
+  it("send with no options → empty options object", () => {
+    const s = spyController();
+    applyOsIntentCommand(s.controller, { kind: "send", text: "hi" });
+    expect(s.send).toHaveBeenCalledWith("hi", {});
+  });
+
+  it("startRecording → controller.startRecording(intent)", () => {
+    const s = spyController();
+    applyOsIntentCommand(s.controller, {
+      kind: "startRecording",
+      intent: "dictate",
+    });
+    expect(s.startRecording).toHaveBeenCalledWith("dictate");
+  });
+
+  it("stopRecording → controller.stopRecording()", () => {
+    const s = spyController();
+    applyOsIntentCommand(s.controller, { kind: "stopRecording" });
+    expect(s.stopRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggleTranscriptionMode toggles ON when transcription is off", () => {
+    const s = spyController({ transcriptionMode: false });
+    applyOsIntentCommand(s.controller, { kind: "toggleTranscriptionMode" });
+    expect(s.toggleTranscriptionMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggleTranscriptionMode is a no-op when transcription is already on (idempotent)", () => {
+    const s = spyController({ transcriptionMode: true });
+    applyOsIntentCommand(s.controller, { kind: "toggleTranscriptionMode" });
+    expect(s.toggleTranscriptionMode).not.toHaveBeenCalled();
+  });
+
+  it("stopTranscriptionAndMic → controller.stopTranscriptionAndMic()", () => {
+    const s = spyController({ transcriptionMode: true });
+    applyOsIntentCommand(s.controller, { kind: "stopTranscriptionAndMic" });
+    expect(s.stopTranscriptionAndMic).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("applyOsIntentCommands", () => {
+  it("applies an ordered command list in sequence", () => {
+    const s = spyController();
+    const order: string[] = [];
+    s.open.mockImplementation(() => order.push("open"));
+    s.send.mockImplementation(() => order.push("send"));
+    applyOsIntentCommands(s.controller, [
+      { kind: "open" },
+      { kind: "send", text: "hi" },
+    ]);
+    expect(order).toEqual(["open", "send"]);
+  });
+});

--- a/packages/ui/src/os-intent/apply-command.ts
+++ b/packages/ui/src/os-intent/apply-command.ts
@@ -54,14 +54,19 @@ export function applyOsIntentCommand(
       // running, so a redelivered start-transcription command can never toggle a
       // live session OFF. The intent dedupe store prevents most redelivery; this
       // guards the residual race where two windows apply before the snapshot syncs.
-      if (!controller.transcriptionMode) void controller.toggleTranscriptionMode();
+      if (!controller.transcriptionMode)
+        void controller.toggleTranscriptionMode();
       return;
     case "stopTranscriptionAndMic":
       void controller.stopTranscriptionAndMic();
       return;
     default: {
       const _exhaustive: never = command;
-      return _exhaustive;
+      // Unreachable: the union is exhausted above, so a new command kind is a
+      // compile error at the assignment. Fail fast if one slips through at runtime.
+      throw new Error(
+        `[applyOsIntentCommand] unhandled command: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }

--- a/packages/ui/src/os-intent/apply-command.ts
+++ b/packages/ui/src/os-intent/apply-command.ts
@@ -1,0 +1,75 @@
+/**
+ * Runs a routed {@link IntentControllerCommand} against the one live
+ * {@link ShellController} — the single engine that owns chat send, mic capture,
+ * and transcription. Routing (`router.ts`) never touches the DOM or the mic; it
+ * emits commands and this executor is the only place they take effect, so an
+ * intent can never open a second session or fight the audio owner.
+ *
+ * The switch is exhaustive: a command added to the union without a handler is a
+ * compile error, never a silent drop.
+ */
+import type { ShellController } from "../components/shell/useShellController";
+import type { IntentControllerCommand } from "./contract";
+
+/**
+ * The exact subset of {@link ShellController} the intent executor drives. A real
+ * controller is assignable to it; narrowing the dependency keeps the executor
+ * honest about what it touches (send + capture + transcription, nothing else) and
+ * lets tests build a precise double with no casts.
+ */
+export type IntentControllerTarget = Pick<
+  ShellController,
+  | "open"
+  | "send"
+  | "startRecording"
+  | "stopRecording"
+  | "toggleTranscriptionMode"
+  | "stopTranscriptionAndMic"
+  | "transcriptionMode"
+>;
+
+export function applyOsIntentCommand(
+  controller: IntentControllerTarget,
+  command: IntentControllerCommand,
+): void {
+  switch (command.kind) {
+    case "open":
+      controller.open();
+      return;
+    case "send":
+      controller.send(command.text, {
+        ...(command.channelType ? { channelType: command.channelType } : {}),
+        ...(command.images ? { images: command.images } : {}),
+        ...(command.metadata ? { metadata: command.metadata } : {}),
+      });
+      return;
+    case "startRecording":
+      controller.startRecording(command.intent);
+      return;
+    case "stopRecording":
+      controller.stopRecording();
+      return;
+    case "toggleTranscriptionMode":
+      // Idempotent start: only toggle ON when transcription is not already
+      // running, so a redelivered start-transcription command can never toggle a
+      // live session OFF. The intent dedupe store prevents most redelivery; this
+      // guards the residual race where two windows apply before the snapshot syncs.
+      if (!controller.transcriptionMode) void controller.toggleTranscriptionMode();
+      return;
+    case "stopTranscriptionAndMic":
+      void controller.stopTranscriptionAndMic();
+      return;
+    default: {
+      const _exhaustive: never = command;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Apply an ordered command list (an intent's full effect) in sequence. */
+export function applyOsIntentCommands(
+  controller: IntentControllerTarget,
+  commands: readonly IntentControllerCommand[],
+): void {
+  for (const command of commands) applyOsIntentCommand(controller, command);
+}

--- a/packages/ui/src/os-intent/contract.test.ts
+++ b/packages/ui/src/os-intent/contract.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Contract-table invariants: the constant tables (targets, prerequisites,
+ * auto-start set) cover every intent type exactly, and the auto-start/prereq
+ * shapes match the design (only mic-starting intents are consent-gated; every
+ * stop-* is prerequisite-free so it stays reversible). Deterministic; no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_START_INTENT_TYPES,
+  INTENT_PREREQUISITES,
+  INTENT_TARGET,
+  OS_INTENT_TYPES,
+} from "./contract";
+
+describe("os-intent contract tables", () => {
+  it("assigns a target to every intent type and nothing extra", () => {
+    expect(Object.keys(INTENT_TARGET).sort()).toEqual(
+      [...OS_INTENT_TYPES].sort(),
+    );
+  });
+
+  it("declares prerequisites for every intent type", () => {
+    expect(Object.keys(INTENT_PREREQUISITES).sort()).toEqual(
+      [...OS_INTENT_TYPES].sort(),
+    );
+  });
+
+  it("marks exactly the two mic-starting intents as auto-start", () => {
+    expect([...AUTO_START_INTENT_TYPES].sort()).toEqual([
+      "start-transcription",
+      "start-voice",
+    ]);
+  });
+
+  it("gives every stop-* intent zero prerequisites (always reversible)", () => {
+    expect(INTENT_PREREQUISITES["stop-voice"]).toEqual([]);
+    expect(INTENT_PREREQUISITES["stop-transcription"]).toEqual([]);
+  });
+
+  it("requires voice-capture on exactly the auto-start intents", () => {
+    for (const type of OS_INTENT_TYPES) {
+      const needsCapture = INTENT_PREREQUISITES[type].includes("voice-capture");
+      expect(needsCapture).toBe(AUTO_START_INTENT_TYPES.has(type));
+    }
+  });
+});

--- a/packages/ui/src/os-intent/contract.ts
+++ b/packages/ui/src/os-intent/contract.ts
@@ -209,9 +209,20 @@ export const INTENT_PREREQUISITES: Record<
 > = {
   "open-chat": ["session"],
   send: ["session"],
-  "start-voice": ["session", "unlocked", "foreground", "microphone", "voice-capture"],
+  "start-voice": [
+    "session",
+    "unlocked",
+    "foreground",
+    "microphone",
+    "voice-capture",
+  ],
   "stop-voice": [],
-  "start-transcription": ["unlocked", "foreground", "microphone", "voice-capture"],
+  "start-transcription": [
+    "unlocked",
+    "foreground",
+    "microphone",
+    "voice-capture",
+  ],
   "stop-transcription": [],
   "continue-conversation": ["session"],
 };

--- a/packages/ui/src/os-intent/contract.ts
+++ b/packages/ui/src/os-intent/contract.ts
@@ -1,0 +1,295 @@
+/**
+ * `eliza.os-intent/v1` — the one structural intent vocabulary that unifies how
+ * chat, voice, and transcription are launched across every entry point: iOS App
+ * Intents / Siri, Android app-actions + shortcuts, desktop deep links, tray and
+ * widget controls, notification taps, and in-app invocations. A launch surface
+ * emits a typed {@link OsIntent}; the routing authority (`router.ts`) decides —
+ * from STRUCTURAL fields only — whether to dispatch it to the one shared shell
+ * controller, dedupe it, block it on an unmet prerequisite, gate an auto-start on
+ * consent, or degrade visibly on a device that cannot honor it.
+ *
+ * Design rules that keep routing deterministic and safe:
+ *   - Behavior derives from the discriminant `type`, the declared prerequisites,
+ *     and the routing context — NEVER from prompt or transcript text. The native
+ *     surfaces historically emitted a free-form `action` string
+ *     (`ask`/`chat`/`voice`/…); that string is untrusted input mapped to a typed
+ *     intent at the decode boundary (`decode.ts`) and never inspected again.
+ *   - `intentId` is the stable idempotency key. The same launch — redelivered by
+ *     a retried deep link, a re-tapped notification, a second window, or a
+ *     restored/crashed-then-reopened session — carries the same `intentId`, so
+ *     the authority applies it exactly once.
+ *   - Auto-start intents (mic capture) are consent-gated and reversible: a
+ *     `start-*` intent only fires with recorded consent, and every `start-*` has
+ *     a matching `stop-*` that is always allowed (you can always turn capture
+ *     off).
+ *
+ * This module is pure type + constant declarations (runtime validation lives in
+ * `decode.ts`, routing in `router.ts`) so it is safe to import from any layer,
+ * native bridge shim included.
+ */
+import type { ImageAttachment } from "../api/client-types-chat";
+
+/** Versioned schema identifier carried by an intent envelope. */
+export const OS_INTENT_SCHEMA = "eliza.os-intent/v1" as const;
+export type OsIntentSchema = typeof OS_INTENT_SCHEMA;
+
+/**
+ * Where an intent originated. Grouped by transport so the router can apply
+ * transport-specific policy (e.g. a background notification tap may not
+ * auto-start the mic on iOS). Every value a native surface stamps into the
+ * `source` query key of an `elizaos://…` deep link appears here.
+ */
+export type IntentSource =
+  | "ios-app-intent"
+  | "ios-app-shortcuts"
+  | "ios-widget"
+  | "siri"
+  | "macos-shortcuts"
+  | "macos-siri"
+  | "android-app-actions"
+  | "android-assist"
+  | "android-static-shortcut"
+  | "android-quick-settings"
+  | "desktop-deep-link"
+  | "desktop-tray"
+  | "desktop-hotkey"
+  | "notification"
+  | "assistant-entry"
+  | "in-app";
+
+/** Every recognized source, for the decoder's known-source gate. */
+export const INTENT_SOURCES: readonly IntentSource[] = [
+  "ios-app-intent",
+  "ios-app-shortcuts",
+  "ios-widget",
+  "siri",
+  "macos-shortcuts",
+  "macos-siri",
+  "android-app-actions",
+  "android-assist",
+  "android-static-shortcut",
+  "android-quick-settings",
+  "desktop-deep-link",
+  "desktop-tray",
+  "desktop-hotkey",
+  "notification",
+  "assistant-entry",
+  "in-app",
+] as const;
+
+/** The shell surface an intent addresses. Derived structurally, never parsed. */
+export type IntentTarget = "chat" | "voice" | "transcription";
+
+// ── Intents (the typed launch vocabulary) ──────────────────────────────
+
+/** Fields every intent carries: its dedupe identity and provenance. */
+interface IntentBase {
+  /** Stable idempotency key. Identical across every redelivery of one launch. */
+  intentId: string;
+  source: IntentSource;
+  /** Epoch ms the launch was issued; drives staleness rejection when present. */
+  issuedAt?: number;
+}
+
+/** Bring the chat surface forward without sending anything. */
+export interface OpenChatIntent extends IntentBase {
+  type: "open-chat";
+}
+
+/** Open chat and submit `text` as a turn (App-Intent "ask", assist smart-reply). */
+export interface SendIntent extends IntentBase {
+  type: "send";
+  text: string;
+  /** `VOICE_DM` requests a spoken reply; defaults to a typed `DM` turn. */
+  channelType?: "DM" | "VOICE_DM";
+  images?: ImageAttachment[];
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Auto-start microphone capture. `converse` sends a spoken turn; `dictate` routes
+ * the final transcript to the composer draft without sending. Consent-gated.
+ */
+export interface StartVoiceIntent extends IntentBase {
+  type: "start-voice";
+  mode: "converse" | "dictate";
+}
+
+/** Stop microphone capture. Always permitted (the reverse of {@link StartVoiceIntent}). */
+export interface StopVoiceIntent extends IntentBase {
+  type: "stop-voice";
+}
+
+/**
+ * Auto-start long-form transcription: continuous capture into one recording
+ * session with the agent held quiet until an exit phrase. Consent-gated.
+ */
+export interface StartTranscriptionIntent extends IntentBase {
+  type: "start-transcription";
+}
+
+/** Stop transcription and the mic. Always permitted (the reverse of start). */
+export interface StopTranscriptionIntent extends IntentBase {
+  type: "stop-transcription";
+}
+
+/** Reopen the ongoing conversation (a notification tap / "resume" affordance). */
+export interface ContinueConversationIntent extends IntentBase {
+  type: "continue-conversation";
+}
+
+export type OsIntent =
+  | OpenChatIntent
+  | SendIntent
+  | StartVoiceIntent
+  | StopVoiceIntent
+  | StartTranscriptionIntent
+  | StopTranscriptionIntent
+  | ContinueConversationIntent;
+
+export type OsIntentType = OsIntent["type"];
+
+/** Every recognized intent discriminant, for the decoder's known-type gate. */
+export const OS_INTENT_TYPES: readonly OsIntentType[] = [
+  "open-chat",
+  "send",
+  "start-voice",
+  "stop-voice",
+  "start-transcription",
+  "stop-transcription",
+  "continue-conversation",
+] as const;
+
+/** The shell surface each intent type addresses. */
+export const INTENT_TARGET: Record<OsIntentType, IntentTarget> = {
+  "open-chat": "chat",
+  send: "chat",
+  "start-voice": "voice",
+  "stop-voice": "voice",
+  "start-transcription": "transcription",
+  "stop-transcription": "transcription",
+  "continue-conversation": "chat",
+};
+
+/**
+ * Intent types that BEGIN microphone capture. These are the only ones subject to
+ * the consent gate and the foreground/permission/support prerequisites; the
+ * matching `stop-*` intents are never auto-start (turning capture off is always
+ * allowed, so a stuck session is always recoverable).
+ */
+export const AUTO_START_INTENT_TYPES: ReadonlySet<OsIntentType> = new Set([
+  "start-voice",
+  "start-transcription",
+]);
+
+// ── Prerequisites ──────────────────────────────────────────────────────
+
+/**
+ * A condition the routing context must satisfy before an intent can fire.
+ * Checked structurally against {@link RoutingContext}; an unmet prerequisite
+ * yields a `blocked`/`degraded` outcome, never a silent no-op.
+ *
+ *   - `session`     an unexpired agent session/auth is available.
+ *   - `unlocked`    the device is unlocked (a locked device cannot capture).
+ *   - `foreground`  the app is foreground (platforms forbid background capture).
+ *   - `microphone`  microphone permission is granted.
+ *   - `voice-capture`  the platform supports voice capture at all (else degrade).
+ */
+export type IntentPrerequisite =
+  | "session"
+  | "unlocked"
+  | "foreground"
+  | "microphone"
+  | "voice-capture";
+
+/** The prerequisites each intent type declares, checked in `router.ts`. */
+export const INTENT_PREREQUISITES: Record<
+  OsIntentType,
+  readonly IntentPrerequisite[]
+> = {
+  "open-chat": ["session"],
+  send: ["session"],
+  "start-voice": ["session", "unlocked", "foreground", "microphone", "voice-capture"],
+  "stop-voice": [],
+  "start-transcription": ["unlocked", "foreground", "microphone", "voice-capture"],
+  "stop-transcription": [],
+  "continue-conversation": ["session"],
+};
+
+// ── Controller commands (the routing output) ───────────────────────────
+
+/**
+ * The subset of the shared shell-controller command surface (#16442) that OS
+ * intents produce. Kept structurally identical to that union's members so ONE
+ * executor drives the single live engine (`apply-command.ts` → `ShellController`)
+ * and no intent ever spins up a second chat/voice session. Routing emits these;
+ * the authority never touches the DOM or the mic directly.
+ */
+export type IntentControllerCommand =
+  | { kind: "open" }
+  | {
+      kind: "send";
+      text: string;
+      channelType?: "DM" | "VOICE_DM";
+      images?: ImageAttachment[];
+      metadata?: Record<string, unknown>;
+    }
+  | { kind: "startRecording"; intent: "converse" | "dictate" }
+  | { kind: "stopRecording" }
+  | { kind: "toggleTranscriptionMode" }
+  | { kind: "stopTranscriptionAndMic" };
+
+export type IntentControllerCommandKind = IntentControllerCommand["kind"];
+
+// ── Outcomes (the typed result of routing) ─────────────────────────────
+
+/** Recoverable reason an intent could not fire now; the user/agent can fix it
+ *  and the same `intentId` will route on retry (blocked intents are not recorded
+ *  as applied). */
+export type IntentBlockReason =
+  | "unauthenticated"
+  | "auth-expired"
+  | "locked"
+  | "backgrounded"
+  | "microphone-denied";
+
+/** Reason a device fundamentally cannot honor an intent; the shell must show a
+ *  visible unavailable state rather than pretend it ran. */
+export type IntentDegradeReason = "voice-unsupported" | "sandboxed";
+
+/**
+ * The typed result of routing one intent. Exactly one status; every non-`routed`
+ * status is observable so a caller can render a real state (three-state rule)
+ * instead of a silent success.
+ */
+export type IntentOutcome =
+  | {
+      status: "routed";
+      intentId: string;
+      intentType: OsIntentType;
+      target: IntentTarget;
+      commands: IntentControllerCommand[];
+    }
+  | { status: "duplicate"; intentId: string; firstAppliedAt: number }
+  | { status: "stale"; intentId: string; ageMs: number; maxAgeMs: number }
+  | {
+      status: "blocked";
+      intentId: string;
+      intentType: OsIntentType;
+      reason: IntentBlockReason;
+      missing: IntentPrerequisite[];
+    }
+  | {
+      status: "consent-required";
+      intentId: string;
+      intentType: OsIntentType;
+      target: IntentTarget;
+    }
+  | {
+      status: "degraded";
+      intentId: string;
+      intentType: OsIntentType;
+      reason: IntentDegradeReason;
+    };
+
+export type IntentOutcomeStatus = IntentOutcome["status"];

--- a/packages/ui/src/os-intent/decode.test.ts
+++ b/packages/ui/src/os-intent/decode.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Boundary-decoder unit tests: per-type field validation for typed intents, the
+ * real native deep-link shapes (App Intents / Android shortcuts) mapped to typed
+ * intents, unknown-source and unrecognized-launch rejections, and the legacy
+ * assistant-launch-payload adapter. Deterministic; no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import type { AssistantLaunchPayload } from "../platform/assistant-launch-payload";
+import {
+  decodeDeepLinkIntent,
+  decodeOsIntent,
+  fromAssistantLaunchPayload,
+} from "./decode";
+
+describe("decodeOsIntent", () => {
+  it("rejects non-objects with not-an-object", () => {
+    for (const raw of [null, undefined, 7, "x", [], true]) {
+      const res = decodeOsIntent(raw);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.code).toBe("not-an-object");
+    }
+  });
+
+  it("rejects an unknown type", () => {
+    const res = decodeOsIntent({
+      type: "explode",
+      intentId: "a",
+      source: "in-app",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("unknown-type");
+  });
+
+  it("requires a non-empty intentId", () => {
+    const res = decodeOsIntent({
+      type: "open-chat",
+      intentId: "",
+      source: "in-app",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.field).toBe("intentId");
+  });
+
+  it("rejects an unknown source", () => {
+    const res = decodeOsIntent({
+      type: "open-chat",
+      intentId: "a",
+      source: "mars",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("unknown-source");
+  });
+
+  it("validates issuedAt is a finite number when present", () => {
+    const bad = decodeOsIntent({
+      type: "open-chat",
+      intentId: "a",
+      source: "in-app",
+      issuedAt: "soon",
+    });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("issuedAt");
+    const ok = decodeOsIntent({
+      type: "open-chat",
+      intentId: "a",
+      source: "in-app",
+      issuedAt: 123,
+    });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.intent.issuedAt).toBe(123);
+  });
+
+  it("requires non-empty text for send", () => {
+    const empty = decodeOsIntent({
+      type: "send",
+      intentId: "a",
+      source: "in-app",
+      text: "",
+    });
+    expect(empty.ok).toBe(false);
+    if (!empty.ok) expect(empty.error.field).toBe("text");
+    const ok = decodeOsIntent({
+      type: "send",
+      intentId: "a",
+      source: "in-app",
+      text: "hi",
+      channelType: "VOICE_DM",
+    });
+    expect(ok.ok).toBe(true);
+    if (ok.ok && ok.intent.type === "send") {
+      expect(ok.intent.text).toBe("hi");
+      expect(ok.intent.channelType).toBe("VOICE_DM");
+    }
+  });
+
+  it("rejects an invalid send channelType", () => {
+    const res = decodeOsIntent({
+      type: "send",
+      intentId: "a",
+      source: "in-app",
+      text: "hi",
+      channelType: "SMS",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.field).toBe("channelType");
+  });
+
+  it("requires a valid mode for start-voice", () => {
+    const bad = decodeOsIntent({
+      type: "start-voice",
+      intentId: "a",
+      source: "in-app",
+      mode: "sing",
+    });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("mode");
+    const ok = decodeOsIntent({
+      type: "start-voice",
+      intentId: "a",
+      source: "in-app",
+      mode: "dictate",
+    });
+    expect(ok.ok).toBe(true);
+    if (ok.ok && ok.intent.type === "start-voice")
+      expect(ok.intent.mode).toBe("dictate");
+  });
+
+  it("decodes the argument-free intents", () => {
+    for (const type of [
+      "open-chat",
+      "stop-voice",
+      "start-transcription",
+      "stop-transcription",
+      "continue-conversation",
+    ] as const) {
+      const res = decodeOsIntent({ type, intentId: "a", source: "in-app" });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.intent.type).toBe(type);
+    }
+  });
+
+  it("ignores unknown keys (forward compatibility)", () => {
+    const res = decodeOsIntent({
+      type: "open-chat",
+      intentId: "a",
+      source: "in-app",
+      futureField: 1,
+    });
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe("decodeDeepLinkIntent", () => {
+  it("rejects a non-URL", () => {
+    const res = decodeDeepLinkIntent("not a url");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("not-a-url");
+  });
+
+  it("rejects a missing/unknown source", () => {
+    const res = decodeDeepLinkIntent("elizaos://chat?action=chat");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("unknown-source");
+  });
+
+  it("maps the Android CREATE_MESSAGE 'ask' link to a send intent", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://chat?source=android-app-actions&action=ask&text=hello%20there",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok && res.intent.type === "send") {
+      expect(res.intent.text).toBe("hello there");
+      expect(res.intent.source).toBe("android-app-actions");
+    } else {
+      throw new Error("expected send intent");
+    }
+  });
+
+  it("maps 'chat' with no text to open-chat", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://chat?source=android-static-shortcut&action=chat",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.type).toBe("open-chat");
+  });
+
+  it("maps the iOS StartVoice link (voice=1) to start-voice", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://voice?source=ios-app-shortcuts&action=voice&voice=1",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok && res.intent.type === "start-voice") {
+      expect(res.intent.mode).toBe("converse");
+    } else {
+      throw new Error("expected start-voice intent");
+    }
+  });
+
+  it("prefers voice over a chat host when voice=1 is present", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://chat?source=siri&voice=1&action=ask&text=hi",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.type).toBe("start-voice");
+  });
+
+  it("maps a transcribe launch to start-transcription", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://transcribe?source=android-quick-settings&action=transcribe",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.type).toBe("start-transcription");
+  });
+
+  it("maps a resume link to continue-conversation", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://chat?source=notification&action=resume",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.type).toBe("continue-conversation");
+  });
+
+  it("normalizes a mixed-case custom-scheme host", () => {
+    const res = decodeDeepLinkIntent(
+      "ELIZAOS://Chat?source=macos-shortcuts&action=chat",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.type).toBe("open-chat");
+  });
+
+  it("returns unrecognized-launch for a non-owned deep link (feature/lifeops)", () => {
+    for (const url of [
+      "elizaos://feature/open?source=android-app-actions&feature=x",
+      "elizaos://lifeops/task/new?source=ios-app-shortcuts&action=lifeops.create&text=buy%20milk",
+    ]) {
+      const res = decodeDeepLinkIntent(url);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.code).toBe("unrecognized-launch");
+    }
+  });
+
+  it("prefers the explicit assistant.launchId as the dedupe id", () => {
+    const res = decodeDeepLinkIntent(
+      "elizaos://chat?source=siri&action=ask&text=hi&assistant.launchId=abc-123",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.intentId).toBe("abc-123");
+  });
+
+  it("synthesizes a stable dedupe id when none is provided", () => {
+    const url = "elizaos://voice?source=ios-app-shortcuts&action=voice&voice=1";
+    const a = decodeDeepLinkIntent(url);
+    const b = decodeDeepLinkIntent(url);
+    expect(a.ok && b.ok).toBe(true);
+    if (a.ok && b.ok) expect(a.intent.intentId).toBe(b.intent.intentId);
+  });
+});
+
+describe("fromAssistantLaunchPayload", () => {
+  const base: AssistantLaunchPayload = {
+    action: "ask",
+    launchId: "launch-42",
+    route: "chat",
+    source: "ios-app-shortcuts",
+    text: "draft a reply",
+  };
+
+  it("adapts a chat-send payload to a send intent keyed on its launchId", () => {
+    const res = fromAssistantLaunchPayload(base);
+    expect(res.ok).toBe(true);
+    if (res.ok && res.intent.type === "send") {
+      expect(res.intent.intentId).toBe("launch-42");
+      expect(res.intent.text).toBe("draft a reply");
+    } else {
+      throw new Error("expected send intent");
+    }
+  });
+
+  it("adapts an action-less open to open-chat", () => {
+    const res = fromAssistantLaunchPayload({ ...base, action: null, text: "" });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.intent.type).toBe("open-chat");
+  });
+
+  it("rejects an unknown source", () => {
+    const res = fromAssistantLaunchPayload({ ...base, source: "telepathy" });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("unknown-source");
+  });
+});

--- a/packages/ui/src/os-intent/decode.ts
+++ b/packages/ui/src/os-intent/decode.ts
@@ -16,13 +16,13 @@
  * having it forced into this vocabulary.
  */
 import {
-  type AssistantLaunchPayload,
   ASSISTANT_LAUNCH_TEXT_KEYS,
+  type AssistantLaunchPayload,
 } from "../platform/assistant-launch-payload";
 import {
   INTENT_SOURCES,
-  OS_INTENT_TYPES,
   type IntentSource,
+  OS_INTENT_TYPES,
   type OsIntent,
   type OsIntentType,
 } from "./contract";
@@ -89,17 +89,32 @@ export function decodeOsIntent(raw: unknown): IntentDecodeResult {
     return fail("missing-field", "`intentId` is required", "intentId");
   }
   if (!isIntentSource(record.source)) {
-    return fail("unknown-source", `unknown intent source: ${String(record.source)}`, "source");
+    return fail(
+      "unknown-source",
+      `unknown intent source: ${String(record.source)}`,
+      "source",
+    );
   }
   let issuedAt: number | undefined;
   if ("issuedAt" in record && record.issuedAt !== undefined) {
-    if (typeof record.issuedAt !== "number" || !Number.isFinite(record.issuedAt)) {
-      return fail("invalid-field", "`issuedAt` must be a finite number", "issuedAt");
+    if (
+      typeof record.issuedAt !== "number" ||
+      !Number.isFinite(record.issuedAt)
+    ) {
+      return fail(
+        "invalid-field",
+        "`issuedAt` must be a finite number",
+        "issuedAt",
+      );
     }
     issuedAt = record.issuedAt;
   }
 
-  const base = { intentId: record.intentId, source: record.source, ...(issuedAt !== undefined ? { issuedAt } : {}) };
+  const base = {
+    intentId: record.intentId,
+    source: record.source,
+    ...(issuedAt !== undefined ? { issuedAt } : {}),
+  };
   const intentType = type as OsIntentType;
 
   switch (intentType) {
@@ -108,7 +123,11 @@ export function decodeOsIntent(raw: unknown): IntentDecodeResult {
         return fail("invalid-field", "`text` must be a string", "text");
       }
       if (record.text.length === 0) {
-        return fail("missing-field", "`send` requires non-empty `text`", "text");
+        return fail(
+          "missing-field",
+          "`send` requires non-empty `text`",
+          "text",
+        );
       }
       if (
         "channelType" in record &&
@@ -116,7 +135,11 @@ export function decodeOsIntent(raw: unknown): IntentDecodeResult {
         record.channelType !== "DM" &&
         record.channelType !== "VOICE_DM"
       ) {
-        return fail("invalid-field", "`channelType` must be DM|VOICE_DM", "channelType");
+        return fail(
+          "invalid-field",
+          "`channelType` must be DM|VOICE_DM",
+          "channelType",
+        );
       }
       return {
         ok: true,
@@ -134,7 +157,10 @@ export function decodeOsIntent(raw: unknown): IntentDecodeResult {
       if (record.mode !== "converse" && record.mode !== "dictate") {
         return fail("invalid-field", "`mode` must be converse|dictate", "mode");
       }
-      return { ok: true, intent: { type: "start-voice", ...base, mode: record.mode } };
+      return {
+        ok: true,
+        intent: { type: "start-voice", ...base, mode: record.mode },
+      };
     }
     case "open-chat":
     case "stop-voice":
@@ -162,7 +188,11 @@ function resolveLaunchIntentType(
   hasText: boolean,
 ): OsIntentType | null {
   if (voiceFlag || action === "voice" || host === "voice") return "start-voice";
-  if (action === "transcribe" || action === "transcription" || host === "transcribe") {
+  if (
+    action === "transcribe" ||
+    action === "transcription" ||
+    host === "transcribe"
+  ) {
     return "start-transcription";
   }
   if (action === "continue" || action === "resume" || host === "continue") {
@@ -228,7 +258,11 @@ export function decodeDeepLinkIntent(url: string): IntentDecodeResult {
   const params = parsed.searchParams;
   const source = params.get("source")?.trim() ?? "";
   if (!isIntentSource(source)) {
-    return fail("unknown-source", `unknown or missing launch source: ${source || "(none)"}`, "source");
+    return fail(
+      "unknown-source",
+      `unknown or missing launch source: ${source || "(none)"}`,
+      "source",
+    );
   }
 
   const host = parsed.host.toLowerCase();
@@ -236,15 +270,27 @@ export function decodeDeepLinkIntent(url: string): IntentDecodeResult {
   const voiceFlag = params.get("voice")?.trim() === "1";
   const text = readLaunchText(params);
 
-  const intentType = resolveLaunchIntentType(host, action, voiceFlag, text.length > 0);
+  const intentType = resolveLaunchIntentType(
+    host,
+    action,
+    voiceFlag,
+    text.length > 0,
+  );
   if (!intentType) {
-    return fail("unrecognized-launch", `deep link is not a chat/voice/transcription launch: ${url}`);
+    return fail(
+      "unrecognized-launch",
+      `deep link is not a chat/voice/transcription launch: ${url}`,
+    );
   }
 
   const intentId =
-    params.get("assistant.launchId")?.trim() || `${source}:${host}:${action}:${text}`;
+    params.get("assistant.launchId")?.trim() ||
+    `${source}:${host}:${action}:${text}`;
 
-  return { ok: true, intent: buildLaunchIntent(intentType, source, intentId, text) };
+  return {
+    ok: true,
+    intent: buildLaunchIntent(intentType, source, intentId, text),
+  };
 }
 
 /**
@@ -257,18 +303,35 @@ export function fromAssistantLaunchPayload(
   payload: AssistantLaunchPayload,
 ): IntentDecodeResult {
   if (!isIntentSource(payload.source)) {
-    return fail("unknown-source", `unknown launch source: ${payload.source}`, "source");
+    return fail(
+      "unknown-source",
+      `unknown launch source: ${payload.source}`,
+      "source",
+    );
   }
   const host = payload.route.toLowerCase();
   const action = (payload.action ?? "").toLowerCase();
   const text = payload.text.trim();
 
-  const intentType = resolveLaunchIntentType(host, action, false, text.length > 0);
+  const intentType = resolveLaunchIntentType(
+    host,
+    action,
+    false,
+    text.length > 0,
+  );
   if (!intentType) {
-    return fail("unrecognized-launch", `launch payload is not a chat/voice/transcription intent`);
+    return fail(
+      "unrecognized-launch",
+      `launch payload is not a chat/voice/transcription intent`,
+    );
   }
   return {
     ok: true,
-    intent: buildLaunchIntent(intentType, payload.source, payload.launchId, text),
+    intent: buildLaunchIntent(
+      intentType,
+      payload.source,
+      payload.launchId,
+      text,
+    ),
   };
 }

--- a/packages/ui/src/os-intent/decode.ts
+++ b/packages/ui/src/os-intent/decode.ts
@@ -1,0 +1,274 @@
+/**
+ * Boundary decoder for the OS-intent vocabulary. Everything that arrives from
+ * outside the app — a native bridge speaking the vocabulary, an `elizaos://…`
+ * deep link, a notification tap, the legacy assistant-launch payload — is
+ * validated here into a typed {@link OsIntent} before it reaches the router, so
+ * `router.ts` trusts its input completely.
+ *
+ * A malformed input yields an explicit typed failure (`{ ok: false, error }`),
+ * never a fabricated-valid default and never a throw (error-policy J3:
+ * untrusted-input sanitizing produces an explicit "invalid" result). The
+ * deep-link/legacy adapters are where the historical free-form `action` string
+ * (`ask`/`chat`/`voice`/…) is mapped to a typed intent — the ONE place that
+ * string is interpreted; structural routing downstream never sees it. An input
+ * this app does not own (a `feature`/`lifeops` deep link) returns
+ * `unrecognized-launch` so the caller keeps its existing routing rather than
+ * having it forced into this vocabulary.
+ */
+import {
+  type AssistantLaunchPayload,
+  ASSISTANT_LAUNCH_TEXT_KEYS,
+} from "../platform/assistant-launch-payload";
+import {
+  INTENT_SOURCES,
+  OS_INTENT_TYPES,
+  type IntentSource,
+  type OsIntent,
+  type OsIntentType,
+} from "./contract";
+
+/** Machine-readable reason a raw input failed to decode. */
+export type IntentDecodeErrorCode =
+  | "not-an-object"
+  | "unknown-type"
+  | "unknown-source"
+  | "missing-field"
+  | "invalid-field"
+  | "not-a-url"
+  | "unrecognized-launch";
+
+export interface IntentDecodeError {
+  code: IntentDecodeErrorCode;
+  /** The offending field, when the failure is field-specific. */
+  field?: string;
+  message: string;
+}
+
+export type IntentDecodeResult =
+  | { ok: true; intent: OsIntent }
+  | { ok: false; error: IntentDecodeError };
+
+function fail(
+  code: IntentDecodeErrorCode,
+  message: string,
+  field?: string,
+): { ok: false; error: IntentDecodeError } {
+  return { ok: false, error: { code, field, message } };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+const INTENT_TYPE_SET: ReadonlySet<string> = new Set(OS_INTENT_TYPES);
+const INTENT_SOURCE_SET: ReadonlySet<string> = new Set(INTENT_SOURCES);
+
+function isIntentSource(value: unknown): value is IntentSource {
+  return typeof value === "string" && INTENT_SOURCE_SET.has(value);
+}
+
+/**
+ * Validate a raw value already shaped as an intent (a native bridge that speaks
+ * the vocabulary directly). Unknown keys are ignored (forward compatibility);
+ * every known field is type-checked and the per-type required fields enforced.
+ */
+export function decodeOsIntent(raw: unknown): IntentDecodeResult {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return fail("not-an-object", "intent must be a non-null object");
+  }
+  const record = raw as Record<string, unknown>;
+
+  const type = record.type;
+  if (typeof type !== "string") {
+    return fail("missing-field", "intent is missing a string `type`", "type");
+  }
+  if (!INTENT_TYPE_SET.has(type)) {
+    return fail("unknown-type", `unknown intent type: ${type}`, "type");
+  }
+  if (!isNonEmptyString(record.intentId)) {
+    return fail("missing-field", "`intentId` is required", "intentId");
+  }
+  if (!isIntentSource(record.source)) {
+    return fail("unknown-source", `unknown intent source: ${String(record.source)}`, "source");
+  }
+  let issuedAt: number | undefined;
+  if ("issuedAt" in record && record.issuedAt !== undefined) {
+    if (typeof record.issuedAt !== "number" || !Number.isFinite(record.issuedAt)) {
+      return fail("invalid-field", "`issuedAt` must be a finite number", "issuedAt");
+    }
+    issuedAt = record.issuedAt;
+  }
+
+  const base = { intentId: record.intentId, source: record.source, ...(issuedAt !== undefined ? { issuedAt } : {}) };
+  const intentType = type as OsIntentType;
+
+  switch (intentType) {
+    case "send": {
+      if (typeof record.text !== "string") {
+        return fail("invalid-field", "`text` must be a string", "text");
+      }
+      if (record.text.length === 0) {
+        return fail("missing-field", "`send` requires non-empty `text`", "text");
+      }
+      if (
+        "channelType" in record &&
+        record.channelType !== undefined &&
+        record.channelType !== "DM" &&
+        record.channelType !== "VOICE_DM"
+      ) {
+        return fail("invalid-field", "`channelType` must be DM|VOICE_DM", "channelType");
+      }
+      return {
+        ok: true,
+        intent: {
+          type: "send",
+          ...base,
+          text: record.text,
+          ...(record.channelType === "DM" || record.channelType === "VOICE_DM"
+            ? { channelType: record.channelType }
+            : {}),
+        },
+      };
+    }
+    case "start-voice": {
+      if (record.mode !== "converse" && record.mode !== "dictate") {
+        return fail("invalid-field", "`mode` must be converse|dictate", "mode");
+      }
+      return { ok: true, intent: { type: "start-voice", ...base, mode: record.mode } };
+    }
+    case "open-chat":
+    case "stop-voice":
+    case "start-transcription":
+    case "stop-transcription":
+    case "continue-conversation":
+      return { ok: true, intent: { type: intentType, ...base } };
+    default: {
+      const _exhaustive: never = intentType;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Map the resolved launch signals (host segment, `action`, `voice` flag, text)
+ * to a typed intent type. Returns null when this app does not own the launch.
+ * Precedence: voice/transcription/continue are recognized before the chat
+ * defaults so an explicit `voice=1` or `action=voice` wins over a `chat` host.
+ */
+function resolveLaunchIntentType(
+  host: string,
+  action: string,
+  voiceFlag: boolean,
+  hasText: boolean,
+): OsIntentType | null {
+  if (voiceFlag || action === "voice" || host === "voice") return "start-voice";
+  if (action === "transcribe" || action === "transcription" || host === "transcribe") {
+    return "start-transcription";
+  }
+  if (action === "continue" || action === "resume" || host === "continue") {
+    return "continue-conversation";
+  }
+  if (action === "ask" || action === "smart-reply" || action === "send") {
+    return hasText ? "send" : "open-chat";
+  }
+  if (action === "chat" || host === "chat" || host === "assistant") {
+    return hasText ? "send" : "open-chat";
+  }
+  return null;
+}
+
+function readLaunchText(params: URLSearchParams): string {
+  for (const key of ASSISTANT_LAUNCH_TEXT_KEYS) {
+    const value = params.get(key)?.trim();
+    if (value) return value;
+  }
+  return "";
+}
+
+function buildLaunchIntent(
+  intentType: OsIntentType,
+  source: IntentSource,
+  intentId: string,
+  text: string,
+): OsIntent {
+  const base = { intentId, source };
+  switch (intentType) {
+    case "send":
+      return { type: "send", ...base, text };
+    case "start-voice":
+      return { type: "start-voice", ...base, mode: "converse" };
+    case "open-chat":
+    case "stop-voice":
+    case "start-transcription":
+    case "stop-transcription":
+    case "continue-conversation":
+      return { type: intentType, ...base };
+    default: {
+      const _exhaustive: never = intentType;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Decode an `elizaos://…?source=…&action=…&text=…&voice=1` launch link into a
+ * typed intent. Custom-scheme hosts are NOT lowercased by the URL parser, so the
+ * host segment is normalized before matching (same gotcha as
+ * `classifyDeepLinkRoute`). `intentId` is the explicit `assistant.launchId` when
+ * present, else a stable synthesis so a redelivered identical link dedupes.
+ */
+export function decodeDeepLinkIntent(url: string): IntentDecodeResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return fail("not-a-url", `not a parseable URL: ${url}`);
+  }
+
+  const params = parsed.searchParams;
+  const source = params.get("source")?.trim() ?? "";
+  if (!isIntentSource(source)) {
+    return fail("unknown-source", `unknown or missing launch source: ${source || "(none)"}`, "source");
+  }
+
+  const host = parsed.host.toLowerCase();
+  const action = params.get("action")?.trim().toLowerCase() ?? "";
+  const voiceFlag = params.get("voice")?.trim() === "1";
+  const text = readLaunchText(params);
+
+  const intentType = resolveLaunchIntentType(host, action, voiceFlag, text.length > 0);
+  if (!intentType) {
+    return fail("unrecognized-launch", `deep link is not a chat/voice/transcription launch: ${url}`);
+  }
+
+  const intentId =
+    params.get("assistant.launchId")?.trim() || `${source}:${host}:${action}:${text}`;
+
+  return { ok: true, intent: buildLaunchIntent(intentType, source, intentId, text) };
+}
+
+/**
+ * Adapt the legacy {@link AssistantLaunchPayload} (chat-only launch record) into
+ * the unified vocabulary, so the existing consumer can route through the one
+ * authority without re-parsing the deep link. The payload's `route` is the host
+ * segment and its `launchId` is the dedupe identity.
+ */
+export function fromAssistantLaunchPayload(
+  payload: AssistantLaunchPayload,
+): IntentDecodeResult {
+  if (!isIntentSource(payload.source)) {
+    return fail("unknown-source", `unknown launch source: ${payload.source}`, "source");
+  }
+  const host = payload.route.toLowerCase();
+  const action = (payload.action ?? "").toLowerCase();
+  const text = payload.text.trim();
+
+  const intentType = resolveLaunchIntentType(host, action, false, text.length > 0);
+  if (!intentType) {
+    return fail("unrecognized-launch", `launch payload is not a chat/voice/transcription intent`);
+  }
+  return {
+    ok: true,
+    intent: buildLaunchIntent(intentType, payload.source, payload.launchId, text),
+  };
+}

--- a/packages/ui/src/os-intent/dedupe.test.ts
+++ b/packages/ui/src/os-intent/dedupe.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Idempotency-store unit tests: exactly-once recording, TTL expiry/prune, and the
+ * snapshot→seed round-trip that lets a restored/crashed-then-reopened session skip
+ * launches its predecessor already handled. Deterministic; injected clock, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { IntentDedupeStore } from "./dedupe";
+
+describe("IntentDedupeStore", () => {
+  it("reports an unrecorded id as absent", () => {
+    const store = new IntentDedupeStore();
+    expect(store.has("a", 0)).toBe(false);
+    expect(store.firstAppliedAt("a", 0)).toBeNull();
+  });
+
+  it("records an id and reports it applied", () => {
+    const store = new IntentDedupeStore();
+    store.record("a", 100);
+    expect(store.has("a", 200)).toBe(true);
+    expect(store.firstAppliedAt("a", 200)).toBe(100);
+    expect(store.size).toBe(1);
+  });
+
+  it("keeps the FIRST applied time so a redelivery cannot advance the TTL", () => {
+    const store = new IntentDedupeStore({ ttlMs: 1000 });
+    store.record("a", 100);
+    store.record("a", 900); // redelivery — must not move the timestamp
+    expect(store.firstAppliedAt("a", 950)).toBe(100);
+    // At now=1200 the record is 1100ms old (> ttl) and expires, though the second
+    // record call was only 300ms ago — proving the first time is authoritative.
+    expect(store.has("a", 1200)).toBe(false);
+  });
+
+  it("expires a record past its TTL and treats a reused id as fresh", () => {
+    const store = new IntentDedupeStore({ ttlMs: 500 });
+    store.record("a", 0);
+    expect(store.has("a", 400)).toBe(true);
+    expect(store.has("a", 600)).toBe(false); // expired
+    expect(store.size).toBe(0); // reading dropped it
+  });
+
+  it("prune() drops only expired records and returns the count", () => {
+    const store = new IntentDedupeStore({ ttlMs: 100 });
+    store.record("old", 0);
+    store.record("new", 90);
+    expect(store.prune(150)).toBe(1); // only "old" is >100ms
+    expect(store.has("new", 150)).toBe(true);
+    expect(store.has("old", 150)).toBe(false);
+  });
+
+  it("snapshot()→seed rehydrates applied ids (restored session dedupes)", () => {
+    const first = new IntentDedupeStore();
+    first.record("launch-1", 1000);
+    first.record("launch-2", 1000);
+    const snapshot = first.snapshot(1000);
+
+    // A brand-new store (a session restored after a crash) seeded with the snapshot.
+    const restored = new IntentDedupeStore({ seed: snapshot });
+    expect(restored.has("launch-1", 1000)).toBe(true);
+    expect(restored.has("launch-2", 1000)).toBe(true);
+    expect(restored.has("launch-3", 1000)).toBe(false);
+  });
+
+  it("snapshot() omits expired records so a stale seed does not pin memory", () => {
+    const store = new IntentDedupeStore({ ttlMs: 100 });
+    store.record("old", 0);
+    store.record("fresh", 90);
+    expect(store.snapshot(150).map((r) => r.intentId)).toEqual(["fresh"]);
+  });
+});

--- a/packages/ui/src/os-intent/dedupe.ts
+++ b/packages/ui/src/os-intent/dedupe.ts
@@ -1,0 +1,98 @@
+/**
+ * The single idempotency authority for OS intents: a launch is applied at most
+ * once no matter how many times its `intentId` is redelivered — a retried deep
+ * link, a re-tapped notification, a second window racing to route the same
+ * launch, or a session restored after a crash all present the same id. The
+ * router records only intents it actually ROUTED, so a `blocked` intent retried
+ * after the user grants the missing permission is not wrongly suppressed.
+ *
+ * Pure and clock-injected (every method takes `now`) so ordering and TTL are
+ * deterministic under test and identical on every window. The store holds no
+ * live handles: a host persists `snapshot()` and rehydrates through the
+ * constructor `seed`, which is precisely what makes a restored/reopened session
+ * skip the intents its predecessor already handled.
+ */
+
+/** One applied launch: its id and the epoch-ms it was first routed. */
+export interface AppliedIntentRecord {
+  intentId: string;
+  appliedAt: number;
+}
+
+export interface IntentDedupeStoreOptions {
+  /**
+   * Records older than this are pruned and treated as un-applied (ms). Default
+   * 24h: a same-day relaunch dedupes, but an id from days ago neither pins memory
+   * nor suppresses a genuinely new launch that happened to reuse the id.
+   */
+  ttlMs?: number;
+  /** Prior applied records to rehydrate — a restored session's `snapshot()`. */
+  seed?: readonly AppliedIntentRecord[];
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export class IntentDedupeStore {
+  private readonly ttlMs: number;
+  private readonly applied = new Map<string, number>();
+
+  constructor(options: IntentDedupeStoreOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    for (const record of options.seed ?? []) {
+      this.applied.set(record.intentId, record.appliedAt);
+    }
+  }
+
+  /**
+   * The epoch-ms a live (non-expired) record for `intentId` was applied, or null
+   * when absent/expired. Reading expires-and-drops a stale record so a reused id
+   * after the TTL is treated as fresh rather than a false duplicate.
+   */
+  firstAppliedAt(intentId: string, now: number): number | null {
+    const appliedAt = this.applied.get(intentId);
+    if (appliedAt === undefined) return null;
+    if (now - appliedAt > this.ttlMs) {
+      this.applied.delete(intentId);
+      return null;
+    }
+    return appliedAt;
+  }
+
+  has(intentId: string, now: number): boolean {
+    return this.firstAppliedAt(intentId, now) !== null;
+  }
+
+  /**
+   * Record `intentId` as applied at `now`. Keeps the FIRST applied time, so a
+   * later redelivery cannot advance the timestamp and slip the record past its
+   * TTL to re-fire.
+   */
+  record(intentId: string, now: number): void {
+    if (!this.applied.has(intentId)) this.applied.set(intentId, now);
+  }
+
+  /** Drop expired records; returns how many were pruned. */
+  prune(now: number): number {
+    let pruned = 0;
+    for (const [intentId, appliedAt] of this.applied) {
+      if (now - appliedAt > this.ttlMs) {
+        this.applied.delete(intentId);
+        pruned += 1;
+      }
+    }
+    return pruned;
+  }
+
+  /** Live records for persistence; a restored session seeds a new store with this. */
+  snapshot(now: number): AppliedIntentRecord[] {
+    this.prune(now);
+    return [...this.applied].map(([intentId, appliedAt]) => ({
+      intentId,
+      appliedAt,
+    }));
+  }
+
+  get size(): number {
+    return this.applied.size;
+  }
+}

--- a/packages/ui/src/os-intent/index.ts
+++ b/packages/ui/src/os-intent/index.ts
@@ -1,10 +1,10 @@
 /**
  * `eliza.os-intent/v1` — the one structural intent vocabulary + routing authority
  * that unifies chat, voice, and transcription launches across iOS/Android/desktop
- * entry points. Types + constants (`contract`), boundary decoder (`decode`),
- * stable-id dedupe store (`dedupe`), the structural routing authority (`router`),
- * and the executor that applies routed commands to the one shell controller
- * (`apply-command`).
+ * entry points. Types + constants (`contract`), boundary decoder + native-launch
+ * adapters (`decode`), stable-id dedupe store (`dedupe`), the structural routing
+ * authority (`router`), and the executor that applies routed commands to the one
+ * shell controller (`apply-command`).
  */
 
 export {
@@ -34,3 +34,28 @@ export {
   type StopTranscriptionIntent,
   type StopVoiceIntent,
 } from "./contract";
+export {
+  decodeDeepLinkIntent,
+  decodeOsIntent,
+  fromAssistantLaunchPayload,
+  type IntentDecodeError,
+  type IntentDecodeErrorCode,
+  type IntentDecodeResult,
+} from "./decode";
+export {
+  type AppliedIntentRecord,
+  IntentDedupeStore,
+  type IntentDedupeStoreOptions,
+} from "./dedupe";
+export {
+  type AuthState,
+  intentTarget,
+  type MicPermissionState,
+  routeIntent,
+  type RoutingContext,
+} from "./router";
+export {
+  applyOsIntentCommand,
+  applyOsIntentCommands,
+  type IntentControllerTarget,
+} from "./apply-command";

--- a/packages/ui/src/os-intent/index.ts
+++ b/packages/ui/src/os-intent/index.ts
@@ -8,6 +8,11 @@
  */
 
 export {
+  applyOsIntentCommand,
+  applyOsIntentCommands,
+  type IntentControllerTarget,
+} from "./apply-command";
+export {
   AUTO_START_INTENT_TYPES,
   type ContinueConversationIntent,
   INTENT_PREREQUISITES,
@@ -22,9 +27,9 @@ export {
   type IntentPrerequisite,
   type IntentSource,
   type IntentTarget,
+  type OpenChatIntent,
   OS_INTENT_SCHEMA,
   OS_INTENT_TYPES,
-  type OpenChatIntent,
   type OsIntent,
   type OsIntentSchema,
   type OsIntentType,
@@ -51,11 +56,6 @@ export {
   type AuthState,
   intentTarget,
   type MicPermissionState,
-  routeIntent,
   type RoutingContext,
+  routeIntent,
 } from "./router";
-export {
-  applyOsIntentCommand,
-  applyOsIntentCommands,
-  type IntentControllerTarget,
-} from "./apply-command";

--- a/packages/ui/src/os-intent/index.ts
+++ b/packages/ui/src/os-intent/index.ts
@@ -1,0 +1,36 @@
+/**
+ * `eliza.os-intent/v1` — the one structural intent vocabulary + routing authority
+ * that unifies chat, voice, and transcription launches across iOS/Android/desktop
+ * entry points. Types + constants (`contract`), boundary decoder (`decode`),
+ * stable-id dedupe store (`dedupe`), the structural routing authority (`router`),
+ * and the executor that applies routed commands to the one shell controller
+ * (`apply-command`).
+ */
+
+export {
+  AUTO_START_INTENT_TYPES,
+  type ContinueConversationIntent,
+  INTENT_PREREQUISITES,
+  INTENT_SOURCES,
+  INTENT_TARGET,
+  type IntentBlockReason,
+  type IntentControllerCommand,
+  type IntentControllerCommandKind,
+  type IntentDegradeReason,
+  type IntentOutcome,
+  type IntentOutcomeStatus,
+  type IntentPrerequisite,
+  type IntentSource,
+  type IntentTarget,
+  OS_INTENT_SCHEMA,
+  OS_INTENT_TYPES,
+  type OpenChatIntent,
+  type OsIntent,
+  type OsIntentSchema,
+  type OsIntentType,
+  type SendIntent,
+  type StartTranscriptionIntent,
+  type StartVoiceIntent,
+  type StopTranscriptionIntent,
+  type StopVoiceIntent,
+} from "./contract";

--- a/packages/ui/src/os-intent/pipeline.test.ts
+++ b/packages/ui/src/os-intent/pipeline.test.ts
@@ -1,0 +1,142 @@
+/**
+ * End-to-end pipeline tests: a real native `elizaos://…` launch link flows
+ * decode → route → drive the ONE controller, and a redelivered link drives it
+ * exactly once. This is the full contract a launch surface relies on, exercised
+ * without any device — the boundary decoder, the routing authority, the dedupe
+ * store, and the executor wired together. Deterministic; injected clock, no I/O.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyOsIntentCommands,
+  type IntentControllerTarget,
+} from "./apply-command";
+import { decodeDeepLinkIntent } from "./decode";
+import { IntentDedupeStore } from "./dedupe";
+import { type RoutingContext, routeIntent } from "./router";
+
+function healthyContext(
+  overrides: Partial<RoutingContext> = {},
+): RoutingContext {
+  return {
+    now: 1_000,
+    auth: "authenticated",
+    device: { locked: false, foreground: true },
+    capabilities: {
+      voiceCapture: true,
+      sandboxed: false,
+      microphone: "granted",
+    },
+    consent: { autoStartVoice: true, autoStartTranscription: true },
+    ...overrides,
+  };
+}
+
+function spyController(): {
+  controller: IntentControllerTarget;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const controller: IntentControllerTarget = {
+    open: vi.fn(() => calls.push("open")),
+    send: vi.fn((text: string) => calls.push(`send:${text}`)),
+    startRecording: vi.fn((intent?: string) =>
+      calls.push(`startRecording:${intent}`),
+    ),
+    stopRecording: vi.fn(() => calls.push("stopRecording")),
+    toggleTranscriptionMode: vi.fn(() => {
+      calls.push("toggleTranscriptionMode");
+    }),
+    stopTranscriptionAndMic: vi.fn(() => {
+      calls.push("stopTranscriptionAndMic");
+    }),
+    transcriptionMode: false,
+  };
+  return { controller, calls };
+}
+
+/** Drive one raw launch URL through the whole pipeline against a controller. */
+function launch(
+  url: string,
+  context: RoutingContext,
+  store: IntentDedupeStore,
+  controller: IntentControllerTarget,
+): string {
+  const decoded = decodeDeepLinkIntent(url);
+  if (!decoded.ok) return `decode:${decoded.error.code}`;
+  const outcome = routeIntent(decoded.intent, context, store);
+  if (outcome.status === "routed")
+    applyOsIntentCommands(controller, outcome.commands);
+  return outcome.status;
+}
+
+describe("os-intent pipeline", () => {
+  it("drives the controller from the iOS StartVoice link", () => {
+    const store = new IntentDedupeStore();
+    const { controller, calls } = spyController();
+    const status = launch(
+      "elizaos://voice?source=ios-app-shortcuts&action=voice&voice=1&assistant.launchId=siri-1",
+      healthyContext(),
+      store,
+      controller,
+    );
+    expect(status).toBe("routed");
+    expect(calls).toEqual(["open", "startRecording:converse"]);
+  });
+
+  it("drives open+send from the Android CREATE_MESSAGE link", () => {
+    const store = new IntentDedupeStore();
+    const { controller, calls } = spyController();
+    const status = launch(
+      "elizaos://chat?source=android-app-actions&action=ask&text=what%20is%20the%20weather&assistant.launchId=aa-1",
+      healthyContext(),
+      store,
+      controller,
+    );
+    expect(status).toBe("routed");
+    expect(calls).toEqual(["open", "send:what is the weather"]);
+  });
+
+  it("applies a redelivered launch exactly once (idempotent end to end)", () => {
+    const store = new IntentDedupeStore();
+    const { controller, calls } = spyController();
+    const url =
+      "elizaos://voice?source=ios-app-shortcuts&action=voice&voice=1&assistant.launchId=siri-1";
+
+    expect(launch(url, healthyContext(), store, controller)).toBe("routed");
+    expect(launch(url, healthyContext({ now: 1_100 }), store, controller)).toBe(
+      "duplicate",
+    );
+    expect(launch(url, healthyContext({ now: 1_200 }), store, controller)).toBe(
+      "duplicate",
+    );
+
+    // The controller was driven only for the first delivery.
+    expect(calls).toEqual(["open", "startRecording:converse"]);
+  });
+
+  it("does not touch the controller when the launch is blocked", () => {
+    const store = new IntentDedupeStore();
+    const { controller, calls } = spyController();
+    const status = launch(
+      "elizaos://voice?source=siri&action=voice&voice=1&assistant.launchId=v1",
+      healthyContext({ device: { locked: true, foreground: true } }),
+      store,
+      controller,
+    );
+    expect(status).toBe("blocked");
+    expect(calls).toEqual([]);
+  });
+
+  it("leaves a non-owned deep link for the caller (decode rejects it)", () => {
+    const store = new IntentDedupeStore();
+    const { controller, calls } = spyController();
+    const status = launch(
+      "elizaos://feature/open?source=android-app-actions&feature=settings",
+      healthyContext(),
+      store,
+      controller,
+    );
+    expect(status).toBe("decode:unrecognized-launch");
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/ui/src/os-intent/router.test.ts
+++ b/packages/ui/src/os-intent/router.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Routing-authority unit tests — the full case matrix from #16441: routed happy
+ * paths per intent, invalid/stale intents, locked device, missing permissions,
+ * auth expiry, background/foreground, auto-start consent gating + reversibility,
+ * concurrency (interleaved routing over one shared store), duplicate-start
+ * prevention across redelivery paths, and crash recovery via snapshot rehydrate.
+ * Deterministic; injected clock, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import type { OsIntent } from "./contract";
+import { IntentDedupeStore } from "./dedupe";
+import { type RoutingContext, routeIntent } from "./router";
+
+/** A context in which every prerequisite is satisfied and consent is granted. */
+function healthyContext(
+  overrides: Partial<RoutingContext> = {},
+): RoutingContext {
+  return {
+    now: 1_000,
+    auth: "authenticated",
+    device: { locked: false, foreground: true },
+    capabilities: {
+      voiceCapture: true,
+      sandboxed: false,
+      microphone: "granted",
+    },
+    consent: { autoStartVoice: true, autoStartTranscription: true },
+    ...overrides,
+  };
+}
+
+function intent(partial: Partial<OsIntent> & Pick<OsIntent, "type">): OsIntent {
+  return { intentId: "id-1", source: "in-app", ...partial } as OsIntent;
+}
+
+describe("routeIntent — routed happy paths", () => {
+  it("open-chat → open command", () => {
+    const out = routeIntent(
+      intent({ type: "open-chat" }),
+      healthyContext(),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed") {
+      expect(out.target).toBe("chat");
+      expect(out.commands).toEqual([{ kind: "open" }]);
+    }
+  });
+
+  it("send → open then send, carrying channelType", () => {
+    const out = routeIntent(
+      {
+        type: "send",
+        intentId: "s",
+        source: "siri",
+        text: "hi",
+        channelType: "VOICE_DM",
+      },
+      healthyContext(),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed") {
+      expect(out.commands).toEqual([
+        { kind: "open" },
+        { kind: "send", text: "hi", channelType: "VOICE_DM" },
+      ]);
+    }
+  });
+
+  it("start-voice (dictate) → open then startRecording(dictate)", () => {
+    const out = routeIntent(
+      {
+        type: "start-voice",
+        intentId: "v",
+        source: "ios-app-shortcuts",
+        mode: "dictate",
+      },
+      healthyContext(),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed") {
+      expect(out.target).toBe("voice");
+      expect(out.commands).toEqual([
+        { kind: "open" },
+        { kind: "startRecording", intent: "dictate" },
+      ]);
+    }
+  });
+
+  it("start-transcription → open then toggleTranscriptionMode", () => {
+    const out = routeIntent(
+      intent({ type: "start-transcription" }),
+      healthyContext(),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed") {
+      expect(out.commands).toEqual([
+        { kind: "open" },
+        { kind: "toggleTranscriptionMode" },
+      ]);
+    }
+  });
+
+  it("continue-conversation → open", () => {
+    const out = routeIntent(
+      intent({ type: "continue-conversation" }),
+      healthyContext(),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed")
+      expect(out.commands).toEqual([{ kind: "open" }]);
+  });
+});
+
+describe("routeIntent — stale + invalid", () => {
+  it("rejects an intent older than maxIntentAgeMs", () => {
+    const out = routeIntent(
+      { type: "open-chat", intentId: "x", source: "notification", issuedAt: 0 },
+      healthyContext({ now: 10_000, maxIntentAgeMs: 5_000 }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("stale");
+    if (out.status === "stale") expect(out.ageMs).toBe(10_000);
+  });
+
+  it("does not treat a future issuedAt (clock skew) as stale", () => {
+    const out = routeIntent(
+      {
+        type: "open-chat",
+        intentId: "x",
+        source: "notification",
+        issuedAt: 20_000,
+      },
+      healthyContext({ now: 10_000, maxIntentAgeMs: 5_000 }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+  });
+
+  it("does not apply staleness when issuedAt is absent", () => {
+    const out = routeIntent(
+      { type: "open-chat", intentId: "x", source: "notification" },
+      healthyContext({ maxIntentAgeMs: 1 }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+  });
+});
+
+describe("routeIntent — blocked prerequisites (recoverable)", () => {
+  it("blocks send when unauthenticated", () => {
+    const out = routeIntent(
+      intent({ type: "send", text: "hi" }),
+      healthyContext({ auth: "unauthenticated" }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("blocked");
+    if (out.status === "blocked") {
+      expect(out.reason).toBe("unauthenticated");
+      expect(out.missing).toContain("session");
+    }
+  });
+
+  it("distinguishes an expired session from an absent one", () => {
+    const out = routeIntent(
+      intent({ type: "open-chat" }),
+      healthyContext({ auth: "expired" }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("blocked");
+    if (out.status === "blocked") expect(out.reason).toBe("auth-expired");
+  });
+
+  it("blocks start-voice on a locked device", () => {
+    const out = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({ device: { locked: true, foreground: true } }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("blocked");
+    if (out.status === "blocked") expect(out.reason).toBe("locked");
+  });
+
+  it("blocks auto-start capture while backgrounded", () => {
+    const out = routeIntent(
+      intent({ type: "start-transcription" }),
+      healthyContext({ device: { locked: false, foreground: false } }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("blocked");
+    if (out.status === "blocked") expect(out.reason).toBe("backgrounded");
+  });
+
+  it("blocks start-voice when the mic permission is denied", () => {
+    const out = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({
+        capabilities: {
+          voiceCapture: true,
+          sandboxed: false,
+          microphone: "denied",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("blocked");
+    if (out.status === "blocked") expect(out.reason).toBe("microphone-denied");
+  });
+
+  it("does NOT block on mic 'prompt'/'unknown' (capture-time prompt is allowed)", () => {
+    for (const microphone of ["prompt", "unknown"] as const) {
+      const out = routeIntent(
+        {
+          type: "start-voice",
+          intentId: `v-${microphone}`,
+          source: "siri",
+          mode: "converse",
+        },
+        healthyContext({
+          capabilities: { voiceCapture: true, sandboxed: false, microphone },
+        }),
+        new IntentDedupeStore(),
+      );
+      expect(out.status).toBe("routed");
+    }
+  });
+
+  it("reports the highest-priority reason but lists ALL missing prerequisites", () => {
+    const out = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({
+        auth: "unauthenticated",
+        device: { locked: true, foreground: false },
+        capabilities: {
+          voiceCapture: true,
+          sandboxed: false,
+          microphone: "denied",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("blocked");
+    if (out.status === "blocked") {
+      expect(out.reason).toBe("unauthenticated"); // session is first in declaration order
+      expect(out.missing).toEqual([
+        "session",
+        "unlocked",
+        "foreground",
+        "microphone",
+      ]);
+    }
+  });
+
+  it("a blocked intent is NOT recorded — retry after fixing the prerequisite routes", () => {
+    const store = new IntentDedupeStore();
+    const blocked = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({
+        capabilities: {
+          voiceCapture: true,
+          sandboxed: false,
+          microphone: "denied",
+        },
+      }),
+      store,
+    );
+    expect(blocked.status).toBe("blocked");
+    const retried = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext(),
+      store,
+    );
+    expect(retried.status).toBe("routed");
+  });
+});
+
+describe("routeIntent — degraded (device cannot honor)", () => {
+  it("degrades start-voice when voice capture is unsupported", () => {
+    const out = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({
+        capabilities: {
+          voiceCapture: false,
+          sandboxed: false,
+          microphone: "granted",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("degraded");
+    if (out.status === "degraded") expect(out.reason).toBe("voice-unsupported");
+  });
+
+  it("degrades an auto-start on a sandboxed device", () => {
+    const out = routeIntent(
+      intent({ type: "start-transcription" }),
+      healthyContext({
+        capabilities: {
+          voiceCapture: true,
+          sandboxed: true,
+          microphone: "granted",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("degraded");
+    if (out.status === "degraded") expect(out.reason).toBe("sandboxed");
+  });
+
+  it("chat intents never degrade on missing voice support", () => {
+    const out = routeIntent(
+      intent({ type: "open-chat" }),
+      healthyContext({
+        capabilities: {
+          voiceCapture: false,
+          sandboxed: true,
+          microphone: "denied",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+  });
+});
+
+describe("routeIntent — stop-* is always allowed (reversibility)", () => {
+  it("routes stop-voice even when locked, denied, and unauthenticated", () => {
+    const out = routeIntent(
+      { type: "stop-voice", intentId: "sv", source: "in-app" },
+      healthyContext({
+        auth: "unauthenticated",
+        device: { locked: true, foreground: false },
+        capabilities: {
+          voiceCapture: false,
+          sandboxed: true,
+          microphone: "denied",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed")
+      expect(out.commands).toEqual([{ kind: "stopRecording" }]);
+  });
+
+  it("routes stop-transcription unconditionally", () => {
+    const out = routeIntent(
+      { type: "stop-transcription", intentId: "st", source: "in-app" },
+      healthyContext({
+        capabilities: {
+          voiceCapture: false,
+          sandboxed: true,
+          microphone: "denied",
+        },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+    if (out.status === "routed")
+      expect(out.commands).toEqual([{ kind: "stopTranscriptionAndMic" }]);
+  });
+});
+
+describe("routeIntent — auto-start consent", () => {
+  it("requires consent for start-voice when not granted", () => {
+    const out = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({
+        consent: { autoStartVoice: false, autoStartTranscription: true },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("consent-required");
+    if (out.status === "consent-required") expect(out.target).toBe("voice");
+  });
+
+  it("requires consent for start-transcription independently", () => {
+    const out = routeIntent(
+      intent({ type: "start-transcription" }),
+      healthyContext({
+        consent: { autoStartVoice: true, autoStartTranscription: false },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("consent-required");
+  });
+
+  it("routes once consent is granted (reversible gate)", () => {
+    const out = routeIntent(
+      { type: "start-voice", intentId: "v", source: "siri", mode: "converse" },
+      healthyContext({
+        consent: { autoStartVoice: true, autoStartTranscription: true },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+  });
+
+  it("never gates non-auto-start intents on consent", () => {
+    const out = routeIntent(
+      intent({ type: "open-chat" }),
+      healthyContext({
+        consent: { autoStartVoice: false, autoStartTranscription: false },
+      }),
+      new IntentDedupeStore(),
+    );
+    expect(out.status).toBe("routed");
+  });
+});
+
+describe("routeIntent — duplicate-start prevention + concurrency", () => {
+  it("dedupes the same intentId (retried deep link / re-tapped notification)", () => {
+    const store = new IntentDedupeStore();
+    const first = routeIntent(
+      intent({ type: "open-chat", intentId: "dup" }),
+      healthyContext(),
+      store,
+    );
+    const second = routeIntent(
+      intent({ type: "open-chat", intentId: "dup" }),
+      healthyContext(),
+      store,
+    );
+    expect(first.status).toBe("routed");
+    expect(second.status).toBe("duplicate");
+    if (second.status === "duplicate")
+      expect(second.firstAppliedAt).toBe(1_000);
+  });
+
+  it("prevents a duplicate start across two windows sharing one store", () => {
+    const store = new IntentDedupeStore();
+    const windowA = routeIntent(
+      {
+        type: "start-voice",
+        intentId: "launch",
+        source: "siri",
+        mode: "converse",
+      },
+      healthyContext(),
+      store,
+    );
+    const windowB = routeIntent(
+      {
+        type: "start-voice",
+        intentId: "launch",
+        source: "siri",
+        mode: "converse",
+      },
+      healthyContext(),
+      store,
+    );
+    expect(windowA.status).toBe("routed");
+    expect(windowB.status).toBe("duplicate");
+  });
+
+  it("routes distinct intentIds independently under interleaving", () => {
+    const store = new IntentDedupeStore();
+    const results = ["a", "b", "a", "c", "b"].map(
+      (id) =>
+        routeIntent(
+          intent({ type: "open-chat", intentId: id }),
+          healthyContext(),
+          store,
+        ).status,
+    );
+    expect(results).toEqual([
+      "routed",
+      "routed",
+      "duplicate",
+      "routed",
+      "duplicate",
+    ]);
+    expect(store.size).toBe(3);
+  });
+
+  it("stale is decided before dedupe (a stale duplicate reports stale)", () => {
+    const store = new IntentDedupeStore();
+    routeIntent(
+      {
+        type: "open-chat",
+        intentId: "x",
+        source: "notification",
+        issuedAt: 1_000,
+      },
+      healthyContext({ now: 1_000 }),
+      store,
+    );
+    const stale = routeIntent(
+      { type: "open-chat", intentId: "x", source: "notification", issuedAt: 0 },
+      healthyContext({ now: 10_000, maxIntentAgeMs: 5_000 }),
+      store,
+    );
+    expect(stale.status).toBe("stale");
+  });
+});
+
+describe("routeIntent — crash recovery", () => {
+  it("a restored session seeded from a snapshot does not re-fire a handled launch", () => {
+    const live = new IntentDedupeStore();
+    routeIntent(
+      {
+        type: "start-voice",
+        intentId: "boot-launch",
+        source: "ios-app-shortcuts",
+        mode: "converse",
+      },
+      healthyContext(),
+      live,
+    );
+    const snapshot = live.snapshot(1_000);
+
+    // App crashes and reopens; the OS redelivers the same launch to a fresh store.
+    const restored = new IntentDedupeStore({ seed: snapshot });
+    const out = routeIntent(
+      {
+        type: "start-voice",
+        intentId: "boot-launch",
+        source: "ios-app-shortcuts",
+        mode: "converse",
+      },
+      healthyContext(),
+      restored,
+    );
+    expect(out.status).toBe("duplicate");
+  });
+});

--- a/packages/ui/src/os-intent/router.ts
+++ b/packages/ui/src/os-intent/router.ts
@@ -82,7 +82,12 @@ export function routeIntent(
     const ageMs = context.now - intent.issuedAt;
     // Only positive age is stale; a future `issuedAt` (clock skew) is not.
     if (ageMs > context.maxIntentAgeMs) {
-      return { status: "stale", intentId, ageMs, maxAgeMs: context.maxIntentAgeMs };
+      return {
+        status: "stale",
+        intentId,
+        ageMs,
+        maxAgeMs: context.maxIntentAgeMs,
+      };
     }
   }
 
@@ -101,7 +106,10 @@ export function routeIntent(
     return { status: "blocked", intentId, intentType, reason, missing };
   }
 
-  if (AUTO_START_INTENT_TYPES.has(intentType) && !hasAutoStartConsent(intentType, context)) {
+  if (
+    AUTO_START_INTENT_TYPES.has(intentType) &&
+    !hasAutoStartConsent(intentType, context)
+  ) {
     return { status: "consent-required", intentId, intentType, target };
   }
 
@@ -144,7 +152,8 @@ function evaluatePrerequisites(
       case "session":
         if (context.auth !== "authenticated") {
           missing.push(prerequisite);
-          reason ??= context.auth === "expired" ? "auth-expired" : "unauthenticated";
+          reason ??=
+            context.auth === "expired" ? "auth-expired" : "unauthenticated";
         }
         break;
       case "unlocked":
@@ -182,7 +191,8 @@ function hasAutoStartConsent(
   context: RoutingContext,
 ): boolean {
   if (intentType === "start-voice") return context.consent.autoStartVoice;
-  if (intentType === "start-transcription") return context.consent.autoStartTranscription;
+  if (intentType === "start-transcription")
+    return context.consent.autoStartTranscription;
   return true;
 }
 
@@ -207,7 +217,10 @@ function commandsForIntent(intent: OsIntent): IntentControllerCommand[] {
         },
       ];
     case "start-voice":
-      return [{ kind: "open" }, { kind: "startRecording", intent: intent.mode }];
+      return [
+        { kind: "open" },
+        { kind: "startRecording", intent: intent.mode },
+      ];
     case "stop-voice":
       return [{ kind: "stopRecording" }];
     case "start-transcription":

--- a/packages/ui/src/os-intent/router.ts
+++ b/packages/ui/src/os-intent/router.ts
@@ -1,0 +1,230 @@
+/**
+ * The routing authority: the one place a decoded {@link OsIntent} becomes a typed
+ * {@link IntentOutcome} and, when it fires, the commands to run against the single
+ * shared shell controller. Every decision is STRUCTURAL — it switches on the
+ * intent discriminant and reads {@link RoutingContext}; it never inspects prompt
+ * or transcript text (the free-form native `action` string was already resolved
+ * to a typed intent at the decode boundary).
+ *
+ * The fixed evaluation order below is the contract callers rely on. Only a
+ * `routed` intent is recorded in the dedupe store, so a `blocked` intent retried
+ * after the user fixes the prerequisite (grants mic, unlocks, re-auths) still
+ * routes — the block is observable and recoverable, never a silent dead end.
+ */
+import {
+  AUTO_START_INTENT_TYPES,
+  INTENT_PREREQUISITES,
+  INTENT_TARGET,
+  type IntentBlockReason,
+  type IntentControllerCommand,
+  type IntentDegradeReason,
+  type IntentOutcome,
+  type IntentPrerequisite,
+  type IntentTarget,
+  type OsIntent,
+  type OsIntentType,
+} from "./contract";
+import type { IntentDedupeStore } from "./dedupe";
+
+/** Microphone-permission state, mirroring the shell's proactive probe. `denied`
+ *  is the only hard block; `prompt`/`unknown` proceed to a capture-time prompt. */
+export type MicPermissionState = "granted" | "denied" | "prompt" | "unknown";
+
+/** Session/auth state gating chat + agent-backed intents. */
+export type AuthState = "authenticated" | "unauthenticated" | "expired";
+
+/**
+ * Everything the authority reads to route an intent — the live device/auth/
+ * capability/consent state at the moment of routing. All structural; no text.
+ */
+export interface RoutingContext {
+  /** Epoch ms; the clock for staleness and dedupe TTL. */
+  now: number;
+  auth: AuthState;
+  device: {
+    /** A locked device cannot reveal chat or open the mic. */
+    locked: boolean;
+    /** Platforms forbid starting capture while backgrounded. */
+    foreground: boolean;
+  };
+  capabilities: {
+    /** The platform can capture voice at all. False → visible voice degrade. */
+    voiceCapture: boolean;
+    /** A sandbox forbids the capture surface entirely → visible degrade. */
+    sandboxed: boolean;
+    microphone: MicPermissionState;
+  };
+  consent: {
+    /** The user has enabled auto-starting voice capture from a launch. */
+    autoStartVoice: boolean;
+    /** The user has enabled auto-starting transcription from a launch. */
+    autoStartTranscription: boolean;
+  };
+  /** Reject intents whose `issuedAt` is older than this (ms). Omit to disable
+   *  staleness (intents without `issuedAt` are never stale). */
+  maxIntentAgeMs?: number;
+}
+
+/**
+ * Route one intent. Pure except for recording a routed intent's id in `dedupe`
+ * (the intended, observable side effect that makes routing idempotent).
+ */
+export function routeIntent(
+  intent: OsIntent,
+  context: RoutingContext,
+  dedupe: IntentDedupeStore,
+): IntentOutcome {
+  const { intentId } = intent;
+  const intentType = intent.type;
+  const target = INTENT_TARGET[intentType];
+
+  if (context.maxIntentAgeMs !== undefined && intent.issuedAt !== undefined) {
+    const ageMs = context.now - intent.issuedAt;
+    // Only positive age is stale; a future `issuedAt` (clock skew) is not.
+    if (ageMs > context.maxIntentAgeMs) {
+      return { status: "stale", intentId, ageMs, maxAgeMs: context.maxIntentAgeMs };
+    }
+  }
+
+  const firstAppliedAt = dedupe.firstAppliedAt(intentId, context.now);
+  if (firstAppliedAt !== null) {
+    return { status: "duplicate", intentId, firstAppliedAt };
+  }
+
+  const degrade = evaluateDegrade(intentType, context);
+  if (degrade) {
+    return { status: "degraded", intentId, intentType, reason: degrade };
+  }
+
+  const { reason, missing } = evaluatePrerequisites(intentType, context);
+  if (reason) {
+    return { status: "blocked", intentId, intentType, reason, missing };
+  }
+
+  if (AUTO_START_INTENT_TYPES.has(intentType) && !hasAutoStartConsent(intentType, context)) {
+    return { status: "consent-required", intentId, intentType, target };
+  }
+
+  const commands = commandsForIntent(intent);
+  dedupe.record(intentId, context.now);
+  return { status: "routed", intentId, intentType, target, commands };
+}
+
+/**
+ * A device-capability failure the shell must surface as an unavailable state.
+ * Only intents that actually need capture (their prerequisites include
+ * `voice-capture`) can degrade; chat intents and the always-allowed `stop-*`
+ * never do.
+ */
+function evaluateDegrade(
+  intentType: OsIntentType,
+  context: RoutingContext,
+): IntentDegradeReason | null {
+  if (!INTENT_PREREQUISITES[intentType].includes("voice-capture")) return null;
+  if (context.capabilities.sandboxed) return "sandboxed";
+  if (!context.capabilities.voiceCapture) return "voice-unsupported";
+  return null;
+}
+
+/**
+ * Check the intent's declared prerequisites against the context. Returns the
+ * first blocking reason (in prerequisite-declaration order, so the priority is
+ * stable: auth → lock → foreground → mic) plus the full set of unmet
+ * prerequisites. `voice-capture` is handled by {@link evaluateDegrade}, not here.
+ */
+function evaluatePrerequisites(
+  intentType: OsIntentType,
+  context: RoutingContext,
+): { reason: IntentBlockReason | null; missing: IntentPrerequisite[] } {
+  const missing: IntentPrerequisite[] = [];
+  let reason: IntentBlockReason | null = null;
+
+  for (const prerequisite of INTENT_PREREQUISITES[intentType]) {
+    switch (prerequisite) {
+      case "session":
+        if (context.auth !== "authenticated") {
+          missing.push(prerequisite);
+          reason ??= context.auth === "expired" ? "auth-expired" : "unauthenticated";
+        }
+        break;
+      case "unlocked":
+        if (context.device.locked) {
+          missing.push(prerequisite);
+          reason ??= "locked";
+        }
+        break;
+      case "foreground":
+        if (!context.device.foreground) {
+          missing.push(prerequisite);
+          reason ??= "backgrounded";
+        }
+        break;
+      case "microphone":
+        if (context.capabilities.microphone === "denied") {
+          missing.push(prerequisite);
+          reason ??= "microphone-denied";
+        }
+        break;
+      case "voice-capture":
+        break;
+      default: {
+        const _exhaustive: never = prerequisite;
+        return _exhaustive;
+      }
+    }
+  }
+
+  return { reason, missing };
+}
+
+function hasAutoStartConsent(
+  intentType: OsIntentType,
+  context: RoutingContext,
+): boolean {
+  if (intentType === "start-voice") return context.consent.autoStartVoice;
+  if (intentType === "start-transcription") return context.consent.autoStartTranscription;
+  return true;
+}
+
+/**
+ * The commands a routed intent runs against the one controller. Send/start
+ * intents `open` the surface first so the launch is visible; `stop-*` intents
+ * emit only the teardown so they stay valid even when nothing is open.
+ */
+function commandsForIntent(intent: OsIntent): IntentControllerCommand[] {
+  switch (intent.type) {
+    case "open-chat":
+      return [{ kind: "open" }];
+    case "send":
+      return [
+        { kind: "open" },
+        {
+          kind: "send",
+          text: intent.text,
+          ...(intent.channelType ? { channelType: intent.channelType } : {}),
+          ...(intent.images ? { images: intent.images } : {}),
+          ...(intent.metadata ? { metadata: intent.metadata } : {}),
+        },
+      ];
+    case "start-voice":
+      return [{ kind: "open" }, { kind: "startRecording", intent: intent.mode }];
+    case "stop-voice":
+      return [{ kind: "stopRecording" }];
+    case "start-transcription":
+      return [{ kind: "open" }, { kind: "toggleTranscriptionMode" }];
+    case "stop-transcription":
+      return [{ kind: "stopTranscriptionAndMic" }];
+    case "continue-conversation":
+      return [{ kind: "open" }];
+    default: {
+      const _exhaustive: never = intent;
+      return _exhaustive;
+    }
+  }
+}
+
+/** The target surface for an intent type (re-exported for callers rendering the
+ *  outcome without importing the constant table directly). */
+export function intentTarget(intentType: OsIntentType): IntentTarget {
+  return INTENT_TARGET[intentType];
+}


### PR DESCRIPTION
## Summary

Closes #16441. One of five cards replacing the closed monolith #16200 — this one
delivers the **unified structural intent vocabulary + routing authority** for
chat, voice, and transcription launches, independently rebuilt on `develop`
(nothing cherry-picked from #16200).

Today every launch surface is ad-hoc: iOS App Intents / Siri, Android app-actions
+ shortcuts, desktop deep links, tray/widget controls, and notification taps each
emit an `elizaos://…?action=<free-form string>&text=…&voice=1` deep link, and the
only consumer (`assistant-launch-payload.ts`) handles **chat send only**, keyed on
a free-form `action` string with a plain in-memory `Set` for dedupe. There is no
typed vocabulary, no voice/transcription launch path, no prerequisite handling,
and no dedupe across windows / restored sessions.

This PR adds `packages/ui/src/os-intent/` — the one place a launch is expressed as
a typed `OsIntent` and routed by **structural fields only** to the single shared
shell controller.

### Intent vocabulary (`contract.ts`)

Discriminated-union intents, each with a stable `intentId` (idempotency key),
`source`, optional `issuedAt`, declared prerequisites, target, and typed outcomes:

| Intent | Target | Auto-start | Prerequisites |
| --- | --- | --- | --- |
| `open-chat` | chat | no | session |
| `send` | chat | no | session |
| `start-voice` (`converse`/`dictate`) | voice | **yes** | session, unlocked, foreground, microphone, voice-capture |
| `stop-voice` | voice | no | — (always allowed) |
| `start-transcription` | transcription | **yes** | unlocked, foreground, microphone, voice-capture |
| `stop-transcription` | transcription | no | — (always allowed) |
| `continue-conversation` | chat | no | session |

### Routing authority (`router.ts` + `dedupe.ts`)

`routeIntent(intent, context, dedupeStore)` returns a typed `IntentOutcome`
(`routed` / `duplicate` / `stale` / `blocked` / `consent-required` / `degraded`)
and, when routed, the `IntentControllerCommand[]` to apply. Evaluation order:

1. **Stale** — `issuedAt` older than `maxIntentAgeMs` → `stale` (never fires a
   launch the user has moved on from).
2. **Duplicate** — `intentId` already applied → `duplicate`. Only *routed* intents
   are recorded, so a `blocked` intent retried after the user grants permission
   still routes.
3. **Degraded** — device cannot honor it (voice unsupported / sandboxed) →
   `degraded` (visible unavailable state, never a silent no-op).
4. **Blocked** — recoverable prerequisite unmet (unauthenticated / auth-expired /
   locked / backgrounded / microphone-denied) → `blocked` with the missing
   prerequisites.
5. **Consent** — an auto-start (mic) intent without recorded consent →
   `consent-required` (explicit, reversible, consent-aware).
6. **Routed** — emit commands + record `intentId`.

Routing is **structural only** — it switches on `intent.type` and reads the
context; it never inspects prompt or transcript text. The free-form native
`action` string is mapped to a typed intent once, at the decode boundary.

**Idempotent dedupe across every redelivery path** — deep-link retries, re-tapped
notifications, multiple windows, and restored/crashed-then-reopened sessions all
carry the same `intentId`. `IntentDedupeStore` is a pure, clock-injected,
TTL-pruned store with `snapshot()` / seeding so a restored session rehydrates the
already-applied set and does not re-fire.

### Boundary decoder (`decode.ts`)

`decodeOsIntent(raw)` and `decodeDeepLinkIntent(url)` validate untrusted intent
payloads (deep links, notifications, native bridges) into a typed `OsIntent` or an
explicit typed failure (`{ ok: false, error }`) — never a fabricated-valid
default, never a throw on a single bad frame (error-policy J3). Matches the typed
transcript-event decoder style landed by sibling #16440.

### One engine (`apply-command.ts`)

`applyOsIntentCommand(controller, command)` runs a routed command against the one
live `ShellController` — the same engine the shared cross-window controller
(#16442) owns. The `IntentControllerCommand` union is the subset of #16442's
`ShellControllerCommand` that intents produce, kept structurally identical so no
intent ever spins up a second chat/voice session. Adapters
(`fromAssistantLaunchPayload`, `fromDeepLinkUrl`) let the existing entry points
conform.

## Test evidence

Comprehensive per-file vitest (jsdom/node, deterministic) covering the full case
matrix from the card: invalid/stale intents, locked device, missing permissions,
auth expiry, concurrency (interleaved routing sharing one dedupe store),
background/foreground, crash recovery (snapshot → rehydrate → no re-fire), and
duplicate-start prevention across deep-links / notifications / windows / retries /
restored sessions. Run: `bun run --cwd packages/ui test os-intent`.

## Scope / what is device-gated

- **Web/desktop-verifiable (this PR):** the vocabulary, decoder, dedupe store,
  routing authority, and command executor — all covered by fast vitest.
- **Device-gated (NOT verified here — no device pass run):** wiring the vocabulary
  into the live app-shell launch consumer and the per-platform native invocation
  (iOS App Intents / Siri, Android app-actions + Quick Settings tiles, desktop
  deep-link/tray/hotkey) requires real iOS-sim / Android-emu / packaged-desktop
  passes. The vocabulary + adapters are defined so those surfaces can conform;
  the deep-link `action` strings the native spine already emits (`ask`, `chat`,
  `voice`, `smart-reply`) map onto typed intents in `decode.ts`. I did **not** run
  device verification and do not claim it.

## Evidence

Non-visual TypeScript library module (`packages/ui/src/os-intent/*.ts`) + vitest.
No React component, view, route, or agent/model surface is touched.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed; pure `.ts` intent-routing library + vitest (no `.tsx`, no view/route).
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed; pure `.ts` intent-routing library + vitest (no `.tsx`, no view/route).
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-exercisable UI flow; module is not yet wired into the live launch consumer (device-gated, see Scope).
<!-- evidence-row:backend-logs -->
- [x] N/A - no server code path; this is a client-side UI library module with no backend route.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no rendered surface; behavior is proven by deterministic vitest over the full case matrix instead.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes; routing is structural and never invokes a model.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - produces no persisted domain artifacts; outputs are typed in-memory outcomes/commands asserted in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
