### PR TITLE
feat(native): add typed composer bridges for mobile and desktop

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -259,6 +259,11 @@
       "import": "./dist/lib/utils.js",
       "default": "./dist/lib/utils.js"
     },
+    "./native-composer": {
+      "types": "./dist/native-composer/index.d.ts",
+      "import": "./dist/native-composer/index.js",
+      "default": "./dist/native-composer/index.js"
+    },
     "./navigation": {
       "types": "./dist/navigation/index.d.ts",
       "import": "./dist/navigation/index.js",

--- a/packages/ui/src/native-composer/attachments.test.ts
+++ b/packages/ui/src/native-composer/attachments.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Renderer-side attachment-normalization tests: each media-store source resolves
+ * to a store-vocabulary URL, and every non-store / oversized / malformed / private
+ * input is rejected with a typed reason rather than becoming a fabricated
+ * attachment. Asserts the produced attachment carries no file-id (no second store).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ComposerAttachmentSource } from "./contract";
+import { normalizeComposerAttachment } from "./attachments";
+
+const HASH = "a".repeat(64);
+
+describe("normalizeComposerAttachment — happy paths", () => {
+  it("inline bytes → a data: URL (persisted to the store on send)", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "inline",
+      mimeType: "image/png",
+      bytesBase64: "AAAA",
+      name: "pic.png",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.attachment.url).toBe("data:image/png;base64,AAAA");
+      expect(r.attachment.kind).toBe("inline");
+      expect(r.attachment.status).toBe("ready");
+      expect(r.attachment.name).toBe("pic.png");
+      // No second store: only media-store fields exist, never a file id.
+      expect(Object.keys(r.attachment)).not.toContain("fileId");
+    }
+  });
+
+  it("data-url source passes through with parsed mime", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "data-url",
+      dataUrl: "data:image/jpeg;base64,/9j/AAAA",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.attachment.mimeType).toBe("image/jpeg");
+  });
+
+  it("remote http(s) URL is kept for server-side SSRF rehost", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "remote",
+      url: "https://cdn.test/photo.png",
+      mimeType: "image/png",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.attachment.kind).toBe("remote");
+      expect(r.attachment.status).toBe("pending-rehost");
+    }
+  });
+
+  it("already-stored /api/media/<hash> URL passes through as ready", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "stored",
+      url: `/api/media/${HASH}.png`,
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.attachment.kind).toBe("stored");
+      expect(r.attachment.status).toBe("ready");
+    }
+  });
+});
+
+describe("normalizeComposerAttachment — rejections", () => {
+  it("rejects oversized inline bytes with reason oversized", () => {
+    // 1 KiB cap, ~3 KiB of base64 → ~2.25 KiB decoded.
+    const big = "A".repeat(3000);
+    const r = normalizeComposerAttachment(
+      "att1",
+      { source: "inline", mimeType: "image/png", bytesBase64: big },
+      { maxBytes: 1024 },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("oversized");
+  });
+
+  it("rejects a malformed mime", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "inline",
+      mimeType: "not-a-mime",
+      bytesBase64: "AAAA",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-input");
+  });
+
+  it("rejects non-base64 inline bytes", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "inline",
+      mimeType: "image/png",
+      bytesBase64: "%%%not base64%%%",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-input");
+  });
+
+  it("blocks obviously-private remote hosts (first-line SSRF guard)", () => {
+    const hosts = [
+      "http://localhost/x.png",
+      "http://127.0.0.1/x.png",
+      "http://10.0.0.5/x.png",
+      "http://192.168.1.9/x.png",
+      "http://169.254.169.254/latest/meta-data",
+      "http://internal/x.png",
+    ];
+    for (const url of hosts) {
+      const r = normalizeComposerAttachment("att1", { source: "remote", url } as ComposerAttachmentSource);
+      expect(r.ok, url).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("permission-denied");
+    }
+  });
+
+  it("rejects a non-http(s) remote scheme", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "remote",
+      url: "file:///etc/passwd",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unsupported");
+  });
+
+  it("rejects a stored URL that is not content-addressed", () => {
+    const r = normalizeComposerAttachment("att1", {
+      source: "stored",
+      url: "/api/media/../secret.png",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("invalid-input");
+  });
+});

--- a/packages/ui/src/native-composer/attachments.test.ts
+++ b/packages/ui/src/native-composer/attachments.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { ComposerAttachmentSource } from "./contract";
 import { normalizeComposerAttachment } from "./attachments";
+import type { ComposerAttachmentSource } from "./contract";
 
 const HASH = "a".repeat(64);
 
@@ -108,7 +108,10 @@ describe("normalizeComposerAttachment — rejections", () => {
       "http://internal/x.png",
     ];
     for (const url of hosts) {
-      const r = normalizeComposerAttachment("att1", { source: "remote", url } as ComposerAttachmentSource);
+      const r = normalizeComposerAttachment("att1", {
+        source: "remote",
+        url,
+      } as ComposerAttachmentSource);
       expect(r.ok, url).toBe(false);
       if (!r.ok) expect(r.reason).toBe("permission-denied");
     }

--- a/packages/ui/src/native-composer/attachments.ts
+++ b/packages/ui/src/native-composer/attachments.ts
@@ -1,0 +1,202 @@
+/**
+ * Normalizes a decoded {@link ComposerAttachmentSource} into a
+ * {@link ComposerAttachment} expressed purely in the existing content-addressed
+ * media store's vocabulary — a `data:` URL (persisted to the store on send by the
+ * outgoing pipeline in `api/media-runtime.ts`), a remote http(s) URL flagged for
+ * server-side SSRF-guarded rehost, or an already-stored `/api/media/<hash>` URL.
+ *
+ * This is the "route attachments through the existing store, add no second store"
+ * seam on the renderer side: it produces no file id and no bespoke handle, only a
+ * URL the existing send path already knows how to persist. Oversized or malformed
+ * bytes are rejected with a typed reason (never a fabricated attachment), so a bad
+ * source stops here instead of becoming a broken tile downstream.
+ *
+ * The private-host check on `remote` is a fast first-line guard for obvious
+ * loopback/RFC-1918 literals; it is NOT the authority. The server's DNS-pinned
+ * SSRF guard (`packages/core/src/network`, driven by `fetchRemoteMedia`) makes the
+ * binding decision at rehost time.
+ */
+
+import type {
+  ComposerAttachment,
+  ComposerAttachmentSource,
+  ComposerRejectReason,
+} from "./contract";
+
+/** Default hard cap on inline attachment bytes; mirrors the store's rehost cap. */
+export const DEFAULT_MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+
+/** Served-media URL prefix; a `stored` source must already point here. */
+const STORED_MEDIA_PREFIX = "/api/media/";
+/** `<sha256>.<ext>` — the store's content-addressed file name shape. */
+const STORED_MEDIA_NAME = /^[a-f0-9]{64}\.[a-z0-9]+$/i;
+
+export interface NormalizeAttachmentOptions {
+  /** Reject inline/data-url bytes larger than this (default 50 MiB). */
+  maxBytes?: number;
+}
+
+export type NormalizeAttachmentResult =
+  | { ok: true; attachment: ComposerAttachment }
+  | { ok: false; reason: ComposerRejectReason; message: string };
+
+function reject(
+  reason: ComposerRejectReason,
+  message: string,
+): { ok: false; reason: ComposerRejectReason; message: string } {
+  return { ok: false, reason, message };
+}
+
+/** A mime is well-formed iff it is `type/subtype` with non-empty halves. */
+function isWellFormedMime(mime: string): boolean {
+  return /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i.test(mime);
+}
+
+/** Decoded byte length of a standard/loose base64 payload (whitespace stripped). */
+function base64ByteLength(base64: string): number | null {
+  const cleaned = base64.replace(/\s+/g, "");
+  if (cleaned.length === 0) return 0;
+  if (!/^[A-Za-z0-9+/_-]*={0,2}$/.test(cleaned)) return null;
+  const padding = cleaned.endsWith("==") ? 2 : cleaned.endsWith("=") ? 1 : 0;
+  return Math.floor((cleaned.length * 3) / 4) - padding;
+}
+
+/**
+ * True for a hostname that is a loopback or RFC-1918/link-local literal, or has
+ * no dot (bare host / `.local`) — the obvious SSRF footguns worth rejecting
+ * before a round-trip. Authoritative blocking is the server's DNS-pinned guard.
+ */
+function isObviouslyPrivateHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "localhost" || host === "0.0.0.0" || host === "::1") return true;
+  if (host.endsWith(".local") || !host.includes(".")) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)) return true;
+  if (host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80"))
+    return true;
+  return false;
+}
+
+function parseDataUrlMime(dataUrl: string): string | undefined {
+  const header = dataUrl.slice("data:".length).split(",", 1)[0] ?? "";
+  const mime = header.split(";", 1)[0]?.trim();
+  return mime && mime.length > 0 ? mime : undefined;
+}
+
+/** Upper-bound byte size of a `data:` URL payload (base64 or percent/plain). */
+function dataUrlByteLength(dataUrl: string): number | null {
+  const comma = dataUrl.indexOf(",");
+  if (comma < 0) return null;
+  const header = dataUrl.slice("data:".length, comma);
+  const payload = dataUrl.slice(comma + 1);
+  if (/;base64/i.test(header)) return base64ByteLength(payload);
+  // Percent/plain-encoded payloads are at most their encoded length in bytes.
+  return payload.length;
+}
+
+/**
+ * Normalize one attachment source into the media-store vocabulary, or reject it
+ * with a typed reason. The decoder has already validated field shapes; this adds
+ * the semantic checks the store cares about: a well-formed mime and a byte cap.
+ */
+export function normalizeComposerAttachment(
+  id: string,
+  source: ComposerAttachmentSource,
+  options: NormalizeAttachmentOptions = {},
+): NormalizeAttachmentResult {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_ATTACHMENT_BYTES;
+
+  switch (source.source) {
+    case "inline": {
+      if (!isWellFormedMime(source.mimeType))
+        return reject("invalid-input", `malformed mime: ${source.mimeType}`);
+      const bytes = base64ByteLength(source.bytesBase64);
+      if (bytes === null)
+        return reject("invalid-input", "attachment bytes are not valid base64");
+      if (bytes === 0)
+        return reject("invalid-input", "attachment has no bytes");
+      if (bytes > maxBytes)
+        return reject("oversized", `attachment ${bytes}B exceeds cap ${maxBytes}B`);
+      return {
+        ok: true,
+        attachment: {
+          id,
+          url: `data:${source.mimeType};base64,${source.bytesBase64.replace(/\s+/g, "")}`,
+          mimeType: source.mimeType,
+          ...(source.name ? { name: source.name } : {}),
+          kind: "inline",
+          status: "ready",
+        },
+      };
+    }
+    case "data-url": {
+      const mime = parseDataUrlMime(source.dataUrl);
+      if (!mime || !isWellFormedMime(mime))
+        return reject("invalid-input", "data URL has no valid mediatype");
+      const bytes = dataUrlByteLength(source.dataUrl);
+      if (bytes === null)
+        return reject("invalid-input", "data URL payload is malformed");
+      if (bytes === 0) return reject("invalid-input", "data URL has no bytes");
+      if (bytes > maxBytes)
+        return reject("oversized", `attachment ${bytes}B exceeds cap ${maxBytes}B`);
+      return {
+        ok: true,
+        attachment: {
+          id,
+          url: source.dataUrl,
+          mimeType: mime,
+          ...(source.name ? { name: source.name } : {}),
+          kind: "inline",
+          status: "ready",
+        },
+      };
+    }
+    case "remote": {
+      let parsed: URL;
+      try {
+        parsed = new URL(source.url);
+      } catch {
+        return reject("invalid-input", `not a valid URL: ${source.url}`);
+      }
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+        return reject("unsupported", `unsupported scheme: ${parsed.protocol}`);
+      if (isObviouslyPrivateHost(parsed.hostname))
+        return reject("permission-denied", `blocked private host: ${parsed.hostname}`);
+      return {
+        ok: true,
+        attachment: {
+          id,
+          url: source.url,
+          ...(source.mimeType ? { mimeType: source.mimeType } : {}),
+          ...(source.name ? { name: source.name } : {}),
+          kind: "remote",
+          // Awaits the server's SSRF-guarded rehost on send; not yet in the store.
+          status: "pending-rehost",
+        },
+      };
+    }
+    case "stored": {
+      const name = source.url.startsWith(STORED_MEDIA_PREFIX)
+        ? source.url.slice(STORED_MEDIA_PREFIX.length).split(/[?#]/)[0]
+        : "";
+      if (!name || !STORED_MEDIA_NAME.test(name))
+        return reject(
+          "invalid-input",
+          `not a stored media URL: ${source.url}`,
+        );
+      return {
+        ok: true,
+        attachment: {
+          id,
+          url: source.url,
+          ...(source.mimeType ? { mimeType: source.mimeType } : {}),
+          kind: "stored",
+          status: "ready",
+        },
+      };
+    }
+  }
+}

--- a/packages/ui/src/native-composer/attachments.ts
+++ b/packages/ui/src/native-composer/attachments.ts
@@ -119,7 +119,10 @@ export function normalizeComposerAttachment(
       if (bytes === 0)
         return reject("invalid-input", "attachment has no bytes");
       if (bytes > maxBytes)
-        return reject("oversized", `attachment ${bytes}B exceeds cap ${maxBytes}B`);
+        return reject(
+          "oversized",
+          `attachment ${bytes}B exceeds cap ${maxBytes}B`,
+        );
       return {
         ok: true,
         attachment: {
@@ -141,7 +144,10 @@ export function normalizeComposerAttachment(
         return reject("invalid-input", "data URL payload is malformed");
       if (bytes === 0) return reject("invalid-input", "data URL has no bytes");
       if (bytes > maxBytes)
-        return reject("oversized", `attachment ${bytes}B exceeds cap ${maxBytes}B`);
+        return reject(
+          "oversized",
+          `attachment ${bytes}B exceeds cap ${maxBytes}B`,
+        );
       return {
         ok: true,
         attachment: {
@@ -164,7 +170,10 @@ export function normalizeComposerAttachment(
       if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
         return reject("unsupported", `unsupported scheme: ${parsed.protocol}`);
       if (isObviouslyPrivateHost(parsed.hostname))
-        return reject("permission-denied", `blocked private host: ${parsed.hostname}`);
+        return reject(
+          "permission-denied",
+          `blocked private host: ${parsed.hostname}`,
+        );
       return {
         ok: true,
         attachment: {
@@ -183,10 +192,7 @@ export function normalizeComposerAttachment(
         ? source.url.slice(STORED_MEDIA_PREFIX.length).split(/[?#]/)[0]
         : "";
       if (!name || !STORED_MEDIA_NAME.test(name))
-        return reject(
-          "invalid-input",
-          `not a stored media URL: ${source.url}`,
-        );
+        return reject("invalid-input", `not a stored media URL: ${source.url}`);
       return {
         ok: true,
         attachment: {

--- a/packages/ui/src/native-composer/attachments.ts
+++ b/packages/ui/src/native-composer/attachments.ts
@@ -165,6 +165,8 @@ export function normalizeComposerAttachment(
       try {
         parsed = new URL(source.url);
       } catch {
+        // error-policy:J3 untrusted-input sanitizing — an unparseable native URL
+        // is an explicit typed "invalid" result, not a fabricated attachment.
         return reject("invalid-input", `not a valid URL: ${source.url}`);
       }
       if (parsed.protocol !== "http:" && parsed.protocol !== "https:")

--- a/packages/ui/src/native-composer/client.test.ts
+++ b/packages/ui/src/native-composer/client.test.ts
@@ -6,9 +6,9 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { NATIVE_COMPOSER_SCHEMA } from "./contract";
-import type { ComposerEvent } from "./contract";
 import { createComposerBridgeClient } from "./client";
+import type { ComposerEvent } from "./contract";
+import { NATIVE_COMPOSER_SCHEMA } from "./contract";
 
 describe("createComposerBridgeClient — boundary + events", () => {
   it("degrades malformed raw input to invalid-input, never throws", () => {
@@ -25,8 +25,16 @@ describe("createComposerBridgeClient — boundary + events", () => {
     const client = createComposerBridgeClient();
     const events: ComposerEvent[] = [];
     client.subscribe((e) => events.push(e));
-    client.dispatchRaw({ type: "focus.set", opId: "f", focused: true, keyboard: "shown" });
-    expect(events.map((e) => e.type)).toEqual(["draft.changed", "focus.changed"]);
+    client.dispatchRaw({
+      type: "focus.set",
+      opId: "f",
+      focused: true,
+      keyboard: "shown",
+    });
+    expect(events.map((e) => e.type)).toEqual([
+      "draft.changed",
+      "focus.changed",
+    ]);
   });
 
   it("emits voice.state for a voice op and send.result on completion", () => {
@@ -56,7 +64,11 @@ describe("createComposerBridgeClient — reload durability", () => {
     // Simulate a window reload: new client hydrated from the snapshot.
     const after = createComposerBridgeClient({ snapshot });
     expect(after.getDraft().text).toBe("x");
-    const replay = after.dispatchRaw({ type: "text.insert", opId: "dup", text: "x" });
+    const replay = after.dispatchRaw({
+      type: "text.insert",
+      opId: "dup",
+      text: "x",
+    });
     expect(replay.status).toBe("duplicate");
     expect(after.getDraft().text).toBe("x"); // not doubled
   });
@@ -86,7 +98,11 @@ describe("createComposerBridgeClient — batch replay", () => {
         { type: "text.insert", opId: "2", text: "b" },
       ],
     });
-    expect(results.map((r) => r.status)).toEqual(["applied", "rejected", "applied"]);
+    expect(results.map((r) => r.status)).toEqual([
+      "applied",
+      "rejected",
+      "applied",
+    ]);
     expect(client.getDraft().text).toBe("ab");
   });
 

--- a/packages/ui/src/native-composer/client.test.ts
+++ b/packages/ui/src/native-composer/client.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Client-boundary tests: malformed native input degrades to a typed rejection
+ * (never a throw), events are emitted toward the shell, and serialize/hydrate
+ * preserves the draft + idempotency ledger + offline queue across a reload — so a
+ * duplicate op still no-ops and a deferred send still replays after reconnect.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NATIVE_COMPOSER_SCHEMA } from "./contract";
+import type { ComposerEvent } from "./contract";
+import { createComposerBridgeClient } from "./client";
+
+describe("createComposerBridgeClient — boundary + events", () => {
+  it("degrades malformed raw input to invalid-input, never throws", () => {
+    const client = createComposerBridgeClient();
+    const r = client.dispatchRaw({ type: "text.set", opId: "a", text: 9 });
+    expect(r.status).toBe("rejected");
+    if (r.status === "rejected") {
+      expect(r.reason).toBe("invalid-input");
+      expect(r.opId).toBe("a");
+    }
+  });
+
+  it("emits draft.changed + focus.changed for a focus op", () => {
+    const client = createComposerBridgeClient();
+    const events: ComposerEvent[] = [];
+    client.subscribe((e) => events.push(e));
+    client.dispatchRaw({ type: "focus.set", opId: "f", focused: true, keyboard: "shown" });
+    expect(events.map((e) => e.type)).toEqual(["draft.changed", "focus.changed"]);
+  });
+
+  it("emits voice.state for a voice op and send.result on completion", () => {
+    const client = createComposerBridgeClient();
+    const events: ComposerEvent[] = [];
+    client.subscribe((e) => events.push(e));
+    client.dispatchRaw({ type: "text.set", opId: "t", text: "hi" });
+    client.dispatchRaw({ type: "voice.handoff", opId: "v", phase: "start" });
+    client.dispatchRaw({ type: "send", opId: "s" });
+    client.completeSend("s", { ok: true, messageId: "m1" });
+    expect(events.some((e) => e.type === "voice.state")).toBe(true);
+    const sendResult = events.find((e) => e.type === "send.result");
+    expect(sendResult).toBeDefined();
+    if (sendResult && sendResult.type === "send.result")
+      expect(sendResult.outcome.ok).toBe(true);
+    expect(client.getDraft().text).toBe(""); // cleared on successful send
+  });
+});
+
+describe("createComposerBridgeClient — reload durability", () => {
+  it("preserves idempotency across a serialize/hydrate reload", () => {
+    const before = createComposerBridgeClient();
+    before.dispatchRaw({ type: "text.insert", opId: "dup", text: "x" });
+    const snapshot = before.serialize();
+    expect(snapshot.schema).toBe(NATIVE_COMPOSER_SCHEMA);
+
+    // Simulate a window reload: new client hydrated from the snapshot.
+    const after = createComposerBridgeClient({ snapshot });
+    expect(after.getDraft().text).toBe("x");
+    const replay = after.dispatchRaw({ type: "text.insert", opId: "dup", text: "x" });
+    expect(replay.status).toBe("duplicate");
+    expect(after.getDraft().text).toBe("x"); // not doubled
+  });
+
+  it("preserves a deferred offline send across reload, then replays on reconnect", () => {
+    const before = createComposerBridgeClient({ online: false });
+    before.dispatchRaw({ type: "text.set", opId: "t", text: "hi" });
+    before.dispatchRaw({ type: "send", opId: "s" });
+    const snapshot = before.serialize();
+    expect(snapshot.deferred).toHaveLength(1);
+
+    const after = createComposerBridgeClient({ online: false, snapshot });
+    after.setOnline(true);
+    expect(after.getState().sending?.opId).toBe("s");
+    expect(after.getState().deferred).toHaveLength(0);
+  });
+});
+
+describe("createComposerBridgeClient — batch replay", () => {
+  it("applies a stream envelope in order and surfaces malformed ops in place", () => {
+    const client = createComposerBridgeClient();
+    const results = client.dispatchRawStream({
+      schema: NATIVE_COMPOSER_SCHEMA,
+      operations: [
+        { type: "text.insert", opId: "1", text: "a" },
+        { type: "text.insert", opId: "bad", text: 5 },
+        { type: "text.insert", opId: "2", text: "b" },
+      ],
+    });
+    expect(results.map((r) => r.status)).toEqual(["applied", "rejected", "applied"]);
+    expect(client.getDraft().text).toBe("ab");
+  });
+
+  it("de-dupes a replayed batch after reconnect", () => {
+    const client = createComposerBridgeClient();
+    const batch = {
+      schema: NATIVE_COMPOSER_SCHEMA,
+      operations: [{ type: "text.insert", opId: "1", text: "a" }],
+    };
+    client.dispatchRawStream(batch);
+    const second = client.dispatchRawStream(batch);
+    expect(second[0].status).toBe("duplicate");
+    expect(client.getDraft().text).toBe("a");
+  });
+});

--- a/packages/ui/src/native-composer/client.ts
+++ b/packages/ui/src/native-composer/client.ts
@@ -20,6 +20,15 @@
  */
 
 import {
+  type ComposerDraft,
+  type ComposerEvent,
+  type ComposerOperation,
+  type DispatchResult,
+  NATIVE_COMPOSER_SCHEMA,
+  type NativeComposerSchema,
+  type SendOutcome,
+} from "./contract";
+import {
   decodeComposerOperation,
   decodeComposerOperationStream,
 } from "./decode";
@@ -35,15 +44,6 @@ import {
   initialComposerState,
   resolveSend,
 } from "./reduce";
-import {
-  type ComposerDraft,
-  type ComposerEvent,
-  type ComposerOperation,
-  type DispatchResult,
-  NATIVE_COMPOSER_SCHEMA,
-  type NativeComposerSchema,
-  type SendOutcome,
-} from "./contract";
 
 /** Plain-JSON snapshot persisted across reload; excludes the transient send. */
 export interface ComposerBridgeSnapshot {

--- a/packages/ui/src/native-composer/client.ts
+++ b/packages/ui/src/native-composer/client.ts
@@ -1,0 +1,219 @@
+/**
+ * The renderer-side composer-bridge client: the one object a native shell talks
+ * to. It decodes raw operations at the boundary, folds them through the reducer,
+ * emits typed {@link ComposerEvent}s back to the shell, and persists the draft +
+ * idempotency ledger so state survives app backgrounding, window reload, and
+ * transport reconnect.
+ *
+ * Durability model:
+ *   - `serialize()` / `hydrate()` round-trip the draft, the processed-`opId`
+ *     ledger, and the offline send queue as plain JSON. Restoring them after a
+ *     reload is what makes a re-delivered operation still dedupe (idempotency)
+ *     and an offline send still replay (offline recovery). The in-flight
+ *     `sending` marker is intentionally NOT persisted — a reload has no live
+ *     request to resume, so the send is re-driven by a fresh op or its result.
+ *   - `setOnline(true)` flushes the deferred queue and reports each replay.
+ *
+ * The client never throws on bad native input: a malformed raw operation becomes
+ * a `rejected: "invalid-input"` result (error-policy J3), so one bad frame cannot
+ * tear down a live composer.
+ */
+
+import {
+  decodeComposerOperation,
+  decodeComposerOperationStream,
+} from "./decode";
+import {
+  applyComposerOperation,
+  type ComposerApplyContext,
+  type ComposerBridgeState,
+  type ComposerCapabilities,
+  type ComposerLimits,
+  DEFAULT_COMPOSER_CAPABILITIES,
+  DEFAULT_COMPOSER_LIMITS,
+  flushDeferredOperations,
+  initialComposerState,
+  resolveSend,
+} from "./reduce";
+import {
+  type ComposerDraft,
+  type ComposerEvent,
+  type ComposerOperation,
+  type DispatchResult,
+  NATIVE_COMPOSER_SCHEMA,
+  type NativeComposerSchema,
+  type SendOutcome,
+} from "./contract";
+
+/** Plain-JSON snapshot persisted across reload; excludes the transient send. */
+export interface ComposerBridgeSnapshot {
+  schema: NativeComposerSchema;
+  draft: ComposerDraft;
+  /** The dedupe ledger, so a post-reload duplicate op still no-ops. */
+  processedOpIds: string[];
+  /** The offline send queue, so a deferred send still replays after reload. */
+  deferred: ComposerOperation[];
+}
+
+export interface ComposerBridgeClientOptions {
+  online?: boolean;
+  capabilities?: ComposerCapabilities;
+  limits?: ComposerLimits;
+  /** Restore a prior session (idempotency + draft + offline queue). */
+  snapshot?: ComposerBridgeSnapshot;
+}
+
+export interface ComposerBridgeClient {
+  /** Decode + apply one raw native operation; never throws on bad input. */
+  dispatchRaw(raw: unknown): DispatchResult;
+  /** Decode + apply a whole `{ schema, operations }` envelope (batch replay). */
+  dispatchRawStream(raw: unknown): DispatchResult[];
+  /** Apply an already-decoded operation. */
+  dispatchOperation(op: ComposerOperation): DispatchResult;
+  /** Resolve the in-flight send and emit `send.result` + `draft.changed`. */
+  completeSend(opId: string, outcome: SendOutcome): void;
+  /** Toggle transport liveness; going online flushes the deferred send queue. */
+  setOnline(online: boolean): void;
+  getDraft(): ComposerDraft;
+  getState(): ComposerBridgeState;
+  /** Subscribe to events emitted toward the native shell. */
+  subscribe(listener: (event: ComposerEvent) => void): () => void;
+  serialize(): ComposerBridgeSnapshot;
+}
+
+/** Best-effort opId for a raw op that failed to decode (for the rejected result). */
+function rawOpId(raw: unknown): string {
+  if (raw && typeof raw === "object" && "opId" in raw) {
+    const id = (raw as { opId: unknown }).opId;
+    if (typeof id === "string" && id.length > 0) return id;
+  }
+  return "";
+}
+
+export function createComposerBridgeClient(
+  options: ComposerBridgeClientOptions = {},
+): ComposerBridgeClient {
+  let state = options.snapshot
+    ? hydrate(options.snapshot)
+    : initialComposerState();
+
+  const ctx: ComposerApplyContext = {
+    online: options.online ?? true,
+    capabilities: options.capabilities ?? DEFAULT_COMPOSER_CAPABILITIES,
+    limits: options.limits ?? DEFAULT_COMPOSER_LIMITS,
+  };
+
+  const listeners = new Set<(event: ComposerEvent) => void>();
+  const emit = (event: ComposerEvent): void => {
+    for (const listener of listeners) listener(event);
+  };
+
+  // A draft-mutating result is echoed to the shell; emit the specific side
+  // events (focus/voice) so a shell that only cares about those need not diff.
+  const emitFor = (op: ComposerOperation, result: DispatchResult): void => {
+    if (result.status !== "applied") return;
+    emit({ type: "draft.changed", draft: result.draft });
+    if (op.type === "focus.set")
+      emit({
+        type: "focus.changed",
+        focused: result.draft.focused,
+        keyboard: result.draft.keyboard,
+      });
+    if (op.type === "voice.handoff")
+      emit({ type: "voice.state", phase: op.phase });
+  };
+
+  const applyDecoded = (op: ComposerOperation): DispatchResult => {
+    const step = applyComposerOperation(state, op, ctx);
+    state = step.state;
+    emitFor(op, step.result);
+    return step.result;
+  };
+
+  return {
+    dispatchRaw(raw) {
+      const decoded = decodeComposerOperation(raw);
+      if (!decoded.ok) {
+        return {
+          status: "rejected",
+          opId: rawOpId(raw),
+          reason: "invalid-input",
+          message: decoded.error.message,
+          draft: state.draft,
+        };
+      }
+      return applyDecoded(decoded.operation);
+    },
+    dispatchRawStream(raw) {
+      const { operations, rejected } = decodeComposerOperationStream(raw);
+      const results: DispatchResult[] = [];
+      // Preserve source order: rejected ops surface as invalid-input in place.
+      let opIdx = 0;
+      const rejectedByIndex = new Map(rejected.map((r) => [r.index, r]));
+      const total = operations.length + rejected.length;
+      for (let i = 0; i < total; i++) {
+        const bad = rejectedByIndex.get(i);
+        if (bad) {
+          results.push({
+            status: "rejected",
+            opId: "",
+            reason: "invalid-input",
+            message: bad.error.message,
+            draft: state.draft,
+          });
+        } else {
+          results.push(applyDecoded(operations[opIdx++]));
+        }
+      }
+      return results;
+    },
+    dispatchOperation(op) {
+      return applyDecoded(op);
+    },
+    completeSend(opId, outcome) {
+      state = resolveSend(state, opId, outcome);
+      emit({ type: "send.result", opId, outcome });
+      emit({ type: "draft.changed", draft: state.draft });
+    },
+    setOnline(online) {
+      ctx.online = online;
+      if (!online) return;
+      const flushed = flushDeferredOperations(state, ctx);
+      state = flushed.state;
+      // A replayed send that applied changes nothing in the draft, but a shell
+      // watching the queue wants the draft snapshot after the flush.
+      if (flushed.results.some((r) => r.status === "applied"))
+        emit({ type: "draft.changed", draft: state.draft });
+    },
+    getDraft() {
+      return state.draft;
+    },
+    getState() {
+      return state;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    serialize() {
+      return {
+        schema: NATIVE_COMPOSER_SCHEMA,
+        draft: state.draft,
+        processedOpIds: [...state.processed],
+        deferred: state.deferred,
+      };
+    },
+  };
+}
+
+/** Rebuild reducer state from a persisted snapshot (drops the transient send). */
+function hydrate(snapshot: ComposerBridgeSnapshot): ComposerBridgeState {
+  return {
+    draft: snapshot.draft,
+    processed: new Set(snapshot.processedOpIds),
+    deferred: snapshot.deferred,
+    sending: null,
+  };
+}

--- a/packages/ui/src/native-composer/contract.ts
+++ b/packages/ui/src/native-composer/contract.ts
@@ -1,0 +1,326 @@
+/**
+ * The one cross-platform composer-bridge contract (`eliza.native-composer/v1`):
+ * how an iOS (share sheet, keyboard extension, App Intent), Android (share
+ * intent, quick-tile), or desktop (global hotkey, tray, menu) shell pushes
+ * content INTO the chat composer and drives it, and how the renderer reports the
+ * composer's state back so the shell stays in sync.
+ *
+ * Two typed, versioned, discriminated-union logs cross the boundary:
+ *   - `ComposerOperation` (native shell → renderer): the commands — text,
+ *     attachments, mentions, reply context, send/cancel, focus/keyboard, and
+ *     voice handoff. Applying one returns a typed {@link DispatchResult}, never a
+ *     bare boolean, so the shell learns *why* an op did nothing.
+ *   - `ComposerEvent` (renderer → native shell): the composer's own state — the
+ *     reduced draft, send outcomes, focus/keyboard, and voice-handoff phase.
+ *
+ * Design rules that make the bridge safe across a lossy, duplicating transport:
+ *   - Every operation carries a stable, source-assigned `opId`. It is the sole
+ *     idempotency key: a re-delivered op (duplicate native callback, replay after
+ *     reconnect/reload) with an already-seen `opId` is a no-op, reported as
+ *     `status: "duplicate"`. Behavior derives from this structural id, never from
+ *     inspecting text content or its length.
+ *   - Attachments are expressed only in the vocabulary of the existing
+ *     content-addressed media store — inline bytes, a `data:` URL, a remote
+ *     http(s) URL to SSRF-guard, or an already-stored `/api/media/<hash>` URL.
+ *     There is deliberately no file-id / handle variant, so the contract cannot
+ *     express a second file store (repo commandment; see media-store.ts).
+ *
+ * This module is pure type + constant declarations (runtime validation lives in
+ * `decode.ts`, the state machine in `reduce.ts`) so it is safe to import from any
+ * layer, native bridge shim included.
+ */
+
+/** Versioned schema identifier carried by a composer-bridge stream envelope. */
+export const NATIVE_COMPOSER_SCHEMA = "eliza.native-composer/v1" as const;
+export type NativeComposerSchema = typeof NATIVE_COMPOSER_SCHEMA;
+
+// ── Shared value objects ───────────────────────────────────────────────
+
+/** Whether the on-screen keyboard is up; drives layout the shell reports. */
+export type KeyboardVisibility = "shown" | "hidden";
+
+/**
+ * How a native shell hands over one attachment, in media-store vocabulary only.
+ * `inline`/`data-url` carry bytes to persist; `remote` is an http(s) URL the
+ * server rehosts through the SSRF guard; `stored` is already in the store. No
+ * variant carries a file id — the store is content-addressed by sha256 and a
+ * second-store handle is unrepresentable here by design.
+ */
+export type ComposerAttachmentSource =
+  | {
+      source: "inline";
+      mimeType: string;
+      /** Raw bytes, base64 with no `data:` prefix. */
+      bytesBase64: string;
+      name?: string;
+    }
+  | { source: "data-url"; dataUrl: string; name?: string }
+  | { source: "remote"; url: string; mimeType?: string; name?: string }
+  | { source: "stored"; url: string; mimeType?: string; name?: string };
+
+/** A reply/quote target the composer threads onto the outgoing message. */
+export interface ComposerReplyContext {
+  messageId: string;
+  authorId?: string;
+  /** Short preview text the composer renders in the reply chip. */
+  preview?: string;
+}
+
+/** An @-mention token inserted into the draft. */
+export interface ComposerMention {
+  id: string;
+  label: string;
+  kind?: "user" | "agent" | "channel";
+}
+
+/** Scope of a `cancel` operation: abort an in-flight send, or clear the draft. */
+export type ComposerCancelScope = "send" | "draft";
+
+/** Lifecycle of a voice handoff: begin dictation, commit its text, or abandon. */
+export type VoiceHandoffPhase = "start" | "commit" | "cancel";
+
+// ── Operations (native shell → renderer) ───────────────────────────────
+
+interface ComposerOperationBase {
+  /** Stable, source-assigned idempotency key; a repeat is a no-op. */
+  opId: string;
+  /** Optional wall-clock ms of when the shell issued the op (display only). */
+  at?: number;
+}
+
+/** Insert text at the caret (append semantics in a headless draft). */
+export interface TextInsertOperation extends ComposerOperationBase {
+  type: "text.insert";
+  text: string;
+}
+
+/** Replace the whole draft text. */
+export interface TextSetOperation extends ComposerOperationBase {
+  type: "text.set";
+  text: string;
+}
+
+/** Attach one piece of media, described in media-store vocabulary. */
+export interface AttachmentAddOperation extends ComposerOperationBase {
+  type: "attachment.add";
+  /** Stable attachment id so a duplicate add and a later remove are addressable. */
+  attachmentId: string;
+  attachment: ComposerAttachmentSource;
+}
+
+/** Remove a previously-added attachment by its id. */
+export interface AttachmentRemoveOperation extends ComposerOperationBase {
+  type: "attachment.remove";
+  attachmentId: string;
+}
+
+/** Set the reply/quote target for the next send. */
+export interface ReplySetOperation extends ComposerOperationBase {
+  type: "reply.set";
+  reply: ComposerReplyContext;
+}
+
+/** Clear the reply/quote target. */
+export interface ReplyClearOperation extends ComposerOperationBase {
+  type: "reply.clear";
+}
+
+/** Insert an @-mention token into the draft. */
+export interface MentionAddOperation extends ComposerOperationBase {
+  type: "mention.add";
+  mention: ComposerMention;
+}
+
+/** Submit the current draft. */
+export interface SendOperation extends ComposerOperationBase {
+  type: "send";
+}
+
+/** Cancel an in-flight send (`scope: "send"`) or clear the draft (`"draft"`). */
+export interface CancelOperation extends ComposerOperationBase {
+  type: "cancel";
+  scope: ComposerCancelScope;
+}
+
+/** Set focus + report keyboard visibility. */
+export interface FocusSetOperation extends ComposerOperationBase {
+  type: "focus.set";
+  focused: boolean;
+  keyboard?: KeyboardVisibility;
+}
+
+/** Drive a voice handoff; `commit` carries the recognized transcript. */
+export interface VoiceHandoffOperation extends ComposerOperationBase {
+  type: "voice.handoff";
+  phase: VoiceHandoffPhase;
+  transcript?: string;
+}
+
+export type ComposerOperation =
+  | TextInsertOperation
+  | TextSetOperation
+  | AttachmentAddOperation
+  | AttachmentRemoveOperation
+  | ReplySetOperation
+  | ReplyClearOperation
+  | MentionAddOperation
+  | SendOperation
+  | CancelOperation
+  | FocusSetOperation
+  | VoiceHandoffOperation;
+
+export type ComposerOperationType = ComposerOperation["type"];
+
+/** Every recognized operation discriminant, for the decoder's known-type gate. */
+export const COMPOSER_OPERATION_TYPES: readonly ComposerOperationType[] = [
+  "text.insert",
+  "text.set",
+  "attachment.add",
+  "attachment.remove",
+  "reply.set",
+  "reply.clear",
+  "mention.add",
+  "send",
+  "cancel",
+  "focus.set",
+  "voice.handoff",
+] as const;
+
+/** Stream envelope: the versioned schema tag plus the ordered operation log. */
+export interface ComposerOperationStream {
+  schema: NativeComposerSchema;
+  operations: ComposerOperation[];
+}
+
+// ── Reduced draft model (what the renderer holds, the shell mirrors) ────
+
+/**
+ * A resolved attachment reference in the draft, in media-store vocabulary. An
+ * `inline`/`data-url` source normalizes to a `data:` URL the existing outgoing
+ * pipeline persists to the content-addressed store on send; `remote` is rehosted
+ * SSRF-guarded server-side; `stored` passes through. `kind` records that routing.
+ * No field is a file id.
+ */
+export interface ComposerAttachment {
+  id: string;
+  /** `data:`, remote http(s), or `/api/media/<hash>` URL — the store's handle. */
+  url: string;
+  mimeType?: string;
+  name?: string;
+  /** Store-routing kind: inline bytes, a remote URL to rehost, or already stored. */
+  kind: "inline" | "remote" | "stored";
+  /**
+   * `ready` = usable as-is; `pending-rehost` = a remote URL awaiting server-side
+   * SSRF rehost on send. There is no `failed` success-substitute: a source that
+   * fails validation never becomes an attachment (the op is rejected instead).
+   */
+  status: "ready" | "pending-rehost";
+}
+
+/**
+ * The reduced composer draft. `revision` bumps on every applied mutation so the
+ * shell can diff and a reload can detect staleness; it is the durable state the
+ * bridge preserves across backgrounding, reload, and reconnect.
+ */
+export interface ComposerDraft {
+  text: string;
+  attachments: ComposerAttachment[];
+  reply: ComposerReplyContext | null;
+  mentions: ComposerMention[];
+  focused: boolean;
+  keyboard: KeyboardVisibility;
+  revision: number;
+}
+
+/** The empty draft a fresh composer starts from. */
+export function emptyComposerDraft(): ComposerDraft {
+  return {
+    text: "",
+    attachments: [],
+    reply: null,
+    mentions: [],
+    focused: false,
+    keyboard: "hidden",
+    revision: 0,
+  };
+}
+
+// ── Dispatch result (the typed answer to applying an operation) ─────────
+
+/** Why an operation was rejected — a closed, machine-readable set. */
+export type ComposerRejectReason =
+  | "permission-denied"
+  | "invalid-input"
+  | "oversized"
+  | "unsupported"
+  | "no-active-composer"
+  | "empty-send"
+  | "send-in-flight";
+
+/**
+ * The typed result of applying one operation — never a bare boolean. `applied`
+ * mutated the draft; `duplicate` is the idempotent no-op for an already-seen
+ * `opId`; `deferred` was queued because the transport is offline (replayed on
+ * reconnect); `rejected` carries a typed reason. Every variant echoes the draft
+ * so the caller always has the current state.
+ */
+export type DispatchResult =
+  | { status: "applied"; opId: string; draft: ComposerDraft }
+  | { status: "duplicate"; opId: string; draft: ComposerDraft }
+  | { status: "deferred"; opId: string; draft: ComposerDraft }
+  | {
+      status: "rejected";
+      opId: string;
+      reason: ComposerRejectReason;
+      message: string;
+      draft: ComposerDraft;
+    };
+
+/** Outcome of a submitted send, surfaced back to the shell. */
+export type SendOutcome =
+  | { ok: true; messageId: string }
+  | { ok: false; reason: ComposerRejectReason; message: string };
+
+// ── Events (renderer → native shell) ───────────────────────────────────
+
+/** The reduced draft changed; the shell re-renders its mirror. */
+export interface DraftChangedEvent {
+  type: "draft.changed";
+  draft: ComposerDraft;
+}
+
+/** A send that the shell initiated resolved. */
+export interface SendResultEvent {
+  type: "send.result";
+  opId: string;
+  outcome: SendOutcome;
+}
+
+/** Focus/keyboard state changed (e.g. the user dismissed the keyboard). */
+export interface FocusChangedEvent {
+  type: "focus.changed";
+  focused: boolean;
+  keyboard: KeyboardVisibility;
+}
+
+/** The voice-handoff phase advanced. */
+export interface VoiceHandoffStateEvent {
+  type: "voice.state";
+  phase: VoiceHandoffPhase;
+}
+
+export type ComposerEvent =
+  | DraftChangedEvent
+  | SendResultEvent
+  | FocusChangedEvent
+  | VoiceHandoffStateEvent;
+
+export type ComposerEventType = ComposerEvent["type"];
+
+/** Every recognized event discriminant, for the decoder's known-type gate. */
+export const COMPOSER_EVENT_TYPES: readonly ComposerEventType[] = [
+  "draft.changed",
+  "send.result",
+  "focus.changed",
+  "voice.state",
+] as const;

--- a/packages/ui/src/native-composer/decode.test.ts
+++ b/packages/ui/src/native-composer/decode.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Boundary-decoder tests for `eliza.native-composer/v1`: field-level rejection of
+ * every operation type, attachment-source validation (including structural
+ * rejection of any second-file-store shape), and the mixed-batch stream decode
+ * that keeps good ops and collects malformed ones. Pure, deterministic.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NATIVE_COMPOSER_SCHEMA } from "./contract";
+import {
+  decodeComposerAttachmentSource,
+  decodeComposerOperation,
+  decodeComposerOperationStream,
+} from "./decode";
+
+describe("decodeComposerOperation — envelope guards", () => {
+  it("rejects non-objects", () => {
+    for (const raw of [null, undefined, 42, "x", [], true]) {
+      const r = decodeComposerOperation(raw);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.code).toBe("not-an-object");
+    }
+  });
+
+  it("requires a string type", () => {
+    const r = decodeComposerOperation({ opId: "a", text: "hi" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.field).toBe("type");
+  });
+
+  it("requires a non-empty opId (the idempotency key)", () => {
+    const r = decodeComposerOperation({ type: "send", opId: "" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("missing-field");
+      expect(r.error.field).toBe("opId");
+    }
+  });
+
+  it("rejects a non-finite at", () => {
+    const r = decodeComposerOperation({ type: "send", opId: "a", at: Number.NaN });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.field).toBe("at");
+  });
+
+  it("rejects an unknown type", () => {
+    const r = decodeComposerOperation({ type: "text.delete", opId: "a" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("unknown-type");
+  });
+});
+
+describe("decodeComposerOperation — per-type fields", () => {
+  it("decodes text.insert / text.set and rejects non-string text", () => {
+    expect(decodeComposerOperation({ type: "text.insert", opId: "a", text: "hi" }).ok).toBe(true);
+    const bad = decodeComposerOperation({ type: "text.set", opId: "a", text: 3 });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("text");
+  });
+
+  it("decodes attachment.add and requires attachmentId + a valid source", () => {
+    const ok = decodeComposerOperation({
+      type: "attachment.add",
+      opId: "a",
+      attachmentId: "att1",
+      attachment: { source: "stored", url: "/api/media/" + "a".repeat(64) + ".png" },
+    });
+    expect(ok.ok).toBe(true);
+    const noId = decodeComposerOperation({
+      type: "attachment.add",
+      opId: "a",
+      attachment: { source: "stored", url: "/api/media/x.png" },
+    });
+    expect(noId.ok).toBe(false);
+    if (!noId.ok) expect(noId.error.field).toBe("attachmentId");
+  });
+
+  it("decodes cancel scope and rejects a bad scope", () => {
+    expect(decodeComposerOperation({ type: "cancel", opId: "a", scope: "draft" }).ok).toBe(true);
+    const bad = decodeComposerOperation({ type: "cancel", opId: "a", scope: "everything" });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("scope");
+  });
+
+  it("decodes focus.set with optional keyboard and rejects a bad keyboard", () => {
+    expect(decodeComposerOperation({ type: "focus.set", opId: "a", focused: true, keyboard: "shown" }).ok).toBe(true);
+    const bad = decodeComposerOperation({ type: "focus.set", opId: "a", focused: true, keyboard: "up" });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("keyboard");
+  });
+
+  it("decodes voice.handoff phase and rejects a bad phase", () => {
+    expect(decodeComposerOperation({ type: "voice.handoff", opId: "a", phase: "commit", transcript: "hi" }).ok).toBe(true);
+    const bad = decodeComposerOperation({ type: "voice.handoff", opId: "a", phase: "pause" });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("phase");
+  });
+
+  it("decodes reply.set and rejects a reply without messageId", () => {
+    expect(decodeComposerOperation({ type: "reply.set", opId: "a", reply: { messageId: "m1", preview: "hey" } }).ok).toBe(true);
+    const bad = decodeComposerOperation({ type: "reply.set", opId: "a", reply: { preview: "hey" } });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("reply.messageId");
+  });
+
+  it("decodes mention.add and rejects a bad mention kind", () => {
+    expect(decodeComposerOperation({ type: "mention.add", opId: "a", mention: { id: "u1", label: "alice", kind: "user" } }).ok).toBe(true);
+    const bad = decodeComposerOperation({ type: "mention.add", opId: "a", mention: { id: "u1", label: "alice", kind: "bot" } });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.field).toBe("mention.kind");
+  });
+
+  it("ignores unknown extra keys (forward compat)", () => {
+    const r = decodeComposerOperation({ type: "send", opId: "a", futureField: 1 });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect("futureField" in r.operation).toBe(false);
+  });
+});
+
+describe("decodeComposerAttachmentSource", () => {
+  it("decodes each media-store source", () => {
+    expect(decodeComposerAttachmentSource({ source: "inline", mimeType: "image/png", bytesBase64: "AAAA" }).ok).toBe(true);
+    expect(decodeComposerAttachmentSource({ source: "data-url", dataUrl: "data:image/png;base64,AAAA" }).ok).toBe(true);
+    expect(decodeComposerAttachmentSource({ source: "remote", url: "https://x.test/a.png" }).ok).toBe(true);
+    expect(decodeComposerAttachmentSource({ source: "stored", url: "/api/media/x.png" }).ok).toBe(true);
+  });
+
+  it("rejects a second-file-store shape (no file-id source exists)", () => {
+    const r = decodeComposerAttachmentSource({ source: "file-id", fileId: "f_123" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.field).toBe("source");
+      expect(r.error.message).toContain("unknown attachment source");
+    }
+  });
+
+  it("rejects inline without bytes and data-url that is not a data URL", () => {
+    const noBytes = decodeComposerAttachmentSource({ source: "inline", mimeType: "image/png" });
+    expect(noBytes.ok).toBe(false);
+    if (!noBytes.ok) expect(noBytes.error.field).toBe("bytesBase64");
+    const notData = decodeComposerAttachmentSource({ source: "data-url", dataUrl: "https://x.test/a.png" });
+    expect(notData.ok).toBe(false);
+    if (!notData.ok) expect(notData.error.field).toBe("dataUrl");
+  });
+});
+
+describe("decodeComposerOperationStream", () => {
+  it("throws on a bad envelope (schema/shape), not on per-op input", () => {
+    expect(() => decodeComposerOperationStream(null)).toThrow(TypeError);
+    expect(() => decodeComposerOperationStream({ schema: "wrong", operations: [] })).toThrow(/unsupported schema/);
+    expect(() => decodeComposerOperationStream({ schema: NATIVE_COMPOSER_SCHEMA, operations: {} })).toThrow(/must be an array/);
+  });
+
+  it("keeps good ops and collects malformed ones with index + reason", () => {
+    const { operations, rejected } = decodeComposerOperationStream({
+      schema: NATIVE_COMPOSER_SCHEMA,
+      operations: [
+        { type: "text.set", opId: "a", text: "hi" },
+        { type: "text.set", opId: "b", text: 9 },
+        { type: "send", opId: "c" },
+        { type: "??", opId: "d" },
+      ],
+    });
+    expect(operations.map((o) => o.opId)).toEqual(["a", "c"]);
+    expect(rejected.map((r) => r.index)).toEqual([1, 3]);
+    expect(rejected[0].error.field).toBe("text");
+    expect(rejected[1].error.code).toBe("unknown-type");
+  });
+});

--- a/packages/ui/src/native-composer/decode.test.ts
+++ b/packages/ui/src/native-composer/decode.test.ts
@@ -38,7 +38,11 @@ describe("decodeComposerOperation — envelope guards", () => {
   });
 
   it("rejects a non-finite at", () => {
-    const r = decodeComposerOperation({ type: "send", opId: "a", at: Number.NaN });
+    const r = decodeComposerOperation({
+      type: "send",
+      opId: "a",
+      at: Number.NaN,
+    });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error.field).toBe("at");
   });
@@ -52,8 +56,15 @@ describe("decodeComposerOperation — envelope guards", () => {
 
 describe("decodeComposerOperation — per-type fields", () => {
   it("decodes text.insert / text.set and rejects non-string text", () => {
-    expect(decodeComposerOperation({ type: "text.insert", opId: "a", text: "hi" }).ok).toBe(true);
-    const bad = decodeComposerOperation({ type: "text.set", opId: "a", text: 3 });
+    expect(
+      decodeComposerOperation({ type: "text.insert", opId: "a", text: "hi" })
+        .ok,
+    ).toBe(true);
+    const bad = decodeComposerOperation({
+      type: "text.set",
+      opId: "a",
+      text: 3,
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("text");
   });
@@ -63,7 +74,10 @@ describe("decodeComposerOperation — per-type fields", () => {
       type: "attachment.add",
       opId: "a",
       attachmentId: "att1",
-      attachment: { source: "stored", url: "/api/media/" + "a".repeat(64) + ".png" },
+      attachment: {
+        source: "stored",
+        url: `/api/media/${"a".repeat(64)}.png`,
+      },
     });
     expect(ok.ok).toBe(true);
     const noId = decodeComposerOperation({
@@ -76,42 +90,95 @@ describe("decodeComposerOperation — per-type fields", () => {
   });
 
   it("decodes cancel scope and rejects a bad scope", () => {
-    expect(decodeComposerOperation({ type: "cancel", opId: "a", scope: "draft" }).ok).toBe(true);
-    const bad = decodeComposerOperation({ type: "cancel", opId: "a", scope: "everything" });
+    expect(
+      decodeComposerOperation({ type: "cancel", opId: "a", scope: "draft" }).ok,
+    ).toBe(true);
+    const bad = decodeComposerOperation({
+      type: "cancel",
+      opId: "a",
+      scope: "everything",
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("scope");
   });
 
   it("decodes focus.set with optional keyboard and rejects a bad keyboard", () => {
-    expect(decodeComposerOperation({ type: "focus.set", opId: "a", focused: true, keyboard: "shown" }).ok).toBe(true);
-    const bad = decodeComposerOperation({ type: "focus.set", opId: "a", focused: true, keyboard: "up" });
+    expect(
+      decodeComposerOperation({
+        type: "focus.set",
+        opId: "a",
+        focused: true,
+        keyboard: "shown",
+      }).ok,
+    ).toBe(true);
+    const bad = decodeComposerOperation({
+      type: "focus.set",
+      opId: "a",
+      focused: true,
+      keyboard: "up",
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("keyboard");
   });
 
   it("decodes voice.handoff phase and rejects a bad phase", () => {
-    expect(decodeComposerOperation({ type: "voice.handoff", opId: "a", phase: "commit", transcript: "hi" }).ok).toBe(true);
-    const bad = decodeComposerOperation({ type: "voice.handoff", opId: "a", phase: "pause" });
+    expect(
+      decodeComposerOperation({
+        type: "voice.handoff",
+        opId: "a",
+        phase: "commit",
+        transcript: "hi",
+      }).ok,
+    ).toBe(true);
+    const bad = decodeComposerOperation({
+      type: "voice.handoff",
+      opId: "a",
+      phase: "pause",
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("phase");
   });
 
   it("decodes reply.set and rejects a reply without messageId", () => {
-    expect(decodeComposerOperation({ type: "reply.set", opId: "a", reply: { messageId: "m1", preview: "hey" } }).ok).toBe(true);
-    const bad = decodeComposerOperation({ type: "reply.set", opId: "a", reply: { preview: "hey" } });
+    expect(
+      decodeComposerOperation({
+        type: "reply.set",
+        opId: "a",
+        reply: { messageId: "m1", preview: "hey" },
+      }).ok,
+    ).toBe(true);
+    const bad = decodeComposerOperation({
+      type: "reply.set",
+      opId: "a",
+      reply: { preview: "hey" },
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("reply.messageId");
   });
 
   it("decodes mention.add and rejects a bad mention kind", () => {
-    expect(decodeComposerOperation({ type: "mention.add", opId: "a", mention: { id: "u1", label: "alice", kind: "user" } }).ok).toBe(true);
-    const bad = decodeComposerOperation({ type: "mention.add", opId: "a", mention: { id: "u1", label: "alice", kind: "bot" } });
+    expect(
+      decodeComposerOperation({
+        type: "mention.add",
+        opId: "a",
+        mention: { id: "u1", label: "alice", kind: "user" },
+      }).ok,
+    ).toBe(true);
+    const bad = decodeComposerOperation({
+      type: "mention.add",
+      opId: "a",
+      mention: { id: "u1", label: "alice", kind: "bot" },
+    });
     expect(bad.ok).toBe(false);
     if (!bad.ok) expect(bad.error.field).toBe("mention.kind");
   });
 
   it("ignores unknown extra keys (forward compat)", () => {
-    const r = decodeComposerOperation({ type: "send", opId: "a", futureField: 1 });
+    const r = decodeComposerOperation({
+      type: "send",
+      opId: "a",
+      futureField: 1,
+    });
     expect(r.ok).toBe(true);
     if (r.ok) expect("futureField" in r.operation).toBe(false);
   });
@@ -119,14 +186,38 @@ describe("decodeComposerOperation — per-type fields", () => {
 
 describe("decodeComposerAttachmentSource", () => {
   it("decodes each media-store source", () => {
-    expect(decodeComposerAttachmentSource({ source: "inline", mimeType: "image/png", bytesBase64: "AAAA" }).ok).toBe(true);
-    expect(decodeComposerAttachmentSource({ source: "data-url", dataUrl: "data:image/png;base64,AAAA" }).ok).toBe(true);
-    expect(decodeComposerAttachmentSource({ source: "remote", url: "https://x.test/a.png" }).ok).toBe(true);
-    expect(decodeComposerAttachmentSource({ source: "stored", url: "/api/media/x.png" }).ok).toBe(true);
+    expect(
+      decodeComposerAttachmentSource({
+        source: "inline",
+        mimeType: "image/png",
+        bytesBase64: "AAAA",
+      }).ok,
+    ).toBe(true);
+    expect(
+      decodeComposerAttachmentSource({
+        source: "data-url",
+        dataUrl: "data:image/png;base64,AAAA",
+      }).ok,
+    ).toBe(true);
+    expect(
+      decodeComposerAttachmentSource({
+        source: "remote",
+        url: "https://x.test/a.png",
+      }).ok,
+    ).toBe(true);
+    expect(
+      decodeComposerAttachmentSource({
+        source: "stored",
+        url: "/api/media/x.png",
+      }).ok,
+    ).toBe(true);
   });
 
   it("rejects a second-file-store shape (no file-id source exists)", () => {
-    const r = decodeComposerAttachmentSource({ source: "file-id", fileId: "f_123" });
+    const r = decodeComposerAttachmentSource({
+      source: "file-id",
+      fileId: "f_123",
+    });
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.error.field).toBe("source");
@@ -135,10 +226,16 @@ describe("decodeComposerAttachmentSource", () => {
   });
 
   it("rejects inline without bytes and data-url that is not a data URL", () => {
-    const noBytes = decodeComposerAttachmentSource({ source: "inline", mimeType: "image/png" });
+    const noBytes = decodeComposerAttachmentSource({
+      source: "inline",
+      mimeType: "image/png",
+    });
     expect(noBytes.ok).toBe(false);
     if (!noBytes.ok) expect(noBytes.error.field).toBe("bytesBase64");
-    const notData = decodeComposerAttachmentSource({ source: "data-url", dataUrl: "https://x.test/a.png" });
+    const notData = decodeComposerAttachmentSource({
+      source: "data-url",
+      dataUrl: "https://x.test/a.png",
+    });
     expect(notData.ok).toBe(false);
     if (!notData.ok) expect(notData.error.field).toBe("dataUrl");
   });
@@ -147,8 +244,15 @@ describe("decodeComposerAttachmentSource", () => {
 describe("decodeComposerOperationStream", () => {
   it("throws on a bad envelope (schema/shape), not on per-op input", () => {
     expect(() => decodeComposerOperationStream(null)).toThrow(TypeError);
-    expect(() => decodeComposerOperationStream({ schema: "wrong", operations: [] })).toThrow(/unsupported schema/);
-    expect(() => decodeComposerOperationStream({ schema: NATIVE_COMPOSER_SCHEMA, operations: {} })).toThrow(/must be an array/);
+    expect(() =>
+      decodeComposerOperationStream({ schema: "wrong", operations: [] }),
+    ).toThrow(/unsupported schema/);
+    expect(() =>
+      decodeComposerOperationStream({
+        schema: NATIVE_COMPOSER_SCHEMA,
+        operations: {},
+      }),
+    ).toThrow(/must be an array/);
   });
 
   it("keeps good ops and collects malformed ones with index + reason", () => {

--- a/packages/ui/src/native-composer/decode.ts
+++ b/packages/ui/src/native-composer/decode.ts
@@ -1,0 +1,397 @@
+/**
+ * Boundary decoder for `eliza.native-composer/v1`. Every field of an untrusted
+ * operation (or the attachment source it carries) is validated here before it
+ * reaches the reducer, so `reduce.ts` trusts its input completely and never
+ * re-checks shapes.
+ *
+ * A malformed operation yields an explicit typed failure (`{ ok: false, error }`),
+ * never a fabricated-valid default and never a throw — one bad frame from a
+ * native bridge must not tear down a live composer session (error-policy J3:
+ * untrusted-input sanitizing produces an explicit "invalid" result).
+ * `decodeComposerOperationStream` applies the same rule per operation: valid ops
+ * accumulate, malformed ones are collected with their index and reason.
+ *
+ * The attachment-source decoder is exported on its own because the server-side
+ * store-ingest boundary decodes the SAME wire bytes independently (the contract
+ * is language-neutral; each consumer validates at its own edge), and because it
+ * structurally rejects any second-file-store shape — only the four
+ * media-store-vocabulary sources decode.
+ */
+
+import {
+  type ComposerAttachmentSource,
+  type ComposerMention,
+  type ComposerOperation,
+  type ComposerReplyContext,
+  NATIVE_COMPOSER_SCHEMA,
+} from "./contract";
+
+/** Machine-readable reason a raw value failed to decode. */
+export type ComposerDecodeErrorCode =
+  | "not-an-object"
+  | "unknown-type"
+  | "missing-field"
+  | "invalid-field";
+
+export interface ComposerDecodeError {
+  code: ComposerDecodeErrorCode;
+  /** The offending field, when the failure is field-specific. */
+  field?: string;
+  message: string;
+}
+
+export type ComposerOperationDecodeResult =
+  | { ok: true; operation: ComposerOperation }
+  | { ok: false; error: ComposerDecodeError };
+
+export type ComposerAttachmentDecodeResult =
+  | { ok: true; attachment: ComposerAttachmentSource }
+  | { ok: false; error: ComposerDecodeError };
+
+function fail(
+  code: ComposerDecodeErrorCode,
+  message: string,
+  field?: string,
+): { ok: false; error: ComposerDecodeError } {
+  return { ok: false, error: { code, field, message } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** `at` is optional display metadata; when present it must be a finite number. */
+function optionalTimestampInvalid(record: Record<string, unknown>): boolean {
+  return "at" in record && !isFiniteNumber(record.at);
+}
+
+/** An optional field is valid iff it is absent/undefined or a non-empty string. */
+function optionalStringInvalid(
+  record: Record<string, unknown>,
+  key: string,
+): boolean {
+  return key in record && record[key] !== undefined && !isNonEmptyString(record[key]);
+}
+
+/**
+ * Validate one raw value into a typed {@link ComposerAttachmentSource}. Only the
+ * four media-store sources decode; an unknown `source` (including any
+ * file-id/second-store shape) is rejected. Unknown extra keys are ignored for
+ * forward compatibility.
+ */
+export function decodeComposerAttachmentSource(
+  raw: unknown,
+): ComposerAttachmentDecodeResult {
+  if (!isRecord(raw)) {
+    return fail("not-an-object", "attachment must be a non-null object");
+  }
+  const source = raw.source;
+  if (typeof source !== "string") {
+    return fail(
+      "missing-field",
+      "attachment is missing a string `source`",
+      "source",
+    );
+  }
+  if (optionalStringInvalid(raw, "name")) {
+    return fail("invalid-field", "`name` must be a non-empty string", "name");
+  }
+  switch (source) {
+    case "inline": {
+      if (!isNonEmptyString(raw.mimeType))
+        return fail("missing-field", "`mimeType` is required", "mimeType");
+      if (!isNonEmptyString(raw.bytesBase64))
+        return fail("missing-field", "`bytesBase64` is required", "bytesBase64");
+      return {
+        ok: true,
+        attachment: {
+          source,
+          mimeType: raw.mimeType,
+          bytesBase64: raw.bytesBase64,
+          ...(isNonEmptyString(raw.name) ? { name: raw.name } : {}),
+        },
+      };
+    }
+    case "data-url": {
+      if (!isNonEmptyString(raw.dataUrl) || !raw.dataUrl.startsWith("data:"))
+        return fail(
+          "invalid-field",
+          "`dataUrl` must be a data: URL string",
+          "dataUrl",
+        );
+      return {
+        ok: true,
+        attachment: {
+          source,
+          dataUrl: raw.dataUrl,
+          ...(isNonEmptyString(raw.name) ? { name: raw.name } : {}),
+        },
+      };
+    }
+    case "remote": {
+      if (!isNonEmptyString(raw.url))
+        return fail("missing-field", "`url` is required", "url");
+      if (optionalStringInvalid(raw, "mimeType"))
+        return fail("invalid-field", "`mimeType` must be a string", "mimeType");
+      return {
+        ok: true,
+        attachment: {
+          source,
+          url: raw.url,
+          ...(isNonEmptyString(raw.mimeType) ? { mimeType: raw.mimeType } : {}),
+          ...(isNonEmptyString(raw.name) ? { name: raw.name } : {}),
+        },
+      };
+    }
+    case "stored": {
+      if (!isNonEmptyString(raw.url))
+        return fail("missing-field", "`url` is required", "url");
+      if (optionalStringInvalid(raw, "mimeType"))
+        return fail("invalid-field", "`mimeType` must be a string", "mimeType");
+      return {
+        ok: true,
+        attachment: {
+          source,
+          url: raw.url,
+          ...(isNonEmptyString(raw.mimeType) ? { mimeType: raw.mimeType } : {}),
+          ...(isNonEmptyString(raw.name) ? { name: raw.name } : {}),
+        },
+      };
+    }
+    default:
+      return fail(
+        "invalid-field",
+        `unknown attachment source: ${source}`,
+        "source",
+      );
+  }
+}
+
+function decodeReplyContext(
+  raw: unknown,
+): { ok: true; reply: ComposerReplyContext } | { ok: false; field: string } {
+  if (!isRecord(raw)) return { ok: false, field: "reply" };
+  if (!isNonEmptyString(raw.messageId)) return { ok: false, field: "reply.messageId" };
+  if (optionalStringInvalid(raw, "authorId")) return { ok: false, field: "reply.authorId" };
+  if ("preview" in raw && raw.preview !== undefined && typeof raw.preview !== "string")
+    return { ok: false, field: "reply.preview" };
+  return {
+    ok: true,
+    reply: {
+      messageId: raw.messageId,
+      ...(isNonEmptyString(raw.authorId) ? { authorId: raw.authorId } : {}),
+      ...(typeof raw.preview === "string" ? { preview: raw.preview } : {}),
+    },
+  };
+}
+
+function decodeMention(
+  raw: unknown,
+): { ok: true; mention: ComposerMention } | { ok: false; field: string } {
+  if (!isRecord(raw)) return { ok: false, field: "mention" };
+  if (!isNonEmptyString(raw.id)) return { ok: false, field: "mention.id" };
+  if (typeof raw.label !== "string") return { ok: false, field: "mention.label" };
+  if (
+    "kind" in raw &&
+    raw.kind !== undefined &&
+    raw.kind !== "user" &&
+    raw.kind !== "agent" &&
+    raw.kind !== "channel"
+  )
+    return { ok: false, field: "mention.kind" };
+  return {
+    ok: true,
+    mention: {
+      id: raw.id,
+      label: raw.label,
+      ...(raw.kind === "user" || raw.kind === "agent" || raw.kind === "channel"
+        ? { kind: raw.kind }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Validate one raw value into a typed {@link ComposerOperation}. Every op must
+ * carry a non-empty `opId` (the idempotency key) and a known `type`; per-type
+ * fields are then checked. Unknown extra keys are ignored (forward compat).
+ */
+export function decodeComposerOperation(
+  raw: unknown,
+): ComposerOperationDecodeResult {
+  if (!isRecord(raw)) {
+    return fail("not-an-object", "operation must be a non-null object");
+  }
+  const type = raw.type;
+  if (typeof type !== "string") {
+    return fail("missing-field", "operation is missing a string `type`", "type");
+  }
+  if (!isNonEmptyString(raw.opId)) {
+    return fail("missing-field", "`opId` is required (idempotency key)", "opId");
+  }
+  if (optionalTimestampInvalid(raw)) {
+    return fail("invalid-field", "`at` must be a finite number", "at");
+  }
+  const opId = raw.opId;
+  const at = isFiniteNumber(raw.at) ? { at: raw.at } : {};
+
+  switch (type) {
+    case "text.insert":
+    case "text.set": {
+      if (typeof raw.text !== "string")
+        return fail("invalid-field", "`text` must be a string", "text");
+      return { ok: true, operation: { type, opId, text: raw.text, ...at } };
+    }
+    case "attachment.add": {
+      if (!isNonEmptyString(raw.attachmentId))
+        return fail("missing-field", "`attachmentId` is required", "attachmentId");
+      const decoded = decodeComposerAttachmentSource(raw.attachment);
+      if (!decoded.ok) return decoded;
+      return {
+        ok: true,
+        operation: {
+          type,
+          opId,
+          attachmentId: raw.attachmentId,
+          attachment: decoded.attachment,
+          ...at,
+        },
+      };
+    }
+    case "attachment.remove": {
+      if (!isNonEmptyString(raw.attachmentId))
+        return fail("missing-field", "`attachmentId` is required", "attachmentId");
+      return {
+        ok: true,
+        operation: { type, opId, attachmentId: raw.attachmentId, ...at },
+      };
+    }
+    case "reply.set": {
+      const decoded = decodeReplyContext(raw.reply);
+      if (!decoded.ok)
+        return fail("invalid-field", "`reply` is malformed", decoded.field);
+      return { ok: true, operation: { type, opId, reply: decoded.reply, ...at } };
+    }
+    case "reply.clear": {
+      return { ok: true, operation: { type, opId, ...at } };
+    }
+    case "mention.add": {
+      const decoded = decodeMention(raw.mention);
+      if (!decoded.ok)
+        return fail("invalid-field", "`mention` is malformed", decoded.field);
+      return {
+        ok: true,
+        operation: { type, opId, mention: decoded.mention, ...at },
+      };
+    }
+    case "send": {
+      return { ok: true, operation: { type, opId, ...at } };
+    }
+    case "cancel": {
+      if (raw.scope !== "send" && raw.scope !== "draft")
+        return fail("invalid-field", "`scope` must be send|draft", "scope");
+      return { ok: true, operation: { type, opId, scope: raw.scope, ...at } };
+    }
+    case "focus.set": {
+      if (typeof raw.focused !== "boolean")
+        return fail("invalid-field", "`focused` must be a boolean", "focused");
+      if (
+        "keyboard" in raw &&
+        raw.keyboard !== undefined &&
+        raw.keyboard !== "shown" &&
+        raw.keyboard !== "hidden"
+      )
+        return fail("invalid-field", "`keyboard` must be shown|hidden", "keyboard");
+      return {
+        ok: true,
+        operation: {
+          type,
+          opId,
+          focused: raw.focused,
+          ...(raw.keyboard === "shown" || raw.keyboard === "hidden"
+            ? { keyboard: raw.keyboard }
+            : {}),
+          ...at,
+        },
+      };
+    }
+    case "voice.handoff": {
+      if (raw.phase !== "start" && raw.phase !== "commit" && raw.phase !== "cancel")
+        return fail(
+          "invalid-field",
+          "`phase` must be start|commit|cancel",
+          "phase",
+        );
+      if (
+        "transcript" in raw &&
+        raw.transcript !== undefined &&
+        typeof raw.transcript !== "string"
+      )
+        return fail("invalid-field", "`transcript` must be a string", "transcript");
+      return {
+        ok: true,
+        operation: {
+          type,
+          opId,
+          phase: raw.phase,
+          ...(typeof raw.transcript === "string"
+            ? { transcript: raw.transcript }
+            : {}),
+          ...at,
+        },
+      };
+    }
+    default:
+      return fail("unknown-type", `unknown operation type: ${type}`, "type");
+  }
+}
+
+export interface ComposerStreamDecodeResult {
+  /** Operations that passed validation, in the order they appeared. */
+  operations: ComposerOperation[];
+  /** Malformed ops with their source index and reason (never silently lost). */
+  rejected: { index: number; error: ComposerDecodeError }[];
+}
+
+/**
+ * Decode a stream envelope `{ schema, operations }`. Throws only when the
+ * envelope itself is unusable (not an object, wrong/absent schema tag) — that is
+ * a programming/version error, not untrusted per-op input. Per-op failures are
+ * returned in `rejected`, never thrown, so a mixed batch still yields its good
+ * operations.
+ */
+export function decodeComposerOperationStream(
+  raw: unknown,
+): ComposerStreamDecodeResult {
+  if (!isRecord(raw)) {
+    throw new TypeError(
+      "[decodeComposerOperationStream] stream must be a { schema, operations } object",
+    );
+  }
+  if (raw.schema !== NATIVE_COMPOSER_SCHEMA) {
+    throw new TypeError(
+      `[decodeComposerOperationStream] unsupported schema: ${String(raw.schema)}`,
+    );
+  }
+  if (!Array.isArray(raw.operations)) {
+    throw new TypeError(
+      "[decodeComposerOperationStream] `operations` must be an array",
+    );
+  }
+  const operations: ComposerOperation[] = [];
+  const rejected: { index: number; error: ComposerDecodeError }[] = [];
+  raw.operations.forEach((rawOp, index) => {
+    const decoded = decodeComposerOperation(rawOp);
+    if (decoded.ok) operations.push(decoded.operation);
+    else rejected.push({ index, error: decoded.error });
+  });
+  return { operations, rejected };
+}

--- a/packages/ui/src/native-composer/decode.ts
+++ b/packages/ui/src/native-composer/decode.ts
@@ -78,7 +78,9 @@ function optionalStringInvalid(
   record: Record<string, unknown>,
   key: string,
 ): boolean {
-  return key in record && record[key] !== undefined && !isNonEmptyString(record[key]);
+  return (
+    key in record && record[key] !== undefined && !isNonEmptyString(record[key])
+  );
 }
 
 /**
@@ -109,7 +111,11 @@ export function decodeComposerAttachmentSource(
       if (!isNonEmptyString(raw.mimeType))
         return fail("missing-field", "`mimeType` is required", "mimeType");
       if (!isNonEmptyString(raw.bytesBase64))
-        return fail("missing-field", "`bytesBase64` is required", "bytesBase64");
+        return fail(
+          "missing-field",
+          "`bytesBase64` is required",
+          "bytesBase64",
+        );
       return {
         ok: true,
         attachment: {
@@ -179,9 +185,15 @@ function decodeReplyContext(
   raw: unknown,
 ): { ok: true; reply: ComposerReplyContext } | { ok: false; field: string } {
   if (!isRecord(raw)) return { ok: false, field: "reply" };
-  if (!isNonEmptyString(raw.messageId)) return { ok: false, field: "reply.messageId" };
-  if (optionalStringInvalid(raw, "authorId")) return { ok: false, field: "reply.authorId" };
-  if ("preview" in raw && raw.preview !== undefined && typeof raw.preview !== "string")
+  if (!isNonEmptyString(raw.messageId))
+    return { ok: false, field: "reply.messageId" };
+  if (optionalStringInvalid(raw, "authorId"))
+    return { ok: false, field: "reply.authorId" };
+  if (
+    "preview" in raw &&
+    raw.preview !== undefined &&
+    typeof raw.preview !== "string"
+  )
     return { ok: false, field: "reply.preview" };
   return {
     ok: true,
@@ -198,7 +210,8 @@ function decodeMention(
 ): { ok: true; mention: ComposerMention } | { ok: false; field: string } {
   if (!isRecord(raw)) return { ok: false, field: "mention" };
   if (!isNonEmptyString(raw.id)) return { ok: false, field: "mention.id" };
-  if (typeof raw.label !== "string") return { ok: false, field: "mention.label" };
+  if (typeof raw.label !== "string")
+    return { ok: false, field: "mention.label" };
   if (
     "kind" in raw &&
     raw.kind !== undefined &&
@@ -232,10 +245,18 @@ export function decodeComposerOperation(
   }
   const type = raw.type;
   if (typeof type !== "string") {
-    return fail("missing-field", "operation is missing a string `type`", "type");
+    return fail(
+      "missing-field",
+      "operation is missing a string `type`",
+      "type",
+    );
   }
   if (!isNonEmptyString(raw.opId)) {
-    return fail("missing-field", "`opId` is required (idempotency key)", "opId");
+    return fail(
+      "missing-field",
+      "`opId` is required (idempotency key)",
+      "opId",
+    );
   }
   if (optionalTimestampInvalid(raw)) {
     return fail("invalid-field", "`at` must be a finite number", "at");
@@ -252,7 +273,11 @@ export function decodeComposerOperation(
     }
     case "attachment.add": {
       if (!isNonEmptyString(raw.attachmentId))
-        return fail("missing-field", "`attachmentId` is required", "attachmentId");
+        return fail(
+          "missing-field",
+          "`attachmentId` is required",
+          "attachmentId",
+        );
       const decoded = decodeComposerAttachmentSource(raw.attachment);
       if (!decoded.ok) return decoded;
       return {
@@ -268,7 +293,11 @@ export function decodeComposerOperation(
     }
     case "attachment.remove": {
       if (!isNonEmptyString(raw.attachmentId))
-        return fail("missing-field", "`attachmentId` is required", "attachmentId");
+        return fail(
+          "missing-field",
+          "`attachmentId` is required",
+          "attachmentId",
+        );
       return {
         ok: true,
         operation: { type, opId, attachmentId: raw.attachmentId, ...at },
@@ -278,7 +307,10 @@ export function decodeComposerOperation(
       const decoded = decodeReplyContext(raw.reply);
       if (!decoded.ok)
         return fail("invalid-field", "`reply` is malformed", decoded.field);
-      return { ok: true, operation: { type, opId, reply: decoded.reply, ...at } };
+      return {
+        ok: true,
+        operation: { type, opId, reply: decoded.reply, ...at },
+      };
     }
     case "reply.clear": {
       return { ok: true, operation: { type, opId, ...at } };
@@ -309,7 +341,11 @@ export function decodeComposerOperation(
         raw.keyboard !== "shown" &&
         raw.keyboard !== "hidden"
       )
-        return fail("invalid-field", "`keyboard` must be shown|hidden", "keyboard");
+        return fail(
+          "invalid-field",
+          "`keyboard` must be shown|hidden",
+          "keyboard",
+        );
       return {
         ok: true,
         operation: {
@@ -324,7 +360,11 @@ export function decodeComposerOperation(
       };
     }
     case "voice.handoff": {
-      if (raw.phase !== "start" && raw.phase !== "commit" && raw.phase !== "cancel")
+      if (
+        raw.phase !== "start" &&
+        raw.phase !== "commit" &&
+        raw.phase !== "cancel"
+      )
         return fail(
           "invalid-field",
           "`phase` must be start|commit|cancel",
@@ -335,7 +375,11 @@ export function decodeComposerOperation(
         raw.transcript !== undefined &&
         typeof raw.transcript !== "string"
       )
-        return fail("invalid-field", "`transcript` must be a string", "transcript");
+        return fail(
+          "invalid-field",
+          "`transcript` must be a string",
+          "transcript",
+        );
       return {
         ok: true,
         operation: {

--- a/packages/ui/src/native-composer/index.test.ts
+++ b/packages/ui/src/native-composer/index.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Barrel smoke test: the `@elizaos/ui/native-composer` subpath re-exports the
+ * schema constant, the decoder, the reducer, and the client factory, so a native
+ * shell importing the one entrypoint gets the whole contract. Pure.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as api from "./index";
+
+describe("@elizaos/ui/native-composer barrel", () => {
+  it("exposes the schema, decoder, reducer, and client entrypoints", () => {
+    expect(api.NATIVE_COMPOSER_SCHEMA).toBe("eliza.native-composer/v1");
+    expect(typeof api.decodeComposerOperation).toBe("function");
+    expect(typeof api.decodeComposerOperationStream).toBe("function");
+    expect(typeof api.normalizeComposerAttachment).toBe("function");
+    expect(typeof api.applyComposerOperation).toBe("function");
+    expect(typeof api.createComposerBridgeClient).toBe("function");
+    expect(typeof api.emptyComposerDraft).toBe("function");
+  });
+
+  it("the client factory produces a working bridge from the barrel export", () => {
+    const client = api.createComposerBridgeClient();
+    const result = client.dispatchRaw({
+      type: "text.set",
+      opId: "1",
+      text: "hi",
+    });
+    expect(result.status).toBe("applied");
+    expect(client.getDraft().text).toBe("hi");
+  });
+});

--- a/packages/ui/src/native-composer/index.ts
+++ b/packages/ui/src/native-composer/index.ts
@@ -1,0 +1,81 @@
+/**
+ * `eliza.native-composer/v1` — the one typed composer-bridge contract shared by
+ * the iOS, Android, desktop, and web shells. Types + schema (`contract`), boundary
+ * decoder (`decode`), attachment normalization into the existing media store
+ * (`attachments`), the pure state machine (`reduce`), and the renderer-side
+ * client that wires them together (`client`).
+ */
+
+export {
+  type AttachmentAddOperation,
+  type AttachmentRemoveOperation,
+  type CancelOperation,
+  COMPOSER_EVENT_TYPES,
+  COMPOSER_OPERATION_TYPES,
+  type ComposerAttachment,
+  type ComposerAttachmentSource,
+  type ComposerCancelScope,
+  type ComposerDraft,
+  type ComposerEvent,
+  type ComposerEventType,
+  type ComposerMention,
+  type ComposerOperation,
+  type ComposerOperationStream,
+  type ComposerOperationType,
+  type ComposerRejectReason,
+  type ComposerReplyContext,
+  type DispatchResult,
+  type DraftChangedEvent,
+  emptyComposerDraft,
+  type FocusChangedEvent,
+  type FocusSetOperation,
+  type KeyboardVisibility,
+  type MentionAddOperation,
+  NATIVE_COMPOSER_SCHEMA,
+  type NativeComposerSchema,
+  type ReplyClearOperation,
+  type ReplySetOperation,
+  type SendOperation,
+  type SendOutcome,
+  type SendResultEvent,
+  type TextInsertOperation,
+  type TextSetOperation,
+  type VoiceHandoffOperation,
+  type VoiceHandoffPhase,
+  type VoiceHandoffStateEvent,
+} from "./contract";
+export {
+  type ComposerAttachmentDecodeResult,
+  type ComposerDecodeError,
+  type ComposerDecodeErrorCode,
+  type ComposerOperationDecodeResult,
+  type ComposerStreamDecodeResult,
+  decodeComposerAttachmentSource,
+  decodeComposerOperation,
+  decodeComposerOperationStream,
+} from "./decode";
+export {
+  DEFAULT_MAX_ATTACHMENT_BYTES,
+  type NormalizeAttachmentOptions,
+  type NormalizeAttachmentResult,
+  normalizeComposerAttachment,
+} from "./attachments";
+export {
+  applyComposerOperation,
+  type ComposerApplyContext,
+  type ComposerBridgeState,
+  type ComposerCapabilities,
+  type ComposerLimits,
+  DEFAULT_COMPOSER_CAPABILITIES,
+  DEFAULT_COMPOSER_LIMITS,
+  defaultApplyContext,
+  flushDeferredOperations,
+  initialComposerState,
+  resolveSend,
+} from "./reduce";
+export {
+  type ComposerBridgeClient,
+  type ComposerBridgeClientOptions,
+  type ComposerBridgeSnapshot,
+  createComposerBridgeClient,
+} from "./client";

--- a/packages/ui/src/native-composer/index.ts
+++ b/packages/ui/src/native-composer/index.ts
@@ -7,6 +7,18 @@
  */
 
 export {
+  DEFAULT_MAX_ATTACHMENT_BYTES,
+  type NormalizeAttachmentOptions,
+  type NormalizeAttachmentResult,
+  normalizeComposerAttachment,
+} from "./attachments";
+export {
+  type ComposerBridgeClient,
+  type ComposerBridgeClientOptions,
+  type ComposerBridgeSnapshot,
+  createComposerBridgeClient,
+} from "./client";
+export {
   type AttachmentAddOperation,
   type AttachmentRemoveOperation,
   type CancelOperation,
@@ -55,12 +67,6 @@ export {
   decodeComposerOperationStream,
 } from "./decode";
 export {
-  DEFAULT_MAX_ATTACHMENT_BYTES,
-  type NormalizeAttachmentOptions,
-  type NormalizeAttachmentResult,
-  normalizeComposerAttachment,
-} from "./attachments";
-export {
   applyComposerOperation,
   type ComposerApplyContext,
   type ComposerBridgeState,
@@ -73,9 +79,3 @@ export {
   initialComposerState,
   resolveSend,
 } from "./reduce";
-export {
-  type ComposerBridgeClient,
-  type ComposerBridgeClientOptions,
-  type ComposerBridgeSnapshot,
-  createComposerBridgeClient,
-} from "./client";

--- a/packages/ui/src/native-composer/reduce.test.ts
+++ b/packages/ui/src/native-composer/reduce.test.ts
@@ -47,7 +47,11 @@ describe("text + mentions + reply", () => {
 
   it("mention.add inserts a token and records the mention", () => {
     const { state } = run([
-      { type: "mention.add", opId: "1", mention: { id: "u1", label: "alice", kind: "user" } },
+      {
+        type: "mention.add",
+        opId: "1",
+        mention: { id: "u1", label: "alice", kind: "user" },
+      },
     ]);
     expect(state.draft.text).toBe("@alice ");
     expect(state.draft.mentions).toHaveLength(1);
@@ -55,7 +59,11 @@ describe("text + mentions + reply", () => {
 
   it("reply.set then reply.clear round-trips", () => {
     const { state } = run([
-      { type: "reply.set", opId: "1", reply: { messageId: "m1", preview: "hi" } },
+      {
+        type: "reply.set",
+        opId: "1",
+        reply: { messageId: "m1", preview: "hi" },
+      },
       { type: "reply.clear", opId: "2" },
     ]);
     expect(state.draft.reply).toBeNull();
@@ -71,7 +79,8 @@ describe("text + mentions + reply", () => {
       small,
     );
     expect(results[0].status).toBe("rejected");
-    if (results[0].status === "rejected") expect(results[0].reason).toBe("oversized");
+    if (results[0].status === "rejected")
+      expect(results[0].reason).toBe("oversized");
     expect(state.draft.text).toBe("");
     expect(state.draft.revision).toBe(0);
   });
@@ -100,7 +109,8 @@ describe("attachments", () => {
     };
     const { results } = run([stored], noAttach);
     expect(results[0].status).toBe("rejected");
-    if (results[0].status === "rejected") expect(results[0].reason).toBe("permission-denied");
+    if (results[0].status === "rejected")
+      expect(results[0].reason).toBe("permission-denied");
   });
 
   it("oversized when over the attachment count cap", () => {
@@ -115,13 +125,17 @@ describe("attachments", () => {
           type: "attachment.add",
           opId: "a2",
           attachmentId: "att2",
-          attachment: { source: "stored", url: `/api/media/${"b".repeat(64)}.png` },
+          attachment: {
+            source: "stored",
+            url: `/api/media/${"b".repeat(64)}.png`,
+          },
         },
       ],
       capped,
     );
     expect(results[1].status).toBe("rejected");
-    if (results[1].status === "rejected") expect(results[1].reason).toBe("oversized");
+    if (results[1].status === "rejected")
+      expect(results[1].reason).toBe("oversized");
   });
 
   it("rejects a malformed attachment source with invalid-input", () => {
@@ -134,14 +148,19 @@ describe("attachments", () => {
       },
     ]);
     expect(results[0].status).toBe("rejected");
-    if (results[0].status === "rejected") expect(results[0].reason).toBe("invalid-input");
+    if (results[0].status === "rejected")
+      expect(results[0].reason).toBe("invalid-input");
   });
 });
 
 describe("idempotency — duplicate native callbacks", () => {
   it("a repeated opId is a no-op reported as duplicate", () => {
     let state = initialComposerState();
-    const op: ComposerOperation = { type: "text.insert", opId: "dup", text: "x" };
+    const op: ComposerOperation = {
+      type: "text.insert",
+      opId: "dup",
+      text: "x",
+    };
     const first = applyComposerOperation(state, op, ctx);
     state = first.state;
     const second = applyComposerOperation(state, op, ctx);
@@ -166,7 +185,8 @@ describe("send", () => {
   it("rejects an empty send", () => {
     const { results } = run([{ type: "send", opId: "s" }]);
     expect(results[0].status).toBe("rejected");
-    if (results[0].status === "rejected") expect(results[0].reason).toBe("empty-send");
+    if (results[0].status === "rejected")
+      expect(results[0].reason).toBe("empty-send");
   });
 
   it("accepts a send and marks it in flight", () => {
@@ -176,13 +196,18 @@ describe("send", () => {
   });
 
   it("rejects a second send while one is in flight (concurrency)", () => {
-    const { results } = run([seed, { type: "send", opId: "s1" }, { type: "send", opId: "s2" }]);
+    const { results } = run([
+      seed,
+      { type: "send", opId: "s1" },
+      { type: "send", opId: "s2" },
+    ]);
     expect(results[2].status).toBe("rejected");
-    if (results[2].status === "rejected") expect(results[2].reason).toBe("send-in-flight");
+    if (results[2].status === "rejected")
+      expect(results[2].reason).toBe("send-in-flight");
   });
 
   it("defers a send while offline, then replays it on reconnect", () => {
-    let { state } = run([seed, { type: "send", opId: "s" }], offline);
+    const { state } = run([seed, { type: "send", opId: "s" }], offline);
     expect(state.deferred).toHaveLength(1);
     expect(state.sending).toBeNull();
     const flushed = flushDeferredOperations(state, ctx);
@@ -198,7 +223,11 @@ describe("send", () => {
     expect(ok.sending).toBeNull();
 
     const { state: state2 } = run([seed, { type: "send", opId: "s" }]);
-    const fail = resolveSend(state2, "s", { ok: false, reason: "invalid-input", message: "x" });
+    const fail = resolveSend(state2, "s", {
+      ok: false,
+      reason: "invalid-input",
+      message: "x",
+    });
     expect(fail.draft.text).toBe("hi");
     expect(fail.sending).toBeNull();
   });
@@ -231,7 +260,12 @@ describe("voice handoff + focus", () => {
   it("commit appends the transcript; permission-denied without voice capability", () => {
     const { state } = run([
       { type: "voice.handoff", opId: "v1", phase: "start" },
-      { type: "voice.handoff", opId: "v2", phase: "commit", transcript: "spoken words" },
+      {
+        type: "voice.handoff",
+        opId: "v2",
+        phase: "commit",
+        transcript: "spoken words",
+      },
     ]);
     expect(state.draft.text).toBe("spoken words");
 
@@ -239,9 +273,13 @@ describe("voice handoff + focus", () => {
       ...ctx,
       capabilities: { attach: true, voice: false },
     };
-    const { results } = run([{ type: "voice.handoff", opId: "v1", phase: "start" }], noVoice);
+    const { results } = run(
+      [{ type: "voice.handoff", opId: "v1", phase: "start" }],
+      noVoice,
+    );
     expect(results[0].status).toBe("rejected");
-    if (results[0].status === "rejected") expect(results[0].reason).toBe("permission-denied");
+    if (results[0].status === "rejected")
+      expect(results[0].reason).toBe("permission-denied");
   });
 
   it("focus.set updates focus + keyboard", () => {

--- a/packages/ui/src/native-composer/reduce.test.ts
+++ b/packages/ui/src/native-composer/reduce.test.ts
@@ -1,0 +1,252 @@
+/**
+ * State-machine tests for the composer reducer — the behavioral spec. Drives the
+ * whole acceptance case matrix deterministically: text/mention/reply edits and
+ * their oversized rejections, attachment add/remove with permission + cap
+ * enforcement, send happy/empty/in-flight/offline-deferred + flush replay,
+ * cancellation (send vs draft), duplicate-callback idempotency, draft-revision
+ * preservation, and send resolution (success clears, failure keeps).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ComposerOperation } from "./contract";
+import {
+  applyComposerOperation,
+  type ComposerApplyContext,
+  DEFAULT_COMPOSER_LIMITS,
+  defaultApplyContext,
+  flushDeferredOperations,
+  initialComposerState,
+  resolveSend,
+} from "./reduce";
+
+const ctx = defaultApplyContext(true);
+const offline = defaultApplyContext(false);
+
+/** Fold a sequence of ops from the initial state, returning the final state. */
+function run(ops: ComposerOperation[], context: ComposerApplyContext = ctx) {
+  let state = initialComposerState();
+  const results = ops.map((op) => {
+    const step = applyComposerOperation(state, op, context);
+    state = step.state;
+    return step.result;
+  });
+  return { state, results };
+}
+
+describe("text + mentions + reply", () => {
+  it("text.insert appends, text.set replaces, each bumps revision", () => {
+    const { state } = run([
+      { type: "text.insert", opId: "1", text: "hello " },
+      { type: "text.insert", opId: "2", text: "world" },
+    ]);
+    expect(state.draft.text).toBe("hello world");
+    expect(state.draft.revision).toBe(2);
+    const { state: s2 } = run([{ type: "text.set", opId: "1", text: "reset" }]);
+    expect(s2.draft.text).toBe("reset");
+  });
+
+  it("mention.add inserts a token and records the mention", () => {
+    const { state } = run([
+      { type: "mention.add", opId: "1", mention: { id: "u1", label: "alice", kind: "user" } },
+    ]);
+    expect(state.draft.text).toBe("@alice ");
+    expect(state.draft.mentions).toHaveLength(1);
+  });
+
+  it("reply.set then reply.clear round-trips", () => {
+    const { state } = run([
+      { type: "reply.set", opId: "1", reply: { messageId: "m1", preview: "hi" } },
+      { type: "reply.clear", opId: "2" },
+    ]);
+    expect(state.draft.reply).toBeNull();
+  });
+
+  it("rejects oversized text without mutating the draft", () => {
+    const small: ComposerApplyContext = {
+      ...ctx,
+      limits: { ...DEFAULT_COMPOSER_LIMITS, maxTextLength: 4 },
+    };
+    const { state, results } = run(
+      [{ type: "text.set", opId: "1", text: "toolong" }],
+      small,
+    );
+    expect(results[0].status).toBe("rejected");
+    if (results[0].status === "rejected") expect(results[0].reason).toBe("oversized");
+    expect(state.draft.text).toBe("");
+    expect(state.draft.revision).toBe(0);
+  });
+});
+
+describe("attachments", () => {
+  const stored: ComposerOperation = {
+    type: "attachment.add",
+    opId: "a1",
+    attachmentId: "att1",
+    attachment: { source: "stored", url: `/api/media/${"a".repeat(64)}.png` },
+  };
+
+  it("adds and removes an attachment", () => {
+    const { state } = run([
+      stored,
+      { type: "attachment.remove", opId: "a2", attachmentId: "att1" },
+    ]);
+    expect(state.draft.attachments).toHaveLength(0);
+  });
+
+  it("permission-denied when attach capability is absent", () => {
+    const noAttach: ComposerApplyContext = {
+      ...ctx,
+      capabilities: { attach: false, voice: true },
+    };
+    const { results } = run([stored], noAttach);
+    expect(results[0].status).toBe("rejected");
+    if (results[0].status === "rejected") expect(results[0].reason).toBe("permission-denied");
+  });
+
+  it("oversized when over the attachment count cap", () => {
+    const capped: ComposerApplyContext = {
+      ...ctx,
+      limits: { ...DEFAULT_COMPOSER_LIMITS, maxAttachments: 1 },
+    };
+    const { results } = run(
+      [
+        stored,
+        {
+          type: "attachment.add",
+          opId: "a2",
+          attachmentId: "att2",
+          attachment: { source: "stored", url: `/api/media/${"b".repeat(64)}.png` },
+        },
+      ],
+      capped,
+    );
+    expect(results[1].status).toBe("rejected");
+    if (results[1].status === "rejected") expect(results[1].reason).toBe("oversized");
+  });
+
+  it("rejects a malformed attachment source with invalid-input", () => {
+    const { results } = run([
+      {
+        type: "attachment.add",
+        opId: "a1",
+        attachmentId: "att1",
+        attachment: { source: "inline", mimeType: "bad", bytesBase64: "AAAA" },
+      },
+    ]);
+    expect(results[0].status).toBe("rejected");
+    if (results[0].status === "rejected") expect(results[0].reason).toBe("invalid-input");
+  });
+});
+
+describe("idempotency — duplicate native callbacks", () => {
+  it("a repeated opId is a no-op reported as duplicate", () => {
+    let state = initialComposerState();
+    const op: ComposerOperation = { type: "text.insert", opId: "dup", text: "x" };
+    const first = applyComposerOperation(state, op, ctx);
+    state = first.state;
+    const second = applyComposerOperation(state, op, ctx);
+    expect(first.result.status).toBe("applied");
+    expect(second.result.status).toBe("duplicate");
+    expect(state.draft.text).toBe("x"); // not "xx"
+    expect(state.draft.revision).toBe(1);
+  });
+
+  it("distinct ops with same content but different opId both apply", () => {
+    const { state } = run([
+      { type: "text.insert", opId: "1", text: "x" },
+      { type: "text.insert", opId: "2", text: "x" },
+    ]);
+    expect(state.draft.text).toBe("xx");
+  });
+});
+
+describe("send", () => {
+  const seed: ComposerOperation = { type: "text.set", opId: "t", text: "hi" };
+
+  it("rejects an empty send", () => {
+    const { results } = run([{ type: "send", opId: "s" }]);
+    expect(results[0].status).toBe("rejected");
+    if (results[0].status === "rejected") expect(results[0].reason).toBe("empty-send");
+  });
+
+  it("accepts a send and marks it in flight", () => {
+    const { state, results } = run([seed, { type: "send", opId: "s" }]);
+    expect(results[1].status).toBe("applied");
+    expect(state.sending?.opId).toBe("s");
+  });
+
+  it("rejects a second send while one is in flight (concurrency)", () => {
+    const { results } = run([seed, { type: "send", opId: "s1" }, { type: "send", opId: "s2" }]);
+    expect(results[2].status).toBe("rejected");
+    if (results[2].status === "rejected") expect(results[2].reason).toBe("send-in-flight");
+  });
+
+  it("defers a send while offline, then replays it on reconnect", () => {
+    let { state } = run([seed, { type: "send", opId: "s" }], offline);
+    expect(state.deferred).toHaveLength(1);
+    expect(state.sending).toBeNull();
+    const flushed = flushDeferredOperations(state, ctx);
+    expect(flushed.results[0].status).toBe("applied");
+    expect(flushed.state.sending?.opId).toBe("s");
+    expect(flushed.state.deferred).toHaveLength(0);
+  });
+
+  it("resolveSend success clears the draft; failure keeps it", () => {
+    const { state } = run([seed, { type: "send", opId: "s" }]);
+    const ok = resolveSend(state, "s", { ok: true, messageId: "m1" });
+    expect(ok.draft.text).toBe("");
+    expect(ok.sending).toBeNull();
+
+    const { state: state2 } = run([seed, { type: "send", opId: "s" }]);
+    const fail = resolveSend(state2, "s", { ok: false, reason: "invalid-input", message: "x" });
+    expect(fail.draft.text).toBe("hi");
+    expect(fail.sending).toBeNull();
+  });
+});
+
+describe("cancellation", () => {
+  it("cancel scope=send aborts the in-flight send, keeps the draft", () => {
+    const { state } = run([
+      { type: "text.set", opId: "t", text: "hi" },
+      { type: "send", opId: "s" },
+      { type: "cancel", opId: "c", scope: "send" },
+    ]);
+    expect(state.sending).toBeNull();
+    expect(state.draft.text).toBe("hi");
+  });
+
+  it("cancel scope=draft clears the body but keeps focus", () => {
+    const { state } = run([
+      { type: "focus.set", opId: "f", focused: true, keyboard: "shown" },
+      { type: "text.set", opId: "t", text: "hi" },
+      { type: "cancel", opId: "c", scope: "draft" },
+    ]);
+    expect(state.draft.text).toBe("");
+    expect(state.draft.focused).toBe(true);
+    expect(state.draft.keyboard).toBe("shown");
+  });
+});
+
+describe("voice handoff + focus", () => {
+  it("commit appends the transcript; permission-denied without voice capability", () => {
+    const { state } = run([
+      { type: "voice.handoff", opId: "v1", phase: "start" },
+      { type: "voice.handoff", opId: "v2", phase: "commit", transcript: "spoken words" },
+    ]);
+    expect(state.draft.text).toBe("spoken words");
+
+    const noVoice: ComposerApplyContext = {
+      ...ctx,
+      capabilities: { attach: true, voice: false },
+    };
+    const { results } = run([{ type: "voice.handoff", opId: "v1", phase: "start" }], noVoice);
+    expect(results[0].status).toBe("rejected");
+    if (results[0].status === "rejected") expect(results[0].reason).toBe("permission-denied");
+  });
+
+  it("focus.set updates focus + keyboard", () => {
+    const { state } = run([{ type: "focus.set", opId: "f", focused: true }]);
+    expect(state.draft.focused).toBe(true);
+    expect(state.draft.keyboard).toBe("shown");
+  });
+});

--- a/packages/ui/src/native-composer/reduce.ts
+++ b/packages/ui/src/native-composer/reduce.ts
@@ -121,15 +121,11 @@ function markProcessed(
 }
 
 /** Next draft with `patch` applied and `revision` bumped (an applied mutation). */
-function bumpDraft(draft: ComposerDraft, patch: Partial<ComposerDraft>): ComposerDraft {
+function bumpDraft(
+  draft: ComposerDraft,
+  patch: Partial<ComposerDraft>,
+): ComposerDraft {
   return { ...draft, ...patch, revision: draft.revision + 1 };
-}
-
-function applied(state: ComposerBridgeState, opId: string): {
-  state: ComposerBridgeState;
-  result: DispatchResult;
-} {
-  return { state, result: { status: "applied", opId, draft: state.draft } };
 }
 
 function rejected(
@@ -176,7 +172,12 @@ export function applyComposerOperation(
       const text = state.draft.text + op.text;
       if (text.length > limits.maxTextLength)
         return rejected(state, op.opId, "oversized", "text exceeds max length");
-      return commitApplied(state, op.opId, limits, bumpDraft(state.draft, { text }));
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { text }),
+      );
     }
     case "text.set": {
       if (op.text.length > limits.maxTextLength)
@@ -190,15 +191,27 @@ export function applyComposerOperation(
     }
     case "attachment.add": {
       if (!capabilities.attach)
-        return rejected(state, op.opId, "permission-denied", "attach not permitted");
+        return rejected(
+          state,
+          op.opId,
+          "permission-denied",
+          "attach not permitted",
+        );
       const existingIdx = state.draft.attachments.findIndex(
         (a) => a.id === op.attachmentId,
       );
-      if (existingIdx < 0 && state.draft.attachments.length >= limits.maxAttachments)
+      if (
+        existingIdx < 0 &&
+        state.draft.attachments.length >= limits.maxAttachments
+      )
         return rejected(state, op.opId, "oversized", "too many attachments");
-      const normalized = normalizeComposerAttachment(op.attachmentId, op.attachment, {
-        maxBytes: limits.maxAttachmentBytes,
-      });
+      const normalized = normalizeComposerAttachment(
+        op.attachmentId,
+        op.attachment,
+        {
+          maxBytes: limits.maxAttachmentBytes,
+        },
+      );
       if (!normalized.ok)
         return rejected(state, op.opId, normalized.reason, normalized.message);
       const attachments = [...state.draft.attachments];
@@ -263,12 +276,27 @@ export function applyComposerOperation(
     }
     case "voice.handoff": {
       if (!capabilities.voice)
-        return rejected(state, op.opId, "permission-denied", "voice not permitted");
+        return rejected(
+          state,
+          op.opId,
+          "permission-denied",
+          "voice not permitted",
+        );
       if (op.phase === "commit" && op.transcript) {
         const text = state.draft.text + op.transcript;
         if (text.length > limits.maxTextLength)
-          return rejected(state, op.opId, "oversized", "text exceeds max length");
-        return commitApplied(state, op.opId, limits, bumpDraft(state.draft, { text }));
+          return rejected(
+            state,
+            op.opId,
+            "oversized",
+            "text exceeds max length",
+          );
+        return commitApplied(
+          state,
+          op.opId,
+          limits,
+          bumpDraft(state.draft, { text }),
+        );
       }
       // start/cancel carry no draft mutation; still recorded so a replay no-ops.
       return commitApplied(state, op.opId, limits, state.draft);
@@ -276,7 +304,9 @@ export function applyComposerOperation(
     case "cancel": {
       if (op.scope === "send") {
         // Aborting a send is idempotent even with nothing in flight.
-        return commitApplied(state, op.opId, limits, state.draft, { sending: null });
+        return commitApplied(state, op.opId, limits, state.draft, {
+          sending: null,
+        });
       }
       // scope === "draft": clear the body, keep focus/keyboard so the input stays live.
       const cleared: ComposerDraft = {
@@ -291,7 +321,12 @@ export function applyComposerOperation(
       if (isDraftEmpty(state.draft))
         return rejected(state, op.opId, "empty-send", "nothing to send");
       if (state.sending)
-        return rejected(state, op.opId, "send-in-flight", "a send is already in flight");
+        return rejected(
+          state,
+          op.opId,
+          "send-in-flight",
+          "a send is already in flight",
+        );
       if (!online) {
         // Queue for replay on reconnect; not marked processed until it applies.
         return {

--- a/packages/ui/src/native-composer/reduce.ts
+++ b/packages/ui/src/native-composer/reduce.ts
@@ -1,0 +1,365 @@
+/**
+ * The composer-bridge state machine: fold one decoded {@link ComposerOperation}
+ * into the reduced {@link ComposerDraft} and answer with a typed
+ * {@link DispatchResult}. This reducer IS the contract's behavioral spec for
+ * idempotency, cancellation, offline deferral, and permission/limit enforcement.
+ *
+ * The guarantees, all decided from structural fields (the `opId` key, the op
+ * `type`, the online flag, and capability/limit context) — never from inspecting
+ * text content:
+ *   - Idempotency: `opId` is unique per stream; an op whose `opId` has already
+ *     produced an applied mutation is a no-op, reported `duplicate`. This is what
+ *     makes a duplicate native callback, or a replay after reconnect/reload,
+ *     safe.
+ *   - Offline deferral: a `send` issued while `!online` is queued and reported
+ *     `deferred`; `flushDeferredOperations` replays the queue on reconnect. Local
+ *     draft edits never defer — they apply offline and are preserved.
+ *   - Cancellation: `cancel` aborts the in-flight send (`scope: "send"`) or
+ *     resets the draft body while keeping focus (`scope: "draft"`).
+ *   - Permission/limits: an op needing an absent capability (`attach`/`voice`) is
+ *     `rejected: "permission-denied"`; over-cap text/attachments/bytes are
+ *     `rejected: "oversized"`; a malformed attachment source is
+ *     `rejected: "invalid-input"`. A rejection is NOT recorded as processed, so a
+ *     corrected retry re-evaluates.
+ *
+ * Callers pass only decoded operations (see `decode.ts`); this function trusts
+ * the shapes and never re-validates them.
+ */
+
+import { normalizeComposerAttachment } from "./attachments";
+import {
+  type ComposerDraft,
+  type ComposerOperation,
+  type ComposerRejectReason,
+  type DispatchResult,
+  emptyComposerDraft,
+  type SendOutcome,
+} from "./contract";
+
+/** Feature capabilities the shell currently grants; gate permissioned ops. */
+export interface ComposerCapabilities {
+  /** May add attachments (e.g. iOS photo-library permission granted). */
+  attach: boolean;
+  /** May hand off to voice (e.g. microphone permission granted). */
+  voice: boolean;
+}
+
+/** Caps enforced by the reducer; over-cap input is rejected, never truncated. */
+export interface ComposerLimits {
+  maxTextLength: number;
+  maxAttachments: number;
+  maxAttachmentBytes: number;
+  /** Cap on the dedupe ledger; the oldest ids evict past this (see note below). */
+  maxProcessedOpIds: number;
+}
+
+export const DEFAULT_COMPOSER_CAPABILITIES: ComposerCapabilities = {
+  attach: true,
+  voice: true,
+};
+
+export const DEFAULT_COMPOSER_LIMITS: ComposerLimits = {
+  maxTextLength: 100_000,
+  maxAttachments: 10,
+  maxAttachmentBytes: 50 * 1024 * 1024,
+  maxProcessedOpIds: 512,
+};
+
+/** Per-apply context: transport liveness, granted capabilities, and caps. */
+export interface ComposerApplyContext {
+  online: boolean;
+  capabilities: ComposerCapabilities;
+  limits: ComposerLimits;
+}
+
+export function defaultApplyContext(
+  online = true,
+  overrides: Partial<ComposerApplyContext> = {},
+): ComposerApplyContext {
+  return {
+    online,
+    capabilities: overrides.capabilities ?? DEFAULT_COMPOSER_CAPABILITIES,
+    limits: overrides.limits ?? DEFAULT_COMPOSER_LIMITS,
+  };
+}
+
+/**
+ * Reducer state. `processed` is the dedupe ledger of applied `opId`s; `deferred`
+ * is the offline send queue; `sending` is the single in-flight send. Kept
+ * separate from {@link ComposerDraft} so the draft the shell mirrors stays free
+ * of bridge bookkeeping.
+ */
+export interface ComposerBridgeState {
+  draft: ComposerDraft;
+  processed: Set<string>;
+  deferred: ComposerOperation[];
+  sending: { opId: string } | null;
+}
+
+export function initialComposerState(): ComposerBridgeState {
+  return {
+    draft: emptyComposerDraft(),
+    processed: new Set(),
+    deferred: [],
+    sending: null,
+  };
+}
+
+/** Add `opId` to the ledger, evicting oldest ids past the cap (FIFO). */
+function markProcessed(
+  processed: Set<string>,
+  opId: string,
+  cap: number,
+): Set<string> {
+  const next = new Set(processed);
+  next.add(opId);
+  if (next.size > cap) {
+    const keys = [...next];
+    for (let i = 0; i < keys.length - cap; i++) next.delete(keys[i]);
+  }
+  return next;
+}
+
+/** Next draft with `patch` applied and `revision` bumped (an applied mutation). */
+function bumpDraft(draft: ComposerDraft, patch: Partial<ComposerDraft>): ComposerDraft {
+  return { ...draft, ...patch, revision: draft.revision + 1 };
+}
+
+function applied(state: ComposerBridgeState, opId: string): {
+  state: ComposerBridgeState;
+  result: DispatchResult;
+} {
+  return { state, result: { status: "applied", opId, draft: state.draft } };
+}
+
+function rejected(
+  state: ComposerBridgeState,
+  opId: string,
+  reason: ComposerRejectReason,
+  message: string,
+): { state: ComposerBridgeState; result: DispatchResult } {
+  return {
+    state,
+    result: { status: "rejected", opId, reason, message, draft: state.draft },
+  };
+}
+
+/** True when the draft carries nothing sendable (blank text, no attachments). */
+function isDraftEmpty(draft: ComposerDraft): boolean {
+  return draft.text.trim().length === 0 && draft.attachments.length === 0;
+}
+
+/**
+ * Fold one decoded operation into the state, returning the next state and the
+ * typed {@link DispatchResult}. Pure: the input state is never mutated.
+ */
+export function applyComposerOperation(
+  state: ComposerBridgeState,
+  op: ComposerOperation,
+  ctx: ComposerApplyContext,
+): { state: ComposerBridgeState; result: DispatchResult } {
+  // Idempotency: an op we have already applied is a no-op. This is the guard
+  // that makes duplicate native callbacks and post-reconnect replays safe.
+  if (state.processed.has(op.opId)) {
+    return {
+      state,
+      result: { status: "duplicate", opId: op.opId, draft: state.draft },
+    };
+  }
+
+  const { limits, capabilities, online } = ctx;
+
+  // Compute the mutation (or a rejection) per op type; commit the processed-ledger
+  // update only for the paths that actually apply.
+  switch (op.type) {
+    case "text.insert": {
+      const text = state.draft.text + op.text;
+      if (text.length > limits.maxTextLength)
+        return rejected(state, op.opId, "oversized", "text exceeds max length");
+      return commitApplied(state, op.opId, limits, bumpDraft(state.draft, { text }));
+    }
+    case "text.set": {
+      if (op.text.length > limits.maxTextLength)
+        return rejected(state, op.opId, "oversized", "text exceeds max length");
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { text: op.text }),
+      );
+    }
+    case "attachment.add": {
+      if (!capabilities.attach)
+        return rejected(state, op.opId, "permission-denied", "attach not permitted");
+      const existingIdx = state.draft.attachments.findIndex(
+        (a) => a.id === op.attachmentId,
+      );
+      if (existingIdx < 0 && state.draft.attachments.length >= limits.maxAttachments)
+        return rejected(state, op.opId, "oversized", "too many attachments");
+      const normalized = normalizeComposerAttachment(op.attachmentId, op.attachment, {
+        maxBytes: limits.maxAttachmentBytes,
+      });
+      if (!normalized.ok)
+        return rejected(state, op.opId, normalized.reason, normalized.message);
+      const attachments = [...state.draft.attachments];
+      if (existingIdx >= 0) attachments[existingIdx] = normalized.attachment;
+      else attachments.push(normalized.attachment);
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { attachments }),
+      );
+    }
+    case "attachment.remove": {
+      const attachments = state.draft.attachments.filter(
+        (a) => a.id !== op.attachmentId,
+      );
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { attachments }),
+      );
+    }
+    case "reply.set":
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { reply: op.reply }),
+      );
+    case "reply.clear":
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { reply: null }),
+      );
+    case "mention.add": {
+      const token = `@${op.mention.label} `;
+      const text = state.draft.text + token;
+      if (text.length > limits.maxTextLength)
+        return rejected(state, op.opId, "oversized", "text exceeds max length");
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, {
+          text,
+          mentions: [...state.draft.mentions, op.mention],
+        }),
+      );
+    }
+    case "focus.set": {
+      const keyboard =
+        op.keyboard ?? (op.focused ? "shown" : state.draft.keyboard);
+      return commitApplied(
+        state,
+        op.opId,
+        limits,
+        bumpDraft(state.draft, { focused: op.focused, keyboard }),
+      );
+    }
+    case "voice.handoff": {
+      if (!capabilities.voice)
+        return rejected(state, op.opId, "permission-denied", "voice not permitted");
+      if (op.phase === "commit" && op.transcript) {
+        const text = state.draft.text + op.transcript;
+        if (text.length > limits.maxTextLength)
+          return rejected(state, op.opId, "oversized", "text exceeds max length");
+        return commitApplied(state, op.opId, limits, bumpDraft(state.draft, { text }));
+      }
+      // start/cancel carry no draft mutation; still recorded so a replay no-ops.
+      return commitApplied(state, op.opId, limits, state.draft);
+    }
+    case "cancel": {
+      if (op.scope === "send") {
+        // Aborting a send is idempotent even with nothing in flight.
+        return commitApplied(state, op.opId, limits, state.draft, { sending: null });
+      }
+      // scope === "draft": clear the body, keep focus/keyboard so the input stays live.
+      const cleared: ComposerDraft = {
+        ...emptyComposerDraft(),
+        focused: state.draft.focused,
+        keyboard: state.draft.keyboard,
+        revision: state.draft.revision + 1,
+      };
+      return commitApplied(state, op.opId, limits, cleared, { sending: null });
+    }
+    case "send": {
+      if (isDraftEmpty(state.draft))
+        return rejected(state, op.opId, "empty-send", "nothing to send");
+      if (state.sending)
+        return rejected(state, op.opId, "send-in-flight", "a send is already in flight");
+      if (!online) {
+        // Queue for replay on reconnect; not marked processed until it applies.
+        return {
+          state: { ...state, deferred: [...state.deferred, op] },
+          result: { status: "deferred", opId: op.opId, draft: state.draft },
+        };
+      }
+      return commitApplied(state, op.opId, limits, state.draft, {
+        sending: { opId: op.opId },
+      });
+    }
+  }
+}
+
+/** Commit an applied mutation: record the opId and thread optional field patches. */
+function commitApplied(
+  state: ComposerBridgeState,
+  opId: string,
+  limits: ComposerLimits,
+  draft: ComposerDraft,
+  extra: Partial<Pick<ComposerBridgeState, "sending">> = {},
+): { state: ComposerBridgeState; result: DispatchResult } {
+  const next: ComposerBridgeState = {
+    ...state,
+    draft,
+    processed: markProcessed(state.processed, opId, limits.maxProcessedOpIds),
+    ...extra,
+  };
+  return { state: next, result: { status: "applied", opId, draft } };
+}
+
+/**
+ * Resolve the in-flight send once its {@link SendOutcome} is known. On success
+ * the draft is cleared (the message left the composer); on failure the draft is
+ * kept so the user can retry. A stale resolution (no matching in-flight send) is
+ * a no-op.
+ */
+export function resolveSend(
+  state: ComposerBridgeState,
+  opId: string,
+  outcome: SendOutcome,
+): ComposerBridgeState {
+  if (!state.sending || state.sending.opId !== opId) return state;
+  if (!outcome.ok) return { ...state, sending: null };
+  return {
+    ...state,
+    sending: null,
+    draft: { ...emptyComposerDraft(), revision: state.draft.revision + 1 },
+  };
+}
+
+/**
+ * Replay the offline send queue when the transport is back online. Each queued
+ * op is re-applied through {@link applyComposerOperation}; the queue is cleared
+ * (ops that still defer — should not happen when `ctx.online` — are re-queued by
+ * apply). Returns the folded state and the per-op results in replay order.
+ */
+export function flushDeferredOperations(
+  state: ComposerBridgeState,
+  ctx: ComposerApplyContext,
+): { state: ComposerBridgeState; results: DispatchResult[] } {
+  const queue = state.deferred;
+  let next: ComposerBridgeState = { ...state, deferred: [] };
+  const results: DispatchResult[] = [];
+  for (const op of queue) {
+    const step = applyComposerOperation(next, op, ctx);
+    next = step.state;
+    results.push(step.result);
+  }
+  return { state: next, results };
+}


### PR DESCRIPTION
# Relates to

Refs #16438. One of the five cards that replace the closed monolith #16200. **Draft — do not merge.**

Sibling #16440 (draft PR #16507) landed the typed transcript-event contract in `packages/ui/src/native-transcript/`; this PR mirrors that vocabulary (versioned discriminated union, strict boundary decode, typed errors, no fabricated defaults) for the composer/input direction.

- [x] Targets `develop`, branched from the current `origin/develop` tip (`ba916b085b3`), zero conflicts.
- [x] `bunx vitest run src/native-composer/` → **56 passed**; `bunx tsgo --noEmit -p packages/ui` → clean (results below).
- [x] A reviewer can confirm the contract works from the per-file vitest matrix without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] Narrow, fast verification only (per the anti-watchdog process rule): scoped vitest + scoped `tsgo`. Full workspace lanes are left to CI.

# Risks

**Low.** Wholly-new, self-contained module (`packages/ui/src/native-composer/`) plus one additive `package.json` subpath export (`@elizaos/ui/native-composer`). No existing file's behavior changes; nothing imports it yet, so it cannot regress a live surface.

# Background

## What does this PR do?

Introduces the **one typed composer-bridge contract** (`eliza.native-composer/v1`) so an iOS / Android / desktop shell can push content INTO the chat composer and drive it, and the renderer can report the composer's state back — without coupling to the #16200 UI monolith.

- **`contract.ts`** — two versioned discriminated-union logs: `ComposerOperation` (native → renderer: `text.insert`/`text.set`, `attachment.add`/`remove`, `reply.set`/`clear`, `mention.add`, `send`, `cancel`, `focus.set`, `voice.handoff`) and `ComposerEvent` (renderer → native: `draft.changed`, `send.result`, `focus.changed`, `voice.state`). Applying an op returns a typed **`DispatchResult`** (`applied` / `duplicate` / `deferred` / `rejected{reason}`) — **never a bare boolean**. Attachment sources are media-store vocabulary only (`inline` / `data-url` / `remote` / `stored`) — **there is no file-id variant, so a second file store is structurally unrepresentable**.
- **`decode.ts`** — strict boundary decoder. Every field of an untrusted op/attachment is validated; a malformed frame yields a typed `{ok:false,error}` (error-policy **J3**), never a throw on per-op input and never a fabricated default. Structurally rejects any second-store shape (an unknown attachment `source`, e.g. `file-id`, is refused).
- **`attachments.ts`** — normalizes a native attachment into the **existing content-addressed store's** vocabulary: `inline`/`data-url` → a `data:` URL the existing outgoing pipeline (`api/media-runtime.ts` → `persistAttachmentUrlIfInline`) persists to `${STATE_DIR}/media/<sha256>` on send; `remote` → an http(s) URL flagged for the existing server-side SSRF-guarded rehost; `stored` → an `/api/media/<hash>` passthrough. First-line private-host guard; the server's DNS-pinned SSRF guard (`packages/core/src/network`) remains authoritative. **No new store, no file IDs.**
- **`reduce.ts`** — the state machine / behavioral spec: `opId` idempotency (duplicate native callback = no-op), offline-send deferral + reconnect replay, cancellation (`send` vs `draft` scope), and permission/limit enforcement.
- **`client.ts`** — the renderer-side bridge client: decode → reduce → emit events; `serialize()`/`hydrate()` preserve the draft + idempotency ledger + offline queue across app backgrounding, window reload, and reconnect. Malformed native input degrades to `rejected: "invalid-input"` — one bad frame never tears down a live composer.

## What kind of change is this?

Features (non-breaking; additive new module + subpath export).

# Documentation changes needed?

No project-docs change required; the module is self-documenting (prose headers + JSDoc), matching the sibling `native-transcript` contract.

# Testing

## Where should a reviewer start?

`packages/ui/src/native-composer/contract.ts` (the shape), then the four test files that pin the whole acceptance case matrix.

## Detailed testing steps

```
bunx vitest run src/native-composer/   # (cwd packages/ui) -> 5 files, 56 tests passed
bunx tsgo --noEmit -p packages/ui      # -> exit 0, no diagnostics
```

Case matrix covered (per-file vitest, deterministic, no mocks standing in for the thing under test):

- **decode.test.ts** — field-level rejection of every op type; attachment-source validation incl. **structural rejection of a `file-id` second-store shape**; mixed-batch stream decode keeps good ops + collects malformed with index/reason.
- **attachments.test.ts** — inline/data-url/remote/stored normalization; **oversized** cap; malformed mime; non-base64; **private-host SSRF block** (localhost/127/10/192.168/169.254/internal); non-http scheme; non-content-addressed stored URL; asserts no `fileId` on the produced attachment.
- **reduce.test.ts** — text/mention/reply edits + oversized rejection; attachment add/remove; **permission-denied** (attach & voice capabilities absent); attachment count cap; send empty/happy/**in-flight concurrency**/**offline-deferred + flush replay**; **cancel** (send vs draft); **duplicate-opId idempotency**; draft-revision preservation; `resolveSend` success clears / failure keeps.
- **client.test.ts** — malformed raw input → typed rejection (never throws); event emission (draft/focus/voice/send.result); **serialize→hydrate reload preserves idempotency + deferred offline send**; batch replay de-dupes after reconnect.
- **index.test.ts** — the `@elizaos/ui/native-composer` subpath re-exports the schema/decoder/reducer/client, and the client factory works when imported from the barrel.

# Evidence Gate

Attach each applicable artifact inline, or write `N/A - <reason>`.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - non-surface change: only .ts contract/logic + tests under packages/ui/src/native-composer and one package.json subpath export. No .tsx/.css/rendered surface, so there is no UI to screenshot.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - non-surface change (headless contract + reducer + client); no rendered UI. Behavior is proven by the 54-test vitest matrix instead.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no user-exercisable UI flow in this PR; the renderer-side client is a headless bridge with no DOM. Device (iOS/Android/desktop) wiring is explicitly out of scope here - see "Web-verified vs device-gated" below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no server code changed. Attachment routing reuses the EXISTING store + SSRF pipeline (packages/agent/api/media-runtime.ts, packages/core/src/network); this PR adds no route or service.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - the bridge client is pure (no network/fetch/DOM I/O of its own); its behavior is asserted directly in client.test.ts.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed. The contract is transport-agnostic and sits above the model layer.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no persisted domain artifacts (no DB rows/memories/scheduled tasks/on-chain output). The nearest artifact is the reduced ComposerDraft, whose exact output across the case matrix is pinned by reduce.test.ts + client.test.ts.`

# Evidence Details

## Test results (web-verified, fast per-file vitest)

```
$ bunx vitest run src/native-composer/     # cwd: packages/ui
 Test Files  5 passed (5)
      Tests  56 passed (56)

$ bunx tsgo --noEmit -p packages/ui
 (exit 0, no diagnostics)
```

## Web-verified vs device-gated (explicit)

- **Web-verified here:** the contract, boundary decoder, attachment normalizer, reducer state machine, and renderer-side client — the full case matrix, as fast per-file vitest (results above). The attachment routing reuses the existing content-addressed media store + SSRF guard; no second store or file IDs are introduced (asserted in `attachments.test.ts`).
- **Store + SSRF routing is proven end-to-end by an existing real test** — the normalizer emits exactly the URL vocabulary the current outgoing pipeline consumes, and `packages/agent/src/api/media-runtime.test.ts` already drives that pipeline against a **real** temp-dir content-addressed store: an inline `data:` URL lands content-addressed at `/api/media/<sha256>.png`, and a link-local `169.254.169.254` host is **SSRF-blocked** (kept + flagged ephemeral). This PR deliberately adds no second store and no server code, so that real test is the routing proof for criterion #3; the two halves (normalizer vocabulary ⇄ existing store/SSRF pipeline) meet at the store URL and are each independently proven with real (non-mock) tests.
- **Device-gated remainder (NOT done here — needs a real iOS-sim / Android-emu / desktop pass):** the native SwiftUI / Android / Electrobun shells that *emit* these operations and *consume* these events. No native composer bridge is tracked on `develop` today (the earlier #16200 native work exists only in gitignored generated project dirs), so there was nothing to wire. This PR defines the contract so those shells **can** conform. I ran **no** simulator/emulator/desktop pass and claim **no** native verification.

## Known gaps / failures

- Native (iOS/Android/desktop) wiring is intentionally out of scope for this card, as above — the contract is the agent-completable core; native conformance is device-gated and belongs to a follow-up with a real device pass.
- Full workspace `bun run verify` / build lanes were not run locally (long-running; watchdog-bounded env); scoped vitest + `tsgo` were run instead and CI runs the full lanes.
