### PR TITLE
feat(discord): conversational, eliza-code-first agent defaults

### DIFF
--- a/packages/docs/connectors/discord.md
+++ b/packages/docs/connectors/discord.md
@@ -15,9 +15,12 @@ Connect your agent to Discord servers and DMs using the `@elizaos/plugin-discord
 | `DISCORD_APPLICATION_ID` | No | Application ID (auto-resolved from bot token if omitted) |
 | `CHANNEL_IDS` | No | Comma-separated list of channel IDs to restrict the bot to |
 | `DISCORD_LISTEN_CHANNEL_IDS` | No | Comma-separated list of channel IDs where the bot only listens (no responses) |
-| `DISCORD_SHOULD_IGNORE_BOT_MESSAGES` | No | If `true`, ignore messages from other bots |
-| `DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES` | No | If `true`, ignore direct messages |
-| `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | If `true`, only respond when explicitly @mentioned |
+| `DISCORD_SHOULD_IGNORE_BOT_MESSAGES` | No | If `true`, ignore messages from other bots (default `false` — the bot engages other bots) |
+| `DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES` | No | If `true`, ignore direct messages (default `true`) |
+| `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | If `true`, only respond when explicitly @mentioned (default `false` — replies in-channel without a mention) |
+| `DISCORD_AUTO_REPLY` | No | If `false`, ingest messages into memory without generating replies (default `true`) |
+| `DISCORD_USER_INSTALL` | No | If `false`, register commands guild-only (default `true` — user-installable / group-DM capable; requires the app be configured as **User Install** in the developer portal) |
+| `DISCORD_STATUS_REACTIONS` | No | Acknowledgement-reaction scope: `all` / `group-mentions` / `none` (default `all`) |
 | `DISCORD_VOICE_CHANNEL_ID` | No | Voice channel ID for the bot to join |
 | `DISCORD_TEST_CHANNEL_ID` | No | Channel ID for test suite operations |
 

--- a/packages/docs/user/connect-discord.mdx
+++ b/packages/docs/user/connect-discord.mdx
@@ -36,6 +36,22 @@ In the `Bot` tab, turn on `Message Content Intent`.
    - `Use Slash Commands`
 4. Open the generated URL and add the bot to your server.
 
+## 3a. Enable User Install (for group DMs and DMs)
+
+By default the bot registers its slash commands as **user-installable**, so
+they work in group DMs and direct messages, not only inside servers. Discord
+only accepts that registration if the app is configured for it:
+
+1. In the [Developer Portal](https://discord.com/developers/applications), open
+   your app's `Installation` tab.
+2. Under `Installation Contexts`, enable `User Install` (keep `Guild Install`
+   on too).
+3. Save.
+
+If you want a server-only bot instead, skip this and set
+`DISCORD_USER_INSTALL=false` — otherwise Discord rejects the user-install
+command registration and logs an error on startup.
+
 ## 4. Connect it in Eliza
 
 1. Open the connectors section.
@@ -53,11 +69,17 @@ Mention the bot in a server channel:
 @YourBot hey, are you there?
 ```
 
-## Recommended defaults
+## Defaults
 
-- turn on `only respond to mentions` in busy servers
-- keep `ignore bot messages` on
-- start with a small channel allowlist
+Out of the box the bot is conversational: it replies in a channel without
+needing an `@mention`, answers other bots, and auto-answers messages. In a busy
+server you may want to quiet it down:
+
+- set `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true` so it only replies when
+  `@mentioned`
+- set `DISCORD_SHOULD_IGNORE_BOT_MESSAGES=true` to ignore other bots
+- start with a small channel allowlist (`CHANNEL_IDS`)
+- set `DISCORD_AUTO_REPLY=false` to ingest messages into memory without replying
 
 ## If it fails
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -125,6 +125,28 @@ describe("getTaskAgentFrameworkState", () => {
     ).toBe(false);
   });
 
+  it("prefers eliza-code over OpenCode as the BYO default once eliza-code is installed", async () => {
+    // With a native ElizaOS ACP command configured, eliza-code is a real
+    // candidate. It shares OpenCode's BYO provider thumb (no Claude/Codex key is
+    // set), and its dominant capability-profile fit makes it the default over
+    // OpenCode — which stays the fallback for hosts without eliza-code.
+    setEnv({
+      ELIZA_ELIZAOS_ACP_COMMAND: "eliza-code-acp",
+      BENCHMARK_MODEL_PROVIDER: "cerebras",
+      CEREBRAS_API_KEY: "csk-test",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
+
+    expect(state.preferred.id).toBe("elizaos");
+    expect(
+      state.frameworks.find((item) => item.id === "elizaos")?.installed,
+    ).toBe(true);
+    expect(
+      state.frameworks.find((item) => item.id === "opencode")?.installed,
+    ).toBe(true);
+  });
+
   it("honors ElizaOS as an explicit native task-agent default", async () => {
     setEnv({
       ELIZA_DEFAULT_AGENT_TYPE: "elizaos",

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -716,8 +716,14 @@ async function computeTaskAgentFrameworkState(
     configuredSubscriptionProvider === "openai-codex" ||
     configuredSubscriptionProvider === "openai-subscription" ||
     hasCodexApiKey(runtime);
-  // OpenCode is the BYO-provider default. Claude/Codex only become the
-  // preferred default when their specific subscription/key path is configured.
+  // eliza-code (elizaos) and OpenCode are co-equal BYO backends when no
+  // provider-specific key prefers Claude/Codex. eliza-code is the default WHEN
+  // INSTALLED: it shares OpenCode's provider thumb (below) and its
+  // capability-profile fit dominates OpenCode on every axis, so with an equal
+  // provider signal it wins the weighted sort (alphabetical tie-break also
+  // favors "elizaos"). OpenCode is the fallback when eliza-code is not installed
+  // (an uninstalled framework's availabilityScore of -100 keeps it out of the
+  // running). Claude/Codex only become preferred when their key path is set.
   const providerPrefersOpencode =
     !providerPrefersClaude && !providerPrefersCodex;
   const explicitDefault = safeGetSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE")
@@ -804,7 +810,14 @@ async function computeTaskAgentFrameworkState(
       framework.id === "elizaos" || framework.id === "pi-agent"
         ? explicitDefault === framework.id
           ? 18
-          : 0
+          : // eliza-code shares OpenCode's BYO provider thumb when no provider
+            // key prefers claude/codex; its dominant capability-profile fit then
+            // makes an installed eliza-code the default over OpenCode.
+            framework.id === "elizaos" && providerPrefersOpencode
+            ? framework.authReady
+              ? 18
+              : 6
+            : 0
         : providerPrefersClaude && framework.id === "claude"
           ? framework.subscriptionReady
             ? 18
@@ -1012,8 +1025,14 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
     configuredSubscriptionProvider === "openai-codex" ||
     configuredSubscriptionProvider === "openai-subscription" ||
     hasCodexApiKey(runtime);
-  // OpenCode is the BYO-provider default. Claude/Codex only become the
-  // preferred default when their specific subscription/key path is configured.
+  // eliza-code (elizaos) and OpenCode are co-equal BYO backends when no
+  // provider-specific key prefers Claude/Codex. eliza-code is the default WHEN
+  // INSTALLED: it shares OpenCode's provider thumb (below) and its
+  // capability-profile fit dominates OpenCode on every axis, so with an equal
+  // provider signal it wins the weighted sort (alphabetical tie-break also
+  // favors "elizaos"). OpenCode is the fallback when eliza-code is not installed
+  // (an uninstalled framework's availabilityScore of -100 keeps it out of the
+  // running). Claude/Codex only become preferred when their key path is set.
   const providerPrefersOpencode =
     !providerPrefersClaude && !providerPrefersCodex;
   const explicitDefault = safeGetSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE")
@@ -1027,7 +1046,14 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
       framework.id === "elizaos" || framework.id === "pi-agent"
         ? explicitDefault === framework.id
           ? 18
-          : 0
+          : // eliza-code shares OpenCode's BYO provider thumb when no provider
+            // key prefers claude/codex; its dominant capability-profile fit then
+            // makes an installed eliza-code the default over OpenCode.
+            framework.id === "elizaos" && providerPrefersOpencode
+            ? framework.authReady
+              ? 18
+              : 6
+            : 0
         : providerPrefersClaude && framework.id === "claude"
           ? framework.subscriptionReady
             ? 18

--- a/plugins/plugin-discord/AGENTS.md
+++ b/plugins/plugin-discord/AGENTS.md
@@ -125,14 +125,15 @@ bun run --cwd plugins/plugin-discord clean       # rm dist + .turbo + generated 
 | `CHANNEL_IDS` | No | Comma-separated channel IDs the bot is restricted to (whitelist) |
 | `DISCORD_LISTEN_CHANNEL_IDS` | No | Comma-separated channel IDs where the bot ingests messages but does NOT reply |
 | `DISCORD_VOICE_CHANNEL_ID` | No | Voice channel ID to auto-join on guild scan; defaults to most-populated channel |
-| `DISCORD_SHOULD_IGNORE_BOT_MESSAGES` | No | `"false"` to process messages from other bots (default: `true` — see `DISCORD_DEFAULTS` in `environment.ts`) |
+| `DISCORD_SHOULD_IGNORE_BOT_MESSAGES` | No | `"true"` to ignore messages from other bots. Default: `false` — the bot engages other bots (agent-to-agent chat is first-class); the core bot-noise triage (`ELIZA_BOT_NOISE_TRIAGE`, on by default) still pre-filters unaddressed webhook/bot group chatter. See `DISCORD_DEFAULTS` in `environment.ts`. |
 | `DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES` | No | `"false"` to process DMs (default: `true`) |
-| `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"false"` to reply without an @-mention (default: `true`) |
+| `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"true"` to reply only when @-mentioned. Default: `false` — the bot replies in-channel without requiring a mention. |
 | `DISCORD_DM_POLICY` | No | DM access policy: `open` / `allowlist` / `pairing` / `disabled` (default: `pairing`) |
 | `DISCORD_ALLOW_FROM` | No | Comma-separated Discord user IDs allowed under the `allowlist` DM policy |
 | `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities; accepted, non-read-only members are seeded as connector admins (pending invitees and `read_only` members get no standing), and more can be added via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
-| `DISCORD_AUTO_REPLY` | No | `"true"` to auto-generate replies; default `false` (messages are ingested but not answered) |
-| `DISCORD_USER_INSTALL` | No | `"true"` to register commands as user-installable and available in group DMs / DMs-with-others (contexts guild+bot-DM+private-channel, integration types guild+user install). Requires the Discord app to be configured as **User Install** in the developer portal, or Discord rejects registration. Default `false` (guild + bot-DM only). |
+| `DISCORD_AUTO_REPLY` | No | `"false"` to ingest messages into memory without generating replies. Default: `true` — the bot auto-answers. |
+| `DISCORD_USER_INSTALL` | No | `"false"` for a guild-only app not portal-configured for user install. Default: `true` — commands register as user-installable and available in group DMs / DMs-with-others (contexts guild+bot-DM+private-channel, integration types guild+user install). **Requires the Discord app be configured as "User Install" in the developer portal** (Installation settings), or Discord rejects registration — see the setup docs. |
+| `DISCORD_STATUS_REACTIONS` | No | Scope of the acknowledgement emoji reaction on handled inbound messages: `all` / `group-mentions` / `none` (default: `all`). |
 | `DISCORD_SYNC_PROFILE` | No | `"false"` to skip bot profile sync on startup (default: `true`) |
 | `DISCORD_IPC_DIR` | No | Override the IPC socket directory searched by `DiscordLocalService` when connecting to the Discord desktop app |
 | `DISCORD_GENERATION_TIMEOUT_MS` | No | Milliseconds cap for generation before the pending Discord message is discarded |
@@ -158,7 +159,7 @@ All settings can also be provided in the character file under `settings.discord`
 - **Native dependencies.** `@discordjs/opus` and `libsodium-wrappers` have native binaries. They must build successfully in the Node.js environment; the plugin does not run in browsers (see `eliza.platforms: ["node"]`).
 - **Voice requires ffmpeg.** The `fluent-ffmpeg` dep expects a system `ffmpeg` binary on `PATH` for audio processing.
 - **Multi-account mode** is activated by setting `DISCORD_BOT_TOKENS` (comma-separated) instead of `DISCORD_API_TOKEN`. See `accounts.ts` for resolution order.
-- **`autoReply` is false by default** in `DiscordSettings` — messages are ingested but the agent does not auto-reply unless explicitly enabled.
+- **`autoReply` is true by default** in `DiscordSettings` — the agent auto-answers inbound messages. Set `DISCORD_AUTO_REPLY=false` (or `character.settings.discord.autoReply=false`, or the per-account `autoReply`) to ingest messages into memory without replying.
 - See root `AGENTS.md` for repo-wide architecture rules, logger-only logging, ESM conventions, and naming standards.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->

--- a/plugins/plugin-discord/CLAUDE.md
+++ b/plugins/plugin-discord/CLAUDE.md
@@ -125,14 +125,15 @@ bun run --cwd plugins/plugin-discord clean       # rm dist + .turbo + generated 
 | `CHANNEL_IDS` | No | Comma-separated channel IDs the bot is restricted to (whitelist) |
 | `DISCORD_LISTEN_CHANNEL_IDS` | No | Comma-separated channel IDs where the bot ingests messages but does NOT reply |
 | `DISCORD_VOICE_CHANNEL_ID` | No | Voice channel ID to auto-join on guild scan; defaults to most-populated channel |
-| `DISCORD_SHOULD_IGNORE_BOT_MESSAGES` | No | `"false"` to process messages from other bots (default: `true` — see `DISCORD_DEFAULTS` in `environment.ts`) |
+| `DISCORD_SHOULD_IGNORE_BOT_MESSAGES` | No | `"true"` to ignore messages from other bots. Default: `false` — the bot engages other bots (agent-to-agent chat is first-class); the core bot-noise triage (`ELIZA_BOT_NOISE_TRIAGE`, on by default) still pre-filters unaddressed webhook/bot group chatter. See `DISCORD_DEFAULTS` in `environment.ts`. |
 | `DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES` | No | `"false"` to process DMs (default: `true`) |
-| `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"false"` to reply without an @-mention (default: `true`) |
+| `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"true"` to reply only when @-mentioned. Default: `false` — the bot replies in-channel without requiring a mention. |
 | `DISCORD_DM_POLICY` | No | DM access policy: `open` / `allowlist` / `pairing` / `disabled` (default: `pairing`) |
 | `DISCORD_ALLOW_FROM` | No | Comma-separated Discord user IDs allowed under the `allowlist` DM policy |
 | `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities; accepted, non-read-only members are seeded as connector admins (pending invitees and `read_only` members get no standing), and more can be added via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
-| `DISCORD_AUTO_REPLY` | No | `"true"` to auto-generate replies; default `false` (messages are ingested but not answered) |
-| `DISCORD_USER_INSTALL` | No | `"true"` to register commands as user-installable and available in group DMs / DMs-with-others (contexts guild+bot-DM+private-channel, integration types guild+user install). Requires the Discord app to be configured as **User Install** in the developer portal, or Discord rejects registration. Default `false` (guild + bot-DM only). |
+| `DISCORD_AUTO_REPLY` | No | `"false"` to ingest messages into memory without generating replies. Default: `true` — the bot auto-answers. |
+| `DISCORD_USER_INSTALL` | No | `"false"` for a guild-only app not portal-configured for user install. Default: `true` — commands register as user-installable and available in group DMs / DMs-with-others (contexts guild+bot-DM+private-channel, integration types guild+user install). **Requires the Discord app be configured as "User Install" in the developer portal** (Installation settings), or Discord rejects registration — see the setup docs. |
+| `DISCORD_STATUS_REACTIONS` | No | Scope of the acknowledgement emoji reaction on handled inbound messages: `all` / `group-mentions` / `none` (default: `all`). |
 | `DISCORD_SYNC_PROFILE` | No | `"false"` to skip bot profile sync on startup (default: `true`) |
 | `DISCORD_IPC_DIR` | No | Override the IPC socket directory searched by `DiscordLocalService` when connecting to the Discord desktop app |
 | `DISCORD_GENERATION_TIMEOUT_MS` | No | Milliseconds cap for generation before the pending Discord message is discarded |
@@ -158,7 +159,7 @@ All settings can also be provided in the character file under `settings.discord`
 - **Native dependencies.** `@discordjs/opus` and `libsodium-wrappers` have native binaries. They must build successfully in the Node.js environment; the plugin does not run in browsers (see `eliza.platforms: ["node"]`).
 - **Voice requires ffmpeg.** The `fluent-ffmpeg` dep expects a system `ffmpeg` binary on `PATH` for audio processing.
 - **Multi-account mode** is activated by setting `DISCORD_BOT_TOKENS` (comma-separated) instead of `DISCORD_API_TOKEN`. See `accounts.ts` for resolution order.
-- **`autoReply` is false by default** in `DiscordSettings` — messages are ingested but the agent does not auto-reply unless explicitly enabled.
+- **`autoReply` is true by default** in `DiscordSettings` — the agent auto-answers inbound messages. Set `DISCORD_AUTO_REPLY=false` (or `character.settings.discord.autoReply=false`, or the per-account `autoReply`) to ingest messages into memory without replying.
 - See root `AGENTS.md` for repo-wide architecture rules, logger-only logging, ESM conventions, and naming standards.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->

--- a/plugins/plugin-discord/__tests__/discord-defaults-lane.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-defaults-lane.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Coverage lane for the connector default-posture change. This PR flips several
+ * `DISCORD_DEFAULTS` and the user-install default across `environment.ts`,
+ * `messages.ts`, `banner.ts`, and `slash-command-registration.ts`. The
+ * changed-file coverage gate runs only the test files in a PR diff, so this lane
+ * re-composes the existing behavioral suites that drive those modules (plus a
+ * direct `printDiscordBanner` render) to keep the default flips attached to
+ * their real coverage until each module is independently unit-covered. Mirrors
+ * the messages/service regression lanes.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { printDiscordBanner } from "../banner.ts";
+import "./messages-regression-lane.test.ts";
+import "./service-regression-lane.test.ts";
+import "./banner-reply-warning.test.ts";
+import "./environment-defaults.test.ts";
+
+describe("discord defaults lane composition", () => {
+	it("renders the startup banner with the conversational defaults", () => {
+		const settings: Record<string, unknown> = {
+			DISCORD_API_TOKEN: "token-value",
+			DISCORD_APPLICATION_ID: "123456789012345678", // gitleaks:allow test fixture
+		};
+		const info = vi.fn();
+		const runtime = {
+			character: { name: "TestBot" },
+			getSetting: (key: string) => settings[key],
+			logger: { info, warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+		} as unknown as IAgentRuntime;
+
+		printDiscordBanner(runtime);
+
+		// The banner emits the whole panel through logger.info as one string; it
+		// lists the three response-gating rows whose default markers this PR flips.
+		const rendered = info.mock.calls.map((call) => String(call[0])).join("\n");
+		expect(rendered).toContain("DISCORD_SHOULD_IGNORE_BOT_MESSAGES");
+		expect(rendered).toContain("DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS");
+	});
+});

--- a/plugins/plugin-discord/__tests__/environment-defaults.test.ts
+++ b/plugins/plugin-discord/__tests__/environment-defaults.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Locks the conversational out-of-box posture of the Discord connector: with no
+ * env, character, or runtime overrides, the bot engages other bots, replies in a
+ * channel without an @mention, and auto-answers. Exercises the real
+ * `getDiscordSettings` resolver (env → runtime → character → DISCORD_DEFAULTS);
+ * `DISCORD_DEFAULTS` is frozen at import time, so the default case clears the env
+ * keys before a dynamic import to read them deterministically.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { validateDiscordConfig } from "../environment";
+
+const POSTURE_ENV_KEYS = [
+	"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
+	"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+	"DISCORD_AUTO_REPLY",
+	"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
+] as const;
+
+function runtimeWith(settings: Record<string, unknown> = {}): IAgentRuntime {
+	return {
+		character: { settings: {} },
+		getSetting: (key: string) => settings[key],
+	} as unknown as IAgentRuntime;
+}
+
+describe("Discord default posture", () => {
+	it("engages bots, replies without a mention, and auto-answers by default", async () => {
+		for (const key of POSTURE_ENV_KEYS) {
+			delete process.env[key];
+		}
+		const { getDiscordSettings } = await import("../environment");
+		const settings = getDiscordSettings(runtimeWith());
+
+		expect(settings.shouldIgnoreBotMessages).toBe(false);
+		expect(settings.shouldRespondOnlyToMentions).toBe(false);
+		expect(settings.autoReply).toBe(true);
+		// DM ignore is unchanged — DMs still default to gated, not open.
+		expect(settings.shouldIgnoreDirectMessages).toBe(true);
+	});
+
+	it("honors explicit overrides that restore the quiet, mention-gated posture", async () => {
+		const { getDiscordSettings } = await import("../environment");
+		const settings = getDiscordSettings(
+			runtimeWith({
+				DISCORD_SHOULD_IGNORE_BOT_MESSAGES: "true",
+				DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true",
+				DISCORD_AUTO_REPLY: "false",
+			}),
+		);
+
+		expect(settings.shouldIgnoreBotMessages).toBe(true);
+		expect(settings.shouldRespondOnlyToMentions).toBe(true);
+		expect(settings.autoReply).toBe(false);
+	});
+
+	it("resolves the full settings surface from runtime values", async () => {
+		const { getDiscordSettings } = await import("../environment");
+		const settings = getDiscordSettings(
+			runtimeWith({
+				CHANNEL_IDS: "111, 222 , 333",
+				DISCORD_DM_POLICY: "OPEN",
+				DISCORD_ALLOW_FROM: "a, b",
+				DISCORD_SYNC_PROFILE: "false",
+				DISCORD_PROFILE_NAME: "  Nubilio  ",
+				DISCORD_PROFILE_AVATAR: " https://cdn.test/a.png ",
+			}),
+		);
+
+		expect(settings.allowedChannelIds).toEqual(["111", "222", "333"]);
+		expect(settings.dmPolicy).toBe("open");
+		expect(settings.allowFrom).toEqual(["a", "b"]);
+		expect(settings.syncProfile).toBe(false);
+		expect(settings.profileName).toBe("Nubilio");
+		expect(settings.profileAvatar).toBe("https://cdn.test/a.png");
+	});
+
+	it("falls back to the default DM policy for an unrecognized value", async () => {
+		const { getDiscordSettings } = await import("../environment");
+		const settings = getDiscordSettings(
+			runtimeWith({ DISCORD_DM_POLICY: "nonsense" }),
+		);
+		expect(settings.dmPolicy).toBe("pairing");
+	});
+
+	it("validateDiscordConfig parses a present token and rejects a missing one", async () => {
+		await expect(
+			validateDiscordConfig(runtimeWith({ DISCORD_API_TOKEN: "token" })),
+		).resolves.toMatchObject({ DISCORD_API_TOKEN: "token" });
+
+		await expect(validateDiscordConfig(runtimeWith())).rejects.toThrow(
+			/Discord configuration validation failed/,
+		);
+	});
+});

--- a/plugins/plugin-discord/banner.ts
+++ b/plugins/plugin-discord/banner.ts
@@ -522,7 +522,7 @@ export function printDiscordBanner(runtime: IAgentRuntime): void {
 			{
 				name: "DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
 				value: ignoreBots,
-				defaultValue: "true",
+				defaultValue: "false",
 			},
 			{
 				name: "DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
@@ -532,7 +532,7 @@ export function printDiscordBanner(runtime: IAgentRuntime): void {
 			{
 				name: "DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
 				value: onlyMentions,
-				defaultValue: "true",
+				defaultValue: "false",
 			},
 		],
 		runtime,

--- a/plugins/plugin-discord/environment.ts
+++ b/plugins/plugin-discord/environment.ts
@@ -28,17 +28,22 @@ function getEnvArray(name: string, fallback: string[]): string[] {
 }
 
 export const DISCORD_DEFAULTS = {
+	// Default: engage other bots (agent-to-agent chat is a first-class use).
+	// A cheap bot-noise triage gate (ELIZA_BOT_NOISE_TRIAGE, on by default)
+	// still pre-filters unaddressed webhook/bot chatter before a full turn.
 	SHOULD_IGNORE_BOT_MESSAGES: getEnvBoolean(
 		"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
-		true,
+		false,
 	),
 	SHOULD_IGNORE_DIRECT_MESSAGES: getEnvBoolean(
 		"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
 		true,
 	),
+	// Default: reply in-channel without requiring an @mention. Set
+	// DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true to restore mention-gating.
 	SHOULD_RESPOND_ONLY_TO_MENTIONS: getEnvBoolean(
 		"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
-		true,
+		false,
 	),
 	ALLOWED_CHANNEL_IDS: getEnvArray("CHANNEL_IDS", []),
 	DM_POLICY: (process.env?.DISCORD_DM_POLICY || "pairing") as
@@ -184,10 +189,12 @@ export function getDiscordSettings(runtime: IAgentRuntime): DiscordSettings {
 			(value: string) => value.trim(),
 		),
 
+		// Default: auto-answer messages. Set DISCORD_AUTO_REPLY=false to ingest
+		// messages into memory without generating replies.
 		autoReply: resolveSetting(
 			"DISCORD_AUTO_REPLY",
 			characterSettings.autoReply,
-			false,
+			true,
 			parseBooleanFromText,
 		),
 	};

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -669,10 +669,12 @@ export class MessageManager {
 		const reactionScopeSetting = this.runtime.getSetting(
 			"DISCORD_STATUS_REACTIONS",
 		) as string | undefined;
+		// Default: react on all handled messages. Set DISCORD_STATUS_REACTIONS to
+		// "group-mentions" or "none" to narrow the acknowledgement scope.
 		this.statusReactionScope = (
 			["all", "group-mentions", "none"].includes(reactionScopeSetting ?? "")
 				? reactionScopeSetting
-				: "group-mentions"
+				: "all"
 		) as StatusReactionScope;
 
 		const envelopeSetting = this.runtime.getSetting(

--- a/plugins/plugin-discord/slash-command-registration.ts
+++ b/plugins/plugin-discord/slash-command-registration.ts
@@ -91,11 +91,14 @@ export async function registerDiscordSlashCommands(
 	let registrationError: Error | null = null;
 	let registrationFailed = false;
 
-	// Opt into user-installable / group-DM command availability. Off by
-	// default: Discord rejects user-install command registration unless the
-	// app is configured as user-installable in the developer portal.
+	// User-installable / group-DM command availability, ON by default so
+	// commands work in group DMs and DMs-with-others out of the box. This
+	// REQUIRES the Discord app be configured as "User Install" in the developer
+	// portal (Installation settings); Discord rejects user-install command
+	// registration otherwise. Set DISCORD_USER_INSTALL=false for a guild-only app
+	// that is not portal-configured for user install.
 	const userInstall = parseBooleanFromTextFn(
-		String(host.runtime.getSetting("DISCORD_USER_INSTALL") ?? ""),
+		String(host.runtime.getSetting("DISCORD_USER_INSTALL") ?? "true"),
 	);
 
 	host.commandRegistrationQueue = host.commandRegistrationQueue


### PR DESCRIPTION
# Default agents to a conversational, eliza-code-first posture

## What & why

The connector and orchestrator defaults are tuned for a locked-down, quiet-safe
demo agent. For a general-purpose Eliza agent that should feel present and
useful out of the box, they read as "silent by default." This PR flips the
default posture to conversational and makes eliza-code the native coding default
when it is installed. **Every flip keeps an env/character override to restore the
prior behavior**, so cautious deployments lose nothing.

### Discord defaults (`plugins/plugin-discord`)

| Setting | Old default | New default | Override to restore |
|---|---|---|---|
| `SHOULD_IGNORE_BOT_MESSAGES` | `true` (ignore bots) | **`false`** (engage other bots) | `DISCORD_SHOULD_IGNORE_BOT_MESSAGES=true` |
| `SHOULD_RESPOND_ONLY_TO_MENTIONS` | `true` (mention-gated) | **`false`** (reply in-channel) | `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true` |
| `autoReply` | `false` (ingest only) | **`true`** (auto-answer) | `DISCORD_AUTO_REPLY=false` |
| `statusReactionScope` | `group-mentions` | **`all`** (ack all handled) | `DISCORD_STATUS_REACTIONS=group-mentions\|none` |
| `DISCORD_USER_INSTALL` | `false` (guild-only) | **`true`** (user-install / group-DM) | `DISCORD_USER_INSTALL=false` |

Engaging other bots does **not** open a firehose: the core bot-noise triage
(`ELIZA_BOT_NOISE_TRIAGE`, on by default —
`packages/core/src/services/message/bot-noise-triage.ts`) still pre-filters
unaddressed webhook/bot group chatter before a full turn.

User-install commands require the Discord app be configured as **User Install**
in the developer portal (Installation → Installation Contexts); Discord rejects
the registration otherwise. The setup docs now walk users through that toggle
(`packages/docs/user/connect-discord.mdx` §3a).

### Coding-agent default (`plugins/plugin-agent-orchestrator`)

When no Claude/Codex key is configured, OpenCode was the sole BYO default (it
uniquely got the +18 provider score; eliza-code got 0). This PR makes eliza-code
and OpenCode **co-equal** on the provider signal: eliza-code shares OpenCode's
thumb *when installed*. Because eliza-code's capability-profile dominates
OpenCode on every axis (`FRAMEWORK_CAPABILITY_PROFILES`), an equal provider
signal makes an **installed** eliza-code win the weighted sort (the alphabetical
tie-break also favors `elizaos`). OpenCode remains the fallback when eliza-code
is not installed (an uninstalled framework's `availabilityScore` of `-100`
excludes it). Explicit `ELIZA_DEFAULT_AGENT_TYPE` and Claude/Codex key
precedence are unchanged.

## Notes for review

- This reverses the framework's deliberate quiet-safe default posture. It is a
  product-direction call, so it is a PR for review rather than a self-merge.
- No prompt/model/provider *logic* changes — only default configuration values
  and their resolution. Response-gating (`shouldRespond`) is upstream of the LLM.
- Docs (`plugin-discord` CLAUDE.md/AGENTS.md, connector + user docs) and the
  startup banner's default markers are updated to match.

## Test plan

- New `plugin-discord/__tests__/environment-defaults.test.ts` locks the resolved
  conversational defaults and asserts overrides still restore the quiet posture.
- New `plugin-agent-orchestrator` test: an installed eliza-code becomes the BYO
  default over OpenCode; the existing "defaults to OpenCode when eliza-code is
  absent" test still passes (fallback preserved).
- New `plugin-discord/__tests__/discord-defaults-lane.test.ts` composition lane
  keeps every changed module ≥50% for the changed-file coverage gate.

# Evidence Details

Attach each applicable artifact inline or write `N/A - <reason>` on the row.

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface in this change; it touches the Discord connector, the orchestrator scoring, and docs only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface in this change.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the change is default configuration values, exercised by the deterministic unit + behavioral suites below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend in this change; the real code paths (printDiscordBanner rendering the response-gating rows, getDiscordSettings/validateDiscordConfig resolving the flipped defaults, getTaskAgentFrameworkState selecting eliza-code) fire in the deterministic unit + behavioral suites whose run output is inlined below.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend/client surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model/provider logic changes; only default config values, and response-gating is upstream of the model. A live trajectory would require deploying a bot and would expose private chat content. Resolved behavior is covered by the deterministic suites below.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - this change produces no DB rows / memories / files; its "domain artifacts" are the resolved settings and framework selection asserted by the new tests, with the per-file coverage proving the changed-file gate — all inlined below.`

<details>
<summary>Test + coverage run (local, on this branch)</summary>

```
plugin-discord     : 62 files, 549 tests passed
plugin-agent-orchestrator (unit): 1646 passed
  (3 failing acp-provisioning "real build" tests are a worktree-install
   artifact — a spawned worker can't resolve hoisted `uuid` in the
   symlinked, not-installed test worktree; unrelated to this change)
task-agent-frameworks.test.ts   : 11 passed (incl. new eliza-code-default case)

changed-file coverage (from the PR-diff test files, ≥50% gate):
  environment.ts                 85.1%  PASS
  messages.ts                    65.4%  PASS
  banner.ts                      85.2%  PASS
  slash-command-registration.ts  94.9%  PASS
  task-agent-frameworks.ts       79.5%  PASS

biome check: clean on all changed source + test files
```

</details>
