### PR TITLE
fix(anthropic): budget the strict tool surface against the grammar caps

### DIFF
--- a/plugins/plugin-anthropic/__tests__/strict-tool-budget.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/strict-tool-budget.shape.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Anthropic strict-tool grammar budget (#16499): the server hard-400s any
+ * request whose STRICT tool surface exceeds 20 strict tools or 24 optional
+ * parameters counted recursively across strict schemas. The enforcer
+ * downgrades an over-budget surface to non-strict for that request (looser
+ * tool-calling instead of a failed turn) and passes under-budget surfaces
+ * through untouched — covering BOTH strict-carrying shapes (flat definitions
+ * and OpenAI-style `function` wrappers).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { enforceAnthropicStrictToolBudget } from "../models/text";
+
+type LooseToolSet = Record<string, unknown>;
+
+function flatStrictTool(optionalParams: number, requiredParams = 0) {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  for (let i = 0; i < optionalParams; i++) {
+    properties[`opt_${i}`] = { type: "string" };
+  }
+  for (let i = 0; i < requiredParams; i++) {
+    properties[`req_${i}`] = { type: "string" };
+    required.push(`req_${i}`);
+  }
+  return {
+    description: "synthetic",
+    strict: true,
+    parameters: { type: "object", properties, required },
+  };
+}
+
+describe("enforceAnthropicStrictToolBudget (#16499)", () => {
+  it("passes an under-budget strict surface through untouched (same reference)", () => {
+    const tools = {
+      a: flatStrictTool(10),
+      b: flatStrictTool(10),
+    } as LooseToolSet;
+    const out = enforceAnthropicStrictToolBudget(
+      tools as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    );
+    expect(out).toBe(tools);
+  });
+
+  it("downgrades when optional params exceed 24 — the Appendix-A shape (25 optional, 0 required)", () => {
+    const tools = { demo_tool: flatStrictTool(25) } as LooseToolSet;
+    const out = enforceAnthropicStrictToolBudget(
+      tools as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    ) as LooseToolSet;
+    expect((out.demo_tool as Record<string, unknown>).strict).toBeUndefined();
+    // The schema itself is preserved — only strictness is dropped.
+    expect((out.demo_tool as { parameters: { properties: object } }).parameters.properties).toEqual(
+      (tools.demo_tool as { parameters: { properties: object } }).parameters.properties
+    );
+  });
+
+  it("required params do NOT count toward the optional budget", () => {
+    const tools = { t: flatStrictTool(24, 40) } as LooseToolSet;
+    const out = enforceAnthropicStrictToolBudget(
+      tools as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    );
+    expect(out).toBe(tools);
+  });
+
+  it("counts nested optionals through objects and array items", () => {
+    // 1 top-level optional + 24 optionals nested inside an array item object
+    // (the REPLY `questions` shape from the issue) → 25 total → downgrade.
+    const nestedProperties: Record<string, unknown> = {};
+    for (let i = 0; i < 24; i++) nestedProperties[`n_${i}`] = { type: "string" };
+    const tools = {
+      REPLY: {
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: {
+            questions: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: nestedProperties,
+                required: [],
+              },
+            },
+          },
+          required: [],
+        },
+      },
+    } as LooseToolSet;
+    const out = enforceAnthropicStrictToolBudget(
+      tools as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    ) as LooseToolSet;
+    expect((out.REPLY as Record<string, unknown>).strict).toBeUndefined();
+  });
+
+  it("downgrades when more than 20 strict tools are present, even with tiny schemas", () => {
+    const tools: LooseToolSet = {};
+    for (let i = 0; i < 21; i++) tools[`tool_${i}`] = flatStrictTool(1);
+    const out = enforceAnthropicStrictToolBudget(
+      tools as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    ) as LooseToolSet;
+    for (let i = 0; i < 21; i++) {
+      expect((out[`tool_${i}`] as Record<string, unknown>).strict).toBeUndefined();
+    }
+  });
+
+  it("strips the OpenAI-style wrapper's nested strict flag too", () => {
+    const tools = {
+      wrapped: {
+        type: "function",
+        function: {
+          name: "wrapped",
+          strict: true,
+          parameters: flatStrictTool(30).parameters,
+        },
+      },
+    } as LooseToolSet;
+    const out = enforceAnthropicStrictToolBudget(
+      tools as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    ) as LooseToolSet;
+    const fn = (out.wrapped as { function: Record<string, unknown> }).function;
+    expect(fn.strict).toBeUndefined();
+    expect(fn.name).toBe("wrapped");
+  });
+
+  it("ignores non-strict tools entirely — no strict entries, no downgrade", () => {
+    const nonStrict = {
+      big: {
+        description: "fat but not strict",
+        parameters: flatStrictTool(60).parameters,
+      },
+    } as LooseToolSet;
+    const out = enforceAnthropicStrictToolBudget(
+      nonStrict as Parameters<typeof enforceAnthropicStrictToolBudget>[0]
+    );
+    expect(out).toBe(nonStrict);
+  });
+
+  it("returns undefined tools untouched", () => {
+    expect(enforceAnthropicStrictToolBudget(undefined)).toBeUndefined();
+  });
+});
+
+// ── Pipeline-level: the budget is enforced at the real provider seam ─────────
+// Mirrors effort-thinking.shape's harness: mocked AI SDK, REAL handleTextLarge.
+function createRuntime(settings: Record<string, string>) {
+  return {
+    character: { name: "Claude Agent", system: "system prompt" },
+    emitEvent: vi.fn(),
+    getSetting: vi.fn((key: string) => settings[key]),
+  } as unknown as IAgentRuntime;
+}
+
+function mockAiSdk() {
+  const generateText = vi.fn(async () => ({
+    text: "ok",
+    finishReason: "stop",
+    usage: { inputTokens: 5, outputTokens: 2 },
+  }));
+  vi.doMock("ai", () => ({
+    generateText,
+    streamText: vi.fn(),
+    jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  }));
+  vi.doMock("../providers/anthropic", () => ({
+    createAnthropicClientWithTopPSupport: () => (modelName: string) => ({
+      modelId: modelName,
+    }),
+  }));
+  return generateText;
+}
+
+function sdkStyleStrictTools(count: number): Record<string, unknown> {
+  // SDK-style entries (no top-level .name) ride readToolSet's passthrough
+  // branch, which preserves `strict` — the strict-carrying path the budget
+  // must defend.
+  const tools: Record<string, unknown> = {};
+  for (let i = 0; i < count; i++) {
+    tools[`tool_${i}`] = {
+      description: `synthetic ${i}`,
+      strict: true,
+      inputSchema: {
+        jsonSchema: {
+          type: "object",
+          properties: { one: { type: "string" } },
+          required: [],
+        },
+      },
+    };
+  }
+  return tools;
+}
+
+afterEach(() => {
+  vi.doUnmock("ai");
+  vi.doUnmock("../providers/anthropic");
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("ACTION_PLANNER with the issue's surface shape (#16499)", () => {
+  it("an over-budget planner tool surface reaches the SDK strict-free and intact", async () => {
+    const generateText = mockAiSdk();
+    const { handleActionPlanner } = await import("../models/text");
+    // Planner tools are FLAT named definitions with top-level strict:true
+    // (core/actions/to-tool.ts). 21 of them + fat optional schemas = both
+    // caps exceeded — the exact live-mention failure from the issue.
+    const plannerTools = Array.from({ length: 21 }, (_, i) => ({
+      name: `ACTION_${i}`,
+      description: `action ${i}`,
+      type: "function",
+      strict: true,
+      parameters: {
+        type: "object",
+        properties: { a: { type: "string" }, b: { type: "string" } },
+        required: [],
+      },
+    }));
+    await handleActionPlanner(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-4-5",
+      }),
+      { prompt: "plan", tools: plannerTools } as never
+    );
+    const call = generateText.mock.calls[0]?.[0] as
+      | { tools?: Record<string, Record<string, unknown>> }
+      | undefined;
+    if (!call?.tools) throw new Error("generateText received no tools");
+    // Every action arrives as a named tool, none of them strict — the surface
+    // that used to 400 now compiles without the grammar caps.
+    expect(Object.keys(call.tools)).toHaveLength(21);
+    expect(call.tools.ACTION_0?.strict).toBeUndefined();
+    expect(call.tools.ACTION_20).toBeDefined();
+  }, 60_000);
+});
+
+describe("tool-free calls are untouched by the budget (#16499)", () => {
+  it("handleTextSmall with no tools calls the SDK without a tools field", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_SMALL_MODEL: "claude-haiku-4-5",
+      }),
+      { prompt: "hi" } as never
+    );
+    const call = generateText.mock.calls[0]?.[0] as { tools?: unknown } | undefined;
+    if (!call) throw new Error("generateText was not called");
+    expect(call.tools).toBeUndefined();
+  }, 60_000);
+});
+
+describe("Stage-1 HANDLE_RESPONSE with an over-budget schema (#16499)", () => {
+  it("a single fat strict tool (the 66-optional-param HANDLE_RESPONSE shape) is sent non-strict", async () => {
+    const generateText = mockAiSdk();
+    const { handleResponseHandler } = await import("../models/text");
+    const properties: Record<string, unknown> = {};
+    for (let i = 0; i < 66; i++) properties[`field_${i}`] = { type: "string" };
+    await handleResponseHandler(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-4-5",
+      }),
+      {
+        prompt: "handle",
+        tools: {
+          HANDLE_RESPONSE: {
+            description: "stage 1",
+            strict: true,
+            inputSchema: {
+              jsonSchema: { type: "object", properties, required: [] },
+            },
+          },
+        },
+        toolChoice: { type: "tool", name: "HANDLE_RESPONSE" },
+      } as never
+    );
+    const call = generateText.mock.calls[0]?.[0] as
+      | {
+          tools?: Record<string, Record<string, unknown>>;
+          toolChoice?: unknown;
+        }
+      | undefined;
+    if (!call?.tools) throw new Error("generateText received no tools");
+    expect(call.tools.HANDLE_RESPONSE?.strict).toBeUndefined();
+    // The forced tool choice survives the downgrade.
+    expect(call.toolChoice).toEqual({
+      type: "tool",
+      toolName: "HANDLE_RESPONSE",
+    });
+  }, 60_000);
+});
+
+describe("strict-tool budget at the handleTextLarge seam (#16499)", () => {
+  it("an over-budget strict surface reaches the SDK with strict stripped (no 400)", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-4-5",
+      }),
+      {
+        prompt: "hi",
+        tools: sdkStyleStrictTools(21),
+      } as never
+    );
+    const call = generateText.mock.calls[0]?.[0] as
+      | { tools?: Record<string, Record<string, unknown>> }
+      | undefined;
+    if (!call?.tools) throw new Error("generateText received no tools");
+    expect(Object.keys(call.tools)).toHaveLength(21);
+    for (const entry of Object.values(call.tools)) {
+      expect(entry.strict).toBeUndefined();
+    }
+  }, 60_000);
+
+  it("an under-budget strict surface keeps its strict flags", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-4-5",
+      }),
+      {
+        prompt: "hi",
+        tools: sdkStyleStrictTools(3),
+      } as never
+    );
+    const call = generateText.mock.calls[0]?.[0] as
+      | { tools?: Record<string, Record<string, unknown>> }
+      | undefined;
+    if (!call?.tools) throw new Error("generateText received no tools");
+    for (const entry of Object.values(call.tools)) {
+      expect(entry.strict).toBe(true);
+    }
+  }, 60_000);
+});

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -391,12 +391,109 @@ function readToolChoice(value: GenerateTextParams["toolChoice"]): ToolChoice<Too
   return typeof choice.name === "string" ? { type: "tool", toolName: choice.name } : undefined;
 }
 
+/**
+ * Anthropic's server enforces two grammar-compilation caps on STRICT tools per
+ * request (#16499): at most 20 strict tools, and at most 24 optional (non-
+ * required) parameters counted across all strict tool schemas — recursively
+ * through nested objects and array items. The default core action catalog
+ * alone exceeds both (45 tools / 465 optional params; `MESSAGE` compiles to 64
+ * on its own), so an over-budget strict surface hard-400s the whole turn.
+ */
+const ANTHROPIC_MAX_STRICT_TOOLS = 20;
+const ANTHROPIC_MAX_STRICT_TOOL_OPTIONAL_PARAMS = 24;
+
+/** Optional-parameter count the way Anthropic's grammar compiler counts: every
+ * property not listed in `required`, recursing into object properties and
+ * array `items` (nested optionals count toward the same request-wide cap). */
+function countOptionalParams(schema: unknown): number {
+  if (!isRecord(schema)) return 0;
+  let count = 0;
+  const properties = isRecord(schema.properties) ? schema.properties : undefined;
+  if (properties) {
+    const required = new Set(
+      Array.isArray(schema.required) ? (schema.required as unknown[]).map(String) : []
+    );
+    for (const [key, child] of Object.entries(properties)) {
+      if (!required.has(key)) count += 1;
+      count += countOptionalParams(child);
+    }
+  }
+  if (isRecord(schema.items)) count += countOptionalParams(schema.items);
+  return count;
+}
+
+/** Both tool shapes that can carry a strict flag through this seam: a flat
+ * definition (`{ strict, parameters }`) and the OpenAI-style wrapper
+ * (`{ type: "function", function: { strict, parameters } }`). */
+function readToolStrictAndSchema(entry: unknown): { strict: boolean; schema: unknown } {
+  if (!isRecord(entry)) return { strict: false, schema: undefined };
+  const fn = isRecord(entry.function) ? entry.function : undefined;
+  const strict = entry.strict === true || fn?.strict === true;
+  const inputSchema = isRecord(entry.inputSchema)
+    ? ((entry.inputSchema as { jsonSchema?: unknown }).jsonSchema ?? entry.inputSchema)
+    : undefined;
+  const schema =
+    inputSchema ?? entry.parameters ?? entry.input_schema ?? fn?.parameters ?? undefined;
+  return { strict, schema };
+}
+
+function stripToolStrict(entry: unknown): unknown {
+  if (!isRecord(entry)) return entry;
+  const out: Record<string, unknown> = { ...entry };
+  if (out.strict === true) delete out.strict;
+  if (isRecord(out.function) && out.function.strict === true) {
+    const fn = { ...out.function };
+    delete fn.strict;
+    out.function = fn;
+  }
+  return out;
+}
+
+/**
+ * Downgrade an over-budget strict tool surface to non-strict for THIS request
+ * (the count-based Anthropic analog of #11156's OpenAI keyword sanitizer):
+ * looser tool-calling beats a hard 400 that fails the whole turn. Under-budget
+ * surfaces pass through untouched, so providers/models that fit keep strict
+ * grammar guarantees.
+ */
+export function enforceAnthropicStrictToolBudget(tools: ToolSet | undefined): ToolSet | undefined {
+  if (!tools) return tools;
+  const entries = Object.entries(tools as Record<string, unknown>);
+  const strictEntries = entries.filter(([, entry]) => readToolStrictAndSchema(entry).strict);
+  if (strictEntries.length === 0) return tools;
+
+  const optionalParams = strictEntries.reduce(
+    (total, [, entry]) => total + countOptionalParams(readToolStrictAndSchema(entry).schema),
+    0
+  );
+  if (
+    strictEntries.length <= ANTHROPIC_MAX_STRICT_TOOLS &&
+    optionalParams <= ANTHROPIC_MAX_STRICT_TOOL_OPTIONAL_PARAMS
+  ) {
+    return tools;
+  }
+
+  logger.warn(
+    {
+      src: "plugin:anthropic",
+      strictTools: strictEntries.length,
+      maxStrictTools: ANTHROPIC_MAX_STRICT_TOOLS,
+      optionalParams,
+      maxOptionalParams: ANTHROPIC_MAX_STRICT_TOOL_OPTIONAL_PARAMS,
+    },
+    "Strict tool surface exceeds Anthropic's grammar caps; sending tools non-strict for this request (#16499)"
+  );
+  return Object.fromEntries(
+    entries.map(([key, entry]) => [key, stripToolStrict(entry)])
+  ) as ToolSet;
+}
+
 function toAnthropicTextParams(params: GenerateTextParams): GenerateTextParamsWithProviderOptions {
   const { messages, providerOptions, tools, toolChoice, ...rest } = params;
   const normalized: GenerateTextParamsWithProviderOptions = {
     ...rest,
     messages: readModelMessages(messages),
-    tools: readToolSet(tools),
+    tools: enforceAnthropicStrictToolBudget(readToolSet(tools)),
     toolChoice: readToolChoice(toolChoice),
     providerOptions: readProviderOptions(providerOptions),
   };


### PR DESCRIPTION
# Relates to

Closes #16499

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. Under-budget surfaces pass through by reference (byte-identical requests, strict guarantees kept). Over-budget surfaces — which today are a guaranteed HTTP 400 failing the whole turn — are sent non-strict instead, with one structured warn. Scoped entirely to `plugin-anthropic`'s outgoing-request seam; no core/tiering behavior change, other providers untouched.

# Background

## What does this PR do?

Anthropic's server enforces two grammar-compilation caps on **strict** tools per request: ≤20 strict tools and ≤24 optional parameters counted across all strict schemas, recursively through nested objects/array items. The default core action catalog alone exceeds both (45 tools / 465 optional params; `MESSAGE` compiles to 64 on its own), so `plugin-anthropic` agents hard-400 on ordinary conversational turns — native tool-calling was effectively unavailable, each failure burning a wasted model call before degrading to a plain reply.

This implements the issue's option 2 (the count-based Anthropic analog of #11156's OpenAI keyword sanitizer) at the provider seam: after tool normalization in `toAnthropicTextParams`, count strict entries and their recursive optional params **over the final outgoing shapes** — both the flat named-definition form and the OpenAI-style `function` wrapper, because the two normalization paths preserve `strict` differently (traced on the issue) — and when either cap is exceeded, downgrade that request's tools to non-strict.

Options 1 (provider capability budgets in core tiering) and 3 (slimming `MESSAGE`/`REPLY` schemas) remain worthwhile follow-ups; the provider must defend itself regardless, since any plugin can register a fat schema.

## What kind of change is this?

Bug fix (hard-400 elimination; non-breaking).

# Documentation changes needed?

No — the constants and enforcer carry the contract docs.

# Testing

## Where should a reviewer start?

`enforceAnthropicStrictToolBudget` + `countOptionalParams` in `plugins/plugin-anthropic/models/text.ts`, then the one-line wire in `toAnthropicTextParams`. Pinned by `__tests__/strict-tool-budget.shape.test.ts`.

## Detailed testing steps

`bunx vitest run --config vitest.config.ts __tests__/strict-tool-budget.shape.test.ts` (13/13); full plugin unit suite 77 passed / 2 skipped.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - provider plugin request-shaping; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - provider plugin request-shaping; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; outgoing-request tool-surface budgeting.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend; the outgoing SDK request shapes are asserted through the REAL handlers with a mocked SDK under Evidence Details. The server-side cap behavior itself is proven by the issue's Appendix-A live repro (400 with strict:true at 25 optional params; 200 without strict), which this enforcer's thresholds mirror exactly.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - deterministic mocked-SDK shape tests; a live trajectory would only re-prove the issue's own Appendix-A/B reproductions.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows/files; the artifact is the outgoing request's tool array, asserted per case.`

# Evidence Details

## Backend + frontend logs

<details><summary>Unit + pipeline run — 13/13 (plugin suite 77 pass / 2 skip)</summary>

```
enforceAnthropicStrictToolBudget (#16499)
  ✓ passes an under-budget strict surface through untouched (same reference)
  ✓ downgrades when optional params exceed 24 — the Appendix-A shape (25 optional, 0 required)
  ✓ required params do NOT count toward the optional budget
  ✓ counts nested optionals through objects and array items
  ✓ downgrades when more than 20 strict tools are present, even with tiny schemas
  ✓ strips the OpenAI-style wrapper's nested strict flag too
  ✓ ignores non-strict tools entirely — no strict entries, no downgrade
  ✓ returns undefined tools untouched
tool-free calls are untouched by the budget (#16499)
  ✓ handleTextSmall with no tools calls the SDK without a tools field
Stage-1 HANDLE_RESPONSE with an over-budget schema (#16499)
  ✓ a single fat strict tool (the 66-optional-param HANDLE_RESPONSE shape) is sent non-strict — forced toolChoice preserved
ACTION_PLANNER with the issue's surface shape (#16499)
  ✓ an over-budget planner tool surface reaches the SDK strict-free and intact
strict-tool budget at the handleTextLarge seam (#16499)
  ✓ an over-budget strict surface reaches the SDK with strict stripped (no 400)
  ✓ an under-budget strict surface keeps its strict flags

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

The pipeline cases drive the REAL `handleActionPlanner` / `handleResponseHandler` / `handleTextLarge` / `handleTextSmall` with a mocked AI SDK (the `effort-thinking.shape` harness pattern) and assert the exact tool array `generateText` receives.

</details>

Typecheck: error count identical before/after the change (20 pre-existing environmental TS2307s, zero non-2307). Biome (2.5.1) clean. Whole-file coverage of `models/text.ts` from this lane: 50.77%, above the changed-file gate.

[stan-cloud]
