### PR TITLE
fix(cli-inference): resolve model self-report per agent

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
@@ -131,6 +131,67 @@ describe("runtimeModelContextProvider", () => {
 		}
 	});
 
+	it("resolves ordered provider settings from the per-agent runtime before defaults", async () => {
+		const runtime = makeRuntime(
+			{
+				ELIZA_CLI_CLAUDE_MODEL: "character-large",
+				ELIZA_CLI_CLAUDE_PLANNER_MODEL: "character-planner",
+			},
+			{
+				models: new Map([
+					[
+						ModelType.RESPONSE_HANDLER,
+						[
+							{
+								metadata: {
+									displayModelSettings: ["ELIZA_CLI_CLAUDE_MODEL"],
+									displayModelDefault: "claude-opus-4-8",
+								},
+								provider: "cli-inference",
+							},
+						],
+					],
+					[
+						ModelType.ACTION_PLANNER,
+						[
+							{
+								metadata: {
+									displayModelSettings: [
+										"ELIZA_CLI_CLAUDE_PLANNER_MODEL",
+										"ELIZA_CLI_CLAUDE_MODEL",
+									],
+									displayModelDefault: "claude-opus-4-8",
+								},
+								provider: "cli-inference",
+							},
+						],
+					],
+				]),
+			} as Partial<IAgentRuntime>,
+		);
+
+		const previousLarge = process.env.ELIZA_CLI_CLAUDE_MODEL;
+		const previousPlanner = process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL;
+		process.env.ELIZA_CLI_CLAUDE_MODEL = "host-large";
+		process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL = "host-planner";
+		try {
+			const result = await runtimeModelContextProvider.get(
+				runtime,
+				makeMessage("what model are you using?"),
+				{} as never,
+			);
+			expect(result.data?.responseHandlerModel).toBe("character-large");
+			expect(result.data?.actionPlannerModel).toBe("character-planner");
+		} finally {
+			if (previousLarge === undefined)
+				delete process.env.ELIZA_CLI_CLAUDE_MODEL;
+			else process.env.ELIZA_CLI_CLAUDE_MODEL = previousLarge;
+			if (previousPlanner === undefined)
+				delete process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL;
+			else process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL = previousPlanner;
+		}
+	});
+
 	it("does not use provider-name branches for display model settings", async () => {
 		const runtime = makeRuntime({}, {
 			models: new Map([

--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
@@ -164,8 +164,20 @@ function displayModelFor(
 		const trimmed = metadata.displayModel.trim();
 		if (trimmed) return trimmed;
 	}
+	if (Array.isArray(metadata.displayModelSettings)) {
+		for (const setting of metadata.displayModelSettings) {
+			if (typeof setting !== "string" || !setting.trim()) continue;
+			const configured = readSetting(runtime, setting);
+			if (configured) return configured;
+		}
+	}
 	if (typeof metadata.displayModelSetting === "string") {
-		return readSetting(runtime, metadata.displayModelSetting);
+		const configured = readSetting(runtime, metadata.displayModelSetting);
+		if (configured) return configured;
+	}
+	if (typeof metadata.displayModelDefault === "string") {
+		const trimmed = metadata.displayModelDefault.trim();
+		if (trimmed) return trimmed;
 	}
 	return undefined;
 }

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1613,6 +1613,18 @@ export interface ModelRegistrationMetadata {
 	 */
 	displayModelSetting?: string;
 	/**
+	 * Ordered runtime setting/env keys used to resolve the concrete display model.
+	 * The first non-empty value wins. Providers whose effective model has a
+	 * fallback chain should declare that chain rather than snapshotting host env
+	 * at plugin construction time.
+	 */
+	displayModelSettings?: string[];
+	/**
+	 * Provider-owned model id used only when no declared display-model setting is
+	 * configured for this runtime.
+	 */
+	displayModelDefault?: string;
+	/**
 	 * Provider-declared capability: this registration runs on local/on-device
 	 * inference (Ollama, LM Studio, MLX, llama.cpp, capacitor-llama, …) rather
 	 * than a hosted cloud API.

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -791,38 +791,48 @@ describe("buildModelMetadata (RUNTIME_MODEL_CONTEXT self-report)", () => {
     expect(buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "gemini" })).toBeUndefined();
   });
 
-  it("reports the configured claude models per tier (nubs's live config shape)", () => {
+  it("declares runtime-resolved Claude settings instead of snapshotting host env", () => {
     process.env.ELIZA_PLANNER_NATIVE_TOOLS = "0";
-    process.env.ELIZA_CLI_CLAUDE_MODEL = "claude-sonnet-5";
-    process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL = "claude-opus-4-8";
+    process.env.ELIZA_CLI_CLAUDE_MODEL = "host-large";
+    process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL = "host-planner";
     const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
     for (const t of LARGE_TIER_MODEL_TYPES) {
-      expect(md?.[t]).toEqual({ displayModel: "claude-sonnet-5" });
+      expect(md?.[t]).toEqual({
+        displayModelSettings: ["ELIZA_CLI_CLAUDE_MODEL"],
+        displayModelDefault: "claude-opus-4-8",
+      });
     }
-    expect(md?.ACTION_PLANNER).toEqual({ displayModel: "claude-opus-4-8" });
+    expect(md?.ACTION_PLANNER).toEqual({
+      displayModelSettings: ["ELIZA_CLI_CLAUDE_PLANNER_MODEL", "ELIZA_CLI_CLAUDE_MODEL"],
+      displayModelDefault: "claude-opus-4-8",
+    });
   });
 
-  it("planner falls back to the large model when its own key is unset", () => {
+  it("cold planners declare only the large-model chain they actually invoke", () => {
     process.env.ELIZA_PLANNER_NATIVE_TOOLS = "0";
-    process.env.ELIZA_CLI_CLAUDE_MODEL = "claude-opus-4-8";
-    process.env.ELIZA_CLI_CLAUDE_PLANNER_MODEL = "";
-    const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
-    expect(md?.ACTION_PLANNER).toEqual({ displayModel: "claude-opus-4-8" });
+    const claude = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "claude" });
+    const codex = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "codex" });
+    expect(claude?.ACTION_PLANNER?.displayModelSettings).toEqual(["ELIZA_CLI_CLAUDE_MODEL"]);
+    expect(codex?.ACTION_PLANNER?.displayModelSettings).toEqual(["ELIZA_CLI_CODEX_MODEL"]);
   });
 
   it("omits ACTION_PLANNER when native-tools planner mode is on (not served here)", () => {
     process.env.ELIZA_PLANNER_NATIVE_TOOLS = "1";
-    process.env.ELIZA_CLI_CLAUDE_MODEL = "claude-opus-4-8";
     const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
     expect(md?.ACTION_PLANNER).toBeUndefined();
-    expect(md?.RESPONSE_HANDLER).toEqual({ displayModel: "claude-opus-4-8" });
+    expect(md?.RESPONSE_HANDLER).toEqual({
+      displayModelSettings: ["ELIZA_CLI_CLAUDE_MODEL"],
+      displayModelDefault: "claude-opus-4-8",
+    });
   });
 
-  it("reports codex models for the codex backend", () => {
+  it("declares the Codex runtime key and provider default", () => {
     process.env.ELIZA_PLANNER_NATIVE_TOOLS = "0";
-    process.env.ELIZA_CLI_CODEX_MODEL = "gpt-5.6-sol";
     const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "codex-sdk" });
-    expect(md?.RESPONSE_HANDLER).toEqual({ displayModel: "gpt-5.6-sol" });
+    expect(md?.RESPONSE_HANDLER).toEqual({
+      displayModelSettings: ["ELIZA_CLI_CODEX_MODEL"],
+      displayModelDefault: "gpt-5.5",
+    });
   });
 });
 
@@ -879,8 +889,12 @@ describe("ALL-TIERS mode (ELIZA_CLI_CLAUDE_ALL_TIERS)", () => {
     process.env.ELIZA_CLI_CLAUDE_MODEL = "claude-sonnet-5";
     delete process.env.ELIZA_CLI_CLAUDE_SMALL_MODEL;
     const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
-    // small tier defaults to the large-tier model (sonnet), NOT the opus planner
-    expect(md?.TEXT_SMALL).toEqual({ displayModel: "claude-sonnet-5" });
+    // Runtime resolution checks the cheap small setting, then the large setting,
+    // and never consults the planner tier.
+    expect(md?.TEXT_SMALL).toEqual({
+      displayModelSettings: ["ELIZA_CLI_CLAUDE_SMALL_MODEL", "ELIZA_CLI_CLAUDE_MODEL"],
+      displayModelDefault: "claude-opus-4-8",
+    });
   });
 });
 

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -601,15 +601,10 @@ export function buildModels(
 }
 
 /**
- * Per-slot display-model metadata so RUNTIME_MODEL_CONTEXT (the provider that
- * answers "what model are you running?") reports the ACTUAL Claude/Codex model
- * this plugin calls, not the losing provider's `SMALL_MODEL` fallback. Resolved
- * from env at construction (service.env is hydrated into process.env before
- * plugin load) using the SAME precedence as resolveSdkModel/resolveCodexModel,
- * so the self-report matches what actually runs. Without it the winning
- * cli-inference registration carries no displayModel and the provider walks the
- * generic OPENAI_/ANTHROPIC_ prefix chain, mis-reporting the cerebras triage
- * model (e.g. "gemma-4-31b") for a slot Claude actually serves.
+ * Declare the same runtime-setting precedence used by the handlers. Metadata is
+ * intentionally serializable and handler-free, but it must not snapshot host
+ * environment values: character settings can differ for every agent sharing a
+ * process and are resolved by RUNTIME_MODEL_CONTEXT at provider execution time.
  */
 export function buildModelMetadata(
   source: { ELIZA_CHAT_VIA_CLI?: string } = {
@@ -619,26 +614,35 @@ export function buildModelMetadata(
   const backend = resolveCliBackend(source);
   if (!backend) return undefined;
   const isCodex = backend === "codex" || backend === "codex-sdk";
-  const large = isCodex
-    ? readEnv("ELIZA_CLI_CODEX_MODEL")?.trim() || "gpt-5.5"
-    : readEnv("ELIZA_CLI_CLAUDE_MODEL")?.trim() || "claude-opus-4-8";
-  const plannerRaw = isCodex
-    ? readEnv("ELIZA_CLI_CODEX_PLANNER_MODEL")?.trim()
-    : readEnv("ELIZA_CLI_CLAUDE_PLANNER_MODEL")?.trim();
-  const planner = plannerRaw || large;
-  const small = isCodex ? large : readEnv("ELIZA_CLI_CLAUDE_SMALL_MODEL")?.trim() || large;
-  const metadata: Record<string, { displayModel: string }> = {};
+  const isWarm = backend === "claude-sdk" || backend === "codex-sdk";
+  const largeSetting = isCodex ? "ELIZA_CLI_CODEX_MODEL" : "ELIZA_CLI_CLAUDE_MODEL";
+  const plannerSetting = isCodex
+    ? "ELIZA_CLI_CODEX_PLANNER_MODEL"
+    : "ELIZA_CLI_CLAUDE_PLANNER_MODEL";
+  const defaultModel = isCodex ? "gpt-5.5" : "claude-opus-4-8";
+  const metadata: NonNullable<Plugin["modelMetadata"]> = {};
+  const declaration = (settings: string[]) => ({
+    displayModelSettings: settings,
+    displayModelDefault: defaultModel,
+  });
+
   for (const modelType of LARGE_TIER_MODEL_TYPES) {
-    metadata[modelType] = { displayModel: large };
+    metadata[modelType] = declaration([largeSetting]);
   }
   if (allTiersEnabled()) {
     for (const modelType of SMALL_TIER_MODEL_TYPES) {
-      metadata[modelType] = { displayModel: small };
+      const settings =
+        backend === "claude-sdk"
+          ? ["ELIZA_CLI_CLAUDE_SMALL_MODEL", largeSetting]
+          : backend === "codex-sdk" && modelType === ModelType.TEXT_SMALL
+            ? [plannerSetting, largeSetting]
+            : [largeSetting];
+      metadata[modelType] = declaration(settings);
     }
   }
   if (textPlannerEnabled()) {
     for (const modelType of PLANNER_MODEL_TYPES) {
-      metadata[modelType] = { displayModel: planner };
+      metadata[modelType] = declaration(isWarm ? [plannerSetting, largeSetting] : [largeSetting]);
     }
   }
   return metadata;


### PR DESCRIPTION
## Summary
- extend serializable model-registration metadata with an ordered runtime setting chain plus provider default
- resolve that chain when `RUNTIME_MODEL_CONTEXT` runs, so each agent's character/runtime settings beat process environment values
- make CLI-inference metadata mirror warm versus cold Claude/Codex handler precedence, including planner fallbacks and all-tier triage models

Fixes #16312.

## Reproduction
The new provider regression was first run against unmodified `develop` source and failed as expected:

```text
Expected: "character-large"
Received: undefined
(fail) runtimeModelContextProvider > resolves ordered provider settings from the per-agent runtime before defaults
```

This demonstrates that the old static `displayModel` snapshot could not resolve per-agent settings.

## Verification
```text
bun test packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
9 pass, 0 fail, 31 expect() calls

bun test __tests__/cli-inference.test.ts
63 pass, 0 fail, 185 expect() calls

bun run typecheck  # packages/core
PASS

bun run typecheck  # plugins/plugin-cli-inference
PASS

bunx @biomejs/biome check <five changed files>
Checked 5 files, no errors

git diff --check
PASS
```

Codex review: no actionable findings. The reviewer confirmed the metadata now resolves runtime settings with appropriate defaults and that targeted tests pass.

No auto-merge. This changes runtime model self-report metadata across a core/plugin boundary.

[sol-orch]

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - provider metadata and prompt-context behavior only, with no rendered UI.

<!-- evidence-row:after-screenshots -->
N/A - provider metadata and prompt-context behavior only, with no rendered UI.

<!-- evidence-row:walkthrough-video -->
N/A - deterministic backend provider tests cover the behavior.

<!-- evidence-row:backend-logs -->
Inline reproduction and focused test transcripts above (pre-fix fails with `character-large` unresolved; exact-head suites pass 9/9 and 63/63), plus the [exact-head CI verification run](https://github.com/elizaOS/eliza/actions/runs/29547481320).

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface or browser network behavior changed.

<!-- evidence-row:llm-trajectory -->
N/A - deterministic model metadata resolution does not invoke an LLM.

<!-- evidence-row:domain-artifacts -->
Inline exact-head core/provider test, plugin metadata test, typecheck, formatter, and Codex review receipts above; aggregate gate at the [exact-head Develop PR Gate run](https://github.com/elizaOS/eliza/actions/runs/29547481264).

