### PR TITLE
fix(core): harden task scheduler failure handling

### DIFF
--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -19,8 +19,8 @@ import {
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
 
-function makeRuntime(): IAgentRuntime {
-	return { agentId: AGENT_ID } as unknown as IAgentRuntime;
+function makeRuntime(reportError = vi.fn()): IAgentRuntime {
+	return { agentId: AGENT_ID, reportError } as unknown as IAgentRuntime;
 }
 
 /**
@@ -64,7 +64,9 @@ describe("task-scheduler", () => {
 		// The rejection is surfaced through the structured logger, not swallowed.
 		expect(errorSpy).toHaveBeenCalledTimes(1);
 		const [context, message] = errorSpy.mock.calls[0];
-		expect(context).toMatchObject({ err: failure });
+		expect(context).toMatchObject({
+			err: { code: "TASK_SCHEDULER_QUERY_FAILED", cause: failure },
+		});
 		expect(message).toContain("tick failed");
 
 		// Scheduling continues: a fresh dirty agent on the next tick still queries.
@@ -151,6 +153,46 @@ describe("task-scheduler", () => {
 		await runOneTick();
 		expect(getTasks).toHaveBeenCalledTimes(1);
 		expect(runTick).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports and rejects adapter rows outside the queried tenant scope", async () => {
+		const reportError = vi.fn();
+		const rogue = {
+			id: "rogue",
+			agentId: "00000000-0000-0000-0000-0000000000ff" as UUID,
+		} as Task;
+		const getTasks = vi.fn(async () => [rogue]);
+		startTaskScheduler({ getTasks } as unknown as IDatabaseAdapter);
+		const runTick = vi.fn(async () => undefined);
+		registerTaskSchedulerRuntime(makeRuntime(reportError), { runTick });
+
+		await runOneTick();
+
+		expect(runTick).not.toHaveBeenCalled();
+		expect(reportError).toHaveBeenCalledWith(
+			"TaskScheduler.scope",
+			expect.objectContaining({ code: "TASK_SCHEDULER_SCOPE_VIOLATION" }),
+			{ agentId: AGENT_ID },
+		);
+	});
+
+	it("reports runTick failures through the owning runtime", async () => {
+		const reportError = vi.fn();
+		const task = { id: "t1", agentId: AGENT_ID } as unknown as Task;
+		startTaskScheduler({
+			getTasks: vi.fn(async () => [task]),
+		} as unknown as IDatabaseAdapter);
+		const failure = new Error("tick exploded");
+		registerTaskSchedulerRuntime(makeRuntime(reportError), {
+			runTick: vi.fn(async () => {
+				throw failure;
+			}),
+		});
+
+		await runOneTick();
+		expect(reportError).toHaveBeenCalledWith("TaskScheduler.runTick", failure, {
+			agentId: AGENT_ID,
+		});
 	});
 
 	it("does not log when getTasks succeeds", async () => {

--- a/packages/core/src/services/task-scheduler.ts
+++ b/packages/core/src/services/task-scheduler.ts
@@ -6,6 +6,7 @@
  * Opt-in: host calls startTaskScheduler(adapter); TaskService registers when daemon is present.
  */
 
+import { ElizaError } from "../errors";
 import { logger } from "../logger";
 import type { IDatabaseAdapter } from "../types/database";
 import type { UUID } from "../types/primitives";
@@ -48,13 +49,18 @@ async function tick(): Promise<void> {
 			tags: ["queue"],
 			agentIds,
 		});
-	} catch (error) {
-		// A transient getTasks rejection must NOT permanently silence the cleared
-		// agents: we already drained dirtyAgents above, so re-arm the ones still
-		// registered before rethrowing. Otherwise one DB hiccup drops every repeat
-		// task (incl. the LifeOps heartbeat) until each agent is marked dirty again.
+	} catch (cause) {
+		const error = new ElizaError("Shared task queue query failed", {
+			code: "TASK_SCHEDULER_QUERY_FAILED",
+			context: { agentIds: snapshot },
+			cause,
+			severity: "ephemeral",
+		});
 		for (const aid of snapshot) {
-			if (registry.has(aid)) dirtyAgents.add(aid);
+			const entry = registry.get(aid);
+			if (!entry) continue;
+			dirtyAgents.add(aid);
+			entry.runtime.reportError("TaskScheduler.query", error, { agentId: aid });
 		}
 		throw error;
 	}
@@ -63,7 +69,28 @@ async function tick(): Promise<void> {
 	const byAgent = new Map<string, Task[]>();
 	for (const task of allTasks) {
 		const aid = task.agentId != null ? String(task.agentId) : "";
-		if (!aid) continue;
+		if (!aid || !snapshot.includes(aid) || !registry.has(aid)) {
+			const error = new ElizaError(
+				"Task scheduler adapter returned an out-of-scope task",
+				{
+					code: "TASK_SCHEDULER_SCOPE_VIOLATION",
+					context: {
+						taskId: task.id,
+						returnedAgentId: aid || null,
+						queriedAgentIds: snapshot,
+					},
+					severity: "fatal",
+				},
+			);
+			for (const queriedAgentId of snapshot) {
+				registry
+					.get(queriedAgentId)
+					?.runtime.reportError("TaskScheduler.scope", error, {
+						agentId: queriedAgentId,
+					});
+			}
+			continue;
+		}
 		const list = byAgent.get(aid) ?? [];
 		list.push(task);
 		byAgent.set(aid, list);
@@ -74,8 +101,10 @@ async function tick(): Promise<void> {
 		if (!entry) continue;
 		try {
 			await entry.taskService.runTick(tasks);
-		} catch (_) {
-			// WHY: one agent's runTick failure must not break other agents' ticks; errors are logged inside runTick/executeTask.
+		} catch (error) {
+			entry.runtime.reportError("TaskScheduler.runTick", error, {
+				agentId: agentIdKey,
+			});
 		}
 		// Non-empty queue: keep the agent dirty so the next tick re-queries. WHY: repeat tasks and
 		// not-yet-due one-shots become due purely by time passing, with no markTaskSchedulerDirty

--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -28,6 +28,7 @@ function makeTaskRuntime() {
 		agentId: AGENT_ID,
 		serverless: false,
 		logger: { debug: noop, info: noop, warn: noop, error: noop },
+		reportError: vi.fn(),
 		registerTaskWorker: (worker: TaskWorker) => {
 			workers.set(worker.name, worker);
 		},
@@ -232,7 +233,7 @@ describe("TaskService tick re-arm", () => {
 				updateInterval: 1_000,
 				baseInterval: 1_000,
 				updatedAt: T0,
-				maxFailures: 0,
+				maxFailures: -1,
 			},
 		});
 
@@ -323,6 +324,112 @@ describe("TaskService tick re-arm", () => {
 		// Paused task stays paused: no further executions.
 		await vi.advanceTimersByTimeAsync(120_000);
 		expect(execute).toHaveBeenCalledTimes(5);
+	});
+
+	it("runs healthy rows before rejecting with every invalid-row failure", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("HEALTHY", { name: "HEALTHY", execute });
+		workers.set("BAD_PREFLIGHT", {
+			name: "BAD_PREFLIGHT",
+			shouldRun: async () => "yes" as unknown as boolean,
+			execute: vi.fn(async () => undefined),
+		});
+		tasks.set("healthy", {
+			id: "healthy" as UUID,
+			name: "HEALTHY",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+		});
+		tasks.set("missing-worker", {
+			id: "missing-worker" as UUID,
+			name: "MISSING",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+		});
+		tasks.set("bad-preflight", {
+			id: "bad-preflight" as UUID,
+			name: "BAD_PREFLIGHT",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+		});
+		(runtime as { serverless: boolean }).serverless = true;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await expect(service.runDueTasks()).rejects.toMatchObject({
+			code: "TASK_TICK_FAILED",
+			context: {
+				failureCodes: ["TASK_WORKER_MISSING", "TASK_PREFLIGHT_INVALID"],
+			},
+		});
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it("manual execution rejects after persisting the worker failure", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		workers.set("FAIL", {
+			name: "FAIL",
+			execute: async () => {
+				throw new Error("worker exploded");
+			},
+		});
+		tasks.set("repeat", {
+			id: "repeat" as UUID,
+			name: "FAIL",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			metadata: { updateInterval: 1_000, updatedAt: T0 },
+		});
+		(runtime as { serverless: boolean }).serverless = true;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await expect(
+			service.executeTaskById("repeat" as UUID),
+		).rejects.toMatchObject({
+			code: "TASK_EXECUTION_FAILED",
+		});
+		expect(tasks.get("repeat")?.metadata).toMatchObject({
+			failureCount: 1,
+			lastError: "worker exploded",
+		});
+	});
+
+	it("preserves bigint dueAt support for adapter-returned tasks", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("BIGINT_DUE", { name: "BIGINT_DUE", execute });
+		tasks.set("bigint", {
+			id: "bigint" as UUID,
+			name: "BIGINT_DUE",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+			dueAt: BigInt(T0 - 1),
+		});
+		(runtime as { serverless: boolean }).serverless = true;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await expect(service.runDueTasks()).resolves.toBeUndefined();
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects invalid zero repeat intervals without running a busy loop", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("ZERO", { name: "ZERO", execute });
+		tasks.set("zero", {
+			id: "zero" as UUID,
+			name: "ZERO",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			metadata: { updateInterval: 0, updatedAt: T0 },
+		});
+		(runtime as { serverless: boolean }).serverless = true;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await expect(service.runDueTasks()).rejects.toMatchObject({
+			code: "TASK_TICK_FAILED",
+		});
+		expect(execute).not.toHaveBeenCalled();
 	});
 
 	it("does not compound backoff and restores the original cadence when baseInterval was never set", async () => {

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -7,6 +7,7 @@
  * via `runtime.getService(ServiceType.TASK)`.
  */
 
+import { ElizaError } from "../errors";
 import type { JsonValue } from "../types";
 import type { UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
@@ -182,14 +183,9 @@ export class TaskService extends Service {
 			}
 			const tick = this.checkTasks()
 				.catch((error) => {
-					this.runtime.logger.error(
-						{
-							src: "plugin:basic-capabilities:service:task",
-							agentId: this.runtime.agentId,
-							error,
-						},
-						"Task timer tick failed",
-					);
+					this.runtime.reportError("TaskService.timer", error, {
+						agentId: this.runtime.agentId,
+					});
 				})
 				.finally(() => {
 					if (this.activeTick === tick) {
@@ -207,30 +203,133 @@ export class TaskService extends Service {
 	 * @param {Task[]} tasks - An array of Task objects to validate.
 	 * @returns {Promise<Task[]>} - A Promise that resolves with an array of validated Task objects.
 	 */
-	private async validateTasks(tasks: Task[]): Promise<Task[]> {
+	private async validateTasks(
+		tasks: Task[],
+	): Promise<{ tasks: Task[]; errors: ElizaError[] }> {
 		const validatedTasks: Task[] = [];
+		const errors: ElizaError[] = [];
 
 		for (const task of tasks) {
+			const context = { taskId: task.id, taskName: task.name };
+			const metadata = task.metadata as TaskMetadata | undefined;
+			if (task.tags?.includes("repeat") && metadata?.paused) continue;
 			if (!task.id) {
+				errors.push(
+					new ElizaError("Scheduled task is missing an id", {
+						code: "TASK_INVALID_ID",
+						context,
+						severity: "fatal",
+					}),
+				);
 				continue;
 			}
 
 			const worker = this.runtime.getTaskWorker(task.name);
 			if (!worker) {
+				errors.push(
+					new ElizaError(`No worker registered for task ${task.name}`, {
+						code: "TASK_WORKER_MISSING",
+						context,
+						severity: "fatal",
+					}),
+				);
+				continue;
+			}
+
+			const invalidField = this.invalidScheduleField(task);
+			if (invalidField) {
+				errors.push(
+					new ElizaError(`Task ${task.name} has invalid ${invalidField}`, {
+						code: "TASK_SCHEDULE_INVALID",
+						context: { ...context, field: invalidField },
+						severity: "fatal",
+					}),
+				);
 				continue;
 			}
 
 			if (worker.shouldRun) {
-				const shouldRun = await worker.shouldRun(this.runtime, task);
-				if (!shouldRun) {
+				let shouldRun: unknown;
+				try {
+					shouldRun = await worker.shouldRun(this.runtime, task);
+				} catch (cause) {
+					errors.push(
+						new ElizaError(`Task ${task.name} preflight failed`, {
+							code: "TASK_PREFLIGHT_FAILED",
+							context,
+							cause,
+							severity: "ephemeral",
+						}),
+					);
 					continue;
 				}
+				if (typeof shouldRun !== "boolean") {
+					errors.push(
+						new ElizaError(
+							`Task ${task.name} preflight returned a non-boolean`,
+							{
+								code: "TASK_PREFLIGHT_INVALID",
+								context: { ...context, resultType: typeof shouldRun },
+								severity: "fatal",
+							},
+						),
+					);
+					continue;
+				}
+				if (!shouldRun) continue;
 			}
 
 			validatedTasks.push(task);
 		}
 
-		return validatedTasks;
+		return { tasks: validatedTasks, errors };
+	}
+
+	private invalidScheduleField(task: Task): string | undefined {
+		const finite = (value: unknown) =>
+			typeof value === "number" && Number.isFinite(value);
+		const metadata = task.metadata as TaskMetadata | undefined;
+		if (task.dueAt != null) {
+			const validDueAt =
+				finite(task.dueAt) ||
+				(typeof task.dueAt === "bigint" && Number.isFinite(Number(task.dueAt)));
+			if (!validDueAt) return "dueAt";
+		}
+		if (
+			metadata?.scheduledAt != null &&
+			!finite(metadata.scheduledAt) &&
+			Number.isNaN(new Date(String(metadata.scheduledAt)).getTime())
+		) {
+			return "metadata.scheduledAt";
+		}
+		if (!task.tags?.includes("repeat")) return undefined;
+		if (
+			!finite(metadata?.updateInterval) ||
+			(metadata?.updateInterval ?? 0) <= 0
+		)
+			return "metadata.updateInterval";
+		for (const field of ["updatedAt", "notBefore", "notAfter"] as const) {
+			const value = metadata?.[field];
+			if (value != null && (!finite(value) || value < 0))
+				return `metadata.${field}`;
+		}
+		const failureCount = metadata?.failureCount;
+		if (failureCount != null && (!finite(failureCount) || failureCount < 0)) {
+			return "metadata.failureCount";
+		}
+		const baseInterval = metadata?.baseInterval;
+		if (baseInterval != null && (!finite(baseInterval) || baseInterval <= 0)) {
+			return "metadata.baseInterval";
+		}
+		const maxFailures = metadata?.maxFailures;
+		if (
+			maxFailures != null &&
+			maxFailures !== Infinity &&
+			!finite(maxFailures)
+		) {
+			return "metadata.maxFailures";
+		}
+		return undefined;
 	}
 
 	/**
@@ -260,7 +359,12 @@ export class TaskService extends Service {
 			// hiccup would silence every repeat task (incl. the LifeOps heartbeat)
 			// until an unrelated createTask/updateTask happened to call markDirty().
 			this.tasksDirty = true;
-			throw error;
+			throw new ElizaError("Task queue query failed", {
+				code: "TASK_QUERY_FAILED",
+				context: { agentId: this.runtime.agentId },
+				cause: error,
+				severity: "ephemeral",
+			});
 		}
 
 		if (!allTasks || allTasks.length === 0) {
@@ -284,15 +388,28 @@ export class TaskService extends Service {
 	 */
 	async runTick(tasks: Task[]): Promise<void> {
 		if (this.stopped) return;
-		const validated = await this.validateTasks(tasks);
+		const validation = await this.validateTasks(tasks);
+		const failures: ElizaError[] = [...validation.errors];
 		const now = Date.now();
 
-		for (const task of validated) {
+		for (const task of validation.tasks) {
 			// Non-repeat tasks: run when due (or immediately if no dueAt/scheduledAt). WHY: one-shot "run at time X" (e.g. follow-up) uses dueAt or metadata.scheduledAt.
 			if (!task.tags?.includes("repeat")) {
 				const dueMs = resolveDueTime(task);
 				if (dueMs != null && now < dueMs) continue;
-				await this.executeTask(task);
+				try {
+					await this.executeTask(task);
+				} catch (error) {
+					failures.push(
+						error instanceof ElizaError
+							? error
+							: new ElizaError(`Task ${task.name} execution failed`, {
+									code: "TASK_EXECUTION_FAILED",
+									context: { taskId: task.id, taskName: task.name },
+									cause: error,
+								}),
+					);
+				}
 				continue;
 			}
 
@@ -370,7 +487,29 @@ export class TaskService extends Service {
 				},
 				"Executing task - interval elapsed",
 			);
-			await this.executeTask(task);
+			try {
+				await this.executeTask(task);
+			} catch (error) {
+				failures.push(
+					error instanceof ElizaError
+						? error
+						: new ElizaError(`Task ${task.name} execution failed`, {
+								code: "TASK_EXECUTION_FAILED",
+								context: { taskId: task.id, taskName: task.name },
+								cause: error,
+							}),
+				);
+			}
+		}
+		if (failures.length > 0) {
+			throw new ElizaError(`${failures.length} scheduled task failure(s)`, {
+				code: "TASK_TICK_FAILED",
+				context: { failureCodes: failures.map((failure) => failure.code) },
+				cause: new AggregateError(failures),
+				severity: failures.some((failure) => failure.severity === "fatal")
+					? "fatal"
+					: "ephemeral",
+			});
 		}
 	}
 
@@ -448,6 +587,21 @@ export class TaskService extends Service {
 					"nextInterval" in result
 						? (result as { nextInterval?: number }).nextInterval
 						: undefined;
+				if (
+					nextInterval != null &&
+					(typeof nextInterval !== "number" ||
+						!Number.isFinite(nextInterval) ||
+						nextInterval <= 0)
+				) {
+					throw new ElizaError(
+						`Task ${task.name} returned an invalid nextInterval`,
+						{
+							code: "TASK_ADAPTIVE_INTERVAL_INVALID",
+							context: { taskId: task.id, taskName: task.name, nextInterval },
+							severity: "fatal",
+						},
+					);
+				}
 				if (nextInterval != null) {
 					newMeta.updateInterval = nextInterval;
 					delete newMeta.baseInterval;
@@ -468,67 +622,90 @@ export class TaskService extends Service {
 				);
 			}
 		} catch (error) {
-			if (task.tags?.includes("repeat")) {
-				const latestTask = await this.runtime.getTask(task.id);
-				if (!latestTask) {
-					return;
-				}
-				const meta = latestTask.metadata as TaskMetadata | undefined;
-				const failureCount = (meta?.failureCount ?? 0) + 1;
-				const rawMax = meta?.maxFailures;
-				// maxFailures <= 0 (or Infinity) = never auto-pause. WHY: critical heartbeats (e.g. the
-				// LifeOps scheduler) must survive transient failure storms; a paused heartbeat is a
-				// permanently-dead subsystem until an operator notices. 0/-1 survive JSON round-trips.
-				const neverPause =
-					rawMax === Infinity || (typeof rawMax === "number" && rawMax <= 0);
-				const maxFailures = neverPause ? Infinity : (rawMax ?? 5);
-				const newMeta: TaskMetadata & Record<string, unknown> = {
-					...(meta ?? {}),
-					updatedAt: Date.now(),
-					failureCount,
-					lastError: error instanceof Error ? error.message : String(error),
-				};
-				if (!neverPause && failureCount >= maxFailures) {
-					newMeta.paused = true;
-					this.runtime.logger.warn(
+			let persistenceError: unknown;
+			try {
+				if (task.tags?.includes("repeat")) {
+					const latestTask = await this.runtime.getTask(task.id);
+					if (!latestTask) {
+						return;
+					}
+					const meta = latestTask.metadata as TaskMetadata | undefined;
+					const failureCount = (meta?.failureCount ?? 0) + 1;
+					const rawMax = meta?.maxFailures;
+					// maxFailures <= 0 (or Infinity) = never auto-pause. WHY: critical heartbeats (e.g. the
+					// LifeOps scheduler) must survive transient failure storms; a paused heartbeat is a
+					// permanently-dead subsystem until an operator notices. 0/-1 survive JSON round-trips.
+					const neverPause =
+						rawMax === Infinity || (typeof rawMax === "number" && rawMax <= 0);
+					const maxFailures = neverPause ? Infinity : (rawMax ?? 5);
+					const newMeta: TaskMetadata & Record<string, unknown> = {
+						...(meta ?? {}),
+						updatedAt: Date.now(),
+						failureCount,
+						lastError: error instanceof Error ? error.message : String(error),
+					};
+					if (!neverPause && failureCount >= maxFailures) {
+						newMeta.paused = true;
+						this.runtime.logger.warn(
+							{
+								taskName: task.name,
+								taskId: task.id,
+								failureCount,
+							},
+							"Task auto-paused after max failures",
+						);
+					} else {
+						const baseInterval =
+							meta?.baseInterval ?? meta?.updateInterval ?? 1000;
+						// Persist the resolved base the FIRST time we back off. Without it,
+						// the next failure's fallback reads the already-doubled
+						// updateInterval (the exponential-of-exponential this branch exists
+						// to prevent) and a later success "restores" updateInterval to the
+						// inflated backoff value permanently instead of the original cadence.
+						newMeta.baseInterval = baseInterval;
+						newMeta.updateInterval = Math.min(
+							baseInterval * 2 ** failureCount,
+							300_000,
+						);
+					}
+					await this.runtime.updateTask(task.id, { metadata: newMeta });
+				} else if (task.id) {
+					await this.runtime.deleteTask(task.id);
+					this.runtime.logger.debug(
 						{
+							src: "plugin:basic-capabilities:service:task",
+							agentId: this.runtime.agentId,
 							taskName: task.name,
 							taskId: task.id,
-							failureCount,
 						},
-						"Task auto-paused after max failures",
-					);
-				} else {
-					const baseInterval =
-						meta?.baseInterval ?? meta?.updateInterval ?? 1000;
-					// Persist the resolved base the FIRST time we back off. Without it,
-					// the next failure's fallback reads the already-doubled
-					// updateInterval (the exponential-of-exponential this branch exists
-					// to prevent) and a later success "restores" updateInterval to the
-					// inflated backoff value permanently instead of the original cadence.
-					newMeta.baseInterval = baseInterval;
-					newMeta.updateInterval = Math.min(
-						baseInterval * 2 ** failureCount,
-						300_000,
+						"Deleted non-repeating task after execution failure",
 					);
 				}
-				await this.runtime.updateTask(task.id, { metadata: newMeta });
-			} else if (task.id) {
-				await this.runtime.deleteTask(task.id);
-				this.runtime.logger.debug(
-					{
-						src: "plugin:basic-capabilities:service:task",
-						agentId: this.runtime.agentId,
-						taskName: task.name,
-						taskId: task.id,
-					},
-					"Deleted non-repeating task after execution failure",
-				);
+			} catch (cause) {
+				persistenceError = cause;
 			}
+			const cause = persistenceError
+				? new AggregateError(
+						[error, persistenceError],
+						"Task execution and state transition failed",
+					)
+				: error;
+			const failure =
+				!persistenceError && error instanceof ElizaError
+					? error
+					: new ElizaError(`Task ${task.name} execution failed`, {
+							code: persistenceError
+								? "TASK_EXECUTION_STATE_FAILED"
+								: "TASK_EXECUTION_FAILED",
+							context: { taskName: task.name, taskId: task.id },
+							cause,
+							severity: persistenceError ? "fatal" : "ephemeral",
+						});
 			this.runtime.logger.error(
-				{ taskName: task.name, taskId: task.id, error },
+				{ taskName: task.name, taskId: task.id, error: failure },
 				"Task execution failed",
 			);
+			throw failure;
 		} finally {
 			this.executingTasks.delete(task.id);
 			const durationMs = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- validate scheduled task identifiers, workers, scheduling/failure metadata, and `shouldRun` contracts per row while continuing healthy work
- reject timer/manual/serverless calls with typed aggregate `ElizaError`s instead of silently swallowing failures
- preserve both worker and persistence failures, validate adaptive intervals, and keep paused tasks dormant
- report timer, shared-query, tenant-scope, and per-agent tick failures through `runtime.reportError`
- keep shared queries tenant-scoped and refuse adapter rows outside the queried agent set

Fixes #16349.

## Reproduction
The new regressions were run first against unmodified `develop` source. They demonstrated the prior silent paths:

```text
runDueTasks expected TASK_TICK_FAILED for missing worker + non-boolean shouldRun, but resolved
executeTaskById expected TASK_EXECUTION_FAILED, but resolved
zero repeat interval expected TASK_TICK_FAILED, but resolved
shared out-of-scope adapter row expected reportError, but was silently ignored
shared runTick failure expected reportError, but was silently ignored
```

## Verification
```text
bun run test -- src/services/task.test.ts src/services/task-scheduler.test.ts
Test Files  2 passed (2)
Tests       25 passed (25)

bun run typecheck  # packages/core
PASS

bunx @biomejs/biome check <four changed files>
Checked 4 files. No fixes applied.

git diff --check
PASS
```

Codex review was run iteratively. It found two edge regressions, both fixed and re-reviewed:
- preserve bigint `dueAt` and `maxFailures <= 0` / Infinity semantics
- skip paused repeat tasks before worker validation

Final Codex result: "No discrete correctness issues were identified in the changed task scheduler/service code. The changes typecheck successfully for packages/core."

No auto-merge. This touches workflow execution and background task failure semantics.

[sol-orch]

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - backend scheduler/error-policy behavior only.

<!-- evidence-row:after-screenshots -->
N/A - backend scheduler/error-policy behavior only.

<!-- evidence-row:walkthrough-video -->
N/A - deterministic focused scheduler tests cover timer, manual, tenant, and persistence behavior.

<!-- evidence-row:backend-logs -->
Inline reproduction and exact-head verification above (25/25 focused tests, package typecheck, Biome, diff-check, and final Codex review all pass), plus the [exact-head CI verification run](https://github.com/elizaOS/eliza/actions/runs/29548306184).

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface changed.

<!-- evidence-row:llm-trajectory -->
N/A - task scheduler behavior is deterministic and invokes no LLM.

<!-- evidence-row:domain-artifacts -->
Inline exact-head test/typecheck/review receipts above; aggregate gate at the [exact-head Develop PR Gate run](https://github.com/elizaOS/eliza/actions/runs/29548306204).

