### PR TITLE
fix(core): resolve simile candidate hints to their catalog parent in action retrieval

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -142,6 +142,75 @@ describe("action catalogue and retrieval", () => {
 		});
 	});
 
+	it("resolves a simile candidate hint to its catalog parent (BASH -> SHELL)", () => {
+		// The live regression this locks: Stage-1 hints candidateActions=["BASH"]
+		// (the documented canonical hint) but the parent action is named SHELL with
+		// BASH only as a simile. Without simile resolution the hint is dead and the
+		// surface cut hands the planner unrelated keyword matches instead.
+		const catalog = buildActionCatalog([
+			{
+				name: "SHELL",
+				description: "Run a shell command on the host.",
+				similes: ["BASH", "EXEC", "RUN_COMMAND"],
+				tags: ["system"],
+			},
+			...actions,
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "how much disk space is left on the server",
+			candidateActions: ["BASH"],
+		});
+		expect(response.results[0]).toMatchObject({
+			name: "SHELL",
+			matchedBy: expect.arrayContaining(["exact"]),
+		});
+	});
+
+	it("resolves a child simile hint to the child's parent", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "TASKS",
+				description: "Manage coding agent task sessions.",
+				subActions: ["SEND_PROMPT"],
+			},
+			{
+				name: "SEND_PROMPT",
+				description: "Send a follow-up prompt to a running session.",
+				similes: ["SEND_TO_AGENT"],
+			},
+			...actions,
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "pass this along",
+			candidateActions: ["SEND_TO_AGENT"],
+		});
+		expect(response.results[0]).toMatchObject({
+			name: "TASKS",
+			matchedBy: expect.arrayContaining(["exact"]),
+		});
+	});
+
+	it("does not let a simile hijack a real parent name", () => {
+		// EMAIL exists as a real parent; a MUSIC simile spelled "EMAIL" must not
+		// reroute an EMAIL candidate hint to MUSIC.
+		const catalog = buildActionCatalog([
+			{
+				name: "MUSIC2",
+				description: "Control playback.",
+				similes: ["EMAIL"],
+			},
+			...actions,
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "message my contact",
+			candidateActions: ["EMAIL"],
+		});
+		expect(response.results[0]?.name).toBe("EMAIL");
+	});
+
 	it("applies exact parent hints as a score floor", () => {
 		const catalog = buildActionCatalog(actions);
 		const response = retrieveActions({

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -302,6 +302,15 @@ export function retrieveActions(
 				? []
 				: parentAliasesForCandidateAction(actionName),
 		),
+		// Stage-1 routinely hints an action by one of its similes — the canonical
+		// documented example is candidateActions=["BASH"] for the SHELL parent
+		// (message-handler.ts). Similes feed the fuzzy search text but carry no
+		// rank guarantee, so a simile hint can lose the surface cut to unrelated
+		// keyword matches and reach the planner as a dead hint (it then improvises
+		// with whatever tools did rank, or falsely reports missing tool access).
+		// Resolve simile hints to their catalog parent so they exact-score like
+		// any explicit parent hint.
+		...resolveSimileParentHints(input.catalog.parents, candidateActions),
 	]);
 	const recentConversationText = shouldUseRecentConversationForActionSearch(
 		input.messageText ?? "",
@@ -983,6 +992,39 @@ function hasOnlyOperationTokens(tokens: Set<string>): boolean {
 		if (!VIEW_OPERATION_TOKENS.has(token)) return false;
 	}
 	return true;
+}
+
+function resolveSimileParentHints(
+	parents: readonly ActionCatalogParent[],
+	candidateActions: readonly string[],
+): string[] {
+	if (candidateActions.length === 0) {
+		return [];
+	}
+	const parentNames = new Set(parents.map((parent) => parent.normalizedName));
+	const parentBySimile = new Map<string, string>();
+	for (const parent of parents) {
+		for (const simile of [
+			...parent.similes,
+			...parent.children.flatMap((child) => child.similes),
+		]) {
+			const normalized = normalizeActionName(simile);
+			// A simile that collides with a real parent name must not hijack it.
+			if (!normalized || parentNames.has(normalized)) {
+				continue;
+			}
+			if (!parentBySimile.has(normalized)) {
+				parentBySimile.set(normalized, parent.normalizedName);
+			}
+		}
+	}
+	return candidateActions.flatMap((actionName) => {
+		if (parentNames.has(actionName)) {
+			return [];
+		}
+		const parent = parentBySimile.get(actionName);
+		return parent ? [parent] : [];
+	});
 }
 
 export function candidateNamespaceParentExists(


### PR DESCRIPTION
## What

`retrieveActions` now resolves Stage-1 candidate hints that name an action by one of its **similes** to the owning catalog parent, and exact-scores that parent like any explicit hint. Child similes resolve to their parent; a simile that collides with a real parent name never hijacks it.

## The live failure this fixes

`message-handler.ts` documents `candidateActions=["BASH"]` as the canonical Stage-1 hint — but the action is named `SHELL` with `BASH` only in `similes`. Similes feed the fuzzy search text with no rank guarantee, so the hint died at the surface cut. Live trace (production Discord bot, "how much disk space is left on the server"):

1. Stage-1: `contexts=[files]`, `candidateActions=["BASH"]` ✅
2. toolSearch results: `WEB_SEARCH (0.85)`, `GENERATE_MEDIA` — **no SHELL**
3. Planner (toolChoice=required): `WEB_SEARCH("how to check disk space on linux server bash")` — literalized the intent into a web search
4. Iteration 2: `REPLY("can't check that right now, don't have the tool access this turn.")` — false capability denial; SHELL was registered the whole time

After the fix, the same turn ranks `SHELL` at **rank 0 matched by `exact`**, the planner runs `df -h`, and the user gets the answer ("23g left. 95% used." — 2.3s turn, verified live).

## Why this layer

The planner prompt already declares dead hints out of scope ("candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint" — planner.ts). The structural gap was upstream: the retrieval layer owns hint→catalog resolution, and the catalog already indexes similes — they just never participated in hint resolution. This uses the catalog's own simile data; no per-action heuristics, no prompt changes.

## Tests

Three new cases in `action-retrieval.test.ts` (21/21 passing):
- parent simile hint resolves (`BASH` → `SHELL`, matchedBy `exact`)
- child simile hint resolves to the child's parent (`SEND_TO_AGENT` → `TASKS`)
- collision guard: a simile spelled like a real parent name does not reroute it

# Evidence Details

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; core retrieval logic.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; deterministic retrieval unit + live Discord trace inlined below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed service in this repo change; the before/after live traces from the production bot (trajectory stage dumps) are inlined below, and the unit suite drives the changed function directly.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - trajectories cannot be attached as files without leaking the production bot's room/user identifiers; the hand-reviewed before/after stage dumps from the real gemma-4-31b + zai-glm-4.7 turns are inlined verbatim in the details block below.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the domain artifact is the retrieval ranking itself, shown in the before/after traces below.`

<details>
<summary>Before/after live traces (hand-reviewed)</summary>

```
BEFORE (tj-7480528f06c395):
  stage-1: contexts=[files] candidateActions=[BASH] replyText="checking"
  toolSearch: [WEB_SEARCH 0.85, GENERATE_MEDIA 0.75]        <- SHELL absent
  planner:   WEB_SEARCH("how to check disk space on linux server bash")
  iter 2:    REPLY("can't check that right now, don't have the tool access this turn.")

AFTER (tj-83b6da357b6, same message, fix deployed):
  stage-1: contexts=[terminal] candidateActions=[BASH] replyText="checking."
  toolSearch: [SHELL rank0 matchedBy=[exact,keyword,bm25,contextMatch], FILE, TERMINAL_SHELL, WORKTREE, WEB_SEARCH]
  planner:   SHELL{command:"df -h /home/milady"} -> exit 0, "387G 364G 23G 95%"
  delivered: "23g left. 95% used."

unit suite: packages/core vitest action-retrieval.test.ts — 21 passed (3 new)
```

</details>
