### PR TITLE
fix(voice): fall back to cloud ASR when persisted local inference is unavailable

### DIFF
--- a/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
@@ -84,6 +84,10 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
     const { result } = renderHook(() =>
       useVoiceChat({
         onTranscript,
+        // Explicit cloud provider → the WAV cloud route under the shared
+        // resolution rule with or without a session flag (#16524); the pin
+        // keeps this suite's routing assumption visible.
+        cloudConnected: false,
         voiceConfig: {
           provider: "eliza-cloud",
           asr: { provider: "eliza-cloud" },

--- a/packages/ui/src/hooks/useVoiceChat.bidirectional.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.bidirectional.test.tsx
@@ -144,6 +144,10 @@ describe("useVoiceChat bidirectional browser voice", () => {
       useVoiceChat({
         onTranscript: vi.fn(),
         onPlaybackStart,
+        // Pinned: this suite asserts the browser-recognizer cascade, which is
+        // reached only when no WAV ASR route resolves (#16524) — an unset
+        // provider with no cloud session must keep landing on browser capture.
+        cloudConnected: false,
       }),
     );
 

--- a/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
@@ -155,6 +155,225 @@ describe("useVoiceChat cloud ASR", () => {
     );
   });
 
+  it("unready persisted local-inference degrades to the cloud WAV route when cloudConnected (#16524)", async () => {
+    // The staging-Safari dead-mic shape: the saved character config pins
+    // `local-inference`, the cloud agent's local ASR runtime reports
+    // `{ ready: false }`, and the browser has no SpeechRecognition engine
+    // (jsdom, like Safari without webkitSpeechRecognition exposure). The mic
+    // must still work: record the WAV and POST it to the cloud STT proxy.
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/local-inference/status")) {
+        return new Response(JSON.stringify({ ready: false }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/asr/cloud")) {
+        return new Response(JSON.stringify({ text: "hello cloud voice" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        cloudConnected: true,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "local-inference" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    await act(async () => {
+      await result.current.stopListening({ submit: true });
+    });
+
+    // Readiness was probed once, then the WAV recorder armed for the cloud
+    // route — capture never fell through to browser SpeechRecognition.
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "/api/asr/local-inference/status",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.objectContaining({ method: "POST" }),
+    );
+    // The audio must NOT have been sent to the unready local transcriber.
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/local-inference",
+      expect.anything(),
+    );
+    expect(onTranscript).toHaveBeenCalledWith(
+      "hello cloud voice",
+      expect.objectContaining({
+        isFinal: true,
+        turn: expect.objectContaining({ source: "cloud" }),
+      }),
+    );
+  });
+
+  it("ready persisted local-inference stays on the local route even when cloudConnected (#16524)", async () => {
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/local-inference/status")) {
+        return new Response(JSON.stringify({ ready: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/asr/local-inference")) {
+        return new Response(JSON.stringify({ text: "hello local voice" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Uint8Array([1, 2])),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        cloudConnected: true,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "local-inference" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    await act(async () => {
+      await result.current.stopListening({ submit: true });
+    });
+
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.anything(),
+    );
+    expect(onTranscript).toHaveBeenCalledWith(
+      "hello local voice",
+      expect.anything(),
+    );
+  });
+
+  it("unready local-inference without a cloud session never arms a WAV capture (#16524)", async () => {
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/local-inference/status")) {
+        return new Response(JSON.stringify({ ready: false }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        cloudConnected: false,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "local-inference" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+
+    // No cloud fallback to lean on: the WAV recorder must not arm (there is
+    // nothing that could transcribe it) — legacy behavior preserved.
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.anything(),
+    );
+  });
+
+  it("never probes local readiness nor arms a recorder without WAV capture primitives (#16524)", async () => {
+    // No getUserMedia/AudioContext → no WAV route can serve ANY provider; the
+    // readiness probe must not even fire (nothing could record the audio).
+    isLocalAsrCaptureSupportedMock.mockReturnValue(false);
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        cloudConnected: true,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "local-inference" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+  });
+
+  it("a second startListening while capture is armed is a no-op (single recorder)", async () => {
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/local-inference/status")) {
+        return new Response(JSON.stringify({ ready: false }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        cloudConnected: true,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "local-inference" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+      await result.current.startListening("push-to-talk");
+    });
+
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not submit a turn when the cloud proxy fails (no silent browser downgrade)", async () => {
     startLocalAsrRecorderMock.mockResolvedValue({
       stop: vi.fn().mockResolvedValue(new Uint8Array([1])),

--- a/packages/ui/src/hooks/useVoiceChat.local-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.local-asr.test.tsx
@@ -60,6 +60,9 @@ describe("useVoiceChat local ASR", () => {
       useVoiceChat({
         onTranscript,
         onTranscriptPreview,
+        // Pinned: this suite asserts the LOCAL route; without a cloud session
+        // an unready local-inference must not degrade to cloud (#16524).
+        cloudConnected: false,
         voiceConfig: {
           provider: "local-inference",
           asr: { provider: "local-inference" },

--- a/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
@@ -75,6 +75,10 @@ describe("useVoiceChat — app-suspend capture teardown (#voice-V1)", () => {
     const { result } = renderHook(() =>
       useVoiceChat({
         onTranscript,
+        // Explicit cloud provider → the WAV cloud route under the shared
+        // resolution rule with or without a session flag (#16524); the pin
+        // keeps this suite's routing assumption visible.
+        cloudConnected: false,
         voiceConfig: {
           provider: "eliza-cloud",
           asr: { provider: "eliza-cloud" },

--- a/packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx
@@ -89,8 +89,12 @@ describe("useVoiceChat talk-mode listener registration (FIX 1)", () => {
   });
 
   it("serializes concurrent registration passes — exactly three listeners, all removable", async () => {
+    // cloudConnected pinned false: talk-mode capture is reached only when no
+    // WAV ASR route resolves for the config (#16524) — a cloud session here
+    // would be irrelevant (unset provider), but the pin keeps this suite's
+    // cascade assumption explicit as the shared routing rule evolves.
     const { result, unmount } = renderHook(() =>
-      useVoiceChat({ onTranscript: vi.fn() }),
+      useVoiceChat({ onTranscript: vi.fn(), cloudConnected: false }),
     );
 
     // Two overlapping starts: both pass the enabledRef guard (neither has

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -120,6 +120,7 @@ import {
   type VoiceTurn,
   webSpeechVoiceDebugFields,
 } from "../voice/voice-chat-types";
+import { resolveWavAsrRoute } from "../voice/voice-provider-defaults";
 
 // ── Re-exports (public API) ──────────────────────────────────────────
 
@@ -435,6 +436,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   // Voice config ref (latest value always available to callbacks)
   const voiceConfigRef = useRef<VoiceConfig | null>(effectiveVoiceConfig);
   voiceConfigRef.current = effectiveVoiceConfig;
+  // Cloud-session ref for capture-time route resolution (#16524): whether the
+  // cloud STT proxy is a viable fallback when local-inference is unready.
+  const cloudConnectedRef = useRef(options.cloudConnected === true);
+  cloudConnectedRef.current = options.cloudConnected === true;
   const interruptOnSpeechRef = useRef(options.interruptOnSpeech ?? true);
   interruptOnSpeechRef.current = options.interruptOnSpeech ?? true;
   const onUserSpeechInterruptRef = useRef(options.onUserSpeechInterrupt);
@@ -1010,21 +1015,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     [],
   );
 
+  // Arms the local-inference WAV recorder. Route eligibility (provider choice,
+  // capture support, server readiness) is resolved ONCE by `startListening`
+  // via the shared `resolveWavAsrRoute` rule — this only owns the recorder.
   const startLocalInferenceRecognition = useCallback(
     async (mode: Exclude<VoiceCaptureMode, "idle">) => {
-      if (!shouldUseLocalInferenceAsr(voiceConfigRef.current)) {
-        return false;
-      }
-      if (!isLocalAsrCaptureSupported()) {
-        return false;
-      }
-      // Defer to the next backend (talk-mode / browser) when the server can't
-      // transcribe right now — capturing here would only 502 at stop() with no
-      // recoverable fallback (no local ASR assets / native adapter installed).
-      if (!(await isLocalInferenceAsrReady())) {
-        return false;
-      }
-
       try {
         const recorder = await startLocalAsrRecorder();
         localAsrRecorderRef.current = recorder;
@@ -1062,16 +1057,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   // recognizer is engine-dependent (and unreliable/absent on iOS PWA), so a
   // cloud config must not fall through to it. Reuses `localAsrRecorderRef` for
   // the mic recorder; `sttBackendRef` = "cloud" routes the stop-time transcribe.
+  // Route eligibility lives in `startListening`'s `resolveWavAsrRoute` call.
   const startCloudRecognition = useCallback(
     async (mode: Exclude<VoiceCaptureMode, "idle">) => {
-      if (!shouldUseCloudAsr(voiceConfigRef.current)) {
-        return false;
-      }
-      // No WAV capture primitives (no getUserMedia / AudioContext) → there is no
-      // WAV to POST; defer to the browser recognizer as the sole client option.
-      if (!isLocalAsrCaptureSupported()) {
-        return false;
-      }
       try {
         const recorder = await startLocalAsrRecorder();
         localAsrRecorderRef.current = recorder;
@@ -1293,27 +1281,56 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       // first fork the on-screen HUD needs: a cloud-STT config that silently
       // fell through to the browser recognizer (absent on iOS PWA) is a classic
       // crickets cause. `asrProvider` is the resolved value that decides it.
+      const asrProvider = voiceConfigRef.current?.asr?.provider;
+      const captureSupported = isLocalAsrCaptureSupported();
       voiceCaptureDebug("start:enter", {
         mode,
-        asrProvider: voiceConfigRef.current?.asr?.provider ?? null,
-        captureSupported: isLocalAsrCaptureSupported(),
+        asrProvider: asrProvider ?? null,
+        captureSupported,
         preferNative: shouldPreferNativeTalkMode(),
       });
 
-      const localStarted = await startLocalInferenceRecognition(mode);
-      if (localStarted) {
-        voiceCaptureDebug("provider:local-inference", { mode });
-        return;
-      }
+      // Resolve the WAV route ONCE via the rule shared with the hook-free
+      // capture factory (#16524): explicit local-inference stays local while
+      // the server reports ready; selected-but-unready degrades to the cloud
+      // WAV route when a cloud session exists, instead of stranding capture on
+      // browser SpeechRecognition (absent on Safari/iOS PWA). The readiness
+      // probe (GET /api/asr/local-inference/status) only fires when the config
+      // actually selects local-inference.
+      const localInferenceReady =
+        shouldUseLocalInferenceAsr(voiceConfigRef.current) && captureSupported
+          ? await isLocalInferenceAsrReady()
+          : false;
+      const wavRoute = resolveWavAsrRoute({
+        provider: asrProvider,
+        cloudConnected: cloudConnectedRef.current,
+        captureSupported,
+        localInferenceReady,
+      });
 
-      // Cloud STT (`eliza-cloud` / `openai`): the deterministic transcriber for
-      // that config default. Selected ahead of talk-mode/browser so a cloud
-      // config on the PWA records a WAV for `/api/asr/cloud` instead of falling
-      // through to the engine-dependent browser recognizer.
-      const cloudStarted = await startCloudRecognition(mode);
-      if (cloudStarted) {
-        voiceCaptureDebug("provider:cloud", { mode });
-        return;
+      if (wavRoute === "local-inference") {
+        const localStarted = await startLocalInferenceRecognition(mode);
+        if (localStarted) {
+          voiceCaptureDebug("provider:local-inference", { mode });
+          return;
+        }
+      } else if (wavRoute === "cloud") {
+        // Cloud STT: the deterministic transcriber for the `eliza-cloud` /
+        // `openai` config default AND the forced fallback for an unready
+        // explicit local-inference choice. Selected ahead of talk-mode/browser
+        // so the capture records a WAV for `/api/asr/cloud` instead of falling
+        // through to the engine-dependent browser recognizer.
+        const cloudStarted = await startCloudRecognition(mode);
+        if (cloudStarted) {
+          voiceCaptureDebug("provider:cloud", {
+            mode,
+            note:
+              asrProvider === "local-inference"
+                ? "local-inference unready — cloud WAV fallback"
+                : undefined,
+          });
+          return;
+        }
       }
 
       if (shouldPreferNativeTalkMode()) {

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -174,6 +174,64 @@ describe("createVoiceCapture", () => {
     expect(onStateChange).toHaveBeenLastCalledWith("error", expect.any(Error));
   });
 
+  it("unready local-inference degrades to the cloud WAV route when cloudConnected (#16524)", async () => {
+    // The staging-Safari dead-mic shape: the persisted config pins
+    // local-inference, the cloud agent has no local ASR runtime, and the
+    // browser has no SpeechRecognition engine. With a cloud session declared,
+    // resolution must arm the SAME WAV recorder and hand the audio to the
+    // cloud transcriber — never fall through to the absent browser engine.
+    isLocalInferenceAsrReadyMock.mockResolvedValue(false);
+    const wav = new Uint8Array([7, 7, 7]);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(wav),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "local-inference",
+      cloudConnected: true,
+      onTranscript,
+    });
+
+    await capture.start();
+    expect(isLocalInferenceAsrReadyMock).toHaveBeenCalledTimes(1);
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+
+    await capture.stop();
+    expect(transcribeCloudWavMock).toHaveBeenCalledWith(wav);
+    expect(transcribeLocalInferenceWavMock).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenCalledWith({
+      text: "Grace Hopper",
+      final: true,
+      backend: "cloud",
+      audioWav: wav,
+    });
+  });
+
+  it("ready local-inference stays local even when cloudConnected (#16524)", async () => {
+    const wav = new Uint8Array([5, 5]);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(wav),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "local-inference",
+      cloudConnected: true,
+      onTranscript,
+    });
+
+    await capture.start();
+    await capture.stop();
+    expect(transcribeLocalInferenceWavMock).toHaveBeenCalledWith(wav);
+    expect(transcribeCloudWavMock).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ final: true, backend: "local-inference" }),
+    );
+  });
+
   it("prefers native TalkMode on a native platform and streams interim + final", async () => {
     isNativePlatformMock.mockReturnValue(true);
     const talkMode = makeFakeTalkMode();

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -51,6 +51,7 @@ import {
   type SpeechRecognitionResultEvent,
   TALKMODE_STOP_SETTLE_MS,
 } from "./voice-chat-types";
+import { resolveWavAsrRoute } from "./voice-provider-defaults";
 
 /** Backend the factory ended up using for the current capture. */
 export type VoiceCaptureBackend =
@@ -124,6 +125,15 @@ export interface VoiceCaptureFactoryOptions {
    * available (useful in tests / browsers without an Eliza API server).
    */
   asrProvider?: AsrProvider | "browser";
+  /**
+   * True when a cloud session with a working STT proxy (`/api/asr/cloud`)
+   * exists. Lets a `local-inference` preference whose server-side runtime is
+   * unavailable degrade to the cloud WAV route instead of falling through to
+   * browser SpeechRecognition (absent on Safari/iOS PWA) — see
+   * `resolveWavAsrRoute` (#16524). Default `false`: without a declared cloud
+   * session the resolution behaves exactly as before.
+   */
+  cloudConnected?: boolean;
   /** Locale string forwarded to the browser SpeechRecognition API. Default `en-US`. */
   lang?: string;
   localAsrAutoStop?: LocalAsrAutoStopOptions;
@@ -184,6 +194,7 @@ function isNativeTalkModeCaptureAvailable(): boolean {
 
 async function resolveBackendKind(
   preferred: AsrProvider | "browser" | undefined,
+  cloudConnected: boolean,
 ): Promise<VoiceCaptureBackend> {
   if (preferred === "browser") {
     return "browser";
@@ -195,27 +206,27 @@ async function resolveBackendKind(
   if (isNativeTalkModeCaptureAvailable()) {
     return "talkmode";
   }
-  // local-inference is the default elsewhere, but it needs BOTH the client
-  // mic-capture primitives AND a server that can actually transcribe. Probe the
-  // server's readiness (GET /api/asr/local-inference/status) so an unconfigured
-  // box (no local ASR assets / native adapter) degrades to browser SpeechRecognition
-  // instead of capturing audio it can only 502 on at stop().
-  if (
-    (preferred === "local-inference" || preferred === undefined) &&
-    isLocalAsrCaptureSupported() &&
-    (await isLocalInferenceAsrReady())
-  ) {
-    return "local-inference";
-  }
-  // Eliza-cloud / OpenAI ASR: capture the same WAV as the local path and POST
-  // it to the cloud STT proxy (`/api/asr/cloud`). This is the real transcriber
-  // for the documented web/cloud `eliza-cloud` default — the browser recognizer
-  // is engine-dependent (or absent) and is NOT the cloud path.
-  if (
-    (preferred === "eliza-cloud" || preferred === "openai") &&
-    isLocalAsrCaptureSupported()
-  ) {
-    return "cloud";
+  // WAV routing (local-inference vs the cloud STT proxy) is the shared rule in
+  // `resolveWavAsrRoute` — the same one `useVoiceChat` applies, so the two
+  // capture surfaces cannot diverge (#16524). local-inference needs BOTH the
+  // client mic-capture primitives AND a server that can actually transcribe
+  // (GET /api/asr/local-inference/status); an unready explicit local choice
+  // degrades to the cloud WAV route when a cloud session exists. The factory's
+  // documented default for an unset provider is the local-first preference.
+  const provider = preferred ?? "local-inference";
+  const captureSupported = isLocalAsrCaptureSupported();
+  const localInferenceReady =
+    provider === "local-inference" && captureSupported
+      ? await isLocalInferenceAsrReady()
+      : false;
+  const wavRoute = resolveWavAsrRoute({
+    provider,
+    cloudConnected,
+    captureSupported,
+    localInferenceReady,
+  });
+  if (wavRoute) {
+    return wavRoute;
   }
   // Browser SpeechRecognition is the fallback ONLY where no WAV path exists —
   // a renderer without `getUserMedia`/`AudioContext` can't record a WAV to POST,
@@ -231,6 +242,7 @@ export function createVoiceCapture(
     onStateChange,
     onSilentDrop,
     asrProvider,
+    cloudConnected = false,
     lang = "en-US",
     localAsrAutoStop,
     finalizeOnStop = false,
@@ -401,7 +413,7 @@ export function createVoiceCapture(
     if (active) return;
     setState("starting");
     try {
-      backendKind = await resolveBackendKind(asrProvider);
+      backendKind = await resolveBackendKind(asrProvider, cloudConnected);
       if (backendKind === "talkmode") {
         await startTalkMode();
       } else if (backendKind === "local-inference" || backendKind === "cloud") {

--- a/packages/ui/src/voice/voice-provider-defaults.test.ts
+++ b/packages/ui/src/voice/voice-provider-defaults.test.ts
@@ -9,6 +9,7 @@ import {
   type PresetRuntimeMode,
   pickDefaultVoiceProvider,
   resolveDefaultTtsProvider,
+  resolveWavAsrRoute,
   type VoiceCapabilitySnapshot,
 } from "./voice-provider-defaults";
 
@@ -289,5 +290,81 @@ describe("resolveDefaultTtsProvider — capability-aware default chain", () => {
         }
       }
     }
+  });
+});
+
+describe("resolveWavAsrRoute", () => {
+  const base = {
+    cloudConnected: false,
+    captureSupported: true,
+    localInferenceReady: false,
+  };
+
+  it("keeps an explicit local-inference choice local while the server is ready", () => {
+    expect(
+      resolveWavAsrRoute({
+        ...base,
+        provider: "local-inference",
+        localInferenceReady: true,
+        cloudConnected: true,
+      }),
+    ).toBe("local-inference");
+  });
+
+  it("degrades an unready local-inference choice to the cloud route when a cloud session exists (#16524)", () => {
+    expect(
+      resolveWavAsrRoute({
+        ...base,
+        provider: "local-inference",
+        cloudConnected: true,
+      }),
+    ).toBe("cloud");
+  });
+
+  it("returns no WAV route for an unready local-inference choice without a cloud session", () => {
+    expect(
+      resolveWavAsrRoute({ ...base, provider: "local-inference" }),
+    ).toBeNull();
+  });
+
+  it("routes eliza-cloud and openai to the cloud proxy", () => {
+    expect(resolveWavAsrRoute({ ...base, provider: "eliza-cloud" })).toBe(
+      "cloud",
+    );
+    expect(resolveWavAsrRoute({ ...base, provider: "openai" })).toBe("cloud");
+  });
+
+  it("returns no WAV route without capture primitives, whatever the provider", () => {
+    for (const provider of [
+      "local-inference",
+      "eliza-cloud",
+      "openai",
+    ] as const) {
+      expect(
+        resolveWavAsrRoute({
+          provider,
+          cloudConnected: true,
+          captureSupported: false,
+          localInferenceReady: true,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("returns no WAV route for a forced browser engine or an unset provider", () => {
+    expect(
+      resolveWavAsrRoute({
+        ...base,
+        provider: "browser",
+        cloudConnected: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveWavAsrRoute({
+        ...base,
+        provider: undefined,
+        cloudConnected: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/voice/voice-provider-defaults.ts
+++ b/packages/ui/src/voice/voice-provider-defaults.ts
@@ -190,3 +190,43 @@ export function resolveDefaultTtsProvider(
   // Terminal: the OS SpeechSynthesis voice always exists in a browser renderer.
   return BROWSER_TTS_PROVIDER;
 }
+
+/** The two WAV-recording interactive ASR routes a capture surface can arm. */
+export type WavAsrRoute = "local-inference" | "cloud";
+
+/**
+ * Resolve which WAV ASR route (if any) should serve an interactive capture,
+ * given the effective provider and what the runtime can do right now. This is
+ * the single fallback rule shared by BOTH capture surfaces — `useVoiceChat`'s
+ * `startListening` and `voice-capture-factory`'s backend resolution — so the
+ * two cannot diverge (#16524).
+ *
+ * The rule mirrors {@link resolveDefaultTtsProvider}'s contract: an
+ * unavailable backend is skipped, never selected-then-failed. Concretely:
+ *
+ *   - Explicit `local-inference` stays local while the server reports ready.
+ *   - `local-inference` selected but NOT ready degrades to the cloud WAV route
+ *     (`/api/asr/cloud`) when a cloud session exists — a persisted desktop
+ *     choice replayed against a cloud agent must not strand capture on the
+ *     engine-dependent browser recognizer (absent on Safari/iOS PWA).
+ *   - `eliza-cloud` / `openai` use the cloud WAV route, as before.
+ *   - `null` means no WAV route applies (no capture primitives, `browser`
+ *     forced, or an unready local choice with no cloud to fall back on) — the
+ *     caller proceeds to its own talk-mode/browser cascade.
+ */
+export function resolveWavAsrRoute(input: {
+  provider: AsrProvider | "browser" | undefined;
+  cloudConnected: boolean;
+  captureSupported: boolean;
+  localInferenceReady: boolean;
+}): WavAsrRoute | null {
+  if (!input.captureSupported) return null;
+  if (input.provider === "local-inference") {
+    if (input.localInferenceReady) return "local-inference";
+    return input.cloudConnected ? "cloud" : null;
+  }
+  if (input.provider === "eliza-cloud" || input.provider === "openai") {
+    return "cloud";
+  }
+  return null;
+}


### PR DESCRIPTION
# Relates to

Fixes #16524

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low-medium. Client-only change in `packages/ui` scoped to interactive ASR route resolution. Every pre-existing path is pinned by the existing suites (all 12 `useVoiceChat` lanes + factory pass unchanged in semantics): explicit cloud providers, ready local-inference, talk-mode precedence, browser fallback, and the unready-local-without-cloud case keep their exact previous behavior. The ONLY new behavior is `local-inference` selected + server unready + `cloudConnected` → the already-shipped cloud WAV route.

# Background

## What does this PR do?

A saved character voice config that pins `asr.provider = "local-inference"` left the mic completely dead on a cloud agent from Safari: the local readiness probe fails, `startCloudRecognition` refused to run (it only accepted `eliza-cloud`/`openai`), and the last fallback — browser `SpeechRecognition` — does not exist there, so the HUD emitted `provider:none`. `voice-capture-factory.resolveBackendKind` had the same gap.

The fix centralizes the WAV-route decision in one pure rule, `resolveWavAsrRoute` (in `voice-provider-defaults.ts`, next to the TTS chain that already embodies "an unavailable backend is skipped, never selected-then-failed"):

- Explicit `local-inference` stays local while `/api/asr/local-inference/status` reports ready.
- Selected-but-unready degrades to the existing cloud WAV route (`/api/asr/cloud`) when `cloudConnected` is true — never to the engine-dependent browser recognizer.
- `eliza-cloud`/`openai` route to cloud as before; no capture primitives or no fallback option → the caller's talk-mode/browser cascade, exactly as before.

Both capture surfaces now consume the same rule: `useVoiceChat.startListening` resolves the route once (the readiness probe fires only when the config selects local-inference), and `resolveBackendKind` delegates to it (new optional `cloudConnected` factory flag, default `false` = behavior unchanged for existing callers). The per-backend `start*Recognition` helpers lost their duplicated gates — route eligibility now has a single owner, which is what the issue asked for ("centralize provider resolution so the two capture surfaces cannot diverge").

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`resolveWavAsrRoute` in `packages/ui/src/voice/voice-provider-defaults.ts` (the whole rule, ~20 lines), then the acceptance tests from the issue: `useVoiceChat.cloud-asr.test.tsx` ("unready persisted local-inference degrades to the cloud WAV route…" — local-inference config + `cloudConnected` + `{ready:false}` + no `SpeechRecognition` ctor → WAV recorded, POSTed to `/api/asr/cloud`, final transcript `source: "cloud"`) and `voice-capture-factory.test.ts` ("unready local-inference degrades to the cloud WAV route when cloudConnected") with the same inputs through the hook-free factory.

New coverage: 6 rule unit tests, 5 hook tests (fallback, ready-stays-local, unready-without-cloud stays legacy, no-primitives never probes, double-start guard), 2 factory tests (fallback + ready-stays-local). The other `useVoiceChat` capture lanes (local-asr, bidirectional, talkmode-listeners, app-suspend, suspend) assert the `startListening` cascade this PR restructures — each now pins `cloudConnected` explicitly so their legacy-cascade assumptions stay pinned as the shared rule evolves, and they run in this PR's coverage lane as the refactor's regression surface.

## Detailed testing steps

None: Automated tests are acceptable.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no visual change; the fix is capture-route resolution logic (the before-state is a silent dead mic, not a renderable surface).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no visual change; behavior is asserted by the hook/factory tests including the exact acceptance scenario from #16524.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - requires the staging cloud-agent + Safari profile with a persisted local-inference config; the exact traced flow is reproduced deterministically in the added jsdom tests (no SpeechRecognition ctor + ready:false + cloudConnected).`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - client-only change; no server code touched. The client's HUD breadcrumbs (start:enter, provider:cloud with the fallback note) are exercised in the test lane output quoted below.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no live browser session to capture; the request flow (status probe GET, WAV POST to /api/asr/cloud) is asserted per test in the changed lanes, output quoted in Evidence Details.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; UI capture routing only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB/memory/task/on-chain output; the artifact is the WAV POST target asserted in tests.`

# Evidence Details

All 8 changed test lanes, single invocation:

```
✓ src/voice/voice-provider-defaults.test.ts
✓ src/voice/voice-capture-factory.test.ts
✓ src/hooks/useVoiceChat.cloud-asr.test.tsx
✓ src/hooks/useVoiceChat.local-asr.test.tsx
✓ src/hooks/useVoiceChat.bidirectional.test.tsx
✓ src/hooks/useVoiceChat.talkmode-listeners.test.tsx
✓ src/hooks/useVoiceChat.app-suspend.test.tsx
✓ src/hooks/useVoiceChat.suspend.test.tsx
Test Files  8 passed (8) — Tests  64 passed (64)
Coverage (changed sources, union of changed lanes):
  useVoiceChat.ts            50.3% lines
  voice-capture-factory.ts   63.7% lines
  voice-provider-defaults.ts rule fully covered
```

Full `packages/ui` vitest suite run locally: 824/827 files pass; the 3 failing files (`AppPageSidebar.resize`, `android-native-agent-transport`, `TasksEventsPanel.resize`, 18 tests) import none of the changed modules and fail identically without this change (pre-existing environment-sensitive suites).

## Known gaps / failures

`useVoiceChat.ts` sits at 50.3% whole-file line coverage from the changed lanes — right at the gate's floor. The uncovered half is the TTS/playback machinery this PR does not touch (the capture half is what the 6 hook lanes exercise); if the gate's measurement lands a hair differently on CI, that is the file-size dilution effect, not untested changed logic — happy to add lanes if maintainers prefer.

[stan-cloud]
