### PR TITLE
fix(agent): deduplicate subscription CLI bootstrap

### DIFF
--- a/packages/agent/src/api/accounts-routes.subscription-cli.test.ts
+++ b/packages/agent/src/api/accounts-routes.subscription-cli.test.ts
@@ -60,6 +60,40 @@ describe("ensureSubscriptionCli (#16518)", () => {
     expect(installs[0]).not.toContain("-g");
   });
 
+  it("deduplicates concurrent bootstrap attempts into one install", async () => {
+    let installs = 0;
+    let installed = false;
+    let releaseInstall: (() => void) | undefined;
+    let notifyInstallStarted: (() => void) | undefined;
+    const installGate = new Promise<void>((resolve) => {
+      releaseInstall = resolve;
+    });
+    const installStarted = new Promise<void>((resolve) => {
+      notifyInstallStarted = resolve;
+    });
+    const deps = {
+      isAvailable: async () => installed,
+      runInstall: async () => {
+        installs += 1;
+        notifyInstallStarted?.();
+        await installGate;
+        installed = true;
+      },
+    };
+
+    const first = ensureSubscriptionCli("anthropic-subscription", deps);
+    const second = ensureSubscriptionCli("anthropic-subscription", deps);
+    await installStarted;
+    expect(installs).toBe(1);
+
+    releaseInstall?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(installs).toBe(1);
+  });
+
   it("makes the tools bin dir visible on PATH for the later bare spawn, idempotently", async () => {
     await ensureSubscriptionCli("openai-codex", {
       isAvailable: async () => true,

--- a/packages/agent/src/api/accounts-routes.test.ts
+++ b/packages/agent/src/api/accounts-routes.test.ts
@@ -534,6 +534,9 @@ describe("accounts routes", () => {
       expect(started.errorCalls[0]?.message).toContain(
         "(SUBSCRIPTION_CLI_INSTALL_FAILED)",
       );
+      expect(started.errorCalls[0]?.message).not.toContain(
+        "/usr/lib/node_modules",
+      );
       expect(fakes.startFlow).not.toHaveBeenCalled();
     } finally {
       process.env.PATH = prevPath;

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -103,10 +103,13 @@ const subscriptionCliInstallFailures = new Map<
   string,
   { error: ElizaError; retryAt: number }
 >();
+/** Coalesce simultaneous OAuth starts so only one npm process runs per CLI. */
+const subscriptionCliInstallsInFlight = new Map<string, Promise<void>>();
 
-/** Test hook: forget cached install failures between tests. */
+/** Test hook: forget cached install state between tests. */
 export function __clearSubscriptionCliInstallFailures(): void {
   subscriptionCliInstallFailures.clear();
+  subscriptionCliInstallsInFlight.clear();
 }
 
 /**
@@ -153,6 +156,19 @@ export async function ensureSubscriptionCli(
     throw cached.error;
   }
 
+  const inFlight = subscriptionCliInstallsInFlight.get(command);
+  if (inFlight) return inFlight;
+  let resolveInstall!: () => void;
+  let rejectInstall!: (error: unknown) => void;
+  const install = new Promise<void>((resolve, reject) => {
+    resolveInstall = resolve;
+    rejectInstall = reject;
+  });
+  // error-policy:J5 -- the leader throws this error directly and concurrent
+  // followers observe it through `install`; suppress only an unobserved copy.
+  void install.catch(() => undefined);
+  subscriptionCliInstallsInFlight.set(command, install);
+
   const packageName =
     providerId === "openai-codex"
       ? "@openai/codex"
@@ -196,6 +212,8 @@ export async function ensureSubscriptionCli(
       error,
       retryAt: now() + SUBSCRIPTION_CLI_RETRY_COOLDOWN_MS,
     });
+    subscriptionCliInstallsInFlight.delete(command);
+    rejectInstall(error);
     throw error;
   }
   if (!(await isAvailable(command))) {
@@ -210,9 +228,13 @@ export async function ensureSubscriptionCli(
       error,
       retryAt: now() + SUBSCRIPTION_CLI_RETRY_COOLDOWN_MS,
     });
+    subscriptionCliInstallsInFlight.delete(command);
+    rejectInstall(error);
     throw error;
   }
   subscriptionCliInstallFailures.delete(command);
+  subscriptionCliInstallsInFlight.delete(command);
+  resolveInstall();
 }
 
 function requestUsesLocalRoot(req: RouteRequestContext["req"]): boolean {


### PR DESCRIPTION
# Relates to

Follow-up to #16518 and #16526.

- [x] Targets `develop` and is based on current `origin/develop` after #16526 merged.
- [x] Adds the missing concurrent-bootstrap acceptance case from #16518.
- [x] Codex gpt-5.5 reviewed commit `1d267205113` with no discrete regression.

# What changed

#16526 fixed the root-owned global npm install, but simultaneous OAuth starts could still each launch their own npm process. This follow-up coalesces bootstrap work per CLI through one in-flight promise and removes that entry after either success or failure. The existing five-minute failure cooldown, user-writable prefix, two-minute npm timeout, structured diagnostics, and PATH behavior are unchanged.

# Testing

```
bunx biome check packages/agent/src/api/accounts-routes.ts packages/agent/src/api/accounts-routes.subscription-cli.test.ts
Checked 2 files. No fixes applied.

bunx vitest run packages/agent/src/api/accounts-routes.subscription-cli.test.ts packages/agent/src/api/accounts-routes.test.ts
Test Files  2 passed (2)
Tests       19 passed (19)
```

The new test starts two Anthropic bootstrap calls behind a controlled install gate and proves exactly one install executes while both callers resolve.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-only bootstrap concurrency fix, no UI surface changed.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-only bootstrap concurrency fix, no UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow changed; concurrency behavior is covered by the scoped test lane.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no OAuth flow was initiated because that requires human interaction; the controlled install gate exercises the real mutex path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or network contract changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, action, provider, or inference behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no database, memory, scheduled task, or on-chain artifact changed.`

## Known gaps / failures

Package-local typecheck in this worktree is blocked by missing optional wallet-plugin dependencies in the shared node_modules tree. The prior #16526 full CI typecheck/build were green. This follow-up changes only the install mutex and its unit test, and the scoped import/transform/test lane is green.



