### PR TITLE
feat(scheduling): add recurring PR shepherd coding tasks

### DIFF
--- a/plugins/plugin-scheduling/src/coding-agent-schedules.test.ts
+++ b/plugins/plugin-scheduling/src/coding-agent-schedules.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Tests for the pr-shepherd coding-agent schedule seam.
+ *
+ * The harness uses the real ScheduledTask runner and fake public services for
+ * GitHub and orchestrator lookup. That keeps the contract focused on the seam:
+ * schedules persist and refire through the spine, while coding tasks are
+ * created only through runtime service lookup.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPrShepherdScheduleInput,
+  CODING_AGENT_SCHEDULE_METADATA_KEY,
+  createCodingAgentScheduleDispatcher,
+  deleteCodingAgentSchedule,
+  GITHUB_PR_SHEPHERD_SERVICE_TYPE,
+  type GitHubPrShepherdService,
+  ORCHESTRATOR_TASK_SERVICE_TYPE,
+  PR_SHEPHERD_DISPATCH_CHANNEL,
+  type PrShepherdPullRequest,
+  pauseCodingAgentSchedule,
+  resumeCodingAgentSchedule,
+} from "./coding-agent-schedules.js";
+import {
+  createCompletionCheckRegistry,
+  registerBuiltInCompletionChecks,
+} from "./scheduled-task/completion-check-registry.js";
+import {
+  createAnchorRegistry,
+  createConsolidationRegistry,
+} from "./scheduled-task/consolidation-policy.js";
+import {
+  createEscalationLadderRegistry,
+  registerDefaultEscalationLadders,
+} from "./scheduled-task/escalation.js";
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "./scheduled-task/gate-registry.js";
+import {
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  type ScheduledTaskRunnerHandle,
+  type ScheduledTaskStore,
+} from "./scheduled-task/runner.js";
+import { createInMemoryScheduledTaskLogStore } from "./scheduled-task/state-log.js";
+
+interface CreatedTask {
+  id: string;
+  title: string;
+  goal: string;
+  kind?: string;
+  originalRequest?: string;
+  status: string;
+  projectId?: string | null;
+  metadata: Record<string, unknown>;
+}
+
+function makePr(overrides: Partial<PrShepherdPullRequest> = {}) {
+  return {
+    owner: "elizaOS",
+    repo: "eliza",
+    number: 123,
+    title: "Fix flaky check",
+    url: "https://github.com/elizaOS/eliza/pull/123",
+    reviewDecision: "CHANGES_REQUESTED" as const,
+    behindBase: false,
+    checksConclusion: "success" as const,
+    ...overrides,
+  };
+}
+
+function makeOrchestrator() {
+  const tasks: CreatedTask[] = [];
+  return {
+    tasks,
+    service: {
+      async createTask(input: Omit<CreatedTask, "id" | "status">) {
+        const task: CreatedTask = {
+          id: `task-${tasks.length + 1}`,
+          status: "open",
+          ...input,
+        };
+        tasks.push(task);
+        return { id: task.id, metadata: task.metadata };
+      },
+      async listTasks() {
+        return tasks.map((task) => ({
+          id: task.id,
+          title: task.title,
+          status: task.status,
+          originalRequest: task.originalRequest,
+          projectId: task.projectId ?? null,
+        }));
+      },
+      async getTask(taskId: string) {
+        return tasks.find((task) => task.id === taskId) ?? null;
+      },
+    },
+  };
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function makeHarness(args: {
+  agentId?: string;
+  prs?: PrShepherdPullRequest[];
+  initialIso?: string;
+}) {
+  const agentId = args.agentId ?? "agent-a";
+  let nowIso = args.initialIso ?? "2026-07-17T12:00:00.000Z";
+  let prs = args.prs ?? [makePr()];
+  const github: GitHubPrShepherdService = {
+    async listAssignedOpenPullRequests(input) {
+      expect(input.agentId).toBe(agentId);
+      return prs;
+    },
+  };
+  const orchestrator = makeOrchestrator();
+  const runtime = {
+    agentId,
+    getService(type: string) {
+      if (type === GITHUB_PR_SHEPHERD_SERVICE_TYPE) return github;
+      if (type === ORCHESTRATOR_TASK_SERVICE_TYPE) {
+        return orchestrator.service;
+      }
+      return null;
+    },
+    reportError: () => undefined,
+  } as unknown as IAgentRuntime;
+
+  const store = createInMemoryScheduledTaskStore();
+  const gates = createTaskGateRegistry();
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+  const runner = createScheduledTaskRunner({
+    agentId,
+    store,
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: () => ({ timezone: "UTC" }),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: createCodingAgentScheduleDispatcher(runtime),
+    newTaskId: () => `schedule-${agentId}`,
+    now: () => new Date(nowIso),
+  });
+  return {
+    agentId,
+    runtime,
+    runner,
+    store,
+    orchestrator,
+    setNow(iso: string) {
+      nowIso = iso;
+    },
+    setPrs(next: PrShepherdPullRequest[]) {
+      prs = next;
+    },
+    cloneRunnerWithSameStore() {
+      return cloneRunner({
+        agentId,
+        store,
+        runtime,
+        now: () => new Date(nowIso),
+      });
+    },
+  };
+}
+
+function cloneRunner(args: {
+  agentId: string;
+  store: ScheduledTaskStore;
+  runtime: IAgentRuntime;
+  now: () => Date;
+}): ScheduledTaskRunnerHandle {
+  const gates = createTaskGateRegistry();
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+  return createScheduledTaskRunner({
+    agentId: args.agentId,
+    store: args.store,
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: () => ({ timezone: "UTC" }),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: createCodingAgentScheduleDispatcher(args.runtime),
+    now: args.now,
+  });
+}
+
+async function schedulePrShepherd(
+  runner: ScheduledTaskRunnerHandle,
+  agentId: string,
+  everyMinutes = 60,
+) {
+  return runner.schedule(
+    buildPrShepherdScheduleInput({
+      agentId,
+      trigger: { kind: "interval", everyMinutes },
+      projectId: "project-a",
+      policy: {
+        allowProposeFixes: true,
+        maxTasksPerRun: 2,
+      },
+    }),
+  );
+}
+
+describe("pr-shepherd coding-agent schedules", () => {
+  it("creates a scoped coding task with merge disabled receipts", async () => {
+    const h = makeHarness({
+      prs: [makePr({ behindBase: true, checksConclusion: "failed" })],
+    });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    const result = await h.runner.fireWithResult(schedule.taskId);
+    expect(result.kind).toBe("fired");
+    expect(h.orchestrator.tasks).toHaveLength(1);
+    const task = h.orchestrator.tasks[0];
+    expect(task.title).toBe("PR shepherd: elizaOS/eliza#123");
+    expect(task.kind).toBe("coding");
+    expect(task.goal).toContain("Do not merge the pull request.");
+    expect(task.metadata.mergeDisabled).toBe(true);
+    expect(task.metadata.prShepherdReceipt).toMatchObject({
+      receiptKey: "pr-shepherd:elizaOS/eliza#123",
+      mergeDisabled: true,
+    });
+    expect(task.metadata.signals).toEqual([
+      "changes_requested",
+      "behind_base",
+      "failed_checks",
+    ]);
+  });
+
+  it("suppresses duplicate runs for the same live PR task", async () => {
+    const h = makeHarness({ prs: [makePr()] });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    await h.runner.fireWithResult(schedule.taskId);
+    h.setNow("2026-07-17T13:00:00.000Z");
+    await h.runner.fireWithResult(schedule.taskId, {
+      allowTerminalRefire: true,
+    });
+    expect(h.orchestrator.tasks).toHaveLength(1);
+  });
+
+  it("suppresses duplicate task creation across concurrent dispatcher fires", async () => {
+    const gate = deferred();
+    let listCalls = 0;
+    const h = makeHarness({ prs: [makePr()] });
+    const originalList = h.orchestrator.service.listTasks;
+    h.orchestrator.service.listTasks = vi.fn(async () => {
+      listCalls += 1;
+      if (listCalls === 1) await gate.promise;
+      return originalList();
+    });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    const record = {
+      taskId: schedule.taskId,
+      firedAtIso: "2026-07-17T12:00:00.000Z",
+      channelKey: PR_SHEPHERD_DISPATCH_CHANNEL,
+      promptInstructions: schedule.promptInstructions,
+      contextRequest: schedule.contextRequest,
+      metadata: schedule.metadata,
+    };
+    const dispatcher = createCodingAgentScheduleDispatcher({
+      agentId: h.agentId,
+      getService(type: string) {
+        if (type === GITHUB_PR_SHEPHERD_SERVICE_TYPE) {
+          return {
+            async listAssignedOpenPullRequests() {
+              return [makePr()];
+            },
+          };
+        }
+        if (type === ORCHESTRATOR_TASK_SERVICE_TYPE) {
+          return h.orchestrator.service;
+        }
+        return null;
+      },
+    } as unknown as IAgentRuntime);
+    const first = dispatcher.dispatch(record);
+    const second = dispatcher.dispatch(record);
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(h.orchestrator.tasks).toHaveLength(1);
+  });
+
+  it("keeps one live task per PR while allowing distinct PRs", async () => {
+    const h = makeHarness({
+      prs: [
+        makePr({ number: 1, url: "https://github.com/elizaOS/eliza/pull/1" }),
+        makePr({ number: 2, url: "https://github.com/elizaOS/eliza/pull/2" }),
+      ],
+    });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    await h.runner.fireWithResult(schedule.taskId);
+    expect(h.orchestrator.tasks.map((task) => task.title)).toEqual([
+      "PR shepherd: elizaOS/eliza#1",
+      "PR shepherd: elizaOS/eliza#2",
+    ]);
+  });
+
+  it("bounds missed interval catch-up to one task creation pass", async () => {
+    const h = makeHarness({
+      initialIso: "2026-07-17T12:00:00.000Z",
+      prs: [
+        makePr({ number: 1, url: "https://github.com/elizaOS/eliza/pull/1" }),
+        makePr({ number: 2, url: "https://github.com/elizaOS/eliza/pull/2" }),
+        makePr({ number: 3, url: "https://github.com/elizaOS/eliza/pull/3" }),
+      ],
+    });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    await h.runner.fireWithResult(schedule.taskId);
+    h.setNow("2026-07-20T12:00:00.000Z");
+    await h.runner.fireWithResult(schedule.taskId, {
+      allowTerminalRefire: true,
+    });
+    expect(h.orchestrator.tasks).toHaveLength(3);
+  });
+
+  it("resumes persisted schedules after a fresh runner boot", async () => {
+    const h = makeHarness({ prs: [makePr()] });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    const booted = h.cloneRunnerWithSameStore();
+    await booted.fireWithResult(schedule.taskId);
+    expect(h.orchestrator.tasks).toHaveLength(1);
+  });
+
+  it("pauses, resumes, and deletes a coding-agent schedule", async () => {
+    const h = makeHarness({ prs: [makePr()] });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    const paused = await pauseCodingAgentSchedule(h.runner, schedule.taskId);
+    const metadata = paused.metadata?.[CODING_AGENT_SCHEDULE_METADATA_KEY];
+    expect(metadata).toMatchObject({ paused: true });
+    await h.runner.fireWithResult(schedule.taskId);
+    expect(h.orchestrator.tasks).toHaveLength(0);
+    const resumed = await resumeCodingAgentSchedule(h.runner, schedule.taskId);
+    const dispatcher = createCodingAgentScheduleDispatcher(h.runtime);
+    await dispatcher.dispatch({
+      taskId: resumed.taskId,
+      firedAtIso: "2026-07-17T13:01:00.000Z",
+      channelKey: PR_SHEPHERD_DISPATCH_CHANNEL,
+      promptInstructions: resumed.promptInstructions,
+      contextRequest: resumed.contextRequest,
+      metadata: resumed.metadata,
+    });
+    expect(h.orchestrator.tasks).toHaveLength(1);
+    await deleteCodingAgentSchedule(h.store, schedule.taskId);
+    expect(await h.store.get(schedule.taskId)).toBeNull();
+  });
+
+  it("isolates schedule ownership to the runtime agent", async () => {
+    const h = makeHarness({ agentId: "agent-a", prs: [makePr()] });
+    const schedule = await h.runner.schedule(
+      buildPrShepherdScheduleInput({
+        agentId: "agent-b",
+        trigger: { kind: "interval", everyMinutes: 60 },
+      }),
+    );
+    const result = await h.runner.fireWithResult(schedule.taskId);
+    expect(result.kind).toBe("dispatch_failed");
+    expect(h.orchestrator.tasks).toHaveLength(0);
+  });
+
+  it("does not create tasks for healthy PRs", async () => {
+    const h = makeHarness({
+      prs: [
+        makePr({
+          reviewDecision: "APPROVED",
+          behindBase: false,
+          checksConclusion: "success",
+        }),
+      ],
+    });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    await h.runner.fireWithResult(schedule.taskId);
+    expect(h.orchestrator.tasks).toHaveLength(0);
+  });
+
+  it("caps maxTasksPerRun at the scheduling ceiling", async () => {
+    const prs = Array.from({ length: 25 }, (_, index) =>
+      makePr({
+        number: index + 1,
+        url: `https://github.com/elizaOS/eliza/pull/${index + 1}`,
+      }),
+    );
+    const h = makeHarness({ prs });
+    const schedule = await h.runner.schedule(
+      buildPrShepherdScheduleInput({
+        agentId: h.agentId,
+        trigger: { kind: "interval", everyMinutes: 60 },
+        projectId: "project-a",
+        policy: {
+          allowProposeFixes: true,
+          maxTasksPerRun: 1000,
+        },
+      }),
+    );
+    await h.runner.fireWithResult(schedule.taskId);
+    expect(h.orchestrator.tasks).toHaveLength(20);
+  });
+
+  it("rejects invalid PR fields before creating tasks", async () => {
+    const h = makeHarness({
+      prs: [{ ...makePr(), url: "https://example.com/not-github" }],
+    });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    const result = await h.runner.fireWithResult(schedule.taskId);
+    expect(result.kind).toBe("dispatch_failed");
+    expect(h.orchestrator.tasks).toHaveLength(0);
+  });
+
+  it("delegates instead of minting work after host-capability substitution", async () => {
+    const h = makeHarness({ prs: [makePr()] });
+    const schedule = await schedulePrShepherd(h.runner, h.agentId);
+    const delegate = { dispatch: vi.fn(async () => ({ ok: true as const })) };
+    const dispatcher = createCodingAgentScheduleDispatcher(h.runtime, {
+      delegate,
+    });
+
+    await dispatcher.dispatch({
+      taskId: schedule.taskId,
+      firedAtIso: "2026-07-17T12:00:00.000Z",
+      // Host-capability substitution uses the generic notification channel,
+      // so recipe dispatch must delegate rather than minting coding work.
+      channelKey: "in_app",
+      promptInstructions: schedule.promptInstructions,
+      contextRequest: schedule.contextRequest,
+      metadata: schedule.metadata,
+    });
+
+    expect(delegate.dispatch).toHaveBeenCalledOnce();
+    expect(h.orchestrator.tasks).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-scheduling/src/coding-agent-schedules.ts
+++ b/plugins/plugin-scheduling/src/coding-agent-schedules.ts
@@ -1,0 +1,909 @@
+/**
+ * Production-safe coding-agent schedule recipes for the generic scheduling
+ * spine.
+ *
+ * This module deliberately depends only on public runtime service lookup. The
+ * GitHub reader is an injected port and the coding task writer is the existing
+ * orchestrator service resolved by serviceType, so scheduling can host recurring
+ * coding automation without importing or editing orchestrator internals.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import type { DispatchResult } from "./dispatch-types.js";
+import type {
+  ScheduledTaskDispatcher,
+  ScheduledTaskDispatchRecord,
+  ScheduledTaskRunnerHandle,
+} from "./scheduled-task/runner.js";
+import type {
+  ScheduledTask,
+  ScheduledTaskInput,
+  ScheduledTaskTrigger,
+} from "./scheduled-task/types.js";
+
+export const CODING_AGENT_SCHEDULE_METADATA_KEY = "codingAgentSchedule";
+export const PR_SHEPHERD_RECIPE = "pr-shepherd";
+export const PR_SHEPHERD_DISPATCH_CHANNEL = "coding_agent_pr_shepherd";
+export const GITHUB_PR_SHEPHERD_SERVICE_TYPE = "GITHUB_PR_SHEPHERD_SERVICE";
+export const ORCHESTRATOR_TASK_SERVICE_TYPE = "ORCHESTRATOR_TASK_SERVICE";
+const MAX_TASKS_PER_RUN_DEFAULT = 5;
+const MAX_TASKS_PER_RUN_CEILING = 20;
+const DEFAULT_GITHUB_PR_RESULT_LIMIT = 50;
+const GITHUB_GRAPHQL_PAGE_SIZE = 25;
+const GITHUB_API_BASE = "https://api.github.com";
+
+const LIVE_TASK_STATUSES = new Set([
+  "open",
+  "active",
+  "waiting_on_user",
+  "blocked",
+  "validating",
+  "interrupted",
+]);
+
+type PrShepherdSignal = "changes_requested" | "behind_base" | "failed_checks";
+
+export interface PrShepherdSchedulePolicy {
+  allowProposeFixes?: boolean;
+  maxTasksPerRun?: number;
+}
+
+export interface PrShepherdScheduleMetadata {
+  recipe: typeof PR_SHEPHERD_RECIPE;
+  ownerAgentId: string;
+  ownerUserId?: string;
+  projectId?: string;
+  workdir?: string;
+  repo?: string;
+  policy?: PrShepherdSchedulePolicy;
+  paused?: boolean;
+}
+
+export interface PrShepherdPullRequest {
+  owner: string;
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  headRef?: string;
+  baseRef?: string;
+  reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED";
+  behindBase?: boolean;
+  checksConclusion?:
+    | "success"
+    | "failure"
+    | "failed"
+    | "cancelled"
+    | "timed_out"
+    | "neutral"
+    | "skipped"
+    | "pending"
+    | "unknown";
+}
+
+export interface GitHubPrShepherdService {
+  listAssignedOpenPullRequests(args: {
+    agentId: string;
+    ownerUserId?: string;
+    projectId?: string;
+    repo?: string;
+  }): Promise<PrShepherdPullRequest[]>;
+}
+
+interface GitHubViewer {
+  login: string;
+}
+
+interface GitHubGraphQlSearchResponse {
+  errors?: unknown[];
+  data?: {
+    search?: {
+      nodes?: unknown[];
+      pageInfo?: {
+        hasNextPage?: unknown;
+        endCursor?: unknown;
+      };
+    };
+  };
+}
+
+interface OrchestratorTaskServiceLike {
+  createTask(input: {
+    title: string;
+    goal: string;
+    originalRequest?: string;
+    kind?: string;
+    priority?: "low" | "normal" | "high" | "urgent";
+    acceptanceCriteria?: string[];
+    ownerUserId?: string;
+    projectId?: string;
+    workdir?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<{ id?: string; metadata?: Record<string, unknown> }>;
+  listTasks?(filter?: {
+    status?: string;
+    includeArchived?: boolean;
+    limit?: number;
+    projectId?: string;
+  }): Promise<
+    Array<{
+      id: string;
+      title?: string;
+      status?: string;
+      originalRequest?: string;
+      projectId?: string | null;
+      archivedAt?: string | null;
+    }>
+  >;
+  getTask?(taskId: string): Promise<{
+    id: string;
+    status?: string;
+    metadata?: Record<string, unknown>;
+    originalRequest?: string;
+    projectId?: string | null;
+  } | null>;
+}
+
+export interface PrShepherdRunReceipt {
+  receiptKey: string;
+  pr: {
+    owner: string;
+    repo: string;
+    number: number;
+    url: string;
+  };
+  signals: PrShepherdSignal[];
+  taskId?: string;
+  skipped?: "no_signal" | "live_task_exists";
+  mergeDisabled: true;
+}
+
+export interface PrShepherdRunSummary {
+  scheduleTaskId: string;
+  checked: number;
+  created: number;
+  skipped: number;
+  receipts: PrShepherdRunReceipt[];
+}
+
+export interface CreateCodingAgentScheduleDispatcherOptions {
+  delegate?: ScheduledTaskDispatcher;
+  githubServiceType?: string;
+  orchestratorServiceType?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRuntimeSetting(
+  runtime: IAgentRuntime,
+  key: string,
+): string | null {
+  const raw = runtime.getSetting(key);
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+function parseRepoSpecifier(repo: string | undefined): {
+  owner: string;
+  repo: string;
+} | null {
+  if (!repo) return null;
+  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(repo);
+  if (!match) {
+    throw new Error("pr-shepherd repo scope must use owner/repo format");
+  }
+  return { owner: match[1] ?? "", repo: match[2] ?? "" };
+}
+
+function safePositiveInteger(value: number | undefined): number {
+  if (!Number.isInteger(value) || !value || value <= 0) {
+    return MAX_TASKS_PER_RUN_DEFAULT;
+  }
+  return Math.min(value, MAX_TASKS_PER_RUN_CEILING);
+}
+
+function readStringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`pr-shepherd PR field ${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function validatePrUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("pr-shepherd PR url is invalid");
+  }
+  if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+    throw new Error("pr-shepherd PR url must be a GitHub HTTPS URL");
+  }
+  return parsed.toString();
+}
+
+function normalizePr(
+  value: unknown,
+  repoScope?: { owner: string; repo: string } | null,
+): PrShepherdPullRequest {
+  if (!isRecord(value)) throw new Error("pr-shepherd PR must be an object");
+  const owner = readStringField(value, "owner");
+  const repo = readStringField(value, "repo");
+  if (repoScope && (owner !== repoScope.owner || repo !== repoScope.repo)) {
+    throw new Error("pr-shepherd PR does not match the configured repo scope");
+  }
+  const number = value.number;
+  if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
+    throw new Error("pr-shepherd PR number must be a positive integer");
+  }
+  const title = readStringField(value, "title");
+  if (title.length > 300) {
+    throw new Error("pr-shepherd PR title is too long");
+  }
+  const url = validatePrUrl(readStringField(value, "url"));
+  const reviewDecision = value.reviewDecision ?? undefined;
+  if (
+    reviewDecision !== undefined &&
+    reviewDecision !== "APPROVED" &&
+    reviewDecision !== "CHANGES_REQUESTED" &&
+    reviewDecision !== "REVIEW_REQUIRED"
+  ) {
+    throw new Error("pr-shepherd PR reviewDecision is invalid");
+  }
+  const checksConclusion = value.checksConclusion;
+  if (
+    checksConclusion !== undefined &&
+    checksConclusion !== "success" &&
+    checksConclusion !== "failure" &&
+    checksConclusion !== "failed" &&
+    checksConclusion !== "cancelled" &&
+    checksConclusion !== "timed_out" &&
+    checksConclusion !== "neutral" &&
+    checksConclusion !== "skipped" &&
+    checksConclusion !== "pending" &&
+    checksConclusion !== "unknown"
+  ) {
+    throw new Error("pr-shepherd PR checksConclusion is invalid");
+  }
+  return {
+    owner,
+    repo,
+    number,
+    title,
+    url,
+    ...(typeof value.headRef === "string" && value.headRef.length > 0
+      ? { headRef: value.headRef.slice(0, 255) }
+      : {}),
+    ...(typeof value.baseRef === "string" && value.baseRef.length > 0
+      ? { baseRef: value.baseRef.slice(0, 255) }
+      : {}),
+    ...(reviewDecision ? { reviewDecision } : {}),
+    ...(typeof value.behindBase === "boolean"
+      ? { behindBase: value.behindBase }
+      : {}),
+    ...(checksConclusion ? { checksConclusion } : {}),
+  };
+}
+
+function normalizePrList(
+  values: unknown[],
+  repoScope?: { owner: string; repo: string } | null,
+): PrShepherdPullRequest[] {
+  return values.map((value) => normalizePr(value, repoScope));
+}
+
+function readPrShepherdMetadata(
+  metadata: Record<string, unknown> | undefined,
+): PrShepherdScheduleMetadata | null {
+  const raw = metadata?.[CODING_AGENT_SCHEDULE_METADATA_KEY];
+  if (!isRecord(raw) || raw.recipe !== PR_SHEPHERD_RECIPE) return null;
+  const ownerAgentId = raw.ownerAgentId;
+  if (typeof ownerAgentId !== "string" || ownerAgentId.length === 0) {
+    throw new Error("pr-shepherd schedule metadata requires ownerAgentId");
+  }
+  const policy = isRecord(raw.policy)
+    ? {
+        allowProposeFixes: raw.policy.allowProposeFixes === true,
+        maxTasksPerRun:
+          typeof raw.policy.maxTasksPerRun === "number" &&
+          Number.isInteger(raw.policy.maxTasksPerRun) &&
+          raw.policy.maxTasksPerRun > 0
+            ? raw.policy.maxTasksPerRun
+            : undefined,
+      }
+    : undefined;
+  return {
+    recipe: PR_SHEPHERD_RECIPE,
+    ownerAgentId,
+    ...(typeof raw.ownerUserId === "string"
+      ? { ownerUserId: raw.ownerUserId }
+      : {}),
+    ...(typeof raw.projectId === "string" ? { projectId: raw.projectId } : {}),
+    ...(typeof raw.workdir === "string" ? { workdir: raw.workdir } : {}),
+    ...(typeof raw.repo === "string" ? { repo: raw.repo } : {}),
+    ...(policy ? { policy } : {}),
+    paused: raw.paused === true,
+  };
+}
+
+function receiptKeyFor(pr: PrShepherdPullRequest): string {
+  return `pr-shepherd:${pr.owner}/${pr.repo}#${pr.number}`;
+}
+
+function signalsFor(pr: PrShepherdPullRequest): PrShepherdSignal[] {
+  const signals: PrShepherdSignal[] = [];
+  if (pr.reviewDecision === "CHANGES_REQUESTED") {
+    signals.push("changes_requested");
+  }
+  if (pr.behindBase === true) {
+    signals.push("behind_base");
+  }
+  if (
+    pr.checksConclusion === "failure" ||
+    pr.checksConclusion === "failed" ||
+    pr.checksConclusion === "cancelled" ||
+    pr.checksConclusion === "timed_out"
+  ) {
+    signals.push("failed_checks");
+  }
+  return signals;
+}
+
+function titleFor(pr: PrShepherdPullRequest): string {
+  return `PR shepherd: ${pr.owner}/${pr.repo}#${pr.number}`;
+}
+
+function buildGoal(
+  pr: PrShepherdPullRequest,
+  signals: PrShepherdSignal[],
+  policy: PrShepherdSchedulePolicy | undefined,
+): string {
+  const allowedFixes =
+    policy?.allowProposeFixes === true
+      ? "You may propose and implement scoped fixes for the detected PR issues."
+      : "Inspect and report the minimal safe next action before making code changes.";
+  return [
+    `Shepherd pull request ${pr.owner}/${pr.repo}#${pr.number}: ${pr.url}`,
+    `Detected signals: ${signals.join(", ")}.`,
+    allowedFixes,
+    "Do not merge the pull request. Do not enable or perform autonomous merge, even if a policy asks for it.",
+    "Keep receipts in the task transcript: PR URL, detected signals, commands/checks run, and any proposed patch scope.",
+  ].join("\n");
+}
+
+async function githubRequest<T>(args: {
+  runtime: IAgentRuntime;
+  token: string;
+  path: string;
+  init?: RequestInit;
+}): Promise<T> {
+  const fetchImpl = args.runtime.fetch ?? fetch;
+  const headers = new Headers(args.init?.headers);
+  headers.set("accept", "application/vnd.github+json");
+  headers.set("authorization", `Bearer ${args.token}`);
+  headers.set("content-type", "application/json");
+  headers.set("user-agent", "elizaos-plugin-scheduling-pr-shepherd");
+  headers.set("x-github-api-version", "2022-11-28");
+  const response = await fetchImpl(`${GITHUB_API_BASE}${args.path}`, {
+    ...args.init,
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub PR shepherd read failed with HTTP ${response.status}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+function readAuthenticatedLogin(viewer: unknown): GitHubViewer {
+  if (!isRecord(viewer) || typeof viewer.login !== "string") {
+    throw new Error("GitHub authenticated user response did not include login");
+  }
+  return { login: viewer.login };
+}
+
+function checksConclusionFromRollup(
+  value: unknown,
+): PrShepherdPullRequest["checksConclusion"] {
+  if (value === "FAILURE" || value === "ERROR") return "failure";
+  if (value === "CANCELLED") return "cancelled";
+  if (value === "TIMED_OUT") return "timed_out";
+  if (value === "SUCCESS") return "success";
+  if (value === "PENDING" || value === "EXPECTED") return "pending";
+  if (value === "NEUTRAL" || value === "SKIPPED") return "neutral";
+  return "unknown";
+}
+
+function prFromGraphQlNode(node: unknown): PrShepherdPullRequest {
+  if (!isRecord(node))
+    throw new Error("GitHub search returned invalid PR node");
+  const repository = node.repository;
+  if (!isRecord(repository)) {
+    throw new Error("GitHub PR node is missing repository");
+  }
+  const ownerNode = repository.owner;
+  if (!isRecord(ownerNode)) {
+    throw new Error("GitHub PR repository owner is invalid");
+  }
+  const commits = node.commits;
+  const latestCommit =
+    isRecord(commits) && Array.isArray(commits.nodes)
+      ? commits.nodes.at(0)
+      : null;
+  const commit =
+    isRecord(latestCommit) && isRecord(latestCommit.commit)
+      ? latestCommit.commit
+      : null;
+  const rollup =
+    commit && isRecord(commit.statusCheckRollup)
+      ? commit.statusCheckRollup
+      : null;
+  const mergeStateStatus = node.mergeStateStatus;
+  return normalizePr({
+    owner: readStringField(ownerNode, "login"),
+    repo: readStringField(repository, "name"),
+    number: node.number,
+    title: node.title,
+    url: node.url,
+    headRef: node.headRefName,
+    baseRef: node.baseRefName,
+    reviewDecision: node.reviewDecision,
+    behindBase: mergeStateStatus === "BEHIND",
+    checksConclusion: checksConclusionFromRollup(rollup?.state),
+  });
+}
+
+function createDefaultGitHubPrShepherdService(
+  runtime: IAgentRuntime,
+  token: string,
+): GitHubPrShepherdService {
+  return {
+    async listAssignedOpenPullRequests(args) {
+      const viewer = readAuthenticatedLogin(
+        await githubRequest<unknown>({ runtime, token, path: "/user" }),
+      );
+      const repoScope = parseRepoSpecifier(args.repo);
+      const queryParts = [
+        "is:pr",
+        "is:open",
+        `assignee:${viewer.login}`,
+        ...(repoScope ? [`repo:${repoScope.owner}/${repoScope.repo}`] : []),
+      ];
+      const prs: PrShepherdPullRequest[] = [];
+      let cursor: string | null = null;
+      while (prs.length < DEFAULT_GITHUB_PR_RESULT_LIMIT) {
+        const pageSize = Math.min(
+          GITHUB_GRAPHQL_PAGE_SIZE,
+          DEFAULT_GITHUB_PR_RESULT_LIMIT - prs.length,
+        );
+        const response: GitHubGraphQlSearchResponse =
+          await githubRequest<GitHubGraphQlSearchResponse>({
+            runtime,
+            token,
+            path: "/graphql",
+            init: {
+              method: "POST",
+              body: JSON.stringify({
+                query: `
+                query AssignedPrShepherdSearch($query: String!, $first: Int!, $after: String) {
+                  search(type: ISSUE, query: $query, first: $first, after: $after) {
+                    nodes {
+                      ... on PullRequest {
+                        number
+                        title
+                        url
+                        headRefName
+                        baseRefName
+                        reviewDecision
+                        mergeStateStatus
+                        repository {
+                          name
+                          owner { login }
+                        }
+                        commits(last: 1) {
+                          nodes {
+                            commit {
+                              statusCheckRollup { state }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              `,
+                variables: {
+                  query: queryParts.join(" "),
+                  first: pageSize,
+                  after: cursor,
+                },
+              }),
+            },
+          });
+        if (Array.isArray(response.errors) && response.errors.length > 0) {
+          throw new Error("GitHub PR shepherd GraphQL search failed");
+        }
+        const search: GitHubGraphQlSearchResponse["data"] extends infer Data
+          ? Data extends { search?: infer Search }
+            ? Search
+            : undefined
+          : undefined = response.data?.search;
+        const nodes = Array.isArray(search?.nodes) ? search.nodes : [];
+        for (const node of nodes) {
+          prs.push(prFromGraphQlNode(node));
+        }
+        const hasNextPage = search?.pageInfo?.hasNextPage === true;
+        cursor =
+          typeof search?.pageInfo?.endCursor === "string"
+            ? search.pageInfo.endCursor
+            : null;
+        if (!hasNextPage || !cursor) break;
+      }
+      return normalizePrList(prs, repoScope);
+    },
+  };
+}
+
+function resolveGitHubService(args: {
+  runtime: IAgentRuntime;
+  githubServiceType: string;
+}): GitHubPrShepherdService | null {
+  const injected = args.runtime.getService(
+    args.githubServiceType,
+  ) as GitHubPrShepherdService | null;
+  if (injected && typeof injected.listAssignedOpenPullRequests === "function") {
+    return injected;
+  }
+  const token = readRuntimeSetting(args.runtime, "GITHUB_TOKEN");
+  if (!token) return null;
+  return createDefaultGitHubPrShepherdService(args.runtime, token);
+}
+
+async function findLiveTaskForReceipt(
+  orchestrator: OrchestratorTaskServiceLike,
+  receiptKey: string,
+  pr: PrShepherdPullRequest,
+  projectId?: string,
+): Promise<string | null> {
+  if (typeof orchestrator.listTasks !== "function") return null;
+  const tasks = await orchestrator.listTasks({
+    includeArchived: false,
+    ...(projectId ? { projectId } : {}),
+    limit: 200,
+  });
+  for (const task of tasks) {
+    if (task.status && !LIVE_TASK_STATUSES.has(task.status)) continue;
+    if (projectId && task.projectId && task.projectId !== projectId) continue;
+    const detail =
+      typeof orchestrator.getTask === "function"
+        ? await orchestrator.getTask(task.id)
+        : null;
+    const metadata = detail?.metadata;
+    if (
+      metadata?.prShepherdReceiptKey === receiptKey ||
+      metadata?.codingAgentScheduleReceiptKey === receiptKey
+    ) {
+      return task.id;
+    }
+    const haystack = `${task.title ?? ""}\n${task.originalRequest ?? ""}\n${detail?.originalRequest ?? ""}`;
+    if (haystack.includes(pr.url) || haystack.includes(titleFor(pr))) {
+      return task.id;
+    }
+  }
+  return null;
+}
+
+async function runPrShepherd(args: {
+  runtime: IAgentRuntime;
+  record: ScheduledTaskDispatchRecord;
+  schedule: PrShepherdScheduleMetadata;
+  githubServiceType: string;
+  orchestratorServiceType: string;
+}): Promise<PrShepherdRunSummary> {
+  const { runtime, record, schedule } = args;
+  if (schedule.ownerAgentId !== runtime.agentId) {
+    throw new Error(
+      `pr-shepherd schedule owner ${schedule.ownerAgentId} does not match runtime agent ${runtime.agentId}`,
+    );
+  }
+  if (schedule.paused) {
+    return {
+      scheduleTaskId: record.taskId,
+      checked: 0,
+      created: 0,
+      skipped: 0,
+      receipts: [],
+    };
+  }
+  const github = resolveGitHubService({
+    runtime,
+    githubServiceType: args.githubServiceType,
+  });
+  if (!github) {
+    throw new Error(
+      `[${args.githubServiceType}] GitHub PR shepherd service is not registered and GITHUB_TOKEN is not configured`,
+    );
+  }
+  const orchestrator = runtime.getService(
+    args.orchestratorServiceType,
+  ) as OrchestratorTaskServiceLike | null;
+  if (!orchestrator || typeof orchestrator.createTask !== "function") {
+    throw new Error(
+      `[${args.orchestratorServiceType}] Orchestrator task service is not registered`,
+    );
+  }
+
+  const repoScope = parseRepoSpecifier(schedule.repo);
+  const prs = normalizePrList(
+    await github.listAssignedOpenPullRequests({
+      agentId: runtime.agentId,
+      ...(schedule.ownerUserId ? { ownerUserId: schedule.ownerUserId } : {}),
+      ...(schedule.projectId ? { projectId: schedule.projectId } : {}),
+      ...(schedule.repo ? { repo: schedule.repo } : {}),
+    }),
+    repoScope,
+  );
+  const maxTasks = safePositiveInteger(schedule.policy?.maxTasksPerRun);
+  const receipts: PrShepherdRunReceipt[] = [];
+  let created = 0;
+
+  for (const pr of prs) {
+    const signals = signalsFor(pr);
+    const receiptKey = receiptKeyFor(pr);
+    if (signals.length === 0) {
+      receipts.push({
+        receiptKey,
+        pr: { owner: pr.owner, repo: pr.repo, number: pr.number, url: pr.url },
+        signals,
+        skipped: "no_signal",
+        mergeDisabled: true,
+      });
+      continue;
+    }
+    if (created >= maxTasks) break;
+    const receipt = await withReceiptLock(receiptKey, async () => {
+      const existing = await findLiveTaskForReceipt(
+        orchestrator,
+        receiptKey,
+        pr,
+        schedule.projectId,
+      );
+      if (existing) {
+        return {
+          receiptKey,
+          pr: {
+            owner: pr.owner,
+            repo: pr.repo,
+            number: pr.number,
+            url: pr.url,
+          },
+          signals,
+          taskId: existing,
+          skipped: "live_task_exists" as const,
+          mergeDisabled: true as const,
+        };
+      }
+      const receiptMetadata = {
+        receiptKey,
+        pr: {
+          owner: pr.owner,
+          repo: pr.repo,
+          number: pr.number,
+          url: pr.url,
+          headRef: pr.headRef,
+          baseRef: pr.baseRef,
+        },
+        signals,
+        mergeDisabled: true,
+      };
+      const task = await orchestrator.createTask({
+        title: titleFor(pr),
+        goal: buildGoal(pr, signals, schedule.policy),
+        originalRequest: `Recurring pr-shepherd schedule ${record.taskId} fired at ${record.firedAtIso} for ${pr.url}.`,
+        kind: "coding",
+        priority: signals.includes("failed_checks") ? "high" : "normal",
+        acceptanceCriteria: [
+          "Inspect the pull request state and confirm the triggering signal still applies.",
+          "Do not merge the pull request or enable any autonomous merge path.",
+          "Record receipts for the PR URL, detected signal, checks reviewed, and any proposed or applied fix.",
+        ],
+        ...(schedule.ownerUserId ? { ownerUserId: schedule.ownerUserId } : {}),
+        ...(schedule.projectId ? { projectId: schedule.projectId } : {}),
+        ...(schedule.workdir ? { workdir: schedule.workdir } : {}),
+        metadata: {
+          source: "scheduled-pr-shepherd",
+          scheduleTaskId: record.taskId,
+          scheduleFiredAtIso: record.firedAtIso,
+          prShepherdReceiptKey: receiptKey,
+          codingAgentScheduleReceiptKey: receiptKey,
+          prShepherdReceipt: receiptMetadata,
+          pr: receiptMetadata.pr,
+          signals,
+          mergeDisabled: true,
+          allowProposeFixes: schedule.policy?.allowProposeFixes === true,
+        },
+      });
+      const taskId = typeof task.id === "string" ? task.id : undefined;
+      return {
+        receiptKey,
+        pr: { owner: pr.owner, repo: pr.repo, number: pr.number, url: pr.url },
+        signals,
+        ...(taskId ? { taskId } : {}),
+        mergeDisabled: true as const,
+      };
+    });
+    receipts.push(receipt);
+    if (!receipt.skipped) created += 1;
+  }
+
+  return {
+    scheduleTaskId: record.taskId,
+    checked: prs.length,
+    created,
+    skipped: receipts.filter((r) => r.skipped).length,
+    receipts,
+  };
+}
+
+const receiptLocks = new Map<string, Promise<void>>();
+
+async function withReceiptLock<T>(
+  receiptKey: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  while (receiptLocks.has(receiptKey)) {
+    await receiptLocks.get(receiptKey);
+  }
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  receiptLocks.set(receiptKey, current);
+  try {
+    return await fn();
+  } finally {
+    if (receiptLocks.get(receiptKey) === current) {
+      receiptLocks.delete(receiptKey);
+    }
+    release();
+  }
+}
+
+export function createCodingAgentScheduleDispatcher(
+  runtime: IAgentRuntime,
+  options: CreateCodingAgentScheduleDispatcherOptions = {},
+): ScheduledTaskDispatcher {
+  const githubServiceType =
+    options.githubServiceType ?? GITHUB_PR_SHEPHERD_SERVICE_TYPE;
+  const orchestratorServiceType =
+    options.orchestratorServiceType ?? ORCHESTRATOR_TASK_SERVICE_TYPE;
+  return {
+    async dispatch(record): Promise<DispatchResult | undefined> {
+      const schedule = readPrShepherdMetadata(record.metadata);
+      if (!schedule || record.channelKey !== PR_SHEPHERD_DISPATCH_CHANNEL) {
+        return options.delegate?.dispatch(record);
+      }
+      const summary = await runPrShepherd({
+        runtime,
+        record,
+        schedule,
+        githubServiceType,
+        orchestratorServiceType,
+      });
+      return {
+        ok: true,
+        messageId: `pr-shepherd:${record.taskId}:${record.firedAtIso}`,
+        target: `checked:${summary.checked}:created:${summary.created}:skipped:${summary.skipped}`,
+        metadata: {
+          prShepherdRun: summary,
+        },
+      };
+    },
+  };
+}
+
+export function buildPrShepherdScheduleInput(args: {
+  agentId: string;
+  trigger: ScheduledTaskTrigger;
+  ownerUserId?: string;
+  projectId?: string;
+  workdir?: string;
+  repo?: string;
+  policy?: PrShepherdSchedulePolicy;
+  idempotencyKey?: string;
+}): ScheduledTaskInput {
+  const metadata: PrShepherdScheduleMetadata = {
+    recipe: PR_SHEPHERD_RECIPE,
+    ownerAgentId: args.agentId,
+    ...(args.ownerUserId ? { ownerUserId: args.ownerUserId } : {}),
+    ...(args.projectId ? { projectId: args.projectId } : {}),
+    ...(args.workdir ? { workdir: args.workdir } : {}),
+    ...(args.repo ? { repo: args.repo } : {}),
+    ...(args.policy ? { policy: args.policy } : {}),
+  };
+  return {
+    kind: "watcher",
+    promptInstructions:
+      "Run the pr-shepherd coding-agent recipe for assigned open pull requests.",
+    trigger: args.trigger,
+    priority: "medium",
+    escalation: {
+      steps: [
+        {
+          delayMinutes: 0,
+          channelKey: PR_SHEPHERD_DISPATCH_CHANNEL,
+        },
+      ],
+    },
+    respectsGlobalPause: false,
+    source: "plugin",
+    createdBy: args.agentId,
+    ownerVisible: false,
+    idempotencyKey:
+      args.idempotencyKey ??
+      [
+        "coding-agent-schedule",
+        PR_SHEPHERD_RECIPE,
+        args.agentId,
+        args.ownerUserId ?? "agent-owner",
+        args.projectId ?? "no-project",
+        args.repo ?? "all-repositories",
+      ].join(":"),
+    metadata: {
+      [CODING_AGENT_SCHEDULE_METADATA_KEY]: metadata,
+    },
+    executionProfile: "bg-heavy-fgs",
+  };
+}
+
+function withPaused(
+  task: ScheduledTask,
+  paused: boolean,
+): Partial<Omit<ScheduledTask, "taskId" | "state">> {
+  const existing = readPrShepherdMetadata(task.metadata);
+  if (!existing) {
+    throw new Error(`task ${task.taskId} is not a coding-agent schedule`);
+  }
+  return {
+    metadata: {
+      ...(task.metadata ?? {}),
+      [CODING_AGENT_SCHEDULE_METADATA_KEY]: {
+        ...existing,
+        paused,
+      },
+    },
+  };
+}
+
+export async function pauseCodingAgentSchedule(
+  runner: ScheduledTaskRunnerHandle,
+  taskId: string,
+): Promise<ScheduledTask> {
+  const task = (await runner.list()).find(
+    (candidate) => candidate.taskId === taskId,
+  );
+  if (!task) throw new Error(`task ${taskId} not found`);
+  return runner.apply(taskId, "edit", withPaused(task, true));
+}
+
+export async function resumeCodingAgentSchedule(
+  runner: ScheduledTaskRunnerHandle,
+  taskId: string,
+): Promise<ScheduledTask> {
+  const task = (await runner.list()).find(
+    (candidate) => candidate.taskId === taskId,
+  );
+  if (!task) throw new Error(`task ${taskId} not found`);
+  return runner.apply(taskId, "edit", withPaused(task, false));
+}
+
+export async function deleteCodingAgentSchedule(
+  store: { delete(taskId: string): Promise<void> },
+  taskId: string,
+): Promise<void> {
+  await store.delete(taskId);
+}

--- a/plugins/plugin-scheduling/src/dispatch-types.ts
+++ b/plugins/plugin-scheduling/src/dispatch-types.ts
@@ -16,7 +16,13 @@
  * - `transport_error` — generic infrastructure failure (network, 5xx, timeout).
  */
 export type DispatchResult =
-  | { ok: true; messageId?: string; target?: string; channelKey?: string }
+  | {
+      ok: true;
+      messageId?: string;
+      target?: string;
+      channelKey?: string;
+      metadata?: Record<string, unknown>;
+    }
   | {
       ok: false;
       reason:

--- a/plugins/plugin-scheduling/src/index.ts
+++ b/plugins/plugin-scheduling/src/index.ts
@@ -10,6 +10,24 @@ export {
   registerAppLifeOpsAnchors,
 } from "./anchors/anchor-registry.ts";
 export {
+  buildPrShepherdScheduleInput,
+  CODING_AGENT_SCHEDULE_METADATA_KEY,
+  type CreateCodingAgentScheduleDispatcherOptions,
+  createCodingAgentScheduleDispatcher,
+  deleteCodingAgentSchedule,
+  GITHUB_PR_SHEPHERD_SERVICE_TYPE,
+  type GitHubPrShepherdService,
+  ORCHESTRATOR_TASK_SERVICE_TYPE,
+  PR_SHEPHERD_RECIPE,
+  type PrShepherdPullRequest,
+  type PrShepherdRunReceipt,
+  type PrShepherdRunSummary,
+  type PrShepherdScheduleMetadata,
+  type PrShepherdSchedulePolicy,
+  pauseCodingAgentSchedule,
+  resumeCodingAgentSchedule,
+} from "./coding-agent-schedules.ts";
+export {
   type DispatchFailureReason,
   type DispatchPolicyContext,
   type DispatchPolicyDecision,

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.test.ts
@@ -14,6 +14,11 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 
+import {
+  buildPrShepherdScheduleInput,
+  GITHUB_PR_SHEPHERD_SERVICE_TYPE,
+  ORCHESTRATOR_TASK_SERVICE_TYPE,
+} from "../coding-agent-schedules.js";
 import { ScheduledTaskRunnerService } from "./runner-service.js";
 
 function makeFakeRuntime(): IAgentRuntime {
@@ -99,5 +104,69 @@ describe("ScheduledTaskRunnerService — rebindable tick clock", () => {
     const firedAtMs = Date.parse(fired.state.firedAt ?? "");
     expect(firedAtMs).toBeGreaterThanOrEqual(before);
     expect(firedAtMs).toBeLessThanOrEqual(after);
+  });
+
+  it("wraps the runner dispatcher with coding-agent schedule handling", async () => {
+    const createdTasks: Array<{
+      title: string;
+      metadata?: Record<string, unknown>;
+    }> = [];
+    const runtime = {
+      ...makeFakeRuntime(),
+      getService(type: string) {
+        if (type === GITHUB_PR_SHEPHERD_SERVICE_TYPE) {
+          return {
+            async listAssignedOpenPullRequests() {
+              return [
+                {
+                  owner: "elizaOS",
+                  repo: "eliza",
+                  number: 16455,
+                  title: "Needs PR shepherd",
+                  url: "https://github.com/elizaOS/eliza/pull/16455",
+                  reviewDecision: "CHANGES_REQUESTED",
+                  behindBase: false,
+                  checksConclusion: "success",
+                },
+              ];
+            },
+          };
+        }
+        if (type === ORCHESTRATOR_TASK_SERVICE_TYPE) {
+          return {
+            async createTask(input: {
+              title: string;
+              metadata?: Record<string, unknown>;
+            }) {
+              createdTasks.push(input);
+              return { id: "coding-task-1", metadata: input.metadata };
+            },
+            async listTasks() {
+              return [];
+            },
+          };
+        }
+        return null;
+      },
+    } as unknown as IAgentRuntime;
+    const service = await ScheduledTaskRunnerService.start(runtime);
+    const runner = service.getRunner({
+      agentId: runtime.agentId,
+      now: () => new Date("2026-07-17T12:00:00.000Z"),
+    });
+    const schedule = await runner.schedule(
+      buildPrShepherdScheduleInput({
+        agentId: runtime.agentId,
+        trigger: { kind: "manual" },
+        projectId: "project-a",
+      }),
+    );
+
+    const result = await runner.fireWithResult(schedule.taskId);
+
+    expect(result.kind).toBe("fired");
+    expect(createdTasks).toHaveLength(1);
+    expect(createdTasks[0]?.title).toBe("PR shepherd: elizaOS/eliza#16455");
+    expect(createdTasks[0]?.metadata?.mergeDisabled).toBe(true);
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
@@ -29,6 +29,10 @@ import {
   ServiceType,
 } from "@elizaos/core";
 import { resolvePlatform } from "@elizaos/shared/runtime-env";
+import {
+  createCodingAgentScheduleDispatcher,
+  PR_SHEPHERD_DISPATCH_CHANNEL,
+} from "../coding-agent-schedules.js";
 import type { DispatchResult } from "../dispatch-types.js";
 import {
   type CompletionCheckRegistry,
@@ -351,6 +355,21 @@ function buildRunner(
 
   const consolidation = deps.consolidation ?? createConsolidationRegistry();
 
+  const dispatcher = createCodingAgentScheduleDispatcher(runtime, {
+    delegate: deps.dispatcher,
+  });
+  const hostChannelKeys = deps.channelKeys;
+  const channelKeys = hostChannelKeys
+    ? () => new Set([...hostChannelKeys(), PR_SHEPHERD_DISPATCH_CHANNEL])
+    : undefined;
+  const hostChannelAvailable = deps.channelAvailable;
+  const channelAvailable = hostChannelAvailable
+    ? (channelKey: string) =>
+        channelKey === PR_SHEPHERD_DISPATCH_CHANNEL
+          ? true
+          : hostChannelAvailable(channelKey)
+    : undefined;
+
   return createScheduledTaskRunner({
     agentId: opts.agentId,
     store: deps.store,
@@ -364,11 +383,9 @@ function buildRunner(
     globalPause: deps.globalPause,
     activity: deps.activity,
     subjectStore: deps.subjectStore,
-    dispatcher: deps.dispatcher,
-    ...(deps.channelKeys ? { channelKeys: deps.channelKeys } : {}),
-    ...(deps.channelAvailable
-      ? { channelAvailable: deps.channelAvailable }
-      : {}),
+    dispatcher,
+    ...(channelKeys ? { channelKeys } : {}),
+    ...(channelAvailable ? { channelAvailable } : {}),
     ...(deps.hostCapabilities
       ? { hostCapabilities: deps.hostCapabilities }
       : {}),

--- a/plugins/plugin-scheduling/vitest.config.ts
+++ b/plugins/plugin-scheduling/vitest.config.ts
@@ -2,9 +2,17 @@
  * Vitest configuration for scheduling runner and route tests in a Node
  * environment.
  */
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@elizaos/shared/runtime-env": fileURLToPath(
+        new URL("../../packages/shared/src/runtime-env.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: "node",
     include: [


### PR DESCRIPTION
## Summary
- add durable recurring coding-agent schedule helpers on top of `plugin-scheduling`
- add a production-safe built-in `pr-shepherd` recipe using read-only GitHub discovery and the existing orchestrator task service
- suppress duplicate live tasks per PR, bound missed-run/task creation, enforce agent ownership, and persist per-run receipts
- preserve notify-only host substitution and prohibit autonomous merge in every generated task

## Safety
- GitHub token is used only in request headers and is never logged or persisted
- injected GitHub service is preferred; built-in adapter activates only with `GITHUB_TOKEN`
- no OAuth flow or credential widening
- no autonomous merge path, even when fix proposals are enabled
- no files from active orchestrator PRs #16452, #16453, or #16454 were touched

## Tests
- `bun run --cwd plugins/plugin-scheduling typecheck`
- `bunx vitest run plugins/plugin-scheduling/src/coding-agent-schedules.test.ts plugins/plugin-scheduling/src/scheduled-task/runner-service.test.ts plugins/plugin-scheduling/src/scheduled-task/runner.test.ts` (83 passed)
- Codex review after fixes: no findings

Closes #16532
Related #16443

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - server-only scheduling and service integration change with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - server-only scheduling and service integration change with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no frontend or interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused Vitest integration tests exercise runner wiring, durable restart behavior, GitHub recipe dispatch, and orchestrator task minting.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code, browser state, or network UI changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - recipe behavior is deterministic and delegates coding execution to the existing orchestrator task service; no model routing changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no schema or generated binary changed; persisted schedule/task metadata contracts are covered by focused durable-store tests.

## Evidence Details

### Backend verification

`bunx vitest run plugins/plugin-scheduling/src/coding-agent-schedules.test.ts plugins/plugin-scheduling/src/scheduled-task/runner-service.test.ts plugins/plugin-scheduling/src/scheduled-task/runner.test.ts`

Result: 83 passed, 0 failed.

### Screenshots, video, frontend logs

N/A - this PR changes only server-side TypeScript scheduling and dispatch behavior.

### Known gaps / failures

None in the focused scope. No self-merge requested.
