### PR TITLE
test(gpu): prove CUDA coverage continuity before retiring gpu-bench authority

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -157,9 +157,26 @@ separate purpose-built fleet and are unaffected by this policy.
 
 The retired `gpu-bench-nightly.yml` scaffold never ran substantive work on its
 schedule: both jobs required an opt-in manual dispatch and invoked removed
-`packages/inference` paths. Real CUDA benchmark continuity belongs to the
-current local-inference and voice benchmark surfaces and is tracked in #16449;
-do not restore the scaffold as a green scheduled placeholder.
+`packages/inference` paths. Do not restore that scaffold as a green scheduled
+placeholder.
+
+`cuda-continuity.yml` is the candidate single authority for real local-inference
+CUDA proof. Its inventory (`scripts/cuda-continuity-inventory.json`) maps both
+retired contexts to the exact-head GPU probe, native CUDA fixtures, and a
+model-backed runtime graph smoke. The run fails closed on a missing GPU/toolkit,
+CPU fallback, skipped graph/kernels, OOM/corruption, incomplete artifacts, or an
+artifact upload error. Because the current native builder no longer exposes a
+Linux CUDA target, dispatch requires a prebuilt binary directory; its recorded
+fork commit must equal the exact workflow head's native-source gitlink or the run
+fails. The resulting manifest records device, driver/toolkit, model, build
+capabilities/provenance, native logs, hashes, and the dispatched commit.
+
+Migration is intentionally two-phase: keep the existing opt-in CUDA leg in
+`local-inference-matrix.yml` until a credentialed `cuda-continuity.yml` run at
+the exact candidate head passes and a maintainer manually reviews the downloaded
+artifacts. Only then may the old leg be retired and the inventory's
+`migrationState` changed. A code-only/non-GPU contract pass is not hardware
+proof and must not close #16449.
 
 ### PR Path Gates
 

--- a/.github/workflows/cuda-continuity.yml
+++ b/.github/workflows/cuda-continuity.yml
@@ -1,0 +1,164 @@
+name: CUDA Coverage Continuity
+
+# Candidate single authority for local-inference CUDA coverage. Do not retire the
+# existing local-inference CUDA leg until an exact-head artifact from this
+# workflow has passed and been manually reviewed (elizaOS/eliza#16449).
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cuda-continuity.yml"
+      - ".github/workflows/README.md"
+      - "scripts/cuda-continuity*"
+      - "plugins/plugin-local-inference/native/verify/cuda_runner.sh"
+  push:
+    branches: [develop]
+    paths:
+      - ".github/workflows/cuda-continuity.yml"
+      - "scripts/cuda-continuity*"
+      - "plugins/plugin-local-inference/native/verify/cuda_runner.sh"
+  workflow_dispatch:
+    inputs:
+      smoke_model_path:
+        description: "Absolute path to a valid GGUF already staged on the GPU runner"
+        required: true
+        type: string
+      cuda_bin_dir:
+        description: "Absolute path to the prebuilt CUDA binaries and CAPABILITIES.json"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel an in-flight hardware proof. A cancelled/partial run cannot
+  # produce the validated manifest, but avoiding cancellation also preserves
+  # native logs for manual diagnosis.
+  group: cuda-continuity
+  cancel-in-progress: false
+
+env:
+  ELIZA_STATE_DIR: ${{ github.workspace }}/.eliza-state
+  CUDA_TARGET: linux-x64-cuda
+
+jobs:
+  contract:
+    name: Fail-closed manifest contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Validate inventory, workflow, and failure modes
+        run: |
+          set -euo pipefail
+          node --test scripts/cuda-continuity.test.mjs
+          node scripts/cuda-continuity.mjs validate-inventory
+          bash -n plugins/plugin-local-inference/native/verify/cuda_runner.sh
+
+  exact-head-cuda:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Exact-head CUDA fixtures + runtime graph
+    runs-on: [self-hosted, gpu-cuda-12.6]
+    timeout-minutes: 180
+    steps:
+      - name: Checkout dispatched head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: canary
+
+      - name: Exact-head GPU capability probe
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/cuda-continuity
+          node scripts/cuda-continuity.mjs probe \
+            --expected-head "$GITHUB_SHA" \
+            --output artifacts/cuda-continuity/cuda-probe.json
+
+      - name: Require staged, non-empty model input
+        env:
+          SMOKE_MODEL: ${{ inputs.smoke_model_path }}
+        run: |
+          set -euo pipefail
+          test -f "$SMOKE_MODEL"
+          test -s "$SMOKE_MODEL"
+          case "$SMOKE_MODEL" in *.gguf) ;; *) echo "model must be a GGUF" >&2; exit 1 ;; esac
+          sha256sum "$SMOKE_MODEL" | tee artifacts/cuda-continuity/model.sha256
+
+      - name: CUDA fixture parity and model-backed graph smoke
+        env:
+          ELIZA_MTP_SMOKE_MODEL: ${{ inputs.smoke_model_path }}
+          ELIZA_MTP_BIN_DIR: ${{ inputs.cuda_bin_dir }}
+          ELIZA_MTP_GRAPH_REPORT_DIR: ${{ github.workspace }}/artifacts/cuda-continuity/graph-smoke
+          # The repository's current build-llama-cpp-mtp script only supports
+          # iOS targets. Require a provenance-matched prebuilt CUDA directory
+          # rather than pretending an unsupported Linux rebuild succeeded.
+          CUDA_BUILD_FORK: "0"
+          CUDA_SKIP_GRAPH_SMOKE: "0"
+        run: |
+          set -euo pipefail
+          plugins/plugin-local-inference/native/verify/cuda_runner.sh \
+            --report "$GITHUB_WORKSPACE/artifacts/cuda-continuity/cuda-report.json" \
+            2>&1 | tee artifacts/cuda-continuity/native.log
+
+          # runtime_graph_smoke redirects backend output into per-command logs.
+          # Require those shards and append them to the hashed/scanned native log
+          # so a fallback or CUDA error cannot hide outside the manifest gate.
+          GRAPH_DIR="$GITHUB_WORKSPACE/artifacts/cuda-continuity/graph-smoke"
+          test -s "$GRAPH_DIR/${CUDA_TARGET}-graph-smoke.summary"
+          mapfile -d '' GRAPH_LOGS < <(find "$GRAPH_DIR" -type f -name '*.log' -print0 | sort -z)
+          test "${#GRAPH_LOGS[@]}" -ge 2
+          for graph_log in "${GRAPH_LOGS[@]}"; do
+            printf '\n===== graph-smoke/%s =====\n' "$(basename "$graph_log")" >> artifacts/cuda-continuity/native.log
+            cat "$graph_log" >> artifacts/cuda-continuity/native.log
+          done
+
+      - name: Collect exact build capabilities
+        env:
+          CUDA_BIN_DIR: ${{ inputs.cuda_bin_dir }}
+        run: |
+          set -euo pipefail
+          CAPABILITIES="$CUDA_BIN_DIR/CAPABILITIES.json"
+          test -s "$CAPABILITIES"
+          cp "$CAPABILITIES" artifacts/cuda-continuity/CAPABILITIES.json
+
+      - name: Assemble and validate continuity manifest
+        run: |
+          set -euo pipefail
+          node scripts/cuda-continuity.mjs assemble \
+            --expected-head "$GITHUB_SHA" \
+            --probe artifacts/cuda-continuity/cuda-probe.json \
+            --report artifacts/cuda-continuity/cuda-report.json \
+            --capabilities artifacts/cuda-continuity/CAPABILITIES.json \
+            --log artifacts/cuda-continuity/native.log \
+            --output artifacts/cuda-continuity/manifest.json
+          node scripts/cuda-continuity.mjs validate \
+            --expected-head "$GITHUB_SHA" \
+            --manifest artifacts/cuda-continuity/manifest.json
+
+      - name: Upload complete CUDA continuity evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cuda-continuity-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts/cuda-continuity/
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0

--- a/plugins/plugin-local-inference/native/verify/cuda_runner.sh
+++ b/plugins/plugin-local-inference/native/verify/cuda_runner.sh
@@ -25,6 +25,10 @@
 #                              graph-smoke log directory, default verify/hardware-results
 #   ELIZA_MTP_LLAMA_DIR     default ~/.cache/eliza-mtp/eliza-llama-cpp
 #   ELIZA_MTP_LIBGGML_CUDA  default $ELIZA_MTP_LLAMA_DIR/build-cuda/ggml/src/ggml-cuda/libggml-cuda.so
+#   ELIZA_MTP_BIN_DIR       optional exact prebuilt llama binary directory;
+#                           forwarded to runtime_graph_smoke.sh --bin-dir
+#   ELIZA_MTP_GRAPH_REPORT_DIR optional graph log directory; forwarded to
+#                           runtime_graph_smoke.sh --report-dir
 #   ELIZA_MTP_SMOKE_MODEL   required unless CUDA_SKIP_GRAPH_SMOKE=1
 #   ELIZA_MTP_SMOKE_CACHE_TYPES/TOKENS/NGL/PROMPT/EXTRA_ARGS
 #                              forwarded to runtime_graph_smoke.sh
@@ -187,6 +191,8 @@ if [[ -n "${CUDA_REMOTE:-}" ]]; then
         ELIZA_MTP_HARDWARE_REPORT_DIR='${ELIZA_MTP_HARDWARE_REPORT_DIR:-}' \
         ELIZA_MTP_LLAMA_DIR=$REMOTE_LLAMA_DIR \
         ELIZA_MTP_LIBGGML_CUDA='${ELIZA_MTP_LIBGGML_CUDA:-}' \
+        ELIZA_MTP_BIN_DIR='${ELIZA_MTP_BIN_DIR:-}' \
+        ELIZA_MTP_GRAPH_REPORT_DIR='${ELIZA_MTP_GRAPH_REPORT_DIR:-}' \
         ELIZA_MTP_SMOKE_MODEL='${ELIZA_MTP_SMOKE_MODEL:-}' \
         ELIZA_MTP_SMOKE_CACHE_TYPES='${ELIZA_MTP_SMOKE_CACHE_TYPES:-}' \
         ELIZA_MTP_SMOKE_TOKENS='${ELIZA_MTP_SMOKE_TOKENS:-}' \
@@ -249,7 +255,20 @@ if [[ "${CUDA_SKIP_GRAPH_SMOKE:-0}" == "1" ]]; then
     fail "CUDA_SKIP_GRAPH_SMOKE=1 — fixture parity only; graph dispatch NOT verified, so no hardware pass can be recorded"
 fi
 
+BIN_DIR_ARGS=()
+if [[ -n "${ELIZA_MTP_BIN_DIR:-}" ]]; then
+    [[ -d "$ELIZA_MTP_BIN_DIR" ]] || fail "ELIZA_MTP_BIN_DIR is not a directory: $ELIZA_MTP_BIN_DIR"
+    BIN_DIR_ARGS=(--bin-dir "$ELIZA_MTP_BIN_DIR")
+fi
+REPORT_DIR_ARGS=()
+if [[ -n "${ELIZA_MTP_GRAPH_REPORT_DIR:-}" ]]; then
+    mkdir -p "$ELIZA_MTP_GRAPH_REPORT_DIR"
+    REPORT_DIR_ARGS=(--report-dir "$ELIZA_MTP_GRAPH_REPORT_DIR")
+fi
+
 "$HERE/runtime_graph_smoke.sh" \
     --target "$CUDA_TARGET" \
     --backend-pattern 'CUDA|cuda|cuBLAS|ggml_cuda|NVIDIA' \
+    "${BIN_DIR_ARGS[@]}" \
+    "${REPORT_DIR_ARGS[@]}" \
     --gen-check

--- a/scripts/cuda-continuity-inventory.json
+++ b/scripts/cuda-continuity-inventory.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": 1,
+  "authority": {
+    "candidateWorkflow": ".github/workflows/cuda-continuity.yml",
+    "harness": "plugins/plugin-local-inference/native/verify/cuda_runner.sh",
+    "migrationState": "candidate-pending-exact-head-hardware-proof",
+    "retireOnlyAfter": "A successful exact-head cuda-continuity artifact manifest has been downloaded and manually reviewed."
+  },
+  "retiredContexts": [
+    {
+      "id": "gpu-bench-nightly.detect",
+      "previousClaim": "detect host GPU and print an autotune plan",
+      "replacementEvidence": ["exact-head", "cuda-probe", "capabilities"]
+    },
+    {
+      "id": "gpu-bench-nightly.bench",
+      "previousClaim": "voice-bench CUDA all-scenario benchmark",
+      "replacementEvidence": [
+        "cuda-fixtures",
+        "runtime-graph-smoke",
+        "native-log"
+      ]
+    }
+  ],
+  "supportedMatrix": [
+    {
+      "id": "rtx-3090-sm86",
+      "gpuProfile": "packages/shared/src/local-inference-gpu/profiles/rtx-3090.yaml",
+      "runtime": "linux-x64-cuda",
+      "backend": "llama.cpp CUDA local inference",
+      "architecture": "sm_86",
+      "minimumToolkit": "12.6",
+      "models": ["eliza-1-2b", "eliza-1-4b", "eliza-1-9b"]
+    },
+    {
+      "id": "rtx-4090-sm89",
+      "gpuProfile": "packages/shared/src/local-inference-gpu/profiles/rtx-4090.yaml",
+      "runtime": "linux-x64-cuda",
+      "backend": "llama.cpp CUDA local inference",
+      "architecture": "sm_89",
+      "minimumToolkit": "12.6",
+      "models": ["eliza-1-2b", "eliza-1-4b", "eliza-1-9b", "eliza-1-27b"]
+    },
+    {
+      "id": "h200-sm90",
+      "gpuProfile": "packages/shared/src/local-inference-gpu/profiles/h200.yaml",
+      "runtime": "linux-x64-cuda",
+      "backend": "llama.cpp CUDA local inference",
+      "architecture": "sm_90",
+      "minimumToolkit": "12.6",
+      "models": [
+        "eliza-1-2b",
+        "eliza-1-4b",
+        "eliza-1-9b",
+        "eliza-1-27b",
+        "eliza-1-27b-256k"
+      ]
+    },
+    {
+      "id": "rtx-5090-sm120",
+      "gpuProfile": "packages/shared/src/local-inference-gpu/profiles/rtx-5090.yaml",
+      "runtime": "linux-x64-cuda",
+      "backend": "llama.cpp CUDA local inference",
+      "architecture": "sm_120",
+      "minimumToolkit": "12.8",
+      "models": [
+        "eliza-1-2b",
+        "eliza-1-4b",
+        "eliza-1-9b",
+        "eliza-1-27b",
+        "eliza-1-27b-256k"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    "exact-head",
+    "cuda-probe",
+    "capabilities",
+    "cuda-fixtures",
+    "runtime-graph-smoke",
+    "native-log"
+  ],
+  "requiredKernels": [
+    "turbo3",
+    "turbo4",
+    "turbo3_tcq",
+    "qjl_full",
+    "polarquant",
+    "mtp"
+  ]
+}

--- a/scripts/cuda-continuity.mjs
+++ b/scripts/cuda-continuity.mjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const INVENTORY_PATH = path.join(HERE, "cuda-continuity-inventory.json");
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const COMMIT_RE = /^[a-f0-9]{40}$/;
+const FORBIDDEN_LOG_SIGNALS = [
+  /fallback(?:-| )to(?:-| )cpu/i,
+  /using cpu backend/i,
+  /cuda(?: device)? unavailable/i,
+  /out of memory/i,
+  /cuda error/i,
+  /corrupt(?:ed|ion)/i,
+  /SKIP(?:PED)?.*(?:gpu|cuda|kernel|graph)/i,
+];
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function capture(command, args = []) {
+  return execFileSync(command, args, { encoding: "utf8" }).trim();
+}
+
+function sha256(file) {
+  const hash = createHash("sha256");
+  hash.update(fs.readFileSync(file));
+  return hash.digest("hex");
+}
+
+function parseVersion(text, pattern, label) {
+  const value = text.match(pattern)?.[1];
+  if (!value) throw new Error(`could not parse ${label}`);
+  return value;
+}
+
+function inferProfile(name, computeCapability) {
+  const normalized = name.toLowerCase();
+  if (normalized.includes("3090")) return "rtx-3090-sm86";
+  if (normalized.includes("4090")) return "rtx-4090-sm89";
+  if (normalized.includes("5090")) return "rtx-5090-sm120";
+  if (normalized.includes("h200")) return "h200-sm90";
+  return `unlisted-sm${computeCapability.replace(".", "")}`;
+}
+
+export function collectProbe({ expectedHead = process.env.GITHUB_SHA } = {}) {
+  const head = capture("git", ["rev-parse", "HEAD"]);
+  const nativeSourceCommit = capture("git", [
+    "rev-parse",
+    "HEAD:plugins/plugin-local-inference/native/llama.cpp",
+  ]);
+  const nvidiaRows = capture("nvidia-smi", [
+    "--query-gpu=index,name,uuid,driver_version,compute_cap,memory.total",
+    "--format=csv,noheader,nounits",
+  ]);
+  if (!nvidiaRows) throw new Error("nvidia-smi reported no CUDA devices");
+  const devices = nvidiaRows.split(/\r?\n/).map((line) => {
+    const fields = line.split(",").map((value) => value.trim());
+    if (fields.length !== 6)
+      throw new Error(`malformed nvidia-smi row: ${line}`);
+    const [index, name, uuid, driverVersion, computeCapability, memoryMiB] =
+      fields;
+    return {
+      index: Number(index),
+      name,
+      uuid,
+      driverVersion,
+      computeCapability,
+      memoryMiB: Number(memoryMiB),
+      inventoryProfile: inferProfile(name, computeCapability),
+    };
+  });
+  const nvcc = capture("nvcc", ["--version"]);
+  const smi = capture("nvidia-smi");
+  const toolkitVersion = parseVersion(
+    nvcc,
+    /release\s+([0-9]+\.[0-9]+)/i,
+    "CUDA toolkit version",
+  );
+  const runtimeVersion = parseVersion(
+    smi,
+    /CUDA Version:\s*([0-9]+\.[0-9]+)/i,
+    "CUDA driver runtime version",
+  );
+  const exactHead = !expectedHead || head === expectedHead;
+  return {
+    schemaVersion: 1,
+    status: exactHead ? "pass" : "fail",
+    exactHead,
+    head,
+    expectedHead: expectedHead || head,
+    nativeSourceCommit,
+    repository: process.env.GITHUB_REPOSITORY || null,
+    workflowRun: {
+      id: process.env.GITHUB_RUN_ID || null,
+      attempt: process.env.GITHUB_RUN_ATTEMPT || null,
+      event: process.env.GITHUB_EVENT_NAME || null,
+    },
+    cuda: { toolkitVersion, driverRuntimeVersion: runtimeVersion },
+    devices,
+  };
+}
+
+export function validateInventory(inventory, { root = process.cwd() } = {}) {
+  const errors = [];
+  if (inventory?.schemaVersion !== 1)
+    errors.push("inventory schemaVersion must be 1");
+  if (
+    inventory?.authority?.candidateWorkflow !==
+    ".github/workflows/cuda-continuity.yml"
+  )
+    errors.push(
+      "candidate workflow must be .github/workflows/cuda-continuity.yml",
+    );
+  const retired = new Set(
+    (inventory?.retiredContexts || []).map((entry) => entry.id),
+  );
+  for (const id of ["gpu-bench-nightly.detect", "gpu-bench-nightly.bench"])
+    if (!retired.has(id)) errors.push(`retired context missing: ${id}`);
+  const matrix = inventory?.supportedMatrix || [];
+  const matrixIds = new Set(matrix.map((entry) => entry.id));
+  for (const id of [
+    "rtx-3090-sm86",
+    "rtx-4090-sm89",
+    "h200-sm90",
+    "rtx-5090-sm120",
+  ])
+    if (!matrixIds.has(id))
+      errors.push(`supported matrix entry missing: ${id}`);
+  for (const entry of matrix) {
+    if (!entry.gpuProfile || !fs.existsSync(path.join(root, entry.gpuProfile)))
+      errors.push(`GPU profile missing for ${entry.id}: ${entry.gpuProfile}`);
+    if (
+      !entry.architecture ||
+      !entry.minimumToolkit ||
+      !entry.backend ||
+      !entry.runtime
+    )
+      errors.push(`incomplete supported matrix entry: ${entry.id}`);
+  }
+  const workflowPath = path.join(
+    root,
+    inventory?.authority?.candidateWorkflow || "",
+  );
+  if (!fs.existsSync(workflowPath)) {
+    errors.push(`candidate workflow missing: ${workflowPath}`);
+  } else {
+    const workflow = fs.readFileSync(workflowPath, "utf8");
+    for (const contract of [
+      "runs-on: [self-hosted, gpu-cuda-12.6]",
+      "cancel-in-progress: false",
+      "cuda_runner.sh",
+      '--expected-head "$GITHUB_SHA"',
+      'CUDA_BUILD_FORK: "0"',
+      "ELIZA_MTP_BIN_DIR",
+      "ELIZA_MTP_GRAPH_REPORT_DIR",
+      'test -s "$GRAPH_DIR/${CUDA_TARGET}-graph-smoke.summary"',
+      'cat "$graph_log" >> artifacts/cuda-continuity/native.log',
+      'CUDA_SKIP_GRAPH_SMOKE: "0"',
+      "if-no-files-found: error",
+      "scripts/cuda-continuity.mjs validate",
+    ]) {
+      if (!workflow.includes(contract))
+        errors.push(`workflow continuity contract missing: ${contract}`);
+    }
+  }
+  const harnessPath = path.join(root, inventory?.authority?.harness || "");
+  if (!fs.existsSync(harnessPath))
+    errors.push(`CUDA harness missing: ${harnessPath}`);
+  if (errors.length) throw new Error(errors.join("\n"));
+  return true;
+}
+
+export function validateManifest(manifest, { expectedHead } = {}) {
+  const inventory = readJson(INVENTORY_PATH);
+  const errors = [];
+  if (manifest?.schemaVersion !== 1)
+    errors.push("manifest schemaVersion must be 1");
+  if (manifest?.status !== "pass") errors.push("manifest status is not pass");
+  if (!manifest?.exactHead || !COMMIT_RE.test(manifest?.head || ""))
+    errors.push("exact-head proof missing or invalid");
+  if (expectedHead && manifest?.head !== expectedHead)
+    errors.push(
+      `head ${manifest?.head} does not match expected ${expectedHead}`,
+    );
+  if (!manifest?.hardware?.devices?.length)
+    errors.push("no GPU device inventory");
+  if (!manifest?.hardware?.cuda?.toolkitVersion)
+    errors.push("CUDA toolkit version missing");
+  if (!manifest?.hardware?.cuda?.driverRuntimeVersion)
+    errors.push("CUDA driver runtime version missing");
+  if (
+    manifest?.nativeVerification?.status !== "pass" ||
+    manifest?.nativeVerification?.passRecordable !== true
+  )
+    errors.push("native CUDA verification is not a recordable pass");
+  if (manifest?.nativeVerification?.graphSmoke !== "required")
+    errors.push("runtime graph smoke was not completed");
+  if (!SHA256_RE.test(manifest?.nativeVerification?.modelSha256 || ""))
+    errors.push("model-backed graph smoke SHA-256 missing or invalid");
+  if (
+    !COMMIT_RE.test(manifest?.buildProvenance?.nativeSourceCommit || "") ||
+    manifest?.buildProvenance?.forkCommit !==
+      manifest?.buildProvenance?.nativeSourceCommit
+  )
+    errors.push(
+      "CUDA binary fork commit does not match the exact-head native source gitlink",
+    );
+  if (!Number.isFinite(Date.parse(manifest?.buildProvenance?.builtAt || "")))
+    errors.push("CUDA binary builtAt provenance missing or invalid");
+  const coverage = new Set(manifest?.coverage || []);
+  for (const id of inventory.requiredEvidence)
+    if (!coverage.has(id)) errors.push(`required evidence missing: ${id}`);
+  const artifacts = manifest?.artifacts || [];
+  const artifactIds = new Set();
+  for (const artifact of artifacts) {
+    if (!artifact?.id || artifactIds.has(artifact.id))
+      errors.push(`duplicate or missing artifact id: ${artifact?.id}`);
+    artifactIds.add(artifact.id);
+    if (
+      !artifact?.path ||
+      !SHA256_RE.test(artifact?.sha256 || "") ||
+      !(artifact?.bytes > 0)
+    )
+      errors.push(`invalid artifact entry: ${artifact?.id || "unknown"}`);
+  }
+  for (const id of ["cuda-probe", "cuda-report", "capabilities", "native-log"])
+    if (!artifactIds.has(id)) errors.push(`artifact shard missing: ${id}`);
+  const missingKernels = manifest?.capabilities?.missingRequiredKernels || [];
+  const kernelClaims = manifest?.capabilities?.kernels || {};
+  const unprovenKernels = inventory.requiredKernels.filter(
+    (kernel) => kernelClaims[kernel] !== true,
+  );
+  if (
+    manifest?.capabilities?.publishable !== true ||
+    missingKernels.length ||
+    unprovenKernels.length
+  )
+    errors.push(
+      `CUDA capabilities are not publishable; missing kernels: ${[
+        ...new Set([...missingKernels, ...unprovenKernels]),
+      ].join(", ")}`,
+    );
+  if ((manifest?.logPolicy?.forbiddenSignals || []).length)
+    errors.push(
+      `native log contains fail-closed signals: ${manifest.logPolicy.forbiddenSignals.join(", ")}`,
+    );
+  if (errors.length) throw new Error(errors.join("\n"));
+  return true;
+}
+
+export function assembleManifest({
+  probePath,
+  reportPath,
+  capabilitiesPath,
+  logPath,
+  outputPath,
+  expectedHead,
+}) {
+  const inventory = readJson(INVENTORY_PATH);
+  validateInventory(inventory);
+  for (const file of [probePath, reportPath, capabilitiesPath, logPath])
+    if (!file || !fs.existsSync(file) || fs.statSync(file).size === 0)
+      throw new Error(`required artifact missing or empty: ${file}`);
+  const probe = readJson(probePath);
+  const report = readJson(reportPath);
+  const capabilities = readJson(capabilitiesPath);
+  const nativeLog = fs.readFileSync(logPath, "utf8");
+  const forbiddenSignals = FORBIDDEN_LOG_SIGNALS.filter((pattern) =>
+    pattern.test(nativeLog),
+  ).map((pattern) => pattern.source);
+  const artifacts = [
+    ["cuda-probe", probePath],
+    ["cuda-report", reportPath],
+    ["capabilities", capabilitiesPath],
+    ["native-log", logPath],
+  ].map(([id, file]) => ({
+    id,
+    path: path.basename(file),
+    bytes: fs.statSync(file).size,
+    sha256: sha256(file),
+  }));
+  const manifest = {
+    schemaVersion: 1,
+    status: "pass",
+    createdAt: new Date().toISOString(),
+    head: probe.head,
+    exactHead: probe.exactHead === true && probe.status === "pass",
+    workflowRun: probe.workflowRun,
+    authority: inventory.authority,
+    hardware: { devices: probe.devices, cuda: probe.cuda },
+    buildProvenance: {
+      nativeSourceCommit: probe.nativeSourceCommit,
+      forkCommit: capabilities.forkCommit,
+      builtAt: capabilities.builtAt,
+      target: capabilities.target || report.target,
+    },
+    nativeVerification: {
+      status: report.status,
+      passRecordable: report.passRecordable,
+      graphSmoke: report.requirements?.graphSmoke,
+      target: report.target,
+      modelSha256: report.evidence?.modelSha256 || null,
+    },
+    capabilities: {
+      publishable: capabilities.publishable,
+      missingRequiredKernels: capabilities.missingRequiredKernels || [],
+      kernels: capabilities.kernels || {},
+    },
+    coverage: inventory.requiredEvidence,
+    retiredContextMapping: inventory.retiredContexts,
+    supportedMatrixInventory: inventory.supportedMatrix,
+    logPolicy: { forbiddenSignals },
+    artifacts,
+  };
+  validateManifest(manifest, {
+    expectedHead: expectedHead || probe.expectedHead,
+  });
+  fs.writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function argsToObject(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--") || !argv[i + 1])
+      throw new Error(`invalid argument: ${key}`);
+    out[key.slice(2)] = argv[++i];
+  }
+  return out;
+}
+
+function usage() {
+  console.error(
+    "Usage: cuda-continuity.mjs probe --output FILE | assemble --probe FILE --report FILE --capabilities FILE --log FILE --output FILE [--expected-head SHA] | validate --manifest FILE [--expected-head SHA] | validate-inventory",
+  );
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = argsToObject(rest);
+  if (command === "probe") {
+    if (!args.output) throw new Error("--output is required");
+    let probe;
+    try {
+      probe = collectProbe({ expectedHead: args["expected-head"] });
+    } catch (error) {
+      probe = {
+        schemaVersion: 1,
+        status: "fail",
+        exactHead: false,
+        failureReason: error instanceof Error ? error.message : String(error),
+      };
+    }
+    fs.mkdirSync(path.dirname(args.output), { recursive: true });
+    fs.writeFileSync(args.output, `${JSON.stringify(probe, null, 2)}\n`);
+    if (probe.status !== "pass")
+      throw new Error(probe.failureReason || "CUDA probe failed");
+  } else if (command === "assemble") {
+    assembleManifest({
+      probePath: args.probe,
+      reportPath: args.report,
+      capabilitiesPath: args.capabilities,
+      logPath: args.log,
+      outputPath: args.output,
+      expectedHead: args["expected-head"],
+    });
+  } else if (command === "validate") {
+    validateManifest(readJson(args.manifest), {
+      expectedHead: args["expected-head"],
+    });
+  } else if (command === "validate-inventory") {
+    validateInventory(readJson(INVENTORY_PATH));
+  } else {
+    usage();
+    process.exitCode = 2;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  main().catch((error) => {
+    console.error(
+      `[cuda-continuity] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/cuda-continuity.test.mjs
+++ b/scripts/cuda-continuity.test.mjs
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  INVENTORY_PATH,
+  assembleManifest,
+  validateInventory,
+  validateManifest,
+} from "./cuda-continuity.mjs";
+
+const HEAD = "a".repeat(40);
+const dirs = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0))
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function fixture(overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cuda-continuity-"));
+  dirs.push(dir);
+  const files = {
+    probe: path.join(dir, "probe.json"),
+    report: path.join(dir, "report.json"),
+    capabilities: path.join(dir, "CAPABILITIES.json"),
+    log: path.join(dir, "native.log"),
+    output: path.join(dir, "manifest.json"),
+  };
+  const probe = overrides.probe || {
+    schemaVersion: 1,
+    status: "pass",
+    exactHead: true,
+    head: HEAD,
+    expectedHead: HEAD,
+    nativeSourceCommit: "d".repeat(40),
+    workflowRun: { id: "123", attempt: "1", event: "workflow_dispatch" },
+    cuda: { toolkitVersion: "12.8", driverRuntimeVersion: "13.0" },
+    devices: [
+      {
+        name: "NVIDIA GeForce RTX 5090",
+        computeCapability: "12.0",
+        driverVersion: "580.1",
+        memoryMiB: 32768,
+      },
+    ],
+  };
+  const report = overrides.report || {
+    schemaVersion: 1,
+    status: "pass",
+    passRecordable: true,
+    target: "linux-x64-cuda",
+    requirements: { graphSmoke: "required" },
+    evidence: { modelSha256: "b".repeat(64) },
+  };
+  const capabilities = overrides.capabilities || {
+    target: "linux-x64-cuda",
+    forkCommit: "d".repeat(40),
+    builtAt: "2026-07-17T09:00:00.000Z",
+    publishable: true,
+    missingRequiredKernels: [],
+    kernels: {
+      turbo3: true,
+      turbo4: true,
+      turbo3_tcq: true,
+      qjl_full: true,
+      polarquant: true,
+      mtp: true,
+    },
+  };
+  fs.writeFileSync(files.probe, JSON.stringify(probe));
+  fs.writeFileSync(files.report, JSON.stringify(report));
+  fs.writeFileSync(files.capabilities, JSON.stringify(capabilities));
+  fs.writeFileSync(
+    files.log,
+    overrides.log ||
+      "CUDA fixtures 8/8 PASS\nruntime graph CUDA generation PASS\n",
+  );
+  return files;
+}
+
+function assemble(files) {
+  return assembleManifest({
+    probePath: files.probe,
+    reportPath: files.report,
+    capabilitiesPath: files.capabilities,
+    logPath: files.log,
+    outputPath: files.output,
+    expectedHead: HEAD,
+  });
+}
+
+describe("CUDA continuity inventory", () => {
+  it("pins every retired context and supported architecture", () => {
+    const inventory = JSON.parse(fs.readFileSync(INVENTORY_PATH, "utf8"));
+    assert.equal(
+      validateInventory(inventory, {
+        root: path.resolve(import.meta.dirname, ".."),
+      }),
+      true,
+    );
+  });
+
+  it("rejects matrix drift", () => {
+    const inventory = JSON.parse(fs.readFileSync(INVENTORY_PATH, "utf8"));
+    inventory.supportedMatrix = inventory.supportedMatrix.filter(
+      (entry) => entry.id !== "h200-sm90",
+    );
+    assert.throws(
+      () =>
+        validateInventory(inventory, {
+          root: path.resolve(import.meta.dirname, ".."),
+        }),
+      /h200-sm90/,
+    );
+  });
+});
+
+describe("CUDA exact-head manifest", () => {
+  it("assembles a complete fail-closed manifest", () => {
+    const manifest = assemble(fixture());
+    assert.equal(validateManifest(manifest, { expectedHead: HEAD }), true);
+    assert.deepEqual(
+      manifest.artifacts.map((entry) => entry.id),
+      ["cuda-probe", "cuda-report", "capabilities", "native-log"],
+    );
+  });
+
+  it("rejects a missing GPU instead of producing a false green", () => {
+    const files = fixture();
+    const probe = JSON.parse(fs.readFileSync(files.probe, "utf8"));
+    probe.devices = [];
+    fs.writeFileSync(files.probe, JSON.stringify(probe));
+    assert.throws(() => assemble(files), /no GPU device inventory/);
+  });
+
+  it("rejects skipped graph smoke and partial native verification", () => {
+    const files = fixture({
+      report: {
+        status: "pass",
+        passRecordable: false,
+        target: "linux-x64-cuda",
+        requirements: { graphSmoke: "skipped" },
+        evidence: {},
+      },
+    });
+    assert.throws(() => assemble(files), /recordable pass|graph smoke/);
+  });
+
+  it("rejects missing kernels or a non-publishable build", () => {
+    const files = fixture({
+      capabilities: {
+        target: "linux-x64-cuda",
+        forkCommit: "d".repeat(40),
+        builtAt: "2026-07-17T09:00:00.000Z",
+        publishable: false,
+        missingRequiredKernels: ["mtp"],
+        kernels: { mtp: false },
+      },
+    });
+    assert.throws(() => assemble(files), /not publishable/);
+  });
+
+  it("rejects a graph smoke report without its model hash", () => {
+    const files = fixture({
+      report: {
+        status: "pass",
+        passRecordable: true,
+        target: "linux-x64-cuda",
+        requirements: { graphSmoke: "required" },
+        evidence: {},
+      },
+    });
+    assert.throws(() => assemble(files), /graph smoke SHA-256/);
+  });
+
+  it("rejects a capability manifest that omits required kernel claims", () => {
+    const files = fixture();
+    const capabilities = JSON.parse(
+      fs.readFileSync(files.capabilities, "utf8"),
+    );
+    capabilities.kernels = {};
+    fs.writeFileSync(files.capabilities, JSON.stringify(capabilities));
+    assert.throws(() => assemble(files), /missing kernels:.*turbo3/);
+  });
+
+  it("rejects a prebuilt binary from a different native source revision", () => {
+    const files = fixture();
+    const capabilities = JSON.parse(
+      fs.readFileSync(files.capabilities, "utf8"),
+    );
+    capabilities.forkCommit = "e".repeat(40);
+    fs.writeFileSync(files.capabilities, JSON.stringify(capabilities));
+    assert.throws(() => assemble(files), /does not match.*native source/i);
+  });
+
+  it("rejects CPU fallback, OOM, corruption, and skipped CUDA evidence in logs", () => {
+    for (const signal of [
+      "fallback to CPU",
+      "CUDA out of memory",
+      "corrupted model input",
+      "SKIPPED CUDA kernel",
+    ]) {
+      const files = fixture({ log: `CUDA started\n${signal}\n` });
+      assert.throws(() => assemble(files), /fail-closed signals/);
+    }
+  });
+
+  it("rejects a non-exact workflow head", () => {
+    const files = fixture();
+    const probe = JSON.parse(fs.readFileSync(files.probe, "utf8"));
+    probe.head = "c".repeat(40);
+    fs.writeFileSync(files.probe, JSON.stringify(probe));
+    assert.throws(() => assemble(files), /does not match expected/);
+  });
+
+  it("rejects partial artifact shards", () => {
+    const manifest = assemble(fixture());
+    manifest.artifacts = manifest.artifacts.filter(
+      (entry) => entry.id !== "native-log",
+    );
+    assert.throws(
+      () => validateManifest(manifest, { expectedHead: HEAD }),
+      /artifact shard missing: native-log/,
+    );
+  });
+
+  it("refuses missing or empty artifact inputs", () => {
+    const files = fixture();
+    fs.writeFileSync(files.capabilities, "");
+    assert.throws(() => assemble(files), /required artifact missing or empty/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a candidate single CUDA continuity authority with exact-head GPU/toolkit probing, native fixture parity, model-backed runtime graph smoke, and fail-closed artifact upload
- inventory the retired `gpu-bench-nightly` contexts and supported RTX 3090/4090/5090 + H200 CUDA profiles with explicit old-to-new evidence mapping
- produce and validate a hashed manifest containing commit, native source/build provenance, GPU/driver/toolkit data, kernel capabilities, model hash, test status, and detailed graph logs
- reject missing GPU, CPU fallback, skipped/partial evidence, missing kernels, source/binary mismatch, OOM/corruption, malformed artifacts, and upload failure
- retain the existing opt-in local-inference CUDA leg until an exact-head hardware artifact passes manual review

## Verification
- `node --test scripts/cuda-continuity.test.mjs` (13/13)
- `node scripts/cuda-continuity.mjs validate-inventory`
- `bash -n plugins/plugin-local-inference/native/verify/cuda_runner.sh`
- `git diff --check`
- Codex review: clean after addressing review findings

## Hardware status
No repository self-hosted runners were visible through the Actions runner API from this credential, so this PR intentionally contains code and non-GPU contract proof only. It does **not** claim a live CUDA pass. Keep #16449 open until `CUDA Coverage Continuity` is dispatched against this exact head with a provenance-matched CUDA binary directory and GGUF, and the uploaded manifest is reviewed.

Closes no issue. Tracks #16449.


## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - test workflow, Node validator, JSON inventory, documentation, and shell harness plumbing only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow changed; the hardware workflow is intentionally pending a real self-hosted GPU.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [non-GPU fail-closed contract job](https://github.com/elizaOS/eliza/actions/runs/29573932937/job/87863958549) passed 13 manifest/inventory failure-mode tests. A live CUDA backend log is intentionally unavailable and #16449 remains open until an exact-head hardware run uploads it.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend code, browser behavior, or network surface changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, model-response, trajectory, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff](https://github.com/elizaOS/eliza/pull/16537/files), [passing CUDA continuity contract run](https://github.com/elizaOS/eliza/actions/runs/29573932937/job/87863958549), and the checked-in `scripts/cuda-continuity-inventory.json`. The exact-head hardware manifest is deliberately not claimed because no eligible repository GPU runner is visible; #16449 stays open pending that artifact.
