### PR TITLE
fix(ci): drop duplicate DEEPGRAM/CARTESIA env keys that broke cloud-cf-deploy parsing

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -514,8 +514,6 @@ jobs:
           ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64 }}
           VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
           VAST_BASE_URL: ${{ secrets.VAST_BASE_URL }}
-          DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
-          CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
           DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
           VOICE_REALTIME_WS_ENABLED: ${{ steps.env.outputs.deploy_environment != 'production' && contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && 'true' || 'false' }}
           # Keep this mirror locked to wrangler.toml's env.production value.


### PR DESCRIPTION
## What
#16192's squash (8549adfc252) appended `DEEPGRAM_API_KEY` and `CARTESIA_API_KEY` to the **Publish Worker AI secrets** env block, but both keys were already defined ~30 lines up in the same block (added by #16525 / #16491 with routing-toggle comments). GitHub Actions refuses to even parse a workflow with duplicate env keys.

## Impact
Every cloud-cf-deploy trigger since the merge fails at the parse stage, before any job starts:
- push run [29602250875](https://github.com/elizaOS/eliza/actions/runs/29602250875) concluded `failure` with **zero jobs**
- `workflow_dispatch` returns HTTP 422: `'DEEPGRAM_API_KEY' is already defined, 'CARTESIA_API_KEY' is already defined`

Staging is frozen at `70dceb852` and cannot pick up develop (including the #16192 realtime voice client + staging flag it was meant to ship) until this parses again.

## Fix
Delete the two duplicate lines; the earlier definitions have identical values (`${{ secrets.* }}`). 2 deletions, no behavior change.

## Verification
- `bun test packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts` -> 9/9 pass (the fail-closed realtime deploy contract, including the secret-gating + preflight bash extraction, still holds)
- YAML parses cleanly (`yaml.safe_load` OK); scanned every `env:` block in the workflow for duplicate keys -> none remain

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - CI workflow YAML only, no rendered UI in the diff`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - CI workflow YAML only, no rendered UI in the diff`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - CI workflow YAML only, no user-facing flow`

<!-- evidence-row:backend-logs -->
- [x] Backend logs: failing parse-stage run with zero jobs https://github.com/elizaOS/eliza/actions/runs/29602250875 plus dispatch rejection `HTTP 422: 'DEEPGRAM_API_KEY' is already defined, 'CARTESIA_API_KEY' is already defined` from `POST /actions/workflows/269943082/dispatches`

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code touched`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/model/prompt/provider change; 2-line CI YAML dedup`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: contract suite on the patched workflow passes 9/9 (11763 expects): https://github.com/elizaOS/eliza/actions/runs/29606988929 ; the PR's own cloud-cf-deploy run now parses and enqueues jobs (Validate Canonical Deploy Source passed: https://github.com/elizaOS/eliza/actions/runs/29606988896 ), which was impossible before the fix

🤖 [sol-orch]
