### PR TITLE
fix(orchestrator): forward Anthropic proxy config to eliza-code

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -6,15 +6,29 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalForwardedEnvKey,
   forwardableSubAgentEnv,
+  isCloudKeyForwardingOptIn,
   isEnvForwardableToSubAgent,
+  SUB_AGENT_PROVIDER_ENV_KEYS,
+  SUB_AGENT_SYSTEM_ENV_KEYS,
   shouldForwardEnv,
-} from "../../src/services/acp-service.js";
+} from "../../src/services/sub-agent-env-policy.js";
 
 // Guards buildEnv's sealed-env allowlist. It is an allowlist (anything not
 // matched is denied), so the risk is twofold: a needed var silently dropped, or
 // a secret silently forwarded. The load-bearing case is PARALLAX_SESSION_ID —
 // without it the loopback /api/coding-agents/<id>/* parent-context bridge is
 // unreachable from an ACP-spawned sub-agent (it does NOT ride the ELIZA_ prefix).
+describe("isCloudKeyForwardingOptIn", () => {
+  it("accepts only explicit truthy values", () => {
+    for (const value of ["1", "true", "TRUE", " yes ", "on"]) {
+      expect(isCloudKeyForwardingOptIn(value), value).toBe(true);
+    }
+    for (const value of [undefined, "", "0", "false", "off", "maybe"]) {
+      expect(isCloudKeyForwardingOptIn(value), String(value)).toBe(false);
+    }
+  });
+});
+
 describe("shouldForwardEnv", () => {
   it("forwards PARALLAX_SESSION_ID (the parent-context bridge id)", () => {
     expect(shouldForwardEnv("PARALLAX_SESSION_ID")).toBe(true);
@@ -26,15 +40,10 @@ describe("shouldForwardEnv", () => {
   });
 
   it("forwards the model/auth vars the backends need", () => {
-    expect(shouldForwardEnv("ANTHROPIC_API_KEY")).toBe(true);
-    expect(shouldForwardEnv("ANTHROPIC_BASE_URL")).toBe(true);
-    expect(shouldForwardEnv("ANTHROPIC_SMALL_MODEL")).toBe(true);
-    expect(shouldForwardEnv("ANTHROPIC_MEDIUM_MODEL")).toBe(true);
-    expect(shouldForwardEnv("ANTHROPIC_LARGE_MODEL")).toBe(true);
-    expect(shouldForwardEnv("OPENAI_API_KEY")).toBe(true);
-    expect(shouldForwardEnv("CEREBRAS_BASE_URL")).toBe(true);
-    expect(shouldForwardEnv("CLAUDE_CODE_EFFORT_LEVEL")).toBe(true);
-    expect(shouldForwardEnv("PATH")).toBe(true);
+    for (const key of SUB_AGENT_PROVIDER_ENV_KEYS) {
+      expect(shouldForwardEnv(key), key).toBe(true);
+      expect(isEnvForwardableToSubAgent(key), key).toBe(true);
+    }
   });
 
   it("forwards ACPX_AUTH_-prefixed vars", () => {
@@ -52,17 +61,9 @@ describe("shouldForwardEnv", () => {
   });
 
   it("forwards the Windows system vars cmd.exe + Bun + the agent need", () => {
-    for (const key of [
-      "PATHEXT",
-      "SystemRoot",
-      "windir",
-      "ComSpec",
-      "TEMP",
-      "USERPROFILE",
-      "APPDATA",
-      "LOCALAPPDATA",
-    ]) {
+    for (const key of SUB_AGENT_SYSTEM_ENV_KEYS) {
       expect(shouldForwardEnv(key)).toBe(true);
+      expect(isEnvForwardableToSubAgent(key)).toBe(true);
     }
   });
 
@@ -119,13 +120,17 @@ describe("shouldForwardEnv", () => {
 // ride the broad ELIZA_ prefix into a sub-agent.
 describe("isEnvForwardableToSubAgent (deny-then-allow)", () => {
   it("strips host secrets even though they match the allowlist", () => {
-    // Each of these IS allowlisted (ELIZA_ prefix / *TOKEN) — the deny-list wins.
+    // Each of these is allowlisted by ELIZA_ or the cloud opt-in, but the
+    // deny-list still wins.
     for (const key of [
       "ELIZA_VAULT_PASSPHRASE",
       "ELIZA_TERMINAL_RUN_TOKEN",
-      "DISCORD_BOT_TOKEN",
+      "ELIZA_DISCORD_TOKEN",
+      "ELIZA_BOT_TOKEN",
+      "ELIZAOS_CLOUD_TERMINAL_RUN_TOKEN",
     ]) {
-      expect(isEnvForwardableToSubAgent(key)).toBe(false);
+      expect(shouldForwardEnv(key, true), key).toBe(true);
+      expect(isEnvForwardableToSubAgent(key, true), key).toBe(false);
     }
   });
 
@@ -139,12 +144,12 @@ describe("isEnvForwardableToSubAgent (deny-then-allow)", () => {
   it("still forwards the bridge id and the vars a sub-agent legitimately needs", () => {
     expect(isEnvForwardableToSubAgent("PARALLAX_SESSION_ID")).toBe(true);
     expect(isEnvForwardableToSubAgent("ELIZA_HOOK_PORT")).toBe(true);
-    expect(isEnvForwardableToSubAgent("ANTHROPIC_API_KEY")).toBe(true);
-    expect(isEnvForwardableToSubAgent("ANTHROPIC_BASE_URL")).toBe(true);
-    expect(isEnvForwardableToSubAgent("ANTHROPIC_SMALL_MODEL")).toBe(true);
-    expect(isEnvForwardableToSubAgent("ANTHROPIC_MEDIUM_MODEL")).toBe(true);
-    expect(isEnvForwardableToSubAgent("ANTHROPIC_LARGE_MODEL")).toBe(true);
-    expect(isEnvForwardableToSubAgent("PATH")).toBe(true);
+    for (const key of SUB_AGENT_PROVIDER_ENV_KEYS) {
+      expect(isEnvForwardableToSubAgent(key), key).toBe(true);
+    }
+    for (const key of SUB_AGENT_SYSTEM_ENV_KEYS) {
+      expect(isEnvForwardableToSubAgent(key), key).toBe(true);
+    }
   });
 });
 
@@ -152,11 +157,9 @@ describe("isEnvForwardableToSubAgent (deny-then-allow)", () => {
 // child never inherits two casings of the same var. Non-system keys are untouched.
 describe("canonicalForwardedEnvKey", () => {
   it("uppercases OS system vars regardless of source casing", () => {
-    expect(canonicalForwardedEnvKey("Path")).toBe("PATH");
-    expect(canonicalForwardedEnvKey("path")).toBe("PATH");
-    expect(canonicalForwardedEnvKey("Pathext")).toBe("PATHEXT");
-    expect(canonicalForwardedEnvKey("SystemRoot")).toBe("SYSTEMROOT");
-    expect(canonicalForwardedEnvKey("ProgramFiles")).toBe("PROGRAMFILES");
+    for (const key of SUB_AGENT_SYSTEM_ENV_KEYS) {
+      expect(canonicalForwardedEnvKey(key.toLowerCase()), key).toBe(key);
+    }
   });
 
   it("leaves non-system keys (prefix/allowlist vars) untouched", () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -27,6 +27,10 @@ describe("shouldForwardEnv", () => {
 
   it("forwards the model/auth vars the backends need", () => {
     expect(shouldForwardEnv("ANTHROPIC_API_KEY")).toBe(true);
+    expect(shouldForwardEnv("ANTHROPIC_BASE_URL")).toBe(true);
+    expect(shouldForwardEnv("ANTHROPIC_SMALL_MODEL")).toBe(true);
+    expect(shouldForwardEnv("ANTHROPIC_MEDIUM_MODEL")).toBe(true);
+    expect(shouldForwardEnv("ANTHROPIC_LARGE_MODEL")).toBe(true);
     expect(shouldForwardEnv("OPENAI_API_KEY")).toBe(true);
     expect(shouldForwardEnv("CEREBRAS_BASE_URL")).toBe(true);
     expect(shouldForwardEnv("CLAUDE_CODE_EFFORT_LEVEL")).toBe(true);
@@ -136,6 +140,10 @@ describe("isEnvForwardableToSubAgent (deny-then-allow)", () => {
     expect(isEnvForwardableToSubAgent("PARALLAX_SESSION_ID")).toBe(true);
     expect(isEnvForwardableToSubAgent("ELIZA_HOOK_PORT")).toBe(true);
     expect(isEnvForwardableToSubAgent("ANTHROPIC_API_KEY")).toBe(true);
+    expect(isEnvForwardableToSubAgent("ANTHROPIC_BASE_URL")).toBe(true);
+    expect(isEnvForwardableToSubAgent("ANTHROPIC_SMALL_MODEL")).toBe(true);
+    expect(isEnvForwardableToSubAgent("ANTHROPIC_MEDIUM_MODEL")).toBe(true);
+    expect(isEnvForwardableToSubAgent("ANTHROPIC_LARGE_MODEL")).toBe(true);
     expect(isEnvForwardableToSubAgent("PATH")).toBe(true);
   });
 });
@@ -194,13 +202,23 @@ describe("forwardableSubAgentEnv", () => {
     const out = forwardableSubAgentEnv({
       ELIZA_HOOK_PORT: "2138",
       ANTHROPIC_API_KEY: "sk-x",
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:8787/v1",
+      ANTHROPIC_SMALL_MODEL: "proxy-small",
+      ANTHROPIC_MEDIUM_MODEL: "proxy-medium",
+      ANTHROPIC_LARGE_MODEL: "proxy-large",
       ELIZA_VAULT_PASSPHRASE: "secret", // allowlisted by ELIZA_ but deny-listed
+      ELIZA_TERMINAL_RUN_TOKEN: "host-shell-token", // allowlisted by ELIZA_ but deny-listed
       DISCORD_BOT_TOKEN: "nope", // not allowlisted
       MISSING: undefined, // non-string skipped
     });
     expect(out.ELIZA_HOOK_PORT).toBe("2138");
     expect(out.ANTHROPIC_API_KEY).toBe("sk-x");
+    expect(out.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:8787/v1");
+    expect(out.ANTHROPIC_SMALL_MODEL).toBe("proxy-small");
+    expect(out.ANTHROPIC_MEDIUM_MODEL).toBe("proxy-medium");
+    expect(out.ANTHROPIC_LARGE_MODEL).toBe("proxy-large");
     expect(out.ELIZA_VAULT_PASSPHRASE).toBeUndefined();
+    expect(out.ELIZA_TERMINAL_RUN_TOKEN).toBeUndefined();
     expect(out.DISCORD_BOT_TOKEN).toBeUndefined();
     expect("MISSING" in out).toBe(false);
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
@@ -3,7 +3,7 @@
  * Deterministic unit test of pure helpers; no runtime, no live model.
  */
 import { describe, expect, it } from "vitest";
-import { isDeniedSubAgentEnvKey } from "../../src/services/acp-service.ts";
+import { isDeniedSubAgentEnvKey } from "../../src/services/sub-agent-env-policy.js";
 
 describe("isDeniedSubAgentEnvKey (customCredentials deny-list)", () => {
   it("denies connector bot tokens and the vault passphrase regardless of case", () => {
@@ -15,6 +15,8 @@ describe("isDeniedSubAgentEnvKey (customCredentials deny-list)", () => {
       "OPENCODE_CONFIG_CONTENT",
       "ELIZA_VAULT_PASSPHRASE",
       "eliza_vault_passphrase",
+      "TERMINAL_RUN_TOKEN",
+      "ELIZA_TERMINAL_RUN_TOKEN",
     ]) {
       expect(isDeniedSubAgentEnvKey(key)).toBe(true);
     }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -4680,11 +4680,15 @@ export function shouldForwardEnv(
     [
       "OPENAI_API_KEY",
       "ANTHROPIC_API_KEY",
+      "ANTHROPIC_BASE_URL",
       "CEREBRAS_API_KEY",
       "CEREBRAS_BASE_URL",
       "CEREBRAS_MODEL",
       "OPENAI_MODEL",
       "ANTHROPIC_MODEL",
+      "ANTHROPIC_SMALL_MODEL",
+      "ANTHROPIC_MEDIUM_MODEL",
+      "ANTHROPIC_LARGE_MODEL",
       "OPENCODE_MODEL",
       // Claude Code CLI reasoning-effort knob; buildEnv also sets it from the
       // validated config-env ELIZA_CLAUDE_EFFORT for claude spawns.

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -96,6 +96,12 @@ import {
 import { buildSkillsManifest } from "./skill-manifest.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
 import {
+  canonicalForwardedEnvKey,
+  forwardableSubAgentEnv as applySubAgentEnvPolicy,
+  isCloudKeyForwardingOptIn,
+  isDeniedSubAgentEnvKey,
+} from "./sub-agent-env-policy.js";
+import {
   appendSubagentStdout,
   isSubagentStdoutLoggingEnabled,
   subagentStdoutLogPath,
@@ -127,6 +133,28 @@ import {
   resolveDiskBudgetConfig,
   type WorkspaceRegistry,
 } from "./workspace-registry.js";
+
+export {
+  canonicalForwardedEnvKey,
+  isDeniedSubAgentEnvKey,
+  isEnvForwardableToSubAgent,
+  shouldForwardEnv,
+} from "./sub-agent-env-policy.js";
+
+/** Resolve the config-backed cloud-key forwarding opt-in for each child spawn. */
+export function isCloudKeyForwardingEnabled(): boolean {
+  return isCloudKeyForwardingOptIn(
+    readConfigEnvKey("ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS"),
+  );
+}
+
+/** Preserve the public config-backed helper while delegating policy to a pure module. */
+export function forwardableSubAgentEnv(
+  source: Record<string, string | undefined>,
+  forwardCloudKey = isCloudKeyForwardingEnabled(),
+): Record<string, string> {
+  return applySubAgentEnvPolicy(source, forwardCloudKey);
+}
 
 type RuntimeLike = IAgentRuntime & {
   logger?: Partial<
@@ -713,38 +741,6 @@ function sessionTransportMode(
   if (mode === "native" || mode === "cli") return mode;
   return serviceTransportMode;
 }
-const DENY_ENV_PATTERNS = [
-  /DISCORD.*TOKEN/i,
-  /TELEGRAM.*TOKEN/i,
-  /SLACK.*TOKEN/i,
-  /BOT.*TOKEN/i,
-  /ELIZA_VAULT_PASSPHRASE/i,
-  // Host-API shell-exec / stdio-MCP auth secret — consumed only by
-  // packages/agent/src/api/*, never by a coding sub-agent. Forwarding it would
-  // hand a child process a credential that re-authorizes arbitrary host command
-  // execution with zero legitimate use for it.
-  /TERMINAL_RUN_TOKEN/i,
-  // Repo-scoped GitHub host credentials must not be injected into sub-agents,
-  // including through customCredentials. Registry push uses the dedicated
-  // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.
-  /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT)$/i,
-  // OpenCode's spawn config is runtime-built (buildOpencodeAcpEnv overwrites it
-  // AFTER this filter runs). A caller- or host-supplied value would let the
-  // spawner inject arbitrary provider config into the child, so it is denied at
-  // both intake paths.
-  /^OPENCODE_CONFIG_CONTENT$/i,
-];
-
-/**
- * A key that must never reach a sub-agent, regardless of source — parent
- * process.env forwarding OR caller-supplied customCredentials. Both paths run
- * through this so a spawn request cannot inject a secret (connector bot token,
- * vault passphrase) the deny-list exists to keep out of sub-agents.
- */
-export function isDeniedSubAgentEnvKey(key: string): boolean {
-  return DENY_ENV_PATTERNS.some((pattern) => pattern.test(key));
-}
-
 export const ACP_SUBPROCESS_SERVICE_TYPE =
   CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE ??
   "ACP_SUBPROCESS_SERVICE";
@@ -4572,176 +4568,6 @@ export function isClaudeOAuthSubscriptionToken(
   value: string | undefined,
 ): boolean {
   return value?.startsWith("sk-ant-oat") ?? false;
-}
-
-/**
- * OS-level environment variables a spawned coding agent needs to function.
- * Matched case-insensitively (see `shouldForwardEnv`): the repo runtime is Bun,
- * and Bun on Windows reports these with native casing — `Path`, not `PATH` —
- * so a case-sensitive check would forward NONE of them, leaving the child with
- * no search path (the opencode shim then fails with "'bun' is not recognized").
- * Includes the Windows essentials cmd.exe + Bun + the agent's config/cache
- * resolution rely on, alongside the POSIX names.
- */
-const FORWARDED_SYSTEM_ENV: ReadonlySet<string> = new Set([
-  "PATH",
-  "PATHEXT",
-  "HOME",
-  "USER",
-  "LANG",
-  "LC_ALL",
-  "LC_CTYPE",
-  "TZ",
-  "TERM",
-  // Windows essentials.
-  "SYSTEMROOT",
-  "WINDIR",
-  "COMSPEC",
-  "SYSTEMDRIVE",
-  "TEMP",
-  "TMP",
-  "USERPROFILE",
-  "HOMEDRIVE",
-  "HOMEPATH",
-  "APPDATA",
-  "LOCALAPPDATA",
-  "PROGRAMDATA",
-  "PROGRAMFILES",
-  "PROGRAMFILES(X86)",
-  "COMMONPROGRAMFILES",
-  "NUMBER_OF_PROCESSORS",
-  "PROCESSOR_ARCHITECTURE",
-  "USERNAME",
-  "USERDOMAIN",
-]);
-
-/**
- * The key a forwarded var is assigned under. OS system vars are canonicalized to
- * their uppercase `FORWARDED_SYSTEM_ENV` form because Bun on Windows reports them
- * with native casing (`Path`, `Pathext`, `SystemRoot`, `ProgramFiles`, …); a
- * child must not inherit two casings of the same var (the winner is undefined on
- * Windows), and JS consumers that read `env.PATH` case-sensitively need the
- * canonical key. Non-system keys (ELIZA_*, API keys, model overrides) keep their
- * original casing.
- */
-export function canonicalForwardedEnvKey(key: string): string {
-  return FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ? key.toUpperCase() : key;
-}
-
-/**
- * Config key that opts a spawn INTO forwarding the owner's raw `ELIZAOS_CLOUD*`
- * creds (the live Cloud API key + URL) into every child env. Default OFF: a
- * sub-agent reaches Cloud through the parent-agent broker instead (`apps.create`
- * / `containers.create` — spend-capped, confirmation-gated), so the owner key
- * never lands in an autonomous child's env where it can leak into files, logs,
- * or artifacts (#14093 had to redact stdout for exactly this class of leak).
- * The one value a self-serving monetized container genuinely needs at RUNTIME
- * (its own upstream cloud bearer) is fetched through the owner-approved,
- * single-use credential bridge, not force-forwarded. Set to `1` only for a flow
- * the broker cannot serve yet.
- */
-const FORWARD_CLOUD_KEY_CONFIG = "ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS";
-
-/**
- * Whether the operator opted into forwarding raw `ELIZAOS_CLOUD*` creds into
- * child envs (see {@link FORWARD_CLOUD_KEY_CONFIG}). Reads config-env so a UI or
- * service.env toggle takes effect without a restart; default OFF.
- */
-export function isCloudKeyForwardingEnabled(): boolean {
-  const raw = readConfigEnvKey(FORWARD_CLOUD_KEY_CONFIG)?.trim().toLowerCase();
-  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
-}
-
-/**
- * The per-var forwarding predicate. `forwardCloudKey` (default false) opts a
- * spawn into forwarding the owner's raw `ELIZAOS_CLOUD*` creds — pure so the
- * gate is unit-testable without touching config; `forwardableSubAgentEnv`
- * resolves the flag from config-env once per build.
- */
-export function shouldForwardEnv(
-  key: string,
-  forwardCloudKey = false,
-): boolean {
-  return (
-    FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ||
-    key.startsWith("ACPX_AUTH_") ||
-    key.startsWith("ELIZA_") ||
-    // The live Cloud creds use the ELIZAOS_ prefix (ELIZAOS_CLOUD_API_KEY /
-    // ELIZAOS_CLOUD_URL), which the broad ELIZA_ rule above does NOT match.
-    // Broker-first (#14118): a child does NOT get the raw owner key by default —
-    // it registers/deploys via the parent broker (spend-gated) and fetches any
-    // container-runtime secret via the owner-approved credential bridge. Only the
-    // explicit ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS opt-in restores raw forwarding.
-    (forwardCloudKey && key.startsWith("ELIZAOS_CLOUD")) ||
-    // Parent-context bridge session id (ELIZA_HOOK_PORT already passes via the
-    // ELIZA_ prefix). Without this the loopback /api/coding-agents/<id>/* bridge
-    // is unreachable from an ACP-spawned sub-agent.
-    key === "PARALLAX_SESSION_ID" ||
-    [
-      "OPENAI_API_KEY",
-      "ANTHROPIC_API_KEY",
-      "ANTHROPIC_BASE_URL",
-      "CEREBRAS_API_KEY",
-      "CEREBRAS_BASE_URL",
-      "CEREBRAS_MODEL",
-      "OPENAI_MODEL",
-      "ANTHROPIC_MODEL",
-      "ANTHROPIC_SMALL_MODEL",
-      "ANTHROPIC_MEDIUM_MODEL",
-      "ANTHROPIC_LARGE_MODEL",
-      "OPENCODE_MODEL",
-      // Claude Code CLI reasoning-effort knob; buildEnv also sets it from the
-      // validated config-env ELIZA_CLAUDE_EFFORT for claude spawns.
-      "CLAUDE_CODE_EFFORT_LEVEL",
-      "OPENCODE_DISABLE_AUTOUPDATE",
-      "OPENCODE_DISABLE_TERMINAL_TITLE",
-      "CODEX_HOME",
-      // Container-registry PUSH credential for app-image builds (docker login
-      // ghcr.io before the deploy contract's docker push). Narrow by design:
-      // these are the dedicated registry-scoped names (a packages:write PAT),
-      // mirrored cloud-side by containersEnv.registryUsername()/registryToken().
-      // The broad GITHUB_TOKEN / GH_TOKEN / CR_PAT stay DENIED — a repo-scoped
-      // host token must never ride into a sub-agent. The canonical
-      // ELIZA_APP_IMAGE_REGISTRY_USERNAME/_TOKEN pair already forwards via the
-      // ELIZA_ prefix above.
-      "GHCR_USERNAME",
-      "GHCR_TOKEN",
-    ].includes(key)
-  );
-}
-
-/**
- * The single forwarding decision buildEnv applies per host env var: the
- * deny-list wins over the allowlist. A few keys (the privileged host secrets in
- * DENY_ENV_PATTERNS) match shouldForwardEnv — e.g. via the broad ELIZA_ prefix —
- * yet must never reach a coding sub-agent, so the deny check runs first.
- */
-export function isEnvForwardableToSubAgent(
-  key: string,
-  forwardCloudKey = false,
-): boolean {
-  if (isDeniedSubAgentEnvKey(key)) return false;
-  return shouldForwardEnv(key, forwardCloudKey);
-}
-
-/**
- * The deny-list-filtered, allowlisted, casing-canonicalized subset of `source`
- * to forward to a coding sub-agent. Pure (no process.env read) so it is unit
- * testable: pass a synthetic env (e.g. `{ Path: "…" }`, the casing Bun reports
- * on Windows) and assert the result is keyed by `PATH`. See
- * `canonicalForwardedEnvKey` for why OS vars are canonicalized.
- */
-export function forwardableSubAgentEnv(
-  source: Record<string, string | undefined>,
-  forwardCloudKey = isCloudKeyForwardingEnabled(),
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [key, value] of Object.entries(source)) {
-    if (typeof value !== "string") continue;
-    if (!isEnvForwardableToSubAgent(key, forwardCloudKey)) continue;
-    out[canonicalForwardedEnvKey(key)] = value;
-  }
-  return out;
 }
 
 function extractSessionId(event: AcpJsonRpcMessage): string | undefined {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -1,0 +1,208 @@
+/**
+ * Environment forwarding policy for coding sub-agent spawns. The ACP service
+ * consumes this as the single host-env projection before adding per-session
+ * model gateway, credential bridge, and adapter-specific overrides.
+ */
+const DENY_ENV_PATTERNS = [
+  /DISCORD.*TOKEN/i,
+  /TELEGRAM.*TOKEN/i,
+  /SLACK.*TOKEN/i,
+  /BOT.*TOKEN/i,
+  /ELIZA_VAULT_PASSPHRASE/i,
+  // Host-API shell-exec / stdio-MCP auth secret — consumed only by
+  // packages/agent/src/api/*, never by a coding sub-agent. Forwarding it would
+  // hand a child process a credential that re-authorizes arbitrary host command
+  // execution with zero legitimate use for it.
+  /TERMINAL_RUN_TOKEN/i,
+  // Repo-scoped GitHub host credentials must not be injected into sub-agents,
+  // including through customCredentials. Registry push uses the dedicated
+  // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.
+  /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT)$/i,
+  // OpenCode's spawn config is runtime-built (buildOpencodeAcpEnv overwrites it
+  // AFTER this filter runs). A caller- or host-supplied value would let the
+  // spawner inject arbitrary provider config into the child, so it is denied at
+  // both intake paths.
+  /^OPENCODE_CONFIG_CONTENT$/i,
+];
+
+/**
+ * A key that must never reach a sub-agent, regardless of source — parent
+ * process.env forwarding OR caller-supplied customCredentials. Both paths run
+ * through this so a spawn request cannot inject a secret (connector bot token,
+ * vault passphrase) the deny-list exists to keep out of sub-agents.
+ */
+export function isDeniedSubAgentEnvKey(key: string): boolean {
+  return DENY_ENV_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+/**
+ * OS-level environment variables a spawned coding agent needs to function.
+ * Matched case-insensitively (see `shouldForwardEnv`): the repo runtime is Bun,
+ * and Bun on Windows reports these with native casing — `Path`, not `PATH` —
+ * so a case-sensitive check would forward NONE of them, leaving the child with
+ * no search path (the opencode shim then fails with "'bun' is not recognized").
+ * Includes the Windows essentials cmd.exe + Bun + the agent's config/cache
+ * resolution rely on, alongside the POSIX names.
+ */
+export const SUB_AGENT_SYSTEM_ENV_KEYS = [
+  "PATH",
+  "PATHEXT",
+  "HOME",
+  "USER",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "TERM",
+  // Windows essentials.
+  "SYSTEMROOT",
+  "WINDIR",
+  "COMSPEC",
+  "SYSTEMDRIVE",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PROGRAMDATA",
+  "PROGRAMFILES",
+  "PROGRAMFILES(X86)",
+  "COMMONPROGRAMFILES",
+  "NUMBER_OF_PROCESSORS",
+  "PROCESSOR_ARCHITECTURE",
+  "USERNAME",
+  "USERDOMAIN",
+] as const;
+
+const FORWARDED_SYSTEM_ENV: ReadonlySet<string> = new Set(
+  SUB_AGENT_SYSTEM_ENV_KEYS,
+);
+
+/**
+ * Provider and adapter configuration keys that are intentionally forwarded even
+ * without an `ELIZA_` prefix. Keep this list narrow: each entry is a runtime
+ * dependency for a supported coding backend or the app-image registry push path.
+ */
+export const SUB_AGENT_PROVIDER_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "CEREBRAS_API_KEY",
+  "CEREBRAS_BASE_URL",
+  "CEREBRAS_MODEL",
+  "OPENAI_MODEL",
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_MODEL",
+  "ANTHROPIC_MEDIUM_MODEL",
+  "ANTHROPIC_LARGE_MODEL",
+  "OPENCODE_MODEL",
+  // Claude Code CLI reasoning-effort knob; buildEnv also sets it from the
+  // validated config-env ELIZA_CLAUDE_EFFORT for claude spawns.
+  "CLAUDE_CODE_EFFORT_LEVEL",
+  "OPENCODE_DISABLE_AUTOUPDATE",
+  "OPENCODE_DISABLE_TERMINAL_TITLE",
+  "CODEX_HOME",
+  // Container-registry PUSH credential for app-image builds (docker login
+  // ghcr.io before the deploy contract's docker push). Narrow by design:
+  // these are the dedicated registry-scoped names (a packages:write PAT),
+  // mirrored cloud-side by containersEnv.registryUsername()/registryToken().
+  // The broad GITHUB_TOKEN / GH_TOKEN / CR_PAT stay DENIED — a repo-scoped
+  // host token must never ride into a sub-agent. The canonical
+  // ELIZA_APP_IMAGE_REGISTRY_USERNAME/_TOKEN pair already forwards via the
+  // ELIZA_ prefix above.
+  "GHCR_USERNAME",
+  "GHCR_TOKEN",
+] as const;
+
+const PROVIDER_ENV: ReadonlySet<string> = new Set(SUB_AGENT_PROVIDER_ENV_KEYS);
+
+/**
+ * The key a forwarded var is assigned under. OS system vars are canonicalized to
+ * their uppercase `FORWARDED_SYSTEM_ENV` form because Bun on Windows reports them
+ * with native casing (`Path`, `Pathext`, `SystemRoot`, `ProgramFiles`, …); a
+ * child must not inherit two casings of the same var (the winner is undefined on
+ * Windows), and JS consumers that read `env.PATH` case-sensitively need the
+ * canonical key. Non-system keys (ELIZA_*, API keys, model overrides) keep their
+ * original casing.
+ */
+export function canonicalForwardedEnvKey(key: string): string {
+  return FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ? key.toUpperCase() : key;
+}
+
+/** Parse the explicit operator opt-in for forwarding raw `ELIZAOS_CLOUD*`
+ * credentials. The caller supplies the config-backed value so this policy
+ * module remains pure and independently testable. Default remains OFF. */
+export function isCloudKeyForwardingOptIn(raw: string | undefined): boolean {
+  const normalized = raw?.trim().toLowerCase();
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
+}
+
+/**
+ * The per-var forwarding predicate. `forwardCloudKey` (default false) opts a
+ * spawn into forwarding the owner's raw `ELIZAOS_CLOUD*` creds — pure so the
+ * gate is unit-testable without touching config; `forwardableSubAgentEnv`
+ * resolves the flag from config-env once per build.
+ */
+export function shouldForwardEnv(
+  key: string,
+  forwardCloudKey = false,
+): boolean {
+  return (
+    FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ||
+    key.startsWith("ACPX_AUTH_") ||
+    key.startsWith("ELIZA_") ||
+    // The live Cloud creds use the ELIZAOS_ prefix (ELIZAOS_CLOUD_API_KEY /
+    // ELIZAOS_CLOUD_URL), which the broad ELIZA_ rule above does NOT match.
+    // Broker-first (#14118): a child does NOT get the raw owner key by default —
+    // it registers/deploys via the parent broker (spend-gated) and fetches any
+    // container-runtime secret via the owner-approved credential bridge. Only the
+    // explicit ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS opt-in restores raw forwarding.
+    (forwardCloudKey && key.startsWith("ELIZAOS_CLOUD")) ||
+    // Parent-context bridge session id (ELIZA_HOOK_PORT already passes via the
+    // ELIZA_ prefix). Without this the loopback /api/coding-agents/<id>/* bridge
+    // is unreachable from an ACP-spawned sub-agent.
+    key === "PARALLAX_SESSION_ID" ||
+    PROVIDER_ENV.has(key)
+  );
+}
+
+/**
+ * The single forwarding decision buildEnv applies per host env var: the
+ * deny-list wins over the allowlist. A few keys (the privileged host secrets in
+ * DENY_ENV_PATTERNS) match shouldForwardEnv — e.g. via the broad ELIZA_ prefix —
+ * yet must never reach a coding sub-agent, so the deny check runs first.
+ */
+export function isEnvForwardableToSubAgent(
+  key: string,
+  forwardCloudKey = false,
+): boolean {
+  if (isDeniedSubAgentEnvKey(key)) return false;
+  return shouldForwardEnv(key, forwardCloudKey);
+}
+
+/**
+ * The deny-list-filtered, allowlisted, casing-canonicalized subset of `source`
+ * to forward to a coding sub-agent. Pure (no process.env read) so it is unit
+ * testable: pass a synthetic env (e.g. `{ Path: "…" }`, the casing Bun reports
+ * on Windows) and assert the result is keyed by `PATH`. See
+ * `canonicalForwardedEnvKey` for why OS vars are canonicalized.
+ */
+export function forwardableSubAgentEnv(
+  source: Record<string, string | undefined>,
+  forwardCloudKey = false,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value !== "string") continue;
+    if (!isEnvForwardableToSubAgent(key, forwardCloudKey)) continue;
+    out[canonicalForwardedEnvKey(key)] = value;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- forward Anthropic base URL and tier model overrides into ACP children
- preserve deny-list precedence and credential hygiene
- cover endpoint/model forwarding and denied secret behavior

## Live failure
Parity round 2 showed headless eliza-code immediately failing before WEB_FETCH/background-shell because it lost the parent subscription proxy endpoint and defaulted to unsupported `claude-sonnet-5`.

## Tests
- `bunx vitest run __tests__/unit/should-forward-env.test.ts` (22 passed)
- Biome check (clean)
- Codex review (clean)

## Evidence Details

<!-- evidence-row:before-screenshots -->
- [x] N/A - non-visual backend/orchestrator change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - non-visual backend/orchestrator change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused unit-test output is recorded in the Tests section above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - focused tests and Codex review are recorded above.

[sol-orch]
