### PR TITLE
fix(ui): narrow settled wallet results per-branch before reading .reason

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-wallet-section.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-wallet-section.tsx
@@ -122,7 +122,11 @@ export function ElizaWalletSection({ agentId }: ElizaWalletSectionProps) {
         // Narrow per-branch: with only the disjunction guard, TS cannot prove
         // either settled result is the rejected one, so .reason is invalid.
         const reason =
-          addrRes.status === "rejected" ? addrRes.reason : balRes.reason;
+          addrRes.status === "rejected"
+            ? addrRes.reason
+            : balRes.status === "rejected"
+              ? balRes.reason
+              : undefined;
         setError(
           reason instanceof Error
             ? reason.message

--- a/packages/ui/src/cloud/instances/components/eliza-wallet-section.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-wallet-section.tsx
@@ -119,7 +119,10 @@ export function ElizaWalletSection({ agentId }: ElizaWalletSectionProps) {
       if (!mountedRef.current) return;
 
       if (addrRes.status === "rejected" || balRes.status === "rejected") {
-        const reason = addrRes.reason ?? balRes.reason;
+        // Narrow per-branch: with only the disjunction guard, TS cannot prove
+        // either settled result is the rejected one, so .reason is invalid.
+        const reason =
+          addrRes.status === "rejected" ? addrRes.reason : balRes.reason;
         setError(
           reason instanceof Error
             ? reason.message


### PR DESCRIPTION
## What

One-line narrowing fix: `addrRes.reason ?? balRes.reason` under only the `||` guard fails typecheck (TS2339 — neither `PromiseSettledResult` is proven rejected). Select the reason with a per-branch ternary instead.

## Why now

Introduced in #16540; `@elizaos/ui:typecheck` is currently red on develop, failing the typecheck lane of every open PR (e.g. https://github.com/elizaOS/eliza/actions/runs/29608965904/job/87978857828). This unblocks the fleet.

# Evidence Details

<!-- evidence-row:before-screenshots -->
- [x] `N/A - typecheck-only fix, no rendered change.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - typecheck-only fix.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - typecheck-only fix.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no runtime behavior change; tsgo --noEmit on packages/ui goes from TS2339 at eliza-wallet-section.tsx:122 to clean (remaining transitive cloud-shared resolution noise is environment-specific and pre-existing).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - identical runtime semantics (the reason expression evaluates the same value in every reachable state).`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model surface.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the artifact is the green typecheck lane on this PR's own CI.`
