### PR TITLE
fix(cloud): keep Headscale agent nodes across Docker restarts

### DIFF
--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -133,8 +133,7 @@ export class HeadscaleClient {
   /** List all registered nodes. */
   async listNodes(): Promise<HeadscaleNode[]> {
     try {
-      const data = await this.request<{ nodes?: HeadscaleNode[] }>("GET", "/api/v1/node");
-      return data.nodes ?? [];
+      return await this.listNodesStrict();
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       logger.error("[headscale] error listing nodes:", msg);
@@ -142,9 +141,21 @@ export class HeadscaleClient {
     }
   }
 
+  /** List nodes while propagating API failures to callers that must fail closed. */
+  async listNodesStrict(): Promise<HeadscaleNode[]> {
+    const data = await this.request<{ nodes?: HeadscaleNode[] }>("GET", "/api/v1/node");
+    return data.nodes ?? [];
+  }
+
   /** Find a node by its hostname. */
   async getNodeByName(name: string): Promise<HeadscaleNode | null> {
     const nodes = await this.listNodes();
+    return nodes.find((n) => n.name === name) ?? null;
+  }
+
+  /** Find a node by hostname while propagating listing failures. */
+  async getNodeByNameStrict(name: string): Promise<HeadscaleNode | null> {
+    const nodes = await this.listNodesStrict();
     return nodes.find((n) => n.name === name) ?? null;
   }
 

--- a/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
@@ -80,6 +80,59 @@ describe("Headscale identity inference", () => {
   });
 });
 
+describe("Headscale container credentials", () => {
+  test("uses a persistent node with a single-use key so Docker restarts can reconnect", async () => {
+    let request: Record<string, unknown> | null = null;
+    const fake = {
+      getNodeByNameStrict: async () => null,
+      createPreAuthKey: async (input: Record<string, unknown>) => {
+        request = input;
+        return { key: "test-preauth-key" };
+      },
+    } as unknown as HeadscaleClient;
+
+    const prepared = await new HeadscaleIntegration(fake).prepareContainerVPN({
+      agentId: "11111111-1111-4111-8111-111111111111",
+      organizationId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(request).toMatchObject({
+      reusable: false,
+      ephemeral: false,
+      aclTags: ["tag:agent"],
+    });
+    expect(prepared.preAuthKey).toBe("test-preauth-key");
+  });
+
+  test("removes a stale persistent registration before issuing a replacement key", async () => {
+    const calls: string[] = [];
+    const fake = {
+      getNodeByNameStrict: async (name: string) => {
+        calls.push(`lookup:${name}`);
+        return { id: "stale-node-70", name, ipAddresses: ["100.64.0.56"] };
+      },
+      deleteNode: async (id: string) => {
+        calls.push(`delete:${id}`);
+      },
+      createPreAuthKey: async () => {
+        calls.push("create-key");
+        return { key: "replacement-key" };
+      },
+    } as unknown as HeadscaleClient;
+
+    await new HeadscaleIntegration(fake).prepareContainerVPN({
+      agentId: "11111111-1111-4111-8111-111111111111",
+      agentName: "Eliza",
+    });
+
+    expect(calls).toEqual([
+      "lookup:eliza-11111111-111",
+      "delete:stale-node-70",
+      "create-key",
+    ]);
+  });
+});
+
 describe("Headscale node lookup is keyed on the node name (not the agentId)", () => {
   // Regression guard: the container registers under TS_HOSTNAME
   // (inferTailscaleHostname = `<agentName>-<id12>`), so lookups must use that

--- a/packages/cloud/shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.ts
@@ -67,8 +67,16 @@ export class HeadscaleIntegration {
   /**
    * Prepare VPN credentials for a new agent container.
    *
-   * Returns a single-use, ephemeral pre-auth key and the full set of
+   * Returns a single-use, persistent-node pre-auth key and the full set of
    * environment variables the container needs to join the VPN on boot.
+   *
+   * The node must not be ephemeral. Docker's `unless-stopped` policy restarts
+   * an agent in the same writable layer, so tailscaled reconnects with its
+   * persisted node identity. Headscale deletes ephemeral nodes as soon as they
+   * disconnect; the restarted container then sees `node no longer exists`,
+   * while its single-use auth key can only return `authkey already used`,
+   * leaving the agent in a permanent restart loop. Explicit sandbox teardown
+   * already calls cleanupContainerVPN(), so persistent nodes are still removed.
    */
   async prepareContainerVPN(input: PrepareContainerVPNInput): Promise<{
     preAuthKey: string;
@@ -78,15 +86,29 @@ export class HeadscaleIntegration {
     logger.info(`[headscale-integration] preparing VPN for agent ${agentId}`);
 
     try {
+      const tsHostname = inferTailscaleHostname(input);
+
+      // Persistent nodes survive ordinary Docker restarts by design. A full
+      // reprovision, however, creates a fresh container and auth key. Remove a
+      // stale registration for the deterministic hostname before issuing that
+      // key, otherwise waitForVPNRegistration() could accept the old node's IP
+      // before the replacement has joined. Fail closed on lookup/deletion
+      // errors so we never route a new sandbox to a stale container.
+      const existingNode = await this.client.getNodeByNameStrict(tsHostname);
+      if (existingNode) {
+        await this.client.deleteNode(existingNode.id);
+        logger.info(
+          `[headscale-integration] removed stale VPN node ${existingNode.id} before reprovisioning ${agentId}`,
+        );
+      }
+
       const preAuthKeyObj = await this.client.createPreAuthKey({
         reusable: false,
-        ephemeral: true,
+        ephemeral: false,
         aclTags: ["tag:agent"],
         user: inferHeadscaleUser(input),
         ensureUser: true,
       });
-
-      const tsHostname = inferTailscaleHostname(input);
 
       const envVars: Record<string, string> = {
         HEADSCALE_URL: headscalePublicUrl(),


### PR DESCRIPTION
## Summary
- provision dedicated-agent Headscale identities as persistent nodes rather than ephemeral nodes
- remove an existing deterministic hostname registration before full reprovisioning
- add strict Headscale node lookup so reprovision fails closed instead of routing to a stale node

## Root cause
Fresh staging agents can boot successfully, then the agent process exits once and Docker's `unless-stopped` policy restarts the same container. Headscale immediately deletes the **ephemeral** node at disconnect. The writable container layer still contains the old tailscaled identity, while the injected pre-auth key is single-use. Every restart then fails permanently:

- `node no longer exists`
- fallback re-auth: `authkey already used`

This reproduced on both fresh accounts reported by Shadow:
- `shadow+test2@shad0w.xyz`, agent `c3881f48-...`, node `100.64.0.56`
- `shadow+test3@shad0w.xyz`, agent `b84f9827-...`, node `100.64.0.62`

The orchestration DB marked both agents `error` after timeout/recovery, while their host containers remained in a restart loop with the exact errors above.

Persistent Headscale nodes allow the persisted tailscaled identity to reconnect after ordinary Docker restarts. Full sandbox teardown already explicitly removes the node. Full reprovision additionally removes any stale registration before creating a replacement key.

## Validation
- `bun test packages/cloud/shared/src/lib/services/headscale-integration.test.ts packages/cloud/shared/src/lib/services/headscale-client.test.ts`
- 18 pass, 0 fail
- `git diff --check`
- Codex review found stale-registration and swallowed-list-error risks; both were addressed with pre-provision cleanup and strict lookup.

## Staging reproduction notes
A separate fresh SIWE account passed account creation, shared-runtime agent creation, conversation creation, and streamed chat end-to-end. A fresh dedicated agent reproduced the boot/restart condition before eventually recovering via a later full reprovision. The two exact email accounts above remain the deterministic failing fixtures for verification after deploy.
