### PR TITLE
fix(connectors): fail closed on trusted account routing (canonical IDs only)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/connectorActionUtils.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/connectorActionUtils.ts
@@ -43,6 +43,28 @@ export function textParam(value: unknown): string | undefined {
 		: undefined;
 }
 
+/** Connector identity is trusted only from the stored Memory envelope. */
+export function trustedConnectorAccountId(message: Memory): string | undefined {
+	const metadata = message.metadata;
+	const accountId =
+		metadata && "accountId" in metadata ? metadata.accountId : undefined;
+	return typeof accountId === "string" && accountId.trim()
+		? accountId.trim()
+		: undefined;
+}
+
+/**
+ * Prefer the connector-authored envelope source. Never pair an envelope account
+ * with the user-facing Content source, where common ids such as "default" could
+ * otherwise be redirected to a different provider.
+ */
+export function trustedConnectorSource(message: Memory): string | undefined {
+	const source = message.metadata?.source;
+	if (typeof source === "string" && source.trim()) return source.trim();
+	if (trustedConnectorAccountId(message)) return undefined;
+	return textParam(message.content.source);
+}
+
 export function boolParam(value: unknown): boolean | undefined {
 	if (typeof value === "boolean") return value;
 	if (typeof value !== "string") return undefined;
@@ -107,12 +129,16 @@ export function buildPostQueryContext(
 	message: Memory,
 	state: State | undefined,
 	source: string | undefined,
+	accountId?: string,
+	account?: PostConnector["account"],
 ): PostConnectorQueryContext {
 	return {
 		runtime,
 		roomId: message.roomId,
 		entityId: message.entityId,
 		source,
+		accountId,
+		account,
 		contexts: getActiveRoutingContextsForTurn(state, message),
 		metadata: {
 			messageText: message.content.text,
@@ -318,6 +344,12 @@ function connectorAliases(connector: {
 	return aliases;
 }
 
+function connectorAccountIds(connector: SelectableConnector): string[] {
+	return [connector.accountId, connector.account?.accountId].filter(
+		(accountId): accountId is string => Boolean(accountId?.trim()),
+	);
+}
+
 function connectorMatchesSource(
 	connector: {
 		source: string;
@@ -342,6 +374,7 @@ type SelectableConnector = {
 	label: string;
 	accountId?: string;
 	account?: { accountId?: string; label?: string; name?: string };
+	accountRouting?: "connector";
 	metadata?: unknown;
 };
 
@@ -351,8 +384,31 @@ function connectorMatchesAccount(
 ): boolean {
 	if (!accountId) return true;
 	const normalized = normalizeConnectorAlias(accountId);
-	return connectorAliases(connector).some(
-		(alias) => normalizeConnectorAlias(alias) === normalized,
+	return (
+		connectorAccountIds(connector).some(
+			(candidate) => normalizeConnectorAlias(candidate) === normalized,
+		) ||
+		(connectorAccountIds(connector).length === 0 &&
+			connector.accountRouting === "connector")
+	);
+}
+
+function selectAccountScopedConnectors<T extends SelectableConnector>(
+	connectors: T[],
+	accountId: string | undefined,
+): T[] {
+	if (!accountId) return connectors;
+	const normalized = normalizeConnectorAlias(accountId);
+	const exact = connectors.filter((connector) =>
+		connectorAccountIds(connector).some(
+			(candidate) => normalizeConnectorAlias(candidate) === normalized,
+		),
+	);
+	if (exact.length > 0) return exact;
+	return connectors.filter(
+		(connector) =>
+			connectorAccountIds(connector).length === 0 &&
+			connector.accountRouting === "connector",
 	);
 }
 
@@ -400,9 +456,11 @@ export function selectConnector<T extends SelectableConnector>(
 			},
 		};
 	}
-	const accountScoped = sourceScoped.filter((connector) =>
-		connectorMatchesAccount(connector, accountId),
-	);
+	const accountScoped = accountId
+		? selectAccountScopedConnectors(sourceScoped, accountId)
+		: sourceScoped.filter((connector) =>
+				connectorMatchesAccount(connector, accountId),
+			);
 	if (accountId && accountScoped.length === 0) {
 		return {
 			result: {

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -235,6 +235,83 @@ describe("MESSAGE op=list_connections", () => {
 	});
 });
 
+describe("MESSAGE trusted connector account routing", () => {
+	it("passes the envelope account to a dispatcher and ignores Content spoofing", async () => {
+		let routedAccountId: string | undefined;
+		const runtime = mockRuntime([
+			{
+				source: "x",
+				label: "X",
+				accountRouting: "connector",
+				capabilities: [],
+				supportedTargetKinds: ["room"],
+				contexts: [],
+				listRooms: async (context: { accountId?: string }) => {
+					routedAccountId = context.accountId;
+					return [];
+				},
+			},
+		]);
+		const inbound = {
+			...message,
+			metadata: { type: "message", source: "x", accountId: "secondary" },
+			content: {
+				text: "show channels",
+				source: "x",
+				metadata: { accountId: "primary" },
+			},
+		} as Memory;
+
+		const result = await messageAction.handler(
+			runtime,
+			inbound,
+			undefined,
+			{ parameters: { action: "list_channels", source: "x" } },
+			undefined,
+			undefined,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(routedAccountId).toBe("secondary");
+		expect(inbound.content.metadata).toEqual({ accountId: "primary" });
+	});
+
+	it("fails closed when another account's display name collides with the trusted account id", async () => {
+		const listRooms = async () => [];
+		const runtime = mockRuntime([
+			{
+				source: "x",
+				label: "X other account",
+				accountId: "other",
+				account: { accountId: "other", name: "original" },
+				capabilities: [],
+				supportedTargetKinds: ["room"],
+				contexts: [],
+				listRooms,
+			},
+		]);
+		const inbound = {
+			...message,
+			metadata: { type: "message", source: "x", accountId: "original" },
+			content: { text: "show channels", source: "x" },
+		} as Memory;
+
+		const result = await messageAction.handler(
+			runtime,
+			inbound,
+			undefined,
+			{ parameters: { action: "list_channels", source: "x" } },
+			undefined,
+			undefined,
+		);
+
+		expect(result?.success).toBe(false);
+		expect(result?.data).toMatchObject({
+			error: "ACCOUNT_CONNECTOR_NOT_FOUND",
+		});
+	});
+});
+
 describe("MESSAGE op=send owner-binding gate", () => {
 	async function runtimeWithAccount(
 		accessGate: "open" | "owner_binding",

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -61,7 +61,11 @@ import { searchMessagesAction as searchInboxMessagesAction } from "../../messagi
 import { sendDraftAction } from "../../messaging/triage/actions/sendDraft.ts";
 import { triageMessagesAction } from "../../messaging/triage/actions/triageMessages.ts";
 import { MANAGE_OPERATION_KINDS } from "../../messaging/triage/types.ts";
-import { refreshMessageConnectorActionDescription } from "./connectorActionUtils.ts";
+import {
+	refreshMessageConnectorActionDescription,
+	trustedConnectorAccountId,
+	trustedConnectorSource,
+} from "./connectorActionUtils.ts";
 
 // ---------------------------------------------------------------------------
 // Op taxonomy
@@ -409,14 +413,28 @@ function connectorAliases(connector: MessageConnector): string[] {
 	return aliases;
 }
 
-function connectorMatchesAccount(
-	connector: ConnectorWithHooks,
+function connectorAccountIds(connector: MessageConnector): string[] {
+	return [connector.accountId, connector.account?.accountId].filter(
+		(accountId): accountId is string => Boolean(accountId?.trim()),
+	);
+}
+
+function selectAccountConnectors(
+	connectors: ConnectorWithHooks[],
 	accountId: string | undefined,
-): boolean {
-	if (!accountId) return true;
+): ConnectorWithHooks[] {
+	if (!accountId) return connectors;
 	const normalized = normalizeComparable(accountId);
-	return connectorAliases(connector).some(
-		(alias) => normalizeComparable(alias) === normalized,
+	const exact = connectors.filter((connector) =>
+		connectorAccountIds(connector).some(
+			(candidate) => normalizeComparable(candidate) === normalized,
+		),
+	);
+	if (exact.length > 0) return exact;
+	return connectors.filter(
+		(connector) =>
+			connectorAccountIds(connector).length === 0 &&
+			connector.accountRouting === "connector",
 	);
 }
 
@@ -449,13 +467,23 @@ function buildQueryContext(
 	source: string | undefined,
 	target?: TargetInfo,
 	connector?: ConnectorWithHooks,
+	accountId?: string,
 ): MessageConnectorQueryContext {
+	const trustedSource = trustedConnectorSource(message);
+	const envelopeAccountId =
+		trustedSource &&
+		source &&
+		normalizeComparable(trustedSource) === normalizeComparable(source)
+			? trustedConnectorAccountId(message)
+			: undefined;
+	const routedAccountId =
+		target?.accountId ?? connector?.accountId ?? accountId ?? envelopeAccountId;
 	return {
 		runtime,
 		roomId: message.roomId,
 		entityId: message.entityId,
 		source,
-		accountId: connector?.accountId,
+		accountId: routedAccountId,
 		account: connector?.account,
 		target,
 		contexts: getActiveRoutingContextsForTurn(state, message),
@@ -479,18 +507,25 @@ function selectConnectorForOp(
 			),
 		};
 	}
-	const explicit = source
-		? connectors.find(
-				(connector) =>
-					connectorAliases(connector).some(
-						(alias) =>
-							normalizeComparable(alias) === normalizeComparable(source),
-					) && connectorMatchesAccount(connector, accountId),
+	const sourceMatches = source
+		? connectors.filter((connector) =>
+				connectorAliases(connector).some(
+					(alias) => normalizeComparable(alias) === normalizeComparable(source),
+				),
 			)
-		: undefined;
-	const sourceExists = source
-		? Boolean(findConnectorBySource(connectors, source))
-		: false;
+		: [];
+	const explicitMatches = selectAccountConnectors(sourceMatches, accountId);
+	if (source && explicitMatches.length > 1) {
+		return {
+			error: opFailure(
+				op,
+				"SOURCE_AMBIGUOUS",
+				`MESSAGE op=${op} needs a connector account for "${source}".`,
+			),
+		};
+	}
+	const explicit = explicitMatches[0];
+	const sourceExists = sourceMatches.length > 0;
 	if (source && !explicit) {
 		return {
 			error: opFailure(
@@ -505,17 +540,18 @@ function selectConnectorForOp(
 		};
 	}
 	if (explicit) return { connector: explicit };
-	const fallback = currentSource
-		? connectors.find(
-				(connector) =>
-					findConnectorBySource([connector], currentSource) &&
-					connectorMatchesAccount(connector, accountId),
+	const fallbackMatches = currentSource
+		? selectAccountConnectors(
+				connectors.filter((connector) =>
+					findConnectorBySource([connector], currentSource),
+				),
+				accountId,
 			)
-		: undefined;
+		: [];
+	const fallback =
+		fallbackMatches.length === 1 ? fallbackMatches[0] : undefined;
 	if (fallback) return { connector: fallback };
-	const accountScoped = connectors.filter((connector) =>
-		connectorMatchesAccount(connector, accountId),
-	);
+	const accountScoped = selectAccountConnectors(connectors, accountId);
 	if (accountId && accountScoped.length === 1) {
 		const sole = accountScoped[0];
 		if (sole) return { connector: sole };
@@ -623,8 +659,10 @@ async function resolveOptionalTarget(
 	params: ParamRecord,
 	op: MessageOperation,
 ): Promise<{ target?: TargetInfo; error?: ActionResult }> {
+	const accountId = accountIdFromParams(params, message);
 	const explicit = explicitTargetFromParams(connector.source, params);
-	if (explicit.target) explicit.target.accountId ??= connector.accountId;
+	if (explicit.target)
+		explicit.target.accountId ??= connector.accountId ?? accountId;
 	const context = buildQueryContext(
 		runtime,
 		message,
@@ -632,6 +670,7 @@ async function resolveOptionalTarget(
 		connector.source,
 		explicit.target,
 		connector,
+		accountId,
 	);
 
 	if (explicit.query && connector.resolveTargets) {
@@ -650,7 +689,7 @@ async function resolveOptionalTarget(
 				}
 				const target = {
 					...sole.target,
-					accountId: sole.target.accountId ?? connector.accountId,
+					accountId: sole.target.accountId ?? connector.accountId ?? accountId,
 				};
 				return { target };
 			}
@@ -663,7 +702,8 @@ async function resolveOptionalTarget(
 					return {
 						target: {
 							...top.target,
-							accountId: top.target.accountId ?? connector.accountId,
+							accountId:
+								top.target.accountId ?? connector.accountId ?? accountId,
 						},
 					};
 				}
@@ -930,50 +970,22 @@ function normalizeAttachments(value: unknown): Media[] | undefined {
 	return attachments.length > 0 ? attachments : undefined;
 }
 
-function recordValue(value: unknown): Record<string, unknown> | undefined {
-	return typeof value === "object" && value !== null && !Array.isArray(value)
-		? (value as Record<string, unknown>)
-		: undefined;
-}
-
-function connectorSendAsMetadata(
-	message: Memory,
-): Record<string, unknown> | undefined {
-	const metadata = recordValue(message.content.metadata);
-	return (
-		recordValue(metadata?.connectorSendAs) ??
-		recordValue(metadata?.connectorAccount)
-	);
-}
-
 function accountIdFromParams(
 	raw: ParamRecord,
 	message: Memory,
 ): string | undefined {
-	const metadata = recordValue(message.content.metadata);
-	const sendAs = connectorSendAsMetadata(message);
 	return (
 		textParam(raw.accountId) ??
 		textParam(raw.connectorAccountId) ??
-		textParam(sendAs?.accountId) ??
-		textParam(metadata?.accountId)
+		trustedConnectorAccountId(message)
 	);
-}
-
-function sourceFromSendAs(message: Memory): string | undefined {
-	const sendAs = connectorSendAsMetadata(message);
-	return textParam(sendAs?.source);
 }
 
 function sourceFromParams(
 	raw: ParamRecord,
-	message: Memory,
+	_message: Memory,
 ): string | undefined {
-	return (
-		textParam(raw.source) ??
-		textParam(raw.platform) ??
-		sourceFromSendAs(message)
-	);
+	return textParam(raw.source) ?? textParam(raw.platform);
 }
 
 function normalizeSendParams(
@@ -1079,13 +1091,14 @@ function normalizeHookCandidate(
 	sourceWasExact: boolean,
 	baseScore: number,
 	reasons: string[],
+	accountId?: string,
 ): SendCandidate | null {
 	if (!kindsCompatible(targetKind, raw.kind)) return null;
 	if (!queryMatchesCandidate(query, raw)) return null;
 	const target = {
 		...raw.target,
 		source: raw.target.source || connector.source,
-		accountId: raw.target.accountId ?? connector.accountId,
+		accountId: raw.target.accountId ?? connector.accountId ?? accountId,
 	} as TargetInfo;
 	return {
 		connector,
@@ -1111,6 +1124,7 @@ async function collectHookTargets(
 	context: MessageConnectorQueryContext,
 	targetKind: MessageTargetKind | undefined,
 	sourceWasExact: boolean,
+	accountId?: string,
 ): Promise<SendCandidate[]> {
 	const candidates: SendCandidate[] = [];
 
@@ -1126,6 +1140,7 @@ async function collectHookTargets(
 					sourceWasExact,
 					0.74,
 					["resolveTargets"],
+					accountId,
 				);
 				if (candidate) candidates.push(candidate);
 			}
@@ -1148,6 +1163,7 @@ async function collectHookTargets(
 					sourceWasExact,
 					query ? 0.52 : 0.62,
 					["listRecentTargets"],
+					accountId,
 				);
 				if (candidate) candidates.push(candidate);
 			}
@@ -1176,6 +1192,7 @@ async function collectHookTargets(
 					sourceWasExact,
 					0.56,
 					["listRooms"],
+					accountId,
 				);
 				if (candidate) candidates.push(candidate);
 			}
@@ -1194,6 +1211,7 @@ function explicitSendTarget(
 	rawTarget: string,
 	targetKind: MessageTargetKind | undefined,
 	sourceWasExact: boolean,
+	accountId?: string,
 ): SendCandidate {
 	let kind = targetKind;
 	let value = rawTarget.trim();
@@ -1206,7 +1224,7 @@ function explicitSendTarget(
 	}
 	const target = {
 		source: connector.source,
-		accountId: connector.accountId,
+		accountId: connector.accountId ?? accountId,
 	} as TargetInfo;
 	const stripped = stripTargetPrefix(value);
 
@@ -1269,6 +1287,7 @@ async function collectEntityCandidates(
 	connectors: ConnectorWithHooks[],
 	targetKind: MessageTargetKind | undefined,
 	sourceWasExact: boolean,
+	accountId?: string,
 ): Promise<SendCandidate[]> {
 	if (
 		!query ||
@@ -1299,7 +1318,7 @@ async function collectEntityCandidates(
 			);
 			const target = {
 				source: connector.source,
-				accountId: connector.accountId,
+				accountId: connector.accountId ?? accountId,
 				entityId: entity.id as UUID,
 			} as TargetInfo;
 			if (matchingComponent) {
@@ -1341,17 +1360,20 @@ async function currentRoomCandidate(
 	state: State | undefined,
 	connector: ConnectorWithHooks,
 	sourceWasExact: boolean,
+	accountId?: string,
 ): Promise<SendCandidate> {
 	const room = state?.data?.room ?? (await runtime.getRoom(message.roomId));
 	const target = {
 		source: connector.source,
-		accountId: connector.accountId,
+		accountId: connector.accountId ?? accountId,
 		roomId: (room?.id ?? message.roomId) as UUID,
 	} as TargetInfo;
 	if (room?.channelId) target.channelId = room.channelId;
 	if (room?.serverId) target.serverId = room.serverId;
 	const roomSource =
-		typeof room?.source === "string" ? room.source : message.content.source;
+		typeof room?.source === "string"
+			? room.source
+			: trustedConnectorSource(message);
 	const sourceMatches =
 		normalizeComparable(roomSource) === normalizeComparable(connector.source);
 	return {
@@ -1369,7 +1391,7 @@ function dedupeCandidates(candidates: SendCandidate[]): SendCandidate[] {
 	for (const c of candidates) {
 		const key = [
 			c.connector.source,
-			c.connector.accountId,
+			c.target.accountId ?? c.connector.accountId,
 			c.target.roomId,
 			c.target.channelId,
 			c.target.serverId,
@@ -1413,7 +1435,7 @@ async function resolveAdminTarget(
 		connector,
 		target: {
 			source: connector.source,
-			accountId: connector.accountId,
+			accountId: connector.accountId ?? params.accountId,
 			entityId: ownerId as UUID,
 		} as TargetInfo,
 		label: params.target,
@@ -1455,9 +1477,7 @@ async function resolveSendTarget(
 			sourceResolution: "exact",
 		};
 	}
-	const accountScoped = sourceScoped.filter((connector) =>
-		connectorMatchesAccount(connector, params.accountId),
-	);
+	const accountScoped = selectAccountConnectors(sourceScoped, params.accountId);
 	if (params.accountId && accountScoped.length === 0) {
 		return {
 			status: "missing_connector",
@@ -1513,7 +1533,7 @@ async function resolveSendTarget(
 	}
 
 	if (!params.target && !params.source) {
-		const currentSource = textParam(message.content.source);
+		const currentSource = trustedConnectorSource(message);
 		const currentConnector = findConnectorBySource(considered, currentSource);
 		if (currentConnector) considered = [currentConnector];
 	}
@@ -1528,6 +1548,7 @@ async function resolveSendTarget(
 			connector.source,
 			undefined,
 			connector,
+			params.accountId,
 		);
 		candidates.push(
 			...(await collectHookTargets(
@@ -1536,6 +1557,7 @@ async function resolveSendTarget(
 				context,
 				params.targetKind,
 				sourceWasExact,
+				params.accountId,
 			)),
 		);
 	}
@@ -1548,6 +1570,7 @@ async function resolveSendTarget(
 			considered,
 			params.targetKind,
 			sourceWasExact,
+			params.accountId,
 		)),
 	);
 
@@ -1559,6 +1582,7 @@ async function resolveSendTarget(
 					params.target,
 					params.targetKind,
 					sourceWasExact,
+					params.accountId,
 				),
 			);
 		}
@@ -1572,6 +1596,7 @@ async function resolveSendTarget(
 					state,
 					soleConnector,
 					sourceWasExact,
+					params.accountId,
 				),
 			);
 		}
@@ -2213,7 +2238,7 @@ async function handleReadChannel(
 			? selectConnectorForOp(
 					hookConnectors,
 					source,
-					message.content.source,
+					trustedConnectorSource(message),
 					"read_channel",
 					accountId,
 				)
@@ -2243,6 +2268,7 @@ async function handleReadChannel(
 			selectedConnector.source,
 			resolved.target,
 			selectedConnector,
+			accountId,
 		);
 		try {
 			let memories: Memory[] = [];
@@ -2435,13 +2461,13 @@ function getRelationshipsServiceLike(
 
 async function handleReadWithContact(
 	runtime: IAgentRuntime,
-	message: Memory,
+	_message: Memory,
 	_state: State | undefined,
 	params: ParamRecord,
 ): Promise<ActionResult> {
 	const contact = textParam(params.contact);
 	const entityId = textParam(params.entityId);
-	const platform = textParam(params.platform) ?? sourceFromSendAs(message);
+	const platform = textParam(params.platform);
 	const limit = clampLimit(
 		numberParam(params.limit),
 		READ_WITH_CONTACT_DEFAULT_LIMIT,
@@ -2642,7 +2668,7 @@ async function handleSearch(
 		const selection = selectConnectorForOp(
 			connectors,
 			source,
-			message.content.source,
+			trustedConnectorSource(message),
 			"search",
 			accountIdFromParams(params, message),
 		);
@@ -2669,6 +2695,7 @@ async function handleSearch(
 				connector.source,
 				resolved.target,
 				connector,
+				accountIdFromParams(params, message),
 			);
 			try {
 				const searchMessages = connector.searchMessages;
@@ -2788,7 +2815,7 @@ async function handleListChannels(
 	const selection = selectConnectorForOp(
 		connectors,
 		sourceFromParams(params, message),
-		message.content.source,
+		trustedConnectorSource(message),
 		"list_channels",
 		accountIdFromParams(params, message),
 	);
@@ -2801,6 +2828,7 @@ async function handleListChannels(
 		connector.source,
 		undefined,
 		connector,
+		accountIdFromParams(params, message),
 	);
 	try {
 		const listRooms = connector.listRooms;
@@ -2852,7 +2880,7 @@ async function handleListServers(
 	const selection = selectConnectorForOp(
 		connectors,
 		sourceFromParams(params, message),
-		message.content.source,
+		trustedConnectorSource(message),
 		"list_servers",
 		accountIdFromParams(params, message),
 	);
@@ -2865,6 +2893,7 @@ async function handleListServers(
 		connector.source,
 		undefined,
 		connector,
+		accountIdFromParams(params, message),
 	);
 	try {
 		const listServers = connector.listServers;
@@ -3002,7 +3031,7 @@ async function handleJoinLeave(
 	const selection = selectConnectorForOp(
 		connectors,
 		sourceFromParams(params, message),
-		message.content.source,
+		trustedConnectorSource(message),
 		op,
 		accountIdFromParams(params, message),
 	);
@@ -3089,7 +3118,7 @@ async function handleMessageMutation(
 	const selection = selectConnectorForOp(
 		connectors,
 		sourceFromParams(params, message),
-		message.content.source,
+		trustedConnectorSource(message),
 		op,
 		accountIdFromParams(params, message),
 	);
@@ -3106,7 +3135,7 @@ async function handleMessageMutation(
 	if (resolved.error) return resolved.error;
 	const target = resolved.target ?? {
 		source: connector.source,
-		accountId: connector.accountId,
+		accountId: connector.accountId ?? accountIdFromParams(params, message),
 	};
 
 	try {
@@ -3218,7 +3247,7 @@ async function handleGetUser(
 	const selection = selectConnectorForOp(
 		connectors,
 		sourceFromParams(params, message),
-		message.content.source,
+		trustedConnectorSource(message),
 		"get_user",
 		accountIdFromParams(params, message),
 	);

--- a/packages/core/src/features/advanced-capabilities/actions/post.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.test.ts
@@ -4,7 +4,9 @@
  * text. Keyword routing (e.g. `/\b(search|find)\b/`) silently fails for every
  * non-English request, so op selection stays structured-only.
  */
-import { describe, expect, it } from "vitest";
+
+import { describe, expect, it, vi } from "vitest";
+import type { Content, IAgentRuntime, Memory } from "../../../types/index.ts";
 import { postAction, resolveOp } from "./post.ts";
 
 describe("post resolveOp is i18n-safe (#10471)", () => {
@@ -43,5 +45,121 @@ describe("POST routing hint (#12209)", () => {
 		expect(hint).toContain("MESSAGE");
 		expect(hint).toContain("REPLY");
 		expect(hint).toContain("ROOM");
+	});
+});
+
+describe("POST trusted connector account routing", () => {
+	it("passes the envelope account to an internal dispatcher and ignores Content spoofing", async () => {
+		let routedAccountId: string | undefined;
+		let sentContent: Content | undefined;
+		const upsertMemory = vi.fn(async () => undefined);
+		const runtime = {
+			agentId: "00000000-0000-0000-0000-000000000001",
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getPostConnectors: () => [
+				{
+					source: "x",
+					label: "X",
+					accountRouting: "connector",
+					capabilities: ["post"],
+					contexts: [],
+					postHandler: async (
+						_runtime: IAgentRuntime,
+						content: Content,
+						context?: { accountId?: string },
+					) => {
+						sentContent = content;
+						routedAccountId = context?.accountId;
+						return undefined;
+					},
+				},
+			],
+			upsertMemory,
+		} as unknown as IAgentRuntime;
+		const message = {
+			id: "00000000-0000-0000-0000-0000000000aa",
+			roomId: "00000000-0000-0000-0000-0000000000bb",
+			entityId: "00000000-0000-0000-0000-0000000000cc",
+			agentId: "00000000-0000-0000-0000-000000000001",
+			metadata: { type: "message", source: "x", accountId: "secondary" },
+			content: {
+				text: "publish this",
+				source: "untrusted-source",
+				metadata: { accountId: "primary" },
+			},
+			createdAt: 1,
+		} as Memory;
+
+		const result = await postAction.handler(
+			runtime,
+			message,
+			undefined,
+			{
+				parameters: {
+					action: "send",
+					text: "publish this",
+					persist: false,
+				},
+			},
+			undefined,
+			undefined,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(routedAccountId).toBe("secondary");
+		expect(sentContent?.source).toBe("x");
+		expect(sentContent?.metadata).toMatchObject({ accountId: "secondary" });
+		expect(message.content.metadata).toEqual({ accountId: "primary" });
+		expect(upsertMemory).toHaveBeenCalledOnce();
+	});
+
+	it("fails closed when another account's display label collides with the trusted account id", async () => {
+		const postHandler = vi.fn(async () => undefined);
+		const runtime = {
+			agentId: "00000000-0000-0000-0000-000000000001",
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getPostConnectors: () => [
+				{
+					source: "x",
+					label: "X other account",
+					accountId: "other",
+					account: { accountId: "other", label: "original" },
+					capabilities: ["post"],
+					contexts: [],
+					postHandler,
+				},
+			],
+		} as unknown as IAgentRuntime;
+		const inbound = {
+			id: "00000000-0000-0000-0000-0000000000aa",
+			roomId: "00000000-0000-0000-0000-0000000000bb",
+			entityId: "00000000-0000-0000-0000-0000000000cc",
+			agentId: "00000000-0000-0000-0000-000000000001",
+			metadata: { type: "message", source: "x", accountId: "original" },
+			content: { text: "publish this", source: "x" },
+			createdAt: 1,
+		} as Memory;
+
+		const result = await postAction.handler(
+			runtime,
+			inbound,
+			undefined,
+			{
+				parameters: {
+					action: "send",
+					text: "publish this",
+					persist: false,
+				},
+			},
+			undefined,
+			undefined,
+		);
+
+		expect(result?.success).toBe(false);
+		expect(result?.data).toMatchObject({
+			error: "ACCOUNT_CONNECTOR_NOT_FOUND",
+			accountId: "original",
+		});
+		expect(postHandler).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/post.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.ts
@@ -40,6 +40,8 @@ import {
 	selectConnector,
 	sourceParam,
 	textParam,
+	trustedConnectorAccountId,
+	trustedConnectorSource,
 } from "./connectorActionUtils.ts";
 
 const POST_OPS = ["send", "read", "search"] as const;
@@ -128,36 +130,22 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
 		: undefined;
 }
 
-function connectorSendAsMetadata(
-	message: Memory,
-): Record<string, unknown> | undefined {
-	const metadata = recordValue(message.content.metadata);
-	return (
-		recordValue(metadata?.connectorSendAs) ??
-		recordValue(metadata?.connectorAccount)
-	);
-}
-
 function accountIdParam(
 	params: ParamRecord,
 	message: Memory,
 ): string | undefined {
-	const metadata = recordValue(message.content.metadata);
-	const sendAs = connectorSendAsMetadata(message);
 	return (
 		textParam(params.accountId) ??
 		textParam(params.connectorAccountId) ??
-		textParam(sendAs?.accountId) ??
-		textParam(metadata?.accountId)
+		trustedConnectorAccountId(message)
 	);
 }
 
 function sourceParamForMessage(
 	params: ParamRecord,
-	message: Memory,
+	_message: Memory,
 ): string | undefined {
-	const sendAs = connectorSendAsMetadata(message);
-	return sourceParam(params) ?? textParam(sendAs?.source);
+	return sourceParam(params);
 }
 
 function buildPostContent(
@@ -279,6 +267,9 @@ async function persistPostMemory(
 			type: "message",
 			source: connector.source,
 			provider: connector.source,
+			accountId:
+				connector.accountId ??
+				textParam(recordValue(content.metadata)?.accountId),
 		},
 		createdAt: sentMemory?.createdAt ?? Date.now(),
 	};
@@ -375,16 +366,18 @@ async function persistChatActionMemory(params: {
 async function handleSend(
 	runtime: IAgentRuntime,
 	message: Memory,
+	state: State | undefined,
 	options?: HandlerOptions,
 ): Promise<ActionResult> {
 	const params = paramsFromOptions(options);
 	const connectors = getPostConnectorsWithHook(runtime, "postHandler");
+	const accountId = accountIdParam(params, message);
 	const selected = selectConnector(
 		"POST",
 		connectors,
 		sourceParamForMessage(params, message),
-		message.content.source,
-		accountIdParam(params, message),
+		trustedConnectorSource(message),
+		accountId,
 	);
 	if ("result" in selected) return selected.result;
 	const content = applyPostContentShaping(
@@ -407,7 +400,15 @@ async function handleSend(
 			{ source: selected.connector.source },
 		);
 	}
-	const sentMemory = (await postHandler(runtime, content)) as
+	const context = buildPostQueryContext(
+		runtime,
+		message,
+		state,
+		selected.connector.source,
+		selected.connector.accountId ?? accountId,
+		selected.connector.account,
+	);
+	const sentMemory = (await postHandler(runtime, content, context)) as
 		| Memory
 		| undefined;
 	const persisted = await persistPostMemory(
@@ -437,7 +438,7 @@ async function handleSend(
 			action: "send",
 			op: "send",
 			source: selected.connector.source,
-			accountId: selected.connector.accountId,
+			accountId: selected.connector.accountId ?? accountId,
 			memoryId: persisted?.id,
 			responseMessageId: platformMessageId,
 		},
@@ -452,12 +453,13 @@ async function handleRead(
 ): Promise<ActionResult> {
 	const params = paramsFromOptions(options);
 	const connectors = getPostConnectorsWithHook(runtime, "fetchFeed");
+	const accountId = accountIdParam(params, message);
 	const selected = selectConnector(
 		"POST",
 		connectors,
 		sourceParamForMessage(params, message),
-		message.content.source,
-		accountIdParam(params, message),
+		trustedConnectorSource(message),
+		accountId,
 	);
 	if ("result" in selected) return selected.result;
 	const fetchFeed = selected.connector.fetchFeed;
@@ -469,22 +471,19 @@ async function handleRead(
 			{ source: selected.connector.source },
 		);
 	}
-	const context = {
-		...buildPostQueryContext(
-			runtime,
-			message,
-			state,
-			selected.connector.source,
-		),
-		accountId: selected.connector.accountId,
-		account: selected.connector.account,
-	};
+	const context = buildPostQueryContext(
+		runtime,
+		message,
+		state,
+		selected.connector.source,
+		selected.connector.accountId ?? accountId,
+		selected.connector.account,
+	);
 	const target = explicitTargetFromParams(
 		selected.connector.source,
 		params,
 	).target;
-	if (target && selected.connector.accountId)
-		target.accountId = selected.connector.accountId;
+	if (target) target.accountId = selected.connector.accountId ?? accountId;
 	const posts = await fetchFeed(context, {
 		feed: textParam(params.feed),
 		target,
@@ -523,12 +522,13 @@ async function handleSearch(
 		);
 	}
 	const connectors = getPostConnectorsWithHook(runtime, "searchPosts");
+	const accountId = accountIdParam(params, message);
 	const selected = selectConnector(
 		"POST",
 		connectors,
 		sourceParamForMessage(params, message),
-		message.content.source,
-		accountIdParam(params, message),
+		trustedConnectorSource(message),
+		accountId,
 	);
 	if ("result" in selected) return selected.result;
 	const searchPosts = selected.connector.searchPosts;
@@ -540,16 +540,14 @@ async function handleSearch(
 			{ source: selected.connector.source },
 		);
 	}
-	const context = {
-		...buildPostQueryContext(
-			runtime,
-			message,
-			state,
-			selected.connector.source,
-		),
-		accountId: selected.connector.accountId,
-		account: selected.connector.account,
-	};
+	const context = buildPostQueryContext(
+		runtime,
+		message,
+		state,
+		selected.connector.source,
+		selected.connector.accountId ?? accountId,
+		selected.connector.account,
+	);
 	const posts = await searchPosts(context, {
 		query,
 		limit: limitParam(params),
@@ -679,7 +677,7 @@ export const postAction: Action = {
 		const op = resolveOp(options);
 		switch (op) {
 			case "send":
-				return handleSend(runtime, message, options);
+				return handleSend(runtime, message, state, options);
 			case "read":
 				return handleRead(runtime, message, state, options);
 			case "search":

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -782,6 +782,8 @@ function normalizeMessageConnector(
 		contexts: metadata.contexts ? [...metadata.contexts] : [],
 	};
 
+	if (metadata.accountRouting === "connector" && !accountId)
+		connector.accountRouting = metadata.accountRouting;
 	if (metadata.description) connector.description = metadata.description;
 	if (metadata.metadata) connector.metadata = { ...metadata.metadata };
 	if (metadata.resolveTargets)
@@ -838,6 +840,8 @@ function normalizePostConnector(
 		contexts: metadata.contexts ? [...metadata.contexts] : [],
 	};
 
+	if (metadata.accountRouting === "connector" && !accountId)
+		connector.accountRouting = metadata.accountRouting;
 	if (metadata.description) connector.description = metadata.description;
 	if (metadata.metadata) connector.metadata = { ...metadata.metadata };
 	if (metadata.postHandler) connector.postHandler = metadata.postHandler;

--- a/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
+++ b/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
@@ -252,6 +252,43 @@ describe("message and post connector registries", () => {
 		expect(runtime.getPostConnectors()).toEqual([]);
 	});
 
+	it("preserves accountRouting: connector through registration normalization (unscoped only)", () => {
+		const runtime = makeRuntime();
+
+		runtime.registerMessageConnector({
+			source: "x",
+			label: "X DMs",
+			accountRouting: "connector",
+			sendHandler: async () => undefined,
+		});
+		runtime.registerPostConnector({
+			source: "x",
+			label: "X",
+			accountRouting: "connector",
+			postHandler: async () => undefined,
+		});
+		// A scoped registration must NOT carry the unscoped dispatcher opt-in.
+		runtime.registerPostConnector({
+			source: "social",
+			accountId: "owner-account",
+			label: "Social Owner",
+			accountRouting: "connector",
+			postHandler: async () => undefined,
+		});
+
+		const message = runtime
+			.getMessageConnectors()
+			.find((connector) => connector.source === "x");
+		expect(message?.accountRouting).toBe("connector");
+		const posts = runtime.getPostConnectors();
+		expect(
+			posts.find((connector) => connector.source === "x")?.accountRouting,
+		).toBe("connector");
+		expect(
+			posts.find((connector) => connector.source === "social")?.accountRouting,
+		).toBeUndefined();
+	});
+
 	it("selects account-scoped connectors without falling back to another account", () => {
 		const connectors = [
 			{

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -362,6 +362,12 @@ export interface MessageConnector {
 	source: string;
 	accountId?: string;
 	account?: ConnectorAccountRef;
+	/**
+	 * `connector` opts an unscoped registration into receiving a trusted
+	 * `MessageConnectorQueryContext.accountId` and dispatching it internally.
+	 * The default is runtime-scoped routing via this connector's `accountId`.
+	 */
+	accountRouting?: "connector";
 	label: string;
 	capabilities: MessageConnectorCapability[];
 	supportedTargetKinds: MessageTargetKind[];
@@ -493,12 +499,21 @@ export interface PostConnector {
 	source: string;
 	accountId?: string;
 	account?: ConnectorAccountRef;
+	/**
+	 * `connector` opts an unscoped registration into receiving a trusted
+	 * `PostConnectorQueryContext.accountId` and dispatching it internally.
+	 */
+	accountRouting?: "connector";
 	label: string;
 	capabilities: PostConnectorCapability[];
 	description?: string;
 	contexts: AgentContext[];
 	metadata?: Metadata;
-	postHandler?: (runtime: IAgentRuntime, content: Content) => SendHandlerResult;
+	postHandler?: (
+		runtime: IAgentRuntime,
+		content: Content,
+		context?: PostConnectorQueryContext,
+	) => SendHandlerResult;
 	fetchFeed?: (
 		context: PostConnectorQueryContext,
 		params: PostConnectorFeedParams,

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -1,6 +1,6 @@
-/** Unit tests for `XService` account-status reporting (config_missing, env capabilities, OAuth-scope mapping) without any network call; mocked runtime. */
-import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+/** Unit tests for X account status and trusted multi-account connector routing. Network clients are deterministic fakes. */
+import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
 import { XService } from "./x.service";
 
 function asRuntime<T extends object>(runtime: T): IAgentRuntime & T {
@@ -25,6 +25,99 @@ function serviceWithRuntime(settings: Record<string, string>): XService {
 }
 
 describe("XService account status", () => {
+  it("declares that its unscoped message connector dispatches trusted account ids", () => {
+    const registerMessageConnector = vi.fn();
+    const runtime = asRuntime({
+      agentId: "agent-1",
+      getSetting: () => undefined,
+      registerMessageConnector,
+      registerPostConnector: vi.fn(),
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const service = new XService(runtime);
+
+    XService.registerSendHandlers(runtime, service);
+
+    expect(registerMessageConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "x",
+        accountRouting: "connector",
+      }),
+    );
+  });
+
+  it("declares that its unscoped post connector dispatches trusted account ids", () => {
+    const registerPostConnector = vi.fn();
+    const runtime = asRuntime({
+      agentId: "agent-1",
+      getSetting: () => undefined,
+      registerPostConnector,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const service = new XService(runtime);
+
+    (
+      service as unknown as {
+        registerPostConnector(runtime: IAgentRuntime): void;
+      }
+    ).registerPostConnector(runtime);
+
+    expect(registerPostConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "x",
+        accountRouting: "connector",
+      }),
+    );
+  });
+
+  it("routes connector user context through the trusted account id", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const getScreenNameByUserId = vi.fn(async () => "secondary-user");
+    type ServiceInternals = {
+      getTwitterClientForAccount: (accountId: unknown) => Promise<{
+        client: {
+          twitterClient: {
+            getScreenNameByUserId: typeof getScreenNameByUserId;
+          };
+        };
+      }>;
+    };
+    const getClient = vi
+      .spyOn(
+        service as unknown as ServiceInternals,
+        "getTwitterClientForAccount",
+      )
+      .mockResolvedValue({
+        client: { twitterClient: { getScreenNameByUserId } },
+      });
+
+    const context = {
+      runtime,
+      source: "x",
+      accountId: "secondary",
+      target: { source: "x", accountId: "secondary" },
+    };
+    const result = await service.getConnectorUserContext("123456", context);
+
+    expect(getClient).toHaveBeenCalledWith("secondary");
+    expect(result).toMatchObject({
+      entityId: "123456",
+      label: "@secondary-user",
+      metadata: { accountId: "secondary" },
+    });
+  });
+
   it("reports config_missing when env auth credentials are absent", async () => {
     const service = serviceWithRuntime({ TWITTER_AUTH_MODE: "env" });
 
@@ -76,5 +169,124 @@ describe("XService account status", () => {
       grantedScopes: ["tweet.read", "users.read", "dm.read"],
       authMode: "oauth",
     });
+  });
+});
+
+describe("XService trusted account routing", () => {
+  it("routes feed reads through the trusted secondary account context", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const fetchHomeTimeline = vi.fn(async () => []);
+    const getClient = vi
+      .spyOn(
+        service as unknown as {
+          getTwitterClientForAccount: (accountId: unknown) => Promise<{
+            client: {
+              fetchHomeTimeline: typeof fetchHomeTimeline;
+              runtime: IAgentRuntime;
+            };
+          }>;
+        },
+        "getTwitterClientForAccount",
+      )
+      .mockResolvedValue({
+        client: { fetchHomeTimeline, runtime },
+      });
+
+    await service.fetchConnectorFeed(
+      {
+        runtime,
+        source: "x",
+        accountId: "secondary",
+        target: { source: "x", accountId: "primary" },
+        metadata: { accountId: "primary" },
+      },
+      {
+        target: { source: "x", accountId: "primary" },
+      },
+    );
+
+    expect(getClient).toHaveBeenCalledWith("secondary");
+    expect(fetchHomeTimeline).toHaveBeenCalledOnce();
+  });
+
+  it("routes post searches through the trusted secondary account context", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const fetchSearchTweets = vi.fn(async () => ({ tweets: [] }));
+    const getClient = vi
+      .spyOn(
+        service as unknown as {
+          getTwitterClientForAccount: (accountId: unknown) => Promise<{
+            client: {
+              fetchSearchTweets: typeof fetchSearchTweets;
+            };
+          }>;
+        },
+        "getTwitterClientForAccount",
+      )
+      .mockResolvedValue({ client: { fetchSearchTweets } });
+
+    await service.searchConnectorPosts(
+      {
+        runtime,
+        source: "x",
+        accountId: "secondary",
+        target: { source: "x", accountId: "primary" },
+        metadata: { accountId: "primary" },
+      },
+      { query: "multi-account routing" },
+    );
+
+    expect(getClient).toHaveBeenCalledWith("secondary");
+    expect(fetchSearchTweets).toHaveBeenCalledWith(
+      "multi-account routing",
+      20,
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it("ignores spoofed content account metadata in the unscoped send handler", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const getClient = vi
+      .spyOn(
+        service as unknown as {
+          getTwitterClientForAccount: (accountId: unknown) => Promise<{
+            client: Record<string, never>;
+          }>;
+        },
+        "getTwitterClientForAccount",
+      )
+      .mockResolvedValue({ client: {} });
+    const sendXDirectMessage = vi
+      .spyOn(
+        service as unknown as {
+          sendXDirectMessage: (
+            accountId: string,
+            recipient: string,
+            text: string,
+          ) => Promise<{ messageId: string | null }>;
+        },
+        "sendXDirectMessage",
+      )
+      .mockResolvedValue({ messageId: "dm-1" });
+
+    await service.handleSendMessage(
+      runtime,
+      { source: "x", entityId: "123456" } as TargetInfo,
+      {
+        text: "hello",
+        metadata: { accountId: "secondary" },
+      } as Content,
+    );
+
+    expect(getClient).toHaveBeenCalledWith("default");
+    expect(sendXDirectMessage).toHaveBeenCalledWith(
+      "default",
+      "123456",
+      "hello",
+    );
   });
 });

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -76,6 +76,9 @@ export interface XAccountCapabilityStatus {
 type XMessageConnectorRegistration = Parameters<
   IAgentRuntime["registerMessageConnector"]
 >[0] & {
+  // Kept explicit while plugin-only typechecks may resolve a previously built
+  // core declaration that predates this typed dispatcher contract.
+  accountRouting?: "connector";
   fetchMessages?: (
     context: MessageConnectorQueryContext,
     params?: {
@@ -95,12 +98,14 @@ interface PostConnectorQueryContext {
   runtime: IAgentRuntime;
   roomId?: UUID;
   source?: string;
+  accountId?: string;
   target?: TargetInfo;
   metadata?: Record<string, unknown>;
 }
 
 interface PostConnectorRegistration {
   source: string;
+  accountRouting?: "connector";
   label?: string;
   description?: string;
   capabilities?: string[];
@@ -544,6 +549,7 @@ export class XService extends Service {
     if (typeof runtime.registerMessageConnector === "function") {
       const registration: XMessageConnectorRegistration = {
         source: "x",
+        accountRouting: "connector",
         label: "X DMs",
         description:
           "X/Twitter direct-message connector. Public tweets remain under X post actions.",
@@ -590,6 +596,7 @@ export class XService extends Service {
 
     withPostConnector.registerPostConnector({
       source: "x",
+      accountRouting: "connector",
       label: "X",
       description:
         "X/Twitter public feed connector for publishing tweets, reading the home/user feed, and searching recent public posts.",
@@ -633,7 +640,7 @@ export class XService extends Service {
       metadata && typeof metadata === "object"
         ? (metadata as Record<string, unknown>)
         : undefined;
-    const accountId = this.resolveAccountId(target, content);
+    const accountId = this.resolveAccountId(target.accountId);
     const client = await this.getTwitterClientForAccount(accountId);
     const recipient = await this.resolveDmRecipient(
       (typeof metadataRecord?.xUserId === "string"
@@ -738,6 +745,7 @@ export class XService extends Service {
     }
 
     const accountId = this.resolveAccountId(
+      context?.accountId,
       context?.target,
       context?.metadata,
       content,
@@ -898,9 +906,10 @@ export class XService extends Service {
   ): Promise<Memory[]> {
     const runtime = context.runtime ?? this.runtime;
     const accountId = this.resolveAccountId(
-      params.target,
+      context.accountId,
       context.target,
       context.metadata,
+      params.target,
     );
     const base = (await this.getTwitterClientForAccount(accountId)).client;
 
@@ -954,7 +963,11 @@ export class XService extends Service {
     }
 
     const runtime = context.runtime ?? this.runtime;
-    const accountId = this.resolveAccountId(context.target, context.metadata);
+    const accountId = this.resolveAccountId(
+      context.accountId,
+      context.target,
+      context.metadata,
+    );
     const base = (await this.getTwitterClientForAccount(accountId)).client;
     const result = await base.fetchSearchTweets(
       query,


### PR DESCRIPTION
## Summary

Rebuilds the recovered aggregate tail `62ba0c2` ("fix(connectors): fail closed on trusted account routing") on current develop. Trusted account routing now matches ONLY canonical connector account IDs; display labels, display names, and metadata aliases can never satisfy an account selector.

Closes #16506

## What changed

**Canonical-ID-only matching** (`connectorActionUtils.ts`, `message.ts`, `post.ts`):
- Account selectors match only `connector.accountId` / `connector.account.accountId`. A second account whose display name or label collides with a trusted account id can no longer hijack routing.
- Connector-managed unscoped dispatch is an explicit opt-in: allowed only when the connector exposes NO canonical account ID and registers `accountRouting: "connector"` (new typed field on `MessageConnector`/`PostConnector`).
- Ambiguous, missing, forged, cross-source, and display-name-collision selectors fail closed with typed errors (`SOURCE_AMBIGUOUS` / `ACCOUNT_CONNECTOR_NOT_FOUND`) and invoke no connector client.

**Trusted envelope only** (`trustedConnectorAccountId` / `trustedConnectorSource`):
- Connector identity is read exclusively from the stored `Memory.metadata` envelope (server-stamped). The `content.metadata.connectorSendAs` / `connectorAccount` smuggling paths are removed from MESSAGE/POST param resolution. An envelope account never pairs with a mismatched user-facing `Content.source`.

**Runtime registration** (`runtime.ts`):
- `normalizeMessageConnector` / `normalizePostConnector` preserve `accountRouting: "connector"` through registration, but only for unscoped registrations, matching selector semantics. (Codex P1 fix; regression test drives a real `AgentRuntime`.)

**plugin-x**:
- DM send, post, feed, search, target resolution, and recent-message ops consume the server-authorized `accountId` from `TargetInfo` or the typed connector context FIRST; registers with `accountRouting: "connector"` and threads `context.accountId` through `postHandler`.

## On the codex "preserve content-metadata send-as fallback" comments

Two codex P1s asked to retain the `content.metadata.connectorSendAs` fallback for user-authored sends. Declined deliberately, with receipts:
- Removing content-metadata routing authority is the core of this issue ("`Content.metadata` never override[s] server-side authority").
- After #16547 (merged), the UI sends the selection as top-level `accountId` on the strict inbox contract; the server validates it and stamps the canonical envelope before dispatch.
- There are no remaining producers of the metadata path: `mergeConnectorSendAsMetadata` has zero call sites outside its own module/tests, and ChatView's send path uses top-level `accountId` only. New adversarial tests pin exactly this ("does not route from untrusted content metadata accountId", display-collision fail-closed cases).

## Tests

- core `message.test.ts` + `post.test.ts`: **21 pass** (trusted envelope dispatch + Content spoofing ignored, display-name collision fails closed for MESSAGE and POST, owner-binding gate)
- core `message-post-connectors.test.ts`: **16 pass** (incl. new normalization-preservation regression + untrusted-metadata rejection)
- plugin-x `x.service.test.ts`: **9 pass** (server-authorized account context consumed for DM/post/feed/search)
- typecheck: core ✅ plugin-x ✅ (0 errors after core rebuild; remaining plugin-x file errors are pre-existing on develop, unrelated files)

## Review

Codex round 1 P1 (accountRouting dropped by runtime normalization) — fixed in `baa8548` with regression test. Round 2 P1s — addressed above (stale path, removal is the issue's intent).

Sequenced after #16547 (merged). [sol-orch]
