### PR TITLE
fix(cloud): preserve realtime bridge upstream errors

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -557,6 +557,39 @@ describe("voice-session WS lifecycle", () => {
     expect(client.closedWith).toBeNull();
   });
 
+  test("canonical 402 becomes a non-retryable insufficient-credits turn error", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: (async () =>
+        Response.json(
+          {
+            success: false,
+            error:
+              "Insufficient credits. Required: $0.0014, Available: $0.0000",
+            code: "insufficient_credits",
+            retryable: false,
+          },
+          { status: 402 },
+        )) as unknown as typeof fetch,
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "please answer");
+    await flush();
+    await flush();
+
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "insufficient_credits",
+        retryable: false,
+      }),
+    );
+    expect(client.controlTypes()).toContain("usage");
+    expect(client.closedWith).toBeNull();
+  });
+
   test("TTS provider error becomes retryable client error and closes the active turn", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -36,7 +36,10 @@ import type {
   VoiceUsageLimits,
   VoiceUsageStore,
 } from "@/lib/services/voice-usage-meter";
-import { streamElizaConversation } from "@/lib/voice-session/eliza-sse-bridge";
+import {
+  ElizaSseBridgeError,
+  streamElizaConversation,
+} from "@/lib/voice-session/eliza-sse-bridge";
 import { PhraseAggregator } from "@/lib/voice-session/phrase-aggregator";
 import type { ServerControlFrame } from "@/lib/voice-session/protocol";
 import {
@@ -594,8 +597,14 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       if (this.currentVoiceTurnId !== traceId) return;
       this.send({
         t: "error",
-        code: error instanceof Error ? error.name : "llm_error",
-        retryable: true,
+        code:
+          error instanceof ElizaSseBridgeError && error.upstreamCode
+            ? error.upstreamCode
+            : error instanceof Error
+              ? error.name
+              : "llm_error",
+        retryable:
+          error instanceof ElizaSseBridgeError ? error.retryable : true,
       });
       this.finishTurn(traceId);
     }

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -15,7 +15,10 @@ function sseResponse(lines: string[], status = 200): Response {
       controller.close();
     },
   });
-  return new Response(body, { status, headers: { "Content-Type": "text/event-stream" } });
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/event-stream" },
+  });
 }
 
 describe("eliza sse bridge", () => {
@@ -191,6 +194,42 @@ describe("eliza sse bridge", () => {
         },
         () => {},
       ),
-    ).rejects.toMatchObject({ code: "upstream_error" });
+    ).rejects.toMatchObject({ code: "upstream_error", retryable: true });
+  });
+
+  test("preserves the canonical insufficient-credits code and retryability", async () => {
+    const fetchImpl = (async () =>
+      Response.json(
+        {
+          success: false,
+          error: "Insufficient credits. Required: $0.0014, Available: $0.0000",
+          code: "insufficient_credits",
+          retryable: false,
+        },
+        { status: 402 },
+      )) as unknown as typeof fetch;
+
+    await expect(
+      streamElizaConversation(
+        {
+          endpoint: "http://x",
+          authorization: "Bearer s",
+          model: "m",
+          transcript: "hi",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          traceId: "t",
+          signal: new AbortController().signal,
+          fetchImpl,
+        },
+        () => {},
+      ),
+    ).rejects.toMatchObject({
+      code: "upstream_error",
+      status: 402,
+      upstreamCode: "insufficient_credits",
+      retryable: false,
+      message: expect.stringContaining("Insufficient credits"),
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -62,6 +62,10 @@ export class ElizaSseBridgeError extends Error {
     message: string,
     readonly code: "upstream_error" | "no_body" | "protocol_error",
     readonly status?: number,
+    /** Canonical route error code, safe to forward to the voice client. */
+    readonly upstreamCode?: string,
+    /** Whether retrying the turn can succeed without user action. */
+    readonly retryable = true,
   ) {
     super(message);
     this.name = "ElizaSseBridgeError";
@@ -119,10 +123,15 @@ export async function streamElizaConversation(
   }
 
   if (!response.ok) {
+    const upstreamError = await readUpstreamError(response);
     throw new ElizaSseBridgeError(
-      `Eliza SSE upstream returned HTTP ${response.status}`,
+      upstreamError.message
+        ? `Eliza SSE upstream returned HTTP ${response.status}: ${upstreamError.message}`
+        : `Eliza SSE upstream returned HTTP ${response.status}`,
       "upstream_error",
       response.status,
+      upstreamError.code,
+      upstreamError.retryable,
     );
   }
   if (!response.body) {
@@ -204,6 +213,70 @@ function canonicalConversationStreamUrl(
   url.search = "";
   url.hash = "";
   return url.toString();
+}
+
+const MAX_UPSTREAM_ERROR_BYTES = 4096;
+const SAFE_UPSTREAM_CODE = /^[a-z0-9_]{1,64}$/;
+
+async function readUpstreamError(response: Response): Promise<{
+  code?: string;
+  message?: string;
+  retryable: boolean;
+}> {
+  const fallbackRetryable =
+    response.status === 408 || response.status === 429 || response.status >= 500;
+  if (!response.body) return { retryable: fallbackRetryable };
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytesRead = 0;
+  try {
+    while (bytesRead < MAX_UPSTREAM_ERROR_BYTES) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      const remaining = MAX_UPSTREAM_ERROR_BYTES - bytesRead;
+      const bytes = chunk.value.subarray(0, remaining);
+      bytesRead += bytes.byteLength;
+      text += decoder.decode(bytes, { stream: true });
+      if (chunk.value.byteLength > remaining) break;
+    }
+    text += decoder.decode();
+  } catch {
+    // error-policy:J3 untrusted upstream body: preserve the status-derived fallback.
+    return { retryable: fallbackRetryable };
+  } finally {
+    try {
+      await reader.cancel();
+    } catch (ignoredError) {
+      void ignoredError;
+      // error-policy:J6 best-effort response teardown must not mask the HTTP error.
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(text) as {
+      code?: unknown;
+      error?: unknown;
+      message?: unknown;
+      retryable?: unknown;
+    };
+    const rawCode = typeof parsed.code === "string" ? parsed.code : "";
+    const rawMessage =
+      typeof parsed.error === "string"
+        ? parsed.error
+        : typeof parsed.message === "string"
+          ? parsed.message
+          : "";
+    return {
+      ...(SAFE_UPSTREAM_CODE.test(rawCode) ? { code: rawCode } : {}),
+      ...(rawMessage.trim() ? { message: rawMessage.trim().slice(0, 512) } : {}),
+      retryable: typeof parsed.retryable === "boolean" ? parsed.retryable : fallbackRetryable,
+    };
+  } catch {
+    // error-policy:J3 malformed/truncated upstream JSON: use status semantics.
+    return { retryable: fallbackRetryable };
+  }
 }
 
 function extractErrorMessage(payload: string): string {


### PR DESCRIPTION
## Summary
- preserve bounded, sanitized canonical route error details across the realtime SSE bridge
- propagate canonical `code` and `retryable` semantics to the realtime WebSocket client
- add contract coverage for the live HTTP 402 `insufficient_credits` failure mode

## Root cause
The staging probe's canonical preflight returned:

```json
{"success":false,"error":"Insufficient credits. Required: $0.0014, Available: $0.0000","code":"insufficient_credits","retryable":false}
```

The SSE bridge discarded that non-2xx body and status semantics, converting it to a generic `ElizaSseBridgeError`; `VoiceSession` then always emitted `retryable:true`. This made a permanent billing rejection look like a transient bridge crash before `llm_first_text`.

The fresh SIWE probe account had no signup grant because anti-abuse grant limits were already exhausted from the same source IP. Billing remains enforced; this PR does not bypass it.

## Validation
- `bun test packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` (29 pass, 0 fail)
- `bun run --cwd packages/cloud/shared typecheck`
- `bunx @biomejs/biome check <4 touched files>`
- `codex review --uncommitted` found one P2 annotation issue; fixed all new fallback catches with required error-policy annotations

## Evidence
- Before: `/tmp/voice-flip/sse-repro-results.json`, canonical preflight HTTP 402 and realtime generic `ElizaSseBridgeError`
- UI/screenshots: N/A, backend protocol fix
- DB/migrations: N/A, no schema changes
