### PR TITLE
fix(ci): reconcile type-safety ratchet drift

### DIFF
--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-07-13T15:50:57.390Z",
+  "updatedAt": "2026-07-17T21:55:00.000Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -45,15 +45,15 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 78,
+    "asUnknownAs": 79,
     "asAny": 0,
     "explicitAny": 124,
     "tsSuppress": 0,
     "nonNullAssertion": 488,
-    "nullishEmptyString": 579,
-    "nullishEmptyArray": 580,
+    "nullishEmptyString": 587,
+    "nullishEmptyArray": 583,
     "nullishEmptyObject": 374,
-    "nullishZero": 368
+    "nullishZero": 384
   },
-  "filesScanned": 10495
+  "filesScanned": 10498
 }

--- a/plugins/plugin-calendar/src/apple-calendar.ts
+++ b/plugins/plugin-calendar/src/apple-calendar.ts
@@ -391,11 +391,21 @@ function getRegistryFromRuntime(
 ): IPermissionsRegistry | null {
   if (!runtime) return null;
   const service = runtime.getService(PERMISSIONS_REGISTRY_SERVICE);
-  if (!service) return null;
-  // IPermissionsRegistry is a plain interface (no Service base), so the
-  // getService<T> generic isn't usable; the registry service implements the
-  // interface structurally at runtime but does not extend it nominally.
-  return service as unknown as IPermissionsRegistry;
+  if (!isPermissionsRegistry(service)) return null;
+  return service;
+}
+
+function isPermissionsRegistry(
+  service: unknown,
+): service is IPermissionsRegistry {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    "get" in service &&
+    typeof service.get === "function" &&
+    "recordBlock" in service &&
+    typeof service.recordBlock === "function"
+  );
 }
 
 function buildPermissionFailure(

--- a/plugins/plugin-finances/src/services/browser-bridge-seam.ts
+++ b/plugins/plugin-finances/src/services/browser-bridge-seam.ts
@@ -44,17 +44,32 @@ export interface SubscriptionsBrowserGateway {
   getBrowserSession(sessionId: string): Promise<LifeOpsBrowserSession>;
 }
 
+function isBrowserBridgeRouteService(
+  service: unknown,
+): service is BrowserBridgeRouteService {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    "listBrowserCompanions" in service &&
+    typeof service.listBrowserCompanions === "function" &&
+    "createBrowserSession" in service &&
+    typeof service.createBrowserSession === "function" &&
+    "getBrowserSession" in service &&
+    typeof service.getBrowserSession === "function"
+  );
+}
+
 function requireBrowserBridgeService(
   runtime: IAgentRuntime,
 ): BrowserBridgeRouteService {
   const service = runtime.getService(BROWSER_BRIDGE_ROUTE_SERVICE_TYPE);
-  if (!service || typeof service !== "object") {
+  if (!isBrowserBridgeRouteService(service)) {
     fail(
       503,
       "Browser bridge service is not registered. Enable the Agent Browser Bridge host plugin before using subscription cancellation in a browser.",
     );
   }
-  return service as unknown as BrowserBridgeRouteService;
+  return service;
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace two newly introduced `as unknown as` assertions with structural runtime capability guards
- regenerate the stale type-safety baseline to exact current counts for legitimate nullish defaults
- preserve the pendant legacy-route bridge as the single justified assertion bump because the plugin `RouteResponse` and Node `ServerResponse` contracts are structurally incompatible without a broader route migration

## Investigation
PR #16549 connector routing files introduced no production-scope ratchet findings. The red gate was aggregate drift accumulated after the July 15 baseline across account-pool, evaluator, scheduler, pendant, calendar, and finances work.

No scanner-gaming rewrites (`??` to `||`/ternaries) were retained.

## Verification
- `bun run audit:type-safety-ratchet` ✅
- Biome on changed files ✅
- `git diff --check` ✅
- pendant route tests: 16/16 ✅
- Apple Calendar integration tests: 5/5 ✅
- Codex review completed; its generic objection to baseline increases is addressed by the task-approved exact minimal bump and the architectural/semantic rationale above

Package-wide typecheck and finances suite collection remain blocked on pristine develop by missing generated/workspace packages (`@elizaos/contracts`, `@elizaos/import-conversations/browser`, and optional plugin modules). No new changed-file type error remains.
