### PR TITLE
chore(plugin-app-control): apply canonical formatting

### DIFF
--- a/plugins/plugin-app-control/src/resolve.test.ts
+++ b/plugins/plugin-app-control/src/resolve.test.ts
@@ -3,10 +3,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-	formatAppCandidates,
-	resolveInstalledApp,
-} from "./resolve.js";
+import { formatAppCandidates, resolveInstalledApp } from "./resolve.js";
 import type { InstalledAppInfo } from "./types.js";
 
 const app = (over: Partial<InstalledAppInfo>): InstalledAppInfo =>


### PR DESCRIPTION
## Summary
- apply the repository-pinned Biome formatter output to `src/resolve.test.ts`
- no logic changes

## Verification
- `bun run format:check` in `plugins/plugin-app-control`: pass
- `git diff --check`: pass
- Codex review: no findings

## Evidence
- Quality (Extended) run 29615306909 identified this exact formatter-only failure
- screenshots/video/trajectory: N/A, formatting-only test import change
