### PR TITLE
fix(cli-inference): bound SDK session teardown so a wedged spawn cannot swallow the turn timeout

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ClaudeSdkSession, type SdkModule } from "../src/claude-sdk-session";
 import { ProviderApiError } from "../src/provider-errors";
 
@@ -13,6 +13,8 @@ import { ProviderApiError } from "../src/provider-errors";
 interface TurnScript {
   /** Never yield a message, used to test the per-turn timeout budget. */
   hang?: boolean;
+  /** Sleep this long before proceeding (slow-but-healthy turn shape). */
+  delayMs?: number;
   /** ROUTE mode: invoke the captured tool handler with this decision. */
   toolCall?: { action: unknown; params?: unknown };
   /** Stream this as assistant text before the result. */
@@ -31,7 +33,10 @@ type ToolHandler = (args: {
 }) => Promise<{ content: Array<{ type: string; text: string }> }>;
 
 /** Build a fake SdkModule that replays `scripts` turn-by-turn over one warm query. */
-function makeFakeSdk(scripts: TurnScript[]): {
+function makeFakeSdk(
+  scripts: TurnScript[],
+  fakeOpts: { interrupt?: () => Promise<void> } = {}
+): {
   sdk: SdkModule;
   starts: () => number;
   queryOptions: () => Array<Record<string, unknown>>;
@@ -59,6 +64,9 @@ function makeFakeSdk(scripts: TurnScript[]): {
           if (s.hang) {
             await new Promise(() => undefined);
           }
+          if (s.delayMs) {
+            await new Promise((res) => setTimeout(res, s.delayMs));
+          }
           if (s.toolCall && handler) {
             await handler({ action: s.toolCall.action, params: s.toolCall.params });
           }
@@ -81,7 +89,7 @@ function makeFakeSdk(scripts: TurnScript[]): {
       const iter = gen();
       return {
         [Symbol.asyncIterator]: () => iter,
-        interrupt: async () => {},
+        interrupt: fakeOpts.interrupt ?? (async () => {}),
       } as unknown as ReturnType<SdkModule["query"]>;
     },
   };
@@ -99,9 +107,12 @@ function makeSession(
     restartAfterTurns?: number;
     turnTimeoutMs?: number;
     subprocessEnv?: Record<string, string | undefined>;
+    interrupt?: () => Promise<void>;
   } = {}
 ) {
-  const { sdk, starts, queryOptions } = makeFakeSdk(scripts);
+  const { sdk, starts, queryOptions } = makeFakeSdk(scripts, {
+    interrupt: opts.interrupt,
+  });
   const session = new ClaudeSdkSession({
     model: "test-model",
     systemPrompt: "test system",
@@ -198,6 +209,52 @@ describe("ClaudeSdkSession — TEXT mode", () => {
     await expect(session.send("hi")).rejects.toBeInstanceOf(ProviderApiError);
     expect(Date.now() - started).toBeLessThan(1_000);
     await session.dispose();
+  });
+
+  it("a wedged interrupt cannot swallow the turn-timeout rejection (#16553)", async () => {
+    // The production incident shape: the turn hangs AND the CLI process never
+    // ACKs the interrupt. The 90s timer used to fire into a catch that awaited
+    // dispose() → interrupt() unboundedly, so the turn never rejected and the
+    // whole inbound pipeline serialized behind it. The bounded teardown must
+    // abandon the wedged interrupt and let the timeout surface.
+    vi.useFakeTimers();
+    try {
+      const { session } = makeSession([{ hang: true }], {
+        turnTimeoutMs: 5_000,
+        interrupt: () => new Promise<void>(() => undefined), // never ACKs
+      });
+      const outcome = session.send("hi");
+      const settled = expect(outcome).rejects.toBeInstanceOf(ProviderApiError);
+      await vi.advanceTimersByTimeAsync(5_000); // turn timeout fires
+      await vi.advanceTimersByTimeAsync(5_000); // dispose teardown budget expires
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("explicit turnTimeoutMs 0 opts out to an unbounded turn (#16553)", async () => {
+    vi.useFakeTimers();
+    try {
+      // With a bounded budget this slow turn rejects…
+      const bounded = makeSession([{ delayMs: 200, text: "late", subtype: "success" }], {
+        turnTimeoutMs: 100,
+      });
+      const boundedOutcome = bounded.session.send("hi");
+      const boundedSettled = expect(boundedOutcome).rejects.toBeInstanceOf(ProviderApiError);
+      await vi.advanceTimersByTimeAsync(200);
+      await boundedSettled;
+      // …while the explicit 0 opt-out lets it finish.
+      const unbounded = makeSession([{ delayMs: 200, text: "late", subtype: "success" }], {
+        turnTimeoutMs: 0,
+      });
+      const unboundedOutcome = unbounded.session.send("hi");
+      await vi.advanceTimersByTimeAsync(200);
+      expect(await unboundedOutcome).toBe("late");
+      await unbounded.session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("self-heals: a throwing turn disposes, the next call re-starts the session", async () => {

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -22,6 +22,7 @@ import {
   cliInferencePlugin,
   findHandleResponseTool,
   LARGE_TIER_MODEL_TYPES,
+  parseTurnTimeout,
   resolveCliBackend,
   resolveSdkEffort,
 } from "../index";
@@ -1197,5 +1198,18 @@ describe("Stage-1 ENVELOPE mode (claude-sdk handle_response tool)", () => {
     expect(body.trimEnd().endsWith("with the completed envelope fields.")).toBe(true);
     // System-less calls still produce a well-formed body.
     expect(buildEnvelopeBody(undefined, "just body")).toContain("just body");
+  });
+});
+
+describe("parseTurnTimeout (#16553)", () => {
+  it('passes an explicit "0" through as the unbounded opt-out', () => {
+    expect(parseTurnTimeout("0")).toBe(0);
+  });
+
+  it("parses a positive budget and rejects junk/negatives to undefined (bounded default applies)", () => {
+    expect(parseTurnTimeout("120000")).toBe(120_000);
+    expect(parseTurnTimeout(undefined)).toBeUndefined();
+    expect(parseTurnTimeout("abc")).toBeUndefined();
+    expect(parseTurnTimeout("-5")).toBeUndefined();
   });
 });

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -298,8 +298,8 @@ function getSdkSession(
     claudeExecutablePath: getSetting(runtime, "ELIZA_CLI_CLAUDE_BIN"),
     restartAfterTurns: parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_RESTART_AFTER_TURNS")),
     turnTimeoutMs:
-      parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_TURN_TIMEOUT_MS")) ??
-      parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+      parseTurnTimeout(getSetting(runtime, "ELIZA_CLI_SDK_TURN_TIMEOUT_MS")) ??
+      parseTurnTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
     effort: resolveSdkEffort(runtime, mode),
     subprocessEnv,
   });
@@ -383,6 +383,17 @@ function parseTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
   const n = Number.parseInt(value, 10);
   return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/** Turn-timeout parse (#16553): like {@link parseTimeout}, but an explicit
+ *  `"0"` passes through as 0 — the documented operator opt-out to an
+ *  unbounded turn. Unset/invalid still return undefined so the session's
+ *  bounded default applies. Exported for tests. */
+export function parseTurnTimeout(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
 }
 
 // One binary setting covers both warm and cold backends so container images can

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -59,6 +59,10 @@ import { ProviderApiError, parseProviderApiErrorText } from "./provider-errors";
 const DEFAULT_MODEL = "claude-opus-4-8";
 const DEFAULT_RESTART_AFTER_TURNS = 20;
 const DEFAULT_TURN_TIMEOUT_MS = 90_000;
+/** Teardown budget for `dispose()`'s interrupt ACK (#16553): long enough for a
+ *  healthy CLI to acknowledge, short enough that a wedged spawn cannot wedge
+ *  the turn's failure path behind it. */
+const DISPOSE_INTERRUPT_BUDGET_MS = 5_000;
 /** Fully-qualified names the SDK assigns our in-process MCP tools. */
 const ROUTE_TOOL = "mcp__eliza__route_action";
 const ENVELOPE_TOOL = "mcp__eliza__handle_response";
@@ -227,7 +231,9 @@ export interface ClaudeSdkSessionConfig {
   claudeExecutablePath?: string | null;
   /** Restart the warm session after this many turns (bounds context growth). */
   restartAfterTurns?: number;
-  /** Hard wall-clock budget for one SDK turn. Defaults below common 120s connector timeouts. */
+  /** Hard wall-clock budget for one SDK turn. Defaults below common 120s
+   *  connector timeouts. Explicit `0` opts out to unbounded (#16553) — an
+   *  operator choice, never a default. */
   turnTimeoutMs?: number;
   /**
    * Reasoning effort for this session's turns, forwarded to the Agent SDK's
@@ -347,10 +353,14 @@ export class ClaudeSdkSession {
       config.restartAfterTurns && config.restartAfterTurns > 0
         ? config.restartAfterTurns
         : DEFAULT_RESTART_AFTER_TURNS;
+    // Explicit 0 = operator opt-out to unbounded (#16553); unset/invalid
+    // falls to the bounded default so a hung spawn can never wedge by default.
     this.turnTimeoutMs =
-      config.turnTimeoutMs && config.turnTimeoutMs > 0
-        ? config.turnTimeoutMs
-        : DEFAULT_TURN_TIMEOUT_MS;
+      config.turnTimeoutMs === 0
+        ? 0
+        : config.turnTimeoutMs && config.turnTimeoutMs > 0
+          ? config.turnTimeoutMs
+          : DEFAULT_TURN_TIMEOUT_MS;
     this.effort = normalizeEffort(config.effort);
     this.subprocessEnv = config.subprocessEnv ?? null;
     this.sdkOverride = config.sdkModule;
@@ -570,6 +580,10 @@ export class ClaudeSdkSession {
     if (!iterator) {
       throw new Error("[cli-inference:sdk] session not started");
     }
+    // Explicit operator opt-out (#16553): no timer, the read is unbounded.
+    if (this.turnTimeoutMs === 0) {
+      return iterator.next();
+    }
 
     let timer: NodeJS.Timeout | undefined;
     try {
@@ -727,7 +741,18 @@ export class ClaudeSdkSession {
     );
   }
 
-  /** Tear down the warm session (on restart, error, or dispose). */
+  /**
+   * Tear down the warm session (on restart, error, or dispose).
+   *
+   * BOUNDED (#16553): `query.interrupt()` sends a control request to the CLI
+   * process and awaits its acknowledgement — a wedged spawn (version-mismatch
+   * download, OAuth refresh hang) never ACKs, so an unbounded await here
+   * swallowed the turn-timeout rejection behind it and serialized the whole
+   * inbound pipeline until an operator restart. The teardown races a short
+   * budget; on expiry the interrupt is abandoned (the session references are
+   * already nulled, so the next turn respawns cleanly) and the wedge is
+   * logged instead of inherited.
+   */
   async dispose(): Promise<void> {
     const q = this.query;
     this.query = null;
@@ -737,11 +762,30 @@ export class ClaudeSdkSession {
     this.pendingDecision = null;
     this.pendingEnvelope = null;
     if (q?.interrupt) {
+      let timer: NodeJS.Timeout | undefined;
       try {
-        await q.interrupt();
+        await Promise.race([
+          q.interrupt(),
+          new Promise<void>((resolve) => {
+            timer = setTimeout(() => {
+              logger.warn(
+                {
+                  src: "cli-inference:sdk",
+                  model: this.model,
+                  mode: this.mode,
+                },
+                `[cli-inference:sdk] abandoning interrupt of a wedged session after ${DISPOSE_INTERRUPT_BUDGET_MS}ms`
+              );
+              resolve();
+            }, DISPOSE_INTERRUPT_BUDGET_MS);
+            timer.unref?.();
+          }),
+        ]);
       } catch {
         // error-policy:J6 best-effort teardown — interrupting an already-dead
         // query on dispose; failure here does not matter (the session is discarded).
+      } finally {
+        if (timer) clearTimeout(timer);
       }
     }
   }


### PR DESCRIPTION
# Relates to

Fixes #16553

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Scoped to the warm claude-sdk session's failure path. Healthy turns are untouched (the teardown budget only matters when the CLI never ACKs an interrupt — a state that previously wedged the pipeline). One deliberate semantic change: explicit `ELIZA_CLI_SDK_TURN_TIMEOUT_MS=0` now truly opts out to unbounded (it silently mapped to the 90s default before) — that matches the issue's documented operator contract.

# Background

## What does this PR do?

**Diagnosis correction first:** the turn timeout was NOT missing — `DEFAULT_TURN_TIMEOUT_MS = 90_000` has applied when the env is unset since July 2. The 90s timer **fired during the incident**; its rejection was swallowed because the timeout catch path awaits `dispose()` → `query.interrupt()` **unboundedly**. `interrupt()` sends a control request to the CLI process and awaits its ACK — the wedged spawn (suspected version-mismatch download / OAuth refresh) never ACKs, so the turn's own failure path inherited the wedge it was handling, and the inbound pipeline serialized behind a turn that could never reject. The test fake's `interrupt` resolved instantly, which is exactly why the existing timeout test stayed green while production hung.

The fix:

- **Bounded teardown** — `dispose()` races the interrupt against a 5s budget; on expiry the interrupt is abandoned with a warn log (the session references are already nulled, so the next turn respawns cleanly — the eviction/respawn semantics the issue asks for were already in place and now actually get reached).
- **Real operator opt-out** — explicit `ELIZA_CLI_SDK_TURN_TIMEOUT_MS=0` passes through as unbounded (`parseTurnTimeout`; the session skips the timer). Unset/invalid still fall to the bounded 90s default, so a hung spawn can never wedge by default.
- **Observable failure** — the turn now actually rejects with the existing `ProviderApiError("turn timed out …")`, which propagates through the model handler to the standard failure reply; the abandoned-interrupt warn carries model/mode context.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`claude-sdk-session.test.ts` — "a wedged interrupt cannot swallow the turn-timeout rejection (#16553)" drives the exact incident shape via the injectable fake (hung turn + an `interrupt` that never ACKs) under fake timers: turn timeout fires, teardown budget expires, and the turn rejects with `ProviderApiError` instead of hanging forever. The opt-out contrast pair proves `turnTimeoutMs: 0` lets a slow turn finish while a bounded budget rejects it. `parseTurnTimeout` unit cases pin the `"0"`-passthrough vs unset/junk semantics.

## Detailed testing steps

None: Automated tests are acceptable.

```
vitest run __tests__/cli-inference.test.ts __tests__/claude-sdk-session.test.ts
Test Files  2 passed (2) — Tests  85 passed | 1 skipped (86)
Coverage (changed sources, union of changed lanes):
  claude-sdk-session.ts  81.0% lines
  index.ts               65.1% lines
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-only inference-plugin fix, no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-only inference-plugin fix, no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; the incident shape is reproduced deterministically in the regression test described above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the incident's defining symptom was the ABSENCE of any log/error (silent wedge); the regression test asserts the turn now fails observably, and the new abandoned-interrupt warn is exercised in that same lane.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - failure-path change only; no prompt/model/decision behavior touched (the SDK fake seam keeps tests deterministic per the suite's existing pattern).`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB/memory/task output; the artifact is the bounded-rejection behavior pinned by the regression test.`

# Evidence Details

Incident timeline (production, 2026-07-17 ~21:11 UTC, from #16553): fresh session key → hung spawn → no error, no timeout, pipeline serialized 10+ min → operator restart. With this change the same shape yields: 90s turn timeout → 5s teardown budget → `ProviderApiError` surfaces → wedged session evicted → next turn respawns. Operator workaround (`ELIZA_CLI_SDK_TURN_TIMEOUT_MS=120000`) keeps working; `0` now genuinely means unbounded.

## Known gaps / failures

None known. The lingering wedged child process (post-abandon) is left to plugin dispose/exit cleanup — killing it requires a process handle the SDK query surface does not expose; noted for an upstream SDK follow-up if it recurs.

[stan-cloud]
