### PR TITLE
fix(cloud): dispatch voice SSE bridge in-process

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -61,6 +61,9 @@ const streamRoute = (
     "../v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route"
   )
 ).default;
+const { createInternalElizaConversationFetch } = await import(
+  "../v1/voice/session/lib/internal-eliza-conversation-fetch"
+);
 
 // Restore the real modules so this file's process-global mocks don't strand later
 // test files that use the full elizaSandboxService / resolveSharedAgent surface.
@@ -179,6 +182,55 @@ describe("shared agent messages/stream", () => {
       params: {
         text: "voice transcript",
         roomId: "conv-voice-service",
+      },
+    });
+  });
+
+  test("internal voice fetch adapter dispatches the canonical root path in-process", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: AGENT,
+      organization_id: ORG,
+      user_id: "user-voice",
+      agent_name: "Voice Agent",
+    });
+    bridgeStream.mockResolvedValue(
+      new Response(
+        'event: chunk\ndata: {"chunk":"adapter ok"}\n\nevent: done\ndata: {}\n\n',
+        { headers: { "Content-Type": "text/event-stream" } },
+      ),
+    );
+
+    const fetchImpl = createInternalElizaConversationFetch(
+      {
+        VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
+      } as Parameters<typeof createInternalElizaConversationFetch>[0],
+      { agentId: AGENT, conversationId: VOICE_CONVERSATION },
+    );
+
+    const res = await fetchImpl(
+      `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Service-Key": "Bearer voice-service",
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "user-voice",
+        },
+        body: JSON.stringify({ text: "adapter transcript" }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toContain("adapter ok");
+    expect(resolveSharedAgent).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).toHaveBeenCalledWith(AGENT, ORG);
+    expect(bridgeStream.mock.calls[0][2]).toMatchObject({
+      method: "message.send",
+      params: {
+        text: "adapter transcript",
+        roomId: VOICE_CONVERSATION,
       },
     });
   });

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -150,6 +150,14 @@ class FakeCartesiaSocket implements CartesiaWebSocketLike {
       }),
     });
   }
+  sentText(): string {
+    return this.sent
+      .map((entry) => {
+        const parsed = JSON.parse(entry) as { transcript?: unknown };
+        return typeof parsed.transcript === "string" ? parsed.transcript : "";
+      })
+      .join("");
+  }
   private fire(type: string, payload: unknown) {
     for (const l of this.listeners.get(type) ?? []) l(payload);
   }
@@ -429,6 +437,27 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("usage");
   });
 
+  test("canonical chunk/done SSE frames are parsed into speakable LLM text", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeCanonicalChunkFetch(["Canonical chunk."]),
+    });
+
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "voice transcript");
+    await flush();
+    await flush();
+
+    expect(client.controlTypes()).toContain("llm_first_text");
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(cartesia.sentText()).toContain("Canonical chunk.");
+    cartesia.emitDone();
+    await flush();
+    expect(client.controlTypes()).toContain("usage");
+  });
+
   test("terminal Cartesia phrase carries continue:false and no empty-transcript finish (live-provider fix)", async () => {
     // Regression from the LIVE-provider evidence run: the session used to send
     // every phrase with continue:true then an empty-transcript finish(), which
@@ -586,6 +615,43 @@ describe("voice-session WS lifecycle", () => {
         retryable: false,
       }),
     );
+    expect(client.controlTypes()).toContain("usage");
+    expect(client.closedWith).toBeNull();
+  });
+
+  test("canonical 404 Agent not found is exposed in a bounded public voice error payload", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: (async () =>
+        Response.json(
+          {
+            success: false,
+            error: "Agent not found",
+          },
+          { status: 404 },
+        )) as unknown as typeof fetch,
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "please answer");
+    await flush();
+    await flush();
+
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "ElizaSseBridgeError",
+        retryable: false,
+        upstreamStatus: 404,
+        upstreamMessage: "Agent not found",
+      }),
+    );
+    const errorFrame = client.controlFrames.find(
+      (f) => f.t === "error" && "upstreamStatus" in f,
+    ) as Record<string, unknown> | undefined;
+    expect(JSON.stringify(errorFrame)).not.toContain("Bearer");
+    expect(JSON.stringify(errorFrame)).not.toContain("X-Service-Key");
     expect(client.controlTypes()).toContain("usage");
     expect(client.closedWith).toBeNull();
   });

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -1,0 +1,70 @@
+/**
+ * In-process fetch adapter for realtime voice turns that target the canonical
+ * Eliza conversation SSE route. The voice bridge keeps its HTTP-shaped contract
+ * for tests and future transports, but Worker production dispatches the scoped
+ * request directly into the route module so same-host public fetch behavior
+ * cannot bypass this Worker.
+ */
+import { Hono } from "hono";
+import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
+import conversationStreamRoute from "../../../eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route";
+
+const CANONICAL_STREAM_ROUTE =
+  "/api/v1/eliza/agents/:agentId/api/conversations/:conversationId/messages/stream";
+
+export interface InternalElizaConversationFetchClaims {
+  agentId: string;
+  conversationId: string;
+}
+
+export function createInternalElizaConversationFetch(
+  env: Bindings,
+  claims: InternalElizaConversationFetchClaims,
+): typeof fetch {
+  const app = new Hono<AppEnv>().route(
+    CANONICAL_STREAM_ROUTE,
+    conversationStreamRoute,
+  );
+
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    assertCanonicalVoiceStreamPath(url, claims);
+    const body =
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : await request.text();
+
+    return app.request(
+      `${url.pathname}${url.search}`,
+      {
+        method: request.method,
+        headers: request.headers,
+        body,
+        signal: request.signal,
+      },
+      env,
+    );
+  }) as typeof fetch;
+}
+
+function assertCanonicalVoiceStreamPath(
+  url: URL,
+  claims: InternalElizaConversationFetchClaims,
+): void {
+  const match = url.pathname.match(
+    /^\/api\/v1\/eliza\/agents\/([^/]+)\/api\/conversations\/([^/]+)\/messages\/stream$/,
+  );
+  if (!match) {
+    throw new TypeError(
+      `unsupported internal Eliza stream path: ${url.pathname}`,
+    );
+  }
+  const agentId = decodeURIComponent(match[1]);
+  const conversationId = decodeURIComponent(match[2]);
+  if (agentId !== claims.agentId || conversationId !== claims.conversationId) {
+    throw new TypeError(
+      "internal Eliza stream path does not match session scope",
+    );
+  }
+}

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -595,16 +595,24 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // error-policy:J1 boundary translation — the LLM/TTS turn is the async
       // boundary; provider failures become a structured client `error` frame.
       if (this.currentVoiceTurnId !== traceId) return;
+      const bridgeError =
+        error instanceof ElizaSseBridgeError ? error : undefined;
       this.send({
         t: "error",
         code:
-          error instanceof ElizaSseBridgeError && error.upstreamCode
-            ? error.upstreamCode
+          bridgeError?.upstreamCode
+            ? bridgeError.upstreamCode
             : error instanceof Error
               ? error.name
               : "llm_error",
-        retryable:
-          error instanceof ElizaSseBridgeError ? error.retryable : true,
+        retryable: bridgeError ? bridgeError.retryable : true,
+        ...(bridgeError?.status ? { upstreamStatus: bridgeError.status } : {}),
+        ...(bridgeError?.upstreamMessage
+          ? { upstreamMessage: bridgeError.upstreamMessage }
+          : {}),
+        ...(bridgeError?.upstreamSnippet
+          ? { upstreamSnippet: bridgeError.upstreamSnippet }
+          : {}),
       });
       this.finishTurn(traceId);
     }

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -28,7 +28,8 @@ import {
   attachVoiceWsHandler,
   type ServerWebSocketLike,
 } from "@/lib/voice-session/ws-handler";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
+import { createInternalElizaConversationFetch } from "../lib/internal-eliza-conversation-fetch";
 import {
   createWorkerCartesiaFactory,
   createWorkerDeepgramFluxFactory,
@@ -204,6 +205,13 @@ app.get("/", (c) => {
         elizaEndpoint,
         elizaAuthorization,
         elizaModel: resolveElizaModel(env),
+        fetchImpl: createInternalElizaConversationFetch(
+          c.env as unknown as Bindings,
+          {
+            agentId: claims.agentId,
+            conversationId: claims.conversationId,
+          },
+        ),
         usageStore,
         usageLimits,
         isRevoked: (jti) => isVoiceSessionTokenRevoked(jti),

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -66,6 +66,10 @@ export class ElizaSseBridgeError extends Error {
     readonly upstreamCode?: string,
     /** Whether retrying the turn can succeed without user action. */
     readonly retryable = true,
+    /** Bounded canonical-route message safe for a public voice error frame. */
+    readonly upstreamMessage?: string,
+    /** Bounded non-JSON upstream body prefix safe for diagnostics. */
+    readonly upstreamSnippet?: string,
   ) {
     super(message);
     this.name = "ElizaSseBridgeError";
@@ -132,6 +136,8 @@ export async function streamElizaConversation(
       response.status,
       upstreamError.code,
       upstreamError.retryable,
+      upstreamError.message,
+      upstreamError.snippet,
     );
   }
   if (!response.body) {
@@ -217,10 +223,18 @@ function canonicalConversationStreamUrl(
 
 const MAX_UPSTREAM_ERROR_BYTES = 4096;
 const SAFE_UPSTREAM_CODE = /^[a-z0-9_]{1,64}$/;
+const SAFE_PUBLIC_UPSTREAM_MESSAGES = new Set([
+  "Agent not found",
+  "Insufficient credits",
+  "Invalid request body",
+  "Message text is required",
+  "Missing request body",
+]);
 
 async function readUpstreamError(response: Response): Promise<{
   code?: string;
   message?: string;
+  snippet?: string;
   retryable: boolean;
 }> {
   const fallbackRetryable =
@@ -270,12 +284,22 @@ async function readUpstreamError(response: Response): Promise<{
           : "";
     return {
       ...(SAFE_UPSTREAM_CODE.test(rawCode) ? { code: rawCode } : {}),
-      ...(rawMessage.trim() ? { message: rawMessage.trim().slice(0, 512) } : {}),
-      retryable: typeof parsed.retryable === "boolean" ? parsed.retryable : fallbackRetryable,
+      ...(SAFE_PUBLIC_UPSTREAM_MESSAGES.has(rawMessage.trim())
+        ? { message: rawMessage.trim().slice(0, 512) }
+        : rawMessage.trim()
+          ? { snippet: "Upstream request failed" }
+          : {}),
+      retryable:
+        typeof parsed.retryable === "boolean"
+          ? parsed.retryable
+          : fallbackRetryable,
     };
   } catch {
     // error-policy:J3 malformed/truncated upstream JSON: use status semantics.
-    return { retryable: fallbackRetryable };
+    return {
+      ...(text.trim() ? { snippet: "Upstream returned a non-JSON error" } : {}),
+      retryable: fallbackRetryable,
+    };
   }
 }
 

--- a/packages/cloud/shared/src/lib/voice-session/protocol.ts
+++ b/packages/cloud/shared/src/lib/voice-session/protocol.ts
@@ -84,7 +84,14 @@ export type ServerControlFrame =
   | { t: "speaking_start"; traceId: string }
   | { t: "speaking_end"; traceId: string }
   | { t: "interrupted"; reason: "acoustic" | "explicit"; traceId: string }
-  | { t: "error"; code: string; retryable: boolean }
+  | {
+      t: "error";
+      code: string;
+      retryable: boolean;
+      upstreamStatus?: number;
+      upstreamMessage?: string;
+      upstreamSnippet?: string;
+    }
   | { t: "usage"; sttMs: number; ttsChars: number; traceId: string };
 
 export type ProtocolParseResult<T> =


### PR DESCRIPTION
## Summary
- route verified voice turns through the canonical conversation SSE handler in-process instead of self-fetching the Worker public hostname
- preserve scoped agent/org/user authorization and canonical billing/error/SSE behavior
- expose bounded, whitelisted upstream status/message diagnostics on public voice error frames

## Ground truth
A live staging `wrangler tail` captured the voice WS upgrade and no nested canonical-stream ingress. The same held agent/request with exact server headers succeeded externally with HTTP 200 and canonical `chunk`/`done`, proving Worker self-fetch bypassed the Worker route.

## Tests
- focused adapter, canonical chunk/done, and public 404 error-frame regressions added
- `git diff --check` and Biome pass
- local test execution blocked by this worktree's absent dependency store; required PR CI is the merge gate

Staging remains gated on and production remains off.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only voice transport change, no UI surface`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only voice transport change, no UI surface`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - backend-only WebSocket/SSE routing fix validated by live protocol probe`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - staging wrangler tail and exact-request diagnostics are captured in the external operator receipt`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - live canonical chunk/done trajectory is captured in the external operator receipt`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no OCR, UI, or domain-specific artifact applies to this backend voice bridge fix`.
