### PR TITLE
fix(orchestrator): resume persisted native ACP sessions

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -23,6 +23,7 @@ import {
   type AcpJsonRpcMessage,
   type ApprovalPreset,
   SessionCapError,
+  type SessionInfo,
 } from "../../src/services/types.js";
 
 type NativeEventHandler = (
@@ -57,6 +58,10 @@ type NativeMockState = {
   NativeAcpClient?: new (opts: NativeOptions) => MockNativeClient;
   instances: MockNativeClient[];
   startImplementation?: (client: MockNativeClient) => Promise<void>;
+  createSessionImplementation?: (
+    client: MockNativeClient,
+    workdir: string,
+  ) => Promise<{ sessionId: string; agentSessionId: string }>;
 };
 
 function getNativeMockState(): NativeMockState {
@@ -71,18 +76,20 @@ const nativeClientMock = getNativeMockState();
 
 vi.mock("../../src/services/acp-native-transport.js", () => {
   const state = getNativeMockState();
-  state.NativeAcpClient = class MockNativeAcpClient
-    implements MockNativeClient
-  {
+  state.NativeAcpClient = class MockNativeAcpClient implements MockNativeClient {
     opts: NativeOptions;
     eventHandler?: NativeEventHandler;
     start = vi.fn(async () => {
       await getNativeMockState().startImplementation?.(this);
     });
-    createSession = vi.fn(async () => ({
-      sessionId: "protocol-session",
-      agentSessionId: "agent-session",
-    }));
+    createSession = vi.fn(async (workdir: string) =>
+      getNativeMockState().createSessionImplementation
+        ? await getNativeMockState().createSessionImplementation(this, workdir)
+        : {
+            sessionId: "protocol-session",
+            agentSessionId: "agent-session",
+          },
+    );
     prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
     cancel = vi.fn(async () => undefined);
     closeSession = vi.fn(async () => undefined);
@@ -118,6 +125,7 @@ import {
   AcpService,
   ensureWorkspaceElizaCodeAcp,
 } from "../../src/services/acp-service.js";
+import { InMemorySessionStore } from "../../src/services/session-store.js";
 
 vi.mock("node:child_process", () => ({
   exec: vi.fn(),
@@ -303,6 +311,7 @@ beforeEach(() => {
   spawnMock.mockReset();
   nativeClientMock.instances.length = 0;
   nativeClientMock.startImplementation = undefined;
+  nativeClientMock.createSessionImplementation = undefined;
 });
 
 afterEach(() => {
@@ -313,6 +322,18 @@ function firstNativeClient(): MockNativeClient {
   const client = nativeClientMock.instances[0];
   if (!client) throw new Error("expected NativeAcpClient to be constructed");
   return client;
+}
+
+async function waitForNativeClient(
+  timeoutMs = 4000,
+): Promise<MockNativeClient> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const client = nativeClientMock.instances[0];
+    if (client) return client;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("expected NativeAcpClient to be constructed");
 }
 
 describe("AcpService", () => {
@@ -411,8 +432,7 @@ describe("AcpService", () => {
     const args = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
     expect(args).not.toContain("--no-terminal");
     const env = spawnMock.mock.calls[0]?.[2]?.env as
-      | Record<string, string>
-      | undefined;
+      Record<string, string> | undefined;
     expect(env?.PARALLAX_SESSION_ID).toBe(result.sessionId);
   });
 
@@ -446,8 +466,7 @@ describe("AcpService", () => {
       await service.stop();
 
       const env = spawnMock.mock.calls[0]?.[2]?.env as
-        | Record<string, string>
-        | undefined;
+        Record<string, string> | undefined;
       expect(env).toMatchObject({
         GIT_AUTHOR_NAME: "Configured Author",
         GIT_AUTHOR_EMAIL: "author@example.test",
@@ -962,6 +981,66 @@ describe("AcpService", () => {
     }
   });
 
+  it("retries Codex ACP once when createSession surfaces the Landlock panic", async () => {
+    const previousOverride = process.env.ELIZA_CODEX_ACP_LANDLOCK;
+    process.env.ELIZA_CODEX_ACP_LANDLOCK = "1";
+    try {
+      nativeClientMock.createSessionImplementation = async (client) => {
+        if (client.opts.env?.INITIAL_AGENT_MODE !== "agent-full-access") {
+          throw new Error(
+            "ACP agent exited with code 101: thread 'main' panicked: permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+          );
+        }
+        return {
+          sessionId: "protocol-session",
+          agentSessionId: "agent-session",
+        };
+      };
+      const rt = runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+      });
+      const service = new AcpService(rt);
+      await service.start();
+
+      const result = await service.spawnSession({
+        name: "codex-create-session-landlock-retry",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+
+      expect(result.status).toBe("ready");
+      expect(nativeClientMock.instances).toHaveLength(2);
+      expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+        undefined,
+      );
+      expect(nativeClientMock.instances[0]?.close).toHaveBeenCalled();
+      expect(nativeClientMock.instances[1]?.opts.command).toBe(
+        nativeClientMock.instances[0]?.opts.command,
+      );
+      expect(nativeClientMock.instances[1]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+        "agent-full-access",
+      );
+      expect(nativeClientMock.instances[1]?.createSession).toHaveBeenCalledWith(
+        RESOLVED_ACP_WORKDIR,
+      );
+      const logger = (rt as { logger: { warn: ReturnType<typeof vi.fn> } })
+        .logger;
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Codex ACP Landlock unavailable"),
+        expect.objectContaining({
+          sandboxMode: "danger-full-access",
+          approvalPolicy: "never",
+        }),
+      );
+    } finally {
+      if (previousOverride === undefined) {
+        delete process.env.ELIZA_CODEX_ACP_LANDLOCK;
+      } else {
+        process.env.ELIZA_CODEX_ACP_LANDLOCK = previousOverride;
+      }
+    }
+  });
+
   it("does not relax an explicit managed sandbox after a Landlock panic", async () => {
     nativeClientMock.startImplementation = async () => {
       throw new Error(
@@ -1060,8 +1139,7 @@ describe("AcpService", () => {
     expect(args).not.toContain("opencode");
 
     const env = spawnMock.mock.calls[0]?.[2]?.env as
-      | Record<string, string>
-      | undefined;
+      Record<string, string> | undefined;
     const config = JSON.parse(env?.OPENCODE_CONFIG_CONTENT ?? "{}") as {
       provider?: Record<
         string,
@@ -1104,8 +1182,7 @@ describe("AcpService", () => {
     expect(args).not.toContain("opencode");
 
     const env = spawnMock.mock.calls[0]?.[2]?.env as
-      | Record<string, string>
-      | undefined;
+      Record<string, string> | undefined;
     expect(env?.OPENCODE_MODEL).toBeUndefined();
     expect(env?.OPENAI_MODEL).toBeUndefined();
   });
@@ -1181,6 +1258,233 @@ describe("AcpService", () => {
         ],
       ]),
     );
+  });
+
+  it("dispatches sendPrompt by persisted session transport in a mixed resumed service", async () => {
+    const stateRoot = await fs.mkdtemp(join(os.tmpdir(), "acp-mixed-mode-"));
+    const store = new InMemorySessionStore();
+    const now = new Date();
+    const session = (
+      id: string,
+      transportMode: "cli" | "native",
+      acpxSessionId: string,
+    ): SessionInfo => ({
+      id,
+      name: id,
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+      status: "ready",
+      acpxSessionId,
+      approvalPreset: "autonomous",
+      createdAt: now,
+      lastActivityAt: now,
+      metadata: { transportMode },
+    });
+    await store.create(session("cli-resumed", "cli", "cli-protocol"));
+    await store.create(session("native-resumed", "native", "native-protocol"));
+    await fs.mkdir(join(stateRoot, "sessions"), { recursive: true });
+    await fs.writeFile(
+      join(stateRoot, "sessions", "cli-protocol.json"),
+      "{}",
+      "utf8",
+    );
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+      }),
+      { store },
+    );
+    Object.defineProperty(service, "acpxStateRoot", {
+      value: () => stateRoot,
+    });
+    const events: Array<[string, string, unknown]> = [];
+    service.onSessionEvent((sid, event, payload) =>
+      events.push([sid, event, payload]),
+    );
+    await service.start();
+
+    const cliPrompt = nextProc();
+    const sentCli = service.sendPrompt("cli-resumed", "hello cli");
+    await waitForSpawn(cliPrompt);
+    cliPrompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        '{"jsonrpc":"2.0","id":"req-1","result":{"stopReason":"end_turn"},"sessionId":"cli-resumed"}\n',
+      ),
+    );
+    closeOk(cliPrompt);
+    await sentCli;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0]?.[0]).toBe("acpx");
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        "prompt",
+        "-s",
+        "cli-resumed",
+        "--",
+        "hello cli",
+      ]),
+    );
+    expect(nativeClientMock.instances).toHaveLength(0);
+
+    const sentNative = service.sendPrompt("native-resumed", "hello native");
+    const client = await waitForNativeClient();
+    await sentNative;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(client.opts.command).toBe("codex-acp --stdio");
+    expect(client.createSession).toHaveBeenCalledWith(RESOLVED_ACP_WORKDIR);
+    expect(client.prompt).toHaveBeenCalledWith(
+      "protocol-session",
+      "hello native",
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        [
+          "native-resumed",
+          "reconnected",
+          expect.objectContaining({ acpxSessionId: "protocol-session" }),
+        ],
+      ]),
+    );
+    await service.stop();
+    await fs.rm(stateRoot, { recursive: true, force: true });
+  });
+
+  it("dispatches cancelSession and closeSession by persisted CLI transport in a native-default service", async () => {
+    const store = new InMemorySessionStore();
+    const now = new Date();
+    const cliSession = (id: string): SessionInfo => ({
+      id,
+      name: id,
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+      status: "ready",
+      acpxSessionId: `${id}-protocol`,
+      approvalPreset: "autonomous",
+      createdAt: now,
+      lastActivityAt: now,
+      metadata: { transportMode: "cli" },
+    });
+    await store.create(cliSession("cli-cancel"));
+    await store.create(cliSession("cli-close"));
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+      }),
+      { store },
+    );
+    await service.start();
+
+    const cancelProc = nextProc();
+    const cancelled = service.cancelSession("cli-cancel");
+    await waitForSpawn(cancelProc);
+    closeOk(cancelProc);
+    await cancelled;
+
+    const closeProc = nextProc();
+    const closed = service.closeSession("cli-close");
+    await waitForSpawn(closeProc);
+    closeOk(closeProc);
+    await closed;
+
+    expect(nativeClientMock.instances).toHaveLength(0);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock.mock.calls[0]?.[0]).toBe("acpx");
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining(["codex", "cancel", "-s", "cli-cancel"]),
+    );
+    expect(spawnMock.mock.calls[1]?.[0]).toBe("acpx");
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(
+      expect.arrayContaining(["codex", "sessions", "close", "cli-close"]),
+    );
+    expect((await service.getSession("cli-cancel"))?.status).toBe("cancelled");
+    expect((await service.getSession("cli-close"))?.status).toBe("stopped");
+    await service.stop();
+  });
+
+  it("retries managed Codex Landlock fallback when reconnecting a native session", async () => {
+    const previousOverride = process.env.ELIZA_CODEX_ACP_LANDLOCK;
+    process.env.ELIZA_CODEX_ACP_LANDLOCK = "1";
+    try {
+      const store = new InMemorySessionStore();
+      const now = new Date();
+      await store.create({
+        id: "native-reconnect",
+        name: "native-reconnect",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+        status: "ready",
+        acpxSessionId: "old-protocol",
+        approvalPreset: "autonomous",
+        createdAt: now,
+        lastActivityAt: now,
+        metadata: {
+          transportMode: "native",
+          spawnModel: "claude-opus-4-1",
+        },
+      });
+      nativeClientMock.createSessionImplementation = async (client) => {
+        if (client.opts.env?.INITIAL_AGENT_MODE !== "agent-full-access") {
+          throw new Error(
+            "ACP agent exited with code 101: thread 'main' panicked: permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+          );
+        }
+        return {
+          sessionId: "protocol-session",
+          agentSessionId: "agent-session",
+        };
+      };
+      const rt = runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+      });
+      const service = new AcpService(rt, { store });
+      await service.start();
+
+      const result = await service.sendPrompt("native-reconnect", "resume");
+
+      expect(result.stopReason).toBe("end_turn");
+      expect(nativeClientMock.instances).toHaveLength(2);
+      expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+        undefined,
+      );
+      expect(nativeClientMock.instances[0]?.opts.env?.OPENAI_MODEL).toBe(
+        "claude-opus-4-1",
+      );
+      expect(nativeClientMock.instances[0]?.close).toHaveBeenCalled();
+      expect(nativeClientMock.instances[1]?.opts.command).toBe(
+        nativeClientMock.instances[0]?.opts.command,
+      );
+      expect(nativeClientMock.instances[1]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+        "agent-full-access",
+      );
+      expect(nativeClientMock.instances[1]?.createSession).toHaveBeenCalledWith(
+        RESOLVED_ACP_WORKDIR,
+      );
+      expect(nativeClientMock.instances[1]?.prompt).toHaveBeenCalledWith(
+        "protocol-session",
+        "resume",
+      );
+      const logger = (rt as { logger: { warn: ReturnType<typeof vi.fn> } })
+        .logger;
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Codex ACP Landlock unavailable"),
+        expect.objectContaining({
+          sandboxMode: "danger-full-access",
+          approvalPolicy: "never",
+        }),
+      );
+      await service.stop();
+    } finally {
+      if (previousOverride === undefined) {
+        delete process.env.ELIZA_CODEX_ACP_LANDLOCK;
+      } else {
+        process.env.ELIZA_CODEX_ACP_LANDLOCK = previousOverride;
+      }
+    }
   });
 
   it("uses an explicit OpenCode ACP command override when configured", async () => {
@@ -1301,8 +1605,7 @@ describe("AcpService", () => {
 
     const result = await sent;
     const promptEnv = spawnMock.mock.calls[1]?.[2]?.env as
-      | Record<string, string>
-      | undefined;
+      Record<string, string> | undefined;
     expect(promptEnv?.PARALLAX_SESSION_ID).toBe(sessionId);
     expect(result.response).toContain("done");
     expect(result.response).toContain("[tool output: Running tool]");
@@ -1481,44 +1784,46 @@ describe("AcpService", () => {
     expect((await service.getSession(sessionId))?.status).toBe("ready");
   });
 
-  it.each([
-    "max_tokens",
-    "interrupted",
-  ])("native sendPrompt does not advertise an incomplete %s turn as task_complete", async (stopReason) => {
-    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
-    const events: string[] = [];
-    service.onSessionEvent((_sid, event) => events.push(event));
-    await service.start();
-    const { sessionId } = await service.spawnSession({
-      name: `native-${stopReason}`,
-      agentType: "codex",
-      workdir: "/tmp/acp-test",
-    });
-    events.length = 0;
-    const client = firstNativeClient();
-    client.prompt.mockImplementationOnce(async () => {
-      client.emit({
-        jsonrpc: "2.0",
-        id: "prompt",
-        sessionId: "protocol-session",
-        result: {
-          stopReason,
-          content: [{ type: "text", text: "partial output" }],
-        },
-      } as AcpJsonRpcMessage);
-      return { stopReason };
-    });
+  it.each(["max_tokens", "interrupted"])(
+    "native sendPrompt does not advertise an incomplete %s turn as task_complete",
+    async (stopReason) => {
+      const service = new AcpService(
+        runtime({ ELIZA_ACP_TRANSPORT: "native" }),
+      );
+      const events: string[] = [];
+      service.onSessionEvent((_sid, event) => events.push(event));
+      await service.start();
+      const { sessionId } = await service.spawnSession({
+        name: `native-${stopReason}`,
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+      events.length = 0;
+      const client = firstNativeClient();
+      client.prompt.mockImplementationOnce(async () => {
+        client.emit({
+          jsonrpc: "2.0",
+          id: "prompt",
+          sessionId: "protocol-session",
+          result: {
+            stopReason,
+            content: [{ type: "text", text: "partial output" }],
+          },
+        } as AcpJsonRpcMessage);
+        return { stopReason };
+      });
 
-    const result = await service.sendPrompt(sessionId, "continue the task");
+      const result = await service.sendPrompt(sessionId, "continue the task");
 
-    expect(result).toMatchObject({
-      stopReason,
-      finalText: "partial output",
-    });
-    expect(events).not.toContain("task_complete");
-    expect(events).not.toContain("stopped");
-    expect((await service.getSession(sessionId))?.status).toBe("ready");
-  });
+      expect(result).toMatchObject({
+        stopReason,
+        finalText: "partial output",
+      });
+      expect(events).not.toContain("task_complete");
+      expect(events).not.toContain("stopped");
+      expect((await service.getSession(sessionId))?.status).toBe("ready");
+    },
+  );
 
   // Fix #2 (PR #9855): a terminal `stopReason === "error"` that nonetheless
   // captured a real deliverable (the sub-agent edited files / deployed / printed

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
@@ -132,6 +132,7 @@ import {
   type ModelGatewayLeaseBroker,
   resetModelGatewayLease,
 } from "../../src/services/model-gateway-lease.js";
+import { InMemorySessionStore } from "../../src/services/session-store.js";
 import { resetSessionSpendUsd } from "../../src/services/spend-allowance.js";
 
 const GATEWAY_URL = "https://gateway.test.invalid/v1";
@@ -579,6 +580,42 @@ describe("strict mode — fail closed rather than hand out a static token", () =
     expect(nativeClientMock.instances).toHaveLength(0);
     expect(await service.listSessions()).toHaveLength(0);
     await service.stop();
+  });
+
+  it("strict reconnect lease rejection preserves the persisted session as errored", async () => {
+    enableGateway();
+    process.env.ELIZA_MODEL_GATEWAY_STRICT = "1";
+    const gateway = new FakeGateway();
+    configureModelGatewayLease({ broker: gateway.broker() });
+    const store = new InMemorySessionStore();
+
+    const { runtime: firstRuntime } = runtime();
+    const firstService = new AcpService(firstRuntime, { store });
+    await firstService.start();
+    const spawned = await firstService.spawnSession({
+      name: "lease-strict-reconnect",
+      agentType: "claude",
+      workdir: "/tmp/acp-lease-test",
+    });
+    await firstService.stop();
+
+    gateway.mintError = new Error("broker unreachable on reconnect");
+    const { runtime: reconnectRuntime } = runtime();
+    const reconnectService = new AcpService(reconnectRuntime, { store });
+    await reconnectService.start();
+
+    await expect(
+      reconnectService.sendToSession(spawned.sessionId, "resume after restart"),
+    ).rejects.toThrow(/strict fail-closed/i);
+
+    expect(nativeClientMock.instances).toHaveLength(1);
+    const persisted = await store.get(spawned.sessionId);
+    expect(persisted).toMatchObject({
+      id: spawned.sessionId,
+      status: "errored",
+    });
+    expect(persisted?.lastError).toMatch(/strict fail-closed/i);
+    await reconnectService.stop();
   });
 
   it("gateway ON, NON-strict, broker mint fails: falls back to the static token", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-orphan-resume.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-orphan-resume.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Restart recovery for persisted ACP sessions that were mid-tool when the
+ * parent runtime died. The test uses the real AcpService resume scanner and
+ * session store, while stubbing the prompt transport so it never launches a
+ * live coding-agent process.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { InMemorySessionStore } from "../services/session-store.js";
+import type { SessionInfo } from "../services/types.js";
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    character: { name: "Tester" },
+    getSetting: (key: string) =>
+      key === "ELIZA_ACP_TRANSPORT" ? "native" : undefined,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    reportError: vi.fn(),
+  } as never;
+}
+
+function busySession(id: string): SessionInfo {
+  const now = new Date(Date.now() - 5 * 60_000);
+  return {
+    id,
+    name: id,
+    agentType: "claude",
+    workdir: "/tmp/acp-orphan-resume",
+    status: "tool_running",
+    acpxSessionId: `protocol-${id}`,
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+    metadata: { label: id },
+  };
+}
+
+describe("AcpService orphan busy-session resume", () => {
+  it("resumes persisted native tool_running sessions with no live client", async () => {
+    const store = new InMemorySessionStore();
+    await store.create(busySession("orphan-native"));
+    const service = new AcpService(makeRuntime(), { store });
+    const sendPrompt = vi.spyOn(service, "sendPrompt").mockResolvedValue({
+      sessionId: "orphan-native",
+      response: "",
+      finalText: "",
+      stopReason: "end_turn",
+      durationMs: 0,
+      exitCode: 0,
+      signal: null,
+    });
+
+    const result = await service.resumeOrphanedBusySessions();
+
+    expect(result).toEqual({ resumed: 1, skipped: 0 });
+    expect(sendPrompt).toHaveBeenCalledTimes(1);
+    expect(sendPrompt).toHaveBeenCalledWith(
+      "orphan-native",
+      expect.stringContaining("runtime restart"),
+    );
+  });
+
+  it("does not duplicate resume when a native client is already attached", async () => {
+    const store = new InMemorySessionStore();
+    await store.create(busySession("live-native"));
+    const service = new AcpService(makeRuntime(), { store });
+    (
+      service as unknown as { nativeClients: Map<string, unknown> }
+    ).nativeClients.set("live-native", {});
+    const sendPrompt = vi.spyOn(service, "sendPrompt");
+
+    const result = await service.resumeOrphanedBusySessions();
+
+    expect(result).toEqual({ resumed: 0, skipped: 1 });
+    expect(sendPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -385,6 +385,7 @@ const ACP_METADATA_WORKDIR_ROOT = "workdirRoot";
 const ACP_METADATA_GIT_INDEX_FILE = "gitIndexFile";
 const ACP_METADATA_GIT_INDEX_BASE_FILE = "gitIndexBaseFile";
 const ACP_METADATA_GIT_WRAPPER_DIR = "gitWrapperDir";
+const ACP_METADATA_SPAWN_MODEL = "spawnModel";
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const SESSION_GIT_WRAPPER = `#!/usr/bin/env node
@@ -703,6 +704,15 @@ const CODEX_PER_ACCOUNT_HOME_MARKER = "_codex-home";
 function isCodexSubscriptionHome(home: string | undefined): boolean {
   return Boolean(home?.includes(CODEX_PER_ACCOUNT_HOME_MARKER));
 }
+
+function sessionTransportMode(
+  session: SessionInfo,
+  serviceTransportMode: "native" | "cli",
+): "native" | "cli" {
+  const mode = session.metadata?.transportMode;
+  if (mode === "native" || mode === "cli") return mode;
+  return serviceTransportMode;
+}
 const DENY_ENV_PATTERNS = [
   /DISCORD.*TOKEN/i,
   /TELEGRAM.*TOKEN/i,
@@ -932,6 +942,13 @@ export class AcpService extends Service {
     const liveCutoffMs = Date.now() - RECONCILE_LIVE_WINDOW_MS;
     const verdicts = await Promise.all(
       orphaned.map(async (s) => {
+        if (sessionTransportMode(s, this.transportMode) === "native") {
+          // Native ACP process state cannot survive a runtime restart, but the
+          // durable session can. Keep every non-terminal native record intact;
+          // busy states are resumed below, while ready/blocked states reconnect
+          // lazily on their next prompt.
+          return { session: s, alive: true };
+        }
         if (!s.acpxSessionId) return { session: s, alive: false };
         // Probe the real `<acpxSessionId>.json` artifact, not the never-written
         // `.stream.ndjson` (which made every session look dead on restart).
@@ -944,15 +961,11 @@ export class AcpService extends Service {
     const dead = verdicts.filter((v) => !v.alive).map((v) => v.session);
     const live = verdicts.filter((v) => v.alive).map((v) => v.session);
     if (live.length > 0) {
-      this.log(
-        "info",
-        "reconcile: keeping recently-active sessions as-is (acpx stream still writing)",
-        {
-          count: live.length,
-          ids: live.map((s) => s.id.slice(0, 8)),
-          windowMs: RECONCILE_LIVE_WINDOW_MS,
-        },
-      );
+      this.log("info", "reconcile: keeping recoverable sessions as-is", {
+        count: live.length,
+        ids: live.map((s) => s.id.slice(0, 8)),
+        windowMs: RECONCILE_LIVE_WINDOW_MS,
+      });
     }
     if (dead.length === 0) return;
     this.log("info", "reconcile: marking stale orphans errored", {
@@ -1465,13 +1478,12 @@ export class AcpService extends Service {
       if (Number.isFinite(lastActivityMs) && lastActivityMs > liveCutoffMs) {
         continue;
       }
-      // A native transport client is the live session state. Its protocol
-      // session id belongs to the adapter (Codex, Claude, etc.), not to acpx's
-      // on-disk session store, so probing that store would falsely declare a
-      // healthy long-running prompt lost whenever it pauses past the grace
-      // window. Detached CLI sessions have no attached client and still take
-      // the state-artifact recovery path below.
-      if (this.nativeClients.has(s.id)) continue;
+      // Native protocol ids belong to the adapter, not acpx's on-disk store.
+      // This remains true after restart before lazy reconnect, when no live
+      // NativeAcpClient exists yet. Never probe native records as CLI state;
+      // persisted native sessions reconnect on the next prompt (and busy ones
+      // are handled by resumeOrphanedBusySessions).
+      if (sessionTransportMode(s, this.transportMode) === "native") continue;
       const { exists } = await this.acpxSessionStateStat(s.acpxSessionId);
       if (!exists) {
         // Descriptive status, NOT an imperative. The old text literally said
@@ -1720,6 +1732,8 @@ export class AcpService extends Service {
           : {}),
         ...(gitIndexIsolation?.metadata ?? {}),
         ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
+        ...(opts.model ? { [ACP_METADATA_SPAWN_MODEL]: opts.model } : {}),
+        transportMode: this.transportMode,
         slotClass,
       };
       const session: SessionInfo = {
@@ -1745,7 +1759,9 @@ export class AcpService extends Service {
       // child. Fail-closed refusals (credit-gate / strict no-broker / strict mint
       // failure) throw here; undo the reserved slot so a refused spawn leaves no
       // orphan session record. No-op when gateway mode / lease broker are off.
-      await this.mintSpawnLease(id, agentType, opts.timeoutMs);
+      await this.mintModelLease(id, agentType, opts.timeoutMs, {
+        rollbackSessionOnFailure: true,
+      });
 
       // App-build tasks lose the parent's deploy contract at the spawn boundary.
       // Re-attach it ONCE here, before the transport branch, so BOTH the native
@@ -1961,7 +1977,12 @@ export class AcpService extends Service {
   ): Promise<PromptResult> {
     this.ensureStarted();
     const session = await this.requireSession(sessionId);
-    if (session.acpxSessionId && !this.nativeClients.has(sessionId)) {
+    const transportMode = sessionTransportMode(session, this.transportMode);
+    if (
+      transportMode !== "native" &&
+      session.acpxSessionId &&
+      !this.nativeClients.has(sessionId)
+    ) {
       const exists = await this.hasAcpxSessionState(session.acpxSessionId);
       if (!exists) {
         const message =
@@ -1975,7 +1996,7 @@ export class AcpService extends Service {
       }
     }
     const startedAt = Date.now();
-    if (this.transportMode === "native") {
+    if (transportMode === "native") {
       if (this.nativePromptSessionIds.has(sessionId)) {
         throw new Error(`ACP session is already busy: ${sessionId}`);
       }
@@ -2091,7 +2112,8 @@ export class AcpService extends Service {
 
   async cancelSession(sessionId: string): Promise<void> {
     const session = await this.requireSession(sessionId);
-    if (this.transportMode === "native") {
+    const transportMode = sessionTransportMode(session, this.transportMode);
+    if (transportMode === "native") {
       const client = this.nativeClients.get(sessionId);
       if (this.nativePromptSessionIds.has(sessionId)) {
         this.nativeCancelledPromptSessionIds.add(sessionId);
@@ -2134,7 +2156,8 @@ export class AcpService extends Service {
 
   async closeSession(sessionId: string): Promise<void> {
     const session = await this.requireSession(sessionId);
-    if (this.transportMode === "native") {
+    const transportMode = sessionTransportMode(session, this.transportMode);
+    if (transportMode === "native") {
       this.nativeStoppingSessionIds.add(sessionId);
       try {
         await this.stopNativeClient(sessionId);
@@ -2271,18 +2294,27 @@ export class AcpService extends Service {
     let skipped = 0;
     for (const session of sessions) {
       if (!ORPHAN_RESUME_STATUSES.has(session.status)) continue;
-      if (!session.acpxSessionId) {
-        skipped += 1;
-        continue;
-      }
-      const stateOk = await this.hasAcpxSessionState(session.acpxSessionId);
-      if (!stateOk) {
-        skipped += 1;
-        continue;
+      const transportMode = sessionTransportMode(session, this.transportMode);
+      if (transportMode === "native") {
+        if (this.nativeClients.has(session.id)) {
+          skipped += 1;
+          continue;
+        }
+      } else {
+        if (!session.acpxSessionId) {
+          skipped += 1;
+          continue;
+        }
+        const stateOk = await this.hasAcpxSessionState(session.acpxSessionId);
+        if (!stateOk) {
+          skipped += 1;
+          continue;
+        }
       }
       this.log("info", "resuming orphaned sub-agent after restart", {
         sessionId: session.id.slice(0, 8),
         status: session.status,
+        transportMode,
         label:
           typeof session.metadata?.label === "string"
             ? session.metadata.label
@@ -2379,6 +2411,10 @@ export class AcpService extends Service {
       workdir: session.workdir,
       approvalPreset: session.approvalPreset,
       metadata: { ...session.metadata, reattachedFrom: session.id },
+      model:
+        typeof session.metadata?.[ACP_METADATA_SPAWN_MODEL] === "string"
+          ? session.metadata[ACP_METADATA_SPAWN_MODEL]
+          : undefined,
     });
     await this.store.update(sessionId, {
       status: "stopped",
@@ -2624,64 +2660,18 @@ export class AcpService extends Service {
     session: SessionInfo,
     opts: SpawnOptions,
   ): Promise<SpawnResult> {
-    const command = this.nativeAgentCommand(session.agentType);
-    const createClient = (
-      clientCommand: string,
-      stderr: string[],
-      codexInitialAgentModeOverride?: CodexAcpInitialAgentMode,
-    ) =>
-      new NativeAcpClient({
-        command: clientCommand,
-        cwd: session.workdir,
-        approvalPreset: session.approvalPreset,
-        timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
-        terminal: !this.shouldDisableTerminalCapability(),
-        env: this.buildEnv(
-          opts.env,
-          opts.customCredentials,
-          opts.model,
-          session.agentType,
-          id,
-          codexInitialAgentModeOverride,
-        ),
-        // Auto-inherit the parent runtime's configured MCP servers (config
-        // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
-        // none are configured → the transport falls back to ELIZA_ACP_MCP_SERVERS.
-        mcpServers: readConfigMcpServers(),
-        onEvent: (event, protocolSessionId) => {
-          this.handleAcpEvent(
-            event,
-            id,
-            "",
-            Date.now(),
-            false,
-            new Set<string>(),
-          );
-          if (protocolSessionId && protocolSessionId !== id) {
-            void this.store
-              .update(id, { acpxSessionId: protocolSessionId })
-              // error-policy:J7 mapping write runs inside the ACP event
-              // callback and must not throw into the transport, but a swallowed
-              // failure leaves the acpxSessionId unpersisted so later protocol
-              // lookups silently miss the session — report it.
-              .catch((err) =>
-                this.runtime.reportError(
-                  "AcpService.persistAcpxSessionId",
-                  err,
-                  {
-                    sessionId: id,
-                  },
-                ),
-              );
-          }
-        },
-        onStderr: (chunk) => {
-          stderr.push(chunk);
-        },
+    let client: NativeAcpClient | undefined;
+    try {
+      const attached = await this.attachNativeClientWithManagedCodexFallback({
+        sessionId: id,
+        session,
+        env: opts.env,
+        customCredentials: opts.customCredentials,
+        model: opts.model,
+        timeoutMs: opts.timeoutMs,
       });
-    const attachClient = async (client: NativeAcpClient) => {
-      await client.start();
-      const nativeSession = await client.createSession(session.workdir);
+      client = attached.client;
+      const { nativeSession } = attached;
       this.nativeClients.set(id, client);
       await this.store.update(id, {
         status: "ready",
@@ -2698,50 +2688,15 @@ export class AcpService extends Service {
       });
       const updated = await this.store.get(id);
       return toSpawnResult(updated ?? { ...session, status: "ready" });
-    };
-    let stderr: string[] = [];
-    let client = createClient(command, stderr);
-    try {
-      return await attachClient(client);
     } catch (err) {
       // error-policy:J6 best-effort teardown of the failed client; the spawn
       // failure `err` is rethrown/handled below.
-      await client.close().catch(() => undefined);
+      await client?.close().catch(() => undefined);
       // A failed spawn must not leave a closed client registered: the entry is
       // set above before the store writes that can throw here. Idempotent when
       // the failure happened before the set.
       this.nativeClients.delete(id);
-      let message = stderr.join("").trim() || errorMessage(err);
-      const shouldRetryLandlock = this.shouldRetryManagedCodexLandlock(
-        session.agentType,
-        command,
-        message,
-      );
-      if (shouldRetryLandlock) {
-        const fallbackSandboxMode = this.codexNoLandlockSandboxMode();
-        const fallbackMode = this.managedCodexAcpInitialAgentMode(true);
-        this.log(
-          "warn",
-          "Codex ACP Landlock unavailable; retrying with sandbox fallback",
-          {
-            sessionId: id,
-            sandboxMode: fallbackSandboxMode,
-            approvalPolicy:
-              fallbackMode === "agent-full-access" ? "never" : "on-request",
-          },
-        );
-        stderr = [];
-        client = createClient(command, stderr, fallbackMode);
-        try {
-          return await attachClient(client);
-        } catch (retryErr) {
-          // error-policy:J6 best-effort teardown of the failed retry client;
-          // `retryErr` is surfaced as the spawn failure below.
-          await client.close().catch(() => undefined);
-          this.nativeClients.delete(id);
-          message = stderr.join("").trim() || errorMessage(retryErr);
-        }
-      }
+      const message = errorMessage(err);
       await this.store.updateStatus(id, "errored", message);
       this.emitSessionEvent(id, "error", {
         message,
@@ -2751,23 +2706,155 @@ export class AcpService extends Service {
     }
   }
 
+  private createNativeClient(
+    session: SessionInfo,
+    opts: {
+      env?: Record<string, string>;
+      customCredentials?: Record<string, string>;
+      model?: string;
+      timeoutMs?: number;
+      codexInitialAgentModeOverride?: CodexAcpInitialAgentMode;
+      stderr: string[];
+    },
+  ): { client: NativeAcpClient; command: string } {
+    const command = this.nativeAgentCommand(session.agentType);
+    return {
+      command,
+      client: new NativeAcpClient({
+        command,
+        cwd: session.workdir,
+        approvalPreset: session.approvalPreset,
+        timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
+        terminal: !this.shouldDisableTerminalCapability(),
+        env: this.buildEnv(
+          opts.env,
+          opts.customCredentials,
+          opts.model,
+          session.agentType,
+          session.id,
+          opts.codexInitialAgentModeOverride,
+        ),
+        // Auto-inherit the parent runtime's configured MCP servers (config
+        // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
+        // none are configured → the transport falls back to ELIZA_ACP_MCP_SERVERS.
+        mcpServers: readConfigMcpServers(),
+        onEvent: (event, protocolSessionId) => {
+          this.handleAcpEvent(
+            event,
+            session.id,
+            "",
+            Date.now(),
+            false,
+            new Set<string>(),
+          );
+          if (protocolSessionId && protocolSessionId !== session.id) {
+            void this.store
+              .update(session.id, { acpxSessionId: protocolSessionId })
+              // error-policy:J7 mapping write runs inside the ACP event
+              // callback and must not throw into the transport, but a swallowed
+              // failure leaves the acpxSessionId unpersisted so later protocol
+              // lookups silently miss the session — report it.
+              .catch((err) =>
+                this.runtime.reportError(
+                  "AcpService.persistAcpxSessionId",
+                  err,
+                  {
+                    sessionId: session.id,
+                  },
+                ),
+              );
+          }
+        },
+        onStderr: (chunk) => {
+          opts.stderr.push(chunk);
+        },
+      }),
+    };
+  }
+
+  private async attachNativeClientWithManagedCodexFallback(opts: {
+    sessionId: string;
+    session: SessionInfo;
+    env?: Record<string, string>;
+    customCredentials?: Record<string, string>;
+    model?: string;
+    timeoutMs?: number;
+  }): Promise<{
+    client: NativeAcpClient;
+    nativeSession: { sessionId: string; agentSessionId?: string };
+    stderr: string[];
+  }> {
+    let stderr: string[] = [];
+    let { client, command } = this.createNativeClient(opts.session, {
+      env: opts.env,
+      customCredentials: opts.customCredentials,
+      model: opts.model,
+      timeoutMs: opts.timeoutMs,
+      stderr,
+    });
+    try {
+      await client.start();
+      const nativeSession = await client.createSession(opts.session.workdir);
+      return { client, nativeSession, stderr };
+    } catch (err) {
+      // error-policy:J6 best-effort teardown of the failed client; the start
+      // or createSession failure is rethrown or retried below.
+      await client.close().catch(() => undefined);
+      let message = stderr.join("").trim() || errorMessage(err);
+      if (
+        !this.shouldRetryManagedCodexLandlock(
+          opts.session.agentType,
+          command,
+          message,
+        )
+      ) {
+        throw new Error(message);
+      }
+      const fallbackSandboxMode = this.codexNoLandlockSandboxMode();
+      const fallbackMode = this.managedCodexAcpInitialAgentMode(true);
+      this.log(
+        "warn",
+        "Codex ACP Landlock unavailable; retrying with sandbox fallback",
+        {
+          sessionId: opts.sessionId,
+          sandboxMode: fallbackSandboxMode,
+          approvalPolicy:
+            fallbackMode === "agent-full-access" ? "never" : "on-request",
+        },
+      );
+      stderr = [];
+      ({ client, command } = this.createNativeClient(opts.session, {
+        env: opts.env,
+        customCredentials: opts.customCredentials,
+        model: opts.model,
+        timeoutMs: opts.timeoutMs,
+        codexInitialAgentModeOverride: fallbackMode,
+        stderr,
+      }));
+      try {
+        await client.start();
+        const nativeSession = await client.createSession(opts.session.workdir);
+        return { client, nativeSession, stderr };
+      } catch (retryErr) {
+        // error-policy:J6 best-effort teardown of the failed retry client;
+        // `retryErr` is surfaced as the attach failure below.
+        await client.close().catch(() => undefined);
+        message = stderr.join("").trim() || errorMessage(retryErr);
+        throw new Error(message);
+      }
+    }
+  }
+
   private async sendNativePrompt(
     session: SessionInfo,
     text: string,
     opts: SendOptions,
     startedAt: number,
   ): Promise<PromptResult> {
-    const client = this.nativeClients.get(session.id);
-    if (!client) {
-      await this.store.updateStatus(
-        session.id,
-        "errored",
-        "Native ACP client is not attached",
-      );
-      throw new Error(`Native ACP client is not attached: ${session.id}`);
-    }
-    const protocolSessionId =
-      session.acpxSessionId ?? session.agentSessionId ?? session.id;
+    const { client, protocolSessionId } = await this.ensureNativeClientAttached(
+      session,
+      opts,
+    );
     let finalText = "";
     let eventStopReason: string | undefined;
     const capturedToolOutputs = new Set<string>();
@@ -2904,6 +2991,83 @@ export class AcpService extends Service {
       this.nativePromptSessionIds.delete(session.id);
       this.nativeCancelledPromptSessionIds.delete(session.id);
       this.nativeStoppingSessionIds.delete(session.id);
+    }
+  }
+
+  private async ensureNativeClientAttached(
+    session: SessionInfo,
+    opts: SendOptions,
+  ): Promise<{ client: NativeAcpClient; protocolSessionId: string }> {
+    const existing = this.nativeClients.get(session.id);
+    if (existing) {
+      return {
+        client: existing,
+        protocolSessionId:
+          session.acpxSessionId ?? session.agentSessionId ?? session.id,
+      };
+    }
+
+    try {
+      await this.mintModelLease(session.id, session.agentType, opts.timeoutMs, {
+        rollbackSessionOnFailure: false,
+      });
+    } catch (err) {
+      // error-policy:J2 context-adding rethrow — reconnect lease refusal must
+      // persist on the existing session before the caller observes the failure.
+      const message = errorMessage(err);
+      await this.store.updateStatus(session.id, "errored", message);
+      this.emitSessionEvent(session.id, "error", {
+        message,
+        ...this.authFailureFields(message, session.agentType),
+      });
+      throw err;
+    }
+    const promptCredentials = await this.accountCredentialsForSession(session);
+    const promptEnv: Record<string, string> = {
+      ...(opts.env ?? {}),
+      ...(this.gitIndexEnvForSession(session) ?? {}),
+    };
+    let client: NativeAcpClient | undefined;
+    try {
+      const attached = await this.attachNativeClientWithManagedCodexFallback({
+        sessionId: session.id,
+        session,
+        env: promptEnv,
+        customCredentials: promptCredentials,
+        model:
+          opts.model ??
+          (typeof session.metadata?.[ACP_METADATA_SPAWN_MODEL] === "string"
+            ? session.metadata[ACP_METADATA_SPAWN_MODEL]
+            : undefined),
+        timeoutMs: opts.timeoutMs,
+      });
+      client = attached.client;
+      const { nativeSession } = attached;
+      this.nativeClients.set(session.id, client);
+      await this.store.update(session.id, {
+        status: "ready",
+        pid: undefined,
+        acpxSessionId: nativeSession.sessionId,
+        agentSessionId: nativeSession.agentSessionId,
+        lastActivityAt: new Date(),
+      });
+      this.emitSessionEvent(session.id, "reconnected", {
+        sessionId: session.id,
+        acpxSessionId: nativeSession.sessionId,
+      });
+      return { client, protocolSessionId: nativeSession.sessionId };
+    } catch (err) {
+      // error-policy:J6 best-effort teardown of a failed restart reattach; the
+      // attach failure itself is persisted and thrown below.
+      await client?.close().catch(() => undefined);
+      this.nativeClients.delete(session.id);
+      const message = errorMessage(err);
+      await this.store.updateStatus(session.id, "errored", message);
+      this.emitSessionEvent(session.id, "error", {
+        message,
+        ...this.authFailureFields(message, session.agentType),
+      });
+      throw new Error(message);
     }
   }
 
@@ -4029,31 +4193,40 @@ export class AcpService extends Service {
   }
 
   /**
-   * Mint a per-spawn model-gateway lease and record it for the session. The
-   * lease TTL equals the task timeout. On a fail-closed refusal (credit-gate,
-   * strict no-broker, or strict mint failure) this throws AND rolls back the
-   * reserved session record so a refused spawn leaves no orphan. No-op (leaves
-   * the static-token path intact) when gateway/broker mode is off.
+   * Mint a model-gateway lease and record it for the session. Fresh spawns pass
+   * `rollbackSessionOnFailure` because the durable record exists only to reserve
+   * capacity until the child starts; reconnects keep the record so history and
+   * retry accounting can show the fail-closed refusal.
    */
-  private async mintSpawnLease(
+  private async mintModelLease(
     sessionId: string,
     agentType: AgentType,
     timeoutMs: number | undefined,
+    options: { rollbackSessionOnFailure: boolean },
   ): Promise<void> {
     const ttlMs = timeoutMs ?? this.sessionTimeoutMs ?? DEFAULT_LEASE_TTL_MS;
     let outcome: Awaited<ReturnType<typeof mintSpawnLease>>;
     try {
       outcome = await mintSpawnLease({ sessionId, agentType, ttlMs });
     } catch (err) {
-      // Fail-closed: drop the reserved slot before surfacing the refusal.
-      // error-policy:J6 best-effort teardown on the fail-closed path; the lease
-      // refusal `err` is rethrown as the spawn failure below.
-      await this.store.delete(sessionId).catch(() => {});
-      this.log("warn", "model-gateway lease refused; spawn blocked", {
-        sessionId,
-        agentType,
-        error: errorMessage(err),
-      });
+      if (options.rollbackSessionOnFailure) {
+        // Fail-closed fresh spawn: drop the reserved slot before surfacing the
+        // refusal.
+        // error-policy:J6 best-effort teardown on the fail-closed path; the
+        // lease refusal `err` is rethrown as the spawn failure below.
+        await this.store.delete(sessionId).catch(() => {});
+      }
+      this.log(
+        "warn",
+        options.rollbackSessionOnFailure
+          ? "model-gateway lease refused; spawn blocked"
+          : "model-gateway lease refused; reconnect blocked",
+        {
+          sessionId,
+          agentType,
+          error: errorMessage(err),
+        },
+      );
       throw err;
     }
     if (outcome.kind === "leased") {
@@ -4290,8 +4463,7 @@ export class AcpService extends Service {
     data?: unknown,
   ): void {
     const loggerFn = this.logger[level] as
-      | ((message: string, data?: unknown) => void)
-      | undefined;
+      ((message: string, data?: unknown) => void) | undefined;
     loggerFn?.call(this.logger, `[AcpService] ${message}`, data);
   }
 


### PR DESCRIPTION
## Summary
- route session lifecycle operations through each persisted transport instead of the current process default
- reconnect durable native ACP sessions lazily after runtime restart, and resume orphaned busy/tool-running sessions
- preserve spawn-time model selection across reconnects
- extend managed Codex Landlock fallback through `session/new`, including reconnect

## Verification
- `bunx vitest run plugins/plugin-agent-orchestrator/src/__tests__/acp-orphan-resume.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts --coverage.enabled=false`
- 3 files, 89 tests passed
- Codex review caught and drove fixes for reconnect model persistence, idle native startup reconciliation, and native health-check misclassification

## Evidence
N/A for screenshots/video: backend session-lifecycle fix with focused deterministic transport/restart tests. No UI surface changed.
