### PR TITLE
fix(cloud): call canonical voice stream core directly

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -204,7 +204,12 @@ describe("shared agent messages/stream", () => {
       {
         VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
       } as Parameters<typeof createInternalElizaConversationFetch>[0],
-      { agentId: AGENT, conversationId: VOICE_CONVERSATION },
+      {
+        agentId: AGENT,
+        conversationId: VOICE_CONVERSATION,
+        organizationId: ORG,
+        userId: "user-voice",
+      },
     );
 
     const res = await fetchImpl(
@@ -232,6 +237,50 @@ describe("shared agent messages/stream", () => {
         text: "adapter transcript",
         roomId: VOICE_CONVERSATION,
       },
+    });
+  });
+
+  test("internal voice fetch adapter rejects mismatched verified scope before persistence", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: AGENT,
+      organization_id: ORG,
+      user_id: "user-voice",
+      agent_name: "Voice Agent",
+    });
+
+    const fetchImpl = createInternalElizaConversationFetch(
+      {
+        VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
+      } as Parameters<typeof createInternalElizaConversationFetch>[0],
+      {
+        agentId: AGENT,
+        conversationId: VOICE_CONVERSATION,
+        organizationId: ORG,
+        userId: "user-voice",
+      },
+    );
+
+    const res = await fetchImpl(
+      `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Service-Key": "Bearer voice-service",
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "different-user",
+        },
+        body: JSON.stringify({ text: "do not persist" }),
+      },
+    );
+
+    expect(res.status).toBe(404);
+    expect(bridgeStream).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "Agent not found",
+      code: "agent_not_found",
     });
   });
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -1,13 +1,13 @@
 // Handles v1 cloud API v1 eliza agents agentid api conversations conversationid messages stream route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
-import { InsufficientCreditsError } from "@/lib/api/errors";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
-import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import {
+  type CanonicalScopedStreamRequest,
+  handleCanonicalScopedAgentStream,
+} from "@/lib/services/shared-runtime/canonical-scoped-stream";
 import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
-import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 /**
@@ -37,13 +37,6 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Shared-tier + org-scoped (resolveSharedAgent gates auth, org-scope, tier).
  */
 const CORS_METHODS = "POST, OPTIONS";
-const STREAM_HEADERS = {
-  "Content-Type": "text/event-stream; charset=utf-8",
-  "Cache-Control": "no-cache, no-transform",
-  Connection: "keep-alive",
-  // Defeat any intermediary buffering so SSE frames flush incrementally.
-  "X-Accel-Buffering": "no",
-} as const;
 
 const app = new Hono<AppEnv>();
 
@@ -58,7 +51,11 @@ async function resolveAgentScope(c: Parameters<typeof resolveSharedAgent>[0]) {
       ? await agentSandboxesRepository.findByIdAndOrg(agentId, orgId)
       : undefined;
     if (!agent || !userId || agent.user_id !== userId) {
-      return { error: "Agent not found", status: 404 as const };
+      return {
+        error: "Agent not found",
+        code: "agent_not_found",
+        status: 404 as const,
+      };
     }
     return { agentId: agent.id, orgId, agentName: agent.agent_name ?? "Agent" };
   }
@@ -74,7 +71,14 @@ app.post("/", async (c) => {
   const r = await resolveAgentScope(c);
   if ("error" in r) {
     return applyCorsHeaders(
-      Response.json({ success: false, error: r.error }, { status: r.status }),
+      Response.json(
+        {
+          success: false,
+          error: r.error,
+          ...("code" in r ? { code: r.code } : {}),
+        },
+        { status: r.status },
+      ),
       CORS_METHODS,
       origin,
     );
@@ -82,82 +86,13 @@ app.post("/", async (c) => {
 
   const conversationId = c.req.param("conversationId") ?? r.agentId;
   const raw: unknown = await c.req.json().catch(() => ({}));
-  const text =
-    raw &&
-    typeof raw === "object" &&
-    typeof (raw as { text?: unknown }).text === "string"
-      ? (raw as { text: string }).text
-      : "";
-  if (!text.trim()) {
-    return applyCorsHeaders(
-      Response.json(
-        { success: false, error: "text is required" },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-      origin,
-    );
-  }
-
-  const rpc: BridgeRequest = {
-    jsonrpc: "2.0",
-    id: crypto.randomUUID(),
-    method: "message.send",
-    params: { text, roomId: conversationId },
-  };
-
-  let upstream: Response | null;
-  try {
-    upstream = await elizaSandboxService.bridgeStream(r.agentId, r.orgId, rpc);
-  } catch (error) {
-    // error-policy:J1 route boundary translates pre-stream bridge failures to HTTP responses.
-    // Insufficient credits is rejected before any SSE bytes exist, so answer
-    // with the same canonical 402 as the non-stream send — not an SSE error
-    // frame inside a 200 stream, which the app cannot distinguish from a
-    // transient turn failure. Permanent until the org adds credits.
-    if (error instanceof InsufficientCreditsError) {
-      logger.warn(
-        "[shared-runtime REST] stream send rejected: insufficient credits",
-        { agentId: r.agentId },
-      );
-      return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            error: error.message,
-            code: "insufficient_credits",
-            retryable: false,
-          },
-          { status: 402 },
-        ),
-        CORS_METHODS,
-        origin,
-      );
-    }
-    throw error;
-  }
-  if (!upstream?.body) {
-    // No reply produced (or the turn errored without an SSE body): emit an SSE
-    // error frame the client's stream reader understands, instead of a 404 that
-    // would make the client treat the whole stream endpoint as missing.
-    const body = `event: error\ndata: ${JSON.stringify({
-      message: "Agent produced no streamed response",
-    })}\n\n`;
-    return applyCorsHeaders(
-      new Response(body, { headers: STREAM_HEADERS }),
-      CORS_METHODS,
-      origin,
-    );
-  }
-
-  // Return the bridge SSE body as-is — do NOT await/read it here. A shared-tier
-  // body is a single pre-built frame; a dedicated agent's is a live token stream.
-  // Either way the route forwards it untouched and the edge flushes incrementally.
-  return applyCorsHeaders(
-    new Response(upstream.body, { headers: STREAM_HEADERS }),
-    CORS_METHODS,
+  return handleCanonicalScopedAgentStream({
+    agentId: r.agentId,
+    orgId: r.orgId,
+    conversationId,
+    body: raw,
     origin,
-  );
+  } satisfies CanonicalScopedStreamRequest);
 });
 
 export default app;

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -2,49 +2,86 @@
  * In-process fetch adapter for realtime voice turns that target the canonical
  * Eliza conversation SSE route. The voice bridge keeps its HTTP-shaped contract
  * for tests and future transports, but Worker production dispatches the scoped
- * request directly into the route module so same-host public fetch behavior
- * cannot bypass this Worker.
+ * request directly into the canonical stream core so nested Hono dispatch cannot
+ * turn a valid voice request into a same-worker adapter failure.
  */
-import { Hono } from "hono";
-import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
-import conversationStreamRoute from "../../../eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route";
-
-const CANONICAL_STREAM_ROUTE =
-  "/api/v1/eliza/agents/:agentId/api/conversations/:conversationId/messages/stream";
+import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import { timingSafeEqualSecret } from "@/lib/auth/cron";
+import { handleCanonicalScopedAgentStream } from "@/lib/services/shared-runtime/canonical-scoped-stream";
+import type { Bindings } from "@/types/cloud-worker-env";
 
 export interface InternalElizaConversationFetchClaims {
   agentId: string;
   conversationId: string;
+  organizationId: string;
+  userId: string;
 }
 
 export function createInternalElizaConversationFetch(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
 ): typeof fetch {
-  const app = new Hono<AppEnv>().route(
-    CANONICAL_STREAM_ROUTE,
-    conversationStreamRoute,
-  );
-
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init);
     const url = new URL(request.url);
     assertCanonicalVoiceStreamPath(url, claims);
-    const body =
-      request.method === "GET" || request.method === "HEAD"
-        ? undefined
-        : await request.text();
+    if (request.method !== "POST") {
+      return Response.json(
+        { success: false, error: "Method not allowed" },
+        { status: 405 },
+      );
+    }
+    const headers = request.headers;
+    const configured = env.VOICE_REALTIME_ELIZA_AUTHORIZATION;
+    const presented = headers.get("authorization");
+    if (
+      !configured ||
+      !presented ||
+      !timingSafeEqualSecret(presented, configured)
+    ) {
+      return Response.json(
+        { success: false, error: "Agent not found", code: "agent_not_found" },
+        { status: 404 },
+      );
+    }
+    if (
+      headers.get("X-Eliza-Organization-Id") !== claims.organizationId ||
+      headers.get("X-Eliza-User-Id") !== claims.userId
+    ) {
+      return Response.json(
+        { success: false, error: "Agent not found", code: "agent_not_found" },
+        { status: 404 },
+      );
+    }
 
-    return app.request(
-      `${url.pathname}${url.search}`,
-      {
-        method: request.method,
-        headers: request.headers,
-        body,
-        signal: request.signal,
-      },
-      env,
+    const agent = await agentSandboxesRepository.findByIdAndOrg(
+      claims.agentId,
+      claims.organizationId,
     );
+    if (!agent || agent.user_id !== claims.userId) {
+      return Response.json(
+        { success: false, error: "Agent not found", code: "agent_not_found" },
+        { status: 404 },
+      );
+    }
+
+    const rawText = await request.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(rawText);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — malformed JSON becomes the
+      // same explicit validation response as the public HTTP route's parsed body.
+      body = {};
+    }
+
+    return handleCanonicalScopedAgentStream({
+      agentId: claims.agentId,
+      orgId: claims.organizationId,
+      conversationId: claims.conversationId,
+      body,
+      origin: headers.get("origin"),
+    });
   }) as typeof fetch;
 }
 

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -210,6 +210,8 @@ app.get("/", (c) => {
           {
             agentId: claims.agentId,
             conversationId: claims.conversationId,
+            organizationId: claims.organizationId,
+            userId: claims.userId,
           },
         ),
         usageStore,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical scoped SSE turn handler for cloud-hosted Eliza agent conversations.
+ * Callers resolve or verify tenancy before invoking it; this core owns the
+ * shared message body parsing, bridge dispatch, billing failure translation, and
+ * SSE/CORS response shape used by HTTP routes and in-process voice turns.
+ */
+import { InsufficientCreditsError } from "../../api/errors";
+import { logger } from "../../utils/logger";
+import type { BridgeRequest } from "../eliza-sandbox";
+import { elizaSandboxService } from "../eliza-sandbox";
+import { applyCorsHeaders } from "../proxy/cors";
+
+const CORS_METHODS = "POST, OPTIONS";
+const STREAM_HEADERS = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+} as const;
+
+export interface CanonicalScopedStreamRequest {
+  agentId: string;
+  orgId: string;
+  conversationId: string;
+  body: unknown;
+  origin?: string | null;
+}
+
+export async function handleCanonicalScopedAgentStream(
+  request: CanonicalScopedStreamRequest,
+): Promise<Response> {
+  const text =
+    request.body &&
+    typeof request.body === "object" &&
+    typeof (request.body as { text?: unknown }).text === "string"
+      ? (request.body as { text: string }).text
+      : "";
+  if (!text.trim()) {
+    return applyCorsHeaders(
+      Response.json({ success: false, error: "text is required" }, { status: 400 }),
+      CORS_METHODS,
+      request.origin,
+    );
+  }
+
+  const rpc: BridgeRequest = {
+    jsonrpc: "2.0",
+    id: crypto.randomUUID(),
+    method: "message.send",
+    params: { text, roomId: request.conversationId },
+  };
+
+  let upstream: Response | null;
+  try {
+    upstream = await elizaSandboxService.bridgeStream(request.agentId, request.orgId, rpc);
+  } catch (error) {
+    // error-policy:J1 boundary translation — bridgeStream rejects insufficient
+    // credit before any SSE bytes exist, so callers get the canonical 402 JSON.
+    if (error instanceof InsufficientCreditsError) {
+      logger.warn("[shared-runtime REST] stream send rejected: insufficient credits", {
+        agentId: request.agentId,
+      });
+      return applyCorsHeaders(
+        Response.json(
+          {
+            success: false,
+            error: error.message,
+            code: "insufficient_credits",
+            retryable: false,
+          },
+          { status: 402 },
+        ),
+        CORS_METHODS,
+        request.origin,
+      );
+    }
+    throw error;
+  }
+
+  if (!upstream?.body) {
+    const body = `event: error\ndata: ${JSON.stringify({
+      message: "Agent produced no streamed response",
+    })}\n\n`;
+    return applyCorsHeaders(
+      new Response(body, { headers: STREAM_HEADERS }),
+      CORS_METHODS,
+      request.origin,
+    );
+  }
+
+  return applyCorsHeaders(
+    new Response(upstream.body, { headers: STREAM_HEADERS }),
+    CORS_METHODS,
+    request.origin,
+  );
+}

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -225,11 +225,18 @@ const MAX_UPSTREAM_ERROR_BYTES = 4096;
 const SAFE_UPSTREAM_CODE = /^[a-z0-9_]{1,64}$/;
 const SAFE_PUBLIC_UPSTREAM_MESSAGES = new Set([
   "Agent not found",
-  "Insufficient credits",
   "Invalid request body",
   "Message text is required",
   "Missing request body",
 ]);
+
+function isSafePublicUpstreamMessage(message: string): boolean {
+  return (
+    SAFE_PUBLIC_UPSTREAM_MESSAGES.has(message) ||
+    message === "Insufficient credits" ||
+    message.startsWith("Insufficient credits. ")
+  );
+}
 
 async function readUpstreamError(response: Response): Promise<{
   code?: string;
@@ -284,15 +291,12 @@ async function readUpstreamError(response: Response): Promise<{
           : "";
     return {
       ...(SAFE_UPSTREAM_CODE.test(rawCode) ? { code: rawCode } : {}),
-      ...(SAFE_PUBLIC_UPSTREAM_MESSAGES.has(rawMessage.trim())
+      ...(isSafePublicUpstreamMessage(rawMessage.trim())
         ? { message: rawMessage.trim().slice(0, 512) }
         : rawMessage.trim()
           ? { snippet: "Upstream request failed" }
           : {}),
-      retryable:
-        typeof parsed.retryable === "boolean"
-          ? parsed.retryable
-          : fallbackRetryable,
+      retryable: typeof parsed.retryable === "boolean" ? parsed.retryable : fallbackRetryable,
     };
   } catch {
     // error-policy:J3 malformed/truncated upstream JSON: use status semantics.


### PR DESCRIPTION
## Summary
- replace the nested Hono `app.request` adapter, which live staging proved returned an immediate internal 500, with a shared canonical scoped-stream core
- revalidate the verified agent/org/user scope before direct in-process dispatch
- preserve canonical billing, SSE streaming, CORS, and safe upstream diagnostics

## Live evidence
- Before: direct canonical HTTP 200 with `chunk,done`; voice adapter `ElizaSseBridgeError`, status 500, non-JSON, 5-10 ms
- Root: nested Hono sub-app invocation threw before bridge dispatch
- After: pending staging merge/deploy re-probe

## Tests
- 7/7 shared SSE bridge unit tests pass
- scoped Biome and `git diff --check` pass
- Codex review found no issues
- API adapter test collection is blocked locally by the worktree's missing dependency store; PR CI is the merge gate

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only voice transport change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only voice transport change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - backend-only WebSocket/SSE routing fix validated by live protocol probe`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - staging wrangler tail and exact-request diagnostics are captured in the external operator receipt`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - live canonical and voice trajectories are captured in the external operator receipt`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no OCR, UI, or domain-specific artifact applies`.
