### PR TITLE
fix(cli-inference): bound the SDK session start path with the turn timeout

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
@@ -326,3 +326,45 @@ describe("ClaudeSdkSession — serialization", () => {
     await session.dispose();
   });
 });
+
+describe("start-path timeout (#16553)", () => {
+  it("bounds a hung session start with the turn budget and fails retryable", async () => {
+    const { session } = makeSession([{ text: "unused", subtype: "success" }], {
+      turnTimeoutMs: 40,
+    });
+    // Simulate the unbounded startup await (SDK dynamic import / spawn
+    // handshake hanging on a CLI version download): start never resolves.
+    (session as unknown as { start: () => Promise<void> }).start = () =>
+      new Promise<void>(() => {});
+    const started = Date.now();
+    await expect(session.send("hi")).rejects.toThrow(/session start timed out/);
+    expect(Date.now() - started).toBeLessThan(2_000);
+    // Self-healed: a follow-up dispose is safe and the session holds no query.
+    await session.dispose();
+  });
+
+  it("tears down a start that resolves after dispose instead of resurrecting", async () => {
+    const { session } = makeSession([{ text: "late", subtype: "success" }], {
+      turnTimeoutMs: 30,
+    });
+    const inner = session as unknown as {
+      start: (...args: unknown[]) => Promise<void>;
+      query: unknown;
+    };
+    const realStart = inner.start.bind(session);
+    let releaseStart: (() => void) | undefined;
+    inner.start = async (...args: unknown[]) => {
+      await new Promise<void>((res) => {
+        releaseStart = res;
+      });
+      await realStart(...args);
+    };
+    const turn = session.send("hi");
+    // The bounded start times out (30ms) and disposes, bumping the epoch.
+    await expect(turn).rejects.toThrow(/session start timed out/);
+    // Now let the stale start finish — it must tear itself down, not attach.
+    releaseStart?.();
+    await new Promise((res) => setTimeout(res, 20));
+    expect(inner.query).toBeNull();
+  });
+});

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -316,6 +316,9 @@ export class ClaudeSdkSession {
   private readonly claudeExecutablePath: string | null;
   private readonly restartAfterTurns: number;
   private readonly turnTimeoutMs: number;
+  /** Bumped by dispose(); a start() that finishes into a stale epoch tears
+   * itself down instead of resurrecting a disposed session. */
+  private epoch = 0;
   private readonly effort: string | null;
   private readonly subprocessEnv: RotationSubprocessEnv | null;
   private readonly sdkOverride?: SdkModule;
@@ -394,7 +397,11 @@ export class ClaudeSdkSession {
       await this.dispose();
     }
     if (!this.query) {
-      await this.start();
+      // The startup path (SDK dynamic import + subprocess spawn) is the one
+      // await the per-read turn timeout cannot see — a hang here (CLI version
+      // download, OAuth refresh at spawn) otherwise wedges the turn forever
+      // (issue #16553). Bound it with the same budget and self-heal.
+      await this.startWithTimeout();
     }
     this.turns += 1;
     try {
@@ -407,7 +414,7 @@ export class ClaudeSdkSession {
     }
   }
 
-  private async start(): Promise<void> {
+  private async start(startEpoch: number = this.epoch): Promise<void> {
     const sdk = this.sdkOverride ?? (await loadSdk());
     // A pull-based async generator the SDK drains; we push the next user message
     // into it via `this.feed`.
@@ -555,6 +562,18 @@ export class ClaudeSdkSession {
     this.query = sdk.query({ prompt: promptStream(), options });
     this.iterator = this.query[Symbol.asyncIterator]();
     this.turns = 0;
+    if (startEpoch !== this.epoch) {
+      // A timeout/dispose raced this start; tear down the late spawn instead of
+      // resurrecting a session the caller already gave up on.
+      const stale = this.query;
+      this.query = null;
+      this.iterator = null;
+      this.feed = null;
+      stale?.interrupt?.().catch(() => {});
+      throw new ProviderApiError("[cli-inference:sdk] session disposed during start", {
+        retryable: true,
+      });
+    }
     logger.debug(
       {
         src: "cli-inference:sdk",
@@ -563,6 +582,34 @@ export class ClaudeSdkSession {
       },
       "warm Claude Agent SDK session started"
     );
+  }
+
+  private async startWithTimeout(): Promise<void> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const startEpoch = this.epoch;
+      await Promise.race([
+        this.start(startEpoch),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new ProviderApiError(
+                `[cli-inference:sdk] session start timed out after ${this.turnTimeoutMs}ms`,
+                { retryable: true }
+              )
+            );
+          }, this.turnTimeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow — dispose (bumping the epoch so
+      // a late-resolving start tears itself down), then rethrow unchanged.
+      await this.dispose();
+      throw error;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private async nextWithTurnTimeout(): Promise<IteratorResult<SdkMessage>> {
@@ -729,6 +776,7 @@ export class ClaudeSdkSession {
 
   /** Tear down the warm session (on restart, error, or dispose). */
   async dispose(): Promise<void> {
+    this.epoch += 1;
     const q = this.query;
     this.query = null;
     this.iterator = null;


### PR DESCRIPTION
## What

`startWithTimeout()` races the SDK session's `start()` against the same `turnTimeoutMs` budget that already guards iterator reads, disposing on expiry with a retryable `ProviderApiError` (matching the read-path contract). `dispose()` now bumps an epoch; a `start()` that resolves into a stale epoch tears down its late spawn instead of resurrecting a session the caller abandoned.

## The production failure this fixes (#16553)

The per-read turn timeout cannot see the startup path — `loadSdk()`'s dynamic import and the subprocess spawn/handshake are unbounded awaits. A hang there (CLI version download at spawn, OAuth refresh) wedges the turn forever, and the message pipeline serializes behind it. Observed live 2026-07-17 ~21:11 UTC: a spawned `claude --output-format stream-json` process alive 5m13s at ~2% CPU, `Message received` events flowing, **zero turns starting** for 10+ minutes until an operator restart.

## Tests

Two new cases in `claude-sdk-session.test.ts` using the injectable `sdkModule` seam:
- a hung `start()` rejects with `session start timed out` within the budget (not the event-loop lifetime), and the session self-heals
- a `start()` resolving **after** a timeout-dispose tears down its late spawn (epoch guard) — `query` stays null, no resurrection

Suite: 21/21; plugin: 132/132.

## Deployment note

Already running in production (the bot that hit the wedge) — post-patch live turn verified healthy.

# Evidence Details

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI; session lifecycle code.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user flow; deterministic session tests + the production incident timeline in the linked issue.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the incident evidence (process age, receipt-flow-without-turns) is documented in #16553; the fix path is covered by the two deterministic session tests.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model behavior change; the timeout path never reaches a model.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the domain artifact is the bounded failure itself, asserted by the new tests.`
