### PR TITLE
fix(orchestrator): forward the OpenAI base-URL and tier-model twins to sub-agents

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -220,6 +220,22 @@ describe("forwardableSubAgentEnv", () => {
     expect(out.ANTHROPIC_SMALL_MODEL).toBe("proxy-small");
     expect(out.ANTHROPIC_MEDIUM_MODEL).toBe("proxy-medium");
     expect(out.ANTHROPIC_LARGE_MODEL).toBe("proxy-large");
+  });
+
+  // Symmetry (#16562): the OpenAI proxy/tier twins forward exactly like the
+  // Anthropic set — a third-party OPENAI_BASE_URL parent must not spawn
+  // children pinned to api.openai.com with default tiers.
+  it("forwards the OpenAI base-URL and tier-model twins verbatim", () => {
+    const out = forwardableSubAgentEnv({
+      OPENAI_API_KEY: "sk-y",
+      OPENAI_BASE_URL: "http://127.0.0.1:9292/v1",
+      OPENAI_SMALL_MODEL: "proxy-oai-small",
+      OPENAI_LARGE_MODEL: "proxy-oai-large",
+    });
+    expect(out.OPENAI_API_KEY).toBe("sk-y");
+    expect(out.OPENAI_BASE_URL).toBe("http://127.0.0.1:9292/v1");
+    expect(out.OPENAI_SMALL_MODEL).toBe("proxy-oai-small");
+    expect(out.OPENAI_LARGE_MODEL).toBe("proxy-oai-large");
     expect(out.ELIZA_VAULT_PASSPHRASE).toBeUndefined();
     expect(out.ELIZA_TERMINAL_RUN_TOKEN).toBeUndefined();
     expect(out.DISCORD_BOT_TOKEN).toBeUndefined();

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -89,6 +89,12 @@ export const SUB_AGENT_PROVIDER_ENV_KEYS = [
   "OPENAI_API_KEY",
   "ANTHROPIC_API_KEY",
   "ANTHROPIC_BASE_URL",
+  // OpenAI twins of the Anthropic proxy/tier forwarding (#16562): a parent on
+  // a third-party OpenAI-compatible endpoint must not spawn children that
+  // silently talk to api.openai.com with default tier models.
+  "OPENAI_BASE_URL",
+  "OPENAI_SMALL_MODEL",
+  "OPENAI_LARGE_MODEL",
   "CEREBRAS_API_KEY",
   "CEREBRAS_BASE_URL",
   "CEREBRAS_MODEL",


### PR DESCRIPTION
# Relates to

Fixes #16562

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Minimal. Three allowlist entries in `SUB_AGENT_PROVIDER_ENV_KEYS` — the exact OpenAI twins of the Anthropic entries #16541 added. Gateway mode already overwrites base URLs last, so no conflict; parents without these vars see zero change.

# Background

## What does this PR do?

#16541 fixed proxy/tier env forwarding for Anthropic but left the OpenAI twin unforwarded: a parent on a third-party OpenAI-compatible endpoint (`OPENAI_BASE_URL` is first-class parent config via `provider-switch-config.ts`) spawned eliza-code children that auto-enable `plugin-openai` from the forwarded key alone and silently talked to `api.openai.com` with default tier models. Adds `OPENAI_BASE_URL`, `OPENAI_SMALL_MODEL`, `OPENAI_LARGE_MODEL` to the allowlist with the symmetry test.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The three-line allowlist diff, then "forwards the OpenAI base-URL and tier-model twins verbatim" in `should-forward-env.test.ts` — the mirror of the existing Anthropic case.

## Detailed testing steps

None: Automated tests are acceptable.

```
vitest run __tests__/unit/should-forward-env.test.ts
Tests  24 passed (24) — sub-agent-env-policy.ts coverage: 100% lines
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-only env-forwarding allowlist change, no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-only env-forwarding allowlist change, no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; behavior pinned by the symmetry unit test.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no deployed run; the forwarding projection is asserted directly by the changed test lane (24/24).`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change; env projection only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the artifact is the projected env asserted in the test.`

# Evidence Details

Gap found by post-merge audit of #16541 (evidence with file:line on the issue). The allowlist previously forwarded `OPENAI_API_KEY`+`OPENAI_MODEL` but none of the base-URL/tier twins that `plugin-openai`'s config resolution reads.

## Known gaps / failures

None.

[stan-cloud]
