### PR TITLE
test(coding-tools): align the FILE simile pin with the carried hint family (#16546 follow-up)

### DIFF
--- a/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
+++ b/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
@@ -65,7 +65,16 @@ describe("@elizaos/plugin-coding-tools — plugin export shape", () => {
     const fileAction = (codingToolsPlugin.actions ?? []).find(
       (action) => action.name === "FILE",
     );
-    expect(fileAction?.similes).toEqual(["FILE_OPERATION", "FILE_IO"]);
+    expect(fileAction?.similes).toEqual([
+      "FILE_OPERATION",
+      "FILE_IO",
+      "FILES_READ",
+      "FILES_LIST",
+      "FILE_READ",
+      "FILE_LIST",
+      "READ_FILE",
+      "LIST_FILES",
+    ]);
   });
 
   it("each action has the required fields", () => {


### PR DESCRIPTION
## What

Aligns `plugin-integration.test.ts`'s exact-equality FILE-similes pin with the hint family carried by #16546. Test-only, one assertion.

## Why

#16546 (merged) added `FILES_READ`/`READ_FILE`/etc. to the FILE action's similes, but its changed-file coverage gate only ran the diff's tests — `plugin-integration.test.ts` wasn't in the diff, so its stale two-name pin never ran and the full lane on develop is now red. My change, my follow-up.

# Evidence Details

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no runtime change; plugin suite local run 362/362 with this pin.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model surface.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the green full lane is the artifact.`
