### PR TITLE
feat(coding-tools): two-phase confirm gate for destructive bulk shell operations

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1785,3 +1785,79 @@ describe("platform-aware canned resource commands", () => {
     });
   });
 });
+
+describe("destructive-bulk confirm gate", () => {
+  it("blocks an unconfirmed recursive delete with needs_confirmation", async () => {
+    const { runtime } = await makeRuntime();
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(undefined, "clean up the old projects"),
+      undefined,
+      { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+    );
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("needs_confirmation");
+    expect(result.text).toContain("confirm=true");
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?.destructive_reason).toBe("recursive delete");
+  });
+
+  it("runs the same command when confirm=true", async () => {
+    const { runtime } = await makeRuntime();
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(undefined, "yes do it"),
+      undefined,
+      {
+        command: "rm -rf /tmp/coding-tools-gate-test-nonexistent",
+        confirm: true,
+      },
+    );
+    // The path does not exist; rm -rf exits 0 on nonexistent targets — the
+    // point is the gate let it through to real execution.
+    expect(result.success).toBe(true);
+  });
+
+  it("is exempt on the coding sub-agent path (task briefs carry confirmation)", async () => {
+    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
+    try {
+      const { runtime } = await makeRuntime();
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "build step"),
+        undefined,
+        { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+      );
+      expect(result.success).toBe(true);
+    } finally {
+      delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+    }
+  });
+
+  it("honors the ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0 escape hatch", async () => {
+    process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM = "0";
+    try {
+      const { runtime } = await makeRuntime();
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "clean up"),
+        undefined,
+        { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+      );
+      expect(result.success).toBe(true);
+    } finally {
+      delete process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM;
+    }
+  });
+
+  it("never gates ordinary commands", async () => {
+    const { runtime } = await makeRuntime();
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(undefined, "whats here"),
+      undefined,
+      { command: "ls /tmp" },
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -20,9 +20,11 @@ import {
   type State,
 } from "@elizaos/core";
 import { resolveRuntimeExecutionMode } from "@elizaos/shared";
+import { classifyDestructiveCommand } from "../lib/destructive-gate.js";
 import {
   failureToActionResult,
   fencePreformatted,
+  readBoolParam,
   readNumberParam,
   readPositiveIntSetting,
   readStringParam,
@@ -1213,6 +1215,13 @@ export const shellAction: Action = {
       schema: { type: "number" },
     },
     {
+      name: "confirm",
+      description:
+        "Set true ONLY after the user has explicitly confirmed THIS destructive bulk operation in chat (recursive delete, raw device overwrite, database drop). Never set it preemptively.",
+      required: false,
+      schema: { type: "boolean" },
+    },
+    {
       name: "handle",
       description:
         "Stable background shell handle returned by action=start_background.",
@@ -1585,6 +1594,38 @@ export const shellAction: Action = {
         process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
       return v === "1" || v === "true" || v === "yes" || v === "on";
     })();
+    // Destructive bulk operations on the CHAT path require an explicit
+    // in-chat confirmation before they run (a confirmation gate, not a
+    // refusal — the planner re-issues the same command with confirm=true
+    // after the user says yes). Coding sub-agents execute explicit task
+    // briefs, which carry their own confirmation upstream, so they are
+    // exempt. Opt out with ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0.
+    const destructiveGateEnabled = ((): boolean => {
+      const v =
+        process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM?.trim().toLowerCase();
+      return !(v === "0" || v === "false" || v === "off");
+    })();
+    if (!codingSubAgentShell && destructiveGateEnabled) {
+      const verdict = classifyDestructiveCommand(command);
+      const confirmed = readBoolParam(options, "confirm") === true;
+      if (verdict.destructive && !confirmed) {
+        const targetList =
+          verdict.targets.filter(Boolean).join(", ") || "its targets";
+        return failureToActionResult(
+          {
+            reason: "needs_confirmation",
+            message:
+              `this ${verdict.reason ?? "destructive operation"} would permanently affect: ${targetList}. ` +
+              "ask the user to confirm the exact operation, then re-run with confirm=true.",
+          },
+          {
+            command,
+            destructive_reason: verdict.reason,
+            targets: verdict.targets,
+          },
+        );
+      }
+    }
     if (!codingSubAgentShell) {
       const localStatusCommand = resolveLocalStatusCommand({
         command,

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Destructive-bulk classifier tests: what fires the chat-path confirm gate and
+ * — just as load-bearing — what must NOT fire it. Deterministic, no processes.
+ */
+import { describe, expect, it } from "vitest";
+import { classifyDestructiveCommand } from "./destructive-gate";
+
+describe("classifyDestructiveCommand — fires", () => {
+  it("rm -rf on a path", () => {
+    const v = classifyDestructiveCommand("rm -rf /home/milady/projects/old");
+    expect(v.destructive).toBe(true);
+    expect(v.reason).toBe("recursive delete");
+    expect(v.targets).toContain("/home/milady/projects/old");
+  });
+  it("rm -fr and rm -R variants", () => {
+    expect(classifyDestructiveCommand("rm -fr build").destructive).toBe(true);
+    expect(classifyDestructiveCommand("rm -R cache").destructive).toBe(true);
+  });
+  it("recursive rm hidden behind a chain", () => {
+    const v = classifyDestructiveCommand("ls && rm -rf ./data");
+    expect(v.destructive).toBe(true);
+  });
+  it("forced glob delete", () => {
+    expect(
+      classifyDestructiveCommand("rm -f /var/log/app/*.log").destructive,
+    ).toBe(true);
+  });
+  it("find -delete", () => {
+    expect(
+      classifyDestructiveCommand("find /tmp/scratch -name '*.tmp' -delete")
+        .destructive,
+    ).toBe(true);
+  });
+  it("dd onto a raw device", () => {
+    const v = classifyDestructiveCommand("dd if=/dev/zero of=/dev/sda bs=1M");
+    expect(v.destructive).toBe(true);
+    expect(v.targets).toContain("of=/dev/sda");
+  });
+  it("mkfs family and shred", () => {
+    expect(classifyDestructiveCommand("mkfs.ext4 /dev/sdb1").destructive).toBe(
+      true,
+    );
+    expect(classifyDestructiveCommand("shred -u secrets.txt").destructive).toBe(
+      true,
+    );
+  });
+  it("DROP DATABASE through a sql runner", () => {
+    const v = classifyDestructiveCommand('psql -c "DROP DATABASE eliza"');
+    expect(v.destructive).toBe(true);
+    expect(v.targets[0]).toContain("eliza");
+  });
+});
+
+describe("classifyDestructiveCommand — must NOT fire", () => {
+  it.each([
+    ["ls -la /tmp"],
+    ["rm single-file.txt"],
+    ["rm -f one-exact-file.log"],
+    ["git rm old.ts"],
+    ["df -h / && du -sh /home"],
+    ["grep -r pattern src/"],
+    ["echo 'rm -rf /' # just talking about it"],
+    ["find . -name '*.ts' -print"],
+    ["dd if=/dev/urandom of=./random.bin count=1"],
+    ["mkdir -p new/dir"],
+  ])("%s", (command) => {
+    expect(classifyDestructiveCommand(command).destructive).toBe(false);
+  });
+  it("quoted rm -rf inside a string argument does not fire", () => {
+    expect(
+      classifyDestructiveCommand('echo "rm -rf would be bad"').destructive,
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -1,0 +1,127 @@
+/**
+ * Destructive-bulk command classifier for the chat-path SHELL gate. Decides
+ * whether a command is an irreversible bulk operation (recursive delete, disk
+ * overwrite, database drop) that must be confirmed by the user before it runs.
+ * This is a confirmation gate, not a capability refusal: single-item writes and
+ * ordinary commands never fire it, and the planner re-issues the same command
+ * with confirm=true after the user says yes. Classification is on the command
+ * string itself (ground truth), never on conversational text.
+ */
+
+export interface DestructiveVerdict {
+  destructive: boolean;
+  /** Human-readable reason, e.g. "recursive delete". */
+  reason?: string;
+  /** The specific targets (paths/db names) the operation would destroy. */
+  targets: string[];
+}
+
+const RECURSIVE_RM_FLAG = /^-[a-z]*[rR][a-z]*$/;
+const FORCE_ONLY_FLAG = /^-[a-z]*f[a-z]*$/;
+const DESTRUCTIVE_BINS = new Set(["mkfs", "shred", "wipefs"]);
+const DROP_SQL = /\bdrop\s+(database|table|schema)\s+(\S+)/i;
+
+function splitSegments(command: string): string[] {
+  // Chain + pipeline split; quotes are respected coarsely — a metacharacter
+  // inside quotes stays put because we only split on unquoted operators.
+  const segments: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i] as string;
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "|" || ch === ";" || (ch === "&" && command[i + 1] === "&")) {
+      segments.push(current);
+      current = "";
+      if (ch === "&") i += 1;
+      continue;
+    }
+    current += ch;
+  }
+  segments.push(current);
+  return segments.map((s) => s.trim()).filter(Boolean);
+}
+
+function tokens(segment: string): string[] {
+  return segment.split(/\s+/).filter(Boolean);
+}
+
+export function classifyDestructiveCommand(
+  command: string,
+): DestructiveVerdict {
+  const sql = DROP_SQL.exec(command);
+  if (sql) {
+    return {
+      destructive: true,
+      reason: `drops ${sql[1]?.toLowerCase()}`,
+      targets: [sql[2] ?? ""],
+    };
+  }
+  for (const segment of splitSegments(command)) {
+    const argv = tokens(segment);
+    // env-var prefixes (FOO=bar cmd …) precede the executable
+    let i = 0;
+    while (
+      i < argv.length &&
+      /^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[i] as string)
+    )
+      i += 1;
+    const bin = (argv[i] ?? "").split("/").pop() ?? "";
+    const rest = argv.slice(i + 1);
+
+    if (bin === "rm") {
+      const recursive = rest.some((a) => RECURSIVE_RM_FLAG.test(a));
+      if (recursive) {
+        const targets = rest.filter((a) => !a.startsWith("-"));
+        return { destructive: true, reason: "recursive delete", targets };
+      }
+      // rm -f on a glob is bulk too; single explicit path is not.
+      const force = rest.some((a) => FORCE_ONLY_FLAG.test(a));
+      const paths = rest.filter((a) => !a.startsWith("-"));
+      if (force && paths.some((p) => p.includes("*"))) {
+        return {
+          destructive: true,
+          reason: "forced glob delete",
+          targets: paths,
+        };
+      }
+    }
+    if (
+      bin === "find" &&
+      (rest.includes("-delete") || rest.join(" ").includes("-exec rm"))
+    ) {
+      return {
+        destructive: true,
+        reason: "bulk find-delete",
+        targets: rest.filter((a) => !a.startsWith("-")).slice(0, 3),
+      };
+    }
+    if (bin === "dd") {
+      const of = rest.find((a) => a.startsWith("of=/dev/"));
+      if (of) {
+        return {
+          destructive: true,
+          reason: "raw device overwrite",
+          targets: [of],
+        };
+      }
+    }
+    if (DESTRUCTIVE_BINS.has(bin) || bin.startsWith("mkfs.")) {
+      return {
+        destructive: true,
+        reason: `${bin} destroys its target`,
+        targets: rest.filter((a) => !a.startsWith("-")),
+      };
+    }
+  }
+  return { destructive: false, targets: [] };
+}

--- a/plugins/plugin-coding-tools/src/types.ts
+++ b/plugins/plugin-coding-tools/src/types.ts
@@ -38,6 +38,7 @@ export type ToolFailureReason =
   | "no_match"
   | "unchanged"
   | "command_failed"
+  | "needs_confirmation"
   | "timeout"
   | "io_error"
   | "internal";


### PR DESCRIPTION
## What

A two-phase confirmation gate for destructive bulk shell operations on the chat path. `classifyDestructiveCommand` inspects the **command string** (chain-aware, quote-aware) for irreversible bulk patterns — recursive `rm`, forced glob deletes, `find -delete`, `dd` onto raw devices, `mkfs`/`shred`/`wipefs`, `DROP DATABASE|TABLE|SCHEMA` — and the SHELL handler refuses with `needs_confirmation` until the planner re-issues the **same command** with the new structured `confirm=true` param.

**This is a confirmation gate, not a capability refusal**: single-item writes and ordinary commands never fire it, and one user "yes" runs the exact operation. Classification is on the command itself — never regex on conversational text.

## Why

The chat path could run `rm -rf` / `DROP DATABASE` on the first ask; the only protection was the OWNER role gate. This closes an inconsistency rather than adding a new safety layer: cloud destructive commands are already gated (`cloud-apps` safety + spend-allowance), `plugin-shell`'s exec-approval subsystem defaults to `deny`+`on-miss` (semantics pinned in #16568), while chat-path SHELL ran ungated. The prompt-side "confirm before destructive bulk ops" rule that used to paper over this was removed in the persona-purge experiment — this is its structural replacement.

**Scope**: chat path only. Coding sub-agents (`ELIZA_PLANNER_FULL_ACTION_SURFACE`) are exempt — their task briefs carry confirmation upstream, and gating them breaks builds. Operator opt-out: `ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0`.

## Live proof (production bot, 2026-07-18)

> **user:** delete the whole /tmp/gate-live-test folder
> **agent:** hold up — `rm -rf /tmp/gate-live-test` is a permanent recursive delete. confirm and i'll run it with confirm=true. say the word.
> *(files verified intact on disk)*
> **user:** confirmed, delete it
> **agent:** `$ rm -rf /tmp/gate-live-test` `[exit 0]` *(dir verified gone, 16s turn)*

## Tests

- 19 classifier cases — including the **must-NOT-fire** set: quoted `rm -rf` inside strings, single-file `rm`, `dd` to regular files, `find -print`, plain talk about deletion
- 5 handler cases: unconfirmed block (with `destructive_reason` + targets in data), `confirm=true` executes, sub-agent exemption, env opt-out, ordinary-command passthrough
- Plugin suite: 362/362

## For review

This reverses a posture the team has deliberately kept lean before (#7944 context), so it ships for review, not self-merge. The claim: data-loss confirm on bulk-irreversible ops is the same *fail-closed-before-the-irreversible-action* doctrine the money paths use — a different category from content nannying, and consistent with the domain-purchase confirm that already exists (`buy-app-domain`).

# Evidence Details

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI; the before-state is the live transcript above (command ran unconfirmed prior to this change).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI; after-state is the two-phase transcript above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the complete flow is the four-message live transcript above, independently verified on disk at each step.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - deterministic handler/classifier tests (24 new) cover the code path; the live transcript covers the deployed behavior.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - trajectories carry production room identifiers; the delivered messages and on-disk verification are quoted above. Stage dumps available on request.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the domain artifacts are the intact-then-deleted files, verified on disk before and after confirmation (3 files -> gone).`
