### PR TITLE
fix(scheduling): persist scheduled tasks across restarts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4933,6 +4933,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.3",
+        "@electric-sql/pglite": "^0.4.5",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -46,6 +46,7 @@ import type {
 import { goalsDbSchema } from "@elizaos/plugin-goals/db/schema";
 import { inboxDbSchema } from "@elizaos/plugin-inbox/db/schema";
 import { remindersDbSchema } from "@elizaos/plugin-reminders/db/schema";
+import { schedulingDbSchema } from "@elizaos/plugin-scheduling";
 import type {
   LifeOpsXDm,
   LifeOpsXFeedItem,
@@ -2304,6 +2305,10 @@ function parseScheduledTaskRow(
     createdBy: toText(row.created_by, ""),
     ownerVisible: toBoolean(row.owner_visible, true),
     metadata: parsedMetadata,
+    executionProfile:
+      typeof row.execution_profile === "string"
+        ? (row.execution_profile as TaskShape["executionProfile"])
+        : undefined,
   };
 }
 
@@ -2512,6 +2517,15 @@ export class LifeOpsRepository {
         {
           name: "@elizaos/plugin-goals",
           schema: goalsDbSchema,
+        },
+        // ScheduledTask tables were carved to @elizaos/plugin-scheduling
+        // (app_scheduling); the runner store and these PA repository methods
+        // now read/write those tables via raw SQL. Mirror the schema here so
+        // test harnesses that only call bootstrapSchema still materialize
+        // them.
+        {
+          name: "@elizaos/plugin-scheduling",
+          schema: schedulingDbSchema,
         },
         // The knowledge-graph tables are runtime-owned (registered by the
         // agent "eliza" plugin in production). Migrate them under the same
@@ -7563,8 +7577,9 @@ export class LifeOpsRepository {
   }
 
   // ScheduledTask spine. The runner is the only writer for these tables;
-  // tables are created by the drizzle plugin-migration system from
-  // `lifeOpsSchema`.
+  // plugin-scheduling owns the physical rows in `app_scheduling`. These PA
+  // methods remain for legacy scheduler paths that still coordinate through
+  // LifeOpsRepository while the runner store itself is scheduling-owned.
 
   /**
    * Upsert a scheduled task. When `expectedVersion` is omitted, behavior
@@ -7596,7 +7611,7 @@ export class LifeOpsRepository {
         ? "NULL"
         : `${sqlQuote(options.nextFireAtIso)}::timestamptz`;
     if (typeof expectedVersion === "number") {
-      const updateSql = `UPDATE app_lifeops.life_scheduled_tasks
+      const updateSql = `UPDATE app_scheduling.life_scheduled_tasks
             SET kind = ${sqlQuote(task.kind)},
                 prompt_instructions = ${sqlQuote(task.promptInstructions)},
                 context_request_json = ${sqlText(task.contextRequest ? JSON.stringify(task.contextRequest) : null)},
@@ -7616,6 +7631,7 @@ export class LifeOpsRepository {
                 created_by = ${sqlQuote(task.createdBy)},
                 owner_visible = ${sqlBoolean(task.ownerVisible)},
                 metadata_json = ${sqlJson(task.metadata ?? {})},
+                execution_profile = ${sqlText(task.executionProfile ?? null)},
                 next_fire_at = ${nextFireAtSql},
                 updated_at = ${sqlQuote(now)},
                 version = version + 1
@@ -7635,13 +7651,13 @@ export class LifeOpsRepository {
       }
       return;
     }
-    const upsertSql = `INSERT INTO app_lifeops.life_scheduled_tasks (
+    const upsertSql = `INSERT INTO app_scheduling.life_scheduled_tasks (
         id, agent_id, kind, prompt_instructions, context_request_json,
         trigger_json, priority, should_fire_json, completion_check_json,
         escalation_json, output_json, pipeline_json, subject_kind, subject_id,
         idempotency_key, respects_global_pause, state_json, source,
-        created_by, owner_visible, metadata_json, next_fire_at,
-        created_at, updated_at
+        created_by, owner_visible, metadata_json, execution_profile,
+        next_fire_at, created_at, updated_at
       ) VALUES (
         ${sqlQuote(task.taskId)},
         ${sqlQuote(agentId)},
@@ -7664,6 +7680,7 @@ export class LifeOpsRepository {
         ${sqlQuote(task.createdBy)},
         ${sqlBoolean(task.ownerVisible)},
         ${sqlJson(task.metadata ?? {})},
+        ${sqlText(task.executionProfile ?? null)},
         ${nextFireAtSql},
         ${sqlQuote(now)},
         ${sqlQuote(now)}
@@ -7688,6 +7705,7 @@ export class LifeOpsRepository {
         created_by = EXCLUDED.created_by,
         owner_visible = EXCLUDED.owner_visible,
         metadata_json = EXCLUDED.metadata_json,
+        execution_profile = EXCLUDED.execution_profile,
         next_fire_at = EXCLUDED.next_fire_at,
         updated_at = ${sqlQuote(now)}`;
     if (tx) {
@@ -7742,7 +7760,7 @@ export class LifeOpsRepository {
       : `AND (state_json::jsonb ->> 'status') = 'scheduled'`;
     const rows = await executeRawSql(
       this.runtime,
-      `UPDATE app_lifeops.life_scheduled_tasks
+      `UPDATE app_scheduling.life_scheduled_tasks
           SET state_json = jsonb_set(
                               jsonb_set(
                                 state_json::jsonb,
@@ -7774,7 +7792,7 @@ export class LifeOpsRepository {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
-         FROM app_lifeops.life_scheduled_tasks
+         FROM app_scheduling.life_scheduled_tasks
         WHERE agent_id = ${sqlQuote(agentId)}
           AND id = ${sqlQuote(taskId)}
         LIMIT 1`,
@@ -7790,7 +7808,7 @@ export class LifeOpsRepository {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
-         FROM app_lifeops.life_scheduled_tasks
+         FROM app_scheduling.life_scheduled_tasks
         WHERE agent_id = ${sqlQuote(agentId)}
           AND idempotency_key = ${sqlQuote(idempotencyKey)}
         LIMIT 1`,
@@ -7868,7 +7886,7 @@ export class LifeOpsRepository {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
-         FROM app_lifeops.life_scheduled_tasks
+         FROM app_scheduling.life_scheduled_tasks
         WHERE ${where}
         ORDER BY created_at ASC`,
     );
@@ -7878,13 +7896,13 @@ export class LifeOpsRepository {
   async deleteScheduledTask(agentId: string, taskId: string): Promise<void> {
     await executeRawSql(
       this.runtime,
-      `DELETE FROM app_lifeops.life_scheduled_tasks
+      `DELETE FROM app_scheduling.life_scheduled_tasks
         WHERE agent_id = ${sqlQuote(agentId)}
           AND id = ${sqlQuote(taskId)}`,
     );
     await executeRawSql(
       this.runtime,
-      `DELETE FROM app_lifeops.life_scheduled_task_log
+      `DELETE FROM app_scheduling.life_scheduled_task_log
         WHERE agent_id = ${sqlQuote(agentId)}
           AND task_id = ${sqlQuote(taskId)}`,
     );
@@ -7905,8 +7923,8 @@ export class LifeOpsRepository {
   async resetSchedulingStateForScenario(agentId: string): Promise<void> {
     const quotedAgent = sqlQuote(agentId);
     for (const statement of [
-      `DELETE FROM app_lifeops.life_scheduled_tasks WHERE agent_id = ${quotedAgent}`,
-      `DELETE FROM app_lifeops.life_scheduled_task_log WHERE agent_id = ${quotedAgent}`,
+      `DELETE FROM app_scheduling.life_scheduled_tasks WHERE agent_id = ${quotedAgent}`,
+      `DELETE FROM app_scheduling.life_scheduled_task_log WHERE agent_id = ${quotedAgent}`,
       `DELETE FROM app_lifeops.life_schedule_merged_states WHERE agent_id = ${quotedAgent}`,
       `DELETE FROM app_lifeops.life_schedule_insights WHERE agent_id = ${quotedAgent}`,
       `DELETE FROM app_lifeops.life_schedule_observations WHERE agent_id = ${quotedAgent}`,
@@ -7921,7 +7939,7 @@ export class LifeOpsRepository {
   ): Promise<void> {
     await executeRawSql(
       this.runtime,
-      `INSERT INTO app_lifeops.life_scheduled_task_log (
+      `INSERT INTO app_scheduling.life_scheduled_task_log (
         id, agent_id, task_id, occurred_at, transition, reason, rolled_up, detail_json
       ) VALUES (
         ${sqlQuote(entry.logId)},
@@ -7959,7 +7977,7 @@ export class LifeOpsRepository {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
-         FROM app_lifeops.life_scheduled_task_log
+         FROM app_scheduling.life_scheduled_task_log
         WHERE ${clauses.join(" AND ")}
         ORDER BY occurred_at ASC
         ${limit}`,
@@ -7975,7 +7993,7 @@ export class LifeOpsRepository {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
-         FROM app_lifeops.life_scheduled_task_log
+         FROM app_scheduling.life_scheduled_task_log
         WHERE agent_id = ${sqlQuote(args.agentId)}
           AND rolled_up = FALSE
           AND occurred_at < ${sqlQuote(args.olderThanIso)}`,
@@ -8013,7 +8031,7 @@ export class LifeOpsRepository {
     // Delete the raw rows we just summarized.
     await executeRawSql(
       this.runtime,
-      `DELETE FROM app_lifeops.life_scheduled_task_log
+      `DELETE FROM app_scheduling.life_scheduled_task_log
         WHERE agent_id = ${sqlQuote(args.agentId)}
           AND rolled_up = FALSE
           AND occurred_at < ${sqlQuote(args.olderThanIso)}`,
@@ -8024,7 +8042,7 @@ export class LifeOpsRepository {
       const id = `rollup-${s.taskId}-${s.dayIso}-${s.transition}-${counter}`;
       await executeRawSql(
         this.runtime,
-        `INSERT INTO app_lifeops.life_scheduled_task_log (
+        `INSERT INTO app_scheduling.life_scheduled_task_log (
           id, agent_id, task_id, occurred_at, transition, reason, rolled_up, detail_json
         ) VALUES (
           ${sqlQuote(id)},

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -1,11 +1,11 @@
 /**
  * Runtime wiring for the ScheduledTask spine.
  *
- * Bridges the runner's typed dependencies to the live `IAgentRuntime` /
- * `LifeOpsRepository`: DB-backed task/log stores, the production dispatcher,
- * owner facts, global pause, the LifeOps subject store, and the runtime
- * event → task-fire bridge. The activity-bus view keeps a warn-once
- * diagnostic stand-in until `registerActivitySignalBus` runs in plugin init.
+ * Bridges the runner's typed dependencies to the live `IAgentRuntime`: the
+ * scheduling-owned SQL task/log stores, production dispatcher, owner facts,
+ * global pause, the LifeOps subject store, and the runtime event → task-fire
+ * bridge. The activity-bus view keeps a warn-once diagnostic stand-in until
+ * `registerActivitySignalBus` runs in plugin init.
  */
 
 import crypto from "node:crypto";
@@ -23,12 +23,10 @@ import type {
   ActivitySignalBusView,
   GlobalPauseView,
   OwnerFactsView,
-  ScheduledTask,
   ScheduledTaskDispatcher,
   ScheduledTaskDispatchRecord,
-  ScheduledTaskFilter,
-  ScheduledTaskLogEntry,
   ScheduledTaskLogStore,
+  ScheduledTaskStore,
   SubjectStoreView,
   TaskExecutionProfile,
 } from "@elizaos/plugin-scheduling";
@@ -38,6 +36,8 @@ import {
   createConsolidationRegistry,
   createEscalationLadderRegistry,
   createScheduledTaskRunner,
+  createSchedulingSqlScheduledTaskLogStore,
+  createSchedulingSqlScheduledTaskStore,
   createTaskGateRegistry,
   getAnchorRegistry,
   getScheduledTaskRunner,
@@ -54,7 +54,6 @@ import {
   renderScheduledDispatchTitle,
   type ScheduledTaskRunnerDepsBundle,
   type ScheduledTaskRunnerHandle,
-  type ScheduledTaskStore,
 } from "@elizaos/plugin-scheduling";
 import { assembleMorningBrief } from "../../default-packs/morning-brief.js";
 import { getChannelRegistry } from "../channels/index.js";
@@ -121,76 +120,17 @@ function makeRuntimeSubjectStoreView(
 }
 
 /**
- * Bind the in-memory facade to the LifeOpsRepository SQL methods. Each
- * call routes through the repository so the runner is DB-backed but
- * agnostic about the storage shape.
+ * Bind PA's runner deps to the scheduling-owned SQL store. PA still injects
+ * owner/channel/subject dependencies, but row ownership now belongs to
+ * `@elizaos/plugin-scheduling`.
  */
 function makeRepositoryBackedStores(
   runtime: IAgentRuntime,
   agentId: string,
 ): RepositoryBackedStores {
-  const repo = new LifeOpsRepository(runtime);
   return {
-    store: {
-      async upsert(task: ScheduledTask, options) {
-        await repo.upsertScheduledTask(agentId, task, {
-          nextFireAtIso: options?.nextFireAtIso ?? null,
-        });
-      },
-      async claimForFire({ taskId, firedAtIso, expected }) {
-        return repo.claimScheduledTaskForFire(agentId, {
-          taskId,
-          firedAtIso,
-          ...(expected ? { expected } : {}),
-        });
-      },
-      async get(taskId: string) {
-        return repo.getScheduledTask(agentId, taskId);
-      },
-      async findByIdempotencyKey(key: string) {
-        return repo.getScheduledTaskByIdempotencyKey(agentId, key);
-      },
-      async list(filter?: ScheduledTaskFilter) {
-        const status = filter?.status;
-        const statusList = Array.isArray(status)
-          ? status
-          : status
-            ? [status]
-            : undefined;
-        return repo.listScheduledTasks(agentId, {
-          kind: filter?.kind,
-          status: statusList,
-          subjectKind: filter?.subject?.kind,
-          subjectId: filter?.subject?.id,
-          source: filter?.source,
-          ownerVisibleOnly: filter?.ownerVisibleOnly,
-        });
-      },
-      async delete(taskId: string) {
-        await repo.deleteScheduledTask(agentId, taskId);
-      },
-    },
-    logStore: {
-      async append(entry: ScheduledTaskLogEntry) {
-        await repo.appendScheduledTaskLog(entry);
-      },
-      async list(args) {
-        return repo.listScheduledTaskLog({
-          agentId,
-          taskId: args.taskId,
-          sinceIso: args.sinceIso,
-          untilIso: args.untilIso,
-          excludeRollups: args.excludeRollups,
-          limit: args.limit,
-        });
-      },
-      async rollupOlderThan(args) {
-        return repo.rollupScheduledTaskLog({
-          agentId,
-          olderThanIso: args.olderThanIso,
-        });
-      },
-    },
+    store: createSchedulingSqlScheduledTaskStore({ runtime, agentId }),
+    logStore: createSchedulingSqlScheduledTaskLogStore({ runtime, agentId }),
   };
 }
 
@@ -884,9 +824,9 @@ export function createRuntimeScheduledTaskRunner(
 /**
  * Register PA's production deps as the runner host's injected deps provider on
  * `@elizaos/plugin-scheduling`. Called during PA `init`. First-wins: the spine
- * keeps this provider once set, so PA rows land in `app_lifeops` via the
- * injected repository-backed store even though the runner service itself lives
- * in `@elizaos/plugin-scheduling`.
+ * keeps this provider once set, so PA dispatch/owner deps wrap the
+ * scheduling-owned SQL store while the runner service itself lives in
+ * `@elizaos/plugin-scheduling`.
  */
 export function registerLifeOpsScheduledTaskRunnerDeps(
   runtime: IAgentRuntime,

--- a/plugins/plugin-personal-assistant/src/lifeops/schema.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schema.ts
@@ -1454,16 +1454,11 @@ export const lifeBlockRules = appLifeopsPgSchema.table("life_block_rules", {
   releasedReason: text("released_reason"),
 });
 
-// ScheduledTask spine + state log.
+// ScheduledTask spine + state log migration source.
 //
-// `life_scheduled_tasks` stores the typed ScheduledTask record. The
-// runner is the only writer; each row's `state_json` carries the
-// `ScheduledTaskState` fields (status, firedAt, …). `idempotency_key`
-// is unique per agent and dedupes schedule() calls.
-//
-// `life_scheduled_task_log` is the append-only state-log; the nightly
-// rollup pass folds expired raw rows into a daily summary row keyed by
-// (task, day, transition).
+// plugin-scheduling now owns the physical ScheduledTask tables in
+// `app_scheduling`. These `app_lifeops` definitions remain as the
+// non-destructive migration source for existing installs.
 
 export const lifeScheduledTasks = appLifeopsPgSchema.table(
   "life_scheduled_tasks",
@@ -1705,8 +1700,6 @@ export const lifeOpsSchema = {
   lifeSchedulingNegotiations,
   lifeSchedulingProposals,
   lifeBlockRules,
-  lifeScheduledTasks,
-  lifeScheduledTaskLog,
   lifeWorkThreads,
   lifeWorkThreadEvents,
   lifeBriefItemEngagements,

--- a/plugins/plugin-scheduling/AGENTS.md
+++ b/plugins/plugin-scheduling/AGENTS.md
@@ -33,10 +33,12 @@ runtime surface that makes them work standalone:
 - **The runner host service** `ScheduledTaskRunnerService` (serviceType
   `"lifeops_scheduled_task_runner"`, in `scheduled-task/runner-service.ts`) +
   the runtime-injected deps port `registerScheduledTaskRunnerDeps` /
-  `getScheduledTaskRunnerDeps`. A built-in **default deps provider** (in-memory
-  store, built-in registries, an `in_app`/NOTIFICATION dispatcher, warn-once
-  ports, an `ELIZA_PLATFORM`-driven host-capability predicate) runs when no host
-  injects production deps — so the runner works on a stock mobile boot.
+  `getScheduledTaskRunnerDeps`. A built-in **default deps provider**
+  (scheduling-owned SQL store when a runtime DB exists, in-memory fallback when
+  it does not, built-in registries, an `in_app`/NOTIFICATION dispatcher,
+  warn-once ports, an `ELIZA_PLATFORM`-driven host-capability predicate) runs
+  when no host injects production deps — so the runner works on a stock mobile
+  boot.
 - **The generic REST surface** at `/api/lifeops/scheduled-tasks`
   (`routes/scheduled-tasks.ts` + `routes/plugin-routes.ts`), registered via the
   plugin's `routes:` array on every platform (path unchanged for the UI).
@@ -53,8 +55,9 @@ runtime surface that makes them work standalone:
 A host (`@elizaos/plugin-personal-assistant`) injects the production deps via
 `registerScheduledTaskRunnerDeps` (first-wins) and registers its domain packs +
 the `SCHEDULED_TASKS` action; PA's dev `/api/lifeops/dev/registries` composite
-stays PA-side. Tables stay in PA's `app_lifeops` and are reached via the
-injected store (a later optional carve can move them to `app_scheduling`).
+stays PA-side. ScheduledTask rows and state-log rows are scheduling-owned in
+`app_scheduling`; the migration service non-destructively copies legacy
+`app_lifeops` rows into that schema.
 
 Gate: `rg "@elizaos/(app-core|agent|plugin-personal-assistant|plugin-google)"
 plugins/plugin-scheduling/src` must return comments/strings only.

--- a/plugins/plugin-scheduling/CLAUDE.md
+++ b/plugins/plugin-scheduling/CLAUDE.md
@@ -33,10 +33,12 @@ runtime surface that makes them work standalone:
 - **The runner host service** `ScheduledTaskRunnerService` (serviceType
   `"lifeops_scheduled_task_runner"`, in `scheduled-task/runner-service.ts`) +
   the runtime-injected deps port `registerScheduledTaskRunnerDeps` /
-  `getScheduledTaskRunnerDeps`. A built-in **default deps provider** (in-memory
-  store, built-in registries, an `in_app`/NOTIFICATION dispatcher, warn-once
-  ports, an `ELIZA_PLATFORM`-driven host-capability predicate) runs when no host
-  injects production deps — so the runner works on a stock mobile boot.
+  `getScheduledTaskRunnerDeps`. A built-in **default deps provider**
+  (scheduling-owned SQL store when a runtime DB exists, in-memory fallback when
+  it does not, built-in registries, an `in_app`/NOTIFICATION dispatcher,
+  warn-once ports, an `ELIZA_PLATFORM`-driven host-capability predicate) runs
+  when no host injects production deps — so the runner works on a stock mobile
+  boot.
 - **The generic REST surface** at `/api/lifeops/scheduled-tasks`
   (`routes/scheduled-tasks.ts` + `routes/plugin-routes.ts`), registered via the
   plugin's `routes:` array on every platform (path unchanged for the UI).
@@ -53,8 +55,9 @@ runtime surface that makes them work standalone:
 A host (`@elizaos/plugin-personal-assistant`) injects the production deps via
 `registerScheduledTaskRunnerDeps` (first-wins) and registers its domain packs +
 the `SCHEDULED_TASKS` action; PA's dev `/api/lifeops/dev/registries` composite
-stays PA-side. Tables stay in PA's `app_lifeops` and are reached via the
-injected store (a later optional carve can move them to `app_scheduling`).
+stays PA-side. ScheduledTask rows and state-log rows are scheduling-owned in
+`app_scheduling`; the migration service non-destructively copies legacy
+`app_lifeops` rows into that schema.
 
 Gate: `rg "@elizaos/(app-core|agent|plugin-personal-assistant|plugin-google)"
 plugins/plugin-scheduling/src` must return comments/strings only.

--- a/plugins/plugin-scheduling/package.json
+++ b/plugins/plugin-scheduling/package.json
@@ -73,6 +73,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
+    "@electric-sql/pglite": "^0.4.5",
     "@types/node": "^25.0.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -9,7 +9,9 @@
  */
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { buildSchedulingRoutes } from "./routes/plugin-routes.js";
+import { schedulingDbSchema } from "./scheduled-task/db-schema.js";
 import { buildFallbackDefaultPack } from "./scheduled-task/default-pack.js";
+
 import {
   getScheduledTaskRunner,
   getScheduledTaskRunnerDeps,
@@ -24,7 +26,9 @@ import {
 export const schedulingPlugin: Plugin = {
   name: "@elizaos/plugin-scheduling",
   description:
-    "Scheduling spine: the always-loaded ScheduledTask runtime primitive — runner host, REST surface, and default-pack seed registry. Persistence and owner/channel deps are injected by a host plugin; built-in defaults run when no host is present.",
+    "Scheduling spine: the always-loaded ScheduledTask runtime primitive — runner host, REST surface, durable store, and default-pack seed registry. Owner/channel deps are injected by a host plugin; built-in defaults run when no host is present.",
+  dependencies: ["@elizaos/plugin-sql"],
+  schema: schedulingDbSchema,
   services: [ScheduledTaskRunnerService],
   routes: buildSchedulingRoutes(),
   views: [

--- a/plugins/plugin-scheduling/src/scheduled-task/db-schema.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/db-schema.ts
@@ -1,0 +1,90 @@
+/**
+ * Drizzle schema for the scheduling-owned ScheduledTask store.
+ *
+ * The table and column names intentionally match their original
+ * `app_lifeops` definitions so the carve-out migration can copy rows into the
+ * plugin-owned `app_scheduling` namespace without data reshaping.
+ */
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  integer,
+  pgSchema,
+  text,
+  timestamp,
+  unique,
+} from "drizzle-orm/pg-core";
+
+export const appSchedulingPgSchema = pgSchema("app_scheduling");
+
+export const lifeScheduledTasks = appSchedulingPgSchema.table(
+  "life_scheduled_tasks",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    kind: text("kind").notNull(),
+    promptInstructions: text("prompt_instructions").notNull(),
+    contextRequestJson: text("context_request_json"),
+    triggerJson: text("trigger_json").notNull(),
+    priority: text("priority").notNull().default("medium"),
+    shouldFireJson: text("should_fire_json"),
+    completionCheckJson: text("completion_check_json"),
+    escalationJson: text("escalation_json"),
+    outputJson: text("output_json"),
+    pipelineJson: text("pipeline_json"),
+    subjectKind: text("subject_kind"),
+    subjectId: text("subject_id"),
+    idempotencyKey: text("idempotency_key"),
+    respectsGlobalPause: boolean("respects_global_pause")
+      .notNull()
+      .default(true),
+    stateJson: text("state_json").notNull().default("{}"),
+    source: text("source").notNull().default("user_chat"),
+    createdBy: text("created_by").notNull().default(""),
+    ownerVisible: boolean("owner_visible").notNull().default(true),
+    metadataJson: text("metadata_json").notNull().default("{}"),
+    executionProfile: text("execution_profile"),
+    version: integer("version").notNull().default(1),
+    nextFireAt: timestamp("next_fire_at", { withTimezone: true }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => [
+    unique().on(t.agentId, t.idempotencyKey),
+    index("idx_scheduling_tasks_agent_kind").on(t.agentId, t.kind),
+    index("idx_scheduling_tasks_subject").on(
+      t.agentId,
+      t.subjectKind,
+      t.subjectId,
+    ),
+    index("idx_scheduling_tasks_due")
+      .on(t.agentId, t.nextFireAt)
+      .where(
+        sql`(state_json::jsonb ->> 'status') IN ('scheduled', 'fired', 'acknowledged', 'completed', 'skipped', 'expired', 'failed')`,
+      ),
+  ],
+);
+
+export const lifeScheduledTaskLog = appSchedulingPgSchema.table(
+  "life_scheduled_task_log",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    taskId: text("task_id").notNull(),
+    occurredAt: text("occurred_at").notNull(),
+    transition: text("transition").notNull(),
+    reason: text("reason"),
+    rolledUp: boolean("rolled_up").notNull().default(false),
+    detailJson: text("detail_json"),
+  },
+  (t) => [
+    index("idx_scheduling_task_log_agent_task").on(t.agentId, t.taskId),
+    index("idx_scheduling_task_log_agent_time").on(t.agentId, t.occurredAt),
+  ],
+);
+
+export const schedulingDbSchema = {
+  lifeScheduledTasks,
+  lifeScheduledTaskLog,
+} as const;

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -19,6 +19,12 @@ export {
   registerFallbackAnchors,
 } from "./consolidation-policy.js";
 export {
+  appSchedulingPgSchema,
+  lifeScheduledTaskLog,
+  lifeScheduledTasks,
+  schedulingDbSchema,
+} from "./db-schema.js";
+export {
   buildFallbackDefaultPack,
   FALLBACK_DEFAULT_PACK_ID,
   FALLBACK_DEFAULT_PACK_IDEMPOTENCY_KEYS,
@@ -67,6 +73,13 @@ export {
   registerBuiltInGates,
   type TaskGateRegistry,
 } from "./gate-registry.js";
+export {
+  ensureSchedulingTables,
+  migrateSchedulingTable,
+  migrateSchedulingTables,
+  SCHEDULING_MIGRATION_SERVICE_TYPE,
+  SchedulingMigrationService,
+} from "./migration.js";
 export { computeNextFireAt } from "./next-fire-at.js";
 export {
   ChannelKeyError,
@@ -114,6 +127,12 @@ export {
   type ScheduledTaskLogStore,
   STATE_LOG_DEFAULT_RETENTION_DAYS,
 } from "./state-log.js";
+export {
+  createSchedulingSqlScheduledTaskLogStore,
+  createSchedulingSqlScheduledTaskStore,
+  parseScheduledTaskLogRow,
+  parseScheduledTaskRow,
+} from "./store.js";
 export { OWNER_LOCAL_TZ, resolveTriggerTz } from "./trigger-tz.js";
 export type {
   ActivitySignalBusView,

--- a/plugins/plugin-scheduling/src/scheduled-task/migration.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/migration.ts
@@ -1,0 +1,225 @@
+/**
+ * Non-destructive data migration for ScheduledTask rows carved out of
+ * @elizaos/plugin-personal-assistant.
+ *
+ * Scheduled tasks and their state log used to live in `app_lifeops`. They now
+ * live in scheduling-owned `app_scheduling`; this service creates/repairs the
+ * target schema and copies existing source rows once without deleting or
+ * mutating the old tables.
+ */
+import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { executeRawSql, getRuntimeDb } from "./sql.js";
+
+export const SCHEDULING_MIGRATION_SERVICE_TYPE = "scheduling_migration";
+export const SCHEDULING_MIGRATION_LOG_PREFIX = "[Scheduling]";
+
+const SOURCE_SCHEMA = "app_lifeops";
+const TARGET_SCHEMA = "app_scheduling";
+
+export const MIGRATED_SCHEDULING_TABLES = [
+  "life_scheduled_tasks",
+  "life_scheduled_task_log",
+] as const;
+
+export type MigratedSchedulingTable =
+  (typeof MIGRATED_SCHEDULING_TABLES)[number];
+
+export type SqlExecutor = (
+  sql: string,
+) => Promise<Array<Record<string, unknown>>>;
+
+export interface TableMigrationResult {
+  table: MigratedSchedulingTable;
+  outcome: "copied" | "source-missing";
+}
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function isTruthy(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+function scalar(
+  row: Record<string, unknown> | undefined,
+  key: string,
+): unknown {
+  if (!row) return undefined;
+  return key in row ? row[key] : Object.values(row)[0];
+}
+
+async function sourceTableExists(
+  exec: SqlExecutor,
+  table: MigratedSchedulingTable,
+): Promise<boolean> {
+  const rows = await exec(
+    `SELECT to_regclass('${SOURCE_SCHEMA}.${table}') IS NOT NULL AS present`,
+  );
+  return isTruthy(scalar(rows[0], "present"));
+}
+
+export async function ensureSchedulingTables(exec: SqlExecutor): Promise<void> {
+  await exec(`CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA}`);
+  await exec(
+    `CREATE TABLE IF NOT EXISTS ${TARGET_SCHEMA}.life_scheduled_tasks (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      prompt_instructions TEXT NOT NULL,
+      context_request_json TEXT,
+      trigger_json TEXT NOT NULL,
+      priority TEXT NOT NULL DEFAULT 'medium',
+      should_fire_json TEXT,
+      completion_check_json TEXT,
+      escalation_json TEXT,
+      output_json TEXT,
+      pipeline_json TEXT,
+      subject_kind TEXT,
+      subject_id TEXT,
+      idempotency_key TEXT,
+      respects_global_pause BOOLEAN NOT NULL DEFAULT TRUE,
+      state_json TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL DEFAULT 'user_chat',
+      created_by TEXT NOT NULL DEFAULT '',
+      owner_visible BOOLEAN NOT NULL DEFAULT TRUE,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      execution_profile TEXT,
+      version INTEGER NOT NULL DEFAULT 1,
+      next_fire_at TIMESTAMPTZ,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )`,
+  );
+  await exec(
+    `ALTER TABLE ${TARGET_SCHEMA}.life_scheduled_tasks
+       ADD COLUMN IF NOT EXISTS execution_profile TEXT`,
+  );
+  await exec(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduling_tasks_agent_idempotency
+      ON ${TARGET_SCHEMA}.life_scheduled_tasks (agent_id, idempotency_key)`,
+  );
+  await exec(
+    `CREATE INDEX IF NOT EXISTS idx_scheduling_tasks_agent_kind
+      ON ${TARGET_SCHEMA}.life_scheduled_tasks (agent_id, kind)`,
+  );
+  await exec(
+    `CREATE INDEX IF NOT EXISTS idx_scheduling_tasks_subject
+      ON ${TARGET_SCHEMA}.life_scheduled_tasks (agent_id, subject_kind, subject_id)`,
+  );
+  await exec(
+    `CREATE INDEX IF NOT EXISTS idx_scheduling_tasks_due
+      ON ${TARGET_SCHEMA}.life_scheduled_tasks (agent_id, next_fire_at)
+      WHERE (state_json::jsonb ->> 'status') IN ('scheduled', 'fired', 'acknowledged', 'completed', 'skipped', 'expired', 'failed')`,
+  );
+  await exec(
+    `CREATE TABLE IF NOT EXISTS ${TARGET_SCHEMA}.life_scheduled_task_log (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      occurred_at TEXT NOT NULL,
+      transition TEXT NOT NULL,
+      reason TEXT,
+      rolled_up BOOLEAN NOT NULL DEFAULT FALSE,
+      detail_json TEXT
+    )`,
+  );
+  await exec(
+    `CREATE INDEX IF NOT EXISTS idx_scheduling_task_log_agent_task
+      ON ${TARGET_SCHEMA}.life_scheduled_task_log (agent_id, task_id)`,
+  );
+  await exec(
+    `CREATE INDEX IF NOT EXISTS idx_scheduling_task_log_agent_time
+      ON ${TARGET_SCHEMA}.life_scheduled_task_log (agent_id, occurred_at)`,
+  );
+}
+
+export async function migrateSchedulingTable(
+  exec: SqlExecutor,
+  table: MigratedSchedulingTable,
+): Promise<TableMigrationResult> {
+  if (!(await sourceTableExists(exec, table))) {
+    return { table, outcome: "source-missing" };
+  }
+  const target = `${TARGET_SCHEMA}.${quoteIdent(table)}`;
+  const source = `${SOURCE_SCHEMA}.${quoteIdent(table)}`;
+  if (table === "life_scheduled_tasks") {
+    const legacyColumns = [
+      "id",
+      "agent_id",
+      "kind",
+      "prompt_instructions",
+      "context_request_json",
+      "trigger_json",
+      "priority",
+      "should_fire_json",
+      "completion_check_json",
+      "escalation_json",
+      "output_json",
+      "pipeline_json",
+      "subject_kind",
+      "subject_id",
+      "idempotency_key",
+      "respects_global_pause",
+      "state_json",
+      "source",
+      "created_by",
+      "owner_visible",
+      "metadata_json",
+      "version",
+      "next_fire_at",
+      "created_at",
+      "updated_at",
+    ].join(", ");
+    await exec(
+      `INSERT INTO ${target} (${legacyColumns})
+       SELECT ${legacyColumns} FROM ${source}
+       ON CONFLICT DO NOTHING`,
+    );
+  } else {
+    await exec(
+      `INSERT INTO ${target}
+       SELECT s.* FROM ${source} AS s
+       ON CONFLICT DO NOTHING`,
+    );
+  }
+  return { table, outcome: "copied" };
+}
+
+export async function migrateSchedulingTables(
+  exec: SqlExecutor,
+): Promise<TableMigrationResult[]> {
+  await ensureSchedulingTables(exec);
+  const results: TableMigrationResult[] = [];
+  for (const table of MIGRATED_SCHEDULING_TABLES) {
+    results.push(await migrateSchedulingTable(exec, table));
+  }
+  return results;
+}
+
+export class SchedulingMigrationService extends Service {
+  static override readonly serviceType = SCHEDULING_MIGRATION_SERVICE_TYPE;
+
+  override capabilityDescription =
+    "Creates app_scheduling ScheduledTask tables and non-destructively copies legacy app_lifeops rows into them.";
+
+  override async stop(): Promise<void> {}
+
+  static override async start(
+    runtime: IAgentRuntime,
+  ): Promise<SchedulingMigrationService> {
+    const service = new SchedulingMigrationService(runtime);
+    if (getRuntimeDb(runtime)) await service.run();
+    return service;
+  }
+
+  private async run(): Promise<void> {
+    const results = await migrateSchedulingTables((sql) =>
+      executeRawSql(this.runtime, sql),
+    );
+    logger.info(
+      { src: "scheduling:migration", results },
+      `${SCHEDULING_MIGRATION_LOG_PREFIX} Scheduling table migration checked.`,
+    );
+  }
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
@@ -4,14 +4,15 @@
  *
  * This is the storage-agnostic home of the scheduled-task spine's runtime
  * surface. `@elizaos/plugin-scheduling` ships a DEFAULT deps provider
- * (in-memory store, built-in registries, an `in_app`/NOTIFICATION dispatcher,
- * warn-once stand-in ports, and an `ELIZA_PLATFORM`-driven host-capability
+ * (scheduling-owned SQL store when a runtime DB exists, otherwise in-memory
+ * fallback; built-in registries; an `in_app`/NOTIFICATION dispatcher;
+ * warn-once stand-in ports; and an `ELIZA_PLATFORM`-driven host-capability
  * predicate) so the runner + its REST surface + the seed mechanism work on ANY
  * platform — including mobile — from this plugin alone.
  *
  * A consumer (e.g. `@elizaos/plugin-personal-assistant`) injects its production
- * deps via {@link registerScheduledTaskRunnerDeps} at init: a repository-backed
- * durable store, the production dispatcher, real owner-facts / channel-keys /
+ * deps via {@link registerScheduledTaskRunnerDeps} at init: the durable store
+ * plus production dispatcher, real owner-facts / channel-keys /
  * host-capability probes. When PA is loaded its deps win; when absent, the
  * default deps run. This keeps `@elizaos/plugin-scheduling` free of any
  * `@elizaos/app-core` / `@elizaos/agent` / `@elizaos/plugin-personal-assistant`
@@ -61,6 +62,7 @@ import {
   registerBuiltInGates,
   type TaskGateRegistry,
 } from "./gate-registry.js";
+import { migrateSchedulingTables } from "./migration.js";
 import {
   createInMemoryScheduledTaskStore,
   createScheduledTaskRunner,
@@ -68,10 +70,15 @@ import {
   type ScheduledTaskRunnerHandle,
   type ScheduledTaskStore,
 } from "./runner.js";
+import { executeRawSql, getRuntimeDb } from "./sql.js";
 import {
   createInMemoryScheduledTaskLogStore,
   type ScheduledTaskLogStore,
 } from "./state-log.js";
+import {
+  createSchedulingSqlScheduledTaskLogStore,
+  createSchedulingSqlScheduledTaskStore,
+} from "./store.js";
 import {
   type ActivitySignalBusView,
   type GlobalPauseView,
@@ -86,8 +93,8 @@ const SERVICE_TYPE = "lifeops_scheduled_task_runner" as const;
 /**
  * Everything the runner needs that is host-specific. A consumer injects a
  * provider via {@link registerScheduledTaskRunnerDeps}; the default provider
- * below supplies a durable-enough in-memory implementation that works on any
- * platform.
+ * below supplies a scheduling-owned SQL store when a runtime DB is available
+ * and an in-memory fallback for isolated hosts/tests.
  *
  * Registries are optional: when omitted, the host service builds the built-in
  * gate / completion-check / ladder / anchor / consolidation registries.
@@ -301,17 +308,24 @@ const ALWAYS_ALLOW_GLOBAL_PAUSE: GlobalPauseView = {
 };
 
 /**
- * The default (no-PA) deps provider. In-memory store + log store, built-in
- * registries (built by the host service), warn-once activity/subject ports, a
- * permissive global-pause view, an empty owner-facts view, a notification-only
- * dispatcher, and the `ELIZA_PLATFORM` host-capability predicate.
+ * The default (no-PA) deps provider. Uses scheduling-owned SQL persistence
+ * when the runtime DB is present, then falls back to in-memory for isolated
+ * tests/hosts without `@elizaos/plugin-sql`; the rest of the bundle is built-in
+ * registries, warn-once activity/subject ports, permissive global-pause, empty
+ * owner-facts, notification-only dispatch, and platform capability probing.
  */
 function defaultRunnerDeps(
   runtime: IAgentRuntime,
+  agentId: string,
 ): ScheduledTaskRunnerDepsBundle {
+  const hasRuntimeDb = getRuntimeDb(runtime) !== null;
   return {
-    store: createInMemoryScheduledTaskStore(),
-    logStore: createInMemoryScheduledTaskLogStore(),
+    store: hasRuntimeDb
+      ? createSchedulingSqlScheduledTaskStore({ runtime, agentId })
+      : createInMemoryScheduledTaskStore(),
+    logStore: hasRuntimeDb
+      ? createSchedulingSqlScheduledTaskLogStore({ runtime, agentId })
+      : createInMemoryScheduledTaskLogStore(),
     dispatcher: createDefaultScheduledTaskDispatcher(runtime),
     ownerFacts: () => ({}) as OwnerFactsView,
     globalPause: ALWAYS_ALLOW_GLOBAL_PAUSE,
@@ -440,6 +454,13 @@ export class ScheduledTaskRunnerService extends Service {
   static override async start(
     runtime: IAgentRuntime,
   ): Promise<ScheduledTaskRunnerService> {
+    // This service is the boot barrier used by routes and seed packs. Copy
+    // legacy rows before either can insert an idempotency-key collision.
+    if (getRuntimeDb(runtime)) {
+      await migrateSchedulingTables((statement) =>
+        executeRawSql(runtime, statement),
+      );
+    }
     logger.debug(
       { src: SERVICE_TYPE, agentId: runtime.agentId },
       "ScheduledTaskRunnerService started",

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -146,7 +146,7 @@ export interface ScheduledTaskStore {
    *
    * The store is the only place where the read-mutate-write becomes
    * atomic; the runner's previous read-then-upsert pattern was racy
-   * across parallel ticks. See `LifeOpsRepository.claimScheduledTaskForFire`.
+   * across parallel ticks.
    */
   claimForFire(args: {
     taskId: string;

--- a/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Restart coverage for the scheduling-owned SQL store.
+ *
+ * These tests use a real PGlite database behind the runner service and recreate
+ * the service between operations, which exercises the boot/re-init path that
+ * previously lost in-memory ScheduledTask rows.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DispatchResult } from "../dispatch-types.js";
+import {
+  migrateSchedulingTables,
+  SchedulingMigrationService,
+} from "./migration.js";
+import type { ScheduledTaskDispatcher } from "./runner.js";
+import {
+  getScheduledTaskRunner,
+  registerScheduledTaskRunnerDeps,
+  ScheduledTaskRunnerService,
+} from "./runner-service.js";
+import {
+  createSchedulingSqlScheduledTaskLogStore,
+  createSchedulingSqlScheduledTaskStore,
+} from "./store.js";
+
+type RawSqlQuery = {
+  queryChunks: Array<{ value?: unknown }>;
+};
+
+function rawQueryText(query: RawSqlQuery): string {
+  return String(query.queryChunks.map((chunk) => chunk.value ?? "").join(""));
+}
+
+interface RuntimeHarness {
+  runtime: IAgentRuntime;
+  pg: PGlite;
+  setService(service: ScheduledTaskRunnerService | null): void;
+  close(): Promise<void>;
+}
+
+async function createRuntimeHarness(): Promise<RuntimeHarness> {
+  const pg = new PGlite();
+  const db = {
+    execute: (query: RawSqlQuery) => pg.query(rawQueryText(query)),
+  };
+  let service: ScheduledTaskRunnerService | null = null;
+  const runtime = {
+    agentId: "agent-sql-persist",
+    adapter: { db },
+    getService: (serviceType: string) =>
+      serviceType === ScheduledTaskRunnerService.serviceType ? service : null,
+    getServiceLoadPromise: async () => service,
+    initPromise: Promise.resolve(),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+
+  await migrateSchedulingTables(async (sql) => {
+    const result = await pg.query<Record<string, unknown>>(sql);
+    return result.rows;
+  });
+  return {
+    runtime,
+    pg,
+    setService(next) {
+      service = next;
+    },
+    async close() {
+      await pg.close();
+    },
+  };
+}
+
+async function startService(
+  harness: RuntimeHarness,
+): Promise<ScheduledTaskRunnerService> {
+  const service = await ScheduledTaskRunnerService.start(harness.runtime);
+  harness.setService(service);
+  return service;
+}
+
+describe("scheduling SQL persistence", () => {
+  const harnesses: RuntimeHarness[] = [];
+
+  afterEach(async () => {
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
+  });
+
+  it("keeps no-database startup on the in-memory fallback path", async () => {
+    const runtime = { agentId: "no-db" } as IAgentRuntime;
+    const service = await SchedulingMigrationService.start(runtime);
+    await expect(service.stop()).resolves.toBeUndefined();
+  });
+
+  it("copies legacy app_lifeops scheduled-task rows non-destructively", async () => {
+    const harness = await createRuntimeHarness();
+    harnesses.push(harness);
+    await harness.pg.query("CREATE SCHEMA IF NOT EXISTS app_lifeops");
+    await harness.pg.query(
+      `CREATE TABLE app_lifeops.life_scheduled_tasks
+        (LIKE app_scheduling.life_scheduled_tasks INCLUDING DEFAULTS INCLUDING CONSTRAINTS)`,
+    );
+    await harness.pg.query(
+      `CREATE TABLE app_lifeops.life_scheduled_task_log
+        (LIKE app_scheduling.life_scheduled_task_log INCLUDING DEFAULTS INCLUDING CONSTRAINTS)`,
+    );
+    await harness.pg.query(
+      `INSERT INTO app_scheduling.life_scheduled_tasks (
+        id, agent_id, kind, prompt_instructions, trigger_json, priority,
+        respects_global_pause, state_json, source, created_by, owner_visible,
+        metadata_json, created_at, updated_at
+      ) VALUES (
+        'current-task', 'agent-sql-persist', 'reminder', 'already present',
+        '{"kind":"manual"}', 'medium', TRUE,
+        '{"status":"scheduled","followupCount":0}', 'plugin', 'current', TRUE,
+        '{}', '2026-07-17T00:00:00.000Z', '2026-07-17T00:00:00.000Z'
+      )`,
+    );
+    await harness.pg.query(
+      `INSERT INTO app_lifeops.life_scheduled_tasks (
+        id, agent_id, kind, prompt_instructions, trigger_json, priority,
+        respects_global_pause, state_json, source, created_by, owner_visible,
+        metadata_json, created_at, updated_at
+      ) VALUES (
+        'legacy-watcher', 'agent-sql-persist', 'watcher', 'watch quietly',
+        '{"kind":"event","eventKind":"owner.message"}', 'medium', TRUE,
+        '{"status":"scheduled","followupCount":0}', 'plugin', 'legacy', TRUE,
+        '{}', '2026-07-17T00:00:00.000Z', '2026-07-17T00:00:00.000Z'
+      )`,
+    );
+    await harness.pg.query(
+      `INSERT INTO app_lifeops.life_scheduled_task_log (
+        id, agent_id, task_id, occurred_at, transition, rolled_up
+      ) VALUES (
+        'legacy-log', 'agent-sql-persist', 'legacy-watcher',
+        '2026-07-17T00:00:00.000Z', 'scheduled', FALSE
+      )`,
+    );
+
+    const results = await migrateSchedulingTables(async (sql) => {
+      const result = await harness.pg.query<Record<string, unknown>>(sql);
+      return result.rows;
+    });
+
+    expect(results.map((result) => result.outcome)).toEqual([
+      "copied",
+      "copied",
+    ]);
+    const target = await harness.pg.query(
+      "SELECT id, kind FROM app_scheduling.life_scheduled_tasks ORDER BY id",
+    );
+    expect(target.rows).toEqual([
+      { id: "current-task", kind: "reminder" },
+      { id: "legacy-watcher", kind: "watcher" },
+    ]);
+    const source = await harness.pg.query(
+      "SELECT id FROM app_lifeops.life_scheduled_tasks",
+    );
+    expect(source.rows).toEqual([{ id: "legacy-watcher" }]);
+  });
+
+  it("keeps a due watcher through runner service re-init and fires it", async () => {
+    const harness = await createRuntimeHarness();
+    harnesses.push(harness);
+    const dispatches: string[] = [];
+    const dispatcher: ScheduledTaskDispatcher = {
+      async dispatch(record): Promise<DispatchResult> {
+        dispatches.push(record.taskId);
+        return { ok: true, messageId: `msg:${record.taskId}` };
+      },
+    };
+    registerScheduledTaskRunnerDeps(harness.runtime, (runtime, agentId) => ({
+      store: createSchedulingSqlScheduledTaskStore({ runtime, agentId }),
+      logStore: createSchedulingSqlScheduledTaskLogStore({ runtime, agentId }),
+      dispatcher,
+      ownerFacts: () => ({ timezone: "UTC" }),
+      globalPause: { current: async () => ({ active: false }) },
+      activity: { hasSignalSince: () => false },
+      subjectStore: { wasUpdatedSince: () => false },
+    }));
+    const firstService = await startService(harness);
+    const firstRunner = getScheduledTaskRunner(harness.runtime, {
+      agentId: harness.runtime.agentId,
+      now: () => new Date("2026-07-17T09:00:00.000Z"),
+    });
+    const scheduled = await firstRunner.schedule({
+      kind: "watcher",
+      promptInstructions: "Check the persisted watcher.",
+      trigger: { kind: "once", atIso: "2026-07-17T09:00:00.000Z" },
+      priority: "medium",
+      respectsGlobalPause: true,
+      source: "plugin",
+      createdBy: "test",
+      ownerVisible: true,
+      executionProfile: "bg-heavy-fgs",
+    });
+
+    await firstService.stop();
+    harness.setService(null);
+    await startService(harness);
+    const restartedRunner = getScheduledTaskRunner(harness.runtime, {
+      agentId: harness.runtime.agentId,
+      now: () => new Date("2026-07-17T09:01:00.000Z"),
+    });
+
+    const restored = await restartedRunner.list({
+      kind: "watcher",
+      status: "scheduled",
+    });
+    expect(restored.map((task) => task.taskId)).toEqual([scheduled.taskId]);
+    expect(restored[0]?.executionProfile).toBe("bg-heavy-fgs");
+
+    const fired = await restartedRunner.fire(scheduled.taskId);
+
+    expect(fired.state.status).toBe("fired");
+    expect(dispatches).toEqual([scheduled.taskId]);
+    const rows = await harness.pg.query<{ status: string }>(
+      `SELECT state_json::jsonb ->> 'status' AS status
+         FROM app_scheduling.life_scheduled_tasks
+        WHERE id = '${scheduled.taskId}'`,
+    );
+    expect(rows.rows[0]?.status).toBe("fired");
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/sql.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql.ts
@@ -1,0 +1,138 @@
+/**
+ * Raw-SQL helpers for the scheduling-owned ScheduledTask store.
+ *
+ * The store uses this tiny seam instead of importing a host repository so the
+ * always-loaded scheduling plugin can own durable rows without depending on
+ * personal-assistant or app-core.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+
+export type RawSqlQuery = {
+  queryChunks: Array<{ value?: unknown }>;
+};
+
+export type RuntimeDb = {
+  execute: (query: RawSqlQuery) => Promise<unknown>;
+};
+
+let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
+
+export function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function toText(value: unknown, fallback = ""): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return fallback;
+  return String(value);
+}
+
+export function toBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off"].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function isMissingJsonValue(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+export function parseJsonValue<T>(value: unknown, fallback: T): T {
+  if (isMissingJsonValue(value)) return fallback;
+  if (typeof value !== "string") {
+    if (typeof value === "object") return value as T;
+    throw new Error(
+      `[SchedulingSql] Expected JSON string or object, received ${typeof value}`,
+    );
+  }
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[SchedulingSql] Invalid JSON value: ${message}`);
+  }
+}
+
+export function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (isMissingJsonValue(value)) return {};
+  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
+  const object = asObject(parsed);
+  if (object) return object;
+  throw new Error("[SchedulingSql] Expected JSON object");
+}
+
+export function extractRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result
+      .map((row) => asObject(row))
+      .filter((row): row is Record<string, unknown> => row !== null);
+  }
+  const object = asObject(result);
+  if (!object) return [];
+  const rows = object.rows;
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => asObject(row))
+    .filter((row): row is Record<string, unknown> => row !== null);
+}
+
+async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
+  if (cachedSqlRaw) return cachedSqlRaw;
+  const drizzle = (await import("drizzle-orm")) as {
+    sql: { raw: (query: string) => RawSqlQuery };
+  };
+  cachedSqlRaw = drizzle.sql.raw;
+  return cachedSqlRaw;
+}
+
+export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb | null {
+  const adapterDb = runtime.adapter?.db as RuntimeDb | undefined;
+  if (adapterDb && typeof adapterDb.execute === "function") return adapterDb;
+  const runtimeDb = (runtime as IAgentRuntime & { db?: RuntimeDb }).db;
+  if (runtimeDb && typeof runtimeDb.execute === "function") return runtimeDb;
+  return null;
+}
+
+export async function executeRawSql(
+  runtime: IAgentRuntime,
+  sqlText: string,
+): Promise<Array<Record<string, unknown>>> {
+  const raw = await getSqlRaw();
+  const db = getRuntimeDb(runtime);
+  if (!db) {
+    throw new Error(
+      "[SchedulingSql] runtime database adapter unavailable; load @elizaos/plugin-sql before durable scheduling.",
+    );
+  }
+  const result = await db.execute(raw(sqlText));
+  return extractRows(result);
+}
+
+export function sqlQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function sqlText(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "NULL";
+  return sqlQuote(value);
+}
+
+export function sqlInteger(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "NULL";
+  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
+  return String(Math.trunc(value));
+}
+
+export function sqlBoolean(value: boolean): string {
+  return value ? "TRUE" : "FALSE";
+}
+
+export function sqlJson(value: unknown): string {
+  return sqlQuote(JSON.stringify(value ?? null));
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/state-log.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/state-log.ts
@@ -34,8 +34,8 @@ export interface ScheduledTaskLogStore {
 
 /**
  * In-memory store used for unit tests + as a fallback when no DB-backed
- * store is wired in. The DB-backed store lives behind the route handlers
- * via `LifeOpsRepository`.
+ * store is wired in. The DB-backed store lives in `store.ts` and is owned by
+ * plugin-scheduling.
  */
 export function createInMemoryScheduledTaskLogStore(): ScheduledTaskLogStore {
   const rows: ScheduledTaskLogEntry[] = [];

--- a/plugins/plugin-scheduling/src/scheduled-task/store.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/store.ts
@@ -1,0 +1,466 @@
+/**
+ * Durable SQL-backed ScheduledTask store owned by plugin-scheduling.
+ *
+ * Hosts inject this adapter through `registerScheduledTaskRunnerDeps`, and the
+ * scheduling plugin's default deps use it directly when a runtime database is
+ * available. The row contract mirrors the runner's store interface exactly:
+ * the runner computes `next_fire_at`, while this adapter owns atomic claims,
+ * idempotency lookup, filtering, and state-log retention.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  ScheduledTaskClaimExpectation,
+  ScheduledTaskClaimResult,
+  ScheduledTaskStore,
+  ScheduledTaskUpsertOptions,
+} from "./runner.js";
+import {
+  executeRawSql,
+  parseJsonRecord,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlQuote,
+  sqlText,
+  toBoolean,
+  toText,
+} from "./sql.js";
+import type { ScheduledTaskLogStore } from "./state-log.js";
+import type {
+  ScheduledTask,
+  ScheduledTaskFilter,
+  ScheduledTaskLogEntry,
+} from "./types.js";
+
+const SCHEDULING_SCHEMA = "app_scheduling";
+const TASK_TABLE = `${SCHEDULING_SCHEMA}.life_scheduled_tasks`;
+const LOG_TABLE = `${SCHEDULING_SCHEMA}.life_scheduled_task_log`;
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+function parseOptionalJsonRecord<T>(value: unknown): T | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string" && value.length === 0) return undefined;
+  const parsed = parseJsonRecord(value);
+  if (Object.keys(parsed).length === 0) return undefined;
+  return parsed as T;
+}
+
+export function parseScheduledTaskRow(
+  row: Record<string, unknown>,
+): ScheduledTask {
+  const stateRaw = parseJsonRecord(row.state_json);
+  const state: ScheduledTask["state"] = {
+    status: ((stateRaw.status as string) ??
+      "scheduled") as ScheduledTask["state"]["status"],
+    firedAt:
+      typeof stateRaw.firedAt === "string" ? stateRaw.firedAt : undefined,
+    acknowledgedAt:
+      typeof stateRaw.acknowledgedAt === "string"
+        ? stateRaw.acknowledgedAt
+        : undefined,
+    completedAt:
+      typeof stateRaw.completedAt === "string"
+        ? stateRaw.completedAt
+        : undefined,
+    followupCount:
+      typeof stateRaw.followupCount === "number" ? stateRaw.followupCount : 0,
+    lastFollowupAt:
+      typeof stateRaw.lastFollowupAt === "string"
+        ? stateRaw.lastFollowupAt
+        : undefined,
+    pipelineParentId:
+      typeof stateRaw.pipelineParentId === "string"
+        ? stateRaw.pipelineParentId
+        : undefined,
+    lastDecisionLog:
+      typeof stateRaw.lastDecisionLog === "string"
+        ? stateRaw.lastDecisionLog
+        : undefined,
+  };
+  const subjectKind = toText(row.subject_kind, "");
+  const subjectId = toText(row.subject_id, "");
+  const parsedMetadata =
+    parseOptionalJsonRecord<Record<string, unknown>>(row.metadata_json) ?? {};
+  if (
+    typeof row.created_at === "string" &&
+    typeof parsedMetadata.createdAtIso !== "string"
+  ) {
+    parsedMetadata.createdAtIso = row.created_at;
+  }
+  return {
+    taskId: toText(row.id),
+    kind: toText(row.kind) as ScheduledTask["kind"],
+    promptInstructions: toText(row.prompt_instructions),
+    contextRequest: parseOptionalJsonRecord<ScheduledTask["contextRequest"]>(
+      row.context_request_json,
+    ),
+    trigger: parseJsonRecord(row.trigger_json) as ScheduledTask["trigger"],
+    priority: toText(row.priority, "medium") as ScheduledTask["priority"],
+    shouldFire: parseOptionalJsonRecord<ScheduledTask["shouldFire"]>(
+      row.should_fire_json,
+    ),
+    completionCheck: parseOptionalJsonRecord<ScheduledTask["completionCheck"]>(
+      row.completion_check_json,
+    ),
+    escalation: parseOptionalJsonRecord<ScheduledTask["escalation"]>(
+      row.escalation_json,
+    ),
+    output: parseOptionalJsonRecord<ScheduledTask["output"]>(row.output_json),
+    pipeline: parseOptionalJsonRecord<ScheduledTask["pipeline"]>(
+      row.pipeline_json,
+    ),
+    subject:
+      subjectKind && subjectId
+        ? ({
+            kind: subjectKind,
+            id: subjectId,
+          } as ScheduledTask["subject"])
+        : undefined,
+    idempotencyKey:
+      typeof row.idempotency_key === "string" && row.idempotency_key.length > 0
+        ? row.idempotency_key
+        : undefined,
+    respectsGlobalPause: toBoolean(row.respects_global_pause, true),
+    state,
+    source: toText(row.source, "user_chat") as ScheduledTask["source"],
+    createdBy: toText(row.created_by, ""),
+    ownerVisible: toBoolean(row.owner_visible, true),
+    metadata: parsedMetadata,
+    executionProfile:
+      typeof row.execution_profile === "string"
+        ? (row.execution_profile as ScheduledTask["executionProfile"])
+        : undefined,
+  };
+}
+
+export function parseScheduledTaskLogRow(
+  row: Record<string, unknown>,
+): ScheduledTaskLogEntry {
+  return {
+    logId: toText(row.id),
+    taskId: toText(row.task_id),
+    agentId: toText(row.agent_id),
+    occurredAtIso: toText(row.occurred_at),
+    transition: toText(row.transition) as ScheduledTaskLogEntry["transition"],
+    reason: typeof row.reason === "string" ? row.reason : undefined,
+    rolledUp: toBoolean(row.rolled_up, false),
+    detail: parseOptionalJsonRecord<Record<string, unknown>>(row.detail_json),
+  };
+}
+
+export interface SchedulingSqlStoreOptions {
+  runtime: IAgentRuntime;
+  agentId: string;
+}
+
+export function createSchedulingSqlScheduledTaskStore(
+  opts: SchedulingSqlStoreOptions,
+): ScheduledTaskStore {
+  const { runtime, agentId } = opts;
+  return {
+    async upsert(task: ScheduledTask, options?: ScheduledTaskUpsertOptions) {
+      const now = isoNow();
+      const nextFireAtSql =
+        options?.nextFireAtIso === null ||
+        options?.nextFireAtIso === undefined ||
+        options.nextFireAtIso.length === 0
+          ? "NULL"
+          : `${sqlQuote(options.nextFireAtIso)}::timestamptz`;
+      await executeRawSql(
+        runtime,
+        `INSERT INTO ${TASK_TABLE} (
+          id, agent_id, kind, prompt_instructions, context_request_json,
+          trigger_json, priority, should_fire_json, completion_check_json,
+          escalation_json, output_json, pipeline_json, subject_kind, subject_id,
+          idempotency_key, respects_global_pause, state_json, source,
+          created_by, owner_visible, metadata_json, execution_profile,
+          next_fire_at, created_at, updated_at
+        ) VALUES (
+          ${sqlQuote(task.taskId)},
+          ${sqlQuote(agentId)},
+          ${sqlQuote(task.kind)},
+          ${sqlQuote(task.promptInstructions)},
+          ${sqlText(task.contextRequest ? JSON.stringify(task.contextRequest) : null)},
+          ${sqlJson(task.trigger)},
+          ${sqlQuote(task.priority)},
+          ${sqlText(task.shouldFire ? JSON.stringify(task.shouldFire) : null)},
+          ${sqlText(task.completionCheck ? JSON.stringify(task.completionCheck) : null)},
+          ${sqlText(task.escalation ? JSON.stringify(task.escalation) : null)},
+          ${sqlText(task.output ? JSON.stringify(task.output) : null)},
+          ${sqlText(task.pipeline ? JSON.stringify(task.pipeline) : null)},
+          ${sqlText(task.subject?.kind ?? null)},
+          ${sqlText(task.subject?.id ?? null)},
+          ${sqlText(task.idempotencyKey ?? null)},
+          ${sqlBoolean(task.respectsGlobalPause)},
+          ${sqlJson(task.state)},
+          ${sqlQuote(task.source)},
+          ${sqlQuote(task.createdBy)},
+          ${sqlBoolean(task.ownerVisible)},
+          ${sqlJson(task.metadata ?? {})},
+          ${sqlText(task.executionProfile ?? null)},
+          ${nextFireAtSql},
+          ${sqlQuote(now)},
+          ${sqlQuote(now)}
+        )
+        ON CONFLICT (id) DO UPDATE SET
+          kind = EXCLUDED.kind,
+          prompt_instructions = EXCLUDED.prompt_instructions,
+          context_request_json = EXCLUDED.context_request_json,
+          trigger_json = EXCLUDED.trigger_json,
+          priority = EXCLUDED.priority,
+          should_fire_json = EXCLUDED.should_fire_json,
+          completion_check_json = EXCLUDED.completion_check_json,
+          escalation_json = EXCLUDED.escalation_json,
+          output_json = EXCLUDED.output_json,
+          pipeline_json = EXCLUDED.pipeline_json,
+          subject_kind = EXCLUDED.subject_kind,
+          subject_id = EXCLUDED.subject_id,
+          idempotency_key = EXCLUDED.idempotency_key,
+          respects_global_pause = EXCLUDED.respects_global_pause,
+          state_json = EXCLUDED.state_json,
+          source = EXCLUDED.source,
+          created_by = EXCLUDED.created_by,
+          owner_visible = EXCLUDED.owner_visible,
+          metadata_json = EXCLUDED.metadata_json,
+          execution_profile = EXCLUDED.execution_profile,
+          next_fire_at = EXCLUDED.next_fire_at,
+          updated_at = ${sqlQuote(now)}`,
+      );
+    },
+    async claimForFire(args: {
+      taskId: string;
+      firedAtIso: string;
+      expected?: ScheduledTaskClaimExpectation;
+    }): Promise<ScheduledTaskClaimResult> {
+      const now = isoNow();
+      const expected = args.expected;
+      const stateGuard = expected
+        ? `AND (state_json::jsonb ->> 'status') = ${sqlQuote(expected.status)}
+            AND ${
+              expected.firedAtIso === null
+                ? `(state_json::jsonb ->> 'firedAt') IS NULL`
+                : `(state_json::jsonb ->> 'firedAt') = ${sqlQuote(expected.firedAtIso)}`
+            }`
+        : `AND (state_json::jsonb ->> 'status') = 'scheduled'`;
+      const rows = await executeRawSql(
+        runtime,
+        `UPDATE ${TASK_TABLE}
+            SET state_json = jsonb_set(
+                                jsonb_set(
+                                  state_json::jsonb,
+                                  '{status}',
+                                  '"fired"'::jsonb,
+                                  true
+                                ),
+                                '{firedAt}',
+                                to_jsonb(${sqlQuote(args.firedAtIso)}::text),
+                                true
+                              )::text,
+                next_fire_at = NULL,
+                updated_at = ${sqlQuote(now)},
+                version = version + 1
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND id = ${sqlQuote(args.taskId)}
+            ${stateGuard}
+          RETURNING *`,
+      );
+      const row = rows[0];
+      if (!row) return { kind: "raced" };
+      return { kind: "fired", task: parseScheduledTaskRow(row) };
+    },
+    async get(taskId: string) {
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT *
+           FROM ${TASK_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND id = ${sqlQuote(taskId)}
+          LIMIT 1`,
+      );
+      const row = rows[0];
+      return row ? parseScheduledTaskRow(row) : null;
+    },
+    async findByIdempotencyKey(key: string) {
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT *
+           FROM ${TASK_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND idempotency_key = ${sqlQuote(key)}
+          LIMIT 1`,
+      );
+      const row = rows[0];
+      return row ? parseScheduledTaskRow(row) : null;
+    },
+    async list(filter?: ScheduledTaskFilter) {
+      const clauses: string[] = [`agent_id = ${sqlQuote(agentId)}`];
+      if (filter?.kind) clauses.push(`kind = ${sqlQuote(filter.kind)}`);
+      if (filter?.subject?.kind) {
+        clauses.push(`subject_kind = ${sqlQuote(filter.subject.kind)}`);
+      }
+      if (filter?.subject?.id) {
+        clauses.push(`subject_id = ${sqlQuote(filter.subject.id)}`);
+      }
+      if (filter?.source) clauses.push(`source = ${sqlQuote(filter.source)}`);
+      if (filter?.ownerVisibleOnly) clauses.push("owner_visible = TRUE");
+      if (filter?.status) {
+        const statusList = (
+          Array.isArray(filter.status) ? filter.status : [filter.status]
+        )
+          .filter((status) => status.length > 0)
+          .map((status) => sqlQuote(status))
+          .join(", ");
+        if (statusList.length > 0) {
+          clauses.push(`(state_json::jsonb ->> 'status') IN (${statusList})`);
+        }
+      }
+      if (filter?.firedSince) {
+        clauses.push(
+          `(state_json::jsonb ->> 'firedAt') >= ${sqlQuote(filter.firedSince)}`,
+        );
+      }
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT *
+           FROM ${TASK_TABLE}
+          WHERE ${clauses.join(" AND ")}
+          ORDER BY created_at ASC`,
+      );
+      return rows.map(parseScheduledTaskRow);
+    },
+    async delete(taskId: string) {
+      await executeRawSql(
+        runtime,
+        `DELETE FROM ${TASK_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND id = ${sqlQuote(taskId)}`,
+      );
+      await executeRawSql(
+        runtime,
+        `DELETE FROM ${LOG_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND task_id = ${sqlQuote(taskId)}`,
+      );
+    },
+  };
+}
+
+export function createSchedulingSqlScheduledTaskLogStore(
+  opts: SchedulingSqlStoreOptions,
+): ScheduledTaskLogStore {
+  const { runtime, agentId } = opts;
+  return {
+    async append(entry: ScheduledTaskLogEntry) {
+      await executeRawSql(
+        runtime,
+        `INSERT INTO ${LOG_TABLE} (
+          id, agent_id, task_id, occurred_at, transition, reason, rolled_up, detail_json
+        ) VALUES (
+          ${sqlQuote(entry.logId)},
+          ${sqlQuote(entry.agentId)},
+          ${sqlQuote(entry.taskId)},
+          ${sqlQuote(entry.occurredAtIso)},
+          ${sqlQuote(entry.transition)},
+          ${sqlText(entry.reason ?? null)},
+          ${sqlBoolean(entry.rolledUp)},
+          ${sqlText(entry.detail ? JSON.stringify(entry.detail) : null)}
+        )`,
+      );
+    },
+    async list(args) {
+      const clauses: string[] = [
+        `agent_id = ${sqlQuote(agentId)}`,
+        `task_id = ${sqlQuote(args.taskId)}`,
+      ];
+      if (args.sinceIso) {
+        clauses.push(`occurred_at >= ${sqlQuote(args.sinceIso)}`);
+      }
+      if (args.untilIso) {
+        clauses.push(`occurred_at < ${sqlQuote(args.untilIso)}`);
+      }
+      if (args.excludeRollups) clauses.push("rolled_up = FALSE");
+      const limit =
+        typeof args.limit === "number" && args.limit > 0
+          ? `LIMIT ${sqlInteger(args.limit)}`
+          : "";
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT *
+           FROM ${LOG_TABLE}
+          WHERE ${clauses.join(" AND ")}
+          ORDER BY occurred_at ASC
+          ${limit}`,
+      );
+      return rows.map(parseScheduledTaskLogRow);
+    },
+    async rollupOlderThan(args) {
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT *
+           FROM ${LOG_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND rolled_up = FALSE
+            AND occurred_at < ${sqlQuote(args.olderThanIso)}`,
+      );
+      if (rows.length === 0) return { rolledUp: 0, deletedRaw: 0 };
+      const summary = new Map<
+        string,
+        {
+          taskId: string;
+          transition: string;
+          dayIso: string;
+          count: number;
+          firstReason: string | null;
+        }
+      >();
+      for (const row of rows) {
+        const occurredAt = toText(row.occurred_at);
+        const dayIso = occurredAt.slice(0, 10);
+        const key = `${toText(row.task_id)}::${dayIso}::${toText(row.transition)}`;
+        const existing = summary.get(key);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          summary.set(key, {
+            taskId: toText(row.task_id),
+            transition: toText(row.transition),
+            dayIso,
+            count: 1,
+            firstReason: typeof row.reason === "string" ? row.reason : null,
+          });
+        }
+      }
+      await executeRawSql(
+        runtime,
+        `DELETE FROM ${LOG_TABLE}
+          WHERE agent_id = ${sqlQuote(agentId)}
+            AND rolled_up = FALSE
+            AND occurred_at < ${sqlQuote(args.olderThanIso)}`,
+      );
+      let counter = 0;
+      for (const item of summary.values()) {
+        counter += 1;
+        const id = `rollup-${item.taskId}-${item.dayIso}-${item.transition}-${counter}`;
+        await executeRawSql(
+          runtime,
+          `INSERT INTO ${LOG_TABLE} (
+            id, agent_id, task_id, occurred_at, transition, reason, rolled_up, detail_json
+          ) VALUES (
+            ${sqlQuote(id)},
+            ${sqlQuote(agentId)},
+            ${sqlQuote(item.taskId)},
+            ${sqlQuote(`${item.dayIso}T00:00:00.000Z`)},
+            ${sqlQuote(item.transition)},
+            ${sqlText(item.firstReason ?? null)},
+            ${sqlBoolean(true)},
+            ${sqlText(JSON.stringify({ rollupCount: item.count }))}
+          )`,
+        );
+      }
+      return { rolledUp: summary.size, deletedRaw: rows.length };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- move `ScheduledTask` records, including watcher-kind rows and transition logs, into a scheduling-owned `app_scheduling` SQL schema
- inject SQL-backed stores by default while preserving explicit PA host dependency overrides and no-database in-memory fallback
- migrate legacy `app_lifeops` rows non-destructively before runner seeding, including persisted execution profiles
- update PA repository queries/bootstrap ownership to the new schema
- add PGlite restart coverage proving a due watcher survives runner service re-initialization and fires

## Validation
- `bun run typecheck` in `plugins/plugin-scheduling`
- `bun run test` in `plugins/plugin-scheduling` (42 files, 425 tests)
- focused SQL persistence + runner-service tests (6 tests)
- `bun run build:js` in `plugins/plugin-scheduling`
- Codex review of final patch: no introduced correctness issues
