### PR TITLE
fix(cloud): stream shared agent replies incrementally

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -10,7 +10,8 @@ import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-run
 import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import * as realAiBillingNs from "./ai-billing";
 import * as realAiBillingRecordsNs from "./ai-billing-records";
-import * as realRunSharedAgentTurnNs from "./shared-runtime/run-shared-agent-turn";
+
+const realRunSharedAgentTurnNs = await import("./shared-runtime/run-shared-agent-turn");
 
 // Bun runs every cloud-shared test file in a single process, and `mock.module`
 // overrides are process-global with no built-in per-file teardown. The mocks
@@ -105,6 +106,24 @@ const runSharedAgentTurn = mock(async () => ({
   },
 }));
 
+const runSharedAgentTurnStream = mock(async () => ({
+  model: "gpt-oss-120b",
+  degraded: false,
+  parts: (async function* () {
+    yield { type: "text-delta" as const, text: "metered " };
+    yield { type: "text-delta" as const, text: "reply" };
+    yield {
+      type: "finish" as const,
+      text: "metered reply",
+      usage: {
+        inputTokens: 11,
+        outputTokens: 7,
+        totalTokens: 18,
+      },
+    };
+  })(),
+}));
+
 const resolveSharedAgentTurnModel = mock(() => "gpt-oss-120b");
 
 beforeAll(() => {
@@ -122,6 +141,7 @@ beforeAll(() => {
   }));
   mock.module("./shared-runtime/run-shared-agent-turn", () => ({
     runSharedAgentTurn,
+    runSharedAgentTurnStream,
     resolveSharedAgentTurnModel,
   }));
 });
@@ -204,8 +224,32 @@ afterEach(() => {
   estimateInputTokens.mockClear();
   aiBillingRecord.mockClear();
   runSharedAgentTurn.mockClear();
+  runSharedAgentTurnStream.mockClear();
   resolveSharedAgentTurnModel.mockClear();
 });
+
+function delay(ms: number): Promise<"timeout"> {
+  return new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+}
+
+async function readSharedStreamEvents(
+  response: Response,
+): Promise<Array<{ event: string | null; data: Record<string, unknown> }>> {
+  const body = await response.text();
+  return body
+    .split("\n\n")
+    .filter((frame) => frame.trim().length > 0)
+    .map((frame) => {
+      const lines = frame.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLine = lines.find((line) => line.startsWith("data: "));
+      if (!dataLine) throw new Error(`SSE frame missing data: ${frame}`);
+      return {
+        event: eventLine ? eventLine.slice("event: ".length) : null,
+        data: JSON.parse(dataLine.slice("data: ".length)),
+      };
+    });
+}
 
 describe("ElizaSandboxService shared runtime billing", () => {
   test("running dedicated turns use the Worker router origin and bypass shared billing", async () => {
@@ -447,6 +491,97 @@ describe("ElizaSandboxService shared runtime billing", () => {
       }));
       findRunningSandboxSpy.mockRestore();
       historyGetSpy.mockRestore();
+    }
+  });
+
+  test("shared-runtime bridgeStream returns before model completion and emits chunks before done", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = sharedSandbox();
+    const findRunningSandboxSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
+    const historyUpsertSpy = spyOn(sharedRuntimeHistoryRepository, "upsert").mockResolvedValue(
+      undefined,
+    );
+    let finishModel!: () => void;
+    const modelCompletion = new Promise<void>((resolve) => {
+      finishModel = resolve;
+    });
+    runSharedAgentTurn.mockImplementationOnce(async () => {
+      await modelCompletion;
+      return {
+        reply: "should not buffer through non-streaming send",
+        history: [],
+        model: "gpt-oss-120b",
+        degraded: false,
+      };
+    });
+    runSharedAgentTurnStream.mockImplementationOnce(async () => ({
+      model: "gpt-oss-120b",
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta" as const, text: "metered " };
+        await modelCompletion;
+        yield { type: "text-delta" as const, text: "reply" };
+        yield {
+          type: "finish" as const,
+          text: "metered reply",
+          usage: {
+            inputTokens: 11,
+            outputTokens: 7,
+            totalTokens: 18,
+          },
+        };
+      })(),
+    }));
+
+    try {
+      const responsePromise = runWithCloudBindings({ CEREBRAS_API_KEY: "test-key" }, () =>
+        new ElizaSandboxService().bridgeStream(sandbox.id, sandbox.organization_id, {
+          jsonrpc: "2.0",
+          id: "shared-stream",
+          method: "message.send",
+          params: { text: "hello" },
+        }),
+      );
+      const earlyResponse = await Promise.race([responsePromise, delay(50)]);
+      expect(earlyResponse).toBeInstanceOf(Response);
+      expect(runSharedAgentTurn).not.toHaveBeenCalled();
+      expect(runSharedAgentTurnStream).toHaveBeenCalledTimes(1);
+
+      finishModel();
+      const response = await responsePromise;
+      if (!response) throw new Error("bridgeStream returned null");
+      const events = await readSharedStreamEvents(response);
+
+      expect(events.map((event) => event.event)).toEqual(["chunk", "chunk", "done"]);
+      expect(events[0]?.data.chunk).toBe("metered ");
+      expect(events[1]?.data.chunk).toBe("reply");
+      expect(events[0]?.data.fullText).toBe("metered ");
+      expect(events[1]?.data.fullText).toBe("metered reply");
+      expect(events[2]?.data.text).toBe("metered reply");
+      expect(reserveCredits).toHaveBeenCalledTimes(1);
+      expect(historyUpsertSpy).toHaveBeenCalledTimes(1);
+      expect(billUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: sandbox.organization_id,
+          model: "gpt-oss-120b",
+        }),
+        { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+      );
+      expect(reconcileReservation).toHaveBeenCalledWith(0.0003);
+      expect(recordUsageAnalytics).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: sandbox.organization_id }),
+        expect.objectContaining({ totalCost: 0.0003 }),
+        expect.objectContaining({ type: "chat", content: "metered reply", prompt: "hello" }),
+      );
+    } finally {
+      finishModel();
+      findRunningSandboxSpy.mockRestore();
+      historyGetSpy.mockRestore();
+      historyUpsertSpy.mockRestore();
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -533,6 +533,51 @@ describe("ElizaSandboxService shared runtime bridge", () => {
       }
     },
   );
+
+  test.skipIf(process.platform === "win32")(
+    "returns an SSE completion without persisting when streaming has no configured model",
+    async () => {
+      const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+      const sandbox = sharedSandbox();
+      const findRunningSandboxSpy = spyOn(
+        agentSandboxesRepository,
+        "findRunningSandbox",
+      ).mockResolvedValue(sandbox);
+      const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
+      const historyUpsertSpy = spyOn(sharedRuntimeHistoryRepository, "upsert").mockResolvedValue(
+        undefined,
+      );
+
+      try {
+        const response = await runWithCloudBindings(
+          {
+            CEREBRAS_API_KEY: "",
+            OPENAI_API_KEY: "",
+          },
+          () =>
+            new ElizaSandboxService().bridgeStream(sandbox.id, sandbox.organization_id, {
+              jsonrpc: "2.0",
+              id: "shared-stream-turn",
+              method: "message.send",
+              params: { text: " hello " },
+            }),
+        );
+
+        expect(response).toBeInstanceOf(Response);
+        expect(response?.headers.get("content-type")).toContain("text/event-stream");
+        const body = await response?.text();
+        expect(body).toContain("event: chunk");
+        expect(body).toContain("no shared model configured");
+        expect(body).toContain("event: done");
+        expect(historyGetSpy).toHaveBeenCalled();
+        expect(historyUpsertSpy).not.toHaveBeenCalled();
+      } finally {
+        findRunningSandboxSpy.mockRestore();
+        historyGetSpy.mockRestore();
+        historyUpsertSpy.mockRestore();
+      }
+    },
+  );
 });
 
 describe("ElizaSandboxService wake", () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -86,7 +86,9 @@ import {
   type RunSharedAgentTurnResult,
   resolveSharedAgentTurnModel,
   runSharedAgentTurn,
+  runSharedAgentTurnStream,
   type SharedAgentCharacter,
+  type SharedAgentTurnUsage,
   type SharedTurnMessage,
 } from "./shared-runtime/run-shared-agent-turn";
 import { applyPooledCredentialsToBootstrapEnv } from "./team-credential-pool/bootstrap-env";
@@ -2449,15 +2451,23 @@ export class ElizaSandboxService {
     turn: RunSharedAgentTurnResult,
     estimatedInputTokens: number,
   ): AIUsage {
-    const inputTokens = turn.usage?.inputTokens ?? turn.usage?.promptTokens ?? 0;
-    const outputTokens = turn.usage?.outputTokens ?? turn.usage?.completionTokens ?? 0;
-    const totalTokens = turn.usage?.totalTokens ?? inputTokens + outputTokens;
+    return this.sharedRuntimeBillingUsageForReply(turn.reply, turn.usage, estimatedInputTokens);
+  }
+
+  private sharedRuntimeBillingUsageForReply(
+    reply: string,
+    usage: SharedAgentTurnUsage | undefined,
+    estimatedInputTokens: number,
+  ): AIUsage {
+    const inputTokens = usage?.inputTokens ?? usage?.promptTokens ?? 0;
+    const outputTokens = usage?.outputTokens ?? usage?.completionTokens ?? 0;
+    const totalTokens = usage?.totalTokens ?? inputTokens + outputTokens;
     if (inputTokens > 0 || outputTokens > 0 || totalTokens > 0) {
-      return turn.usage ?? {};
+      return usage ?? {};
     }
     return {
       inputTokens: estimatedInputTokens,
-      outputTokens: estimateInputTokens([{ content: turn.reply }]),
+      outputTokens: estimateInputTokens([{ content: reply }]),
     };
   }
 
@@ -2655,6 +2665,206 @@ export class ElizaSandboxService {
       // Refund the upfront hold on any post-reserve failure, then rethrow.
       await settleReservation(0);
       throw settleError;
+    }
+  }
+
+  private async bridgeSharedMessageStream(
+    rec: AgentSandbox,
+    rpc: BridgeRequest,
+  ): Promise<Response> {
+    const params = rpc.params && typeof rpc.params === "object" ? rpc.params : {};
+    const text = typeof params.text === "string" ? params.text : "";
+    if (!text.trim()) {
+      return this.createBridgeSseErrorResponse("message.send requires params.text");
+    }
+
+    const channelId = this.stableBridgeChannelId(rec.id, params);
+    const [character, history] = await Promise.all([
+      this.buildSharedRuntimeCharacter(rec),
+      this.loadSharedRuntimeHistory(rec.id, channelId),
+    ]);
+    const billingModel = resolveSharedAgentTurnModel(character.model);
+    const estimatedInputTokens = billingModel
+      ? estimateInputTokens(this.sharedRuntimeBillingPrompt(character, history, text))
+      : 0;
+    const idempotencyKey = `shared-runtime:${rec.id}:${channelId}:${crypto.randomUUID()}`;
+    const requestId = `shared-runtime-${crypto.randomUUID()}`;
+    const billingContext: BillingContext | null = billingModel
+      ? {
+          organizationId: rec.organization_id,
+          userId: rec.user_id,
+          model: billingModel,
+          requestId,
+          description: `Shared runtime turn: ${character.name}`,
+          metadata: {
+            agentId: rec.id,
+            channelId,
+            executionTier: rec.execution_tier,
+            idempotencyKey,
+            prompt: text,
+            runtime: "shared",
+          },
+        }
+      : null;
+    let reservation: CreditReservation | null = null;
+    let reservationSettled = false;
+    const settleReservation = async (
+      actualCost: number,
+    ): Promise<CreditReconciliationResult | null> => {
+      if (!reservation || reservationSettled) return null;
+      reservationSettled = true;
+      return (await reservation.reconcile(actualCost)) ?? null;
+    };
+    if (billingContext) {
+      try {
+        reservation = await reserveCredits(billingContext, estimatedInputTokens, 500);
+      } catch (error) {
+        // error-policy:J1 boundary translation — no SSE bytes exist before credit
+        // reservation, so the HTTP route can still return the canonical 402.
+        if (error instanceof InsufficientCreditsError) {
+          throw new InsufficientCreditsApiError(
+            `Insufficient credits. Required: $${error.required.toFixed(4)}, Available: $${error.available.toFixed(4)}`,
+          );
+        }
+        throw error;
+      }
+    }
+
+    try {
+      const turn = await runSharedAgentTurnStream({
+        character,
+        history,
+        message: text,
+      });
+      if (turn.degraded) {
+        await settleReservation(0);
+        return this.createBridgeSseTextResponse(turn.reply ?? "");
+      }
+      if (!turn.parts) {
+        await settleReservation(0);
+        return this.createBridgeSseErrorResponse("Shared runtime stream did not start");
+      }
+
+      const messageId = crypto.randomUUID();
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start: async (controller) => {
+          let reply = "";
+          let finished = false;
+          try {
+            for await (const part of turn.parts!) {
+              if (part.type === "text-delta") {
+                reply += part.text;
+                controller.enqueue(
+                  encoder.encode(
+                    `event: chunk\ndata: ${JSON.stringify({
+                      messageId,
+                      chunk: part.text,
+                      text: part.text,
+                      fullText: reply,
+                      timestamp: Date.now(),
+                    })}\n\n`,
+                  ),
+                );
+                continue;
+              }
+
+              finished = true;
+              const finalReply = part.text.trim() || reply.trim() || "…";
+              const sentAt = Date.now();
+              const nextHistory: SharedTurnMessage[] = [
+                ...history,
+                { role: "user", content: text.trim(), createdAt: sentAt },
+                { role: "assistant", content: finalReply, createdAt: sentAt + 1 },
+              ];
+              await this.saveSharedRuntimeHistory(rec.id, channelId, nextHistory);
+              if (billingContext) {
+                try {
+                  const billing = await billUsage(
+                    billingContext,
+                    this.sharedRuntimeBillingUsageForReply(
+                      finalReply,
+                      part.usage,
+                      estimatedInputTokens,
+                    ),
+                  );
+                  const settlement = await settleReservation(billing.totalCost);
+                  const usageRecord = await recordUsageAnalytics(billingContext, billing, {
+                    type: "chat",
+                    content: finalReply,
+                    prompt: text,
+                  });
+                  if (usageRecord) {
+                    await aiBillingRecordsService
+                      .record({
+                        context: billingContext,
+                        billing,
+                        usageRecord,
+                        idempotencyKey,
+                        reconciliation: settlement,
+                      })
+                      .catch((error) => {
+                        logger.error("[shared-runtime] AI billing audit record failed", {
+                          error: error instanceof Error ? error.message : String(error),
+                          agentId: rec.id,
+                        });
+                      });
+                  }
+                } catch (error) {
+                  // error-policy:J1 billing boundary translation — the user got
+                  // the reply, but a failed meter write must release the hold.
+                  await settleReservation(0);
+                  logger.error("[shared-runtime] billing failed", {
+                    error: error instanceof Error ? error.message : String(error),
+                    agentId: rec.id,
+                  });
+                }
+              }
+              controller.enqueue(
+                encoder.encode(
+                  `event: done\ndata: ${JSON.stringify({ messageId, text: finalReply })}\n\n`,
+                ),
+              );
+            }
+            if (!finished) {
+              await settleReservation(0);
+              controller.enqueue(
+                encoder.encode(
+                  `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream ended without completion" })}\n\n`,
+                ),
+              );
+            }
+          } catch (error) {
+            // error-policy:J1 stream boundary translation — partial SSE streams
+            // cannot become HTTP errors, so emit a terminal error frame.
+            await settleReservation(0);
+            logger.warn("[shared-runtime] stream failed", {
+              error: error instanceof Error ? error.message : String(error),
+              agentId: rec.id,
+            });
+            controller.enqueue(
+              encoder.encode(
+                `event: error\ndata: ${JSON.stringify({ message: "Shared runtime stream failed" })}\n\n`,
+              ),
+            );
+          } finally {
+            controller.close();
+          }
+        },
+      });
+
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache, no-transform",
+        },
+      });
+    } catch (error) {
+      // error-policy:J2 context is added by runSharedAgentTurnStream; the bridge
+      // boundary only owns releasing the reservation before rethrowing.
+      await settleReservation(0);
+      throw error;
     }
   }
 
@@ -3970,24 +4180,8 @@ export class ElizaSandboxService {
     const fallbackText = this.buildBridgeNoReplyFallbackText(params);
 
     if (rec.execution_tier === "shared") {
-      const sharedResponse = await this.bridgeSharedMessageSend(rec, rpc);
-      const text = sharedResponse.result?.text;
-      if (typeof text === "string" && text.trim()) {
-        return this.createBridgeSseTextResponse(text);
-      }
-      if (sharedResponse.error) {
-        // A credit-reserve rejection is not a stream failure — no SSE bytes
-        // exist yet, so throw the canonical typed 402 for the route boundary
-        // to translate (messages/stream → 402 JSON; agent stream routes'
-        // errorToResponse / control-plane errorBody map ApiError natively).
-        // Wrapping it in an SSE error frame here would bury a permanent
-        // add-credits condition inside a 200 stream.
-        if (sharedResponse.error.code === BRIDGE_INSUFFICIENT_CREDITS_CODE) {
-          throw new InsufficientCreditsApiError(sharedResponse.error.message);
-        }
-        return this.createBridgeSseErrorResponse(sharedResponse.error.message);
-      }
-      return fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null;
+      const response = await this.bridgeSharedMessageStream(rec, rpc);
+      return response ?? (fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null);
     }
 
     if (!rec.bridge_url) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -10,10 +10,17 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Per-test controls for the two collaborators runSharedAgentTurn calls.
+// Per-test controls for the collaborators used by both turn entry points.
 let providerConfigured = true;
 let generateTextImpl: () => Promise<{ text: string; usage?: unknown }> = async () => ({
   text: "ok reply",
+});
+let streamTextImpl: () => { fullStream: AsyncIterable<unknown> } = () => ({
+  fullStream: (async function* () {
+    yield { type: "text-delta", text: "ok " };
+    yield { type: "text-delta", text: "reply" };
+    yield { type: "finish", totalUsage: { totalTokens: 3 } };
+  })(),
 });
 
 mock.module("../../providers/language-model", () => ({
@@ -25,18 +32,23 @@ mock.module("../../providers/language-model", () => ({
 
 mock.module("ai", () => ({
   generateText: async () => generateTextImpl(),
-  streamText: () => {
-    throw new Error("streamText is not used by non-stream error-policy tests");
-  },
+  streamText: () => streamTextImpl(),
 }));
 
-const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+const { runSharedAgentTurn, runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
 
 const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
   providerConfigured = true;
   generateTextImpl = async () => ({ text: "ok reply" });
+  streamTextImpl = () => ({
+    fullStream: (async function* () {
+      yield { type: "text-delta", text: "ok " };
+      yield { type: "text-delta", text: "reply" };
+      yield { type: "finish", totalUsage: { totalTokens: 3 } };
+    })(),
+  });
   globalThis.fetch = mock(async () => {
     throw new Error("no network expected in this unit test");
   }) as unknown as typeof fetch;
@@ -128,5 +140,81 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
       content: "hi from Nova",
     });
     expect(typeof result.history[3]?.createdAt).toBe("number");
+  });
+});
+
+describe("runSharedAgentTurnStream — incremental provider policy", () => {
+  test("streams text deltas and a final usage-bearing finish part", async () => {
+    const result = await runSharedAgentTurnStream({
+      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
+      history: [],
+      message: " hello ",
+    });
+
+    expect(result.degraded).toBe(false);
+    expect(result.model).toBe("gpt-oss-120b");
+    if (!("parts" in result)) throw new Error("expected streaming result");
+    const parts = [];
+    for await (const part of result.parts) parts.push(part);
+    expect(parts).toEqual([
+      { type: "text-delta", text: "ok " },
+      { type: "text-delta", text: "reply" },
+      { type: "finish", text: "ok reply", usage: { totalTokens: 3 } },
+    ]);
+  });
+
+  test("keeps no-model turns degraded without starting a provider stream", async () => {
+    providerConfigured = false;
+    streamTextImpl = () => {
+      throw new Error("streamText must not be reached when no model is configured");
+    };
+
+    const result = await runSharedAgentTurnStream({
+      character: { name: "Nova" },
+      history: [],
+      message: " hello ",
+    });
+
+    expect(result).toMatchObject({
+      degraded: true,
+      model: "none",
+      reply: "Nova is temporarily unavailable (no shared model configured).",
+    });
+    if (!("history" in result)) throw new Error("expected degraded history result");
+    expect(result.history.map((entry) => entry.content)).toEqual([
+      "hello",
+      "Nova is temporarily unavailable (no shared model configured).",
+    ]);
+  });
+
+  test("wraps failures raised while consuming the provider stream", async () => {
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "partial" };
+        throw new Error("provider stream reset");
+      })(),
+    });
+
+    const result = await runSharedAgentTurnStream({
+      character: { name: "Nova", model: "gpt-oss-120b" },
+      history: [],
+      message: "hello",
+    });
+    if (!("parts" in result)) throw new Error("expected streaming result");
+
+    const error = await (async () => {
+      try {
+        for await (const _part of result.parts) {
+          // Consume the stream so the late provider failure is observable.
+        }
+        throw new Error("expected stream consumption to fail");
+      } catch (caught) {
+        return caught;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("streaming agent turn failed");
+    expect(((error as Error).cause as Error).message).toContain("provider stream reset");
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -25,6 +25,9 @@ mock.module("../../providers/language-model", () => ({
 
 mock.module("ai", () => ({
   generateText: async () => generateTextImpl(),
+  streamText: () => {
+    throw new Error("streamText is not used by non-stream error-policy tests");
+  },
 }));
 
 const { runSharedAgentTurn } = await import("./run-shared-agent-turn");

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -20,7 +20,7 @@
  *  - route only shared-eligible agents here (see `agent-tier.ts`)
  */
 
-import { generateText } from "ai";
+import { generateText, streamText } from "ai";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
 import {
   getLanguageModel,
@@ -65,6 +65,18 @@ export interface RunSharedAgentTurnResult {
    */
   degraded: boolean;
   usage?: SharedAgentTurnUsage;
+}
+
+export type SharedAgentTurnStreamPart =
+  | { type: "text-delta"; text: string }
+  | { type: "finish"; text: string; usage?: SharedAgentTurnUsage };
+
+export interface RunSharedAgentTurnStreamResult {
+  model: string;
+  degraded: boolean;
+  reply?: string;
+  history?: SharedTurnMessage[];
+  parts?: AsyncIterable<SharedAgentTurnStreamPart>;
 }
 
 /**
@@ -174,6 +186,80 @@ export async function runSharedAgentTurn(
     // caller (bridgeSharedMessageSend) refunds the credit hold instead of billing.
     throw new Error(
       `[shared-runtime] agent turn failed (agent=${input.character.name}, model=${modelId})`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Start one shared turn and expose provider text deltas as they arrive. The
+ * caller still owns history persistence and billing because it knows the
+ * agent/channel/accounting context; this function only bridges the AI SDK
+ * stream into the shared-runtime turn shape.
+ */
+export async function runSharedAgentTurnStream(
+  input: RunSharedAgentTurnInput,
+): Promise<RunSharedAgentTurnStreamResult> {
+  const message = input.message.trim();
+  const modelId = resolveSharedAgentTurnModel(input.character.model);
+
+  if (!modelId) {
+    const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
+    return {
+      reply,
+      history: appendTurn(input.history, message, reply),
+      model: "none",
+      degraded: true,
+    };
+  }
+
+  try {
+    const result = streamText({
+      model: getLanguageModel(modelId),
+      system: buildSystemPrompt(input.character),
+      messages: [
+        ...input.history.map((m) => ({ role: m.role, content: m.content })),
+        { role: "user" as const, content: message },
+      ],
+    });
+
+    const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
+      let reply = "";
+      try {
+        for await (const part of result.fullStream) {
+          if (part.type === "text-delta") {
+            reply += part.text;
+            yield { type: "text-delta", text: part.text };
+          }
+          if (part.type === "finish") {
+            yield {
+              type: "finish",
+              text: reply.trim() || "…",
+              usage: part.totalUsage,
+            };
+          }
+        }
+      } catch (error) {
+        // error-policy:J2 context-adding rethrow. Stream failures happen after
+        // the HTTP response may have started, so callers need this failure to
+        // settle the reservation instead of treating a partial answer as billable.
+        throw new Error(
+          `[shared-runtime] streaming agent turn failed (agent=${input.character.name}, model=${modelId})`,
+          { cause: error },
+        );
+      }
+    })();
+
+    return {
+      model: modelId,
+      degraded: false,
+      parts,
+    };
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow. A provider setup failure occurs
+    // before any stream bytes exist and must refund the upfront reservation.
+    throw new Error(
+      `[shared-runtime] streaming agent turn failed (agent=${input.character.name}, model=${modelId})`,
       { cause: error },
     );
   }


### PR DESCRIPTION
## Summary
- stream shared-runtime model deltas instead of buffering the full generated reply
- preserve history, billing, reconciliation, analytics, and refund behavior
- add a regression test that proves chunks arrive before model completion and before `done`

## Staging evidence
Five canonical SSE turns on the pre-fix staging deployment had headers/first chunk/done at the same instant. Median was 3,886.9 ms, mean 6,235.7 ms, proving the shared `generateText()` path buffered the full response before opening SSE.

## Validation
- Biome clean on touched files
- `git diff --check` clean
- shared turn error-policy tests: 3/3 pass
- integration billing tests: 5/5 pass in CI, including incremental streaming regression
- Codex review completed; its test mock leak finding was fixed

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only shared-runtime streaming change with no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only shared-runtime streaming change with no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only protocol behavior is covered by deterministic SSE frame tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - pre-fix canonical SSE wire timings are summarized above; post-fix live measurement follows staging deployment.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or frontend state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - model/provider/prompt selection is unchanged; this only forwards existing provider deltas incrementally.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database schema, memory, task, wallet, file-generation, or audio artifact changed.

Co-authored-by: wakesync <shadow@shad0w.xyz>
