### PR TITLE
fix(cloud): restore voice turn request context

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -61,9 +61,13 @@ const streamRoute = (
     "../v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route"
   )
 ).default;
-const { createInternalElizaConversationFetch } = await import(
-  "../v1/voice/session/lib/internal-eliza-conversation-fetch"
-);
+const {
+  createInternalElizaConversationFetch,
+  createInternalElizaConversationFetchFactory,
+} = await import("../v1/voice/session/lib/internal-eliza-conversation-fetch");
+const { hasDbCacheContext, runWithDbCacheAsync } = await import("@/db/client");
+const { getCloudAwareEnv, hasCloudBindingsContext, runWithCloudBindingsAsync } =
+  await import("@/lib/runtime/cloud-bindings");
 
 // Restore the real modules so this file's process-global mocks don't strand later
 // test files that use the full elizaSandboxService / resolveSharedAgent surface.
@@ -238,6 +242,72 @@ describe("shared agent messages/stream", () => {
         roomId: VOICE_CONVERSATION,
       },
     });
+  });
+
+  test("late voice callback restores captured Worker bindings and a fresh DB cache", async () => {
+    const env = {
+      DATABASE_URL: "postgresql://captured.example/eliza",
+      VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
+    } as Parameters<typeof createInternalElizaConversationFetchFactory>[0];
+    let createLateFetch!: ReturnType<
+      typeof createInternalElizaConversationFetchFactory
+    >;
+
+    await runWithCloudBindingsAsync(env, () =>
+      runWithDbCacheAsync(async () => {
+        expect(hasCloudBindingsContext()).toBe(true);
+        expect(hasDbCacheContext()).toBe(true);
+        createLateFetch = createInternalElizaConversationFetchFactory(env);
+      }),
+    );
+
+    // Route setup has returned. This models the later WebSocket message event,
+    // whose async chain no longer owns the upgrade request's ALS stores.
+    expect(hasCloudBindingsContext()).toBe(false);
+    expect(hasDbCacheContext()).toBe(false);
+
+    findByIdAndOrg.mockImplementation(async () => {
+      expect(hasCloudBindingsContext()).toBe(true);
+      expect(hasDbCacheContext()).toBe(true);
+      expect(getCloudAwareEnv().DATABASE_URL).toBe(env.DATABASE_URL);
+      return {
+        id: AGENT,
+        organization_id: ORG,
+        user_id: "user-voice",
+        agent_name: "Voice Agent",
+      };
+    });
+    bridgeStream.mockImplementation(async () => {
+      expect(hasCloudBindingsContext()).toBe(true);
+      expect(hasDbCacheContext()).toBe(true);
+      return new Response("event: done\ndata: {}\n\n", {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    });
+
+    const fetchImpl = createLateFetch({
+      agentId: AGENT,
+      conversationId: VOICE_CONVERSATION,
+      organizationId: ORG,
+      userId: "user-voice",
+    });
+    const res = await fetchImpl(
+      `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "user-voice",
+        },
+        body: JSON.stringify({ text: "late callback transcript" }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(findByIdAndOrg).toHaveBeenCalledTimes(1);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
   });
 
   test("internal voice fetch adapter rejects mismatched verified scope before persistence", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -1,13 +1,17 @@
 /**
- * In-process fetch adapter for realtime voice turns that target the canonical
- * Eliza conversation SSE route. The voice bridge keeps its HTTP-shaped contract
- * for tests and future transports, but Worker production dispatches the scoped
- * request directly into the canonical stream core so nested Hono dispatch cannot
- * turn a valid voice request into a same-worker adapter failure.
+ * Keeps realtime voice turns inside a fresh Worker bindings/DB context even
+ * though the WebSocket message arrives after the upgrade request has returned.
  */
+
+import { hasDbCacheContext, runWithDbCacheAsync } from "@/db/client";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
+import {
+  hasCloudBindingsContext,
+  runWithCloudBindingsAsync,
+} from "@/lib/runtime/cloud-bindings";
 import { handleCanonicalScopedAgentStream } from "@/lib/services/shared-runtime/canonical-scoped-stream";
+import { logger } from "@/lib/utils/logger";
 import type { Bindings } from "@/types/cloud-worker-env";
 
 export interface InternalElizaConversationFetchClaims {
@@ -17,72 +21,140 @@ export interface InternalElizaConversationFetchClaims {
   userId: string;
 }
 
+export type InternalElizaConversationFetchFactory = (
+  claims: InternalElizaConversationFetchClaims,
+) => typeof fetch;
+
+/**
+ * Capture durable Worker bindings while the upgrade request is live. Each late
+ * WebSocket turn restores those bindings plus a fresh per-turn DB cache before
+ * repository/service access. A DB cache from the upgrade request must not be
+ * reused because Workers prohibit I/O across request/event lifetimes.
+ */
+export function createInternalElizaConversationFetchFactory(
+  env: Bindings,
+): InternalElizaConversationFetchFactory {
+  logger.info("[voice-sse-context] route construction", {
+    cloudBindingsContext: hasCloudBindingsContext(),
+    dbCacheContext: hasDbCacheContext(),
+  });
+
+  return (claims) =>
+    (async (input: RequestInfo | URL, init?: RequestInit) => {
+      logger.info("[voice-sse-context] adapter entry", {
+        cloudBindingsContext: hasCloudBindingsContext(),
+        dbCacheContext: hasDbCacheContext(),
+      });
+
+      return runWithCloudBindingsAsync(
+        env as unknown as Record<string, unknown>,
+        () =>
+          runWithDbCacheAsync(async () => {
+            try {
+              const response = await dispatchInternalElizaConversationFetch(
+                env,
+                claims,
+                input,
+                init,
+              );
+              logger.info("[voice-sse-context] before response", {
+                cloudBindingsContext: hasCloudBindingsContext(),
+                dbCacheContext: hasDbCacheContext(),
+                status: response.status,
+              });
+              return response;
+            } catch (error) {
+              // error-policy:J2 preserve the original failure after recording
+              // bounded context-lifetime diagnostics at the adapter boundary.
+              logger.error(
+                "[voice-sse-context] adapter failed before response",
+                {
+                  errorClass:
+                    error instanceof Error ? error.name : typeof error,
+                  errorMessage:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
+              throw error;
+            }
+          }),
+      );
+    }) as typeof fetch;
+}
+
+/** Compatibility helper for direct/test callers. */
 export function createInternalElizaConversationFetch(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
 ): typeof fetch {
-  return (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const request = new Request(input, init);
-    const url = new URL(request.url);
-    assertCanonicalVoiceStreamPath(url, claims);
-    if (request.method !== "POST") {
-      return Response.json(
-        { success: false, error: "Method not allowed" },
-        { status: 405 },
-      );
-    }
-    const headers = request.headers;
-    const configured = env.VOICE_REALTIME_ELIZA_AUTHORIZATION;
-    const presented = headers.get("authorization");
-    if (
-      !configured ||
-      !presented ||
-      !timingSafeEqualSecret(presented, configured)
-    ) {
-      return Response.json(
-        { success: false, error: "Agent not found", code: "agent_not_found" },
-        { status: 404 },
-      );
-    }
-    if (
-      headers.get("X-Eliza-Organization-Id") !== claims.organizationId ||
-      headers.get("X-Eliza-User-Id") !== claims.userId
-    ) {
-      return Response.json(
-        { success: false, error: "Agent not found", code: "agent_not_found" },
-        { status: 404 },
-      );
-    }
+  return createInternalElizaConversationFetchFactory(env)(claims);
+}
 
-    const agent = await agentSandboxesRepository.findByIdAndOrg(
-      claims.agentId,
-      claims.organizationId,
+async function dispatchInternalElizaConversationFetch(
+  env: Bindings,
+  claims: InternalElizaConversationFetchClaims,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const request = new Request(input, init);
+  const url = new URL(request.url);
+  assertCanonicalVoiceStreamPath(url, claims);
+  if (request.method !== "POST") {
+    return Response.json(
+      { success: false, error: "Method not allowed" },
+      { status: 405 },
     );
-    if (!agent || agent.user_id !== claims.userId) {
-      return Response.json(
-        { success: false, error: "Agent not found", code: "agent_not_found" },
-        { status: 404 },
-      );
-    }
+  }
+  const headers = request.headers;
+  const configured = env.VOICE_REALTIME_ELIZA_AUTHORIZATION;
+  const presented = headers.get("authorization");
+  if (
+    !configured ||
+    !presented ||
+    !timingSafeEqualSecret(presented, configured)
+  ) {
+    return Response.json(
+      { success: false, error: "Agent not found", code: "agent_not_found" },
+      { status: 404 },
+    );
+  }
+  if (
+    headers.get("X-Eliza-Organization-Id") !== claims.organizationId ||
+    headers.get("X-Eliza-User-Id") !== claims.userId
+  ) {
+    return Response.json(
+      { success: false, error: "Agent not found", code: "agent_not_found" },
+      { status: 404 },
+    );
+  }
 
-    const rawText = await request.text();
-    let body: unknown;
-    try {
-      body = JSON.parse(rawText);
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing — malformed JSON becomes the
-      // same explicit validation response as the public HTTP route's parsed body.
-      body = {};
-    }
+  const agent = await agentSandboxesRepository.findByIdAndOrg(
+    claims.agentId,
+    claims.organizationId,
+  );
+  if (!agent || agent.user_id !== claims.userId) {
+    return Response.json(
+      { success: false, error: "Agent not found", code: "agent_not_found" },
+      { status: 404 },
+    );
+  }
 
-    return handleCanonicalScopedAgentStream({
-      agentId: claims.agentId,
-      orgId: claims.organizationId,
-      conversationId: claims.conversationId,
-      body,
-      origin: headers.get("origin"),
-    });
-  }) as typeof fetch;
+  const rawText = await request.text();
+  let body: unknown;
+  try {
+    body = JSON.parse(rawText);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing. Match the public route.
+    body = {};
+  }
+
+  return handleCanonicalScopedAgentStream({
+    agentId: claims.agentId,
+    orgId: claims.organizationId,
+    conversationId: claims.conversationId,
+    body,
+    origin: headers.get("origin"),
+  });
 }
 
 function assertCanonicalVoiceStreamPath(

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -4,7 +4,9 @@
  * provider sockets and metering remain closed until that frame is verified.
  */
 import { Hono } from "hono";
+import { hasDbCacheContext } from "@/db/client";
 import { buildRedisClient } from "@/lib/cache/redis-factory";
+import { hasCloudBindingsContext } from "@/lib/runtime/cloud-bindings";
 import {
   createDurableVoiceUsageStore,
   InMemoryVoiceUsageStore,
@@ -29,7 +31,7 @@ import {
   type ServerWebSocketLike,
 } from "@/lib/voice-session/ws-handler";
 import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
-import { createInternalElizaConversationFetch } from "../lib/internal-eliza-conversation-fetch";
+import { createInternalElizaConversationFetchFactory } from "../lib/internal-eliza-conversation-fetch";
 import {
   createWorkerCartesiaFactory,
   createWorkerDeepgramFluxFactory,
@@ -182,14 +184,24 @@ app.get("/", (c) => {
     durableStore && evalCapable ? durableStore : getWorkerFallbackUsageStore();
 
   const maxSessions = resolveMaxSessions(env);
+  // Capture Worker bindings while this upgrade request is live. The returned
+  // factory restores a fresh bindings/DB context for each later WS voice turn.
+  const createScopedElizaFetch = createInternalElizaConversationFetchFactory(
+    c.env as unknown as Bindings,
+  );
   attachVoiceWsHandler(server, {
     requestedSessionId: sessionId,
     claimToken: (jti, expSeconds) => claimVoiceSessionToken(jti, expSeconds),
     // Enforce the per-worker ceiling against the LIVE registry at start time,
     // closing the race where many upgrades pass the earlier route-level check.
     admitSession: () => getVoiceSessionRegistry().size() < maxSessions,
-    buildSession: ({ claims, jti, tokenExpSeconds, downlink }) =>
-      new VoiceSession({
+    buildSession: ({ claims, jti, tokenExpSeconds, downlink }) => {
+      logger.info("[voice-sse-context] websocket callback", {
+        agentId: claims.agentId,
+        cloudBindingsContext: hasCloudBindingsContext(),
+        dbCacheContext: hasDbCacheContext(),
+      });
+      return new VoiceSession({
         sessionId: claims.sessionId,
         jti,
         organizationId: claims.organizationId,
@@ -205,22 +217,20 @@ app.get("/", (c) => {
         elizaEndpoint,
         elizaAuthorization,
         elizaModel: resolveElizaModel(env),
-        fetchImpl: createInternalElizaConversationFetch(
-          c.env as unknown as Bindings,
-          {
-            agentId: claims.agentId,
-            conversationId: claims.conversationId,
-            organizationId: claims.organizationId,
-            userId: claims.userId,
-          },
-        ),
+        fetchImpl: createScopedElizaFetch({
+          agentId: claims.agentId,
+          conversationId: claims.conversationId,
+          organizationId: claims.organizationId,
+          userId: claims.userId,
+        }),
         usageStore,
         usageLimits,
         isRevoked: (jti) => isVoiceSessionTokenRevoked(jti),
         onTeardownRevoke: (jti, expSeconds) =>
           revokeVoiceSessionToken(jti, expSeconds),
         downlink,
-      }),
+      });
+    },
   });
 
   return new Response(null, {

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -334,6 +334,11 @@ function createConnection(url: string): Database {
  */
 const dbCacheAls = new AsyncLocalStorage<Map<string, Database>>();
 
+/** Whether the current async chain still owns a request-scoped DB cache. */
+export function hasDbCacheContext(): boolean {
+  return dbCacheAls.getStore() !== undefined;
+}
+
 export async function runWithDbCacheAsync<T>(fn: () => Promise<T>): Promise<T> {
   return await dbCacheAls.run(new Map(), fn);
 }

--- a/packages/cloud/shared/src/lib/runtime/cloud-bindings.ts
+++ b/packages/cloud/shared/src/lib/runtime/cloud-bindings.ts
@@ -13,6 +13,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 const als = new AsyncLocalStorage<Record<string, unknown>>();
 
+/** Whether the current async chain still owns a Worker bindings context. */
+export function hasCloudBindingsContext(): boolean {
+  return als.getStore() !== undefined;
+}
+
 /**
  * Run `fn` with Worker bindings visible to `getCloudAwareEnv()`.
  */


### PR DESCRIPTION
## Summary
- capture durable Worker bindings while the voice WS upgrade request is live
- restore bindings plus a fresh per-turn DB cache before repository/service access in late WS callbacks
- add bounded context instrumentation at route construction, WS callback, adapter entry, and immediately before `Response`
- add a regression that invokes the voice fetch callback after route setup/context teardown

## Why
After `stt_final`, the late WebSocket callback ran outside the upgrade request's async-local Worker bindings and DB-cache context. `agentSandboxesRepository.findByIdAndOrg(...)` therefore failed before the in-process SSE adapter could construct a `Response`.

## Validation
- `bun test packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts` (13 pass)
- `bun run --cwd packages/cloud/api build`
- focused Biome check and `git diff --check`
- `codex review --uncommitted`: no issues

## Scope
Staging path remains hard-gated by `VOICE_REALTIME_WS_ENABLED`; no production flag change.
