### PR TITLE
fix(workflow): route the automation vocabulary to the WORKFLOW action

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
@@ -376,3 +376,34 @@ describe('workflowAction chat operations', () => {
     });
   });
 });
+
+describe('automation vocabulary (#16570)', () => {
+  test('carries the automation simile family a live agent actually guessed', () => {
+    const similes = new Set(workflowAction.similes ?? []);
+    // The two exact names from the production repro must resolve, plus the
+    // core family the "automations" UI vocabulary produces.
+    for (const guessed of [
+      'AUTOMATION_DELETE',
+      'AUTOMATION_CANCEL',
+      'DELETE_AUTOMATION',
+      'CANCEL_AUTOMATION',
+      'LIST_AUTOMATIONS',
+      'CREATE_AUTOMATION',
+      'DISABLE_AUTOMATION',
+    ]) {
+      expect(similes.has(guessed)).toBe(true);
+    }
+  });
+
+  test('describes itself with the automation vocabulary so keyword retrieval matches', () => {
+    expect(workflowAction.description.toLowerCase()).toContain('automation');
+    expect(workflowAction.descriptionCompressed?.toLowerCase()).toContain('automation');
+  });
+
+  test('the delete op the vocabulary routes to actually exists', () => {
+    const opParam = (workflowAction.parameters ?? []).find((p) => p.name === 'action');
+    const allowed = (opParam?.schema as { enum?: string[] } | undefined)?.enum ?? [];
+    expect(allowed).toContain('delete');
+    expect(allowed).toContain('deactivate');
+  });
+});

--- a/plugins/plugin-workflow/src/actions/workflow.ts
+++ b/plugins/plugin-workflow/src/actions/workflow.ts
@@ -721,6 +721,25 @@ export const workflowAction: Action = {
   contextGate: { anyOf: [...WORKFLOW_CONTEXTS] },
   roleGate: { minRole: 'OWNER' },
   similes: [
+    // Automation vocabulary (#16570): the product UI calls these
+    // "automations", and a live agent guessed AUTOMATION_DELETE /
+    // AUTOMATION_CANCEL when asked to remove a broken one — none of the
+    // WORKFLOW_* names below matched, so the planner had to refuse despite
+    // the delete op existing. Kept ONLY on this action (not TRIGGER): a
+    // simile claimed by two parents is dropped as ambiguous by the resolver
+    // (#16561), which would kill the routing this family exists to provide.
+    'AUTOMATION',
+    'AUTOMATIONS',
+    'LIST_AUTOMATIONS',
+    'CREATE_AUTOMATION',
+    'DELETE_AUTOMATION',
+    'AUTOMATION_DELETE',
+    'CANCEL_AUTOMATION',
+    'AUTOMATION_CANCEL',
+    'REMOVE_AUTOMATION',
+    'ENABLE_AUTOMATION',
+    'DISABLE_AUTOMATION',
+    'MANAGE_AUTOMATIONS',
     'LIST_WORKFLOWS',
     'SHOW_WORKFLOWS',
     'GET_WORKFLOW',
@@ -765,11 +784,11 @@ export const workflowAction: Action = {
     'OPTIMIZE_WORKFLOW_SAMPLES',
   ],
   description:
-    'Manage workflows. Action-based dispatch - provide an `action` parameter:\n' +
+    'Manage workflows (automations). Action-based dispatch - provide an `action` parameter:\n' +
     '  list, get, create, modify, activate, deactivate, toggle_active, delete, run, executions, revisions, restore, diagnose, eval_samples.\n' +
     'For creating/updating scheduled triggers (including promoting a task to a workflow), use the TRIGGER action.',
   descriptionCompressed:
-    'workflow list|get|create|modify|activate|deactivate|toggle_active|delete|run|executions|revisions|restore|diagnose|eval_samples',
+    'workflow/automation list|get|create|modify|activate|deactivate|toggle_active|delete|run|executions|revisions|restore|diagnose|eval_samples',
   parameters: [
     {
       name: 'action',


### PR DESCRIPTION
# Relates to

Fixes #16570

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Metadata-only change on one action (similes + two description strings): no handler, route, or op changes. The new names were verified collision-free across the default runtime's action surface (the only other `AUTOMATION*` string in tree is a UI group label) — important because the resolver drops any simile claimed by two parents as ambiguous (#16561), which would neuter this family.

# Background

## What does this PR do?

**Diagnosis refinement over the issue's ask:** the delete/cancel verbs are NOT missing — `WORKFLOW` has carried the full 16-op lifecycle (including `delete` and `deactivate`) all along, mirroring `DELETE /api/workflow/workflows/:id`. What failed in the production repro is retrieval: the planner guessed `AUTOMATION_DELETE` / `AUTOMATION_CANCEL` (the product UI's own vocabulary — the "automations page"), and no stage could match them — every simile was a `WORKFLOW_*` name and neither description field said "automation". The agent had the verb and could not find it.

The fix routes the vocabulary: the `AUTOMATION` simile family (including the two exact names the live agent guessed) plus the word "automation(s)" in both description fields, so exact-hint, keyword, and BM25 retrieval all match. Deliberately NOT mirrored onto `TRIGGER` — a simile claimed by two parents is dropped as ambiguous by the resolver (#16561), which would kill the routing this family exists to provide; the scheduled-task side keeps its own `TRIGGER` vocabulary.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The similes/description diff, then the three new pins in `workflow-action.test.ts`: the guessed names resolve, both description fields carry the vocabulary, and the `delete`/`deactivate` ops the vocabulary routes to actually exist in the parameter enum.

## Detailed testing steps

None: Automated tests are acceptable.

```
bun test --conditions=eliza-source __tests__/unit/workflow-action.test.ts
11 pass, 0 fail — src/actions/workflow.ts 61.2% lines (lcov)
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - planner-routing metadata fix, no UI surface changed.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - planner-routing metadata fix, no UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow change; the routing vocabulary is pinned by unit tests and the incident's guessed names are asserted present.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no runtime behavior change to log; the production repro's failure mode (planner refusing on invented names) is a retrieval outcome asserted via the simile pins.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic retrieval-surface metadata; no prompt/model behavior change. The live repro trajectory is quoted in #16570.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the artifact is the action's simile/description surface asserted in the changed test lane.`

# Evidence Details

Production repro quoted in #16570 (agent: "automation page rejected AUTOMATION_DELETE and AUTOMATION_CANCEL, neither is a valid action there"). Both exact names are now first-class similes; collision sweep across `packages/agent`, `packages/core`, and all plugin action surfaces found no other claimant.

## Known gaps / failures

Two pre-existing TS2307 errors in the package's typecheck (`@elizaos/shared` dist not built locally) reproduce identically on clean `origin/develop` — environmental, untouched by this diff.

[stan-cloud]
