### PR TITLE
fix: cloud-api lint drift breaking lint-and-types on clean develop

### DIFF
--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -599,12 +599,11 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         error instanceof ElizaSseBridgeError ? error : undefined;
       this.send({
         t: "error",
-        code:
-          bridgeError?.upstreamCode
-            ? bridgeError.upstreamCode
-            : error instanceof Error
-              ? error.name
-              : "llm_error",
+        code: bridgeError?.upstreamCode
+          ? bridgeError.upstreamCode
+          : error instanceof Error
+            ? error.name
+            : "llm_error",
         retryable: bridgeError ? bridgeError.retryable : true,
         ...(bridgeError?.status ? { upstreamStatus: bridgeError.status } : {}),
         ...(bridgeError?.upstreamMessage

--- a/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
@@ -125,11 +125,7 @@ describe("Headscale container credentials", () => {
       agentName: "Eliza",
     });
 
-    expect(calls).toEqual([
-      "lookup:eliza-11111111-111",
-      "delete:stale-node-70",
-      "create-key",
-    ]);
+    expect(calls).toEqual(["lookup:eliza-11111111-111", "delete:stale-node-70", "create-key"]);
   });
 });
 


### PR DESCRIPTION
# Relates to

CI unblock: `bun run --cwd packages/cloud/api lint:check` fails on **clean develop** (one unformatted hunk in the bridge-error ternary), which fails the `lint-and-types` lane for every open cloud PR (observed on #16584).

# Risks

None — `biome check --write` output only, zero semantic change (formatting of an existing ternary).

# Background

## What does this PR do?

Applies the biome formatting the lane enforces. `lint:check` goes red→green with this single hunk.

## What kind of change is this?

Bug fix (CI drift).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`bun run --cwd packages/cloud/api lint:check` on develop (fails) vs this branch (passes).

## Detailed testing steps

None: Automated tests are acceptable — lint lane is the test.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - formatting-only, no UI.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - formatting-only.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - formatting-only.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no runtime change; lint:check red→green is the observable.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model surface.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - formatting-only; the lint lane result is the artifact.`

# Evidence Details

## Real LLM-call trajectory

`N/A - formatting-only.`

## Backend + frontend logs

`N/A - formatting-only.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)