### PR TITLE
fix: deliver verified tool output AND evaluator prose instead of discarding the answer

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -622,6 +622,29 @@ describe("planner-loop — verified tool text + evaluator prose combine", () => 
 		expect(finalMessage).toContain("hasn't budged");
 	});
 
+	it("preserves an already-fenced multiline result without nesting fences", async () => {
+		const alreadyFenced = `\`\`\`text\n${dfStdout}\n\`\`\``;
+		const { runtime, executeToolCall, evaluate } = makeHarness({
+			toolResult: {
+				success: true,
+				text: "Shell command completed: `df -h`\nExit code: 0",
+				userFacingText: alreadyFenced,
+				verifiedUserFacing: true,
+			},
+			messageToUser: dfProse,
+		});
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(`${alreadyFenced}\n\n${dfProse}`);
+	});
+
 	it("returns prose alone when it already embeds the verified text verbatim", async () => {
 		const verified = "/home/example/.bun";
 		const prose = `biggest offender is /home/example/.bun — 19G. want me to clear it?`;

--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -548,3 +548,160 @@ describe("looksLikeSpawnEnvelopeJson — spawn-arg leak detector", () => {
 		expect(looksLikeSpawnEnvelopeJson("")).toBe(false);
 	});
 });
+
+/**
+ * Verified tool output + grounded evaluator prose are complementary — both must
+ * reach the user. Texts mirror the live regression: `df -h` through the
+ * terminal action marked its clean stdout `verifiedUserFacing`, and the old
+ * precedence returned only the mount table, silently discarding the
+ * evaluator's actual answer.
+ */
+describe("planner-loop — verified tool text + evaluator prose combine", () => {
+	const dfStdout =
+		"Filesystem      Size  Used Avail Use% Mounted on\n/dev/sda1       387G  366G   22G  95% /\ntmpfs            16G     0   16G   0% /dev/shm";
+	const dfProse =
+		"third check, still `/` at 95% — 366G used, 22G free. hasn't budged. say the word and i'll hunt the big offenders.";
+
+	const makeHarness = (opts: {
+		toolResult: Record<string, unknown>;
+		messageToUser?: string;
+	}) => {
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [{ id: "call-1", name: "TERMINAL_SHELL", arguments: {} }],
+					usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+				})
+				.mockResolvedValueOnce({
+					text: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Tool ran; answering.",
+						...(opts.messageToUser
+							? { messageToUser: opts.messageToUser }
+							: {}),
+					}),
+					usage: { promptTokens: 50, completionTokens: 20, totalTokens: 70 },
+				}),
+		};
+		const executeToolCall = vi.fn(async () => opts.toolResult);
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "Tool ran; answering.",
+			...(opts.messageToUser ? { messageToUser: opts.messageToUser } : {}),
+		}));
+		return { runtime, executeToolCall, evaluate };
+	};
+
+	it("delivers verified tool output AND the evaluator's grounded prose", async () => {
+		const { runtime, executeToolCall, evaluate } = makeHarness({
+			toolResult: {
+				success: true,
+				text: "Shell command completed: `df -h`\nExit code: 0",
+				userFacingText: dfStdout,
+				verifiedUserFacing: true,
+			},
+			messageToUser: dfProse,
+		});
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+		expect(result.status).toBe("finished");
+		const finalMessage = result.finalMessage ?? "";
+		// The verbatim output survives (#7960) …
+		expect(finalMessage).toContain(dfStdout);
+		// … fenced as multiline command output …
+		expect(finalMessage).toContain("```");
+		// … and the evaluator's answer is no longer discarded.
+		expect(finalMessage).toContain("hasn't budged");
+	});
+
+	it("returns prose alone when it already embeds the verified text verbatim", async () => {
+		const verified = "/home/example/.bun";
+		const prose = `biggest offender is /home/example/.bun — 19G. want me to clear it?`;
+		const { runtime, executeToolCall, evaluate } = makeHarness({
+			toolResult: {
+				success: true,
+				text: "diag",
+				userFacingText: verified,
+				verifiedUserFacing: true,
+			},
+			messageToUser: prose,
+		});
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+		expect(result.finalMessage).toBe(prose);
+	});
+
+	it("keeps the verified text alone when the prose adds nothing over it", async () => {
+		const verified =
+			"Root disk: 65% used, 138G available. Biggest cleanup candidate: /home/example/.bun (19G).";
+		const { runtime, executeToolCall, evaluate } = makeHarness({
+			toolResult: {
+				success: true,
+				text: "diag",
+				userFacingText: verified,
+				verifiedUserFacing: true,
+			},
+			// A pure fragment/restatement of the verified text.
+			messageToUser: "Root disk: 65% used, 138G available.",
+		});
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+		expect(result.finalMessage).toBe(verified);
+	});
+
+	it("keeps the verified text alone when the evaluator omits messageToUser", async () => {
+		const { runtime, executeToolCall, evaluate } = makeHarness({
+			toolResult: {
+				success: true,
+				text: "diag",
+				userFacingText: dfStdout,
+				verifiedUserFacing: true,
+			},
+		});
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+		expect(result.finalMessage).toBe(dfStdout);
+	});
+
+	it("never decorates a verified confirmation preview with evaluator prose", async () => {
+		const preview =
+			"About to delete 3 reminders. Reply yes to confirm or no to cancel.";
+		const { runtime, executeToolCall, evaluate } = makeHarness({
+			toolResult: {
+				success: false,
+				text: "diag",
+				userFacingText: preview,
+				verifiedUserFacing: true,
+				data: { requiresConfirmation: true },
+			},
+			messageToUser: "i queued the delete — confirm when ready.",
+		});
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+		expect(result.finalMessage).toBe(preview);
+	});
+});

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -7,10 +7,10 @@
  * model.
  */
 import { describe, expect, it, vi } from "vitest";
+import { promoteSubactionsToActions } from "../../actions/promote-subactions";
 import { plannerTemplate } from "../../prompts/planner";
 import { type ChatMessage, ModelType } from "../../types/model";
 import { TrajectoryLimitExceeded } from "../limits";
-import { promoteSubactionsToActions } from "../../actions/promote-subactions";
 import {
 	__renderRoutingHintsBlockForTests,
 	PROGRESS_ONLY_ANSWER_REJECT,
@@ -3274,8 +3274,7 @@ describe("routing hints — promoted-family fallback", () => {
 				},
 			],
 		};
-		const [createVirtual, deleteVirtual] =
-			promoteSubactionsToActions(parent);
+		const [createVirtual, deleteVirtual] = promoteSubactionsToActions(parent);
 		const ctx = {
 			events: [createVirtual, deleteVirtual].map((action, i) => ({
 				id: `tool-${i}`,
@@ -3287,9 +3286,9 @@ describe("routing hints — promoted-family fallback", () => {
 		expect(block).toContain("# Routing hints");
 		expect(block).toContain("reminders -> TRIGGER_CREATE");
 		// One line for the whole family, not one per virtual.
-		expect(
-			(block ?? "").split("reminders -> TRIGGER_CREATE").length - 1,
-		).toBe(1);
+		expect((block ?? "").split("reminders -> TRIGGER_CREATE").length - 1).toBe(
+			1,
+		);
 	});
 });
 
@@ -3299,7 +3298,8 @@ describe("verified widget payloads stay pure in the combine path", () => {
 	// the combine path must return the widget alone even when the evaluator
 	// also supplied grounded prose.
 	it("never appends evaluator prose to a verified interaction block", async () => {
-		const widget = "[CHOICE:contact id=pick]\nvalue=Shaw\nvalue=Stan\n[/CHOICE]";
+		const widget =
+			"[CHOICE:contact id=pick]\nvalue=Shaw\nvalue=Stan\n[/CHOICE]";
 		const runtime = {
 			useModel: vi
 				.fn()

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -3292,3 +3292,51 @@ describe("routing hints — promoted-family fallback", () => {
 		).toBe(1);
 	});
 });
+
+describe("verified widget payloads stay pure in the combine path", () => {
+	// A verified [CHOICE]/[FORM] interaction block is grammar the client
+	// renders; appending evaluator prose would corrupt the block contract, so
+	// the combine path must return the widget alone even when the evaluator
+	// also supplied grounded prose.
+	it("never appends evaluator prose to a verified interaction block", async () => {
+		const widget = "[CHOICE:contact id=pick]\nvalue=Shaw\nvalue=Stan\n[/CHOICE]";
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [{ id: "call-1", name: "MESSAGE", arguments: {} }],
+					usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+				})
+				.mockResolvedValueOnce({
+					text: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Tool asked the user to pick.",
+						messageToUser: "pick whichever contact you meant.",
+					}),
+					usage: { promptTokens: 50, completionTokens: 20, totalTokens: 70 },
+				}),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "disambiguation required",
+			userFacingText: widget,
+			verifiedUserFacing: true,
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "Tool asked the user to pick.",
+			messageToUser: "pick whichever contact you meant.",
+		}));
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(widget);
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3469,6 +3469,9 @@ function combinedVerifiedToolTextAndProse(
 	// client renders; appended prose would corrupt the block contract.
 	if (parseInteractionBlocks(verified).blocks.length > 0) return undefined;
 	const prose = modelText.trim();
+	// Combining must preserve the same user-safety boundary as selecting model
+	// text directly; evaluator channels can contain serialized tool invocations.
+	if (isUnsafeUserVisibleText(prose)) return undefined;
 	// Prose that already embeds the verbatim output IS the combined message.
 	if (prose.includes(verified)) return prose;
 	const normalize = (text: string) =>

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3398,7 +3398,10 @@ function preferredFinalMessageFromToolOrModel(
 	//   1. A single successful tool whose result was explicitly marked
 	//      `verifiedUserFacing: true` — used for structured outputs
 	//      (paths, ids, counts) where evaluator paraphrase risks
-	//      hallucinating a value.
+	//      hallucinating a value. When the evaluator ALSO supplied grounded
+	//      prose, the two are combined (verbatim output first, prose after)
+	//      instead of discarding the evaluator's answer — see
+	//      `combinedVerifiedToolTextAndProse`.
 	//   2. A grammar-valid widget emitted for a structurally-marked missing-input
 	//      result. The widget preserves the planner's field types and supersedes
 	//      the tool's prose question, but never a lifeDraft confirmation preview.
@@ -3415,17 +3418,69 @@ function preferredFinalMessageFromToolOrModel(
 	//   - `planner-loop-user-facing-text.test.ts` → "does not regress
 	//     evaluator's explicit messageToUser path" — evaluator wins when
 	//     no tool sets `verifiedUserFacing`.
-	//   - `planner-happy-path.test.ts` → "prefers a single tool's verified
-	//     user-facing text over evaluator paraphrase" — tool wins when it
-	//     opts in via `verifiedUserFacing: true`.
+	//   - `planner-happy-path.test.ts` → "falls back to a single tool's
+	//     user-facing text when the evaluator omits messageToUser" — the
+	//     verified verbatim text stands alone when there is no prose.
+	//   - `planner-loop-user-facing-text.test.ts` → "delivers verified tool
+	//     output AND the evaluator's grounded prose" — both survive when both
+	//     exist and neither contains the other.
+	const verifiedToolText = singleVerifiedUserFacingToolResultText(trajectory);
 	return (
-		singleVerifiedUserFacingToolResultText(trajectory) ??
+		combinedVerifiedToolTextAndProse(
+			trajectory,
+			verifiedToolText,
+			modelTextWithoutUnlicensedNoopWidget,
+		) ??
+		verifiedToolText ??
 		(widgetCollectsLatestMissingInput ? widgetReply : undefined) ??
 		deterministicRequiresConfirmationRelay(trajectory) ??
 		modelTextWithoutUnlicensedNoopWidget ??
 		latestToolResultText(trajectory) ??
 		getNonEmptyString(fallback)
 	);
+}
+
+/**
+ * A verified tool result and a grounded evaluator reply are complementary, not
+ * competing: the verified text is the verbatim output (#7960 — never dropped,
+ * never paraphrased) and the evaluator's `messageToUser` answers what the user
+ * actually asked. Returning only the verified text silently discarded grounded
+ * evaluator prose (observed live: `df -h` via the terminal action posted a bare
+ * mount table and dropped the evaluator's "still 95%, 22G free" answer).
+ * Deliver both — the verbatim output, fenced when it is multiline command
+ * output, followed by the prose. Containment collapses the pair when one side
+ * already carries the other, and confirmation previews stay pure (action-owned
+ * copy is never decorated with extra prose).
+ */
+function combinedVerifiedToolTextAndProse(
+	trajectory: PlannerTrajectory,
+	verifiedToolText: string | undefined,
+	modelText: string | undefined,
+): string | undefined {
+	if (!verifiedToolText || !modelText) return undefined;
+	const hasVerifiedConfirmationPreview = trajectory.steps.some(
+		(step) =>
+			step.result?.verifiedUserFacing === true &&
+			hasRequiresConfirmationMarker(step.result),
+	);
+	if (hasVerifiedConfirmationPreview) return undefined;
+	const verified = verifiedToolText.trim();
+	// Widget payloads ([CHOICE]/[FORM] interaction blocks) are grammar the
+	// client renders; appended prose would corrupt the block contract.
+	if (parseInteractionBlocks(verified).blocks.length > 0) return undefined;
+	const prose = modelText.trim();
+	// Prose that already embeds the verbatim output IS the combined message.
+	if (prose.includes(verified)) return prose;
+	const normalize = (text: string) =>
+		text.toLowerCase().replace(/\s+/g, " ").trim();
+	// Prose that adds nothing over the verified output (a restatement or
+	// fragment of it) keeps the verbatim-echo behavior unchanged.
+	if (normalize(verified).includes(normalize(prose))) return undefined;
+	const fenced =
+		verified.includes("\n") && !verified.includes("```")
+			? `\`\`\`\n${verified}\n\`\`\``
+			: verified;
+	return `${fenced}\n\n${prose}`;
 }
 
 function latestToolResultIsGenericNoop(trajectory: PlannerTrajectory): boolean {


### PR DESCRIPTION
# Relates to

Live-observed answer loss on tool turns (same family as #7960's verbatim-echo design).

# Risks

Low. The verbatim guarantee (#7960) is preserved — the verified text always survives; the evaluator's prose is *appended*, never substituted. Confirmation previews and widget (`[CHOICE]`/`[FORM]`) payloads stay pure; containment collapses the pair when one side already carries the other.

# Background

## What does this PR do?

A tool result marked `verifiedUserFacing: true` used to be returned **alone** as the final message (precedence #1 in `preferredFinalMessageFromToolOrModel`), silently discarding the evaluator's grounded `messageToUser`.

Observed live (production Discord agent): "check disk and tell me if we're good" → `df -h` through the terminal action posted a **bare unfenced mount table** and dropped the evaluator's actual answer ("still 95%, 22G free — say the word and i'll hunt the big offenders").

New `combinedVerifiedToolTextAndProse`: fenced verbatim output (when multiline) + prose beneath, one message. If the prose embeds the verified text verbatim, prose alone is delivered; if the prose adds nothing over the verified text, the verified text stands alone (unchanged behavior).

## What kind of change is this?

Bug fix (grounded answers were being discarded).

# Documentation changes needed?

No — the precedence doc-comment in `planner-loop.ts` is updated in place.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts` — the new "verified tool text + evaluator prose combine" describe block (5 cases mirroring the live texts).

## Detailed testing steps

- `bunx vitest run src/runtime/__tests__/planner-loop-user-facing-text.test.ts src/__tests__/planner-happy-path.test.ts src/__tests__/message-v5-widget-markers.test.ts` → 40/40
- Full runtime unit dir on this branch: **73 files / 952 tests green**

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - runtime message-path change, no UI code; before/after live Discord transcripts are in Evidence Details.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - see live transcripts below.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - single-message behavior change, transcripts below capture it fully.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no logger-path change; the trajectory evaluation stage + delivered Discord message pair in Evidence Details show the path firing.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - attached inline as text in Evidence Details: live trajectory evaluation stage (FINISH + messageToUser) recorded on a production agent before/after this fix.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no persistent artifacts; the delivered Discord message (below) is the observable output.`

# Evidence Details

## Real LLM-call trajectory

Live production trajectory (before fix): evaluation stage recorded
`decision: FINISH, messageToUser: "third check, still \`/\` at 95% — 366G used, 22G free. hasn't budged…"`
while the only delivered Discord message was the bare unfenced `df` table — the prose was discarded by the old precedence.

## Backend + frontend logs

After fix, same scenario, one delivered message (live Discord, verified via API read):

```
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1       387G  366G   21G  95% /
…
```

disk checked. root `/` is at 95% — 366G used, only 21G free of 387G. technically still up but that's the danger zone. we're *ok for now* but you want to clean up soon before / fills.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)