### PR TITLE
fix: read-only FILE ops (ls/grep/glob) stop posting visible callbacks

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/glob.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.test.ts
@@ -69,7 +69,7 @@ afterEach(async () => {
 const state: State | undefined = undefined;
 
 describe("GLOB", () => {
-    it("matches **/*.ts and returns expected count", async () => {
+  it("matches **/*.ts and returns expected count", async () => {
     const { runtime, message } = await buildRuntime();
     const result = await globHandler(runtime, message, state, {
       parameters: { pattern: "**/*.ts" },
@@ -172,7 +172,13 @@ describe("globHandler — read-only query stays silent", () => {
   it("does not invoke the visible chat callback", async () => {
     const { runtime, message } = await buildRuntime();
     const callback = vi.fn();
-    const result = await globHandler(runtime, message, undefined, { parameters: { pattern: "**/*.ts" } }, callback);
+    const result = await globHandler(
+      runtime,
+      message,
+      undefined,
+      { parameters: { pattern: "**/*.ts" } },
+      callback,
+    );
     expect(result.success).toBe(true);
     expect(callback).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-coding-tools/src/actions/glob.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.test.ts
@@ -8,7 +8,7 @@ import {
   type Memory,
   type State,
 } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SandboxService } from "../services/sandbox-service.js";
 import { SessionCwdService } from "../services/session-cwd-service.js";
@@ -69,33 +69,7 @@ afterEach(async () => {
 const state: State | undefined = undefined;
 
 describe("GLOB", () => {
-  it("fences and source-tags the user-facing path listing (#16563)", async () => {
-    const { runtime, message } = await buildRuntime();
-    const posts: Array<{ text: string; source?: string }> = [];
-
-    const result = await globHandler(
-      runtime,
-      message,
-      state,
-      { parameters: { pattern: "**/*.ts" } },
-      async (content) => {
-        posts.push(content as { text: string; source?: string });
-        return [];
-      },
-    );
-
-    expect(result.success).toBe(true);
-    // Planner-facing text stays raw; the user-facing relay is fenced (paths
-    // like __tests__/ get bold-consumed unfenced) and tagged like every
-    // sibling coding-tools relay.
-    expect(result.text?.startsWith("```")).toBe(false);
-    expect(posts).toHaveLength(1);
-    expect(posts[0].source).toBe("coding-tools");
-    expect(posts[0].text.startsWith("```")).toBe(true);
-    expect(posts[0].text.trimEnd().endsWith("```")).toBe(true);
-  });
-
-  it("matches **/*.ts and returns expected count", async () => {
+    it("matches **/*.ts and returns expected count", async () => {
     const { runtime, message } = await buildRuntime();
     const result = await globHandler(runtime, message, state, {
       parameters: { pattern: "**/*.ts" },
@@ -188,5 +162,18 @@ describe("globToRegExp (fallback matcher)", () => {
     expect(globToRegExp("a.ts").test("aXts")).toBe(false);
     expect(globToRegExp("a+(b).ts").test("a+(b).ts")).toBe(true);
     expect(globToRegExp("a+(b).ts").test("ab.ts")).toBe(false);
+  });
+});
+
+describe("globHandler — read-only query stays silent", () => {
+  // The contract this PR establishes: raw listings/matches reach the model via
+  // the ActionResult and the user via the planner's final message. Posting each
+  // exploratory call's dump spammed chat (#16589) — the callback must never fire.
+  it("does not invoke the visible chat callback", async () => {
+    const { runtime, message } = await buildRuntime();
+    const callback = vi.fn();
+    const result = await globHandler(runtime, message, undefined, { parameters: { pattern: "**/*.ts" } }, callback);
+    expect(result.success).toBe(true);
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-coding-tools/src/actions/glob.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.ts
@@ -150,6 +150,10 @@ export async function globHandler(
   message: Memory,
   _state: State | undefined,
   options: unknown,
+  // Read-only query: deliberately no visible callback. Raw listings/matches
+  // reach the model via the ActionResult and the user via the planner's final
+  // message; posting each mid-turn dump spammed chat channels (one message per
+  // exploratory call).
   callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
@@ -248,11 +252,6 @@ export async function globHandler(
     `${CODING_TOOLS_LOG_PREFIX} GLOB pattern=${JSON.stringify(pattern)} root=${root} found=${limited.length} truncated=${truncated}`,
   );
 
-  // Fenced + source-tagged (#16563): the path listing is the structural twin
-  // of the fenced ls output, and paths like __tests__/ or *.md get
-  // bold/italic-consumed unfenced; the source tag matches every sibling relay.
-  if (callback)
-    await callback({ text: fencePreformatted(text), source: "coding-tools" });
 
   return successActionResult(text, {
     files: limited,

--- a/plugins/plugin-coding-tools/src/actions/glob.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.ts
@@ -17,7 +17,6 @@ import {
 
 import {
   failureToActionResult,
-  fencePreformatted,
   readStringParam,
   successActionResult,
 } from "../lib/format.js";
@@ -154,7 +153,7 @@ export async function globHandler(
   // reach the model via the ActionResult and the user via the planner's final
   // message; posting each mid-turn dump spammed chat channels (one message per
   // exploratory call).
-  callback?: HandlerCallback,
+  _callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
     message.roomId !== undefined && message.roomId !== null
@@ -251,7 +250,6 @@ export async function globHandler(
   coreLogger.debug(
     `${CODING_TOOLS_LOG_PREFIX} GLOB pattern=${JSON.stringify(pattern)} root=${root} found=${limited.length} truncated=${truncated}`,
   );
-
 
   return successActionResult(text, {
     files: limited,

--- a/plugins/plugin-coding-tools/src/actions/grep.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.test.ts
@@ -9,7 +9,7 @@ import {
   type Memory,
   type State,
 } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RipgrepService } from "../services/ripgrep-service.js";
 import { SandboxService } from "../services/sandbox-service.js";
@@ -237,5 +237,18 @@ describe("GREP", () => {
     });
     expect(result.success).toBe(false);
     expect(result.text).toContain("missing_param");
+  });
+});
+
+describe("grepHandler — read-only query stays silent", () => {
+  // The contract this PR establishes: raw listings/matches reach the model via
+  // the ActionResult and the user via the planner's final message. Posting each
+  // exploratory call's dump spammed chat (#16589) — the callback must never fire.
+  it("does not invoke the visible chat callback", async () => {
+    const { runtime, message } = await buildRuntime();
+    const callback = vi.fn();
+    const result = await grepHandler(runtime, message, undefined, { parameters: { pattern: "alpha" } }, callback);
+    expect(result.success).toBe(true);
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-coding-tools/src/actions/grep.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.test.ts
@@ -241,14 +241,46 @@ describe("GREP", () => {
 });
 
 describe("grepHandler — read-only query stays silent", () => {
-  // The contract this PR establishes: raw listings/matches reach the model via
-  // the ActionResult and the user via the planner's final message. Posting each
-  // exploratory call's dump spammed chat (#16589) — the callback must never fire.
-  it("does not invoke the visible chat callback", async () => {
-    const { runtime, message } = await buildRuntime();
+  // Read-only query results reach the model through ActionResult and the user
+  // through the planner's final message, so exploratory calls stay out of chat.
+  it("does not invoke the visible chat callback for matching results", async () => {
+    const bundle = await buildRuntime();
+    if (!bundle) return;
+    const { runtime, message } = bundle;
     const callback = vi.fn();
-    const result = await grepHandler(runtime, message, undefined, { parameters: { pattern: "alpha" } }, callback);
+
+    const result = await grepHandler(
+      runtime,
+      message,
+      undefined,
+      { parameters: { pattern: "NEEDLE" } },
+      callback,
+    );
+
     expect(result.success).toBe(true);
+    expect(result.text).toContain("a.ts");
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke the visible chat callback for the zero-match early return", async () => {
+    const bundle = await buildRuntime();
+    if (!bundle) return;
+    const { runtime, message } = bundle;
+    const callback = vi.fn();
+
+    const result = await grepHandler(
+      runtime,
+      message,
+      undefined,
+      { parameters: { pattern: "ZZZ_DEFINITELY_NO_MATCH_ZZZ" } },
+      callback,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("no matches");
+    expect(
+      (result.data as Record<string, unknown> | undefined)?.matches_count,
+    ).toBe(0);
     expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-coding-tools/src/actions/grep.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.ts
@@ -14,7 +14,6 @@ import {
 
 import {
   failureToActionResult,
-  fencePreformatted,
   readBoolParam,
   readNumberParam,
   readPositiveIntSetting,
@@ -48,6 +47,10 @@ export async function grepHandler(
   message: Memory,
   _state: State | undefined,
   options: unknown,
+  // Read-only query: deliberately no visible callback. Raw listings/matches
+  // reach the model via the ActionResult and the user via the planner's final
+  // message; posting each mid-turn dump spammed chat channels (one message per
+  // exploratory call).
   callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
@@ -138,7 +141,6 @@ export async function grepHandler(
       (mode === "content" || mode === "files_with_matches")
     ) {
       const text = "no matches";
-      if (callback) await callback({ text, source: "coding-tools" });
       return successActionResult(text, {
         matches_count: 0,
         mode,
@@ -179,15 +181,9 @@ export async function grepHandler(
     const truncated = headTruncated || result.truncated;
     const text =
       outputLines.length === 0 ? "no matches" : outputLines.join("\n");
-    const callbackText =
-      outputLines.length === 0 ? text : fencePreformatted(text);
-
     coreLogger.debug(
       `${CODING_TOOLS_LOG_PREFIX} GREP pattern=${JSON.stringify(pattern)} mode=${mode} matches=${outputLines.length} truncated=${truncated}`,
     );
-
-    if (callback)
-      await callback({ text: callbackText, source: "coding-tools" });
 
     return successActionResult(text, {
       matches_count: outputLines.length,

--- a/plugins/plugin-coding-tools/src/actions/grep.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.ts
@@ -51,7 +51,7 @@ export async function grepHandler(
   // reach the model via the ActionResult and the user via the planner's final
   // message; posting each mid-turn dump spammed chat channels (one message per
   // exploratory call).
-  callback?: HandlerCallback,
+  _callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
     message.roomId !== undefined && message.roomId !== null

--- a/plugins/plugin-coding-tools/src/actions/ls.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.test.ts
@@ -269,7 +269,7 @@ describe("lsHandler — read-only query stays silent", () => {
   // The contract this PR establishes: raw listings/matches reach the model via
   // the ActionResult and the user via the planner's final message. Posting each
   // exploratory call's dump spammed chat (#16589) — the callback must never fire.
-  it("does not invoke the visible chat callback", async () => {
+  it("does not invoke the visible chat callback for local listings", async () => {
     const { runtime, message } = await buildRuntime();
     const callback = vi.fn();
     const result = await lsHandler(
@@ -280,6 +280,39 @@ describe("lsHandler — read-only query stays silent", () => {
       callback,
     );
     expect(result.success).toBe(true);
+    expect(result.text).toContain("alpha.ts");
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke the visible chat callback for routed listings", async () => {
+    const router = makeListRouter(async (params) => ({
+      root: { id: "workspace", path: tmpRoot },
+      path: params.path ?? tmpRoot,
+      entries: [
+        {
+          path: path.join(tmpRoot, "routed.ts"),
+          name: "routed.ts",
+          kind: "file",
+          size: 12,
+          isText: true,
+        },
+      ],
+      truncated: false,
+      totalAfterIgnore: 1,
+    }));
+    const { runtime, message } = await buildRuntime(router);
+    const callback = vi.fn();
+
+    const result = await lsHandler(
+      runtime,
+      message,
+      undefined,
+      { parameters: {} },
+      callback,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("routed.ts");
     expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-coding-tools/src/actions/ls.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.test.ts
@@ -12,7 +12,7 @@ import {
   type State,
   UnavailableCapabilityRouter,
 } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SandboxService } from "../services/sandbox-service.js";
 import { SessionCwdService } from "../services/session-cwd-service.js";
@@ -262,5 +262,18 @@ describe("LS", () => {
     const alpha = entries?.find((e) => e.name === "alpha.ts");
     expect(alpha?.type).toBe("file");
     expect(typeof alpha?.size).toBe("number");
+  });
+});
+
+describe("lsHandler — read-only query stays silent", () => {
+  // The contract this PR establishes: raw listings/matches reach the model via
+  // the ActionResult and the user via the planner's final message. Posting each
+  // exploratory call's dump spammed chat (#16589) — the callback must never fire.
+  it("does not invoke the visible chat callback", async () => {
+    const { runtime, message } = await buildRuntime();
+    const callback = vi.fn();
+    const result = await lsHandler(runtime, message, undefined, { parameters: {} }, callback);
+    expect(result.success).toBe(true);
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-coding-tools/src/actions/ls.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.test.ts
@@ -272,7 +272,13 @@ describe("lsHandler — read-only query stays silent", () => {
   it("does not invoke the visible chat callback", async () => {
     const { runtime, message } = await buildRuntime();
     const callback = vi.fn();
-    const result = await lsHandler(runtime, message, undefined, { parameters: {} }, callback);
+    const result = await lsHandler(
+      runtime,
+      message,
+      undefined,
+      { parameters: {} },
+      callback,
+    );
     expect(result.success).toBe(true);
     expect(callback).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-coding-tools/src/actions/ls.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.ts
@@ -161,7 +161,7 @@ export async function lsHandler(
   // reach the model via the ActionResult and the user via the planner's final
   // message; posting each mid-turn dump spammed chat channels (one message per
   // exploratory call).
-  callback?: HandlerCallback,
+  _callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
     message.roomId !== undefined && message.roomId !== null

--- a/plugins/plugin-coding-tools/src/actions/ls.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.ts
@@ -20,7 +20,6 @@ import {
 
 import {
   failureToActionResult,
-  fencePreformatted,
   readArrayParam,
   readStringParam,
   successActionResult,
@@ -158,6 +157,10 @@ export async function lsHandler(
   message: Memory,
   _state: State | undefined,
   options: unknown,
+  // Read-only query: deliberately no visible callback. Raw listings/matches
+  // reach the model via the ActionResult and the user via the planner's final
+  // message; posting each mid-turn dump spammed chat channels (one message per
+  // exploratory call).
   callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
@@ -213,9 +216,6 @@ export async function lsHandler(
     coreLogger.debug(
       `${CODING_TOOLS_LOG_PREFIX} LS dir=${routed.payload.path} count=${sorted.length} truncated=${routed.payload.truncated}`,
     );
-
-    if (callback)
-      await callback({ text: fencePreformatted(text), source: "coding-tools" });
 
     return successActionResult(text, {
       entries: sorted,
@@ -290,9 +290,6 @@ export async function lsHandler(
   coreLogger.debug(
     `${CODING_TOOLS_LOG_PREFIX} LS dir=${dir} count=${sorted.length} truncated=${truncated}`,
   );
-
-  if (callback)
-    await callback({ text: fencePreformatted(text), source: "coding-tools" });
 
   return successActionResult(text, {
     entries: sorted,


### PR DESCRIPTION
# Relates to

Live-observed chat spam: one raw dump per exploratory FILE call. Pairs with #16588 (final-message combine) — together they make tool turns deliver one clean answer.

# Risks

Low. The model's view is unchanged (raw listings still flow through `ActionResult.text`); only the per-call **visible chat callback** is removed. `write`/`edit` keep their one-line receipts (real side effects). `read` never had a visible callback — this aligns the other read-only ops with it.

# Background

## What does this PR do?

`ls`, `grep`, and `glob` posted their raw output as a visible chat message on **every call**. On a multi-iteration turn that's one raw dump per exploratory call — observed live (production Discord agent): a single "read your config and tell me what keys you see" produced **three consecutive raw directory listings** before the actual answer.

Read-only FILE ops are queries, not side effects: data reaches the model via the ActionResult and the user via the planner's final message (which, with #16588, carries verbatim output when a tool marks it verified).

## What kind of change is this?

Bug fix (chat-surface spam).

# Documentation changes needed?

No — the durable rationale is commented at each handler signature.

# Testing

## Where should a reviewer start?

The three handlers in `plugins/plugin-coding-tools/src/actions/` — the diff is deletions plus a why-comment.

## Detailed testing steps

- `bun run --cwd plugins/plugin-coding-tools test` on this branch → **27 files / 333 tests green**
- `bun run --cwd plugins/plugin-coding-tools typecheck` → clean

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - chat-message behavior; before/after live transcripts in Evidence Details.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - see transcripts below.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - single-turn message-count change, fully captured in transcripts.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no logger-path change; the delivered message sequence is the observable.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt/model change; the live trajectory for the before-case (4 FILE iterations, one visible dump each) is quoted in Evidence Details.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no persistent artifacts; delivered message counts are the observable.`

# Evidence Details

## Real LLM-call trajectory

Before (live production trajectory): planner iterations `FILE read → FILE ls ~ → FILE ls ~/.eliza → FILE ls ~/.elizaos`, each `ls` posting its raw listing to Discord — 3 raw dumps + 1 answer for one question.

## Backend + frontend logs

After (same question re-sent live, verified via Discord API read): **one** message —

```
no eliza.json where it'd actually live. checked ~ (ENOENT) and ~/.eliza — that dir has exec-approvals.json, computer-use-approval.json, skills.json, swarm-history.jsonl, plus dirs like auth/, models/, plugins/, workspace…
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)