### PR TITLE
fix(security): make GH_PAT visible to every credential-hygiene surface

### DIFF
--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -80,3 +80,21 @@ describe("sensitive config handling", () => {
     ).toBeUndefined();
   });
 });
+
+describe("PAT credential names (#16564)", () => {
+  it("classifies GH_PAT and dotted pat paths as sensitive", () => {
+    expect(isSensitiveConfigKey("GH_PAT")).toBe(true);
+    expect(isSensitiveConfigKey("github.gh_pat")).toBe(true);
+  });
+
+  it("never classifies PATH/FORMAT/PATTERN names", () => {
+    for (const key of [
+      "PATH",
+      "XDG_DATA_PATH",
+      "output.format",
+      "TEMPLATE_PATTERN",
+    ]) {
+      expect(isSensitiveConfigKey(key)).toBe(false);
+    }
+  });
+});

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -6,7 +6,7 @@
  * sensitivity hints for arbitrary config paths.
  */
 const SENSITIVE_CONFIG_KEY_RE =
-  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$/i;
+  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$|(?:^|[._-])pat$/i;
 
 export function isSensitiveConfigKey(key: string): boolean {
   const lastSegment = key.split(".").at(-1) ?? key;

--- a/packages/app-core/src/api/server-config-filter.ts
+++ b/packages/app-core/src/api/server-config-filter.ts
@@ -18,6 +18,9 @@ export const SENSITIVE_ENV_RESPONSE_KEYS = new Set([
   "ELIZAOS_CLOUD_API_KEY",
   // Third-party auth tokens
   "GITHUB_TOKEN",
+  // PR-shepherd fallback PAT (#16544): a live GitHub bearer credential the
+  // sensitive-suffix regex below cannot catch (no *TOKEN/KEY suffix).
+  "GH_PAT",
   // Database connection strings (may contain credentials)
   "DATABASE_URL",
   "POSTGRES_URL",

--- a/packages/app-core/test/server-config-filter.test.ts
+++ b/packages/app-core/test/server-config-filter.test.ts
@@ -29,6 +29,24 @@ describe("filterConfigEnvForResponse", () => {
     });
   });
 
+  test("redacts GH_PAT — a bearer credential the suffix regex cannot catch (#16564)", () => {
+    const filtered = filterConfigEnvForResponse({
+      env: {
+        GH_PAT: "ghp_livecredential",
+        GITHUB_TOKEN: "ghs_repo_scoped",
+        XDG_DATA_PATH: "/home/user/.local/share",
+      },
+    });
+
+    const env = filtered.env as Record<string, unknown>;
+    // Set members are REMOVED outright (stronger than redaction), exactly
+    // like the sibling GITHUB_TOKEN entry.
+    expect("GH_PAT" in env).toBe(false);
+    expect("GITHUB_TOKEN" in env).toBe(false);
+    // PATH-like names stay readable — no false positives from the PAT entry.
+    expect(env.XDG_DATA_PATH).toBe("/home/user/.local/share");
+  });
+
   test("removes blocked env keys after redaction", () => {
     const filtered = filterConfigEnvForResponse({
       env: {

--- a/packages/core/src/constants/secrets.test.ts
+++ b/packages/core/src/constants/secrets.test.ts
@@ -13,6 +13,7 @@ import {
 	getProviderForApiKey,
 	getRequiredSecretsForChannel,
 	isCanonicalSecretKey,
+	isSecretKey,
 	isSecretKeyAlias,
 	MODEL_PROVIDER_SECRETS,
 	resolveSecretKeyAlias,
@@ -69,5 +70,18 @@ describe("channel secrets", () => {
 			required: [],
 			optional: [],
 		});
+	});
+});
+
+describe("isSecretKey — PAT names (#16564)", () => {
+	it("classifies bare PAT credential names without a KEY/TOKEN suffix", () => {
+		expect(isSecretKey("GH_PAT")).toBe(true);
+		expect(isSecretKey("CR_PAT")).toBe(true);
+	});
+
+	it("never classifies PATH-like or PATTERN-like names", () => {
+		for (const key of ["PATH", "XDG_DATA_PATH", "TEMPLATE_PATTERN", "FORMAT"]) {
+			expect(isSecretKey(key)).toBe(false);
+		}
 	});
 });

--- a/packages/core/src/constants/secrets.ts
+++ b/packages/core/src/constants/secrets.ts
@@ -259,7 +259,7 @@ export function isCanonicalSecretKey(key: string): key is CanonicalSecretKey {
  * swap from config/registry rather than a hand-copied list.
  */
 const SECRET_KEY_NAME_PATTERN =
-	/(?:API)?_?(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL|PRIVATE_KEY)\b|SECRET|PASSWORD|MNEMONIC|CREDENTIAL/i;
+	/(?:API)?_?(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL|PRIVATE_KEY)\b|(?:^|_)PAT\b|SECRET|PASSWORD|MNEMONIC|CREDENTIAL/i;
 
 export function isSecretKey(key: string): boolean {
 	if (!key) return false;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -109,6 +109,10 @@ describe("shouldForwardEnv", () => {
     expect(isEnvForwardableToSubAgent("GHCR_TOKEN")).toBe(true);
     expect(shouldForwardEnv("GH_TOKEN")).toBe(false);
     expect(shouldForwardEnv("CR_PAT")).toBe(false);
+    // #16564: the PR-shepherd fallback PAT is a live GitHub bearer credential;
+    // children must never inherit it implicitly.
+    expect(shouldForwardEnv("GH_PAT")).toBe(false);
+    expect(isEnvForwardableToSubAgent("GH_PAT")).toBe(false);
     expect(isEnvForwardableToSubAgent("GITHUB_TOKEN")).toBe(false);
     expect(isEnvForwardableToSubAgent("GH_TOKEN")).toBe(false);
     expect(isEnvForwardableToSubAgent("CR_PAT")).toBe(false);

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -17,7 +17,7 @@ const DENY_ENV_PATTERNS = [
   // Repo-scoped GitHub host credentials must not be injected into sub-agents,
   // including through customCredentials. Registry push uses the dedicated
   // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.
-  /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT)$/i,
+  /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT|GH_PAT)$/i,
   // OpenCode's spawn config is runtime-built (buildOpencodeAcpEnv overwrites it
   // AFTER this filter runs). A caller- or host-supplied value would let the
   // spawner inject arbitrary provider config into the child, so it is denied at


### PR DESCRIPTION
# Relates to

Fixes #16564

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low-medium (security-hardening, all additive). Four surfaces gain `GH_PAT`/`*_PAT` coverage; nothing loses coverage. Pattern boundaries are the one real risk — verified with explicit negative tests against `PATH`, `XDG_DATA_PATH`, `FORMAT`, `TEMPLATE_PATTERN`, `output.format` on every touched predicate (the `\b`/anchored forms cannot match PATH-like names). The #16544 feature keeps working: the config-env forwarding path the shepherd reads from is untouched — only implicit child inheritance and value exposure are closed.

# Background

## What does this PR do?

#16544 made `GH_PAT` a live GitHub bearer credential, but every hygiene surface covering its `GITHUB_TOKEN`/`GH_TOKEN`/`CR_PAT` siblings was blind to the name (no `TOKEN`/`KEY` suffix for the suffix-based classifiers):

- **core secret-swap** — `isSecretKey("GH_PAT")` was false, so `deriveKnownSecrets` never seeded it into the layer that keeps credential values out of LLM-visible text/logs. Now `(?:^|_)PAT\b` is part of the secret-name pattern.
- **agent config sensitivity** — `isSensitiveConfigKey("GH_PAT")` was false (no UI hint, no redaction). Now an anchored pat-suffix matches it (and dotted config paths).
- **app-core config API** — `GET /api/config` returned the raw value; `GH_PAT` now joins the removal set next to `GITHUB_TOKEN` (removed outright, stronger than redaction).
- **orchestrator sub-agent env** — children could inherit the credential implicitly; `GH_PAT` joins the deny-list with its siblings. The shepherd's explicit `readGitHubToken` remains the only consumer.

**Deliberately out of scope** (flagged on the issue for the #16544 author): the credential-flow design question — the downstream coding pipeline still reads only `GITHUB_TOKEN`; whether/how the shepherd's PAT should flow there is a product call, not hygiene.

## What kind of change is this?

Bug fix (security hardening; non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The four one-line-ish predicate/set diffs, then the symmetry tests: each surface asserts `GH_PAT` classified/removed/denied AND the PATH-family negatives (`PATH`, `XDG_DATA_PATH`, `TEMPLATE_PATTERN`, `output.format`) stay untouched.

## Detailed testing steps

None: Automated tests are acceptable.

```
core secrets.test.ts            7/7   (secrets.ts 75.9% lines)
agent sensitive-keys.test.ts    6/6   (sensitive-keys.ts 100%)
app-core server-config-filter   3/3   (server-config-filter.ts 70%)
orchestrator should-forward-env 24/24 (sub-agent-env-policy.ts 100%)
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-side credential-hygiene predicates; no UI surface changed (the UI sensitivity hint follows the predicate automatically).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; behavior pinned by symmetry tests on all four surfaces.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the change PREVENTS values from reaching logs/responses; the removal/classification is asserted directly in the changed lanes.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the secret-swap layer's seeding is deterministic; no model behavior change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the artifact is the classification/removal verdict asserted per surface.`

# Evidence Details

Per-surface evidence (file:line, verified on develop) is on #16564. No secret values appear anywhere in this PR — test fixtures use obvious placeholders.

## Known gaps / failures

The shepherd→downstream credential-flow question stays open on #16564 by design.

[stan-cloud]
