### PR TITLE
fix(ui): bypass stale dedicated ASR proxy

### DIFF
--- a/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
@@ -26,7 +26,8 @@ const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
  * Regression guard for the cloud STT wiring gap: an `eliza-cloud` / `openai`
  * voice config used to fall straight through to the browser SpeechRecognition
  * engine in the chat composer (`useVoiceChat` only branched local-inference vs
- * browser), so the documented cloud transcriber (`/api/asr/cloud`) was never
+ * browser), so the documented cloud transcriber (direct worker when the cloud
+ * session is available, otherwise `/api/asr/cloud`) was never
  * reached from the PWA. These tests lock the composer capture to the cloud
  * proxy when the config selects a cloud provider.
  */

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -1010,7 +1010,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
   const transcribeCloudAudio = useCallback(
     async (audio: Uint8Array, signal?: AbortSignal): Promise<string> => {
-      return transcribeCloudWav(audio, { signal });
+      return transcribeCloudWav(audio, {
+        signal,
+        configuredCloudOrigin: configuredCloudVoiceOrigin(),
+        cloudSessionToken: getCloudAuthToken(),
+      });
     },
     [],
   );

--- a/packages/ui/src/voice/local-asr-transcribe.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.test.ts
@@ -6,12 +6,13 @@
 // live server.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchWithCsrf } from "../api/csrf-client";
+import { fetchWithCsrf, requestViaAgentTransport } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
 import { transcribeCloudWav } from "./local-asr-transcribe";
 
 vi.mock("../api/csrf-client", () => ({
   fetchWithCsrf: vi.fn(),
+  requestViaAgentTransport: vi.fn(),
 }));
 
 vi.mock("../utils", () => ({
@@ -29,6 +30,7 @@ vi.mock("../utils/eliza-globals", () => ({
 import { getElizaApiBase } from "../utils/eliza-globals";
 
 const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const requestViaAgentTransportMock = vi.mocked(requestViaAgentTransport);
 const resolveApiUrlMock = vi.mocked(resolveApiUrl);
 const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
 
@@ -66,6 +68,75 @@ describe("transcribeCloudWav", () => {
     expect(init?.body).toBe(wav);
     // Transcript is trimmed.
     expect(text).toBe("hello world");
+  });
+
+  it("bypasses a dedicated container and posts multipart WAV to the configured cloud Worker", async () => {
+    requestViaAgentTransportMock.mockResolvedValue(
+      jsonResponse({ transcript: "  direct cloud hello " }),
+    );
+    const wav = new Uint8Array([82, 73, 70, 70]);
+
+    const text = await transcribeCloudWav(wav, {
+      configuredCloudOrigin: "https://staging.elizacloud.ai/",
+      cloudSessionToken: "staging-session-token",
+    });
+
+    const [url, init] = requestViaAgentTransportMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://staging.elizacloud.ai/api/v1/voice/stt");
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+    expect(resolveApiUrlMock).not.toHaveBeenCalledWith("/api/asr/cloud");
+    expect(init?.headers).toMatchObject({
+      Accept: "application/json",
+      Authorization: "Bearer staging-session-token",
+    });
+    expect(init?.body).toBeInstanceOf(FormData);
+    expect((init?.body as FormData).get("audio")).toBeInstanceOf(File);
+    expect(text).toBe("direct cloud hello");
+  });
+
+  it("falls back to the dedicated proxy when direct cloud auth is stale", async () => {
+    requestViaAgentTransportMock.mockResolvedValue(
+      jsonResponse({ error: "expired" }, false, 401),
+    );
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "proxy rescue" }));
+
+    const text = await transcribeCloudWav(new Uint8Array([1]), {
+      configuredCloudOrigin: "https://staging.elizacloud.ai",
+      cloudSessionToken: "stale-token",
+    });
+
+    expect(requestViaAgentTransportMock).toHaveBeenCalledOnce();
+    expect(resolveApiUrlMock).toHaveBeenCalledWith("/api/asr/cloud");
+    expect(text).toBe("proxy rescue");
+  });
+
+  it("preserves direct cloud application failures without changing principals", async () => {
+    requestViaAgentTransportMock.mockResolvedValue(
+      jsonResponse({ error: "insufficient credits" }, false, 402),
+    );
+
+    await expect(
+      transcribeCloudWav(new Uint8Array([1]), {
+        configuredCloudOrigin: "https://staging.elizacloud.ai",
+        cloudSessionToken: "valid-token",
+      }),
+    ).rejects.toThrow("Cloud ASR 402");
+
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dedicated proxy when direct cloud auth is unavailable", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "proxy hello" }));
+
+    await transcribeCloudWav(new Uint8Array([1]), {
+      configuredCloudOrigin: "https://staging.elizacloud.ai",
+      cloudSessionToken: null,
+    });
+
+    expect(resolveApiUrlMock).toHaveBeenCalledWith("/api/asr/cloud");
+    expect(fetchWithCsrfMock.mock.calls[0]?.[0]).toBe(
+      "http://agent.local/api/asr/cloud",
+    );
   });
 
   it("throws on a non-2xx response (fail-loud, no silent empty result)", async () => {

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -12,7 +12,7 @@
  * hook swallows + cleans up state) stays at the call-site.
  */
 
-import { fetchWithCsrf } from "../api/csrf-client";
+import { fetchWithCsrf, requestViaAgentTransport } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
 import {
   buildSharedRuntimeSttBody,
@@ -30,6 +30,10 @@ export interface TranscribeWavOptions {
 export const DEFAULT_CLOUD_STT_TIMEOUT_MS = 15_000;
 
 export interface TranscribeCloudWavOptions extends TranscribeWavOptions {
+  /** Cloud Worker origin used to bypass a dedicated container proxy. */
+  configuredCloudOrigin?: string | null;
+  /** Cloud session bearer for the direct Worker request. */
+  cloudSessionToken?: string | null;
   /**
    * Per-attempt client-side timeout (#voice-V4). A flaky-cellular POST that
    * never resolves would otherwise hang the turn in "processing" forever
@@ -193,29 +197,68 @@ export async function transcribeCloudWav(
       // Shared-tier fallback (#15395): a shared-runtime agent has no
       // `/api/asr/cloud` container route (404s), so target the cloud API
       // worker's provider-agnostic v1 STT route instead — multipart `audio`
-      // File in, `{ transcript }` out. Dedicated-tier agents keep the raw-WAV
-      // `/api/asr/cloud` proxy path unchanged (sharedOrigin is null for them).
+      // File in, `{ transcript }` out. A cloud-authenticated dedicated session
+      // also bypasses the container proxy and calls that Worker route directly;
+      // local/remote dedicated agents without cloud auth keep the raw-WAV proxy.
       const sharedOrigin = currentSharedRuntimeVoiceOrigin();
-      const res = sharedOrigin
-        ? await fetchWithCsrf(sharedRuntimeSttUrl(sharedOrigin), {
-            method: "POST",
-            // No explicit Content-Type: the browser sets the multipart boundary.
-            headers: { Accept: "application/json" },
-            body: buildSharedRuntimeSttBody(audio),
-            signal: timeoutController.signal,
-          })
-        : await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
-            method: "POST",
-            headers: {
-              "Content-Type": "audio/wav",
-              Accept: "application/json",
-            },
-            // A Uint8Array is a valid BufferSource body; the cast bridges the
-            // DOM lib's stricter `ArrayBuffer` generic on BodyInit (runtime
-            // accepts it).
-            body: audio as BodyInit,
-            signal: timeoutController.signal,
-          });
+      const directOrigin = options?.configuredCloudOrigin?.replace(/\/+$/, "");
+      const cloudToken = options?.cloudSessionToken?.trim();
+      const directRoute =
+        !sharedOrigin && directOrigin && cloudToken
+          ? { origin: directOrigin, token: cloudToken }
+          : null;
+      const workerOrigin = sharedOrigin ?? directRoute?.origin ?? null;
+      const workerRequest: RequestInit = {
+        method: "POST",
+        // No explicit Content-Type: the browser sets the multipart boundary.
+        headers: {
+          Accept: "application/json",
+          ...(directRoute
+            ? { Authorization: `Bearer ${directRoute.token}` }
+            : {}),
+        },
+        body: buildSharedRuntimeSttBody(audio),
+        signal: timeoutController.signal,
+      };
+      const fetchDedicatedProxy = () =>
+        fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
+          method: "POST",
+          headers: {
+            "Content-Type": "audio/wav",
+            Accept: "application/json",
+          },
+          // A Uint8Array is a valid BufferSource body; the cast bridges the
+          // DOM lib's stricter `ArrayBuffer` generic on BodyInit (runtime
+          // accepts it).
+          body: audio as BodyInit,
+          signal: timeoutController.signal,
+        });
+
+      let usedWorkerRoute = Boolean(workerOrigin);
+      let res: Response;
+      if (directRoute) {
+        try {
+          res = await requestViaAgentTransport(
+            sharedRuntimeSttUrl(directRoute.origin),
+            workerRequest,
+          );
+          if (res.status === 401 || res.status === 403) {
+            res = await fetchDedicatedProxy();
+            usedWorkerRoute = false;
+          }
+        } catch (error) {
+          if (timeoutController.signal.aborted) throw error;
+          res = await fetchDedicatedProxy();
+          usedWorkerRoute = false;
+        }
+      } else if (workerOrigin) {
+        res = await fetchWithCsrf(
+          sharedRuntimeSttUrl(workerOrigin),
+          workerRequest,
+        );
+      } else {
+        res = await fetchDedicatedProxy();
+      }
       if (!res.ok) {
         // error-policy:J6 the error body is diagnostic-only; a failed read must
         // not mask the HTTP status the error below already carries.
@@ -234,7 +277,7 @@ export async function transcribeCloudWav(
         text?: unknown;
         transcript?: unknown;
       } | null;
-      const text = sharedOrigin
+      const text = usedWorkerRoute
         ? parseSharedRuntimeSttResponse(parsed)
         : typeof parsed?.text === "string"
           ? parsed.text.trim()


### PR DESCRIPTION
## Summary
- route authenticated dedicated-cloud STT directly to `/api/v1/voice/stt`
- preserve shared-runtime and non-cloud dedicated proxy behavior
- fall back on stale auth/transport failures without masking application errors

## Root cause
The mobile client always posted dedicated sessions to the per-container `/api/asr/cloud` route. Staging containers can run an image without that newer plugin route, producing the observed 404 even though the central cloud STT route is live.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - transport-only TypeScript change, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - transport-only TypeScript change, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction or layout changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend code changed; live HTTP probes are documented below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: [CI checks](https://github.com/elizaOS/eliza/pull/16594/checks), local Vitest 18/18 and UI build passed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, or agent trajectory changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff](https://github.com/elizaOS/eliza/pull/16594/files), direct endpoint maps to 401 without auth while malformed authenticated audio is covered by route tests.

## Tests
- `bunx vitest run src/voice/local-asr-transcribe.test.ts --config vitest.config.ts` (18 passed)
- `bun run build` in packages/ui
- Biome and diff checks clean
- Codex review addressed twice: transport fallback added; application errors remain on the original principal

Co-authored-by: wakesync <shadow@shad0w.xyz>
