### PR TITLE
fix(ui): keep cloud ASR routing self-contained

### DIFF
--- a/packages/ui/src/voice/local-asr-transcribe.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.test.ts
@@ -5,10 +5,20 @@
 // stubbed so the assertions run against the request the helper builds, not a
 // live server.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getCloudAuthToken } from "../api/client-cloud";
 import { fetchWithCsrf, requestViaAgentTransport } from "../api/csrf-client";
+import { getBootConfig } from "../config/boot-config-store";
 import { resolveApiUrl } from "../utils";
 import { transcribeCloudWav } from "./local-asr-transcribe";
+
+vi.mock("../api/client-cloud", () => ({
+  getCloudAuthToken: vi.fn(() => null),
+}));
+
+vi.mock("../config/boot-config-store", () => ({
+  getBootConfig: vi.fn(() => ({})),
+}));
 
 vi.mock("../api/csrf-client", () => ({
   fetchWithCsrf: vi.fn(),
@@ -29,6 +39,8 @@ vi.mock("../utils/eliza-globals", () => ({
 
 import { getElizaApiBase } from "../utils/eliza-globals";
 
+const getCloudAuthTokenMock = vi.mocked(getCloudAuthToken);
+const getBootConfigMock = vi.mocked(getBootConfig);
 const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
 const requestViaAgentTransportMock = vi.mocked(requestViaAgentTransport);
 const resolveApiUrlMock = vi.mocked(resolveApiUrl);
@@ -44,8 +56,12 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
 }
 
 describe("transcribeCloudWav", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCloudAuthTokenMock.mockReturnValue(null);
+    getBootConfigMock.mockReturnValue({} as ReturnType<typeof getBootConfig>);
+    getElizaApiBaseMock.mockReturnValue(undefined);
+    resolveApiUrlMock.mockImplementation((path) => `http://agent.local${path}`);
   });
 
   it("POSTs the raw WAV bytes to /api/asr/cloud and returns the transcript", async () => {
@@ -68,6 +84,26 @@ describe("transcribeCloudWav", () => {
     expect(init?.body).toBe(wav);
     // Transcript is trimmed.
     expect(text).toBe("hello world");
+  });
+
+  it("discovers the configured cloud Worker and session token by default", async () => {
+    getBootConfigMock.mockReturnValue({
+      cloudApiBase: "https://staging.elizacloud.ai",
+    } as ReturnType<typeof getBootConfig>);
+    getCloudAuthTokenMock.mockReturnValue("stored-session-token");
+    requestViaAgentTransportMock.mockResolvedValue(
+      jsonResponse({ transcript: "default route" }),
+    );
+
+    const text = await transcribeCloudWav(new Uint8Array([1]));
+
+    expect(requestViaAgentTransportMock.mock.calls[0]?.[0]).toBe(
+      "https://staging.elizacloud.ai/api/v1/voice/stt",
+    );
+    expect(
+      requestViaAgentTransportMock.mock.calls[0]?.[1]?.headers,
+    ).toMatchObject({ Authorization: "Bearer stored-session-token" });
+    expect(text).toBe("default route");
   });
 
   it("bypasses a dedicated container and posts multipart WAV to the configured cloud Worker", async () => {
@@ -289,8 +325,12 @@ describe("transcribeCloudWav", () => {
 });
 
 describe("transcribeCloudWav (shared-tier fallback, #15395)", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCloudAuthTokenMock.mockReturnValue(null);
+    getBootConfigMock.mockReturnValue({} as ReturnType<typeof getBootConfig>);
+    getElizaApiBaseMock.mockReturnValue(undefined);
+    resolveApiUrlMock.mockImplementation((path) => `http://agent.local${path}`);
   });
 
   it("targets the v1 /api/v1/voice/stt route with a multipart `audio` File", async () => {

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -12,10 +12,12 @@
  * hook swallows + cleans up state) stays at the call-site.
  */
 
+import { getCloudAuthToken } from "../api/client-cloud";
 import { fetchWithCsrf, requestViaAgentTransport } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
 import {
   buildSharedRuntimeSttBody,
+  configuredCloudVoiceOrigin,
   currentSharedRuntimeVoiceOrigin,
   parseSharedRuntimeSttResponse,
   sharedRuntimeSttUrl,
@@ -201,8 +203,12 @@ export async function transcribeCloudWav(
       // also bypasses the container proxy and calls that Worker route directly;
       // local/remote dedicated agents without cloud auth keep the raw-WAV proxy.
       const sharedOrigin = currentSharedRuntimeVoiceOrigin();
-      const directOrigin = options?.configuredCloudOrigin?.replace(/\/+$/, "");
-      const cloudToken = options?.cloudSessionToken?.trim();
+      const directOrigin = (
+        options?.configuredCloudOrigin ?? configuredCloudVoiceOrigin()
+      )?.replace(/\/+$/, "");
+      const cloudToken = (
+        options?.cloudSessionToken ?? getCloudAuthToken()
+      )?.trim();
       const directRoute =
         !sharedOrigin && directOrigin && cloudToken
           ? { origin: directOrigin, token: cloudToken }


### PR DESCRIPTION
## Summary
Follow-up to #16594: move cloud session discovery into the tested ASR transport helper and restore the hook call site. Runtime behavior is unchanged; this removes the large hook from the changed-source coverage surface.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - non-visual TypeScript refactor.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - non-visual TypeScript refactor.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual behavior changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend changed.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - focused local ASR Vitest passed 18/18; no browser console capture needed for this non-visual refactor.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff](https://github.com/elizaOS/eliza/pulls).

Co-authored-by: wakesync <shadow@shad0w.xyz>
