### PR TITLE
fix(cloud): preserve the live Headscale node through blue/green upgrades

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-provider-lane.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-provider-lane.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Coverage lane composing the DockerSandboxProvider suites for the
+ * changed-file gate (#16565) — same pattern as the orchestrator's
+ * curated-coding-memory composite: the provider's lifecycle surface spans
+ * many co-located suites, and a provider-touching change needs their UNION
+ * to exercise the class (no single suite drives create+health+teardown).
+ */
+import { describe, expect, test } from "bun:test";
+import "./app-docker-cmd.test.ts";
+import "./docker-ensure-network.test.ts";
+import "./docker-port-allocation.test.ts";
+import "./docker-sandbox-already-gone.test.ts";
+import "./docker-sandbox-headscale-route.test.ts";
+import "./docker-sandbox-health-fallback.test.ts";
+import "./docker-sandbox-health-stale-node.test.ts";
+import "./docker-sandbox-probe-transport.test.ts";
+import "./docker-sandbox-unreachable-terminal.test.ts";
+import "./docker-ssh-probe-classify.test.ts";
+
+describe("docker-sandbox-provider composite lane", () => {
+  test("runs under bun with the suites it composes present", () => {
+    expect(typeof test).toBe("function");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -88,6 +88,10 @@ export interface DockerSandboxMetadata {
    */
   imageDigest: string | null;
   headscaleIp?: string;
+  /** Preserved live node id from a reclaimStaleVpnNode=false provision
+   *  (#16565) — the upgrade orchestrator deletes it BY ID after the atomic
+   *  swap; rolled-back paths must leave it untouched. */
+  previousVpnNodeId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,6 +107,12 @@ interface ContainerMeta {
   agentId: string;
   /** Headscale node name (TS_HOSTNAME) used at registration, for cleanup lookup. */
   tsHostname?: string;
+  /** THIS container's registered Headscale node id (#16565): the only safe
+   *  teardown identifier while a blue/green overlap shares the hostname. */
+  vpnNodeId?: string;
+  /** The preserved live node's id when created with reclaimStaleVpnNode=false
+   *  (#16565); the upgrade orchestrator deletes it by id after cutover. */
+  previousVpnNodeId?: string;
   sshPort: number;
   sshUser: string;
   hostKeyFingerprint?: string;
@@ -1023,6 +1033,8 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 4. Optionally prepare Headscale VPN
     let headscaleIp: string | null = null;
+    let previousVpnNodeId: string | undefined;
+    let vpnNodeId: string | undefined;
 
     // Collect VPN env vars separately to avoid mutating the caller's environmentVars
     let vpnEnvVars: Record<string, string> = {};
@@ -1032,8 +1044,12 @@ export class DockerSandboxProvider implements SandboxProvider {
           agentId,
           agentName,
           organizationId,
+          // Blue/green passes false: the same-name node is LIVE and serving;
+          // it is recorded here and deleted by id only after cutover (#16565).
+          reclaimStaleNode: config.reclaimStaleVpnNode !== false,
         });
         vpnEnvVars = vpnSetup.envVars;
+        previousVpnNodeId = vpnSetup.previousNodeId;
         logger.info(`[docker-sandbox] Headscale VPN enabled for ${agentId}`);
       } catch (err) {
         if (headscaleRouteRequired) {
@@ -1481,6 +1497,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Headscale node name (TS_HOSTNAME) the container registered under, so
       // deletion can find and remove the node by the same name it was created with.
       tsHostname: vpnEnvVars.TS_HOSTNAME,
+      previousVpnNodeId,
       sshPort,
       sshUser,
       hostKeyFingerprint,
@@ -1494,7 +1511,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         // inferTailscaleHostname), NOT the bare agentId — Headscale only knows the
         // node by that hostname, so polling by agentId never matched and the node
         // "timed out" registering despite being online.
-        headscaleIp = await headscaleIntegration.waitForVPNRegistration(
+        const registration = await headscaleIntegration.waitForVPNRegistration(
           vpnEnvVars.TS_HOSTNAME ?? agentId,
           // 180s default (env-overridable via VPN_REGISTRATION_TIMEOUT_MS), not
           // a hardcoded 60s: a cold container needs >1 min to boot + register,
@@ -1502,7 +1519,13 @@ export class DockerSandboxProvider implements SandboxProvider {
           // → 404 despite running. Single source of truth lives in
           // headscale-integration so the constant and this call agree.
           DEFAULT_REGISTRATION_TIMEOUT_MS,
+          // During a blue/green overlap the preserved live node shares this
+          // hostname — matching it would route the new sandbox to the OLD
+          // container, the race the reclaim-mode deletion used to guard (#16565).
+          previousVpnNodeId ? { excludeNodeId: previousVpnNodeId } : undefined,
         );
+        headscaleIp = registration?.ip ?? null;
+        vpnNodeId = registration?.nodeId;
         if (headscaleIp) {
           logger.info(
             `[docker-sandbox] Container ${containerName} registered on VPN: ${headscaleIp}`,
@@ -1516,6 +1539,12 @@ export class DockerSandboxProvider implements SandboxProvider {
         logger.warn(
           `[docker-sandbox] VPN registration failed for ${containerName}: ${err instanceof Error ? err.message : String(err)}`,
         );
+      }
+      // Registered node id onto the in-memory meta so teardown can delete
+      // THIS container's node by id — by-name is ambiguous while a blue/green
+      // overlap shares the hostname (#16565).
+      if (vpnNodeId) {
+        meta.vpnNodeId = vpnNodeId;
       }
     }
 
@@ -1572,6 +1601,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       dockerImage: resolvedImage,
       imageDigest,
       headscaleIp: headscaleIp || undefined,
+      previousVpnNodeId,
     };
 
     // Over the headscale mesh the agent-router and the daemon's runtime calls
@@ -1847,13 +1877,15 @@ export class DockerSandboxProvider implements SandboxProvider {
     const headscaleEnv = currentHeadscaleRouteEnv();
     const registeredNodeName = meta.tsHostname;
     if (shouldCleanupHeadscaleVpn(headscaleEnv, registeredNodeName)) {
-      // Delete the node by the hostname it registered under (TS_HOSTNAME), not the
-      // bare agentId — Headscale identifies the node by that name.
-      await withTimeout(
-        headscaleIntegration.cleanupContainerVPN(registeredNodeName),
-        HEADSCALE_CLEANUP_TIMEOUT_MS,
-        "headscale cleanup",
-      ).catch((err) => {
+      // Prefer deletion by THIS container's registered node id (#16565): during
+      // a blue/green overlap the old and new nodes share the hostname, and a
+      // by-name delete from a rolled-back blue would kill the LIVE old node.
+      // The by-name path remains for containers that never resolved an id
+      // (registration timeout — nothing ambiguous exists then).
+      const cleanup = meta.vpnNodeId
+        ? headscaleIntegration.removeVpnNodeById(meta.vpnNodeId)
+        : headscaleIntegration.cleanupContainerVPN(registeredNodeName);
+      await withTimeout(cleanup, HEADSCALE_CLEANUP_TIMEOUT_MS, "headscale cleanup").catch((err) => {
         logger.warn(
           `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
         );

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -42,6 +42,7 @@ import {
   requiresDockerHostGateway,
   resolveAgentContainerClass,
   resolveStewardContainerUrl,
+  resolveVpnTeardown,
   shellQuote,
   validateAgentId,
   validateAgentName,
@@ -1472,15 +1473,26 @@ export class DockerSandboxProvider implements SandboxProvider {
           );
         });
       }
-      // Deletes the Headscale pre-auth key if VPN was prepared
+      // Removes blue's Headscale node if VPN was prepared. Preserve-aware
+      // (#16565): when previousVpnNodeId is recorded, blue has NOT registered
+      // yet, so the only node under this hostname is the LIVE preserved one —
+      // a by-name cleanup here would delete it, the exact hole this feature
+      // closes. Nothing of blue's exists in Headscale at this point; its
+      // unused single-use pre-auth key is inert.
       if (headscaleEnabled) {
-        await headscaleIntegration
-          .cleanupContainerVPN(vpnEnvVars.TS_HOSTNAME ?? agentId)
-          .catch((cleanupErr) => {
-            logger.warn(
-              `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
-            );
-          });
+        if (resolveVpnTeardown({ previousVpnNodeId }).kind === "skip-preserved") {
+          logger.info(
+            `[docker-sandbox] Skipping Headscale cleanup during rollback for ${agentId}: preserved live node holds the hostname and blue never registered`,
+          );
+        } else {
+          await headscaleIntegration
+            .cleanupContainerVPN(vpnEnvVars.TS_HOSTNAME ?? agentId)
+            .catch((cleanupErr) => {
+              logger.warn(
+                `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+              );
+            });
+        }
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -1877,19 +1889,30 @@ export class DockerSandboxProvider implements SandboxProvider {
     const headscaleEnv = currentHeadscaleRouteEnv();
     const registeredNodeName = meta.tsHostname;
     if (shouldCleanupHeadscaleVpn(headscaleEnv, registeredNodeName)) {
-      // Prefer deletion by THIS container's registered node id (#16565): during
-      // a blue/green overlap the old and new nodes share the hostname, and a
-      // by-name delete from a rolled-back blue would kill the LIVE old node.
-      // The by-name path remains for containers that never resolved an id
-      // (registration timeout — nothing ambiguous exists then).
-      const cleanup = meta.vpnNodeId
-        ? headscaleIntegration.removeVpnNodeById(meta.vpnNodeId)
-        : headscaleIntegration.cleanupContainerVPN(registeredNodeName);
-      await withTimeout(cleanup, HEADSCALE_CLEANUP_TIMEOUT_MS, "headscale cleanup").catch((err) => {
-        logger.warn(
-          `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+      // One pinned decision for every teardown path (#16565): by-id when this
+      // container registered, forbidden by-name in preserve mode where the
+      // only same-name node is the LIVE preserved one, historical by-name for
+      // plain provisions.
+      const teardown = resolveVpnTeardown(meta);
+      const cleanup =
+        teardown.kind === "by-id"
+          ? headscaleIntegration.removeVpnNodeById(teardown.nodeId)
+          : teardown.kind === "by-name"
+            ? headscaleIntegration.cleanupContainerVPN(registeredNodeName)
+            : null;
+      if (cleanup) {
+        await withTimeout(cleanup, HEADSCALE_CLEANUP_TIMEOUT_MS, "headscale cleanup").catch(
+          (err) => {
+            logger.warn(
+              `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          },
         );
-      });
+      } else {
+        logger.info(
+          `[docker-sandbox] Skipping Headscale cleanup for ${meta.agentId}: preserved live node holds the hostname and this container never registered`,
+        );
+      }
     }
 
     // Remove from in-memory registry

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -1,5 +1,10 @@
 // Exercises docker sandbox utils behavior with deterministic cloud-shared lib fixtures.
-import { describe, expect, test } from "vitest";
+// bun:test, not vitest: this package runs unit lanes under bun
+// (scripts/run-bun-tests.mjs); its vitest config includes ONLY the
+// direct-wallet integration test, and the coverage-gate classifier routes
+// test files by their runner import — a vitest import here would send this
+// lane to a vitest invocation whose filter matches nothing (exit 1).
+import { describe, expect, test } from "bun:test";
 import {
   allocatePort,
   buildAgentContainerLabelArgs,

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -16,6 +16,7 @@ import {
   requiresDockerHostGateway,
   resolveAgentContainerClass,
   resolveStewardContainerUrl,
+  resolveVpnTeardown,
   shellQuote,
   validateAgentId,
   validateContainerName,
@@ -217,5 +218,30 @@ describe("agent container labels", () => {
     // Embedded single quote must be escaped, not break out of the quoting.
     expect(flags[2]).toContain(`'"'"'`);
     expect(flags[3]).toBe("--label 'ai.elizaos.container-class=test'");
+  });
+});
+
+describe("resolveVpnTeardown (#16565)", () => {
+  test("a registered id always wins — the only unambiguous deletion handle", () => {
+    expect(resolveVpnTeardown({ vpnNodeId: "blue-3", previousVpnNodeId: "old-7" })).toEqual({
+      kind: "by-id",
+      nodeId: "blue-3",
+    });
+    expect(resolveVpnTeardown({ vpnNodeId: "blue-3" })).toEqual({
+      kind: "by-id",
+      nodeId: "blue-3",
+    });
+  });
+
+  test("preserve mode with no registered id forbids by-name deletion — the same-name node is the LIVE one", () => {
+    // The review-blocking hole: container-start failure or required-registration
+    // timeout while the old node is preserved must never resolve to by-name.
+    expect(resolveVpnTeardown({ previousVpnNodeId: "old-7" })).toEqual({
+      kind: "skip-preserved",
+    });
+  });
+
+  test("plain provisions without an id keep the historical by-name cleanup", () => {
+    expect(resolveVpnTeardown({})).toEqual({ kind: "by-name" });
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -490,3 +490,25 @@ export function parseDockerNodes(): DockerNodeEnv[] {
   _cachedDockerNodesRaw = raw;
   return nodes;
 }
+
+/**
+ * Which Headscale teardown applies to a container's VPN state (#16565).
+ * During a blue/green overlap old and new nodes share the deterministic
+ * hostname, so:
+ *  - a registered id is the only safe deletion handle (`by-id`);
+ *  - preserve-mode with NO registered id means the container never joined —
+ *    the only same-name node is the LIVE preserved one, and by-name deletion
+ *    is forbidden (`skip-preserved`);
+ *  - plain provisions without an id fall back to the historical by-name
+ *    cleanup (`by-name`) — nothing ambiguous exists there.
+ * Pure so every caller (stop teardown, create-failure rollback) shares one
+ * pinned decision instead of re-deriving it.
+ */
+export function resolveVpnTeardown(state: {
+  vpnNodeId?: string;
+  previousVpnNodeId?: string;
+}): { kind: "by-id"; nodeId: string } | { kind: "by-name" } | { kind: "skip-preserved" } {
+  if (state.vpnNodeId) return { kind: "by-id", nodeId: state.vpnNodeId };
+  if (state.previousVpnNodeId) return { kind: "skip-preserved" };
+  return { kind: "by-name" };
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3991,7 +3991,7 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   }
 
   // A genuine DockerSandboxMetadata for blue — isDockerSandboxMetadata() passes.
-  function blueMetadata(imageDigest: string | null) {
+  function blueMetadata(imageDigest: string | null, previousVpnNodeId?: string) {
     return {
       provider: "docker" as const,
       nodeId: "node-new",
@@ -4003,15 +4003,16 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       volumePath: "/var/lib/eliza/agent-new-1",
       dockerImage: DOCKER_IMAGE,
       imageDigest,
+      ...(previousVpnNodeId ? { previousVpnNodeId } : {}),
     };
   }
 
-  function blueHandle(imageDigest: string | null) {
+  function blueHandle(imageDigest: string | null, previousVpnNodeId?: string) {
     return {
       sandboxId: "sandbox-new-1",
       bridgeUrl: "https://new-bridge.example",
       healthUrl: "https://new-bridge.example/health",
-      metadata: blueMetadata(imageDigest),
+      metadata: blueMetadata(imageDigest, previousVpnNodeId),
     };
   }
 
@@ -4256,6 +4257,107 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       lockSpy.mockRestore();
       readSpy.mockRestore();
       snapshotSpy.mockRestore();
+    }
+  });
+
+  test("(h1) preserved live VPN node: create gets reclaimStaleVpnNode=false, node deleted BY ID only after the swap (#16565)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const { headscaleIntegration } = await import("./headscale-integration");
+    const agent = liveAgentRow();
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const { provider, create, stopOnSpecificNode } = await makeDockerProvider({
+      create: async () => blueHandle(TO_DIGEST, "old-live-node-7"),
+      checkHealth: async () => true,
+    });
+    const svc = new ElizaSandboxService(provider);
+    const lockSpy = spyOn(
+      svc as unknown as { lockLifecycle: (...a: unknown[]) => Promise<void> },
+      "lockLifecycle",
+    ).mockResolvedValue(undefined);
+    const readSpy = spyOn(
+      svc as unknown as {
+        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+      },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue(agent);
+    const snapshotSpy = spyOn(
+      svc as unknown as {
+        snapshot: (...a: unknown[]) => Promise<{ success: boolean }>;
+      },
+      "snapshot",
+    ).mockResolvedValue({ success: true });
+    // Event order: the old node's by-id deletion must come AFTER the swap
+    // commit AND after old-container teardown started — never before.
+    const events: string[] = [];
+    const removeSpy = spyOn(headscaleIntegration, "removeVpnNodeById").mockImplementation(
+      async (id: string) => {
+        events.push(`vpn-delete:${id}`);
+      },
+    );
+    stopOnSpecificNode.mockImplementation(async () => {
+      events.push("old-teardown");
+    });
+    upgradeTransactionImpl = async (fn) => {
+      const tx: UpgradeTx = {
+        execute: async () => {
+          events.push("swap-commit");
+          return { rows: [{ id: AGENT }] };
+        },
+      };
+      return fn(tx);
+    };
+    try {
+      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      expect(res.success).toBe(true);
+      // Blue was provisioned in preserve mode.
+      const createConfig = create.mock.calls[0]?.[0] as
+        | { reclaimStaleVpnNode?: boolean }
+        | undefined;
+      expect(createConfig?.reclaimStaleVpnNode).toBe(false);
+      // The preserved node was deleted exactly once, by id, after the swap.
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith("old-live-node-7");
+      expect(events).toEqual(["swap-commit", "old-teardown", "vpn-delete:old-live-node-7"]);
+    } finally {
+      findSpy.mockRestore();
+      nodeSpy.mockRestore();
+      lockSpy.mockRestore();
+      readSpy.mockRestore();
+      snapshotSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  test("(h2) rolled-back upgrade never deletes the preserved live node (#16565)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const { headscaleIntegration } = await import("./headscale-integration");
+    const agent = liveAgentRow();
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const { provider, stop } = await makeDockerProvider({
+      create: async () => blueHandle(TO_DIGEST, "old-live-node-7"),
+      checkHealth: async () => false, // blue never comes up → rollback
+    });
+    const removeSpy = spyOn(headscaleIntegration, "removeVpnNodeById").mockResolvedValue(undefined);
+    try {
+      const res = await new ElizaSandboxService(provider).executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
+      expect(res.success).toBe(false);
+      expect(res.rolledBack).toBe(true);
+      // Blue is torn down; the preserved live node is left untouched — the
+      // agent keeps serving on old.
+      expect(stop).toHaveBeenCalledWith("sandbox-new-1");
+      expect(removeSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      nodeSpy.mockRestore();
+      removeSpy.mockRestore();
     }
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -71,6 +71,7 @@ import {
   elizaCodingContainerImageAdvisoryLockSql,
   elizaProvisionAdvisoryLockSql,
 } from "./eliza-provision-lock";
+import { headscaleIntegration } from "./headscale-integration";
 import { applyManagedAgentInferenceEnvDefaults } from "./managed-eliza-config";
 import { prepareManagedElizaEnvironment } from "./managed-eliza-env";
 import { JOB_TYPES } from "./provisioning-job-types";
@@ -5674,6 +5675,10 @@ export class ElizaSandboxService {
       },
       dockerImage: digestPinnedImageRef(dockerImage, toDigest),
       excludeNodeId: oldNodeId,
+      // Preserve the LIVE Headscale node during the overlap (#16565): the
+      // provider records its id as metadata.previousVpnNodeId; it is deleted
+      // by id below only after the atomic swap succeeds.
+      reclaimStaleVpnNode: false,
     };
 
     let blueHandle: Awaited<ReturnType<typeof provider.create>>;
@@ -5867,6 +5872,13 @@ export class ElizaSandboxService {
 
     // Old container teardown is best-effort: traffic is already on blue.
     await provider.stopOnSpecificNode(oldNode, oldContainerName, 30);
+    // The preserved live node (recorded pre-provision under
+    // reclaimStaleVpnNode=false) is deleted BY ID only now, after the swap —
+    // by-name would be ambiguous with blue sharing the hostname, and every
+    // rolled-back path above deliberately leaves it untouched (#16565).
+    if (blueMeta?.previousVpnNodeId) {
+      await headscaleIntegration.removeVpnNodeById(blueMeta.previousVpnNodeId);
+    }
 
     logger.info("[agent-sandbox] Fleet upgrade completed", {
       agentId,
@@ -5998,6 +6010,10 @@ export class ElizaSandboxService {
       },
       dockerImage: digestPinnedImageRef(rollbackImage, toDigest),
       excludeNodeId: oldNodeId,
+      // Preserve the LIVE Headscale node during the overlap (#16565): the
+      // provider records its id as metadata.previousVpnNodeId; it is deleted
+      // by id below only after the atomic swap succeeds.
+      reclaimStaleVpnNode: false,
     };
 
     let blueHandle: Awaited<ReturnType<typeof provider.create>>;
@@ -6192,6 +6208,10 @@ export class ElizaSandboxService {
 
     // Old (post-upgrade) container teardown is best-effort: traffic is on blue.
     await provider.stopOnSpecificNode(oldNode, oldContainerName, 30);
+    // Same post-cutover, by-id-only deletion of the preserved node (#16565).
+    if (blueMeta?.previousVpnNodeId) {
+      await headscaleIntegration.removeVpnNodeById(blueMeta.previousVpnNodeId);
+    }
 
     logger.info("[agent-sandbox] Fleet rollback completed", {
       agentId,

--- a/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
@@ -127,6 +127,34 @@ describe("Headscale container credentials", () => {
 
     expect(calls).toEqual(["lookup:eliza-11111111-111", "delete:stale-node-70", "create-key"]);
   });
+
+  test("reclaimStaleNode=false records the live node instead of deleting it (#16565)", async () => {
+    // Blue/green: the same-name node is the LIVE serving one — deleting it
+    // pre-provision cuts the agent's mesh route mid-upgrade.
+    const calls: string[] = [];
+    const fake = {
+      getNodeByNameStrict: async (name: string) => {
+        calls.push(`lookup:${name}`);
+        return { id: "live-node-4", name, ipAddresses: ["100.64.0.56"] };
+      },
+      deleteNode: async (id: string) => {
+        calls.push(`delete:${id}`);
+      },
+      createPreAuthKey: async () => {
+        calls.push("create-key");
+        return { key: "blue-key" };
+      },
+    } as unknown as HeadscaleClient;
+
+    const prepared = await new HeadscaleIntegration(fake).prepareContainerVPN({
+      agentId: "11111111-1111-4111-8111-111111111111",
+      agentName: "Eliza",
+      reclaimStaleNode: false,
+    });
+
+    expect(calls).toEqual(["lookup:eliza-11111111-111", "create-key"]);
+    expect(prepared.previousNodeId).toBe("live-node-4");
+  });
 });
 
 describe("Headscale node lookup is keyed on the node name (not the agentId)", () => {
@@ -148,9 +176,13 @@ describe("Headscale node lookup is keyed on the node name (not the agentId)", ()
       },
     } as unknown as HeadscaleClient;
 
-    const ip = await new HeadscaleIntegration(fake).waitForVPNRegistration(nodeName, 1_000);
+    const registration = await new HeadscaleIntegration(fake).waitForVPNRegistration(
+      nodeName,
+      1_000,
+    );
 
-    expect(ip).toBe("100.64.0.7");
+    expect(registration?.ip).toBe("100.64.0.7");
+    expect(registration?.nodeId).toBe("node-1");
     expect(lookups).toEqual([nodeName]);
     expect(nodeName).not.toBe("11111111-1111-4111-8111-111111111111");
   });
@@ -159,7 +191,7 @@ describe("Headscale node lookup is keyed on the node name (not the agentId)", ()
     const lookups: string[] = [];
     let deletedId: string | null = null;
     const fake = {
-      getNodeByName: async (name: string) => {
+      getNodeByNameStrict: async (name: string) => {
         lookups.push(name);
         return { id: "node-9", name, ipAddresses: ["100.64.0.7"] };
       },
@@ -172,6 +204,70 @@ describe("Headscale node lookup is keyed on the node name (not the agentId)", ()
 
     expect(lookups).toEqual([nodeName]);
     expect(deletedId).toBe("node-9");
+  });
+
+  test("waitForVPNRegistration skips the excluded live node until its replacement appears (#16565)", async () => {
+    // During the blue/green overlap old + new nodes share the hostname; the
+    // preserved live node's id must never satisfy the registration wait.
+    let polls = 0;
+    const fake = {
+      getNodeByName: async (name: string) => {
+        polls += 1;
+        return polls < 3
+          ? { id: "old-live-node", name, ipAddresses: ["100.64.0.7"] }
+          : { id: "blue-node", name, ipAddresses: ["100.64.0.8"] };
+      },
+    } as unknown as HeadscaleClient;
+
+    const registration = await new HeadscaleIntegration(fake).waitForVPNRegistration(
+      nodeName,
+      5_000,
+      { excludeNodeId: "old-live-node" },
+    );
+
+    expect(registration?.nodeId).toBe("blue-node");
+    expect(registration?.ip).toBe("100.64.0.8");
+    expect(polls).toBeGreaterThanOrEqual(3);
+  });
+
+  test("cleanupContainerVPN surfaces an API failure instead of reading it as nothing-to-clean-up (#16565)", async () => {
+    // The lossy lookup swallowed API errors into null → "nothing to clean up"
+    // → silently leaked persistent node. Strict lookup lands in the warn path;
+    // still non-blocking for container deletion.
+    let deleteCalled = false;
+    const fake = {
+      getNodeByNameStrict: async () => {
+        throw new Error("headscale API 502");
+      },
+      deleteNode: async () => {
+        deleteCalled = true;
+      },
+    } as unknown as HeadscaleClient;
+
+    await expect(
+      new HeadscaleIntegration(fake).cleanupContainerVPN(nodeName),
+    ).resolves.toBeUndefined();
+    expect(deleteCalled).toBe(false);
+  });
+
+  test("removeVpnNodeById deletes by id and never throws on failure (#16565)", async () => {
+    const deleted: string[] = [];
+    const ok = {
+      deleteNode: async (id: string) => {
+        deleted.push(id);
+      },
+    } as unknown as HeadscaleClient;
+    await new HeadscaleIntegration(ok).removeVpnNodeById("node-42");
+    expect(deleted).toEqual(["node-42"]);
+
+    const failing = {
+      deleteNode: async () => {
+        throw new Error("headscale down");
+      },
+    } as unknown as HeadscaleClient;
+    await expect(
+      new HeadscaleIntegration(failing).removeVpnNodeById("node-43"),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.ts
@@ -51,6 +51,17 @@ export interface PrepareContainerVPNInput {
   agentName?: string;
   organizationId?: string;
   userId?: string;
+  /**
+   * When false, an existing node under the deterministic hostname is RECORDED
+   * (returned as `previousNodeId`) instead of deleted (#16565). Blue/green
+   * upgrade/downgrade set this: the "stale" registration is the LIVE serving
+   * node until the atomic swap commits, and deleting it pre-provision cuts
+   * the agent's mesh route mid-upgrade (its single-use auth key then leaves
+   * the evicted container in a permanent restart loop). Default true — the
+   * plain reprovision path keeps today's reclaim behavior, which guards
+   * `waitForVPNRegistration` from accepting the stale node's IP.
+   */
+  reclaimStaleNode?: boolean;
 }
 
 export class HeadscaleIntegration {
@@ -81,6 +92,10 @@ export class HeadscaleIntegration {
   async prepareContainerVPN(input: PrepareContainerVPNInput): Promise<{
     preAuthKey: string;
     envVars: Record<string, string>;
+    /** The pre-existing node's id when `reclaimStaleNode` is false (#16565):
+     *  the caller excludes it from registration matching and deletes it BY ID
+     *  only after its replacement has taken over. */
+    previousNodeId?: string;
   }> {
     const { agentId } = input;
     logger.info(`[headscale-integration] preparing VPN for agent ${agentId}`);
@@ -94,12 +109,22 @@ export class HeadscaleIntegration {
       // key, otherwise waitForVPNRegistration() could accept the old node's IP
       // before the replacement has joined. Fail closed on lookup/deletion
       // errors so we never route a new sandbox to a stale container.
+      // Blue/green callers pass reclaimStaleNode=false: the same-name node is
+      // the LIVE one, so it is recorded for post-cutover deletion instead.
+      let previousNodeId: string | undefined;
       const existingNode = await this.client.getNodeByNameStrict(tsHostname);
       if (existingNode) {
-        await this.client.deleteNode(existingNode.id);
-        logger.info(
-          `[headscale-integration] removed stale VPN node ${existingNode.id} before reprovisioning ${agentId}`,
-        );
+        if (input.reclaimStaleNode === false) {
+          previousNodeId = existingNode.id;
+          logger.info(
+            `[headscale-integration] preserving live VPN node ${existingNode.id} during blue/green provision for ${agentId}`,
+          );
+        } else {
+          await this.client.deleteNode(existingNode.id);
+          logger.info(
+            `[headscale-integration] removed stale VPN node ${existingNode.id} before reprovisioning ${agentId}`,
+          );
+        }
       }
 
       const preAuthKeyObj = await this.client.createPreAuthKey({
@@ -120,7 +145,11 @@ export class HeadscaleIntegration {
 
       logger.info(`[headscale-integration] VPN prepared for agent ${agentId}`);
 
-      return { preAuthKey: preAuthKeyObj.key, envVars };
+      return {
+        preAuthKey: preAuthKeyObj.key,
+        envVars,
+        ...(previousNodeId ? { previousNodeId } : {}),
+      };
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       logger.error(`[headscale-integration] failed to prepare VPN for ${agentId}:`, msg);
@@ -143,7 +172,14 @@ export class HeadscaleIntegration {
   async waitForVPNRegistration(
     nodeName: string,
     timeoutMs: number = DEFAULT_REGISTRATION_TIMEOUT_MS,
-  ): Promise<string | null> {
+    options?: {
+      /** Ignore this node id when matching by name (#16565): during a
+       *  blue/green overlap the preserved LIVE node shares the hostname, and
+       *  accepting its IP would route the new sandbox to the old container —
+       *  the exact race the reclaim-mode deletion used to guard against. */
+      excludeNodeId?: string;
+    },
+  ): Promise<{ ip: string; nodeId: string } | null> {
     logger.info(
       `[headscale-integration] waiting for VPN registration: ${nodeName} (timeout ${timeoutMs}ms)`,
     );
@@ -155,10 +191,10 @@ export class HeadscaleIntegration {
       try {
         const node = await this.client.getNodeByName(nodeName);
 
-        if (node && node.ipAddresses.length > 0) {
+        if (node && node.ipAddresses.length > 0 && node.id !== options?.excludeNodeId) {
           const ip = node.ipAddresses[0];
           logger.info(`[headscale-integration] VPN registered for ${nodeName}: ${ip}`);
-          return ip;
+          return { ip, nodeId: node.id };
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -196,7 +232,10 @@ export class HeadscaleIntegration {
     logger.info(`[headscale-integration] cleaning up VPN node for ${nodeName}`);
 
     try {
-      const node = await this.client.getNodeByName(nodeName);
+      // Strict lookup (#16565): the lossy variant swallows API errors into
+      // "no node", silently leaking a persistent node. Failures now land in
+      // the catch below — logged, still non-blocking for container deletion.
+      const node = await this.client.getNodeByNameStrict(nodeName);
 
       if (!node) {
         logger.info(
@@ -211,6 +250,23 @@ export class HeadscaleIntegration {
       const msg = error instanceof Error ? error.message : String(error);
       logger.warn(`[headscale-integration] error cleaning up VPN for ${nodeName}:`, msg);
       // Do not rethrow because Headscale deletion failures should not block container deletion
+    }
+  }
+
+  /**
+   * Delete a VPN node by its Headscale id — the only safe identifier during a
+   * blue/green overlap, where old and new nodes share the deterministic
+   * hostname (#16565). Best-effort like {@link cleanupContainerVPN}: a
+   * deletion failure must not block the container lifecycle, and an
+   * already-gone node (404) counts as success in the client.
+   */
+  async removeVpnNodeById(nodeId: string): Promise<void> {
+    try {
+      await this.client.deleteNode(nodeId);
+      logger.info(`[headscale-integration] VPN node ${nodeId} removed by id`);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.warn(`[headscale-integration] error removing VPN node ${nodeId}:`, msg);
     }
   }
 

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -85,4 +85,14 @@ export interface SandboxCreateConfig {
    * Used for retry-on-failure to avoid re-selecting a node that just failed.
    */
   excludeNodeId?: string;
+  /**
+   * When false, an existing Headscale node under the agent's deterministic
+   * hostname is preserved and recorded instead of deleted pre-provision
+   * (#16565). Blue/green upgrade/downgrade set this: the "stale" node is the
+   * LIVE serving one until the atomic swap commits. The orchestrator deletes
+   * it by the recorded id (`metadata.previousVpnNodeId`) after cutover;
+   * rolled-back paths leave it untouched. Default true (plain reprovision
+   * keeps today's reclaim).
+   */
+  reclaimStaleVpnNode?: boolean;
 }

--- a/scripts/security/coverage-lcov-excluded.txt
+++ b/scripts/security/coverage-lcov-excluded.txt
@@ -16,3 +16,8 @@
 # absent until the Rolldown issue is fixed.
 packages/agent/src/api/server.ts
 packages/agent/src/runtime/eliza.ts
+
+# Interface/type-only module: zero executable statements, so neither bun nor
+# vitest emits an LCOV record for it (#16565 touched its SandboxCreateConfig
+# doc surface). Delete this entry if the file ever gains runtime code.
+packages/cloud/shared/src/lib/services/sandbox-provider-types.ts


### PR DESCRIPTION
# Relates to

Fixes #16565

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Medium — this touches the fleet-upgrade path, mitigated three ways: (1) plain provision is byte-identical in behavior (`reclaimStaleNode` defaults true; the reclaim deletion, its logging, and the registration wait are unchanged for every existing caller); (2) blue/green now does strictly LESS destructive work before the swap and the post-swap deletion is by captured ID only; (3) the event-order invariants are pinned in the LARP-H3 harness (`swap-commit → old-teardown → vpn-delete`, and rollback deletes nothing). The full causal map (verified file:line) is on #16565.

# Background

## What does this PR do?

Implements option A from the map posted on #16565. The #16548 pre-provision stale-node deletion deletes whatever holds the agent's deterministic hostname — but during `executeUpgrade`/`executeDowngrade` that node is the LIVE serving one: mesh route cut mid-upgrade, evicted container wedged on its single-use auth key, mandatory pre-upgrade snapshot riding the destroyed route, and every `rolledBack` path violating its own "old container still serving" invariant. The deletion is simultaneously load-bearing on plain reprovision (it guards `waitForVPNRegistration` from accepting the stale node's IP) — so the fix discriminates callers instead of removing it:

- **`reclaimStaleNode` caller intent** — blue/green passes false: the existing node is RECORDED (`previousNodeId`) instead of deleted; plain provision keeps today's reclaim.
- **Registration exclusion** — `waitForVPNRegistration` gains `excludeNodeId` and returns `{ip, nodeId}`: the preserved live node can never satisfy blue's wait (the exact race the reclaim deletion guarded).
- **Teardown by ID** — the provider records blue's registered node id; `stop()` deletes by id when known, because a by-name delete from a rolled-back blue would kill the live old node while both share the hostname.
- **Post-cutover only** — upgrade/downgrade delete the preserved node BY ID strictly after the atomic swap + old-container teardown; rolled-back paths leave it untouched.
- **Leak fix (acceptance criterion 2)** — `cleanupContainerVPN` uses the strict lookup so a Headscale API failure surfaces as the warn instead of silently reading as "nothing to clean up".

Option B (per-generation hostnames) remains the architectural follow-up on the issue — it needs a shared-DB schema call.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`headscale-integration.test.ts` — the #16548 delete-order lane still passes untouched (reclaim mode), and its inversion pins record-don't-delete; then the two LARP-H3 invariants in `eliza-sandbox.test.ts`: **(h1)** happy path asserts `create` received `reclaimStaleVpnNode: false` and the event order `swap-commit → old-teardown → vpn-delete:<id>`; **(h2)** a rolled-back upgrade tears down blue and never calls the by-id delete.

## Detailed testing steps

None: Automated tests are acceptable.

```
headscale-integration.test.ts   18/18  (headscale-integration.ts 90.9% lines)
eliza-sandbox.test.ts          104/104 (eliza-sandbox.ts 50.1%)
docker-sandbox-provider composite lane: 85 tests
  (docker-sandbox-provider.ts 56.2% from the composed union)
sandbox-provider-types.ts: interface-only → LCOV-excluded manifest entry with reason
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - fleet-infrastructure lifecycle fix, no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - fleet-infrastructure lifecycle fix, no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; the upgrade lifecycle is pinned by the LARP-H3 event-order invariants described above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - reproducing requires a live blue/green fleet upgrade against a real Headscale; the deterministic reproduction of the exact incident ordering lives in the changed test lanes (122 tests + 85-test composite).`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; container/VPN lifecycle only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the verified causal map and per-claim file:line evidence: https://github.com/elizaOS/eliza/issues/16565#issuecomment-5009745458

# Evidence Details

The full verified chain (including the compounding rollback defect and why naive fixes fail) is the map comment on #16565. Every behavioral claim in this PR corresponds to a pinned test: record-vs-delete, exclusion wait, strict cleanup surfacing API failures, by-id removal, both event-order invariants.

## Known gaps / failures

Headscale can hold two same-name nodes during the overlap; remaining by-name helpers (`getNodeIP`, `getContainerVPNIP`) are first-match until option B (per-generation hostnames) lands — flagged on the issue as the follow-up. The overlap window is short (provision → swap) and blue's own operations use ids from this PR onward.

[stan-cloud]
