### PR TITLE
fix(orchestrator): harden ACP runtime startup

### DIFF
--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -348,5 +348,3 @@ const _connection = new AgentSideConnection(
   }),
   stream,
 );
-
-log("ACP server listening on stdio");

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -124,6 +124,7 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
 import {
   AcpService,
   ensureWorkspaceElizaCodeAcp,
+  normalizeClaudeAcpModelId,
 } from "../../src/services/acp-service.js";
 import { InMemorySessionStore } from "../../src/services/session-store.js";
 
@@ -434,6 +435,70 @@ describe("AcpService", () => {
     const env = spawnMock.mock.calls[0]?.[2]?.env as
       Record<string, string> | undefined;
     expect(env?.PARALLAX_SESSION_ID).toBe(result.sessionId);
+  });
+
+  it("normalizes Claude ACP model context suffixes on explicit spawn models", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CLAUDE_ACP_COMMAND: "claude-agent-acp --stdio",
+      }),
+    );
+    await service.start();
+
+    const result = await service.spawnSession({
+      name: "claude-normalized-model",
+      agentType: "claude",
+      model: "claude-opus-4-8[1m]",
+      workdir: "/tmp/acp-test",
+    });
+
+    const session = await service.getSession(result.sessionId);
+    expect(normalizeClaudeAcpModelId(" claude-sonnet-5[200k][1m] ")).toBe(
+      "claude-sonnet-5",
+    );
+    expect(nativeClientMock.instances[0]?.opts.env?.ANTHROPIC_MODEL).toBe(
+      "claude-opus-4-8",
+    );
+    expect(nativeClientMock.instances[0]?.opts.env?.OPENAI_MODEL).toBe(
+      "claude-opus-4-8",
+    );
+    expect(session?.metadata?.spawnModel).toBe("claude-opus-4-8");
+    await service.stop();
+  });
+
+  it("normalizes Claude ACP model context suffixes inherited from config env", async () => {
+    const previous = snapshotEnv([
+      "ELIZA_CLAUDE_MODEL_POWERFUL",
+      "ELIZA_CONFIG_PATH",
+    ]);
+    process.env.ELIZA_CLAUDE_MODEL_POWERFUL = "claude-opus-4-8[1m]";
+    process.env.ELIZA_CONFIG_PATH = join(
+      tmpdir(),
+      "acp-claude-model-config-does-not-exist.json",
+    );
+    try {
+      const service = new AcpService(
+        runtime({
+          ELIZA_ACP_TRANSPORT: "native",
+          ELIZA_CLAUDE_ACP_COMMAND: "claude-agent-acp --stdio",
+        }),
+      );
+      await service.start();
+
+      await service.spawnSession({
+        name: "claude-config-normalized-model",
+        agentType: "claude",
+        workdir: "/tmp/acp-test",
+      });
+
+      expect(nativeClientMock.instances[0]?.opts.env?.ANTHROPIC_MODEL).toBe(
+        "claude-opus-4-8",
+      );
+      await service.stop();
+    } finally {
+      restoreEnv(previous);
+    }
   });
 
   it("pins configured coding git identity over inherited GIT env on CLI spawns", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -23,6 +23,7 @@ const ENV_KEYS = [
   "CLAUDE_CODE_API_KEY",
   "CODEX_API_KEY",
   "ELIZA_AGENT_SELECTION_STRATEGY",
+  "ELIZA_CODEX_ACP_COMMAND",
   "ELIZA_CONFIG_PATH",
   "ELIZA_DEFAULT_AGENT_TYPE",
   "ELIZA_ELIZAOS_ACP_COMMAND",
@@ -81,6 +82,11 @@ function setEnv(values: Record<string, string | undefined>) {
   }
 }
 
+function writeExecutable(filePath: string) {
+  fs.writeFileSync(filePath, "#!/bin/sh\nexit 0\n");
+  fs.chmodSync(filePath, 0o755);
+}
+
 describe("getTaskAgentFrameworkState", () => {
   beforeEach(() => {
     for (const key of ENV_KEYS) {
@@ -130,6 +136,7 @@ describe("getTaskAgentFrameworkState", () => {
     // candidate. It shares OpenCode's BYO provider thumb (no Claude/Codex key is
     // set), and its dominant capability-profile fit makes it the default over
     // OpenCode — which stays the fallback for hosts without eliza-code.
+    writeExecutable(path.join(tempHome, "eliza-code-acp"));
     setEnv({
       ELIZA_ELIZAOS_ACP_COMMAND: "eliza-code-acp",
       BENCHMARK_MODEL_PROVIDER: "cerebras",
@@ -208,6 +215,53 @@ describe("getTaskAgentFrameworkState", () => {
     expect(
       state.frameworks.find((item) => item.id === "codex")?.authReady,
     ).toBe(true);
+  });
+
+  it("fails Codex readiness closed when a configured ACP command is missing", async () => {
+    writeExecutable(path.join(tempHome, "codex"));
+    setEnv({
+      CODEX_API_KEY: "codex-test",
+      ELIZA_CODEX_ACP_COMMAND: "missing-codex-acp --stdio",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime());
+
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(false);
+  });
+
+  it("accepts a configured Codex ACP shell command when the leading executable exists", async () => {
+    writeExecutable(path.join(tempHome, "codex-acp"));
+    setEnv({
+      CODEX_API_KEY: "codex-test",
+      ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio --flag value",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime());
+
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(true);
+  });
+
+  it("validates configured ElizaOS ACP absolute commands instead of trusting the env var", async () => {
+    const commandPath = path.join(tempHome, "eliza-code-acp");
+    writeExecutable(commandPath);
+
+    setEnv({ ELIZA_ELIZAOS_ACP_COMMAND: `"${commandPath}" --stdio` });
+    const installedState = await getTaskAgentFrameworkState(runtime());
+    expect(
+      installedState.frameworks.find((item) => item.id === "elizaos")
+        ?.installed,
+    ).toBe(true);
+
+    clearTaskAgentFrameworkStateCache();
+    setEnv({ ELIZA_ELIZAOS_ACP_COMMAND: `${commandPath}-missing --stdio` });
+    const missingState = await getTaskAgentFrameworkState(runtime());
+    expect(
+      missingState.frameworks.find((item) => item.id === "elizaos")?.installed,
+    ).toBe(false);
   });
 
   it("prefers Claude when a Claude-specific key is present", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -231,6 +231,22 @@ describe("getTaskAgentFrameworkState", () => {
     ).toBe(false);
   });
 
+  it("rejects a configured Codex ACP command when the file is not executable", async () => {
+    const commandPath = path.join(tempHome, "codex-acp");
+    fs.writeFileSync(commandPath, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(commandPath, 0o644);
+    setEnv({
+      CODEX_API_KEY: "codex-test",
+      ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime());
+
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(false);
+  });
+
   it("accepts a configured Codex ACP shell command when the leading executable exists", async () => {
     writeExecutable(path.join(tempHome, "codex-acp"));
     setEnv({

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -342,6 +342,16 @@ function findExecutableOnPath(name: string): string | undefined {
   return undefined;
 }
 
+export function normalizeClaudeAcpModelId(
+  model: string | undefined,
+): string | undefined {
+  const normalized = model
+    ?.trim()
+    .replace(/(?:\s*\[[0-9]+[a-zA-Z]+\])+$/u, "")
+    .trim();
+  return normalized || undefined;
+}
+
 /**
  * Provision the workspace-native ACP executable on first use, crash-safely.
  * Development and self-hosted checkouts deliberately do not require a global
@@ -1666,6 +1676,10 @@ export class AcpService extends Service {
         ...(opts.env ?? {}),
         ...(gitIndexIsolation?.env ?? {}),
       };
+      const spawnModel =
+        agentType === "claude"
+          ? normalizeClaudeAcpModelId(opts.model)
+          : opts.model;
 
       // Multi-account selection: pick the least-used (default) linked subscription
       // for this agent type and inject its credentials into the spawn env so the
@@ -1677,7 +1691,7 @@ export class AcpService extends Service {
       const resolvedAccount = await selectCodingAccount(agentType, {
         sessionKey: id,
         ...(accountStrategy ? { strategy: accountStrategy } : {}),
-        ...(opts.model ? { model: opts.model } : {}),
+        ...(spawnModel ? { model: spawnModel } : {}),
       });
       const customCredentials = resolvedAccount
         ? {
@@ -1728,7 +1742,7 @@ export class AcpService extends Service {
           : {}),
         ...(gitIndexIsolation?.metadata ?? {}),
         ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
-        ...(opts.model ? { [ACP_METADATA_SPAWN_MODEL]: opts.model } : {}),
+        ...(spawnModel ? { [ACP_METADATA_SPAWN_MODEL]: spawnModel } : {}),
         transportMode: this.transportMode,
         slotClass,
       };
@@ -1773,6 +1787,7 @@ export class AcpService extends Service {
       if (this.transportMode === "native") {
         const result = await this.spawnNativeSession(id, session, {
           ...opts,
+          model: spawnModel,
           env: sessionEnv,
           customCredentials,
         });
@@ -1782,7 +1797,7 @@ export class AcpService extends Service {
               ?.keepAliveAfterComplete === true;
           void this.sendPrompt(id, initialTask ?? "", {
             timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
-            model: opts.model,
+            model: spawnModel,
           })
             .catch((err: unknown) => {
               // error-policy:J5 fire-and-forget initial prompt; the underlying
@@ -1807,7 +1822,7 @@ export class AcpService extends Service {
         workdir,
         approvalPreset,
         timeoutMs: opts.timeoutMs,
-        model: opts.model,
+        model: spawnModel,
       });
       args.push(
         ...this.agentCommandArgs(agentType, [
@@ -1826,7 +1841,7 @@ export class AcpService extends Service {
         env: this.buildEnv(
           sessionEnv,
           customCredentials,
-          opts.model,
+          spawnModel,
           agentType,
           id,
         ),
@@ -1862,7 +1877,7 @@ export class AcpService extends Service {
             ?.keepAliveAfterComplete === true;
         void this.sendPrompt(id, initialTask ?? "", {
           timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
-          model: opts.model,
+          model: spawnModel,
         })
           .catch((err: unknown) => {
             // error-policy:J5 fire-and-forget initial prompt; the underlying
@@ -1992,6 +2007,10 @@ export class AcpService extends Service {
       }
     }
     const startedAt = Date.now();
+    const promptModel =
+      session.agentType === "claude"
+        ? normalizeClaudeAcpModelId(opts.model)
+        : opts.model;
     if (transportMode === "native") {
       if (this.nativePromptSessionIds.has(sessionId)) {
         throw new Error(`ACP session is already busy: ${sessionId}`);
@@ -2006,7 +2025,12 @@ export class AcpService extends Service {
       this.turnOutputBuffers.set(sessionId, []);
       try {
         await this.store.updateStatus(sessionId, "busy");
-        return await this.sendNativePrompt(session, text, opts, startedAt);
+        return await this.sendNativePrompt(
+          session,
+          text,
+          { ...opts, model: promptModel },
+          startedAt,
+        );
       } catch (err) {
         // error-policy:J2 release the synchronous busy-claim on the pre-prompt
         // error path, then propagate the original error unchanged.
@@ -2020,7 +2044,7 @@ export class AcpService extends Service {
       workdir: session.workdir,
       approvalPreset: session.approvalPreset,
       timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
-      model: opts.model,
+      model: promptModel,
     });
     args.push(
       ...this.agentCommandArgs(session.agentType, [
@@ -2050,7 +2074,7 @@ export class AcpService extends Service {
       env: this.buildEnv(
         promptEnv,
         promptCredentials,
-        opts.model,
+        promptModel,
         session.agentType,
         sessionId,
       ),
@@ -4008,8 +4032,12 @@ export class AcpService extends Service {
       if (typeof value === "string") env[canonicalForwardedEnvKey(key)] = value;
     }
     if (model) {
-      env.OPENAI_MODEL = model;
-      if (agentType === "claude") env.ANTHROPIC_MODEL = model;
+      const normalizedModel =
+        agentType === "claude" ? normalizeClaudeAcpModelId(model) : model;
+      if (normalizedModel) env.OPENAI_MODEL = normalizedModel;
+      if (agentType === "claude" && normalizedModel) {
+        env.ANTHROPIC_MODEL = normalizedModel;
+      }
       if (agentType === "opencode") env.OPENCODE_MODEL = model;
     } else if (agentType === "claude") {
       // No per-spawn model: fall back to the app-configured claude coding
@@ -4019,7 +4047,8 @@ export class AcpService extends Service {
       const configured = readConfigEnvKey(
         "ELIZA_CLAUDE_MODEL_POWERFUL",
       )?.trim();
-      if (configured) env.ANTHROPIC_MODEL = configured;
+      const normalizedConfigured = normalizeClaudeAcpModelId(configured);
+      if (normalizedConfigured) env.ANTHROPIC_MODEL = normalizedConfigured;
     }
     if (childSessionId?.trim()) {
       env.PARALLAX_SESSION_ID = childSessionId.trim();

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -602,17 +602,27 @@ function isOpencodeLocalMode(): boolean {
   return flag === "1" || flag?.toLowerCase() === "true";
 }
 
+function isExecutableFile(candidate: string): boolean {
+  try {
+    if (!fs.statSync(candidate).isFile()) return false;
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function hasBinaryOnPath(binaryName: string): boolean {
   for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
     if (!dir) continue;
     const candidate = path.join(dir, binaryName);
-    if (fs.existsSync(candidate)) return true;
+    if (isExecutableFile(candidate)) return true;
     if (process.platform === "win32") {
       for (const ext of (process.env.PATHEXT ?? ".EXE;.CMD;.BAT")
         .split(";")
         .filter(Boolean)) {
-        if (fs.existsSync(`${candidate}${ext.toLowerCase()}`)) return true;
-        if (fs.existsSync(`${candidate}${ext.toUpperCase()}`)) return true;
+        if (isExecutableFile(`${candidate}${ext.toLowerCase()}`)) return true;
+        if (isExecutableFile(`${candidate}${ext.toUpperCase()}`)) return true;
       }
     }
   }
@@ -627,9 +637,9 @@ function leadingCommandToken(command: string): string | undefined {
 function isCommandExecutableAvailable(command: string | undefined): boolean {
   const executable = leadingCommandToken(command?.trim() ?? "");
   if (!executable) return false;
-  if (path.isAbsolute(executable)) return fs.existsSync(executable);
+  if (path.isAbsolute(executable)) return isExecutableFile(executable);
   if (executable.includes("/") || executable.includes("\\")) {
-    return fs.existsSync(resolveUserPath(executable));
+    return isExecutableFile(resolveUserPath(executable));
   }
   return hasBinaryOnPath(executable);
 }

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -603,29 +603,45 @@ function isOpencodeLocalMode(): boolean {
 }
 
 function hasBinaryOnPath(binaryName: string): boolean {
-  const command = process.platform === "win32" ? "where" : "which";
-  const args = [binaryName];
-  try {
-    execFileSync(command, args, {
-      encoding: "utf8",
-      timeout: 1500,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return true;
-  } catch {
-    // error-policy:J3 binary existence probe (`which`/`where`); a non-zero exit
-    // or missing command means the binary is absent (false).
-    return false;
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, binaryName);
+    if (fs.existsSync(candidate)) return true;
+    if (process.platform === "win32") {
+      for (const ext of (process.env.PATHEXT ?? ".EXE;.CMD;.BAT")
+        .split(";")
+        .filter(Boolean)) {
+        if (fs.existsSync(`${candidate}${ext.toLowerCase()}`)) return true;
+        if (fs.existsSync(`${candidate}${ext.toUpperCase()}`)) return true;
+      }
+    }
   }
+  return false;
+}
+
+function leadingCommandToken(command: string): string | undefined {
+  const [token] = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? [];
+  return token?.replace(/^(['"])(.*)\1$/u, "$2");
+}
+
+function isCommandExecutableAvailable(command: string | undefined): boolean {
+  const executable = leadingCommandToken(command?.trim() ?? "");
+  if (!executable) return false;
+  if (path.isAbsolute(executable)) return fs.existsSync(executable);
+  if (executable.includes("/") || executable.includes("\\")) {
+    return fs.existsSync(resolveUserPath(executable));
+  }
+  return hasBinaryOnPath(executable);
 }
 
 function hasFrameworkBinary(id: SupportedTaskAgentAdapter): boolean {
   switch (id) {
-    case "elizaos":
-      return (
-        Boolean(readConfigEnvKey("ELIZA_ELIZAOS_ACP_COMMAND")) ||
-        hasBinaryOnPath("eliza-code-acp")
-      );
+    case "elizaos": {
+      const configured = readConfigEnvKey("ELIZA_ELIZAOS_ACP_COMMAND");
+      return configured
+        ? isCommandExecutableAvailable(configured)
+        : hasBinaryOnPath("eliza-code-acp");
+    }
     case "pi-agent":
       return (
         Boolean(readConfigEnvKey("ELIZA_PI_AGENT_ACP_COMMAND")) ||
@@ -633,8 +649,12 @@ function hasFrameworkBinary(id: SupportedTaskAgentAdapter): boolean {
       );
     case "claude":
       return hasBinaryOnPath("claude");
-    case "codex":
-      return hasBinaryOnPath("codex");
+    case "codex": {
+      const configured = readConfigEnvKey("ELIZA_CODEX_ACP_COMMAND");
+      return configured
+        ? isCommandExecutableAvailable(configured)
+        : hasBinaryOnPath("codex");
+    }
     case "opencode":
       return hasOpencodeBinary();
   }

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -608,6 +608,8 @@ function isExecutableFile(candidate: string): boolean {
     fs.accessSync(candidate, fs.constants.X_OK);
     return true;
   } catch {
+    // error-policy:J3 command-path probe; a missing, inaccessible, or
+    // non-executable candidate means the framework is unavailable.
     return false;
   }
 }

--- a/scripts/security/coverage-subprocess-sources.txt
+++ b/scripts/security/coverage-subprocess-sources.txt
@@ -23,3 +23,6 @@ packages/eliza-hub/deployment/hetzner-staging/scripts/steward-evidence.mjs
 packages/eliza-hub/deployment/hetzner-staging/scripts/storage-evidence.mjs
 packages/eliza-hub/services/merge-steward/scripts/sync-openapi-production-evidence-schema.mjs
 packages/eliza-hub/services/merge-steward/src/cli.js
+
+# ACP stdio entrypoint is exercised via spawned runtime contract tests; importing it in-process starts the protocol server.
+packages/examples/code/src/acp.ts


### PR DESCRIPTION
## Summary
- fail task-agent readiness closed when configured Codex or Eliza ACP executables are missing
- normalize unsupported trailing Claude context suffixes such as `[1m]` before account routing and ACP spawn
- remove Eliza ACP startup chatter from the stdio protocol channel

## Verification
- task-agent-framework focused tests: 14 passed
- live sol-dev reproduction now completes ACP initialize/session/new and reaches the model request instead of failing before tool use
- full acp-service unit import remains blocked in this checkout by unresolved workspace package build links (`@elizaos/core` from packages/auth), not by the patch

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend ACP runtime hardening; no visual surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend ACP runtime hardening; no visual surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - focused ACP suites passed 87/87 in CI and live spawn reached ACP session readiness.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - model ID normalization is covered by unit tests; no trajectory artifact is applicable.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - CODE-AGENT-BLOCKERS-2026-07-18.md records live runtime verification.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or visual text changed.
