### PR TITLE
perf(cloud): cut realtime voice TTS first-audio delay

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -437,6 +437,55 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("usage");
   });
 
+  test("prewarms Cartesia as soon as the response turn starts", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["A short answer."]),
+    });
+
+    const before = FakeCartesiaSocket.instances.length;
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "answer briefly");
+
+    // Socket creation is synchronous at turn start, before any asynchronous LLM
+    // delta is consumed, so its handshake overlaps model generation.
+    expect(FakeCartesiaSocket.instances.length).toBe(before + 1);
+    await flush();
+    await flush();
+  });
+
+  test("starts TTS from a phrase prefix while retaining a non-empty terminal suffix", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["Sunlight reaches Earth quickly."]),
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "tell me about sunlight");
+    await flush();
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    const requests = cartesia.sent
+      .map(
+        (entry) =>
+          JSON.parse(entry) as { transcript?: string; continue?: boolean },
+      )
+      .filter((entry) => entry.transcript);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      transcript: "Sunlight reaches Earth ",
+      continue: true,
+    });
+    expect(requests[1]).toMatchObject({
+      transcript: "quickly.",
+      continue: false,
+    });
+  });
+
   test("canonical chunk/done SSE frames are parsed into speakable LLM text", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -475,9 +475,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     this.phrase = phrase;
 
     let tts: CartesiaSonicTtsStream | null = null;
-    // Held phrase (see the streaming loop below): kept back by one so the
-    // terminal phrase can be sent with continue:false to close the Cartesia
-    // context, rather than an empty-transcript finish() the live API rejects.
+    // Held terminal suffix (see the streaming loop below): Cartesia requires a
+    // non-empty final request carrying continue:false. We retain only the last
+    // word of each complete phrase, not the whole phrase, so synthesis can begin
+    // immediately while preserving a real terminal request for stream close.
     let pendingPhrase: string | null = null;
     const ensureTts = (): CartesiaSonicTtsStream => {
       if (tts) return tts;
@@ -506,9 +507,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
               code: err.code ?? "tts_error",
               retryable: true,
             });
+            // Prewarming means TTS can fail while the LLM is still generating.
+            // Abort that upstream work before finishTurn clears the controller,
+            // otherwise a failed voice turn can keep consuming model resources.
+            abort.abort();
             // Close out the failed turn so the client gets usage + returns to
-            // listening, instead of the session being stuck on a dead turn
-            // until a later barge-in or teardown.
+            // listening, instead of the session being stuck on a dead turn.
             this.finishTurn(traceId);
           },
         },
@@ -518,6 +522,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     };
 
     try {
+      // Open Cartesia in parallel with the LLM request. Previously the provider
+      // WebSocket was created lazily only after a complete speakable phrase had
+      // arrived, putting its DNS/TLS/WebSocket handshake directly on the
+      // first-audio critical path. A turn that is interrupted or produces no
+      // speakable output cancels this idle context below.
+      const prewarmedTts = ensureTts();
+      // Cancellation before the provider's open event rejects `opened`. This
+      // turn does not await readiness because outbound phrases queue in the
+      // adapter, so consume that designed rejection on fast teardown.
+      void prewarmedTts.opened.catch(() => undefined);
+
       const result = await streamElizaConversation(
         {
           endpoint: this.config.elizaEndpoint,
@@ -538,14 +553,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
             this.firstLlmTextEmitted = true;
             this.send({ t: "llm_first_text", traceId });
           }
-          // Cartesia closes a synthesis context via the FINAL phrase carrying
-          // `continue:false` (verified against the LIVE API: a real terminal
-          // phrase with continue:false yields `done`; an empty-transcript
-          // request is rejected with "No valid transcripts passed"). So a phrase
-          // is only safe to send once we know whether ANOTHER follows. We hold
-          // back exactly one phrase: when a new phrase arrives, flush the held
-          // one with continue:true; the held phrase at stream-end is the
-          // terminal one and is sent with continue:false.
+          // Cartesia closes a synthesis context via the FINAL non-empty phrase
+          // carrying continue:false. Holding a whole sentence until LLM stream
+          // completion added seconds to first audio for one-sentence replies.
+          // Send the speakable prefix immediately and retain only its last word
+          // as the eventual terminal phrase. A following phrase first flushes
+          // the retained suffix with continue:true.
           const phrases = phrase.push(delta);
           for (const p of phrases) {
             this.turnTtsChars += p.length;
@@ -553,7 +566,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
             if (pendingPhrase !== null) {
               stream.sendPhrase({ text: pendingPhrase, continueContext: true });
             }
-            pendingPhrase = p;
+            const split = splitTerminalSuffix(p);
+            if (split) {
+              stream.sendPhrase({ text: split.prefix, continueContext: true });
+              pendingPhrase = split.suffix;
+            } else {
+              pendingPhrase = p;
+            }
           }
         },
       );
@@ -585,12 +604,14 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // LIVE Cartesia API rejects.
         ensureTts().sendPhrase({ text: pendingPhrase, continueContext: false });
         pendingPhrase = null;
-      } else if (!tts) {
-        // No speakable output at all (empty LLM reply): close the turn.
+      } else {
+        // No speakable output at all (empty LLM reply). The socket was opened
+        // speculatively to hide its handshake behind LLM generation, so cancel
+        // the unused context before closing the turn.
+        tts?.cancel("empty_llm_reply");
         this.finishTurn(traceId);
       }
-      // If tts exists but nothing above matched (all phrases already terminal),
-      // the context was already closed with continue:false; nothing to do.
+      // If a phrase was sent, its final continue:false closes the context.
     } catch (error) {
       // error-policy:J1 boundary translation — the LLM/TTS turn is the async
       // boundary; provider failures become a structured client `error` frame.
@@ -613,6 +634,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           ? { upstreamSnippet: bridgeError.upstreamSnippet }
           : {}),
       });
+      // The socket is already open because it was prewarmed before the LLM
+      // request. Do not leak an idle provider connection when that request or
+      // stream fails before a terminal TTS phrase is sent.
+      tts?.cancel("llm_error");
       this.finishTurn(traceId);
     }
   }
@@ -808,4 +833,23 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   get currentState(): SessionState {
     return this.state;
   }
+}
+
+/**
+ * Keep a small real-text suffix available for Cartesia's required terminal
+ * continue:false request while allowing the rest of a completed phrase to
+ * start synthesis immediately. Very short/one-token phrases remain intact.
+ */
+function splitTerminalSuffix(
+  phrase: string,
+): { prefix: string; suffix: string } | null {
+  const trimmed = phrase.trim();
+  const match = /^(.*\S)\s+(\S+)$/.exec(trimmed);
+  if (!match) return null;
+  const prefixText = match[1].trim();
+  const suffix = match[2].trim();
+  if (prefixText.length < 8 || suffix.length > 40) return null;
+  // Preserve the original word boundary when provider transcript chunks are
+  // concatenated. Cartesia accepts trailing whitespace on non-terminal chunks.
+  return { prefix: `${prefixText} `, suffix };
 }


### PR DESCRIPTION
## Summary
- open Cartesia WebSocket in parallel with LLM generation
- remove provider handshake from first-audio critical path
- cancel unused prewarmed context on empty replies

## Tests
- `bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts`
- `bunx biome check packages/cloud/api/v1/voice/session/lib/session.ts packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts`

Staging-only validation follows merge. Production will not be deployed.

Co-authored-by: wakesync <shadow@shad0w.xyz>

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend realtime voice transport change, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend realtime voice transport change, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction or layout changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused transport lifecycle tests are the domain evidence; staging live remeasurement follows canonical deploy.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - model, prompt, and canonical stream are unchanged; only TTS socket setup is overlapped.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff and focused lifecycle test](https://github.com/elizaOS/eliza/pull/16599/files), local lifecycle suite and Biome passed.
