### PR TITLE
fix(cloud): unblock staging deploy typecheck in voice session

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -456,6 +456,27 @@ describe("voice-session WS lifecycle", () => {
     await flush();
   });
 
+  test("empty LLM reply cancels the prewarmed Cartesia context", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch([]),
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "say nothing");
+    await flush();
+    await flush();
+
+    // The socket was opened speculatively at turn start; with no speakable
+    // output it must be cancelled (closed) rather than leaked, and the turn
+    // still closes out with a usage frame.
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(cartesia.closed).toBe(true);
+    expect(client.controlTypes()).toContain("usage");
+    expect(client.controlTypes()).not.toContain("speaking_start");
+  });
+
   test("starts TTS from a phrase prefix while retaining a non-empty terminal suffix", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -607,8 +607,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       } else {
         // No speakable output at all (empty LLM reply). The socket was opened
         // speculatively to hide its handshake behind LLM generation, so cancel
-        // the unused context before closing the turn.
-        tts?.cancel("empty_llm_reply");
+        // the unused context before closing the turn. (Read via the class field:
+        // `tts` is only assigned inside closures, so outer-flow narrowing would
+        // otherwise collapse its type to never.)
+        this.ttsStream?.cancel("empty_llm_reply");
         this.finishTurn(traceId);
       }
       // If a phrase was sent, its final continue:false closes the context.
@@ -636,8 +638,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       });
       // The socket is already open because it was prewarmed before the LLM
       // request. Do not leak an idle provider connection when that request or
-      // stream fails before a terminal TTS phrase is sent.
-      tts?.cancel("llm_error");
+      // stream fails before a terminal TTS phrase is sent. finishTurn has not
+      // run yet, so ttsStream still belongs to this turn.
+      this.ttsStream?.cancel("llm_error");
       this.finishTurn(traceId);
     }
   }


### PR DESCRIPTION
## Summary
- #16599 merged but the staging Deploy API Worker job failed typecheck: tsgo collapses the closure-assigned `tts` local to `never` on outer-flow reads (TS2339 at session.ts:611/640)
- cancel the prewarmed Cartesia context through `this.ttsStream` (same stream for the active turn) instead of the local

## Tests
- `bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` (26/26)
- `bunx tsgo --noEmit` in packages/cloud/api now passes the failing check

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - type-level fix, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - type-level fix, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [failed staging deploy typecheck](https://github.com/elizaOS/eliza/actions/runs/29632130978/job/88050332828) is the before-state evidence.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff](https://github.com/elizaOS/eliza/pull/new/fix/voice-latency-hotpath), lifecycle suite green.

Co-authored-by: wakesync <shadow@shad0w.xyz>