### PR TITLE
ci: proposal, fail-closed checkout hygiene for self-hosted runners

### DIFF
--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -34,6 +34,34 @@ jobs:
           # `audit:test-realness` compares touched tests against origin/develop.
           # Keep the merge base available so the diff-scoped ratchet runs in CI.
           fetch-depth: 0
+          clean: true
+
+      - name: Enforce runner workspace hygiene
+        run: |
+          # Self-hosted runners reuse the _work checkout across workflows. Jobs
+          # that check out submodules (nightly, build-android, publish-packages,
+          # voice-live-e2e, ...) leave populated submodule trees behind, and
+          # actions/checkout with `submodules: false` does not remove them.
+          # Their vendored test files then leak into repo-wide scans: on
+          # 2026-07-18, audit:test-realness scanned 7,914 files (todoTest=1)
+          # on runner-2 vs 7,520 (todoTest=0) in a clean checkout, because
+          # plugins/plugin-agent-orchestrator/vendor/opencode and
+          # plugins/plugin-local-inference/native/llama.cpp were still
+          # populated from a prior submodule-enabled run.
+          git submodule deinit -f --all >/dev/null
+          git clean -ffdx --quiet
+          status_output=$(git status --porcelain)
+          if [ -n "$status_output" ]; then
+            echo "::error::Runner workspace contaminated: git status is not clean after submodule deinit + clean. This is a stale-runner-workspace problem, not a branch regression."
+            echo "$status_output"
+            exit 1
+          fi
+          populated=$(git submodule status | grep -cv '^-' || true)
+          if [ "$populated" != "0" ]; then
+            echo "::error::Runner workspace contaminated: $populated submodule(s) still populated in a submodules:false job."
+            git submodule status
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -259,6 +259,34 @@ jobs:
           # `audit:test-realness` compares touched tests against origin/develop.
           # Keep the merge base available so the diff-scoped ratchet runs in CI.
           fetch-depth: 0
+          clean: true
+
+      - name: Enforce runner workspace hygiene
+        run: |
+          # Self-hosted runners reuse the _work checkout across workflows. Jobs
+          # that check out submodules (nightly, build-android, publish-packages,
+          # voice-live-e2e, ...) leave populated submodule trees behind, and
+          # actions/checkout with `submodules: false` does not remove them.
+          # Their vendored test files then leak into repo-wide scans: on
+          # 2026-07-18, audit:test-realness scanned 7,914 files (todoTest=1)
+          # on runner-2 vs 7,520 (todoTest=0) in a clean checkout, because
+          # plugins/plugin-agent-orchestrator/vendor/opencode and
+          # plugins/plugin-local-inference/native/llama.cpp were still
+          # populated from a prior submodule-enabled run.
+          git submodule deinit -f --all >/dev/null
+          git clean -ffdx --quiet
+          status_output=$(git status --porcelain)
+          if [ -n "$status_output" ]; then
+            echo "::error::Runner workspace contaminated: git status is not clean after submodule deinit + clean. This is a stale-runner-workspace problem, not a branch regression."
+            echo "$status_output"
+            exit 1
+          fi
+          populated=$(git submodule status | grep -cv '^-' || true)
+          if [ "$populated" != "0" ]; then
+            echo "::error::Runner workspace contaminated: $populated submodule(s) still populated in a submodules:false job."
+            git submodule status
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e


### PR DESCRIPTION
## PROPOSAL — do not auto-merge

### Problem (receipt: CI-CONVERGENCE-2026-07-18)

Quality (Fork) Lint for #16593 (run 29631839395, job 88050685829, runner `eliza-prod-robot-3-r2`) failed `audit:test-realness` with:

- runner checkout: **7,914** test files scanned, `todoTest=1` → FAIL
- clean detached checkout of the same head (42ce0619): **7,520** files, `todoTest=0` → pass

Deterministic across the single allowed rerun. This blocked #16593 and, transitively, #16578's post-fix green.

### Root cause (proven on the runner)

The 394 extra files were **stale populated submodule worktrees** left in the shared `_work/eliza/eliza` checkout by submodule-enabled workflows (nightly, build-android, publish-packages, voice-live-e2e, etc.):

- `plugins/plugin-agent-orchestrator/vendor/opencode` → 379 test files (incl. `packages/opencode/test/session/instruction.test.ts` with an `it.todo`, and literally `e2e/todo.spec.ts`)
- `plugins/plugin-local-inference/native/llama.cpp` → 15 test files

`actions/checkout` with `submodules: false` neither updates nor removes populated submodules, and `git clean` does not descend into submodule worktrees, so the vendored trees survive every subsequent checkout and leak into `test-realness-audit.mjs`'s filesystem walk (it walks `packages/` + `plugins/` with `readdirSync`, not `git ls-files`).

Fleet audit 2026-07-18: **13 of 18 idle lanes contaminated** (robot-3 r1/r2/r4, robot-4 r1-r4, robot-5 r1-r3, robot-6 r3/r4); all manually `git submodule deinit -f --all`'d back to purity (verified: 7,520 files, `git status` clean, head unchanged). robot-2 lanes were already clean.

### Fix (fail-closed)

For the two jobs that run the repo-wide test-realness scan (Quality (Fork) `Lint`, quality.yml `develop-static-gate`):

1. `clean: true` made explicit on checkout.
2. New **Enforce runner workspace hygiene** step: `git submodule deinit -f --all` + `git clean -ffdx`, then fail with a clear `Runner workspace contaminated` error if `git status --porcelain` is non-empty or any submodule is still populated.

Future contamination becomes an explicit infra error at the top of the job instead of a false `todoTest` branch regression. No gate weakened, no baseline bumped.

Receipt: `RUNNER-DECONTAM-2026-07-18.md`

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI workflow YAML change only, no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI workflow YAML change only, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual behavior changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend runtime changed; CI-only hygiene step.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: root-cause proof in PR description (runner file-count deltas: 7,914 contaminated vs 7,520 clean, todoTest=1 vs 0) and fleet audit results (13/18 lanes decontaminated, verified clean). Failed run: https://github.com/elizaOS/eliza/actions/runs/29631839395/job/88050685829

Co-authored-by: wakesync <shadow@shad0w.xyz>
