### PR TITLE
fix(app-core): realign merged account and entitlement contracts

### DIFF
--- a/packages/app-core/platforms/apple-store-entitlements.reviewed.json
+++ b/packages/app-core/platforms/apple-store-entitlements.reviewed.json
@@ -109,6 +109,11 @@
           "reviewSensitive": true,
           "appReviewJustification": "Required for Screen Time and website blocking features exposed through the iOS app and extension."
         },
+        "com.apple.developer.associated-domains": {
+          "arrayStringPatterns": ["^applinks:eliza\\.app$"],
+          "reviewSensitive": true,
+          "appReviewJustification": "Required for the reviewed production Universal Link host used by native app association. The exact host is pinned so additional domains require a new review."
+        },
         "com.apple.security.application-groups": {
           "arrayStringPatterns": ["^group\\.[A-Za-z0-9.-]+$"],
           "justification": "Required to share scoped state with app extensions."

--- a/packages/app-core/src/api/server-compat-route-chain.guard.test.ts
+++ b/packages/app-core/src/api/server-compat-route-chain.guard.test.ts
@@ -127,6 +127,7 @@ describe("compat-route registry drift guard (#12089 item 5)", () => {
       "auth-pairing",
       "embed-auth",
       "sensitive-request",
+      "account-pool-status",
       "credential-tunnel",
       "background-tasks",
       "internal-wake",

--- a/packages/app-core/src/services/account-pool-availability.test.ts
+++ b/packages/app-core/src/services/account-pool-availability.test.ts
@@ -249,7 +249,10 @@ describe("account health mutation lifecycle", () => {
 
     const inserted = account("inserted", { priority: 4 });
     await pool.upsert(inserted);
-    expect(pool.get("inserted", "anthropic-subscription")).toEqual(inserted);
+    expect(pool.get("inserted", "anthropic-subscription")).toEqual({
+      ...inserted,
+      prioritySource: "generated",
+    });
     expect(pool.list("anthropic-subscription")).toHaveLength(4);
 
     await pool.deleteMetadata("anthropic-subscription", "inserted");

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -1209,6 +1209,12 @@ export function selectionForProvider(providerId: PoolProviderId): {
   };
 }
 
+export function configuredAccountStrategyForProvider(
+  providerId: string,
+): Strategy | undefined {
+  return normalizeStrategy(defaultSelectionConfig.accountStrategies?.[providerId]);
+}
+
 export function configureDefaultAccountPoolSelection(
   config: AccountPoolSelectionConfig = {},
 ): void {

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -1212,7 +1212,13 @@ export function selectionForProvider(providerId: PoolProviderId): {
 export function configuredAccountStrategyForProvider(
   providerId: string,
 ): Strategy | undefined {
-  return normalizeStrategy(defaultSelectionConfig.accountStrategies?.[providerId]);
+  const route = defaultSelectionConfig.serviceRouting?.llmText;
+  return (
+    (routeTargetsProvider(route, providerId)
+      ? normalizeStrategy(route?.strategy)
+      : undefined) ??
+    normalizeStrategy(defaultSelectionConfig.accountStrategies?.[providerId])
+  );
 }
 
 export function configureDefaultAccountPoolSelection(

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -221,6 +221,17 @@ describe("coding-account-bridge", () => {
     const configOverEnv = await bridge?.select("claude");
     expect(configOverEnv?.strategy).toBe("least-used");
     expect(configOverEnv?.accountId).toBe("spare");
+
+    // The active llmText route remains the highest-precedence app config.
+    configureDefaultAccountPoolSelection({
+      accountStrategies: { "anthropic-subscription": "least-used" },
+      serviceRouting: {
+        llmText: { backend: "anthropic", strategy: "priority" },
+      },
+    });
+    const routeOverAccountStrategy = await bridge?.select("claude");
+    expect(routeOverAccountStrategy?.strategy).toBe("priority");
+    expect(routeOverAccountStrategy?.accountId).toBe("primary");
   });
 
   it("materializes a per-account CODEX_HOME/auth.json for Codex (incl. id_token)", async () => {

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -188,9 +188,10 @@ describe("coding-account-bridge", () => {
     await setUsage("anthropic-subscription", "spare", 5);
     const bridge = getCodingAgentSelectorBridge();
 
-    // Unconfigured: least-used default.
+    // Unconfigured Anthropic subscriptions drain the weekly window that resets
+    // soonest. With no reset metadata, the lower-usage account is selected.
     const unconfigured = await bridge?.select("claude");
-    expect(unconfigured?.strategy).toBe("least-used");
+    expect(unconfigured?.strategy).toBe("drain-soonest-reset");
     expect(unconfigured?.accountId).toBe("spare");
 
     // The picker writes config.accountStrategies — selection must follow it.
@@ -594,10 +595,10 @@ describe("coding-account-bridge", () => {
   });
 
   // Follow-up pinning: session affinity alone expires after 3 selects, after
-  // which least-used actively prefers the SIBLING (the affine account carries
-  // the freshest selection stamp). The first test documents that real-pool
-  // failure mode; the pin tests prove `accountIds` is what keeps a continuing
-  // session's token resolves on its spawn-time account.
+  // which the configured strategy may choose another account. Force least-used
+  // here to exercise that drift independently of the Anthropic weekly-window
+  // drain default. The pin tests prove `accountIds` keeps a continuing session
+  // on its spawn-time account.
   it("drifts to the sibling once session affinity expires when NOT pinned", async () => {
     writeAccount("anthropic-subscription", "pin-a", "sk-ant-oat-PIN-A");
     writeAccount("anthropic-subscription", "pin-b", "sk-ant-oat-PIN-B");
@@ -611,7 +612,8 @@ describe("coding-account-bridge", () => {
     const followUps: Array<string | undefined> = [];
     for (let i = 0; i < 3; i += 1) {
       followUps.push(
-        (await bridge?.select("claude", { sessionKey }))?.accountId,
+        (await bridge?.select("claude", { sessionKey, strategy: "least-used" }))
+          ?.accountId,
       );
     }
     expect(followUps[0]).toBe(spawnId);

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -63,6 +63,7 @@ import {
 import type { LinkedAccountProviderId } from "@elizaos/shared/contracts/service-routing";
 import {
   type AccountPool,
+  configuredAccountStrategyForProvider,
   isAccountSelectableNow,
   type Strategy,
   selectionForProvider,
@@ -81,20 +82,20 @@ const VALID_CODING_STRATEGIES = new Set<Strategy>([
   "drain-soonest-reset",
 ]);
 
-/** Last-resort strategy — the ELIZA_CODING_ACCOUNT_STRATEGY env var, else least-used. */
-function getDefaultCodingStrategy(): Strategy {
+/** Optional process-level strategy fallback. */
+function getEnvCodingStrategy(): Strategy | undefined {
   const env =
     typeof process !== "undefined"
       ? process.env.ELIZA_CODING_ACCOUNT_STRATEGY?.trim()
       : undefined;
-  if (!env) return "least-used";
+  if (!env) return undefined;
   if (VALID_CODING_STRATEGIES.has(env as Strategy)) return env as Strategy;
   logger.warn(
     `[coding-account-bridge] ignoring invalid ELIZA_CODING_ACCOUNT_STRATEGY=${JSON.stringify(
       env,
-    )}; using least-used`,
+    )}`,
   );
-  return "least-used";
+  return undefined;
 }
 
 /**
@@ -834,8 +835,10 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
         // chat brain's account, not coding sub-agents.
         const strategy =
           opts?.strategy ??
+          configuredAccountStrategyForProvider(providerId) ??
+          getEnvCodingStrategy() ??
           selectionForProvider(providerId).strategy ??
-          getDefaultCodingStrategy();
+          "least-used";
         const account = await pool.select({
           providerId,
           strategy,


### PR DESCRIPTION
## Summary
- preserve app-config > env > provider-default strategy precedence after the Anthropic weekly-drain default landed
- realign exact route and persisted-account assertions with the merged public pool route and `prioritySource`
- review and pin the production iOS Universal Link entitlement in the entitlement allowlist

## Tests
- `bun run test -- src/api/server-compat-route-chain.guard.test.ts src/services/account-pool-availability.test.ts src/services/coding-account-bridge.test.ts scripts/lib/apple-entitlement-audit.test.mjs` (43/43)

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - server contracts only, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - server contracts only, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [develop Server Tests failure](https://github.com/elizaOS/eliza/actions/runs/29632130974/job/88047916488).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [focused contract diff](https://github.com/elizaOS/eliza/pull/16602/files), 43 focused tests green.

Co-authored-by: wakesync <shadow@shad0w.xyz>
