### PR TITLE
fix(ui): fail closed on malformed voice identity ids

### DIFF
--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -165,7 +165,7 @@ async function driveReady(
 }
 
 describe("useRealtimeVoiceSession", () => {
-  it("fails closed instead of crashing on a non-string legacy conversation id", () => {
+  it("fails closed instead of crashing on a non-string legacy conversation id", async () => {
     const { options } = makeOptions({
       conversationId: { id: CONV_ID } as unknown as string,
     });
@@ -173,6 +173,9 @@ describe("useRealtimeVoiceSession", () => {
     const { result } = renderHook(() => useRealtimeVoiceSession(options));
 
     expect(result.current.available).toBe(false);
+    await expect(result.current.start()).resolves.toEqual({
+      kind: "unavailable",
+    });
   });
 
   it("invokes the advertised onMinted callback with the validated mint", async () => {

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -165,6 +165,16 @@ async function driveReady(
 }
 
 describe("useRealtimeVoiceSession", () => {
+  it("fails closed instead of crashing on a non-string legacy conversation id", () => {
+    const { options } = makeOptions({
+      conversationId: { id: CONV_ID } as unknown as string,
+    });
+
+    const { result } = renderHook(() => useRealtimeVoiceSession(options));
+
+    expect(result.current.available).toBe(false);
+  });
+
   it("invokes the advertised onMinted callback with the validated mint", async () => {
     const onMinted = vi.fn();
     const { options, ws } = makeOptions({ onMinted });

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -314,19 +314,28 @@ export function useRealtimeVoiceSession(
     resolve: (outcome: RealtimeVoiceStartOutcome) => void;
   } | null>(null);
 
+  const normalizedAgentId = normalizeVoiceIdentityId(agentId);
+  const normalizedConversationId = normalizeVoiceIdentityId(conversationId);
+
   // Keep the latest callbacks/config in refs so the stable `start`/`stop`
   // identities don't churn the mic button bindings each render.
   const getConsentNonceRef = useRef(getConsentNonce);
   const createClientRef = useRef(createClient);
   const clientOptionsRef = useRef(clientOptions);
   const onMintedRef = useRef(onMinted);
-  const idsRef = useRef({ agentId, conversationId });
+  const idsRef = useRef({
+    agentId: normalizedAgentId,
+    conversationId: normalizedConversationId,
+  });
   const readyTimeoutMsRef = useRef(readyTimeoutMs);
   getConsentNonceRef.current = getConsentNonce;
   createClientRef.current = createClient;
   clientOptionsRef.current = clientOptions;
   onMintedRef.current = onMinted;
-  idsRef.current = { agentId, conversationId };
+  idsRef.current = {
+    agentId: normalizedAgentId,
+    conversationId: normalizedConversationId,
+  };
   readyTimeoutMsRef.current = readyTimeoutMs;
 
   const clearReadyTimer = useCallback(() => {
@@ -349,8 +358,6 @@ export function useRealtimeVoiceSession(
     [],
   );
 
-  const normalizedAgentId = normalizeVoiceIdentityId(agentId);
-  const normalizedConversationId = normalizeVoiceIdentityId(conversationId);
   const hasIds = Boolean(normalizedAgentId) && Boolean(normalizedConversationId);
   const available = flagEnabled && hasIds && !featureDisabled;
 
@@ -420,7 +427,7 @@ export function useRealtimeVoiceSession(
     }
     if (!flagEnabled) return { kind: "unavailable" };
     const { agentId: aId, conversationId: cId } = idsRef.current;
-    if (!aId?.trim() || !cId?.trim()) return { kind: "unavailable" };
+    if (!aId || !cId) return { kind: "unavailable" };
 
     startingRef.current = true;
     micOwnedRef.current = false;
@@ -730,7 +737,7 @@ export function useRealtimeVoiceSession(
       const { agentId: nextAgentId, conversationId: nextConversationId } =
         idsRef.current;
       identityRestartPendingRef.current = false;
-      if (flagEnabled && nextAgentId?.trim() && nextConversationId?.trim()) {
+      if (flagEnabled && nextAgentId && nextConversationId) {
         await start();
       }
     })();

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -248,6 +248,10 @@ const LIVE_SESSION_PHASES: ReadonlySet<string> = new Set([
 
 const DEFAULT_READY_TIMEOUT_MS = 15_000;
 
+function normalizeVoiceIdentityId(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 function fallbackReasonForError(
   error: RealtimeVoiceError,
 ): "consent" | "mint" | "transport" | "unknown" | null {
@@ -345,7 +349,9 @@ export function useRealtimeVoiceSession(
     [],
   );
 
-  const hasIds = Boolean(agentId?.trim()) && Boolean(conversationId?.trim());
+  const normalizedAgentId = normalizeVoiceIdentityId(agentId);
+  const normalizedConversationId = normalizeVoiceIdentityId(conversationId);
+  const hasIds = Boolean(normalizedAgentId) && Boolean(normalizedConversationId);
   const available = flagEnabled && hasIds && !featureDisabled;
 
   const applyServerEventToTranscript = useCallback(
@@ -696,7 +702,7 @@ export function useRealtimeVoiceSession(
   // changes while a start/live session owns the mic, stop the old socket and
   // re-mint against the latest ids. A generation guard prevents rapid thread
   // switches from resurrecting an intermediate identity.
-  const identityKey = `${agentId?.trim() ?? ""}\n${conversationId?.trim() ?? ""}`;
+  const identityKey = `${normalizedAgentId}\n${normalizedConversationId}`;
   const previousIdentityRef = useRef(identityKey);
   useEffect(() => {
     if (previousIdentityRef.current === identityKey) return;


### PR DESCRIPTION
## Summary
- normalize realtime voice identity values at the hook boundary
- fail closed when legacy/story state supplies a non-string conversation ID
- preserve all valid string identity behavior

## Tests
- `bun run test -- src/hooks/useRealtimeVoiceSession.test.tsx` (22/22)

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - render-time exception, no visual styling changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - guard only, no visual styling changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend code changed.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [develop Client Tests failure](https://github.com/elizaOS/eliza/actions/runs/29632130974/job/88047916503) shows `conversationId?.trim is not a function`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [focused hook diff](https://github.com/elizaOS/eliza/pull/16603/files), 22 focused tests green.

Co-authored-by: wakesync <shadow@shad0w.xyz>
