### PR TITLE
fix(app-core): type configured provider strategy lookup

### DIFF
--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -1210,7 +1210,7 @@ export function selectionForProvider(providerId: PoolProviderId): {
 }
 
 export function configuredAccountStrategyForProvider(
-  providerId: string,
+  providerId: PoolProviderId,
 ): Strategy | undefined {
   const route = defaultSelectionConfig.serviceRouting?.llmText;
   return (


### PR DESCRIPTION
## Summary
- type the configured strategy helper with `PoolProviderId`
- restore strict indexing and route-matching type safety after #16602

## Tests
- focused account bridge/availability suites passed (33/33)
- strict typecheck no longer reports the helper's TS2345/TS7053 errors

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - type-only server correction.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - compile-time correction.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [one-line type diff](https://github.com/elizaOS/eliza/pull/new/fix/configured-provider-strategy-type).

Co-authored-by: wakesync <shadow@shad0w.xyz>
