### PR TITLE
perf(cloud): stream first voice clause after 24 chars

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -477,6 +477,45 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).not.toContain("speaking_start");
   });
 
+  test("starts TTS after 24 chars before an unpunctuated LLM stream completes", async () => {
+    let aborted = false;
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(
+        ["This answer starts speaking now and keeps going"],
+        {
+          hang: true,
+          onAbort: () => {
+            aborted = true;
+          },
+        },
+      ),
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "answer quickly");
+    await flush();
+    await flush();
+
+    // No punctuation or stream-end was delivered, but the voice-specific
+    // clause ceiling must already have sent a continuation phrase to Cartesia.
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    const requests = cartesia.sent
+      .map(
+        (entry) =>
+          JSON.parse(entry) as { transcript?: string; continue?: boolean },
+      )
+      .filter((entry) => entry.transcript);
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests[0]?.continue).toBe(true);
+    expect(client.controlTypes()).toContain("speaking_start");
+
+    client.clientSend(JSON.stringify({ t: "barge_in" }));
+    await flush();
+    expect(aborted).toBe(true);
+  });
+
   test("starts TTS from a phrase prefix while retaining a non-empty terminal suffix", async () => {
     const client = new FakeClientSocket();
     await connectSession({
@@ -496,15 +535,12 @@ describe("voice-session WS lifecycle", () => {
           JSON.parse(entry) as { transcript?: string; continue?: boolean },
       )
       .filter((entry) => entry.transcript);
-    expect(requests).toHaveLength(2);
-    expect(requests[0]).toMatchObject({
-      transcript: "Sunlight reaches Earth ",
-      continue: true,
-    });
-    expect(requests[1]).toMatchObject({
-      transcript: "quickly.",
-      continue: false,
-    });
+    expect(requests.length).toBeGreaterThanOrEqual(2);
+    expect(requests.map((request) => request.transcript).join("")).toBe(
+      "Sunlight reaches Earth quickly.",
+    );
+    expect(requests[0]?.continue).toBe(true);
+    expect(requests.at(-1)?.continue).toBe(false);
   });
 
   test("canonical chunk/done SSE frames are parsed into speakable LLM text", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -76,6 +76,14 @@ const REVOCATION_POLL_MS = 400;
  * and severs fail-closed instead of streaming unbounded paid audio.
  */
 const MAX_OUTSTANDING_METER_WINDOWS = 2;
+/**
+ * Voice cannot wait for the generic 180-character phrase ceiling: short spoken
+ * replies often have no punctuation until the model's final token, which put
+ * ~2.8s of generation after `llm_first_text` on the first-audio path. Emit a
+ * speakable clause after a small token-sized prefix; Cartesia's continuation
+ * context preserves prosody across the resulting chunks.
+ */
+const VOICE_TTS_FIRST_CLAUSE_CHARS = 24;
 
 export type { VoiceSessionDownlink } from "@/lib/voice-session/ws-handler";
 
@@ -471,7 +479,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   ): Promise<void> {
     const abort = new AbortController();
     this.llmAbort = abort;
-    const phrase = new PhraseAggregator();
+    const phrase = new PhraseAggregator({
+      maxBufferChars: VOICE_TTS_FIRST_CLAUSE_CHARS,
+      preferWordBoundaryAtMax: true,
+    });
     this.phrase = phrase;
 
     let tts: CartesiaSonicTtsStream | null = null;
@@ -846,13 +857,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 function splitTerminalSuffix(
   phrase: string,
 ): { prefix: string; suffix: string } | null {
+  const hasTrailingBoundary = /\s$/.test(phrase);
   const trimmed = phrase.trim();
   const match = /^(.*\S)\s+(\S+)$/.exec(trimmed);
   if (!match) return null;
   const prefixText = match[1].trim();
-  const suffix = match[2].trim();
-  if (prefixText.length < 8 || suffix.length > 40) return null;
-  // Preserve the original word boundary when provider transcript chunks are
-  // concatenated. Cartesia accepts trailing whitespace on non-terminal chunks.
-  return { prefix: `${prefixText} `, suffix };
+  const suffixText = match[2].trim();
+  if (prefixText.length < 8 || suffixText.length > 40) return null;
+  // Preserve both word boundaries when provider transcript chunks are
+  // concatenated. Cartesia accepts trailing whitespace on continuation chunks.
+  return {
+    prefix: `${prefixText} `,
+    suffix: hasTrailingBoundary ? `${suffixText} ` : suffixText,
+  };
 }

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/protocol-and-aggregation.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/protocol-and-aggregation.test.ts
@@ -136,6 +136,28 @@ describe("phrase aggregator", () => {
     expect(out.length).toBe(1);
   });
 
+  test("can defer the max threshold to a word boundary for TTS", () => {
+    const agg = new PhraseAggregator({
+      maxBufferChars: 10,
+      preferWordBoundaryAtMax: true,
+    });
+    expect(agg.push("abcdefghij")).toEqual([]);
+    const first = agg.push(" klm");
+    expect(first).toEqual(["abcdefghij "]);
+    const tail = agg.flush();
+    expect(tail).toBe("klm");
+    expect(`${first.join("")}${tail}`).toBe("abcdefghij klm");
+  });
+
+  test("word-boundary mode still hard-caps an unbroken token", () => {
+    const agg = new PhraseAggregator({
+      maxBufferChars: 10,
+      preferWordBoundaryAtMax: true,
+    });
+    expect(agg.push("a".repeat(25))).toEqual([]);
+    expect(agg.push("a")).toEqual(["a".repeat(26)]);
+  });
+
   test("emitted count sequences continueContext", () => {
     const agg = new PhraseAggregator();
     agg.push("First. Second.");

--- a/packages/cloud/shared/src/lib/voice-session/phrase-aggregator.ts
+++ b/packages/cloud/shared/src/lib/voice-session/phrase-aggregator.ts
@@ -27,6 +27,12 @@ const CLAUSE_BREAKS = new Set([",", ";", ":", "—"]);
 export interface PhraseAggregatorOptions {
   maxBufferChars?: number;
   minEmitChars?: number;
+  /**
+   * When true, crossing maxBufferChars waits for the next whitespace so a TTS
+   * chunk never cuts through a word. A bounded overrun prevents an unbroken
+   * token/URL from buffering forever.
+   */
+  preferWordBoundaryAtMax?: boolean;
 }
 
 export class PhraseAggregator {
@@ -34,10 +40,12 @@ export class PhraseAggregator {
   private emittedCount = 0;
   private readonly maxBufferChars: number;
   private readonly minEmitChars: number;
+  private readonly preferWordBoundaryAtMax: boolean;
 
   constructor(options?: PhraseAggregatorOptions) {
     this.maxBufferChars = options?.maxBufferChars ?? PHRASE_MAX_BUFFER_CHARS;
     this.minEmitChars = options?.minEmitChars ?? PHRASE_MIN_EMIT_CHARS;
+    this.preferWordBoundaryAtMax = options?.preferWordBoundaryAtMax ?? false;
   }
 
   /** Number of phrases emitted so far (for `continueContext` sequencing). */
@@ -66,8 +74,17 @@ export class PhraseAggregator {
         continue;
       }
       if (this.buffer.length >= this.maxBufferChars) {
-        const phrase = this.take();
-        if (phrase) phrases.push(phrase);
+        const wordBoundary = /\s/.test(ch);
+        const hardCapReached = this.buffer.length >= this.maxBufferChars + 16;
+        if (!this.preferWordBoundaryAtMax || wordBoundary || hardCapReached) {
+          const phrase = this.take();
+          if (phrase) {
+            // `take()` trims for normal punctuation boundaries. In this mode the
+            // whitespace is semantic: it separates this TTS chunk from the next
+            // word, so carry one space forward on the emitted phrase.
+            phrases.push(this.preferWordBoundaryAtMax && wordBoundary ? `${phrase} ` : phrase);
+          }
+        }
       }
     }
     return phrases;


### PR DESCRIPTION
## Summary
- use a voice-specific 24-character phrase ceiling instead of generic 180 chars
- send unpunctuated LLM output into prewarmed Cartesia before stream completion
- preserve terminal-suffix `continue:false` closure and existing prosody context

## Measured root cause
Live short-utterance staging probe after #16599/#16600: warm LLM first text 1.33-1.42s, but first audio remained another 2.76-2.78s later because the phrase aggregator waited for punctuation/end-of-stream. Flux finalization was only 203-306ms after speech end.

## Tests
- WS lifecycle 28/28
- new hanging, unpunctuated LLM test proves Cartesia receives a `continue:true` phrase and emits speaking_start before stream completion
- Biome clean

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend voice streaming policy, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend voice streaming policy, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual layout changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [staging measurement context](https://github.com/elizaOS/eliza/pull/16599), warm turns measured 2.76-2.78s LLM-first-text to audio before this patch.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, or agent trajectory changes; only already-streamed text chunking into TTS changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff and focused lifecycle test](https://github.com/elizaOS/eliza/pull/new/fix/voice-first-clause).

Co-authored-by: wakesync <shadow@shad0w.xyz>