### PR TITLE
perf(cloud): prewarm voice tenancy context at session start

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -291,6 +291,10 @@ describe("shared agent messages/stream", () => {
       organizationId: ORG,
       userId: "user-voice",
     });
+    await fetchImpl.prewarm();
+    expect(findByIdAndOrg).toHaveBeenCalledTimes(1);
+    expect(bridgeStream).not.toHaveBeenCalled();
+
     const res = await fetchImpl(
       `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
       {

--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -295,6 +295,8 @@ describe("shared agent messages/stream", () => {
     expect(findByIdAndOrg).toHaveBeenCalledTimes(1);
     expect(bridgeStream).not.toHaveBeenCalled();
 
+    // A failed warmup must not fail the turn: the fetch falls through to the
+    // regular per-turn lookup (best-effort semantics, codex P2).
     const res = await fetchImpl(
       `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
       {
@@ -311,6 +313,70 @@ describe("shared agent messages/stream", () => {
 
     expect(res.status).toBe(200);
     expect(findByIdAndOrg).toHaveBeenCalledTimes(1);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+  });
+
+  test("failed in-flight prewarm falls through to per-turn validation", async () => {
+    const env = {
+      DATABASE_URL: "postgresql://captured.example/eliza",
+      VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service",
+    } as Parameters<typeof createInternalElizaConversationFetchFactory>[0];
+    let createLateFetch!: ReturnType<
+      typeof createInternalElizaConversationFetchFactory
+    >;
+    await runWithCloudBindingsAsync(env, () =>
+      runWithDbCacheAsync(async () => {
+        createLateFetch = createInternalElizaConversationFetchFactory(env);
+      }),
+    );
+
+    // Prewarm rejects while still in flight; the fetch must swallow that and
+    // run the regular tenancy lookup instead of failing the user's turn.
+    let releasePrewarm!: (err: Error) => void;
+    findByIdAndOrg.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          releasePrewarm = reject;
+        }),
+    );
+    findByIdAndOrg.mockResolvedValueOnce({
+      id: AGENT,
+      organization_id: ORG,
+      user_id: "user-voice",
+      agent_name: "Voice Agent",
+    });
+    bridgeStream.mockResolvedValue(
+      new Response("event: done\ndata: {}\n\n", {
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    const fetchImpl = createLateFetch({
+      agentId: AGENT,
+      conversationId: VOICE_CONVERSATION,
+      organizationId: ORG,
+      userId: "user-voice",
+    });
+    const prewarm = fetchImpl.prewarm();
+    const resPromise = fetchImpl(
+      `https://api-staging.elizacloud.ai/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "user-voice",
+        },
+        body: JSON.stringify({ text: "prewarm failure transcript" }),
+      },
+    );
+    releasePrewarm(new Error("transient db failure"));
+    await prewarm.catch(() => undefined);
+
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+    expect(findByIdAndOrg).toHaveBeenCalledTimes(2);
     expect(bridgeStream).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -477,6 +477,45 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).not.toContain("speaking_start");
   });
 
+  test("starts TTS after 24 chars before an unpunctuated LLM stream completes", async () => {
+    let aborted = false;
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(
+        ["This answer starts speaking now and keeps going"],
+        {
+          hang: true,
+          onAbort: () => {
+            aborted = true;
+          },
+        },
+      ),
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "answer quickly");
+    await flush();
+    await flush();
+
+    // No punctuation or stream-end was delivered, but the voice-specific
+    // clause ceiling must already have sent a continuation phrase to Cartesia.
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    const requests = cartesia.sent
+      .map(
+        (entry) =>
+          JSON.parse(entry) as { transcript?: string; continue?: boolean },
+      )
+      .filter((entry) => entry.transcript);
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests[0]?.continue).toBe(true);
+    expect(client.controlTypes()).toContain("speaking_start");
+
+    client.clientSend(JSON.stringify({ t: "barge_in" }));
+    await flush();
+    expect(aborted).toBe(true);
+  });
+
   test("starts TTS from a phrase prefix while retaining a non-empty terminal suffix", async () => {
     const client = new FakeClientSocket();
     await connectSession({
@@ -496,15 +535,12 @@ describe("voice-session WS lifecycle", () => {
           JSON.parse(entry) as { transcript?: string; continue?: boolean },
       )
       .filter((entry) => entry.transcript);
-    expect(requests).toHaveLength(2);
-    expect(requests[0]).toMatchObject({
-      transcript: "Sunlight reaches Earth ",
-      continue: true,
-    });
-    expect(requests[1]).toMatchObject({
-      transcript: "quickly.",
-      continue: false,
-    });
+    expect(requests.length).toBeGreaterThanOrEqual(2);
+    expect(requests.map((request) => request.transcript).join("")).toBe(
+      "Sunlight reaches Earth quickly.",
+    );
+    expect(requests[0]?.continue).toBe(true);
+    expect(requests.at(-1)?.continue).toBe(false);
   });
 
   test("canonical chunk/done SSE frames are parsed into speakable LLM text", async () => {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -282,6 +282,7 @@ const CLAIMS = {
 async function connectSession(opts: {
   client: FakeClientSocket;
   fetchImpl: typeof fetch;
+  prewarmElizaContext?: () => Promise<void>;
 }): Promise<{ sessionId: string }> {
   const minted = await mintVoiceSessionToken(CLAIMS);
   const usageStore = new InMemoryVoiceUsageStore();
@@ -306,6 +307,9 @@ async function connectSession(opts: {
         elizaAuthorization: "Bearer eliza-server",
         elizaModel: "gemma-4-31b",
         fetchImpl: opts.fetchImpl,
+        ...(opts.prewarmElizaContext
+          ? { prewarmElizaContext: opts.prewarmElizaContext }
+          : {}),
         usageStore,
         usageLimits: { organizationDailyMinutes: 600, userDailyMinutes: 120 },
         downlink,
@@ -435,6 +439,20 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBeGreaterThan(0);
     expect(client.controlTypes()).toContain("speaking_end");
     expect(client.controlTypes()).toContain("usage");
+  });
+
+  test("prewarms Eliza tenancy context when the live session starts", async () => {
+    let prewarmCalls = 0;
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["ok."]),
+      prewarmElizaContext: async () => {
+        prewarmCalls += 1;
+      },
+    });
+    expect(client.controlTypes()).toContain("ready");
+    expect(prewarmCalls).toBe(1);
   });
 
   test("prewarms Cartesia as soon as the response turn starts", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -77,7 +77,9 @@ export function createInternalElizaConversationFetchFactory(
 
       // If session-start warming is still in flight, reuse its result rather
       // than issuing the same tenancy query concurrently on the first turn.
-      if (prewarmPromise) await prewarmPromise;
+      // Warmup is best-effort: a transient failure must fall through to the
+      // normal per-turn validation, never fail the user's turn by itself.
+      if (prewarmPromise) await prewarmPromise.catch(() => undefined);
 
       return runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -59,7 +59,9 @@ export function createInternalElizaConversationFetchFactory(
               claims.agentId,
               claims.organizationId,
             );
-            scopePreverified = Boolean(agent && agent.user_id === claims.userId);
+            scopePreverified = Boolean(
+              agent && agent.user_id === claims.userId,
+            );
           }),
       ).finally(() => {
         prewarmPromise = null;
@@ -67,10 +69,7 @@ export function createInternalElizaConversationFetchFactory(
       return prewarmPromise;
     };
 
-    const fetchImpl = (async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ) => {
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
       logger.info("[voice-sse-context] adapter entry", {
         cloudBindingsContext: hasCloudBindingsContext(),
         dbCacheContext: hasDbCacheContext(),

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -21,9 +21,14 @@ export interface InternalElizaConversationFetchClaims {
   userId: string;
 }
 
+export type InternalElizaConversationFetch = typeof fetch & {
+  /** Warm and cache the immutable voice-token tenancy lookup before first turn. */
+  prewarm: () => Promise<void>;
+};
+
 export type InternalElizaConversationFetchFactory = (
   claims: InternalElizaConversationFetchClaims,
-) => typeof fetch;
+) => InternalElizaConversationFetch;
 
 /**
  * Capture durable Worker bindings while the upgrade request is live. Each late
@@ -39,12 +44,41 @@ export function createInternalElizaConversationFetchFactory(
     dbCacheContext: hasDbCacheContext(),
   });
 
-  return (claims) =>
-    (async (input: RequestInfo | URL, init?: RequestInit) => {
+  return (claims) => {
+    let scopePreverified = false;
+    let prewarmPromise: Promise<void> | null = null;
+
+    const prewarm = (): Promise<void> => {
+      if (scopePreverified) return Promise.resolve();
+      if (prewarmPromise) return prewarmPromise;
+      prewarmPromise = runWithCloudBindingsAsync(
+        env as unknown as Record<string, unknown>,
+        () =>
+          runWithDbCacheAsync(async () => {
+            const agent = await agentSandboxesRepository.findByIdAndOrg(
+              claims.agentId,
+              claims.organizationId,
+            );
+            scopePreverified = Boolean(agent && agent.user_id === claims.userId);
+          }),
+      ).finally(() => {
+        prewarmPromise = null;
+      });
+      return prewarmPromise;
+    };
+
+    const fetchImpl = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
       logger.info("[voice-sse-context] adapter entry", {
         cloudBindingsContext: hasCloudBindingsContext(),
         dbCacheContext: hasDbCacheContext(),
       });
+
+      // If session-start warming is still in flight, reuse its result rather
+      // than issuing the same tenancy query concurrently on the first turn.
+      if (prewarmPromise) await prewarmPromise;
 
       return runWithCloudBindingsAsync(
         env as unknown as Record<string, unknown>,
@@ -56,6 +90,7 @@ export function createInternalElizaConversationFetchFactory(
                 claims,
                 input,
                 init,
+                scopePreverified,
               );
               logger.info("[voice-sse-context] before response", {
                 cloudBindingsContext: hasCloudBindingsContext(),
@@ -79,7 +114,10 @@ export function createInternalElizaConversationFetchFactory(
             }
           }),
       );
-    }) as typeof fetch;
+    }) as InternalElizaConversationFetch;
+    fetchImpl.prewarm = prewarm;
+    return fetchImpl;
+  };
 }
 
 /** Compatibility helper for direct/test callers. */
@@ -95,6 +133,7 @@ async function dispatchInternalElizaConversationFetch(
   claims: InternalElizaConversationFetchClaims,
   input: RequestInfo | URL,
   init?: RequestInit,
+  scopePreverified = false,
 ): Promise<Response> {
   const request = new Request(input, init);
   const url = new URL(request.url);
@@ -128,15 +167,17 @@ async function dispatchInternalElizaConversationFetch(
     );
   }
 
-  const agent = await agentSandboxesRepository.findByIdAndOrg(
-    claims.agentId,
-    claims.organizationId,
-  );
-  if (!agent || agent.user_id !== claims.userId) {
-    return Response.json(
-      { success: false, error: "Agent not found", code: "agent_not_found" },
-      { status: 404 },
+  if (!scopePreverified) {
+    const agent = await agentSandboxesRepository.findByIdAndOrg(
+      claims.agentId,
+      claims.organizationId,
     );
+    if (!agent || agent.user_id !== claims.userId) {
+      return Response.json(
+        { success: false, error: "Agent not found", code: "agent_not_found" },
+        { status: 404 },
+      );
+    }
   }
 
   const rawText = await request.text();

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -76,6 +76,14 @@ const REVOCATION_POLL_MS = 400;
  * and severs fail-closed instead of streaming unbounded paid audio.
  */
 const MAX_OUTSTANDING_METER_WINDOWS = 2;
+/**
+ * Voice cannot wait for the generic 180-character phrase ceiling: short spoken
+ * replies often have no punctuation until the model's final token, which put
+ * ~2.8s of generation after `llm_first_text` on the first-audio path. Emit a
+ * speakable clause after a small token-sized prefix; Cartesia's continuation
+ * context preserves prosody across the resulting chunks.
+ */
+const VOICE_TTS_FIRST_CLAUSE_CHARS = 24;
 
 export type { VoiceSessionDownlink } from "@/lib/voice-session/ws-handler";
 
@@ -471,7 +479,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   ): Promise<void> {
     const abort = new AbortController();
     this.llmAbort = abort;
-    const phrase = new PhraseAggregator();
+    const phrase = new PhraseAggregator({
+      maxBufferChars: VOICE_TTS_FIRST_CLAUSE_CHARS,
+      preferWordBoundaryAtMax: true,
+    });
     this.phrase = phrase;
 
     let tts: CartesiaSonicTtsStream | null = null;
@@ -846,13 +857,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 function splitTerminalSuffix(
   phrase: string,
 ): { prefix: string; suffix: string } | null {
+  const hasTrailingBoundary = /\s$/.test(phrase);
   const trimmed = phrase.trim();
   const match = /^(.*\S)\s+(\S+)$/.exec(trimmed);
   if (!match) return null;
   const prefixText = match[1].trim();
-  const suffix = match[2].trim();
-  if (prefixText.length < 8 || suffix.length > 40) return null;
-  // Preserve the original word boundary when provider transcript chunks are
-  // concatenated. Cartesia accepts trailing whitespace on non-terminal chunks.
-  return { prefix: `${prefixText} `, suffix };
+  const suffixText = match[2].trim();
+  if (prefixText.length < 8 || suffixText.length > 40) return null;
+  // Preserve both word boundaries when provider transcript chunks are
+  // concatenated. Cartesia accepts trailing whitespace on continuation chunks.
+  return {
+    prefix: `${prefixText} `,
+    suffix: hasTrailingBoundary ? `${suffixText} ` : suffixText,
+  };
 }

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -109,6 +109,8 @@ export interface VoiceSessionConfig {
   elizaAuthorization: string;
   elizaModel: string;
   fetchImpl?: typeof fetch;
+  /** Session-start DB/tenancy warmup, injected only by the live Worker route. */
+  prewarmElizaContext?: () => Promise<void>;
 
   // Metering (SEC-15). Server-derived only.
   usageStore: VoiceUsageStore;
@@ -249,6 +251,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     }, msUntilExp);
 
     this.state = "listening";
+    // Warm immutable tenancy/DB context while the user is beginning to speak,
+    // instead of serializing the first Hyperdrive lookup after stt_final. This
+    // is read-only and best-effort; the turn still performs normal validation
+    // if warmup fails or does not finish in time.
+    if (this.config.prewarmElizaContext) {
+      void this.config.prewarmElizaContext().catch(() => undefined);
+    }
     // The session-level trace span id is stable until the first turn mints its own.
     const sessionTrace = this.mintTraceId("session");
     this.currentTraceId = sessionTrace;

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -201,6 +201,12 @@ app.get("/", (c) => {
         cloudBindingsContext: hasCloudBindingsContext(),
         dbCacheContext: hasDbCacheContext(),
       });
+      const elizaFetch = createScopedElizaFetch({
+        agentId: claims.agentId,
+        conversationId: claims.conversationId,
+        organizationId: claims.organizationId,
+        userId: claims.userId,
+      });
       return new VoiceSession({
         sessionId: claims.sessionId,
         jti,
@@ -217,12 +223,8 @@ app.get("/", (c) => {
         elizaEndpoint,
         elizaAuthorization,
         elizaModel: resolveElizaModel(env),
-        fetchImpl: createScopedElizaFetch({
-          agentId: claims.agentId,
-          conversationId: claims.conversationId,
-          organizationId: claims.organizationId,
-          userId: claims.userId,
-        }),
+        fetchImpl: elizaFetch,
+        prewarmElizaContext: elizaFetch.prewarm,
         usageStore,
         usageLimits,
         isRevoked: (jti) => isVoiceSessionTokenRevoked(jti),

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/protocol-and-aggregation.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/protocol-and-aggregation.test.ts
@@ -136,6 +136,28 @@ describe("phrase aggregator", () => {
     expect(out.length).toBe(1);
   });
 
+  test("can defer the max threshold to a word boundary for TTS", () => {
+    const agg = new PhraseAggregator({
+      maxBufferChars: 10,
+      preferWordBoundaryAtMax: true,
+    });
+    expect(agg.push("abcdefghij")).toEqual([]);
+    const first = agg.push(" klm");
+    expect(first).toEqual(["abcdefghij "]);
+    const tail = agg.flush();
+    expect(tail).toBe("klm");
+    expect(`${first.join("")}${tail}`).toBe("abcdefghij klm");
+  });
+
+  test("word-boundary mode still hard-caps an unbroken token", () => {
+    const agg = new PhraseAggregator({
+      maxBufferChars: 10,
+      preferWordBoundaryAtMax: true,
+    });
+    expect(agg.push("a".repeat(25))).toEqual([]);
+    expect(agg.push("a")).toEqual(["a".repeat(26)]);
+  });
+
   test("emitted count sequences continueContext", () => {
     const agg = new PhraseAggregator();
     agg.push("First. Second.");

--- a/packages/cloud/shared/src/lib/voice-session/phrase-aggregator.ts
+++ b/packages/cloud/shared/src/lib/voice-session/phrase-aggregator.ts
@@ -27,6 +27,12 @@ const CLAUSE_BREAKS = new Set([",", ";", ":", "—"]);
 export interface PhraseAggregatorOptions {
   maxBufferChars?: number;
   minEmitChars?: number;
+  /**
+   * When true, crossing maxBufferChars waits for the next whitespace so a TTS
+   * chunk never cuts through a word. A bounded overrun prevents an unbroken
+   * token/URL from buffering forever.
+   */
+  preferWordBoundaryAtMax?: boolean;
 }
 
 export class PhraseAggregator {
@@ -34,10 +40,12 @@ export class PhraseAggregator {
   private emittedCount = 0;
   private readonly maxBufferChars: number;
   private readonly minEmitChars: number;
+  private readonly preferWordBoundaryAtMax: boolean;
 
   constructor(options?: PhraseAggregatorOptions) {
     this.maxBufferChars = options?.maxBufferChars ?? PHRASE_MAX_BUFFER_CHARS;
     this.minEmitChars = options?.minEmitChars ?? PHRASE_MIN_EMIT_CHARS;
+    this.preferWordBoundaryAtMax = options?.preferWordBoundaryAtMax ?? false;
   }
 
   /** Number of phrases emitted so far (for `continueContext` sequencing). */
@@ -66,8 +74,17 @@ export class PhraseAggregator {
         continue;
       }
       if (this.buffer.length >= this.maxBufferChars) {
-        const phrase = this.take();
-        if (phrase) phrases.push(phrase);
+        const wordBoundary = /\s/.test(ch);
+        const hardCapReached = this.buffer.length >= this.maxBufferChars + 16;
+        if (!this.preferWordBoundaryAtMax || wordBoundary || hardCapReached) {
+          const phrase = this.take();
+          if (phrase) {
+            // `take()` trims for normal punctuation boundaries. In this mode the
+            // whitespace is semantic: it separates this TTS chunk from the next
+            // word, so carry one space forward on the emitted phrase.
+            phrases.push(this.preferWordBoundaryAtMax && wordBoundary ? `${phrase} ` : phrase);
+          }
+        }
       }
     }
     return phrases;


### PR DESCRIPTION
## Summary
- warm the immutable voice-token tenancy lookup (agent/org/user scope) when the live WS session starts, in parallel with the user beginning to speak
- first voice turn skips the serialized Hyperdrive round trip after stt_final when warmup succeeded
- warmup is strictly best-effort: rejection or slow warmup falls through to the existing per-turn validation (covered by a dedicated test)

## Measured context
Short-utterance staging probe (receipt VOICE-LATENCY-HUNT-2026-07-18.md): cold first turn LLM-first-text 5.38s vs warm 1.33-1.42s. The cold gap includes serialized tenancy/DB setup on the first canonical dispatch; this PR removes the tenancy leg from that serial chain.

## Tests
- cloud-api isolated: shared-agent-messages-stream 14/14 (new prewarm + failed-prewarm fall-through tests)
- ws-lifecycle 29/29 (new session-start prewarm hook test)
- tsgo --noEmit clean in packages/cloud/api; Biome clean

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend voice session setup, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend voice session setup, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - focused isolated unit suites are the domain evidence; staging live remeasure follows deploy.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, or trajectory changes; only when the tenancy lookup happens.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff with prewarm + fall-through tests](https://github.com/elizaOS/eliza/pull/new/fix/voice-context-prewarm).

Co-authored-by: wakesync <shadow@shad0w.xyz>