### PR TITLE
perf(cloud): cap Cartesia server buffer delay for realtime voice

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -455,6 +455,30 @@ describe("voice-session WS lifecycle", () => {
     expect(prewarmCalls).toBe(1);
   });
 
+  test("caps Cartesia server-side buffer delay for realtime voice", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["A short answer."]),
+    });
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "answer briefly");
+    await flush();
+    await flush();
+
+    // Cartesia defaults to a 3000ms server aggregation window; the realtime
+    // session must cap it so already-aggregated clauses start synthesis fast.
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    const requests = cartesia.sent
+      .map((entry) => JSON.parse(entry) as { max_buffer_delay_ms?: number })
+      .filter((entry) => entry.max_buffer_delay_ms !== undefined);
+    expect(requests.length).toBeGreaterThan(0);
+    for (const request of requests) {
+      expect(request.max_buffer_delay_ms).toBe(250);
+    }
+  });
+
   test("prewarms Cartesia as soon as the response turn starts", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
@@ -119,7 +119,7 @@ const baseEnv = {
   VOICE_REALTIME_WS_ENABLED: "true",
   DEEPGRAM_API_KEY: "dg",
   CARTESIA_API_KEY: "cartesia",
-  VOICE_REALTIME_CARTESIA_VOICE_ID: "voice",
+  VOICE_REALTIME_CARTESIA_VOICE_ID: "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
   VOICE_REALTIME_ELIZA_ENDPOINT: "https://eliza.test/sse",
   VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer service",
 };
@@ -247,6 +247,51 @@ describe("voice-session ws upgrade (happy path)", () => {
     const res = await upgrade();
     expect(res.status).toBe(101);
     expect(attachCalls.length).toBe(1);
+  });
+
+  test("buildSession wires a prewarm-capable scoped Eliza fetch", async () => {
+    const res = await upgrade();
+    expect(res.status).toBe(101);
+    const deps = attachCalls[0].deps as unknown as {
+      buildSession: (args: {
+        claims: Record<string, string>;
+        jti: string;
+        tokenExpSeconds: number;
+        downlink: Record<string, unknown>;
+      }) => {
+        config?: unknown;
+      };
+    };
+    // Construct a REAL VoiceSession through the route's closure. No providers
+    // are dialed at construction time (start() is never called here), so this
+    // exercises the fetchImpl/prewarmElizaContext wiring added for the
+    // session-start tenancy warmup.
+    const session = deps.buildSession({
+      claims: {
+        sessionId: "sess-upgrade-wire",
+        organizationId: "org-1",
+        userId: "user-1",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+      jti: "jti-upgrade-wire",
+      tokenExpSeconds: Math.floor(Date.now() / 1000) + 60,
+      downlink: {
+        sendControl: () => undefined,
+        sendAudio: () => undefined,
+        close: () => undefined,
+      },
+    }) as unknown as {
+      config: {
+        fetchImpl?: { prewarm?: unknown };
+        prewarmElizaContext?: unknown;
+      };
+    };
+    expect(typeof session.config.fetchImpl).toBe("function");
+    expect(typeof session.config.prewarmElizaContext).toBe("function");
+    expect(session.config.prewarmElizaContext).toBe(
+      (session.config.fetchImpl as { prewarm?: unknown }).prewarm,
+    );
   });
 
   test("returns 503 transport-unavailable when WebSocketPair is absent", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -84,6 +84,14 @@ const MAX_OUTSTANDING_METER_WINDOWS = 2;
  * context preserves prosody across the resulting chunks.
  */
 const VOICE_TTS_FIRST_CLAUSE_CHARS = 24;
+/**
+ * Cartesia's server buffers streamed transcript for up to 3000ms by default
+ * before starting synthesis, which measured ~2.7s of the speaking_start gap on
+ * staging even after phrases were sent early. The realtime session already
+ * batches text into speakable clauses via PhraseAggregator, so stacking the
+ * provider's own aggregation window on top is pure added latency.
+ */
+const VOICE_TTS_MAX_BUFFER_DELAY_MS = 250;
 
 export type { VoiceSessionDownlink } from "@/lib/voice-session/ws-handler";
 
@@ -503,7 +511,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const ensureTts = (): CartesiaSonicTtsStream => {
       if (tts) return tts;
       tts = this.cartesiaAdapter.createStream(
-        { traceId },
+        { traceId, maxBufferDelayMs: VOICE_TTS_MAX_BUFFER_DELAY_MS },
         {
           onFirstAudio: () => {
             if (this.currentVoiceTurnId !== traceId) return;


### PR DESCRIPTION
## Summary
- cap Cartesia `max_buffer_delay_ms` at 250ms on the realtime voice path (provider default: 3000ms)
- includes the ws-route buildSession prewarm wiring test that closes the #16606 coverage-gate gap on ws/route.ts

## Measured root cause
Staging short-utterance probe on commit 06fe871d (three turns, one session): `llm_first_text -> speaking_start` stayed at 2,659-2,699ms across all turns even with prewarmed sockets and 24-char first-clause streaming. That constant matches Cartesia's default 3000ms server-side text aggregation window. Our PhraseAggregator already batches deltas into speakable clauses, so the provider window is pure stacked latency.

## Tests
- ws-lifecycle 30/30 (new test asserts every generation request carries max_buffer_delay_ms=250)
- ws-route-upgrade 8/8 (new buildSession wiring test, real VoiceSession constructed through the route closure)
- Biome clean

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend TTS provider parameter, no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend TTS provider parameter, no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - staging probe timings are summarized in the Measured root cause section; focused provider-payload tests are the domain evidence.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model or prompt changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff with provider-payload assertion test](https://github.com/elizaOS/eliza/pull/new/fix/voice-tts-buffer-delay).

Co-authored-by: wakesync <shadow@shad0w.xyz>