### PR TITLE
fix(ci): route default-eliza-character.test.ts through the cloud/shared vitest lane

### DIFF
--- a/packages/cloud/shared/vitest.config.ts
+++ b/packages/cloud/shared/vitest.config.ts
@@ -9,12 +9,23 @@ import { defineConfig } from "vitest/config";
  * anywhere — a vacuous skip on the crypto-payments money path. This config
  * runs it for real against in-process PGlite.
  *
+ * `default-eliza-character.test.ts` is also listed: it imports from "vitest",
+ * so the changed-file coverage lane (run-changed-vitest-coverage.mjs) routes
+ * it through this config whenever a PR touches it. Vitest treats CLI file
+ * arguments as filters against `include`, so a file absent from `include` can
+ * never match — the lane exits "No test files found" (code 1) and hard-fails
+ * the coverage gate for any PR touching that test. It already runs under the
+ * bun lane; double execution is the only cost of listing it here.
+ *
  * Do NOT set `passWithNoTests`: if the include glob ever matches nothing, the
  * lane must red rather than silently pass.
  */
 export default defineConfig({
   test: {
-    include: ["src/lib/services/__tests__/direct-wallet-payments.integration.test.ts"],
+    include: [
+      "src/lib/services/__tests__/direct-wallet-payments.integration.test.ts",
+      "src/lib/utils/default-eliza-character.test.ts",
+    ],
     environment: "node",
     testTimeout: 120_000,
     hookTimeout: 120_000,


### PR DESCRIPTION
## Problem

Any PR touching `packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts` hard-fails the **coverage on changed files** gate:

```
No test files found, exiting with code 1
filter:  packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
include: src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
```

Observed on #16584 (see PR comment 5010443105), where it is the only blocker on an otherwise-green PR.

## Root cause

`run-changed-vitest-coverage.mjs` routes each changed vitest-import test file through its nearest `vitest.config.ts` and passes the file path as a CLI argument. Vitest treats CLI file args as **filters against `include`**, so a file not present in `include` can never match. `packages/cloud/shared/vitest.config.ts` deliberately pins `include` to only the direct-wallet integration proof and (correctly) refuses `passWithNoTests`, so the lane cannot help but exit 1.

## Fix

Add `src/lib/utils/default-eliza-character.test.ts` to the config's `include` (the option suggested in the review comment). This:

- keeps the fail-closed contract: no `passWithNoTests`, an empty match still reds the lane
- lets the changed-file lane actually execute the test it was asked to cover
- costs only double execution (the file already runs green under the bun `test:cloud` lane)

The alternative (teaching `run-changed-vitest-coverage.mjs` to skip files outside a package's include set) would silently drop coverage for exactly the files the gate is meant to measure, so the explicit include is the safer shape.

## Verification

- The gate on this PR itself exercises the new path if CI considers the config change; #16584 re-run after merge is the real proof.
- No production code touched; single workflow-support config file.

Unblocks #16584.

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI vitest lane config only, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI vitest lane config only, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - CI-only config; the coverage-on-changed-files check on this PR and the #16584 re-run are the executable proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - single vitest config include addition; the test itself already runs green in the bun lane (see #16584 CI, 11/11 pass).
