### PR TITLE
style(ui): wrap hasIds line to satisfy biome format gate

### DIFF
--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -358,7 +358,8 @@ export function useRealtimeVoiceSession(
     [],
   );
 
-  const hasIds = Boolean(normalizedAgentId) && Boolean(normalizedConversationId);
+  const hasIds =
+    Boolean(normalizedAgentId) && Boolean(normalizedConversationId);
   const available = flagEnabled && hasIds && !featureDisabled;
 
   const applyServerEventToTranscript = useCallback(


### PR DESCRIPTION
## Problem

`Quality (Extended)` is failing on every develop push since #16603 (fea9c8fa7) landed:

```
@elizaos/ui:format:check: src/hooks/useRealtimeVoiceSession.ts format
  × Formatter would have printed the following content:
    361     │ - ··const·hasIds·=·Boolean(normalizedAgentId)·&&·Boolean(normalizedConversationId);
        361 │ + ··const·hasIds·=
        362 │ + ····Boolean(normalizedAgentId)·&&·Boolean(normalizedConversationId);
```

Observed red on develop runs 29636895624 (96cb91528) and 29636221208 (e820d8083), Format + Type Safety Ratchet job. This blocks the develop 3-consecutive-green streak.

## Fix

Apply exactly the wrap biome prints. One line becomes two; no behavior change.

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - whitespace-only formatting fix, no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - whitespace-only formatting fix, no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code touched; the Quality (Extended) format:check job on this PR and next develop push is the executable proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no runtime behavior changed (identical AST, formatting only).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - single-line wrap applied verbatim from biome's own diff output.