### PR TITLE
fix(ci): use configured Anthropic API key for Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
 
           # Prompt for automated review (no @claude mention needed)


### PR DESCRIPTION
## Problem

After #16569 correctly removed `continue-on-error`, every new PR fails `claude-review` before review starts:

```
Environment variable validation failed:
Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation ... is required
```

Repository secrets contain `ANTHROPIC_API_KEY` (updated 2026-03-26) but no `CLAUDE_CODE_OAUTH_TOKEN`. The workflow passes only the absent OAuth secret. This is currently red on #16608 and #16609 and affects all PRs since #16569 landed.

## Fix

Pass the configured `ANTHROPIC_API_KEY` via the action supported input `anthropic_api_key`. This matches the credential already used by `claude-security-review.yml` and preserves #16569 fail-closed behavior.

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI credential wiring only, no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI credential wiring only, no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - failing Claude review logs on #16608/#16609 are quoted above; post-merge reruns are the executable proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this restores the mandatory review invocation; it does not change agent/model product behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - workflow-only credential source correction.