### PR TITLE
fix(ci): use API-supported Claude review model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -88,7 +88,7 @@ jobs:
 
           # Claude CLI arguments for model and allowed tools
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-opus-4-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api *)"
 
       # claude-code-action can return exit 0 after posting its own internal-error


### PR DESCRIPTION
## Problem

After #16610 restored direct API-key authentication, mandatory `claude-review` now reaches Claude Code but exits in 643ms with `is_error:true`, zero turns, and zero cost while initialized as `claude-opus-4-7`. This is red on refreshed #16608/#16609 runs.

## Fix

Use `claude-opus-4-5`, the model already configured by this repository in `claude-security-review.yml`. This keeps the review mandatory and fail closed.

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI model configuration only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI model configuration only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - #16608 job 88063594227 records the 643ms, zero-turn, zero-cost `is_error:true`; refreshed post-merge runs are the proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - CI review-model correction only; no product agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - one workflow model identifier changed to the repository-established security-review model.