### PR TITLE
fix(ci): let Claude review select an API-supported default model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -88,7 +88,6 @@ jobs:
 
           # Claude CLI arguments for model and allowed tools
           claude_args: |
-            --model claude-opus-4-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api *)"
 
       # claude-code-action can return exit 0 after posting its own internal-error


### PR DESCRIPTION
## Problem

With configured API-key auth, both explicit `claude-opus-4-7` and `claude-opus-4-5` initialize but immediately return `is_error:true`, zero cost, and no assistant turn. Refreshed #16608/#16609 runs prove both pins are unusable for this account/action path.

## Fix

Remove the explicit model override and let `claude-code-action` select its account-supported default. Mandatory/fail-closed review remains unchanged.

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI model selection only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI model selection only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - #16608 jobs 88063594227 and 88065142593 show both explicit model pins fail before an assistant turn; refreshed runs are the executable proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - CI review model selection only; no product agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - one unsupported model override removed.