### PR TITLE
fix(voice): make end-of-turn state truthful

### DIFF
--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
@@ -414,7 +414,7 @@ describe("Deepgram Flux realtime adapter", () => {
       }),
     ).toMatchObject({
       eagerEotThreshold: 0.35,
-      eotThreshold: 0.8,
+      eotThreshold: 0.9,
       eotTimeoutMs: 5_000,
     });
     expect(() =>

--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
@@ -16,7 +16,10 @@ export const DEEPGRAM_FLUX_CHUNK_MILLISECONDS = 80;
 export const DEEPGRAM_FLUX_CHUNK_BYTES = 2_560;
 
 const DEFAULT_EAGER_EOT_THRESHOLD = 0.35;
-const DEFAULT_EOT_THRESHOLD = 0.8;
+// 0.8 committed incomplete turns during ordinary 700 ms mid-sentence pauses in
+// live-provider testing (3/5 runs). 0.9 completed the same slow-speaker fixture
+// 5/5 without a premature EOT. Keep the 5 s silence fallback unchanged.
+const DEFAULT_EOT_THRESHOLD = 0.9;
 const DEFAULT_EOT_TIMEOUT_MS = 5_000;
 const DEFAULT_CLOSE_CODE = 1000;
 

--- a/packages/ui/src/components/pages/chat-view-hooks.test.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.test.tsx
@@ -514,6 +514,7 @@ describe("useChatVoiceController voice playback unlock", () => {
     }));
     realtimeHarness.state.available = true;
     realtimeHarness.state.active = true;
+    realtimeHarness.state.status = "listening";
     const { result, rerender } = renderHook(() =>
       useChatVoiceController({
         ...baseOptions,
@@ -528,6 +529,14 @@ describe("useChatVoiceController voice playback unlock", () => {
       captureMode: "compose",
     });
 
+    realtimeHarness.state.status = "thinking";
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+    expect(result.current.composerVoice.isListening).toBe(false);
+
+    realtimeHarness.state.status = "speaking";
     realtimeHarness.state.agentSpeaking = true;
     await act(async () => {
       rerender();

--- a/packages/ui/src/components/pages/chat-view-hooks.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.tsx
@@ -1022,11 +1022,17 @@ export function useChatVoiceController(options: {
   // existing start handler's barge-in branch instead of the stop branch.
   const realtimeOwnsComposer =
     manualRealtimeRequested || voiceSession.realtimeActive;
+  const realtimeIsCapturingSpeech =
+    voiceSession.status === "listening" ||
+    voiceSession.status === "transcribing";
+  const realtimeStartAwaitingActivation =
+    manualRealtimeRequested && !voiceSession.realtimeActive;
   const composerVoice = useMemo(
     () => ({
       isListening:
         voice.isListening ||
-        (realtimeOwnsComposer && !voiceSession.agentSpeaking),
+        realtimeStartAwaitingActivation ||
+        (voiceSession.realtimeActive && realtimeIsCapturingSpeech),
       captureMode: realtimeOwnsComposer
         ? ("compose" as const)
         : voice.captureMode,
@@ -1039,7 +1045,8 @@ export function useChatVoiceController(options: {
       voice.interimTranscript,
       voice.isListening,
       realtimeOwnsComposer,
-      voiceSession.agentSpeaking,
+      realtimeIsCapturingSpeech,
+      realtimeStartAwaitingActivation,
       voiceSession.interimTranscript,
       voiceSession.realtimeActive,
     ],

--- a/packages/ui/src/hooks/useContinuousVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useContinuousVoiceSession.test.tsx
@@ -135,6 +135,21 @@ describe("useContinuousVoiceSession", () => {
     expect(result.current.agentSpeaking).toBe(true);
   });
 
+  it("keeps the committed transcript visible while the EOT request is thinking", () => {
+    const batch = makeBatch({ interimTranscript: "batch interim" });
+    const realtime = makeRealtime({
+      available: true,
+      active: true,
+      status: "thinking",
+      transcriptPartial: "",
+      transcriptFinal: "committed request",
+    });
+    const { result } = renderHook(() =>
+      useContinuousVoiceSession({ batch, realtime }),
+    );
+    expect(result.current.interimTranscript).toBe("committed request");
+  });
+
   it("surfaces realtime autoplay unlock state and action while realtime is active", () => {
     const batch = makeBatch({ needsAudioUnlock: false });
     const realtime = makeRealtime({

--- a/packages/ui/src/hooks/useContinuousVoiceSession.ts
+++ b/packages/ui/src/hooks/useContinuousVoiceSession.ts
@@ -36,7 +36,7 @@ export interface ContinuousVoiceSessionState {
   realtimeEligible: boolean;
   /** Unified status for `ChatVoiceStatusBar` (realtime wins when active). */
   status: VoiceContinuousStatus;
-  /** Live partial transcript (realtime `stt_partial`, else batch interim). */
+  /** Visible in-flight transcript: partial while speaking, committed final while thinking. */
   interimTranscript: string;
   /** Committed final transcript from the realtime path ("" on batch). */
   finalTranscript: string;
@@ -108,7 +108,8 @@ export function useContinuousVoiceSession(
       ? realtime.status
       : batch.status;
     const interimTranscript = realtimeActive
-      ? realtime.transcriptPartial
+      ? realtime.transcriptPartial ||
+        (status === "thinking" ? realtime.transcriptFinal : "")
       : batch.interimTranscript;
 
     return {

--- a/packages/ui/src/voice/__tests__/voice-session-state.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-state.test.ts
@@ -42,7 +42,7 @@ describe("voice-session-state machine (§7.4)", () => {
     expect(phases).toEqual([
       "ready",
       "transcribing",
-      "transcribing",
+      "thinking",
       "thinking",
       "speaking",
       "complete",

--- a/packages/ui/src/voice/voice-session-state.ts
+++ b/packages/ui/src/voice/voice-session-state.ts
@@ -106,10 +106,9 @@ export function applyClientAction(
  *   ready            → ready (client then starts capture → listening)
  *   stt_partial      → transcribing (+ interim text)
  *   stt_eager_eot    → transcribing (no phase change; speculative)
- *   stt_final        → transcribing→thinking is deferred to llm_first_text; we
- *                      commit the final text + set traceId, phase stays
- *                      transcribing until the LLM leg starts (thinking)
- *   llm_first_text   → thinking
+ *   stt_final        → thinking (the authoritative EOT committed the user turn
+ *                      and the server dispatches the LLM request immediately)
+ *   llm_first_text   → thinking (first response text, phase already truthful)
  *   speaking_start   → speaking
  *   speaking_end     → complete → (caller loops to listening)
  *   interrupted      → interrupted → (caller loops to listening)
@@ -143,7 +142,11 @@ export function applyServerEvent(
     case "stt_final":
       return {
         ...state,
-        phase: "transcribing",
+        // `stt_final` is the server's commit/request-dispatch edge. Keeping the
+        // UI in "Transcribing" until the first LLM token makes a completed EOT
+        // look late by the entire model TTFT and leaves the mic surface claiming
+        // it is still listening while the request is already in flight.
+        phase: "thinking",
         traceId: event.traceId,
         finalTranscript: event.text,
         interimTranscript: "",


### PR DESCRIPTION
## Summary
- raise Flux authoritative EOT confidence from 0.8 to 0.9 after live-provider slow-speaker testing found 700 ms mid-sentence pauses were committed early in 3/5 runs at 0.8 and 0/5 at 0.9
- move the client to `thinking` at authoritative `stt_final`, which is also the server request-dispatch edge, instead of falsely showing `Transcribing` through the full LLM TTFT
- keep the committed transcript visible while thinking
- make composer mic ownership truthful during both pending realtime startup and post-EOT request flight, preventing double-start without claiming the mic is listening while thinking

## Evidence
Direct Flux A/B, same PCM streamed realtime:
- threshold 0.8: short median EOT tail 242 ms, slow-speaker premature EOT 3/5
- threshold 0.7: short median 180 ms, slow-speaker premature EOT 5/5
- threshold 0.85: short median 320 ms, slow-speaker premature EOT 2/5
- threshold 0.9: short median 1,094 ms, slow-speaker premature EOT 0/5

The 0.9 tradeoff is deliberate: correctness over cutting off a speaker. It adds roughly 850 ms to the short synthetic fixture, so this is not presented as a latency win.

Staging WS barge-in remained green after #16607: `interrupted` arrived 6.8 ms after the control frame, the second utterance transcribed correctly, and the second reply delivered 180,902 PCM bytes.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - this patch changes voice state semantics only and introduces no visual layout or styling changes; Shadow's phone test is the authoritative before baseline and remains RED.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: Canonical staging deployment run 29651949859 succeeded. Chromium mobile-viewport capture and network trace loaded `index-D3vGZFKC.js` and realtime client chunk `voice-session-client-EYCsAwkU.js`; Shadow phone retest remains required.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no honest real-device walkthrough exists yet; Shadow's phone retest is required after staging deployment.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: Direct Flux A/B above plus 11/11 Deepgram adapter tests; live provider result was 0/5 premature EOT at threshold 0.9.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: 60/60 focused UI/hook tests passed. Actual Chromium network trace loaded the staging index bundle and realtime voice client chunk with HTTP 200. The index embeds `VITE_VOICE_REALTIME_WS:"1"`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt/model/trajectory behavior changed; this patch changes EOT confidence and client phase rendering.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: PR diff and direct Flux A/B measurements above. Repository variable `VOICE_REALTIME_WS_ENABLED=true` was set separately so the canonical staging frontend build bakes in the realtime path.

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: N/A - no text labels or visual layout changed; state labels reuse the existing status component.

## Tests
- `bun test packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts` (11 pass)
- `bun run test -- src/components/pages/chat-view-hooks.test.tsx src/hooks/useContinuousVoiceSession.test.tsx src/voice/__tests__/voice-session-state.test.ts` from `packages/ui` (38 pass)
- Biome on touched composer controller (pass)

## Deployment
Canonical staging run https://github.com/elizaOS/eliza/actions/runs/29651949859 succeeded for App Pages, Console Pages, API Worker, and staging routing. API health served merge commit `ea953ec2c43e2425a3e3c0166ab9de165a3fa418`.

## Status
Treat voice as RED pending Shadow's real-device retest. Server-only timings and desktop/browser traces are not acceptance evidence.
