### PR TITLE
fix(ios): bind HTTPS auth callback association

### DIFF
--- a/packages/app-core/platforms/apple-store-entitlements.reviewed.json
+++ b/packages/app-core/platforms/apple-store-entitlements.reviewed.json
@@ -110,9 +110,12 @@
           "appReviewJustification": "Required for Screen Time and website blocking features exposed through the iOS app and extension."
         },
         "com.apple.developer.associated-domains": {
-          "arrayStringPatterns": ["^applinks:eliza\\.app$"],
+          "arrayStringPatterns": [
+            "^applinks:eliza\\.app$",
+            "^webcredentials:eliza\\.app$"
+          ],
           "reviewSensitive": true,
-          "appReviewJustification": "Required for the reviewed production Universal Link host used by native app association. The exact host is pinned so additional domains require a new review."
+          "appReviewJustification": "Required for the reviewed production Universal Link host and ASWebAuthenticationSession HTTPS callback. Apple requires the exact callback host to be associated through web credentials; both services remain pinned to eliza.app so additional domains require a new review."
         },
         "com.apple.security.application-groups": {
           "arrayStringPatterns": ["^group\\.[A-Za-z0-9.-]+$"],

--- a/packages/app-core/platforms/ios/App/App/App.entitlements
+++ b/packages/app-core/platforms/ios/App/App/App.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:eliza.app</string>
+		<string>webcredentials:eliza.app</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/packages/homepage/edge/apple-app-site-association.json
+++ b/packages/homepage/edge/apple-app-site-association.json
@@ -44,5 +44,8 @@
         ]
       }
     ]
+  },
+  "webcredentials": {
+    "apps": ["25877RY2EH.ai.elizaos.app"]
   }
 }

--- a/packages/homepage/edge/apple-app-site-association.test.ts
+++ b/packages/homepage/edge/apple-app-site-association.test.ts
@@ -101,6 +101,9 @@ describe("eliza.app AASA edge Worker", () => {
           },
         ],
       },
+      webcredentials: {
+        apps: ["25877RY2EH.ai.elizaos.app"],
+      },
     });
   });
 
@@ -285,11 +288,37 @@ describe("eliza.app AASA edge Worker", () => {
       "applinks components differ from the reviewed legacy routes plus /auth/callback",
     );
 
-    const webCredentials = JSON.parse(associationBody);
-    webCredentials.webcredentials = {
+    const wrongWebCredentials = JSON.parse(associationBody);
+    wrongWebCredentials.webcredentials.apps = ["ATTACKER.ai.elizaos.app"];
+    expect(
+      validateAsCanonicalOrigin(JSON.stringify(wrongWebCredentials)),
+    ).toContain(
+      "webcredentials does not bind exactly 25877RY2EH.ai.elizaos.app",
+    );
+
+    const missingWebCredentials = JSON.parse(associationBody);
+    delete missingWebCredentials.webcredentials;
+    expect(
+      validateAsCanonicalOrigin(JSON.stringify(missingWebCredentials)),
+    ).toEqual(
+      expect.arrayContaining([
+        "webcredentials contains unreviewed fields",
+        "webcredentials does not bind exactly 25877RY2EH.ai.elizaos.app",
+        "association contains unreviewed top-level services or fields",
+      ]),
+    );
+
+    const extraWebCredentialField = JSON.parse(associationBody);
+    extraWebCredentialField.webcredentials.passwords = true;
+    expect(
+      validateAsCanonicalOrigin(JSON.stringify(extraWebCredentialField)),
+    ).toContain("webcredentials contains unreviewed fields");
+
+    const extraService = JSON.parse(associationBody);
+    extraService.activitycontinuation = {
       apps: ["25877RY2EH.ai.elizaos.app"],
     };
-    expect(validateAsCanonicalOrigin(JSON.stringify(webCredentials))).toContain(
+    expect(validateAsCanonicalOrigin(JSON.stringify(extraService))).toContain(
       "association contains unreviewed top-level services or fields",
     );
   });
@@ -614,23 +643,20 @@ describe("eliza.app AASA edge Worker", () => {
     );
 
     const unreviewedDomain = entitlements.replace(
-      "<string>applinks:eliza.app</string>",
-      "<string>applinks:eliza.app</string>\n\t\t<string>webcredentials:eliza.app</string>",
+      "<string>webcredentials:eliza.app</string>",
+      "<string>webcredentials:attacker.example</string>",
     );
     const entitlementFailures = validateReleaseAppConfiguration({
       project,
       entitlements: unreviewedDomain,
     });
     expect(entitlementFailures).toContain(
-      "App entitlements must contain exactly the applinks:eliza.app associated domain",
-    );
-    expect(entitlementFailures).toContain(
-      "App entitlements must not claim unreviewed webcredentials",
+      "App entitlements must contain exactly the applinks and webcredentials eliza.app domains",
     );
 
     const duplicateAssociatedDomains = entitlements.replace(
       "</dict>",
-      "\t<key>com.apple.developer.associated-domains</key>\n\t<array>\n\t\t<string>applinks:eliza.app</string>\n\t</array>\n</dict>",
+      "\t<key>com.apple.developer.associated-domains</key>\n\t<array>\n\t\t<string>applinks:eliza.app</string>\n\t\t<string>webcredentials:eliza.app</string>\n\t</array>\n</dict>",
     );
     expect(
       validateReleaseAppConfiguration({
@@ -638,7 +664,7 @@ describe("eliza.app AASA edge Worker", () => {
         entitlements: duplicateAssociatedDomains,
       }),
     ).toContain(
-      "App entitlements must contain exactly the applinks:eliza.app associated domain",
+      "App entitlements must contain exactly the applinks and webcredentials eliza.app domains",
     );
   });
 

--- a/packages/homepage/public/.well-known/README.md
+++ b/packages/homepage/public/.well-known/README.md
@@ -22,9 +22,10 @@ The reviewed production document is
 public tree. It uses the Xcode App target's Release Team ID and bundle ID
 (`25877RY2EH.ai.elizaos.app`), preserves the normalized legacy routes, and adds
 `/auth/callback` for the mobile Authorization Code + PKCE return path. The
-paired App target carries only the required `applinks:eliza.app` entitlement;
-password AutoFill is not part of this release, so `webcredentials` is not
-claimed by either side.
+paired App target carries both `applinks:eliza.app` and
+`webcredentials:eliza.app`: Apple requires the latter association for
+`ASWebAuthenticationSession.Callback.https`, independently of password
+AutoFill. Both AASA services bind only the reviewed release application ID.
 
 GitHub Pages does not control response headers, so
 `.github/workflows/deploy-aasa.yml` publishes an exact-path Cloudflare Worker.

--- a/packages/homepage/scripts/verify-aasa-response.mjs
+++ b/packages/homepage/scripts/verify-aasa-response.mjs
@@ -16,6 +16,7 @@ export const APPLE_CDN_AASA_URL =
   "https://app-site-association.cdn-apple.com/a/v1/eliza.app";
 export const MAX_AASA_BYTES = 128 * 1024;
 export const RELEASE_APP_ID = "25877RY2EH.ai.elizaos.app";
+export const RELEASE_WEBCREDENTIAL_APPS = [RELEASE_APP_ID];
 export const RELEASE_APPLINK_COMPONENTS = [
   { "/": "/auth/callback" },
   { "/": "/chat*" },
@@ -81,10 +82,27 @@ function validateAssociationSemantics(association) {
     failures.push("applinks contains unreviewed fields");
   }
   if (
+    !association?.webcredentials ||
+    !isDeepStrictEqual(Object.keys(association.webcredentials).sort(), ["apps"])
+  ) {
+    failures.push("webcredentials contains unreviewed fields");
+  }
+  if (
+    !isDeepStrictEqual(
+      association?.webcredentials?.apps,
+      RELEASE_WEBCREDENTIAL_APPS,
+    )
+  ) {
+    failures.push(`webcredentials does not bind exactly ${RELEASE_APP_ID}`);
+  }
+  if (
     !association ||
     typeof association !== "object" ||
     Array.isArray(association) ||
-    !isDeepStrictEqual(Object.keys(association).sort(), ["applinks"])
+    !isDeepStrictEqual(Object.keys(association).sort(), [
+      "applinks",
+      "webcredentials",
+    ])
   ) {
     failures.push(
       "association contains unreviewed top-level services or fields",
@@ -187,13 +205,15 @@ export function validateReleaseAppConfiguration({ project, entitlements }) {
         (match) => match[1],
       )
     : [];
-  if (!isDeepStrictEqual(domains, ["applinks:eliza.app"])) {
+  if (
+    !isDeepStrictEqual(domains, [
+      "applinks:eliza.app",
+      "webcredentials:eliza.app",
+    ])
+  ) {
     failures.push(
-      "App entitlements must contain exactly the applinks:eliza.app associated domain",
+      "App entitlements must contain exactly the applinks and webcredentials eliza.app domains",
     );
-  }
-  if (entitlements.includes("webcredentials:")) {
-    failures.push("App entitlements must not claim unreviewed webcredentials");
   }
   return failures;
 }


### PR DESCRIPTION
## Summary

- adds the exact `webcredentials:eliza.app` entitlement required by `ASWebAuthenticationSession.Callback.https`
- binds the reviewed release application ID in the edge-only AASA `webcredentials.apps` service
- keeps the existing exact `applinks` routes and fail-closed production deployment gate
- updates the App Store entitlement allowlist and release verifier so extra domains, apps, services, fields, or ordering still fail

## Why

Xcode 26.6's AuthenticationServices SDK declares the claimed-HTTPS callback API on iOS 17.4+ and states that its host must be associated through web credentials domains. The current #16420 prerequisite has `applinks` only and explicitly rejects `webcredentials`, so the native browser session can fail to start even after the Cloud mobile-auth routes are deployed.

This is an exact first-party association, not a password or token transport: both entitlement services are pinned to `eliza.app`, and both AASA services bind only `25877RY2EH.ai.elizaos.app`.

Contributes to #16420.

## Verification

- rebased onto `origin/develop` at `f749cbccf` with zero conflicts
- `bun run --cwd packages/homepage test:aasa-edge` — 17 passed, 104 assertions
- `bun run --cwd packages/app-core test:apple-entitlements` — 5 passed
- `bun run --cwd packages/app-core entitlements:audit` — reviewed source entitlements OK
- Biome on every changed code/config file — passed
- error-policy, type-safety, and alias-read ratchets — passed
- `git diff --check` — passed

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - This PR changes no rendered UI surface; the pre-change state is a tracked machine-readable AASA and entitlement contract.

<!-- evidence-row:after-screenshots -->
- [x] N/A - This PR changes no rendered UI surface; the post-change result is represented by the reviewed entitlement and AASA artifacts linked below.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - There is no interactive user flow in this PR; it only updates static association declarations and their fail-closed validators.

<!-- evidence-row:backend-logs -->
- [x] N/A - No backend process or runtime request path changes; the AASA edge artifact is static, and protected live deployment is intentionally deferred until this commit reaches `main`.

<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend runtime, console, network, or client state-management code changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent, action, provider, prompt, model, or LLM behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Manually reviewed static contract artifacts at commit `5d9613fa719181e96aaff18aeee8262fb963d443`: [App entitlements](https://github.com/elizaOS/eliza/blob/5d9613fa719181e96aaff18aeee8262fb963d443/packages/app-core/platforms/ios/App/App/App.entitlements), [AASA document](https://github.com/elizaOS/eliza/blob/5d9613fa719181e96aaff18aeee8262fb963d443/packages/homepage/edge/apple-app-site-association.json), and [reviewed entitlement allowlist](https://github.com/elizaOS/eliza/blob/5d9613fa719181e96aaff18aeee8262fb963d443/packages/app-core/platforms/apple-store-entitlements.reviewed.json). They bind only `applinks:eliza.app` and `webcredentials:eliza.app` to `25877RY2EH.ai.elizaos.app`; this row does not claim pre-merge live-edge deployment proof.
