### PR TITLE
perf(chat): remove cold conversation round trip

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -130,7 +130,11 @@ describe("shared agent messages/stream", () => {
     bridgeStream.mockReset();
     findByIdAndOrg.mockReset();
     resolveSharedAgent.mockResolvedValue({
-      agent: {},
+      agent: {
+        id: AGENT,
+        organization_id: ORG,
+        execution_tier: "shared",
+      },
       agentId: AGENT,
       orgId: ORG,
       agentName: "Eliza",
@@ -503,6 +507,26 @@ describe("shared agent messages/stream", () => {
     expect(res.headers.get("access-control-allow-credentials")).toBe("true");
   });
 
+  test("exposes pre-header phase timing on successful streams", async () => {
+    bridgeStream.mockResolvedValue(
+      new Response('event: done\ndata: {"text":"ok"}\n\n', {
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    const res = await postStream({ text: "timed" }, "https://localhost");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-expose-headers")).toContain(
+      "Server-Timing",
+    );
+    expect(res.headers.get("server-timing")).toContain("scope;dur=");
+    expect(res.headers.get("server-timing")).toContain("body;dur=");
+    expect(res.headers.get("server-timing")).toContain("bridge;dur=");
+    expect(res.headers.get("x-eliza-stream-scope-ms")).not.toBeNull();
+    expect(res.headers.get("x-eliza-stream-bridge-ms")).not.toBeNull();
+  });
+
   test("empty text → 400 (not a stream)", async () => {
     const res = await postStream({ text: "  " });
     expect(res.status).toBe(400);
@@ -535,6 +559,7 @@ describe("shared agent messages/stream", () => {
     expect(res.headers.get("access-control-allow-origin")).toBe(
       "https://localhost",
     );
+    expect(res.headers.get("server-timing")).toContain("bridge;dur=");
     await expect(res.json()).resolves.toEqual({
       success: false,
       error: "Insufficient credits. Required: $0.0500, Available: $0.0000",

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -40,6 +40,14 @@ const CORS_METHODS = "POST, OPTIONS";
 
 const app = new Hono<AppEnv>();
 
+function nowMs(): number {
+  return performance.now();
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.round((nowMs() - startedAt) * 10) / 10;
+}
+
 async function resolveAgentScope(c: Parameters<typeof resolveSharedAgent>[0]) {
   const configured = c.env?.VOICE_REALTIME_ELIZA_AUTHORIZATION;
   const presented = c.req.header("authorization");
@@ -68,7 +76,24 @@ app.options("/", (c) =>
 
 app.post("/", async (c) => {
   const origin = c.req.header("origin");
-  const r = await resolveAgentScope(c);
+  const scopeStartedAt = nowMs();
+  const scopePromise = resolveAgentScope(c).then((result) => ({
+    result,
+    durationMs: elapsedMs(scopeStartedAt),
+  }));
+  const bodyStartedAt = nowMs();
+  const bodyPromise = c.req
+    .json()
+    .catch(() => ({}))
+    .then((body: unknown) => ({
+      body,
+      durationMs: elapsedMs(bodyStartedAt),
+    }));
+
+  const [
+    { result: r, durationMs: scopeMs },
+    { body: raw, durationMs: bodyMs },
+  ] = await Promise.all([scopePromise, bodyPromise]);
   if ("error" in r) {
     return applyCorsHeaders(
       Response.json(
@@ -85,13 +110,16 @@ app.post("/", async (c) => {
   }
 
   const conversationId = c.req.param("conversationId") ?? r.agentId;
-  const raw: unknown = await c.req.json().catch(() => ({}));
   return handleCanonicalScopedAgentStream({
     agentId: r.agentId,
     orgId: r.orgId,
     conversationId,
     body: raw,
     origin,
+    timings: {
+      scope: scopeMs,
+      body: bodyMs,
+    },
   } satisfies CanonicalScopedStreamRequest);
 });
 

--- a/packages/cloud/shared/src/lib/cors-constants.ts
+++ b/packages/cloud/shared/src/lib/cors-constants.ts
@@ -64,6 +64,10 @@ export const CORS_EXPOSE_HEADER_NAMES = [
   "X-Eliza-Preforward-Ms",
   "X-Eliza-Auth-Trace",
   "X-Eliza-Inference-Path",
+  "X-Eliza-Stream-Scope-Ms",
+  "X-Eliza-Stream-Body-Ms",
+  "X-Eliza-Stream-Parse-Ms",
+  "X-Eliza-Stream-Bridge-Ms",
 ] as const;
 
 export const CORS_ALLOW_METHOD_NAMES = [

--- a/packages/cloud/shared/src/lib/services/proxy/cors.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/cors.ts
@@ -3,6 +3,7 @@ import {
   APP_LOCAL_ORIGIN_RE,
   APP_SCHEME_ORIGIN_RE,
   CORS_ALLOW_HEADERS,
+  CORS_EXPOSE_HEADER_NAMES,
   CORS_MAX_AGE,
 } from "../../cors-constants";
 
@@ -62,6 +63,7 @@ export function getCorsHeaders(methods?: string, origin?: string | null): Record
       "Access-Control-Allow-Methods": methods || "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers": CORS_ALLOW_HEADERS,
       "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Expose-Headers": CORS_EXPOSE_HEADER_NAMES.join(", "),
       "Access-Control-Max-Age": CORS_MAX_AGE,
       // Reflecting the origin makes the response vary by Origin; declare it so a
       // shared cache never serves one origin's ACAO to another.
@@ -72,6 +74,7 @@ export function getCorsHeaders(methods?: string, origin?: string | null): Record
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": methods || "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": CORS_ALLOW_HEADERS,
+    "Access-Control-Expose-Headers": CORS_EXPOSE_HEADER_NAMES.join(", "),
     "Access-Control-Max-Age": CORS_MAX_AGE,
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -4,6 +4,7 @@
  * shared message body parsing, bridge dispatch, billing failure translation, and
  * SSE/CORS response shape used by HTTP routes and in-process voice turns.
  */
+
 import { InsufficientCreditsError } from "../../api/errors";
 import { logger } from "../../utils/logger";
 import type { BridgeRequest } from "../eliza-sandbox";
@@ -24,17 +25,48 @@ export interface CanonicalScopedStreamRequest {
   conversationId: string;
   body: unknown;
   origin?: string | null;
+  timings?: Record<string, number>;
+}
+
+function nowMs(): number {
+  return performance.now();
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.round((nowMs() - startedAt) * 10) / 10;
+}
+
+function addStreamTimingHeaders(response: Response, timings: Record<string, number>): Response {
+  const headers = new Headers(response.headers);
+  const entries = Object.entries(timings).filter(([, duration]) => Number.isFinite(duration));
+  if (entries.length) {
+    headers.set(
+      "Server-Timing",
+      entries.map(([phase, duration]) => `${phase};dur=${duration}`).join(", "),
+    );
+    for (const [phase, duration] of entries) {
+      headers.set(`X-Eliza-Stream-${phase}-Ms`, String(duration));
+    }
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 export async function handleCanonicalScopedAgentStream(
   request: CanonicalScopedStreamRequest,
 ): Promise<Response> {
+  const timings = request.timings ?? {};
+  const parseStartedAt = nowMs();
   const text =
     request.body &&
     typeof request.body === "object" &&
     typeof (request.body as { text?: unknown }).text === "string"
       ? (request.body as { text: string }).text
       : "";
+  timings.parse = elapsedMs(parseStartedAt);
   if (!text.trim()) {
     return applyCorsHeaders(
       Response.json({ success: false, error: "text is required" }, { status: 400 }),
@@ -51,46 +83,64 @@ export async function handleCanonicalScopedAgentStream(
   };
 
   let upstream: Response | null;
+  const bridgeStartedAt = nowMs();
   try {
     upstream = await elizaSandboxService.bridgeStream(request.agentId, request.orgId, rpc);
+    timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {
+    timings.bridge = elapsedMs(bridgeStartedAt);
     // error-policy:J1 boundary translation — bridgeStream rejects insufficient
     // credit before any SSE bytes exist, so callers get the canonical 402 JSON.
     if (error instanceof InsufficientCreditsError) {
       logger.warn("[shared-runtime REST] stream send rejected: insufficient credits", {
         agentId: request.agentId,
       });
-      return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            error: error.message,
-            code: "insufficient_credits",
-            retryable: false,
-          },
-          { status: 402 },
+      return addStreamTimingHeaders(
+        applyCorsHeaders(
+          Response.json(
+            {
+              success: false,
+              error: error.message,
+              code: "insufficient_credits",
+              retryable: false,
+            },
+            { status: 402 },
+          ),
+          CORS_METHODS,
+          request.origin,
         ),
-        CORS_METHODS,
-        request.origin,
+        timings,
       );
     }
     throw error;
+  } finally {
+    logger.info("[shared-runtime REST] stream pre-header timing", {
+      agentId: request.agentId,
+      conversationId: request.conversationId,
+      ...timings,
+    });
   }
 
   if (!upstream?.body) {
     const body = `event: error\ndata: ${JSON.stringify({
       message: "Agent produced no streamed response",
     })}\n\n`;
-    return applyCorsHeaders(
-      new Response(body, { headers: STREAM_HEADERS }),
-      CORS_METHODS,
-      request.origin,
+    return addStreamTimingHeaders(
+      applyCorsHeaders(
+        new Response(body, { headers: STREAM_HEADERS }),
+        CORS_METHODS,
+        request.origin,
+      ),
+      timings,
     );
   }
 
-  return applyCorsHeaders(
-    new Response(upstream.body, { headers: STREAM_HEADERS }),
-    CORS_METHODS,
-    request.origin,
+  return addStreamTimingHeaders(
+    applyCorsHeaders(
+      new Response(upstream.body, { headers: STREAM_HEADERS }),
+      CORS_METHODS,
+      request.origin,
+    ),
+    timings,
   );
 }

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -13,6 +13,7 @@ import {
   buildCloudSharedAgentApiBase,
   buildDedicatedCloudAgentApiBase,
   dedicatedCloudAgentIdFromBase,
+  directCloudSharedAgentIdFromBase,
   isCloudAgentsCollectionBase,
   isElizaCloudControlPlaneAgentlessBase,
 } from "../utils/cloud-agent-base";
@@ -173,6 +174,22 @@ describe("cloud-agent-base helpers", () => {
     expect(
       dedicatedCloudAgentIdFromBase("https://agent-123.staging.elizacloud.ai"),
     ).toBe("agent-123");
+  });
+
+  it("directCloudSharedAgentIdFromBase extracts REST and legacy bridge agent ids", () => {
+    expect(
+      directCloudSharedAgentIdFromBase(
+        "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123",
+      ),
+    ).toBe("agent-123");
+    expect(
+      directCloudSharedAgentIdFromBase(
+        "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent%20id/bridge",
+      ),
+    ).toBe("agent id");
+    expect(
+      directCloudSharedAgentIdFromBase("https://agent-123.elizacloud.ai"),
+    ).toBeNull();
   });
 
   it("isCloudAgentsCollectionBase flags blank/bare/collection bases", () => {

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -30,6 +30,7 @@ import {
 import type { LoadConversationMessagesResult } from "./internal";
 import {
   buildSendFailureNotice,
+  createConversationForFirstSend,
   getSendValidationFailureMessage,
   isRetryableSendError,
   resolveAbortRoomId,
@@ -2616,11 +2617,52 @@ describe("useChatSend manual resend still works after auto-retry exhausts", () =
   });
 });
 
+describe("createConversationForFirstSend", () => {
+  it("synthesizes the canonical shared conversation without a create request", async () => {
+    const createConversation = vi.fn();
+    const result = await createConversationForFirstSend(
+      {
+        getBaseUrl: () => SHARED_BASE,
+        createConversation,
+      } as never,
+      "en",
+    );
+
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(result.conversation).toMatchObject({
+      id: "agent-123",
+      roomId: "agent-123",
+      title: "Chat",
+    });
+  });
+
+  it("keeps dedicated conversation creation on the REST client", async () => {
+    const conversation = {
+      id: "dedicated-conversation",
+      roomId: "dedicated-room",
+      title: "Chat",
+      createdAt: "2026-07-18T00:00:00.000Z",
+      updatedAt: "2026-07-18T00:00:00.000Z",
+    };
+    const createConversation = vi.fn(async () => ({ conversation }));
+    const result = await createConversationForFirstSend(
+      {
+        getBaseUrl: () => DEDICATED_BASE,
+        createConversation,
+      } as never,
+      "en",
+    );
+
+    expect(createConversation).toHaveBeenCalledWith(undefined, { lang: "en" });
+    expect(result.conversation).toEqual(conversation);
+  });
+});
+
 describe("resolveAbortRoomId", () => {
   it("resolves synchronously without requiring a conversation refresh", () => {
-    expect(resolveAbortRoomId("conversation-1", " room-known ", "room-cached")).toBe(
-      "room-known",
-    );
+    expect(
+      resolveAbortRoomId("conversation-1", " room-known ", "room-cached"),
+    ).toBe("room-known");
     expect(resolveAbortRoomId("conversation-1", null, " room-cached ")).toBe(
       "room-cached",
     );

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -39,6 +39,7 @@ import {
   type CloudHandoffPhaseDetail,
 } from "../events";
 import { getWindowNavigationPath, type Tab } from "../navigation";
+import { directCloudSharedAgentIdFromBase } from "../utils/cloud-agent-base";
 import {
   dispatchViewActionHandoff,
   findViewActionHandoff,
@@ -680,6 +681,28 @@ export interface UseChatSendDeps {
 }
 
 // ── Hook ────────────────────────────────────────────────────────────
+
+export async function createConversationForFirstSend(
+  chatClient: Pick<typeof client, "createConversation" | "getBaseUrl">,
+  lang: string,
+): Promise<{ conversation: Conversation }> {
+  const sharedAgentId = directCloudSharedAgentIdFromBase(
+    chatClient.getBaseUrl(),
+  );
+  if (sharedAgentId) {
+    const createdAt = new Date().toISOString();
+    return {
+      conversation: {
+        id: sharedAgentId,
+        title: "Chat",
+        roomId: sharedAgentId,
+        createdAt,
+        updatedAt: createdAt,
+      },
+    };
+  }
+  return chatClient.createConversation(undefined, { lang });
+}
 
 export function useChatSend(deps: UseChatSendDeps) {
   const {
@@ -1397,9 +1420,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       if (!convId) {
         try {
           const { conversation: rawConversation } =
-            await client.createConversation(undefined, {
-              lang: uiLanguage,
-            });
+            await createConversationForFirstSend(client, uiLanguage);
           if (!isConversationRecord(rawConversation)) {
             throw new Error(
               "Conversation creation returned an invalid payload.",

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -49,6 +49,30 @@ export function normalizeDirectCloudSharedAgentApiBase(value: string): string {
   return stripTrailingSlash(url.toString());
 }
 
+/**
+ * Extract the agent id from a direct shared-runtime Cloud agent base. Shared
+ * agents expose exactly one REST conversation and its id is the agent id, so
+ * callers can use this to avoid a redundant `/api/conversations` create round
+ * trip when the selected base is already scoped to that agent.
+ */
+export function directCloudSharedAgentIdFromBase(
+  value: string | null | undefined,
+): string | null {
+  if (!value?.trim()) return null;
+  const url = normalizeHttpUrl(value.trim());
+  if (!url) return null;
+  const sharedPath = directSharedAgentPath(url.pathname);
+  if (!sharedPath) return null;
+  const path = stripTrailingSlash(sharedPath.apiPath);
+  const agentId = path.slice("/api/v1/eliza/agents/".length);
+  try {
+    return agentId ? decodeURIComponent(agentId) : null;
+  } catch {
+    // error-policy:J3 malformed URL encoding yields the explicit null signal.
+    return null;
+  }
+}
+
 // Staging apex + API. Without these, `staging.elizacloud.ai` ends with
 // `.elizacloud.ai` and is misclassified as a per-agent subdomain.
 const STAGING_CONSOLE_HOSTS = new Set([


### PR DESCRIPTION
## Summary
- synthesize the canonical shared-runtime conversation client-side instead of blocking first send on `POST /conversations`
- preserve real conversation creation for dedicated agents and greeting/bootstrap requests
- overlap request-body parsing with auth/scope resolution on the stream route
- expose `scope`, `body`, `parse`, and `bridge` pre-header phase timings through `Server-Timing` and `X-Eliza-Stream-*` headers
- preserve the canonical pre-stream HTTP 402 credit contract

## Root cause
The cold browser trace showed first send serialized two separate cold Worker/Hyperdrive requests. The canonical conversation create is idempotent and always returns `conversation.id === roomId === agentId`, but the client still awaited it before dispatching the actual stream. PR #16606's prewarm is voice/session-scoped and does not cover this ordinary REST chat path.

## Test notes
- `biome check` passes on all 10 changed source/test files
- `git diff --check` passes
- focused tests were attempted but this detached worktree does not have a complete dependency install (`vitest`, then `drizzle-orm`, unresolved via the available shared node_modules). CI is authoritative.

## Acceptance
Staging only. After deploy, measure real browser click to first painted text on a newly selected conversation and recheck warm turns. The response now exposes phase timings so any remaining server cold cost can be assigned precisely.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - latency-only transport/control-flow change; no rendered pixels, styles, copy, or layout changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - latency-only transport/control-flow change; no rendered pixels, styles, copy, or layout changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction or layout changed; acceptance is browser timestamp instrumentation.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [PR checks and test runs](https://github.com/elizaOS/eliza/pull/16619/checks). This PR adds structured stream pre-header timing logs and browser-readable Server-Timing phases.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: [PR checks](https://github.com/elizaOS/eliza/pull/16619/checks). Baseline real-browser trace measured 4,058 ms click-to-stream-dispatch and 4,980 ms dispatch-to-SSE-headers on the authoritative cold turn.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - provider/model/prompt/response behavior is unchanged; this removes redundant prerequisite work and instruments timing.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [focused PR diff](https://github.com/elizaOS/eliza/pull/16619/files), [CI checks](https://github.com/elizaOS/eliza/pull/16619/checks).

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: N/A - no visual text or rendered UI changed.

Co-authored-by: wakesync <shadow@shad0w.xyz>

