### PR TITLE
fix(auth): persist hosted PWA agent session

### DIFF
--- a/PWA-SESSION-PERSIST-2026-07-18.md
+++ b/PWA-SESSION-PERSIST-2026-07-18.md
@@ -1,0 +1,83 @@
+# PWA Session Persist - 2026-07-18
+
+## Flow
+
+Eliza Cloud opens a hosted dedicated agent at `/pair?token=<one-time-token>`.
+The agent-side pairing route exchanges that short-lived token with Cloud for the
+agent-local `ELIZA_API_TOKEN`, returns a no-store HTML handoff page, stores the
+token in browser storage, seeds the boot-config singleton for the current page,
+and redirects to `/`. The app boot code then adopts the stored token, configures
+the API client, and persists the active cloud agent profile.
+
+## Root Cause
+
+The long-lived per-agent API token was stored only in `sessionStorage` under
+`eliza:cloud-pair:api-token`. iOS standalone PWA sessions can lose
+`sessionStorage` when the PWA process is terminated, so a previously paired
+agent relaunched without the bearer token and fell back to the Cloud-hosted auth
+notice.
+
+## Secret And Deploy Analysis
+
+The paired token is the container's existing `ELIZA_API_TOKEN`; this change does
+not mint, transform, shorten, or lengthen it. The pairing-token exchange and its
+existing expiry/validation remain unchanged.
+
+Blue/green image upgrades preserve the same token. In
+`packages/cloud/shared/src/lib/services/eliza-sandbox.ts`, `executeUpgrade`
+decrypts the stored `environment_vars`, builds the blue container's
+`environmentVars` as the decrypted env plus managed inference defaults, and the
+inline comment explicitly records that `DATABASE_URL`, `ELIZA_API_TOKEN`,
+`ELIZAOS_CLOUD_API_KEY`, and other non-inference values are preserved verbatim.
+That path avoids the full provision merge that would mint a new API key.
+
+## Fix
+
+The pairing handoff now writes the same key,
+`eliza:cloud-pair:api-token`, to both `sessionStorage` and `localStorage`.
+`sessionStorage` remains for same-tab migration and compatibility; `localStorage`
+is the durable PWA channel.
+
+Updated paths:
+
+- `packages/ui/src/components/auth/CloudPairRelay.tsx`
+- `packages/agent/src/api/cloud-pair-route.ts`
+- `packages/app-core/src/api/cloud-pair-route.ts`
+- `packages/app/src/main.tsx`
+
+`applyCloudPairSessionToken()` now resolves `localStorage` first, falls back to
+`sessionStorage`, and migrates a legacy session token into durable storage when
+possible. The Cloud-hosted auth notice now includes a tappable "Re-open from
+Eliza Cloud" CTA. The CTA is environment-aware for staging dedicated-agent
+hosts and uses the agent-specific detail URL when the subdomain identifies the
+agent. It does not auto-navigate.
+
+## Tests
+
+Focused tests added or updated for:
+
+- React relay durable token persistence.
+- Server-generated HTML relay writes to both storage channels.
+- App boot source guard for durable-first read, legacy fallback, and migration.
+- Cloud-hosted notice CTA and staging/agent-aware URL resolution.
+
+Local verification in this worktree:
+
+- `bun test packages/app/test/cloud-pair-session-token.test.ts` passed.
+- A direct source guard confirmed the UI relay, both HTML relays, and app boot
+  resolver all contain the durable storage behavior.
+- `git diff --check` passed.
+- Package Vitest runners could not complete because dependencies are not
+  installed in this worktree (`vitest`, React JSX runtime, and core transitive
+  packages such as `handlebars`/`fs-extra`/`mammoth` are missing). The app
+  package's `test` script also runs the broader `scripts` suite first, which is
+  blocked here by missing optional deps and sandboxed loopback binds before the
+  focused Vitest file runs.
+
+## Staging Verification Status
+
+Live staging PWA verification has not been run from this worktree. The intended
+manual staging proof is: pair a staging dedicated agent, confirm
+`localStorage["eliza:cloud-pair:api-token"]` equals the paired agent token,
+terminate the iOS standalone PWA, relaunch it, and confirm authenticated API
+requests continue without opening a new pairing link.

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -133,7 +133,13 @@ describe("handleStandaloneCloudPairRoute", () => {
       }),
     );
     expect(harness.body()).toContain(
-      'window.sessionStorage.setItem("eliza:cloud-pair:api-token", key)',
+      "persist(window.sessionStorage)",
+    );
+    expect(harness.body()).toContain(
+      "persist(window.localStorage)",
+    );
+    expect(harness.body()).toContain(
+      'throw new Error("No browser storage accepted the paired token.")',
     );
     expect(harness.body()).toContain("apiToken: key");
     expect(harness.body()).toContain('window.location.replace("/")');

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -95,7 +95,19 @@ function renderRedirectHtml(apiKey: string): string {
     (function () {
       try {
         var key = ${safeKey};
-        window.sessionStorage.setItem("eliza:cloud-pair:api-token", key);
+        function persist(storage) {
+          try {
+            storage.setItem("eliza:cloud-pair:api-token", key);
+            return true;
+          } catch (_storageError) {
+            return false;
+          }
+        }
+        var storedInSession = persist(window.sessionStorage);
+        var storedDurably = persist(window.localStorage);
+        if (!(storedInSession || storedDurably)) {
+          throw new Error("No browser storage accepted the paired token.");
+        }
         var slot = Symbol.for("elizaos.app.boot-config");
         var previous = window.__ELIZAOS_APP_BOOT_CONFIG__ ||
           window.__ELIZA_APP_BOOT_CONFIG__ ||

--- a/packages/app-core/src/api/cloud-pair-route.test.ts
+++ b/packages/app-core/src/api/cloud-pair-route.test.ts
@@ -1,7 +1,8 @@
 /**
  * Exercises `handleCloudPairRoute` — the `/pair` HTTP handler that redeems a
  * cloud pairing token against the cloud API and returns an HTML handoff page
- * that stores the returned apiKey in sessionStorage. Drives real
+ * that stores the returned apiKey in durable localStorage plus sessionStorage.
+ * Drives real
  * http.IncomingMessage/ServerResponse fakes and stubs `globalThis.fetch` to
  * simulate the cloud API; covers the missing-token, expired, unreachable, no-key,
  * XSS-escaping, origin-forwarding, and per-IP rate-limit branches.
@@ -216,7 +217,7 @@ describe("handleCloudPairRoute", () => {
     expect(headers.origin).toBe("https://203.0.113.10:21363");
   });
 
-  it("renders happy-path HTML with the apiKey stored in sessionStorage and pinned on window globals", async () => {
+  it("renders happy-path HTML with the apiKey stored durably and pinned on window globals", async () => {
     globalThis.fetch = vi
       .fn()
       .mockResolvedValue(
@@ -232,8 +233,10 @@ describe("handleCloudPairRoute", () => {
     expect(harness.status()).toBe(200);
     const body = harness.body();
     expect(body).toContain('"agent_secret_value"');
+    expect(body).toContain("persist(window.sessionStorage)");
+    expect(body).toContain("persist(window.localStorage)");
     expect(body).toContain(
-      'window.sessionStorage.setItem("eliza:cloud-pair:api-token", key)',
+      'throw new Error("No browser storage accepted the paired token.")',
     );
     expect(body).toContain('Symbol.for("elizaos.app.boot-config")');
     expect(body).toContain("apiToken: key");

--- a/packages/app-core/src/api/cloud-pair-route.ts
+++ b/packages/app-core/src/api/cloud-pair-route.ts
@@ -11,8 +11,9 @@
  *   3. Cloud-api validates + consumes the token, returns
  *      `{ apiKey: <ELIZA_API_TOKEN> }`.
  *   4. This handler serves an HTML page with an inline script that stores the
- *      apiKey in sessionStorage and the typed boot-config singleton, then
- *      redirects to `/`. The SPA consumes that same-tab session handoff on boot.
+ *      apiKey in localStorage + sessionStorage and the typed boot-config
+ *      singleton, then redirects to `/`. The SPA consumes the durable handoff
+ *      on boot, with sessionStorage retained for same-tab compatibility.
  *
  * Why server-side relay: the agent web UI runs on the docker node's public
  * IP, which is not in cloud-api's CORS allowlist. A direct browser fetch to
@@ -96,7 +97,19 @@ function renderRedirectHtml(apiKey: string): string {
     (function () {
       try {
         var key = ${safeKey};
-        window.sessionStorage.setItem("eliza:cloud-pair:api-token", key);
+        function persist(storage) {
+          try {
+            storage.setItem("eliza:cloud-pair:api-token", key);
+            return true;
+          } catch (_storageError) {
+            return false;
+          }
+        }
+        var storedInSession = persist(window.sessionStorage);
+        var storedDurably = persist(window.localStorage);
+        if (!(storedInSession || storedDurably)) {
+          throw new Error("No browser storage accepted the paired token.");
+        }
         var slot = Symbol.for("elizaos.app.boot-config");
         var previous = window.__ELIZAOS_APP_BOOT_CONFIG__ ||
           window.__ELIZA_APP_BOOT_CONFIG__ ||

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -457,34 +457,52 @@ function getWindowUrlSearchParams(): URLSearchParams {
 
 function applyCloudPairSessionToken(): void {
   if (typeof window === "undefined") return;
+  let token: string | null = null;
   try {
-    const token = window.sessionStorage
-      .getItem(CLOUD_PAIR_SESSION_TOKEN_KEY)
-      ?.trim();
-    if (!token) return;
-    client.setToken(token);
-    const apiBase = isDedicatedCloudAgentBase(window.location.origin)
-      ? window.location.origin
-      : getBootConfig().apiBase?.trim();
-    if (!isDedicatedCloudAgentBase(apiBase)) return;
-    const agentId = dedicatedCloudAgentIdFromBase(apiBase);
-    const activeServer = createPersistedActiveServer({
-      kind: "cloud",
-      ...(agentId ? { id: `cloud:${agentId}` } : {}),
-      apiBase,
-      accessToken: token,
-    });
-    savePersistedActiveServer(activeServer);
-    upsertAndActivateAgentProfile({
-      kind: "cloud",
-      label: activeServer.label,
-      ...(activeServer.apiBase ? { apiBase: activeServer.apiBase } : {}),
-      accessToken: token,
-    });
+    token =
+      window.localStorage.getItem(CLOUD_PAIR_SESSION_TOKEN_KEY)?.trim() || null;
   } catch {
-    // error-policy:J4 sessionStorage can be unavailable in hardened browser
-    // contexts — the pairing token is simply not adopted
+    // error-policy:J4 localStorage can be unavailable in hardened browser
+    // contexts — sessionStorage remains the compatibility handoff.
   }
+  if (!token) {
+    try {
+      token =
+        window.sessionStorage.getItem(CLOUD_PAIR_SESSION_TOKEN_KEY)?.trim() ||
+        null;
+    } catch {
+      // error-policy:J4 sessionStorage can be unavailable in hardened browser
+      // contexts — the pairing token is simply not adopted.
+    }
+    if (token) {
+      try {
+        window.localStorage.setItem(CLOUD_PAIR_SESSION_TOKEN_KEY, token);
+      } catch {
+        // error-policy:J4 migration is best-effort; the same-tab token still
+        // authenticates this launch.
+      }
+    }
+  }
+  if (!token) return;
+  client.setToken(token);
+  const apiBase = isDedicatedCloudAgentBase(window.location.origin)
+    ? window.location.origin
+    : getBootConfig().apiBase?.trim();
+  if (!isDedicatedCloudAgentBase(apiBase)) return;
+  const agentId = dedicatedCloudAgentIdFromBase(apiBase);
+  const activeServer = createPersistedActiveServer({
+    kind: "cloud",
+    ...(agentId ? { id: `cloud:${agentId}` } : {}),
+    apiBase,
+    accessToken: token,
+  });
+  savePersistedActiveServer(activeServer);
+  upsertAndActivateAgentProfile({
+    kind: "cloud",
+    label: activeServer.label,
+    ...(activeServer.apiBase ? { apiBase: activeServer.apiBase } : {}),
+    accessToken: token,
+  });
 }
 
 /**

--- a/packages/app/test/cloud-pair-session-token.test.ts
+++ b/packages/app/test/cloud-pair-session-token.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Static guard for the cloud-pair session adoption in the app entrypoint.
+ * Importing `main.tsx` boots the full renderer, so this test pins the storage
+ * order in source: durable PWA storage first, legacy same-tab storage second,
+ * and migration back into durable storage.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MAIN_SOURCE = readFileSync(
+  join(import.meta.dirname, "..", "src", "main.tsx"),
+  "utf8",
+);
+
+describe("cloud pair session token adoption", () => {
+  it("reads the durable token before the legacy session token", () => {
+    const resolverStart = MAIN_SOURCE.indexOf(
+      "function applyCloudPairSessionToken()",
+    );
+    const localRead = MAIN_SOURCE.indexOf(
+      "window.localStorage.getItem(CLOUD_PAIR_SESSION_TOKEN_KEY)",
+      resolverStart,
+    );
+    const sessionRead = MAIN_SOURCE.indexOf(
+      "window.sessionStorage.getItem(CLOUD_PAIR_SESSION_TOKEN_KEY)",
+      resolverStart,
+    );
+
+    expect(resolverStart).toBeGreaterThanOrEqual(0);
+    expect(localRead).toBeGreaterThan(resolverStart);
+    expect(sessionRead).toBeGreaterThan(localRead);
+  });
+
+  it("migrates a legacy session token into durable storage", () => {
+    const resolverStart = MAIN_SOURCE.indexOf(
+      "function applyCloudPairSessionToken()",
+    );
+    const sessionRead = MAIN_SOURCE.indexOf(
+      "window.sessionStorage.getItem(CLOUD_PAIR_SESSION_TOKEN_KEY)",
+      resolverStart,
+    );
+    const durableWrite = MAIN_SOURCE.indexOf(
+      "window.localStorage.setItem(CLOUD_PAIR_SESSION_TOKEN_KEY, token)",
+      sessionRead,
+    );
+
+    expect(sessionRead).toBeGreaterThan(resolverStart);
+    expect(durableWrite).toBeGreaterThan(sessionRead);
+  });
+});

--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -3,6 +3,7 @@ import { getBootConfig, setBootConfig } from "../../config/boot-config";
 import { setElizaApiToken } from "../../utils/eliza-globals";
 
 export const CLOUD_PAIR_SESSION_STORAGE_KEY = "eliza:cloud-pair:api-token";
+export const CLOUD_PAIR_LOCAL_STORAGE_KEY = CLOUD_PAIR_SESSION_STORAGE_KEY;
 
 interface PairExchangeResponse {
   apiKey?: unknown;
@@ -98,13 +99,17 @@ export async function exchangeCloudPairToken(
   return body.apiKey.trim();
 }
 
-function tryPersistCloudPairSessionToken(apiToken: string): boolean {
+function tryPersistBrowserStorage(
+  storage: Storage | undefined,
+  apiToken: string,
+): boolean {
+  if (!storage) return false;
   try {
-    window.sessionStorage.setItem(CLOUD_PAIR_SESSION_STORAGE_KEY, apiToken);
+    storage.setItem(CLOUD_PAIR_SESSION_STORAGE_KEY, apiToken);
     return true;
   } catch (_storageError) {
-    // Session storage can be disabled by hardened browsers. Boot config still
-    // carries the token for this page load, so the redirect can continue.
+    // Browser storage can be disabled by hardened settings. Boot config still
+    // carries the token for this page load when at least one channel fails.
     return false;
   }
 }
@@ -113,7 +118,14 @@ export function persistCloudPairApiToken(apiToken: string): void {
   const token = apiToken.trim();
   if (!token) throw new Error("Missing cloud pair API token.");
 
-  tryPersistCloudPairSessionToken(token);
+  const persistedInSession = tryPersistBrowserStorage(
+    typeof window === "undefined" ? undefined : window.sessionStorage,
+    token,
+  );
+  const persistedDurably = tryPersistBrowserStorage(
+    typeof window === "undefined" ? undefined : window.localStorage,
+    token,
+  );
 
   const nextConfig = { ...getBootConfig(), apiToken: token };
   setBootConfig(nextConfig);
@@ -124,6 +136,37 @@ export function persistCloudPairApiToken(apiToken: string): void {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent("steward-token-sync"));
   }
+
+  if (!(persistedInSession || persistedDurably)) {
+    throw new Error("Cloud pair API token could not be stored in this browser.");
+  }
+}
+
+export function resolveCloudHostedAgentUrl(
+  locationLike: Pick<Location, "hostname"> | null =
+    typeof window === "undefined" ? null : window.location,
+): string {
+  const hostname = locationLike?.hostname.trim().toLowerCase() ?? "";
+  const staging =
+    hostname === "staging.elizacloud.ai" ||
+    hostname === "app-staging.elizacloud.ai" ||
+    hostname.endsWith(".staging.elizacloud.ai");
+  const base = staging
+    ? "https://staging.elizacloud.ai"
+    : "https://elizacloud.ai";
+  const agentId = hostname.endsWith(".staging.elizacloud.ai")
+    ? hostname.slice(0, -".staging.elizacloud.ai".length)
+    : hostname.endsWith(".elizacloud.ai")
+      ? hostname.slice(0, -".elizacloud.ai".length)
+      : "";
+  const agentPath =
+    agentId &&
+    !["www", "app", "app-staging", "api", "api-staging", "staging"].includes(
+      agentId,
+    )
+      ? `/${encodeURIComponent(agentId)}`
+      : "";
+  return `${base}/dashboard/agents${agentPath}`;
 }
 
 type CloudPairStatus =
@@ -173,6 +216,7 @@ function describePairFailure(error: unknown): Exclude<
 }
 
 export function CloudHostedAgentAuthNotice() {
+  const reopenUrl = resolveCloudHostedAgentUrl();
   return (
     <main className="flex min-h-[100dvh] flex-col items-center overflow-y-auto bg-[#08090b] px-6 text-center font-body text-white">
       <div className="my-auto w-full max-w-[25rem]">
@@ -185,6 +229,14 @@ export function CloudHostedAgentAuthNotice() {
           This Cloud agent uses your Eliza Cloud session. Open it from Eliza
           Cloud again to create a fresh secure sign-in link.
         </p>
+        <a
+          className="mt-7 inline-flex min-h-11 items-center justify-center rounded-md bg-[#f3a51f] px-5 text-sm font-semibold text-[#101010] transition hover:bg-[#c97710] focus:outline-none focus:ring-2 focus:ring-[#f3a51f] focus:ring-offset-2 focus:ring-offset-[#08090b]"
+          href={reopenUrl}
+          rel="noopener"
+          target="_top"
+        >
+          Re-open from Eliza Cloud
+        </a>
       </div>
     </main>
   );

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -15,6 +15,7 @@ import {
   getElizaApiToken,
 } from "../../../utils/eliza-globals";
 import {
+  CLOUD_PAIR_LOCAL_STORAGE_KEY,
   CLOUD_PAIR_SESSION_STORAGE_KEY,
   CloudHostedAgentAuthNotice,
   CloudPairExchangeError,
@@ -23,6 +24,7 @@ import {
   getCloudPairTokenFromLocation,
   isElizaCloudHostedLocation,
   persistCloudPairApiToken,
+  resolveCloudHostedAgentUrl,
   resolveCloudPairExchangeUrl,
 } from "../CloudPairRelay";
 
@@ -38,6 +40,7 @@ describe("CloudPairRelay", () => {
     setBootConfig(DEFAULT_BOOT_CONFIG);
     clearElizaApiToken();
     window.sessionStorage.clear();
+    window.localStorage.clear();
     window.history.replaceState(null, "", "/");
   });
 
@@ -134,6 +137,9 @@ describe("CloudPairRelay", () => {
     expect(window.sessionStorage.getItem(CLOUD_PAIR_SESSION_STORAGE_KEY)).toBe(
       "agent-key",
     );
+    expect(window.localStorage.getItem(CLOUD_PAIR_LOCAL_STORAGE_KEY)).toBe(
+      "agent-key",
+    );
     expect(
       (globalThis as Record<string, unknown>).__ELIZA_APP_BOOT_CONFIG__,
     ).toEqual(expect.objectContaining({ apiToken: "agent-key" }));
@@ -159,6 +165,9 @@ describe("CloudPairRelay", () => {
     expect(window.sessionStorage.getItem(CLOUD_PAIR_SESSION_STORAGE_KEY)).toBe(
       "agent-key",
     );
+    expect(window.localStorage.getItem(CLOUD_PAIR_LOCAL_STORAGE_KEY)).toBe(
+      "agent-key",
+    );
   });
 
   it("shows a clean Cloud-pair error instead of the local password form", async () => {
@@ -181,13 +190,38 @@ describe("CloudPairRelay", () => {
     expect(screen.queryByText("Remember this device for 30 days")).toBeNull();
   });
 
-  it("shows a Cloud-hosted auth notice without the local password wall", () => {
+  it("shows a Cloud-hosted auth notice with a tappable Cloud reopen CTA", () => {
     render(<CloudHostedAgentAuthNotice />);
 
     expect(screen.getByText("Open this agent from Eliza Cloud")).toBeTruthy();
+    const link = screen.getByRole("link", {
+      name: "Re-open from Eliza Cloud",
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://elizacloud.ai/dashboard/agents",
+    );
+    expect(link.getAttribute("target")).toBe("_top");
     expect(screen.queryByText("Display name")).toBeNull();
     expect(screen.queryByText("Password")).toBeNull();
     expect(screen.queryByText("Remember this device for 30 days")).toBeNull();
+  });
+
+  it("resolves production, staging, and agent-specific Cloud reopen URLs", () => {
+    expect(
+      resolveCloudHostedAgentUrl({
+        hostname: "agent-123.elizacloud.ai",
+      }),
+    ).toBe("https://elizacloud.ai/dashboard/agents/agent-123");
+    expect(
+      resolveCloudHostedAgentUrl({
+        hostname: "agent-123.staging.elizacloud.ai",
+      }),
+    ).toBe("https://staging.elizacloud.ai/dashboard/agents/agent-123");
+    expect(
+      resolveCloudHostedAgentUrl({
+        hostname: "app-staging.elizacloud.ai",
+      }),
+    ).toBe("https://staging.elizacloud.ai/dashboard/agents");
   });
 });
 


### PR DESCRIPTION
# PWA Session Persist - 2026-07-18

## Flow

Eliza Cloud opens a hosted dedicated agent at `/pair?token=<one-time-token>`.
The agent-side pairing route exchanges that short-lived token with Cloud for the
agent-local `ELIZA_API_TOKEN`, returns a no-store HTML handoff page, stores the
token in browser storage, seeds the boot-config singleton for the current page,
and redirects to `/`. The app boot code then adopts the stored token, configures
the API client, and persists the active cloud agent profile.

## Root Cause

The long-lived per-agent API token was stored only in `sessionStorage` under
`eliza:cloud-pair:api-token`. iOS standalone PWA sessions can lose
`sessionStorage` when the PWA process is terminated, so a previously paired
agent relaunched without the bearer token and fell back to the Cloud-hosted auth
notice.

## Secret And Deploy Analysis

The paired token is the container's existing `ELIZA_API_TOKEN`; this change does
not mint, transform, shorten, or lengthen it. The pairing-token exchange and its
existing expiry/validation remain unchanged.

Blue/green image upgrades preserve the same token. In
`packages/cloud/shared/src/lib/services/eliza-sandbox.ts`, `executeUpgrade`
decrypts the stored `environment_vars`, builds the blue container's
`environmentVars` as the decrypted env plus managed inference defaults, and the
inline comment explicitly records that `DATABASE_URL`, `ELIZA_API_TOKEN`,
`ELIZAOS_CLOUD_API_KEY`, and other non-inference values are preserved verbatim.
That path avoids the full provision merge that would mint a new API key.

## Fix

The pairing handoff now writes the same key,
`eliza:cloud-pair:api-token`, to both `sessionStorage` and `localStorage`.
`sessionStorage` remains for same-tab migration and compatibility; `localStorage`
is the durable PWA channel.

Updated paths:

- `packages/ui/src/components/auth/CloudPairRelay.tsx`
- `packages/agent/src/api/cloud-pair-route.ts`
- `packages/app-core/src/api/cloud-pair-route.ts`
- `packages/app/src/main.tsx`

`applyCloudPairSessionToken()` now resolves `localStorage` first, falls back to
`sessionStorage`, and migrates a legacy session token into durable storage when
possible. The Cloud-hosted auth notice now includes a tappable "Re-open from
Eliza Cloud" CTA. The CTA is environment-aware for staging dedicated-agent
hosts and uses the agent-specific detail URL when the subdomain identifies the
agent. It does not auto-navigate.

## Tests

Focused tests added or updated for:

- React relay durable token persistence.
- Server-generated HTML relay writes to both storage channels.
- App boot source guard for durable-first read, legacy fallback, and migration.
- Cloud-hosted notice CTA and staging/agent-aware URL resolution.

Local verification in this worktree:

- `bun test packages/app/test/cloud-pair-session-token.test.ts` passed.
- A direct source guard confirmed the UI relay, both HTML relays, and app boot
  resolver all contain the durable storage behavior.
- `git diff --check` passed.
- Package Vitest runners could not complete because dependencies are not
  installed in this worktree (`vitest`, React JSX runtime, and core transitive
  packages such as `handlebars`/`fs-extra`/`mammoth` are missing). The app
  package's `test` script also runs the broader `scripts` suite first, which is
  blocked here by missing optional deps and sandboxed loopback binds before the
  focused Vitest file runs.

## Staging Verification Status

Live staging PWA verification has not been run from this worktree. The intended
manual staging proof is: pair a staging dedicated agent, confirm
`localStorage["eliza:cloud-pair:api-token"]` equals the paired agent token,
terminate the iOS standalone PWA, relaunch it, and confirm authenticated API
requests continue without opening a new pairing link.
