### PR TITLE
fix(cloud): enforce rate-limit outage policy

### DIFF
--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -14,14 +14,17 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import * as loggerActual from "../utils/logger";
 
+const loggerError = mock(() => undefined);
+const loggerWarn = mock(() => undefined);
+
 mock.module("@elizaos/cloud-routing", () => ({}));
 mock.module("../utils/logger", () => ({
   ...loggerActual,
   logger: {
     debug: mock(() => undefined),
-    error: mock(() => undefined),
+    error: loggerError,
     info: mock(() => undefined),
-    warn: mock(() => undefined),
+    warn: loggerWarn,
   },
 }));
 
@@ -49,15 +52,29 @@ const throwingRedis = {
   },
 };
 
-const { rateLimit, RateLimitPresets, getIpKey, _resetRedisUnavailableFallbackBuckets } =
-  await import("./rate-limit-hono-cloudflare");
+const {
+  rateLimit,
+  RateLimitPresets,
+  getIpKey,
+  _checkRedisUnavailableFallback,
+  _redisUnavailableFallbackBucketCount,
+  _redisUnavailableFallbackMaxKeys,
+  _resetRedisUnavailableFallbackBuckets,
+} = await import("./rate-limit-hono-cloudflare");
 
 // A configured, non-disabled env so getRedis returns the (throwing) client.
 const ENV = { REDIS_URL: "redis://mock:6379", NODE_ENV: "production" };
 
 function appWith(config: Parameters<typeof rateLimit>[0]) {
+  return appWithBuilder(config, () => throwingRedis);
+}
+
+function appWithBuilder(
+  config: Parameters<typeof rateLimit>[0],
+  buildRedisClient: NonNullable<Parameters<typeof rateLimit>[2]>["buildRedisClient"],
+) {
   const app = new Hono();
-  app.use(rateLimit(config, undefined, { buildRedisClient: () => throwingRedis }));
+  app.use(rateLimit(config, undefined, { buildRedisClient }));
   app.get("/", (c) => c.json({ ok: true }));
   return app;
 }
@@ -76,9 +93,64 @@ afterAll(() => {
 
 beforeEach(() => {
   _resetRedisUnavailableFallbackBuckets();
+  loggerError.mockClear();
+  loggerWarn.mockClear();
 });
 
 describe("rateLimit — fail-closed vs fall-open on runtime Redis error (M11)", () => {
+  test("fail-closed route rejects when no Redis client can be constructed", async () => {
+    const app = appWithBuilder(
+      {
+        ...RateLimitPresets.STRICT,
+        keyGenerator: getIpKey,
+        failClosed: true,
+      },
+      () => null,
+    );
+
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    expect(loggerError).toHaveBeenCalledWith(
+      "[RateLimit] Redis client unavailable on fail-closed route; rejecting",
+      { error: "Redis client is not configured" },
+    );
+  });
+
+  test("a Redis constructor failure follows fail-closed policy with an observable cause", async () => {
+    const app = appWithBuilder(
+      {
+        ...RateLimitPresets.STRICT,
+        keyGenerator: getIpKey,
+        failClosed: true,
+      },
+      () => {
+        throw new Error("invalid Redis URL");
+      },
+    );
+
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(503);
+    expect(loggerError).toHaveBeenCalledWith(
+      "[RateLimit] Redis client unavailable on fail-closed route; rejecting",
+      { error: "invalid Redis URL" },
+    );
+  });
+
+  test("a Redis constructor failure falls open visibly on an ordinary route", async () => {
+    const app = appWithBuilder(RateLimitPresets.STANDARD, () => {
+      throw new Error("invalid Redis URL");
+    });
+
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable");
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[RateLimit] Redis client construction failed; falling open",
+      { error: "invalid Redis URL" },
+    );
+  });
+
   test("fail-closed route rejects with 503 when Redis throws", async () => {
     const app = appWith({
       ...RateLimitPresets.STRICT,
@@ -127,5 +199,59 @@ describe("rateLimit — fail-closed vs fall-open on runtime Redis error (M11)", 
       code: "rate_limit_exceeded",
     });
     expect(third.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable-local");
+  });
+
+  test("a missing Redis client activates the configured local fallback", async () => {
+    const app = appWithBuilder(
+      {
+        ...RateLimitPresets.STRICT,
+        keyGenerator: getIpKey,
+        redisUnavailableFallback: {
+          namespace: "missing-client-fallback",
+          maxRequests: 2,
+        },
+        failClosed: true,
+      },
+      () => null,
+    );
+
+    const first = await app.fetch(req(), ENV);
+    const second = await app.fetch(req(), ENV);
+    const third = await app.fetch(req(), ENV);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    expect(first.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable-local");
+    expect(third.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable-local");
+  });
+
+  test("the outage fallback stays bounded under adversarial key cardinality", () => {
+    const now = 10_000;
+    const config = {
+      ...RateLimitPresets.STRICT,
+      redisUnavailableFallback: {
+        namespace: "bounded-fallback",
+        maxRequests: 2,
+      },
+    };
+    for (let index = 0; index < _redisUnavailableFallbackMaxKeys; index += 1) {
+      _checkRedisUnavailableFallback(`ip:${index}`, config, now);
+    }
+    expect(_redisUnavailableFallbackBucketCount()).toBe(_redisUnavailableFallbackMaxKeys);
+
+    // Refresh key zero before a new key forces eviction; the LRU bucket, not
+    // this hot bucket, must be discarded.
+    _checkRedisUnavailableFallback("ip:0", config, now + 1);
+    _checkRedisUnavailableFallback("ip:overflow", config, now + 1);
+    expect(_redisUnavailableFallbackBucketCount()).toBe(_redisUnavailableFallbackMaxKeys);
+    expect(_checkRedisUnavailableFallback("ip:0", config, now + 2).allowed).toBe(false);
+
+    _checkRedisUnavailableFallback(
+      "ip:after-expiry",
+      config,
+      now + RateLimitPresets.STRICT.windowMs + 1,
+    );
+    expect(_redisUnavailableFallbackBucketCount()).toBe(1);
   });
 });

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -20,7 +20,8 @@ export interface RateLimitConfig {
   maxRequests: number;
   keyGenerator?: (c: AppContext) => string;
   /**
-   * Use an in-isolate fallback bucket when Redis throws at request time.
+   * Use an in-isolate fallback bucket when Redis cannot be constructed or
+   * throws at request time.
    * This is weaker than the shared Redis limiter because every Worker isolate
    * has its own map, but it keeps low-risk login/session paths throttled during
    * a Redis outage instead of choosing between total outage and unlimited
@@ -208,6 +209,7 @@ interface LocalFallbackBucket {
 }
 
 const redisUnavailableFallbackBuckets = new Map<string, LocalFallbackBucket>();
+const REDIS_UNAVAILABLE_FALLBACK_MAX_KEYS = 4096;
 
 const HONO_RATE_LIMIT_LEASE_TTL_MS = 5_000;
 const HONO_RATE_LIMIT_LEASE_MAX_KEYS = 4096;
@@ -317,6 +319,26 @@ function fallbackHeadersConfig(config: RateLimitConfig): RateLimitConfig {
   };
 }
 
+function makeRoomForRedisUnavailableFallback(now: number): void {
+  if (redisUnavailableFallbackBuckets.size < REDIS_UNAVAILABLE_FALLBACK_MAX_KEYS) {
+    return;
+  }
+  for (const [key, bucket] of redisUnavailableFallbackBuckets) {
+    if (bucket.resetAt <= now) redisUnavailableFallbackBuckets.delete(key);
+  }
+  if (redisUnavailableFallbackBuckets.size < REDIS_UNAVAILABLE_FALLBACK_MAX_KEYS) {
+    return;
+  }
+
+  // Map iteration order is the access order maintained below. Bounding the
+  // degraded store is more important than retaining one cold IP bucket when a
+  // Redis outage and high-cardinality traffic coincide.
+  const leastRecentlyUsedKey = redisUnavailableFallbackBuckets.keys().next().value;
+  if (leastRecentlyUsedKey !== undefined) {
+    redisUnavailableFallbackBuckets.delete(leastRecentlyUsedKey);
+  }
+}
+
 function checkRedisUnavailableFallback(
   key: string,
   config: RateLimitConfig,
@@ -326,8 +348,16 @@ function checkRedisUnavailableFallback(
   if (!fallback) return fallOpenResult(config);
   const bucketKey = `${fallback.namespace}:${key}`;
   const current = redisUnavailableFallbackBuckets.get(bucketKey);
-  const bucket =
-    current && current.resetAt > now ? current : { count: 0, resetAt: now + fallback.windowMs };
+  let bucket: LocalFallbackBucket;
+  if (current && current.resetAt > now) {
+    bucket = current;
+    // Delete + reinsert below so the map's first entry remains the LRU key.
+    redisUnavailableFallbackBuckets.delete(bucketKey);
+  } else {
+    if (current) redisUnavailableFallbackBuckets.delete(bucketKey);
+    makeRoomForRedisUnavailableFallback(now);
+    bucket = { count: 0, resetAt: now + fallback.windowMs };
+  }
   bucket.count += 1;
   redisUnavailableFallbackBuckets.set(bucketKey, bucket);
   const allowed = bucket.count <= fallback.maxRequests;
@@ -483,19 +513,84 @@ export function rateLimit(
       }
     }
 
-    const redis = dependencies?.buildRedisClient
-      ? dependencies.buildRedisClient(env)
-      : getRedis(env);
+    let redis: CompatibleRedis | null = null;
+    let redisConstructionFailure: { error: unknown } | undefined;
+    try {
+      redis = dependencies?.buildRedisClient ? dependencies.buildRedisClient(env) : getRedis(env);
+    } catch (error) {
+      // error-policy:J1 middleware boundary applies the route's declared unavailable-store policy.
+      redisConstructionFailure = { error };
+    }
+    const key = (config.keyGenerator ?? getDefaultKey)(c);
     if (!redis) {
+      if (effectiveConfig.redisUnavailableFallback) {
+        logger.warn("[RateLimit] Redis client unavailable; using local fallback limiter", {
+          error:
+            redisConstructionFailure?.error instanceof Error
+              ? redisConstructionFailure.error.message
+              : redisConstructionFailure
+                ? String(redisConstructionFailure.error)
+                : undefined,
+        });
+        const fallbackResult = checkRedisUnavailableFallback(key, effectiveConfig);
+        const fallbackConfig = fallbackHeadersConfig(effectiveConfig);
+        const headers = rateLimitHeaders(fallbackConfig, fallbackResult, "redis-unavailable-local");
+        if (!fallbackResult.allowed) {
+          return c.json(
+            {
+              success: false,
+              error: "Too many requests",
+              code: "rate_limit_exceeded" as const,
+              message: `Rate limit exceeded. Maximum ${fallbackConfig.maxRequests} requests per ${Math.ceil(
+                fallbackConfig.windowMs / 1000,
+              )} seconds.`,
+              retryAfter: fallbackResult.retryAfter,
+            },
+            429,
+            { ...headers, "Retry-After": String(fallbackResult.retryAfter ?? 60) },
+          );
+        }
+        await next();
+        applyRateLimitHeaders(c, headers);
+        return;
+      }
+      if (effectiveConfig.failClosed) {
+        logger.error("[RateLimit] Redis client unavailable on fail-closed route; rejecting", {
+          error:
+            redisConstructionFailure?.error instanceof Error
+              ? redisConstructionFailure.error.message
+              : redisConstructionFailure
+                ? String(redisConstructionFailure.error)
+                : "Redis client is not configured",
+        });
+        return c.json(
+          {
+            success: false,
+            error: "Service temporarily unavailable",
+            code: "rate_limit_unavailable" as const,
+            message: "Rate limiter backing store is unavailable; request rejected.",
+          },
+          503,
+          { "Retry-After": "30" },
+        );
+      }
+      const policy = redisConstructionFailure ? "redis-unavailable" : "fall-open";
+      if (redisConstructionFailure) {
+        logger.warn("[RateLimit] Redis client construction failed; falling open", {
+          error:
+            redisConstructionFailure.error instanceof Error
+              ? redisConstructionFailure.error.message
+              : String(redisConstructionFailure.error),
+        });
+      }
       await next();
       applyRateLimitHeaders(
         c,
-        rateLimitHeaders(effectiveConfig, fallOpenResult(effectiveConfig), "fall-open"),
+        rateLimitHeaders(effectiveConfig, fallOpenResult(effectiveConfig), policy),
       );
       return;
     }
 
-    const key = (config.keyGenerator ?? getDefaultKey)(c);
     let result: CheckResult;
     let policy = "redis";
     let headersConfig = effectiveConfig;
@@ -632,4 +727,7 @@ export const RateLimitPresets = {
 export { getDefaultKey, getIpKey, getRequestIp };
 export const _multiplier = multiplier;
 export const _resetRedisUnavailableFallbackBuckets = () => redisUnavailableFallbackBuckets.clear();
+export const _redisUnavailableFallbackBucketCount = () => redisUnavailableFallbackBuckets.size;
+export const _redisUnavailableFallbackMaxKeys = REDIS_UNAVAILABLE_FALLBACK_MAX_KEYS;
+export const _checkRedisUnavailableFallback = checkRedisUnavailableFallback;
 export const _resetHonoRateLimitLeases = () => honoRateLimitLeases.clear();


### PR DESCRIPTION
# Relates to

Contributes to #16420 by making the mobile-auth prerequisite limiter honor its declared Redis-outage policy.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The focused package install, typecheck, tests, and repository ratchets were run after sync.
- [x] A reviewer can confirm the backend behavior from the executable evidence below.

# Sync with develop

- [x] Based on `origin/develop` at `f749cbccf`; zero conflicts.
- [x] Focused validation passes post-sync. Full monorepo `bun run verify` is delegated to CI because this two-file backend prerequisite has no unrelated-package changes.

# Risks

Low-to-medium. This changes only degraded behavior when Redis cannot be constructed or fails at request time. Fail-closed routes now consistently return 503, configured low-risk routes use a bounded per-isolate fallback, and existing fall-open routes remain fall-open.

# Background

## What does this PR do?

- Applies the same declared outage policy when Redis client construction fails as when a constructed Redis client throws.
- Bounds the per-isolate degraded limiter to 4,096 LRU buckets so adversarial key cardinality cannot grow Worker memory without limit.
- Adds regression coverage for missing-client fail-closed behavior and bounded fallback eviction/expiry.

## What kind of change is this?

Bug fix and security hardening; no public API or UI change.

# Documentation changes needed?

No external documentation change. The middleware contract comments are updated in place.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts`

## Detailed testing steps

```bash
bun --conditions=eliza-source test --coverage-reporter=lcov packages/cloud/shared/src/lib/middleware/rate-limit-*.test.ts
bun run --cwd packages/cloud/shared typecheck
node_modules/.bin/biome check packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
bun run audit:error-policy-ratchet
bun run audit:type-safety-ratchet
bun run audit:alias-read-guard
git diff --check origin/develop...HEAD
```

Observed locally: 56 tests passed across 8 files with 214 assertions; package typecheck, Biome, all three ratchets, and diff check passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend middleware only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend middleware only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend middleware only; the degraded branches are proven by direct Hono request tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - No deployed environment was intentionally forced into a Redis outage for this prerequisite; real Hono middleware responses and structured logger calls are asserted by the 56-test suite instead.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - Rate-limit middleware creates no durable domain artifact; the 56-test suite proves 503 fail-closed, observable constructor failure, bounded local throttling, fall-open compatibility, leases, native binding behavior, and Redis scoping.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

Backend validation: 56/56 tests passed, including real Hono requests through every changed degraded branch. Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

No change-specific failures. This focused worktree required a no-save dependency materialization because the repository lockfile is not accepted by Bun 1.3.14 under `--frozen-lockfile`; the install left the tracked tree clean. Full cross-repository verification remains a CI responsibility for this isolated two-file prerequisite.
