### PR TITLE
fix(voice): surface and retry realtime fallback

### DIFF
--- a/packages/cloud/shared/src/lib/cors-constants.ts
+++ b/packages/cloud/shared/src/lib/cors-constants.ts
@@ -68,6 +68,7 @@ export const CORS_EXPOSE_HEADER_NAMES = [
   "X-Eliza-Stream-Body-Ms",
   "X-Eliza-Stream-Parse-Ms",
   "X-Eliza-Stream-Bridge-Ms",
+  "X-Eliza-TTS-Provider",
 ] as const;
 
 export const CORS_ALLOW_METHOD_NAMES = [

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -117,6 +117,7 @@ describe("corsMiddleware — first-party origins (credentialed)", () => {
     const exposed = (res.headers.get("access-control-expose-headers") || "").toLowerCase();
     expect(exposed).toContain("server-timing");
     expect(exposed).toContain("x-eliza-trace-id");
+    expect(exposed).toContain("x-eliza-tts-provider");
     expect(exposed).toContain("x-eliza-preforward-ms");
     expect(exposed).toContain("x-eliza-auth-trace");
   });

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.test.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.test.tsx
@@ -225,4 +225,15 @@ describe("ChatVoiceStatusBar", () => {
     expect(screen.queryByTestId("chat-voice-realtime-live")).toBeNull();
     expect(screen.queryByTestId("chat-voice-realtime-armed")).toBeNull();
   });
+
+  it("shows the standard-mode notice with a debuggable fallback reason", () => {
+    render(
+      <ChatVoiceStatusBar status="listening" realtimeFallbackReason="mint" />,
+    );
+    const notice = screen.getByTestId("chat-voice-realtime-fallback");
+    expect(notice.textContent).toContain(
+      "Realtime voice unavailable, using standard voice mode",
+    );
+    expect(notice.getAttribute("data-reason")).toBe("mint");
+  });
 });

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
@@ -84,6 +84,8 @@ export interface ChatVoiceStatusBarProps {
    * realtime session is never silent (UI three-state rule).
    */
   realtimeErrorMessage?: string | null;
+  /** Non-blocking notice when this interaction handed the mic to batch voice. */
+  realtimeFallbackReason?: string | null;
   /** Visible only when continuous mode is on AND we have something to show. */
   visible?: boolean;
   className?: string;
@@ -145,6 +147,7 @@ export function ChatVoiceStatusBar({
   realtimeEligible = false,
   realtimePaused = false,
   realtimeErrorMessage = null,
+  realtimeFallbackReason = null,
   visible = true,
   className,
   "data-testid": dataTestId,
@@ -225,6 +228,20 @@ export function ChatVoiceStatusBar({
         >
           <Radio className="h-3 w-3" aria-hidden="true" />
           <span>Realtime armed</span>
+        </span>
+      ) : null}
+
+      {realtimeFallbackReason ? (
+        <span
+          className="inline-flex min-w-0 items-center gap-1 rounded-sm border border-warn/40 bg-warn/10 px-2 py-0.5 font-medium text-warn"
+          data-testid="chat-voice-realtime-fallback"
+          data-reason={realtimeFallbackReason}
+          title={`Realtime fallback reason: ${realtimeFallbackReason}`}
+        >
+          <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <span className="truncate">
+            Realtime voice unavailable, using standard voice mode
+          </span>
         </span>
       ) : null}
 

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -861,6 +861,7 @@ export function ChatView({
       // Three-state rule: a realtime failure keeps the bar visible so the
       // error pill renders even when continuous mode is off (manual mic tap).
       Boolean(voiceSession.realtimeError) ||
+      Boolean(voiceSession.realtimeFallbackReason) ||
       Boolean(voiceSpeaker) ||
       Boolean(voiceSession.interimTranscript));
   const continuousChatToggleVisible =
@@ -889,6 +890,7 @@ export function ChatView({
           // Every realtime error renders, actionable or not — a consent/mint
           // failure must never read as healthy-idle (UI three-state rule).
           realtimeErrorMessage={voiceSession.realtimeError?.message ?? null}
+          realtimeFallbackReason={voiceSession.realtimeFallbackReason}
           visible={voiceStatusBarVisible}
           className={`mb-1 relative${isGameModal ? " pointer-events-auto" : ""}`}
           data-testid="chat-view-voice-status-bar"

--- a/packages/ui/src/components/pages/chat-view-hooks.test.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.test.tsx
@@ -59,6 +59,8 @@ const realtimeHarness = vi.hoisted(() => {
     needsUnlock: false,
     paused: false,
     error: null as RealtimeVoiceError | null,
+    fallbackReason: null,
+    reportFallback: vi.fn(),
     speaker: null,
     start: vi.fn<() => Promise<RealtimeVoiceStartOutcome>>(async () => ({
       kind: "live",

--- a/packages/ui/src/components/pages/chat-view-hooks.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.tsx
@@ -550,6 +550,8 @@ export function useChatVoiceController(options: {
     [
       chatInput,
       conversationMessages,
+      activeConversationId,
+      realtimeAgentId,
       isComposerLocked,
       startListening,
       stopSpeaking,
@@ -959,10 +961,7 @@ export function useChatVoiceController(options: {
       // must re-enter the realtime branch (start() clears the error); only
       // non-actionable failures (consent/mint, which also latch eligibility
       // off) hand the tap to the batch path as their copy promises.
-      if (
-        voiceSession.realtimeEligible &&
-        (!voiceSession.realtimeError || voiceSession.realtimeError.actionable)
-      ) {
+      if (voiceSession.realtimeEligible) {
         setManualRealtimeIntent(true);
         realtimeStartPendingRef.current = true;
         const latestAssistant =
@@ -979,6 +978,12 @@ export function useChatVoiceController(options: {
           beginBatchVoiceCapture(mode);
         });
         return;
+      }
+      if (
+        isRealtimeVoiceFlagEnabled() &&
+        (!realtimeAgentId || !activeConversationId)
+      ) {
+        voiceSession.reportRealtimeFallback("missing-identity");
       }
       beginBatchVoiceCapture(mode);
     },

--- a/packages/ui/src/hooks/useContinuousVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useContinuousVoiceSession.test.tsx
@@ -73,6 +73,8 @@ function makeRealtime(
     needsUnlock: false,
     paused: false,
     error: null,
+    fallbackReason: null,
+    reportFallback: vi.fn(),
     speaker: null,
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/hooks/useContinuousVoiceSession.ts
+++ b/packages/ui/src/hooks/useContinuousVoiceSession.ts
@@ -44,6 +44,10 @@ export interface ContinuousVoiceSessionState {
   agentSpeaking: boolean;
   /** Realtime session paused by a visibility-hide (paused, not broken). */
   paused: boolean;
+  /** Why this interaction fell back to standard voice, retained for UI diagnostics. */
+  realtimeFallbackReason: UseRealtimeVoiceSessionState["fallbackReason"];
+  /** Record an eligibility fallback discovered before realtime start. */
+  reportRealtimeFallback: UseRealtimeVoiceSessionState["reportFallback"];
   /** Typed realtime error, actionable or not (null on the batch path). */
   realtimeError: RealtimeVoiceError | null;
   /** Latency snapshot for the badge (batch — realtime latency is server-side). */
@@ -123,6 +127,8 @@ export function useContinuousVoiceSession(
         ? realtime.agentSpeaking
         : batch.status === "speaking",
       paused: realtimeActive ? realtime.paused : false,
+      realtimeFallbackReason: realtime.fallbackReason,
+      reportRealtimeFallback: realtime.reportFallback,
       realtimeError: realtime.error,
       latency: batch.latency,
       speaker: realtime.speaker ?? batch.speaker,

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -365,7 +365,7 @@ describe("useRealtimeVoiceSession", () => {
     });
   });
 
-  it("fallback: a mint 404 flips `available` false with NO error surface (caller uses batch)", async () => {
+  it("fallback: a mint 404 stays retryable and records the indicator reason", async () => {
     const { options } = makeOptions({ mintStatus: 404 });
     const { result } = renderHook(() => useRealtimeVoiceSession(options));
 
@@ -376,16 +376,15 @@ describe("useRealtimeVoiceSession", () => {
       await flushAsync();
     });
 
-    // 404 = feature disabled server-side. The hook latches it: available flips
-    // false, active stays false, and NO error is surfaced (batch fallback is a
-    // normal path, not an error).
-    await waitFor(() => expect(result.current.available).toBe(false));
+    // The current interaction falls back, but the next tap probes realtime again.
+    await waitFor(() => expect(result.current.available).toBe(true));
     expect(result.current.active).toBe(false);
     expect(result.current.error).toBeNull();
     expect(startOutcome!).toEqual({
       kind: "fallback-to-batch",
       reason: "mint",
     });
+    expect(result.current.fallbackReason).toBe("mint");
   });
 
   it("fallback: a pre-ready mint failure resolves to same-gesture batch fallback", async () => {
@@ -535,9 +534,8 @@ describe("useRealtimeVoiceSession", () => {
     // No mint request was made — consent is a hard precondition client-side too.
     expect(mint.calls.length).toBe(0);
     expect(result.current.active).toBe(false);
-    // The copy promises the batch path, so realtime must actually disarm: the
-    // next mic tap sees available=false and runs standard voice.
-    expect(result.current.available).toBe(false);
+    // This interaction falls back, while the next user tap may retry realtime.
+    expect(result.current.available).toBe(true);
     expect(result.current.error?.actionable).toBe(false);
     expect(result.current.error?.message).toMatch(/standard voice/i);
     expect(startOutcome!).toEqual({

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -67,6 +67,9 @@ export type RealtimeVoiceStartOutcome =
   | { kind: "error"; error: RealtimeVoiceError }
   | { kind: "unavailable" };
 
+export type RealtimeVoiceFallbackReason =
+  "consent" | "mint" | "transport" | "unknown" | "missing-identity";
+
 /** Consent-nonce source. Returns null when consent could not be issued. */
 export type MintConsentNonce = () => Promise<string | null>;
 
@@ -155,6 +158,10 @@ export interface UseRealtimeVoiceSessionState {
   paused: boolean;
   /** Actionable/typed error, or null. */
   error: RealtimeVoiceError | null;
+  /** Last reason realtime handed this interaction to batch. */
+  fallbackReason: RealtimeVoiceFallbackReason | null;
+  /** Record a pre-start eligibility fallback such as missing identity. */
+  reportFallback: (reason: RealtimeVoiceFallbackReason) => void;
   /** Speaker attribution passthrough. */
   speaker: VoiceSpeakerMetadata | null;
   /**
@@ -286,10 +293,8 @@ export function useRealtimeVoiceSession(
   const [active, setActive] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<RealtimeVoiceError | null>(null);
-  // `featureDisabled` latches when a mint reports 404 so we stop advertising the
-  // realtime path as available for this mounted chat surface (the caller uses
-  // batch rather than repeatedly probing a disabled route on every mic tap).
-  const [featureDisabled, setFeatureDisabled] = useState(false);
+  const [fallbackReason, setFallbackReason] =
+    useState<RealtimeVoiceFallbackReason | null>(null);
 
   const clientRef = useRef<VoiceSessionClient | null>(null);
   // A generation counter so a stale client's async callbacks (a teardown that
@@ -352,14 +357,18 @@ export function useRealtimeVoiceSession(
         return;
       }
       pending.settled = true;
+      if (outcome.kind === "fallback-to-batch") {
+        setFallbackReason(outcome.reason);
+      }
       pending.resolve(outcome);
       startOutcomeRef.current = null;
     },
     [],
   );
 
-  const hasIds = Boolean(normalizedAgentId) && Boolean(normalizedConversationId);
-  const available = flagEnabled && hasIds && !featureDisabled;
+  const hasIds =
+    Boolean(normalizedAgentId) && Boolean(normalizedConversationId);
+  const available = flagEnabled && hasIds;
 
   const applyServerEventToTranscript = useCallback(
     (event: ServerControlFrame) => {
@@ -432,6 +441,7 @@ export function useRealtimeVoiceSession(
     startingRef.current = true;
     micOwnedRef.current = false;
     setError(null);
+    setFallbackReason(null);
     setNeedsUnlock(false);
     const gen = ++sessionGenRef.current;
     const isCurrent = () => sessionGenRef.current === gen;
@@ -543,12 +553,10 @@ export function useRealtimeVoiceSession(
         clearReadyTimer();
         // A 404 mint (feature disabled server-side) reaches us through the
         // client's onError (the client swallows the throw + tears down). Treat
-        // it as a fall-back-to-batch signal, NOT an error surface: latch
-        // `featureDisabled` so `available` flips false and the caller uses the
-        // batch path. Any other error is a real, surfaced failure.
+        // it as a fall-back-to-batch signal, NOT an error surface. Eligibility
+        // remains retryable on the next user interaction.
         if (err instanceof VoiceSessionMintError) {
           failedThisSession = true;
-          setFeatureDisabled(true);
           if (err.isFeatureDisabled) {
             setConnecting(false);
             resolveStartOutcome(gen, {
@@ -567,9 +575,6 @@ export function useRealtimeVoiceSession(
         // path ("standard voice"): mint and consent. Actionable kinds
         // (permission, no-device, transport) keep `available` true so the
         // advertised mic-tap retry is actually possible.
-        if (classified.kind === "mint" || classified.kind === "consent") {
-          setFeatureDisabled(true);
-        }
         if (
           !micOwnedRef.current ||
           classified.kind === "transport" ||
@@ -596,7 +601,7 @@ export function useRealtimeVoiceSession(
       // `start()` creates the playback AudioContext + mints + connects. The
       // client swallows a mint failure internally (emits via onError, tears
       // down), so this resolves even on a 404 — the fall-back branch is driven
-      // by `featureDisabled` (set in onError), not a throw here.
+      // by the typed onError callback, not a throw here.
       await client.start();
       if (!isCurrent()) {
         // A newer start/stop superseded us mid-connect; tear this one down.
@@ -626,13 +631,6 @@ export function useRealtimeVoiceSession(
       setError(classified);
       // Same latch policy as onError: only failures whose copy promises the
       // batch path disarm realtime; actionable kinds stay retryable.
-      if (
-        classified.kind === "mint" ||
-        classified.kind === "consent" ||
-        classified.kind === "unknown"
-      ) {
-        setFeatureDisabled(true);
-      }
       clientRef.current = null;
       // error-policy:J6 Failed startup teardown follows the surfaced primary error.
       await client.stop().catch(() => {});
@@ -661,6 +659,10 @@ export function useRealtimeVoiceSession(
     resolveStartOutcome,
   ]);
 
+  const reportFallback = useCallback((reason: RealtimeVoiceFallbackReason) => {
+    setFallbackReason(reason);
+  }, []);
+
   const bargeIn = useCallback(() => {
     clientRef.current?.bargeIn();
   }, []);
@@ -675,7 +677,6 @@ export function useRealtimeVoiceSession(
           error instanceof Error ? error : new Error(String(error)),
         ),
       );
-      setFeatureDisabled(true);
     }
   }, []);
 
@@ -717,8 +718,8 @@ export function useRealtimeVoiceSession(
 
     const shouldRestart = Boolean(
       identityRestartPendingRef.current ||
-        clientRef.current ||
-        startingRef.current,
+      clientRef.current ||
+      startingRef.current,
     );
     if (!shouldRestart) return;
 
@@ -758,6 +759,8 @@ export function useRealtimeVoiceSession(
       needsUnlock,
       paused,
       error,
+      fallbackReason,
+      reportFallback,
       speaker: speaker ?? null,
       start,
       stop,
@@ -775,6 +778,8 @@ export function useRealtimeVoiceSession(
       needsUnlock,
       paused,
       error,
+      fallbackReason,
+      reportFallback,
       speaker,
       start,
       stop,

--- a/packages/ui/src/voice/__tests__/voice-session-client.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-client.test.ts
@@ -25,6 +25,7 @@ interface MintOverrides {
   downlinkCodecs?: string[];
   status?: number;
   malformed?: boolean;
+  code?: string;
 }
 
 /** A mint fetch that returns the §7.1 shape, tracking each call. */
@@ -40,7 +41,9 @@ function makeMintFetch(overrides: MintOverrides[] = []) {
     n += 1;
     const status = o.status ?? 200;
     if (status !== 200) {
-      return new Response(JSON.stringify({ error: "nope" }), { status });
+      return new Response(JSON.stringify({ error: "nope", code: o.code }), {
+        status,
+      });
     }
     const payload = o.malformed
       ? { sessionId: "", wsUrl: "", token: "" }
@@ -106,6 +109,30 @@ function playbackScriptNodeOf(ctx: FakePlaybackAudioContext) {
 }
 
 describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
+  it("retries a transient post-mint agent_not_found race, then connects", async () => {
+    const mint = makeMintFetch([
+      { status: 404, code: "agent_not_found" },
+      { status: 404, code: "agent_not_found" },
+      {},
+    ]);
+    const ws = makeWsFactory();
+    const client = createVoiceSessionClient({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      conversationId: "22222222-2222-2222-2222-222222222222",
+      getConsentNonce: async () => crypto.randomUUID(),
+      fetch: mint.fetch,
+      webSocketFactory: ws.factory,
+      getUserMedia: fakeGetUserMedia(),
+      createMicAudioContext: () => new FakeMicAudioContext(16_000),
+      createPlaybackAudioContext: () => new FakePlaybackAudioContext(16_000),
+      preLiveRetryDelayMs: 0,
+    });
+
+    await client.start();
+    expect(mint.calls).toHaveLength(3);
+    expect(ws.sockets).toHaveLength(1);
+    await client.stop();
+  });
   it("invokes playback resume before the first mint await consumes user activation", async () => {
     const mint = makeMintFetch();
     const ws = makeWsFactory();

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -186,6 +186,10 @@ export interface VoiceSessionClientOptions {
    * re-mints a fresh token, never reuses the old one.
    */
   maxReconnects?: number;
+  /** Bounded attempts for transient failures before the first socket opens. */
+  preLiveMaxAttempts?: number;
+  /** Backoff base for pre-live retries. Attempt n waits base * n. */
+  preLiveRetryDelayMs?: number;
 }
 
 type ConnectionPhase = "idle" | "connecting" | "open" | "closing" | "closed";
@@ -226,6 +230,8 @@ export function createVoiceSessionClient(
   const preferredUplink = options.uplinkCodec ?? DEFAULT_UPLINK_CODEC;
   const preferredDownlink = options.downlinkCodec ?? DEFAULT_DOWNLINK_CODEC;
   const maxReconnects = options.maxReconnects ?? 2;
+  const preLiveMaxAttempts = Math.max(1, options.preLiveMaxAttempts ?? 3);
+  const preLiveRetryDelayMs = Math.max(0, options.preLiveRetryDelayMs ?? 500);
 
   let state: VoiceSessionMachineState = { ...INITIAL_VOICE_SESSION_STATE };
   let connPhase: ConnectionPhase = "idle";
@@ -282,7 +288,16 @@ export function createVoiceSessionClient(
     }
   };
 
-  async function mint(generation: number): Promise<VoiceSessionMintResponse> {
+  const waitForRetry = async (attempt: number, generation: number) => {
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, preLiveRetryDelayMs * attempt),
+    );
+    assertLifecycleCurrent(generation);
+  };
+
+  async function mintOnce(
+    generation: number,
+  ): Promise<VoiceSessionMintResponse> {
     let consentNonce: string | null;
     try {
       consentNonce = await options.getConsentNonce();
@@ -300,21 +315,38 @@ export function createVoiceSessionClient(
       );
     }
 
-    const res = await doFetch(mintPath, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      signal: lifecycleAbort?.signal,
-      body: JSON.stringify({
-        agentId: options.agentId,
-        conversationId: options.conversationId,
-        transport: "websocket",
-        consentNonce,
-      }),
-    });
+    let res: Response;
+    try {
+      res = await doFetch(mintPath, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        signal: lifecycleAbort?.signal,
+        body: JSON.stringify({
+          agentId: options.agentId,
+          conversationId: options.conversationId,
+          transport: "websocket",
+          consentNonce,
+        }),
+      });
+    } catch (cause) {
+      assertLifecycleCurrent(generation);
+      throw new VoiceSessionMintError(
+        0,
+        "voice session mint transport failed",
+        undefined,
+        cause,
+      );
+    }
     assertLifecycleCurrent(generation);
     if (!res.ok) {
-      // 404 => flag off; caller falls back to batch. Surface as a typed error.
-      throw new VoiceSessionMintError(res.status);
+      let code: string | undefined;
+      try {
+        const body = (await res.json()) as { code?: unknown };
+        if (typeof body.code === "string") code = body.code;
+      } catch {
+        // The body is diagnostic only; status still drives fallback.
+      }
+      throw new VoiceSessionMintError(res.status, undefined, code);
     }
     const json = (await res.json()) as unknown;
     assertLifecycleCurrent(generation);
@@ -328,6 +360,26 @@ export function createVoiceSessionClient(
       void ignoredError;
     }
     return json;
+  }
+
+  async function mint(generation: number): Promise<VoiceSessionMintResponse> {
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= preLiveMaxAttempts; attempt += 1) {
+      try {
+        return await mintOnce(generation);
+      } catch (error) {
+        assertLifecycleCurrent(generation);
+        const typed = error instanceof Error ? error : new Error(String(error));
+        lastError = typed;
+        const retryable =
+          (typed instanceof VoiceSessionMintError && typed.isTransient) ||
+          typed instanceof VoiceSessionConsentError;
+        if (!retryable || attempt >= preLiveMaxAttempts) throw typed;
+        mark(`prelive_retry(${attempt})`, state.traceId);
+        await waitForRetry(attempt, generation);
+      }
+    }
+    throw lastError ?? new Error("voice session mint failed");
   }
 
   function sendControl(frame: Parameters<typeof encodeClientControl>[0]): void {
@@ -814,13 +866,25 @@ export class VoiceSessionMintError extends Error {
   constructor(
     readonly status: number,
     message?: string,
+    readonly code?: string,
+    options?: unknown,
   ) {
-    super(message ?? `voice session mint failed (${status})`);
+    super(
+      message ?? `voice session mint failed (${status})`,
+      options === undefined ? undefined : { cause: options },
+    );
     this.name = "VoiceSessionMintError";
   }
 
-  /** True when the realtime feature is off; the caller should use batch. */
+  /** True for an actual feature-off 404, not the post-create visibility race. */
   get isFeatureDisabled(): boolean {
-    return this.status === 404;
+    return this.status === 404 && this.code !== "agent_not_found";
+  }
+
+  /** Safe bounded retries before the realtime transport owns the mic. */
+  get isTransient(): boolean {
+    return (
+      this.status === 0 || this.status >= 500 || this.code === "agent_not_found"
+    );
   }
 }


### PR DESCRIPTION
## Summary
- retry transient pre-live failures up to 3 attempts with bounded 500ms/1s backoff, including post-create `404 agent_not_found` visibility races
- keep realtime eligible for the next explicit voice interaction after batch fallback
- show a non-blocking standard voice mode notice with a diagnostic reason
- expose `X-Eliza-TTS-Provider` through CORS

## Tests
- 68 focused UI/client tests pass
- 17 Cloud API CORS tests pass
- added retry-then-success, fallback reason state, visible indicator, and exposed-header coverage

Staging-only deployment requested after merge. No auth changes.

Co-authored-by: wakesync <wakesync@users.noreply.github.com>