### PR TITLE
fix(voice): repair realtime fallback hook contract

### DIFF
--- a/packages/ui/src/components/pages/chat-view-hooks.test.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.test.tsx
@@ -39,8 +39,11 @@ import {
 
 type RealtimeHarnessState = Omit<
   UseRealtimeVoiceSessionState,
-  "start" | "stop" | "bargeIn" | "unlock"
+  "start" | "stop" | "bargeIn" | "unlock" | "reportFallback"
 > & {
+  reportFallback: ReturnType<
+    typeof vi.fn<UseRealtimeVoiceSessionState["reportFallback"]>
+  >;
   start: ReturnType<typeof vi.fn<() => Promise<RealtimeVoiceStartOutcome>>>;
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   bargeIn: ReturnType<typeof vi.fn<() => void>>;
@@ -185,6 +188,7 @@ describe("useChatVoiceController voice playback unlock", () => {
     realtimeHarness.state.agentSpeaking = false;
     realtimeHarness.state.needsUnlock = false;
     realtimeHarness.state.error = null;
+    realtimeHarness.state.reportFallback.mockClear();
     realtimeHarness.state.start.mockReset();
     realtimeHarness.state.start.mockResolvedValue({ kind: "live" });
     realtimeHarness.state.stop.mockClear();
@@ -257,7 +261,7 @@ describe("useChatVoiceController voice playback unlock", () => {
     expect(voiceState.startListening).not.toHaveBeenCalled();
   });
 
-  it("hands the mic tap to batch after a NON-actionable error (copy promises standard voice)", async () => {
+  it("retries realtime on the next mic tap after a non-actionable fallback", async () => {
     realtimeHarness.state.available = true;
     realtimeHarness.state.error = {
       kind: "consent" as const,
@@ -278,8 +282,8 @@ describe("useChatVoiceController voice playback unlock", () => {
       await Promise.resolve();
     });
 
-    expect(realtimeHarness.state.start).not.toHaveBeenCalled();
-    expect(voiceState.startListening).toHaveBeenCalledTimes(1);
+    expect(realtimeHarness.state.start).toHaveBeenCalledTimes(1);
+    expect(voiceState.startListening).not.toHaveBeenCalled();
   });
 
   it("routes the primary mic to realtime when the force-armed session is available", async () => {
@@ -346,6 +350,9 @@ describe("useChatVoiceController voice playback unlock", () => {
 
     expect(realtimeHarness.state.start).not.toHaveBeenCalled();
     expect(voiceState.startListening).toHaveBeenCalledTimes(1);
+    expect(realtimeHarness.state.reportFallback).toHaveBeenCalledWith(
+      "missing-identity",
+    );
   });
 
   it("does not fall back to batch after realtime has owned the mic", async () => {

--- a/packages/ui/src/components/pages/chat-view-hooks.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.tsx
@@ -550,8 +550,6 @@ export function useChatVoiceController(options: {
     [
       chatInput,
       conversationMessages,
-      activeConversationId,
-      realtimeAgentId,
       isComposerLocked,
       startListening,
       stopSpeaking,
@@ -955,12 +953,9 @@ export function useChatVoiceController(options: {
   const beginVoiceCapture = useCallback(
     (mode: Exclude<VoiceCaptureMode, "idle"> = "compose") => {
       if (isComposerLocked) return;
-      // Realtime owns the tap while available and not in a NON-actionable error
-      // state. An actionable error (permission re-granted, transport drop,
-      // connect timeout) advertises "tap the mic to try again" — so that tap
-      // must re-enter the realtime branch (start() clears the error); only
-      // non-actionable failures (consent/mint, which also latch eligibility
-      // off) hand the tap to the batch path as their copy promises.
+      // A fallback applies to the failed interaction, not every later mic tap.
+      // Consent, mint, and transport failures keep realtime eligible so the
+      // next explicit gesture probes it again; start() clears the prior error.
       if (voiceSession.realtimeEligible) {
         setManualRealtimeIntent(true);
         realtimeStartPendingRef.current = true;
@@ -988,10 +983,12 @@ export function useChatVoiceController(options: {
       beginBatchVoiceCapture(mode);
     },
     [
+      activeConversationId,
       beginBatchVoiceCapture,
       chatInput,
       conversationMessages,
       isComposerLocked,
+      realtimeAgentId,
       stopSpeaking,
       setManualRealtimeIntent,
       voiceSession,

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -68,7 +68,11 @@ export type RealtimeVoiceStartOutcome =
   | { kind: "unavailable" };
 
 export type RealtimeVoiceFallbackReason =
-  "consent" | "mint" | "transport" | "unknown" | "missing-identity";
+  | "consent"
+  | "mint"
+  | "transport"
+  | "unknown"
+  | "missing-identity";
 
 /** Consent-nonce source. Returns null when consent could not be issued. */
 export type MintConsentNonce = () => Promise<string | null>;
@@ -718,8 +722,8 @@ export function useRealtimeVoiceSession(
 
     const shouldRestart = Boolean(
       identityRestartPendingRef.current ||
-      clientRef.current ||
-      startingRef.current,
+        clientRef.current ||
+        startingRef.current,
     );
     if (!shouldRestart) return;
 


### PR DESCRIPTION
## Summary

- move the realtime identity dependencies from the batch-only callback to the callback that actually reads them
- preserve the intended retry-on-next-tap behavior for consent, mint, and transport fallbacks, with an updated contract test
- cover the new visible `missing-identity` fallback reason
- format the two source hunks introduced by #16627 so the package lint lane is reproducible

## Root cause

#16627 added `activeConversationId` and `realtimeAgentId` to `beginBatchVoiceCapture`, where neither value is read, while `beginVoiceCapture` directly read both values without declaring them. Biome correctly rejected both dependency arrays. The same change intentionally made realtime fallbacks retryable on the next explicit tap, but one hook test still asserted the previous permanent-batch behavior.

This PR repairs that merged `develop` regression without changing the voice UI or expanding the feature surface.

## Validation

- [x] `bun run --cwd packages/ui test -- src/components/pages/chat-view-hooks.test.tsx src/hooks/useRealtimeVoiceSession.test.tsx src/hooks/useContinuousVoiceSession.test.tsx` — 51 passed
- [x] `bun run --cwd packages/ui typecheck` — passed after building the standard `@elizaos/cloud-routing` workspace prerequisite
- [x] `bun run --cwd packages/ui lint` — exact package command exited 0 in a disposable clean proof worktree at this commit
- [x] Biome check on all three changed files
- [x] `bun run audit:type-safety-ratchet`
- [x] `bun run audit:error-policy-ratchet`
- [x] `bun run audit:view-action-ratchet`
- [x] `bun run audit:ui-determinism`
- [x] `git diff --check`
- [x] Independent review confirmed the dependency move, retry contract, and formatting changes
- [x] `bun run --cwd packages/app audit:app` — 246 Playwright view checks passed; 244 packaged-OCR captures produced zero broken renders
- [x] Manually reviewed the affected chat surface at mobile portrait, mobile landscape, desktop landscape, and iPad portrait; no clipping, overflow, error overlay, or voice-control regression
- [x] Real browser microphone-capture regression passed before and after; reviewed the full-page JPGs and start/active/completed frames from the MP4

## Evidence

The focused Playwright proof drives the real client path from a button press
through `getUserMedia`, recorder/WAV encoding, ASR POST, SSE reply, TTS fetch,
and audio decoding. Its external ASR/agent/TTS services are deterministic route
fixtures, so the evidence is intentionally described as client proof rather
than a live backend/model trajectory.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16628-before-voice-selftest.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16628-after-voice-selftest.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16628-voice-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only hook and test repair; no backend code path changed

<!-- evidence-row:frontend-logs -->
- [x] [Playwright trace with browser console/network/state](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16628-trace.zip)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by a React hook dependency repair

<!-- evidence-row:ocr-review -->
- [x] [Packaged OCR text readout and manual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16628-ocr-review.txt)

Refs #16627.
