### PR TITLE
fix(voice): preserve batch ASR speech onset with bounded pre-roll

### DIFF
--- a/ISSUE-16424-2026-07-18.md
+++ b/ISSUE-16424-2026-07-18.md
@@ -1,0 +1,45 @@
+# Issue #16424 receipt
+
+Signed: `[sol-orch]`
+Date: 2026-07-18
+Issue: https://github.com/elizaOS/eliza/issues/16424
+
+## Freshness and claim
+
+- Verified issue #16424 was open and unassigned before starting.
+- Verified no open or closed PR referenced #16424.
+- Verified Project 12 card was in `Todo` with no `Claimed by` value.
+- Claimed via issue comment and moved the card to `Claimed` with `Claimed by: [sol-orch]`.
+
+## Fix
+
+Browser batch-ASR auto-stop capture now keeps a sample-rate-bounded 200 ms PCM pre-roll before VAD begins buffering. On first speech detection, the retained frames are prepended exactly once and normal buffering continues. The pre-roll is not used by realtime/non-auto-stop capture and all retained PCM is cleared on stop, cancel, and teardown.
+
+The bound is duration-based rather than frame-count-based:
+
+- 16 kHz: at most 3,200 samples
+- 48 kHz: at most 9,600 samples
+
+The existing 12,000 ms maximum speech duration remains unchanged.
+
+## Verification
+
+- `bunx --bun vitest@4.0.18 run --config /tmp/vitest-16424.config.mjs packages/ui/src/voice/local-asr-capture.test.ts`
+  - 29/29 tests passed.
+- `bunx @biomejs/biome check packages/ui/src/voice/local-asr-capture.ts packages/ui/src/voice/local-asr-capture.test.ts`
+  - Passed, no diagnostics.
+- `git diff --check`
+  - Passed.
+
+New recorder-level synthetic tests cover:
+
+- 16 kHz and 48 kHz bounded newest-sample retention and ordering
+- fast-start onset preservation
+- exactly-once prepend
+- no-speech pre-roll not promoted into output
+- cancel and stop/teardown clearing
+- unchanged non-auto-stop capture behavior
+
+## Staging
+
+PR preview/staging verification is pending the repository deployment workflow after push. The deterministic fake browser audio stack verifies the capture path locally without microphone hardware.

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -86,8 +86,9 @@ async function createFakeRecorder(
   vi.stubGlobal("window", { AudioContext: FakeAudioContext });
 
   const recorder = await startLocalAsrRecorder(options);
-  if (!context) throw new Error("fake AudioContext was not created");
-  return { recorder, context, trackStop };
+  const createdContext = context as RecorderFakeAudioContext | null;
+  if (!createdContext) throw new Error("fake AudioContext was not created");
+  return { recorder, context: createdContext, trackStop };
 }
 
 function emitMonoFrame(

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -16,6 +16,112 @@ import {
   startLocalAsrRecorder,
 } from "./local-asr-capture";
 
+type FakeAudioProcessEvent = {
+  inputBuffer: {
+    length: number;
+    numberOfChannels: number;
+    getChannelData(channel: number): Float32Array;
+  };
+};
+
+type FakeAudioProcessHandler = (event: FakeAudioProcessEvent) => void;
+
+class FakeAudioNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class FakeScriptProcessor extends FakeAudioNode {
+  onaudioprocess: FakeAudioProcessHandler | null = null;
+}
+
+class FakeAnalyserNode extends FakeAudioNode {
+  fftSize = 0;
+  smoothingTimeConstant = 0;
+}
+
+class RecorderFakeAudioContext {
+  readonly sampleRate: number;
+  state: AudioContextState = "running";
+  destination = {};
+  processor = new FakeScriptProcessor();
+  close = vi.fn().mockResolvedValue(undefined);
+  resume = vi.fn().mockResolvedValue(undefined);
+  createMediaStreamSource = vi.fn(() => new FakeAudioNode());
+  createScriptProcessor = vi.fn(() => this.processor);
+  createAnalyser = vi.fn(() => new FakeAnalyserNode());
+
+  constructor(sampleRate: number) {
+    this.sampleRate = sampleRate;
+  }
+}
+
+async function createFakeRecorder(
+  sampleRate: number,
+  options: Parameters<typeof startLocalAsrRecorder>[0] = {
+    autoStop: {
+      startGraceMs: 0,
+      minSpeechMs: 0,
+      silenceMs: 10_000,
+      speechRmsThreshold: 0.5,
+      speechPeakThreshold: 0.5,
+    },
+  },
+) {
+  const trackStop = vi.fn();
+  const stream = {
+    getTracks: () => [{ stop: trackStop }],
+    getAudioTracks: () => [{ stop: trackStop }],
+  } as unknown as MediaStream;
+  const getUserMedia = vi.fn().mockResolvedValue(stream);
+  vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+  let context: RecorderFakeAudioContext | null = null;
+  class FakeAudioContext extends RecorderFakeAudioContext {
+    constructor() {
+      super(sampleRate);
+      context = this;
+    }
+  }
+  vi.stubGlobal("window", { AudioContext: FakeAudioContext });
+
+  const recorder = await startLocalAsrRecorder(options);
+  if (!context) throw new Error("fake AudioContext was not created");
+  return { recorder, context, trackStop };
+}
+
+function emitMonoFrame(
+  context: RecorderFakeAudioContext,
+  samples: Float32Array,
+): void {
+  const handler = context.processor.onaudioprocess;
+  if (!handler) throw new Error("recorder process handler was not installed");
+  handler({
+    inputBuffer: {
+      length: samples.length,
+      numberOfChannels: 1,
+      getChannelData: () => samples,
+    },
+  });
+}
+
+function constantFrame(length: number, value: number): Float32Array {
+  const frame = new Float32Array(length);
+  frame.fill(value);
+  return frame;
+}
+
+function expectSamplesClose(
+  samples: Float32Array,
+  start: number,
+  length: number,
+  value: number,
+): void {
+  for (let index = start; index < start + length; index += 1) {
+    expect(samples[index]).toBeCloseTo(value, 3);
+  }
+}
+
 describe("local ASR capture", () => {
   it("detects truly silent PCM before sending it to ASR", () => {
     const pcm = new Float32Array(16000);
@@ -118,6 +224,118 @@ describe("local ASR capture", () => {
       shouldBuffer: true,
       shouldStop: false,
     });
+  });
+});
+
+describe("startLocalAsrRecorder auto-stop pre-roll", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("prepends only the newest bounded 200ms of 16k PCM when speech starts", async () => {
+    const { recorder, context } = await createFakeRecorder(16_000);
+
+    emitMonoFrame(context, constantFrame(1000, 0.01));
+    emitMonoFrame(context, constantFrame(1000, 0.02));
+    emitMonoFrame(context, constantFrame(1000, 0.03));
+    emitMonoFrame(context, constantFrame(1000, 0.04));
+    emitMonoFrame(context, constantFrame(1000, 0.05));
+    emitMonoFrame(context, new Float32Array([0.8, -0.8]));
+
+    const pcm = decodeMonoPcm16Wav(await recorder.stop());
+
+    expect(pcm.length).toBe(3202);
+    expectSamplesClose(pcm, 0, 200, 0.02);
+    expectSamplesClose(pcm, 200, 1000, 0.03);
+    expectSamplesClose(pcm, 1200, 1000, 0.04);
+    expectSamplesClose(pcm, 2200, 1000, 0.05);
+    expect(pcm[3200]).toBeCloseTo(0.8, 3);
+    expect(pcm[3201]).toBeCloseTo(-0.8, 3);
+  });
+
+  it("prepends only the newest bounded 200ms of 48k PCM in frame order", async () => {
+    const { recorder, context } = await createFakeRecorder(48_000);
+
+    emitMonoFrame(context, constantFrame(4096, 0.01));
+    emitMonoFrame(context, constantFrame(4096, 0.02));
+    emitMonoFrame(context, constantFrame(4096, 0.03));
+    emitMonoFrame(context, new Float32Array([0.7]));
+
+    const pcm = decodeMonoPcm16Wav(await recorder.stop());
+
+    expect(pcm.length).toBe(9601);
+    expectSamplesClose(pcm, 0, 1408, 0.01);
+    expectSamplesClose(pcm, 1408, 4096, 0.02);
+    expectSamplesClose(pcm, 5504, 4096, 0.03);
+    expect(pcm[9600]).toBeCloseTo(0.7, 3);
+  });
+
+  it("prepends the pre-roll once, then buffers later speech normally", async () => {
+    const { recorder, context } = await createFakeRecorder(16_000);
+
+    emitMonoFrame(context, constantFrame(600, 0.02));
+    emitMonoFrame(context, constantFrame(600, 0.03));
+    emitMonoFrame(context, new Float32Array([0.75]));
+    emitMonoFrame(context, new Float32Array([0.65]));
+
+    const pcm = decodeMonoPcm16Wav(await recorder.stop());
+
+    expect(pcm.length).toBe(1202);
+    expectSamplesClose(pcm, 0, 600, 0.02);
+    expectSamplesClose(pcm, 600, 600, 0.03);
+    expect(pcm[1200]).toBeCloseTo(0.75, 3);
+    expect(pcm[1201]).toBeCloseTo(0.65, 3);
+  });
+
+  it("does not promote no-speech pre-roll into a stopped capture", async () => {
+    const { recorder, context } = await createFakeRecorder(16_000);
+
+    emitMonoFrame(context, constantFrame(5000, 0.02));
+
+    await expect(recorder.stop()).rejects.toThrow(
+      "No microphone audio was captured for local ASR",
+    );
+  });
+
+  it("clears pending pre-roll on cancel so later frames cannot leak into stop", async () => {
+    const { recorder, context, trackStop } = await createFakeRecorder(16_000);
+
+    emitMonoFrame(context, constantFrame(1000, 0.02));
+    recorder.cancel();
+
+    expect(context.processor.onaudioprocess).toBeNull();
+    await expect(recorder.stop()).rejects.toThrow(
+      "No microphone audio was captured for local ASR",
+    );
+    expect(trackStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears buffered PCM on stop and ignores frames after teardown", async () => {
+    const { recorder, context } = await createFakeRecorder(16_000);
+
+    emitMonoFrame(context, constantFrame(100, 0.02));
+    emitMonoFrame(context, new Float32Array([0.8]));
+
+    const firstPcm = decodeMonoPcm16Wav(await recorder.stop());
+
+    expect(firstPcm.length).toBe(101);
+    expect(context.processor.onaudioprocess).toBeNull();
+    await expect(recorder.stop()).rejects.toThrow(
+      "No microphone audio was captured for local ASR",
+    );
+  });
+
+  it("leaves non-auto-stop captures buffering every frame unchanged", async () => {
+    const { recorder, context } = await createFakeRecorder(16_000, {});
+
+    emitMonoFrame(context, constantFrame(2, 0.01));
+    emitMonoFrame(context, new Float32Array([0.8]));
+
+    const pcm = decodeMonoPcm16Wav(await recorder.stop());
+
+    expect(pcm.length).toBe(3);
+    expectSamplesClose(pcm, 0, 2, 0.01);
+    expect(pcm[2]).toBeCloseTo(0.8, 3);
   });
 });
 

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -134,6 +134,35 @@ function concatPcm(chunks: Float32Array[]): Float32Array {
   return out;
 }
 
+function appendBoundedPcmFrame(
+  chunks: Float32Array[],
+  frame: Float32Array,
+  maxSamples: number,
+): void {
+  if (maxSamples <= 0) return;
+
+  chunks.push(frame);
+  let retainedSamples = 0;
+  for (let index = chunks.length - 1; index >= 0; index -= 1) {
+    const chunk = chunks[index];
+    if (!chunk) continue;
+    const nextRetainedSamples = retainedSamples + chunk.length;
+    if (nextRetainedSamples <= maxSamples) {
+      retainedSamples = nextRetainedSamples;
+      continue;
+    }
+
+    const keepFromChunk = maxSamples - retainedSamples;
+    if (keepFromChunk > 0) {
+      chunks[index] = chunk.slice(chunk.length - keepFromChunk);
+      chunks.splice(0, index);
+    } else {
+      chunks.splice(0, index + 1);
+    }
+    return;
+  }
+}
+
 function writeAscii(view: DataView, offset: number, value: string): void {
   for (let index = 0; index < value.length; index += 1) {
     view.setUint8(offset + index, value.charCodeAt(index));
@@ -185,6 +214,7 @@ export function isSilentPcmAudio(pcm: Float32Array): boolean {
  * 0.003 to 0.012 and the peak gate from 0.012 to 0.048.
  */
 export const POST_TTS_ECHO_THRESHOLD_MULTIPLIER = 4;
+const AUTO_STOP_PRE_ROLL_MS = 200;
 
 export const DEFAULT_LOCAL_ASR_AUTO_STOP: LocalAsrAutoStopConfig = {
   startGraceMs: 250,
@@ -491,10 +521,15 @@ export async function startLocalAsrRecorder(
   analyser.smoothingTimeConstant = 0.8;
   source.connect(analyser);
   const chunks: Float32Array[] = [];
+  const preRollChunks: Float32Array[] = [];
+  const preRollMaxSamples = Math.round(
+    (context.sampleRate * AUTO_STOP_PRE_ROLL_MS) / 1000,
+  );
   let stopped = false;
   let autoStopRequested = false;
   let firstChunkTraced = false;
   const autoStopDetector = createLocalAsrAutoStopDetector(options.autoStop);
+  let preRollPromoted = !autoStopDetector;
 
   processor.onaudioprocess = (event) => {
     if (stopped) return;
@@ -521,7 +556,14 @@ export async function startLocalAsrRecorder(
       shouldStop: false,
     };
     if (autoStopUpdate.shouldBuffer) {
+      if (!preRollPromoted) {
+        chunks.push(...preRollChunks);
+        preRollChunks.length = 0;
+        preRollPromoted = true;
+      }
       chunks.push(mono);
+    } else if (!preRollPromoted) {
+      appendBoundedPcmFrame(preRollChunks, mono, preRollMaxSamples);
     }
     if (autoStopUpdate.shouldStop && !autoStopRequested && options.onAutoStop) {
       autoStopRequested = true;
@@ -533,7 +575,9 @@ export async function startLocalAsrRecorder(
   processor.connect(context.destination);
 
   const cleanup = async () => {
+    if (stopped) return;
     stopped = true;
+    preRollChunks.length = 0;
     processor.onaudioprocess = null;
     try {
       analyser?.disconnect();
@@ -566,12 +610,15 @@ export async function startLocalAsrRecorder(
       const sampleRate = context.sampleRate;
       await cleanup();
       const pcm = concatPcm(chunks);
+      chunks.length = 0;
       if (pcm.length === 0) {
         throw new Error("No microphone audio was captured for local ASR");
       }
       return encodeMonoPcm16Wav(pcm, sampleRate);
     },
     cancel() {
+      chunks.length = 0;
+      preRollChunks.length = 0;
       void cleanup();
     },
   };


### PR DESCRIPTION
## Summary

- retain the newest 200ms of PCM while browser batch-ASR VAD is waiting for speech
- prepend the bounded pre-roll exactly once when speech starts
- clear retained capture state on stop, cancel, and teardown
- leave realtime/non-auto-stop capture and the existing 12s speech cap unchanged

## Why

Fast speech immediately after mic-open could lose its first syllable because frames received before VAD transitioned to buffering were discarded. The pre-roll is sample-rate bounded (3,200 samples at 16kHz, 9,600 at 48kHz), preserving onset without unbounded idle memory.

## Tests

- synthetic 16kHz and 48kHz newest-window bounds/order
- fast-start onset retention
- no double-prepend
- no-speech pre-roll is not promoted
- cancel and stop/teardown clearing
- non-auto-stop behavior unchanged

29/29 focused tests passed. Scoped Biome and git diff checks passed.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - internal microphone PCM capture behavior only; no rendered UI or visual baseline changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - internal microphone PCM capture behavior only; no rendered UI or visual output changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - deterministic synthetic AudioContext coverage exercises the PCM path; this change has no visual interaction to record and CI has no microphone hardware.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend, API, worker, database, or service behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no console or network behavior changed; verification is recorder-level Vitest over the browser AudioContext boundary.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, agent trajectory, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff and synthetic PCM tests](https://github.com/elizaOS/eliza/pull/16631/files), plus committed receipt `ISSUE-16424-2026-07-18.md`. Tests verify exact sample counts and ordering at 16kHz and 48kHz, one-time prepend, and teardown clearing.

Receipt: `ISSUE-16424-2026-07-18.md`

Closes #16424

[sol-orch]