### PR TITLE
fix(voice): reject oversized STT bodies before parsing

### DIFF
--- a/ISSUE-16433-2026-07-18.md
+++ b/ISSUE-16433-2026-07-18.md
@@ -1,0 +1,66 @@
+# Issue #16433 - STT Multipart Request Body Limit
+
+Date: 2026-07-18
+
+## Implementation Evidence
+
+- Added a pre-auth body-size guard to `packages/cloud/api/v1/voice/stt/route.ts`.
+- Default total multipart body cap is 25 MiB, including MIME boundary and field overhead.
+- Trustworthy `Content-Length` values over the cap return structured HTTP 413 before auth, multipart parsing, provider lookup, credit reservation, billing, or usage writes.
+- Missing/chunked bodies and falsely small `Content-Length` bodies are read incrementally with the same strict cap; the reader is cancelled immediately once received bytes exceed the ceiling.
+- Successful in-limit reads reconstruct a `Request` preserving URL, method, and headers for the existing `formData()` parsing path.
+- The in-limit reconstruction path snapshots sanitized headers before reading buffered bodies; Bun can drop generated multipart headers after a FormData body is consumed.
+- Added `VOICE_STT_MAX_MULTIPART_BYTES` to `AppEnv["Bindings"]` and `wrangler.toml` config comments.
+- Invalid `VOICE_STT_MAX_MULTIPART_BYTES` values fail closed with a logged structured configuration error and HTTP 500, with no permissive fallback.
+
+## Test Evidence
+
+Focused tests added/updated in `packages/cloud/api/v1/voice/stt/route.test.ts`:
+
+- Oversized trustworthy `Content-Length` precheck returns 413 before auth.
+- Missing/chunked stream overflow returns 413 and calls stream cancellation.
+- Lying smaller `Content-Length` still returns 413 once streamed bytes exceed the cap.
+- Exact configured cap including multipart overhead is accepted.
+- One byte over configured cap including multipart overhead is rejected.
+- Legitimate STT request path remains successful.
+- Malformed multipart under the cap still reaches the existing authenticated parse-failure behavior.
+- Side-effect mocks assert oversized requests do not call auth, provider, credit reservation, billing, or usage.
+- The previous over-25 MiB file test now asserts request-level 413 before auth/provider work.
+
+Commands run:
+
+```bash
+bun test packages/cloud/api/v1/voice/stt/route.test.ts
+```
+
+Initial result: 34 pass, 2 fail. Both failing acceptance cases returned HTTP 400 with:
+
+```json
+{"error":"Expected multipart form data with audio field"}
+```
+
+Diagnostic result: the test helper consumed the FormData request before copying its auto-generated `content-type` boundary, so the cloned request only carried `content-length`. The route then correctly rejected it as non-multipart.
+
+```bash
+bun test packages/cloud/api/v1/voice/stt/route.test.ts
+```
+
+Final result after rebasing onto current `develop` and preserving its Deepgram STT path: passed. 48 pass, 1 skip, 0 fail, 242 assertions.
+
+```bash
+cd packages/cloud/api && bun run lint
+```
+
+Result: passed. Biome checked 39 files with no fixes required.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Staging Verification
+
+Pending. `wrangler whoami` confirmed this lane is not authenticated, so staging could not be deployed and a real staging 413 trace could not be captured. The route-level suite exercises a real 25 MiB-plus multipart request and verifies HTTP 413 with no auth/provider/billing/usage calls.
+
+[sol-orch]

--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -194,6 +194,61 @@ function sttRequest(
   });
 }
 
+async function cloneMultipartRequestWithHeaders(
+  request: Request,
+  headers: HeadersInit,
+): Promise<Request> {
+  const nextHeaders = new Headers(request.headers);
+  const body = await request.arrayBuffer();
+  for (const [key, value] of new Headers(headers)) {
+    nextHeaders.set(key, value);
+  }
+  return new Request(request.url, {
+    body,
+    headers: nextHeaders,
+    method: request.method,
+  });
+}
+
+async function multipartBodyLength(request: Request): Promise<number> {
+  return (await request.clone().arrayBuffer()).byteLength;
+}
+
+function streamRequest(
+  chunks: Uint8Array[],
+  headers: HeadersInit,
+  onCancel: () => void = () => {},
+): Request {
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      onCancel();
+    },
+    pull(controller) {
+      const chunk = chunks[index];
+      index += 1;
+      if (chunk) {
+        controller.enqueue(chunk);
+        return;
+      }
+      controller.close();
+    },
+  });
+  return new Request("http://localhost/api/v1/voice/stt", {
+    body,
+    headers,
+    method: "POST",
+  });
+}
+
+function expectNoOversizedSideEffects() {
+  expect(requireAuthOrApiKeyWithOrg).not.toHaveBeenCalled();
+  expect(reserve).not.toHaveBeenCalled();
+  expect(billFlatUsage).not.toHaveBeenCalled();
+  expect(speechToText).not.toHaveBeenCalled();
+  expect(usageCreate).not.toHaveBeenCalled();
+}
+
 /**
  * The merged workers-types/DOM/bun globals leave `Response#json()`'s generic
  * unresolvable at bare call sites (it infers `undefined`, which rejects every
@@ -424,6 +479,167 @@ beforeEach(() => {
 });
 
 describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
+  test("rejects trustworthy oversized Content-Length before auth or body parsing", async () => {
+    const cancel = mock(() => {});
+    const res = await app.request(
+      streamRequest(
+        [new Uint8Array(8)],
+        {
+          "content-type": "multipart/form-data; boundary=oversized",
+          "content-length": String(25 * 1024 * 1024 + 1),
+        },
+        cancel,
+      ),
+      undefined,
+      whisperEnv,
+    );
+
+    expect(res.status).toBe(413);
+    expect(await readJson(res)).toEqual({
+      error: "STT multipart request body too large",
+      maxBytes: 25 * 1024 * 1024,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expectNoOversizedSideEffects();
+  });
+
+  test("cancels a chunked body as soon as it exceeds the configured multipart cap", async () => {
+    const cancel = mock(() => {});
+    const res = await app.request(
+      streamRequest(
+        [new Uint8Array(8), new Uint8Array(8)],
+        { "content-type": "multipart/form-data; boundary=chunked" },
+        cancel,
+      ),
+      undefined,
+      { VOICE_STT_MAX_MULTIPART_BYTES: "10" } as never,
+    );
+
+    expect(res.status).toBe(413);
+    expect(await readJson(res)).toEqual({
+      error: "STT multipart request body too large",
+      maxBytes: 10,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expectNoOversizedSideEffects();
+  });
+
+  test("does not trust a smaller Content-Length when the streamed body grows past the cap", async () => {
+    const cancel = mock(() => {});
+    const res = await app.request(
+      streamRequest(
+        [new Uint8Array(8), new Uint8Array(8)],
+        {
+          "content-type": "multipart/form-data; boundary=lying",
+          "content-length": "1",
+        },
+        cancel,
+      ),
+      undefined,
+      { VOICE_STT_MAX_MULTIPART_BYTES: "10" } as never,
+    );
+
+    expect(res.status).toBe(413);
+    expect(await readJson(res)).toEqual({
+      error: "STT multipart request body too large",
+      maxBytes: 10,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expectNoOversizedSideEffects();
+  });
+
+  test("removes a false smaller Content-Length from buffered in-limit multipart requests", async () => {
+    upstreamReply = () => Response.json({ text: "false length accepted" });
+    const base = sttRequest(wavFile(), { languageCode: "en" });
+    const bodyBytes = await multipartBodyLength(base);
+    const falseLength = await cloneMultipartRequestWithHeaders(base, {
+      "content-length": "1",
+    });
+
+    const res = await app.request(falseLength, undefined, {
+      ...whisperEnv,
+      VOICE_STT_MAX_MULTIPART_BYTES: String(bodyBytes + 1),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const body = (await readJson(res)) as Record<string, unknown>;
+    expect(body.transcript).toBe("false length accepted");
+    expect(captured.fields.language).toEqual(["en"]);
+    expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts a multipart body exactly at the configured cap including overhead", async () => {
+    upstreamReply = () => Response.json({ text: "exact boundary" });
+    const base = sttRequest(wavFile(), { languageCode: "en" });
+    const bodyBytes = await multipartBodyLength(base);
+    const exact = await cloneMultipartRequestWithHeaders(base, {
+      "content-length": String(bodyBytes),
+    });
+
+    const res = await app.request(exact, undefined, {
+      ...whisperEnv,
+      VOICE_STT_MAX_MULTIPART_BYTES: String(bodyBytes),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const body = (await readJson(res)) as Record<string, unknown>;
+    expect(body.transcript).toBe("exact boundary");
+    expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(speechToText).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+  });
+
+  test("rejects a multipart body one byte over the configured cap including overhead", async () => {
+    const base = sttRequest(wavFile(), { languageCode: "en" });
+    const bodyBytes = await multipartBodyLength(base);
+    const over = await cloneMultipartRequestWithHeaders(base, {
+      "content-length": String(bodyBytes),
+    });
+
+    const res = await app.request(over, undefined, {
+      VOICE_STT_MAX_MULTIPART_BYTES: String(bodyBytes - 1),
+    } as never);
+
+    expect(res.status).toBe(413);
+    expect(await readJson(res)).toEqual({
+      error: "STT multipart request body too large",
+      maxBytes: bodyBytes - 1,
+    });
+    expectNoOversizedSideEffects();
+  });
+
+  test("invalid optional multipart limit configuration fails closed", async () => {
+    const res = await app.request(sttRequest(), undefined, {
+      VOICE_STT_MAX_MULTIPART_BYTES: "not-a-number",
+    } as never);
+
+    expect(res.status).toBe(500);
+    expect(await readJson(res)).toEqual({
+      error: "Speech-to-text service is misconfigured",
+    });
+    expect(logError).toHaveBeenCalledWith(
+      "[Voice STT API] Invalid multipart body limit configuration",
+      { errorType: "Error" },
+    );
+    expectNoOversizedSideEffects();
+  });
+
+  test("blank multipart limit configuration fails closed instead of using the default", async () => {
+    const res = await app.request(sttRequest(), undefined, {
+      VOICE_STT_MAX_MULTIPART_BYTES: "   ",
+    } as never);
+
+    expect(res.status).toBe(500);
+    expect(await readJson(res)).toEqual({
+      error: "Speech-to-text service is misconfigured",
+    });
+    expect(logError).toHaveBeenCalledWith(
+      "[Voice STT API] Invalid multipart body limit configuration",
+      { errorType: "Error" },
+    );
+    expectNoOversizedSideEffects();
+  });
+
   test("a non-multipart body is a 400", async () => {
     const res = await app.request(
       new Request("http://localhost/api/v1/voice/stt", {
@@ -450,7 +666,7 @@ describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
     expect(await readJson(res)).toEqual({ error: "No audio file provided" });
   });
 
-  test("a file over the 25MB cap is rejected before any provider call", async () => {
+  test("a file over the 25 MiB request cap is rejected before auth or provider calls", async () => {
     const res = await app.request(
       sttRequest(
         new File([new ArrayBuffer(25 * 1024 * 1024 + 1)], "big.wav", {
@@ -460,10 +676,12 @@ describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
       undefined,
       whisperEnv,
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(413);
     expect(await readJson(res)).toEqual({
-      error: "File too large. Maximum size is 25MB",
+      error: "STT multipart request body too large",
+      maxBytes: 25 * 1024 * 1024,
     });
+    expectNoOversizedSideEffects();
   });
 
   test("an unsupported declared MIME type is a 400", async () => {
@@ -510,6 +728,29 @@ describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
     const res = await app.request(sttRequest(), undefined, whisperEnv);
     expect(res.status).toBe(401);
     expect(await readJson(res)).toEqual({ error: "Unauthorized" });
+  });
+
+  test("malformed multipart remains a parse failure after auth when it is under the cap", async () => {
+    const res = await app.request(
+      new Request("http://localhost/api/v1/voice/stt", {
+        method: "POST",
+        headers: {
+          "content-type": "multipart/form-data",
+        },
+        body: "not a multipart body",
+      }),
+      undefined,
+      whisperEnv,
+    );
+
+    expect(res.status).toBe(500);
+    expect(await readJson(res)).toEqual({
+      error: "Failed to transcribe audio. Please try again.",
+    });
+    expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(reserve).not.toHaveBeenCalled();
+    expect(speechToText).not.toHaveBeenCalled();
+    expect(billFlatUsage).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -557,7 +557,7 @@ describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
     });
 
     const res = await app.request(falseLength, undefined, {
-      ...whisperEnv,
+      ...(whisperEnv as unknown as Record<string, string>),
       VOICE_STT_MAX_MULTIPART_BYTES: String(bodyBytes + 1),
     } as never);
 
@@ -577,7 +577,7 @@ describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
     });
 
     const res = await app.request(exact, undefined, {
-      ...whisperEnv,
+      ...(whisperEnv as unknown as Record<string, string>),
       VOICE_STT_MAX_MULTIPART_BYTES: String(bodyBytes),
     } as never);
 

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -1,4 +1,8 @@
-// Handles v1 cloud API v1 voice stt route traffic with route-local auth expectations.
+/**
+ * Cloud voice transcription route for multipart audio uploads. The request
+ * body is size-gated before auth and multipart parsing so rejected uploads do
+ * not spend provider, billing, or signature-parsing work.
+ */
 import { Hono } from "hono";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -50,6 +54,12 @@ const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
 const DEEPGRAM_PRERECORDED_URL = "https://api.deepgram.com/v1/listen";
 const DEEPGRAM_PRERECORDED_MODEL = "nova-3";
 const STT_PRICING_PROXY_MODEL = "elevenlabs/scribe_v1";
+const DEFAULT_MAX_MULTIPART_BODY_BYTES = 25 * 1024 * 1024;
+const MAX_MULTIPART_BODY_BYTES_ENV = "VOICE_STT_MAX_MULTIPART_BYTES";
+const OVERSIZED_MULTIPART_RESPONSE = {
+  error: "STT multipart request body too large",
+  maxBytes: DEFAULT_MAX_MULTIPART_BODY_BYTES,
+};
 
 const SUPPORTED_MIME_TYPES = [
   "audio/mp3",
@@ -198,6 +208,135 @@ function parseDeepgramTranscription(
   };
 }
 
+function parseSttMultipartBodyLimit(env: AppEnv["Bindings"]): number {
+  const configured = env.VOICE_STT_MAX_MULTIPART_BYTES;
+  if (configured === undefined) {
+    return DEFAULT_MAX_MULTIPART_BODY_BYTES;
+  }
+
+  const parsed = Number(configured);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `${MAX_MULTIPART_BODY_BYTES_ENV} must be a positive integer`,
+    );
+  }
+  return parsed;
+}
+
+function oversizedMultipartResponse(maxBytes: number): Response {
+  return Response.json(
+    {
+      ...OVERSIZED_MULTIPART_RESPONSE,
+      maxBytes,
+    },
+    { status: 413 },
+  );
+}
+
+function parseTrustworthyContentLength(request: Request): number | null {
+  const raw = request.headers.get("content-length");
+  if (!raw) return null;
+  if (!/^\d+$/.test(raw.trim())) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function headersForBufferedRequest(request: Request): Headers {
+  const headers = new Headers(request.headers);
+  headers.delete("content-length");
+  return headers;
+}
+
+function cancelUploadBodyBestEffort(
+  body: ReadableStream<Uint8Array>,
+  label: string,
+): void {
+  const reportFailure = (error: unknown) => {
+    // error-policy:J6 best-effort teardown for an upload already rejected.
+    logger.warn("[Voice STT API] Failed to cancel oversized upload body", {
+      errorType: error instanceof Error ? error.name : "unknown",
+      label,
+    });
+  };
+  try {
+    body.cancel().catch(reportFailure);
+  } catch (error) {
+    reportFailure(error);
+  }
+}
+
+function cancelUploadReaderBestEffort(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): void {
+  const reportFailure = (error: unknown) => {
+    // error-policy:J6 best-effort teardown for an upload already rejected.
+    logger.warn("[Voice STT API] Failed to cancel oversized upload reader", {
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
+  };
+  try {
+    reader.cancel().catch(reportFailure);
+  } catch (error) {
+    reportFailure(error);
+  }
+}
+
+async function readRequestWithMultipartLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<Request | Response> {
+  const declaredLength = parseTrustworthyContentLength(request);
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    if (request.body) {
+      cancelUploadBodyBestEffort(request.body, "content-length-precheck");
+    }
+    return oversizedMultipartResponse(maxBytes);
+  }
+
+  const bufferedHeaders = headersForBufferedRequest(request);
+
+  if (!request.body) {
+    const buffer = await request.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      return oversizedMultipartResponse(maxBytes);
+    }
+    return new Request(request.url, {
+      body: buffer,
+      headers: bufferedHeaders,
+      method: request.method,
+    });
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    received += value.byteLength;
+    if (received > maxBytes) {
+      cancelUploadReaderBestEffort(reader);
+      return oversizedMultipartResponse(maxBytes);
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new Request(request.url, {
+    body,
+    headers: bufferedHeaders,
+    method: request.method,
+  });
+}
+
 /**
  * POST /api/v1/voice/stt
  * Converts speech to text using the voice transcription service.
@@ -211,6 +350,32 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
   let reservation: CreditReservation | undefined;
 
   try {
+    let multipartBodyLimit: number;
+    try {
+      multipartBodyLimit = parseSttMultipartBodyLimit(env);
+    } catch (error) {
+      // error-policy:J1 boundary translation for pre-auth operator config.
+      logger.error(
+        "[Voice STT API] Invalid multipart body limit configuration",
+        {
+          errorType: error instanceof Error ? error.name : "unknown",
+        },
+      );
+      return Response.json(
+        { error: "Speech-to-text service is misconfigured" },
+        { status: 500 },
+      );
+    }
+
+    const sizeCheckedRequest = await readRequestWithMultipartLimit(
+      request,
+      multipartBodyLimit,
+    );
+    if (sizeCheckedRequest instanceof Response) {
+      return sizeCheckedRequest;
+    }
+    request = sizeCheckedRequest;
+
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
 
     const contentType = request.headers.get("content-type") ?? "";

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -263,6 +263,8 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   ATLASCLOUD_BASE_URL                Optional AtlasCloud API base URL override
 #   BIRDEYE_API_KEY                    Birdeye defi/price proxy key
 #   ELEVENLABS_API_KEY                 ElevenLabs TTS
+#   VOICE_STT_MAX_MULTIPART_BYTES      Optional STT multipart body cap in bytes
+#                                      (default 25 MiB, invalid values fail closed)
 #   HF_TOKEN                           HuggingFace token for the /api/v1/hf-proxy/* route
 #       (gated eliza-1 bundle downloads; clients never hold an HF key)
 #   VAST_API_KEY                       Vast.ai Serverless endpoint API token (Bearer)

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -101,6 +101,12 @@ export interface Bindings {
    * different hosted model for a deployment.
    */
   WHISPER_STT_MODEL?: string;
+  /**
+   * Positive integer byte cap for the whole STT multipart request, including
+   * MIME boundaries and field overhead. Unset defaults to 25 MiB; invalid
+   * values fail the STT route closed instead of weakening the upload guard.
+   */
+  VOICE_STT_MAX_MULTIPART_BYTES?: string;
 
   // ---- Realtime voice-session WebSocket (Phase 1, flag-gated) ----
   /**


### PR DESCRIPTION
## Summary
- reject trustworthy oversized `Content-Length` before auth or multipart parsing
- incrementally bound missing/chunked and falsely-small-length bodies at 25 MiB, cancelling on overflow
- preserve legitimate multipart parsing while removing untrusted `Content-Length` after bounded buffering
- fail closed on invalid optional body-limit configuration
- ensure oversized requests never enter auth, provider, credit reservation, billing, or usage paths

## Tests
- `bun test packages/cloud/api/v1/voice/stt/route.test.ts` (48 pass, 1 skip, 0 fail, 242 assertions)
- `cd packages/cloud/api && bun run lint` (clean)
- `git diff --check`

## Staging
Staging deploy and real staging 413 trace are pending because `wrangler whoami` reports this lane is unauthenticated. Canonical staging deploys are also restricted to `develop`; PR runs are frontend-only previews. The route suite includes a real 25 MiB-plus multipart request and verifies 413 plus zero auth/provider/billing/usage calls.

Closes #16433
## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - backend-only STT request handling; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - backend-only STT request handling; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive or visual flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [implementation and test receipt](https://github.com/elizaOS/eliza/blob/f6326559ec241eaed977b4b718a165f9fdb916f6/ISSUE-16433-2026-07-18.md) records 48 pass, 1 live skip, 0 fail, 242 assertions, plus Biome and diff-check evidence.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend code or network client behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, trajectory, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [security receipt](https://github.com/elizaOS/eliza/blob/f6326559ec241eaed977b4b718a165f9fdb916f6/ISSUE-16433-2026-07-18.md), [focused code and tests](https://github.com/elizaOS/eliza/pull/16635/files). Oversized bodies are asserted to return 413 with zero auth/provider/credit/billing/usage calls.
