### PR TITLE
fix(voice): recover realtime sessions after disconnect

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -27,7 +27,10 @@ import type { CartesiaWebSocketLike } from "../../../../../shared/src/lib/servic
 import { InMemoryVoiceUsageStore } from "../../../../../shared/src/lib/services/voice-usage-meter";
 import { mintVoiceSessionToken } from "../../../../../shared/src/lib/voice-session/jwt";
 import type { ServerControlFrame } from "../../../../../shared/src/lib/voice-session/protocol";
-import { __resetVoiceSessionRegistryForTests } from "../../../../../shared/src/lib/voice-session/session-registry";
+import {
+  __resetVoiceSessionRegistryForTests,
+  getVoiceSessionRegistry,
+} from "../../../../../shared/src/lib/voice-session/session-registry";
 import { installVoiceSessionTestSigningKey } from "../../../../../shared/src/lib/voice-session/test-signing";
 import { attachVoiceWsHandler } from "../../../../../shared/src/lib/voice-session/ws-handler";
 import type { DeepgramFluxWebSocket } from "../../stt/providers/deepgram-flux";
@@ -896,6 +899,31 @@ describe("voice-session WS lifecycle", () => {
     await flush();
     expect(aborted).toBe(true);
     expect(client.controlTypes()).toContain("interrupted");
+  });
+
+  test("abrupt mid-turn disconnect synchronously reaps the registry before replacement hello", async () => {
+    const source = new FakeClientSocket();
+    await connectSession({
+      client: source,
+      fetchImpl: makeSseFetch(["still generating"], { hang: true }),
+    });
+    const sourceFlux = FakeFluxSocket.instances.at(-1)!;
+    sourceFlux.emitTurn("StartOfTurn");
+    sourceFlux.emitTurn("EndOfTurn", "disconnect me");
+    await flush();
+    expect(getVoiceSessionRegistry().size()).toBe(1);
+
+    source.clientClose();
+    expect(getVoiceSessionRegistry().size()).toBe(0);
+    expect(sourceFlux.closed).toBe(true);
+
+    const replacement = new FakeClientSocket();
+    await connectSession({
+      client: replacement,
+      fetchImpl: makeSseFetch(["recovered."]),
+    });
+    expect(replacement.controlTypes()).toContain("ready");
+    expect(getVoiceSessionRegistry().size()).toBe(1);
   });
 
   test("bye tears down providers, unregisters, closes cleanly, and revokes the bootstrap token", async () => {

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -23,7 +23,7 @@ import {
 import {
   claimVoiceSessionToken,
   isVoiceSessionTokenRevoked,
-  revokeVoiceSessionToken,
+  verifyVoiceSessionToken,
 } from "@/lib/voice-session/jwt";
 import { getVoiceSessionRegistry } from "@/lib/voice-session/session-registry";
 import {
@@ -191,7 +191,16 @@ app.get("/", (c) => {
   );
   attachVoiceWsHandler(server, {
     requestedSessionId: sessionId,
-    claimToken: (jti, expSeconds) => claimVoiceSessionToken(jti, expSeconds),
+    // Reuse one request-scoped Redis client for verify + single-use claim.
+    // Creating two Railway TCP connections serially put 2-5s on hello->ready
+    // and made abrupt-disconnect recovery contend with teardown traffic.
+    verifyToken: (token, expected, options) =>
+      verifyVoiceSessionToken(token, expected, {
+        ...options,
+        ...(rawRedis ? { store: rawRedis } : {}),
+      }),
+    claimToken: (jti, expSeconds) =>
+      claimVoiceSessionToken(jti, expSeconds, rawRedis ?? undefined),
     // Enforce the per-worker ceiling against the LIVE registry at start time,
     // closing the race where many upgrades pass the earlier route-level check.
     admitSession: () => getVoiceSessionRegistry().size() < maxSessions,
@@ -228,8 +237,10 @@ app.get("/", (c) => {
         usageStore,
         usageLimits,
         isRevoked: (jti) => isVoiceSessionTokenRevoked(jti),
-        onTeardownRevoke: (jti, expSeconds) =>
-          revokeVoiceSessionToken(jti, expSeconds),
+        // A successful hello atomically claimed this jti until expiry, so it
+        // cannot be replayed. Avoid a redundant denylist write during abrupt
+        // disconnect: it contended with the immediate replacement hello.
+        // Explicit cross-device revoke and its 400ms poll remain unchanged.
         downlink,
       });
     },

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/jwt.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/jwt.test.ts
@@ -171,7 +171,37 @@ describe("voice-session jwt", () => {
       const minted = await mintVoiceSessionToken(CLAIMS);
       await expect(
         verifyVoiceSessionToken(minted.token, { sessionId: CLAIMS.sessionId }),
-      ).rejects.toMatchObject({ code: "revoked" });
+      ).rejects.toMatchObject({ code: "store_unavailable" });
+    } finally {
+      __setVoiceSessionRevocationStoreForTests(null);
+    }
+  });
+
+  test("a transient revocation read failure does not falsely revoke a fresh token", async () => {
+    let reads = 0;
+    const transient = {
+      async get() {
+        reads += 1;
+        if (reads === 1) throw new Error("stale redis socket");
+        return null;
+      },
+      async set() {
+        return "OK";
+      },
+      async getdel() {
+        return null;
+      },
+      async del() {
+        return 0;
+      },
+    };
+    __setVoiceSessionRevocationStoreForTests(transient as never);
+    try {
+      const minted = await mintVoiceSessionToken(CLAIMS);
+      await expect(
+        verifyVoiceSessionToken(minted.token, { sessionId: CLAIMS.sessionId }),
+      ).resolves.toMatchObject({ jti: minted.jti });
+      expect(reads).toBe(2);
     } finally {
       __setVoiceSessionRevocationStoreForTests(null);
     }

--- a/packages/cloud/shared/src/lib/voice-session/jwt.ts
+++ b/packages/cloud/shared/src/lib/voice-session/jwt.ts
@@ -101,6 +101,7 @@ export class VoiceSessionTokenError extends Error {
       | "invalid_input"
       | "invalid_token"
       | "revoked"
+      | "store_unavailable"
       | "claim_mismatch",
   ) {
     super(message);
@@ -207,7 +208,7 @@ function readClaim(payload: Record<string, unknown>, key: string): string {
 export async function verifyVoiceSessionToken(
   token: string,
   expected?: Partial<VoiceSessionTokenClaims>,
-  options?: { now?: () => number },
+  options?: { now?: () => number; store?: CompatibleRedis },
 ): Promise<VoiceSessionTokenVerifyResult> {
   if (!isVoiceSessionJwtConfigured()) {
     throw new VoiceSessionTokenError(
@@ -271,7 +272,7 @@ export async function verifyVoiceSessionToken(
     }
   }
 
-  if (await isVoiceSessionTokenRevoked(jti)) {
+  if (await readVoiceSessionRevocation(jti, options?.store)) {
     throw new VoiceSessionTokenError("voice-session token has been revoked", "revoked");
   }
 
@@ -346,12 +347,33 @@ export async function revokeVoiceSessionToken(jti: string, expSeconds?: number):
  * token is treated as revoked (never `catch -> allow`). When no store is
  * configured, revocation is genuinely unsupported and this returns false.
  */
-export async function isVoiceSessionTokenRevoked(jti: string): Promise<boolean> {
-  const redis = getRedis();
+async function readVoiceSessionRevocation(jti: string, store?: CompatibleRedis): Promise<boolean> {
+  const redis = store ?? getRedis();
   if (!redis) return false;
+  let lastError: unknown;
+  // SocketRedis already bounds each operation. One immediate retry on the same
+  // request-scoped client recovers a stale Railway TCP connection without
+  // turning an infrastructure timeout into a false `revoked` result for a
+  // freshly minted random jti. Persistent failures still reject fail-closed.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const value = await redis.get(revocationKey(jti));
+      return value !== null && value !== undefined;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new VoiceSessionTokenError(
+    `voice-session revocation store unavailable: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+    "store_unavailable",
+  );
+}
+
+export async function isVoiceSessionTokenRevoked(jti: string): Promise<boolean> {
   try {
-    const value = await redis.get(revocationKey(jti));
-    return value !== null && value !== undefined;
+    return await readVoiceSessionRevocation(jti);
   } catch (error) {
     logger.error(
       `[voice-session-jwt] revocation check failed (fail-closed): ${
@@ -439,8 +461,12 @@ function claimKey(jti: string): string {
  * registry supersede is the only guard (single-worker dev), so we return true;
  * production requires Redis for cross-worker single-use enforcement.
  */
-export async function claimVoiceSessionToken(jti: string, expSeconds: number): Promise<boolean> {
-  const redis = getRedis();
+export async function claimVoiceSessionToken(
+  jti: string,
+  expSeconds: number,
+  store?: CompatibleRedis,
+): Promise<boolean> {
+  const redis = store ?? getRedis();
   if (!redis) return true;
   const nowSeconds = Math.floor(Date.now() / 1000);
   const ttl = Math.min(Math.max(Math.ceil(expSeconds - nowSeconds), 1), MAX_REVOCATION_TTL_SECONDS);


### PR DESCRIPTION
## Summary
- reuse one request-scoped Redis connection across revocation verification and single-use claim
- retry one transient revocation read and distinguish store failure from actual revocation, still fail-closed
- remove redundant teardown denylist writes because accepted JTIs are already claimed through expiry
- test abrupt mid-turn disconnect reaping before replacement ready

No auth weakening. TTL, validation, explicit revoke, and the 400ms poll are unchanged.

Tests: 41 focused JWT/lifecycle cases passed; Biome clean.

Co-authored-by: wakesync <wakesync@users.noreply.github.com>