### PR TITLE
fix(cloud): preserve public host through tunnel proxy

### DIFF
--- a/packages/cloud/services/tunnel-proxy/main.go
+++ b/packages/cloud/services/tunnel-proxy/main.go
@@ -103,7 +103,7 @@ func main() {
 			targetHost, _ := pr.In.Context().Value(targetHostContextKey{}).(string)
 			pr.SetURL(&url.URL{Scheme: "https", Host: targetHost})
 			pr.Out.Host = targetHost
-			pr.Out.Header.Set("X-Forwarded-Host", pr.In.Host)
+			pr.Out.Header.Set("X-Forwarded-Host", forwardedHost(pr.In))
 			pr.Out.Header.Set("X-Forwarded-Proto", forwardedProto(pr.In))
 		},
 		Transport: transport,
@@ -270,6 +270,16 @@ func normalizeHost(host string) string {
 		host = withoutPort
 	}
 	return strings.TrimSuffix(host, ".")
+}
+
+// forwardedHost preserves the original public agent host supplied by the
+// trusted Cloudflare worker. Overwriting it with the tunnel origin host breaks
+// origin-bound pairing tokens after the second proxy hop.
+func forwardedHost(r *http.Request) string {
+	if host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); host != "" {
+		return host
+	}
+	return r.Host
 }
 
 func forwardedProto(r *http.Request) string {

--- a/packages/cloud/services/tunnel-proxy/main_test.go
+++ b/packages/cloud/services/tunnel-proxy/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -63,6 +64,31 @@ func TestTargetHostForRequest(t *testing.T) {
 	}
 	if want := label + ".tunnel.eliza.local"; target != want {
 		t.Fatalf("target host = %q, want %q", target, want)
+	}
+}
+
+func TestForwardedHostPreservesOriginalPublicHost(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://eliza-staging-1.elizacloud.ai/pair", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "eliza-staging-1.elizacloud.ai"
+	req.Header.Set("X-Forwarded-Host", "agent-id.staging.elizacloud.ai")
+
+	if got, want := forwardedHost(req), "agent-id.staging.elizacloud.ai"; got != want {
+		t.Fatalf("forwardedHost() = %q, want %q", got, want)
+	}
+}
+
+func TestForwardedHostFallsBackToRequestHost(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://tunnel.elizacloud.ai/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "tunnel.elizacloud.ai"
+
+	if got, want := forwardedHost(req), "tunnel.elizacloud.ai"; got != want {
+		t.Fatalf("forwardedHost() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve the Cloudflare worker-provided `X-Forwarded-Host` across the tunnel-proxy hop
- fall back to the tunnel request host only when no forwarded host is present
- add focused regression tests

## Live staging evidence
The hosted-agent `/pair` relay received:
```json
{"host":"100.64.0.115:2138","x-forwarded-host":"eliza-staging-1.elizacloud.ai","x-forwarded-proto":"https"}
```
The pairing token was minted for `https://<agent-id>.staging.elizacloud.ai`, so `/api/auth/pair` correctly rejected the overwritten origin with HTTP 403. A direct relay preserving the original host returned the shipped dual-storage HTML (`sessionStorage` + `localStorage`).

## Test note
`go test ./...` could not be run locally because Go is not installed on the orchestrator host. CI owns execution. `git diff --check` passes.

— [sol-orch]

Co-authored-by: wakesync <wakesync@users.noreply.github.com>

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend tunnel-proxy header propagation only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend tunnel-proxy header propagation only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface changed; live request/response evidence is documented above.
<!-- evidence-row:backend-logs -->
- [x] N/A - live staging header probe is transcribed above and contains no credential; direct relay with the preserved host returned the expected dual-storage HTML.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed; public HTTP 403 and direct-relay success are documented above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, on-chain, generated-media, or audio artifact changed.
