### PR TITLE
test(orchestrator): repair drifted service harnesses

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
@@ -316,8 +316,16 @@ describe("startup GC reclaims orphaned scratch dirs", () => {
     const id = UUID_KILL;
     const workdir = join(ROOT, `task-${id}`);
     await makeDir(workdir);
-    await store.create(session(id, workdir, "running"));
-    const service = makeService(store);
+    await store.create({
+      ...session(id, workdir, "running"),
+      lastActivityAt: new Date(Date.now() - 5 * 60_000),
+      metadata: {
+        isolatedWorkdir: true,
+        workdirRoot: ROOT,
+        transportMode: "cli",
+      },
+    });
+    const service = makeService(store, { ELIZA_ACP_TRANSPORT: "cli" });
 
     await service.start();
     try {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/auto-verify-completion-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/auto-verify-completion-evidence.test.ts
@@ -9,6 +9,7 @@
 
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../../src/services/acp-service.js";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import type { WorkspaceChangeSet } from "../../src/services/workspace-diff.js";
@@ -89,7 +90,9 @@ function runtime(
   useModel: (modelType: unknown, params: unknown) => Promise<string>,
 ): IAgentRuntime {
   return {
-    getService: () => acp,
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : null,
+    getSetting: () => undefined,
     useModel,
     logger: {
       debug: vi.fn(),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../../src/services/acp-service.js";
 import { classifyToolOutput } from "../../src/services/completion-evidence.js";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
@@ -111,7 +112,9 @@ function runtime(
   useModel: (modelType: unknown, params: unknown) => Promise<string>,
 ): IAgentRuntime {
   return {
-    getService: () => acp,
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : null,
+    getSetting: () => undefined,
     useModel,
     logger: {
       debug: vi.fn(),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
@@ -12,6 +12,7 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { tasksAction } from "../../src/actions/tasks.js";
+import { AcpService } from "../../src/services/acp-service.js";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import {
@@ -151,10 +152,13 @@ async function harness(): Promise<{
   const acp = new FakeAcp();
   let taskService: OrchestratorTaskService | null = null;
   const runtime = {
-    getService: vi.fn((type: string) =>
-      type === OrchestratorTaskService.serviceType ? taskService : acp,
-    ),
+    getService: vi.fn((type: string) => {
+      if (type === OrchestratorTaskService.serviceType) return taskService;
+      if (type === AcpService.serviceType) return acp;
+      return null;
+    }),
     hasService: vi.fn(() => true),
+    getSetting: vi.fn(() => undefined),
     getRoom: vi.fn(async () => null),
     reportError: vi.fn(),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
@@ -16,6 +16,7 @@ import { Readable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { handleOrchestratorRoutes } from "../../src/api/orchestrator-routes.js";
 import type { RouteContext } from "../../src/api/route-utils.js";
+import { AcpService } from "../../src/services/acp-service.js";
 import { BUILT_APPS_CACHE_KEY } from "../../src/services/built-apps-registry.js";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
@@ -37,7 +38,9 @@ const acpStub = {
 function makeService(): OrchestratorTaskService {
   return new OrchestratorTaskService(
     {
-      getService: () => acpStub,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? acpStub : null,
+      getSetting: () => undefined,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     } as never,
     { store: new OrchestratorTaskStore({ backend: "memory" }) },

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -20,6 +20,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../../src/services/acp-service.js";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import {
@@ -166,7 +167,8 @@ function runtime(
   settings: Record<string, string> = {},
 ): IAgentRuntime {
   return {
-    getService: () => acp ?? null,
+    getService: (type: string) =>
+      type === AcpService.serviceType ? (acp ?? null) : null,
     getSetting: (key: string) => settings[key],
     reportError: vi.fn(),
     logger: {
@@ -205,8 +207,11 @@ function runtimeWithWorkspace(
   useModel?: IAgentRuntime["useModel"],
 ): IAgentRuntime {
   return {
-    getService: (type: string) =>
-      type === CodingWorkspaceService.serviceType ? workspace : (acp ?? null),
+    getService: (type: string) => {
+      if (type === CodingWorkspaceService.serviceType) return workspace;
+      if (type === AcpService.serviceType) return acp ?? null;
+      return null;
+    },
     getSetting: () => undefined,
     useModel,
     reportError: vi.fn(),
@@ -878,16 +883,25 @@ describe("OrchestratorTaskService — lifecycle", () => {
   });
 
   it("auto-spawns a coding agent when a message is posted with no session live", async () => {
+    const prevHome = process.env.HOME;
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ots-home-"));
+    process.env.HOME = tempHome;
     const acp = new FakeAcp();
     const service = makeService(acp);
-    const { id } = await service.createTask(createInput());
-    const result = must(await service.postUserMessage(id, "hello"), "post");
-    // Parity: messaging a task with no live agent "just works" — it spawns one
-    // (the default vendored opencode backend) to act on the message, rather than
-    // silently recording it with nowhere to go.
-    expect(result.forwardedTo).toEqual(["auto-spawned"]);
-    expect(acp.spawnArgs).toHaveLength(1);
-    expect(acp.sent).toHaveLength(0);
+    try {
+      const { id } = await service.createTask(createInput());
+      const result = must(await service.postUserMessage(id, "hello"), "post");
+      // Parity: messaging a task with no live agent "just works" — it spawns one
+      // (the default vendored opencode backend) to act on the message, rather than
+      // silently recording it with nowhere to go.
+      expect(result.forwardedTo).toEqual(["auto-spawned"]);
+      expect(acp.spawnArgs).toHaveLength(1);
+      expect(acp.sent).toHaveLength(0);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 
   it("reports ACP-unavailable auto-spawn failure when no session is live", async () => {
@@ -2122,7 +2136,9 @@ describe("OrchestratorTaskService — store degradation resilience (#11641)", ()
   } {
     const warn = vi.fn();
     const rt = {
-      getService: () => acp ?? null,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? (acp ?? null) : null,
+      getSetting: () => undefined,
       reportError: vi.fn(),
       logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
     } as never as IAgentRuntime;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-resume.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-resume.test.ts
@@ -242,6 +242,9 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
       configurable: true,
     });
   }
+  function cliService(): AcpService {
+    return new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "cli" }));
+  }
   function stubSendPrompt(service: AcpService) {
     const calls: Array<{ sessionId: string; text: string }> = [];
     const stub = vi.fn(async (sessionId: string, text: string) => {
@@ -265,7 +268,7 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
 
   it("resumes sessions in busy/tool_running/running with intact state", async () => {
     await withSessionState(async (root) => {
-      const service = new AcpService(runtime());
+      const service = cliService();
       pointStateRootAt(service, root);
       const calls = stubSendPrompt(service);
       const store = getStore(service);
@@ -308,7 +311,7 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
 
   it("skips idle sessions (ready/blocked/authenticating)", async () => {
     await withSessionState(async (root) => {
-      const service = new AcpService(runtime());
+      const service = cliService();
       pointStateRootAt(service, root);
       const calls = stubSendPrompt(service);
       const store = getStore(service);
@@ -345,7 +348,7 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
 
   it("skips terminal sessions (stopped/errored/cancelled/completed)", async () => {
     await withSessionState(async (root) => {
-      const service = new AcpService(runtime());
+      const service = cliService();
       pointStateRootAt(service, root);
       const calls = stubSendPrompt(service);
       const store = getStore(service);
@@ -374,7 +377,7 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
 
   it("skips busy sessions missing acpxSessionId", async () => {
     await withSessionState(async (root) => {
-      const service = new AcpService(runtime());
+      const service = cliService();
       pointStateRootAt(service, root);
       const calls = stubSendPrompt(service);
       const store = getStore(service);
@@ -394,7 +397,7 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
 
   it("skips busy sessions whose acpx state file is missing", async () => {
     await withSessionState(async (root) => {
-      const service = new AcpService(runtime());
+      const service = cliService();
       pointStateRootAt(service, root);
       const calls = stubSendPrompt(service);
       const store = getStore(service);
@@ -415,7 +418,7 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
 
   it("returns zeros when there are no sessions at all", async () => {
     await withSessionState(async (root) => {
-      const service = new AcpService(runtime());
+      const service = cliService();
       pointStateRootAt(service, root);
       stubSendPrompt(service);
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3060,6 +3060,23 @@ export class OrchestratorTaskService extends Service {
       return undefined;
     }
 
+    // Automatic completion already verifies and stores these exact remote facts
+    // before invoking the model judge. Reuse that verdict when the claimed PR
+    // and file set are unchanged instead of issuing a second GitHub request in
+    // the same validation pass. A manual retry with different evidence or files
+    // misses this identity check and is verified afresh.
+    const recorded = _readGroundTruthVerdict(doc.task.metadata);
+    const claimedPr = extractPullRequestLink(completion)?.url;
+    const normalizedClaimedFiles = [...new Set(claimedFiles)].sort();
+    if (
+      recorded &&
+      recorded.pr.url === claimedPr &&
+      JSON.stringify(recorded.files.claimed) ===
+        JSON.stringify(normalizedClaimedFiles)
+    ) {
+      return recorded;
+    }
+
     const workspace = getCodingWorkspaceService(this.runtime);
     const verdict = await verifyGroundTruth(
       {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -161,7 +161,9 @@ import {
   type OrchestratorTaskStatus,
   type OrchestratorTaskUsage,
   RETRY_BUDGET_EPOCH_METADATA_KEY,
+  RETRY_BUDGET_SESSION_METADATA_KEY,
   readRetryBudgetEpoch,
+  readRetryBudgetFirstSessionId,
   resolveStateLostRespawnCap,
   resolveTaskTransition,
   stateLostRespawnUnderCap,
@@ -2211,12 +2213,19 @@ export class OrchestratorTaskService extends Service {
     // lineage) must not count, or a restarted task re-fails on its first blip
     // (#14104). Absent epoch → every session counts (pre-restart lifetime).
     const budgetEpoch = readRetryBudgetEpoch(doc.task.metadata);
+    const firstBudgetSessionId = readRetryBudgetFirstSessionId(
+      doc.task.metadata,
+    );
+    const firstBudgetSessionIndex = firstBudgetSessionId
+      ? doc.sessions.findIndex((s) => s.sessionId === firstBudgetSessionId)
+      : -1;
+    const budgetSessions =
+      firstBudgetSessionIndex >= 0
+        ? doc.sessions.slice(firstBudgetSessionIndex)
+        : doc.sessions.filter((s) => s.spawnedAt >= budgetEpoch);
     const erroredSessionIds = new Set(
-      doc.sessions
-        .filter(
-          (s) =>
-            SESSION_ERROR_STATUSES.has(s.status) && s.spawnedAt >= budgetEpoch,
-        )
+      budgetSessions
+        .filter((s) => SESSION_ERROR_STATUSES.has(s.status))
         .map((s) => s.sessionId),
     );
     erroredSessionIds.add(sessionId);
@@ -4149,10 +4158,20 @@ export class OrchestratorTaskService extends Service {
         [RETRY_BUDGET_EPOCH_METADATA_KEY]: Date.now(),
       },
     });
-    await this.spawnAgentForTask(taskId, {
+    const restartedDetail = await this.spawnAgentForTask(taskId, {
       ...input.agent,
       task: instruction,
     });
+    const firstRestartedSessionId = restartedDetail?.sessions.at(-1)?.sessionId;
+    if (firstRestartedSessionId) {
+      const afterSpawn = await this.store.getTask(taskId);
+      await this.store.updateTask(taskId, {
+        metadata: {
+          ...afterSpawn?.task.metadata,
+          [RETRY_BUDGET_SESSION_METADATA_KEY]: firstRestartedSessionId,
+        },
+      });
+    }
     if (input.stopActive !== false) await this.stopActiveSessions(doc);
     if (planRevision) {
       await this.store.updateTask(taskId, { currentPlan: planRevision.plan });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -200,6 +200,10 @@ export function readSessionRetryCount(
  * dead sessions still fill the budget (#14104). */
 export const RETRY_BUDGET_EPOCH_METADATA_KEY = "retryBudgetEpochMs";
 
+/** Session boundary for the current retry-budget run. Unlike an epoch alone,
+ * this remains unambiguous when the restart and an old spawn share a millisecond. */
+export const RETRY_BUDGET_SESSION_METADATA_KEY = "retryBudgetFirstSessionId";
+
 /** Read the current run's budget epoch (epoch ms) off a task-metadata bag.
  * Absent/non-positive reads to 0 — every session then counts, which is the
  * correct pre-restart lifetime behavior. */
@@ -208,6 +212,13 @@ export function readRetryBudgetEpoch(
 ): number {
   const raw = metadata?.[RETRY_BUDGET_EPOCH_METADATA_KEY];
   return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+export function readRetryBudgetFirstSessionId(
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  const raw = metadata?.[RETRY_BUDGET_SESSION_METADATA_KEY];
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
 }
 
 export interface TaskProviderPolicy {


### PR DESCRIPTION
## Summary

Fixes #16586.

The orchestrator suite had drifted from current runtime contracts in three places:

- ACP doubles were returned for every service key, so the wave-supervisor lookup received an ACP object and threw `waveSupervisor?.enabled is not a function` in 74 tests.
- ACP resume and scratch-GC fixtures implicitly relied on CLI/acpx behavior while the default transport is now native.
- several runtime doubles omitted the current `getSetting` contract or leaked host HOME state into auto-spawn behavior.

This PR makes those fixtures explicit and service-key aware. It also activates the existing stored-ground-truth contract: automatic validation reuses the completion-time verdict only when the PR URL and normalized claimed-file set still match, avoiding an immediate duplicate GitHub query while requiring changed evidence to be verified afresh.

## Evidence

| Check | Before | After |
|---|---:|---:|
| Full `plugin-agent-orchestrator` suite | 82 failed, 2,438 passed | 2,520 passed, 7 skipped, 0 failed |
| Primary failure signature | 74 × `waveSupervisor?.enabled is not a function` | 0 |
| Focused affected files | failing across 7 files | 159 passed, 0 failed |
| Scoped Biome | not run | 8 files checked, no fixes/errors |
| Plugin typecheck | not run | `tsgo --noEmit -p tsconfig.json` passed |

### Commands

```text
bun run --cwd packages/core prebuild
bun run --cwd packages/core build:node
bun run --cwd plugins/plugin-agent-orchestrator test

Test Files  217 passed | 4 skipped (221)
Tests       2520 passed | 7 skipped (2527)
Duration    58.89s
```

```text
bunx vitest run --config vitest.config.ts \
  __tests__/unit/orchestrator-task-service.test.ts \
  __tests__/unit/orchestrator-routes.test.ts \
  __tests__/unit/completion-evidence-bundle.test.ts \
  __tests__/unit/session-resume.test.ts \
  __tests__/unit/acp-scratch-gc.test.ts \
  __tests__/unit/control-resume-clears-paused.test.ts \
  __tests__/unit/auto-verify-completion-evidence.test.ts

Test Files  7 passed (7)
Tests       159 passed (159)
```

```text
bunx @biomejs/biome check <8 touched files> --no-errors-on-unmatched
Checked 8 files in 271ms. No fixes applied.

bun run --cwd plugins/plugin-agent-orchestrator typecheck
$ tsgo --noEmit -p tsconfig.json
```

## Guardrails

- No test deletion, check removal, coverage/baseline bump, or lockfile change.
- Full plugin suite covers the shared ACP/orchestrator paths used by the auth, billing, and voice-latency stack.
- Production change is narrowly scoped to identity-matched reuse of a verdict already recorded in the same completion pipeline.

[sol-orch]


## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - test harness and backend validation change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - test harness and backend validation change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive or rendered user flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server process or backend request path is exercised; complete Vitest output is recorded above.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or network flow changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, model, provider, or action behavior changed; ACP and model calls are deterministic test doubles.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, schedule, wallet, on-chain, audio, device, or generated domain artifact changed.
