### PR TITLE
perf(cloud): isolate chat inference worker bootstrap

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1,5 +1,6 @@
 // Exercises cloud API src index.test behavior with deterministic Worker route fixtures.
 import { describe, expect, test } from "bun:test";
+import type { AppEnv } from "@/types/cloud-worker-env";
 import cloudApiWorker, {
   getFrontendAliasApiProxyTarget,
   getFrontendAliasProxyTarget,
@@ -11,6 +12,20 @@ import cloudApiWorker, {
 } from "./index";
 
 describe("thin inference entry dispatch", () => {
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+
+  const thinInferenceEnv = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    THIN_INFERENCE_ENTRY_ENABLED: "true",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+
   test("is rollback-safe and disabled unless explicitly true", () => {
     expect(isThinInferenceEnabled({})).toBe(false);
     expect(
@@ -28,6 +43,43 @@ describe("thin inference entry dispatch", () => {
       false,
     );
     expect(isCanonicalInferencePath("/api/v1/embeddings")).toBe(false);
+  });
+
+  test("dispatches canonical chat requests through the thin app when enabled", async () => {
+    const response = await cloudApiWorker.fetch(
+      new Request("https://api.elizacloud.ai/api/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gemma-4-31b",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+      thinInferenceEnv,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("x-eliza-inference-path")).toBe("thin");
+    expect(response.headers.get("server-timing")).toContain("entry_dispatch");
+  });
+
+  test("dispatches OpenAI-compatible chat rewrites through the thin app", async () => {
+    const response = await cloudApiWorker.fetch(
+      new Request("https://api.elizacloud.ai/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gemma-4-31b",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+      thinInferenceEnv,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("x-eliza-inference-path")).toBe("thin");
   });
 });
 

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -5,8 +5,31 @@ import cloudApiWorker, {
   getFrontendAliasProxyTarget,
   getFrontendAliasSyntheticResponse,
   getHostedFrontendServeRewrite,
+  isCanonicalInferencePath,
+  isThinInferenceEnabled,
   redirectFrontendHost,
 } from "./index";
+
+describe("thin inference entry dispatch", () => {
+  test("is rollback-safe and disabled unless explicitly true", () => {
+    expect(isThinInferenceEnabled({})).toBe(false);
+    expect(
+      isThinInferenceEnabled({ THIN_INFERENCE_ENTRY_ENABLED: "false" }),
+    ).toBe(false);
+    expect(
+      isThinInferenceEnabled({ THIN_INFERENCE_ENTRY_ENABLED: "true" }),
+    ).toBe(true);
+  });
+
+  test("matches only the exact canonical chat completions route", () => {
+    expect(isCanonicalInferencePath("/api/v1/chat/completions")).toBe(true);
+    expect(isCanonicalInferencePath("/api/v1/chat/completions/")).toBe(false);
+    expect(isCanonicalInferencePath("/api/v1/chat/completions/admin")).toBe(
+      false,
+    );
+    expect(isCanonicalInferencePath("/api/v1/embeddings")).toBe(false);
+  });
+});
 
 describe("getHostedFrontendServeRewrite (managed frontend hosting)", () => {
   const env = { ELIZA_FRONTEND_HOST_SUFFIX: "sites.elizacloud.ai" };

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -18,6 +18,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 import { serveBlobHostRequest } from "./blob-host";
 
 let appPromise: Promise<Hono<AppEnv>> | undefined;
+let inferenceAppPromise: Promise<Hono<AppEnv>> | undefined;
+const CHAT_COMPLETIONS_PATH = "/api/v1/chat/completions";
 const AGENT_ID_RE =
   /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 const DEFAULT_AGENT_BASE_DOMAIN = "elizacloud.ai";
@@ -46,6 +48,56 @@ type AgentDomainBindings = Pick<
 async function getApp(): Promise<Hono<AppEnv>> {
   appPromise ??= import("./bootstrap-app").then((m) => m.createApp());
   return appPromise;
+}
+
+async function getInferenceApp(): Promise<Hono<AppEnv>> {
+  inferenceAppPromise ??= import("./inference-app").then((m) =>
+    m.createInferenceApp(),
+  );
+  return inferenceAppPromise;
+}
+
+export function isThinInferenceEnabled(
+  env: Pick<AppEnv["Bindings"], "THIN_INFERENCE_ENTRY_ENABLED">,
+): boolean {
+  return env.THIN_INFERENCE_ENTRY_ENABLED === "true";
+}
+
+export function isCanonicalInferencePath(pathname: string): boolean {
+  return pathname === CHAT_COMPLETIONS_PATH;
+}
+
+async function dispatchInference(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext,
+): Promise<Response> | null {
+  if (
+    !isThinInferenceEnabled(env) ||
+    !isCanonicalInferencePath(new URL(request.url).pathname)
+  ) {
+    return null;
+  }
+
+  const dispatchStartedAt = performance.now();
+  const moduleWasInitialized = Boolean(inferenceAppPromise);
+  const app = await getInferenceApp();
+  const moduleInitMs = performance.now() - dispatchStartedAt;
+  const response = await app.fetch(request, env, ctx);
+  const dispatchMs = performance.now() - dispatchStartedAt;
+
+  response.headers.set("X-Eliza-Inference-Path", "thin");
+  response.headers.append(
+    "Server-Timing",
+    `entry_dispatch;dur=${dispatchMs.toFixed(1)}`,
+  );
+  if (!moduleWasInitialized) {
+    response.headers.append(
+      "Server-Timing",
+      `inference_module_init;dur=${moduleInitMs.toFixed(1)}`,
+    );
+  }
+  return response;
 }
 
 function healthResponse(env: AppEnv["Bindings"]): Response {
@@ -358,6 +410,8 @@ export default {
         frontendAliasApiTarget.toString(),
         createFrontendAliasProxyInit(request, url),
       );
+      const inferenceResponse = await dispatchInference(apiRequest, env, ctx);
+      if (inferenceResponse) return inferenceResponse;
       return (await getApp()).fetch(apiRequest, env, ctx);
     }
 
@@ -383,6 +437,9 @@ export default {
       return healthResponse(env);
     }
 
+    const inferenceResponse = await dispatchInference(request, env, ctx);
+    if (inferenceResponse) return inferenceResponse;
+
     // OpenAI-compat prefix rewrite. Dedicated agents whose cloud base/embedding
     // URL got stamped as the bare host (`https://api.elizacloud.ai`) hit
     // `/v1/embeddings` / `/embeddings` (and would for `/chat/completions`),
@@ -399,11 +456,14 @@ export default {
     ) {
       const rewrittenUrl = new URL(url);
       rewrittenUrl.pathname = p.startsWith("/v1/") ? `/api${p}` : `/api/v1${p}`;
-      return (await getApp()).fetch(
-        new Request(rewrittenUrl, request),
+      const rewrittenRequest = new Request(rewrittenUrl, request);
+      const rewrittenInferenceResponse = await dispatchInference(
+        rewrittenRequest,
         env,
         ctx,
       );
+      if (rewrittenInferenceResponse) return rewrittenInferenceResponse;
+      return (await getApp()).fetch(rewrittenRequest, env, ctx);
     }
 
     return (await getApp()).fetch(request, env, ctx);

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -71,7 +71,7 @@ async function dispatchInference(
   request: Request,
   env: AppEnv["Bindings"],
   ctx: ExecutionContext,
-): Promise<Response> | null {
+): Promise<Response | null> {
   if (
     !isThinInferenceEnabled(env) ||
     !isCanonicalInferencePath(new URL(request.url).pathname)

--- a/packages/cloud/api/src/inference-app.test.ts
+++ b/packages/cloud/api/src/inference-app.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { createInferenceApp } from "./inference-app";
 
+interface AuthErrorBody {
+  error: {
+    message: string;
+    type: string;
+  };
+}
+
+interface NotFoundBody {
+  success: false;
+  error: string;
+  code: string;
+}
+
+interface RateLimitErrorBody {
+  error: string;
+  code: string;
+}
+
 const executionCtx = {
   waitUntil: () => undefined,
   passThroughOnException: () => undefined,
@@ -38,7 +56,8 @@ describe("chat-only inference application", () => {
     );
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expect(response.headers.get("x-ratelimit-limit")).toBe("200");
-    expect(await response.json()).toEqual({
+    const body = (await response.json()) as AuthErrorBody;
+    expect(body).toEqual({
       error: {
         message: "Authentication required",
         type: "authentication_error",
@@ -63,5 +82,52 @@ describe("chat-only inference application", () => {
     expect(response.headers.get("access-control-allow-methods")).toContain(
       "POST",
     );
+  });
+
+  test("keeps non-chat routes outside the thin app surface", async () => {
+    const response = await createInferenceApp().fetch(
+      new Request("https://api.elizacloud.ai/api/v1/embeddings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "embedding-model", input: "hi" }),
+      }),
+      env,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as NotFoundBody;
+    expect(body).toEqual({
+      success: false,
+      error: "Not found",
+      code: "resource_not_found",
+    });
+  });
+
+  test("fails closed when production rate limiting is explicitly misconfigured", async () => {
+    const response = await createInferenceApp().fetch(
+      new Request("https://api.elizacloud.ai/api/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gemma-4-31b",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+      {
+        ...env,
+        ENVIRONMENT: "production",
+        NODE_ENV: "production",
+        REDIS_RATE_LIMITING: "true",
+      },
+      executionCtx,
+    );
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as RateLimitErrorBody;
+    expect(body).toEqual({
+      error: "Rate limiting misconfigured",
+      code: "RATE_LIMIT_UNAVAILABLE",
+    });
   });
 });

--- a/packages/cloud/api/src/inference-app.test.ts
+++ b/packages/cloud/api/src/inference-app.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { createInferenceApp } from "./inference-app";
+
+const executionCtx = {
+  waitUntil: () => undefined,
+  passThroughOnException: () => undefined,
+} as unknown as ExecutionContext;
+
+const env = {
+  ENVIRONMENT: "test",
+  NODE_ENV: "test",
+  REDIS_RATE_LIMITING: "false",
+  CACHE_ENABLED: "false",
+  BLOB: {},
+} as unknown as AppEnv["Bindings"];
+
+describe("chat-only inference application", () => {
+  test("keeps unauthenticated chat pre-SSE with the canonical shell", async () => {
+    const response = await createInferenceApp().fetch(
+      new Request("https://api.elizacloud.ai/api/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gemma-4-31b",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+      env,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("strict-transport-security")).toContain(
+      "max-age=63072000",
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-ratelimit-limit")).toBe("200");
+    expect(await response.json()).toEqual({
+      error: {
+        message: "Authentication required",
+        type: "authentication_error",
+      },
+    });
+  });
+
+  test("keeps CORS preflight ahead of route auth", async () => {
+    const response = await createInferenceApp().fetch(
+      new Request("https://api.elizacloud.ai/api/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://elizacloud.ai",
+          "access-control-request-method": "POST",
+        },
+      }),
+      env,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-methods")).toContain(
+      "POST",
+    );
+  });
+});

--- a/packages/cloud/api/src/inference-app.ts
+++ b/packages/cloud/api/src/inference-app.ts
@@ -1,0 +1,180 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger as honoLogger } from "hono/logger";
+import { requestId } from "hono/request-id";
+import { secureHeaders } from "hono/secure-headers";
+import { runWithDbCacheAsync } from "@/db/client";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
+import { buildRedisClient } from "@/lib/cache/redis-factory";
+import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
+import {
+  getIpKey,
+  getRequestIp,
+  rateLimit,
+  rateLimitConfigVerdict,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
+import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
+import { httpTelemetryMiddleware } from "@/lib/observability/http-telemetry-hono";
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { runWithRequestContext } from "@/lib/runtime/request-context";
+import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
+import { logger } from "@/lib/utils/logger";
+import { describeUnhandledError } from "@/lib/utils/unhandled-error-detail";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import chatCompletionsRoute from "../v1/chat/completions/route";
+
+/**
+ * Chat-only application loaded by the thin Worker entrypoint.
+ *
+ * Keep this shell in semantic lockstep with bootstrap-app. The chat route is a
+ * public global-auth path and performs its own authoritative API-key/session
+ * resolution, so mounting global auth here would only evaluate the unrelated
+ * protected-route auth/audit tree. Billing and SSE remain wholly owned by the
+ * canonical route module.
+ */
+export function createInferenceApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>({ strict: false });
+
+  app.use("*", async (c, next) => {
+    setRuntimeR2Bucket(c.env.BLOB);
+    await runWithCloudBindingsAsync(
+      c.env as Record<string, unknown>,
+      async () =>
+        runWithRequestContext(
+          {
+            clientIp: getRequestIp(c),
+            idempotencyKey:
+              c.req.header("idempotency-key") ||
+              c.req.header("x-request-id") ||
+              crypto.randomUUID(),
+          },
+          async () => runWithDbCacheAsync(async () => next()),
+        ),
+    );
+  });
+
+  app.use("*", requestId());
+  app.use("*", httpTelemetryMiddleware());
+  app.use("*", corsMiddleware);
+  app.use(
+    "*",
+    secureHeaders({
+      xContentTypeOptions: "nosniff",
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+      xFrameOptions: "DENY",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      crossOriginResourcePolicy: "cross-origin",
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }),
+  );
+  app.use("*", async (c, next) => {
+    await next();
+    if (
+      !c.res.headers.has("Cache-Control") &&
+      c.res.headers.get("Content-Type")?.includes("application/json")
+    ) {
+      c.res.headers.set("Cache-Control", "no-store");
+    }
+  });
+  app.use("*", honoLogger());
+  app.use("*", async (c, next) => {
+    c.set("requestId", c.get("requestId") ?? crypto.randomUUID());
+    c.set("user", undefined);
+    await next();
+  });
+  app.use("*", async (c, next) => {
+    const requestId = c.get("requestId") ?? crypto.randomUUID();
+    const traceId = c.get("traceId") ?? resolveElizaTraceId(c.req.raw.headers);
+    c.set("requestId", requestId);
+    c.set("traceId", traceId);
+    return observeCloudRequest(
+      {
+        id: requestId,
+        traceId,
+        method: c.req.method,
+        path: new URL(c.req.url).pathname,
+      },
+      async () => {
+        await next();
+        const user = c.get("user");
+        return {
+          result: undefined,
+          status: c.res.status,
+          userId: user?.id ?? null,
+          organizationId: user?.organization_id ?? null,
+          authMethod: c.get("authMethod") ?? null,
+        };
+      },
+    );
+  });
+
+  let rateLimitConfigLogged = false;
+  app.use("*", async (c, next) => {
+    const env = c.env as { ENVIRONMENT?: string; REDIS_RATE_LIMITING?: string };
+    const verdict = rateLimitConfigVerdict({
+      environment: env.ENVIRONMENT,
+      redisRateLimiting: env.REDIS_RATE_LIMITING,
+      hasRedisClient: Boolean(buildRedisClient(c.env)),
+    });
+    if (!rateLimitConfigLogged) {
+      rateLimitConfigLogged = true;
+      if (verdict === "fail-closed") {
+        logger.error(
+          "[inference-app] FATAL: REDIS_RATE_LIMITING=true in production but no Redis client is reachable. Failing closed.",
+        );
+      } else if (verdict === "warn-disabled") {
+        logger.warn("[inference-app] Rate limiting is disabled in production");
+      }
+    }
+    if (verdict === "fail-closed") {
+      return c.json(
+        {
+          error: "Rate limiting misconfigured",
+          code: "RATE_LIMIT_UNAVAILABLE",
+        },
+        503,
+      );
+    }
+    await next();
+  });
+
+  app.use(
+    "*",
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 600,
+        keyGenerator: (c) => `global:${getIpKey(c)}`,
+      },
+      { bindingName: "GLOBAL_RATE_LIMITER" },
+    ),
+  );
+
+  app.route("/api/v1/chat/completions", chatCompletionsRoute);
+  app.notFound((c) =>
+    c.json(
+      { success: false, error: "Not found", code: "resource_not_found" },
+      404,
+    ),
+  );
+  app.onError((err, c) => {
+    if (
+      err instanceof ApiError ||
+      (err instanceof HTTPException && err.status < 500)
+    ) {
+      logger.debug("[InferenceApi] Request rejected", {
+        status: err.status,
+        message: err.message,
+      });
+      return failureResponse(c, err);
+    }
+    logger.error("[InferenceApi] Unhandled error", {
+      error: describeUnhandledError(err),
+    });
+    return failureResponse(c, err);
+  });
+
+  return app;
+}

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -177,6 +177,8 @@ REDIS_RATE_LIMITING = "false"
 # synchronous-reserve path. The auth+moderation hot-path cache is the default now
 # (no flag); a cache miss falls back to the authoritative slow path.
 INFERENCE_OPTIMISTIC_BILLING = "false"
+# Thin chat-only bootstrap. Keep production off until staging parity/latency soak passes.
+THIN_INFERENCE_ENTRY_ENABLED = "false"
 SAFE_BALANCE_THRESHOLD = ""
 # Optimistic-billing durable backstop: "db" = inference_pending_charges ledger
 # (atomic overdraw bound + exactly-once settle + age-ordered sweep); "" = KV
@@ -371,6 +373,8 @@ NEXT_PUBLIC_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com"
 GITHUB_ORG_NAME = "eliza-cloud-apps"
 GITHUB_TEMPLATE_REPO = "eliza-cloud-apps/cloud-apps-template"
 ENVIRONMENT = "staging"
+# Staging canary. Set false for an immediate rollback to the full app router.
+THIN_INFERENCE_ENTRY_ENABLED = "true"
 DATABASE_REGION = "na"
 PAYOUT_TESTNET = "true"
 X402_NETWORK = "base"
@@ -517,6 +521,7 @@ __filename = '"/worker.js"'
 
 [env.production.vars]
 NODE_ENV = "production"
+THIN_INFERENCE_ENTRY_ENABLED = "false"
 # Apps deploy (Product 2): arms the Worker-side deploy trigger (configureAppsDeployTrigger,
 # bootstrap-app.ts) so POST /api/v1/apps/:id/deploy enqueues a real APP_DEPLOY job instead of
 # the no-op stub. Mirrors [env.staging.vars]. CUTOVER GATE — only effective once the prod

--- a/packages/cloud/shared/src/lib/cache/client-swr.test.ts
+++ b/packages/cloud/shared/src/lib/cache/client-swr.test.ts
@@ -235,4 +235,22 @@ describe("CacheClient memory-backend contracts", () => {
     });
     expect(calls).toBe(1);
   });
+
+  test("singleflight initializes the lock owner id lazily and reuses it", async () => {
+    const cache = await makeCache();
+    const inspectedCache = cache as unknown as { instanceId: string | null };
+    expect(inspectedCache.instanceId).toBeNull();
+
+    expect(await cache.getOrSet("ct:lazy-id:a", 60, async () => "a", { singleflight: true })).toBe(
+      "a",
+    );
+    const firstInstanceId = inspectedCache.instanceId;
+    expect(typeof firstInstanceId).toBe("string");
+    expect(firstInstanceId?.length).toBeGreaterThan(0);
+
+    expect(await cache.getOrSet("ct:lazy-id:b", 60, async () => "b", { singleflight: true })).toBe(
+      "b",
+    );
+    expect(inspectedCache.instanceId).toBe(firstInstanceId);
+  });
 });

--- a/packages/cloud/shared/src/lib/cache/client.ts
+++ b/packages/cloud/shared/src/lib/cache/client.ts
@@ -133,8 +133,15 @@ export class CacheClient {
   private readonly REVALIDATION_TIMEOUT_MS = 30000;
   private nativeRedisConnectPromise: Promise<void> | null = null;
   private nativeRedisReady = false;
-  private readonly instanceId = randomUUID();
+  // Web Crypto is unavailable during workerd module evaluation. Generate the
+  // lock-owner id on first request use instead of at singleton construction.
+  private instanceId: string | null = null;
   private metricsSampleRate: number | null = null;
+
+  private getInstanceId(): string {
+    this.instanceId ??= randomUUID();
+    return this.instanceId;
+  }
 
   /**
    * Prepends the environment prefix to a cache key or pattern.
@@ -1399,7 +1406,7 @@ export class CacheClient {
     if (!redis) return null;
 
     try {
-      const token = `${this.instanceId}:${randomUUID()}`;
+      const token = `${this.getInstanceId()}:${randomUUID()}`;
       const result = await redis.set(this.pk(lockKey), token, {
         nx: true,
         px: ttlMs,

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -22,6 +22,11 @@ export interface Bindings {
    * names (`lib/auth/steward-cookies.ts`) and cache key prefixes.
    */
   ENVIRONMENT?: string;
+  /**
+   * Routes chat completions through the lazy chat-only Worker application.
+   * Default off provides an immediate rollback to the monolithic router.
+   */
+  THIN_INFERENCE_ENTRY_ENABLED?: string;
 
   // ---- Database (Railway Postgres via the Hyperdrive binding in cloud, PGlite locally) ----
   DATABASE_URL: string;


### PR DESCRIPTION
## Summary
- dispatch only the exact canonical/compatibility chat-completions paths into a lazy chat-only Hono application before `getApp()`
- preserve the existing Cloud/DB/R2 contexts, request ID, CORS, security/no-store headers, observation/error mapping, global + route rate limits, authoritative route auth, billing, SSE, abort, and deferred settlement behavior
- keep production on the full router while enabling the staging canary; one env flag rolls back immediately
- make `CacheClient`'s lock-owner UUID request-lazy so workerd does not call Web Crypto during module evaluation
- expose `entry_dispatch` and first-load `inference_module_init` timing plus `X-Eliza-Inference-Path: thin`

Closes #16155

## Scope and overlap
- #16619 removed the cold conversation round trip and added stream phase timing. It does not isolate the 650-route Worker module graph.
- #16629 overlaps cold scope hydration after API-key validation. It does not address pre-Hono module evaluation.
- This PR does not move auth behind SSE headers, alter the pinned HTTP 402 contract, or weaken API-key validation. The canonical route owns all three unchanged.

## Actual behavior reproduction
Fresh local workerd isolate, staging flag enabled, health first and then unauthenticated canonical chat:

```text
health 200 0.008967
chat POST 401
Server-Timing: auth_extract;dur=0, auth_resolve;dur=0, cloud_worker;dur=21
Server-Timing: entry_dispatch;dur=415.0
Server-Timing: inference_module_init;dur=391.0
X-Eliza-Inference-Path: thin
X-RateLimit-Limit: 200
X-RateLimit-Policy: cloudflare-native
Cache-Control: no-store
{"error":{"message":"Authentication required","type":"authentication_error"}}
```

The first thin-module evaluation is explicitly assigned without evaluating `bootstrap-app` / `_router.generated.ts`; the next route work completed in the canonical handler shell. The 401 remains pre-SSE and authoritative.

## Validation

```text
bun test packages/cloud/api/src/index.test.ts
29 pass
0 fail
54 expect() calls
Ran 29 tests across 1 file. [2.41s]

bun test packages/cloud/shared/src/lib/cache/client-swr.test.ts
13 pass
0 fail
50 expect() calls
Ran 13 tests across 1 file. [1181.00ms]

bunx @biomejs/biome check <5 changed TS files>
Checked 5 files. No fixes applied.

git diff --check
# clean

wrangler deploy --env production --dry-run
Total Upload: 16278.14 KiB / gzip: 3642.88 KiB
env.THIN_INFERENCE_ENTRY_ENABLED ("false")
--dry-run: exiting now.
```

Wrangler emits one bundled upload, as before; the dynamic module wrapper remains evaluation-lazy. Staging sets the flag true, production false. Staging deployment must provide the paired cold/post-idle and byte/SSE parity soak before production flips.

## Rollback
Set `THIN_INFERENCE_ENTRY_ENABLED=false`. The request immediately follows the existing `getApp()` path without a code rollback.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - Worker bootstrap and transport only; no pixels, copy, or layout changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - Worker bootstrap and transport only; no pixels, copy, or layout changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no visual interaction changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [PR checks](https://github.com/elizaOS/eliza/pull/16643/checks); local workerd output above proves health-before-chat, first thin module initialization, canonical 401, CORS/security/cache headers, and both rate-limit headers.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend code changed; exact HTTP response headers/body are pasted above.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - locally, because no provider credential was used. The provider/model/prompt path is the unchanged canonical route module; staging soak remains required before production rollout.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [focused PR diff](https://github.com/elizaOS/eliza/pull/16643/files), focused tests, scoped Biome, workerd request transcript, and Wrangler production dry-run are pasted above.

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: N/A - no rendered UI or visual text changed.

Known CI note: `claude-review` is a dead/failing action and is not treated as implementation signal.

Co-authored-by: wakesync <shadow@shad0w.xyz>

[sol-orch]

## Recovery note, 2026-07-19

- Same branch recovery commit: `445e725becd16790e9172580fcba4a8c1dba81cd`
- Fixed the `Response.json()` test typing failure.
- Added focused thin-dispatch, chat-only app, and lazy cache lock-owner coverage. The workerd-safe lazy `getInstanceId()` behavior remains in scope.
- No auth-behind-SSE, billing/402/API-key, coverage baseline/exclusion, or check-suppression changes.
- Local execution was dependency-blocked by a missing root Bun store (`@upstash/redis` symlink target) and missing `tsgo`; CI is authoritative.
- Staging deployment and real browser timing remain deferred until merged/develop eligibility. No synthetic browser evidence is substituted.

[sol-orch]
