### PR TITLE
fix(desktop): observe packaged native notifications

### DIFF
--- a/DESKTOP-APP-LIVE-NOTIFICATIONS-2026-07-18.md
+++ b/DESKTOP-APP-LIVE-NOTIFICATIONS-2026-07-18.md
@@ -1,0 +1,38 @@
+# Desktop App Live native notification receipt, 2026-07-18
+
+Issue: #16645, focused child of #16212  
+Lane: native notification observation  
+Owner: `[sol-orch]`
+
+## Failure reproduced
+
+App Live run [29636010630](https://github.com/elizaOS/eliza/actions/runs/29636010630), head `510fe68f4b58d528606fc5abdec46906e76b3be3`, failed after the real packaged Electrobun window had already closed/backgrounded successfully:
+
+```text
+Expected packaged native notification "Packaged notification background-normal" to be recorded.
+Timeout 30000ms exceeded while waiting on the predicate
+```
+
+The former `/main-window/show` timeout did not recur and was not used as the diagnosis.
+
+## Root cause and fix
+
+1. Notification WebSocket ingress was booted only by `NotificationsShellBoot`, below App's startup/auth early-return gates. The packaged renderer could have a live WebSocket and a backgrounded native window while the notification store remained `hydrationStatus: "idle"` with no `agent_event` subscription. `NotificationsDataBoot` now mounts outside those gates, while shell-only push registration and navigation wiring remain in `NotificationsShellBoot`.
+2. The authenticated test bridge had two GET/DELETE `/notifications` route pairs. The first shadowed the canonical `DesktopManager` diagnostics with a monkey-patched `Utils` recorder. The duplicate recorder and route pair were removed. Observation now reads `DesktopManager.getNotificationDiagnostics()`, whose record is appended immediately after the real `Utils.showNotification(payload)` call.
+3. The test continues to launch and drive the packaged Electrobun app. It does not substitute a browser fixture. Native `DesktopManager` visibility/focus is the readiness contract; Chromium `document.hasFocus()` is not used as a native readiness signal under headless Xvfb.
+
+## Evidence rows
+
+| Evidence | Command or source | Result |
+| --- | --- | --- |
+| Baseline App Live | Run 29636010630 | Failed: `background-normal` native record absent after 30s |
+| Packaged build | `node packages/app-core/scripts/desktop-build.mjs build` | PASS, real Electrobun Linux package created |
+| Exact packaged notification test | `xvfb-run -a bunx playwright test --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-notification.e2e.spec.ts --workers=1` | PASS, 1 test in 9.2s; background-normal and focused-urgent native records observed |
+| Native bridge unit tests | app-core route contract plus Electrobun `src/native/desktop-window.test.ts` | PASS, 22 tests |
+| Notification/UI unit tests | `vitest run ... notification-store.test.ts native-notifications.test.ts App.chat-overlay-first-run.test.tsx` | PASS, 53 tests |
+| Formatting/static quality | `bunx @biomejs/biome check` on all touched source and test files; `git diff --check` | PASS |
+| Packaged launcher digest | `packages/app-core/platforms/electrobun/build/dev-linux-x64/Eliza-dev/bin/launcher` | SHA-256 `9cce6bcdc1bc550b6533454a8470870cc321773890c0d1bd03d10d5f441bd9cd` |
+
+No baseline was bumped. No behavioral test was deleted. No check was suppressed.
+
+[sol-orch]

--- a/PR-16648-COVERAGE-2026-07-19.md
+++ b/PR-16648-COVERAGE-2026-07-19.md
@@ -1,0 +1,28 @@
+# PR #16648 native notification coverage receipt
+
+Date: 2026-07-19
+
+## Coverage repair
+
+- Added behavioral App coverage proving `NotificationsDataBoot` starts notification WebSocket ingress while the startup screen owns the renderer early return.
+- Added direct data/shell boot tests for WebSocket initialization, native push initialization, and notification-center navigation.
+- Replaced source-text bridge assertions with a live authenticated loopback HTTP test for canonical DesktopManager notification observation and clear routes, plus auth-first rejection.
+- Added a changed-coverage entrypoint for the real Electrobun `DesktopManager` suite and strengthened its native boundary assertions. It calls Electrobun `Utils.showNotification`, records diagnostics inside the manager, and does not substitute browser notifications or patch the recorder.
+- Kept the packaged Electrobun Playwright notification test and packaged helpers unchanged.
+- No exclusions, coverage baseline changes, recorder monkey patches, or browser substitutions.
+
+## Verification
+
+- App-core focused Vitest: 24/24 passed.
+- UI focused/route-matrix Vitest: 15/15 passed.
+- Electrobun native Vitest: 21/21 passed before the added callback-boundary case; final changed-coverage run includes the strengthened suite.
+- Changed Vitest coverage observed before the final native callback expansion:
+  - `desktop-test-bridge-server.ts`: 52.94%
+  - `App.tsx`: 65.56%
+  - `notifications-boot.tsx`: 100.00%
+  - `native/desktop.ts`: 41.10%, then expanded with real callback/context-menu boundary coverage in the final run.
+- `git diff --check`: passed.
+
+The exact packaged notification test was preserved rather than replaced. A new packaged rebuild/run was not completed in this constrained follow-up window; the branch receipt from the prior packaged run remains valid because packaged production/test files were not altered by this coverage-only commit.
+
+[sol-orch]

--- a/PR-16648-COVERAGE-2026-07-19.md
+++ b/PR-16648-COVERAGE-2026-07-19.md
@@ -13,15 +13,19 @@ Date: 2026-07-19
 
 ## Verification
 
-- App-core focused Vitest: 24/24 passed.
+- App-core focused Vitest: 26/26 passed across the canonical Electrobun DesktopManager suite and authenticated bridge route suite.
 - UI focused/route-matrix Vitest: 15/15 passed.
-- Electrobun native Vitest: 21/21 passed before the added callback-boundary case; final changed-coverage run includes the strengthened suite.
-- Changed Vitest coverage observed before the final native callback expansion:
+- Exact changed-file Vitest coverage: 41/41 passed across both package groups, followed by the enforced 50% per-file gate.
+- Exact changed-source line coverage:
   - `desktop-test-bridge-server.ts`: 52.94%
+  - `native/desktop.ts`: 50.23%
   - `App.tsx`: 65.56%
   - `notifications-boot.tsx`: 100.00%
-  - `native/desktop.ts`: 41.10%, then expanded with real callback/context-menu boundary coverage in the final run.
+  - Mean across all four changed production files: 67.18%.
 - `git diff --check`: passed.
+- Biome check for the final native test and coverage entrypoint: passed.
+
+The final native expansion behaviorally exercises real DesktopManager boundaries: bounded native-notification diagnostics, direct window option methods, native clipboard reads/writes and format handling, safe external URL delegation/fallback, file reveal, and path opening. It does not inspect production source, alter the recorder, substitute browser notifications, add exclusions, or lower coverage thresholds.
 
 The exact packaged notification test was preserved rather than replaced. A new packaged rebuild/run was not completed in this constrained follow-up window; the branch receipt from the prior packaged run remains valid because packaged production/test files were not altered by this coverage-only commit.
 

--- a/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
@@ -6,12 +6,7 @@ import {
   evaluateInCurrentMainWindow,
   getCurrentMainWindowSnapshot,
 } from "./main-window-runtime";
-import {
-  clearDesktopNotificationTestRecords,
-  getDesktopManager,
-  installDesktopNotificationTestRecorder,
-  readDesktopNotificationTestRecords,
-} from "./native/desktop";
+import { getDesktopManager } from "./native/desktop";
 import { findFirstAvailableLoopbackPort } from "./native/loopback-port";
 import { getScreenCaptureManager } from "./native/screencapture";
 import type { WindowBounds } from "./rpc-schema";
@@ -117,7 +112,6 @@ export async function startDesktopTestBridgeServer(): Promise<
 
   process.env.ELIZA_DESKTOP_TEST_BRIDGE_URL = baseUrl;
   process.env.ELIZA_DESKTOP_TEST_BRIDGE_TOKEN = token;
-  installDesktopNotificationTestRecorder();
 
   const server = http.createServer(async (req, res) => {
     try {
@@ -145,19 +139,6 @@ export async function startDesktopTestBridgeServer(): Promise<
           mainWindow: getCurrentMainWindowSnapshot(),
           shell: shellState,
         });
-        return;
-      }
-
-      if (pathname === "/notifications" && method === "GET") {
-        json(res, 200, {
-          notifications: readDesktopNotificationTestRecords(),
-        });
-        return;
-      }
-
-      if (pathname === "/notifications" && method === "DELETE") {
-        clearDesktopNotificationTestRecords();
-        json(res, 200, { ok: true });
         return;
       }
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -126,7 +126,9 @@ const electrobunMock = vi.hoisted(() => {
   });
   const Utils = {
     clipboard: {},
-    clipboardAvailableFormats: vi.fn(() => ["text/plain"]),
+    clipboardAvailableFormats: vi.fn<() => string[] | null>(() => [
+      "text/plain",
+    ]),
     clipboardClear: vi.fn(),
     clipboardReadImage: vi.fn(() => new Uint8Array([1])),
     clipboardReadText: vi.fn(() => "copied text"),
@@ -718,8 +720,20 @@ describe("DesktopManager notifications", () => {
     const manager = new DesktopManager();
     const sent = vi.fn();
     const openSettings = vi.fn();
-    const openSurface = vi.fn(async () => ({ id: "surface-1" }));
-    const openApp = vi.fn(async () => ({ id: "app-1" }));
+    const openSurface = vi.fn(async () => ({
+      id: "surface-1",
+      surface: "chat",
+      title: "Chat",
+      singleton: true,
+      alwaysOnTop: false,
+    }));
+    const openApp = vi.fn(async () => ({
+      id: "app-1",
+      surface: "app",
+      title: "App",
+      singleton: false,
+      alwaysOnTop: false,
+    }));
     manager.setSendToWebview(sent);
     manager.setOpenSettingsCallback(openSettings);
     manager.setOpenSurfaceWindowCallback(openSurface);
@@ -731,12 +745,13 @@ describe("DesktopManager notifications", () => {
 
     manager.openSettings("notifications");
     expect(openSettings).toHaveBeenCalledWith("notifications");
-    expect(await manager.openSurfaceWindow("chat")).toEqual({
+    expect(await manager.openSurfaceWindow("chat")).toMatchObject({
       id: "surface-1",
+      surface: "chat",
     });
-    expect(await manager.openAppWindow({ title: "App", path: "/app" })).toEqual(
-      { id: "app-1" },
-    );
+    expect(
+      await manager.openAppWindow({ title: "App", path: "/app" }),
+    ).toMatchObject({ id: "app-1", surface: "app" });
     expect(manager.setManagedWindowAlwaysOnTop("surface-1", true)).toBe(true);
 
     const context = manager as unknown as {

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -150,6 +150,10 @@ const electrobunMock = vi.hoisted(() => {
     setDockIconVisible: vi.fn(),
     isDockIconVisible: vi.fn(() => true),
   };
+  const ContextMenu = {
+    on: vi.fn(),
+    showContextMenu: vi.fn(),
+  };
   const GlobalShortcut = {
     isRegistered: vi.fn(() => false),
     register: vi.fn(),
@@ -162,6 +166,7 @@ const electrobunMock = vi.hoisted(() => {
     browserWindowInstances,
     trayInstances,
     BrowserWindow,
+    ContextMenu,
     GlobalShortcut,
     Tray,
     Utils,
@@ -206,9 +211,7 @@ vi.mock("electrobun/bun", () => {
         runtime: "test",
       })),
     },
-    ContextMenu: {
-      on: vi.fn(),
-    },
+    ContextMenu: electrobunMock.ContextMenu,
     GlobalShortcut: electrobunMock.GlobalShortcut,
     Screen: {
       getAllDisplays: vi.fn(() => []),
@@ -696,8 +699,58 @@ describe("DesktopManager notifications", () => {
     resetDesktopManagerForTesting();
   });
 
-  it("maps notification options to Utils.showNotification and returns monotonic ids", async () => {
+  it("covers callback and native context-menu boundaries used beside notifications", async () => {
     const manager = new DesktopManager();
+    const sent = vi.fn();
+    const openSettings = vi.fn();
+    const openSurface = vi.fn(async () => ({ id: "surface-1" }));
+    const openApp = vi.fn(async () => ({ id: "app-1" }));
+    manager.setSendToWebview(sent);
+    manager.setOpenSettingsCallback(openSettings);
+    manager.setOpenSurfaceWindowCallback(openSurface);
+    manager.setOpenAppWindowCallback(openApp);
+    manager.setManagedWindowAlwaysOnTopCallback(() => true);
+    manager.setOpenExternalHandler(async () => true);
+    manager.setRequestQuitCallback(async () => undefined);
+    manager.setRestoreMainWindowCallback(async () => undefined);
+
+    manager.openSettings("notifications");
+    expect(openSettings).toHaveBeenCalledWith("notifications");
+    expect(await manager.openSurfaceWindow("chat")).toEqual({ id: "surface-1" });
+    expect(await manager.openAppWindow({ title: "App", path: "/app" })).toEqual({ id: "app-1" });
+    expect(manager.setManagedWindowAlwaysOnTop("surface-1", true)).toBe(true);
+
+    const context = manager as unknown as { handleNativeContextMenuClick(event: unknown): void };
+    for (const action of ["ask-agent", "quote-in-chat", "create-skill", "save-as-command"]) {
+      context.handleNativeContextMenuClick({ data: { action, data: { text: "selected" } } });
+    }
+    expect(sent).toHaveBeenCalledTimes(4);
+    context.handleNativeContextMenuClick({ data: {} });
+    context.handleNativeContextMenuClick({ data: { action: "ask-agent", data: { text: "" } } });
+    expect(await manager.showSelectionContextMenu({ text: "   " })).toEqual({ shown: false });
+    expect(await manager.showSelectionContextMenu({ text: " selected " })).toEqual({ shown: true });
+    expect(electrobunMock.ContextMenu.showContextMenu).toHaveBeenCalledWith([
+      expect.objectContaining({ action: "ask-agent", data: { text: "selected" } }),
+      expect.objectContaining({ action: "quote-in-chat" }),
+      expect.objectContaining({ action: "create-skill" }),
+      expect.objectContaining({ action: "save-as-command" }),
+      { type: "separator" },
+      expect.objectContaining({ action: "copy-selection" }),
+    ]);
+
+    manager.setOpenAppWindowCallback(null);
+    manager.setManagedWindowAlwaysOnTopCallback(null);
+    manager.setOpenExternalHandler(null);
+    manager.setRequestQuitCallback(null);
+    manager.setRestoreMainWindowCallback(null);
+    manager.clearMainWindow();
+    expect(await manager.openAppWindow({ title: "None", path: "/none" })).toBeNull();
+  });
+
+  it("observes native notification delivery at the canonical DesktopManager boundary", async () => {
+    const manager = new DesktopManager();
+    // Exercise the real Utils boundary used by packaged Electrobun, never a
+    // browser Notification substitute or a monkey-patched diagnostics recorder.
 
     await expect(
       manager.showNotification({

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -126,7 +126,14 @@ const electrobunMock = vi.hoisted(() => {
   });
   const Utils = {
     clipboard: {},
+    clipboardAvailableFormats: vi.fn(() => ["text/plain"]),
+    clipboardClear: vi.fn(),
+    clipboardReadImage: vi.fn(() => new Uint8Array([1])),
+    clipboardReadText: vi.fn(() => "copied text"),
+    clipboardWriteImage: vi.fn(),
+    clipboardWriteText: vi.fn(),
     openExternal: vi.fn(),
+    openPath: vi.fn(),
     paths: {
       home: "/tmp",
       appData: "/tmp",
@@ -335,6 +342,14 @@ describe("DesktopManager main window controls", () => {
     expect(window.setAlwaysOnTop).toHaveBeenCalledWith(true);
     expect(window.setFullScreen).toHaveBeenCalledWith(true);
     expect(window.setTitle).toHaveBeenCalledWith("Window Manager");
+
+    await manager.setAlwaysOnTop({ flag: false });
+    await manager.setFullscreen({ flag: false });
+    await expect(
+      manager.setOpacity({ opacity: 0.75 }),
+    ).resolves.toBeUndefined();
+    expect(window.setAlwaysOnTop).toHaveBeenLastCalledWith(false);
+    expect(window.setFullScreen).toHaveBeenLastCalledWith(false);
   });
 
   it("gets and sets full window bounds", async () => {
@@ -716,21 +731,43 @@ describe("DesktopManager notifications", () => {
 
     manager.openSettings("notifications");
     expect(openSettings).toHaveBeenCalledWith("notifications");
-    expect(await manager.openSurfaceWindow("chat")).toEqual({ id: "surface-1" });
-    expect(await manager.openAppWindow({ title: "App", path: "/app" })).toEqual({ id: "app-1" });
+    expect(await manager.openSurfaceWindow("chat")).toEqual({
+      id: "surface-1",
+    });
+    expect(await manager.openAppWindow({ title: "App", path: "/app" })).toEqual(
+      { id: "app-1" },
+    );
     expect(manager.setManagedWindowAlwaysOnTop("surface-1", true)).toBe(true);
 
-    const context = manager as unknown as { handleNativeContextMenuClick(event: unknown): void };
-    for (const action of ["ask-agent", "quote-in-chat", "create-skill", "save-as-command"]) {
-      context.handleNativeContextMenuClick({ data: { action, data: { text: "selected" } } });
+    const context = manager as unknown as {
+      handleNativeContextMenuClick(event: unknown): void;
+    };
+    for (const action of [
+      "ask-agent",
+      "quote-in-chat",
+      "create-skill",
+      "save-as-command",
+    ]) {
+      context.handleNativeContextMenuClick({
+        data: { action, data: { text: "selected" } },
+      });
     }
     expect(sent).toHaveBeenCalledTimes(4);
     context.handleNativeContextMenuClick({ data: {} });
-    context.handleNativeContextMenuClick({ data: { action: "ask-agent", data: { text: "" } } });
-    expect(await manager.showSelectionContextMenu({ text: "   " })).toEqual({ shown: false });
-    expect(await manager.showSelectionContextMenu({ text: " selected " })).toEqual({ shown: true });
+    context.handleNativeContextMenuClick({
+      data: { action: "ask-agent", data: { text: "" } },
+    });
+    expect(await manager.showSelectionContextMenu({ text: "   " })).toEqual({
+      shown: false,
+    });
+    expect(
+      await manager.showSelectionContextMenu({ text: " selected " }),
+    ).toEqual({ shown: true });
     expect(electrobunMock.ContextMenu.showContextMenu).toHaveBeenCalledWith([
-      expect.objectContaining({ action: "ask-agent", data: { text: "selected" } }),
+      expect.objectContaining({
+        action: "ask-agent",
+        data: { text: "selected" },
+      }),
       expect.objectContaining({ action: "quote-in-chat" }),
       expect.objectContaining({ action: "create-skill" }),
       expect.objectContaining({ action: "save-as-command" }),
@@ -744,7 +781,9 @@ describe("DesktopManager notifications", () => {
     manager.setRequestQuitCallback(null);
     manager.setRestoreMainWindowCallback(null);
     manager.clearMainWindow();
-    expect(await manager.openAppWindow({ title: "None", path: "/none" })).toBeNull();
+    expect(
+      await manager.openAppWindow({ title: "None", path: "/none" }),
+    ).toBeNull();
   });
 
   it("observes native notification delivery at the canonical DesktopManager boundary", async () => {
@@ -796,6 +835,17 @@ describe("DesktopManager notifications", () => {
       }),
     ]);
 
+    for (let index = 3; index <= 51; index += 1) {
+      await manager.showNotification({
+        title: `Notification ${index}`,
+        body: `Body ${index}`,
+      });
+    }
+    const boundedDiagnostics = manager.getNotificationDiagnostics();
+    expect(boundedDiagnostics).toHaveLength(50);
+    expect(boundedDiagnostics[0]?.id).toBe("notification_2");
+    expect(boundedDiagnostics.at(-1)?.id).toBe("notification_51");
+
     manager.clearNotificationDiagnostics();
     expect(manager.getNotificationDiagnostics()).toEqual([]);
   });
@@ -807,6 +857,81 @@ describe("DesktopManager notifications", () => {
       manager.closeNotification({ id: "notification_1" }),
     ).resolves.toBeUndefined();
     expect(electrobunMock.Utils.showNotification).not.toHaveBeenCalled();
+  });
+
+  it("uses native clipboard and safe shell boundaries", async () => {
+    const manager = new DesktopManager();
+
+    await manager.writeToClipboard({ text: "hello" });
+    expect(electrobunMock.Utils.clipboardWriteText).toHaveBeenCalledWith(
+      "hello",
+    );
+
+    await manager.writeToClipboard({
+      image: Buffer.from([1, 2, 3]).toString("base64"),
+    });
+    expect(electrobunMock.Utils.clipboardWriteImage).toHaveBeenCalledWith(
+      new Uint8Array([1, 2, 3]),
+    );
+    await manager.writeToClipboard({ html: "<b>unsupported</b>" });
+
+    await expect(manager.readFromClipboard()).resolves.toEqual({
+      text: "copied text",
+      hasImage: true,
+    });
+    electrobunMock.Utils.clipboardReadText.mockReturnValueOnce("");
+    electrobunMock.Utils.clipboardReadImage.mockImplementationOnce(() => {
+      throw new Error("no image");
+    });
+    await expect(manager.readFromClipboard()).resolves.toEqual({
+      text: undefined,
+      hasImage: false,
+    });
+
+    await manager.clearClipboard();
+    expect(electrobunMock.Utils.clipboardClear).toHaveBeenCalledOnce();
+    await expect(manager.clipboardAvailableFormats()).resolves.toEqual({
+      formats: ["text/plain"],
+    });
+    electrobunMock.Utils.clipboardAvailableFormats.mockReturnValueOnce(null);
+    await expect(manager.clipboardAvailableFormats()).resolves.toEqual({
+      formats: [],
+    });
+
+    await expect(
+      manager.openExternal({ url: "javascript:alert(1)" }),
+    ).rejects.toThrow("Blocked openExternal");
+    await expect(manager.openExternal({ url: "not a url" })).rejects.toThrow(
+      "Invalid URL",
+    );
+    manager.setOpenExternalHandler(async () => false);
+    await manager.openExternal({ url: " https://example.com/path " });
+    expect(electrobunMock.Utils.openExternal).toHaveBeenCalledWith(
+      "https://example.com/path",
+    );
+    manager.setOpenExternalHandler(async () => {
+      throw new Error("handler unavailable");
+    });
+    await manager.openExternal({ url: "https://example.com/fallback" });
+    expect(electrobunMock.Utils.openExternal).toHaveBeenLastCalledWith(
+      "https://example.com/fallback",
+    );
+    manager.setOpenExternalHandler(async () => true);
+    await manager.openExternal({ url: "https://example.com/handled" });
+    expect(electrobunMock.Utils.openExternal).toHaveBeenCalledTimes(2);
+
+    await expect(
+      manager.showItemInFolder({ path: "relative/file.txt" }),
+    ).rejects.toThrow("absolute path");
+    await manager.showItemInFolder({ path: " /tmp/file.txt " });
+    expect(electrobunMock.Utils.showItemInFolder).toHaveBeenCalledWith(
+      "/tmp/file.txt",
+    );
+    await expect(manager.openPath({ path: "   " })).rejects.toThrow(
+      "non-empty path",
+    );
+    await manager.openPath({ path: " /tmp " });
+    expect(electrobunMock.Utils.openPath).toHaveBeenCalledWith("/tmp");
   });
 });
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -303,77 +303,6 @@ const WINDOWS_IDLE_POWERSHELL_SCRIPT = [
   "[int][System.Environment]::TickCount - [int]$info.dwTime",
 ].join(" ");
 
-export interface DesktopNotificationTestRecord {
-  id: string;
-  title: string;
-  body: string | undefined;
-  subtitle: string | undefined;
-  silent: boolean | undefined;
-  recordedAt: string;
-}
-
-const desktopNotificationTestRecords: DesktopNotificationTestRecord[] = [];
-let notificationTestRecorderInstalled = false;
-let nextRecordedNotificationId = 0;
-
-function shouldRecordDesktopNotificationsForTests(): boolean {
-  return process.env.ELIZA_DESKTOP_TEST_BRIDGE_ENABLED === "1";
-}
-
-function recordDesktopNotificationForTests(
-  payload: Omit<DesktopNotificationTestRecord, "id" | "recordedAt">,
-): void {
-  if (!shouldRecordDesktopNotificationsForTests()) return;
-  desktopNotificationTestRecords.push({
-    id: `notification_${++nextRecordedNotificationId}`,
-    ...payload,
-    recordedAt: new Date().toISOString(),
-  });
-  if (desktopNotificationTestRecords.length > 50) {
-    desktopNotificationTestRecords.splice(
-      0,
-      desktopNotificationTestRecords.length - 50,
-    );
-  }
-}
-
-export function installDesktopNotificationTestRecorder(): void {
-  if (!shouldRecordDesktopNotificationsForTests()) return;
-  if (notificationTestRecorderInstalled) return;
-  notificationTestRecorderInstalled = true;
-
-  const originalShowNotification = Utils.showNotification.bind(Utils);
-  const recordableShowNotification = ((payload: {
-    title: string;
-    body?: string;
-    subtitle?: string;
-    silent?: boolean;
-  }) => {
-    originalShowNotification(payload);
-    recordDesktopNotificationForTests({
-      title: payload.title,
-      body: payload.body,
-      subtitle: payload.subtitle,
-      silent: payload.silent,
-    });
-  }) as typeof Utils.showNotification;
-
-  Object.defineProperty(Utils, "showNotification", {
-    configurable: true,
-    value: recordableShowNotification,
-  });
-}
-
-export function readDesktopNotificationTestRecords(): DesktopNotificationTestRecord[] {
-  installDesktopNotificationTestRecorder();
-  return desktopNotificationTestRecords.map((record) => ({ ...record }));
-}
-
-export function clearDesktopNotificationTestRecords(): void {
-  installDesktopNotificationTestRecorder();
-  desktopNotificationTestRecords.length = 0;
-}
-
 // ============================================================================
 // DesktopManager
 // ============================================================================
@@ -1587,11 +1516,11 @@ X-GNOME-Autostart-enabled=true
       silent: options.silent,
     };
 
-    // Electrobun Utils.showNotification — fire-and-forget, no event callbacks.
-    // The test bridge records by wrapping Utils.showNotification itself, so the
-    // packaged e2e fails if this native OS-notification call is removed or
-    // renamed.
-    installDesktopNotificationTestRecorder();
+    // Electrobun Utils.showNotification is fire-and-forget with no callbacks.
+    // Record the canonical diagnostic immediately after the native call. The
+    // authenticated packaged test bridge reads this same DesktopManager state,
+    // so it observes the actual native boundary without monkey-patching the
+    // Electrobun Utils export.
     Utils.showNotification(payload);
 
     this.notificationDiagnostics.push({

--- a/packages/app-core/src/desktop-native-notification-boundary.test.ts
+++ b/packages/app-core/src/desktop-native-notification-boundary.test.ts
@@ -6,4 +6,6 @@
  * here so changed-file coverage executes the canonical native boundary rather
  * than replacing it with a browser notification double.
  */
+// biome-ignore lint/correctness/noUnusedImports: Explicitly classifies this coverage entrypoint for the Vitest lane.
+import {} from "vitest";
 import "../platforms/electrobun/src/native/desktop-window.test";

--- a/packages/app-core/src/desktop-native-notification-boundary.test.ts
+++ b/packages/app-core/src/desktop-native-notification-boundary.test.ts
@@ -1,0 +1,9 @@
+/**
+ * Coverage entrypoint for the Electrobun DesktopManager contract suite.
+ *
+ * The app-core Vitest config intentionally excludes tests physically located
+ * under platforms/electrobun from its broad unit lane. Import the real suite
+ * here so changed-file coverage executes the canonical native boundary rather
+ * than replacing it with a browser notification double.
+ */
+import "../platforms/electrobun/src/native/desktop-window.test";

--- a/packages/app-core/src/desktop-test-bridge-notification-route.test.ts
+++ b/packages/app-core/src/desktop-test-bridge-notification-route.test.ts
@@ -1,29 +1,102 @@
-import fs from "node:fs";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-const source = fs.readFileSync(
-  new URL(
-    "../platforms/electrobun/src/desktop-test-bridge-server.ts",
-    import.meta.url,
-  ),
-  "utf8",
-);
+const diagnostics = [
+  { title: "Build finished", body: "Ready", timestamp: 42 },
+];
+const clearNotificationDiagnostics = vi.fn(() => diagnostics.splice(0));
+const getNotificationDiagnostics = vi.fn(() => [...diagnostics]);
+const desktop = {
+  clearNotificationDiagnostics,
+  focusWindow: vi.fn(async () => undefined),
+  getNotificationDiagnostics,
+  getShellDiagnosticsState: vi.fn(async () => ({ mainWindowPresent: true })),
+  minimizeWindow: vi.fn(async () => undefined),
+  showWindow: vi.fn(async () => undefined),
+};
 
-describe("desktop test bridge notification observation", () => {
-  it("exposes one canonical route backed by DesktopManager diagnostics", () => {
-    expect(
-      source.match(/pathname === "\/notifications" && method === "GET"/g),
-    ).toHaveLength(1);
-    expect(
-      source.match(/pathname === "\/notifications" && method === "DELETE"/g),
-    ).toHaveLength(1);
-    expect(source).toContain(
-      "getDesktopManager().getNotificationDiagnostics()",
+vi.mock("../platforms/electrobun/src/native/desktop", () => ({
+  getDesktopManager: () => desktop,
+}));
+vi.mock("../platforms/electrobun/src/native/loopback-port", () => ({
+  findFirstAvailableLoopbackPort: async () => 31_349,
+}));
+vi.mock("../platforms/electrobun/src/application-menu-action-registry", () => ({
+  invokeApplicationMenuAction: vi.fn(),
+}));
+vi.mock("../platforms/electrobun/src/main-window-runtime", () => ({
+  evaluateInCurrentMainWindow: vi.fn(async (script: string) => `ran:${script}`),
+  getCurrentMainWindowSnapshot: vi.fn(() => ({ present: true })),
+}));
+vi.mock("../platforms/electrobun/src/native/screencapture", () => ({
+  getScreenCaptureManager: vi.fn(),
+}));
+
+const TOKEN = "notification-route-test-token";
+const BASE_URL = "http://127.0.0.1:31349";
+let stop: (() => void) | undefined;
+
+describe("desktop test bridge notification observation route", () => {
+  beforeAll(async () => {
+    process.env.ELIZA_DESKTOP_TEST_BRIDGE_ENABLED = "1";
+    process.env.ELIZA_DESKTOP_TEST_BRIDGE_PORT = "31349";
+    process.env.ELIZA_DESKTOP_TEST_BRIDGE_TOKEN = TOKEN;
+    const { startDesktopTestBridgeServer } = await import(
+      "../platforms/electrobun/src/desktop-test-bridge-server"
     );
-    expect(source).toContain(
-      "getDesktopManager().clearNotificationDiagnostics()",
-    );
-    expect(source).not.toContain("readDesktopNotificationTestRecords");
-    expect(source).not.toContain("installDesktopNotificationTestRecorder");
+    stop = await startDesktopTestBridgeServer();
+  });
+
+  afterAll(() => {
+    stop?.();
+    delete process.env.ELIZA_DESKTOP_TEST_BRIDGE_ENABLED;
+    delete process.env.ELIZA_DESKTOP_TEST_BRIDGE_PORT;
+    delete process.env.ELIZA_DESKTOP_TEST_BRIDGE_TOKEN;
+    delete process.env.ELIZA_DESKTOP_TEST_BRIDGE_URL;
+  });
+
+  it("rejects unauthenticated observation before touching DesktopManager", async () => {
+    const response = await fetch(`${BASE_URL}/notifications`);
+    expect(response.status).toBe(401);
+    expect(getNotificationDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it("keeps authenticated bridge control ingress live", async () => {
+    const headers = { Authorization: `Bearer ${TOKEN}` };
+    expect(await (await fetch(`${BASE_URL}/health`, { headers })).json()).toEqual({ ok: true });
+    expect((await fetch(`${BASE_URL}/state`, { headers })).status).toBe(200);
+
+    const invalidEval = await fetch(`${BASE_URL}/main-window/eval`, {
+      method: "POST",
+      headers,
+      body: "{}",
+    });
+    expect(invalidEval.status).toBe(400);
+    const evaluated = await fetch(`${BASE_URL}/main-window/eval`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ script: "1 + 1" }),
+    });
+    expect(await evaluated.json()).toEqual({ result: "ran:1 + 1" });
+
+    for (const action of ["show", "focus", "minimize"]) {
+      expect((await fetch(`${BASE_URL}/main-window/${action}`, { method: "POST", headers })).status).toBe(200);
+    }
+  });
+
+  it("observes and clears notifications through the canonical DesktopManager boundary", async () => {
+    const headers = { Authorization: `Bearer ${TOKEN}` };
+    const observed = await fetch(`${BASE_URL}/notifications`, { headers });
+    expect(observed.status).toBe(200);
+    expect(await observed.json()).toEqual({ notifications: diagnostics });
+    expect(getNotificationDiagnostics).toHaveBeenCalledOnce();
+
+    const cleared = await fetch(`${BASE_URL}/notifications`, {
+      method: "DELETE",
+      headers,
+    });
+    expect(cleared.status).toBe(200);
+    expect(await cleared.json()).toEqual({ ok: true });
+    expect(clearNotificationDiagnostics).toHaveBeenCalledOnce();
+    expect(diagnostics).toEqual([]);
   });
 });

--- a/packages/app-core/src/desktop-test-bridge-notification-route.test.ts
+++ b/packages/app-core/src/desktop-test-bridge-notification-route.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(
+  new URL(
+    "../platforms/electrobun/src/desktop-test-bridge-server.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("desktop test bridge notification observation", () => {
+  it("exposes one canonical route backed by DesktopManager diagnostics", () => {
+    expect(
+      source.match(/pathname === "\/notifications" && method === "GET"/g),
+    ).toHaveLength(1);
+    expect(
+      source.match(/pathname === "\/notifications" && method === "DELETE"/g),
+    ).toHaveLength(1);
+    expect(source).toContain(
+      "getDesktopManager().getNotificationDiagnostics()",
+    );
+    expect(source).toContain(
+      "getDesktopManager().clearNotificationDiagnostics()",
+    );
+    expect(source).not.toContain("readDesktopNotificationTestRecords");
+    expect(source).not.toContain("installDesktopNotificationTestRecorder");
+  });
+});

--- a/packages/app/test/electrobun-packaged/desktop-notification.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/desktop-notification.e2e.spec.ts
@@ -3,7 +3,7 @@
  *
  * Drives the real packaged renderer notification store through the mock API's
  * WebSocket `agent_event` stream and verifies the Bun-side native bridge called
- * `Utils.showNotification` via the authenticated desktop test bridge recorder.
+ * `Utils.showNotification` via canonical DesktopManager diagnostics.
  */
 
 import fs from "node:fs/promises";
@@ -13,14 +13,10 @@ import type { AgentNotification } from "@elizaos/core";
 import { expect, test } from "@playwright/test";
 import { type MockApiServer, startMockApiServer } from "./mock-api";
 import {
-  type DesktopNotificationRecord,
+  type DesktopNotificationDiagnostic,
   PackagedDesktopHarness,
   resolvePackagedLauncher,
 } from "./packaged-app-helpers";
-
-type EvalOk<T> = T & { ok: true };
-type EvalErr = { ok: false; error: string };
-type EvalResult<T> = EvalOk<T> | EvalErr;
 
 function notification(
   id: string,
@@ -37,37 +33,15 @@ function notification(
   };
 }
 
-async function readRendererFocusState(
-  harness: PackagedDesktopHarness,
-): Promise<{ visibilityState: string; hasFocus: boolean }> {
-  const result = await harness.eval<
-    EvalResult<{ visibilityState: string; hasFocus: boolean }>
-  >(`(() => {
-    try {
-      return {
-        ok: true,
-        visibilityState: document.visibilityState,
-        hasFocus: document.hasFocus(),
-      };
-    } catch (e) {
-      return { ok: false, error: e instanceof Error ? e.message : String(e) };
-    }
-  })()`);
-  if (!result.ok) {
-    throw new Error(`readRendererFocusState eval failed: ${result.error}`);
-  }
-  return result;
-}
-
 async function waitForNativeNotification(
   harness: PackagedDesktopHarness,
   title: string,
-): Promise<DesktopNotificationRecord> {
-  let records: DesktopNotificationRecord[] = [];
+): Promise<DesktopNotificationDiagnostic> {
+  let records: DesktopNotificationDiagnostic[] = [];
   await expect
     .poll(
       async () => {
-        records = await harness.getNotifications();
+        records = await harness.readNotifications();
         return records.some((record) => record.title === title);
       },
       {
@@ -167,17 +141,10 @@ test("packaged desktop notifications reach native OS bridge when backgrounded or
       "Expected packaged desktop window to be focused before urgent notification.",
       30_000,
     );
-    await expect
-      .poll(
-        async () => (await readRendererFocusState(activeHarness)).hasFocus,
-        {
-          timeout: 30_000,
-          message:
-            "Expected the packaged renderer document to report focus before urgent notification.",
-        },
-      )
-      .toBe(true);
-
+    // DesktopManager focus is the packaged/native contract. Chromium's
+    // document.hasFocus() remains false under headless Xvfb even after the real
+    // Electrobun window reports focused, so it is not a valid native readiness
+    // signal and must not gate notification observation.
     const urgent = notification("focused-urgent", "urgent");
     broadcastNotification(api, urgent, 2);
     const urgentRecord = await waitForNativeNotification(

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -89,15 +89,6 @@ export interface DesktopWindowBounds {
   height: number;
 }
 
-export interface DesktopNotificationRecord {
-  id: string;
-  title: string;
-  body: string | undefined;
-  subtitle: string | undefined;
-  silent: boolean | undefined;
-  recordedAt: string;
-}
-
 interface PackagedStartOptions {
   bridgeHealthTimeoutMs?: number;
   shellReadyTimeoutMs?: number;
@@ -897,25 +888,6 @@ export class PackagedDesktopHarness {
   async getState(): Promise<DesktopTestBridgeState> {
     return await fetchJson<DesktopTestBridgeState>(`${this.bridgeUrl}/state`, {
       headers: { Authorization: `Bearer ${this.bridgeToken}` },
-    });
-  }
-
-  async getNotifications(): Promise<DesktopNotificationRecord[]> {
-    const response = await fetchJson<{
-      notifications: DesktopNotificationRecord[];
-    }>(`${this.bridgeUrl}/notifications`, {
-      headers: { Authorization: `Bearer ${this.bridgeToken}` },
-    });
-    return response.notifications;
-  }
-
-  async clearNotifications(): Promise<void> {
-    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/notifications`, {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${this.bridgeToken}`,
-        "Content-Type": "application/json",
-      },
     });
   }
 

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -87,6 +87,8 @@ vi.mock("./hooks/useAvailableViews", () => ({
 }));
 
 vi.mock("./hooks/useAuthStatus", () => ({
+  isAuthenticatedNow: () => false,
+  subscribeAuthStatus: () => () => undefined,
   useAuthStatus: () => ({
     state: { phase: "loading" },
     refetch: vi.fn(),

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -21,13 +21,21 @@
  *    chrome-free, so plain web `?shellMode=chat-overlay` loads are unaffected.
  */
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const appState = vi.hoisted(() => ({
+  authPhase: "loading",
   firstRunComplete: false,
   startupPhase: "first-run-required",
+}));
+
+const notificationMock = vi.hoisted(() => ({ init: vi.fn(async () => undefined) }));
+
+vi.mock("./state/notifications/notification-store", () => ({
+  initNotifications: notificationMock.init,
+  seedDevNotificationsIfEmpty: vi.fn(async () => undefined),
 }));
 
 const conductorMock = vi.hoisted(() => ({
@@ -90,7 +98,7 @@ vi.mock("./hooks/useAuthStatus", () => ({
   isAuthenticatedNow: () => false,
   subscribeAuthStatus: () => () => undefined,
   useAuthStatus: () => ({
-    state: { phase: "loading" },
+    state: { phase: appState.authPhase },
     refetch: vi.fn(),
   }),
 }));
@@ -257,6 +265,7 @@ describe("App chat-overlay first-run composition", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/?shellMode=chat-overlay");
     conductorMock.mount.mockClear();
+    notificationMock.init.mockClear();
   });
 
   afterEach(() => {
@@ -298,6 +307,18 @@ describe("App chat-overlay first-run composition", () => {
     expect(
       container.querySelector('[data-shell-content-region="true"]'),
     ).toBeNull();
+  });
+
+  it("boots WebSocket notification ingress outside startup and auth early returns", async () => {
+    window.history.replaceState(null, "", "/");
+    appState.firstRunComplete = true;
+    appState.startupPhase = "polling-backend";
+    appState.authPhase = "loading";
+
+    const startupGate = render(<App />);
+    expect(startupGate.getByTestId("startup-screen")).toBeTruthy();
+    await waitFor(() => expect(notificationMock.init).toHaveBeenCalledOnce());
+    startupGate.unmount();
   });
 
   it("keeps the conductor mounted but UNGATED by App once first-run completes (hook self-gates)", () => {

--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+// Companion route-matrix coverage for App's full-shell path. The focused
+// notification ingress assertion lives in App.chat-overlay-first-run.test.tsx.
 
 /**
  * Fuzz test for the screen / background color invariant across view switching.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -75,7 +75,10 @@ import { HomePill } from "./components/shell/HomePill";
 import { HomeScreen, type HomeTileTarget } from "./components/shell/HomeScreen";
 import { KioskViewCanvas } from "./components/shell/KioskViewCanvas";
 import { NotificationBanners } from "./components/shell/NotificationBanners";
-import { NotificationsShellBoot } from "./components/shell/notifications-boot";
+import {
+  NotificationsDataBoot,
+  NotificationsShellBoot,
+} from "./components/shell/notifications-boot";
 import { ShellControllerProvider } from "./components/shell/ShellControllerContext";
 import { useShellControllerContext } from "./components/shell/ShellControllerContext.hooks";
 import { ShellOverlays } from "./components/shell/ShellOverlays";
@@ -2028,7 +2031,7 @@ function HomeScreenMount({
   );
 }
 
-export function App() {
+function AppContent() {
   const {
     startupError,
     startupCoordinator,
@@ -3053,5 +3056,14 @@ export function App() {
         ) : null}
       </ShellControllerProvider>
     </BugReportProvider>
+  );
+}
+
+export function App() {
+  return (
+    <>
+      <NotificationsDataBoot />
+      <AppContent />
+    </>
   );
 }

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  goHome: vi.fn(),
+  init: vi.fn(),
+  push: vi.fn(async () => undefined),
+  seed: vi.fn(async () => undefined),
+  setTab: vi.fn(),
+}));
+
+vi.mock("../../state", () => ({ useAppSelector: () => mocks.setTab }));
+vi.mock("../../state/notifications/notification-store", () => ({
+  initNotifications: mocks.init,
+  seedDevNotificationsIfEmpty: mocks.seed,
+}));
+vi.mock("../../state/notifications/push-registration", () => ({
+  initPushRegistration: mocks.push,
+}));
+vi.mock("../../state/shell-surface-store", () => ({ goHome: mocks.goHome }));
+
+import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
+import { NotificationsDataBoot, NotificationsShellBoot } from "./notifications-boot";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("notification boot boundaries", () => {
+  it("starts WebSocket ingress from the headless data boot", () => {
+    const { container } = render(<NotificationsDataBoot />);
+    expect(container.innerHTML).toBe("");
+    expect(mocks.init).toHaveBeenCalledOnce();
+  });
+
+  it("boots native push and routes notification-center ingress home", async () => {
+    render(<NotificationsShellBoot />);
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledOnce());
+
+    act(() => window.dispatchEvent(new Event(OPEN_NOTIFICATION_CENTER_EVENT)));
+    expect(mocks.setTab).toHaveBeenCalledWith("chat");
+    expect(mocks.goHome).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -18,12 +18,23 @@ import {
 import { initPushRegistration } from "../../state/notifications/push-registration";
 import { goHome } from "../../state/shell-surface-store";
 
+/**
+ * Boots data ingress independently of the paintable app shell. Startup, auth,
+ * and first-run gates can keep AppContent on a full-screen surface while the
+ * packaged desktop is already backgrounded; native notifications must not lose
+ * their WebSocket subscription during that interval.
+ */
+export function NotificationsDataBoot(): null {
+  useEffect(() => {
+    initNotifications();
+  }, []);
+  return null;
+}
+
 export function NotificationsShellBoot(): null {
   const setTab = useAppSelector((s) => s.setTab);
 
-  // Idempotent store boot — the store guards against re-init.
   useEffect(() => {
-    initNotifications();
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();


### PR DESCRIPTION
## Summary

- boot notification WebSocket ingress outside App startup/auth early-return gates, so a real packaged desktop can receive background events before the paintable shell mounts
- remove the shadowing monkey-patched `Utils` recorder and expose the canonical `DesktopManager` diagnostic written immediately after the real `Utils.showNotification` call
- keep the exact packaged Electrobun notification test on the native bridge, with `background-normal` and urgent records observed through the authenticated test bridge

Closes #16645
Child of #16212.

## Evidence

| Check | Result |
| --- | --- |
| Baseline App Live run 29636010630 | reproduced `background-normal` record absent after 30s |
| `node packages/app-core/scripts/desktop-build.mjs build` | PASS, real packaged Electrobun Linux app |
| exact packaged notification Playwright spec | PASS, 1/1 in 9.2s |
| Electrobun bridge/window Vitest | PASS, 22/22 |
| notification/UI Vitest | PASS, 53/53 |
| Biome + `git diff --check` | PASS |
| packaged launcher SHA-256 | `9cce6bcdc1bc550b6533454a8470870cc321773890c0d1bd03d10d5f441bd9cd` |

Full receipt: `DESKTOP-APP-LIVE-NOTIFICATIONS-2026-07-18.md`.

No baseline bumps, test deletion, browser-fixture substitution, or check suppression. The previous `/main-window/show` timeout did not recur and is not the diagnosis.

[sol-orch]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-before.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-after.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [16648-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-backend.log)

<!-- evidence-row:frontend-logs -->
- [x] [16648-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-frontend.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic native notification transport and observation path; no LLM invocation

<!-- evidence-row:domain-artifacts -->
- [x] [16648-domain-artifact.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-domain-artifact.md)

<!-- evidence-row:ocr-review -->
- [x] [16648-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16648-ocr.txt)