### PR TITLE
fix: recover terminally closed PGlite agents

### DIFF
--- a/PGLITE-LIVENESS-RECOVERY-2026-07-18.md
+++ b/PGLITE-LIVENESS-RECOVERY-2026-07-18.md
@@ -1,0 +1,50 @@
+# PGlite liveness recovery receipt, 2026-07-18
+
+Signed: `[sol-orch]`
+
+## Incident and Block-0
+
+Staging left a live dedicated-agent process false-green while all DB-backed work failed continuously with `PGlite is closed` and `Database is shutting down - operation rejected`. A manual container restart restored service.
+
+Before implementation, open issues, open PRs, and ElizaOS Project 12 were searched for the exact terminal-PGlite/liveness/automatic-recovery scope. No duplicate was found. Related work was non-overlapping:
+
+- #16309 / #16311: fresh-boot service/schema/scheduler failures.
+- #15228: stale PGlite lock crash loops where pid 1 exits.
+- #15603 / #15783: hosted-agent hardening and off-box durability.
+
+Created and claimed #16650 and added it to Project 12:
+
+- https://github.com/elizaOS/eliza/issues/16650
+
+## Implementation
+
+Branch: `fix/16650-pglite-liveness`
+
+- Added a real `SELECT 1` runtime database probe with explicit `ok`, `unknown`, `transient_error`, and `terminal_error` states.
+- Terminal classification preserves nested causes and recognizes the incident's PGlite closed/shutdown signatures.
+- `/api/health` now reports `ready: false`, `canRespond: false`, terminal DB state, and HTTP 503 after terminal closure.
+- Dedicated cloud-agent `/health`, `/api/health`, and `status.get` now expose the same DB liveness contract.
+- PGlite `isReady()` now exercises the DB rather than trusting cached manager state.
+- The fleet heartbeat consumer parses the truthful health payload and enqueues the existing deduplicated restart job on terminal DB closure.
+- Transient DB probe failures use normal heartbeat retries/hysteresis and do not immediately restart.
+- DB recovery has an isolated three-restart budget in a one-hour window plus a ten-minute cooldown. Unrelated `error_count` values cannot consume the budget, and old episodes age out rather than permanently disabling recovery.
+- Existing restart/provisioning paths remain responsible for state-preserving recovery. No auth, billing, backup, restore, or persistence policy was weakened.
+
+## Proof
+
+Passing focused tests:
+
+1. `packages/agent`: real in-memory PGlite is healthy, is closed after boot, then `/api/health` returns 503 with terminal DB state.
+   - 1 passed.
+2. `packages/app-core`: cloud-agent liveness classification covers terminal closed DB, preserved terminal errors when `isReady()` collapses to false, and bounded transient classification.
+   - 5 passed.
+3. `packages/cloud/shared`: terminal recovery enqueue, transient no-immediate-restart, unrelated-budget isolation, cooldown suppression, and budget exhaustion.
+   - 5 passed, 104 filtered out.
+4. `packages/cloud/shared` typecheck passed.
+5. Biome check/write on all touched source and test files passed, and `git diff --check` passed.
+
+Agent/app-core/plugin-sql package-wide typechecks were attempted but are blocked in this isolated worktree by pre-existing/missing generated optional workspace packages and dist artifacts, including `@elizaos/plugin-app-control`, Capacitor packages, `@elizaos/cloud-routing`, and `@elizaos/contracts`. Focused tests compile and execute every changed recovery surface.
+
+Commit includes:
+
+`Co-authored-by: wakesync <wakesync@users.noreply.github.com>`

--- a/PR-16653-COVERAGE-2026-07-19.md
+++ b/PR-16653-COVERAGE-2026-07-19.md
@@ -1,0 +1,125 @@
+# PR #16653 Coverage Receipt — 2026-07-19
+
+## Claims
+
+- Added focused behavioral coverage for real PGlite liveness probes, including a closed real `PGlite` handle and transient non-terminal probe failures.
+- Added health-route assertions that terminal DB liveness returns HTTP `503`, `ready: false`, and `canRespond: false`; transient DB errors stay HTTP `200` and distinguish `databaseLiveness.status`.
+- Added runtime health-check coverage for the database liveness wrapper and adjacent promotion checks.
+- Added cloud-agent HTTP handler coverage for health, snapshot, restore, bridge message, stream, heartbeat, status, auth failure, bad JSON, and missing routes.
+- Added PGlite adapter coverage for the `SELECT 1` readiness probe and write-back wrapper behavior.
+- Added fleet heartbeat recovery coverage for terminal restart enqueue, transient suppression, cooldown dedupe, restart budget exhaustion, unrelated error-count isolation, and per-agent budget isolation.
+- Production code semantics were not changed in this pass; changes are tests plus this receipt.
+
+## Behavioral Evidence
+
+- `packages/agent/src/api/health-routes.database-liveness.test.ts`
+  - Uses a real `@electric-sql/pglite` instance, verifies green `/api/health`, closes it, then verifies HTTP `503`, `ready: false`, `canRespond: false`, and `databaseLiveness.terminal: true`.
+  - Verifies transient probe errors are reported as `transient_error` without tripping terminal readiness.
+- `packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts`
+  - Verifies terminal DB liveness enqueues `enqueueAgentRestartOnce`.
+  - Verifies transient DB liveness does not immediately enqueue restart inside heartbeat grace.
+  - Verifies cooldown suppresses duplicate restart enqueue.
+  - Verifies budget exhaustion marks `status: "error"` instead of looping.
+  - Verifies unrelated `error_count` and another agent's exhausted marker do not consume a fresh agent's DB-liveness restart budget.
+
+## Commands And Results
+
+```bash
+bun run --cwd packages/core build
+# PASS
+```
+
+```bash
+bunx biome check --write \
+  packages/agent/src/api/health-routes.database-liveness.test.ts \
+  packages/agent/src/runtime/operations/health-checks.database-liveness.test.ts \
+  packages/app-core/deploy/cloud-agent-shared.test.ts \
+  packages/app-core/deploy/cloud-agent-shared.server.test.ts \
+  packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts \
+  plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
+# PASS: Checked 6 files. Fixed 3 files.
+```
+
+```bash
+bunx vitest run \
+  packages/agent/src/api/health-routes.database-liveness.test.ts \
+  packages/agent/src/runtime/operations/health-checks.database-liveness.test.ts \
+  --config packages/agent/vitest.config.ts
+# PASS: 2 files, 9 tests
+```
+
+```bash
+bunx vitest run \
+  packages/app-core/deploy/cloud-agent-shared.test.ts \
+  packages/app-core/deploy/cloud-agent-shared.server.test.ts \
+  --config packages/app-core/vitest.config.ts
+# PASS: 2 files, 6 tests
+```
+
+```bash
+bunx vitest run \
+  plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts \
+  --config plugins/plugin-sql/src/vitest.config.ts
+# PASS: 1 file, 3 tests
+```
+
+```bash
+bun test --conditions=eliza-source \
+  packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+# PASS: 110 tests
+```
+
+```bash
+rm -rf coverage
+bun test --conditions=eliza-source \
+  packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts \
+  --coverage --coverage-reporter=lcov --coverage-dir=coverage/bun/shared
+node packages/scripts/run-changed-vitest-coverage.mjs \
+  packages/agent/src/api/health-routes.database-liveness.test.ts \
+  packages/agent/src/runtime/operations/health-checks.database-liveness.test.ts \
+  packages/app-core/deploy/cloud-agent-shared.test.ts \
+  packages/app-core/deploy/cloud-agent-shared.server.test.ts \
+  plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
+scripts/security/coverage-changed-files.sh origin/develop HEAD > /tmp/changed-coverage-16653.txt
+awk '/^files<<EOF$/{flag=1;next}/^EOF$/{if(flag){flag=0}}flag' \
+  /tmp/changed-coverage-16653.txt > /tmp/changed-files-16653.txt
+LCOV_EXCLUDED_FILES=$(grep -vE '^#|^$' scripts/security/coverage-lcov-excluded.txt || true)
+CHANGED_FILES=$(cat /tmp/changed-files-16653.txt)
+COVERAGE_GATE_ENFORCE=1 awk \
+  -v changed="$CHANGED_FILES" \
+  -v threshold=50 \
+  -v excluded="$LCOV_EXCLUDED_FILES" \
+  -f scripts/security/coverage-gate.awk \
+  $(find coverage -name lcov.info -type f | sort)
+# PASS: coverage gate OK
+```
+
+Final changed-file coverage:
+
+| File | Coverage |
+| --- | ---: |
+| `packages/app-core/deploy/cloud-agent-shared.ts` | 59.61% |
+| `packages/agent/src/runtime/operations/health-checks.ts` | 86.79% |
+| `packages/cloud/shared/src/lib/services/eliza-sandbox.ts` | 51.36% |
+| `plugins/plugin-sql/src/pglite/adapter.ts` | 88.44% |
+| `packages/agent/src/api/database-liveness.ts` | 73.08% |
+| `packages/agent/src/api/health-routes.ts` | 80.09% |
+
+Mean changed-file coverage: 73.23%. Threshold: 50%. Result: `coverage gate OK`.
+
+```bash
+bun run --cwd plugins/plugin-sql typecheck
+# PASS
+```
+
+```bash
+bun run --cwd packages/cloud/shared typecheck
+# PASS
+```
+
+## Remaining Blockers
+
+- `bun run --cwd packages/agent typecheck` fails in this sparse checkout on pre-existing missing optional workspace plugin declarations, including `@elizaos/plugin-app-control`, `@elizaos/plugin-capacitor-bridge/*`, `@elizaos/plugin-streaming`, `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, and `@elizaos/plugin-native-filesystem`. No reported errors pointed at the touched files in this pass.
+- `bun run --cwd packages/app-core typecheck` fails on the same transitive sparse-checkout optional declarations plus existing iOS runtime unknown-type errors and `@elizaos/capacitor-*` side-effect imports. No reported errors pointed at the touched files in this pass.
+
+[sol-orch]

--- a/packages/agent/src/api/database-liveness.ts
+++ b/packages/agent/src/api/database-liveness.ts
@@ -1,0 +1,147 @@
+/**
+ * Database liveness probing for process health endpoints. The probe performs a
+ * real `SELECT 1` round trip against the active adapter instead of trusting
+ * cached adapter state, so a closed embedded PGlite instance cannot report as
+ * healthy while every real operation is failing.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import { sql } from "drizzle-orm";
+
+export type DatabaseLivenessStatus =
+  | "ok"
+  | "unknown"
+  | "transient_error"
+  | "terminal_error";
+
+export interface DatabaseLivenessProbeResult {
+  status: DatabaseLivenessStatus;
+  ok: boolean;
+  terminal: boolean;
+  message?: string;
+}
+
+interface RawQueryable {
+  query(sql: string): Promise<unknown>;
+}
+
+interface DrizzleExecutable {
+  execute(query: unknown): Promise<unknown>;
+}
+
+interface LivenessAdapter {
+  isReady?: () => Promise<boolean>;
+  getRawConnection?: () => RawQueryable;
+  getConnection?: () => Promise<unknown>;
+  db?: unknown;
+}
+
+const TERMINAL_PGLITE_PATTERNS = [
+  /pglite is closed/i,
+  /database is shutting down/i,
+  /operation rejected/i,
+  /cannot query.*closed/i,
+  /closed database/i,
+] as const;
+
+function describeProbeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    // error-policy:J3 diagnostic formatting fallback for non-serializable input
+    return String(error);
+  }
+}
+
+export function isTerminalDatabaseLivenessError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    const message =
+      current instanceof Error
+        ? current.message
+        : typeof current === "string"
+          ? current
+          : "";
+    if (TERMINAL_PGLITE_PATTERNS.some((pattern) => pattern.test(message))) {
+      return true;
+    }
+    current =
+      current instanceof Error
+        ? (current as Error & { cause?: unknown }).cause
+        : typeof current === "object" && current !== null && "cause" in current
+          ? (current as { cause?: unknown }).cause
+          : null;
+  }
+  return false;
+}
+
+function asAdapter(runtime: AgentRuntime): LivenessAdapter | null {
+  const adapter = runtime.adapter;
+  if (!adapter || typeof adapter !== "object") return null;
+  return adapter as LivenessAdapter;
+}
+
+async function probeHandle(handle: unknown): Promise<void> {
+  if (handle && typeof handle === "object") {
+    const raw = handle as Partial<RawQueryable>;
+    if (typeof raw.query === "function") {
+      await raw.query("SELECT 1");
+      return;
+    }
+    const executable = handle as Partial<DrizzleExecutable>;
+    if (typeof executable.execute === "function") {
+      await executable.execute(sql`SELECT 1`);
+      return;
+    }
+  }
+  throw new Error("database connection does not expose query or execute");
+}
+
+async function runProbe(adapter: LivenessAdapter): Promise<void> {
+  if (typeof adapter.getRawConnection === "function") {
+    await probeHandle(adapter.getRawConnection());
+    return;
+  }
+  if (typeof adapter.getConnection === "function") {
+    await probeHandle(await adapter.getConnection());
+    return;
+  }
+  if (adapter.db) {
+    await probeHandle(adapter.db);
+    return;
+  }
+  if (typeof adapter.isReady === "function") {
+    const ready = await adapter.isReady();
+    if (ready) return;
+    throw new Error("adapter.isReady() returned false");
+  }
+  throw new Error("database adapter exposes no liveness probe surface");
+}
+
+export async function probeRuntimeDatabaseLiveness(
+  runtime: AgentRuntime | null,
+): Promise<DatabaseLivenessProbeResult> {
+  if (!runtime) {
+    return { status: "unknown", ok: false, terminal: false };
+  }
+  const adapter = asAdapter(runtime);
+  if (!adapter) {
+    return { status: "unknown", ok: true, terminal: false };
+  }
+  try {
+    await runProbe(adapter);
+    return { status: "ok", ok: true, terminal: false };
+  } catch (error) {
+    // error-policy:J4 health probe translates database failure into liveness state
+    const terminal = isTerminalDatabaseLivenessError(error);
+    return {
+      status: terminal ? "terminal_error" : "transient_error",
+      ok: false,
+      terminal,
+      message: describeProbeError(error),
+    };
+  }
+}

--- a/packages/agent/src/api/health-routes.database-liveness.test.ts
+++ b/packages/agent/src/api/health-routes.database-liveness.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Real-PGlite health-route regression coverage for closed embedded databases.
+ * The route must exercise the database, not just cached adapter state, because
+ * Docker and cloud supervisors consume this signal to decide whether a running
+ * agent needs recovery.
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  type HealthRouteContext,
+  handleHealthRoutes,
+} from "./health-routes.ts";
+
+function makeContext(runtime: AgentRuntime | null): {
+  ctx: HealthRouteContext;
+  responses: Array<{ data: unknown; status: number }>;
+} {
+  const responses: Array<{ data: unknown; status: number }> = [];
+  const state = {
+    runtime,
+    config: { connectors: {} } as ElizaConfig,
+    agentState: "running",
+    agentName: "test-agent",
+    model: undefined,
+    startedAt: Date.now(),
+    startup: { phase: "ready", attempt: 1 },
+    plugins: [],
+    pendingRestartReasons: [],
+    connectorHealthMonitor: null,
+  };
+  return {
+    responses,
+    ctx: {
+      req: {} as HealthRouteContext["req"],
+      res: {} as HealthRouteContext["res"],
+      method: "GET",
+      pathname: "/api/health",
+      url: new URL("http://127.0.0.1/api/health"),
+      state,
+      json: (_res, data, status = 200) => {
+        responses.push({ data, status });
+      },
+      error: (_res, message, status = 500) => {
+        responses.push({ data: { error: message }, status });
+      },
+    },
+  };
+}
+
+describe("GET /api/health database liveness", () => {
+  let pglite: PGlite | null = null;
+
+  afterEach(async () => {
+    if (pglite) {
+      await pglite.close();
+      pglite = null;
+    }
+  });
+
+  it("turns red after a real PGlite database is closed post-boot", async () => {
+    pglite = new PGlite();
+    await pglite.waitReady;
+    const runtime = {
+      adapter: { getRawConnection: () => pglite },
+      plugins: [],
+      getModel: () => undefined,
+    } as unknown as AgentRuntime;
+
+    const green = makeContext(runtime);
+    await expect(handleHealthRoutes(green.ctx)).resolves.toBe(true);
+    expect(green.responses).toHaveLength(1);
+    expect(green.responses[0].status).toBe(200);
+    expect(green.responses[0].data).toMatchObject({
+      ready: true,
+      database: "ok",
+      databaseLiveness: { ok: true, status: "ok", terminal: false },
+    });
+
+    await pglite.close();
+
+    const red = makeContext(runtime);
+    await expect(handleHealthRoutes(red.ctx)).resolves.toBe(true);
+    expect(red.responses).toHaveLength(1);
+    expect(red.responses[0].status).toBe(503);
+    expect(red.responses[0].data).toMatchObject({
+      ready: false,
+      canRespond: false,
+      database: "terminal_error",
+      databaseLiveness: { ok: false, status: "terminal_error", terminal: true },
+    });
+    pglite = null;
+  });
+});

--- a/packages/agent/src/api/health-routes.database-liveness.test.ts
+++ b/packages/agent/src/api/health-routes.database-liveness.test.ts
@@ -93,4 +93,129 @@ describe("GET /api/health database liveness", () => {
     });
     pglite = null;
   });
+
+  it("distinguishes transient database errors from terminal liveness failures", async () => {
+    const runtime = {
+      adapter: {
+        getRawConnection: () => ({
+          async query() {
+            throw new Error("temporary network timeout");
+          },
+        }),
+      },
+      plugins: [{ name: "sql" }],
+      getModel: () => undefined,
+    } as unknown as AgentRuntime;
+
+    const transient = makeContext(runtime);
+    await expect(handleHealthRoutes(transient.ctx)).resolves.toBe(true);
+
+    expect(transient.responses[0].status).toBe(200);
+    expect(transient.responses[0].data).toMatchObject({
+      ready: true,
+      database: "transient_error",
+      databaseLiveness: {
+        ok: false,
+        status: "transient_error",
+        terminal: false,
+        message: "temporary network timeout",
+      },
+    });
+  });
+
+  it("returns non-ready health without a runtime and includes configured connectors", async () => {
+    const { ctx, responses } = makeContext(null);
+    ctx.state.config = {
+      connectors: {
+        discord: { enabled: true },
+        slack: { enabled: false },
+      },
+    } as unknown as ElizaConfig;
+    ctx.state.agentState = "starting";
+    ctx.state.plugins = [
+      { enabled: true, configured: true },
+      { enabled: false, configured: true, loadError: "boom" },
+    ];
+
+    await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
+
+    expect(responses[0].status).toBe(200);
+    expect(responses[0].data).toMatchObject({
+      ready: false,
+      canRespond: false,
+      runtime: "not_initialized",
+      database: "unknown",
+      plugins: { loaded: 1, failed: 1 },
+      connectors: { discord: "configured" },
+      databaseLiveness: { ok: false, status: "unknown", terminal: false },
+    });
+  });
+
+  it("serves status and runtime introspection without treating optional health as fatal", async () => {
+    const circular: Record<string, unknown> = { name: "loop" };
+    circular.self = circular;
+    const runtime = {
+      agentId: "agent-id",
+      character: { name: "Debug Agent" },
+      plugins: [{ name: "plugin-a" }, { id: "plugin-b" }],
+      actions: [{ name: "act" }],
+      providers: [{ serviceType: "provider-kind" }],
+      evaluators: [() => undefined],
+      services: new Map([
+        [
+          "runtime",
+          [
+            circular,
+            new Map([["k", { nested: true }]]),
+            new Set(["a", "b"]),
+            Buffer.from("abcdef"),
+            new Error("diagnostic"),
+          ],
+        ],
+      ]),
+      getModel: () => undefined,
+      adapter: {
+        getRawConnection: () => ({
+          async query() {
+            return [{ "?column?": 1 }];
+          },
+        }),
+      },
+    } as unknown as AgentRuntime;
+
+    const status = makeContext(runtime);
+    status.ctx.pathname = "/api/status";
+    await expect(handleHealthRoutes(status.ctx)).resolves.toBe(true);
+    expect(status.responses[0].data).toMatchObject({
+      state: "running",
+      agentName: "test-agent",
+      cloud: {
+        connectionStatus: "disconnected",
+        cloudProvisioned: false,
+        hasApiKey: false,
+      },
+    });
+
+    const debug = makeContext(runtime);
+    debug.ctx.pathname = "/api/runtime";
+    debug.ctx.url = new URL(
+      "http://127.0.0.1/api/runtime?depth=5&maxArrayLength=3&maxObjectEntries=10&maxStringLength=64",
+    );
+    await expect(handleHealthRoutes(debug.ctx)).resolves.toBe(true);
+
+    expect(debug.responses[0].data).toMatchObject({
+      runtimeAvailable: true,
+      meta: {
+        agentId: "agent-id",
+        agentName: "Debug Agent",
+        pluginCount: 2,
+        actionCount: 1,
+        providerCount: 1,
+        evaluatorCount: 1,
+        serviceTypeCount: 1,
+        serviceCount: 5,
+      },
+    });
+    expect(debug.responses[0].data).toHaveProperty("sections.runtime");
+  });
 });

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -22,6 +22,7 @@ import type { ElizaConfig } from "../config/config.ts";
 import { getDeferredBootStatus } from "../runtime/deferred-boot-status.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
 import type { ConnectorHealthMonitor } from "./connector-health.ts";
+import { probeRuntimeDatabaseLiveness } from "./database-liveness.ts";
 import { loadLocalInferenceRouteApi } from "./local-inference-server-api.ts";
 
 type CloudHealthApi = {
@@ -586,28 +587,42 @@ export async function handleHealthRoutes(
       }
     }
 
+    const databaseLiveness = await probeRuntimeDatabaseLiveness(runtime);
     const ready =
-      state.agentState !== "starting" && state.agentState !== "restarting";
+      state.agentState !== "starting" &&
+      state.agentState !== "restarting" &&
+      !databaseLiveness.terminal;
 
-    json(res, {
-      ready,
-      canRespond: computeCanRespond(runtime, state.agentState),
-      runtime: runtime ? "ok" : "not_initialized",
-      database: runtime ? "ok" : "unknown",
-      plugins: {
-        loaded: loadedPluginCount,
-        failed: failedPluginCount,
+    json(
+      res,
+      {
+        ready,
+        canRespond: databaseLiveness.terminal
+          ? false
+          : computeCanRespond(runtime, state.agentState),
+        runtime: runtime ? "ok" : "not_initialized",
+        database: databaseLiveness.ok
+          ? runtime
+            ? "ok"
+            : "unknown"
+          : databaseLiveness.status,
+        databaseLiveness,
+        plugins: {
+          loaded: loadedPluginCount,
+          failed: failedPluginCount,
+        },
+        coordinator: coordinatorStatus,
+        connectors,
+        uptime,
+        agentState: state.agentState,
+        startup: state.startup,
+        // Deferred capabilities (feature routes, connectors, non-essential
+        // plugins) register AFTER `ready` flips. Poll `deferredBoot.settled`
+        // before hitting feature routes right after boot instead of sleeping.
+        deferredBoot: getDeferredBootStatus(),
       },
-      coordinator: coordinatorStatus,
-      connectors,
-      uptime,
-      agentState: state.agentState,
-      startup: state.startup,
-      // Deferred capabilities (feature routes, connectors, non-essential
-      // plugins) register AFTER `ready` flips. Poll `deferredBoot.settled`
-      // before hitting feature routes right after boot instead of sleeping.
-      deferredBoot: getDeferredBootStatus(),
-    });
+      databaseLiveness.terminal ? 503 : 200,
+    );
     return true;
   }
 

--- a/packages/agent/src/runtime/operations/health-checks.database-liveness.test.ts
+++ b/packages/agent/src/runtime/operations/health-checks.database-liveness.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit coverage for the runtime health checks that gate runtime promotion.
+ * The database check delegates to the same real probe as `/api/health`, while
+ * the surrounding checks keep optional runtime surfaces fail-closed only where
+ * they can prove a real broken dependency.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  builtInHealthChecks,
+  dbConnectionCheck,
+  describeError,
+  essentialServicesCheck,
+  providerSmokeCheck,
+  runtimeReadyCheck,
+} from "./health-checks.ts";
+
+function runtime(overrides: Record<string, unknown> = {}): AgentRuntime {
+  return {
+    agentId: "agent-id",
+    character: { name: "Health Agent" },
+    plugins: [],
+    actions: [],
+    providers: [],
+    evaluators: [],
+    services: new Map(),
+    ...overrides,
+  } as unknown as AgentRuntime;
+}
+
+describe("built-in runtime health checks", () => {
+  it("checks required runtime identity before promotion", async () => {
+    await expect(runtimeReadyCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ agentId: "" })),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "runtime.agentId is empty",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: { name: " " } })),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "runtime.character.name is empty",
+    });
+  });
+
+  it("fails only registered services that report failed", async () => {
+    await expect(essentialServicesCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+    await expect(
+      essentialServicesCheck.run(
+        runtime({
+          getRegisteredServiceTypes: () => ["ok", "bad"],
+          getServiceRegistrationStatus: (type: string) =>
+            type === "bad" ? "failed" : "registered",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "service bad is in failed state",
+    });
+  });
+
+  it("passes unknown database surfaces but fails transient and terminal probe errors", async () => {
+    await expect(dbConnectionCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            getRawConnection: () => ({
+              async query() {
+                throw new Error("temporary probe timeout");
+              },
+            }),
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "transient_error: temporary probe timeout",
+    });
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            db: {
+              async execute() {
+                throw new Error("PGlite is closed");
+              },
+            },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "terminal_error: PGlite is closed",
+    });
+  });
+
+  it("classifies provider smoke responses without hiding quota failures", async () => {
+    await expect(providerSmokeCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            return "";
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    const noOutput = new Error("empty");
+    noOutput.name = "AI_NoOutputGeneratedError";
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw noOutput;
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw new Error("transport down");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "provider unreachable: transport down",
+    });
+  });
+
+  it("exports the expected default check set and diagnostic formatter", () => {
+    expect(builtInHealthChecks.map((check) => check.name)).toEqual([
+      "runtime-ready",
+      "essential-services",
+      "db-connection",
+      "provider-smoke",
+    ]);
+    expect(describeError("plain")).toBe("plain");
+    expect(describeError({ code: "E_TEST" })).toBe('{"code":"E_TEST"}');
+  });
+});

--- a/packages/agent/src/runtime/operations/health-checks.ts
+++ b/packages/agent/src/runtime/operations/health-checks.ts
@@ -14,6 +14,7 @@
 
 import { type AgentRuntime, logger, ModelType } from "@elizaos/core";
 import { isInsufficientCreditsError } from "../../api/credit-detection.ts";
+import { probeRuntimeDatabaseLiveness } from "../../api/database-liveness.ts";
 import type { HealthCheck, HealthCheckResult } from "./types.ts";
 
 const LOG_PREFIX = "[runtime-ops:health-checks]";
@@ -22,21 +23,11 @@ const LOG_PREFIX = "[runtime-ops:health-checks]";
 // Runtime guards — keep us off `any` while accommodating partial typings.
 // ---------------------------------------------------------------------------
 
-interface DbAdapterLike {
-  isReady?: () => Promise<boolean>;
-}
-
 interface ServiceRegistryLike {
   getRegisteredServiceTypes?: () => readonly string[];
   getServiceRegistrationStatus?: (
     serviceType: string,
   ) => "pending" | "registering" | "registered" | "failed" | "unknown";
-}
-
-function getDbAdapter(runtime: AgentRuntime): DbAdapterLike | null {
-  const adapter = runtime.adapter;
-  if (adapter == null || typeof adapter !== "object") return null;
-  return adapter as DbAdapterLike;
 }
 
 function asServiceRegistry(runtime: AgentRuntime): ServiceRegistryLike {
@@ -132,27 +123,13 @@ export const dbConnectionCheck: HealthCheck = {
   required: true,
   timeoutMs: 1500,
   async run(runtime: AgentRuntime): Promise<HealthCheckResult> {
-    const adapter = getDbAdapter(runtime);
-    if (!adapter) {
-      // Runtime without a database adapter (rare but supported) — pass.
-      return { ok: true };
-    }
-    if (typeof adapter.isReady !== "function") {
-      // Older adapter without isReady — best-effort pass; don't block on
-      // a missing API surface we cannot probe.
-      return { ok: true };
-    }
-    try {
-      const ready = await adapter.isReady();
-      if (ready === true) return { ok: true };
-      return { ok: false, reason: "adapter.isReady() returned false" };
-    } catch (err) {
-      return {
-        ok: false,
-        reason: `adapter.isReady() threw: ${describeError(err)}`,
-        cause: err,
-      };
-    }
+    const liveness = await probeRuntimeDatabaseLiveness(runtime);
+    if (liveness.ok) return { ok: true };
+    if (liveness.status === "unknown") return { ok: true };
+    return {
+      ok: false,
+      reason: `${liveness.status}: ${liveness.message ?? "database probe failed"}`,
+    };
   },
 };
 

--- a/packages/app-core/deploy/cloud-agent-shared.server.test.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.server.test.ts
@@ -1,0 +1,296 @@
+/**
+ * HTTP harness coverage for the cloud-agent entrypoint. The test captures the
+ * real `node:http` request handlers before they bind sockets, then drives health,
+ * snapshot, restore, bridge, stream, and status requests through the same code
+ * the Docker image runs.
+ */
+
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type CapturedServer = {
+  handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+  listen: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const capturedServers: CapturedServer[] = [];
+
+vi.mock("node:http", () => ({
+  createServer: vi.fn(
+    (
+      handler: (
+        req: IncomingMessage,
+        res: ServerResponse,
+      ) => void | Promise<void>,
+    ) => {
+      const server = {
+        handler,
+        listen: vi.fn((_port: number, _host: string, cb?: () => void) => {
+          cb?.();
+          return server;
+        }),
+        close: vi.fn(),
+      };
+      capturedServers.push(server);
+      return server;
+    },
+  ),
+}));
+
+vi.mock("@elizaos/core", () => {
+  throw new Error("force echo-mode fallback");
+});
+
+type FakeResponse = ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+  statusCode: number;
+};
+
+function makeResponse(): FakeResponse {
+  return {
+    body: "",
+    headers: {},
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      this.headers[name.toLowerCase()] = value;
+      return this;
+    },
+    writeHead(status: number, headers?: Record<string, string>) {
+      this.statusCode = status;
+      for (const [key, value] of Object.entries(headers ?? {})) {
+        this.headers[key.toLowerCase()] = value;
+      }
+      return this;
+    },
+    write(chunk: string) {
+      this.body += chunk;
+      return true;
+    },
+    end(chunk?: string) {
+      if (chunk) this.body += chunk;
+      return this;
+    },
+  } as FakeResponse;
+}
+
+function makeRequest(
+  method: string,
+  url: string,
+  body?: string,
+  headers: Record<string, string> = {},
+): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage;
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  if (body !== undefined) {
+    queueMicrotask(() => {
+      req.emit("data", Buffer.from(body));
+      req.emit("end");
+    });
+  }
+  return req;
+}
+
+async function dispatch(
+  server: CapturedServer,
+  method: string,
+  url: string,
+  body?: string,
+  headers?: Record<string, string>,
+): Promise<FakeResponse> {
+  const res = makeResponse();
+  await server.handler(makeRequest(method, url, body, headers), res);
+  return res;
+}
+
+function parseJson(res: FakeResponse): Record<string, unknown> {
+  return JSON.parse(res.body) as Record<string, unknown>;
+}
+
+async function waitForEchoRuntime(healthServer: CapturedServer): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const res = await dispatch(healthServer, "GET", "/api/health");
+    if (parseJson(res).runtimeReady === true) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("echo runtime did not become ready");
+}
+
+describe("startCloudAgent HTTP handlers", () => {
+  const originalEnv = { ...process.env };
+  let onSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    capturedServers.length = 0;
+    process.env = { ...originalEnv };
+    onSpy = vi.spyOn(process, "on").mockReturnValue(process);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    onSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("routes health, snapshot, restore, message, stream, and status requests", async () => {
+    const { startCloudAgent } = await import("./cloud-agent-shared");
+    startCloudAgent({
+      port: 0,
+      bridgePort: 0,
+      bridgeSecret: "secret",
+      maxMemories: 2,
+      enableChatMode: true,
+    });
+    await Promise.resolve();
+
+    expect(capturedServers).toHaveLength(2);
+    const [healthServer, bridgeServer] = capturedServers;
+    await waitForEchoRuntime(healthServer);
+
+    const greenHealth = await dispatch(healthServer, "GET", "/api/health");
+    expect(greenHealth.statusCode).toBe(200);
+    expect(parseJson(greenHealth)).toMatchObject({
+      status: "healthy",
+      runtimeReady: true,
+      database: "ok",
+      databaseLiveness: { ok: true, status: "unknown", terminal: false },
+    });
+
+    const root = await dispatch(healthServer, "GET", "/");
+    expect(parseJson(root)).toMatchObject({
+      service: "elizaos-cloud-agent",
+      status: "running",
+    });
+    expect((await dispatch(healthServer, "GET", "/missing")).statusCode).toBe(
+      404,
+    );
+
+    const unauthorized = await dispatch(bridgeServer, "POST", "/bridge", "{}");
+    expect(unauthorized.statusCode).toBe(401);
+
+    const auth = { authorization: "Bearer secret" };
+    const message = await dispatch(
+      bridgeServer,
+      "POST",
+      "/bridge",
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "message.send",
+        params: {
+          text: "hello",
+          roomId: " room-a ",
+          mode: "simple",
+          channelType: "GROUP",
+          source: "discord",
+          sender: {
+            id: " user-1 ",
+            username: " sol ",
+            displayName: " Sol ",
+            metadata: { role: "tester" },
+          },
+          metadata: { trace: "m1" },
+        },
+      }),
+      auth,
+    );
+    expect(parseJson(message)).toMatchObject({
+      result: { text: "[echo] hello" },
+    });
+
+    const status = await dispatch(
+      bridgeServer,
+      "POST",
+      "/bridge",
+      JSON.stringify({ jsonrpc: "2.0", id: 2, method: "status.get" }),
+      auth,
+    );
+    expect(parseJson(status)).toMatchObject({
+      result: {
+        status: "running",
+        memoriesCount: 2,
+        database: "ok",
+      },
+    });
+
+    const snapshot = await dispatch(
+      bridgeServer,
+      "POST",
+      "/api/snapshot",
+      "",
+      auth,
+    );
+    expect(parseJson(snapshot)).toMatchObject({
+      memories: expect.any(Array),
+      config: {},
+      workspaceFiles: {},
+    });
+
+    const restore = await dispatch(
+      bridgeServer,
+      "POST",
+      "/api/restore",
+      JSON.stringify({
+        memories: [{ role: "user", text: "restored" }],
+        config: { name: "restored" },
+        workspaceFiles: { "README.md": "ok" },
+      }),
+      auth,
+    );
+    expect(parseJson(restore)).toEqual({ success: true });
+
+    const stream = await dispatch(
+      bridgeServer,
+      "POST",
+      "/bridge/stream",
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "s1",
+        method: "message.send",
+        params: { text: "stream me" },
+      }),
+      auth,
+    );
+    expect(stream.headers["content-type"]).toBe("text/event-stream");
+    expect(stream.body).toContain("event: connected");
+    expect(stream.body).toContain("event: chunk");
+    expect(stream.body).toContain("event: done");
+
+    const heartbeat = await dispatch(
+      bridgeServer,
+      "POST",
+      "/bridge",
+      JSON.stringify({ jsonrpc: "2.0", method: "heartbeat" }),
+      auth,
+    );
+    expect(parseJson(heartbeat)).toMatchObject({
+      method: "heartbeat.ack",
+    });
+
+    const badJson = await dispatch(bridgeServer, "POST", "/bridge", "{", auth);
+    expect(badJson.statusCode).toBe(400);
+
+    const notFoundMethod = await dispatch(
+      bridgeServer,
+      "POST",
+      "/bridge",
+      JSON.stringify({ jsonrpc: "2.0", id: 3, method: "missing.method" }),
+      auth,
+    );
+    expect(parseJson(notFoundMethod)).toMatchObject({
+      error: { code: -32601 },
+    });
+    expect(
+      (await dispatch(bridgeServer, "POST", "/missing", "", auth)).statusCode,
+    ).toBe(404);
+  });
+});

--- a/packages/app-core/deploy/cloud-agent-shared.test.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.test.ts
@@ -9,6 +9,7 @@ import {
   appendBridgeCallbackContent,
   type BridgeMessageResult,
   bridgeResultText,
+  checkRuntimeDatabaseLiveness,
 } from "./cloud-agent-shared";
 
 describe("cloud-agent bridge callback results", () => {
@@ -38,5 +39,66 @@ describe("cloud-agent bridge callback results", () => {
 
     expect(bridgeResultText(result)).toBe("(no response)");
     expect(result.failureKind).toBe("no_response");
+  });
+});
+
+describe("cloud-agent database liveness", () => {
+  it("classifies a real queryable closed-PGlite error as terminal", async () => {
+    await expect(
+      checkRuntimeDatabaseLiveness({
+        adapter: {
+          getRawConnection: () => ({
+            async query() {
+              throw new Error("PGlite is closed");
+            },
+          }),
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: "terminal_error",
+      terminal: true,
+      message: "PGlite is closed",
+    });
+  });
+
+  it("preserves terminal closure from a DB handle even when isReady collapses it", async () => {
+    await expect(
+      checkRuntimeDatabaseLiveness({
+        adapter: {
+          isReady: async () => false,
+          db: {
+            async execute() {
+              throw new Error("Database is shutting down - operation rejected");
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: "terminal_error",
+      terminal: true,
+    });
+  });
+
+  it("classifies bounded non-terminal probe failures separately", async () => {
+    await expect(
+      checkRuntimeDatabaseLiveness({
+        adapter: {
+          async getConnection() {
+            return {
+              async execute() {
+                throw new Error("probe timeout");
+              },
+            };
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: "transient_error",
+      terminal: false,
+      message: "probe timeout",
+    });
   });
 });

--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -8,6 +8,7 @@
 
 import * as crypto from "node:crypto";
 import * as http from "node:http";
+import { sql } from "drizzle-orm";
 import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with {
   type: "json",
 };
@@ -94,6 +95,128 @@ type BridgeCallbackContent = {
   text?: unknown;
   failureKind?: unknown;
 };
+
+export type DatabaseLivenessPayload = {
+  status: "ok" | "unknown" | "transient_error" | "terminal_error";
+  ok: boolean;
+  terminal: boolean;
+  message?: string;
+};
+
+export interface AgentRuntimeAdapterLike {
+  isReady?: () => Promise<boolean>;
+  getRawConnection?: () => { query(sql: string): Promise<unknown> };
+  getConnection?: () => Promise<unknown>;
+  db?: unknown;
+}
+
+export interface RuntimeWithDatabaseLiveness {
+  adapter?: AgentRuntimeAdapterLike;
+  checkDatabaseLiveness?: () => Promise<DatabaseLivenessPayload>;
+}
+
+const TERMINAL_DATABASE_LIVENESS_PATTERNS = [
+  /pglite is closed/i,
+  /database is shutting down/i,
+  /operation rejected/i,
+  /cannot query.*closed/i,
+  /closed database/i,
+] as const;
+
+function describeDatabaseProbeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    // error-policy:J3 diagnostic formatting fallback for non-serializable input
+    return String(error);
+  }
+}
+
+function isTerminalDatabaseProbeError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    const message =
+      current instanceof Error
+        ? current.message
+        : typeof current === "string"
+          ? current
+          : "";
+    if (
+      TERMINAL_DATABASE_LIVENESS_PATTERNS.some((pattern) =>
+        pattern.test(message),
+      )
+    ) {
+      return true;
+    }
+    current =
+      current instanceof Error
+        ? (current as Error & { cause?: unknown }).cause
+        : typeof current === "object" && current !== null && "cause" in current
+          ? (current as { cause?: unknown }).cause
+          : null;
+  }
+  return false;
+}
+
+async function probeDatabaseHandle(handle: unknown): Promise<void> {
+  if (handle && typeof handle === "object") {
+    const queryable = handle as { query?: unknown };
+    if (typeof queryable.query === "function") {
+      await (queryable.query as (sql: string) => Promise<unknown>)("SELECT 1");
+      return;
+    }
+    const executable = handle as { execute?: unknown };
+    if (typeof executable.execute === "function") {
+      await (executable.execute as (query: unknown) => Promise<unknown>)(
+        sql`SELECT 1`,
+      );
+      return;
+    }
+  }
+  throw new Error("database connection does not expose query or execute");
+}
+
+export async function checkRuntimeDatabaseLiveness(
+  runtime: RuntimeWithDatabaseLiveness | null,
+): Promise<DatabaseLivenessPayload> {
+  if (!runtime) return { status: "unknown", ok: false, terminal: false };
+  if (typeof runtime.checkDatabaseLiveness === "function") {
+    return runtime.checkDatabaseLiveness();
+  }
+  const adapter = runtime.adapter;
+  if (!adapter) return { status: "unknown", ok: true, terminal: false };
+  try {
+    if (typeof adapter.getRawConnection === "function") {
+      await probeDatabaseHandle(adapter.getRawConnection());
+    } else if (typeof adapter.getConnection === "function") {
+      await probeDatabaseHandle(await adapter.getConnection());
+    } else if (adapter.db) {
+      // Probe the handle before isReady(). PGlite's readiness method returns a
+      // boolean and would otherwise erase the terminal `PGlite is closed`
+      // error that the supervisor needs in order to recover the container.
+      await probeDatabaseHandle(adapter.db);
+    } else if (typeof adapter.isReady === "function") {
+      const ready = await adapter.isReady();
+      if (!ready) throw new Error("adapter.isReady() returned false");
+    } else {
+      throw new Error("database adapter exposes no liveness probe surface");
+    }
+    return { status: "ok", ok: true, terminal: false };
+  } catch (error) {
+    // error-policy:J4 health probe translates database failure into liveness state
+    const terminal = isTerminalDatabaseProbeError(error);
+    return {
+      status: terminal ? "terminal_error" : "transient_error",
+      ok: false,
+      terminal,
+      message: describeDatabaseProbeError(error),
+    };
+  }
+}
 
 export function appendBridgeCallbackContent(
   result: BridgeMessageResult,
@@ -191,6 +314,7 @@ interface AgentRuntime {
   ) => Promise<BridgeMessageResult>;
   getMemories: () => Array<Record<string, unknown>>;
   getConfig: () => Record<string, unknown>;
+  checkDatabaseLiveness?: () => Promise<DatabaseLivenessPayload>;
 }
 
 // ─── Main entry ─────────────────────────────────────────────────────────
@@ -555,6 +679,7 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         },
         getMemories: () => state.memories,
         getConfig: () => state.config,
+        checkDatabaseLiveness: () => checkRuntimeDatabaseLiveness(runtime),
       };
 
       logger.info("elizaOS runtime initialized with real agent");
@@ -614,11 +739,12 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
   /** Consider the runtime hung if no activity for 10 minutes after init. */
   const HUNG_RUNTIME_THRESHOLD_MS = 10 * 60_000;
 
-  const healthServer = http.createServer((req, res) => {
+  const healthServer = http.createServer(async (req, res) => {
     if (
       req.method === "GET" &&
       (req.url === "/health" || req.url === "/api/health")
     ) {
+      const databaseLiveness = await checkRuntimeDatabaseLiveness(agentRuntime);
       const lastActivityAge =
         Date.now() - new Date(state.lastActivityAt).getTime();
       const possiblyHung =
@@ -627,7 +753,9 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         lastActivityAge > HUNG_RUNTIME_THRESHOLD_MS;
 
       let status: string;
-      if (!agentRuntime) {
+      if (databaseLiveness.terminal) {
+        status = "unhealthy";
+      } else if (!agentRuntime) {
         status = "initializing";
       } else if (possiblyHung) {
         status = "possibly_hung";
@@ -635,7 +763,9 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         status = "healthy";
       }
 
-      res.writeHead(200, { "Content-Type": "application/json" });
+      res.writeHead(databaseLiveness.terminal ? 503 : 200, {
+        "Content-Type": "application/json",
+      });
       res.end(
         JSON.stringify({
           status,
@@ -644,6 +774,8 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           lastActivityAt: state.lastActivityAt,
           memoryUsage: process.memoryUsage().rss,
           runtimeReady: agentRuntime !== null,
+          database: databaseLiveness.ok ? "ok" : databaseLiveness.status,
+          databaseLiveness,
         }),
       );
       return;
@@ -827,16 +959,24 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
       }
 
       if (rpc.method === "status.get") {
+        const databaseLiveness =
+          await checkRuntimeDatabaseLiveness(agentRuntime);
         res.writeHead(200);
         res.end(
           JSON.stringify({
             jsonrpc: "2.0",
             id: rpc.id,
             result: {
-              status: agentRuntime ? "running" : "initializing",
+              status: databaseLiveness.terminal
+                ? "unhealthy"
+                : agentRuntime
+                  ? "running"
+                  : "initializing",
               uptime: process.uptime(),
               memoriesCount: state.memories.length,
               startedAt: state.startedAt,
+              database: databaseLiveness.ok ? "ok" : databaseLiveness.status,
+              databaseLiveness,
             },
           }),
         );

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1678,6 +1678,76 @@ describe("ElizaSandboxService heartbeat", () => {
       enqueueSpy.mockRestore();
     }
   });
+
+  test("database-liveness restart budget is isolated per agent record", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const exhausted: AgentSandbox = {
+      ...customSandbox(),
+      id: "11111111-1111-4111-8111-111111111111",
+      error_count: 3,
+      error_message: `[db-liveness-restart] count=3 at=${new Date(Date.now() - 20 * 60_000).toISOString()} reason=PGlite is closed`,
+    };
+    const fresh: AgentSandbox = {
+      ...customSandbox(),
+      id: "22222222-2222-4222-8222-222222222222",
+      error_count: 3,
+      error_message: "unrelated launch failures",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async (agentId) => (agentId === exhausted.id ? exhausted : fresh),
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async () => undefined as never,
+    );
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+      async () =>
+        ({
+          created: true,
+          job: { id: "job-agent-isolated" },
+        }) as never,
+    );
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        {
+          databaseLiveness: {
+            ok: false,
+            status: "terminal_error",
+            terminal: true,
+            message: "PGlite is closed",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+
+    try {
+      await expect(
+        new ElizaSandboxService().heartbeat(exhausted.id, exhausted.organization_id),
+      ).resolves.toBe(false);
+      await expect(
+        new ElizaSandboxService().heartbeat(fresh.id, fresh.organization_id),
+      ).resolves.toBe(false);
+
+      expect(updateSpy).toHaveBeenCalledTimes(2);
+      expect(updateSpy.mock.calls[0][1]).toMatchObject({
+        status: "error",
+        error_count: 3,
+      });
+      expect(updateSpy.mock.calls[1][1]).toMatchObject({
+        error_count: 1,
+      });
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueSpy).toHaveBeenCalledWith({
+        agentId: fresh.id,
+        organizationId: fresh.organization_id,
+        userId: fresh.user_id,
+      });
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
 });
 
 // Stale-tailnet-IP reconciliation (heartbeat + recoverDisconnected). Agent

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -31,6 +31,7 @@ import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
 import { DockerSSHClient } from "./docker-ssh";
+import { provisioningJobService } from "./provisioning-jobs";
 import { resolveSandboxContainerLaunchConfig } from "./sandbox-container-launch-config";
 import type { SandboxProvider } from "./sandbox-provider-types";
 
@@ -1437,6 +1438,244 @@ describe("ElizaSandboxService heartbeat", () => {
     } finally {
       findSpy.mockRestore();
       updateSpy.mockRestore();
+    }
+  });
+
+  test("terminal database liveness failure enqueues a bounded restart", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async () => undefined as never,
+    );
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+      async () =>
+        ({
+          created: true,
+          job: { id: "job-db-liveness-restart" },
+        }) as never,
+    );
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        {
+          status: "unhealthy",
+          database: "terminal_error",
+          databaseLiveness: {
+            ok: false,
+            status: "terminal_error",
+            terminal: true,
+            message: "PGlite is closed",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.error_count).toBe(1);
+      expect(String(patch.error_message)).toContain("[db-liveness-restart]");
+      expect(enqueueSpy).toHaveBeenCalledWith({
+        agentId: sandbox.id,
+        organizationId: sandbox.organization_id,
+        userId: sandbox.user_id,
+      });
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("transient database liveness failures do not enqueue an immediate restart", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      last_heartbeat_at: new Date(Date.now() - 30_000),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async () => undefined as never,
+    );
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+      async () =>
+        ({
+          created: true,
+          job: { id: "job-should-not-start" },
+        }) as never,
+    );
+    globalThis.fetch = mock(async () =>
+      Response.json({
+        status: "healthy",
+        database: "transient_error",
+        databaseLiveness: {
+          ok: false,
+          status: "transient_error",
+          terminal: false,
+          message: "temporary probe timeout",
+        },
+      }),
+    );
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(enqueueSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("unrelated error_count does not consume the database-liveness restart budget", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      error_count: 9,
+      error_message: "tailnet reconciliation failures",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async () => undefined as never,
+    );
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+      async () =>
+        ({
+          created: true,
+          job: { id: "job-db-budget-isolated" },
+        }) as never,
+    );
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        {
+          databaseLiveness: {
+            ok: false,
+            status: "terminal_error",
+            terminal: true,
+            message: "PGlite is closed",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.error_count).toBe(1);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("database-liveness restart cooldown suppresses duplicate enqueue", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      error_count: 1,
+      error_message: `[db-liveness-restart] count=1 at=${new Date().toISOString()} reason=PGlite is closed`,
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async () => undefined as never,
+    );
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+      async () =>
+        ({
+          created: true,
+          job: { id: "job-duplicate" },
+        }) as never,
+    );
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        {
+          databaseLiveness: {
+            ok: false,
+            status: "terminal_error",
+            terminal: true,
+            message: "Database is shutting down - operation rejected",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(enqueueSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("database-liveness restart budget exhausts to error instead of looping", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      error_count: 3,
+      error_message: `[db-liveness-restart] count=3 at=${new Date(Date.now() - 20 * 60_000).toISOString()} reason=PGlite is closed`,
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async () => undefined as never,
+    );
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+      async () =>
+        ({
+          created: true,
+          job: { id: "job-budget-exhausted" },
+        }) as never,
+    );
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        {
+          databaseLiveness: {
+            ok: false,
+            status: "terminal_error",
+            terminal: true,
+            message: "PGlite is closed",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.status).toBe("error");
+      expect(patch.error_count).toBe(3);
+      expect(String(patch.error_message)).toContain("budget-exhausted");
+      expect(enqueueSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -384,10 +384,22 @@ type AgentRuntimeHealthPayload = {
   ready?: unknown;
   runtime?: unknown;
   database?: unknown;
+  databaseLiveness?: {
+    status?: unknown;
+    ok?: unknown;
+    terminal?: unknown;
+    message?: unknown;
+  } | null;
   plugins?: { failed?: unknown } | null;
   agentState?: unknown;
   startup?: { lastError?: unknown } | null;
 };
+
+type BridgeHealthProbeResult =
+  | { ok: true; kind: "healthy" }
+  | { ok: false; kind: "transient"; reason: string }
+  | { ok: false; kind: "terminal-db"; reason: string }
+  | { ok: false; kind: "unreachable"; reason: string };
 
 export interface SnapshotResult {
   success: boolean;
@@ -431,6 +443,10 @@ const RECONCILE_SSH_CMD_TIMEOUT_MS = 15_000;
 // escalates to `disconnected` so the recovery cycle's reprovision self-heal
 // still fires — an unreachable paid agent must never look "running" forever.
 const IP_RECONCILE_MAX_UNRESOLVED_CYCLES = 3;
+const DB_LIVENESS_RESTART_MARKER = "[db-liveness-restart]";
+const DB_LIVENESS_RESTART_BUDGET = 3;
+const DB_LIVENESS_RESTART_COOLDOWN_MS = 10 * 60_000;
+const DB_LIVENESS_RESTART_BUDGET_WINDOW_MS = 60 * 60_000;
 const SNAPSHOT_FETCH_TIMEOUT_MS = 120_000;
 const SNAPSHOT_RESTORE_TIMEOUT_MS = 120_000;
 const UPGRADE_RUNTIME_HEALTH_GATE_TIMEOUT_MS = 30_000;
@@ -4557,9 +4573,14 @@ export class ElizaSandboxService {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec?.bridge_url) return false;
 
-    const reachable = await this.probeBridgeHealth(rec);
+    const probe = await this.probeBridgeHealthDetailed(rec);
 
-    if (!reachable) {
+    if (probe.kind === "terminal-db") {
+      await this.handleTerminalDatabaseLivenessFailure(rec, probe.reason);
+      return false;
+    }
+
+    if (!probe.ok) {
       // Hysteresis: one failed cycle is not enough to evict. last_heartbeat_at
       // is bumped only on success, so its age is how long the agent has been
       // continuously unreachable. Stay running inside the grace window (the next
@@ -4573,6 +4594,7 @@ export class ElizaSandboxService {
         logger.warn("[agent-sandbox] Heartbeat miss within grace window, keeping running", {
           agentId,
           downForMs,
+          reason: probe.reason,
         });
         return false;
       }
@@ -4617,6 +4639,7 @@ export class ElizaSandboxService {
       logger.warn("[agent-sandbox] Heartbeat failed past grace window, marking disconnected", {
         agentId,
         downForMs,
+        reason: probe.reason,
         reconcileOutcome: reconcile.outcome,
       });
       await agentSandboxesRepository.update(rec.id, {
@@ -4650,8 +4673,21 @@ export class ElizaSandboxService {
   private async probeBridgeHealth(
     rec: Pick<AgentSandbox, "id" | "environment_vars" | "bridge_url">,
   ): Promise<boolean> {
-    if (!rec.bridge_url) return false;
+    return (await this.probeBridgeHealthDetailed(rec)).ok;
+  }
+
+  private async probeBridgeHealthDetailed(
+    rec: Pick<AgentSandbox, "id" | "environment_vars" | "bridge_url">,
+  ): Promise<BridgeHealthProbeResult> {
+    if (!rec.bridge_url) {
+      return { ok: false, kind: "unreachable", reason: "missing bridge_url" };
+    }
     const endpoint = new URL("/api/health", rec.bridge_url).toString();
+    let lastFailure: BridgeHealthProbeResult = {
+      ok: false,
+      kind: "unreachable",
+      reason: "bridge health probe failed",
+    };
     for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
       if (attempt > 0) {
         await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
@@ -4662,8 +4698,16 @@ export class ElizaSandboxService {
           headers: this.getAgentJsonHeaders(rec),
           signal: AbortSignal.timeout(10_000),
         });
-        if (res.ok) return true;
+        const classified = await this.classifyBridgeHealthResponse(res);
+        if (classified.ok) return classified;
+        lastFailure = classified;
+        if (classified.kind === "terminal-db") return classified;
       } catch (error) {
+        lastFailure = {
+          ok: false,
+          kind: "unreachable",
+          reason: error instanceof Error ? error.message : String(error),
+        };
         logger.debug("[agent-sandbox] Bridge health probe attempt failed, retrying", {
           agentId: rec.id,
           attempt,
@@ -4671,7 +4715,122 @@ export class ElizaSandboxService {
         });
       }
     }
-    return false;
+    return lastFailure;
+  }
+
+  private async classifyBridgeHealthResponse(res: Response): Promise<BridgeHealthProbeResult> {
+    let payload: AgentRuntimeHealthPayload | null = null;
+    try {
+      payload = (await res.clone().json()) as AgentRuntimeHealthPayload;
+    } catch {
+      // error-policy:J3 malformed health JSON is an explicit unreachable probe result
+      payload = null;
+    }
+    const databaseLiveness = payload?.databaseLiveness;
+    const terminal =
+      databaseLiveness?.terminal === true ||
+      databaseLiveness?.status === "terminal_error" ||
+      payload?.database === "terminal_error";
+    if (terminal) {
+      return {
+        ok: false,
+        kind: "terminal-db",
+        reason:
+          typeof databaseLiveness?.message === "string"
+            ? databaseLiveness.message
+            : "database liveness probe reported terminal failure",
+      };
+    }
+    const transient =
+      databaseLiveness?.status === "transient_error" || payload?.database === "transient_error";
+    if (transient) {
+      return {
+        ok: false,
+        kind: "transient",
+        reason:
+          typeof databaseLiveness?.message === "string"
+            ? databaseLiveness.message
+            : "database liveness probe reported transient failure",
+      };
+    }
+    if (res.ok) return { ok: true, kind: "healthy" };
+    return {
+      ok: false,
+      kind: "unreachable",
+      reason: `/api/health returned ${res.status}`,
+    };
+  }
+
+  private parseDatabaseLivenessRestartMarker(message: string | null): {
+    count: number;
+    at: number | null;
+  } {
+    if (!message?.includes(DB_LIVENESS_RESTART_MARKER)) {
+      return { count: 0, at: null };
+    }
+    const countMatch = message.match(/count=(\d+)/);
+    const atMatch = message.match(/at=([0-9TZ:.-]+)/);
+    const parsedAt = atMatch ? Date.parse(atMatch[1]) : Number.NaN;
+    return {
+      count: countMatch ? Number(countMatch[1]) : 0,
+      at: Number.isFinite(parsedAt) ? parsedAt : null,
+    };
+  }
+
+  private async handleTerminalDatabaseLivenessFailure(
+    rec: AgentSandbox,
+    reason: string,
+  ): Promise<void> {
+    const marker = this.parseDatabaseLivenessRestartMarker(rec.error_message);
+    const now = Date.now();
+    // Keep this budget scoped to DB-liveness recovery. error_count is shared
+    // with unrelated reconciliation paths and must not consume this budget.
+    // An old DB-liveness episode also ages out so an agent is not permanently
+    // barred from automatic recovery after three failures over its lifetime.
+    const markerAge = marker.at === null ? null : now - marker.at;
+    const markerActive =
+      markerAge !== null && markerAge >= 0 && markerAge < DB_LIVENESS_RESTART_BUDGET_WINDOW_MS;
+    const count = markerActive ? marker.count : 0;
+    if (markerActive && markerAge !== null && markerAge < DB_LIVENESS_RESTART_COOLDOWN_MS) {
+      logger.warn("[agent-sandbox] Terminal database liveness failure inside restart cooldown", {
+        agentId: rec.id,
+        count,
+        reason,
+      });
+      return;
+    }
+    if (count >= DB_LIVENESS_RESTART_BUDGET) {
+      await agentSandboxesRepository.update(rec.id, {
+        status: "error",
+        error_count: count,
+        error_message: `${DB_LIVENESS_RESTART_MARKER} budget-exhausted count=${count} at=${new Date(now).toISOString()} reason=${reason}`,
+      });
+      logger.error("[agent-sandbox] Terminal database liveness restart budget exhausted", {
+        agentId: rec.id,
+        count,
+        reason,
+      });
+      return;
+    }
+
+    const nextCount = count + 1;
+    await agentSandboxesRepository.update(rec.id, {
+      error_count: nextCount,
+      error_message: `${DB_LIVENESS_RESTART_MARKER} count=${nextCount} at=${new Date(now).toISOString()} reason=${reason}`,
+    });
+    const { provisioningJobService } = await import("./provisioning-jobs");
+    const result = await provisioningJobService.enqueueAgentRestartOnce({
+      agentId: rec.id,
+      organizationId: rec.organization_id,
+      userId: rec.user_id,
+    });
+    logger.warn("[agent-sandbox] Enqueued restart for terminal database liveness failure", {
+      agentId: rec.id,
+      jobId: result.job.id,
+      created: result.created,
+      count: nextCount,
+      reason,
+    });
   }
 
   /**

--- a/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Focused unit coverage for the PGlite adapter's liveness probe and write-back
+ * wrapper contract. The base persistence methods are stubbed at the superclass
+ * boundary so this test exercises adapter behavior without requiring migrated
+ * SQL tables.
+ */
+
+import type { UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BaseDrizzleAdapter } from "../base";
+import { PgliteDatabaseAdapter } from "../pglite/adapter";
+
+const agentId = "00000000-0000-4000-8000-000000000001" as UUID;
+const entityId = "00000000-0000-4000-8000-000000000002" as UUID;
+const roomId = "00000000-0000-4000-8000-000000000003" as UUID;
+const worldId = "00000000-0000-4000-8000-000000000004" as UUID;
+const memoryId = "00000000-0000-4000-8000-000000000005" as UUID;
+const relationshipId = "00000000-0000-4000-8000-000000000006" as UUID;
+const taskId = "00000000-0000-4000-8000-000000000007" as UUID;
+
+function makeAdapter() {
+  const rawConnection = {
+    query: vi.fn(async (query: string) => {
+      if (query.includes("participants")) {
+        return { rows: [{ id: "participant-row" }] };
+      }
+      if (query.includes("relationships")) {
+        return { rows: [{ id: relationshipId }] };
+      }
+      if (query.includes("memories")) {
+        return { rows: [{ id: memoryId }] };
+      }
+      return { rows: [] };
+    }),
+  };
+  const manager = {
+    close: vi.fn(async () => undefined),
+    ensureSync: vi.fn(async () => undefined),
+    getConnection: vi.fn(() => rawConnection),
+    initialize: vi.fn(async () => undefined),
+    isInitialized: vi.fn(() => true),
+    isShuttingDown: vi.fn(() => false),
+    notifyWrite: vi.fn(),
+  };
+  const adapter = new PgliteDatabaseAdapter(agentId, manager as never);
+  const db = {
+    execute: vi.fn(async () => [{ "?column?": 1 }]),
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(db)),
+  };
+  (adapter as unknown as { db: typeof db }).db = db;
+  return { adapter, db, manager, rawConnection };
+}
+
+describe("PgliteDatabaseAdapter liveness", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses a real SELECT probe and fails closed when the handle is closed", async () => {
+    const { adapter, db, manager } = makeAdapter();
+
+    await expect(adapter.isReady()).resolves.toBe(true);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+
+    db.execute.mockRejectedValueOnce(new Error("PGlite is closed"));
+    await expect(adapter.isReady()).resolves.toBe(false);
+
+    manager.isShuttingDown.mockReturnValueOnce(true);
+    await expect(adapter.isReady()).resolves.toBe(false);
+
+    manager.isInitialized.mockReturnValueOnce(false);
+    await expect(adapter.isReady()).resolves.toBe(false);
+  });
+
+  it("keeps initialization, transaction, connection, close, and shutdown rejection semantics", async () => {
+    const { adapter, db, manager, rawConnection } = makeAdapter();
+
+    await expect(adapter.init()).resolves.toBeUndefined();
+    await expect(adapter.getConnection()).resolves.toBe(db);
+    expect(adapter.getRawConnection()).toBe(rawConnection);
+    await expect(
+      adapter.withEntityContext(null, async (tx) => {
+        expect(tx).toBe(db);
+        return "ok";
+      })
+    ).resolves.toBe("ok");
+    await expect(
+      (
+        adapter as unknown as {
+          withDatabase: <T>(operation: () => Promise<T>) => Promise<T>;
+        }
+      ).withDatabase(async () => "ready")
+    ).resolves.toBe("ready");
+
+    manager.isShuttingDown.mockReturnValueOnce(true);
+    await expect(
+      (
+        adapter as unknown as {
+          withDatabase: <T>(operation: () => Promise<T>) => Promise<T>;
+        }
+      ).withDatabase(async () => "never")
+    ).rejects.toThrow("Database is shutting down - operation rejected");
+
+    await adapter.close();
+    expect(manager.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits write-back records for successful adapter writes only", async () => {
+    const { adapter, manager } = makeAdapter();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createAgent").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateAgent").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteAgent").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteAgents").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createEntities").mockResolvedValue([entityId]);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateEntity").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteEntity").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createWorld").mockResolvedValue(worldId);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateWorld").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "removeWorld").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createRooms").mockResolvedValue([roomId]);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateRoom").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteRoom").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "addParticipant").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "removeParticipant").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createMemory").mockResolvedValue(memoryId);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateMemory").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteMemory").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteManyMemories").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteAllMemories").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createRelationship").mockResolvedValue(true);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateRelationship").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteRelationships").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "createTask").mockResolvedValue(taskId);
+    vi.spyOn(BaseDrizzleAdapter.prototype, "updateTask").mockResolvedValue();
+    vi.spyOn(BaseDrizzleAdapter.prototype, "deleteTask").mockResolvedValue();
+
+    await adapter.createAgent({ id: agentId, name: "Agent" });
+    await adapter.updateAgent(agentId, { name: "Updated" });
+    await adapter.deleteAgent(agentId);
+    await adapter.deleteAgents([agentId]);
+    await adapter.createEntities([{ id: entityId, names: ["Entity"], agentId }]);
+    await adapter.updateEntity({ id: entityId, names: ["Entity"], agentId });
+    await adapter.deleteEntity(entityId);
+    await adapter.createWorld({ id: worldId, name: "World", agentId });
+    await adapter.updateWorld({ id: worldId, name: "World", agentId });
+    await adapter.removeWorld(worldId);
+    await adapter.createRooms([{ id: roomId, name: "Room", agentId }]);
+    await adapter.updateRoom({ id: roomId, name: "Room", agentId });
+    await adapter.deleteRoom(roomId);
+    await adapter.addParticipant(entityId, roomId);
+    await adapter.removeParticipant(entityId, roomId);
+    await adapter.createMemory(
+      { id: memoryId, entityId, roomId, agentId, content: { text: "hi" } },
+      "messages"
+    );
+    await adapter.updateMemory({ id: memoryId, content: { text: "bye" } });
+    await adapter.deleteMemory(memoryId);
+    await adapter.deleteManyMemories([memoryId]);
+    await adapter.deleteAllMemories([roomId], "messages");
+    await adapter.createRelationship({ sourceEntityId: entityId, targetEntityId: agentId });
+    await adapter.updateRelationship({
+      id: relationshipId,
+      sourceEntityId: entityId,
+      targetEntityId: agentId,
+      agentId,
+    });
+    await adapter.deleteRelationships([relationshipId]);
+    await adapter.createTask({ id: taskId, name: "Task", agentId });
+    await adapter.updateTask(taskId, { name: "Updated task" });
+    await adapter.deleteTask(taskId);
+
+    expect(manager.notifyWrite.mock.calls.map((call) => call.slice(0, 2))).toEqual(
+      expect.arrayContaining([
+        ["agents", "insert"],
+        ["agents", "upsert"],
+        ["agents", "delete"],
+        ["entities", "insert"],
+        ["worlds", "insert"],
+        ["rooms", "insert"],
+        ["participants", "insert"],
+        ["memories", "insert"],
+        ["relationships", "insert"],
+        ["tasks", "insert"],
+      ])
+    );
+  });
+});

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -19,6 +19,7 @@ import {
   type UUID,
   type World,
 } from "@elizaos/core";
+import { sql } from "drizzle-orm";
 import { drizzle, type PgliteDatabase } from "drizzle-orm/pglite";
 import { BaseDrizzleAdapter } from "../base";
 import { DIMENSION_MAP, type EmbeddingDimensionColumn } from "../schema/embedding";
@@ -123,7 +124,16 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
     const managerWithState = this.manager as PGliteClientManager & {
       isInitialized?: () => boolean;
     };
-    return !this.manager.isShuttingDown() && managerWithState.isInitialized() === true;
+    if (this.manager.isShuttingDown() || managerWithState.isInitialized() !== true) {
+      return false;
+    }
+    try {
+      await this.db.execute(sql`SELECT 1`);
+      return true;
+    } catch {
+      // error-policy:J4 readiness probe returns explicit unavailable state
+      return false;
+    }
   }
 
   async close() {


### PR DESCRIPTION
## Summary

Fixes #16650.

A dedicated agent could keep process/container health green while its embedded PGlite was terminally closed, leaving all DB-backed operations dead until a manual restart. This PR makes database liveness an exercised end-to-end contract and gives the fleet supervisor a bounded recovery path.

- perform a real `SELECT 1` in runtime and cloud-agent health paths
- classify terminal PGlite closure separately from transient probe failures
- return HTTP 503 with `ready: false` and `canRespond: false` on terminal closure
- expose DB liveness in cloud-agent health and status RPC payloads
- consume terminal DB health in fleet heartbeat and enqueue the existing deduplicated restart job
- bound recovery to three restarts per one-hour window with a ten-minute cooldown
- keep transient failures on normal retry/hysteresis, with no immediate restart
- isolate the DB recovery budget from unrelated shared `error_count` uses
- make PGlite `isReady()` exercise the database rather than cached manager state

No auth, billing, backup/restore, persistence, or state-durability behavior is weakened.

## Incident proof

The regression test starts a real in-memory PGlite, proves `/api/health` is green, closes PGlite while the runtime remains alive, and proves health flips to HTTP 503 with terminal DB state. Supervisor tests prove terminal recovery enqueue, transient suppression, cooldown, and budget exhaustion.

Receipt: `PGLITE-LIVENESS-RECOVERY-2026-07-18.md`

## Tests

- `packages/agent`: focused real-PGlite health route, **1 passed**
- `packages/app-core`: cloud-agent DB liveness classification, **5 passed**
- `packages/cloud/shared`: recovery, transient, cooldown, budget tests, **5 passed**, 104 filtered
- `packages/cloud/shared`: `bun run typecheck`, **passed**
- Biome on all touched files, **passed**
- `git diff --check`, **passed**

Package-wide agent/app-core/plugin-sql typechecks were attempted but are blocked in this isolated worktree by missing pre-existing generated optional workspace packages/dist artifacts. Exact blockers and commands are recorded in the receipt. Focused suites compile and execute every changed liveness/recovery surface.

[sol-orch]

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend database-liveness and supervisor recovery change with no visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend database-liveness and supervisor recovery change with no visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or browser workflow changed; focused runtime and supervisor tests exercise the contract.
<!-- evidence-row:backend-logs -->
- [x] [Passing integration-tests job](https://github.com/elizaOS/eliza/actions/runs/29672893499/job/88154963110) exercises the changed runtime and cloud recovery paths.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console behavior, or network client changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, inference, or agent trajectory behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [PGlite liveness recovery receipt](https://github.com/elizaOS/eliza/blob/542d614c93dd4d6f0bed2a6b099b50b59ccab7ca/PGLITE-LIVENESS-RECOVERY-2026-07-18.md) records the incident proof, recovery policy, commands, and focused results.

[sol-orch]
