### PR TITLE
feat(redis): support atomic realtime voice quotas

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
@@ -33,7 +33,6 @@ const realWsHandlerExports = { ...realWsHandler };
 
 const attachCalls: Array<Record<string, unknown>> = [];
 let registrySize = 0;
-let evalCapableRedis = true;
 let durableStoreValue: unknown = { kind: "durable" };
 let binaryTypeWritable = true;
 
@@ -101,11 +100,11 @@ mock.module(`${sharedRoot}/lib/services/voice-usage-meter.ts`, usageMeterStub);
 
 mock.module("@/lib/cache/redis-factory", () => ({
   ...realRedisFactoryExports,
-  buildRedisClient: () => (evalCapableRedis ? { eval: () => undefined } : {}),
+  buildRedisClient: () => ({ eval: () => undefined }),
 }));
 mock.module(`${sharedRoot}/lib/cache/redis-factory.ts`, () => ({
   ...realRedisFactoryExports,
-  buildRedisClient: () => (evalCapableRedis ? { eval: () => undefined } : {}),
+  buildRedisClient: () => ({ eval: () => undefined }),
 }));
 
 // NOTE: we do NOT mock `../lib/session`. Mocking VoiceSession would clobber it
@@ -142,7 +141,6 @@ const originalWebSocketPair = (globalThis as { WebSocketPair?: unknown })
 beforeEach(() => {
   attachCalls.length = 0;
   registrySize = 0;
-  evalCapableRedis = true;
   durableStoreValue = { kind: "durable" };
   binaryTypeWritable = true;
   (globalThis as { WebSocketPair?: unknown }).WebSocketPair = class {
@@ -209,6 +207,28 @@ function upgrade(env: Record<string, string> = {}) {
   );
 }
 
+function buildCapturedSession(): { config: Record<string, unknown> } {
+  const deps = attachCalls[0].deps as {
+    buildSession: (args: Record<string, unknown>) => unknown;
+  };
+  return deps.buildSession({
+    claims: {
+      sessionId: "sess-upgrade-wire",
+      organizationId: "org-1",
+      userId: "user-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+    jti: "jti-upgrade-wire",
+    tokenExpSeconds: Math.floor(Date.now() / 1000) + 60,
+    downlink: {
+      sendControl: () => undefined,
+      sendAudio: () => undefined,
+      close: () => undefined,
+    },
+  }) as { config: Record<string, unknown> };
+}
+
 describe("voice-session ws upgrade (happy path)", () => {
   test("mints the socket pair, accepts the server, and returns a 101 with the client socket", async () => {
     const res = await upgrade();
@@ -219,27 +239,18 @@ describe("voice-session ws upgrade (happy path)", () => {
     expect(server.binaryType).toBe("arraybuffer");
   });
 
-  test("prefers the durable usage store when Redis is eval-capable", async () => {
-    evalCapableRedis = true;
+  test("prefers the durable usage store when the factory provides one", async () => {
     durableStoreValue = { kind: "durable" };
     const res = await upgrade();
     expect(res.status).toBe(101);
-    // The buildSession closure ran (invoked by the ws-handler stub) without throwing.
-    expect(attachCalls.length).toBe(1);
-  });
-
-  test("falls back to the in-memory store when Redis has no eval (Railway TCP)", async () => {
-    evalCapableRedis = false;
-    const res = await upgrade();
-    expect(res.status).toBe(101);
-    expect(attachCalls.length).toBe(1);
+    expect(buildCapturedSession().config.usageStore).toBe(durableStoreValue);
   });
 
   test("falls back to the in-memory store when no durable store is available", async () => {
     durableStoreValue = null;
     const res = await upgrade();
     expect(res.status).toBe(101);
-    expect(attachCalls.length).toBe(1);
+    expect(buildCapturedSession().config.usageStore).not.toBeNull();
   });
 
   test("still upgrades when the live registry is under the ceiling; admitSession reflects it", async () => {
@@ -252,41 +263,9 @@ describe("voice-session ws upgrade (happy path)", () => {
   test("buildSession wires a prewarm-capable scoped Eliza fetch", async () => {
     const res = await upgrade();
     expect(res.status).toBe(101);
-    const deps = attachCalls[0].deps as unknown as {
-      buildSession: (args: {
-        claims: Record<string, string>;
-        jti: string;
-        tokenExpSeconds: number;
-        downlink: Record<string, unknown>;
-      }) => {
-        config?: unknown;
-      };
-    };
     // Construct a REAL VoiceSession through the route's closure. No providers
-    // are dialed at construction time (start() is never called here), so this
-    // exercises the fetchImpl/prewarmElizaContext wiring added for the
-    // session-start tenancy warmup.
-    const session = deps.buildSession({
-      claims: {
-        sessionId: "sess-upgrade-wire",
-        organizationId: "org-1",
-        userId: "user-1",
-        agentId: "agent-1",
-        conversationId: "conv-1",
-      },
-      jti: "jti-upgrade-wire",
-      tokenExpSeconds: Math.floor(Date.now() / 1000) + 60,
-      downlink: {
-        sendControl: () => undefined,
-        sendAudio: () => undefined,
-        close: () => undefined,
-      },
-    }) as unknown as {
-      config: {
-        fetchImpl?: { prewarm?: unknown };
-        prewarmElizaContext?: unknown;
-      };
-    };
+    // are dialed at construction time (start() is never called here).
+    const session = buildCapturedSession();
     expect(typeof session.config.fetchImpl).toBe("function");
     expect(typeof session.config.prewarmElizaContext).toBe("function");
     expect(session.config.prewarmElizaContext).toBe(

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -55,11 +55,9 @@ import { VoiceSession } from "../lib/session";
 const app = new Hono<AppEnv>();
 
 /**
- * Per-worker fallback usage store, used ONLY when no eval-capable durable Redis
- * is configured (SocketRedis lacks Lua). Module-scoped so daily org/user caps
- * are shared across ALL sessions on this worker isolate, instead of resetting
- * per connection. Cross-worker aggregation still requires an Upstash durable
- * store; this bounds abuse to per-worker caps rather than none.
+ * Per-worker fallback usage store, used only when no eval-capable durable Redis
+ * is configured. Module-scoped so daily org/user caps are shared across all
+ * sessions on this worker isolate instead of resetting per connection.
  */
 let workerFallbackUsageStore: InMemoryVoiceUsageStore | null = null;
 function getWorkerFallbackUsageStore(): InMemoryVoiceUsageStore {
@@ -159,29 +157,16 @@ app.get("/", (c) => {
   server.accept();
 
   const usageLimits = resolveVoiceUsageLimits(env);
-  // Prefer the durable cross-worker store, but ONLY when its backing Redis
-  // supports the atomic `eval` (Lua) the RedisVoiceUsageStore requires. The
-  // Railway TCP SocketRedis client has no `eval`, so using it would make every
-  // admission throw and close sessions as `metering_unavailable`. In that case
-  // fall back to the per-worker InMemory store: metering is still enforced
-  // (fail-closed, per-worker caps) rather than the session being unusable.
+  // Prefer durable, atomic cross-worker metering whenever the configured Redis
+  // exposes EVAL. SocketRedis and Upstash do; the non-Lua test mock does not.
   const durableStore = createDurableVoiceUsageStore(
     env as unknown as Parameters<typeof createDurableVoiceUsageStore>[0],
   );
-  // The RedisVoiceUsageStore uses atomic `eval` (Lua). Only the Upstash REST
-  // client implements it; the Railway TCP SocketRedis (REDIS_URL) does not, and
-  // using it would make every admission throw `eval is not a function` and
-  // close sessions as `metering_unavailable`. Confirm eval before trusting the
-  // durable store; otherwise fall back to the per-worker InMemory store so
-  // metering is still enforced (fail-closed) instead of the session being dead.
+  const usageStore: VoiceUsageStore =
+    durableStore ?? getWorkerFallbackUsageStore();
   const rawRedis = buildRedisClient(
     env as unknown as Parameters<typeof buildRedisClient>[0],
   );
-  const evalCapable =
-    typeof (rawRedis as unknown as { eval?: unknown } | null)?.eval ===
-    "function";
-  const usageStore: VoiceUsageStore =
-    durableStore && evalCapable ? durableStore : getWorkerFallbackUsageStore();
 
   const maxSessions = resolveMaxSessions(env);
   // Capture Worker bindings while this upgrade request is live. The returned

--- a/packages/cloud/shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud/shared/src/lib/cache/redis-factory.ts
@@ -37,11 +37,27 @@ interface CompatibleRedisPipeline {
 // the same public surface. This avoids a double cast (which hid pipeline drift)
 // without adding a third overloaded class to the Upstash union. Override the
 // pipeline class itself because its private fields are intentionally nominal.
+export interface EvalCapableRedis {
+  eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown>;
+}
+
 type CompatibleSocketRedis = Pick<
   SocketRedis,
-  Exclude<Extract<keyof SocketRedis, keyof MockSocketRedis>, "pipeline">
-> & { pipeline(): CompatibleRedisPipeline };
+  Exclude<Extract<keyof SocketRedis, keyof MockSocketRedis>, "pipeline" | "eval">
+> & {
+  pipeline(): CompatibleRedisPipeline;
+  // The in-memory factory client intentionally has no Lua support. Keeping the
+  // capability optional makes that limitation visible instead of hiding it
+  // behind a cast at the durable-store boundary.
+  eval?: EvalCapableRedis["eval"];
+};
 export type CompatibleRedis = CompatibleSocketRedis | UpstashRedis;
+
+export function supportsRedisEval(
+  redis: CompatibleRedis,
+): redis is CompatibleRedis & EvalCapableRedis {
+  return typeof redis.eval === "function";
+}
 
 export interface RedisFactoryEnv {
   REDIS_URL?: string;

--- a/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
@@ -22,6 +22,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { createServer, type Socket as NetSocket, type Server } from "node:net";
+import { RedisVoiceUsageStore } from "../services/voice-usage-meter";
 import { SocketRedis } from "./socket-redis";
 
 const servers: Server[] = [];
@@ -124,6 +125,67 @@ describe("SocketRedis connection resilience", () => {
     expect(await redis.get("fresh")).toBeNull();
     expect(connections).toBe(2);
 
+    await redis.quit();
+  });
+
+  test("voice admission fails closed on outage and recovers on a fresh connection", async () => {
+    let connections = 0;
+    const server = createServer((socket: NetSocket) => {
+      connections += 1;
+      if (connections === 1) {
+        socket.once("data", () => socket.destroy());
+        return;
+      }
+      socket.once("data", () => socket.write("*4\r\n:1\r\n:0\r\n:1000000\r\n:1000000\r\n"));
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+    const store = new RedisVoiceUsageStore(redis, () => Date.UTC(2026, 6, 10));
+    const identity = { organizationId: "org", userId: "user" };
+    const limits = { organizationDailyMinutes: 10, userDailyMinutes: 5 };
+
+    await expect(store.checkAndRecord(identity, 1, limits)).rejects.toThrow();
+    await expect(store.checkAndRecord(identity, 1, limits)).resolves.toMatchObject({
+      allowed: true,
+      organizationUsedMinutes: 1,
+      userUsedMinutes: 1,
+    });
+    expect(connections).toBe(2);
+
+    await redis.quit();
+  });
+
+  test("serializes EVAL in Upstash order and decodes nested RESP arrays", async () => {
+    let request = "";
+    const server = createServer((socket: NetSocket) => {
+      socket.once("data", (chunk) => {
+        request = chunk.toString("utf8");
+        socket.write("*3\r\n:1\r\n*2\r\n$3\r\norg\r\n$4\r\nuser\r\n$-1\r\n");
+      });
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+
+    expect(await redis.eval("return 1", ["org", "user"], [7, "arg"])).toEqual([
+      1,
+      ["org", "user"],
+      null,
+    ]);
+    expect(request).toBe(
+      "*7\r\n$4\r\nEVAL\r\n$8\r\nreturn 1\r\n$1\r\n2\r\n$3\r\norg\r\n$4\r\nuser\r\n$1\r\n7\r\n$3\r\narg\r\n",
+    );
+
+    await redis.quit();
+  });
+
+  test("propagates an error nested inside an EVAL response", async () => {
+    const server = createServer((socket: NetSocket) => {
+      socket.once("data", () => socket.write("*2\r\n:1\r\n-ERR script failed\r\n"));
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+
+    await expect(redis.eval("return 1", [], [])).rejects.toThrow("ERR script failed");
     await redis.quit();
   });
 });

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -807,6 +807,12 @@ export class SocketRedis {
     return asString(v) ?? "PONG";
   }
 
+  /** Execute a Lua script using the Upstash-compatible argument shape. */
+  async eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown> {
+    const [value] = await this.conn.send([["EVAL", script, keys.length, ...keys, ...args]]);
+    return unwrap(value);
+  }
+
   pipeline(): Pipeline {
     return new Pipeline(this.conn);
   }

--- a/packages/cloud/shared/src/lib/services/voice-usage-meter.redis.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/voice-usage-meter.redis.integration.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SocketRedis } from "../cache/socket-redis";
+import { RedisVoiceUsageStore } from "./voice-usage-meter";
+
+const redisUrl = process.env.REDIS_INTEGRATION_URL;
+const run = typeof redisUrl === "string" && redisUrl.length > 0;
+const suite = run ? describe : describe.skip;
+const nonce = `integration-${process.pid}-${Date.now()}`;
+const clients = run ? [new SocketRedis(redisUrl), new SocketRedis(redisUrl)] : [];
+
+function identity(suffix: string, user = "user") {
+  return { organizationId: `${nonce}-${suffix}`, userId: user };
+}
+
+function key(day: string, organizationId: string, userId?: string): string {
+  return userId
+    ? `voice-usage:${day}:user:${organizationId}:${userId}`
+    : `voice-usage:${day}:org:${organizationId}`;
+}
+
+afterAll(async () => {
+  await Promise.all(clients.map((client) => client.quit()));
+});
+
+suite("RedisVoiceUsageStore with real Redis", () => {
+  test("shares atomic admission across clients and isolates organizations and users", async () => {
+    const now = Date.UTC(2026, 6, 10, 12);
+    const stores = clients.map((client) => new RedisVoiceUsageStore(client, () => now));
+    const shared = identity("atomic");
+    const tightLimits = { organizationDailyMinutes: 1, userDailyMinutes: 1 };
+
+    const decisions = await Promise.all([
+      stores[0].checkAndRecord(shared, 1, tightLimits),
+      stores[1].checkAndRecord(shared, 1, tightLimits),
+    ]);
+    expect(decisions.filter((decision) => decision.allowed)).toHaveLength(1);
+    expect(decisions.filter((decision) => !decision.allowed)).toHaveLength(1);
+
+    const orgAUser1 = identity("isolation", "user-1");
+    const orgAUser2 = identity("isolation", "user-2");
+    const orgBUser1 = identity("other-org", "user-1");
+    const limits = { organizationDailyMinutes: 10, userDailyMinutes: 2 };
+    expect((await stores[0].checkAndRecord(orgAUser1, 2, limits)).allowed).toBe(true);
+    expect(await stores[1].checkAndRecord(orgAUser1, 1, limits)).toMatchObject({
+      allowed: false,
+      scope: "user",
+    });
+    expect((await stores[1].checkAndRecord(orgAUser2, 2, limits)).allowed).toBe(true);
+    expect((await stores[1].checkAndRecord(orgBUser1, 2, limits)).allowed).toBe(true);
+  });
+
+  test("releases reservations, applies TTL, and rolls over at UTC midnight", async () => {
+    let now = Date.UTC(2026, 6, 10, 23, 59, 59);
+    const store = new RedisVoiceUsageStore(clients[0], () => now);
+    const subject = identity("lifecycle");
+    const limits = { organizationDailyMinutes: 2, userDailyMinutes: 2 };
+
+    expect((await store.checkAndRecord(subject, 2, limits)).allowed).toBe(true);
+    await store.release(subject, 1);
+    expect((await store.checkAndRecord(subject, 1, limits)).allowed).toBe(true);
+
+    const ttl = await clients[1].pttl(key("2026-07-10", subject.organizationId));
+    expect(ttl).not.toBeNull();
+    expect(ttl as number).toBeGreaterThan(86_400_000);
+    expect(ttl as number).toBeLessThanOrEqual(86_402_000);
+
+    now = Date.UTC(2026, 6, 11);
+    expect(await store.checkAndRecord(subject, 2, limits)).toMatchObject({
+      allowed: true,
+      day: "2026-07-11",
+    });
+
+    await clients[0].del(
+      key("2026-07-10", subject.organizationId),
+      key("2026-07-10", subject.organizationId, subject.userId),
+      key("2026-07-11", subject.organizationId),
+      key("2026-07-11", subject.organizationId, subject.userId),
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/voice-usage-meter.test.ts
+++ b/packages/cloud/shared/src/lib/services/voice-usage-meter.test.ts
@@ -55,8 +55,11 @@ describe("InMemoryVoiceUsageStore", () => {
 });
 
 describe("RedisVoiceUsageStore", () => {
-  test("does not misclassify the non-Lua mock client as durable", () => {
+  test("selects SocketRedis as durable for REDIS_URL but not the non-Lua mock", () => {
     expect(createDurableVoiceUsageStore({ MOCK_REDIS: "1" })).toBeNull();
+    expect(createDurableVoiceUsageStore({ REDIS_URL: "redis://127.0.0.1:6379" })).toBeInstanceOf(
+      RedisVoiceUsageStore,
+    );
   });
 
   test("uses one atomic script with day-scoped org and user keys", async () => {
@@ -104,6 +107,21 @@ describe("RedisVoiceUsageStore", () => {
       userDailyMinutes: 5,
     });
     expect(decision).toMatchObject({ allowed: false, scope: "user", usedMinutes: 4.5 });
+  });
+
+  test("fails closed on malformed script responses instead of fabricating success", async () => {
+    const redis: AtomicVoiceUsageRedis = {
+      async eval() {
+        return [1, 0, "not-a-counter", 1_000_000];
+      },
+    };
+    const store = new RedisVoiceUsageStore(redis, () => Date.UTC(2026, 6, 10));
+    await expect(
+      store.checkAndRecord({ organizationId: "org", userId: "user" }, 1, {
+        organizationDailyMinutes: 10,
+        userDailyMinutes: 5,
+      }),
+    ).rejects.toThrow("invalid response");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/voice-usage-meter.ts
+++ b/packages/cloud/shared/src/lib/services/voice-usage-meter.ts
@@ -1,4 +1,9 @@
-import { buildRedisClient, type RedisFactoryEnv } from "../cache/redis-factory";
+import {
+  buildRedisClient,
+  type EvalCapableRedis,
+  type RedisFactoryEnv,
+  supportsRedisEval,
+} from "../cache/redis-factory";
 
 const DAY_MS = 86_400_000;
 const COUNTER_SCALE = 1_000_000;
@@ -101,9 +106,7 @@ export class InMemoryVoiceUsageStore implements VoiceUsageStore {
   }
 }
 
-export interface AtomicVoiceUsageRedis {
-  eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown>;
-}
+export interface AtomicVoiceUsageRedis extends EvalCapableRedis {}
 
 const RELEASE_LUA = `
 for _, key in ipairs(KEYS) do
@@ -156,10 +159,20 @@ export class RedisVoiceUsageStore implements VoiceUsageStore {
       ],
       [requested, orgLimit, userLimit, ttlSeconds],
     );
-    if (!Array.isArray(raw) || raw.length < 4) {
+    if (!Array.isArray(raw) || raw.length !== 4) {
       throw new Error("Voice usage store returned an invalid response");
     }
     const [allowed, deniedScope, orgRaw, userRaw] = raw.map(Number);
+    if (
+      ![allowed, deniedScope, orgRaw, userRaw].every(Number.isFinite) ||
+      (allowed !== 0 && allowed !== 1) ||
+      (allowed === 1 && deniedScope !== 0) ||
+      (allowed === 0 && deniedScope !== 1 && deniedScope !== 2) ||
+      orgRaw < 0 ||
+      userRaw < 0
+    ) {
+      throw new Error("Voice usage store returned an invalid response");
+    }
     const orgUsed = orgRaw / COUNTER_SCALE;
     const userUsed = userRaw / COUNTER_SCALE;
     if (allowed === 1) {
@@ -207,7 +220,7 @@ export function createDurableVoiceUsageStore(
   // not Lua. Local/tests use the isolate-safe in-memory store instead.
   if (env.MOCK_REDIS === "1") return null;
   const redis = buildRedisClient(env);
-  return redis ? new RedisVoiceUsageStore(redis as AtomicVoiceUsageRedis, now) : null;
+  return redis && supportsRedisEval(redis) ? new RedisVoiceUsageStore(redis, now) : null;
 }
 
 export type ByteRateDecision = {


### PR DESCRIPTION
## Summary

Fixes #16435.

- add a typed Upstash-shaped `SocketRedis.eval(script, keys, args)` that emits RESP `EVAL`, key count, keys, then arguments
- recursively unwrap nested RESP values and propagate nested Redis errors
- expose eval capability through `CompatibleRedis` and a type guard, removing the durable-store cast
- select `RedisVoiceUsageStore` for `REDIS_URL` instead of isolate-local metering
- reject malformed Lua tuples so metering cannot fabricate a successful admission
- preserve connection timeout, queue, reconnect, and stale-context ownership behavior

## Reproduction

On `develop`, a `REDIS_URL` client has no `eval` method:

```text
typeof eval: undefined
TypeError: SocketRedis.eval is not a function
```

This forced the voice route onto `InMemoryVoiceUsageStore` despite configured durable Redis.

## Evidence

| Check | Result |
| --- | --- |
| focused SocketRedis + voice meter tests | 17 passed, 0 failed |
| real Redis 7 integration, two TCP clients | 2 passed, 0 failed; atomic shared admission, org/user isolation, release, TTL, UTC rollover |
| voice WS route assertions | 7 passed, 0 failed assertions; Bun canary process retains an existing open handle after reporting passes |
| scoped Biome on all 8 touched files | passed |
| `git diff --check` | passed |
| cloud shared/API `tsgo --noEmit` | no touched-file errors; blocked by existing `service-routing.ts` baseline errors for `drain-soonest-reset`, `expired`, and `weeklyModelBuckets` in shared/core |

The outage test drops the first TCP connection during voice admission, proves that admission rejects fail-closed, then proves the same store reconnects with a fresh socket and admits successfully.

No auth, billing, provider selection, or voice latency path changes. No baseline, lockfile, test deletion, suppression, or check configuration changes.

`[sol-orch]`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend Redis protocol and metering selection only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend Redis protocol and metering selection only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - backend-only test logs are summarized in the Evidence section; no persistent deployed backend log artifact is produced by this protocol-unit change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source or browser network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, trajectory, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the real Redis integration test creates only ephemeral unique keys, asserts their values/TTLs, and deletes or expires them; no persistent domain artifact is produced.

## Known gaps / failures

- The scoped cloud typechecks reach only existing unrelated `service-routing.ts` baseline errors. No touched file appears in the diagnostics.
- The focused WS route file reports all 7 tests passed, then this Bun canary retains an existing open handle until the command watchdog ends it. The same file exhibited this behavior before the final test edits; individual assertions are green.
- Per #16633, obsolete Anthropic/Claude review failures are not treated as blockers.