### PR TITLE
feat(app): host wallpaper behind native chat glass (#15891)

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GlassBridgePlugin.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GlassBridgePlugin.java
@@ -28,13 +28,17 @@ package ai.elizaos.app;
 
 import android.animation.ValueAnimator;
 import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.RectF;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.CookieManager;
 import android.webkit.WebView;
+import android.widget.ImageView;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -42,8 +46,15 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Native material regions behind the WebView; see the file header. */
 @CapacitorPlugin(name = "GlassBridge")
@@ -60,6 +71,10 @@ public class GlassBridgePlugin extends Plugin {
     private final Map<String, View> regions = new HashMap<>();
     private float groupingSpacing = 0f;
     private boolean webViewMadeTransparent = false;
+    private ImageView backdropView;
+    private View.OnLayoutChangeListener backdropLayoutListener;
+    private final AtomicInteger backdropGeneration = new AtomicInteger();
+    private final ExecutorService backdropLoader = Executors.newSingleThreadExecutor();
 
     private static boolean glassSupported() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
@@ -70,6 +85,51 @@ public class GlassBridgePlugin extends Plugin {
         JSObject result = new JSObject();
         result.put("available", glassSupported());
         call.resolve(result);
+    }
+
+    /**
+     * Decode and install the current wallpaper below the WebView. The web side
+     * keeps painting CSS until {@code applied:true}, so a load error can never
+     * expose the activity window as a black region.
+     */
+    @PluginMethod
+    public void setBackdrop(PluginCall call) {
+        if (!glassSupported()) {
+            resolveApplied(call, false);
+            return;
+        }
+        String imageUrl = call.getString("imageUrl");
+        Integer parsedColor = parseCssHexColor(call.getString("color"));
+        int color = parsedColor != null ? parsedColor : Color.BLACK;
+        int generation = backdropGeneration.incrementAndGet();
+        Activity activity = getActivity();
+        if (activity == null) {
+            resolveApplied(call, false);
+            return;
+        }
+        if (imageUrl == null) {
+            activity.runOnUiThread(() -> installBackdrop(
+                    call, generation, null, color));
+            return;
+        }
+        URI uri;
+        try {
+            uri = URI.create(imageUrl);
+        } catch (IllegalArgumentException exception) {
+            resolveApplied(call, false);
+            return;
+        }
+        String scheme = uri.getScheme();
+        if (!("http".equals(scheme) || "https".equals(scheme)
+                || "capacitor".equals(scheme))) {
+            resolveApplied(call, false);
+            return;
+        }
+        backdropLoader.execute(() -> {
+            Bitmap bitmap = loadBackdropBitmap(activity, uri);
+            activity.runOnUiThread(() -> installBackdrop(
+                    call, generation, bitmap, color));
+        });
     }
 
     @PluginMethod
@@ -312,6 +372,99 @@ public class GlassBridgePlugin extends Plugin {
         // the backdrop, mirroring the iOS glass rim.
         drawable.setStroke(1, light ? 0x1A000000 : 0x1FFFFFFF);
         return drawable;
+    }
+
+    private void installBackdrop(
+            PluginCall call, int generation, Bitmap bitmap, int color) {
+        if (generation != backdropGeneration.get()) {
+            resolveApplied(call, false);
+            return;
+        }
+        if (call.getString("imageUrl") != null && bitmap == null) {
+            resolveApplied(call, false);
+            return;
+        }
+        WebView webView = bridge.getWebView();
+        ViewGroup container = webView != null ? (ViewGroup) webView.getParent() : null;
+        if (webView == null || container == null) {
+            resolveApplied(call, false);
+            return;
+        }
+        Activity activity = getActivity();
+        if (activity == null) {
+            resolveApplied(call, false);
+            return;
+        }
+        makeWebViewTransparentOnce(webView);
+        ImageView next = new ImageView(activity);
+        next.setScaleType(ImageView.ScaleType.CENTER_CROP);
+        next.setBackgroundColor(color);
+        next.setImageBitmap(bitmap);
+        ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(
+                webView.getWidth(), webView.getHeight());
+        next.setLayoutParams(params);
+        next.setX(webView.getX());
+        next.setY(webView.getY());
+        container.addView(next, 0);
+        if (backdropLayoutListener != null) {
+            webView.removeOnLayoutChangeListener(backdropLayoutListener);
+        }
+        if (backdropView != null && backdropView.getParent() instanceof ViewGroup) {
+            ((ViewGroup) backdropView.getParent()).removeView(backdropView);
+        }
+        backdropView = next;
+        backdropLayoutListener = (view, left, top, right, bottom,
+                oldLeft, oldTop, oldRight, oldBottom) -> {
+            ViewGroup.LayoutParams layout = next.getLayoutParams();
+            layout.width = right - left;
+            layout.height = bottom - top;
+            next.setLayoutParams(layout);
+            next.setX(view.getX());
+            next.setY(view.getY());
+        };
+        webView.addOnLayoutChangeListener(backdropLayoutListener);
+        resolveApplied(call, true);
+    }
+
+    private Bitmap loadBackdropBitmap(Activity activity, URI uri) {
+        String path = uri.getPath() != null ? uri.getPath() : "";
+        boolean bundled = "capacitor".equals(uri.getScheme())
+                || ("localhost".equals(uri.getHost()) && !path.startsWith("/api/"));
+        try {
+            if (bundled) {
+                String asset = "public/" + path.replaceFirst("^/+", "");
+                try (InputStream stream = activity.getAssets().open(asset)) {
+                    return BitmapFactory.decodeStream(stream);
+                }
+            }
+            HttpURLConnection connection = (HttpURLConnection) new URL(uri.toString())
+                    .openConnection();
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(20_000);
+            String cookie = CookieManager.getInstance().getCookie(uri.toString());
+            if (cookie != null && !cookie.isEmpty()) {
+                connection.setRequestProperty("Cookie", cookie);
+            }
+            connection.connect();
+            if (connection.getResponseCode() < 200
+                    || connection.getResponseCode() >= 300) {
+                connection.disconnect();
+                return null;
+            }
+            try (InputStream stream = connection.getInputStream()) {
+                return BitmapFactory.decodeStream(stream);
+            } finally {
+                connection.disconnect();
+            }
+        } catch (Exception exception) {
+            return null;
+        }
+    }
+
+    private static void resolveApplied(PluginCall call, boolean applied) {
+        JSObject result = new JSObject();
+        result.put("applied", applied);
+        call.resolve(result);
     }
 
     private void makeWebViewTransparentOnce(WebView webView) {

--- a/packages/app-core/platforms/ios/App/App/GlassBridge.swift
+++ b/packages/app-core/platforms/ios/App/App/GlassBridge.swift
@@ -34,6 +34,7 @@ public class GlassBridge: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "updateRect", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "detachGlass", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setGrouping", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setBackdrop", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getRegionState", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isAvailable", returnType: CAPPluginReturnPromise),
     ]
@@ -44,6 +45,8 @@ public class GlassBridge: CAPPlugin, CAPBridgedPlugin {
     /// next attach (see setGrouping).
     private var groupingSpacing: CGFloat = 0
     private var webViewMadeTransparent = false
+    private var backdropView: UIImageView?
+    private var backdropGeneration = 0
 
     private static var glassSupported: Bool {
         #if compiler(>=6.2) && canImport(UIKit)
@@ -56,6 +59,54 @@ public class GlassBridge: CAPPlugin, CAPBridgedPlugin {
 
     @objc public func isAvailable(_ call: CAPPluginCall) {
         call.resolve(["available": Self.glassSupported])
+    }
+
+    /// Host the wallpaper below the WebView so native glass has real pixels to
+    /// sample. The promise resolves true only after an image has decoded and
+    /// been installed; web keeps its DOM wallpaper until that acknowledgement.
+    @objc public func setBackdrop(_ call: CAPPluginCall) {
+        guard Self.glassSupported else {
+            call.resolve(["applied": false])
+            return
+        }
+        let imageUrl = call.getString("imageUrl")
+        let color = call.getString("color").flatMap(Self.color(fromCSSHex:)) ?? .black
+        backdropGeneration += 1
+        let generation = backdropGeneration
+
+        guard let imageUrl else {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, generation == self.backdropGeneration,
+                    let webView = self.webView, let container = webView.superview
+                else {
+                    call.resolve(["applied": false])
+                    return
+                }
+                self.makeWebViewTransparentOnce(webView)
+                self.installBackdrop(image: nil, color: color, in: container, below: webView)
+                call.resolve(["applied": true])
+            }
+            return
+        }
+        guard let url = URL(string: imageUrl), ["http", "https", "capacitor"].contains(url.scheme ?? "") else {
+            call.resolve(["applied": false])
+            return
+        }
+
+        loadBackdropData(url: url) { [weak self] data in
+            DispatchQueue.main.async {
+                guard let self, generation == self.backdropGeneration,
+                    let data, let image = UIImage(data: data),
+                    let webView = self.webView, let container = webView.superview
+                else {
+                    call.resolve(["applied": false])
+                    return
+                }
+                self.makeWebViewTransparentOnce(webView)
+                self.installBackdrop(image: image, color: color, in: container, below: webView)
+                call.resolve(["applied": true])
+            }
+        }
     }
 
     @objc public func attachGlass(_ call: CAPPluginCall) {
@@ -192,6 +243,46 @@ public class GlassBridge: CAPPlugin, CAPBridgedPlugin {
     }
 
     // MARK: - Helpers
+
+    private func installBackdrop(
+        image: UIImage?, color: UIColor, in container: UIView, below webView: UIView
+    ) {
+        let next = UIImageView(frame: webView.frame)
+        next.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        next.contentMode = .scaleAspectFill
+        next.clipsToBounds = true
+        next.backgroundColor = color
+        next.image = image
+        container.insertSubview(next, at: 0)
+        backdropView?.removeFromSuperview()
+        backdropView = next
+    }
+
+    private func loadBackdropData(url: URL, completion: @escaping (Data?) -> Void) {
+        // Capacitor-served public assets live in the app bundle; its custom URL
+        // scheme is a WebView handler, not a URLSession endpoint.
+        if url.scheme == "capacitor" || (url.host == "localhost" && !url.path.hasPrefix("/api/")) {
+            let relative = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            let bundled = Bundle.main.resourceURL?
+                .appendingPathComponent("public", isDirectory: true)
+                .appendingPathComponent(relative)
+            completion(bundled.flatMap { try? Data(contentsOf: $0) })
+            return
+        }
+        guard let webView else {
+            completion(nil)
+            return
+        }
+        webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+            var request = URLRequest(url: url)
+            let headers = HTTPCookie.requestHeaderFields(with: cookies)
+            for (key, value) in headers { request.setValue(value, forHTTPHeaderField: key) }
+            URLSession.shared.dataTask(with: request) { data, response, _ in
+                let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                completion((200..<300).contains(status) ? data : nil)
+            }.resume()
+        }
+    }
 
     /// Rects arrive viewport-relative (CSS px == points); offset into the
     /// container's coordinate space by the webview's frame origin.

--- a/packages/app-core/scripts/native-glass-backdrop-contract.test.mjs
+++ b/packages/app-core/scripts/native-glass-backdrop-contract.test.mjs
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (relative) =>
+  readFileSync(new URL(relative, import.meta.url), "utf8");
+
+const ios = read("../platforms/ios/App/App/GlassBridge.swift");
+const android = read(
+  "../platforms/android/app/src/main/java/ai/elizaos/app/GlassBridgePlugin.java",
+);
+
+describe("native GlassBridge wallpaper contract", () => {
+  it("exposes setBackdrop on both native plugins", () => {
+    expect(ios).toContain('CAPPluginMethod(name: "setBackdrop"');
+    expect(ios).toContain("func setBackdrop(");
+    expect(android).toContain("void setBackdrop(PluginCall call)");
+  });
+
+  it("acknowledges images only after decode and keeps a solid clear path", () => {
+    expect(ios).toContain("UIImage(data: data)");
+    expect(ios).toContain('call.resolve(["applied": true])');
+    expect(android).toContain("BitmapFactory.decodeStream");
+    expect(android).toContain("resolveApplied(call, true)");
+    expect(ios).toContain("installBackdrop(image: nil, color: color");
+    expect(android).toContain("generation, null, color");
+  });
+
+  it("reuses WebView cookies for content-addressed media requests", () => {
+    expect(ios).toContain("httpCookieStore.getAllCookies");
+    expect(android).toContain("CookieManager.getInstance().getCookie");
+  });
+});

--- a/packages/app/test/android/glass-bridge.android.spec.ts
+++ b/packages/app/test/android/glass-bridge.android.spec.ts
@@ -20,6 +20,7 @@ type RegionState = {
 
 type GlassPlugin = {
   isAvailable(): Promise<{ available: boolean }>;
+  setBackdrop(o: unknown): Promise<{ applied: boolean }>;
   attachGlass(o: unknown): Promise<{ attached: boolean }>;
   updateRect(o: unknown): Promise<void>;
   detachGlass(o: unknown): Promise<void>;
@@ -101,6 +102,10 @@ test("GlassBridge native-view lifecycle, boundary validation, and rendered pixel
     if (!plugin) return { error: "GlassBridge plugin not registered" } as const;
     (window as unknown as { __glass: GlassPlugin }).__glass = plugin;
     const availability = await plugin.isAvailable();
+    const backdrop = await plugin.setBackdrop({
+      imageUrl: new URL("/wallpapers/canopy.webp", window.location.href).href,
+      color: "#002244",
+    });
     // Bright saturated tint so the pixel capture proves the panel is OUR
     // native material, not the window background.
     const attach = await plugin.attachGlass({
@@ -122,6 +127,7 @@ test("GlassBridge native-view lifecycle, boundary validation, and rendered pixel
     const afterReattach = await plugin.getRegionState({ id: "e2e-probe" });
     return {
       availability,
+      backdrop,
       attach,
       reattach,
       afterAttach,
@@ -132,6 +138,7 @@ test("GlassBridge native-view lifecycle, boundary validation, and rendered pixel
   if ("error" in boot) throw new Error(String(boot.error));
 
   expect(boot.availability.available).toBe(expectedAvailable);
+  expect(boot.backdrop.applied).toBe(expectedAvailable);
   expect(boot.attach.attached).toBe(expectedAvailable);
   expect(boot.reattach.attached).toBe(expectedAvailable);
   if (!expectedAvailable) return; // pre-31 device: CSS tier, nothing to render

--- a/packages/docs/ongoing-development/liquid-glass-unification.md
+++ b/packages/docs/ongoing-development/liquid-glass-unification.md
@@ -27,14 +27,18 @@ chat sheet and notification cards used it, each with hand-tuned numbers.
   document (App root, next to `AppBackground`).
 - **`useNativeGlass`** — the tier probe: `native` → `css-refraction`
   (Chromium `@supports (backdrop-filter: url(#x))`) → `css-frosted`
-  (universal). Resolves synchronously to a CSS tier and upgrades to native
-  async — no flash, no layout shift.
+  (universal). Resolves synchronously to a CSS tier and upgrades only after
+  both the plugin capability probe and native image-wallpaper acknowledgement
+  succeed. A shader, unsupported URL, decode failure, or old shell stays CSS,
+  so a transparent WebView region can never expose a black window.
 - **`native-bridge.ts` + `GlassBridge.swift` + `GlassBridgePlugin.java`** —
   real native material on both mobile platforms, one JS API. The Swift plugin
   (`packages/app-core/platforms/ios/App/App/GlassBridge.swift`, same
   registration pattern as `ElizaKeyboardBridge`) attaches a
   `UIVisualEffectView(UIGlassEffect)` **below the webview**, anchored to a
-  web-reported rect, and flips the webview transparent on first attach. Gated
+  web-reported rect. `setBackdrop({ imageUrl?, color? })` installs an image or
+  solid host layer below the WebView first; both platforms reuse WebView cookies
+  for `/api/media/<sha256>` and acknowledge only after image decode. Gated
   `#if compiler(>=6.2)` + `if #available(iOS 26, *)`. The Java plugin
   (`packages/app-core/platforms/android/.../GlassBridgePlugin.java`,
   registered in `MainActivity`) mirrors the API with a Material
@@ -73,13 +77,13 @@ Findings that shaped this (2026-07 research):
 | Surface | State |
 | --- | --- |
 | Notification cards | already on the liquid-glass optical stack (shade v4) |
-| Chat sheet | already on sheet-tier numbers; tokens now canonical in `glass/tokens.ts` |
+| Chat sheet | native material at settled inset detents over native-hosted image wallpaper; detaches to CSS blur for every active drag; full bleed stays opaque |
 | + menu (chat composer) | migrated — `DropdownMenuContent glass` → `menu` variant |
 | Other dropdowns/popovers (slash menu, config selects) | pending — same `glass` prop |
 | ViewHeader back button / pills | pending — `pill` variant |
 | NotificationBanners (toasts) | pending — `banner` variant |
 | `HOME_GLASS_CLASS` / `WALLPAPER_GLASS` family | pending consolidation into tokens |
-| Native tier wiring (attach pill/sheet regions) | plugin + probe shipped on iOS AND Android (device e2e: `packages/app/test/android/glass-bridge.android.spec.ts`); surface adoption blocked on native-hosted wallpaper — design + workplan in #15891 |
+| Native tier wiring (wallpaper + stable regions) | `setBackdrop` and chat-sheet rest anchoring shipped on iOS + Android; Android device spec covers real native wallpaper/material lifecycle; iOS/Android attended capture and GPU/battery traces remain the release-verification gate for #15891 |
 
 Each pending row is a small mechanical PR: swap the hand-rolled recipe for a
 variant, delete the local numbers, screenshot before/after.

--- a/packages/ui/src/backgrounds/AppBackground.test.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.test.tsx
@@ -244,6 +244,21 @@ describe("AppBackground", () => {
     ).toBeNull();
   });
 
+  it("clears native wallpaper too when the visual layer is hidden", async () => {
+    const bridge = installNativeGlassBridge();
+    seed({
+      mode: "image",
+      color: "#160d07",
+      imageUrl: "/wallpapers/canopy.webp",
+    });
+    render(<AppBackground visible={false} />);
+    await waitFor(() => expect(bridge.setBackdrop).toHaveBeenCalledTimes(1));
+    expect(bridge.setBackdrop).toHaveBeenCalledWith({ color: "#160d07" });
+    expect(document.documentElement.classList).not.toContain(
+      "eliza-native-backdrop",
+    );
+  });
+
   it("mirrors an image background onto the ROOT canvas so the strip shows the wallpaper, not #160d07", () => {
     // The canvas-propagation cure (device r8): the ROOT element's background
     // paints the always-full-screen viewport canvas, immune to the collapsed

--- a/packages/ui/src/backgrounds/AppBackground.test.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.test.tsx
@@ -6,10 +6,31 @@
  * `mode: shader`, an image host for `mode: image`. jsdom render over a seeded
  * store double.
  */
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetNativeBackdropForTests } from "../glass/native-backdrop";
+import { resetGlassBridgeForTests } from "../glass/native-bridge";
 import { __setAppValueForTests } from "../state/app-store";
 import { AppBackground } from "./AppBackground";
+
+function installNativeGlassBridge() {
+  const bridge = {
+    attachGlass: vi.fn(async () => ({ attached: true })),
+    updateRect: vi.fn(async () => {}),
+    detachGlass: vi.fn(async () => {}),
+    setGrouping: vi.fn(async () => {}),
+    isAvailable: vi.fn(async () => ({ available: true })),
+    setBackdrop: vi.fn(async () => ({ applied: true })),
+  };
+  (globalThis as { Capacitor?: unknown }).Capacitor = {
+    isNativePlatform: () => true,
+    getPlatform: () => "ios",
+    registerPlugin: () => bridge,
+  };
+  resetGlassBridgeForTests();
+  resetNativeBackdropForTests();
+  return bridge;
+}
 
 function seed(backgroundConfig: unknown) {
   __setAppValueForTests({
@@ -21,6 +42,9 @@ function seed(backgroundConfig: unknown) {
 afterEach(() => {
   cleanup();
   __setAppValueForTests(null);
+  (globalThis as { Capacitor?: unknown }).Capacitor = undefined;
+  resetGlassBridgeForTests();
+  resetNativeBackdropForTests();
 });
 
 describe("AppBackground", () => {
@@ -92,6 +116,46 @@ describe("AppBackground", () => {
     expect(
       container.querySelector('[data-testid="app-background-shader"]'),
     ).toBeNull();
+  });
+
+  it("pipes an image wallpaper native before removing the DOM paint", async () => {
+    const bridge = installNativeGlassBridge();
+    seed({
+      mode: "image",
+      color: "#160d07",
+      imageUrl: "/wallpapers/canopy.webp",
+    });
+    const { container } = render(<AppBackground />);
+
+    // Safety invariant: CSS remains painted until native confirms the image.
+    expect(
+      container.querySelector('[data-testid="app-background-image"]'),
+    ).not.toBeNull();
+    await waitFor(() => expect(bridge.setBackdrop).toHaveBeenCalledTimes(1));
+    expect(bridge.setBackdrop).toHaveBeenCalledWith({
+      imageUrl: expect.stringMatching(/^https?:\/\//),
+      color: "#160d07",
+    });
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-testid="app-background-image"]'),
+      ).toBeNull(),
+    );
+    expect(document.documentElement.classList).toContain(
+      "eliza-native-backdrop",
+    );
+    expect(document.documentElement.style.backgroundColor).toBe("transparent");
+  });
+
+  it("keeps shader backgrounds in the CSS tier and clears a stale native image", async () => {
+    const bridge = installNativeGlassBridge();
+    seed({ mode: "shader", color: "#3a1f0d" });
+    const { container } = render(<AppBackground />);
+    await waitFor(() => expect(bridge.setBackdrop).toHaveBeenCalledTimes(1));
+    expect(bridge.setBackdrop).toHaveBeenCalledWith({ color: "#3a1f0d" });
+    expect(
+      container.querySelector('[data-testid="app-background-shader"]'),
+    ).not.toBeNull();
   });
 
   it("always paints the legibility scrim inside the image wallpaper", () => {

--- a/packages/ui/src/backgrounds/AppBackground.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.tsx
@@ -102,7 +102,11 @@ export function AppBackground({
     setNativeBackdropActive(false);
 
     const color = backgroundConfig?.color ?? DEFAULT_BACKGROUND_COLOR;
-    if (backgroundConfig?.mode !== "image" || !backgroundConfig.imageUrl) {
+    if (
+      !visible ||
+      backgroundConfig?.mode !== "image" ||
+      !backgroundConfig.imageUrl
+    ) {
       // Clear a previously hosted image. Shader animation remains web-rendered,
       // so the glass tier deliberately stays CSS even when this color succeeds.
       void setNativeBackdrop({ color });
@@ -148,7 +152,7 @@ export function AppBackground({
       current = false;
       document.documentElement.classList.remove("eliza-native-backdrop");
     };
-  }, [backgroundConfig]);
+  }, [backgroundConfig, visible]);
 
   if (!visible) return null;
   // Defensive: the app store can return a non-object slice before the provider

--- a/packages/ui/src/backgrounds/AppBackground.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.tsx
@@ -5,12 +5,14 @@
  */
 import type * as React from "react";
 import { lazy, Suspense, useEffect, useState } from "react";
+import { setNativeBackdropActive } from "../glass/native-backdrop";
+import { setNativeBackdrop } from "../glass/native-bridge";
 import type { ShaderConfig } from "../state/ui-preferences";
 import { DEFAULT_BACKGROUND_COLOR } from "../state/ui-preferences";
 import { useBackgroundConfig } from "../state/useBackgroundConfig";
 import { useVoiceSettingsApplyChannel } from "../voice/useVoiceSettingsApplyChannel";
 import { applyRootCanvasPaint } from "./html-canvas-paint";
-import { ImageBackground } from "./ImageBackground";
+import { ImageBackground, resolveWallpaperUrl } from "./ImageBackground";
 import { ShaderBackground } from "./ShaderBackground";
 import { useAppearanceApplyChannel } from "./useAppearanceApplyChannel";
 import { useBackgroundApplyChannel } from "./useBackgroundApplyChannel";
@@ -74,6 +76,7 @@ export function AppBackground({
   visible = true,
 }: AppBackgroundProps = {}): React.JSX.Element | null {
   const { backgroundConfig } = useBackgroundConfig();
+  const [nativeHostedImage, setNativeHostedImage] = useState(false);
   useBackgroundApplyChannel();
   useAppearanceApplyChannel();
   useVoiceSettingsApplyChannel();
@@ -92,6 +95,61 @@ export function AppBackground({
     applyRootCanvasPaint(backgroundConfig);
   }, [backgroundConfig]);
 
+  useEffect(() => {
+    let current = true;
+    document.documentElement.classList.remove("eliza-native-backdrop");
+    setNativeHostedImage(false);
+    setNativeBackdropActive(false);
+
+    const color = backgroundConfig?.color ?? DEFAULT_BACKGROUND_COLOR;
+    if (backgroundConfig?.mode !== "image" || !backgroundConfig.imageUrl) {
+      // Clear a previously hosted image. Shader animation remains web-rendered,
+      // so the glass tier deliberately stays CSS even when this color succeeds.
+      void setNativeBackdrop({ color });
+      return () => {
+        current = false;
+        document.documentElement.classList.remove("eliza-native-backdrop");
+      };
+    }
+
+    const resolved = resolveWallpaperUrl(backgroundConfig.imageUrl);
+    let absolute: string;
+    try {
+      absolute = new URL(
+        resolved,
+        typeof window === "undefined" ? undefined : window.location.href,
+      ).href;
+    } catch {
+      return () => {
+        current = false;
+        document.documentElement.classList.remove("eliza-native-backdrop");
+      };
+    }
+    // blob/data/custom schemes cannot be fetched by the native host. Keep the
+    // existing DOM image and CSS glass rather than manufacturing a black hole.
+    if (!/^(https?:|capacitor:)$/i.test(new URL(absolute).protocol)) {
+      return () => {
+        current = false;
+        document.documentElement.classList.remove("eliza-native-backdrop");
+      };
+    }
+
+    void setNativeBackdrop({ imageUrl: absolute, color }).then((applied) => {
+      if (!current || !applied) return;
+      setNativeHostedImage(true);
+      setNativeBackdropActive(true);
+      document.documentElement.classList.add("eliza-native-backdrop");
+      // The root canvas mirror is itself a WebView pixel. Once native owns the
+      // image it must become transparent too, not merely the ImageBackground.
+      document.documentElement.style.backgroundImage = "none";
+      document.documentElement.style.backgroundColor = "transparent";
+    });
+    return () => {
+      current = false;
+      document.documentElement.classList.remove("eliza-native-backdrop");
+    };
+  }, [backgroundConfig]);
+
   if (!visible) return null;
   // Defensive: the app store can return a non-object slice before the provider
   // seeds it (e.g. the test fallback proxy). Fall back to the default shader.
@@ -101,7 +159,9 @@ export function AppBackground({
       : null;
   const color = config?.color ?? DEFAULT_BACKGROUND_COLOR;
   if (config?.mode === "image" && config.imageUrl) {
-    return <ImageBackground imageUrl={config.imageUrl} />;
+    return nativeHostedImage ? null : (
+      <ImageBackground imageUrl={config.imageUrl} />
+    );
   }
   if (config?.mode === "glsl" && config.shader) {
     // Key by source so a replacement shader remounts (fresh compile attempt +

--- a/packages/ui/src/backgrounds/ImageBackground.tsx
+++ b/packages/ui/src/backgrounds/ImageBackground.tsx
@@ -26,7 +26,7 @@ export interface ImageBackgroundProps {
  *    would resolve to `file:///wallpapers` and fail. This is the same
  *    URL-resolution trap `resolveTileImageUrl` handles for launcher hero art.
  */
-function resolveWallpaperUrl(url: string): string {
+export function resolveWallpaperUrl(url: string): string {
   if (
     url.startsWith("data:") ||
     url.startsWith("blob:") ||

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -69,6 +69,11 @@ import type {
 import { reportComposerActivity } from "../../chat/report-composer-activity";
 import { CHAT_PREFILL_EVENT, ELIZA_BACK_INTENT_EVENT } from "../../events";
 import {
+  resetNativeBackdropForTests,
+  setNativeBackdropActive,
+} from "../../glass/native-backdrop";
+import { resetGlassBridgeForTests } from "../../glass/native-bridge";
+import {
   GLASS_SHEET_BACKDROP_FILTER,
   GLASS_SHEET_FILL,
 } from "../../glass/tokens";
@@ -112,6 +117,9 @@ afterEach(() => {
   // Search-jump tests seed the AppContext store with spies; clear it so the
   // inert test-fallback proxy backs every other test again.
   __setAppValueForTests(null);
+  (globalThis as { Capacitor?: unknown }).Capacitor = undefined;
+  resetGlassBridgeForTests();
+  resetNativeBackdropForTests();
 });
 
 function makeController(
@@ -248,6 +256,34 @@ describe("ContinuousChatOverlay", () => {
     expect(surface.style.backdropFilter).toBe(GLASS_SHEET_BACKDROP_FILTER);
     expect(surface.style.backdropFilter).not.toMatch(/saturate|brightness/);
     expect(surface.style.backgroundColor).toBe(GLASS_SHEET_FILL);
+  });
+
+  it("adopts native glass only for the settled open sheet after wallpaper acknowledgement", async () => {
+    const bridge = {
+      attachGlass: vi.fn(async () => ({ attached: true })),
+      updateRect: vi.fn(async () => {}),
+      detachGlass: vi.fn(async () => {}),
+      setGrouping: vi.fn(async () => {}),
+      setBackdrop: vi.fn(async () => ({ applied: true })),
+      isAvailable: vi.fn(async () => ({ available: true })),
+    };
+    (globalThis as { Capacitor?: unknown }).Capacitor = {
+      isNativePlatform: () => true,
+      getPlatform: () => "ios",
+      registerPlugin: () => bridge,
+    };
+    resetGlassBridgeForTests();
+    setNativeBackdropActive(true);
+
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    fireEvent.focus(screen.getByLabelText("message"));
+
+    const sheet = screen.getByTestId("chat-sheet");
+    const surface = screen.getByTestId("chat-sheet-surface");
+    await waitFor(() => expect(sheet.dataset.glassTier).toBe("native"));
+    await waitFor(() => expect(bridge.attachGlass).toHaveBeenCalledTimes(1));
+    expect(surface.style.backgroundColor).toBe("transparent");
+    expect(surface.style.backdropFilter).toBe("");
   });
 
   it("reports typing start and pause from the real composer draft", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -62,6 +62,7 @@ import {
   TOUCH_TAP_MOVE_SLOP as OUTSIDE_SHEET_TAP_SLOP,
   useRafCoalescer,
 } from "../../gestures";
+import { useNativeGlassAnchor } from "../../glass/GlassSurface";
 import {
   GLASS_SHEET_BACKDROP_FILTER,
   GLASS_SHEET_FILL,
@@ -4744,6 +4745,22 @@ export function ContinuousChatOverlay({
     return null;
   }, [firstRunOpen, messages]);
 
+  // Native material is anchored only after the release spring has settled.
+  // An active drag detaches it and immediately restores CSS blur, keeping every
+  // finger-tracked frame off the JS-to-native bridge. Full bleed remains opaque.
+  const nativeSheetTier = useNativeGlassAnchor(
+    panelRef as React.RefObject<HTMLElement | null>,
+    {
+      enabled:
+        sheetOpen &&
+        !isDragging &&
+        !fullBleed &&
+        !restoreDragging &&
+        !firstRunOpen,
+    },
+  );
+  const nativeInsetSheet = nativeSheetTier === "native";
+
   return (
     <motion.div
       ref={overlayRef}
@@ -4946,6 +4963,7 @@ export function ContinuousChatOverlay({
           data-revealed={threadPresented ? "true" : "false"}
           data-chat-state={chatState}
           data-header-shown={headerVisible ? "true" : "false"}
+          data-glass-tier={nativeSheetTier}
           // The active conversation id + its position in the most-recent-first
           // list, surfaced so flows like the tutorial can observe a new-chat or a
           // swipe-between-chats without reaching into controller internals.
@@ -4958,6 +4976,8 @@ export function ContinuousChatOverlay({
           // maxHeight keeps it from spilling off the top (thread scrolls instead).
           style={{
             ...CHAT_PANEL_THEME,
+            // Native anchor reads this computed radius when the sheet settles.
+            borderRadius: morphRadius,
             // Morph-driven cap: the inset ceiling at rest, growing to the
             // full-bleed ceiling in lock-step with the shape morph (see
             // panelCapH) so an over-pull grows 1:1 under the finger.
@@ -5032,17 +5052,20 @@ export function ContinuousChatOverlay({
               // fieldset, not the orange app theme behind. Full-bleed stays fully
               // opaque (it covers the whole screen — there is nothing to see
               // through, and the blur would be wasted battery).
-              backgroundColor: firstRunOpen
-                ? "transparent"
-                : fullBleed
-                  ? "var(--bg)"
-                  : GLASS_SHEET_FILL,
-              backdropFilter: fullBleed
-                ? undefined
-                : GLASS_SHEET_BACKDROP_FILTER,
-              WebkitBackdropFilter: fullBleed
-                ? undefined
-                : GLASS_SHEET_BACKDROP_FILTER,
+              backgroundColor:
+                firstRunOpen || nativeInsetSheet
+                  ? "transparent"
+                  : fullBleed
+                    ? "var(--bg)"
+                    : GLASS_SHEET_FILL,
+              backdropFilter:
+                fullBleed || nativeInsetSheet
+                  ? undefined
+                  : GLASS_SHEET_BACKDROP_FILTER,
+              WebkitBackdropFilter:
+                fullBleed || nativeInsetSheet
+                  ? undefined
+                  : GLASS_SHEET_BACKDROP_FILTER,
               // Liquid-glass bevel: a bright top-left rim over a soft
               // bottom-right shade so the frosted edge catches light like a real
               // glass slab. Only on the inset sheet — full-bleed has no edge to
@@ -5085,6 +5108,9 @@ export function ContinuousChatOverlay({
               chat committed to edge-to-edge full-bleed. */}
           <span className="sr-only" data-testid="chat-maximized-probe">
             {`chat-maximized:${fullBleed ? "true" : "false"}`}
+          </span>
+          <span className="sr-only" data-testid="chat-glass-tier-probe">
+            {`chat-glass-tier:${nativeSheetTier}`}
           </span>
           {firstRunProbe ? (
             <span className="sr-only" data-testid="onboarding-state-probe">

--- a/packages/ui/src/glass/GlassSurface.tsx
+++ b/packages/ui/src/glass/GlassSurface.tsx
@@ -20,7 +20,7 @@
  */
 
 import type * as React from "react";
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import {
   LiquidGlassRefractionDefs,
   liquidGlassRimCss,
@@ -82,28 +82,43 @@ export interface GlassSurfaceProps
 }
 
 /** Anchor/unanchor the native material to this element's rect. */
-function useNativeAnchor(
-  ref: React.RefObject<HTMLDivElement | null>,
-  tier: GlassTier,
-  interactive: boolean,
-): void {
+export interface NativeGlassAnchorOptions {
+  /** False detaches native material and returns a CSS tier immediately. */
+  enabled?: boolean;
+  interactive?: boolean;
+}
+
+/**
+ * Anchor native material to any stable element. Bridge rejection is an honest
+ * CSS fallback, never a transparent element over a missing native view.
+ */
+export function useNativeGlassAnchor(
+  ref: React.RefObject<HTMLElement | null>,
+  { enabled = true, interactive = false }: NativeGlassAnchorOptions = {},
+): GlassTier {
+  const tier = useNativeGlass();
   const regionId = useId();
+  const [failed, setFailed] = useState(false);
   useEffect(() => {
-    if (tier !== "native") return;
+    if (tier !== "native" || !enabled) return;
     const el = ref.current;
     const bridge = glassBridge();
     if (!el || !bridge) return;
+    setFailed(false);
     const radius = Number.parseFloat(getComputedStyle(el).borderRadius) || 12;
     const rectOf = () => {
       const r = el.getBoundingClientRect();
       return { x: r.x, y: r.y, width: r.width, height: r.height };
     };
-    void bridge.attachGlass({
-      id: regionId,
-      rect: rectOf(),
-      cornerRadius: radius,
-      interactive,
-    });
+    void bridge
+      .attachGlass({
+        id: regionId,
+        rect: rectOf(),
+        cornerRadius: radius,
+        interactive,
+      })
+      .then((result) => setFailed(!result.attached))
+      .catch(() => setFailed(true));
     const sync = () => void bridge.updateRect({ id: regionId, rect: rectOf() });
     const observer = new ResizeObserver(sync);
     observer.observe(el);
@@ -113,7 +128,8 @@ function useNativeAnchor(
       window.removeEventListener("resize", sync);
       void bridge.detachGlass({ id: regionId });
     };
-  }, [tier, interactive, ref, regionId]);
+  }, [tier, enabled, interactive, ref, regionId]);
+  return tier === "native" && (!enabled || failed) ? "css-frosted" : tier;
 }
 
 export function GlassSurface({
@@ -123,9 +139,8 @@ export function GlassSurface({
   children,
   ...rest
 }: GlassSurfaceProps): React.JSX.Element {
-  const tier = useNativeGlass();
   const ref = useRef<HTMLDivElement>(null);
-  useNativeAnchor(ref, tier, interactive);
+  const tier = useNativeGlassAnchor(ref, { interactive });
   return (
     <div
       {...rest}

--- a/packages/ui/src/glass/GlassSurface.tsx
+++ b/packages/ui/src/glass/GlassSurface.tsx
@@ -120,11 +120,12 @@ export function useNativeGlassAnchor(
       .then((result) => setFailed(!result.attached))
       .catch(() => setFailed(true));
     const sync = () => void bridge.updateRect({ id: regionId, rect: rectOf() });
-    const observer = new ResizeObserver(sync);
-    observer.observe(el);
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(sync);
+    observer?.observe(el);
     window.addEventListener("resize", sync);
     return () => {
-      observer.disconnect();
+      observer?.disconnect();
       window.removeEventListener("resize", sync);
       void bridge.detachGlass({ id: regionId });
     };

--- a/packages/ui/src/glass/glass.test.tsx
+++ b/packages/ui/src/glass/glass.test.tsx
@@ -9,8 +9,17 @@
  */
 
 import { cleanup, render, waitFor } from "@testing-library/react";
+import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GlassStyles, GlassSurface } from "./GlassSurface";
+import {
+  GlassStyles,
+  GlassSurface,
+  useNativeGlassAnchor,
+} from "./GlassSurface";
+import {
+  resetNativeBackdropForTests,
+  setNativeBackdropActive,
+} from "./native-backdrop";
 import { resetGlassBridgeForTests } from "./native-bridge";
 import {
   GLASS_RECIPES,
@@ -45,10 +54,12 @@ function installCapacitor(
       return bridge as unknown as T;
     },
   };
+  setNativeBackdropActive(true);
 }
 
 beforeEach(() => {
   resetGlassBridgeForTests();
+  resetNativeBackdropForTests();
   // jsdom has no ResizeObserver; the anchor effect uses it for rect sync.
   if (typeof globalThis.ResizeObserver === "undefined") {
     globalThis.ResizeObserver = class {
@@ -63,6 +74,7 @@ afterEach(() => {
   cleanup();
   (globalThis as CapGlobal).Capacitor = undefined;
   resetGlassBridgeForTests();
+  resetNativeBackdropForTests();
 });
 
 describe("glass tokens", () => {
@@ -116,6 +128,12 @@ describe("glass tokens", () => {
   });
 });
 
+function AnchorHarness({ enabled }: { enabled: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const tier = useNativeGlassAnchor(ref, { enabled });
+  return <div ref={ref} data-testid="anchor" data-glass-tier={tier} />;
+}
+
 describe("GlassSurface", () => {
   it("renders the variant class and a css tier off-native", () => {
     const { getByTestId } = render(
@@ -159,6 +177,31 @@ describe("GlassSurface", () => {
     await waitFor(() => expect(bridge.attachGlass).toHaveBeenCalledTimes(1));
     unmount();
     await waitFor(() => expect(bridge.detachGlass).toHaveBeenCalledTimes(1));
+  });
+
+  it("detaches native material and restores CSS immediately when an anchor starts dragging", async () => {
+    const bridge = fakeBridge();
+    installCapacitor(bridge);
+    const { getByTestId, rerender } = render(<AnchorHarness enabled />);
+    await waitFor(() =>
+      expect(getByTestId("anchor").dataset.glassTier).toBe("native"),
+    );
+    await waitFor(() => expect(bridge.attachGlass).toHaveBeenCalledTimes(1));
+
+    rerender(<AnchorHarness enabled={false} />);
+    expect(getByTestId("anchor").dataset.glassTier).toBe("css-frosted");
+    await waitFor(() => expect(bridge.detachGlass).toHaveBeenCalledTimes(1));
+  });
+
+  it("falls back to CSS when native attach rejects instead of leaving a transparent hole", async () => {
+    const bridge = fakeBridge({
+      attachGlass: vi.fn(async () => ({ attached: false })),
+    });
+    installCapacitor(bridge);
+    const { getByTestId } = render(<AnchorHarness enabled />);
+    await waitFor(() =>
+      expect(getByTestId("anchor").dataset.glassTier).toBe("css-frosted"),
+    );
   });
 
   it("stays on the css tier when the plugin reports unavailable", async () => {

--- a/packages/ui/src/glass/index.ts
+++ b/packages/ui/src/glass/index.ts
@@ -4,12 +4,22 @@ export {
   GlassStyles,
   GlassSurface,
   type GlassSurfaceProps,
+  type NativeGlassAnchorOptions,
+  useNativeGlassAnchor,
 } from "./GlassSurface";
+export {
+  isNativeBackdropActive,
+  resetNativeBackdropForTests,
+  setNativeBackdropActive,
+  useNativeBackdropActive,
+} from "./native-backdrop";
 export {
   glassBridge,
   isNativeGlassAvailable,
+  type NativeBackdropOptions,
   type NativeGlassOptions,
   resetGlassBridgeForTests,
+  setNativeBackdrop,
 } from "./native-bridge";
 export {
   GLASS_BANNER_FILL,

--- a/packages/ui/src/glass/native-backdrop.ts
+++ b/packages/ui/src/glass/native-backdrop.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from "react";
+
+let active = false;
+const listeners = new Set<() => void>();
+
+function snapshot(): boolean {
+  return active;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * True only after the native host has decoded and installed the current image
+ * wallpaper. Native glass must never activate before this flips true, because
+ * an under-WebView material without a native backdrop reveals the window
+ * background instead of the wallpaper.
+ */
+export function useNativeBackdropActive(): boolean {
+  return useSyncExternalStore(subscribe, snapshot, () => false);
+}
+
+export function setNativeBackdropActive(next: boolean): void {
+  if (active === next) return;
+  active = next;
+  for (const listener of listeners) listener();
+}
+
+export function isNativeBackdropActive(): boolean {
+  return active;
+}
+
+export function resetNativeBackdropForTests(): void {
+  active = false;
+  listeners.clear();
+}

--- a/packages/ui/src/glass/native-bridge.ts
+++ b/packages/ui/src/glass/native-bridge.ts
@@ -49,6 +49,13 @@ export interface NativeGlassRegionState {
   rect?: { x: number; y: number; width: number; height: number };
 }
 
+export interface NativeBackdropOptions {
+  /** Fully resolved renderer-reachable URL. Omit to install only the color. */
+  imageUrl?: string;
+  /** Safe paint shown while the image decodes, or as the cleared backdrop. */
+  color?: string;
+}
+
 interface GlassBridgePlugin {
   attachGlass(options: NativeGlassOptions): Promise<{ attached: boolean }>;
   updateRect(options: {
@@ -58,6 +65,8 @@ interface GlassBridgePlugin {
   detachGlass(options: { id: string }): Promise<void>;
   /** UIGlassContainerEffect merge distance for sibling regions. */
   setGrouping(options: { spacing: number }): Promise<void>;
+  /** Decode and install a wallpaper layer below the WebView. */
+  setBackdrop(options: NativeBackdropOptions): Promise<{ applied: boolean }>;
   isAvailable(): Promise<{ available: boolean }>;
   /**
    * Reads the region's REAL native view state (existence, count, z-order,
@@ -128,6 +137,25 @@ export function isNativeGlassAvailable(): Promise<boolean> {
     }
   })();
   return availability;
+}
+
+/**
+ * Install the native host's wallpaper. A false result is the explicit fallback
+ * signal: callers keep the DOM wallpaper painted and native glass disabled.
+ */
+export async function setNativeBackdrop(
+  options: NativeBackdropOptions,
+): Promise<boolean> {
+  if (!(await isNativeGlassAvailable())) return false;
+  const bridge = glassBridge();
+  if (!bridge) return false;
+  try {
+    return (await bridge.setBackdrop(options)).applied;
+  } catch {
+    // error-policy:J4 capability write — old native shells do not implement
+    // setBackdrop. Keep CSS paint rather than exposing a black transparency.
+    return false;
+  }
 }
 
 /** Test seam: reset memoized plugin + availability between cases. */

--- a/packages/ui/src/glass/useNativeGlass.ts
+++ b/packages/ui/src/glass/useNativeGlass.ts
@@ -19,6 +19,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { useNativeBackdropActive } from "./native-backdrop";
 import { isNativeGlassAvailable } from "./native-bridge";
 
 /**
@@ -41,15 +42,19 @@ function cssTier(): GlassTier {
 }
 
 export function useNativeGlass(): GlassTier {
-  const [tier, setTier] = useState<GlassTier>(cssTier);
+  const fallbackTier = cssTier();
+  const [available, setAvailable] = useState(false);
+  const backdropActive = useNativeBackdropActive();
   useEffect(() => {
     let alive = true;
-    void isNativeGlassAvailable().then((available) => {
-      if (alive && available) setTier("native");
+    void isNativeGlassAvailable().then((next) => {
+      if (alive) setAvailable(next);
     });
     return () => {
       alive = false;
     };
   }, []);
-  return tier;
+  // The capability alone is insufficient: native material lives below the
+  // WebView and would reveal black until the image wallpaper is native too.
+  return available && backdropActive ? "native" : fallbackTier;
 }

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -136,6 +136,15 @@ html.eliza-chat-overlay-shell #root {
   background: transparent;
 }
 
+/* A native image backdrop has been decoded and installed below the WebView.
+   Every web canvas layer must become transparent together; hiding only the DOM
+   ImageBackground would leave body/#root's launch color as an opaque black hole. */
+html.eliza-native-backdrop,
+html.eliza-native-backdrop body,
+html.eliza-native-backdrop #root {
+  background: transparent;
+}
+
 html.eliza-chat-overlay-shell #root {
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary

- add `GlassBridge.setBackdrop({ imageUrl?, color? })` on iOS and Android, with bundled-asset loading, authenticated media fetches, stale-load rejection, cover-fit hosting, and decode-before-acknowledgement
- keep the DOM/root wallpaper painted until native confirms installation, then make the complete WebView canvas transparent and unlock the native glass tier
- anchor the chat sheet to native material only at settled inset detents; detach and restore CSS blur for every active drag, keep full bleed opaque, and expose an AX tier probe
- hard-fallback to CSS for shaders, unsupported URLs, unavailable/old plugins, decode failures, and failed native region attachment

## Implementation evidence

| Requirement | Evidence |
| --- | --- |
| Native-hosted wallpaper behind WebView | `GlassBridge.swift#setBackdrop`, `GlassBridgePlugin.java#setBackdrop`; both install an image/color view at container index 0 before acknowledging |
| Existing content-addressed media path | native loaders forward WKWebView/Android CookieManager cookies; bundled Capacitor assets resolve from `public/` |
| No black-screen transition | `AppBackground` retains DOM paint until `{ applied: true }`; native tier also requires the shared backdrop-active acknowledgement; failed attach returns `css-frosted` |
| Chat native at rest, CSS during drag | `ContinuousChatOverlay` gates `useNativeGlassAnchor` on settled inset state and exposes `chat-glass-tier:*`; hook detach/fallback tests cover gesture-state switching |
| Full-screen behavior unchanged | native sheet gate excludes `fullBleed`; existing 171 chat-overlay tests remain green |
| Android native lifecycle coverage | `glass-bridge.android.spec.ts` now installs the bundled wallpaper before native material and validates the real rendered hierarchy/pixels |
| Auth/billing/voice invariants | no auth, billing, transport, capture, ASR, TTS, or voice-latency paths changed |

## Verification

- `bun run --cwd packages/ui test src/backgrounds/AppBackground.test.tsx src/glass/glass.test.tsx src/components/shell/ContinuousChatOverlay.test.tsx src/no-backdrop-blur-gate.test.ts` (201 passed)
- full Chromium chat-sheet gesture/state E2E (72 screenshots, drag + autoscroll recordings, zero page errors, zero error-level console messages)
- `bunx vitest run scripts/native-glass-backdrop-contract.test.mjs` in `packages/app-core` (3 passed)
- focused production TypeScript check for all touched UI roots via `tsgo --noEmit` (passed)
- Biome check on all touched TS/TSX/MJS files (passed)
- `git diff --check` (passed)

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline (`develop` f2b1c6ed3e9): ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-before-desktop.png) ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-before-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-after-desktop.png) ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-after-mobile.png) ![after mid-drag](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-after-mid-drag.png). Browser parity report: [pixel diff](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-pixel-diff.txt).

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [real pointer/touch drag suite MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-walkthrough.mp4).

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server route, database, worker, billing, or backend behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [full chat-sheet E2E log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-after-e2e.log), showing 72 reviewed captures, complete gesture/state traversal, zero page errors, and zero error-level console messages.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, provider, model, agent action, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [native/UI implementation diff](https://github.com/elizaOS/eliza/pull/16656/files), [pixel parity report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-pixel-diff.txt), and [Android installed-device spec](https://github.com/elizaOS/eliza/blob/82697f3760c242ca6463a66531e43001fe81b960/packages/app/test/android/glass-bridge.android.spec.ts).

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: [desktop + mobile Tesseract readout and manual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16656-ocr-review.txt). Before/after mobile is byte-identical; desktop RMS channel delta is below 0.005 and was manually reviewed as animation-timing noise.

## Native verification still required

This environment has no JDK (`JAVA_HOME`/`java` unavailable), Xcode, simulator, or attached device, so I could not honestly produce the attended iOS 26/Android native screenshots, GPU frame trace, or 10-minute battery/thermal trace here. The Android on-device spec is extended and ready for the existing device lane. Those hardware artifacts remain the release-verification gate rather than being fabricated or replaced with browser pixels. The concrete browser evidence above verifies web/CSS fallback parity and mid-drag geometry only.

Refs #15891

[sol-orch]
