### PR TITLE
fix(voice): bind realtime turns to selected agent conversation

### DIFF
--- a/ISSUE-16437-RECOVERY-2026-07-19.md
+++ b/ISSUE-16437-RECOVERY-2026-07-19.md
@@ -1,0 +1,78 @@
+/**
+ * Recovery receipt for issue #16437: realtime voice turns execute through the
+ * selected Eliza agent conversation, with structural identity checked before
+ * any persisted turn.
+ */
+
+# Issue #16437 Recovery Receipt
+
+Signed: [sol-orch]
+Date: 2026-07-19
+Worktree: `/mnt/HC_Volume_106234565/eliza-workers/sol-16437-recovery`
+
+## Collision and recovery check
+
+- Rechecked live issue #16437: open and unassigned at claim time.
+- Rechecked open PRs by issue number, selected-agent/realtime/conversation phrases,
+  and relevant voice/realtime files. No competing implementation or open PR was
+  found.
+- Rechecked issue claim comments and Project 12. The vanished lane had left a
+  prior claim/board marker but no PR or receipt. Posted the required recovery
+  claim: `[sol-orch] recovery lane claiming`.
+- Recovered the vanished worktree at
+  `/mnt/HC_Volume_106234565/eliza-workers/wt-16437` read-only. Its broad,
+  uncommitted shared-history replay/billing experiment was not ported. Current
+  `develop` already contains the later token recovery, reconnect, cancellation,
+  fallback, prewarm, latency, and billing work, and changing durable history
+  shape here would be speculative.
+
+## Implementation
+
+- Hardened the dedicated voice-service credential path for
+  `POST /api/v1/eliza/agents/:agentId/api/conversations/:conversationId/messages/stream`.
+- Required `X-Eliza-Agent-Id`, `X-Eliza-Conversation-Id`,
+  `X-Eliza-Organization-Id`, and `X-Eliza-User-Id` to match the canonical URL
+  and verified voice session scope before sandbox lookup or `message.send`.
+- Kept the bearer boundary on `VOICE_REALTIME_ELIZA_AUTHORIZATION`. No generic
+  model-gateway secret or speculative deployment setting was added.
+- Propagated the verified selected user as `message.send.params.userId`, retained
+  the selected conversation as `roomId`, and retained `source: "voice"`, so the
+  selected agent executes and persists in the selected conversation channel.
+- Suppressed duplicate STT `EndOfTurn` events for one active semantic turn before
+  a second canonical Eliza request, persistence action, or billing path can run.
+- Added deterministic tests for missing identity, wrong conversation, wrong
+  agent, wrong user/org ownership, selected user/room/source propagation, and
+  duplicate-final dispatch. Existing focused lifecycle tests also exercise
+  provider failure, interruption/cancellation, reconnect replacement, token
+  single-use/revocation, insufficient credits, and billing usage behavior.
+
+## Verification
+
+Passed:
+
+```text
+bun test packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+7 pass, 0 fail
+
+bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+32 pass, 0 fail
+
+bun test packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+18 pass, 0 fail
+
+bunx biome check <all touched TypeScript files>
+passed
+
+git diff --check
+passed
+```
+
+The sparse checkout used ignored dependency/build links from a current local
+`develop` pool only to execute tests. Those artifacts are not part of the diff.
+
+## Staging evidence
+
+No staging deployment was available from this worktree, so no live protocol
+staging evidence is claimed. The deterministic protocol tests above are the
+available evidence. This receipt intentionally does not fabricate deployment or
+staging results.

--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -115,6 +115,8 @@ function postVoiceServiceStream(body: unknown) {
       headers: {
         Authorization: "Bearer voice-service",
         "Content-Type": "application/json",
+        "X-Eliza-Agent-Id": AGENT,
+        "X-Eliza-Conversation-Id": VOICE_CONVERSATION,
         "X-Eliza-Organization-Id": ORG,
         "X-Eliza-User-Id": "user-voice",
       },
@@ -190,6 +192,8 @@ describe("shared agent messages/stream", () => {
       params: {
         text: "voice transcript",
         roomId: "conv-voice-service",
+        userId: "user-voice",
+        source: "voice",
       },
     });
   });
@@ -228,6 +232,8 @@ describe("shared agent messages/stream", () => {
           Authorization: "Bearer voice-service",
           "Content-Type": "application/json",
           "X-Service-Key": "Bearer voice-service",
+          "X-Eliza-Agent-Id": AGENT,
+          "X-Eliza-Conversation-Id": VOICE_CONVERSATION,
           "X-Eliza-Organization-Id": ORG,
           "X-Eliza-User-Id": "user-voice",
         },
@@ -244,6 +250,8 @@ describe("shared agent messages/stream", () => {
       params: {
         text: "adapter transcript",
         roomId: VOICE_CONVERSATION,
+        userId: "user-voice",
+        source: "voice",
       },
     });
   });
@@ -308,6 +316,8 @@ describe("shared agent messages/stream", () => {
         headers: {
           Authorization: "Bearer voice-service",
           "Content-Type": "application/json",
+          "X-Eliza-Agent-Id": AGENT,
+          "X-Eliza-Conversation-Id": VOICE_CONVERSATION,
           "X-Eliza-Organization-Id": ORG,
           "X-Eliza-User-Id": "user-voice",
         },
@@ -369,6 +379,8 @@ describe("shared agent messages/stream", () => {
         headers: {
           Authorization: "Bearer voice-service",
           "Content-Type": "application/json",
+          "X-Eliza-Agent-Id": AGENT,
+          "X-Eliza-Conversation-Id": VOICE_CONVERSATION,
           "X-Eliza-Organization-Id": ORG,
           "X-Eliza-User-Id": "user-voice",
         },
@@ -412,6 +424,8 @@ describe("shared agent messages/stream", () => {
           Authorization: "Bearer voice-service",
           "Content-Type": "application/json",
           "X-Service-Key": "Bearer voice-service",
+          "X-Eliza-Agent-Id": AGENT,
+          "X-Eliza-Conversation-Id": VOICE_CONVERSATION,
           "X-Eliza-Organization-Id": ORG,
           "X-Eliza-User-Id": "different-user",
         },
@@ -426,6 +440,97 @@ describe("shared agent messages/stream", () => {
       error: "Agent not found",
       code: "agent_not_found",
     });
+  });
+
+  test("voice service credential rejects missing structural voice identity", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: AGENT,
+      organization_id: ORG,
+      user_id: "user-voice",
+      agent_name: "Voice Agent",
+    });
+
+    const res = await voiceServiceApp.request(
+      `/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "user-voice",
+        },
+        body: JSON.stringify({ text: "do not persist" }),
+      },
+      { VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service" },
+    );
+
+    expect(res.status).toBe(404);
+    expect(resolveSharedAgent).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(bridgeStream).not.toHaveBeenCalled();
+  });
+
+  test("voice service credential rejects mismatched conversation identity", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: AGENT,
+      organization_id: ORG,
+      user_id: "user-voice",
+      agent_name: "Voice Agent",
+    });
+
+    const res = await voiceServiceApp.request(
+      `/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Eliza-Agent-Id": AGENT,
+          "X-Eliza-Conversation-Id": "wrong-conversation",
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "user-voice",
+        },
+        body: JSON.stringify({ text: "do not persist" }),
+      },
+      { VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service" },
+    );
+
+    expect(res.status).toBe(404);
+    expect(resolveSharedAgent).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(bridgeStream).not.toHaveBeenCalled();
+  });
+
+  test("voice service credential rejects mismatched agent identity", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      id: AGENT,
+      organization_id: ORG,
+      user_id: "user-voice",
+      agent_name: "Voice Agent",
+    });
+
+    const res = await voiceServiceApp.request(
+      `/api/v1/eliza/agents/${AGENT}/api/conversations/${VOICE_CONVERSATION}/messages/stream`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer voice-service",
+          "Content-Type": "application/json",
+          "X-Eliza-Agent-Id": "wrong-agent",
+          "X-Eliza-Conversation-Id": VOICE_CONVERSATION,
+          "X-Eliza-Organization-Id": ORG,
+          "X-Eliza-User-Id": "user-voice",
+        },
+        body: JSON.stringify({ text: "do not persist" }),
+      },
+      { VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer voice-service" },
+    );
+
+    expect(res.status).toBe(404);
+    expect(resolveSharedAgent).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    expect(bridgeStream).not.toHaveBeenCalled();
   });
 
   test("voice service credential rejects an agent outside the scoped user or org before persistence", async () => {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -37,6 +37,10 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Shared-tier + org-scoped (resolveSharedAgent gates auth, org-scope, tier).
  */
 const CORS_METHODS = "POST, OPTIONS";
+const VOICE_AGENT_HEADER = "X-Eliza-Agent-Id";
+const VOICE_CONVERSATION_HEADER = "X-Eliza-Conversation-Id";
+const VOICE_ORGANIZATION_HEADER = "X-Eliza-Organization-Id";
+const VOICE_USER_HEADER = "X-Eliza-User-Id";
 
 const app = new Hono<AppEnv>();
 
@@ -53,8 +57,25 @@ async function resolveAgentScope(c: Parameters<typeof resolveSharedAgent>[0]) {
   const presented = c.req.header("authorization");
   if (configured && presented && timingSafeEqualSecret(presented, configured)) {
     const agentId = c.req.param("agentId") ?? "";
-    const orgId = c.req.header("X-Eliza-Organization-Id") ?? "";
-    const userId = c.req.header("X-Eliza-User-Id") ?? "";
+    const conversationId = c.req.param("conversationId") ?? "";
+    const scopedAgentId = c.req.header(VOICE_AGENT_HEADER) ?? "";
+    const scopedConversationId = c.req.header(VOICE_CONVERSATION_HEADER) ?? "";
+    const orgId = c.req.header(VOICE_ORGANIZATION_HEADER) ?? "";
+    const userId = c.req.header(VOICE_USER_HEADER) ?? "";
+    if (
+      !agentId ||
+      !conversationId ||
+      scopedAgentId !== agentId ||
+      scopedConversationId !== conversationId ||
+      !orgId ||
+      !userId
+    ) {
+      return {
+        error: "Agent not found",
+        code: "agent_not_found",
+        status: 404 as const,
+      };
+    }
     const agent = orgId
       ? await agentSandboxesRepository.findByIdAndOrg(agentId, orgId)
       : undefined;
@@ -65,7 +86,12 @@ async function resolveAgentScope(c: Parameters<typeof resolveSharedAgent>[0]) {
         status: 404 as const,
       };
     }
-    return { agentId: agent.id, orgId, agentName: agent.agent_name ?? "Agent" };
+    return {
+      agentId: agent.id,
+      orgId,
+      userId,
+      agentName: agent.agent_name ?? "Agent",
+    };
   }
   return resolveSharedAgent(c);
 }
@@ -84,7 +110,12 @@ app.post("/", async (c) => {
   const bodyStartedAt = nowMs();
   const bodyPromise = c.req
     .json()
-    .catch(() => ({}))
+    .catch(() => {
+      // error-policy:J3 untrusted-input sanitizing. Match the canonical stream
+      // contract: malformed JSON is an invalid request body, not a fabricated
+      // successful turn.
+      return {};
+    })
     .then((body: unknown) => ({
       body,
       durationMs: elapsedMs(bodyStartedAt),
@@ -114,6 +145,7 @@ app.post("/", async (c) => {
     agentId: r.agentId,
     orgId: r.orgId,
     conversationId,
+    ...("userId" in r ? { userId: r.userId } : {}),
     body: raw,
     origin,
     timings: {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -410,6 +410,35 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).toContain("usage");
   });
 
+  test("duplicate final events for one semantic turn dispatch and persist exactly once", async () => {
+    const requests: Array<{ body: unknown }> = [];
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: (async (url: string, init?: RequestInit) => {
+        requests.push({
+          body: JSON.parse(String(init?.body)),
+        });
+        return makeCanonicalChunkFetch(["Only once."])(url, init);
+      }) as unknown as typeof fetch,
+    });
+
+    const flux = FakeFluxSocket.instances.at(-1)!;
+    flux.emitTurn("StartOfTurn");
+    flux.emitTurn("EndOfTurn", "hello agent");
+    flux.emitTurn("EndOfTurn", "hello agent");
+    await flush();
+    await flush();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      body: { text: "hello agent" },
+    });
+    expect(
+      client.controlFrames.filter((frame) => frame.t === "stt_final"),
+    ).toHaveLength(1);
+  });
+
   test("hello -> ready -> full turn produces stt_final, llm_first_text, speaking, usage", async () => {
     const client = new FakeClientSocket();
     await connectSession({

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -159,6 +159,8 @@ async function dispatchInternalElizaConversationFetch(
     );
   }
   if (
+    headers.get("X-Eliza-Agent-Id") !== claims.agentId ||
+    headers.get("X-Eliza-Conversation-Id") !== claims.conversationId ||
     headers.get("X-Eliza-Organization-Id") !== claims.organizationId ||
     headers.get("X-Eliza-User-Id") !== claims.userId
   ) {
@@ -194,6 +196,7 @@ async function dispatchInternalElizaConversationFetch(
     agentId: claims.agentId,
     orgId: claims.organizationId,
     conversationId: claims.conversationId,
+    userId: claims.userId,
     body,
     origin: headers.get("origin"),
   });

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -174,6 +174,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private turnCounter = 0;
   private currentTraceId: string | null = null;
   private currentVoiceTurnId: string | null = null;
+  private activeSttTurn = false;
   private llmAbort: AbortController | null = null;
   private phrase: PhraseAggregator | null = null;
   private turnSttMs = 0;
@@ -416,6 +417,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         if (this.state === "speaking" || this.state === "thinking") {
           this.interrupt("acoustic");
         }
+        this.activeSttTurn = true;
         this.state = "transcribing";
         break;
       }
@@ -437,6 +439,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "end-of-turn": {
+        if (!this.activeSttTurn) return;
+        this.activeSttTurn = false;
         // A missing transcript commits as "" on purpose: commitTurn's empty-
         // final path still reports+resets the turn's metered usage and clears
         // the turn id, which skipping the commit would leak into the next turn.

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -23,6 +23,7 @@ export interface CanonicalScopedStreamRequest {
   agentId: string;
   orgId: string;
   conversationId: string;
+  userId?: string;
   body: unknown;
   origin?: string | null;
   timings?: Record<string, number>;
@@ -79,7 +80,11 @@ export async function handleCanonicalScopedAgentStream(
     jsonrpc: "2.0",
     id: crypto.randomUUID(),
     method: "message.send",
-    params: { text, roomId: request.conversationId },
+    params: {
+      text,
+      roomId: request.conversationId,
+      ...(request.userId ? { userId: request.userId, source: "voice" } : {}),
+    },
   };
 
   let upstream: Response | null;


### PR DESCRIPTION
## Summary

- harden the dedicated realtime voice bearer path so URL agent/conversation identity must match all verified structural headers before lookup or persistence
- propagate the verified selected user and selected conversation into canonical `message.send` (`userId`, `roomId`, `source: voice`)
- suppress duplicate Flux final events before a second selected-conversation execution/persistence/billing path
- add deterministic missing/wrong identity, selected user/conversation, and duplicate-final coverage
- include recovery receipt `ISSUE-16437-RECOVERY-2026-07-19.md`

## Preserved behavior

This is a narrow recovery patch on current `develop`. It does not change the bootstrap token TTL/revocation flow, #16636 reconnect recovery, cancellation/barge-in, provider fallback/retry, latency stack, durable history schema, or billing implementation. It retains the dedicated `VOICE_REALTIME_ELIZA_AUTHORIZATION` boundary and adds no speculative staging configuration.

## Verification

- `bun test packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts` (7 pass)
- `bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` (32 pass)
- `bun test packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts` (18 pass)
- Biome on all touched TypeScript files
- `git diff --check`

No staging deployment was available, so no live staging evidence is claimed.

Closes #16437

[sol-orch]

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only realtime voice routing change; no UI surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only realtime voice routing change; no UI surface

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only protocol routing change with deterministic lifecycle tests; no UI walkthrough

<!-- evidence-row:backend-logs -->
- [x] N/A - no staging deployment was available; focused local test results are recorded in the committed recovery receipt

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface or frontend network behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic mocked selected-agent conversation protocol tests; no real-LLM staging invocation was available

<!-- evidence-row:domain-artifacts -->
- [x] [ISSUE-16437-RECOVERY-2026-07-19.md](https://github.com/elizaOS/eliza/blob/sol/issue-16437-recovery/ISSUE-16437-RECOVERY-2026-07-19.md)
