### PR TITLE
fix(ci): run cloud TTS route test under Vitest

### DIFF
--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -5,7 +5,7 @@
  * so the cloud route can replay the direct attempt's committed reservation —
  * plus the handler's auth/validation/success/error envelope.
  */
-import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
 import type http from "node:http";
 import { handleCloudTtsPreviewRoute } from "./server-cloud-tts";
 


### PR DESCRIPTION
## Summary

The fresh develop Windows plugins shard executes `bun run --cwd plugins/plugin-elizacloud test`, whose package script is `vitest run`. `src/lib/server-cloud-tts.test.ts` was included by that Vitest config but imported `bun:test`, so Windows Node/Vite collection failed before running the route assertions:

> Cannot find package 'bun:test' imported from .../server-cloud-tts.test.ts

Use Vitest's API for this Vitest-owned test. The test body, assertions, error paths, package include, and Windows command are unchanged.

Baseline log: Develop Exhaustive run `29698528797`, Windows plugins job `88223381764`.

## Validation

- `git diff --check` passed.
- The file only uses the shared `afterAll`, `beforeEach`, `describe`, `expect`, and `test` API.
- Fresh PR CI is the Windows execution proof.

Manual merge only. No test/baseline deletion, `passWithNoTests`, `|| true`, or check removal.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-runner compatibility only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow change.
<!-- evidence-row:backend-logs -->
- [x] [Baseline Windows collection log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16674-baseline-windows-bun-test-collection.log) contains the exact `bun:test` module-resolution failure from job `88223381764`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - backend route test only.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact changed; this only corrects the test-runner import.

[sol-orch]

