### PR TITLE
fix(ci): classify coding web actions in scenario manifest

### DIFF
--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -77,7 +77,13 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
     "SETTINGS",
     "VIEWS",
   ],
-  "@elizaos/plugin-coding-tools": ["FILE", "SHELL", "WORKTREE"],
+  "@elizaos/plugin-coding-tools": [
+    "FILE",
+    "SHELL",
+    "WEB_FETCH",
+    "WEB_SEARCH",
+    "WORKTREE",
+  ],
   "@elizaos/plugin-commands": [
     "ACCOUNTS_COMMAND",
     "BACKEND_COMMAND",
@@ -204,6 +210,10 @@ const KNOWN_UNCOVERED: readonly string[] = [
   // current runtime action surface without registering them as top-level actions.
   "CLOSE_ALL_VIEWS",
   "CLOSE_VIEW",
+  // Coding-tools web actions are unit-covered but do not yet have a strict,
+  // network-free scenario fixture. Keep them visible in the no-growth ledger.
+  "WEB_FETCH",
+  "WEB_SEARCH",
   // New speaker-diarization action; no deterministic keyless scenario yet.
   "IDENTIFY_SPEAKER",
   // New on-device transcription actions; no deterministic keyless scenario yet.


### PR DESCRIPTION
## Summary

`@elizaos/plugin-coding-tools` now registers `WEB_FETCH` and `WEB_SEARCH`, but the scenario-runner's fail-closed imported-action manifest still expected only `FILE`, `SHELL`, and `WORKTREE`. Both Linux scenario coverage and the Windows framework shard therefore failed before their substantive suites could complete.

Record the two real imported actions in `CORE_ACTION_SURFACE`, and classify them honestly in the existing no-growth `KNOWN_UNCOVERED` ledger until a strict network-free end-to-end scenario exists. Their plugin unit tests remain intact. This does not claim scenario coverage or delete/shrink a baseline.

Baseline logs:

- Develop Exhaustive `29698528797`, Zero-Key unit + UI coverage job `88223457746`
- same run, Windows framework job `88223381744`

Both report the exact drift: real `[FILE, SHELL, WEB_FETCH, WEB_SEARCH, WORKTREE]` vs manifest `[FILE, SHELL, WORKTREE]`.

## Validation

- `git diff --check` passed.
- The manifest exactly matches the imported plugin order after sorting.
- The no-growth uncovered ledger remains enforced and grows explicitly by the two newly registered actions.
- Fresh PR CI is the full scenario/Windows proof.

Manual merge only. No test/baseline deletion, `passWithNoTests`, `|| true`, or check removal.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - deterministic manifest repair.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow change.
<!-- evidence-row:backend-logs -->
- [x] [Baseline Linux and Windows manifest-drift log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16675-baseline-zero-key-manifest-drift.log) contains the exact assertions from jobs `88223457746` and `88223381744`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - manifest-only change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model invocation.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no generated/domain artifact changed; the deterministic manifest test is the validation authority.

[sol-orch]

