### PR TITLE
fix(test): reset account pool status mock behavior

### DIFF
--- a/packages/app-core/src/api/account-pool-status-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.test.ts
@@ -33,7 +33,7 @@ const previousPublicStatus =
   process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  getPublicAccountPoolStatus.mockReset();
   process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED = "1";
 });
 


### PR DESCRIPTION
## Summary

The app-core Vitest config intentionally runs one non-isolated worker. `account-pool-status-routes.test.ts` only called `vi.clearAllMocks()`, which clears call history but preserves queued/default implementations on its hoisted service mock. In the exhaustive Windows app-and-cli shard, the nominal success test inherited rejection behavior and returned 503 instead of 200.

Reset the owning mock's behavior and history before every test with `mockReset()`. All three real route assertions remain unchanged: disabled 404, successful public-safe 200, and failed refresh 503 with retry-after.

Baseline: Develop Exhaustive `29698528797`, Windows app-and-cli job `88223381811`, `expected 503 to be 200` in `account-pool-status-routes.test.ts`.

## Validation

- `git diff --check` passed.
- Focused one-line fixture lifecycle correction, no production behavior changed.
- Fresh PR CI is the Windows full-worker proof.

Manual merge only. No test/baseline deletion, `passWithNoTests`, `|| true`, or check removal.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test isolation repair.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow change.
<!-- evidence-row:backend-logs -->
- [x] [Baseline Windows job log](https://github.com/elizaOS/eliza/actions/runs/29698528797/job/88223381811) records the real `expected 503 to be 200` assertion in the nominal success case.
<!-- evidence-row:frontend-logs -->
- [x] N/A - route unit test only.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact changed; this only resets a deterministic route mock.

[sol-orch]

