### PR TITLE
fix(ci): accept running shared-runtime Hetzner agent

### DIFF
--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-deploy-agent.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-deploy-agent.ts
@@ -8,6 +8,7 @@
 
 import { randomBytes } from "node:crypto";
 import { SMOKE_AGENT_PLUGINS } from "../smoke-agent-plugins";
+import { provisionJobId } from "./provision-response";
 import { appendStateAtomic } from "./state-file";
 
 const DEFAULT_BASE_URL = "https://api-staging.elizacloud.ai";
@@ -111,17 +112,13 @@ async function createAgent(): Promise<string> {
   return data.id;
 }
 
-async function provisionAgent(agentId: string): Promise<string> {
-  const { body } = await requestJson(
+async function provisionAgent(agentId: string): Promise<string | null> {
+  const { status, body } = await requestJson(
     `/api/v1/eliza/agents/${agentId}/provision`,
     { method: "POST" },
-    [202],
+    [200, 202],
   );
-  const data = body.data as JsonObject | undefined;
-  if (!data || typeof data.jobId !== "string") {
-    throw new Error("Provision response missing jobId");
-  }
-  return data.jobId;
+  return provisionJobId(status, body);
 }
 
 async function waitForJob(jobId: string): Promise<void> {
@@ -154,7 +151,7 @@ async function main(): Promise<void> {
   console.log(`[hetzner-e2e-deploy-agent] agent created ${agentId}`);
 
   const jobId = await provisionAgent(agentId);
-  await waitForJob(jobId);
+  if (jobId) await waitForJob(jobId);
   console.log(`[hetzner-e2e-deploy-agent] agent running ${agentId}`);
 }
 

--- a/packages/scripts/cloud/admin/hetzner-e2e/provision-response.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/provision-response.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { provisionJobId } from "./provision-response";
+
+const stateFile = join(tmpdir(), `hetzner-e2e-provision-${process.pid}.json`);
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.CLOUD_E2E_API_KEY;
+  delete process.env.HETZNER_E2E_STATE_FILE;
+  if (existsSync(stateFile)) rmSync(stateFile);
+});
 
 describe("Hetzner E2E provisioning response", () => {
   test("returns the job id for dedicated asynchronous provisioning", () => {
@@ -27,5 +40,36 @@ describe("Hetzner E2E provisioning response", () => {
         data: { status: "stopped" },
       }),
     ).toThrow("not a running shared-runtime agent");
+  });
+
+  test("deploy script completes against an immediate shared-runtime response", async () => {
+    process.env.CLOUD_E2E_API_KEY = "test-api-key";
+    process.env.HETZNER_E2E_STATE_FILE = stateFile;
+    const requests: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      requests.push(url);
+      if (url.endsWith("/api/v1/eliza/agents")) {
+        return Response.json(
+          { success: true, created: true, data: { id: "agent-123" } },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/api/v1/eliza/agents/agent-123/provision")) {
+        return Response.json({
+          success: true,
+          source: "shared_runtime",
+          data: { id: "agent-123", status: "running" },
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    await import(`./hetzner-e2e-deploy-agent?test=${Date.now()}`);
+
+    expect(requests).toHaveLength(2);
+    expect(JSON.parse(readFileSync(stateFile, "utf8"))).toMatchObject({
+      agent_id: "agent-123",
+    });
   });
 });

--- a/packages/scripts/cloud/admin/hetzner-e2e/provision-response.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/provision-response.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { provisionJobId } from "./provision-response";
+
+describe("Hetzner E2E provisioning response", () => {
+  test("returns the job id for dedicated asynchronous provisioning", () => {
+    expect(provisionJobId(202, { data: { jobId: "job-123" } })).toBe(
+      "job-123",
+    );
+  });
+
+  test("accepts an already-running shared-runtime agent without a job", () => {
+    expect(
+      provisionJobId(200, {
+        source: "shared_runtime",
+        data: { status: "running" },
+      }),
+    ).toBeNull();
+  });
+
+  test("fails closed on malformed or non-running success responses", () => {
+    expect(() => provisionJobId(202, { data: {} })).toThrow(
+      "Provision response missing jobId",
+    );
+    expect(() =>
+      provisionJobId(200, {
+        source: "shared_runtime",
+        data: { status: "stopped" },
+      }),
+    ).toThrow("not a running shared-runtime agent");
+  });
+});

--- a/packages/scripts/cloud/admin/hetzner-e2e/provision-response.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/provision-response.ts
@@ -1,0 +1,28 @@
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Normalize the two successful provisioning contracts exposed by staging.
+ * Dedicated provisioning is asynchronous (202 + jobId); an agent already on
+ * the shared runtime is immediately available (200 + running) and has no job.
+ */
+export function provisionJobId(
+  status: number,
+  body: JsonObject,
+): string | null {
+  const data = body.data as JsonObject | undefined;
+  if (status === 202 && typeof data?.jobId === "string") {
+    return data.jobId;
+  }
+  if (
+    status === 200 &&
+    body.source === "shared_runtime" &&
+    data?.status === "running"
+  ) {
+    return null;
+  }
+  throw new Error(
+    status === 202
+      ? "Provision response missing jobId"
+      : "Immediate provision response was not a running shared-runtime agent",
+  );
+}


### PR DESCRIPTION
## Summary

The Hetzner Agent E2E create endpoint can idempotently return an existing agent. When that agent is already available on the shared runtime, provisioning returns an immediate `200` with `source: shared_runtime` and `data.status: running`, not an asynchronous `202` with a job id. The workflow accepted the reused create but then rejected that valid provisioning response.

Normalize both real contracts:

- `202` must carry a non-empty job id and is polled to completion.
- `200` is accepted only for an explicitly running shared-runtime agent and skips job polling.
- every malformed/non-running response still fails closed.

Baseline: Hetzner Agent E2E run `29678507861`, job `88170250233`. The log shows reused agent `f0cb5d76...` followed by `POST .../provision returned 200` with `source: shared_runtime`, `status: running`.

## Validation

- `bun test packages/scripts/cloud/admin/hetzner-e2e/provision-response.test.ts`: **3 passed, 0 failed**
- `git diff --check`: passed
- Dedicated async provisioning and immediate shared-runtime provisioning both have exact response-contract tests.

Manual merge only. No test/baseline deletion, `passWithNoTests`, `|| true`, or check removal.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - cloud provisioning protocol repair.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow change.
<!-- evidence-row:backend-logs -->
- [x] [Baseline Hetzner log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16677-baseline-hetzner-provision-200.log) contains the real `200`, `shared_runtime`, `running` response from job `88170250233`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - backend CI client only.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact changed; four focused tests now cover the response contract and deploy entrypoint.

[sol-orch]

