### PR TITLE
fix(ui): preserve contrast in disabled account rows

### DIFF
--- a/packages/ui/src/components/accounts/AccountCommandTable.test.tsx
+++ b/packages/ui/src/components/accounts/AccountCommandTable.test.tsx
@@ -209,11 +209,12 @@ describe("AccountCommandTable", () => {
     expect(onReauthenticate).toHaveBeenCalledWith(reauthAccount);
   });
 
-  it("dims disabled rows and forwards enabled toggles through onPatch", () => {
+  it("marks disabled rows without lowering descendant contrast and forwards enabled toggles", () => {
     const onPatch = vi.fn().mockResolvedValue(undefined);
     renderTable([account({ id: "off", enabled: false })], { onPatch });
     const row = screen.getByTestId("account-row-off");
-    expect(row.className).toContain("opacity-55");
+    expect(row.className).toContain("bg-bg-accent/20");
+    expect(row.className).not.toContain("opacity-");
     fireEvent.click(within(row).getByRole("checkbox"));
     expect(onPatch).toHaveBeenCalledWith("off", { enabled: true });
   });

--- a/packages/ui/src/components/accounts/AccountCommandTable.tsx
+++ b/packages/ui/src/components/accounts/AccountCommandTable.tsx
@@ -480,7 +480,7 @@ export function AccountCommandTable({
                   data-active={isActive ? "true" : undefined}
                   className={cn(
                     "border-b border-border/25 transition-colors last:border-b-0 hover:bg-bg-accent/25",
-                    !account.enabled && "opacity-55",
+                    !account.enabled && "bg-bg-accent/20",
                     isActive && "bg-accent/5",
                   )}
                 >


### PR DESCRIPTION
## Summary

The exhaustive Storybook accessibility gate found the same new `color-contrast` violation in both populated `AccountCommandTable` stories, 14 descendant nodes each. The shared cause is the disabled account row's `opacity-55`, which composites every already-muted label, usage value, timestamp, and control down to failing contrast.

Keep the disabled state visible with a subtle background tint instead of lowering the opacity of all descendants. The enabled checkbox remains the semantic/control indication. Extend the existing disabled-row test to reject any row-level opacity class.

Baseline: Develop Exhaustive `29698528797`, story gate job `88223381711`, artifact `story-gate-output` (`8445896327`):

- `accounts-accountcommandtable--with-observability`: `color-contrast`
- `accounts-accountcommandtable--without-observability`: `color-contrast`

## Validation

- `git diff --check` passed.
- Existing disabled-row interaction assertion remains and now pins contrast-safe styling.
- Fresh PR aesthetic/story CI is the rendered accessibility proof.

Manual merge only. No screenshot baseline update, test deletion, `passWithNoTests`, `|| true`, or check removal.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] [Before, with observability](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16679-before-with-observability.png) and [before, without observability](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16679-before-without-observability.png), extracted unchanged from baseline Storybook artifact `8445896327`.
<!-- evidence-row:after-screenshots -->
- [x] [Fresh after render](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16679-after-account-command-table.png), actual PR-head `AccountCommandTable` markup rendered in Chromium with repository Tailwind CSS.
<!-- evidence-row:walkthrough-video -->
- [x] [Fresh Chromium walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16679-account-command-table-walkthrough.webm) of the rendered PR-head table.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend change.
<!-- evidence-row:frontend-logs -->
- [x] [Fresh OCR and axe report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16679-ocr-and-axe-review.txt) records the rendered text and zero serious/critical WCAG A/AA violations; baseline job `88223381711` records both original contrast violations.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no generated/domain artifact changed; the unit test and fresh axe report validate the UI behavior.

<!-- evidence-row:ocr-review -->
- [x] [OCR visual text and axe review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16679-ocr-and-axe-review.txt) for the fresh Chromium render.

[sol-orch]

