### PR TITLE
fix(ui): restore account command contrast

### DIFF
--- a/packages/ui/src/components/accounts/AccountCommandTable.test.tsx
+++ b/packages/ui/src/components/accounts/AccountCommandTable.test.tsx
@@ -183,7 +183,9 @@ describe("AccountCommandTable", () => {
     expect(screen.getByText("Leases")).toBeTruthy();
     const row = screen.getByTestId("account-row-a");
     expect(within(row).getByText("3")).toBeTruthy();
-    expect(within(row).getByText("served last")).toBeTruthy();
+    expect(within(row).getByText("served last").className).toContain(
+      "text-accent",
+    );
   });
 
   it("renders the reauth CTA only for accounts needing repair", () => {
@@ -197,7 +199,7 @@ describe("AccountCommandTable", () => {
     const okRow = screen.getByTestId("account-row-ok");
     const reRow = screen.getByTestId("account-row-re");
     expect(within(okRow).queryByText("Reauth")).toBeNull();
-    expect(within(reRow).getByText("Reauth")).toBeTruthy();
+    expect(within(reRow).getByText("Reauth").className).toContain("text-bg");
   });
 
   it("invokes onReauthenticate with the account via the existing repair flow", () => {

--- a/packages/ui/src/components/accounts/AccountCommandTable.tsx
+++ b/packages/ui/src/components/accounts/AccountCommandTable.tsx
@@ -642,7 +642,7 @@ export function AccountCommandTable({
                           {lease?.activeLeaseCount ?? 0}
                         </span>
                         {lease?.servedLastRequest ? (
-                          <span className="text-[9px] uppercase tracking-wider text-accent-muted">
+                          <span className="text-[9px] uppercase tracking-wider text-accent">
                             {t("accounts.table.leases.servedLast", {
                               defaultValue: "served last",
                             })}
@@ -757,7 +757,7 @@ export function AccountCommandTable({
                           size="sm"
                           disabled={rowSaving}
                           onClick={() => onReauthenticate(account)}
-                          className="h-7 gap-1 px-2 text-[11px]"
+                          className="h-7 gap-1 px-2 text-[11px] text-bg"
                         >
                           <KeyRound className="h-3 w-3" aria-hidden />
                           {account.source === "oauth"


### PR DESCRIPTION
## Summary
- give compact account repair CTAs a dark foreground that clears 4.5:1 on the orange accent surface
- promote the 9px `served last` marker from the muted accent to the full accent token
- lock both contrast-bearing classes in the focused component test

## Root cause
#16679 removed the disabled-row opacity regression, but the exhaustive gate still found two pre-existing compact accent treatments introduced with #16399:

- repair CTA: `#fdfaf7` on `#ff6a1f`, **2.75:1** (required 4.5:1)
- `served last`: `#c94400` on `#0d0502`, **4.14:1** (required 4.5:1)

No threshold, baseline, workflow, or allowlist changed.

## Before / after evidence

**Before, exact develop failure:** [UI Story Gate run 29712098067](https://github.com/elizaOS/eliza/actions/runs/29712098067), 2 regressed stories, `color-contrast`, node counts 2 without observability and 3 with observability.

![With observability before and after](https://raw.githubusercontent.com/0xSolace/eliza/evidence/ui-gate-finish-r2-20260720/with-observability-comparison.png)

![Without observability before and after](https://raw.githubusercontent.com/0xSolace/eliza/evidence/ui-gate-finish-r2-20260720/without-observability-comparison.png)

The unchanged empty-pool screenshot remained byte-identical (`29a09f44...`); the affected screenshots changed only 280 and 536 pixels respectively.

**After, same gate locally:**

```text
$ node packages/ui/test/story-gate/run-story-gate.mjs --static-dir packages/ui/storybook-static --concurrency 4 --grep AccountCommandTable
story-gate: 3 stories | good=3 | broken=0 | needs-runtime=0 | console-err=0 | a11y=0 | play=0/0
OK story-gate PASSED
```

## Verification
- `bunx vitest run packages/ui/src/components/accounts/AccountCommandTable.test.tsx --config packages/ui/vitest.config.ts` (20 passed)
- `bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet`
- `node packages/ui/test/story-gate/run-story-gate.mjs --static-dir packages/ui/storybook-static --concurrency 4 --grep AccountCommandTable`
- `git diff --check`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16687-with-observability-comparison.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16687-without-observability-comparison.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16687-contrast-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changed.
<!-- evidence-row:frontend-logs -->
- [x] [16687-story-gate.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16687-story-gate.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] [16687-focused-test.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16687-focused-test.log)

Co-authored-by: wakesync <wakesync@users.noreply.github.com>

[sol-orch]

<!-- evidence-row:ocr-review -->
- [x] [16687-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16687-ocr-review.txt)
