### PR TITLE
test(runtime): await requested plugin services

### DIFF
--- a/packages/app-core/test/helpers/real-runtime.ts
+++ b/packages/app-core/test/helpers/real-runtime.ts
@@ -482,6 +482,18 @@ export async function createRealTestRuntime(
 
     await runtime.initialize();
 
+    // `initialize()` resolves the service-start barrier, but the service starts
+    // kicked off by `registerPlugin()` still complete asynchronously. This
+    // helper promises callers a fully initialized runtime, and integration
+    // tests call synchronous service accessors immediately after it returns.
+    // Drain services declared by the explicitly requested plugins in plugin
+    // order so those accessors cannot race the registration microtask.
+    for (const plugin of options?.plugins ?? []) {
+      for (const service of plugin.services ?? []) {
+        await runtime.getServiceLoadPromise(service.serviceType);
+      }
+    }
+
     // Eagerly start the OptimizedPromptService so the planner-loop's
     // synchronous `runtime.getService('optimized_prompt')` call hits an
     // already-instantiated service. Without this the service is registered


### PR DESCRIPTION
## Summary
- drain service starts declared by explicitly requested plugins before `createRealTestRuntime` returns
- closes the fresh-boot race where synchronous scheduling accessors observed `lifeops_scheduled_task_runner` in `registering` state
- preserves strict service failures, no skip or fallback

## Evidence
Develop run 29712098103 failed the PA integration/unit corpus with `ScheduledTaskRunnerService is not registered` after #16676. Local reproduction showed the service type registered but still `registering` after runtime initialization returned.

## Verification
- approval queue integration: 8 passed
- scheduled task trigger boundary + fire budget: 15 passed
- Biome check passed

Co-authored-by: wakesync <shadow@shad0w.xyz>


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - this PR changes test/runtime, CLI, dependency, or command-classification code only and does not change rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - this PR changes no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - there is no user-facing visual flow in this CI remediation.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [exact source failure run](https://github.com/elizaOS/eliza/actions/runs/29712098103) and [PR checks](https://github.com/elizaOS/eliza/pull/16689/checks).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend runtime or network behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, trajectory, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [focused source and test diff](https://github.com/elizaOS/eliza/pull/16689/files), with exact local verification recorded above.

<!-- evidence-refresh: r7 1930 -->
