### PR TITLE
style(app-core): format desktop notification route test

### DIFF
--- a/packages/app-core/src/desktop-test-bridge-notification-route.test.ts
+++ b/packages/app-core/src/desktop-test-bridge-notification-route.test.ts
@@ -1,8 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-const diagnostics = [
-  { title: "Build finished", body: "Ready", timestamp: 42 },
-];
+const diagnostics = [{ title: "Build finished", body: "Ready", timestamp: 42 }];
 const clearNotificationDiagnostics = vi.fn(() => diagnostics.splice(0));
 const getNotificationDiagnostics = vi.fn(() => [...diagnostics]);
 const desktop = {
@@ -62,7 +60,9 @@ describe("desktop test bridge notification observation route", () => {
 
   it("keeps authenticated bridge control ingress live", async () => {
     const headers = { Authorization: `Bearer ${TOKEN}` };
-    expect(await (await fetch(`${BASE_URL}/health`, { headers })).json()).toEqual({ ok: true });
+    expect(
+      await (await fetch(`${BASE_URL}/health`, { headers })).json(),
+    ).toEqual({ ok: true });
     expect((await fetch(`${BASE_URL}/state`, { headers })).status).toBe(200);
 
     const invalidEval = await fetch(`${BASE_URL}/main-window/eval`, {
@@ -79,7 +79,14 @@ describe("desktop test bridge notification observation route", () => {
     expect(await evaluated.json()).toEqual({ result: "ran:1 + 1" });
 
     for (const action of ["show", "focus", "minimize"]) {
-      expect((await fetch(`${BASE_URL}/main-window/${action}`, { method: "POST", headers })).status).toBe(200);
+      expect(
+        (
+          await fetch(`${BASE_URL}/main-window/${action}`, {
+            method: "POST",
+            headers,
+          })
+        ).status,
+      ).toBe(200);
     }
   });
 


### PR DESCRIPTION
## Summary

- applies Biome's canonical formatting to `desktop-test-bridge-notification-route.test.ts`
- keeps the change formatter-only, with no semantic or assertion changes
- traces the residual to merged PR #16648 (`fix/16645-native-notification-record`, commit `970e42513bba`)

## Block-0 ownership check

- no current open PR changes the target file
- no current open issue or PR claim mentions the target formatter residual
- originating PR #16648 merged at 2026-07-20T00:55:18Z

## Validation

- `bunx @biomejs/biome format packages/app-core/src/desktop-test-bridge-notification-route.test.ts` ✅
- `bun run --cwd packages/app-core test -- src/desktop-test-bridge-notification-route.test.ts` ✅, 1 file / 3 tests
- exact Quality contract through guide parity, type-safety ratchet, and type-duplication self-test ✅
- root `bun run format:check` now clears `@elizaos/app-core`, then exposes two additional pre-existing formatter violations from the same merged #16648 commit in:
  - `packages/ui/src/App.chat-overlay-first-run.test.tsx`
  - `packages/ui/src/components/shell/notifications-boot.test.tsx`

Those UI files are deliberately excluded here to keep this PR scoped to the assigned app-core residual.

[sol-orch]


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - formatter-only change to test source does not alter rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - formatter-only change to test source does not alter rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or runtime behavior changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime code path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or generated runtime artifact changed.
