### PR TITLE
ci: proposal, dispatch cloud-hybrid Android APK artifacts

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,6 +3,14 @@ name: Build Android
 on:
   workflow_dispatch:
     inputs:
+      build_target:
+        description: "Android renderer/runtime lane"
+        required: true
+        type: choice
+        default: android
+        options:
+          - android
+          - android-cloud-hybrid
       upload_to_release:
         description: "Upload APK/AAB to latest GitHub release"
         required: false
@@ -150,7 +158,17 @@ jobs:
 
       - name: Prepare Android platform
         working-directory: ${{ env.APP_DIR }}
-        run: bun run build:android
+        env:
+          ANDROID_BUILD_TARGET: ${{ inputs.build_target || 'android' }}
+        run: |
+          case "$ANDROID_BUILD_TARGET" in
+            android) bun run build:android ;;
+            android-cloud-hybrid) bun run build:android:cloud-hybrid ;;
+            *)
+              echo "::error::unsupported Android build target: $ANDROID_BUILD_TARGET" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Run Android developer-install preflight
         working-directory: ${{ env.APP_DIR }}
@@ -228,12 +246,39 @@ jobs:
             | xargs -0 sha256sum > "${{ env.ANDROID_DIR }}/app/build/outputs/SHA256SUMS.txt"
           cat "${{ env.ANDROID_DIR }}/app/build/outputs/SHA256SUMS.txt"
 
-      - name: Upload debug APK artifact
-        if: github.event_name == 'workflow_dispatch'
+      - name: Prepare cloud-hybrid APK artifact
+        if: github.event_name == 'workflow_dispatch' && inputs.build_target == 'android-cloud-hybrid'
+        env:
+          SOURCE_APK: ${{ env.ANDROID_DIR }}/app/build/outputs/apk/debug/app-debug.apk
+          ARTIFACT_BASENAME: eliza-android-cloud-hybrid-${{ github.sha }}
+        run: |
+          set -euo pipefail
+          install -m 0644 "$SOURCE_APK" "$RUNNER_TEMP/$ARTIFACT_BASENAME.apk"
+          {
+            echo "repository=${{ github.repository }}"
+            echo "commit=${{ github.sha }}"
+            echo "build_target=android-cloud-hybrid"
+            echo "build_command=bun run build:android:cloud-hybrid"
+            echo "java_version=21"
+          } > "$RUNNER_TEMP/$ARTIFACT_BASENAME.provenance.txt"
+
+      - name: Upload standard debug APK artifact
+        if: github.event_name == 'workflow_dispatch' && inputs.build_target == 'android'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: eliza-android-debug
           path: ${{ env.ANDROID_DIR }}/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload cloud-hybrid debug APK artifact
+        if: github.event_name == 'workflow_dispatch' && inputs.build_target == 'android-cloud-hybrid'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: eliza-android-cloud-hybrid-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/eliza-android-cloud-hybrid-${{ github.sha }}.apk
+            ${{ runner.temp }}/eliza-android-cloud-hybrid-${{ github.sha }}.provenance.txt
           if-no-files-found: error
           retention-days: 7
 

--- a/packages/scripts/__tests__/native-build-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/native-build-workflow-contract.test.ts
@@ -119,6 +119,28 @@ describe("Android native build authority", () => {
     );
   });
 
+  test("dispatches the explicit cloud-hybrid target without changing the standard lane", () => {
+    expect(consumer).toMatch(
+      /build_target:\n[\s\S]*?default: android\n[\s\S]*?options:\n\s+- android\n\s+- android-cloud-hybrid/,
+    );
+    expect(consumer).toContain("android) bun run build:android ;;");
+    expect(consumer).toContain(
+      "android-cloud-hybrid) bun run build:android:cloud-hybrid ;;",
+    );
+    expect(consumer).toContain(
+      "if: github.event_name == 'workflow_dispatch' && inputs.build_target == 'android'",
+    );
+    expect(consumer).toContain("name: eliza-android-debug");
+    expect(consumer).toContain(
+      "name: eliza-android-cloud-hybrid-${{ github.sha }}",
+    );
+    expect(consumer).toContain(
+      "eliza-android-cloud-hybrid-${{ github.sha }}.apk",
+    );
+    expect(consumer).toContain("build_command=bun run build:android:cloud-hybrid");
+    expect(consumer).toContain("java_version=21");
+  });
+
   test("removes uncalled scaffolds without replacing mobile or Apple authorities", () => {
     const retired = [
       ...["ios", "linux", "macos"].map(


### PR DESCRIPTION
## Summary

Stacked on #16683. This is the narrow workflow proposal that lets `Build Android` dispatch the PR-head `android-cloud-hybrid` lane under JDK 21 and retain a clearly named APK plus provenance receipt.

- adds a fail-closed `build_target` choice: `android` (default) or `android-cloud-hybrid`
- preserves the existing `bun run build:android` path and `eliza-android-debug` artifact unchanged for normal manual builds
- invokes the first-class `bun run build:android:cloud-hybrid` command introduced by #16683
- uploads `eliza-android-cloud-hybrid-<full commit SHA>.apk` with a same-name provenance file recording repository, exact commit, target, command, and Java version
- retains the pinned JDK 21 and input-compatible fused-native artifact staging already owned by this workflow

## Dependency and collision block

- Base is `fix/android-cloud-hybrid-first-class`, the head branch of #16683. Merge #16683 first, then retarget/rebase this proposal onto `develop`.
- #16640 overlaps #16683 in `mobile-lane-stamp.mjs`, `mobile-lane-stamp.test.mts`, `run-mobile-build.mjs`, and `packages/app/package.json`. It does not overlap this proposal's `build-android.yml` or native workflow contract test.
- Open workflow PRs touch other workflow authorities, but the current open-PR scan found no other change to `.github/workflows/build-android.yml`.
- Workflow change: manual maintainer merge only. Do not auto-merge.

## Dispatch

The first exact-head dispatch exposed a missing CLI allowlist/dispatch branch in #16683. That block is fixed on #16683 by `a0dda5fc8dd872421c084d5bc4e7059f1f5c65f4`, with focused contract coverage. The corrected stacked head is `6d109776b8992412ce51dfcacdf41ce92a564847`.

Reusable dispatch command:

```text
gh workflow run build-android.yml \
  --repo elizaOS/eliza \
  --ref sol/16683-cloud-hybrid-artifact \
  -f build_target=android-cloud-hybrid \
  -f upload_to_release=false
```

The artifact is named `eliza-android-cloud-hybrid-<github.sha>` and contains:

```text
eliza-android-cloud-hybrid-<github.sha>.apk
eliza-android-cloud-hybrid-<github.sha>.provenance.txt
```

## Evidence

| Check | Result |
|---|---|
| Native workflow contract | `5 pass`, `0 fail`, exit 0 |
| YAML parse | `yaml parse ok`, exit 0 |
| Biome | touched TypeScript contract test clean, exit 0 |
| Whitespace | `git diff --check`, exit 0 |
| Normal Android path | contract pins default `android`, command `bun run build:android`, artifact `eliza-android-debug` |
| Hybrid provenance | contract pins SHA-named APK, exact command, and `java_version=21` receipt |

## Hosted exact-head artifact

- Run: https://github.com/elizaOS/eliza/actions/runs/29722051581
- Conclusion: success, 13m31s
- JDK: 21 setup passed
- Exact head: `6d109776b8992412ce51dfcacdf41ce92a564847`
- Artifact: `eliza-android-cloud-hybrid-6d109776b8992412ce51dfcacdf41ce92a564847`
- Artifact ID: `8452955399`
- Archive size: `305254555` bytes
- GitHub artifact digest: `sha256:1a8495c1d2a5109665048d8d571c74cdccc459112352956a8d68b7f340e58e0d`

Manual merge only. No auto-merge was enabled.

[sol-orch]

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- N/A - workflow-only proposal; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- N/A - workflow-only proposal; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- N/A - manual workflow dispatch has no interactive product flow.
<!-- evidence-row:backend-logs -->
- N/A - no backend service or request path changed.
<!-- evidence-row:frontend-logs -->
- N/A - no browser runtime or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- N/A - no model invocation, prompt, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- Successful exact-head JDK 21 run with SHA-named APK and provenance artifact: https://github.com/elizaOS/eliza/actions/runs/29722051581
