### PR TITLE
fix(scenarios): checkpoint live evidence incrementally

### DIFF
--- a/packages/scenario-runner/src/cli.test.ts
+++ b/packages/scenario-runner/src/cli.test.ts
@@ -5,7 +5,7 @@
  * semantics stay deterministic and cheap enough for the unit lane.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ScenarioDefinition } from "@elizaos/scenario-runner/schema";
@@ -16,6 +16,7 @@ import {
   parseArgs,
   runCli,
 } from "./cli.ts";
+import { writeReport as writeReportToDisk } from "./reporter.ts";
 import type { AggregateReport, ScenarioReport } from "./types.ts";
 
 const ENV_KEYS = [
@@ -298,5 +299,128 @@ describe("scenario-runner CLI", () => {
       runDir,
       { nativeJsonlPath: nativePath },
     );
+  });
+
+  it("refreshes aggregate evidence after every completed scenario and keeps the final report equivalent to the last checkpoint", async () => {
+    writeScenario(tempDir, "cli-first");
+    writeScenario(tempDir, "cli-second");
+    const runDir = path.join(tempDir, "run");
+    const reportPath = path.join(tempDir, "report.json");
+    const dependencies = createDependencies(() => "passed");
+
+    const code = await runCli(
+      [
+        "run",
+        tempDir,
+        "--run-dir",
+        runDir,
+        "--runId",
+        "checkpoint-run",
+        "--report",
+        reportPath,
+      ],
+      dependencies,
+    );
+
+    expect(code).toBe(0);
+    const reportWrites = vi
+      .mocked(dependencies.writeReport)
+      .mock.calls.filter(([, filePath]) => filePath === reportPath)
+      .map(([report]) => report);
+    expect(
+      reportWrites.map((report) => report.scenarios.map((s) => s.id)),
+    ).toEqual([
+      ["cli-first"],
+      ["cli-first", "cli-second"],
+      ["cli-first", "cli-second"],
+    ]);
+    expect(reportWrites.at(-1)).toEqual(reportWrites.at(-2));
+    // Expensive derived artifacts are rebuilt once at deterministic finalization,
+    // not by every incremental checkpoint.
+    expect(dependencies.writeScenarioRunViewer).toHaveBeenCalledTimes(1);
+    expect(dependencies.exportScenarioNativeJsonl).toHaveBeenCalledTimes(0);
+  });
+
+  it("stops after a graceful interrupt only after checkpointing the completed scenario", async () => {
+    writeScenario(tempDir, "cli-alpha-signal");
+    writeScenario(tempDir, "cli-beta-after-signal");
+    const runDir = path.join(tempDir, "run");
+    const reportPath = path.join(tempDir, "report.json");
+    const dependencies = createDependencies(() => "passed", {
+      runScenario: vi.fn(async (scenario) => {
+        const report = scenarioReport(scenario.id, "passed");
+        process.emit("SIGTERM", "SIGTERM");
+        return report;
+      }),
+      writeReport: writeReportToDisk,
+    });
+
+    const code = await runCli(
+      [
+        "run",
+        tempDir,
+        "--run-dir",
+        runDir,
+        "--runId",
+        "interrupted-run",
+        "--report",
+        reportPath,
+      ],
+      dependencies,
+    );
+
+    expect(code).toBe(1);
+    expect(dependencies.runScenario).toHaveBeenCalledTimes(1);
+    const recoveredReport = JSON.parse(
+      readFileSync(reportPath, "utf8"),
+    ) as AggregateReport;
+    expect(recoveredReport.scenarios.map((s) => s.id)).toEqual([
+      "cli-alpha-signal",
+    ]);
+    const recoveredRunMatrix = JSON.parse(
+      readFileSync(path.join(runDir, "matrix.json"), "utf8"),
+    ) as AggregateReport;
+    expect(recoveredRunMatrix).toEqual(recoveredReport);
+    expect(stderr).toContain("checkpoint evidence reflects exactly");
+  });
+
+  it("redacts sensitive keyed values before writing checkpoint reports", async () => {
+    writeScenario(tempDir, "cli-secret");
+    const reportPath = path.join(tempDir, "report.json");
+    const dependencies = createDependencies(() => "passed", {
+      runScenario: vi.fn(async (scenario) => ({
+        ...scenarioReport(scenario.id, "passed"),
+        turns: [
+          {
+            name: "api",
+            kind: "api",
+            responseText: "ok",
+            responseBody: { token: "secret-token-value" },
+            actionsCalled: [],
+            durationMs: 1,
+            failedAssertions: [],
+          },
+        ],
+        actionsCalled: [
+          {
+            name: "SECRET_ACTION",
+            result: {
+              data: { authorization: "Bearer secret-token-value" },
+              success: true,
+            },
+          } as never,
+        ],
+      })),
+    });
+
+    const code = await runCli(
+      ["run", tempDir, "--report", reportPath],
+      dependencies,
+    );
+
+    expect(code).toBe(0);
+    const persisted = vi.mocked(dependencies.writeReport).mock.calls.at(-1)?.[0];
+    expect(JSON.stringify(persisted)).not.toContain("secret-token-value");
+    expect(JSON.stringify(persisted)).toContain("[REDACTED]");
   });
 });

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -25,8 +25,9 @@ import {
   loadAllScenarios,
   validateScenarioCorpus,
 } from "./loader.ts";
+import { redactForScenarioReport } from "./redaction.ts";
 import { shouldOptInScenarioTrajectoryLogging } from "./trajectory-opt-in.ts";
-import type { ScenarioReport } from "./types.ts";
+import type { AggregateReport, ScenarioReport } from "./types.ts";
 
 const SCENARIO_LANES: readonly ScenarioLane[] = [
   "pr-deterministic",
@@ -85,6 +86,115 @@ export interface CliDependencies {
   createScenarioRuntime: ScenarioRuntimeFactoryModule["createScenarioRuntime"];
   shouldUseDeterministicLlmProxy: ScenarioRuntimeFactoryModule["shouldUseDeterministicLlmProxy"];
   exportScenarioNativeJsonl: NativeExportModule["exportScenarioNativeJsonl"];
+}
+
+type EvidencePaths = {
+  reportPath?: string;
+  reportDir?: string;
+  runDir?: string;
+  nativeJsonlPath?: string;
+};
+
+function scenarioOutcomeMaps(reports: readonly ScenarioReport[]): {
+  outcomes: Map<string, ScenarioReport["status"]>;
+  judgeScores: Map<string, number>;
+  tiers: Map<string, string>;
+} {
+  const outcomes = new Map(
+    reports.map((report) => [report.id, report.status] as const),
+  );
+  const judgeScores = new Map<string, number>();
+  const tiers = new Map<string, string>();
+  for (const report of reports) {
+    if (typeof report.judgeScore === "number") {
+      judgeScores.set(report.id, report.judgeScore);
+    }
+    if (typeof report.tier === "string") {
+      tiers.set(report.id, report.tier);
+    }
+  }
+  return { outcomes, judgeScores, tiers };
+}
+
+function attachArtifactPaths(
+  aggregate: AggregateReport,
+  paths: EvidencePaths,
+): void {
+  if (!paths.runDir) return;
+  const viewerIndex = path.join(paths.runDir, "viewer", "index.html");
+  const viewerData = path.join(paths.runDir, "viewer", "data.js");
+  aggregate.artifactPaths = {
+    runDir: paths.runDir,
+    matrixJson: path.join(paths.runDir, "matrix.json"),
+    viewerIndex,
+    viewerData,
+    ...(paths.nativeJsonlPath
+      ? {
+          nativeJsonl: paths.nativeJsonlPath,
+          nativeManifest: scenarioNativeManifestPath(paths.nativeJsonlPath),
+        }
+      : {}),
+  };
+}
+
+function writeScenarioEvidence(params: {
+  aggregate: AggregateReport;
+  reports: readonly ScenarioReport[];
+  paths: EvidencePaths;
+  finalize: boolean;
+  dependencies: Pick<
+    CliDependencies,
+    | "exportScenarioNativeJsonl"
+    | "writeReport"
+    | "writeReportBundle"
+    | "writeScenarioRunViewer"
+  >;
+}): void {
+  const { aggregate, reports, paths, finalize, dependencies } = params;
+  const persistedAggregate = redactForScenarioReport(
+    aggregate,
+  ) as AggregateReport;
+
+  // Checkpoints deliberately write only the bounded evidence needed for crash
+  // recovery. Native export and the viewer scan every recorded trajectory, and
+  // a full report bundle rewrites every preceding scenario, so doing those on
+  // every iteration would make a long run quadratic. Finalization regenerates
+  // those derived artifacts deterministically from the same aggregate.
+  if (finalize && paths.nativeJsonlPath && paths.runDir) {
+    const { outcomes, judgeScores, tiers } = scenarioOutcomeMaps(reports);
+    dependencies.exportScenarioNativeJsonl(
+      paths.runDir,
+      paths.nativeJsonlPath,
+      outcomes,
+      judgeScores,
+      tiers,
+    );
+  }
+  attachArtifactPaths(persistedAggregate, paths);
+  if (finalize && paths.runDir) {
+    dependencies.writeScenarioRunViewer(persistedAggregate, paths.runDir, {
+      nativeJsonlPath: paths.nativeJsonlPath,
+    });
+  }
+  if (paths.reportPath) {
+    dependencies.writeReport(persistedAggregate, paths.reportPath);
+  }
+  if (paths.reportDir) {
+    if (finalize) {
+      dependencies.writeReportBundle(persistedAggregate, paths.reportDir);
+    } else {
+      dependencies.writeReport(
+        persistedAggregate,
+        path.join(paths.reportDir, "matrix.json"),
+      );
+    }
+  }
+  if (paths.runDir) {
+    dependencies.writeReport(
+      persistedAggregate,
+      path.join(paths.runDir, "matrix.json"),
+    );
+  }
 }
 
 function scenarioNativeManifestPath(
@@ -413,8 +523,49 @@ export async function runCli(
   })();
 
   const reports: ScenarioReport[] = [];
+  let interruptedSignal: NodeJS.Signals | undefined;
+  const onInterrupt = (signal: NodeJS.Signals): void => {
+    interruptedSignal = signal;
+    process.stderr.write(
+      `[eliza-scenarios] received ${signal}; finishing the current scenario, writing checkpoint evidence, then stopping.\n`,
+    );
+  };
+  process.once("SIGINT", onInterrupt);
+  process.once("SIGTERM", onInterrupt);
+  const evidencePaths: EvidencePaths = {
+    reportPath: parsed.reportPath,
+    reportDir: parsed.reportDir,
+    runDir: effectiveRunDir,
+    nativeJsonlPath: parsed.exportNativePath,
+  };
+  let latestAggregate: AggregateReport | undefined;
+  const writeCheckpoint = (): AggregateReport => {
+    const checkpoint = buildAggregate(
+      reports,
+      providerName,
+      startedAtIso,
+      new Date().toISOString(),
+      effectiveRunId,
+      effectiveRunDir,
+    );
+    writeScenarioEvidence({
+      aggregate: checkpoint,
+      reports,
+      paths: evidencePaths,
+      finalize: false,
+      dependencies: {
+        exportScenarioNativeJsonl,
+        writeReport,
+        writeReportBundle,
+        writeScenarioRunViewer,
+      },
+    });
+    latestAggregate = checkpoint;
+    return checkpoint;
+  };
   try {
     for (const { scenario } of loaded) {
+      if (interruptedSignal) break;
       logger.info(`[eliza-scenarios] ▶ ${scenario.id}`);
       // Surface scenario id to the recorder via env so trajectories are
       // tagged with the right scenarioId without changing internal APIs.
@@ -428,85 +579,46 @@ export async function runCli(
       logger.info(
         `[eliza-scenarios] ${report.status === "passed" ? "✓" : report.status === "skipped" ? "∼" : "✗"} ${scenario.id} ${report.status} (${report.durationMs}ms)${report.skipReason ? ` — ${report.skipReason}` : ""}`,
       );
+      writeCheckpoint();
     }
   } finally {
+    process.off("SIGINT", onInterrupt);
+    process.off("SIGTERM", onInterrupt);
     await cleanup();
   }
 
-  const completedAtIso = new Date().toISOString();
-  const aggregate = buildAggregate(
-    reports,
-    providerName,
-    startedAtIso,
-    completedAtIso,
-    effectiveRunId,
-    // Sum real per-trajectory spend from <runDir>/trajectories/ so
-    // matrix.json's totalCostUsd reflects the run instead of a hardcoded 0.
-    effectiveRunDir,
-  );
-
-  if (parsed.exportNativePath && effectiveRunDir) {
-    // Convert the recorded per-turn trajectory JSON under <runDir>/trajectories/
-    // into canonical eliza_native_v1 model-boundary rows for the eliza-1
-    // training corpus (see packages/training/docs/dataset/CANONICAL_RECORD.md).
-    // The training prep script runs the mandatory privacy filter on every row.
-    // Thread each scenario's assertion outcome so failed/regressed trajectories
-    // are stamped status="failed" and routed to rating="repair"/weight=0 instead
-    // of being exported as gold-weight training data.
-    const scenarioOutcomes = new Map(
-      reports.map((report) => [report.id, report.status] as const),
-    );
-    // Thread the numeric judge score (minimum across judged turns + rubric
-    // final checks) so rows carry metadata.judge_score for reward-weighted
-    // training (#8795).
-    const scenarioJudgeScores = new Map<string, number>();
-    const scenarioTiers = new Map<string, string>();
-    for (const report of reports) {
-      if (typeof report.judgeScore === "number") {
-        scenarioJudgeScores.set(report.id, report.judgeScore);
-      }
-      if (typeof report.tier === "string") {
-        scenarioTiers.set(report.id, report.tier);
-      }
-    }
-    exportScenarioNativeJsonl(
+  const aggregate =
+    latestAggregate ??
+    buildAggregate(
+      reports,
+      providerName,
+      startedAtIso,
+      new Date().toISOString(),
+      effectiveRunId,
+      // Sum real per-trajectory spend from <runDir>/trajectories/ so
+      // matrix.json's totalCostUsd reflects the run instead of a hardcoded 0.
       effectiveRunDir,
-      parsed.exportNativePath,
-      scenarioOutcomes,
-      scenarioJudgeScores,
-      scenarioTiers,
     );
-  }
-  if (effectiveRunDir) {
-    const viewerIndex = path.join(effectiveRunDir, "viewer", "index.html");
-    const viewerData = path.join(effectiveRunDir, "viewer", "data.js");
-    aggregate.artifactPaths = {
-      runDir: effectiveRunDir,
-      matrixJson: path.join(effectiveRunDir, "matrix.json"),
-      viewerIndex,
-      viewerData,
-      ...(parsed.exportNativePath
-        ? {
-            nativeJsonl: parsed.exportNativePath,
-            nativeManifest: scenarioNativeManifestPath(parsed.exportNativePath),
-          }
-        : {}),
-    };
-    writeScenarioRunViewer(aggregate, effectiveRunDir, {
-      nativeJsonlPath: parsed.exportNativePath,
-    });
-  }
-  if (parsed.reportPath) {
-    writeReport(aggregate, parsed.reportPath);
-  }
-  if (parsed.reportDir) {
-    writeReportBundle(aggregate, parsed.reportDir);
-  }
-  if (effectiveRunDir) {
-    // Drop the matrix.json next to trajectories/ so the aggregator can find it.
-    writeReport(aggregate, path.join(effectiveRunDir, "matrix.json"));
-  }
+  writeScenarioEvidence({
+    aggregate,
+    reports,
+    paths: evidencePaths,
+    finalize: true,
+    dependencies: {
+      exportScenarioNativeJsonl,
+      writeReport,
+      writeReportBundle,
+      writeScenarioRunViewer,
+    },
+  });
   printStdoutSummary(aggregate);
+
+  if (interruptedSignal) {
+    process.stderr.write(
+      `[eliza-scenarios] stopped after ${reports.length}/${loaded.length} completed scenario(s) because ${interruptedSignal} was received; checkpoint evidence reflects exactly the completed scenarios.\n`,
+    );
+    return 1;
+  }
 
   // SKIP_REASON guard: if any scenarios skipped and no SKIP_REASON is set, fail.
   const skipReason = (process.env.SKIP_REASON ?? "").trim();

--- a/packages/scenario-runner/src/native-export.test.ts
+++ b/packages/scenario-runner/src/native-export.test.ts
@@ -2,6 +2,7 @@
 import {
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -611,6 +612,51 @@ describe("exportScenarioNativeJsonl", () => {
         skippedFiles: 0,
         rows: 0,
       });
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes the jsonl, manifest, and privacy attestation atomically with no leftover temp files", () => {
+    const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-atomic-"));
+    try {
+      const trajDir = path.join(runDir, "trajectories", "agent-test");
+      mkdirSync(trajDir, { recursive: true });
+      writeFileSync(
+        path.join(trajDir, "tj-test-1.json"),
+        JSON.stringify(syntheticTrajectory()),
+        "utf-8",
+      );
+
+      const outPath = path.join(runDir, "native.jsonl");
+      const manifestPath = path.join(runDir, "native.manifest.json");
+      const attestationPath = path.join(
+        runDir,
+        "native.privacy-attestation.json",
+      );
+
+      const count = exportScenarioNativeJsonl(runDir, outPath);
+      expect(count).toBe(1);
+
+      // Every output now lands via writeFileAtomic (temp file + rename). The
+      // rename must consume the temp file, so no `.native.*.tmp` sidecar may
+      // survive in the output directory. A leftover temp would mean a
+      // writeFileSync path slipped back in or the rename never fired.
+      const leftovers = readdirSync(runDir).filter((entry) =>
+        entry.endsWith(".tmp"),
+      );
+      expect(leftovers).toEqual([]);
+
+      // The atomically-renamed files carry the fully-written final content.
+      const rows = readFileSync(outPath, "utf-8").trim().split("\n");
+      expect(rows).toHaveLength(1);
+      expect(JSON.parse(rows[0] as string).format).toBe("eliza_native_v1");
+      expect(JSON.parse(readFileSync(manifestPath, "utf-8")).counts.rows).toBe(
+        1,
+      );
+      expect(JSON.parse(readFileSync(attestationPath, "utf-8")).passed).toBe(
+        true,
+      );
     } finally {
       rmSync(runDir, { recursive: true, force: true });
     }

--- a/packages/scenario-runner/src/native-export.ts
+++ b/packages/scenario-runner/src/native-export.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type {
   RecordedModelCall,
@@ -27,6 +27,7 @@ import type {
   RecordedTrajectory,
 } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
+import { writeFileAtomic } from "./reporter.js";
 import { toRecord } from "./utils.js";
 
 const NATIVE_FORMAT = "eliza_native_v1" as const;
@@ -1206,7 +1207,7 @@ export function exportScenarioNativeJsonl(
     rows.length === 0
       ? ""
       : `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
-  writeFileSync(outPath, body, "utf-8");
+  writeFileAtomic(outPath, body);
   const privacyAttestation = buildScenarioNativePrivacyAttestation({
     jsonlPath: outPath,
     runDir,
@@ -1214,10 +1215,9 @@ export function exportScenarioNativeJsonl(
     rows: rows.length,
     stats: privacyStats,
   });
-  writeFileSync(
+  writeFileAtomic(
     privacyAttestationPath,
     `${JSON.stringify(privacyAttestation, null, 2)}\n`,
-    "utf-8",
   );
   let passedRows = 0;
   let failedRows = 0;
@@ -1262,10 +1262,9 @@ export function exportScenarioNativeJsonl(
       categories: privacyCategories(privacyStats),
     },
   };
-  writeFileSync(
+  writeFileAtomic(
     manifestPath,
     `${JSON.stringify(manifest, null, 2)}\n`,
-    "utf-8",
   );
   logger.info(
     `[scenario-runner] wrote ${rows.length} redacted eliza_native_v1 row(s) from ${files.length} trajectory file(s) → ${outPath} (passed=${passedRows} failed=${failedRows} skipped=${skippedScenarioRows} unknown=${unknownOutcomeRows} redactions=${privacyStats.redactionsTotal} residuals=${privacyStats.residualTotal}) (manifest → ${manifestPath}; privacy attestation → ${privacyAttestationPath})`,

--- a/packages/scenario-runner/src/reporter.test.ts
+++ b/packages/scenario-runner/src/reporter.test.ts
@@ -15,6 +15,7 @@ import {
   buildAggregate,
   printStdoutSummary,
   sumTrajectoryCostUsd,
+  writeFileAtomic,
   writeReportBundle,
   writeScenarioRunViewer,
 } from "./reporter.ts";
@@ -307,6 +308,19 @@ describe("scenario report aggregation", () => {
     ]);
     expect(existsSync(path.join(outDir, "001-todos_create_basic.json"))).toBe(
       true,
+    );
+  });
+
+  it("replaces existing evidence files atomically without leaving temp files", () => {
+    const outDir = makeTempDir("scenario-atomic-");
+    const target = path.join(outDir, "matrix.json");
+    writeFileSync(target, "previous", "utf-8");
+
+    writeFileAtomic(target, "replacement");
+
+    expect(readFileSync(target, "utf8")).toBe("replacement");
+    expect(readdirSync(outDir).filter((name) => name.endsWith(".tmp"))).toEqual(
+      [],
     );
   });
 

--- a/packages/scenario-runner/src/reporter.ts
+++ b/packages/scenario-runner/src/reporter.ts
@@ -9,6 +9,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -94,8 +95,18 @@ export function buildAggregate(
 
 export function writeReport(report: AggregateReport, filePath: string): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileSync(filePath, JSON.stringify(report, null, 2), "utf-8");
+  writeFileAtomic(filePath, `${JSON.stringify(report, null, 2)}\n`);
   logger.info(`[scenario-runner] wrote report → ${filePath}`);
+}
+
+export function writeFileAtomic(filePath: string, body: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  writeFileSync(tmpPath, body, "utf-8");
+  renameSync(tmpPath, filePath);
 }
 
 function scenarioReportFileName(id: string, index: number): string {
@@ -110,17 +121,16 @@ export function writeReportBundle(
   mkdirSync(reportDir, { recursive: true });
 
   const matrixPath = path.join(reportDir, "matrix.json");
-  writeFileSync(matrixPath, JSON.stringify(report, null, 2), "utf-8");
+  writeFileAtomic(matrixPath, `${JSON.stringify(report, null, 2)}\n`);
 
   report.scenarios.forEach((scenarioReport, index) => {
     const scenarioPath = path.join(
       reportDir,
       scenarioReportFileName(scenarioReport.id, index),
     );
-    writeFileSync(
+    writeFileAtomic(
       scenarioPath,
-      JSON.stringify(scenarioReport, null, 2),
-      "utf-8",
+      `${JSON.stringify(scenarioReport, null, 2)}\n`,
     );
   });
 
@@ -509,11 +519,10 @@ export function writeScenarioRunViewer(
     runDir,
     options.nativeJsonlPath,
   );
-  writeFileSync(viewerIndex, scenarioViewerHtml(), "utf-8");
-  writeFileSync(
+  writeFileAtomic(viewerIndex, scenarioViewerHtml());
+  writeFileAtomic(
     viewerData,
     `window.SCENARIO_RUN_DATA = ${JSON.stringify(payload)};\n`,
-    "utf-8",
   );
   logger.info(`[scenario-runner] wrote run viewer → ${viewerIndex}`);
   return {


### PR DESCRIPTION
## Summary
- atomically checkpoint the redacted aggregate report after every completed scenario
- retain exact completed checks/results when a live run is interrupted, including SIGTERM/SIGINT graceful stop handling
- defer quadratic native/viewer/full-bundle regeneration to deterministic finalization
- make report, bundle, viewer, native JSONL, manifest, and privacy-attestation replacements atomic

## Safety and gate posture
- no scenarios are skipped and no assertion/judge/threshold behavior changes
- checkpoint writes fail closed
- every aggregate checkpoint is passed through the existing scenario report redactor
- native export keeps the existing mandatory privacy filter and attestations

## Tests
- `../../node_modules/.bin/vitest run src/cli.test.ts src/reporter.test.ts src/native-export.test.ts`
- 43 tests passed
- covers per-scenario progression, deterministic final/checkpoint equivalence, on-disk interrupted-run recovery, keyed-secret redaction, and atomic replacement

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - scenario-runner CLI/reporter change; touches packages/scenario-runner only, no UI surface exists or is changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI surface changed; backend/test-only change.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing flow; behavior is covered by the unit tests listed above.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - deterministic logic change verified by the checked-in unit tests rather than a captured runtime log.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent prompt, model, provider, evaluator, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - the deliverable is a backend logic fix plus its unit tests (see the Tests/Verification section above); no DB rows, media, or generated files are produced.

Co-authored-by: wakesync <60821182+wakesync@users.noreply.github.com>

