### PR TITLE
fix(discord): suppress durable duplicate inbound turns

### DIFF
--- a/plugins/plugin-discord/__tests__/messages-inbound-idempotency.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-inbound-idempotency.test.ts
@@ -36,7 +36,9 @@ interface RuntimeHarness {
 	handleCalls: () => number;
 }
 
-function makeRuntime(): RuntimeHarness {
+function makeRuntime(options?: {
+	failFirstHandleBeforePersistence?: boolean;
+}): RuntimeHarness {
 	const memories = new Map<string, Memory>();
 	const sends: Sent[] = [];
 	let handleCalls = 0;
@@ -67,6 +69,9 @@ function makeRuntime(): RuntimeHarness {
 				callback: (content: Content) => Promise<unknown>,
 			) => {
 				handleCalls += 1;
+				if (options?.failFirstHandleBeforePersistence && handleCalls === 1) {
+					throw new Error("generation failed before inbound persistence");
+				}
 				if (message.id && !memories.has(message.id)) {
 					await runtime.createMemory(message, "messages");
 				}
@@ -188,19 +193,20 @@ describe("Discord inbound durable idempotency", () => {
 	});
 
 	it("suppresses a duplicate after manager reconstruction when inbound memory was persisted", async () => {
+		const messageId = "666000000000000001";
 		const harness = makeRuntime();
 		const channel = makeDmChannel(harness.sends);
 		const firstService = makeDiscordService({ user: { id: CLIENT_ID } });
 		const firstManager = new MessageManager(firstService, harness.runtime);
 
-		await firstManager.handleMessage(makeInbound(channel));
+		await firstManager.handleMessage(makeInbound(channel, messageId));
 
 		const secondService = makeDiscordService({ user: { id: CLIENT_ID } });
 		const reconstructedManager = new MessageManager(
 			secondService,
 			harness.runtime,
 		);
-		await reconstructedManager.handleMessage(makeInbound(channel));
+		await reconstructedManager.handleMessage(makeInbound(channel, messageId));
 
 		expect(firstService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
 		expect(secondService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
@@ -208,14 +214,15 @@ describe("Discord inbound durable idempotency", () => {
 		expect(harness.sends).toHaveLength(1);
 		expect(harness.runtime.logger.debug).toHaveBeenCalledWith(
 			expect.objectContaining({
-				messageId: DISCORD_MESSAGE_ID,
-				memoryId: makeInboundMemory(DISCORD_MESSAGE_ID).id,
+				messageId,
+				memoryId: makeInboundMemory(messageId).id,
 			}),
 			"Skipping already persisted Discord inbound message",
 		);
 	});
 
 	it("allows a reconstructed manager to retry when the first delivery failed before persistence", async () => {
+		const messageId = "666000000000000002";
 		const harness = makeRuntime();
 		const channel = makeDmChannel(harness.sends);
 		const failingService = makeDiscordService(
@@ -226,25 +233,26 @@ describe("Discord inbound durable idempotency", () => {
 		);
 		const firstManager = new MessageManager(failingService, harness.runtime);
 
-		await firstManager.handleMessage(makeInbound(channel));
+		await firstManager.handleMessage(makeInbound(channel, messageId));
 
 		const retryService = makeDiscordService({ user: { id: CLIENT_ID } });
 		const reconstructedManager = new MessageManager(
 			retryService,
 			harness.runtime,
 		);
-		await reconstructedManager.handleMessage(makeInbound(channel));
+		await reconstructedManager.handleMessage(makeInbound(channel, messageId));
 
 		expect(failingService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
 		expect(retryService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
 		expect(harness.handleCalls()).toBe(1);
 		expect(harness.sends).toHaveLength(1);
 		expect(
-			harness.memories.has(makeInboundMemory(DISCORD_MESSAGE_ID).id as string),
+			harness.memories.has(makeInboundMemory(messageId).id as string),
 		).toBe(true);
 	});
 
 	it("releases the same-process duplicate guard when processing fails before persistence", async () => {
+		const messageId = "666000000000000003";
 		const harness = makeRuntime();
 		const channel = makeDmChannel(harness.sends);
 		const buildMemoryFromMessage = vi
@@ -259,11 +267,28 @@ describe("Discord inbound durable idempotency", () => {
 		);
 		const manager = new MessageManager(service, harness.runtime);
 
-		await manager.handleMessage(makeInbound(channel));
-		await manager.handleMessage(makeInbound(channel));
+		await manager.handleMessage(makeInbound(channel, messageId));
+		await manager.handleMessage(makeInbound(channel, messageId));
 
 		expect(buildMemoryFromMessage).toHaveBeenCalledTimes(2);
 		expect(harness.handleCalls()).toBe(1);
 		expect(harness.sends).toHaveLength(1);
+	});
+	it("retries in the same manager when generation fails before inbound persistence", async () => {
+		const messageId = "666000000000000004";
+		const harness = makeRuntime({ failFirstHandleBeforePersistence: true });
+		const channel = makeDmChannel(harness.sends);
+		const service = makeDiscordService({ user: { id: CLIENT_ID } });
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(makeInbound(channel, messageId));
+		await manager.handleMessage(makeInbound(channel, messageId));
+
+		expect(service.buildMemoryFromMessage).toHaveBeenCalledTimes(2);
+		expect(harness.handleCalls()).toBe(2);
+		expect(harness.sends).toHaveLength(2);
+		expect(
+			harness.memories.has(makeInboundMemory(messageId).id as string),
+		).toBe(true);
 	});
 });

--- a/plugins/plugin-discord/__tests__/messages-inbound-idempotency.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-inbound-idempotency.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Discord inbound idempotency tests drive the manager boundary where a gateway
+ * message becomes a durable message memory and then a model turn. The harness
+ * keeps Discord network objects stubbed while preserving the real manager
+ * ordering: memory build, connection setup, inbound persistence, model dispatch,
+ * and outbound callback persistence.
+ */
+import { randomUUID } from "node:crypto";
+import {
+	ChannelType,
+	type Content,
+	createUniqueUuid,
+	type Memory,
+	type UUID,
+} from "@elizaos/core";
+import type { Message as DiscordMessage } from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "../messages.ts";
+import type { ICompatRuntime, IDiscordService } from "../types.ts";
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+const AUTHOR_ID = "555000111222333444";
+const CHANNEL_ID = "777000000000000000";
+const CLIENT_ID = "888000000000000000";
+const DISCORD_MESSAGE_ID = "666000000000000000";
+
+interface Sent {
+	content?: string;
+}
+
+interface RuntimeHarness {
+	runtime: ICompatRuntime;
+	memories: Map<string, Memory>;
+	sends: Sent[];
+	handleCalls: () => number;
+}
+
+function makeRuntime(): RuntimeHarness {
+	const memories = new Map<string, Memory>();
+	const sends: Sent[] = [];
+	let handleCalls = 0;
+	const runtime = {
+		agentId: AGENT_ID,
+		character: { name: "Eliza" },
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+		getSetting: (key: string) =>
+			key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ? "false" : undefined,
+		getService: () => null,
+		ensureConnection: vi.fn(async () => {}),
+		getMemoryById: vi.fn(async (id: UUID) => memories.get(id) ?? null),
+		createMemory: vi.fn(async (memory: Memory) => {
+			const id =
+				memory.id ?? createUniqueUuid(runtime as ICompatRuntime, randomUUID());
+			memories.set(id, { ...memory, id });
+			return id;
+		}),
+		messageService: {
+			handleMessage: async (
+				_runtime: unknown,
+				message: Memory,
+				callback: (content: Content) => Promise<unknown>,
+			) => {
+				handleCalls += 1;
+				if (message.id && !memories.has(message.id)) {
+					await runtime.createMemory(message, "messages");
+				}
+				await callback({ text: "one durable reply", source: "discord" });
+			},
+		},
+		emitEvent: vi.fn(),
+	} as unknown as ICompatRuntime;
+	return { runtime, memories, sends, handleCalls: () => handleCalls };
+}
+
+function makeDmChannel(sends: Sent[]) {
+	return {
+		id: CHANNEL_ID,
+		type: DiscordChannelType.DM,
+		isThread: () => false,
+		send: async (options: Sent) => {
+			sends.push(options);
+			return {
+				id: `99000000000000000${sends.length}`,
+				content: options.content ?? "",
+				url: `https://discord.com/channels/@me/${CHANNEL_ID}/99000000000000000${sends.length}`,
+				createdTimestamp: Date.now(),
+				attachments: { size: 0 },
+			};
+		},
+		sendTyping: async () => {},
+	};
+}
+
+function makeInboundMemory(messageId: string): Memory {
+	return {
+		id: createUniqueUuid(
+			{ agentId: AGENT_ID } as ICompatRuntime,
+			messageId,
+		) as UUID,
+		entityId: createUniqueUuid(
+			{ agentId: AGENT_ID } as ICompatRuntime,
+			AUTHOR_ID,
+		) as UUID,
+		agentId: AGENT_ID,
+		roomId: createUniqueUuid(
+			{ agentId: AGENT_ID } as ICompatRuntime,
+			CHANNEL_ID,
+		) as UUID,
+		content: { text: "hello", source: "discord" },
+	};
+}
+
+function makeDiscordService(
+	client: unknown,
+	buildMemoryFromMessage = vi.fn(async (message: DiscordMessage) =>
+		makeInboundMemory(message.id),
+	),
+): IDiscordService & {
+	buildMemoryFromMessage: ReturnType<typeof vi.fn>;
+} {
+	return {
+		client,
+		accountId: "default",
+		getChannelType: async () => ChannelType.DM,
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "open",
+			shouldIgnoreBotMessages: true,
+			shouldIgnoreDirectMessages: false,
+			replyToMode: "off",
+		},
+		buildMemoryFromMessage,
+	} as unknown as IDiscordService & {
+		buildMemoryFromMessage: ReturnType<typeof vi.fn>;
+	};
+}
+
+function makeInbound(
+	channel: unknown,
+	messageId = DISCORD_MESSAGE_ID,
+): DiscordMessage {
+	return {
+		id: messageId,
+		content: "hello",
+		createdTimestamp: Date.now(),
+		author: {
+			id: AUTHOR_ID,
+			bot: false,
+			username: "tester",
+			globalName: "Tester",
+			displayName: "Tester",
+			discriminator: "0",
+		},
+		member: null,
+		channel,
+		guild: undefined,
+		interaction: null,
+		reference: undefined,
+		embeds: [],
+		stickers: { size: 0 },
+		attachments: { size: 0 },
+		mentions: { users: new Map(), repliedUser: undefined },
+	} as unknown as DiscordMessage;
+}
+
+describe("Discord inbound durable idempotency", () => {
+	it("preserves first delivery and suppresses a duplicate messageCreate in the same manager", async () => {
+		const harness = makeRuntime();
+		const channel = makeDmChannel(harness.sends);
+		const service = makeDiscordService({ user: { id: CLIENT_ID } });
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(makeInbound(channel));
+		await manager.handleMessage(makeInbound(channel));
+
+		expect(service.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
+		expect(harness.handleCalls()).toBe(1);
+		expect(harness.sends).toHaveLength(1);
+		expect(
+			harness.memories.has(makeInboundMemory(DISCORD_MESSAGE_ID).id as string),
+		).toBe(true);
+	});
+
+	it("suppresses a duplicate after manager reconstruction when inbound memory was persisted", async () => {
+		const harness = makeRuntime();
+		const channel = makeDmChannel(harness.sends);
+		const firstService = makeDiscordService({ user: { id: CLIENT_ID } });
+		const firstManager = new MessageManager(firstService, harness.runtime);
+
+		await firstManager.handleMessage(makeInbound(channel));
+
+		const secondService = makeDiscordService({ user: { id: CLIENT_ID } });
+		const reconstructedManager = new MessageManager(
+			secondService,
+			harness.runtime,
+		);
+		await reconstructedManager.handleMessage(makeInbound(channel));
+
+		expect(firstService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
+		expect(secondService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
+		expect(harness.handleCalls()).toBe(1);
+		expect(harness.sends).toHaveLength(1);
+		expect(harness.runtime.logger.debug).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messageId: DISCORD_MESSAGE_ID,
+				memoryId: makeInboundMemory(DISCORD_MESSAGE_ID).id,
+			}),
+			"Skipping already persisted Discord inbound message",
+		);
+	});
+
+	it("allows a reconstructed manager to retry when the first delivery failed before persistence", async () => {
+		const harness = makeRuntime();
+		const channel = makeDmChannel(harness.sends);
+		const failingService = makeDiscordService(
+			{ user: { id: CLIENT_ID } },
+			vi.fn(async () => {
+				throw new Error("memory build failed");
+			}),
+		);
+		const firstManager = new MessageManager(failingService, harness.runtime);
+
+		await firstManager.handleMessage(makeInbound(channel));
+
+		const retryService = makeDiscordService({ user: { id: CLIENT_ID } });
+		const reconstructedManager = new MessageManager(
+			retryService,
+			harness.runtime,
+		);
+		await reconstructedManager.handleMessage(makeInbound(channel));
+
+		expect(failingService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
+		expect(retryService.buildMemoryFromMessage).toHaveBeenCalledTimes(1);
+		expect(harness.handleCalls()).toBe(1);
+		expect(harness.sends).toHaveLength(1);
+		expect(
+			harness.memories.has(makeInboundMemory(DISCORD_MESSAGE_ID).id as string),
+		).toBe(true);
+	});
+
+	it("releases the same-process duplicate guard when processing fails before persistence", async () => {
+		const harness = makeRuntime();
+		const channel = makeDmChannel(harness.sends);
+		const buildMemoryFromMessage = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("memory build failed"))
+			.mockImplementation(async (message: DiscordMessage) =>
+				makeInboundMemory(message.id),
+			);
+		const service = makeDiscordService(
+			{ user: { id: CLIENT_ID } },
+			buildMemoryFromMessage,
+		);
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(makeInbound(channel));
+		await manager.handleMessage(makeInbound(channel));
+
+		expect(buildMemoryFromMessage).toHaveBeenCalledTimes(2);
+		expect(harness.handleCalls()).toBe(1);
+		expect(harness.sends).toHaveLength(1);
+	});
+});

--- a/plugins/plugin-discord/__tests__/messages-regression-lane.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-regression-lane.test.ts
@@ -17,6 +17,7 @@ import "./generation-abort.test.ts";
 import "./generation-timeout-dispatch.test.ts";
 import "./generation-timeout.test.ts";
 import "./messages-component-delivery.test.ts";
+import "./messages-inbound-idempotency.test.ts";
 import "./messages-url.test.ts";
 import "./numeric-fact-dedup.test.ts";
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -796,6 +796,37 @@ export class MessageManager {
 		}
 	}
 
+	private async releaseMessageProcessingIfInboundNotPersisted(
+		messageId: string | undefined,
+		inboundMemoryId: UUID | undefined,
+	): Promise<boolean> {
+		let inboundMemoryCommitted = false;
+		if (inboundMemoryId) {
+			try {
+				inboundMemoryCommitted =
+					!!(await this.runtime.getMemoryById(inboundMemoryId));
+			} catch (persistenceCheckError) {
+				this.runtime.logger.warn(
+					{
+						src: "plugin:discord",
+						agentId: this.runtime.agentId,
+						messageId,
+						memoryId: inboundMemoryId,
+						error:
+							persistenceCheckError instanceof Error
+								? persistenceCheckError.message
+								: String(persistenceCheckError),
+					},
+					"Could not verify Discord inbound persistence after failure",
+				);
+			}
+		}
+		if (!inboundMemoryCommitted) {
+			this.releaseMessageProcessing(messageId);
+		}
+		return inboundMemoryCommitted;
+	}
+
 	/**
 	 * Handles incoming Discord messages and processes them accordingly.
 	 *
@@ -1835,6 +1866,13 @@ export class MessageManager {
 							: "I hit a provider issue while generating the reply. Please retry.",
 					);
 				}
+				if (!inboundMemoryCommitted) {
+					inboundMemoryCommitted =
+						await this.releaseMessageProcessingIfInboundNotPersisted(
+							message.id,
+							inboundMemoryId,
+						);
+				}
 				return;
 			} finally {
 				if (generationTimeoutHandle) {
@@ -1848,28 +1886,12 @@ export class MessageManager {
 				await finalizePendingDraft();
 			}
 		} catch (error) {
-			if (!inboundMemoryCommitted && inboundMemoryId) {
-				try {
-					inboundMemoryCommitted =
-						!!(await this.runtime.getMemoryById(inboundMemoryId));
-				} catch (persistenceCheckError) {
-					this.runtime.logger.warn(
-						{
-							src: "plugin:discord",
-							agentId: this.runtime.agentId,
-							messageId: message.id,
-							memoryId: inboundMemoryId,
-							error:
-								persistenceCheckError instanceof Error
-									? persistenceCheckError.message
-									: String(persistenceCheckError),
-						},
-						"Could not verify Discord inbound persistence after failure",
-					);
-				}
-			}
 			if (!inboundMemoryCommitted) {
-				this.releaseMessageProcessing(message.id);
+				inboundMemoryCommitted =
+					await this.releaseMessageProcessingIfInboundNotPersisted(
+						message.id,
+						inboundMemoryId,
+					);
 			}
 			this.runtime.logger.error(
 				{

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -563,9 +563,33 @@ export async function createDiscordMessageMemoryOnce(
 		platformMessageId?: string;
 	} = { operation: "discord-message-persist" },
 ): Promise<Memory | null> {
+	const result = await persistDiscordMessageMemoryOnce(
+		runtime,
+		memory,
+		context,
+	);
+	return result.memory;
+}
+
+interface DiscordMessageMemoryPersistenceResult {
+	memory: Memory;
+	created: boolean;
+}
+
+async function persistDiscordMessageMemoryOnce(
+	runtime: Pick<
+		IAgentRuntime,
+		"agentId" | "createMemory" | "getMemoryById" | "logger"
+	>,
+	memory: Memory,
+	context: {
+		operation: string;
+		platformMessageId?: string;
+	} = { operation: "discord-message-persist" },
+): Promise<DiscordMessageMemoryPersistenceResult> {
 	if (!memory.id) {
 		const id = await runtime.createMemory(memory, "messages");
-		return { ...memory, id };
+		return { memory: { ...memory, id }, created: true };
 	}
 
 	const existing = await runtime.getMemoryById(memory.id);
@@ -580,11 +604,11 @@ export async function createDiscordMessageMemoryOnce(
 			},
 			"Skipping duplicate Discord message memory",
 		);
-		return existing;
+		return { memory: existing, created: false };
 	}
 
 	await runtime.createMemory(memory, "messages");
-	return memory;
+	return { memory, created: true };
 }
 
 /** Options handed to `User.send` when delivering a Discord DM reply. */
@@ -710,14 +734,44 @@ export class MessageManager {
 		);
 	}
 
-	private async persistInboundMemory(memory: Memory): Promise<void> {
+	private async persistInboundMemory(
+		memory: Memory,
+		platformMessageId?: string,
+	): Promise<"created" | "existing" | "missing-id"> {
 		if (!memory.id) {
-			return;
+			return "missing-id";
 		}
 
-		await createDiscordMessageMemoryOnce(this.runtime, memory, {
+		const result = await persistDiscordMessageMemoryOnce(this.runtime, memory, {
 			operation: "discord-inbound",
+			platformMessageId,
 		});
+		return result.created ? "created" : "existing";
+	}
+
+	private async hasPersistedInboundMemory(
+		memory: Memory,
+		platformMessageId?: string,
+	): Promise<boolean> {
+		if (!memory.id) {
+			return false;
+		}
+
+		const existing = await this.runtime.getMemoryById(memory.id);
+		if (!existing) {
+			return false;
+		}
+
+		this.runtime.logger.debug(
+			{
+				src: "plugin:discord",
+				agentId: this.runtime.agentId,
+				messageId: platformMessageId,
+				memoryId: memory.id,
+			},
+			"Skipping already persisted Discord inbound message",
+		);
+		return true;
 	}
 
 	private markMessageAsProcessing(messageId: string): boolean {
@@ -734,6 +788,12 @@ export class MessageManager {
 
 		this.recentlyProcessedMessageIds.set(messageId, now);
 		return true;
+	}
+
+	private releaseMessageProcessing(messageId: string | undefined): void {
+		if (messageId) {
+			this.recentlyProcessedMessageIds.delete(messageId);
+		}
 	}
 
 	/**
@@ -855,6 +915,8 @@ export class MessageManager {
 				? message.id
 				: undefined;
 		const strictModeShouldProcess = isDM || isBotDirectlyAddressed;
+		let inboundMemoryCommitted = false;
+		let inboundMemoryId: UUID | undefined;
 
 		const userName = message.author.bot
 			? `${message.author.username}#${message.author.discriminator}`
@@ -1006,6 +1068,7 @@ export class MessageManager {
 				);
 				return;
 			}
+			inboundMemoryId = newMessage.id;
 
 			await this.runtime.ensureConnection({
 				entityId: newMessage.entityId,
@@ -1033,11 +1096,20 @@ export class MessageManager {
 				},
 			});
 
+			if (await this.hasPersistedInboundMemory(newMessage, message.id)) {
+				inboundMemoryCommitted = true;
+				return;
+			}
+
 			if (
 				!this.discordSettings.autoReply ||
 				lifeOpsPassiveConnectorsEnabled(this.runtime)
 			) {
-				await this.persistInboundMemory(newMessage);
+				const inboundPersistence = await this.persistInboundMemory(
+					newMessage,
+					message.id,
+				);
+				inboundMemoryCommitted = inboundPersistence !== "missing-id";
 				this.runtime.logger.debug(
 					{
 						src: "plugin:discord",
@@ -1050,7 +1122,11 @@ export class MessageManager {
 			}
 
 			if (ignoresOtherTarget) {
-				await this.persistInboundMemory(newMessage);
+				const inboundPersistence = await this.persistInboundMemory(
+					newMessage,
+					message.id,
+				);
+				inboundMemoryCommitted = inboundPersistence !== "missing-id";
 				this.runtime.logger.debug(
 					{
 						src: "plugin:discord",
@@ -1063,7 +1139,11 @@ export class MessageManager {
 			}
 
 			if (strictModeEnabled && !strictModeShouldProcess) {
-				await this.persistInboundMemory(newMessage);
+				const inboundPersistence = await this.persistInboundMemory(
+					newMessage,
+					message.id,
+				);
+				inboundMemoryCommitted = inboundPersistence !== "missing-id";
 				this.runtime.logger.debug(
 					{
 						src: "plugin:discord",
@@ -1088,7 +1168,11 @@ export class MessageManager {
 
 			const canSendResult = canSendMessage(message.channel);
 			if (!canSendResult.canSend) {
-				await this.persistInboundMemory(newMessage);
+				const inboundPersistence = await this.persistInboundMemory(
+					newMessage,
+					message.id,
+				);
+				inboundMemoryCommitted = inboundPersistence !== "missing-id";
 				return this.runtime.logger.warn(
 					{
 						src: "plugin:discord",
@@ -1764,6 +1848,29 @@ export class MessageManager {
 				await finalizePendingDraft();
 			}
 		} catch (error) {
+			if (!inboundMemoryCommitted && inboundMemoryId) {
+				try {
+					inboundMemoryCommitted =
+						!!(await this.runtime.getMemoryById(inboundMemoryId));
+				} catch (persistenceCheckError) {
+					this.runtime.logger.warn(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							messageId: message.id,
+							memoryId: inboundMemoryId,
+							error:
+								persistenceCheckError instanceof Error
+									? persistenceCheckError.message
+									: String(persistenceCheckError),
+						},
+						"Could not verify Discord inbound persistence after failure",
+					);
+				}
+			}
+			if (!inboundMemoryCommitted) {
+				this.releaseMessageProcessing(message.id);
+			}
 			this.runtime.logger.error(
 				{
 					src: "plugin:discord",


### PR DESCRIPTION
## Summary

- check deterministic inbound memory identity before dispatching a Discord model turn
- suppress redelivered `messageCreate` events after connector/process restart
- release the in-process guard when processing fails before durable persistence so retries remain possible
- add focused same-process, reconstructed-manager, and pre-persistence retry regression tests

## Cutover motivation

This closes an independent P0 mechanism gap for sovereign Soliza Discord cutover. Existing in-memory suppression expires after two minutes and disappears on restart. The durable memory check prevents an already-persisted Discord event from triggering a second model turn/reply after reconstruction.

This does **not** claim exactly-once delivery. A crash before inbound persistence remains retryable. A crash after persistence but before reply is suppressed on replay, so live reconnect/replay acceptance is still required.

## Validation

- `bunx @biomejs/biome check` on touched files: pass
- focused Vitest authored, but local execution was blocked by the clean worktree dependency graph (`uuid` absent when borrowing stale node_modules); CI is authoritative
- `git diff --check`: pass

Co-authored-by: wakesync <shadow@shad0w.xyz>

Signed-off-by: [sol-orch]

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only Discord connector change, no UI surface`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only Discord connector change, no UI surface`.

<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - focused connector idempotency behavior is covered by automated tests, with no UI flow`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no live Discord credentials were used; focused Vitest exercises the real MessageManager ordering with network sends stubbed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - model output quality is unchanged; this change gates duplicate dispatch at the connector boundary`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no visual, OCR, audio, or document domain artifact applies`.


<!-- evidence-refresh: r6 -->