### PR TITLE
fix(openai): make planner args strict-schema compatible

### DIFF
--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -26,6 +26,8 @@ const aiMocks = vi.hoisted(() => ({
 const ENV_KEYS_TO_CLEAR = [
   "ELIZA_PROVIDER",
   "CEREBRAS_API_KEY",
+  "OPENAI_ACTION_PLANNER_MODEL",
+  "ACTION_PLANNER_MODEL",
   "OPENAI_SMALL_MODEL",
   "SMALL_MODEL",
   "OPENAI_LARGE_MODEL",
@@ -131,12 +133,287 @@ function expectNativeTextResult(value: unknown): asserts value is Record<string,
   expect(value).toEqual(expect.objectContaining({ text: expect.any(String) }));
 }
 
+function plannerResponseSchema() {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      thought: { type: "string" },
+      toolCalls: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+            args: { type: "object" },
+          },
+          required: ["name"],
+        },
+      },
+      messageToUser: { type: "string" },
+      completed: { type: "boolean" },
+    },
+    required: ["thought", "toolCalls"],
+  };
+}
+
+function assertOpenAIStrictObjectContract(schema: unknown): void {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return;
+  }
+
+  const node = schema as Record<string, unknown>;
+  if (node.type === "object") {
+    expect(node.additionalProperties).toBe(false);
+    const properties =
+      node.properties && typeof node.properties === "object" && !Array.isArray(node.properties)
+        ? (node.properties as Record<string, unknown>)
+        : {};
+    expect(new Set(Array.isArray(node.required) ? node.required : [])).toEqual(
+      new Set(Object.keys(properties))
+    );
+  }
+
+  for (const key of [
+    "properties",
+    "$defs",
+    "definitions",
+    "patternProperties",
+    "dependentSchemas",
+  ]) {
+    const children = node[key];
+    if (children && typeof children === "object" && !Array.isArray(children)) {
+      for (const child of Object.values(children)) {
+        assertOpenAIStrictObjectContract(child);
+      }
+    }
+  }
+
+  if (Array.isArray(node.items)) {
+    for (const item of node.items) {
+      assertOpenAIStrictObjectContract(item);
+    }
+  } else {
+    assertOpenAIStrictObjectContract(node.items);
+  }
+
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    if (Array.isArray(node[key])) {
+      for (const item of node[key]) {
+        assertOpenAIStrictObjectContract(item);
+      }
+    }
+  }
+
+  assertOpenAIStrictObjectContract(node.not);
+  assertOpenAIStrictObjectContract(node.contains);
+  assertOpenAIStrictObjectContract(node.if);
+  assertOpenAIStrictObjectContract(node.then);
+  assertOpenAIStrictObjectContract(node.else);
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.clearAllMocks();
 });
 
 describe("OpenAI native text plumbing", () => {
+  it("uses a strict-safe wire schema for planner tool args and restores returned args", async () => {
+    const wirePlannerText = JSON.stringify({
+      thought: "Need the calendar tool.",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "CALENDAR",
+          args: {
+            __eliza_planner_arg_entries: [
+              { key: "action", valueJson: JSON.stringify("create") },
+              {
+                key: "event",
+                valueJson: JSON.stringify({
+                  title: "Deep work",
+                  durationMinutes: 90,
+                  attendees: ["ada@example.com"],
+                  flexible: false,
+                  metadata: null,
+                }),
+              },
+              { key: "literalNumericString", valueJson: JSON.stringify("42") },
+            ],
+          },
+        },
+      ],
+    });
+    aiMocks.generateText.mockResolvedValue({
+      text: wirePlannerText,
+      finishReason: "stop",
+      usage: { inputTokens: 11, outputTokens: 9 },
+    });
+
+    const { handleActionPlanner } = await import("../models/text");
+    const result = (await handleActionPlanner(createRuntime(), {
+      messages: [{ role: "user", content: "Schedule deep work" }],
+      responseSchema: plannerResponseSchema(),
+    } as never)) as { text: string };
+
+    const call = aiMocks.generateText.mock.calls[0][0] as Record<string, unknown>;
+    const responseFormat = await (call.output as { responseFormat: Promise<unknown> })
+      .responseFormat;
+    const schema = (responseFormat as { schema: Record<string, unknown> }).schema;
+    const toolCalls = (schema.properties as Record<string, Record<string, unknown>>).toolCalls;
+    const toolCallItem = toolCalls.items as Record<string, unknown>;
+    const itemProperties = toolCallItem.properties as Record<string, Record<string, unknown>>;
+    const args = itemProperties.args;
+
+    expect(itemProperties.args).toBeDefined();
+    expect(new Set(toolCallItem.required as string[])).toEqual(new Set(["id", "name", "args"]));
+    expect(args.additionalProperties).toBe(false);
+    expect(args.required).toEqual(["__eliza_planner_arg_entries"]);
+    expect(args.properties).toHaveProperty("__eliza_planner_arg_entries");
+    assertOpenAIStrictObjectContract(schema);
+
+    expect(JSON.parse(result.text)).toEqual({
+      thought: "Need the calendar tool.",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "CALENDAR",
+          args: {
+            action: "create",
+            event: {
+              title: "Deep work",
+              durationMinutes: 90,
+              attendees: ["ada@example.com"],
+              flexible: false,
+              metadata: null,
+            },
+            literalNumericString: "42",
+          },
+        },
+      ],
+    });
+  }, 180_000);
+
+  it("does not apply the planner wire transform to matching schemas on other model types", async () => {
+    const wirePlannerText = JSON.stringify({
+      thought: "Looks planner-shaped but is an ordinary text schema.",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "CALENDAR",
+          args: {
+            __eliza_planner_arg_entries: [{ key: "action", valueJson: JSON.stringify("create") }],
+          },
+        },
+      ],
+    });
+    aiMocks.generateText.mockResolvedValue({
+      text: wirePlannerText,
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const result = (await handleTextSmall(createRuntime(), {
+      messages: [{ role: "user", content: "Use a normal response schema" }],
+      responseSchema: plannerResponseSchema(),
+    } as never)) as { text: string };
+
+    const call = aiMocks.generateText.mock.calls[0][0] as Record<string, unknown>;
+    const responseFormat = await (call.output as { responseFormat: Promise<unknown> })
+      .responseFormat;
+    const schema = (responseFormat as { schema: Record<string, unknown> }).schema;
+    const toolCalls = (schema.properties as Record<string, Record<string, unknown>>).toolCalls;
+    const toolCallItem = toolCalls.items as Record<string, unknown>;
+    const itemProperties = toolCallItem.properties as Record<string, Record<string, unknown>>;
+    const args = itemProperties.args;
+
+    const argsProperties =
+      args.properties && typeof args.properties === "object" && !Array.isArray(args.properties)
+        ? (args.properties as Record<string, unknown>)
+        : {};
+    expect(argsProperties).not.toHaveProperty("__eliza_planner_arg_entries");
+    expect(result.text).toBe(wirePlannerText);
+  }, 180_000);
+
+  it.each([
+    ["entries not array", "not-array"],
+    ["non-object entry", [null]],
+    ["extra row field", [{ key: "x", valueJson: JSON.stringify("x"), extra: true }]],
+    ["missing key", [{ valueJson: JSON.stringify("x") }]],
+    ["invalid key", [{ key: 1, valueJson: JSON.stringify("x") }]],
+    ["missing valueJson", [{ key: "x" }]],
+    ["invalid valueJson", [{ key: "x", valueJson: "{nope" }]],
+    [
+      "duplicate keys",
+      [
+        { key: "x", valueJson: JSON.stringify(1) },
+        { key: "x", valueJson: JSON.stringify(2) },
+      ],
+    ],
+  ])(
+    "rejects malformed strict-safe planner args: %s",
+    async (_name, entries) => {
+      aiMocks.generateText.mockResolvedValue({
+        text: JSON.stringify({
+          thought: "bad args",
+          toolCalls: [
+            { id: "call-1", name: "BROKEN", args: { __eliza_planner_arg_entries: entries } },
+          ],
+        }),
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      });
+
+      const { handleActionPlanner } = await import("../models/text");
+      await expect(
+        handleActionPlanner(createRuntime(), {
+          messages: [{ role: "user", content: "Plan" }],
+          responseSchema: plannerResponseSchema(),
+        } as never)
+      ).rejects.toThrow("Malformed strict-safe planner args");
+    },
+    180_000
+  );
+
+  it("restores empty-string and __proto__ planner arg keys losslessly", async () => {
+    aiMocks.generateText.mockResolvedValue({
+      text: JSON.stringify({
+        thought: "special keys",
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "SPECIAL",
+            args: {
+              __eliza_planner_arg_entries: [
+                { key: "", valueJson: JSON.stringify("empty key") },
+                { key: "__proto__", valueJson: JSON.stringify({ preserved: true }) },
+              ],
+            },
+          },
+        ],
+      }),
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    const { handleActionPlanner } = await import("../models/text");
+    const result = (await handleActionPlanner(createRuntime(), {
+      messages: [{ role: "user", content: "Plan" }],
+      responseSchema: plannerResponseSchema(),
+    } as never)) as { text: string };
+
+    const args = JSON.parse(result.text).toolCalls[0].args;
+    expect(Object.hasOwn(args, "")).toBe(true);
+    expect(Object.hasOwn(args, "__proto__")).toBe(true);
+    expect(args[""]).toBe("empty key");
+    expect(Object.getOwnPropertyDescriptor(args, "__proto__")?.value).toEqual({
+      preserved: true,
+    });
+  }, 180_000);
+
   it("passes messages, tools, toolChoice, schema, and provider options through", async () => {
     aiMocks.generateText.mockResolvedValue({
       text: "ok",

--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -231,8 +231,9 @@ describe("#13111 strict-safe record/map tool args", () => {
 });
 
 /**
- * response_format still uses plain schema sanitization: it is not a tool-call
- * contract and has no returned arguments to reverse-map.
+ * Ordinary response_format schemas still use plain schema sanitization: unlike
+ * the planner envelope, they are not a tool-call contract and have no returned
+ * arguments to reverse-map.
  */
 describe("response_format schema sanitization stays closed", () => {
   it("still closes a map with no tool transform", () => {

--- a/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
@@ -38,6 +38,30 @@ function createRuntime() {
   } as never;
 }
 
+function plannerResponseSchema() {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      thought: { type: "string" },
+      toolCalls: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+            args: { type: "object" },
+          },
+          required: ["name"],
+        },
+      },
+    },
+    required: ["thought", "toolCalls"],
+  };
+}
+
 const TRANSIENT = {
   message: "Encountered a server error, please try again",
   type: "server_error",
@@ -282,6 +306,53 @@ describe("live-stream start retry", () => {
     } finally {
       delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
     }
+  }, 20_000);
+
+  it("buffered transformed planner stream replays only restored final text without the env gate", async () => {
+    delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+    const wireText = JSON.stringify({
+      thought: "Need a tool.",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "CALENDAR",
+          args: {
+            __eliza_planner_arg_entries: [
+              { key: "action", valueJson: JSON.stringify("create") },
+              { key: "durationMinutes", valueJson: JSON.stringify(30) },
+            ],
+          },
+        },
+      ],
+    });
+    const rawChunks = [wireText.slice(0, 24), wireText.slice(24)];
+    aiMocks.streamText.mockImplementation(() => successResult(rawChunks));
+
+    const onStreamChunk = vi.fn();
+    const { handleActionPlanner } = await import("../models/text");
+    const stream = (await handleActionPlanner(createRuntime(), {
+      messages: [{ role: "user", content: "Plan" }],
+      responseSchema: plannerResponseSchema(),
+      stream: true,
+      onStreamChunk,
+    } as never)) as { textStream: AsyncIterable<string>; text: Promise<string> };
+
+    const restoredText = JSON.stringify({
+      thought: "Need a tool.",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "CALENDAR",
+          args: { action: "create", durationMinutes: 30 },
+        },
+      ],
+    });
+    await expect(collect(stream)).resolves.toEqual([restoredText]);
+    await expect(stream.text).resolves.toBe(restoredText);
+    expect(onStreamChunk).toHaveBeenCalledTimes(1);
+    expect(onStreamChunk).toHaveBeenCalledWith(restoredText);
+    expect(onStreamChunk).not.toHaveBeenCalledWith(rawChunks[0]);
+    expect(onStreamChunk).not.toHaveBeenCalledWith(rawChunks[1]);
   }, 20_000);
 
   it("non-streaming with native tools (the coding-build path): transient failure retries and tool calls survive", async () => {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -146,6 +146,15 @@ interface RecordArgTransform {
   valueMode: RecordArgValueMode;
 }
 
+interface ResponseSchemaTransform {
+  restoreText(text: string): string;
+}
+
+interface PreparedStructuredOutput {
+  output: NativeOutput;
+  transform?: ResponseSchemaTransform;
+}
+
 interface NormalizedNativeToolsResult {
   tools?: ToolSet;
   recordArgTransformsByTool: Record<string, RecordArgTransform[]>;
@@ -423,26 +432,200 @@ function resolveProviderOptions(
   return Object.keys(providerOptions).length > 0 ? providerOptions : undefined;
 }
 
-function buildStructuredOutput(responseSchema: unknown): NativeOutput {
+function buildStructuredOutput(
+  responseSchema: unknown,
+  modelType: ModelTypeName
+): PreparedStructuredOutput {
   if (
     responseSchema &&
     typeof responseSchema === "object" &&
     "responseFormat" in responseSchema &&
     "parseCompleteOutput" in responseSchema
   ) {
-    return responseSchema as NativeOutput;
+    return { output: responseSchema as NativeOutput };
   }
 
   const schemaOptions =
     responseSchema && typeof responseSchema === "object" && "schema" in responseSchema
       ? (responseSchema as { schema: unknown; name?: string; description?: string })
       : { schema: responseSchema };
+  const preparedSchema = prepareResponseFormatSchema(schemaOptions.schema, modelType);
 
-  return Output.object({
-    schema: jsonSchema(sanitizeJsonSchema(schemaOptions.schema, true)),
-    ...(schemaOptions.name ? { name: schemaOptions.name } : {}),
-    ...(schemaOptions.description ? { description: schemaOptions.description } : {}),
-  }) as NativeOutput;
+  return {
+    output: Output.object({
+      schema: jsonSchema(sanitizeJsonSchema(preparedSchema.schema, true)),
+      ...(schemaOptions.name ? { name: schemaOptions.name } : {}),
+      ...(schemaOptions.description ? { description: schemaOptions.description } : {}),
+    }) as NativeOutput,
+    ...(preparedSchema.transform ? { transform: preparedSchema.transform } : {}),
+  };
+}
+
+const STRICT_SAFE_PLANNER_ARGS_ENTRIES_KEY = "__eliza_planner_arg_entries";
+
+function prepareResponseFormatSchema(
+  schema: unknown,
+  modelType: ModelTypeName
+): {
+  schema: unknown;
+  transform?: ResponseSchemaTransform;
+} {
+  if (modelType !== ACTION_PLANNER_MODEL_TYPE || !isPlannerResponseSchema(schema)) {
+    return { schema };
+  }
+
+  const root = schema as Record<string, unknown>;
+  const rootProperties = asRecord(root.properties);
+  const toolCalls = asRecord(rootProperties.toolCalls);
+  const toolCallItems = asRecord(toolCalls.items);
+  const toolCallProperties = asRecord(toolCallItems.properties);
+
+  return {
+    schema: {
+      ...root,
+      properties: {
+        ...rootProperties,
+        toolCalls: {
+          ...toolCalls,
+          items: {
+            ...toolCallItems,
+            properties: {
+              ...toolCallProperties,
+              args: strictSafePlannerArgsSchema(),
+            },
+          },
+        },
+      },
+    },
+    transform: { restoreText: restorePlannerArgsResponseText },
+  };
+}
+
+function isPlannerResponseSchema(schema: unknown): boolean {
+  const root = asOptionalRecord(schema);
+  const rootProperties = asOptionalRecord(root?.properties);
+  const toolCalls = asOptionalRecord(rootProperties?.toolCalls);
+  const toolCallItems = asOptionalRecord(toolCalls?.items);
+  const toolCallProperties = asOptionalRecord(toolCallItems?.properties);
+  const args = asOptionalRecord(toolCallProperties?.args);
+
+  return (
+    root?.type === "object" &&
+    toolCalls?.type === "array" &&
+    toolCallItems?.type === "object" &&
+    args?.type === "object" &&
+    args.additionalProperties !== false &&
+    Array.isArray(root?.required) &&
+    root.required.includes("toolCalls")
+  );
+}
+
+function strictSafePlannerArgsSchema(): JSONSchema7 {
+  return {
+    type: "object",
+    description:
+      "Arbitrary planner tool arguments. Put every original args property in __eliza_planner_arg_entries as {key,valueJson}; valueJson must be JSON.stringify(value), so strings include JSON quotes and objects, arrays, numbers, booleans, and null round-trip exactly.",
+    properties: {
+      [STRICT_SAFE_PLANNER_ARGS_ENTRIES_KEY]: {
+        type: "array",
+        description:
+          "Key/value entries restored to the original planner args object before runtime tool validation.",
+        items: {
+          type: "object",
+          properties: {
+            key: { type: "string" },
+            valueJson: {
+              type: "string",
+              description: "JSON.stringify(value) for this argument key.",
+            },
+          },
+          required: ["key", "valueJson"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: [STRICT_SAFE_PLANNER_ARGS_ENTRIES_KEY],
+    additionalProperties: false,
+  };
+}
+
+function restorePlannerArgsResponseText(text: string): string {
+  const parsed = JSON.parse(text) as unknown;
+  return JSON.stringify(restorePlannerArgsEnvelope(parsed));
+}
+
+function restorePlannerArgsEnvelope(value: unknown): unknown {
+  const envelope = asOptionalRecord(value);
+  if (!envelope || !Array.isArray(envelope.toolCalls)) {
+    return value;
+  }
+
+  return {
+    ...envelope,
+    toolCalls: envelope.toolCalls.map((toolCall) => {
+      const call = asOptionalRecord(toolCall);
+      if (!call || !("args" in call)) {
+        return toolCall;
+      }
+      return {
+        ...call,
+        args: restoreStrictSafePlannerArgs(call.args),
+      };
+    }),
+  };
+}
+
+function restoreStrictSafePlannerArgs(value: unknown): unknown {
+  const record = asOptionalRecord(value);
+  if (!record) return value;
+  if (!Object.hasOwn(record, STRICT_SAFE_PLANNER_ARGS_ENTRIES_KEY)) return value;
+  const entries = record[STRICT_SAFE_PLANNER_ARGS_ENTRIES_KEY];
+  if (!Array.isArray(entries)) {
+    throw new Error("Malformed strict-safe planner args: entries must be an array.");
+  }
+
+  const restored: Record<string, unknown> = Object.create(null);
+  const seenKeys = new Set<string>();
+  for (const entry of entries) {
+    const row = asOptionalRecord(entry);
+    if (!row) {
+      throw new Error("Malformed strict-safe planner args: entry must be an object.");
+    }
+    const rowKeys = Object.keys(row);
+    if (rowKeys.length !== 2 || !rowKeys.includes("key") || !rowKeys.includes("valueJson")) {
+      throw new Error(
+        "Malformed strict-safe planner args: entry must contain only key and valueJson."
+      );
+    }
+    const key = typeof row.key === "string" ? row.key : undefined;
+    if (key === undefined || typeof row.valueJson !== "string") {
+      throw new Error(
+        "Malformed strict-safe planner args: entry requires string key and valueJson."
+      );
+    }
+    if (seenKeys.has(key)) {
+      throw new Error(`Malformed strict-safe planner args: duplicate key ${JSON.stringify(key)}.`);
+    }
+    seenKeys.add(key);
+    let parsedValue: unknown;
+    try {
+      parsedValue = JSON.parse(row.valueJson) as unknown;
+    } catch (error) {
+      throw new Error(
+        `Malformed strict-safe planner args: invalid JSON for key ${JSON.stringify(key)}.`,
+        {
+          cause: error,
+        }
+      );
+    }
+    Object.defineProperty(restored, key, {
+      value: parsedValue,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return restored;
 }
 
 /**
@@ -1577,12 +1760,14 @@ async function generateTextByModelType(
           "type" in callerResponseFormat
         ? (callerResponseFormat as { type: string }).type
         : undefined;
-  const requestedOutput: NativeOutput | undefined =
+  const preparedOutput =
     paramsWithAttachments.responseSchema && !cerebrasMode
-      ? buildStructuredOutput(paramsWithAttachments.responseSchema)
-      : responseFormatType === "json_object"
-        ? Output.json()
-        : undefined;
+      ? buildStructuredOutput(paramsWithAttachments.responseSchema, modelType)
+      : undefined;
+  const requestedOutput: NativeOutput | undefined =
+    preparedOutput?.output ?? (responseFormatType === "json_object" ? Output.json() : undefined);
+  const restoreResponseText = (text: string): string =>
+    preparedOutput?.transform?.restoreText(text) ?? text;
 
   const generateParams: NativeTextParams = {
     model,
@@ -1609,12 +1794,13 @@ async function generateTextByModelType(
     // consumeStreamWithTransientRetry). Token streaming isn't user-visible for
     // coding. Regular chat falls through to the live-streaming path below.
     const fullActionSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
-    if (
+    const shouldBufferStream =
+      preparedOutput?.transform !== undefined ||
       fullActionSurface === "1" ||
       fullActionSurface === "true" ||
       fullActionSurface === "yes" ||
-      fullActionSurface === "on"
-    ) {
+      fullActionSurface === "on";
+    if (shouldBufferStream) {
       const details = createLlmCallDetails(
         modelName,
         params,
@@ -1625,14 +1811,19 @@ async function generateTextByModelType(
         generateParams
       );
       details.response = "";
+      const hasResponseTransform = preparedOutput?.transform !== undefined;
       const buffered = await recordLlmCall(runtime, details, () =>
-        consumeStreamWithTransientRetry(generateParams, params.onStreamChunk)
+        consumeStreamWithTransientRetry(
+          generateParams,
+          hasResponseTransform ? undefined : params.onStreamChunk
+        )
       );
+      const restoredText = restoreResponseText(buffered.text);
       const restoredToolCalls = restoreRecordArgToolCalls(
         buffered.toolCalls,
         normalizedToolResult.recordArgTransformsByTool
       );
-      details.response = buffered.text;
+      details.response = restoredText;
       details.toolCalls = restoredToolCalls;
       details.finishReason = buffered.finishReason;
       if (buffered.usage) {
@@ -1641,9 +1832,14 @@ async function generateTextByModelType(
       }
       return {
         textStream: (async function* replayBufferedStream() {
-          if (buffered.text) yield buffered.text;
+          if (restoredText) {
+            if (hasResponseTransform) {
+              params.onStreamChunk?.(restoredText);
+            }
+            yield restoredText;
+          }
         })(),
-        text: Promise.resolve(buffered.text),
+        text: Promise.resolve(restoredText),
         ...(shouldReturnNativeResult ? { toolCalls: Promise.resolve(restoredToolCalls) } : {}),
         usage: Promise.resolve(convertUsage(buffered.usage)),
         finishReason: Promise.resolve(buffered.finishReason),
@@ -1748,10 +1944,13 @@ async function generateTextByModelType(
         rejectStructuredText(error);
         return;
       }
-      resolveStructuredText(responseChunks.join(""));
+      resolveStructuredText(restoreResponseText(responseChunks.join("")));
     };
     const sdkTextPromise = handledPromise(result.text);
-    const textPromise = params.streamStructured === true ? structuredTextPromise : sdkTextPromise;
+    const textPromise =
+      params.streamStructured === true
+        ? structuredTextPromise
+        : handledMappedPromise(sdkTextPromise, restoreResponseText);
     const rawUsagePromise = handledPromise(result.usage);
     const rawFinishReasonPromise = handledPromise(result.finishReason);
     const rawToolCallsPromise = handledPromise(result.toolCalls);
@@ -1774,7 +1973,7 @@ async function generateTextByModelType(
         restoredToolCallsPromise,
       ]);
 
-      details.response = responseChunks.join("");
+      details.response = restoreResponseText(responseChunks.join(""));
       if (usageResult.status === "fulfilled" && usageResult.value) {
         applyUsageToDetails(details, usageResult.value);
         emitModelUsageEvent(runtime, modelType, params.prompt ?? "", usageResult.value);
@@ -1878,17 +2077,18 @@ async function generateTextByModelType(
   );
   const result = await recordLlmCall(runtime, details, async () => {
     const result = await generateTextWithTransientRetry(generateParams);
+    const restoredText = restoreResponseText(result.text);
     const restoredToolCalls = restoreRecordArgToolCalls(
       result.toolCalls,
       normalizedToolResult.recordArgTransformsByTool
     );
-    details.response = result.text;
+    details.response = restoredText;
     details.toolCalls = restoredToolCalls;
     details.finishReason = result.finishReason as string | undefined;
     details.providerMetadata = result.providerMetadata;
     applyUsageToDetails(details, result.usage);
     return {
-      text: result.text,
+      text: restoredText,
       toolCalls: restoredToolCalls as typeof result.toolCalls,
       finishReason: result.finishReason,
       usage: result.usage,


### PR DESCRIPTION
## Summary

Fixes the seven OpenAI `response_format` 400s from the live scenario run where `toolCalls[].args` was rejected under strict structured output:

`Invalid schema for response_format 'response': In context=('properties', 'toolCalls', 'items'), 'required' is required to be supplied and to be an array including every key in properties. Extra required key 'args' supplied.`

OpenAI strict mode cannot represent the planner's intentionally dynamic args object directly. This change adds an OpenAI ACTION_PLANNER-only wire transform:

- encode arbitrary args as strict-safe `{ key, valueJson }[]` entries
- make every object in the transmitted schema satisfy `additionalProperties: false` and `required === Object.keys(properties)`
- restore the original args object before core planner parsing and action-schema validation
- buffer transformed streaming responses so internal wire chunks never escape
- reject malformed, duplicate, or invalid encoded entries instead of silently weakening validation
- preserve special keys, including empty strings and `__proto__`, without prototype mutation

Other model types and matching non-planner schemas are left unchanged. Billing, provider auth, model selection/routing, timeout behavior, and scenario assertions are untouched.

## Regression coverage

- strict provider-contract validation across nested objects
- non-streaming planner schema generation and lossless reverse decode
- transformed streaming replay with no raw wire chunk leakage
- explicit ACTION_PLANNER scoping
- malformed, extra-field, duplicate-key, and invalid-JSON rejection
- empty-string and `__proto__` key preservation
- request/response observability remains on restored action args

## Validation

- `bunx @biomejs/biome check` on all four changed files: pass
- focused Vitest: 3 files, 47 tests passed
- `git diff --check origin/develop...HEAD`: pass
- package typecheck attempted, blocked by the sparse/shared dependency environment missing pre-existing `js-tiktoken`; no type errors from changed files were reported before that resolver failure

Co-authored-by: wakesync <wakesync@users.noreply.github.com>


## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - provider adapter and shape-test changes only; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - provider adapter and shape-test changes only; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user interface or interactive flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [focused provider checks](https://github.com/elizaOS/eliza/pull/16697/checks) - 47 focused OpenAI adapter tests pass, including strict wire-schema restoration and streaming buffering.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend code, browser request path, or UI behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - the regression is covered at the provider wire-contract boundary with deterministic mocked SDK responses; this review does not claim a new live provider run.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff](https://github.com/elizaOS/eliza/pull/16697/files), [CI checks](https://github.com/elizaOS/eliza/pull/16697/checks). Scope is limited to the OpenAI text adapter and three focused shape-test files.
