### PR TITLE
fix(lifeops): preserve disabled scheduler worker identity

### DIFF
--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -360,6 +360,18 @@ describe("TaskService tick re-arm", () => {
 			code: "TASK_TICK_FAILED",
 			context: {
 				failureCodes: ["TASK_WORKER_MISSING", "TASK_PREFLIGHT_INVALID"],
+				failures: [
+					{
+						code: "TASK_WORKER_MISSING",
+						taskId: "missing-worker",
+						taskName: "MISSING",
+					},
+					{
+						code: "TASK_PREFLIGHT_INVALID",
+						taskId: "bad-preflight",
+						taskName: "BAD_PREFLIGHT",
+					},
+				],
 			},
 		});
 		expect(execute).toHaveBeenCalledTimes(1);

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -504,7 +504,18 @@ export class TaskService extends Service {
 		if (failures.length > 0) {
 			throw new ElizaError(`${failures.length} scheduled task failure(s)`, {
 				code: "TASK_TICK_FAILED",
-				context: { failureCodes: failures.map((failure) => failure.code) },
+				context: {
+					failureCodes: failures.map((failure) => failure.code),
+					failures: failures.map((failure) => ({
+						code: failure.code,
+						...(typeof failure.context?.taskId === "string"
+							? { taskId: failure.context.taskId }
+							: {}),
+						...(typeof failure.context?.taskName === "string"
+							? { taskName: failure.context.taskName }
+							: {}),
+					})),
+				},
 				cause: new AggregateError(failures),
 				severity: failures.some((failure) => failure.severity === "fatal")
 					? "fatal"

--- a/plugins/plugin-personal-assistant/src/lifeops/runtime.scheduler-tick.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/runtime.scheduler-tick.test.ts
@@ -1,9 +1,10 @@
 /** Verifies the LifeOps scheduler tick processes scheduled work and surfaces subsystem failures rather than swallowing them. Deterministic vitest with the scheduled-work path mocked. */
-import type { IAgentRuntime, UUID } from "@elizaos/core";
+import type { IAgentRuntime, TaskWorker, UUID } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { escalateUnacknowledgedIntents } from "./intent-sync.js";
 import {
   executeLifeOpsSchedulerTask,
+  registerLifeOpsTaskWorker,
   resolveLifeOpsTaskIntervalMs,
 } from "./runtime.js";
 
@@ -14,6 +15,18 @@ const scheduledWorkFixture = vi.hoisted(() => ({
   scheduledTaskFires: [],
   scheduledTaskCompletionTimeouts: [],
   subsystemFailures: [{ subsystem: "reminders", error: "reminders down" }],
+}));
+
+vi.mock("./scheduler-task.js", () => ({
+  ensureLifeOpsSchedulerTask: vi.fn(),
+  ensureRuntimeAgentRecord: vi.fn(),
+  isMissingLifeOpsRelationError: vi.fn(() => false),
+  LIFEOPS_TASK_INTERVAL_MS: 60_000,
+  LIFEOPS_TASK_JITTER_MS: 10_000,
+  LIFEOPS_TASK_NAME: "LIFEOPS_SCHEDULER",
+  LIFEOPS_TASK_TAGS: ["queue", "repeat", "lifeops"],
+  rerunLifeOpsPluginMigrations: vi.fn(),
+  resolveLifeOpsTaskIntervalMs: vi.fn(() => 60_000),
 }));
 
 vi.mock("./service.js", () => ({
@@ -30,6 +43,27 @@ vi.mock("./intent-sync.js", () => ({
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000ee" as UUID;
 const runtime = { agentId: AGENT_ID } as unknown as IAgentRuntime;
+
+describe("registerLifeOpsTaskWorker", () => {
+  it("keeps the task identity valid without executing when scheduler is disabled", async () => {
+    let registered: TaskWorker | undefined;
+    const disabledRuntime = {
+      getTaskWorker: () => undefined,
+      registerTaskWorker: (worker: TaskWorker) => {
+        registered = worker;
+      },
+    } as unknown as IAgentRuntime;
+
+    registerLifeOpsTaskWorker(disabledRuntime, { disabled: true });
+
+    expect(registered?.name).toBe("LIFEOPS_SCHEDULER");
+    await expect(
+      registered?.shouldRun?.(disabledRuntime, {
+        name: "LIFEOPS_SCHEDULER",
+      }),
+    ).resolves.toBe(false);
+  });
+});
 
 describe("executeLifeOpsSchedulerTask", () => {
   beforeEach(() => {

--- a/plugins/plugin-personal-assistant/src/lifeops/runtime.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/runtime.ts
@@ -123,16 +123,24 @@ export async function executeLifeOpsSchedulerTask(
   };
 }
 
-export function registerLifeOpsTaskWorker(runtime: IAgentRuntime): void {
+export function registerLifeOpsTaskWorker(
+  runtime: IAgentRuntime,
+  options: { disabled?: boolean } = {},
+): void {
   if (runtime.getTaskWorker(LIFEOPS_TASK_NAME)) {
     return;
   }
+  const disabled = options.disabled === true;
   runtime.registerTaskWorker({
     name: LIFEOPS_TASK_NAME,
-    // Skip execution when the user has disabled LifeOps via the UI. The task
-    // record and worker stay registered so toggling back on requires no
-    // restart — cycles just become cheap no-ops while disabled.
+    // Keep the worker identity registered even when the process-level scheduler
+    // kill switch is set. Owner-profile writes use the scheduler row as their
+    // metadata store and may create it lazily; without this disabled worker the
+    // live TaskService treats that valid row as an orphan and emits a fatal
+    // TASK_WORKER_MISSING error every second. Returning false preserves the kill
+    // switch exactly: the timer still validates the row, but never executes it.
     shouldRun: async (rt) => {
+      if (disabled) return false;
       try {
         const state = await loadLifeOpsAppState(rt as IAgentRuntime);
         return state.enabled;
@@ -145,7 +153,7 @@ export function registerLifeOpsTaskWorker(runtime: IAgentRuntime): void {
         return false;
       }
     },
-    execute: async (rt, options) =>
-      executeLifeOpsSchedulerTask(rt, isRecord(options) ? options : {}),
+    execute: async (rt, taskOptions) =>
+      executeLifeOpsSchedulerTask(rt, isRecord(taskOptions) ? taskOptions : {}),
   });
 }

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Drives the personal-assistant plugin `init` to verify the LifeOps scheduler
+ * worker identity is registered EVEN when the scheduler is disabled via
+ * ELIZA_DISABLE_LIFEOPS_SCHEDULER (issue: preserve disabled scheduler worker
+ * identity). A recording stub runtime captures every registerTaskWorker call so
+ * the disabled-path behavior is asserted against the real init wiring rather
+ * than a hand-rolled fragment. The dynamic Google connector import is stubbed so
+ * init runs without the optional third-party plugin present.
+ */
+import type { IAgentRuntime, Plugin, TaskWorker, UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Isolate PA's own init wiring (registries, workers, policies, the scheduler
+// identity under test) from the cross-plugin connector boot. Each connector
+// package has its own dedicated suite; here they are neutralized so init runs
+// deterministically without booting eight sibling plugins. The register-helper
+// re-runs contributed by plugin-health depend on registries created later in
+// init, which is the boot-order seam these hooks exist to paper over — not the
+// behavior this test asserts.
+vi.mock("@elizaos/plugin-google", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  googlePlugin: { name: "@elizaos/plugin-google", init: vi.fn() },
+}));
+vi.mock("@elizaos/plugin-health", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  registerHealthConnectors: vi.fn(),
+  registerHealthAnchors: vi.fn(),
+  registerHealthBusFamilies: vi.fn(),
+  registerHealthDefaultPacks: vi.fn(),
+  registerCircadianInsightContract: vi.fn(),
+  createDefaultCircadianInsightContract: vi.fn(() => ({})),
+}));
+
+import { personalAssistantPlugin } from "./plugin.js";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000ab" as UUID;
+
+interface RecordingRuntime {
+  runtime: IAgentRuntime;
+  taskWorkers: Map<string, TaskWorker>;
+  registeredPlugins: Plugin[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const taskWorkers = new Map<string, TaskWorker>();
+  const registeredPlugins: Plugin[] = [];
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+  };
+  // The core-typed methods init reads back are special-cased; every other
+  // runtime method init (or its registration helpers) touches is a recorded
+  // no-op via the Proxy trap so the full init wiring executes deterministically
+  // without a live AgentRuntime.
+  const explicit: Record<string, unknown> = {
+    agentId: AGENT_ID,
+    logger,
+    plugins: registeredPlugins,
+    initPromise: Promise.resolve(),
+    stopped: false,
+    character: { name: "test-agent", settings: {} },
+    getTaskWorker: (name: string) => taskWorkers.get(name),
+    registerTaskWorker: (worker: TaskWorker) => {
+      taskWorkers.set(worker.name, worker);
+    },
+    registerPlugin: async (plugin: Plugin) => {
+      registeredPlugins.push(plugin);
+    },
+    getSetting: () => undefined,
+    getService: () => null,
+    getRoom: async () => null,
+    getMemories: async () => [],
+  };
+  const noopCache = new Map<string, unknown>();
+  const runtime = new Proxy(explicit, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      if (!noopCache.has(prop)) {
+        noopCache.set(prop, (..._args: unknown[]) => undefined);
+      }
+      return noopCache.get(prop);
+    },
+  }) as unknown as IAgentRuntime;
+  return { runtime, taskWorkers, registeredPlugins };
+}
+
+const LIFEOPS_TASK_NAME = "LIFEOPS_SCHEDULER";
+
+describe("personalAssistantPlugin.init scheduler identity", () => {
+  const originalEnv = process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER;
+    } else {
+      process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER = originalEnv;
+    }
+  });
+
+  it("registers the LifeOps worker identity even when the scheduler is disabled", async () => {
+    process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER = "1";
+    const { runtime, taskWorkers } = createRecordingRuntime();
+
+    await personalAssistantPlugin.init?.({}, runtime);
+
+    const worker = taskWorkers.get(LIFEOPS_TASK_NAME);
+    expect(worker).toBeDefined();
+    // Disabled worker keeps a valid identity but never executes.
+    await expect(worker?.shouldRun?.(runtime)).resolves.toBe(false);
+  });
+
+  it("registers a LifeOps worker whose shouldRun is gated by app state when enabled", async () => {
+    delete process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER;
+    const { runtime, taskWorkers } = createRecordingRuntime();
+
+    await personalAssistantPlugin.init?.({}, runtime);
+
+    const worker = taskWorkers.get(LIFEOPS_TASK_NAME);
+    expect(worker).toBeDefined();
+    // When enabled, shouldRun consults live app state (not a hardcoded false).
+    expect(typeof worker?.shouldRun).toBe("function");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -1050,8 +1050,12 @@ const rawPersonalAssistantPlugin: Plugin = {
     const lifeOpsSchedulerDisabled = isDisabledByEnv(
       "ELIZA_DISABLE_LIFEOPS_SCHEDULER",
     );
+    // Register the identity even when execution is disabled. Owner-profile
+    // updates persist on the LIFEOPS_SCHEDULER row and can create it lazily;
+    // the disabled worker keeps that row valid while shouldRun=false preserves
+    // the process-level kill switch.
+    registerLifeOpsTaskWorker(runtime, { disabled: lifeOpsSchedulerDisabled });
     if (!lifeOpsSchedulerDisabled) {
-      registerLifeOpsTaskWorker(runtime);
       scheduleTaskEnsureAfterRuntimeInit({
         runtime,
         prefix: "[lifeops]",


### PR DESCRIPTION
## Summary

- preserve the `LIFEOPS_SCHEDULER` worker identity when `ELIZA_DISABLE_LIFEOPS_SCHEDULER=1`, while keeping `shouldRun=false`
- prevent lazy owner-profile metadata rows from becoming fatal orphaned queue tasks
- include nested `taskId` and `taskName` identity in aggregate `TASK_TICK_FAILED` context

## Root cause

Live Scenarios intentionally disables scheduler execution, but owner-profile writers still use the scheduler task row as persistent metadata and can create it lazily. The worker was skipped entirely under the kill switch, so TaskService correctly emitted `TASK_WORKER_MISSING` every second. Run 29681190032 accumulated 6,596 fatal events. Focused live reproduction identified the missing row as `LIFEOPS_SCHEDULER`.

This keeps the timer and fatal semantics intact. It registers a disabled worker identity rather than suppressing ticks, deleting rows, or downgrading failures.

## Verification

- `bunx vitest run packages/core/src/services/task.test.ts` (18 passed)
- `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/runtime.scheduler-tick.test.ts` (3 passed)
- Biome check on all changed source/test files
- focused live OpenAI four-scenario reproduction before fix: repeated fatal `TASK_WORKER_MISSING`, identity `LIFEOPS_SCHEDULER`
- same 99.4-second live sequence after fix: zero `TASK_WORKER_MISSING`, zero `TASK_TICK_FAILED`

Receipt: `SCENARIO-TASK-WORKER-FIX-2026-07-20.md`

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - backend task/scheduler worker fix; touches packages/core services and plugin-personal-assistant lifeops, no UI surface exists or is changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI surface changed; backend/test-only change.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing flow; behavior is covered by the unit tests listed above.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - deterministic logic change verified by the checked-in unit tests rather than a captured runtime log.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent prompt, model, provider, evaluator, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - the deliverable is a backend logic fix plus its unit tests (see the Tests/Verification section above); no DB rows, media, or generated files are produced.

Co-authored-by: wakesync <wakesync@users.noreply.github.com>

