### PR TITLE
feat(agent): canonical file boot — sovereign identity from files, not a JSON shadow copy

### DIFF
--- a/packages/agent/src/runtime/canonical-file-boot.test.ts
+++ b/packages/agent/src/runtime/canonical-file-boot.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests the canonical file boot mechanism: composing an allowlisted set of
+ * on-disk files into the boot character's system prompt, with a sha256 audit
+ * per file, loud failure on a missing REQUIRED file, and a canary proof that a
+ * changed line in an allowed file reaches the composed boot context.
+ *
+ * FILE FIREWALL: every fixture here is SYNTHETIC. No real SOUL.md / USER.md /
+ * memory content is read or embedded. Tests inject a fake fs or write throwaway
+ * files into an os tmpdir, then delete them.
+ */
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  applyCanonicalFileBootToConfig,
+  CANONICAL_BOOT_MANIFEST_ENV,
+  CANONICAL_BOOT_ROOT_ENV,
+  composeCanonicalBootContext,
+  DEFAULT_CANONICAL_MANIFEST,
+  resolveCanonicalManifest,
+  type CanonicalBootFs,
+  type ResolvedCanonicalEntry,
+} from "./canonical-file-boot.ts";
+
+// A synthetic in-memory fs: label/path -> content. Anything not present throws
+// (ENOENT-like), which the composer treats as "file absent".
+function fakeFs(files: Record<string, string>): CanonicalBootFs {
+  return {
+    readFileSync(path: string) {
+      if (path in files) return files[path];
+      throw new Error(`ENOENT: ${path}`);
+    },
+  };
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+const ENV_KEYS = [CANONICAL_BOOT_ROOT_ENV, CANONICAL_BOOT_MANIFEST_ENV];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("resolveCanonicalManifest", () => {
+  it("is inert (returns null) when no env is configured", () => {
+    expect(resolveCanonicalManifest({}, fakeFs({}))).toBeNull();
+  });
+
+  it("resolves the default manifest under ELIZA_CANONICAL_BOOT_ROOT", () => {
+    const manifest = resolveCanonicalManifest(
+      { [CANONICAL_BOOT_ROOT_ENV]: "/srv/ws" },
+      fakeFs({}),
+    );
+    expect(manifest).not.toBeNull();
+    expect(manifest?.length).toBe(DEFAULT_CANONICAL_MANIFEST.length);
+    const soul = manifest?.find((e) => e.label === "SOUL.md");
+    expect(soul?.path).toBe("/srv/ws/SOUL.md");
+    expect(soul?.required).toBe(true);
+    const handoff = manifest?.find((e) => e.label === "memory/HANDOFF.md");
+    expect(handoff?.path).toBe("/srv/ws/memory/HANDOFF.md");
+    expect(handoff?.required).toBe(false);
+  });
+
+  it("resolves an explicit JSON manifest with its own root + required flags", () => {
+    const manifestPath = "/cfg/manifest.json";
+    const manifestJson = JSON.stringify({
+      root: "/data/agent",
+      files: [
+        { label: "SOUL", path: "soul.md", required: true },
+        { label: "ABS", path: "/etc/agent/extra.md" },
+      ],
+    });
+    const manifest = resolveCanonicalManifest(
+      { [CANONICAL_BOOT_MANIFEST_ENV]: manifestPath },
+      fakeFs({ [manifestPath]: manifestJson }),
+    );
+    expect(manifest).toHaveLength(2);
+    expect(manifest?.[0]).toEqual({
+      label: "SOUL",
+      path: "/data/agent/soul.md",
+      required: true,
+    });
+    // absolute path passes through unchanged
+    expect(manifest?.[1].path).toBe("/etc/agent/extra.md");
+    expect(manifest?.[1].required).toBe(false);
+  });
+
+  it("throws loudly on a broken/unreadable manifest file", () => {
+    expect(() =>
+      resolveCanonicalManifest(
+        { [CANONICAL_BOOT_MANIFEST_ENV]: "/cfg/missing.json" },
+        fakeFs({}),
+      ),
+    ).toThrow(/Failed to read\/parse manifest/);
+  });
+});
+
+describe("composeCanonicalBootContext", () => {
+  const soulBody = "SYNTHETIC SOUL: be kind, be sharp. canary=ALPHA-1";
+  const idBody = "SYNTHETIC IDENTITY: name is TestAgent.";
+
+  function manifest(root = "/ws"): ResolvedCanonicalEntry[] {
+    return [
+      { label: "SOUL.md", path: `${root}/SOUL.md`, required: true },
+      { label: "IDENTITY.md", path: `${root}/IDENTITY.md`, required: true },
+      {
+        label: "memory/HANDOFF.md",
+        path: `${root}/memory/HANDOFF.md`,
+        required: false,
+      },
+    ];
+  }
+
+  it("composes present files with a correct sha256 per file, skips absent optional", () => {
+    const fs = fakeFs({
+      "/ws/SOUL.md": soulBody,
+      "/ws/IDENTITY.md": idBody,
+      // HANDOFF.md deliberately absent (optional)
+    });
+    const { text, audit } = composeCanonicalBootContext(manifest(), {
+      fs,
+      log: false,
+    });
+
+    // exact content is present verbatim
+    expect(text).toContain(soulBody);
+    expect(text).toContain(idBody);
+    // sha256 in header matches the actual bytes
+    expect(text).toContain(`sha256=${sha256(soulBody)}`);
+    expect(text).toContain(`sha256=${sha256(idBody)}`);
+
+    const soulAudit = audit.find((a) => a.label === "SOUL.md");
+    expect(soulAudit?.present).toBe(true);
+    expect(soulAudit?.sha256).toBe(sha256(soulBody));
+    expect(soulAudit?.bytes).toBe(Buffer.byteLength(soulBody, "utf8"));
+
+    const handoffAudit = audit.find((a) => a.label === "memory/HANDOFF.md");
+    expect(handoffAudit?.present).toBe(false);
+    expect(handoffAudit?.sha256).toBeNull();
+  });
+
+  it("throws loudly when a REQUIRED file is missing", () => {
+    const fs = fakeFs({ "/ws/IDENTITY.md": idBody }); // SOUL.md missing
+    expect(() =>
+      composeCanonicalBootContext(manifest(), { fs, log: false }),
+    ).toThrow(/Required canonical file missing or empty: SOUL\.md/);
+  });
+
+  it("throws loudly when a REQUIRED file is present but empty", () => {
+    const fs = fakeFs({ "/ws/SOUL.md": "   \n  ", "/ws/IDENTITY.md": idBody });
+    expect(() =>
+      composeCanonicalBootContext(manifest(), { fs, log: false }),
+    ).toThrow(/Required canonical file missing or empty: SOUL\.md/);
+  });
+
+  it("CANARY: a changed line in an allowed file appears in composed context", () => {
+    const before = composeCanonicalBootContext(manifest(), {
+      fs: fakeFs({
+        "/ws/SOUL.md": "SYNTHETIC SOUL canary=BEFORE-VALUE",
+        "/ws/IDENTITY.md": idBody,
+      }),
+      log: false,
+    });
+    expect(before.text).toContain("canary=BEFORE-VALUE");
+    expect(before.text).not.toContain("canary=AFTER-VALUE");
+
+    // "edit the file + reboot" == recompose from the mutated fs
+    const after = composeCanonicalBootContext(manifest(), {
+      fs: fakeFs({
+        "/ws/SOUL.md": "SYNTHETIC SOUL canary=AFTER-VALUE",
+        "/ws/IDENTITY.md": idBody,
+      }),
+      log: false,
+    });
+    expect(after.text).toContain("canary=AFTER-VALUE");
+    expect(after.text).not.toContain("canary=BEFORE-VALUE");
+    // the sha256 changed too, proving byte-exact tracking
+    const beforeSha = before.audit.find((a) => a.label === "SOUL.md")?.sha256;
+    const afterSha = after.audit.find((a) => a.label === "SOUL.md")?.sha256;
+    expect(beforeSha).not.toBe(afterSha);
+  });
+});
+
+describe("applyCanonicalFileBootToConfig", () => {
+  it("is inert when no env configured (config unchanged)", () => {
+    const config: ElizaConfig = {
+      agents: { list: [{ id: "main", default: true, name: "X", system: "S" }] },
+    } as unknown as ElizaConfig;
+    const out = applyCanonicalFileBootToConfig(config, {}, { log: false });
+    expect(out.agents?.list?.[0].system).toBe("S");
+  });
+
+  it("appends composed files onto the existing primary system prompt", () => {
+    const fs = fakeFs({
+      "/ws/SOUL.md": "SYNTHETIC SOUL canary=APPEND-OK",
+      "/ws/IDENTITY.md": "SYNTHETIC IDENTITY",
+      "/ws/AGENTS.md": "SYNTHETIC AGENTS",
+      "/ws/USER.md": "SYNTHETIC USER",
+    });
+    const config: ElizaConfig = {
+      agents: {
+        list: [{ id: "main", default: true, name: "X", system: "BASE-PROMPT" }],
+      },
+    } as unknown as ElizaConfig;
+
+    // use an explicit manifest of only the 4 required-ish synthetic files
+    const manifestPath = "/cfg/m.json";
+    const fsWithManifest = fakeFs({
+      "/ws/SOUL.md": "SYNTHETIC SOUL canary=APPEND-OK",
+      "/ws/IDENTITY.md": "SYNTHETIC IDENTITY",
+      "/ws/AGENTS.md": "SYNTHETIC AGENTS",
+      "/ws/USER.md": "SYNTHETIC USER",
+      [manifestPath]: JSON.stringify({
+        root: "/ws",
+        files: [
+          { label: "SOUL.md", path: "SOUL.md", required: true },
+          { label: "USER.md", path: "USER.md", required: true },
+        ],
+      }),
+    });
+
+    const out = applyCanonicalFileBootToConfig(
+      config,
+      { [CANONICAL_BOOT_MANIFEST_ENV]: manifestPath },
+      { fs: fsWithManifest, log: false },
+    );
+    const sys = out.agents?.list?.[0].system ?? "";
+    expect(sys.startsWith("BASE-PROMPT")).toBe(true);
+    expect(sys).toContain("canary=APPEND-OK");
+    expect(sys).toContain("SYNTHETIC USER");
+    void fs; // (kept for parity with sibling tests; unused directly)
+  });
+
+  it("creates a primary entry when none exists", () => {
+    const manifestPath = "/cfg/m.json";
+    const fs = fakeFs({
+      "/ws/SOUL.md": "SYNTHETIC SOUL",
+      [manifestPath]: JSON.stringify({
+        root: "/ws",
+        files: [{ label: "SOUL.md", path: "SOUL.md", required: true }],
+      }),
+    });
+    const config: ElizaConfig = {
+      agents: { list: [] },
+    } as unknown as ElizaConfig;
+    const out = applyCanonicalFileBootToConfig(
+      config,
+      { [CANONICAL_BOOT_MANIFEST_ENV]: manifestPath },
+      { fs, log: false },
+    );
+    expect(out.agents?.list?.[0].default).toBe(true);
+    expect(out.agents?.list?.[0].system).toContain("SYNTHETIC SOUL");
+  });
+});
+
+describe("real-disk round trip (synthetic tmpdir fixtures + canary reboot)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "canon-boot-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads default-manifest required files off disk and canary-flips on rewrite", () => {
+    // Write only the 4 required synthetic files under the root.
+    writeFileSync(join(dir, "SOUL.md"), "SOUL canary=DISK-V1");
+    writeFileSync(join(dir, "IDENTITY.md"), "IDENTITY synthetic");
+    writeFileSync(join(dir, "AGENTS.md"), "AGENTS synthetic");
+    writeFileSync(join(dir, "USER.md"), "USER synthetic");
+
+    const env = { [CANONICAL_BOOT_ROOT_ENV]: dir } as NodeJS.ProcessEnv;
+    const m1 = resolveCanonicalManifest(env)!;
+    const c1 = composeCanonicalBootContext(m1, { log: false });
+    expect(c1.text).toContain("canary=DISK-V1");
+
+    // "restart" after editing the file
+    writeFileSync(join(dir, "SOUL.md"), "SOUL canary=DISK-V2");
+    const c2 = composeCanonicalBootContext(resolveCanonicalManifest(env)!, {
+      log: false,
+    });
+    expect(c2.text).toContain("canary=DISK-V2");
+    expect(c2.text).not.toContain("canary=DISK-V1");
+  });
+});

--- a/packages/agent/src/runtime/canonical-file-boot.ts
+++ b/packages/agent/src/runtime/canonical-file-boot.ts
@@ -1,0 +1,318 @@
+/**
+ * Canonical file boot (sovereign runtime, direct-from-file identity).
+ *
+ * A self-hosted, single-tenant runtime that wants its identity to be the
+ * operator's real, hand-authored files (SOUL.md, IDENTITY.md, AGENTS.md,
+ * USER.md, a memory system handoff, etc.) should NOT depend on a separately
+ * maintained compressed character JSON as the source of truth. A JSON shadow
+ * copy drifts: it silently goes stale while the real files move on, and there
+ * is no boot-time proof that what the model sees matches the files on disk.
+ *
+ * This module composes an allowlisted MANIFEST of files into the boot
+ * character's system prompt. At boot it:
+ *   1. resolves a manifest (explicit JSON manifest file, or a root dir + a
+ *      default filename list) — generic, not tied to any one operator's paths;
+ *   2. reads each allowlisted file, computes a sha256 of the exact bytes, and
+ *      logs `<sha256>  <label>` so the boot log is an auditable content record;
+ *   3. FAILS LOUDLY (throws) if a file marked `required` is missing or empty —
+ *      a sovereign identity boot must not silently fall back to a default
+ *      preset when the operator's own soul file vanished;
+ *   4. appends the exact file contents, wrapped in labeled delimiters, onto
+ *      the primary agent's `system` prompt so the model receives them verbatim
+ *      in boot context.
+ *
+ * It reads files READ-ONLY. It does not write, and it does not manage the
+ * daily/handoff WRITE root (that is a separate controlled-write concern).
+ *
+ * Inert by default: with no manifest env configured it returns the config
+ * unchanged, so every non-sovereign runtime is unaffected.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve as resolvePath } from "node:path";
+
+import { logger } from "@elizaos/core";
+import type { ElizaConfig } from "../config/config.ts";
+
+/**
+ * Default canonical file set, resolved relative to
+ * `ELIZA_CANONICAL_BOOT_ROOT` when no explicit manifest is provided. Order is
+ * the boot-context order. `required: true` files fail the boot loudly when
+ * absent; the rest are best-effort (a handoff or awareness file may legitimately
+ * not exist yet on a fresh workspace).
+ */
+export const DEFAULT_CANONICAL_MANIFEST: CanonicalManifestEntry[] = [
+  { label: "SOUL.md", relPath: "SOUL.md", required: true },
+  { label: "IDENTITY.md", relPath: "IDENTITY.md", required: true },
+  { label: "AGENTS.md", relPath: "AGENTS.md", required: true },
+  { label: "USER.md", relPath: "USER.md", required: true },
+  { label: "TOOLS.md", relPath: "TOOLS.md", required: false },
+  { label: "memory/SYSTEM.md", relPath: "memory/SYSTEM.md", required: false },
+  { label: "memory/HANDOFF.md", relPath: "memory/HANDOFF.md", required: false },
+  {
+    label: "memory/sol-awareness.md",
+    relPath: "memory/sol-awareness.md",
+    required: false,
+  },
+  {
+    label: "memory/conversation-playbook.md",
+    relPath: "memory/conversation-playbook.md",
+    required: false,
+  },
+  {
+    label: "memory/channel-guide.md",
+    relPath: "memory/channel-guide.md",
+    required: false,
+  },
+];
+
+/** One allowlisted file in the boot manifest. */
+export interface CanonicalManifestEntry {
+  /** Human-readable label used in the composed block header and the sha log. */
+  label: string;
+  /**
+   * Path to read. When resolved from `DEFAULT_CANONICAL_MANIFEST` this is a
+   * path relative to `ELIZA_CANONICAL_BOOT_ROOT`. An explicit manifest entry
+   * may instead carry an absolute `path`.
+   */
+  relPath?: string;
+  /** Absolute (or manifest-root-relative) explicit path from a JSON manifest. */
+  path?: string;
+  /** When true, a missing/empty file throws and aborts boot. */
+  required?: boolean;
+}
+
+/** Result of composing the canonical boot context. */
+export interface CanonicalBootComposition {
+  /** The composed text to append to the system prompt (empty when nothing read). */
+  text: string;
+  /** Per-file audit record: label -> { path, sha256, bytes, present }. */
+  audit: CanonicalFileAudit[];
+}
+
+export interface CanonicalFileAudit {
+  label: string;
+  path: string;
+  present: boolean;
+  bytes: number;
+  /** sha256 hex of the exact file bytes, or null when the file was absent. */
+  sha256: string | null;
+}
+
+/** Minimal filesystem surface, injectable for tests (no real disk needed). */
+export interface CanonicalBootFs {
+  readFileSync(path: string): Buffer | string;
+}
+
+const DEFAULT_FS: CanonicalBootFs = {
+  readFileSync: (p: string) => readFileSync(p),
+};
+
+/** Env keys that drive canonical file boot. */
+export const CANONICAL_BOOT_ROOT_ENV = "ELIZA_CANONICAL_BOOT_ROOT";
+export const CANONICAL_BOOT_MANIFEST_ENV = "ELIZA_CANONICAL_BOOT_MANIFEST";
+
+interface ManifestFileShape {
+  /** Optional root the entries' relative paths resolve against. */
+  root?: string;
+  files?: Array<{
+    label?: string;
+    path?: string;
+    relPath?: string;
+    required?: boolean;
+  }>;
+}
+
+/**
+ * Resolve the effective manifest (absolute path per entry) from the
+ * environment. Returns null when canonical file boot is not configured, so the
+ * caller stays inert.
+ *
+ * Two modes:
+ *  - `ELIZA_CANONICAL_BOOT_MANIFEST=/path/to/manifest.json`: an explicit
+ *    manifest listing files (each with a path, optional label/required). Paths
+ *    resolve against the manifest's own `root` (if given) else the manifest
+ *    file's directory is NOT assumed — absolute paths are used as-is and
+ *    relative paths resolve against `ELIZA_CANONICAL_BOOT_ROOT` or cwd.
+ *  - `ELIZA_CANONICAL_BOOT_ROOT=/path/to/workspace`: use the built-in
+ *    DEFAULT_CANONICAL_MANIFEST, resolving each relPath under that root.
+ */
+export function resolveCanonicalManifest(
+  env: NodeJS.ProcessEnv = process.env,
+  fs: CanonicalBootFs = DEFAULT_FS,
+): ResolvedCanonicalEntry[] | null {
+  const manifestPath = env[CANONICAL_BOOT_MANIFEST_ENV]?.trim();
+  const root = env[CANONICAL_BOOT_ROOT_ENV]?.trim();
+
+  if (manifestPath) {
+    let parsed: ManifestFileShape;
+    try {
+      const raw = bufferToString(fs.readFileSync(manifestPath));
+      parsed = JSON.parse(raw) as ManifestFileShape;
+    } catch (err) {
+      // A configured-but-broken manifest is an operator error we must not
+      // paper over: fail loudly rather than silently boot a default preset.
+      throw new Error(
+        `[canonical-file-boot] Failed to read/parse manifest at ${manifestPath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    const manifestRoot = parsed.root?.trim() || root || process.cwd();
+    const files = Array.isArray(parsed.files) ? parsed.files : [];
+    return files
+      .filter((f) => (f.path ?? f.relPath)?.trim())
+      .map((f) => {
+        const rawPath = (f.path ?? f.relPath) as string;
+        const abs = isAbsolute(rawPath)
+          ? rawPath
+          : resolvePath(manifestRoot, rawPath);
+        return {
+          label: f.label?.trim() || rawPath,
+          path: abs,
+          required: f.required === true,
+        };
+      });
+  }
+
+  if (root) {
+    return DEFAULT_CANONICAL_MANIFEST.map((entry) => ({
+      label: entry.label,
+      path: resolvePath(root, entry.relPath ?? entry.label),
+      required: entry.required === true,
+    }));
+  }
+
+  return null;
+}
+
+export interface ResolvedCanonicalEntry {
+  label: string;
+  /** Absolute path to read. */
+  path: string;
+  required: boolean;
+}
+
+/**
+ * Read the manifest files and compose them into a single boot-context string.
+ * Computes and (optionally) logs a sha256 per file. Throws if a `required`
+ * file is missing or empty.
+ */
+export function composeCanonicalBootContext(
+  manifest: ResolvedCanonicalEntry[],
+  opts: { fs?: CanonicalBootFs; log?: boolean } = {},
+): CanonicalBootComposition {
+  const fs = opts.fs ?? DEFAULT_FS;
+  const log = opts.log ?? true;
+  const audit: CanonicalFileAudit[] = [];
+  const blocks: string[] = [];
+
+  for (const entry of manifest) {
+    let content: string | null = null;
+    try {
+      content = bufferToString(fs.readFileSync(entry.path));
+    } catch {
+      content = null;
+    }
+
+    if (content === null || content.trim() === "") {
+      if (entry.required) {
+        throw new Error(
+          `[canonical-file-boot] Required canonical file missing or empty: ${entry.label} (${entry.path}). ` +
+            "Refusing to boot the sovereign identity from an incomplete file set.",
+        );
+      }
+      audit.push({
+        label: entry.label,
+        path: entry.path,
+        present: false,
+        bytes: 0,
+        sha256: null,
+      });
+      if (log) {
+        logger.warn(
+          `[canonical-file-boot] optional file absent: ${entry.label} (${entry.path})`,
+        );
+      }
+      continue;
+    }
+
+    const bytes = Buffer.byteLength(content, "utf8");
+    const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
+    audit.push({
+      label: entry.label,
+      path: entry.path,
+      present: true,
+      bytes,
+      sha256,
+    });
+    if (log) {
+      logger.info(
+        `[canonical-file-boot] ${sha256}  ${entry.label} (${bytes} bytes)`,
+      );
+    }
+    blocks.push(
+      `<<<CANONICAL FILE: ${entry.label} sha256=${sha256}>>>\n${content}\n<<<END ${entry.label}>>>`,
+    );
+  }
+
+  const text =
+    blocks.length > 0
+      ? `# Canonical boot files (read verbatim from disk)\n\n${blocks.join(
+          "\n\n",
+        )}`
+      : "";
+
+  return { text, audit };
+}
+
+/**
+ * Apply canonical file boot onto the runtime config. Reads the manifest,
+ * composes the file contents, and appends them to the primary agent's system
+ * prompt. Returns the (mutated) config for chaining.
+ *
+ * Inert when no manifest env is configured. Throws when configured but a
+ * required file is missing — a loud failure is the point.
+ */
+export function applyCanonicalFileBootToConfig(
+  config: ElizaConfig,
+  env: NodeJS.ProcessEnv = process.env,
+  deps: { fs?: CanonicalBootFs; log?: boolean } = {},
+): ElizaConfig {
+  const manifest = resolveCanonicalManifest(env, deps.fs);
+  if (!manifest || manifest.length === 0) return config;
+
+  const { text, audit } = composeCanonicalBootContext(manifest, deps);
+  if (!text) return config;
+
+  const agents = (config.agents ?? {}) as NonNullable<ElizaConfig["agents"]>;
+  const list = Array.isArray(agents.list) ? [...agents.list] : [];
+  let idx = list.findIndex((a) => a?.default);
+  if (idx < 0) {
+    // No primary entry yet: create a minimal one so the composed identity
+    // still lands. buildCharacterFromConfig fills name/bio from the preset.
+    list.unshift({ id: "main", default: true, name: "" });
+    idx = 0;
+  }
+
+  const existing = list[idx];
+  const priorSystem =
+    typeof existing?.system === "string" ? existing.system : "";
+  const nextSystem = priorSystem ? `${priorSystem}\n\n${text}` : text;
+  list[idx] = { ...existing, system: nextSystem };
+  config.agents = { ...agents, list };
+
+  const present = audit.filter((a) => a.present).length;
+  if (deps.log ?? true) {
+    logger.info(
+      `[canonical-file-boot] Composed ${present}/${audit.length} canonical files into the primary agent system prompt.`,
+    );
+  }
+
+  return config;
+}
+
+function bufferToString(v: Buffer | string): string {
+  return typeof v === "string" ? v : v.toString("utf8");
+}

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3940,6 +3940,22 @@ export async function startEliza(
     applySandboxCharacterFromEnv(config);
     sandboxRouteAgentId = resolveSandboxRouteAgentId();
   }
+
+  // 3b. Canonical file boot (sovereign identity): when configured via
+  // ELIZA_CANONICAL_BOOT_ROOT / ELIZA_CANONICAL_BOOT_MANIFEST, read the
+  // operator's allowlisted files (SOUL.md, IDENTITY.md, AGENTS.md, USER.md,
+  // the memory system + handoff, awareness, playbook, channel guide) directly
+  // from disk, hash each file into the boot log, and compose their exact
+  // contents onto the primary agent's system prompt. This replaces a stale
+  // JSON shadow copy as the identity source of truth. Fails loudly if a file
+  // marked required is missing. Inert when the env vars are absent.
+  {
+    const { applyCanonicalFileBootToConfig } = await import(
+      "./canonical-file-boot.ts"
+    );
+    applyCanonicalFileBootToConfig(config);
+  }
+
   const character = buildCharacterFromConfig(config);
 
   // Pin the runtime agent id to the platform character_id so the gateways can


### PR DESCRIPTION
## What

Adds a **canonical file boot** mechanism so a self-hosted, single-tenant Eliza runtime can boot its identity by reading the operator's real hand-authored files directly, instead of depending on a separately maintained (and silently drifting) compressed character JSON (`ELIZA_AGENT_CHARACTER_JSON`) as the source of truth.

At boot the composer:
1. resolves an allowlisted **manifest** of files — either a default set under `ELIZA_CANONICAL_BOOT_ROOT` (SOUL.md, IDENTITY.md, AGENTS.md, USER.md, TOOLS.md, memory/SYSTEM.md, the current handoff, awareness, playbook, channel guide) or an explicit JSON manifest via `ELIZA_CANONICAL_BOOT_MANIFEST`;
2. reads each file **READ-ONLY**, computes a **sha256** of the exact bytes, and logs `<sha256>  <label>` so the boot log is an auditable content record;
3. **fails loudly** (throws, aborting boot) if a file marked `required` is missing or empty — a sovereign identity must not silently fall back to a default preset;
4. appends the exact file contents, wrapped in labeled delimiters, onto the primary agent's `system` prompt so the model receives them verbatim.

## Why

A JSON shadow copy of the character drifts out of sync with the real files and gives no boot-time proof that what the model sees matches disk. Reading + hashing the files at boot makes the identity provable and eliminates the hand-maintained JSON as the source of truth.

## Design

- New module `packages/agent/src/runtime/canonical-file-boot.ts`: `resolveCanonicalManifest`, `composeCanonicalBootContext` (sha256 audit + loud required-file failure), `applyCanonicalFileBootToConfig`.
- Wired into `startEliza` right after `applySandboxCharacterFromEnv`, before `buildCharacterFromConfig`.
- Generic (no operator-specific paths hardcoded). **Inert** when neither env var is set, so every existing runtime is unaffected.
- Reads files read-only. Does **not** manage the daily/handoff write root (separate controlled-write concern).

## Tests

`packages/agent/src/runtime/canonical-file-boot.test.ts` — 12 tests, **synthetic fixtures only** (file firewall; no real personal file content is read or embedded). Covers manifest resolution (default + explicit JSON), sha256 correctness, required-missing / required-empty loud failure, a **canary** proof that a changed line in an allowed file reaches the composed boot context (with a changed sha256), and a tmpdir real-disk round-trip.

```
✓ packages/agent/src/runtime/canonical-file-boot.test.ts (12 tests)
✓ packages/agent/src/runtime/build-character-config.test.ts (4 tests)  # unchanged, still green
Test Files  2 passed (2)
     Tests  16 passed (16)
```

Format + lint clean (biome).

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - backend agent-runtime boot mechanism only; touches `packages/agent/src/runtime/*.ts`, no UI surface exists or is changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI surface; the change is a file-reading + sha256 boot composer wired into `startEliza`.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing flow; behavior is boot-time file resolution proven by unit tests and (pending) a live canary-restart proof.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - the composer logs `<sha256>  <label>` per resolved file at boot and the unit suite asserts this path, but a captured end-to-end boot-log artifact is the pending live-canary proof under "Remaining"; this PR stays draft until that capture exists.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend code changed; no request/response or client state to capture.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent prompt template, model, provider, evaluator, or action behavior is changed. The mechanism appends verbatim file bytes onto the system prompt only when `ELIZA_CANONICAL_BOOT_ROOT`/`ELIZA_CANONICAL_BOOT_MANIFEST` is set; it is inert by default, so no trajectory changes for existing runtimes. A live canary-restart proof is the pending GREEN gate (see "Remaining").
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: the generated boot artifact is the composed, sha256-audited system-prompt context, proven by the checked-in [boot composer](packages/agent/src/runtime/canonical-file-boot.ts) and [test suite](packages/agent/src/runtime/canonical-file-boot.test.ts) (12 tests: manifest resolution, sha256 correctness, loud required-missing/empty failure, canary line-change reaching boot context with a changed sha256, tmpdir real-disk round-trip).

## Remaining (to flip charter M1 GREEN)

Unit mechanism is proven. The final GREEN gate is a **live canary-restart proof** on the immutable sovereign candidate: set `ELIZA_CANONICAL_BOOT_ROOT` to the workspace, change one canary line in an allowed file, restart, and show it appears in the agent's boot context / system prompt. That requires a scratch/candidate boot on a separate port + DB and is intentionally out of scope for this reviewable code change.

Base: `origin/develop` @ `8688b66e02af146dcb175c9b9e170e5525ed6e82`

Co-authored-by: wakesync <shadow@shad0w.xyz>

