### PR TITLE
fix(embeddings): honor local-primary before deferred probe + fix Google embedding 404

### DIFF
--- a/packages/agent/src/runtime/eliza-embedding-boot-order.test.ts
+++ b/packages/agent/src/runtime/eliza-embedding-boot-order.test.ts
@@ -74,6 +74,9 @@ describe("runDeferredBoot embedding-dimension ordering (#8769)", () => {
   const waveIdx = body.indexOf(
     "await preregisterCorePluginsInDependencyWaves({",
   );
+  const earlyLocalEnvIdx = body.indexOf(
+    "await configureLocalEmbeddingEnvEarlyIfNeeded(config);",
+  );
   const probeIdx = body.indexOf("await runtime.ensureEmbeddingDimension();");
   const seedIdx = body.indexOf("await seedBundledDocumentsIfEnabled();");
 
@@ -95,6 +98,21 @@ describe("runDeferredBoot embedding-dimension ordering (#8769)", () => {
     // to dim1536 before any bundled-doc embedding is written, so the inserts are
     // not dropped on a dimension mismatch.
     expect(probeIdx).toBeLessThan(seedIdx);
+  });
+
+  it("configures local-embedding env BEFORE the dimension probe (#16630 follow-up fix a)", () => {
+    // Root cause: warmEmbeddingModel() (which owns configureLocalEmbeddingPlugin)
+    // is fired fire-and-forget by startEmbeddingWarmup() AFTER this probe, so
+    // without an early call EMBEDDING_PROVIDER is unset here and a remote handler
+    // (e.g. Google text-embedding-004) wins the probe and 404s, permanently
+    // choosing the remote route. The early guarded config must therefore run
+    // before both the probe and the bundled-doc seed.
+    expect(
+      earlyLocalEnvIdx,
+      "early local-embedding env config must run in runDeferredBoot",
+    ).toBeGreaterThan(-1);
+    expect(earlyLocalEnvIdx).toBeLessThan(probeIdx);
+    expect(earlyLocalEnvIdx).toBeLessThan(seedIdx);
   });
 });
 

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1055,6 +1055,49 @@ export async function configureLocalEmbeddingPlugin(
   );
 }
 
+/**
+ * Populate the LOCAL_EMBEDDING_* / EMBEDDING_PROVIDER env from config +
+ * hardware preset EARLY — before the deferred-boot ensureEmbeddingDimension()
+ * probe and the bundled-document seed — but ONLY when local embeddings are the
+ * intended backend for this configuration.
+ *
+ * Root cause it addresses (#16630 follow-up): configureLocalEmbeddingPlugin()
+ * is otherwise only reached via warmEmbeddingModel(), which startEmbeddingWarmup()
+ * fires fire-and-forget AFTER the deferred embedding-dimension probe. During that
+ * window EMBEDDING_PROVIDER is unset, so a remote TEXT_EMBEDDING handler (e.g.
+ * Google text-embedding-004) wins the probe, 404s on an incompatible API
+ * version, and the runtime never fails back to the local model — breaking
+ * memory embedding writes and bundled-document seeding.
+ *
+ * Guard: shouldWarmupLocalEmbeddingModel() returns false when local embeddings
+ * are disabled or Eliza Cloud embeddings are explicitly configured, so this is a
+ * no-op in those setups and never forces local env over an intended cloud path.
+ * The underlying env writes use setEnvIfMissing (idempotent), so a later
+ * warmEmbeddingModel() call is unaffected. Best-effort: any failure is logged
+ * and swallowed so it can never block or crash the deferred boot phase.
+ *
+ * @internal Exported for regression coverage.
+ */
+export async function configureLocalEmbeddingEnvEarlyIfNeeded(
+  config?: ElizaConfig,
+): Promise<void> {
+  if (process.env.NODE_ENV === "test") return;
+  if (isMobilePlatform() || isBundledMobileRuntime()) return;
+  try {
+    const li = await getPluginLocalEmbedding();
+    if (!li) return;
+    const { shouldWarmupLocalEmbeddingModel } = await import(
+      /* @vite-ignore */ "@elizaos/plugin-local-inference/runtime"
+    );
+    if (!shouldWarmupLocalEmbeddingModel()) return;
+    await configureLocalEmbeddingPlugin({} as Plugin, config);
+  } catch (err) {
+    logger.warn(
+      `[eliza] Early local-embedding env configuration failed (deferred warmup will retry): ${formatError(err)}`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -5228,6 +5271,19 @@ export async function startEliza(
     // ensureEmbeddingDimension() is public, idempotent, and self-guarding (it
     // no-ops when no TEXT_EMBEDDING handler is registered, e.g. cloud-proxied
     // agents), so this is safe on every boot path.
+    //
+    // BEFORE the probe, populate the LOCAL_EMBEDDING_* / EMBEDDING_PROVIDER env
+    // for local-primary configurations (#16630 follow-up). warmEmbeddingModel()
+    // — which owns configureLocalEmbeddingPlugin() today — is fired
+    // fire-and-forget by startEmbeddingWarmup() AFTER this block, so without
+    // this early call the probe (and the bundled-document seed right below it)
+    // runs while EMBEDDING_PROVIDER is unset. A remote provider (e.g. Google
+    // text-embedding-004) then wins the probe and 404s, permanently choosing
+    // the remote route and dropping local-primary. Configuring the env here is
+    // idempotent (setEnvIfMissing) and gated on shouldWarmupLocalEmbeddingModel
+    // so it never forces local env when local embeddings are disabled or Eliza
+    // Cloud embeddings are explicitly configured.
+    await configureLocalEmbeddingEnvEarlyIfNeeded(config);
     try {
       await runtime.ensureEmbeddingDimension();
     } catch (err) {

--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -31,8 +31,10 @@ vi.mock("@google/genai", () => ({
 }));
 
 import {
+  DEFAULT_GOOGLE_EMBEDDING_MODEL,
   createGoogleGenAI,
   getApiKey,
+  getEmbeddingModel,
   getLargeModel,
   getResponseHandlerModel,
   getSmallModel,
@@ -111,5 +113,21 @@ describe("Google GenAI config", () => {
     );
 
     expect(mocks.googleGenAI).toHaveBeenCalledWith({ apiKey: "test-key" });
+  });
+
+  it("defaults the embedding model to a v1beta-valid id, not the 404-ing text-embedding-004", () => {
+    // Regression: the historical default text-embedding-004 404s on the current
+    // v1beta embedContent route. The default must be a currently-served id.
+    expect(DEFAULT_GOOGLE_EMBEDDING_MODEL).toBe("gemini-embedding-001");
+    expect(DEFAULT_GOOGLE_EMBEDDING_MODEL).not.toBe("text-embedding-004");
+    expect(getEmbeddingModel(runtimeWith({}))).toBe("gemini-embedding-001");
+  });
+
+  it("honors an explicit GOOGLE_EMBEDDING_MODEL override over the default", () => {
+    expect(
+      getEmbeddingModel(
+        runtimeWith({ GOOGLE_EMBEDDING_MODEL: " text-embedding-004 " }),
+      ),
+    ).toBe("text-embedding-004");
   });
 });

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -117,4 +117,32 @@ describe("Google GenAI embeddings", () => {
       "Google GenAI API returned no embedding",
     );
   });
+
+  it("fails closed with one clear, model-named error on a 404 NOT_FOUND (no infinite retry spam)", async () => {
+    // Regression for the text-embedding-004 v1beta 404: the raw SDK 404 must be
+    // converted into a single actionable error naming the model and the
+    // GOOGLE_EMBEDDING_MODEL escape hatch, not re-propagated verbatim on every
+    // call.
+    mocks.embedContent.mockRejectedValue(
+      new Error(
+        "got status: 404 NOT_FOUND. models/text-embedding-004 is not found for API version v1beta",
+      ),
+    );
+
+    const promise = handleTextEmbedding(createRuntime(), "hello");
+    await expect(promise).rejects.toThrow(
+      "is not available on the current API version (404 NOT_FOUND)",
+    );
+    await expect(promise).rejects.toThrow("gemini-embedding-001");
+    // Exactly one call: the handler does not retry a 404 internally.
+    expect(mocks.embedContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not rewrite non-404 provider errors", async () => {
+    mocks.embedContent.mockRejectedValue(new Error("503 UNAVAILABLE"));
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "503 UNAVAILABLE",
+    );
+  });
 });

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -1,10 +1,18 @@
 /**
- * `TEXT_EMBEDDING` handler backed by Google's `text-embedding-004` (768-dim).
+ * `TEXT_EMBEDDING` handler backed by Google's embedding model (default
+ * `gemini-embedding-001`; overridable via `GOOGLE_EMBEDDING_MODEL`).
  * A `null`/empty-object input is treated as an initialization probe and answered
  * with a fixed 768-length marker vector so the runtime can size its embedding
  * column without a network call; real text is truncated to the model's ~8192
  * token limit, embedded, and reported via `emitModelUsageEvent`. Throws on empty
  * text and on an empty API response rather than fabricating a vector.
+ *
+ * A 404 / NOT_FOUND from the provider (e.g. a decommissioned model id like
+ * `text-embedding-004` on the current `v1beta` route) fails CLOSED with one
+ * clear, model-named error instead of surfacing the raw SDK 404 on every call.
+ * The runtime treats a thrown probe as "this provider cannot embed" and advances
+ * to the next TEXT_EMBEDDING provider (or disables embedding generation), so a
+ * misconfigured model id can no longer produce an infinite 404 retry spam.
  */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import * as ElizaCore from "@elizaos/core";
@@ -98,9 +106,22 @@ export async function handleTextEmbedding(
   } catch (error) {
     // error-policy:J2 context-adding rethrow — never fabricate a vector; the
     // provider failure surfaces to the caller (#9324: throw, never fabricate).
-    logger.error(
-      `Error generating embedding: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const message = error instanceof Error ? error.message : String(error);
+    // Fail CLOSED on a 404 / NOT_FOUND with one clear, model-named error rather
+    // than propagating the raw SDK 404 on every subsequent call. This is the
+    // "invalid model id for the API version" case (e.g. text-embedding-004 on
+    // v1beta): retrying can never succeed, so surface an actionable message once
+    // and let the runtime advance to the next provider / disable embeddings
+    // instead of spamming 404s.
+    if (/\b404\b|NOT_FOUND|not found/i.test(message)) {
+      const failClosed = new Error(
+        `Google embedding model "${embeddingModelName}" is not available on the current API version (404 NOT_FOUND). ` +
+          `Set GOOGLE_EMBEDDING_MODEL to a supported id (e.g. gemini-embedding-001), or disable the Google embedding provider. Original error: ${message}`,
+      );
+      logger.error(`Error generating embedding: ${failClosed.message}`);
+      throw failClosed;
+    }
+    logger.error(`Error generating embedding: ${message}`);
     throw error instanceof Error ? error : new Error(String(error));
   }
 }

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -112,10 +112,23 @@ export function getImageModel(runtime: IAgentRuntime): string {
   );
 }
 
+/**
+ * Default Google embedding model. `text-embedding-004` (the historical default)
+ * 404s on the current `v1beta` `embedContent` route used by `@google/genai`
+ * — see Gate-1 evidence: bare `text-embedding-004` → 404 NOT_FOUND (v1beta),
+ * breaking every memory embedding write and bundled-document seed. Google's
+ * supported replacement on that route is `gemini-embedding-001`, so that is the
+ * default now. An explicit `GOOGLE_EMBEDDING_MODEL` override still wins.
+ */
+export const DEFAULT_GOOGLE_EMBEDDING_MODEL = "gemini-embedding-001";
+
 export function getEmbeddingModel(runtime: IAgentRuntime): string {
   return (
-    getSetting(runtime, "GOOGLE_EMBEDDING_MODEL", "text-embedding-004") ??
-    "text-embedding-004"
+    getSetting(
+      runtime,
+      "GOOGLE_EMBEDDING_MODEL",
+      DEFAULT_GOOGLE_EMBEDDING_MODEL,
+    ) ?? DEFAULT_GOOGLE_EMBEDDING_MODEL
   );
 }
 


### PR DESCRIPTION
## Problem

On candidate SHA `8688b66` (which already contains #16630 local-primary embeddings, 604976a), a scratch instance configured with local embeddings (`gte-small_fp16.gguf`) still routed `embedContent` to Google `text-embedding-004` and got **404 NOT_FOUND (v1beta)**, breaking memory embedding writes and bundled-document seeding. Boot logged `Deferring local embedding warmup until runtime ready`.

Diagnosed via the Gate-1 receipt finding (`SOLIZA-CANDIDATE-GATE1-2026-07-20.md`, charter M2). Two defects:

### (a) Local-primary not honored around the deferred warmup window
`configureLocalEmbeddingPlugin()` (which sets `LOCAL_EMBEDDING_*` and `EMBEDDING_PROVIDER=local`) was only reached via `warmEmbeddingModel()`, fired **fire-and-forget by `startEmbeddingWarmup()` AFTER** `runDeferredBoot`'s `ensureEmbeddingDimension()` probe and the bundled-document seed. During that window `EMBEDDING_PROVIDER` was unset, so a remote TEXT_EMBEDDING handler (Google) won the probe, 404'd, and the runtime never failed back to local.

**Fix:** new `configureLocalEmbeddingEnvEarlyIfNeeded()`, called **before** `ensureEmbeddingDimension()` in `runDeferredBoot`, gated on `shouldWarmupLocalEmbeddingModel()` (no-op when local embeddings are disabled or Eliza Cloud embeddings are explicitly configured). Idempotent (`setEnvIfMissing`) and best-effort (never blocks boot; `warmEmbeddingModel()` still runs later).

### (b) Google embedding model id invalid for the API version
Default `text-embedding-004` 404s on the current `v1beta` `embedContent` route. Default is now **`gemini-embedding-001`** (explicit `GOOGLE_EMBEDDING_MODEL` override still wins). A 404/NOT_FOUND now **fails closed** with one clear, model-named error instead of re-propagating the raw SDK 404 on every call — no infinite 404 retry spam; the runtime advances to the next provider or disables embedding generation coherently.

## Tests

- `packages/agent/src/runtime/eliza-embedding-boot-order.test.ts` — new source-order invariant: early local-embedding env config runs **before** the probe and seed (fix a). **6/6 green.**
- `plugins/plugin-google-genai/__tests__/embedding.shape.test.ts` — 404 fail-closed (single call, model-named error, suggests `gemini-embedding-001`) + non-404 errors pass through unchanged. **7/7 green.**
- `plugins/plugin-google-genai/__tests__/config.test.ts` — default is `gemini-embedding-001` not `text-embedding-004`, explicit override honored. **6/6 green.**

Total: 6 + 13 passed.

## Links
Gate-1 receipt finding: `SOLIZA-CANDIDATE-GATE1-2026-07-20.md` (charter M2 embedding routing).

No self-merge.

Co-authored-by: wakesync


## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots `N/A - backend-only embedding boot-order + Google model-id fix; no UI surface touched (packages/agent/src/runtime + plugin-google-genai only)`.

<!-- evidence-row:after-screenshots -->
- After screenshots `N/A - backend-only change, no rendered UI surface in the diff`.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video `N/A - deterministic boot-order + fail-closed 404 behavior is covered by focused automated tests, no interactive UI flow`.

<!-- evidence-row:backend-logs -->
- Backend logs `N/A - no live Google API credentials used; the shape test asserts the single-call, model-named fail-closed error path against a stubbed 404, and the boot-order test asserts source-order invariants deterministically`.

<!-- evidence-row:frontend-logs -->
- Frontend logs `N/A - no frontend change`.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory `N/A - this change fixes embedding provider selection/routing and a 404 fail-closed path; it does not alter model output quality or generation trajectory`.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts `N/A - no visual, OCR, audio, or document domain artifact applies; this is an embedding provider-selection/boot-order + 404 fail-closed backend fix verified by the three focused test modules cited under Tests`.