### PR TITLE
fix(voice): retry transient SIWE nonce outage before login fails

### DIFF
--- a/packages/ui/src/state/cloud-siwe-login.test.ts
+++ b/packages/ui/src/state/cloud-siwe-login.test.ts
@@ -278,4 +278,101 @@ describe("e2e wallet + SIWE login", () => {
     ).rejects.toThrow(/verify failed: 401/);
     expect(window.localStorage.getItem("steward_session_token")).toBeNull();
   });
+
+  it("retries a transient 503 nonce store outage, then completes the handshake", async () => {
+    window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
+    await installE2eWalletIfRequested();
+    let nonceCalls = 0;
+    const verified: { message?: string } = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/auth/siwe/nonce")) {
+          nonceCalls += 1;
+          // First two attempts hit a Redis-backed nonce-store outage.
+          if (nonceCalls < 3) {
+            return new Response(
+              JSON.stringify({
+                error: "Nonce storage unavailable",
+                code: "nonce_storage_unavailable",
+              }),
+              { status: 503, headers: { "content-type": "application/json" } },
+            );
+          }
+          return new Response(JSON.stringify(NONCE_RESPONSE), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.endsWith("/api/auth/siwe/verify")) {
+          verified.message = (
+            JSON.parse(String(init?.body)) as { message: string }
+          ).message;
+          return new Response(
+            JSON.stringify({ apiKey: "eliza_test_api_key", address: "0x" }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const apiKey = await siweLoginWithInjectedWallet("https://api.test");
+    expect(apiKey).toBe("eliza_test_api_key");
+    expect(nonceCalls).toBe(3);
+    expect(verified.message).toContain(`Nonce: ${NONCE_RESPONSE.nonce}`);
+    expect(window.localStorage.getItem("steward_session_token")).toBe(
+      "eliza_test_api_key",
+    );
+  });
+
+  it("does NOT retry a deterministic 4xx nonce rejection", async () => {
+    window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
+    await installE2eWalletIfRequested();
+    let nonceCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/auth/siwe/nonce")) {
+          nonceCalls += 1;
+          return new Response("bad request", { status: 400 });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    await expect(
+      siweLoginWithInjectedWallet("https://api.test"),
+    ).rejects.toThrow(/nonce request failed: 400/);
+    expect(nonceCalls).toBe(1);
+    expect(window.localStorage.getItem("steward_session_token")).toBeNull();
+  });
+
+  it("surfaces the failure after exhausting nonce retries on a sustained outage", async () => {
+    window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
+    await installE2eWalletIfRequested();
+    let nonceCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/auth/siwe/nonce")) {
+          nonceCalls += 1;
+          return new Response(
+            JSON.stringify({ code: "nonce_storage_unavailable" }),
+            { status: 503, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    await expect(
+      siweLoginWithInjectedWallet("https://api.test"),
+    ).rejects.toThrow(/nonce request failed: 503/);
+    expect(nonceCalls).toBe(3);
+    expect(window.localStorage.getItem("steward_session_token")).toBeNull();
+  });
 });

--- a/packages/ui/src/state/cloud-siwe-login.ts
+++ b/packages/ui/src/state/cloud-siwe-login.ts
@@ -119,6 +119,73 @@ async function readBody(res: Response): Promise<string> {
   }
 }
 
+/** Bounded pre-signature nonce attempts before surfacing the failure. */
+const NONCE_MAX_ATTEMPTS = 3;
+/** Backoff between nonce attempts: 500ms then 1000ms (1.5s total worst case). */
+const NONCE_RETRY_BASE_DELAY_MS = 500;
+
+/**
+ * Fetch the SIWE nonce with bounded retry on *transient* failures.
+ *
+ * The nonce leg is Redis-backed and fails CLOSED: when the cloud's nonce store
+ * is briefly unreachable it returns `503 nonce_storage_unavailable` (unlike
+ * rate-limiting, which fails open). A single un-retried fetch turns that
+ * momentary blip into a hard, user-visible login failure — the same transient
+ * class the downstream voice-session mint already retries (#16627). Mirror that
+ * bounded policy here so the auth leg upstream of voice is not the weak link.
+ *
+ * Retryable: network/transport error (no response) and any 5xx (503 included).
+ * Non-retryable: 4xx — a real, deterministic rejection the user must see now.
+ * Runs entirely before any wallet signature, so retrying is side-effect free;
+ * each attempt consumes a fresh server nonce.
+ */
+async function fetchSiweNonce(base: string): Promise<SiweNonceResponse> {
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= NONCE_MAX_ATTEMPTS; attempt += 1) {
+    let nonceRes: Response;
+    try {
+      nonceRes = await fetch(`${base}/api/auth/siwe/nonce`, {
+        headers: { accept: "application/json" },
+      });
+    } catch (error) {
+      // Transport failure (offline, DNS, TLS, aborted): transient, retry.
+      lastError =
+        error instanceof Error
+          ? error
+          : new Error(
+              `Eliza Cloud SIWE nonce request failed: ${String(error)}`,
+            );
+      if (attempt >= NONCE_MAX_ATTEMPTS) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, NONCE_RETRY_BASE_DELAY_MS * attempt),
+      );
+      continue;
+    }
+    if (!nonceRes.ok) {
+      const body = await readBody(nonceRes);
+      const failure = new Error(
+        `Eliza Cloud SIWE nonce request failed: ${nonceRes.status} ${body}`,
+      );
+      // Only 5xx is transient (e.g. 503 nonce_storage_unavailable). A 4xx is a
+      // deterministic rejection — surface it immediately, do not retry.
+      if (nonceRes.status < 500 || attempt >= NONCE_MAX_ATTEMPTS) throw failure;
+      lastError = failure;
+      await new Promise((resolve) =>
+        setTimeout(resolve, NONCE_RETRY_BASE_DELAY_MS * attempt),
+      );
+      continue;
+    }
+    const nonce: unknown = await nonceRes.json();
+    if (!isNonceResponse(nonce)) {
+      throw new Error("Eliza Cloud SIWE nonce response was malformed.");
+    }
+    return nonce;
+  }
+  throw (
+    lastError ?? new Error("Eliza Cloud SIWE nonce request failed: exhausted")
+  );
+}
+
 /**
  * Run the SIWE handshake through the injected wallet and persist the verified
  * session. Resolves the API key on success; null when no provider is injected
@@ -147,18 +214,7 @@ export async function siweLoginWithInjectedWallet(
   const address = getAddress(rawAddress);
 
   const base = cloudApiBase.replace(/\/+$/, "");
-  const nonceRes = await fetch(`${base}/api/auth/siwe/nonce`, {
-    headers: { accept: "application/json" },
-  });
-  if (!nonceRes.ok) {
-    throw new Error(
-      `Eliza Cloud SIWE nonce request failed: ${nonceRes.status} ${await readBody(nonceRes)}`,
-    );
-  }
-  const nonce: unknown = await nonceRes.json();
-  if (!isNonceResponse(nonce)) {
-    throw new Error("Eliza Cloud SIWE nonce response was malformed.");
-  }
+  const nonce = await fetchSiweNonce(base);
 
   const message = buildSiweMessage({
     domain: nonce.domain,


### PR DESCRIPTION
## Problem

The realtime voice loop requires a logged-in session. The SIWE login's nonce leg (`/api/auth/siwe/nonce`) is Redis-backed and **fails closed**: on a brief nonce-store blip it returns `503 nonce_storage_unavailable` (rate-limiting fails *open*; this path does not). The shipping login (`packages/ui/src/state/cloud-siwe-login.ts`) did a **single un-retried fetch**, so a momentary Redis flap becomes a hard, user-visible login failure — and blocks the voice loop upstream of the voice-session mint.

Observed live on staging this session: `/api/auth/siwe/nonce` returned 503 on ~2 of 3 back-to-back requests during a Redis blip (plausibly correlated with #16654 adding atomic Redis voice quotas to the same store on 07-20). A single retry cleared it. A phone user hitting login mid-flap just fails with no recovery.

## Fix

Bounded pre-signature retry on **transient** nonce failures, mirroring the downstream voice-session mint policy already shipped in #16627:
- 3 attempts, 500ms then 1000ms backoff (1.5s worst case)
- **Retryable:** transport/network error (no response) + any 5xx (503 included)
- **Non-retryable:** 4xx — a deterministic rejection surfaced immediately
- Runs entirely **before** the wallet signature, so retrying is side-effect free; each attempt consumes a fresh server nonce

No change to verify-leg behavior, storage, or the deterministic 4xx path.

## Scope

Backend-only client logic (network retry in a `.ts` module). **No UI/visual surface changed** — the diff is `cloud-siwe-login.ts` + its `.test.ts` only, no `.tsx`/CSS/render path. Production untouched; staging-verified root cause.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - no UI/visual surface; diff is network-retry logic in cloud-siwe-login.ts (.ts only, no .tsx/CSS/render change)`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no UI/visual surface; behavior is auth-network retry, not rendered output`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no interactive surface to walk through; deterministic retry logic covered by unit tests`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - client-side login path; no server code changed. The 503 nonce_storage_unavailable it recovers from was observed live on staging /api/auth/siwe/nonce (~2/3 requests during a Redis blip) and documented in projects/eliza-fleet/VOICE-PILLAR-2026-07-20.md`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no network-log fixture harness for this login module; the transient/deterministic branches are exercised directly by the mocked-fetch unit tests below`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no LLM involved in the SIWE auth path`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: https://github.com/elizaOS/eliza/pull/16704/files (diff) + focused unit suite `packages/ui/src/state/cloud-siwe-login.test.ts` — **16/16 passing**, Biome clean. Three new cases prove the real code path: (1) transient 503 x2 then success completes the handshake and stores the session (3 nonce calls); (2) deterministic 4xx is NOT retried (1 nonce call, throws); (3) sustained 503 surfaces the failure after exhausting retries (3 nonce calls, no session stored). Retry/exhaustion tests spent 1507ms/1505ms confirming the real bounded backoff fires.

Co-authored-by: wakesync