### PR TITLE
fix(ci): retire wedged cloud-cf-deploy v3 concurrency groups

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -86,9 +86,12 @@ concurrency:
   # by ref allowed a feature-branch dispatch and a develop push to interleave
   # their API, console, and app jobs against the same staging resources. PR
   # previews remain isolated per PR and cancel superseded preview runs.
-  # The v3 suffix retires the prior per-ref groups without inheriting a wedged
-  # pending run; cancel stale deploys instead of rejecting environment gates.
-  group: cloud-cf-deploy-v3-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging') }}
+  # The v4 suffix retires the wedged v3 groups: a stale 2026-05-15 queued run
+  # (25907128646) wedged v3-staging admission, so dispatched staging deploys sat
+  # pending with zero jobs while cancel and force-cancel both returned HTTP 500.
+  # Same retirement pattern as v2 -> v3; cancel stale deploys instead of
+  # rejecting environment gates.
+  group: cloud-cf-deploy-v4-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging') }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default to least privilege. Override per-job where needed.


### PR DESCRIPTION
## What

Staging deploys are wedged: a stale 2026-05-15 queued run ([25907128646](https://github.com/elizaOS/eliza/actions/runs/25907128646)) is stuck in the `cloud-cf-deploy-v3-staging` concurrency group. Newly dispatched staging deploys (e.g. run 29773115548 today) are admitted as `pending` with **zero jobs** and never start, while `cancel` and `force-cancel` on the wedged run both return HTTP 500 from the API.

This is exactly the failure mode the v2 → v3 suffix retirement fixed, recurring. Bump the suffix to v4 so canonical deploys stop inheriting the wedged group.

**No semantic changes:** per-environment serialization (staging/production) and per-PR preview isolation with cancel-in-progress behave exactly as before. Comment updated to document the wedge for the next archaeologist.

## Why it matters now

develop is 109 commits ahead of staging (e3717b55, Jul 18). The chat cold-stall fix #16629 is merged but undeployable until this group unwedges. Chat pillar latency verification is blocked behind it.

## Evidence

<!-- evidence-row:diagnosis --> Dispatched staging run 29773115548 at develop HEAD: status pending, 0 jobs, updated_at frozen at creation+2s; PR-event runs of the same workflow admit jobs normally (repro: STAGING-DEPLOY-LATENCY receipt + prior R2 watch receipt, fleet workspace).
<!-- evidence-row:wedge --> Wedged run 25907128646 (2026-05-15, status queued): POST /cancel and /force-cancel both return HTTP 500.
<!-- evidence-row:change --> Diff is a concurrency group-name suffix bump + comment only; expression logic byte-identical otherwise.
<!-- evidence-row:tests --> N/A (no code paths; workflow group naming only, validated by YAML parse in CI).
<!-- evidence-row:ui --> N/A (no UI surface).

## Review notes

Workflow file change: per fleet rules this is NOT auto-merged and needs human review. After merge, dispatch Cloud CF Deploy (develop, staging) and confirm jobs admit.

Co-authored-by: wakesync <shadow@shad0w.xyz>