### PR TITLE
fix(ci): format UI test files

### DIFF
--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -31,7 +31,9 @@ const appState = vi.hoisted(() => ({
   startupPhase: "first-run-required",
 }));
 
-const notificationMock = vi.hoisted(() => ({ init: vi.fn(async () => undefined) }));
+const notificationMock = vi.hoisted(() => ({
+  init: vi.fn(async () => undefined),
+}));
 
 vi.mock("./state/notifications/notification-store", () => ({
   initNotifications: notificationMock.init,

--- a/packages/ui/src/backgrounds/shader-presets.test.ts
+++ b/packages/ui/src/backgrounds/shader-presets.test.ts
@@ -20,24 +20,25 @@ describe("shader-presets library", () => {
     expect(getShaderPreset(DEFAULT_SHADER_PRESET_ID)).toBeDefined();
   });
 
-  it.each(
-    SHADER_PRESETS.map((p) => [p.id, p] as const),
-  )("preset %s is a well-formed, safe fragment shader", (_id, preset) => {
-    // Passes the static safety gate (has an output write, bounded, sized).
-    expect(isPlausibleFragmentSource(preset.source)).toBe(true);
-    // Declares precision + writes gl_FragColor with full alpha somewhere.
-    expect(preset.source).toContain("precision highp float");
-    expect(preset.source).toContain("gl_FragColor");
-    // Reads the injected + tunable uniforms it is contracted to.
-    for (const u of ["u_time", "u_resolution", "u_color"]) {
-      expect(preset.source).toContain(u);
-    }
-    // No unbounded loops (GPU-hang guard) — bounded `for` only.
-    expect(/\bwhile\b/.test(preset.source)).toBe(false);
-    expect(/\bdo\b/.test(preset.source)).toBe(false);
-    // Has a human label.
-    expect(preset.label.length).toBeGreaterThan(0);
-  });
+  it.each(SHADER_PRESETS.map((p) => [p.id, p] as const))(
+    "preset %s is a well-formed, safe fragment shader",
+    (_id, preset) => {
+      // Passes the static safety gate (has an output write, bounded, sized).
+      expect(isPlausibleFragmentSource(preset.source)).toBe(true);
+      // Declares precision + writes gl_FragColor with full alpha somewhere.
+      expect(preset.source).toContain("precision highp float");
+      expect(preset.source).toContain("gl_FragColor");
+      // Reads the injected + tunable uniforms it is contracted to.
+      for (const u of ["u_time", "u_resolution", "u_color"]) {
+        expect(preset.source).toContain(u);
+      }
+      // No unbounded loops (GPU-hang guard) — bounded `for` only.
+      expect(/\bwhile\b/.test(preset.source)).toBe(false);
+      expect(/\bdo\b/.test(preset.source)).toBe(false);
+      // Has a human label.
+      expect(preset.label.length).toBeGreaterThan(0);
+    },
+  );
 
   it("getShaderPreset is case-insensitive and returns undefined for unknown ids", () => {
     expect(getShaderPreset("LAVA")?.id).toBe("lava");

--- a/packages/ui/src/cloud/analytics/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/analytics/lib/auth-query.test.tsx
@@ -62,31 +62,34 @@ afterEach(() => {
 describe.each([
   ["analytics", useAnalyticsGate],
   ["api-keys", useApiKeysGate],
-])("%s query gate — session from persisted JWT only (page-reload reality)", (_name, useGate) => {
-  it("enables the query and exposes the user id when a valid JWT is persisted", () => {
-    storage.setItem(
-      "steward_session_token",
-      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
-    );
+])(
+  "%s query gate — session from persisted JWT only (page-reload reality)",
+  (_name, useGate) => {
+    it("enables the query and exposes the user id when a valid JWT is persisted", () => {
+      storage.setItem(
+        "steward_session_token",
+        makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+      );
 
-    const { result } = renderHook(() => useGate());
+      const { result } = renderHook(() => useGate());
 
-    expect(result.current.enabled).toBe(true);
-    expect(result.current.userId).toBe("u1");
-  });
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.userId).toBe("u1");
+    });
 
-  it("stays disabled with no persisted session", () => {
-    const { result } = renderHook(() => useGate());
-    expect(result.current.enabled).toBe(false);
-  });
+    it("stays disabled with no persisted session", () => {
+      const { result } = renderHook(() => useGate());
+      expect(result.current.enabled).toBe(false);
+    });
 
-  it("stays disabled for an expired token", () => {
-    storage.setItem(
-      "steward_session_token",
-      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
-    );
+    it("stays disabled for an expired token", () => {
+      storage.setItem(
+        "steward_session_token",
+        makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
+      );
 
-    const { result } = renderHook(() => useGate());
-    expect(result.current.enabled).toBe(false);
-  });
-});
+      const { result } = renderHook(() => useGate());
+      expect(result.current.enabled).toBe(false);
+    });
+  },
+);

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts
@@ -50,16 +50,17 @@ describe("wallet sign-in connector peer dependencies", () => {
   };
   const declared = { ...pkg.dependencies, ...pkg.devDependencies };
 
-  it.each(
-    RUNTIME_LAZY_CONNECTOR_DEPS,
-  )("declares %s so the no-injected-wallet EVM fallback resolves at click-time (#15600)", (dep) => {
-    expect(
-      declared[dep],
-      `${dep} must be a declared dependency of @elizaos/ui — wagmi/RainbowKit ` +
-        `dynamically imports it on the no-wallet EVM path; dropping it resurrects ` +
-        `the "Could not resolve ${dep}" click-time dead-end (#15600 / #15608).`,
-    ).toBeTruthy();
-  });
+  it.each(RUNTIME_LAZY_CONNECTOR_DEPS)(
+    "declares %s so the no-injected-wallet EVM fallback resolves at click-time (#15600)",
+    (dep) => {
+      expect(
+        declared[dep],
+        `${dep} must be a declared dependency of @elizaos/ui — wagmi/RainbowKit ` +
+          `dynamically imports it on the no-wallet EVM path; dropping it resurrects ` +
+          `the "Could not resolve ${dep}" click-time dead-end (#15600 / #15608).`,
+      ).toBeTruthy();
+    },
+  );
 
   // The wallet modal stylesheets live in the host CSS entry (see the header).
   // jsdom cannot see an unstyled portal, so pin the @imports statically.
@@ -71,14 +72,15 @@ describe("wallet sign-in connector peer dependencies", () => {
   const cloudCssEntryPath = resolve(here, "../../../../cloud-ui/index.css");
   const cloudCssEntry = readFileSync(cloudCssEntryPath, "utf8");
 
-  it.each(
-    WALLET_MODAL_STYLESHEETS,
-  )("cloud-ui/index.css imports %s so the wallet modals render styled (#15600)", (sheet) => {
-    expect(
-      cloudCssEntry.includes(`@import "${sheet}";`),
-      `cloud-ui/index.css must \`@import "${sheet}"\` — steward-wallet-providers ` +
-        `is CSS-import-free by design, so dropping this import leaves the wallet ` +
-        `modal unstyled (the Solana modal renders invisible, #15600).`,
-    ).toBe(true);
-  });
+  it.each(WALLET_MODAL_STYLESHEETS)(
+    "cloud-ui/index.css imports %s so the wallet modals render styled (#15600)",
+    (sheet) => {
+      expect(
+        cloudCssEntry.includes(`@import "${sheet}";`),
+        `cloud-ui/index.css must \`@import "${sheet}"\` — steward-wallet-providers ` +
+          `is CSS-import-free by design, so dropping this import leaves the wallet ` +
+          `modal unstyled (the Solana modal renders invisible, #15600).`,
+      ).toBe(true);
+    },
+  );
 });

--- a/packages/ui/src/components/accounts/AddAccountDialog.test.ts
+++ b/packages/ui/src/components/accounts/AddAccountDialog.test.ts
@@ -2,21 +2,17 @@ import { describe, expect, it } from "vitest";
 import { subscriptionOAuthModeForHostname } from "./subscription-oauth-mode";
 
 describe("subscriptionOAuthModeForHostname", () => {
-  it.each([
-    "localhost",
-    "LOCALHOST",
-    "127.0.0.1",
-    "::1",
-    "[::1]",
-  ])("uses loopback PKCE on %s", (hostname) => {
-    expect(subscriptionOAuthModeForHostname(hostname)).toBe("localhost");
-  });
+  it.each(["localhost", "LOCALHOST", "127.0.0.1", "::1", "[::1]"])(
+    "uses loopback PKCE on %s",
+    (hostname) => {
+      expect(subscriptionOAuthModeForHostname(hostname)).toBe("localhost");
+    },
+  );
 
-  it.each([
-    "ovh-eliza.tail4e11f5.ts.net",
-    "192.168.1.20",
-    "eliza.test",
-  ])("uses headless/device auth on %s", (hostname) => {
-    expect(subscriptionOAuthModeForHostname(hostname)).toBe("device");
-  });
+  it.each(["ovh-eliza.tail4e11f5.ts.net", "192.168.1.20", "eliza.test"])(
+    "uses headless/device auth on %s",
+    (hostname) => {
+      expect(subscriptionOAuthModeForHostname(hostname)).toBe("device");
+    },
+  );
 });

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -113,21 +113,20 @@ afterEach(() => {
 });
 
 describe("useHomeModelStatus", () => {
-  it.each([
-    "loading",
-    "cloud",
-    "remote",
-  ] as const)("does not poll local inference while runtime mode is %s", async (mode) => {
-    setRuntimeMode(mode);
+  it.each(["loading", "cloud", "remote"] as const)(
+    "does not poll local inference while runtime mode is %s",
+    async (mode) => {
+      setRuntimeMode(mode);
 
-    const { result } = renderHook(() => useHomeModelStatus());
+      const { result } = renderHook(() => useHomeModelStatus());
 
-    await waitFor(() => {
-      expect(result.current.kind).toBe("not-required");
-    });
-    expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
-    expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
-  });
+      await waitFor(() => {
+        expect(result.current.kind).toBe("not-required");
+      });
+      expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
+      expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
+    },
+  );
 
   it("polls local inference for local runtime mode", async () => {
     renderHook(() => useHomeModelStatus());

--- a/packages/ui/src/components/pages/chat-view-hooks.test.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.test.tsx
@@ -309,29 +309,32 @@ describe("useChatVoiceController voice playback unlock", () => {
     ["consent failure", "consent" as const],
     ["mint 404/failure", "mint" as const],
     ["pre-ready WS failure", "transport" as const],
-  ])("falls back to batch on the same mic tap after %s", async (_label, reason) => {
-    realtimeHarness.state.available = true;
-    realtimeHarness.state.start.mockResolvedValueOnce({
-      kind: "fallback-to-batch",
-      reason,
-    });
-    const { result } = renderHook(() =>
-      useChatVoiceController({
-        ...baseOptions,
-        realtimeAgentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
-        getRealtimeConsentNonce: vi.fn(async () => "nonce-1"),
-      }),
-    );
+  ])(
+    "falls back to batch on the same mic tap after %s",
+    async (_label, reason) => {
+      realtimeHarness.state.available = true;
+      realtimeHarness.state.start.mockResolvedValueOnce({
+        kind: "fallback-to-batch",
+        reason,
+      });
+      const { result } = renderHook(() =>
+        useChatVoiceController({
+          ...baseOptions,
+          realtimeAgentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+          getRealtimeConsentNonce: vi.fn(async () => "nonce-1"),
+        }),
+      );
 
-    await act(async () => {
-      result.current.beginVoiceCapture("compose");
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+      await act(async () => {
+        result.current.beginVoiceCapture("compose");
+        await Promise.resolve();
+        await Promise.resolve();
+      });
 
-    expect(realtimeHarness.state.start).toHaveBeenCalledTimes(1);
-    expect(voiceState.startListening).toHaveBeenCalledTimes(1);
-  });
+      expect(realtimeHarness.state.start).toHaveBeenCalledTimes(1);
+      expect(voiceState.startListening).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("starts batch directly when realtime eligibility is off", async () => {
     realtimeHarness.state.available = false;

--- a/packages/ui/src/components/pages/view-glyph-cleanup.test.ts
+++ b/packages/ui/src/components/pages/view-glyph-cleanup.test.ts
@@ -42,13 +42,14 @@ describe("shared view glyph cleanup", () => {
   // check/cross glyphs anywhere; use Lucide icon components instead. (× is the
   // multiplication sign and is intentionally not banned globally; close/delete
   // controls use the X icon.)
-  it.each(
-    listViewFiles(),
-  )("%s uses Lucide icons, not raw check/cross glyphs", (fileName) => {
-    const source = readPageSource(fileName);
-    expect(source, `${fileName} contains a raw ✓`).not.toContain("✓");
-    expect(source, `${fileName} contains a raw ✗`).not.toContain("✗");
-    expect(source, `${fileName} contains a raw ✘`).not.toContain("✘");
-    expect(source, `${fileName} contains a raw ✕`).not.toContain("✕");
-  });
+  it.each(listViewFiles())(
+    "%s uses Lucide icons, not raw check/cross glyphs",
+    (fileName) => {
+      const source = readPageSource(fileName);
+      expect(source, `${fileName} contains a raw ✓`).not.toContain("✓");
+      expect(source, `${fileName} contains a raw ✗`).not.toContain("✗");
+      expect(source, `${fileName} contains a raw ✘`).not.toContain("✘");
+      expect(source, `${fileName} contains a raw ✕`).not.toContain("✕");
+    },
+  );
 });

--- a/packages/ui/src/components/settings/no-native-select.test.ts
+++ b/packages/ui/src/components/settings/no-native-select.test.ts
@@ -39,16 +39,17 @@ function listTsxFiles(dir: string): string[] {
 describe("settings controls: no native <select>", () => {
   const files = [...listTsxFiles(settingsRoot), ...extraGuardedFiles];
 
-  it.each(
-    files.map((f) => relative(settingsRoot, f)),
-  )("%s uses canonical settings controls, not a raw <select>", (relPath) => {
-    const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
-    expect(
-      source.includes("<select"),
-      `${relPath} hand-rolls a native <select>. Use SettingsSelectRow ` +
-        `(Radix sheet select) or SettingsSegmentedRow (segmented control) ` +
-        `from ./settings-agent-rows instead — they are themed, 44px-touch, ` +
-        `and agent-addressable.`,
-    ).toBe(false);
-  });
+  it.each(files.map((f) => relative(settingsRoot, f)))(
+    "%s uses canonical settings controls, not a raw <select>",
+    (relPath) => {
+      const source = readFileSync(resolve(settingsRoot, relPath), "utf8");
+      expect(
+        source.includes("<select"),
+        `${relPath} hand-rolls a native <select>. Use SettingsSelectRow ` +
+          `(Radix sheet select) or SettingsSegmentedRow (segmented control) ` +
+          `from ./settings-agent-rows instead — they are themed, 44px-touch, ` +
+          `and agent-addressable.`,
+      ).toBe(false);
+    },
+  );
 });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -812,12 +812,15 @@ describe("ContinuousChatOverlay", () => {
     it.each([
       ["recording", { recording: true }],
       ["transcribing", { transcriptionMode: true }],
-    ] as const)("keeps the pulsing waveform neutral while %s", (_label, override) => {
-      render(<ContinuousChatOverlay controller={makeController(override)} />);
-      const waveform = screen.getByTestId("chat-composer-mic");
-      expect(waveform.className).toContain("animate-pulse");
-      expect(waveform.className).not.toContain("text-accent");
-    });
+    ] as const)(
+      "keeps the pulsing waveform neutral while %s",
+      (_label, override) => {
+        render(<ContinuousChatOverlay controller={makeController(override)} />);
+        const waveform = screen.getByTestId("chat-composer-mic");
+        expect(waveform.className).toContain("animate-pulse");
+        expect(waveform.className).not.toContain("text-accent");
+      },
+    );
 
     it("drops the pulse the moment the capture predicate clears", () => {
       const { rerender } = render(

--- a/packages/ui/src/components/shell/notifications-boot.test.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.test.tsx
@@ -21,7 +21,10 @@ vi.mock("../../state/notifications/push-registration", () => ({
 vi.mock("../../state/shell-surface-store", () => ({ goHome: mocks.goHome }));
 
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
-import { NotificationsDataBoot, NotificationsShellBoot } from "./notifications-boot";
+import {
+  NotificationsDataBoot,
+  NotificationsShellBoot,
+} from "./notifications-boot";
 
 afterEach(() => {
   cleanup();

--- a/packages/ui/src/components/ui/button.test.ts
+++ b/packages/ui/src/components/ui/button.test.ts
@@ -7,15 +7,13 @@ import { describe, expect, it } from "vitest";
 import { buttonVariants } from "./button";
 
 describe("buttonVariants", () => {
-  it.each([
-    "default",
-    "sm",
-    "icon",
-    "icon-sm",
-  ] as const)("adds the coarse-pointer 44px floor for compact %s buttons", (size) => {
-    const className = buttonVariants({ size });
+  it.each(["default", "sm", "icon", "icon-sm"] as const)(
+    "adds the coarse-pointer 44px floor for compact %s buttons",
+    (size) => {
+      const className = buttonVariants({ size });
 
-    expect(className).toContain("pointer-coarse:min-h-touch");
-    expect(className).toContain("pointer-coarse:min-w-touch");
-  });
+      expect(className).toContain("pointer-coarse:min-h-touch");
+      expect(className).toContain("pointer-coarse:min-w-touch");
+    },
+  );
 });

--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -114,22 +114,21 @@ afterEach(() => {
 });
 
 describe("routeFirstRunDeepLink", () => {
-  it.each([
-    "local",
-    "cloud",
-    "remote",
-  ] as const)("%s deep link forces first-run into that runtime target via the real reload path", (target) => {
-    const handled = routeFirstRunDeepLink(
-      `eliza://first-run/runtime/${target}`,
-      URL_SCHEME,
-    );
+  it.each(["local", "cloud", "remote"] as const)(
+    "%s deep link forces first-run into that runtime target via the real reload path",
+    (target) => {
+      const handled = routeFirstRunDeepLink(
+        `eliza://first-run/runtime/${target}`,
+        URL_SCHEME,
+      );
 
-    expect(handled).toBe(true);
-    // The fix: it does REAL work (clears active-server + location.href reload)
-    // instead of a replaceState no-op that no live code reads (#13984).
-    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledTimes(1);
-    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith(target);
-  });
+      expect(handled).toBe(true);
+      // The fix: it does REAL work (clears active-server + location.href reload)
+      // instead of a replaceState no-op that no live code reads (#13984).
+      expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledTimes(1);
+      expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith(target);
+    },
+  );
 
   it("unknown step forces first-run WITHOUT a pinned target (user picks)", () => {
     const handled = routeFirstRunDeepLink(
@@ -414,19 +413,19 @@ describe("parseFirstRunRemoteConnectDeepLink", () => {
   // becomes an unattended credential against a pairing-enabled remote agent.
   // Documented in packages/app/docs/TEST_AUTH.md and asserted end-to-end in
   // packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts.
-  it.each([
-    "token",
-    "accessToken",
-  ])("drops a smuggled %s credential param, surfacing only the address (#13692)", (credentialKey) => {
-    const result = parseFirstRunRemoteConnectDeepLink(
-      `eliza://first-run/runtime/remote?api=https://agent.example.com&${credentialKey}=smuggled-secret`,
-      URL_SCHEME,
-    );
-    expect(result).toEqual({ apiBase: "https://agent.example.com" });
-    expect(
-      (result as Record<string, unknown> | null)?.[credentialKey],
-    ).toBeUndefined();
-  });
+  it.each(["token", "accessToken"])(
+    "drops a smuggled %s credential param, surfacing only the address (#13692)",
+    (credentialKey) => {
+      const result = parseFirstRunRemoteConnectDeepLink(
+        `eliza://first-run/runtime/remote?api=https://agent.example.com&${credentialKey}=smuggled-secret`,
+        URL_SCHEME,
+      );
+      expect(result).toEqual({ apiBase: "https://agent.example.com" });
+      expect(
+        (result as Record<string, unknown> | null)?.[credentialKey],
+      ).toBeUndefined();
+    },
+  );
 
   it("returns null for a link carrying ONLY a credential and no address (#13692 §4)", () => {
     expect(

--- a/packages/ui/src/first-run/__tests__/mobile-runtime-mode-hardening.test.ts
+++ b/packages/ui/src/first-run/__tests__/mobile-runtime-mode-hardening.test.ts
@@ -78,14 +78,12 @@ afterEach(async () => {
 });
 
 describe("normalizeMobileRuntimeMode", () => {
-  it.each([
-    "remote-mac",
-    "cloud",
-    "cloud-hybrid",
-    "local",
-  ] as const)("passes %s through unchanged", (mode) => {
-    expect(normalizeMobileRuntimeMode(mode)).toBe(mode);
-  });
+  it.each(["remote-mac", "cloud", "cloud-hybrid", "local"] as const)(
+    "passes %s through unchanged",
+    (mode) => {
+      expect(normalizeMobileRuntimeMode(mode)).toBe(mode);
+    },
+  );
 
   it("trims surrounding whitespace before matching", () => {
     expect(normalizeMobileRuntimeMode("  local  ")).toBe("local");
@@ -128,15 +126,13 @@ describe("readPersistedMobileRuntimeMode", () => {
     expect(readPersistedMobileRuntimeMode()).toBeNull();
   });
 
-  it.each([
-    "remote-mac",
-    "cloud",
-    "cloud-hybrid",
-    "local",
-  ] as const)("round-trips %s through localStorage", (mode) => {
-    window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, mode);
-    expect(readPersistedMobileRuntimeMode()).toBe(mode);
-  });
+  it.each(["remote-mac", "cloud", "cloud-hybrid", "local"] as const)(
+    "round-trips %s through localStorage",
+    (mode) => {
+      window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, mode);
+      expect(readPersistedMobileRuntimeMode()).toBe(mode);
+    },
+  );
 
   it("ignores garbage values written by an older build", () => {
     window.localStorage.setItem(
@@ -166,20 +162,23 @@ describe("persistMobileRuntimeModeForServerTarget", () => {
     ["elizacloud", "cloud"],
     ["elizacloud-hybrid", "cloud-hybrid"],
     ["local", "local"],
-  ] as const)("writes %s as %s to localStorage and Capacitor Preferences", async (target, expected) => {
-    persistMobileRuntimeModeForServerTarget(target);
+  ] as const)(
+    "writes %s as %s to localStorage and Capacitor Preferences",
+    async (target, expected) => {
+      persistMobileRuntimeModeForServerTarget(target);
 
-    expect(window.localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBe(
-      expected,
-    );
-    await vi.waitFor(() => {
-      expect(preferencesSetMock).toHaveBeenCalledWith({
-        key: MOBILE_RUNTIME_MODE_STORAGE_KEY,
-        value: expected,
+      expect(window.localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBe(
+        expected,
+      );
+      await vi.waitFor(() => {
+        expect(preferencesSetMock).toHaveBeenCalledWith({
+          key: MOBILE_RUNTIME_MODE_STORAGE_KEY,
+          value: expected,
+        });
       });
-    });
-    expect(preferencesRemoveMock).not.toHaveBeenCalled();
-  });
+      expect(preferencesRemoveMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("clears a prior selection from localStorage when called with an empty target", async () => {
     window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "local");

--- a/packages/ui/src/pendant/pendant-transcript-session.test.ts
+++ b/packages/ui/src/pendant/pendant-transcript-session.test.ts
@@ -381,31 +381,31 @@ describe("pendant transcript session storage", () => {
     );
   });
 
-  it.each([
-    "QuotaExceededError",
-    "SecurityError",
-  ])("surfaces a setItem failure with %s", (errorName) => {
-    const storage = new ThrowingSetStorage(errorName);
-    const state = sessionWithSegments(1);
+  it.each(["QuotaExceededError", "SecurityError"])(
+    "surfaces a setItem failure with %s",
+    (errorName) => {
+      const storage = new ThrowingSetStorage(errorName);
+      const state = sessionWithSegments(1);
 
-    expect(() => savePendantTranscriptSession(state, storage)).toThrow(
-      "Pendant transcript cache could not be saved.",
-    );
-    expect(loadPendantTranscriptSession(storage)).toEqual(
-      EMPTY_PENDANT_TRANSCRIPT_SESSION,
-    );
-  });
+      expect(() => savePendantTranscriptSession(state, storage)).toThrow(
+        "Pendant transcript cache could not be saved.",
+      );
+      expect(loadPendantTranscriptSession(storage)).toEqual(
+        EMPTY_PENDANT_TRANSCRIPT_SESSION,
+      );
+    },
+  );
 
-  it.each([
-    "SecurityError",
-    "UnknownError",
-  ])("surfaces a getItem failure with %s", (errorName) => {
-    const storage = new ThrowingGetStorage(errorName);
+  it.each(["SecurityError", "UnknownError"])(
+    "surfaces a getItem failure with %s",
+    (errorName) => {
+      const storage = new ThrowingGetStorage(errorName);
 
-    expect(() => loadPendantTranscriptSession(storage)).toThrow(
-      "Pendant transcript cache could not be read.",
-    );
-  });
+      expect(() => loadPendantTranscriptSession(storage)).toThrow(
+        "Pendant transcript cache could not be read.",
+      );
+    },
+  );
 
   it("surfaces a blocked window.localStorage getter", () => {
     const descriptor = Object.getOwnPropertyDescriptor(window, "localStorage");

--- a/packages/ui/src/voice/audio-worklet-module-urls.test.ts
+++ b/packages/ui/src/voice/audio-worklet-module-urls.test.ts
@@ -31,24 +31,24 @@ const modules = [
 ] as const;
 
 describe("AudioWorklet module assets", () => {
-  it.each(modules)("uses a CSP-compatible URL for $processorName", ({
-    url,
-    fileName,
-  }) => {
-    expect(url).not.toMatch(/^(?:blob|data):/);
-    expect(new URL(url).pathname).toContain(`/worklets/${fileName}`);
-  });
+  it.each(modules)(
+    "uses a CSP-compatible URL for $processorName",
+    ({ url, fileName }) => {
+      expect(url).not.toMatch(/^(?:blob|data):/);
+      expect(new URL(url).pathname).toContain(`/worklets/${fileName}`);
+    },
+  );
 
-  it.each(modules)("ships the $processorName processor as a static module", ({
-    fileName,
-    processorName,
-  }) => {
-    const source = readFileSync(
-      resolve(voiceDirectory, "worklets", fileName),
-      "utf8",
-    );
-    expect(source).toContain(`registerProcessor("${processorName}"`);
-  });
+  it.each(modules)(
+    "ships the $processorName processor as a static module",
+    ({ fileName, processorName }) => {
+      const source = readFileSync(
+        resolve(voiceDirectory, "worklets", fileName),
+        "utf8",
+      );
+      expect(source).toContain(`registerProcessor("${processorName}"`);
+    },
+  );
 
   it("prevents Vite from inlining worklets and copies them into package dist", () => {
     const moduleUrlSource = readFileSync(moduleUrlSourcePath, "utf8");


### PR DESCRIPTION
## Summary

- formats the UI test files that currently fail `@elizaos/ui:format:check`
- keeps this PR formatter-only; no test logic or runtime behavior changes

## CI Context

Current develop is failing `Quality (Extended) / Format + Type Safety Ratchet` in `@elizaos/ui:format:check`. The GitHub log surfaced two files, and the package formatter check showed the full set of 16 files needing Biome output.

## Verification

- `bun run --cwd packages/ui format:check`
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - formatter-only change to `*.test.tsx`/`*.test.ts` files under packages/ui; no rendered-UI source touched.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI surface changed; Biome formatting of test files only.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing flow changed; verified via `format:check`.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no runtime/backend behavior changed.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime code changed; test files only.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent prompt, model, provider, evaluator, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - deliverable is Biome formatting of existing test files; no DB rows, media, or generated files.


<!-- evidence refreshed 1784593220 -->
