### PR TITLE
fix(ci): retire wedged un-versioned cloud-db-migrate job concurrency group

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -158,8 +158,12 @@ jobs:
     runs-on: ${{ fromJSON(vars.CLOUD_CF_MIGRATE_RUNNER_JSON || '["ubuntu-latest"]') }}
     # Job-level concurrency groups are repo-wide, so this also serializes
     # against an explicitly dispatched legacy cloud-deploy-backend migration.
+    # The v2 suffix retires the un-versioned group: the same stale 2026-05-15
+    # queued run (25907128646) that wedged the workflow-level v3 group also
+    # pins cloud-db-migrate-staging, so migration jobs sat pending forever
+    # while cancel/force-cancel returned HTTP 500 (see #16705).
     concurrency:
-      group: cloud-db-migrate-${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
+      group: cloud-db-migrate-v2-${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       cancel-in-progress: false
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
     timeout-minutes: 10

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -57,7 +57,11 @@ jobs:
     # legacy migration against the canonical migrate-db gate in
     # cloud-cf-deploy.yml (#11208).
     concurrency:
-      group: cloud-db-migrate-${{ needs.determine-env.outputs.environment }}
+      # v2 suffix matches cloud-cf-deploy.yml: the un-versioned group is pinned
+      # by a stale 2026-05-15 queued run (25907128646) that cannot be cancelled
+      # (HTTP 500). Both workflows must share the same group name so canonical
+      # and legacy migrations still serialize against each other.
+      group: cloud-db-migrate-v2-${{ needs.determine-env.outputs.environment }}
       cancel-in-progress: false
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 10


### PR DESCRIPTION
## What

Follow-up to #16705. The same stale 2026-05-15 queued run ([25907128646](https://github.com/elizaOS/eliza/actions/runs/25907128646)) that wedged the workflow-level `cloud-cf-deploy-v3-staging` group ALSO pins the **job-level** `cloud-db-migrate-staging` group. Post-#16705, staging deploys admit jobs but stall forever at **Run Database Migrations** (observed on run 29776079332: validate completed, migrations pending indefinitely). Cancel/force-cancel on the wedged run still return HTTP 500.

Bump the job group suffix to `v2` so migration jobs stop inheriting the wedge. Per-environment serialization and `cancel-in-progress: false` semantics unchanged; expression logic otherwise byte-identical.

This is the remaining blocker for the prod-promotion checkpoint (PROD-PROMOTION-2026-07-20 receipt: staging cannot land the new SHA while migrations never start).

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - CI workflow concurrency group rename, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - CI workflow concurrency group rename, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - one-line job concurrency group suffix bump`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: staging deploy run 29776079332 post-#16705: Validate Canonical Deploy Source completed=success, Run Database Migrations status=pending indefinitely; wedged run 25907128646 cancel + force-cancel = HTTP 500. Diagnosis trail in PROD-PROMOTION-2026-07-20 fleet receipt.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent/model behavior change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: diff = job concurrency group-name suffix bump (un-versioned → v2) + explanatory comment; validation plan: post-merge, dispatch Cloud CF Deploy (develop → staging) and confirm the migrations job starts.

## Review notes

Workflow file change: dual-model fine-tooth review per Shadow's 2026-07-20 directive (same protocol as #16705).

Co-authored-by: wakesync <shadow@shad0w.xyz>