### PR TITLE
perf(voice): reuse bridge conversation per session (context fix + first-token round-trip removed)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-conversation-reuse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-conversation-reuse.test.ts
@@ -231,3 +231,192 @@ describe("bridgeStream conversation reuse", () => {
     expect(creates(calls)).toHaveLength(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// bridgeStream fallback ladder: when the conversation-stream route is
+// unavailable (persistent 404), bridgeStream must degrade through the
+// OpenAI-compat SSE path, then the central-channel path, then the no-reply
+// fallback text. These are the downstream legs of the same entry point whose
+// conversation-reuse behavior this PR changes, so they are exercised here
+// through the real bridgeStream (mocked network) rather than in isolation.
+// ---------------------------------------------------------------------------
+
+type LadderFetchOptions = {
+  // conversation stream POST status (default 404 → forces the ladder)
+  streamStatus?: number;
+  // /v1/chat/completions response (status + json body); default 404 → skip.
+  // `"throw"` makes the fetch reject so bridgeStream's compat leg catches and
+  // proceeds to the central-channel leg (a 404 here returns null and short-
+  // circuits bridgeStream, so a throw is required to reach central-channel).
+  openai?: { status: number; body: unknown } | "throw";
+  // ensureRuntimeAgentStarted result for the central-channel leg
+  runtimeAgent?: { id: string; name?: string } | null;
+  // central-channel POST status (default 404 → route unavailable)
+  centralPostStatus?: number;
+  // messages the central-channel poll GET returns (first attempt)
+  centralPollMessages?: unknown[];
+};
+
+function makeLadderDeps(runtimeAgent: { id: string; name?: string } | null | undefined) {
+  return {
+    getAgentApiEndpoint: async (_rec: unknown, path: string) => `https://bridge.example${path}`,
+    getAgentJsonHeaders: () => ({ "content-type": "application/json" }),
+    listRuntimeAgents: async () => ({ supported: false, agents: [] }),
+    selectRuntimeAgent: () => undefined,
+    isRuntimeAgentReady: () => false,
+    ensureRuntimeAgentStarted: async () => runtimeAgent ?? null,
+  } as never;
+}
+
+function installLadderFetch(options: LadderFetchOptions) {
+  const calls: FetchCall[] = [];
+  const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = typeof init?.body === "string" ? init.body : "";
+    calls.push({ url, method, body });
+
+    if (url.endsWith("/api/conversations") && method === "POST") {
+      return conversationCreateResponse("conv-1");
+    }
+    if (url.includes("/messages/stream") && method === "POST") {
+      return new Response("", { status: options.streamStatus ?? 404 });
+    }
+    if (url.endsWith("/v1/chat/completions") && method === "POST") {
+      const o = options.openai ?? { status: 404, body: {} };
+      if (o === "throw") throw new Error("openai-compat unreachable");
+      return new Response(JSON.stringify(o.body), {
+        status: o.status,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("/central-channels/") && method === "POST") {
+      return new Response(JSON.stringify({ data: { id: "msg-1" } }), {
+        status: options.centralPostStatus ?? 404,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("/central-channels/") && method === "GET") {
+      return new Response(JSON.stringify({ messages: options.centralPollMessages ?? [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("", { status: 404 });
+  });
+  globalThis.fetch = fetchMock as never;
+  return { calls };
+}
+
+async function readSse(response: Response | null): Promise<string> {
+  if (!response?.body) return "";
+  return response.text();
+}
+
+describe("bridgeStream fallback ladder (conversation route unavailable)", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("degrades to the OpenAI-compat SSE path and streams its reply", async () => {
+    const svc = new ElizaSandboxBridgeService(makeLadderDeps(null));
+    const { calls } = installLadderFetch({
+      openai: {
+        status: 200,
+        body: { model: "eliza", choices: [{ message: { content: "compat reply" } }] },
+      },
+    });
+
+    const res = await svc.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    const sse = await readSse(res);
+
+    expect(res).not.toBeNull();
+    expect(sse).toContain("compat reply");
+    // It really went through /v1/chat/completions after the 404 stream.
+    expect(calls.some((c) => c.url.endsWith("/v1/chat/completions"))).toBe(true);
+  });
+
+  test("OpenAI-compat error status yields an SSE error frame", async () => {
+    const svc = new ElizaSandboxBridgeService(makeLadderDeps(null));
+    installLadderFetch({
+      openai: { status: 500, body: { error: { message: "upstream boom" } } },
+    });
+
+    const res = await svc.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    const sse = await readSse(res);
+
+    expect(sse).toContain("event: error");
+    expect(sse).toContain("upstream boom");
+  });
+
+  test("falls through to the central-channel path and returns the polled agent reply", async () => {
+    const svc = new ElizaSandboxBridgeService(
+      makeLadderDeps({ id: "11111111-1111-4111-8111-111111111111", name: "Sol" }),
+    );
+    const { calls } = installLadderFetch({
+      openai: "throw", // compat leg unreachable → reach central-channel
+      centralPostStatus: 200,
+      centralPollMessages: [
+        { id: "m-user", role: "user", text: "hi" },
+        { id: "m-agent", isAgent: true, text: "central reply" },
+      ],
+    });
+
+    const res = await svc.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    const sse = await readSse(res);
+
+    expect(sse).toContain("central reply");
+    expect(calls.some((c) => c.url.includes("/central-channels/") && c.method === "POST")).toBe(
+      true,
+    );
+    expect(calls.some((c) => c.url.includes("/central-channels/") && c.method === "GET")).toBe(
+      true,
+    );
+  });
+
+  test("emits the exact-words no-reply fallback when every transport is unavailable", async () => {
+    // openai throws AND the central-channel POST 404s (route unavailable →
+    // BridgeRouteUnavailableError, caught) so bridgeStream reaches the
+    // exact-words no-reply fallback. A runtime agent must exist, else central
+    // returns an error response that short-circuits before the fallback.
+    const svc = new ElizaSandboxBridgeService(
+      makeLadderDeps({ id: "22222222-2222-4222-8222-222222222222", name: "Sol" }),
+    );
+    installLadderFetch({
+      openai: "throw",
+      centralPostStatus: 404,
+    });
+
+    const rpc = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      method: "message.send",
+      params: {
+        // buildBridgeNoReplyFallbackText parses this exact-words directive.
+        text: 'Please reply with exact words: "pong"',
+        source: "voice",
+        roomId: "room-A",
+      },
+    };
+    const res = await svc.bridgeStream("agent-1", "org-1", rpc);
+    const sse = await readSse(res);
+
+    expect(sse).toContain("pong");
+  });
+
+  test("returns null when there is no reply and no fallback text", async () => {
+    // openai 404 short-circuits bridgeStream to null (no central-channel leg),
+    // and empty text means there is no fallback string either.
+    const svc = new ElizaSandboxBridgeService(makeLadderDeps(null));
+    installLadderFetch({ openai: { status: 404, body: {} } });
+
+    const rpc = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      method: "message.send",
+      params: { text: "", source: "voice", roomId: "room-A" }, // empty text → no fallback
+    };
+    const res = await svc.bridgeStream("agent-1", "org-1", rpc);
+    expect(res).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-conversation-reuse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-conversation-reuse.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression: a voice session must REUSE its bridge conversation across turns.
+ *
+ * `bridgeStream` used to POST `/api/conversations` on EVERY turn — a serialized
+ * round-trip on the first-token critical path that also started a brand-new
+ * conversation each turn, dropping prior-turn context. It now caches the created
+ * conversation id keyed by the stable session identity `(agentId, orgId,
+ * roomId)`:
+ *   - turn 1 creates,
+ *   - turn 2+ reuse (no create round-trip; the SAME conversation id carries the
+ *     turn, so multi-turn context survives),
+ *   - a stale/expired cached id (the stream POST answers 404) evicts and
+ *     recreates exactly once,
+ *   - a distinct session (different roomId/agent) gets its own fresh
+ *     conversation,
+ *   - a caller with no stable roomId keeps create-per-call behavior.
+ *
+ * Real `bridgeStream`, no network: the sandbox repo and `fetch` are mocked so we
+ * can count creates vs stream POSTs and assert which conversation id each turn's
+ * stream request carried.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const sandboxRecord = {
+  id: "sandbox-1",
+  bridge_url: "https://bridge.example",
+  environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+};
+
+const findRunningSandbox = mock(async (_agentId: string, _orgId: string) => sandboxRecord);
+
+mock.module("../../db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    findRunningSandbox,
+  },
+}));
+
+const { ElizaSandboxBridgeService } = await import("./eliza-sandbox-bridge");
+
+const originalFetch = globalThis.fetch;
+
+/** Minimal deps: endpoints echo the path, headers are static. */
+function makeDeps() {
+  return {
+    getAgentApiEndpoint: async (_rec: unknown, path: string) => `https://bridge.example${path}`,
+    getAgentJsonHeaders: () => ({ "content-type": "application/json" }),
+    listRuntimeAgents: async () => ({ supported: false, agents: [] }),
+    selectRuntimeAgent: () => undefined,
+    isRuntimeAgentReady: () => false,
+    ensureRuntimeAgentStarted: async () => null,
+  } as never;
+}
+
+function sseOk(): Response {
+  return new Response('data: {"type":"done","fullText":"hi"}\n\n', {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function conversationCreateResponse(id: string): Response {
+  return new Response(JSON.stringify({ conversation: { id } }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type FetchCall = { url: string; method: string; body: string };
+
+/**
+ * Install a fetch mock that:
+ *  - answers `/api/conversations` (create) with sequential ids conv-1, conv-2…
+ *  - answers `/messages/stream` per the `streamStatus` sequence (200 unless a
+ *    status is queued, letting us simulate a stale-id 404), and
+ *  - records every call for assertions.
+ * Every other endpoint (the compat ladder) 404s so we never leave the cached
+ * conversation path silently.
+ */
+function installFetch(options?: { streamStatuses?: number[] }) {
+  const calls: FetchCall[] = [];
+  let createSeq = 0;
+  const streamStatuses = [...(options?.streamStatuses ?? [])];
+  const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = typeof init?.body === "string" ? init.body : "";
+    calls.push({ url, method, body });
+
+    if (url.endsWith("/api/conversations") && method === "POST") {
+      createSeq += 1;
+      return conversationCreateResponse(`conv-${createSeq}`);
+    }
+    if (url.includes("/messages/stream") && method === "POST") {
+      const status = streamStatuses.shift() ?? 200;
+      if (status === 200) return sseOk();
+      return new Response("", { status });
+    }
+    // compat ladder (openai-compat / central-channel) — force it unavailable.
+    return new Response("", { status: 404 });
+  });
+  globalThis.fetch = fetchMock as never;
+  return { calls };
+}
+
+function streamRpc(roomId?: string) {
+  return {
+    jsonrpc: "2.0" as const,
+    id: 1,
+    method: "message.send",
+    params: {
+      text: "hello",
+      source: "voice",
+      ...(roomId ? { roomId } : {}),
+    },
+  };
+}
+
+const creates = (calls: FetchCall[]) =>
+  calls.filter((c) => c.url.endsWith("/api/conversations") && c.method === "POST");
+
+const streamCalls = (calls: FetchCall[]) =>
+  calls.filter((c) => c.url.includes("/messages/stream") && c.method === "POST");
+
+// The conversation id lives in the stream URL: /api/conversations/<id>/messages/stream
+const streamConversationId = (url: string) =>
+  /\/api\/conversations\/([^/]+)\/messages\/stream/.exec(url)?.[1] ?? null;
+
+let service: InstanceType<typeof ElizaSandboxBridgeService>;
+
+beforeEach(() => {
+  service = new ElizaSandboxBridgeService(makeDeps());
+  findRunningSandbox.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("bridgeStream conversation reuse", () => {
+  test("first turn creates a conversation, second turn reuses it (no second create)", async () => {
+    const { calls } = installFetch();
+
+    const first = await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    const second = await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+
+    // Only ONE create across two turns.
+    expect(creates(calls)).toHaveLength(1);
+
+    // Both turns streamed against the SAME (reused) conversation id — context
+    // is preserved across the session.
+    const streams = streamCalls(calls);
+    expect(streams).toHaveLength(2);
+    expect(streamConversationId(streams[0].url)).toBe("conv-1");
+    expect(streamConversationId(streams[1].url)).toBe("conv-1");
+  });
+
+  test("a stale/invalid cached id (stream 404) recreates exactly once and reuses after", async () => {
+    // turn 1: create conv-1, stream 200.
+    // turn 2: stream against conv-1 → 404 (sandbox dropped it) → evict, create
+    //         conv-2, stream 200.
+    // turn 3: reuse conv-2, stream 200 (no new create).
+    const { calls } = installFetch({ streamStatuses: [200, 404, 200, 200] });
+
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    const recovered = await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+
+    // The 404 turn still succeeds via the recreated conversation.
+    expect(recovered).not.toBeNull();
+
+    // Exactly two creates total: the initial one and the single stale-recovery
+    // recreate. NOT one-per-turn, and NOT more than one recovery.
+    expect(creates(calls)).toHaveLength(2);
+
+    const streams = streamCalls(calls);
+    // turn1 conv-1, turn2 first-attempt conv-1 (404), turn2 retry conv-2, turn3 conv-2.
+    expect(streams.map((c) => streamConversationId(c.url))).toEqual([
+      "conv-1",
+      "conv-1",
+      "conv-2",
+      "conv-2",
+    ]);
+  });
+
+  test("a persistent 404 recreates only once, then falls through (no infinite loop)", async () => {
+    // Every stream 404s: first attempt (conv-1) → recreate conv-2 → still 404 →
+    // stop. Exactly two creates, two stream attempts, then the compat ladder.
+    const { calls } = installFetch({ streamStatuses: [404, 404, 404, 404] });
+
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+
+    expect(creates(calls)).toHaveLength(2);
+    expect(streamCalls(calls)).toHaveLength(2);
+  });
+
+  test("distinct sessions (different roomId) each get their own fresh conversation", async () => {
+    const { calls } = installFetch();
+
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-B"));
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+
+    // room-A create, room-B create; room-A's second turn reuses → 2 creates.
+    expect(creates(calls)).toHaveLength(2);
+
+    const streams = streamCalls(calls);
+    expect(streamConversationId(streams[0].url)).toBe("conv-1"); // room-A turn 1
+    expect(streamConversationId(streams[1].url)).toBe("conv-2"); // room-B turn 1
+    expect(streamConversationId(streams[2].url)).toBe("conv-1"); // room-A turn 2 reuse
+  });
+
+  test("a different agent with the same roomId does not share a conversation", async () => {
+    const { calls } = installFetch();
+
+    await service.bridgeStream("agent-1", "org-1", streamRpc("room-A"));
+    await service.bridgeStream("agent-2", "org-1", streamRpc("room-A"));
+
+    // Session identity includes agentId → two separate conversations.
+    expect(creates(calls)).toHaveLength(2);
+  });
+
+  test("no roomId falls back to create-per-call (one-shot callers unchanged)", async () => {
+    const { calls } = installFetch();
+
+    await service.bridgeStream("agent-1", "org-1", streamRpc());
+    await service.bridgeStream("agent-1", "org-1", streamRpc());
+
+    // No stable session key → each call creates its own conversation.
+    expect(creates(calls)).toHaveLength(2);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -100,8 +100,90 @@ class BridgeRouteUnavailableError extends Error {
   }
 }
 
+/**
+ * How long a session-scoped bridge conversation id is trusted before we force a
+ * fresh create. A voice session reuses one conversation across turns (stable
+ * `roomId`); without a TTL a long-lived process would pin a conversation id that
+ * the sandbox may have GC'd or that belongs to a since-restarted agent. 30 min
+ * comfortably covers a live voice session while bounding staleness/memory.
+ */
+const BRIDGE_CONVERSATION_TTL_MS = 30 * 60 * 1000;
+
+type BridgeConversationCacheEntry = {
+  conversationId: string;
+  createdAt: number;
+};
+
 export class ElizaSandboxBridgeService {
+  /**
+   * Session-scoped conversation reuse. A voice turn used to POST
+   * `/api/conversations` on EVERY turn (a serialized round-trip on the
+   * first-token critical path) AND started a brand-new conversation each time,
+   * losing prior-turn context. We cache the created conversation id keyed by the
+   * stable session identity `(agentId, orgId, roomId)`: the first turn creates,
+   * subsequent turns reuse (no create round-trip, context preserved). A stale id
+   * (sandbox restarted / conversation expired → 404 on the stream POST) evicts
+   * the entry and recreates exactly once. Only the streaming voice path uses
+   * this cache; one-shot REST callers keep their create-per-call behavior.
+   */
+  private readonly bridgeConversationCache = new Map<string, BridgeConversationCacheEntry>();
+
   constructor(private readonly deps: BridgeServiceDeps) {}
+
+  private bridgeConversationCacheKey(
+    agentId: string,
+    orgId: string,
+    params: Record<string, unknown>,
+  ): string | null {
+    const roomId =
+      typeof params.roomId === "string" && params.roomId.trim() ? params.roomId.trim() : null;
+    // No stable room => no session to key on; fall back to create-per-call.
+    if (!roomId) return null;
+    return `${agentId}\u0000${orgId}\u0000${roomId}`;
+  }
+
+  /**
+   * Return a reusable conversation id for this session, creating (and caching)
+   * one only on the first turn or after a forced invalidation. `forceNew` skips
+   * and overwrites any cached entry (used for the create-once stale recovery).
+   * When there is no stable session key (no roomId) this always creates.
+   */
+  private async getOrCreateBridgeConversation(
+    agentId: string,
+    orgId: string,
+    rec: AgentSandbox,
+    params: Record<string, unknown>,
+    options?: { forceNew?: boolean },
+  ): Promise<string> {
+    const key = this.bridgeConversationCacheKey(agentId, orgId, params);
+    if (!key) {
+      return this.createBridgeConversation(rec, params);
+    }
+
+    if (!options?.forceNew) {
+      const cached = this.bridgeConversationCache.get(key);
+      if (cached && Date.now() - cached.createdAt < BRIDGE_CONVERSATION_TTL_MS) {
+        return cached.conversationId;
+      }
+      if (cached) {
+        // Expired by TTL: drop and recreate below.
+        this.bridgeConversationCache.delete(key);
+      }
+    }
+
+    const conversationId = await this.createBridgeConversation(rec, params);
+    this.bridgeConversationCache.set(key, { conversationId, createdAt: Date.now() });
+    return conversationId;
+  }
+
+  private invalidateBridgeConversation(
+    agentId: string,
+    orgId: string,
+    params: Record<string, unknown>,
+  ): void {
+    const key = this.bridgeConversationCacheKey(agentId, orgId, params);
+    if (key) this.bridgeConversationCache.delete(key);
+  }
 
   async bridge(agentId: string, orgId: string, rpc: BridgeRequest): Promise<BridgeResponse> {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
@@ -159,23 +241,49 @@ export class ElizaSandboxBridgeService {
     const fallbackText = this.buildBridgeNoReplyFallbackText(params);
 
     try {
-      const conversationId = await this.createBridgeConversation(rec, params);
-      const bridgeEndpoint = await this.deps.getAgentApiEndpoint(
-        rec,
-        `/api/conversations/${encodeURIComponent(conversationId)}/messages/stream`,
-      );
-      const res = await fetch(bridgeEndpoint, {
-        method: "POST",
-        headers: this.deps.getAgentJsonHeaders(rec),
-        body: JSON.stringify(this.buildBridgeConversationMessageBody(params)),
-        signal: AbortSignal.timeout(120_000),
-      });
-      if (res.ok) return this.normalizeBridgeSseResponse(res);
-      if (res.status !== 404) {
+      // Reuse this session's conversation across turns; create only on the first
+      // turn. A cached id that the sandbox has since dropped answers 404 on the
+      // stream POST — evict and recreate exactly once before falling through to
+      // the compatibility ladder.
+      let forcedFreshConversation = false;
+      for (;;) {
+        const conversationId = await this.getOrCreateBridgeConversation(
+          agentId,
+          orgId,
+          rec,
+          params,
+          {
+            forceNew: forcedFreshConversation,
+          },
+        );
+        const bridgeEndpoint = await this.deps.getAgentApiEndpoint(
+          rec,
+          `/api/conversations/${encodeURIComponent(conversationId)}/messages/stream`,
+        );
+        const res = await fetch(bridgeEndpoint, {
+          method: "POST",
+          headers: this.deps.getAgentJsonHeaders(rec),
+          body: JSON.stringify(this.buildBridgeConversationMessageBody(params)),
+          signal: AbortSignal.timeout(120_000),
+        });
+        if (res.ok) return this.normalizeBridgeSseResponse(res);
+        if (res.status === 404) {
+          // Stale/expired cached conversation id: evict and retry once with a
+          // freshly created conversation. If the retry (or a create-per-call
+          // session) still 404s, the route genuinely doesn't exist — stop and
+          // fall through to the compatibility ladder below.
+          if (!forcedFreshConversation) {
+            this.invalidateBridgeConversation(agentId, orgId, params);
+            forcedFreshConversation = true;
+            continue;
+          }
+          break;
+        }
         logger.warn("[agent-sandbox] Bridge stream conversation request failed", {
           agentId,
           status: res.status,
         });
+        break;
       }
     } catch (error) {
       if (!(error instanceof BridgeRouteUnavailableError)) {
@@ -185,6 +293,8 @@ export class ElizaSandboxBridgeService {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      // A create failure invalidates any cached id so the next turn retries clean.
+      this.invalidateBridgeConversation(agentId, orgId, params);
     }
 
     try {


### PR DESCRIPTION
# Relates to

Voice pillar p95 + multi-turn context-loss bug. Root-caused in `VOICE-P95-2026-07-20.md` (workspace receipt): `bridgeStream` created a brand-new conversation on every voice turn.

Definition of Done: full standard in CONTRIBUTING.md.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branched off `6087097a76`).
- [x] Targeted tests + `typecheck` + biome run green after sync (full-monorepo `bun run verify` blocked in worktree — see Known gaps).
- [x] A reviewer can confirm the change from the tests + backend log anchors below without reading the code.

# Sync with develop

- [x] Branched off latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` not run locally — see **Known gaps** (unrelated workspace-build blocker). CI runs the full suite.

# Risks

Low. Change is scoped to `bridgeStream` in `eliza-sandbox-bridge.ts`. Conversation-threading semantics are the only behavioral surface; covered by 6 tests including stale-id recovery and one-shot-caller preservation. One-shot REST callers (`bridgeConversationMessageSend`) are untouched. Worst case if the cache misbehaves, the existing 404 → compat-ladder fallback still fires.

# Background

## What does this PR do?

`bridgeStream` called `createBridgeConversation` — a serialized `POST /api/conversations` — on **every voice turn**, then streamed against that brand-new conversation. Two problems:

1. **Context-loss bug:** each turn started a *fresh* conversation, so multi-turn voice context never survived.
2. **Latency:** that create is a serialized round-trip on the first-token critical path (top *codeable* p95 tail contributor per the P95 receipt).

Fix: session-scoped conversation cache keyed by stable session identity `(agentId, orgId, roomId)`:

- **First turn** creates + caches the conversation id.
- **Subsequent turns** reuse it — no create round-trip, same conversation id carries the turn (context preserved).
- **Stale/expired id** (stream POST → `404`): evict + recreate **exactly once**, then fall through to the existing compat ladder if it still 404s (bounded loop, no infinite retry).
- **Create failure**: invalidate so the next turn retries clean.
- **30-min TTL** bounds staleness (agent restart / sandbox GC) and memory.
- **No stable `roomId`** → create-per-call, so one-shot REST callers are unchanged.

## What kind of change is this?

Bug fix (multi-turn context loss) + improvement (removes one serialized round-trip from every voice turn's first-token path).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-conversation-reuse.test.ts` — exercises the real `bridgeStream` with a mocked sandbox repo + `fetch`, counting create vs stream POSTs and asserting which conversation id each turn carried.

## Detailed testing steps

Automated tests are acceptable for this backend-only, no-UI path.

```
cd packages/cloud/shared
bun test src/lib/services/eliza-sandbox-bridge-conversation-reuse.test.ts
```

```
(pass) first turn creates a conversation, second turn reuses it (no second create)
(pass) a stale/invalid cached id (stream 404) recreates exactly once and reuses after
(pass) a persistent 404 recreates only once, then falls through (no infinite loop)
(pass) distinct sessions (different roomId) each get their own fresh conversation
(pass) a different agent with the same roomId does not share a conversation
(pass) no roomId falls back to create-per-call (one-shot callers unchanged)

 6 pass / 0 fail / 17 expect() calls
```

`typecheck` exit 0 (0 `error TS`); biome check clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend-only change (packages/cloud/shared service), no UI surface rendered or modified.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend-only change, no UI surface rendered or modified.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow changed; behavior is a server-side conversation-id reuse in the voice bridge, covered by unit tests.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the fired code path is asserted by unit tests (create-once vs reuse + stale-id recovery, see Backend logs section); a live end-to-end structured-log capture is blocked on staging welcome-credit OFF (VOICE-P95-2026-07-20.md). Production log anchor for a funded re-measure is the existing [shared-runtime REST] stream pre-header timing (timings.bridge).`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; this is transport/threading plumbing in the cloud→sandbox bridge. A live-model round-trip is additionally blocked on staging welcome-credit OFF (VOICE-P95-2026-07-20.md).`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, or generated files. The only artifact is the conversation id, whose reuse/recreation is asserted directly in the tests.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model/prompt/provider change; and a live run is blocked on staging welcome-credit OFF (fresh accounts start at $0 → LLM leg 402s, documented in VOICE-P95-2026-07-20.md).`

## Backend + frontend logs

Backend (test-proven code path — real `bridgeStream`, mocked network):

<details><summary>bun test output</summary>

```
bridgeStream conversation reuse
  ✓ first turn creates a conversation, second turn reuses it (no second create)
      → exactly 1 POST /api/conversations across 2 turns; both stream POSTs carry conv-1
  ✓ a stale/invalid cached id (stream 404) recreates exactly once and reuses after
      → stream ids: [conv-1, conv-1(404), conv-2, conv-2]; create count = 2
  ✓ a persistent 404 recreates only once, then falls through (no infinite loop)
      → create count = 2, stream attempts = 2
  ✓ distinct sessions (different roomId) each get their own fresh conversation
  ✓ a different agent with the same roomId does not share a conversation
  ✓ no roomId falls back to create-per-call (one-shot callers unchanged)

6 pass / 0 fail / 17 expect() calls
```
</details>

Frontend: `N/A - no frontend change.`

## Screenshots (before / after) + video walkthrough

### Before
`N/A - backend-only change, no UI surface.`

### After
`N/A - backend-only change, no UI surface.`

### Walkthrough video
`N/A - no user-facing flow changed.`

## Audio / voice walkthrough

`N/A - this change is in the cloud→sandbox conversation transport, not the audio/TTS/STT path; no audible behavior changes. A live voice round-trip capture is additionally blocked on staging welcome-credit OFF (VOICE-P95-2026-07-20.md).`

# Known gaps / failures

- **Full `bun run verify` not run locally:** in a fresh worktree the sibling `?actual` bridge suites (delta-sse/ssrf/failurekind) import `@elizaos/core`/plugin-sql and need a full workspace build that isn't present; they fail *identically* on the untouched `wt-integration` develop tree, so it's an environmental constraint, not a regression. My new test avoids that by importing only `ElizaSandboxBridgeService` + mocking the repo. CI runs the full built suite.
- **Live latency re-measure blocked:** staging welcome-credit is OFF (fresh accounts $0 → LLM leg 402s), per `VOICE-P95-2026-07-20.md`. So the latency win is **mechanistic** (one serialized sandbox round-trip removed from every turn's first-token path); the **context-loss fix is test-proven**. A funded-key holder can compare `timings.bridge` before/after via the existing `[shared-runtime REST] stream pre-header timing` log.

## Collision check

No open PR modifies `eliza-sandbox-bridge.ts` (checked #16669/#16671/#16672 — voice-labeled but none touch this file). No workflow edits.

Co-authored-by: wakesync <wakesync@users.noreply.github.com>

[sol-voice-convreuse]
