### PR TITLE
fix(ci): clear develop reds — type-safety ratchet + live-scenarios workflow guard

### DIFF
--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -61,6 +61,38 @@ describe("applySandboxCharacterFromEnv", () => {
     expect((out as { agents: { list: unknown[] } }).agents.list).toEqual([]);
   });
 
+  it("treats an absent config.agents as an empty list (no empty-object sludge)", () => {
+    // Regression for the typed-optional read of config.agents: when the field
+    // is entirely absent the injected character must still land at list[0]
+    // without materializing intermediate `?? {}` objects (ratchet #9940).
+    const config = {} as never;
+    const out = applySandboxCharacterFromEnv(config, {
+      ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({ name: "Nyx", system: "x" }),
+    });
+    const agents = (out as { agents: { list: Array<Record<string, unknown>> } })
+      .agents;
+    expect(Array.isArray(agents.list)).toBe(true);
+    expect(agents.list).toHaveLength(1);
+    expect(agents.list[0]?.name).toBe("Nyx");
+    expect(agents.list[0]?.default).toBe(true);
+  });
+
+  it("preserves sibling keys on config.agents while replacing the list", () => {
+    // The typed-optional path spreads the existing agents object; sibling
+    // settings (e.g. defaults) must survive the character injection.
+    const config = {
+      agents: { list: [], defaults: { temperature: 0.3 } },
+    } as never;
+    const out = applySandboxCharacterFromEnv(config, {
+      ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({ name: "Nyx", system: "x" }),
+    });
+    const agents = (out as {
+      agents: { list: unknown[]; defaults?: { temperature: number } };
+    }).agents;
+    expect(agents.defaults?.temperature).toBe(0.3);
+    expect(agents.list).toHaveLength(1);
+  });
+
   it("falls back to AGENT_NAME when the character has no name", () => {
     const config = {} as never;
     const out = applySandboxCharacterFromEnv(config, {

--- a/packages/agent/src/runtime/sandbox-character.ts
+++ b/packages/agent/src/runtime/sandbox-character.ts
@@ -153,8 +153,8 @@ export function applySandboxCharacterFromEnv(
     ...(parsed.knowledge ? { knowledge: parsed.knowledge } : {}),
   };
 
-  const agents = (config.agents ?? {}) as NonNullable<ElizaConfig["agents"]>;
-  const list = Array.isArray(agents.list) ? [...agents.list] : [];
+  const agents = config.agents as ElizaConfig["agents"] | undefined;
+  const list = Array.isArray(agents?.list) ? [...agents.list] : [];
   // Replace any existing primary entry; the injected character is authoritative.
   const existingIdx = list.findIndex((a) => a?.default) ?? -1;
   if (existingIdx >= 0) {

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -223,7 +223,11 @@ test("keeps retired no-op workflow entry points absent", () => {
   expect(auditSource).not.toContain("scenario-matrix.yml");
 
   const workflowReadme = readFileSync(workflowReadmePath, "utf8");
-  expect(workflowReadme).toContain("tracked in #16449");
+  // The GPU/scenario retirement must stay owned by #16449. #16537 reworded the
+  // guide from "tracked in #16449" to "must not close #16449" while keeping the
+  // same tracking issue; assert the issue reference survives regardless of the
+  // surrounding phrasing so a future reword can't silently drop the owner.
+  expect(workflowReadme).toContain("#16449");
   expect(workflowReadme).not.toContain("packages/inference/voice-bench");
 });
 


### PR DESCRIPTION
## Develop RED required checks triage (2026-07-20)

Two required-check reds on develop HEAD (`2b91780ed`) after today's merge wave.

### 1. Format + Type Safety Ratchet
`?? {}` (core/agent/app-core): **375 > 374 baseline**. #16700 introduced `config.agents ?? {}` in `sandbox-character.ts` — an empty-object fallback that conflates "not loaded" with "legitimately empty" (exactly the sludge the ratchet guards, #9940). Fix reads `config.agents` as a typed optional and guards `agents?.list`; behavior identical, no empty-object literal. **Ratchet back to 374/374 — no baseline bump, no weakening.**

### 2. Zero-Key scenario runner E2E
`live-scenarios-workflow.test.ts > keeps retired no-op workflow entry points absent` asserted the workflow README contains the exact phrase `tracked in #16449`. #16537 deliberately reworded that line to `must not close #16449` (same tracking issue, richer wording) without updating the test — so this guard has been red since #16537 landed. Fix asserts the **#16449 owner reference survives regardless of phrasing**, keeping the guard's intent (GPU/scenario retirement stays owned) while decoupling from exact wording.

### Validation (local)
- `audit:type-safety-ratchet` → exit 0, `?? {}` 374/374
- `@elizaos/agent` typecheck → green (64/64 tasks)
- `bun test packages/scripts/__tests__/live-scenarios-workflow.test.ts` → 14/14 pass

No check weakening. No workflow edits. Scoped to the two source files causing the reds.

[sol-develop-reds]

---

## Evidence

CI-only fix: touches `packages/agent/src/runtime/sandbox-character.ts` (type-safety ratchet cast) and `packages/scripts/__tests__/live-scenarios-workflow.test.ts` (assertion reword). No UI surface, no runtime user-facing behavior change, no backend endpoint change. Validation is the CI gates themselves (ratchet 374/374, agent typecheck green, workflow-guard test 14/14).

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - no UI surface touched (agent runtime cast + scripts test only)
<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no UI surface touched
<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing flow; change is a type-safety ratchet cast and a test-assertion reword
<!-- evidence-row:backend-logs -->
Backend logs: N/A - no server/endpoint behavior change; `audit:type-safety-ratchet` exits 0 at 374/374
<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend code touched
<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - deterministic CI-gate fix, no model/agent behavior path exercised
<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - CI/type-safety hygiene; verification is `bun test packages/scripts/__tests__/live-scenarios-workflow.test.ts` (14/14 pass)