### PR TITLE
test(scheduling): await declared plugin services in real-runtime boot barrier

### DIFF
--- a/packages/app-core/test/helpers/real-runtime.ts
+++ b/packages/app-core/test/helpers/real-runtime.ts
@@ -482,6 +482,38 @@ export async function createRealTestRuntime(
 
     await runtime.initialize();
 
+    // Boot barrier: services register asynchronously. `registerPlugin` fires a
+    // fire-and-forget `_ensureServiceStarted` for each declared service that
+    // awaits `initPromise` before running the service's `start()`, and some
+    // starts do real async work (e.g. @elizaos/plugin-scheduling's
+    // ScheduledTaskRunnerService runs the durable-scheduling table migration
+    // added in #16574). `runtime.initialize()` can resolve one or more
+    // microtasks BEFORE those starts finish registering. Production never
+    // observes this because every caller reaches a service only after boot
+    // settles; tests, however, synchronously call e.g.
+    // `getScheduledTaskRunner(...)` immediately after this helper returns and
+    // intermittently hit "<service> is not registered". Await the load promise
+    // for every service declared by the caller-provided plugins so the harness
+    // hands back a runtime whose declared services are live, exactly as
+    // production boots them. Failures are non-fatal: a service that fails to
+    // start surfaces at the call site with its real error, and services that
+    // are intentionally optional in a given test stay best-effort.
+    for (const plugin of options?.plugins ?? []) {
+      for (const service of plugin.services ?? []) {
+        const serviceType = (
+          service as unknown as { serviceType?: string }
+        ).serviceType;
+        if (!serviceType) continue;
+        try {
+          await runtime.getServiceLoadPromise(serviceType);
+        } catch (err) {
+          logger.debug(
+            `[real-runtime] declared service '${serviceType}' from ${plugin.name} did not start during boot barrier: ${err}`,
+          );
+        }
+      }
+    }
+
     // Eagerly start the OptimizedPromptService so the planner-loop's
     // synchronous `runtime.getService('optimized_prompt')` call hits an
     // already-instantiated service. Without this the service is registered

--- a/plugins/plugin-personal-assistant/test/helpers/runtime.ts
+++ b/plugins/plugin-personal-assistant/test/helpers/runtime.ts
@@ -120,6 +120,9 @@ export async function createLifeOpsTestRuntime(
     // The ScheduledTaskRunnerService + the generic scheduled-task route now
     // live in the always-loaded @elizaos/plugin-scheduling. Load it alongside
     // PA (as the real runtime does) so PA's injected deps have a runner host.
+    // createRealTestRuntime awaits each declared plugin service's load promise
+    // after init (its boot barrier), so the runner host is live before this
+    // helper returns, so callers can synchronously reach getScheduledTaskRunner.
     const { schedulingPlugin } = await import("@elizaos/plugin-scheduling");
     const result = await createRealTestRuntime({
       ...options,


### PR DESCRIPTION
## Root cause

`createRealTestRuntime` returned as soon as `runtime.initialize()` resolved, but plugin services register **asynchronously**: `registerPlugin` fires a fire-and-forget `_ensureServiceStarted` that awaits `initPromise` and then runs the service `start()`.

Commit **2101e58deee — fix(scheduling): persist scheduled tasks across restarts (#16574)** (07-17) added a `migrateSchedulingTables` call into `ScheduledTaskRunnerService.start()`, which does real async DB work and widens that async gap. Tests that synchronously call `getScheduledTaskRunner(...)` immediately after building the runtime intermittently resolve **before** the service finishes registering and throw `ScheduledTaskRunnerService is not registered` (Integration Lane + Plugin Tests red since 07-19; 113x in one job).

## Prod-affected verdict: harness-only

Production is **not** affected. The scheduling boot-seed (`plugin.ts`) and every action/route reach the runner only **after** `waitForScheduledTaskRunnerService` resolves, so the synchronous accessor is never invoked before the service is live. The failure only manifests in test harnesses that grab the runner synchronously right after `createRealTestRuntime` returns. (Consistent with S1/S3 real-runtime proofs passing.)

## Fix

After `runtime.initialize()`, await `getServiceLoadPromise` for every service **declared by the caller-provided plugins**, so the harness hands back a runtime whose declared services are live — exactly as production boots them. Generic (no scheduling-specific import), non-fatal on start failure (real errors still surface at the call site; optional services stay best-effort). No test weakening, no skips.

## Verification (all previously-red slices green)

- `plugin-scheduling` full suite: **286/286** (23 files)
- PA src-integration lane: **72/72** (13 files) — includes approval-queue x2 + meeting-ghost that were failing
- `scheduled-task-end-to-end.e2e`: **8/8** (global-pause subtest was the failing one)
- repo integration lane (integration-lane.smoke / life-smoke / owner-agent-permission-matrix): **17 pass / 1 pre-existing skip**
- `getScheduledTaskRunnerService is not registered` occurrences after fix: **0** (was 113x)

Breaking commit identified: `2101e58deee` (#16574).

[sol-scheduling-fix]

Co-authored-by: wakesync <shadow@shad0w.xyz>

---

## Evidence

Test-harness-only change (two `test/helpers/*.ts` files). No product runtime, UI, backend, or LLM path is modified. Verification is the test suites listed above; there is no user-facing surface to capture.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-harness-only change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-harness-only change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - test-harness-only change, no interactive surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no product code path changed; the real code path is exercised by the test slices above (plugin-scheduling 286/286, PA src-integration 72/72, scheduled-task e2e 8/8, repo integration lane 17 pass/1 skip)`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic test-harness boot-ordering fix; no model calls involved`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain/product artifact produced; change is limited to the real-runtime test harness boot barrier`.
