### PR TITLE
test(portability): make platform boundaries explicit

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
@@ -3,7 +3,9 @@
  *
  * `getMobileDeviceBridgeServingStatus` reports the host as serving only after
  * handler registration and a live abstract-UDS probe, which is the readiness
- * signal consumed by smoke tests and local-inference provider status.
+ * signal consumed by smoke tests and local-inference provider status. Abstract
+ * AF_UNIX sockets are a Linux kernel feature, so live-socket cases run there;
+ * every host still proves registration and unavailable-host decisions.
  */
 
 import net from "node:net";
@@ -19,6 +21,7 @@ const ENV_KEYS = [
 	"ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD",
 ];
 const saved: Record<string, string | undefined> = {};
+const linuxAbstractSocketIt = process.platform === "linux" ? it : it.skip;
 
 function fakeRuntime() {
 	return {
@@ -72,39 +75,45 @@ describe("getMobileDeviceBridgeServingStatus — true bionic serving signal (#11
 		});
 	});
 
-	it("bionic env set + live socket but handlers NOT registered is NOT serving", async () => {
-		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
-		process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-unreg";
-		const server = await listenOnAbstractSocket("eliza-test-serving-unreg");
-		try {
-			const mod = await freshBootstrap();
-			const status = await mod.getMobileDeviceBridgeServingStatus();
-			expect(status.registeredTrigger).toBeNull();
-			expect(status.bionicHostServing).toBe(false);
-		} finally {
-			await closeServer(server);
-		}
-	});
+	linuxAbstractSocketIt(
+		"bionic env set + live socket but handlers NOT registered is NOT serving",
+		async () => {
+			process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
+			process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-unreg";
+			const server = await listenOnAbstractSocket("eliza-test-serving-unreg");
+			try {
+				const mod = await freshBootstrap();
+				const status = await mod.getMobileDeviceBridgeServingStatus();
+				expect(status.registeredTrigger).toBeNull();
+				expect(status.bionicHostServing).toBe(false);
+			} finally {
+				await closeServer(server);
+			}
+		},
+	);
 
-	it("handlers bound via bionic-host AND a live host socket IS serving", async () => {
-		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
-		process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-live";
-		const server = await listenOnAbstractSocket("eliza-test-serving-live");
-		try {
-			const mod = await freshBootstrap();
-			const runtime = fakeRuntime();
-			await expect(
-				mod.ensureMobileDeviceBridgeInferenceHandlers(runtime as never),
-			).resolves.toBe(true);
-			const status = await mod.getMobileDeviceBridgeServingStatus();
-			expect(status).toEqual({
-				registeredTrigger: "bionic-host",
-				bionicHostServing: true,
-			});
-		} finally {
-			await closeServer(server);
-		}
-	});
+	linuxAbstractSocketIt(
+		"handlers bound via bionic-host AND a live host socket IS serving",
+		async () => {
+			process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
+			process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-live";
+			const server = await listenOnAbstractSocket("eliza-test-serving-live");
+			try {
+				const mod = await freshBootstrap();
+				const runtime = fakeRuntime();
+				await expect(
+					mod.ensureMobileDeviceBridgeInferenceHandlers(runtime as never),
+				).resolves.toBe(true);
+				const status = await mod.getMobileDeviceBridgeServingStatus();
+				expect(status).toEqual({
+					registeredTrigger: "bionic-host",
+					bionicHostServing: true,
+				});
+			} finally {
+				await closeServer(server);
+			}
+		},
+	);
 
 	it("handlers bound via bionic-host but the host socket is DOWN is NOT serving", async () => {
 		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";

--- a/plugins/plugin-personal-assistant/test/run-cerebras-journey-eval.test.ts
+++ b/plugins/plugin-personal-assistant/test/run-cerebras-journey-eval.test.ts
@@ -8,6 +8,7 @@ import {
   chmodSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -117,7 +118,9 @@ describe("Cerebras journey eval runner", () => {
       "eliza/packages/test/vitest/live-e2e.config.ts",
       "eliza/plugins/plugin-personal-assistant/test/journey-cerebras-eval.live.e2e.test.ts",
     ]);
-    expect(readFileSync(cwdFile, "utf8").trim()).toBe(directory);
+    expect(realpathSync(readFileSync(cwdFile, "utf8").trim())).toBe(
+      realpathSync(directory),
+    );
   });
 
   it("propagates a real child process failure", async () => {


### PR DESCRIPTION
Closes #16718.

## Summary

- run Linux abstract-namespace AF_UNIX socket assertions only where that kernel feature exists
- keep the cross-platform registration and unavailable-host assertions active on every OS
- compare the Cerebras subprocess working directory through filesystem canonicalization so macOS `/var` and `/private/var` aliases describe the same real directory
- preserve the real socket and child-process boundaries; no product code or mocks changed

## Exact-head validation

After the rebase onto current `develop`, both focused suites, both package typechecks, focused Biome, the error-policy ratchet, and the diff check pass at the exact head below.

Base: `8ecd9615dd2923bfe0ab839115162816ff2c8347`  
Head: `aa6b8be7a1af17a79cb89e62cab876f727b89868`

- Capacitor bridge Vitest: 2 passed, 2 explicitly Linux-only skips on macOS
- personal-assistant Cerebras runner Vitest: 6 passed, including the real child-process case
- both package typechecks passed
- focused Biome, error-policy ratchet, and `git diff --check` passed
- dependency/workspace build passed before the final one-file base rebase; the rebased exact head was rerun through both package typecheckers

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - test-only portability change; no rendered interface changes.

<!-- evidence-row:after-screenshots -->
N/A - test-only portability change; no rendered interface changes.

<!-- evidence-row:walkthrough-video -->
N/A - no interactive user flow changed.

<!-- evidence-row:backend-logs -->
N/A - no backend runtime behavior changed; the real subprocess is asserted by the focused Vitest run.

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime or network behavior changed.

<!-- evidence-row:llm-trajectory -->
N/A - no action, prompt, provider, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
N/A - the deliverable is deterministic cross-platform test behavior; CI and focused test receipts are the verification surface.

<!-- evidence-row:ocr-review -->
N/A - no pixels or visual text changed.