### PR TITLE
fix(sql): preserve structured websearch semantics

### DIFF
--- a/plugins/plugin-sql/__tests__/base-adapter.harness.test.ts
+++ b/plugins/plugin-sql/__tests__/base-adapter.harness.test.ts
@@ -2,10 +2,12 @@
  * Composed real-PGlite lane for `src/base.ts` — imports every hermetic
  * integration suite so the changed-file coverage gate can execute the
  * adapter's actual behavioral matrix (real DDL, real queries, real vectors)
- * against a `BaseDrizzleAdapter` change. The `.real.test.ts` filename filter
- * keeps these suites out of the gate individually; each one is in-process
- * PGlite via `createIsolatedTestDatabase` with no network or credentials, so
- * composing them here trades no hermeticity for real coverage.
+ * against a `BaseDrizzleAdapter` change. Direct policy assertions complement
+ * the database matrix for query-shape decisions made before SQL execution.
+ * The `.real.test.ts` filename filter keeps these suites out of the gate
+ * individually; each one is in-process PGlite via
+ * `createIsolatedTestDatabase` with no network or credentials, so composing
+ * them here trades no hermeticity for real coverage.
  *
  * Runs only under `vitest.harness.config.ts` (the default package config never
  * includes plugin-root `__tests__/`), so the fast PR lane is unchanged.
@@ -13,6 +15,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { usesWebsearchSyntax } from "../src/message-search";
 import "../src/__tests__/integration/advanced-memory-storage.real.test.ts";
 import "../src/__tests__/integration/agent.real.test.ts";
 import "../src/__tests__/integration/base-adapter-methods.real.test.ts";
@@ -61,5 +64,27 @@ describe("base-adapter harness lane composition", () => {
       )
       .sort();
     expect(imported).toEqual(onDisk);
+  });
+});
+
+describe("structured websearch query classification", () => {
+  it.each([
+    '"alpha beta"',
+    "alpha -far",
+    "-excluded",
+    "alpha OR zephyr",
+    "alpha\tor\tzephyr",
+  ])("preserves structural semantics for %s", (query) => {
+    expect(usesWebsearchSyntax(query)).toBe(true);
+  });
+
+  it.each([
+    "alpha beta",
+    "quarterly-budget",
+    "word-or-word",
+    "orphan",
+    "-",
+  ])("keeps lexical fallback for %s", (query) => {
+    expect(usesWebsearchSyntax(query)).toBe(false);
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts
@@ -7,10 +7,11 @@
  * multi-word non-adjacent (`websearch_to_tsquery`), case/accent/apostrophe
  * folding, partial-word + typo (trigram), stemming, code metacharacters treated
  * literally, URL/emoji/CJK substrings, quoted phrase vs bare-term semantics,
- * near-duplicate deterministic ordering, attachment-filename indexing, deleted-
- * row exclusion, room access-scoping, and corpus-wide recall of a hit far older
- * than any recency window on a multi-thousand-row corpus. Default harness is
- * PGlite (WASM, in-process); set `POSTGRES_URL` to run against real Postgres.
+ * websearch operator isolation from fuzzy fallbacks, near-duplicate deterministic
+ * ordering, attachment-filename indexing, deleted-row exclusion, room access-
+ * scoping, and corpus-wide recall of a hit far older than any recency window on
+ * a multi-thousand-row corpus. Default harness is PGlite (WASM, in-process); set
+ * `POSTGRES_URL` to run against real Postgres.
  */
 import { ChannelType, type Entity, type Room, type UUID, type World } from "@elizaos/core";
 import { sql } from "drizzle-orm";
@@ -126,6 +127,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
     await seed(roomA, "北京 is the capital of China", "assistant");
     await seed(roomA, "the exact phrase alpha beta lives here", "user");
     await seed(roomA, "alpha appears alone and beta appears far away later", "assistant");
+    await seed(roomA, "alpah or zephry are deliberately misspelled", "user");
     await seed(roomA, "here is the file you asked for", "user", [
       {
         title: "quarterly-budget-2026.xlsx",
@@ -197,12 +199,24 @@ describe("searchMessages FTS + trigram (real DB)", () => {
     expect((await searchTexts("北京")).some((t) => t.includes("北京"))).toBe(true);
   });
 
-  it("10. quoted phrase vs OR", async () => {
+  it("10. quoted phrase stays adjacent while bare terms may be non-adjacent", async () => {
     const phrase = await searchTexts('"alpha beta"');
     expect(phrase.some((t) => t.includes("exact phrase alpha beta"))).toBe(true);
     expect(phrase.some((t) => t.includes("appears alone and beta appears far away"))).toBe(false);
     const bare = await searchTexts("alpha beta");
     expect(bare.some((t) => t.includes("exact phrase alpha beta"))).toBe(true);
+    expect(bare.some((t) => t.includes("appears alone and beta appears far away"))).toBe(true);
+  });
+
+  it("10b. negation and OR are not relaxed by the fuzzy fallback", async () => {
+    const negated = await searchTexts("alpha -far");
+    expect(negated.some((t) => t.includes("exact phrase alpha beta"))).toBe(true);
+    expect(negated.some((t) => t.includes("appears alone and beta appears far away"))).toBe(false);
+
+    const union = await searchTexts("alpha OR zephyr");
+    expect(union.some((t) => t.includes("exact phrase alpha beta"))).toBe(true);
+    expect(union.some((t) => t.includes("duplicate marker zephyr"))).toBe(true);
+    expect(union.some((t) => t.includes("deliberately misspelled"))).toBe(false);
   });
 
   it("11. near-duplicates all returned, deterministically ordered by recency then id", async () => {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -172,6 +172,16 @@ function escapeIlikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
 
+/**
+ * Quotes, leading-minus terms, and standalone ORs carry structural meaning in
+ * `websearch_to_tsquery`. Literal and trigram fallbacks cannot preserve that
+ * structure, so they must not be OR-ed into those queries. Interior hyphens
+ * remain ordinary text for attachment names, ticket IDs, and similar tokens.
+ */
+function usesWebsearchSyntax(value: string): boolean {
+  return value.includes('"') || /(^|\s)-(?=\S)/.test(value) || /(^|\s)or(?=\s|$)/i.test(value);
+}
+
 function isMessageSearchObjectsMissing(error: unknown): boolean {
   const seen = new Set<unknown>();
   let current: unknown = error;
@@ -1879,13 +1889,19 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const tsvector = sql`to_tsvector('english', ${document})`;
       const tsquery = sql`websearch_to_tsquery('english', ${foldedQuery})`;
       const ftsRankExpr = sql<number>`ts_rank_cd(${tsvector}, ${tsquery})`;
+      const allowLexicalFallback = !usesWebsearchSyntax(params.query);
       // `similarity()` only exists when pg_trgm is installed; degrade to 0 so the
       // ORDER BY and DTO carry a real (extension-absent) signal, not a fake rank.
-      const trigramExpr = trigramAvailable
-        ? sql<number>`GREATEST(similarity(${document}, ${foldedQuery}), word_similarity(${foldedQuery}, ${document}))`
-        : sql<number>`0`;
-      const trigramMatch = trigramAvailable
-        ? sql`NOT EXISTS (
+      const trigramExpr =
+        trigramAvailable && allowLexicalFallback
+          ? sql<number>`GREATEST(similarity(${document}, ${foldedQuery}), word_similarity(${foldedQuery}, ${document}))`
+          : sql<number>`0`;
+      const literalMatch = allowLexicalFallback
+        ? sql`${document} LIKE eliza_search_like_pattern(${params.query})`
+        : sql`FALSE`;
+      const trigramMatch =
+        trigramAvailable && allowLexicalFallback
+          ? sql`NOT EXISTS (
             SELECT 1
             FROM unnest(regexp_split_to_array(${foldedQuery}, '[[:space:]]+')) AS query_terms(term)
             WHERE query_terms.term <> ''
@@ -1894,14 +1910,14 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
                 OR word_similarity(query_terms.term, ${document}) >= 0.45
               )
           )`
-        : sql`FALSE`;
+          : sql`FALSE`;
 
       const conditions = [
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
         ...timeConditions,
-        sql`(${tsvector} @@ ${tsquery} OR ${document} LIKE eliza_search_like_pattern(${params.query}) OR ${trigramMatch})`,
+        sql`(${tsvector} @@ ${tsquery} OR ${literalMatch} OR ${trigramMatch})`,
       ];
 
       let rows: Array<{

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -172,16 +172,6 @@ function escapeIlikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
 
-/**
- * Quotes, leading-minus terms, and standalone ORs carry structural meaning in
- * `websearch_to_tsquery`. Literal and trigram fallbacks cannot preserve that
- * structure, so they must not be OR-ed into those queries. Interior hyphens
- * remain ordinary text for attachment names, ticket IDs, and similar tokens.
- */
-function usesWebsearchSyntax(value: string): boolean {
-  return value.includes('"') || /(^|\s)-(?=\S)/.test(value) || /(^|\s)or(?=\s|$)/i.test(value);
-}
-
 function isMessageSearchObjectsMissing(error: unknown): boolean {
   const seen = new Set<unknown>();
   let current: unknown = error;
@@ -259,6 +249,7 @@ function isDuplicateKeyError(error: unknown): boolean {
   return false;
 }
 
+import { usesWebsearchSyntax } from "./message-search";
 import type { DatabaseBackend, DatabaseMigrationService } from "./migration-service";
 import { DIMENSION_MAP, type EmbeddingDimensionColumn } from "./schema/embedding";
 import {

--- a/plugins/plugin-sql/src/message-search.ts
+++ b/plugins/plugin-sql/src/message-search.ts
@@ -34,6 +34,16 @@ import type { DrizzleDatabase } from "./types";
 export const FTS_CONFIG = "english";
 export const MESSAGE_SEARCH_TABLE_TYPE = "messages";
 
+/**
+ * Quotes, leading-minus terms, and standalone ORs carry structural meaning in
+ * `websearch_to_tsquery`. Literal and trigram fallbacks cannot preserve that
+ * structure, so they must not be OR-ed into those queries. Interior hyphens
+ * remain ordinary text for attachment names, ticket IDs, and similar tokens.
+ */
+export function usesWebsearchSyntax(value: string): boolean {
+  return value.includes('"') || /(^|\s)-(?=\S)/.test(value) || /(^|\s)or(?=\s|$)/i.test(value);
+}
+
 // Accent-folding map: each accented Latin letter → its ASCII base. `from` and
 // `to` are equal length; the three trailing chars in `from` (straight/curly
 // apostrophe, backtick) have no `to` counterpart and are therefore deleted by


### PR DESCRIPTION
# Relates to

Closes #16719.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync. The unrelated repository-level audit blocker is recorded below.
- [x] A reviewer can confirm the change from the real PGlite and PostgreSQL evidence below.

# Sync with develop

Post-rebase validation at the exact head repeated the real PGlite integration (21/21), full plugin suite (102/102), package typecheck, focused Biome, error-policy ratchet, and diff check.

- [x] Final base: `598ec0c460fe3e1bbd985b4d8a4e0032dc70a033`.
- [x] Final head: `128dd277e826718e167ca2cd42f5a04771b37001`.
- [x] Zero rebase conflicts; the branch contains two focused commits and four changed files.

# Risks

Low. The behavior change is confined to SQL message search. Queries containing quoted phrases, leading-minus terms, or standalone `OR` now use only `websearch_to_tsquery`; ordinary queries retain literal and trigram fallback behavior. The risk is reduced fuzzy recall for structured queries by design, because fuzzy relaxation cannot preserve their logical operators.

# Background

## What does this PR do?

- Detects structured web-search syntax at the SQL adapter boundary.
- Prevents literal/trigram fallbacks from reintroducing rows excluded by phrase, negation, or `OR` semantics.
- Leaves interior hyphens ordinary text, preserving attachment/ticket-style searches.
- Extends the real database integration suite with positive and negative result assertions.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

N/A - runtime behavior and existing public interfaces/configuration are unchanged; the package test documents the semantic contract.

# Testing

## Where should a reviewer start?

`plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts`, especially cases 10, 10b, and 12, then the guarded fallback construction in `plugins/plugin-sql/src/base.ts`; the real-adapter coverage composition is in `plugins/plugin-sql/__tests__/base-adapter.harness.test.ts`.

## Detailed testing steps

1. `env -u POSTGRES_URL bun run --cwd plugins/plugin-sql test -- __tests__/integration/message-search-fts.test.ts`
2. Start isolated `pgvector/pgvector:pg16`, then run the same command with `POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:<ephemeral-port>/postgres`.
3. `bun run --cwd plugins/plugin-sql test`
4. `bun run --cwd plugins/plugin-sql build`
5. `bun run --cwd plugins/plugin-sql typecheck`
6. `bun run --cwd plugins/plugin-sql lint:check`
7. `bun run --cwd plugins/plugin-sql format:check`
8. `bun run audit:error-policy-ratchet`
9. `bun run verify` (repository-wide result documented under Known gaps).

Results:

- Focused PGlite: 21 passed, 0 failed; real migration applied; FTS path active.
- Focused PostgreSQL 16 + `pg_trgm`: 21 passed, 0 failed; `trigramAvailable=true`.
- Full plugin-sql suite: 16 files, 102 passed, 0 failed.
- Changed-file coverage harness: 279 passed; `base.ts` 57.08% and `message-search.ts` 90.00% line coverage.
- Coverage policy classifier selected only the two changed production files and the real adapter/message-search suites.
- Package build, typecheck, lint check, format check: passed.
- Error-policy ratchet, test-integrity (6,384 tests), and diff check: passed.
- Repository verify: 573/573 Turbo tasks passed before an unrelated `audit:scripts` baseline blocker.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI, frontend, native, or rendered-view source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI, frontend, native, or rendered-view source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a database query-semantics fix with no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] [16728-sql-message-search-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16728-sql-message-search-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or agent-loop behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [16728-sql-message-search-results.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16728-sql-message-search-results.json)

# Evidence Details

## Real database logs

<details>
<summary>PGlite — actual migration + adapter query path</summary>

```text
[TEST] Creating isolated PGLite database: .../eliza-test-message_search_fts-...
[PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=167)
[PLUGIN:SQL] Migration completed successfully (pluginName=@elizaos/plugin-sql)
[PLUGIN:SQL] All migrations completed successfully (successCount=1)
[PLUGIN:SQL] [MessageSearch] full-text search objects applied (trigramAvailable=false)
Test Files  1 passed (1)
Tests       21 passed (21)
```

</details>

<details>
<summary>PostgreSQL 16 + pgvector + pg_trgm — actual migration + adapter query path</summary>

```text
[TEST] Using PostgreSQL with superuser for: message_search_fts
[PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=167)
[PLUGIN:SQL] Migration completed successfully (pluginName=@elizaos/plugin-sql)
[PLUGIN:SQL] All migrations completed successfully (successCount=1)
[PLUGIN:SQL] [MessageSearch] full-text search objects applied (trigramAvailable=true)
Test Files  1 passed (1)
Tests       21 passed (21)
```

</details>

## Query/result artifacts manually reviewed

| Query | Required result | Observed assertion |
| --- | --- | --- |
| `"alpha beta"` | adjacent phrase included; separated tokens excluded | pass / pass |
| `alpha beta` | both adjacent and separated-token rows included | pass / pass |
| `alpha -far` | alpha row included; row containing `far` excluded | pass / pass |
| `alpha OR zephyr` | alpha and zephyr rows included; misspelled fuzzy row excluded | pass / pass / pass |
| `quarterly-budget` | attachment filename `quarterly-budget-2026.xlsx` remains searchable | pass |
| `configuraton` on PostgreSQL | typo still resolves through `pg_trgm` for an unstructured query | pass |
| `configuraton deployment` | all fuzzy query terms remain required | empty result, pass |

## Real LLM-call trajectory

N/A - no model, prompt, provider, action, or agent-loop behavior changed.

## Backend + frontend logs

Backend logs are attached inline above. Frontend logs: N/A - no frontend path changed.

## Screenshots / walkthrough / audio

N/A - no UI, native, audio, voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

- `bun run verify`: all 573 Turbo typecheck/lint tasks passed, then `audit:scripts` failed on two unrelated files not touched by this PR: orphan `packages/scripts/quality-fork-browser-contract.mjs` and existing coupling in `scripts/cuda-continuity.mjs`. Package-local and diff-scoped gates are green.
- A first disposable plain `postgres:16-alpine` harness attempt lacked the repository-required `vector` extension and failed before this suite ran. It was replaced by isolated `pgvector/pgvector:pg16`; the complete real-Postgres run then passed with `pg_trgm` active. The container was removed after capture.
- UI/LLM/media evidence is N/A for the concrete reasons above.