### PR TITLE
feat(agent): bounded retention for the append-only logs table

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -250,6 +250,14 @@ export {
   shouldUseSandboxExecution,
 } from "./runtime/local-execution-mode.ts";
 export {
+  LOGS_RETENTION_PREFIX,
+  LOGS_RETENTION_SERVICE,
+  type LogsRetentionAdapter,
+  LogsRetentionService,
+  type LogsSweepResult,
+  resolveLogsRetentionService,
+} from "./runtime/logs-retention-service.ts";
+export {
   planRetention,
   policyIsActive,
   type ResolvedRetentionConfig,
@@ -257,6 +265,7 @@ export {
   type RetentionPlan,
   type RetentionPolicy,
   resolveRetentionConfig,
+  resolveRetentionConfigWithPrefix,
 } from "./runtime/memory-retention.ts";
 export {
   MEMORY_RETENTION_SERVICE,

--- a/packages/agent/src/runtime/eliza-plugin.test.ts
+++ b/packages/agent/src/runtime/eliza-plugin.test.ts
@@ -19,6 +19,7 @@
 import { AgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createElizaPlugin } from "./eliza-plugin.ts";
+import { LogsRetentionService } from "./logs-retention-service.ts";
 import { MemoryRetentionService } from "./memory-retention-service.ts";
 
 /** Assert the plugin declares an `init` hook and return it (no non-null `!`). */
@@ -74,6 +75,19 @@ describe("createElizaPlugin — structure & service wiring", () => {
     expect(plugin.services).toContain(MemoryRetentionService);
     expect((plugin.services ?? []).map((s) => s.serviceType)).toContain(
       MemoryRetentionService.serviceType,
+    );
+  });
+
+  it("registers LogsRetentionService (the append-only logs-table bound)", () => {
+    const plugin = createElizaPlugin({ workspaceDir: "/tmp/ws", agentId: "u" });
+    expect(plugin.services).toContain(LogsRetentionService);
+    expect((plugin.services ?? []).map((s) => s.serviceType)).toContain(
+      LogsRetentionService.serviceType,
+    );
+    // Two distinct, independently-configured subsystems (memories vs logs),
+    // not the same service double-counted.
+    expect(MemoryRetentionService.serviceType).not.toBe(
+      LogsRetentionService.serviceType,
     );
   });
 

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -91,6 +91,7 @@ import { registerTriggerTaskWorker } from "../triggers/runtime.ts";
 import { migrateWorkbenchScheduleTags } from "../triggers/workbench-migration.ts";
 import { setCustomActionsRuntime } from "./custom-actions.ts";
 import { registerErrorEscalation } from "./error-escalation.ts";
+import { LogsRetentionService } from "./logs-retention-service.ts";
 import { MemoryRetentionService } from "./memory-retention-service.ts";
 
 export type ElizaPluginConfig = {
@@ -168,6 +169,11 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       // ELIZA_MEMORY_RETENTION_MAX_ROWS_PER_ROOM is set — the mechanism that
       // keeps the append-only memory store from filling the disk.
       MemoryRetentionService as ServiceClass,
+      // Bounded retention for the append-only logs table (empirically the
+      // biggest growth surface). Registers always but stays a no-op unless
+      // ELIZA_LOGS_RETENTION_DAYS or ELIZA_LOGS_RETENTION_MAX_ROWS_PER_ROOM is
+      // set. Independent config + adapter from the memory sweep above.
+      LogsRetentionService as ServiceClass,
       ApprovalService as ServiceClass,
       // OWNER_BIND_VERIFY: backend authority for the connector /eliza-pair
       // commands. Registered here (before connector plugins start) so the

--- a/packages/agent/src/runtime/logs-retention-service.test.ts
+++ b/packages/agent/src/runtime/logs-retention-service.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for bounded LOGS-table retention.
+ *
+ * Mirrors the memory-retention test matrix (#16714), re-scoped to the `logs`
+ * table + its own adapter surface:
+ *   1. Config parsing under the INDEPENDENT `ELIZA_LOGS_RETENTION_*` prefix
+ *      (OFF-by-default, positive parse, blank/non-numeric/non-positive => unset).
+ *   2. The service ({@link LogsRetentionService}) against an in-memory fake
+ *      adapter: synthetic 500-row growth then prune keeps the bound with the
+ *      newest surviving; age prune; the global per-sweep delete budget clamps;
+ *      ONLY the logs table is touched (memories / central_messages / auth-audit
+ *      are never queried or deleted); restart-safe / idempotent; re-entrancy
+ *      guard; Date-valued timestamps; null-room bucketing; safe stop().
+ *
+ * The eviction MATH itself is already proven table-agnostically in
+ * memory-retention.test.ts (both share `planRetention`), so this file focuses on
+ * the logs adapter wiring + scope isolation rather than re-deriving the planner.
+ *
+ * No database, no real runtime — deterministic.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  LOGS_RETENTION_PREFIX,
+  type LogsRetentionAdapter,
+  LogsRetentionService,
+} from "./logs-retention-service.ts";
+import { resolveRetentionConfigWithPrefix } from "./memory-retention.ts";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000; // fixed epoch for determinism
+
+describe("resolveRetentionConfigWithPrefix — logs config parsing", () => {
+  const cfg = (m: Record<string, string>) =>
+    resolveRetentionConfigWithPrefix((k) => m[k], LOGS_RETENTION_PREFIX);
+
+  it("returns all-undefined (OFF) for an empty map", () => {
+    expect(cfg({})).toEqual({
+      retentionDays: undefined,
+      maxRowsPerRoom: undefined,
+      maxDeletePerSweep: undefined,
+      intervalMinutes: undefined,
+    });
+  });
+
+  it("parses positive numeric values under the ELIZA_LOGS_RETENTION_ prefix", () => {
+    const r = cfg({
+      ELIZA_LOGS_RETENTION_DAYS: "14",
+      ELIZA_LOGS_RETENTION_MAX_ROWS_PER_ROOM: "10000",
+      ELIZA_LOGS_RETENTION_MAX_DELETE_PER_SWEEP: "5000",
+      ELIZA_LOGS_RETENTION_INTERVAL_MINUTES: "120",
+    });
+    expect(r).toEqual({
+      retentionDays: 14,
+      maxRowsPerRoom: 10000,
+      maxDeletePerSweep: 5000,
+      intervalMinutes: 120,
+    });
+  });
+
+  it("treats blank / non-numeric / non-positive as unset (fail safe)", () => {
+    expect(
+      cfg({
+        ELIZA_LOGS_RETENTION_DAYS: " ",
+        ELIZA_LOGS_RETENTION_MAX_ROWS_PER_ROOM: "xyz",
+        ELIZA_LOGS_RETENTION_MAX_DELETE_PER_SWEEP: "0",
+        ELIZA_LOGS_RETENTION_INTERVAL_MINUTES: "-1",
+      }),
+    ).toEqual({
+      retentionDays: undefined,
+      maxRowsPerRoom: undefined,
+      maxDeletePerSweep: undefined,
+      intervalMinutes: undefined,
+    });
+  });
+
+  it("does NOT read the memory-retention keys (independent config)", () => {
+    // Setting the memory keys must leave the logs config OFF.
+    expect(
+      cfg({
+        ELIZA_MEMORY_RETENTION_DAYS: "30",
+        ELIZA_MEMORY_RETENTION_MAX_ROWS_PER_ROOM: "5000",
+      }),
+    ).toEqual({
+      retentionDays: undefined,
+      maxRowsPerRoom: undefined,
+      maxDeletePerSweep: undefined,
+      intervalMinutes: undefined,
+    });
+  });
+});
+
+/**
+ * In-memory adapter that records the logs it serves + deletes, PLUS decoy
+ * memory/central_messages/auth tables that must never be touched (the logs
+ * service has no method to reach them, but we assert it anyway).
+ */
+class FakeLogsAdapter implements LogsRetentionAdapter {
+  logsTable: Array<{ id: string; roomId?: string; createdAt: number | Date }> =
+    [];
+  deletedIds: string[] = [];
+  getLogsCalls = 0;
+
+  // Decoy tables to prove scope isolation — the service can't see these.
+  memories = [{ id: "mem1", roomId: "r1", createdAt: NOW - 999 * DAY }];
+  centralMessages = [{ id: "cm1", roomId: "r1", createdAt: NOW - 999 * DAY }];
+  authAudit = [{ id: "aae1", roomId: "r1", createdAt: NOW - 999 * DAY }];
+
+  seed(rows: Array<{ id: string; roomId?: string; createdAt: number | Date }>) {
+    this.logsTable = [...rows];
+  }
+
+  async getLogs(params: {
+    limit?: number;
+  }): Promise<
+    Array<{ id?: string; roomId?: string; createdAt?: number | Date }>
+  > {
+    this.getLogsCalls++;
+    return this.logsTable.slice(0, params.limit ?? this.logsTable.length);
+  }
+
+  async deleteLogs(ids: string[]): Promise<void> {
+    this.deletedIds.push(...ids);
+    for (let i = this.logsTable.length - 1; i >= 0; i--) {
+      if (ids.includes(this.logsTable[i].id)) this.logsTable.splice(i, 1);
+    }
+  }
+}
+
+/** Build a service with an injected fake adapter + settings map, no scheduling. */
+function makeService(
+  adapter: FakeLogsAdapter,
+  settings: Record<string, string>,
+): LogsRetentionService {
+  const runtime = {
+    agentId: "agent-1",
+    adapter,
+    getSetting: (k: string) => settings[k],
+    getService: () => null,
+  } as unknown as import("@elizaos/core").IAgentRuntime;
+  const svc = Object.create(
+    LogsRetentionService.prototype,
+  ) as LogsRetentionService;
+  // @ts-expect-error assign protected runtime for the test harness
+  svc.runtime = runtime;
+  // @ts-expect-error seed resolved config (no timers unless active + start())
+  svc.retentionConfig = resolveRetentionConfigWithPrefix(
+    (k) => settings[k] ?? process.env[k],
+    LOGS_RETENTION_PREFIX,
+  );
+  // @ts-expect-error init private guard field
+  svc.sweeping = false;
+  return svc;
+}
+
+describe("LogsRetentionService.sweep — against a fake logs adapter", () => {
+  it("off-by-default: empty settings => no getLogs, no deletes, no-op", async () => {
+    const adapter = new FakeLogsAdapter();
+    adapter.seed([{ id: "old", roomId: "r1", createdAt: NOW - 1000 * DAY }]);
+    const svc = makeService(adapter, {});
+    const result = await svc.sweep();
+    expect(result.deleted).toBe(0);
+    expect(adapter.getLogsCalls).toBe(0);
+    expect(adapter.deletedIds).toEqual([]);
+  });
+
+  it("synthetic 500-row growth then prune keeps the count bound; newest survive", async () => {
+    const adapter = new FakeLogsAdapter();
+    const rows = Array.from({ length: 500 }, (_, i) => ({
+      id: `log${String(i).padStart(3, "0")}`,
+      roomId: "r1",
+      createdAt: NOW - i * 60_000, // i minutes old; log000 newest
+    }));
+    adapter.seed(rows);
+
+    const svc = makeService(adapter, {
+      ELIZA_LOGS_RETENTION_MAX_ROWS_PER_ROOM: "100",
+    });
+    const result = await svc.sweep();
+
+    expect(adapter.logsTable).toHaveLength(100);
+    const survivors = new Set(adapter.logsTable.map((r) => r.id));
+    expect(survivors.has("log000")).toBe(true); // newest kept
+    expect(survivors.has("log099")).toBe(true);
+    expect(survivors.has("log100")).toBe(false); // pruned
+    expect(result.deleted).toBe(400);
+    expect(adapter.deletedIds).toHaveLength(400);
+  });
+
+  it("AGE bound prunes rows past retentionDays, keeps recent (Date-valued ts)", async () => {
+    const realNow = Date.now();
+    const adapter = new FakeLogsAdapter();
+    // Timestamps as Date objects (matches the real Log.createdAt shape).
+    adapter.seed([
+      { id: "recent", roomId: "r1", createdAt: new Date(realNow - 2 * DAY) },
+      { id: "stale1", roomId: "r1", createdAt: new Date(realNow - 40 * DAY) },
+      { id: "stale2", roomId: "r1", createdAt: new Date(realNow - 90 * DAY) },
+    ]);
+    const svc = makeService(adapter, { ELIZA_LOGS_RETENTION_DAYS: "30" });
+    await svc.sweep();
+    expect(adapter.logsTable.map((r) => r.id)).toEqual(["recent"]);
+    expect(new Set(adapter.deletedIds)).toEqual(new Set(["stale1", "stale2"]));
+  });
+
+  it("buckets null-room logs together so the count bound still applies", async () => {
+    const adapter = new FakeLogsAdapter();
+    // 4 logs with NO roomId; cap 2 => 2 oldest pruned from the shared bucket.
+    adapter.seed([
+      { id: "nr0", createdAt: NOW - 1 * 60_000 },
+      { id: "nr1", createdAt: NOW - 2 * 60_000 },
+      { id: "nr2", createdAt: NOW - 3 * 60_000 },
+      { id: "nr3", createdAt: NOW - 4 * 60_000 },
+    ]);
+    const svc = makeService(adapter, {
+      ELIZA_LOGS_RETENTION_MAX_ROWS_PER_ROOM: "2",
+    });
+    await svc.sweep();
+    // newest two (nr0, nr1) survive.
+    expect(new Set(adapter.logsTable.map((r) => r.id))).toEqual(
+      new Set(["nr0", "nr1"]),
+    );
+    expect(new Set(adapter.deletedIds)).toEqual(new Set(["nr2", "nr3"]));
+  });
+
+  it("clamps to the global maxDeletePerSweep; remainder pruned next sweep", async () => {
+    const adapter = new FakeLogsAdapter();
+    adapter.seed(
+      Array.from({ length: 10 }, (_, i) => ({
+        id: `l${i}`,
+        roomId: "r1",
+        createdAt: NOW - (100 + i) * DAY, // all past age; l9 oldest
+      })),
+    );
+    const svc = makeService(adapter, {
+      ELIZA_LOGS_RETENTION_DAYS: "7",
+      ELIZA_LOGS_RETENTION_MAX_DELETE_PER_SWEEP: "4",
+    });
+    const first = await svc.sweep();
+    expect(first.deleted).toBe(4);
+    expect(first.clamped).toBe(true);
+    expect(adapter.logsTable).toHaveLength(6);
+    // Idempotent progress: the rest drains on subsequent sweeps.
+    const second = await svc.sweep();
+    expect(second.deleted).toBe(4);
+    const third = await svc.sweep();
+    expect(third.deleted).toBe(2);
+    expect(adapter.logsTable).toHaveLength(0);
+  });
+
+  it("ONLY touches the logs table — memories/central_messages/auth untouched", async () => {
+    const adapter = new FakeLogsAdapter();
+    adapter.seed([{ id: "old", roomId: "r1", createdAt: NOW - 100 * DAY }]);
+    const svc = makeService(adapter, { ELIZA_LOGS_RETENTION_DAYS: "7" });
+    await svc.sweep();
+
+    // Only the logs table was pruned.
+    expect(adapter.deletedIds).toEqual(["old"]);
+    expect(adapter.logsTable).toHaveLength(0);
+    // Decoy tables are structurally unreachable AND provably unchanged.
+    expect(adapter.memories).toHaveLength(1);
+    expect(adapter.centralMessages).toHaveLength(1);
+    expect(adapter.authAudit).toHaveLength(1);
+  });
+
+  it("is restart-safe: a fresh service re-plans from current DB (idempotent)", async () => {
+    const realNow = Date.now();
+    const adapter = new FakeLogsAdapter();
+    adapter.seed([
+      { id: "old", roomId: "r1", createdAt: new Date(realNow - 100 * DAY) },
+      { id: "new", roomId: "r1", createdAt: new Date(realNow - 1 * DAY) },
+    ]);
+    const settings = { ELIZA_LOGS_RETENTION_DAYS: "7" };
+
+    const first = makeService(adapter, settings);
+    await first.sweep();
+    expect(adapter.logsTable.map((r) => r.id)).toEqual(["new"]);
+
+    // Simulate restart: brand-new instance, same DB, sweep again.
+    const second = makeService(adapter, settings);
+    const result = await second.sweep();
+    expect(result.deleted).toBe(0); // no duplicate work
+    expect(adapter.logsTable.map((r) => r.id)).toEqual(["new"]);
+  });
+
+  it("skips overlapping sweeps (re-entrancy guard)", async () => {
+    const adapter = new FakeLogsAdapter();
+    adapter.seed([{ id: "old", roomId: "r1", createdAt: NOW - 100 * DAY }]);
+    const svc = makeService(adapter, { ELIZA_LOGS_RETENTION_DAYS: "7" });
+    // @ts-expect-error toggle private guard for the test
+    svc.sweeping = true;
+    const result = await svc.sweep();
+    expect(result.deleted).toBe(0);
+    expect(adapter.getLogsCalls).toBe(0);
+    expect(adapter.deletedIds).toEqual([]);
+  });
+
+  it("stop() is safe to call with no timers running", async () => {
+    const adapter = new FakeLogsAdapter();
+    const svc = makeService(adapter, {});
+    await expect(svc.stop()).resolves.toBeUndefined();
+  });
+
+  it("tolerates a getLogs failure without throwing (sweep no-ops)", async () => {
+    const adapter = new FakeLogsAdapter();
+    adapter.getLogs = async () => {
+      throw new Error("boom");
+    };
+    const svc = makeService(adapter, { ELIZA_LOGS_RETENTION_DAYS: "7" });
+    const result = await svc.sweep();
+    expect(result.deleted).toBe(0);
+    expect(adapter.deletedIds).toEqual([]);
+  });
+});

--- a/packages/agent/src/runtime/logs-retention-service.ts
+++ b/packages/agent/src/runtime/logs-retention-service.ts
@@ -1,0 +1,265 @@
+/**
+ * LogsRetentionService — the scheduled sweep that enforces
+ * {@link planRetention} against the append-only `logs` table, keeping it
+ * bounded so it cannot fill the disk.
+ *
+ * WHY a SECOND service (not just another partition on MemoryRetentionService):
+ * the `logs` table is NOT a memory partition. It has its own adapter surface
+ * (`getLogs` / `deleteLogs`) that is entirely separate from the memory
+ * partitions' `getMemories` / `deleteManyMemories`, and deleting a log must NOT
+ * cascade to any embedding. Sharing the memory sweep would either couple two
+ * unrelated table families or smuggle `logs` into `RETENTION_PARTITIONS`
+ * (which is deliberately memory-only). So logs get their own restart-safe
+ * service that REUSES the pure planner + config primitives from
+ * `memory-retention.ts` and only swaps the table adapter.
+ *
+ * Empirically (SOLIZA-M5-RETENTION-2026-07-20) `logs` is the single biggest
+ * always-growing surface — ~3.9 log rows per memory row, ~3.4 KB/row, i.e. the
+ * dominant linear-growth term left after #16714 bounded memories+embeddings.
+ *
+ * SCOPE: `logs` ONLY. `central_messages` and `memory_access_logs` were flagged
+ * as unbounded too, but the core `IDatabaseAdapter` exposes NO clean
+ * get-by-time + delete-by-id pair for them (unlike `logs`' getLogs/deleteLogs),
+ * so bounding them cleanly would require new adapter methods / raw SQL — a
+ * separate, larger change. They are intentionally deferred here rather than
+ * bounded through a leaky back door. See the receipt for the follow-up note.
+ *
+ * Boot-time contract (identical discipline to MemoryRetentionService):
+ *   - Config from `runtime.getSetting` (host-folded) with a `process.env`
+ *     fallback, under the INDEPENDENT `ELIZA_LOGS_RETENTION_*` prefix.
+ *   - OFF by default: no active bound => never schedules a sweep, no-op.
+ *   - When active: one sweep after a short boot-settle delay, then every
+ *     `intervalMinutes` (default 360 = 6h). Timers are `unref`'d so retention
+ *     never keeps the process alive.
+ *   - `stop()` clears timers; restart-safe / idempotent (re-plans from the
+ *     live DB each boot, no persisted cursor).
+ */
+
+import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import {
+  planRetention,
+  policyIsActive,
+  type ResolvedRetentionConfig,
+  type RetainableRow,
+  resolveRetentionConfigWithPrefix,
+} from "./memory-retention.ts";
+
+export const LOGS_RETENTION_SERVICE = "eliza_logs_retention";
+
+/** Env/settings prefix — independent from the memory retention config. */
+export const LOGS_RETENTION_PREFIX = "ELIZA_LOGS_RETENTION";
+
+const DEFAULT_INTERVAL_MINUTES = 360; // 6h
+const START_DELAY_MS = 30_000; // let boot settle before first sweep
+/** Upper bound on rows scanned per sweep (memory safety on the fetch). */
+const SCAN_LIMIT = 100_000;
+/** Stable bucket key for logs that carry no roomId (count bound still applies). */
+const NULL_ROOM_KEY = "__no_room__";
+
+/**
+ * Minimal adapter surface the logs sweep needs — narrowed to exactly the two
+ * `logs`-table methods on `IDatabaseAdapter`, for testability without a DB.
+ */
+export interface LogsRetentionAdapter {
+  getLogs(params: {
+    entityId?: string;
+    roomId?: string;
+    type?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<
+    Array<{ id?: string; roomId?: string; createdAt?: number | Date }>
+  >;
+  deleteLogs(logIds: string[]): Promise<void>;
+}
+
+/**
+ * Structural guard: narrow the runtime's `adapter` (typed as the broad
+ * IDatabaseAdapter) to the {@link LogsRetentionAdapter} surface the sweep needs.
+ * Runtime-checks the two methods it calls so a non-conforming adapter is a
+ * clean skip rather than a throw, and lets us narrow without an unsafe cast.
+ */
+function asLogsRetentionAdapter(adapter: unknown): LogsRetentionAdapter | null {
+  if (!adapter || typeof adapter !== "object") return null;
+  const candidate = adapter as Partial<LogsRetentionAdapter>;
+  if (
+    typeof candidate.getLogs !== "function" ||
+    typeof candidate.deleteLogs !== "function"
+  ) {
+    return null;
+  }
+  return candidate as LogsRetentionAdapter;
+}
+
+export interface LogsSweepResult {
+  scanned: number;
+  evictable: number;
+  deleted: number;
+  clamped: boolean;
+}
+
+export class LogsRetentionService extends Service {
+  static override serviceType = LOGS_RETENTION_SERVICE;
+
+  override capabilityDescription =
+    "Scheduled bounded retention for the append-only logs table: prunes oldest rows past a day/row-count bound so the logs table (the biggest growth surface) cannot fill the disk";
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private startTimer: ReturnType<typeof setTimeout> | null = null;
+  private sweeping = false;
+  private retentionConfig: ResolvedRetentionConfig = {};
+
+  static async start(runtime: IAgentRuntime): Promise<LogsRetentionService> {
+    const svc = new LogsRetentionService(runtime);
+    svc.init();
+    return svc;
+  }
+
+  private init(): void {
+    this.retentionConfig = resolveRetentionConfigWithPrefix((key) => {
+      const fromSettings = this.runtime.getSetting(key);
+      if (fromSettings !== undefined && fromSettings !== null) {
+        return String(fromSettings);
+      }
+      return process.env[key];
+    }, LOGS_RETENTION_PREFIX);
+
+    if (!policyIsActive(this.retentionConfig)) {
+      logger.info(
+        "[logs-retention] no active bound (ELIZA_LOGS_RETENTION_DAYS/MAX_ROWS_PER_ROOM unset) — logs retention DISABLED",
+      );
+      return;
+    }
+
+    const intervalMinutes =
+      this.retentionConfig.intervalMinutes ?? DEFAULT_INTERVAL_MINUTES;
+    logger.info(
+      `[logs-retention] enabled: retentionDays=${this.retentionConfig.retentionDays ?? "off"} maxRowsPerRoom=${this.retentionConfig.maxRowsPerRoom ?? "off"} maxDeletePerSweep=${this.retentionConfig.maxDeletePerSweep ?? "none"} intervalMinutes=${intervalMinutes}`,
+    );
+
+    // First sweep after a short delay (don't block boot), then on cadence.
+    this.startTimer = setTimeout(() => {
+      void this.sweep();
+      this.timer = setInterval(
+        () => void this.sweep(),
+        intervalMinutes * 60 * 1000,
+      );
+      this.timer.unref?.();
+    }, START_DELAY_MS);
+    this.startTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (this.startTimer) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Run one sweep over the logs table. Re-entrancy-guarded so a long sweep
+   * never overlaps the next tick. Returns the sweep result (also useful in
+   * tests / ops probes).
+   */
+  async sweep(): Promise<LogsSweepResult> {
+    const empty: LogsSweepResult = {
+      scanned: 0,
+      evictable: 0,
+      deleted: 0,
+      clamped: false,
+    };
+    if (this.sweeping) {
+      logger.debug("[logs-retention] sweep already in progress, skipping tick");
+      return empty;
+    }
+    if (!policyIsActive(this.retentionConfig)) return empty;
+
+    this.sweeping = true;
+    try {
+      const adapter = asLogsRetentionAdapter(this.runtime.adapter);
+      if (!adapter) {
+        logger.warn("[logs-retention] adapter missing getLogs, skipping sweep");
+        return empty;
+      }
+
+      let rows: Array<{
+        id?: string;
+        roomId?: string;
+        createdAt?: number | Date;
+      }>;
+      try {
+        rows = await adapter.getLogs({ limit: SCAN_LIMIT });
+      } catch (err) {
+        logger.debug(
+          `[logs-retention] getLogs failed (${(err as Error)?.message}); skipping sweep`,
+        );
+        return empty;
+      }
+
+      const retainable: RetainableRow[] = [];
+      for (const r of rows) {
+        if (!r.id) continue;
+        retainable.push({
+          id: r.id,
+          // Bucket per room; null-room logs share one stable bucket so the
+          // count bound still applies to them as a group.
+          roomId: r.roomId ?? NULL_ROOM_KEY,
+          createdAt: toMs(r.createdAt),
+        });
+      }
+
+      const plan = planRetention(
+        retainable,
+        {
+          retentionDays: this.retentionConfig.retentionDays,
+          maxRowsPerRoom: this.retentionConfig.maxRowsPerRoom,
+          maxDeletePerSweep: this.retentionConfig.maxDeletePerSweep,
+        },
+        Date.now(),
+      );
+
+      let deleted = 0;
+      if (plan.deleteIds.length > 0) {
+        await adapter.deleteLogs(plan.deleteIds);
+        deleted = plan.deleteIds.length;
+      }
+
+      const result: LogsSweepResult = {
+        scanned: retainable.length,
+        evictable: plan.evictable,
+        deleted,
+        clamped: plan.clamped,
+      };
+
+      if (deleted > 0) {
+        logger.info(
+          `[logs-retention] scanned=${result.scanned} evictable=${result.evictable} deleted=${deleted}${plan.clamped ? " (clamped, more next sweep)" : ""}`,
+        );
+      }
+      return result;
+    } catch (err) {
+      logger.error(`[logs-retention] sweep failed: ${(err as Error)?.message}`);
+      return empty;
+    } finally {
+      this.sweeping = false;
+    }
+  }
+}
+
+/** Coerce a Date | epoch-ms | undefined into epoch ms (undefined => NaN). */
+function toMs(v: number | Date | undefined): number {
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === "number") return v;
+  return Number.NaN; // planner's tsOf treats NaN as "now" (keep-safe)
+}
+
+/** Resolve the registered service, or null when logs retention isn't installed. */
+export function resolveLogsRetentionService(
+  runtime: IAgentRuntime,
+): LogsRetentionService | null {
+  return runtime.getService<LogsRetentionService>(LOGS_RETENTION_SERVICE);
+}

--- a/packages/agent/src/runtime/memory-retention.ts
+++ b/packages/agent/src/runtime/memory-retention.ts
@@ -177,18 +177,35 @@ export interface ResolvedRetentionConfig extends RetentionPolicy {
 export function resolveRetentionConfig(
   get: (key: string) => string | undefined,
 ): ResolvedRetentionConfig {
+  return resolveRetentionConfigWithPrefix(get, "ELIZA_MEMORY_RETENTION");
+}
+
+/**
+ * Generic resolver shared by every table-scoped retention subsystem. Reads the
+ * same four bound keys under a caller-chosen prefix so a second surface (logs,
+ * central_messages, ...) gets an INDEPENDENT, separately-defaulted-OFF config
+ * without duplicating the parse/fail-safe logic.
+ *
+ * Keys read (all optional; absent/blank/non-positive => bound disabled):
+ *   - `${prefix}_DAYS`
+ *   - `${prefix}_MAX_ROWS_PER_ROOM`
+ *   - `${prefix}_MAX_DELETE_PER_SWEEP`
+ *   - `${prefix}_INTERVAL_MINUTES`
+ */
+export function resolveRetentionConfigWithPrefix(
+  get: (key: string) => string | undefined,
+  prefix: string,
+): ResolvedRetentionConfig {
   return {
-    retentionDays: positiveNumberOrUndefined(
-      get("ELIZA_MEMORY_RETENTION_DAYS"),
-    ),
+    retentionDays: positiveNumberOrUndefined(get(`${prefix}_DAYS`)),
     maxRowsPerRoom: positiveNumberOrUndefined(
-      get("ELIZA_MEMORY_RETENTION_MAX_ROWS_PER_ROOM"),
+      get(`${prefix}_MAX_ROWS_PER_ROOM`),
     ),
     maxDeletePerSweep: positiveNumberOrUndefined(
-      get("ELIZA_MEMORY_RETENTION_MAX_DELETE_PER_SWEEP"),
+      get(`${prefix}_MAX_DELETE_PER_SWEEP`),
     ),
     intervalMinutes: positiveNumberOrUndefined(
-      get("ELIZA_MEMORY_RETENTION_INTERVAL_MINUTES"),
+      get(`${prefix}_INTERVAL_MINUTES`),
     ),
   };
 }


### PR DESCRIPTION
## What

Extends #16714's bounded-retention mechanism from the memories/embeddings partitions to the `logs` table, empirically the single biggest always-growing surface (~3.9 log rows per memory row, ~3.4KB/row).

- Reuse the pure planner (`planRetention`/`policyIsActive`) unchanged.
- Generalize the config resolver: `resolveRetentionConfigWithPrefix` reads the same four bound keys under a caller-chosen prefix; `resolveRetentionConfig` delegates to it (no behavior change to memory retention).
- New `LogsRetentionService` (`eliza_logs_retention`): scans via `getLogs`, plans with the shared planner, deletes via `deleteLogs`. Independent `ELIZA_LOGS_RETENTION_*` config, **OFF by default**, unref'd timers, re-entrancy guard, restart-safe (no persisted cursor), shared per-sweep delete budget. Null-room logs bucket together so the count bound still applies. Registered in `eliza-plugin.ts` + exported from `index.ts`. Adapter narrowed via a structural type-guard rather than an unsafe cast.

## Scope

Logs ONLY. `central_messages` + `memory_access_logs` were also flagged unbounded, but the core IDatabaseAdapter exposes no clean get-by-time + delete-by-id pair for them, so bounding them cleanly needs new adapter methods; intentionally deferred.

## Config (all optional; absent => bound disabled)

```
ELIZA_LOGS_RETENTION_DAYS
ELIZA_LOGS_RETENTION_MAX_ROWS_PER_ROOM
ELIZA_LOGS_RETENTION_MAX_DELETE_PER_SWEEP
ELIZA_LOGS_RETENTION_INTERVAL_MINUTES   # default 360 (6h)
```

## Tests / gates (all green locally)

- 14 new logs-suite tests + `eliza-plugin.test.ts` extended to assert the new service registration (also gives the modified `eliza-plugin.ts` real coverage in this PR's changed-files lane).
- Coverage gate (threshold 50, enforced): logs-service 54.6%, eliza-plugin 100%, memory-retention 94.1%, `index.ts` EXCLUDED (re-export barrel), mean **82.9%**, OK.
- Ratchets: type-safety 79/79, test-realness regressions=0. Biome clean.

Retarget of the stacked 0xSolace/eliza#2 onto mainline develop, now that #16714 has landed.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only change (agent runtime service + pure module), no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - backend-only deterministic module, covered by unit tests`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server run in this PR; the code path is proven by 14 deterministic unit tests (service against a fake logs adapter) plus the changed-files coverage gate`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model calls; log eviction is timestamp/count deterministic`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: logs-retention service unit tests (14/14 green) + eliza-plugin registration test: https://github.com/0xSolace/eliza/blob/sol/m6-logs-retention-mainline/packages/agent/src/runtime/logs-retention-service.test.ts . Extends the #16714 retention mechanism; growth-surface rationale in the fleet receipt (16714-COVERAGE-2026-07-20).
