### PR TITLE
style(agent): biome format 15 unformatted files (unblock lint-and-format + coverage gates)

### DIFF
--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -86,9 +86,11 @@ describe("applySandboxCharacterFromEnv", () => {
     const out = applySandboxCharacterFromEnv(config, {
       ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({ name: "Nyx", system: "x" }),
     });
-    const agents = (out as {
-      agents: { list: unknown[]; defaults?: { temperature: number } };
-    }).agents;
+    const agents = (
+      out as {
+        agents: { list: unknown[]; defaults?: { temperature: number } };
+      }
+    ).agents;
     expect(agents.defaults?.temperature).toBe(0.3);
     expect(agents.list).toHaveLength(1);
   });

--- a/packages/agent/src/runtime/canonical-memory-writeback.test.ts
+++ b/packages/agent/src/runtime/canonical-memory-writeback.test.ts
@@ -27,14 +27,19 @@ describe("canonical-memory-writeback", () => {
 
   const cfg = () => ({ writeRoot: root, now: () => FIXED_NOW });
 
-  const fact = (text: string, extra: Partial<Parameters<typeof recordCanonicalFact>[0]> = {}) => ({
+  const fact = (
+    text: string,
+    extra: Partial<Parameters<typeof recordCanonicalFact>[0]> = {},
+  ) => ({
     text,
     provenance: { source: "test", userId: "user-1", conversationRef: "room-9" },
     ...extra,
   });
 
   it("denies every write when no root is configured (deny-by-default)", async () => {
-    const res = await recordCanonicalFact(fact("hello"), { now: () => FIXED_NOW });
+    const res = await recordCanonicalFact(fact("hello"), {
+      now: () => FIXED_NOW,
+    });
     expect(res.ok).toBe(false);
     expect(res.denialReason).toBe("write-root-unset");
     expect(res.auditReason).toMatch(/no approved write root/);
@@ -52,11 +57,15 @@ describe("canonical-memory-writeback", () => {
   it("denies files not matching the allowed patterns", () => {
     const authz = authorizeWrite("memory/secrets.txt", cfg());
     expect(authz.ok).toBe(false);
-    if (!authz.ok) expect(authz.result.denialReason).toBe("pattern-not-allowed");
+    if (!authz.ok)
+      expect(authz.result.denialReason).toBe("pattern-not-allowed");
   });
 
   it("appends a fact with full provenance to today's daily file", async () => {
-    const res = await recordCanonicalFact(fact("Shadow started a new habit"), cfg());
+    const res = await recordCanonicalFact(
+      fact("Shadow started a new habit"),
+      cfg(),
+    );
     expect(res.ok).toBe(true);
     expect(res.outcome).toBe("appended");
     const content = await readFile(path.join(root, DAILY_REL), "utf8");
@@ -67,8 +76,14 @@ describe("canonical-memory-writeback", () => {
   });
 
   it("is exactly-once per fact id: duplicate submission does not duplicate", async () => {
-    const first = await recordCanonicalFact(fact("only once", { factId: "abc123" }), cfg());
-    const second = await recordCanonicalFact(fact("only once", { factId: "abc123" }), cfg());
+    const first = await recordCanonicalFact(
+      fact("only once", { factId: "abc123" }),
+      cfg(),
+    );
+    const second = await recordCanonicalFact(
+      fact("only once", { factId: "abc123" }),
+      cfg(),
+    );
     expect(first.outcome).toBe("appended");
     expect(second.outcome).toBe("duplicate");
     const content = await readFile(path.join(root, DAILY_REL), "utf8");
@@ -83,10 +98,16 @@ describe("canonical-memory-writeback", () => {
   });
 
   it("corrections supersede instead of duplicating, append-only", async () => {
-    const orig = await recordCanonicalFact(fact("gym at 4pm", { factId: "f-orig" }), cfg());
+    const orig = await recordCanonicalFact(
+      fact("gym at 4pm", { factId: "f-orig" }),
+      cfg(),
+    );
     expect(orig.outcome).toBe("appended");
     const corr = await recordCanonicalFact(
-      fact("gym at 5pm actually", { factId: "f-corr", supersedesFactId: "f-orig" }),
+      fact("gym at 5pm actually", {
+        factId: "f-corr",
+        supersedesFactId: "f-orig",
+      }),
       cfg(),
     );
     expect(corr.outcome).toBe("appended");
@@ -122,7 +143,9 @@ describe("canonical-memory-writeback", () => {
 
   it("honors CANONICAL_MEMORY_WRITE_ROOT env when config omits writeRoot", async () => {
     process.env.CANONICAL_MEMORY_WRITE_ROOT = root;
-    const res = await recordCanonicalFact(fact("env root works"), { now: () => FIXED_NOW });
+    const res = await recordCanonicalFact(fact("env root works"), {
+      now: () => FIXED_NOW,
+    });
     expect(res.ok).toBe(true);
     expect(res.outcome).toBe("appended");
   });

--- a/packages/agent/src/runtime/canonical-memory-writeback.ts
+++ b/packages/agent/src/runtime/canonical-memory-writeback.ts
@@ -93,7 +93,9 @@ interface JournalEntry {
   supersedesFactId?: string;
 }
 
-function resolveWriteRoot(config: CanonicalMemoryWritebackConfig): string | undefined {
+function resolveWriteRoot(
+  config: CanonicalMemoryWritebackConfig,
+): string | undefined {
   const root = config.writeRoot ?? process.env.CANONICAL_MEMORY_WRITE_ROOT;
   if (!root || root.trim() === "") return undefined;
   return path.resolve(root);
@@ -124,7 +126,9 @@ function formatEntry(entry: JournalEntry): string {
     entry.supersedesFactId ? ` supersedes:${entry.supersedesFactId}` : ""
   } -->`;
   const prov = `provenance: ${entry.provenance.source} user=${entry.provenance.userId}${
-    entry.provenance.conversationRef ? ` ref=${entry.provenance.conversationRef}` : ""
+    entry.provenance.conversationRef
+      ? ` ref=${entry.provenance.conversationRef}`
+      : ""
   } at=${entry.provenance.recordedAt}`;
   const label = entry.supersedesFactId ? "CORRECTION" : "FACT";
   return `\n${meta}\n- **${label}:** ${entry.text}\n  - ${prov}\n`;
@@ -134,7 +138,10 @@ function formatEntry(entry: JournalEntry): string {
  * Atomically write `content` to `filePath` via same-directory temp + rename.
  * A crash between write and rename leaves the previous file intact.
  */
-async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+async function writeFileAtomic(
+  filePath: string,
+  content: string,
+): Promise<void> {
   const dir = path.dirname(filePath);
   await fs.mkdir(dir, { recursive: true });
   const tmp = path.join(dir, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
@@ -147,10 +154,7 @@ async function writeFileAtomic(filePath: string, content: string): Promise<void>
   }
 }
 
-function deny(
-  reason: WritebackDenialReason,
-  audit: string,
-): WritebackResult {
+function deny(reason: WritebackDenialReason, audit: string): WritebackResult {
   logger.warn(`[canonical-memory-writeback] denied (${reason}): ${audit}`);
   return { ok: false, denialReason: reason, auditReason: audit };
 }
@@ -226,7 +230,10 @@ export async function recordCanonicalFact(
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
 
-  if (existing.includes(`${FACT_MARKER}${factId} `) || existing.includes(`${FACT_MARKER}${factId} -->`)) {
+  if (
+    existing.includes(`${FACT_MARKER}${factId} `) ||
+    existing.includes(`${FACT_MARKER}${factId} -->`)
+  ) {
     return { ok: true, outcome: "duplicate", factId, file: authz.absPath };
   }
 
@@ -234,10 +241,15 @@ export async function recordCanonicalFact(
     factId,
     text: fact.text.trim(),
     provenance: { ...fact.provenance, recordedAt: now.toISOString() },
-    ...(fact.supersedesFactId ? { supersedesFactId: fact.supersedesFactId } : {}),
+    ...(fact.supersedesFactId
+      ? { supersedesFactId: fact.supersedesFactId }
+      : {}),
   };
 
-  const header = existing === "" ? `# ${relPath.replace(/^memory\//, "").replace(/\.md$/, "")}\n` : "";
+  const header =
+    existing === ""
+      ? `# ${relPath.replace(/^memory\//, "").replace(/\.md$/, "")}\n`
+      : "";
   await writeFileAtomic(authz.absPath, existing + header + formatEntry(entry));
   return { ok: true, outcome: "appended", factId, file: authz.absPath };
 }
@@ -250,7 +262,9 @@ export async function recordCanonicalFact(
 export async function readCanonicalFacts(
   day: Date,
   config: CanonicalMemoryWritebackConfig = {},
-): Promise<Array<{ factId: string; supersedesFactId?: string; supersededBy?: string }>> {
+): Promise<
+  Array<{ factId: string; supersedesFactId?: string; supersededBy?: string }>
+> {
   const relPath = dailyFileRelPath(day);
   const authz = authorizeWrite(relPath, config);
   if (!authz.ok) return [];
@@ -260,7 +274,11 @@ export async function readCanonicalFacts(
   } catch {
     return [];
   }
-  const out: Array<{ factId: string; supersedesFactId?: string; supersededBy?: string }> = [];
+  const out: Array<{
+    factId: string;
+    supersedesFactId?: string;
+    supersededBy?: string;
+  }> = [];
   const re = /<!-- fact:([0-9a-zA-Z_-]+)(?: supersedes:([0-9a-zA-Z_-]+))? -->/g;
   for (const m of content.matchAll(re)) {
     out.push({ factId: m[1], ...(m[2] ? { supersedesFactId: m[2] } : {}) });


### PR DESCRIPTION
## What

Mechanical `biome format --write` pass (workspace-pinned biome, matching CI's `format:check`) over the **3 files** in `@elizaos/agent` flagged by the required **lint-and-format** check on the develop line:

- `packages/agent/src/runtime/__tests__/sandbox-character.test.ts`
- `packages/agent/src/runtime/canonical-memory-writeback.test.ts`
- `packages/agent/src/runtime/canonical-memory-writeback.ts`

## Why

The develop-line snapshot was failing two required gates due to formatting drift:
- **lint-and-format** — `@elizaos/agent:format:check` reported these 3 files unformatted.
- **coverage on changed files** — could not proceed cleanly with the format gate red.

`sandbox-character.test.ts` was force-pushed unformatted during a prior emergency deadlock-break. This is develop hygiene, blocking the standard promotion pipeline; landing it on develop (not smuggled through a promote PR) is the correct fix.

## Scope: purely mechanical

- No logic, identifier, string, or control-flow changes. Only line-wrapping and trailing-comma normalization to match the repo's own `biome.json`.
- The one **source** file (`canonical-memory-writeback.ts`) is reformat-only. No UI/tsx/css/frontend surface.

## Local verification (workspace-pinned biome + CI's exact commands)

- `bun run format:check` in `packages/agent` → **"Checked 814 files. No fixes applied."** (green)
- Coverage gate reproduced with the workflow's classifier + `run-changed-vitest-coverage.mjs` + `coverage-gate.awk`:
  - changed vitest suites pass
  - changed source `canonical-memory-writeback.ts`: **95.71%** line coverage vs **50%** floor → **coverage gate OK**

## Evidence

Non-surface, formatter-only PR: no UI changed, no runtime behavior changed, so the visual/log/trajectory artifacts are not applicable.

<!-- evidence-row:before-screenshots -->
- [x] N/A - formatter-only change, no UI surface touched (agent .ts/.test.ts only).
<!-- evidence-row:after-screenshots -->
- [x] N/A - formatter-only change, no UI surface touched (agent .ts/.test.ts only).
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed; pure `biome format` whitespace/trailing-comma normalization.
<!-- evidence-row:backend-logs -->
- [x] N/A - no code path changed; reformat only. Proof is the format:check + coverage-gate output above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or request/response behavior changed; formatter-only.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model logic changed; the one source file is reformatted only (95.71% coverage unchanged).
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, tasks, or generated artifacts produced; mechanical formatting.

Signed: [sol-promotion-go4]