### PR TITLE
fix(orchestrator): fail pi-agent readiness closed on a missing ACP command

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -190,6 +190,47 @@ describe("getTaskAgentFrameworkState", () => {
     ).toBe(true);
   });
 
+  it("fails Pi Agent readiness closed when a configured ACP command is missing", async () => {
+    writeExecutable(path.join(tempHome, "pi-agent"));
+    setEnv({
+      ELIZA_PI_AGENT_ACP_COMMAND: "missing-pi-agent-acp --stdio",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime());
+
+    expect(
+      state.frameworks.find((item) => item.id === "pi-agent")?.installed,
+    ).toBe(false);
+  });
+
+  it("rejects a configured Pi Agent ACP command when the file is not executable", async () => {
+    const commandPath = path.join(tempHome, "pi-agent-acp");
+    fs.writeFileSync(commandPath, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(commandPath, 0o644);
+    setEnv({
+      ELIZA_PI_AGENT_ACP_COMMAND: "pi-agent-acp --stdio",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime());
+
+    expect(
+      state.frameworks.find((item) => item.id === "pi-agent")?.installed,
+    ).toBe(false);
+  });
+
+  it("accepts a configured Pi Agent ACP shell command when the leading executable exists", async () => {
+    writeExecutable(path.join(tempHome, "pi-agent-acp"));
+    setEnv({
+      ELIZA_PI_AGENT_ACP_COMMAND: "pi-agent-acp --stdio --flag value",
+    });
+
+    const state = await getTaskAgentFrameworkState(runtime());
+
+    expect(
+      state.frameworks.find((item) => item.id === "pi-agent")?.installed,
+    ).toBe(true);
+  });
+
   it("does not treat a Cerebras-mirrored OpenAI key as Codex auth", async () => {
     setEnv({
       BENCHMARK_MODEL_PROVIDER: "cerebras",

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -654,11 +654,12 @@ function hasFrameworkBinary(id: SupportedTaskAgentAdapter): boolean {
         ? isCommandExecutableAvailable(configured)
         : hasBinaryOnPath("eliza-code-acp");
     }
-    case "pi-agent":
-      return (
-        Boolean(readConfigEnvKey("ELIZA_PI_AGENT_ACP_COMMAND")) ||
-        hasBinaryOnPath("pi-agent")
-      );
+    case "pi-agent": {
+      const configured = readConfigEnvKey("ELIZA_PI_AGENT_ACP_COMMAND");
+      return configured
+        ? isCommandExecutableAvailable(configured)
+        : hasBinaryOnPath("pi-agent");
+    }
     case "claude":
       return hasBinaryOnPath("claude");
     case "codex": {


### PR DESCRIPTION
## What

Fixes issue #16664, gap #1: `hasFrameworkBinary("pi-agent")` still used the pre-#16598 fail-open pattern, so a configured-but-missing `ELIZA_PI_AGENT_ACP_COMMAND` advertised pi-agent as `installed`/`authReady` while its spawn path ENOENTs.

`plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts` (before):
```ts
case "pi-agent":
  return (
    Boolean(readConfigEnvKey("ELIZA_PI_AGENT_ACP_COMMAND")) ||
    hasBinaryOnPath("pi-agent")
  );
```
This is the exact pattern the #16598 commit already replaced for the `elizaos` and `codex` sibling cases with `isCommandExecutableAvailable()`. pi-agent is a first-class `STANDARD_FRAMEWORKS` entry whose `installed` feeds `authReady` for native adapters and preferred-framework scoring, so the bug ships a "ready" framework that fails to spawn.

## Fix

Mirror the fixed sibling cases — validate the configured command's executability, fall back to the PATH probe only when unset:
```ts
case "pi-agent": {
  const configured = readConfigEnvKey("ELIZA_PI_AGENT_ACP_COMMAND");
  return configured
    ? isCommandExecutableAvailable(configured)
    : hasBinaryOnPath("pi-agent");
}
```

## Tests

Adds three fail-closed unit tests twinning the existing codex coverage in `task-agent-frameworks.test.ts` (no-probe path, real temp FS): configured command missing → `installed:false`; file present but not executable → `installed:false`; valid shell command with args, leading executable exists → `installed:true`.

## Scope note

Lands gap #1 (the direct sibling mirror, deterministic + headless-provable). Gap #2 (`AcpService.getAvailableAgents()` hardcoding `installed:true` and short-circuiting the executability gate on probe-backed discovery paths) is a broader cross-cutting change touching three production probe call sites; left for a focused follow-up rather than half-landing it here.

Closes #16664

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — N/A - backend-only change in a task-agent readiness helper (`task-agent-frameworks.ts`); no UI surface touched.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — N/A - backend-only change; no UI surface touched.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — N/A - no user-facing flow; pure readiness-predicate logic proven by deterministic unit tests below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — N/A - no live backend service in this path; it is a synchronous filesystem/PATH executability predicate (`getTaskAgentFrameworkState` → `hasFrameworkBinary("pi-agent")`). The real code path is exercised end to end by the deterministic vitest run against a real temp filesystem shown below, and re-run in CI by the `Test Integrity (lane coverage)` and `coverage on changed files` lanes.

**Before (old fail-open source, new tests exposing the bug):**
```
 ✓ honors Pi Agent as an explicit native task-agent default
 × fails Pi Agent readiness closed when a configured ACP command is missing
 × rejects a configured Pi Agent ACP command when the file is not executable
 ✓ accepts a configured Pi Agent ACP shell command when the leading executable exists

 FAIL  ... > fails Pi Agent readiness closed when a configured ACP command is missing
 AssertionError: expected true to be false // Object.is equality
 FAIL  ... > rejects a configured Pi Agent ACP command when the file is not executable
 AssertionError: expected true to be false // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed | 14 skipped (18)
```
The two failures ARE the bug: a missing/non-executable configured command reports `installed: true`.

**After (fixed source, full file):**
```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```
All pass, including the pre-existing pi-agent native-default test (no regression).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — N/A - no frontend/request path involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — N/A - no agent/action/provider/prompt/model behavior changes; this is a filesystem/PATH executability predicate.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — N/A - no DB rows, scheduled tasks, wallet output, or generated files; the only artifacts are the unit-test results above.

Co-authored-by: wakesync <shadow@shad0w.xyz>
