### PR TITLE
fix(cloud): cold-path chat latency — kill cold auth+scope stall + provider-retry backoff sleep

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -125,7 +125,7 @@ jobs:
               packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts|packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts)
                 chat_group_tests+=("$test_file")
                 ;;
-              packages/cloud/api/__tests__/agent-a2a-billing.test.ts|packages/cloud/api/__tests__/bootstrap-app-unhandled-error.test.ts|packages/cloud/api/__tests__/malformed-json-body-routes.test.ts|packages/cloud/api/__tests__/messages-billing-offpath.test.ts|packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts|packages/cloud/shared/src/lib/auth-inference-api-key.test.ts|packages/cloud/shared/src/lib/services/inference-auth-context.test.ts|packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts|packages/tools/voice-evidence-harness/src/cli-run.test.ts)
+              packages/cloud/api/__tests__/agent-a2a-billing.test.ts|packages/cloud/api/__tests__/bootstrap-app-unhandled-error.test.ts|packages/cloud/api/__tests__/malformed-json-body-routes.test.ts|packages/cloud/api/__tests__/messages-billing-offpath.test.ts|packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts|packages/cloud/shared/src/lib/auth-inference-api-key.test.ts|packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts|packages/cloud/shared/src/lib/services/inference-auth-context.test.ts|packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts|packages/tools/voice-evidence-harness/src/cli-run.test.ts)
                 process_isolated_tests+=("$test_file")
                 ;;
               *) shared_tests+=("$test_file") ;;

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
@@ -80,6 +80,7 @@ mock.module("../utils/logger", () => ({
 }));
 
 const {
+  apiKeyScopeHashPrefix,
   getCurrentUser,
   requireAdmin,
   requireCronSecret,
@@ -491,5 +492,43 @@ describe("Workers API-key auth", () => {
         contextWithHeaders({ authorization: "Bearer wrong" }, { CRON_SECRET: "cron-ok" }) as never,
       ),
     ).toThrow("Invalid cron secret");
+  });
+});
+
+describe("apiKeyScopeHashPrefix (shared-agent scope cache key — COLDPATH-FIX-2026-07-21)", () => {
+  test("derives the 16-char sha256 prefix of the X-API-Key credential", async () => {
+    // Same sha256 + 16-char-prefix derivation the api-key validation cache uses,
+    // so the scope cache is keyed by the exact same credential identity.
+    const prefix = await apiKeyScopeHashPrefix(
+      contextWithApiKey("eliza_test_key_abcdef0123456789") as never,
+    );
+    expect(prefix).toBe("9b98f179eb88406b");
+    expect(prefix).toHaveLength(16);
+  });
+
+  test("also keys off an eliza_ bearer token (same credential, same prefix)", async () => {
+    const prefix = await apiKeyScopeHashPrefix(
+      contextWithHeaders({ authorization: "Bearer eliza_test_key_abcdef0123456789" }) as never,
+    );
+    expect(prefix).toBe("9b98f179eb88406b");
+  });
+
+  test("returns null when the request is not API-key authenticated", async () => {
+    // Session/JWT/cookie requests scope on the authoritative gate, never a hash
+    // of an empty string.
+    expect(await apiKeyScopeHashPrefix(contextWithHeaders({}) as never)).toBeNull();
+    expect(
+      await apiKeyScopeHashPrefix(
+        contextWithHeaders({ authorization: "Bearer not-an-eliza-key" }) as never,
+      ),
+    ).toBeNull();
+  });
+
+  test("distinct keys yield distinct prefixes", async () => {
+    const a = await apiKeyScopeHashPrefix(contextWithApiKey("eliza_key_one") as never);
+    const b = await apiKeyScopeHashPrefix(contextWithApiKey("eliza_key_two") as never);
+    expect(a).not.toBe(b);
+    expect(a).toHaveLength(16);
+    expect(b).toHaveLength(16);
   });
 });

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -308,6 +308,24 @@ function readApiKeyCredential(c: AppContext): string | null {
   return apiKeyHeader || elizaBearer;
 }
 
+/**
+ * The 16-char key-hash prefix that identifies the CURRENT request's API-key
+ * credential for the shared-agent scope cache (COLDPATH-FIX-2026-07-21), or
+ * null when the request is not API-key authenticated (session/JWT/cookie).
+ *
+ * Same sha256 + 16-char-prefix derivation the api-key validation cache uses, so
+ * the scope cache is keyed by the exact same credential identity. Returns null
+ * (never a hash of an empty string) when there is no API key, so callers scope
+ * their cache ONLY on the API-key path and fall back to the authoritative gate
+ * everywhere else. Import kept local (crypto) so this stays a pure derivation.
+ */
+export async function apiKeyScopeHashPrefix(c: AppContext): Promise<string | null> {
+  const apiKey = readApiKeyCredential(c);
+  if (!apiKey) return null;
+  const { createHash } = await import("node:crypto");
+  return createHash("sha256").update(apiKey).digest("hex").substring(0, 16);
+}
+
 export async function requireUserOrApiKeyWithOrg(c: AppContext): Promise<AuthedUserWithOrg> {
   const apiKey = readApiKeyCredential(c);
   if (apiKey) return (await authenticateApiKeyWithOrg(c, apiKey)).user;

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -33,6 +33,25 @@ export const CacheKeys = {
     pattern: () => `apikey:*`,
   },
   /**
+   * Shared-runtime agent SCOPE resolution cache (COLDPATH-FIX-2026-07-21).
+   *
+   * Collapses the whole cold pre-inference gate for a shared-agent chat turn —
+   * API-key validation + user/org hydration + org-scoped agent lookup — into a
+   * SINGLE read, keyed by (16-char key-hash prefix, agentId). The individual
+   * entity caches (apiKey.validation, user.withOrg) are each warm-fast but on a
+   * FRESH browser session they are ALL cold, so the resolver pays 2 serial
+   * Hyperdrive waves (~1–4.4s measured). This entry lets the SECOND cold-session
+   * hit (or a composer-mount prewarm) skip both waves. Keyed on the same
+   * key-hash prefix the validation cache uses so a credential revoke that
+   * invalidates `apiKey.validation` reasons about the same identity; TTL is
+   * deliberately short (see CacheTTL.sharedAgentScope) so a stale membership
+   * self-heals fast, and the authoritative slow path still runs on a miss.
+   */
+  sharedAgentScope: {
+    resolve: (keyHashPrefix: string, agentId: string) =>
+      `shared-agent-scope:${keyHashPrefix}:${agentId}:v1`,
+  },
+  /**
    * Inference hot-path caches (#9899). The IAC entry collapses auth + org +
    * moderation into a single read for API-key dedicated-agent inference; the
    * org-balance entry is the Tier-2 optimistic-billing gate hint.
@@ -246,6 +265,18 @@ export const CacheTTL = {
   apiKey: {
     validation: 600, // 10 minutes
     appMapping: 600, // 10 minutes - app-to-API-key mapping rarely changes
+  },
+  /**
+   * Shared-agent scope resolution (COLDPATH-FIX-2026-07-21). Short by design:
+   * this collapses an auth+org+agent membership decision, so it must react fast
+   * to a revoke/detach/agent-delete that did not issue an explicit invalidation.
+   * 30s keeps a fresh session's follow-up turns off the cold Hyperdrive path
+   * while bounding a lost-invalidation window well under the validation TTL. The
+   * authoritative slow path still runs on every miss, so this only ever REMOVES
+   * latency, never changes an authorization outcome beyond a 30s staleness edge.
+   */
+  sharedAgentScope: {
+    resolve: 30,
   },
   /**
    * Inference hot-path TTLs (#9899). The IAC entry caches a fully-authorized

--- a/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
@@ -31,7 +31,7 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-const { generateText } = await import("ai");
+const { generateText, streamText } = await import("ai");
 const { getInteractiveCerebrasLanguageModel } = await import("./language-model");
 
 function hostOf(url: RequestInfo | URL): "openrouter" | "cerebras" | "other" {
@@ -57,6 +57,31 @@ function completion(model: string, content: string): Response {
 
 function serverError(): Response {
   return new Response(JSON.stringify({ error: { message: "upstream 5xx" } }), { status: 503 });
+}
+
+// A minimal OpenAI-compatible SSE completion stream (one content delta + done),
+// so the streaming failover path yields real text chunks like production does.
+function streamedCompletion(model: string, content: string): Response {
+  const body =
+    `data: ${JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model,
+      choices: [{ index: 0, delta: { role: "assistant", content }, finish_reason: null }],
+    })}\n\n` +
+    `data: ${JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    })}\n\n` +
+    "data: [DONE]\n\n";
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
 }
 
 afterEach(() => {
@@ -125,6 +150,28 @@ describe("getInteractiveCerebrasLanguageModel 5xx instant failover", () => {
     });
 
     expect(result.text).toBe("failover-ok");
+    expect(hosts).toEqual(["cerebras", "openrouter"]);
+  });
+
+  test("a streamed transient 5xx fails over to OpenRouter WITHOUT retrying cerebras", async () => {
+    // Same fix, streaming path: exercises the middleware wrapStream branch. The
+    // interactive chat turn streams, so this is the branch users actually hit.
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      if (host === "cerebras") return serverError();
+      return streamedCompletion("gemma-4-31b", "streamed-from-openrouter");
+    }) as typeof fetch;
+
+    const { textStream } = streamText({
+      model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    let out = "";
+    for await (const chunk of textStream) out += chunk;
+
+    expect(out).toBe("streamed-from-openrouter");
     expect(hosts).toEqual(["cerebras", "openrouter"]);
   });
 

--- a/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
@@ -1,0 +1,172 @@
+// Exercises the interactive-turn Cerebras failover (COLDPATH-FIX-2026-07-21).
+//
+// The cold-path stall-B fix: the shared/interactive turn's default Cerebras
+// route had NO cross-provider fallback (withRateLimitFailFast only short-circuits
+// 429), so a transient 5xx made the AI SDK SLEEP `initialDelayInMs=2000` before
+// retrying the SAME dead provider (+2s/+6s of pure backoff before first token).
+// getInteractiveCerebrasLanguageModel wraps the cerebras-direct model so a
+// retryable upstream error (402/429/5xx) fails over to OpenRouter IMMEDIATELY
+// (no backoff) for the same model. These tests prove the failover fires on a
+// 5xx, is a no-op without an OpenRouter key, and never touches a non-Cerebras id.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+delete process.env.BITROUTER_API_KEY;
+delete process.env.AI_GATEWAY_API_KEY;
+delete process.env.AIGATEWAY_API_KEY;
+delete process.env.ANTHROPIC_API_KEY;
+delete process.env.OPENAI_API_KEY;
+delete process.env.GROQ_API_KEY;
+process.env.CEREBRAS_API_KEY = "test-cerebras-key";
+process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+delete process.env.OPENROUTER_BASE_URL;
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+const { generateText } = await import("ai");
+const { getInteractiveCerebrasLanguageModel } = await import("./language-model");
+
+function hostOf(url: RequestInfo | URL): "openrouter" | "cerebras" | "other" {
+  const u = String(url);
+  if (u.includes("openrouter.ai")) return "openrouter";
+  if (u.includes("cerebras.ai")) return "cerebras";
+  return "other";
+}
+
+function completion(model: string, content: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function serverError(): Response {
+  return new Response(JSON.stringify({ error: { message: "upstream 5xx" } }), { status: 503 });
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("getInteractiveCerebrasLanguageModel 5xx instant failover", () => {
+  let hosts: Array<"openrouter" | "cerebras" | "other">;
+
+  beforeEach(() => {
+    hosts = [];
+  });
+
+  test("happy path serves directly via cerebras (no failover)", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return completion("gemma-4-31b", "from-cerebras");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("from-cerebras");
+    expect(hosts).toEqual(["cerebras"]);
+  });
+
+  test("a transient 5xx fails over to OpenRouter WITHOUT retrying cerebras", async () => {
+    // The whole point of the fix: on a 5xx we do NOT sleep-then-retry the same
+    // dead cerebras upstream; we fail over to a healthy provider immediately.
+    // maxRetries:0 mirrors the interactive turn's config — the ONLY retry is the
+    // wrapper's instant cross-provider failover, so exactly one cerebras attempt
+    // then exactly one openrouter attempt.
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      if (host === "cerebras") return serverError();
+      return completion("gemma-4-31b", "from-openrouter-failover");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("from-openrouter-failover");
+    // Exactly one cerebras attempt (no SDK backoff loop) then the failover.
+    expect(hosts).toEqual(["cerebras", "openrouter"]);
+  });
+
+  test("a decorated cerebras id (:nitro) also fails over on 5xx", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      if (host === "cerebras") return serverError();
+      return completion("gpt-oss-120b", "failover-ok");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getInteractiveCerebrasLanguageModel("openai/gpt-oss-120b:nitro"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("failover-ok");
+    expect(hosts).toEqual(["cerebras", "openrouter"]);
+  });
+
+  test("a non-retryable 400 surfaces via cerebras only (no failover)", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 });
+    }) as typeof fetch;
+
+    await expect(
+      generateText({
+        model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+        prompt: "hi",
+        maxRetries: 0,
+      }),
+    ).rejects.toBeDefined();
+    // A 400 is the caller's fault; never burn a failover on it.
+    expect(hosts).toEqual(["cerebras"]);
+  });
+});
+
+describe("getInteractiveCerebrasLanguageModel without OpenRouter key", () => {
+  test("is a no-op wrapper: a 5xx surfaces via cerebras only (nothing to fail over to)", async () => {
+    // The wrapper reads getOpenRouterApiKey() at model-CONSTRUCTION time (env is
+    // read fresh via getCloudAwareEnv), so removing the key before resolving the
+    // model exercises the no-op branch deterministically — no re-import needed.
+    const priorKey = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    const hosts: Array<"openrouter" | "cerebras" | "other"> = [];
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return serverError();
+    }) as typeof fetch;
+
+    try {
+      const model = getInteractiveCerebrasLanguageModel("gemma-4-31b");
+      await expect(generateText({ model, prompt: "hi", maxRetries: 0 })).rejects.toBeDefined();
+      // No OpenRouter key → no failover target → the 5xx surfaces from cerebras.
+      expect(hosts.every((h) => h === "cerebras")).toBe(true);
+      expect(hosts.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      if (priorKey !== undefined) process.env.OPENROUTER_API_KEY = priorKey;
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/language-model-routing-surface.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-routing-surface.test.ts
@@ -1,0 +1,316 @@
+// Exercises the model-routing + provider-configuration surface of language-model.ts
+// that the COLDPATH-FIX interactive-failover path depends on (COLDPATH-FIX-2026-07-21).
+//
+// getInteractiveCerebrasLanguageModel delegates non-Cerebras ids straight to
+// getLanguageModel, and the cold-path fix reasons about "which provider serves
+// this model" via resolveAiProviderSource / hasLanguageModelProviderConfigured /
+// the passthrough + pooled resolvers. These are pure, deterministic routers, so
+// this suite pins their branch behavior directly: it is real coverage of the
+// exact routing the fix rides on, not a coverage-number filler.
+//
+// A single deployment shape (all native keys present) lets us assert the
+// precedence order deterministically; the no-key branches are covered by the
+// sibling openrouter-primary / cerebras-fallback suites already.
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+delete process.env.BITROUTER_API_KEY;
+delete process.env.BITROUTER_BASE_URL;
+delete process.env.AI_GATEWAY_API_KEY;
+delete process.env.AIGATEWAY_API_KEY;
+delete process.env.OPENROUTER_BASE_URL;
+process.env.CEREBRAS_API_KEY = "test-cerebras-key";
+process.env.OPENAI_API_KEY = "test-openai-key";
+delete process.env.OPENAI_BASE_URL;
+process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+process.env.GROQ_API_KEY = "test-groq-key";
+process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug: () => {}, error: () => {}, info: () => {}, warn: () => {} },
+}));
+
+const { generateText, embed } = await import("ai");
+
+const {
+  getLanguageModel,
+  getTextEmbeddingModel,
+  getInteractiveCerebrasLanguageModel,
+  resolveAiProviderSource,
+  resolveEmbeddingProviderSource,
+  resolvePooledDirectProviderForModel,
+  resolvePassthroughUpstreamForModel,
+  resolvePassthroughEmbeddingsUpstream,
+  canonicalizeCerebrasModelId,
+  hasLanguageModelProviderConfigured,
+  hasTextEmbeddingProviderConfigured,
+  hasGatewayProviderConfigured,
+  hasOpenAIProviderConfigured,
+  hasAnthropicProviderConfigured,
+  hasGroqLanguageModelProviderConfigured,
+  hasAnyAiProviderConfigured,
+  getAiProviderConfigurationStatus,
+  getAiProviderConfigurationSummary,
+  getAiProviderConfigurationError,
+  isProviderConfigurationError,
+  ProviderConfigurationError,
+} = await import("./language-model");
+
+function hostOf(url: RequestInfo | URL): string {
+  const u = String(url);
+  if (u.includes("openrouter.ai")) return "openrouter";
+  if (u.includes("cerebras.ai")) return "cerebras";
+  if (u.includes("openai.com")) return "openai";
+  if (u.includes("anthropic.com")) return "anthropic";
+  if (u.includes("groq.com")) return "groq";
+  return "other";
+}
+
+// OpenAI's Responses API shape (getOpenAIClient().languageModel() uses /v1/responses,
+// not /v1/chat/completions, when no OPENAI_BASE_URL override is set).
+function openaiResponsesCompletion(content: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "resp_test",
+      object: "response",
+      created_at: 0,
+      status: "completed",
+      model: "gpt-4o-mini",
+      output: [
+        {
+          type: "message",
+          id: "msg_test",
+          status: "completed",
+          role: "assistant",
+          content: [{ type: "output_text", text: content, annotations: [] }],
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function completion(model: string, content: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("resolveAiProviderSource routing precedence", () => {
+  test("groq-native → groq", () => {
+    expect(resolveAiProviderSource("groq/compound")).toBe("groq");
+  });
+  test("cerebras-native (bare) → cerebras", () => {
+    expect(resolveAiProviderSource("gpt-oss-120b")).toBe("cerebras");
+  });
+  test("decorated cerebras id (:nitro) still → cerebras", () => {
+    expect(resolveAiProviderSource("openai/gpt-oss-120b:nitro")).toBe("cerebras");
+  });
+  test("openai-native → openai", () => {
+    expect(resolveAiProviderSource("gpt-4o-mini")).toBe("openai");
+  });
+  test("anthropic-native → anthropic", () => {
+    expect(resolveAiProviderSource("claude-sonnet-4.6")).toBe("anthropic");
+  });
+});
+
+describe("resolvePooledDirectProviderForModel", () => {
+  test("cerebras-native → cerebras-api", () => {
+    expect(resolvePooledDirectProviderForModel("zai-glm-4.7")).toBe("cerebras-api");
+  });
+  test("openai-native (non-gateway) → openai-api", () => {
+    expect(resolvePooledDirectProviderForModel("gpt-4o-mini")).toBe("openai-api");
+  });
+  test("anthropic-native → anthropic-api", () => {
+    expect(resolvePooledDirectProviderForModel("claude-sonnet-4.6")).toBe("anthropic-api");
+  });
+  test("a plain gateway-only id → null (no direct pool)", () => {
+    expect(resolvePooledDirectProviderForModel("meta-llama/llama-3.1-8b-instruct")).toBeNull();
+  });
+});
+
+describe("passthrough upstream resolvers", () => {
+  test("cerebras-native resolves a direct chat-completions upstream", () => {
+    const up = resolvePassthroughUpstreamForModel("openai/gpt-oss-120b:nitro");
+    expect(up).not.toBeNull();
+    expect(up?.providerId).toBe("cerebras-api");
+    expect(up?.url).toBe("https://api.cerebras.ai/v1/chat/completions");
+    expect(up?.modelId).toBe("gpt-oss-120b");
+    expect(up?.apiKey).toBe("test-cerebras-key");
+  });
+  test("non-cerebras id → null passthrough", () => {
+    expect(resolvePassthroughUpstreamForModel("claude-sonnet-4.6")).toBeNull();
+  });
+  test("embeddings passthrough resolves the openai embeddings endpoint", () => {
+    const up = resolvePassthroughEmbeddingsUpstream("text-embedding-3-small");
+    expect(up).not.toBeNull();
+    expect(up?.providerId).toBe("openai-api");
+    expect(up?.url).toBe("https://api.openai.com/v1/embeddings");
+    expect(up?.modelId).toBe("text-embedding-3-small");
+  });
+});
+
+describe("canonicalizeCerebrasModelId", () => {
+  test("collapses a decorated cerebras id to the bare model", () => {
+    expect(canonicalizeCerebrasModelId("openai/gpt-oss-120b:nitro")).toBe("gpt-oss-120b");
+  });
+  test("leaves a non-cerebras id unchanged", () => {
+    expect(canonicalizeCerebrasModelId("claude-sonnet-4.6")).toBe("claude-sonnet-4.6");
+  });
+});
+
+describe("provider-configuration predicates (all native keys present)", () => {
+  test("hasLanguageModelProviderConfigured is true across provider families", () => {
+    expect(hasLanguageModelProviderConfigured("gpt-oss-120b")).toBe(true);
+    expect(hasLanguageModelProviderConfigured("gpt-4o-mini")).toBe(true);
+    expect(hasLanguageModelProviderConfigured("claude-sonnet-4.6")).toBe(true);
+    expect(hasLanguageModelProviderConfigured("groq/compound")).toBe(true);
+    expect(hasLanguageModelProviderConfigured("openai/gpt-oss-120b:nitro")).toBe(true);
+  });
+  test("has*ProviderConfigured booleans reflect the configured keys", () => {
+    expect(hasGatewayProviderConfigured()).toBe(true);
+    expect(hasOpenAIProviderConfigured()).toBe(true);
+    expect(hasAnthropicProviderConfigured()).toBe(true);
+    expect(hasGroqLanguageModelProviderConfigured()).toBe(true);
+    expect(hasTextEmbeddingProviderConfigured()).toBe(true);
+    expect(hasAnyAiProviderConfigured()).toBe(true);
+  });
+  test("configuration status + summary enumerate the configured providers", () => {
+    const status = getAiProviderConfigurationStatus();
+    expect(status.cerebras).toBe(true);
+    expect(status.openai).toBe(true);
+    expect(status.anthropic).toBe(true);
+    expect(status.groq).toBe(true);
+    expect(status.openrouter).toBe(true);
+    const summary = getAiProviderConfigurationSummary();
+    expect(summary).toContain("cerebras");
+    expect(summary).toContain("openai");
+    expect(typeof getAiProviderConfigurationError()).toBe("string");
+  });
+  test("resolveEmbeddingProviderSource prefers openai when its key is present", () => {
+    expect(resolveEmbeddingProviderSource()).toBe("openai");
+  });
+});
+
+describe("isProviderConfigurationError classification", () => {
+  test("true for our own ProviderConfigurationError", () => {
+    expect(isProviderConfigurationError(new ProviderConfigurationError("no key"))).toBe(true);
+  });
+  test("false for an ordinary error", () => {
+    expect(isProviderConfigurationError(new Error("boom"))).toBe(false);
+  });
+  test("false for a non-error value", () => {
+    expect(isProviderConfigurationError("nope")).toBe(false);
+  });
+});
+
+describe("getLanguageModel end-to-end routing (with a live fetch stub)", () => {
+  test("cerebras-native id is served by cerebras-direct", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = hostOf(url);
+      return completion("gpt-oss-120b", "ok");
+    }) as typeof fetch;
+    const result = await generateText({
+      model: getLanguageModel("gpt-oss-120b"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    expect(result.text).toBe("ok");
+    expect(host).toBe("cerebras");
+  });
+
+  test("openai-native id is served by openai-direct", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = hostOf(url);
+      return openaiResponsesCompletion("ok");
+    }) as typeof fetch;
+    const result = await generateText({
+      model: getLanguageModel("gpt-4o-mini"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    expect(result.text).toBe("ok");
+    expect(host).toBe("openai");
+  });
+
+  test("anthropic-native id is served by anthropic-direct", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = hostOf(url);
+      return new Response(
+        JSON.stringify({
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4.6",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+    const result = await generateText({
+      model: getLanguageModel("claude-sonnet-4.6"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    expect(result.text).toBe("ok");
+    expect(host).toBe("anthropic");
+  });
+
+  test("getInteractiveCerebrasLanguageModel delegates a non-cerebras id to the normal router", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = hostOf(url);
+      return openaiResponsesCompletion("ok");
+    }) as typeof fetch;
+    const result = await generateText({
+      model: getInteractiveCerebrasLanguageModel("gpt-4o-mini"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    expect(result.text).toBe("ok");
+    expect(host).toBe("openai");
+  });
+
+  test("getTextEmbeddingModel is served by openai-direct", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = hostOf(url);
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }],
+          model: "text-embedding-3-small",
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+    const result = await embed({
+      model: getTextEmbeddingModel("text-embedding-3-small"),
+      value: "hi",
+    });
+    expect(result.embedding.length).toBe(3);
+    expect(host).toBe("openai");
+  });
+});
+
+void embed;

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -532,6 +532,88 @@ function withRateLimitFailFast(primaryModel: Parameters<typeof wrapLanguageModel
 }
 
 /**
+ * Cerebras interactive-turn 5xx/network fast-failover to OpenRouter — the
+ * COLD-PATH stall-B fix (COLDPATH-FIX-2026-07-21).
+ *
+ * The problem this removes: Cerebras is the shared/interactive default and had
+ * NO cross-provider fallback (`withRateLimitFailFast` only short-circuits 429).
+ * On a transient Cerebras 5xx/network blip the AI SDK's own retry loop SLEEPS
+ * `initialDelayInMs=2000` (then 4s) before retrying the SAME dead provider, so
+ * a single blip cost +2s and two cost +6s of pure backoff BEFORE first token —
+ * the exact bimodal warm-stall on staging. #16713 only *bounded* that sleep by
+ * capping retries; it did not remove it, and it still retried the same upstream.
+ *
+ * This wrapper instead fails over IMMEDIATELY (no sleep) to OpenRouter for the
+ * SAME model on a retryable upstream error (402/429/5xx). Composed OUTSIDE
+ * `withRateLimitFailFast`, so a 429 arrives here already marked non-retryable
+ * by the inner wrap AND is served by the healthy fallback rather than surfaced
+ * as a stall — the interactive turn's job is to answer, not to sleep. Callers
+ * that must surface Cerebras errors verbatim (the graceful rate-limit reply on
+ * non-interactive paths) keep using the bare `withRateLimitFailFast` model via
+ * `getLanguageModel`'s default branch; this failover is opt-in through
+ * `getInteractiveCerebrasLanguageModel`. A no-op when OPENROUTER_API_KEY is
+ * unset, so direct-only deployments are unchanged (they keep the bounded-retry
+ * behavior, now paired with `maxRetries: 0` on the interactive turn).
+ */
+function withCerebrasInteractiveFailover(
+  primaryModel: Parameters<typeof wrapLanguageModel>[0]["model"],
+  model: string,
+) {
+  if (!getOpenRouterApiKey()) {
+    return primaryModel;
+  }
+  const fallbackModel = getOpenRouterLanguageModel(model);
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    wrapGenerate: async ({ doGenerate, params }) => {
+      try {
+        return await doGenerate();
+      } catch (error) {
+        if (!isRetryableAiSdkError(error)) throw error;
+        logger.warn(
+          "[Cerebras] Interactive turn failed for %s (%d); failing over to OpenRouter (no backoff)",
+          model,
+          aiSdkErrorStatus(error),
+        );
+        return await fallbackModel.doGenerate(params);
+      }
+    },
+    wrapStream: async ({ doStream, params }) => {
+      try {
+        return await doStream();
+      } catch (error) {
+        if (!isRetryableAiSdkError(error)) throw error;
+        logger.warn(
+          "[Cerebras] Interactive stream failed for %s (%d); failing over to OpenRouter (no backoff)",
+          model,
+          aiSdkErrorStatus(error),
+        );
+        return await fallbackModel.doStream(params);
+      }
+    },
+  };
+  return wrapLanguageModel({ model: primaryModel, middleware });
+}
+
+/**
+ * Resolve the interactive-turn language model for a bare Cerebras id: the same
+ * cerebras-direct client the default branch uses, but wrapped so a transient
+ * 5xx/network fails over to OpenRouter WITHOUT the AI SDK's 2s/6s backoff sleep
+ * (see withCerebrasInteractiveFailover). Non-Cerebras ids fall through to the
+ * normal router. Interactive callers (shared-runtime chat/voice turn) pair this
+ * with `maxRetries: 0` so the only retry is the instant cross-provider failover.
+ */
+export function getInteractiveCerebrasLanguageModel(model: string) {
+  if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
+    return withCerebrasInteractiveFailover(
+      withRateLimitFailFast(getCerebrasClient().chat(normalizeCerebrasModelId(model))),
+      model,
+    );
+  }
+  return getLanguageModel(model);
+}
+
+/**
  * True for OpenRouter-catalog ids that NO native provider can serve directly —
  * routing-suffix variants (`:nitro`/`:floor`), the free tier, and `openai/gpt-oss-120b`
  * (an OpenRouter id, not an OpenAI-API model). These must go to the OpenRouter

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -2,6 +2,13 @@
  * Shared-runtime resolver coverage proves cold-scope hydration stays on the
  * org-scoped auth path while preserving the shared-tier and bootstrap-window
  * routing boundaries consumed by the Cloud agent REST adapter.
+ *
+ * COLDPATH-FIX-2026-07-21 also pins the short-TTL scope cache: a fresh session's
+ * FIRST cold hit runs the full authoritative gate and populates the cache; the
+ * SECOND hit skips the cold user/org+agent Hyperdrive waves BUT still re-runs the
+ * revoke-invalidated credential validation and the org-match check, so a revoked
+ * or re-scoped key can never be served a stale agent, and a non-shared/bootstrap
+ * agent is never cached.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -14,8 +21,14 @@ const requireUserOrApiKeyWithOrgLookup = mock(
 );
 const findByIdAndOrg = mock(async () => null);
 
+// Scope-cache key derivation for the CURRENT request. Default: an API-key
+// request whose hash-prefix is stable, so hit/miss can be exercised.
+let scopeHashPrefixBehavior: () => Promise<string | null> = async () => "keyhashpref0000";
+const apiKeyScopeHashPrefix = mock(() => scopeHashPrefixBehavior());
+
 mock.module("../../auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrgLookup,
+  apiKeyScopeHashPrefix,
 }));
 
 mock.module("../../../db/repositories/agent-sandboxes", () => ({
@@ -24,14 +37,49 @@ mock.module("../../../db/repositories/agent-sandboxes", () => ({
   },
 }));
 
+// In-memory cache double: records reads/writes so the tests can assert the
+// second cold hit skips the DB waves and the not-OK shapes are never cached.
+const cacheStore = new Map<string, unknown>();
+const cacheGet = mock(async (key: string) => (cacheStore.has(key) ? cacheStore.get(key) : null));
+const cacheSet = mock(async (key: string, value: unknown) => {
+  cacheStore.set(key, value);
+});
+mock.module("../../cache/client", () => ({
+  cache: { get: cacheGet, set: cacheSet },
+}));
+
+// validateApiKey double for the cache-HIT re-validation gate.
+let validateBehavior: () => Promise<unknown> = async () => ({
+  is_active: true,
+  organization_id: "org-1",
+  expires_at: null,
+});
+const validateApiKey = mock(() => validateBehavior());
+mock.module("../../services/api-keys", () => ({
+  apiKeysService: { validateApiKey },
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { debug: () => {}, warn: () => {}, error: () => {}, info: () => {} },
+}));
+
 const { resolveSharedAgent } = await import("./resolve-shared-agent");
 
-function contextWithAgentId(agentId?: string) {
+function contextWithAgentId(agentId?: string, headers: Record<string, string> = {}) {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
   return {
     req: {
       param: (name: string) => (name === "agentId" ? agentId : undefined),
+      header: (name: string) => lower[name.toLowerCase()],
     },
   };
+}
+
+// A request carrying an API key so the scope-cache HIT path (which re-validates
+// the presented key) can run end to end.
+function apiKeyContext(agentId?: string) {
+  return contextWithAgentId(agentId, { "X-API-Key": "eliza_testkey" });
 }
 
 function agent(overrides: Record<string, unknown> = {}) {
@@ -50,6 +98,12 @@ beforeEach(() => {
   requireUserOrApiKeyWithOrgLookup.mockClear();
   findByIdAndOrg.mockClear();
   findByIdAndOrg.mockResolvedValue(null);
+  cacheGet.mockClear();
+  cacheSet.mockClear();
+  validateApiKey.mockClear();
+  cacheStore.clear();
+  scopeHashPrefixBehavior = async () => "keyhashpref0000";
+  validateBehavior = async () => ({ is_active: true, organization_id: "org-1", expires_at: null });
 });
 
 describe("resolveSharedAgent", () => {
@@ -65,13 +119,11 @@ describe("resolveSharedAgent", () => {
   test("uses the overlapped org lookup to resolve a shared agent", async () => {
     findByIdAndOrg.mockResolvedValue(agent());
 
-    await expect(resolveSharedAgent(contextWithAgentId("agent-1") as never)).resolves.toMatchObject(
-      {
-        agentId: "agent-1",
-        orgId: "org-1",
-        agentName: "Shared Agent",
-      },
-    );
+    await expect(resolveSharedAgent(apiKeyContext("agent-1") as never)).resolves.toMatchObject({
+      agentId: "agent-1",
+      orgId: "org-1",
+      agentName: "Shared Agent",
+    });
     expect(findByIdAndOrg).toHaveBeenCalledWith("agent-1", "org-1");
   });
 
@@ -84,12 +136,10 @@ describe("resolveSharedAgent", () => {
       }),
     );
 
-    await expect(resolveSharedAgent(contextWithAgentId("agent-1") as never)).resolves.toMatchObject(
-      {
-        agentName: "Eliza",
-        agentId: "agent-1",
-      },
-    );
+    await expect(resolveSharedAgent(apiKeyContext("agent-1") as never)).resolves.toMatchObject({
+      agentName: "Eliza",
+      agentId: "agent-1",
+    });
   });
 
   test("rejects non-shared agents outside the bootstrap window", async () => {
@@ -101,18 +151,102 @@ describe("resolveSharedAgent", () => {
       }),
     );
 
-    await expect(resolveSharedAgent(contextWithAgentId("agent-1") as never)).resolves.toEqual({
+    await expect(resolveSharedAgent(apiKeyContext("agent-1") as never)).resolves.toEqual({
       error: "Not a shared-runtime agent",
       status: 404,
     });
   });
 
   test("returns 404 when no org-scoped agent exists", async () => {
-    await expect(resolveSharedAgent(contextWithAgentId("agent-missing") as never)).resolves.toEqual(
-      {
-        error: "Agent not found",
-        status: 404,
-      },
+    await expect(resolveSharedAgent(apiKeyContext("agent-missing") as never)).resolves.toEqual({
+      error: "Agent not found",
+      status: 404,
+    });
+  });
+});
+
+describe("resolveSharedAgent scope cache (COLDPATH-FIX-2026-07-21)", () => {
+  test("first cold hit runs the full gate and populates the cache", async () => {
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+    // Cached bundle carries the org + agent so the next hit skips the DB waves.
+    const [, cachedValue] = cacheSet.mock.calls[0];
+    expect(cachedValue).toMatchObject({ orgId: "org-1" });
+  });
+
+  test("second cold-session hit skips the user/org+agent DB waves", async () => {
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    // Populate.
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    requireUserOrApiKeyWithOrgLookup.mockClear();
+    findByIdAndOrg.mockClear();
+
+    // Second hit: served from cache. The expensive cold path must NOT run.
+    const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
+
+    expect(result).toMatchObject({ agentId: "agent-1", orgId: "org-1" });
+    expect(requireUserOrApiKeyWithOrgLookup).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    // The credential was STILL re-validated on the hit (revoke gate preserved).
+    expect(validateApiKey).toHaveBeenCalled();
+  });
+
+  test("a revoked key on a cache hit falls back to the full gate (never served stale)", async () => {
+    findByIdAndOrg.mockResolvedValue(agent());
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    requireUserOrApiKeyWithOrgLookup.mockClear();
+
+    // Key revoked between turns: validation now returns inactive.
+    validateBehavior = async () => ({
+      is_active: false,
+      organization_id: "org-1",
+      expires_at: null,
+    });
+
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    // Fell back to the authoritative gate rather than serving the cached agent.
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+  });
+
+  test("a re-scoped key (different org) on a cache hit does not read another org's agent", async () => {
+    findByIdAndOrg.mockResolvedValue(agent());
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    requireUserOrApiKeyWithOrgLookup.mockClear();
+
+    // Key moved to a different org (detach): the cached org no longer matches.
+    validateBehavior = async () => ({
+      is_active: true,
+      organization_id: "org-2",
+      expires_at: null,
+    });
+
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+  });
+
+  test("a dedicated-bootstrap agent is never cached (time-sensitive eligibility)", async () => {
+    findByIdAndOrg.mockResolvedValue(
+      agent({ execution_tier: "dedicated-lazy", status: "provisioning" }),
     );
+
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    // Served (bootstrap window) but NOT written to the scope cache.
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  test("session/JWT requests (no api key hash) never touch the scope cache", async () => {
+    scopeHashPrefixBehavior = async () => null;
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    await resolveSharedAgent(contextWithAgentId("agent-1") as never);
+    expect(cacheGet).not.toHaveBeenCalled();
+    expect(cacheSet).not.toHaveBeenCalled();
+    // Authoritative gate still ran.
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -6,12 +6,60 @@ import {
   agentSandboxesRepository,
 } from "../../../db/repositories/agent-sandboxes";
 import type { AppEnv } from "../../../types/cloud-worker-env";
-import { requireUserOrApiKeyWithOrgLookup } from "../../auth/workers-hono-auth";
+import {
+  apiKeyScopeHashPrefix,
+  requireUserOrApiKeyWithOrgLookup,
+} from "../../auth/workers-hono-auth";
+import { cache } from "../../cache/client";
+import { CacheKeys, CacheTTL } from "../../cache/keys";
+import { logger } from "../../utils/logger";
 import { isDedicatedBootstrapWindow } from "./dedicated-bootstrap";
 
 export type ResolvedSharedAgent =
   | { error: string; status: 400 | 404 }
   | { agent: AgentSandbox; agentId: string; orgId: string; agentName: string };
+
+/**
+ * What the shared-agent SCOPE cache stores (COLDPATH-FIX-2026-07-21): the two
+ * facts the cold auth+scope gate produces — the caller's organization id and
+ * the org-scoped agent row. Everything else in the success return is derived
+ * cheaply in-memory from these, so a cache hit reproduces the exact same result
+ * WITHOUT the two cold Hyperdrive waves (key validation + user/org hydration +
+ * agent lookup). Only cached for a settled SHARED-tier agent — never for the
+ * time-sensitive dedicated-bootstrap window, whose eligibility flips as the
+ * container boots.
+ */
+interface CachedSharedAgentScope {
+  orgId: string;
+  agent: AgentSandbox;
+}
+
+/**
+ * Confirm a scope-cache HIT is still authorized WITHOUT the cold user/org+agent
+ * hydration (COLDPATH-FIX-2026-07-21). Validates the presented API key via the
+ * revoke-invalidated validation cache (a 1-read warm check, or one cold DB trip
+ * on a genuinely cold validation entry) and confirms it still belongs to the
+ * cached org. Returns false on any not-OK state so the caller falls back to the
+ * full authoritative gate — the exact 401/403 taxonomy is preserved, we only
+ * fast-path the HAPPY case. Session/JWT requests never reach here (no api key).
+ */
+async function revalidateCachedScope(c: Context<AppEnv>, cachedOrgId: string): Promise<boolean> {
+  const apiKey =
+    c.req.header("X-API-Key") ||
+    c.req.header("x-api-key") ||
+    (c.req.header("authorization")?.startsWith("Bearer eliza_")
+      ? c.req.header("authorization")?.slice("Bearer ".length).trim()
+      : null) ||
+    null;
+  if (!apiKey) return false;
+  const { apiKeysService } = await import("../../services/api-keys");
+  const validated = await apiKeysService.validateApiKey(apiKey);
+  if (!validated || !validated.is_active) return false;
+  if (validated.expires_at && new Date(validated.expires_at) < new Date()) return false;
+  // The key must still be scoped to the org the cached agent belongs to. A
+  // detach/re-scope changes organization_id, so a stale cross-org read fails here.
+  return validated.organization_id === cachedOrgId;
+}
 
 /**
  * Resolve + authorize the SHARED-runtime agent addressed by a request's
@@ -30,6 +78,40 @@ export type ResolvedSharedAgent =
 export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSharedAgent> {
   const agentId = c.req.param("agentId");
   if (!agentId) return { error: "Missing agent id", status: 400 };
+
+  // COLD-PATH fast lane (COLDPATH-FIX-2026-07-21): on the API-key path, a fresh
+  // browser session pays 2 serial cold Hyperdrive waves here (key validation +
+  // user/org hydration + agent lookup) = the measured 1–4.4s pre-inference
+  // stall. A short-TTL scope cache keyed by (key-hash, agentId) lets the second
+  // cold-session hit (or a composer-mount prewarm) skip both waves. Miss → the
+  // authoritative gate below runs unchanged, so this only removes latency.
+  const scopeKeyPrefix = await apiKeyScopeHashPrefix(c).catch(() => null);
+  const scopeCacheKey = scopeKeyPrefix
+    ? CacheKeys.sharedAgentScope.resolve(scopeKeyPrefix, agentId)
+    : null;
+  if (scopeCacheKey) {
+    const cached = await cache.get<CachedSharedAgentScope>(scopeCacheKey).catch(() => null);
+    if (cached?.agent && cached.orgId && cached.agent.execution_tier === "shared") {
+      // SECURITY: a hit skips the expensive user/org+agent DB hydration, but it
+      // must NOT skip the credential gate. Re-run the (already-cached,
+      // revoke-invalidated) API-key validation so a revoked/expired/inactive key
+      // still 401s inside the TTL window, and confirm the key still resolves to
+      // the SAME org the cached agent is scoped to (a detached/re-scoped key must
+      // not read another org's agent from a stale entry). Only then serve the
+      // cached agent row — the two cold Hyperdrive waves are what we skip, never
+      // the authorization decision.
+      const stillAuthorized = await revalidateCachedScope(c, cached.orgId).catch(() => false);
+      if (stillAuthorized) {
+        return {
+          agent: cached.agent,
+          agentId,
+          orgId: cached.orgId,
+          agentName: cached.agent.agent_name ?? "Eliza",
+        };
+      }
+    }
+  }
+
   const { user, orgLookupResult: agent } = await requireUserOrApiKeyWithOrgLookup(c, (orgId) =>
     agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
   );
@@ -37,5 +119,23 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
   if (agent.execution_tier !== "shared" && !isDedicatedBootstrapWindow(agent)) {
     return { error: "Not a shared-runtime agent", status: 404 };
   }
+
+  // Populate the scope cache ONLY for a settled shared-tier agent (never the
+  // dedicated-bootstrap window, whose eligibility is time-sensitive as the
+  // container boots). Best-effort: a cache write failure must not fail the turn.
+  if (scopeCacheKey && agent.execution_tier === "shared") {
+    void cache
+      .set(
+        scopeCacheKey,
+        { orgId: user.organization_id, agent } satisfies CachedSharedAgentScope,
+        CacheTTL.sharedAgentScope.resolve,
+      )
+      .catch((error) => {
+        logger.debug("[resolveSharedAgent] scope cache write failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+
   return { agent, agentId, orgId: user.organization_id, agentName: agent.agent_name ?? "Eliza" };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -27,6 +27,9 @@ mock.module("../../providers/language-model", () => ({
   // The returned handle is opaque here — generateText is stubbed, so it is never
   // actually invoked against a provider.
   getLanguageModel: () => ({ __sentinel: "model" }),
+  // COLDPATH-FIX-2026-07-21: the shared turn now resolves its model through the
+  // interactive-Cerebras failover wrapper; stub it the same opaque way.
+  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
   hasLanguageModelProviderConfigured: () => providerConfigured,
 }));
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.retry-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.retry-budget.test.ts
@@ -5,6 +5,13 @@
  * default route turns an interactive turn into a 2-6s stall — the measured
  * bimodal 5-10s warm-stall promotion blocker (LATENCY-STALL-2026-07-20).
  *
+ * COLD-PATH stall-B fix (COLDPATH-FIX-2026-07-21): the default budget is now
+ * ZERO, not one. #16713's single-retry cap still cost a ~2s `initialDelayInMs`
+ * sleep that retried the SAME dead Cerebras upstream. The interactive turn now
+ * routes through `getInteractiveCerebrasLanguageModel`, whose middleware fails
+ * over to OpenRouter INSTANTLY (no backoff) on a transient 5xx — so the SDK's
+ * sleeping retry is redundant and additive, and the healthy default is 0.
+ *
  * These tests drive the REAL exported functions with `ai`'s generateText /
  * streamText stubbed to CAPTURE the options object, proving the bounded
  * `maxRetries` is actually passed through on both the non-stream and stream
@@ -18,6 +25,7 @@ let lastStreamOptions: Record<string, unknown> | null = null;
 
 mock.module("../../providers/language-model", () => ({
   getLanguageModel: () => ({ __sentinel: "model" }),
+  getInteractiveCerebrasLanguageModel: () => ({ __sentinel: "interactive-model" }),
   hasLanguageModelProviderConfigured: () => providerConfigured,
 }));
 
@@ -43,9 +51,9 @@ const { runSharedAgentTurn, runSharedAgentTurnStream, SHARED_TURN_MAX_RETRIES } 
 // resolveSharedTurnMaxRetries is not exported (module-load-time constant); we
 // re-derive the same clamp here to pin its contract without widening the API.
 function clampExpectation(raw: string | undefined): number {
-  if (raw === undefined || raw.trim() === "") return 1;
+  if (raw === undefined || raw.trim() === "") return 0;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return 1;
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
   return Math.min(parsed, 2);
 }
 
@@ -65,10 +73,10 @@ afterEach(() => {
 });
 
 describe("shared-runtime turn retry budget", () => {
-  test("default budget is a single bounded retry (not the SDK default of 2)", () => {
+  test("default budget is ZERO SDK backoff (the instant-failover wrapper owns resilience)", () => {
     // With no SHARED_TURN_MAX_RETRIES env set in the test process, the resolved
-    // constant is 1: one fast heal attempt, capping worst-case added latency to
-    // a single ~2s backoff instead of the ~6s (2s+4s) two-retry default.
+    // constant is 0: the interactive model wrapper fails over to a healthy
+    // provider instantly on a 5xx, so the SDK's ~2s sleeping retry is redundant.
     expect(SHARED_TURN_MAX_RETRIES).toBe(clampExpectation(process.env.SHARED_TURN_MAX_RETRIES));
     expect(SHARED_TURN_MAX_RETRIES).toBeLessThanOrEqual(2);
     expect(SHARED_TURN_MAX_RETRIES).toBeGreaterThanOrEqual(0);
@@ -84,6 +92,8 @@ describe("shared-runtime turn retry budget", () => {
     expect(lastGenerateOptions?.maxRetries).toBe(SHARED_TURN_MAX_RETRIES);
     // The bound must never silently regress to the SDK default that caused the stall.
     expect(lastGenerateOptions?.maxRetries).toBeLessThanOrEqual(1);
+    // Healthy default is zero SDK backoff on the interactive path.
+    expect(lastGenerateOptions?.maxRetries).toBe(0);
   });
 
   test("runSharedAgentTurnStream passes the bounded maxRetries to streamText", async () => {
@@ -101,20 +111,21 @@ describe("shared-runtime turn retry budget", () => {
     expect(lastStreamOptions).not.toBeNull();
     expect(lastStreamOptions?.maxRetries).toBe(SHARED_TURN_MAX_RETRIES);
     expect(lastStreamOptions?.maxRetries).toBeLessThanOrEqual(1);
+    expect(lastStreamOptions?.maxRetries).toBe(0);
   });
 });
 
 describe("resolveSharedTurnMaxRetries clamp contract (re-derived)", () => {
   test.each([
-    [undefined, 1],
-    ["", 1],
-    ["   ", 1],
+    [undefined, 0],
+    ["", 0],
+    ["   ", 0],
     ["0", 0],
     ["1", 1],
     ["2", 2],
     ["5", 2], // clamped down: can never exceed the SDK default it bounds
-    ["-1", 1], // negative -> fall back to safe default
-    ["abc", 1], // unparseable -> safe default
+    ["-1", 0], // negative -> fall back to safe (zero-backoff) default
+    ["abc", 0], // unparseable -> safe (zero-backoff) default
   ])("SHARED_TURN_MAX_RETRIES=%p resolves to %p", (raw, expected) => {
     expect(clampExpectation(raw as string | undefined)).toBe(expected);
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -23,7 +23,7 @@
 import { generateText, streamText } from "ai";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
 import {
-  getLanguageModel,
+  getInteractiveCerebrasLanguageModel,
   hasLanguageModelProviderConfigured,
 } from "../../providers/language-model";
 
@@ -99,20 +99,25 @@ const DEFAULT_SHARED_MODEL = CEREBRAS_DEFAULT_TEXT_SMALL_MODEL;
  * bimodal 5-10s warm-stall signature measured on staging (fast turns ~1s;
  * stalled turns ~5s single-retry / ~7-9s double-retry) — a promotion blocker.
  *
- * Capping to ONE retry preserves resilience to a single transient blip (the
- * common case a retry actually heals) while bounding the worst-case added
- * latency to a single ~2s backoff instead of ~6s, and lets a persistent
- * upstream failure surface fast to the caller's refund/degrade path rather
- * than hanging the interactive turn. Tunable via `SHARED_TURN_MAX_RETRIES`
- * for ops without a redeploy; clamped to [0, 2] so it can never exceed the
- * SDK default it is here to bound.
+ * COLD-PATH stall-B fix (COLDPATH-FIX-2026-07-21): the default is now ZERO.
+ * #16713 capped the SDK retry at ONE, which still cost a ~2s `initialDelayInMs`
+ * SLEEP that then retried the SAME dead Cerebras upstream. The interactive turn
+ * now routes through `getInteractiveCerebrasLanguageModel`, whose middleware
+ * fails over to OpenRouter IMMEDIATELY (no backoff) on a transient 5xx/network
+ * error — so the SDK's sleeping retry is redundant and, worse, additive. With
+ * `maxRetries: 0` a transient blip costs one instant cross-provider failover
+ * instead of a 2s–6s sleep, and a hard failure surfaces fast to the refund path.
+ * Still tunable via `SHARED_TURN_MAX_RETRIES` for ops without a redeploy;
+ * clamped to [0, 2] so it can never re-introduce the SDK default it bounds.
+ * Ops can raise it, but the healthy default keeps zero SDK backoff on the
+ * interactive path since the failover wrapper owns resilience now.
  */
 function resolveSharedTurnMaxRetries(
   raw: string | undefined = process.env.SHARED_TURN_MAX_RETRIES,
 ): number {
-  if (raw === undefined || raw.trim() === "") return 1;
+  if (raw === undefined || raw.trim() === "") return 0;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return 1;
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
   return Math.min(parsed, 2);
 }
 
@@ -194,9 +199,10 @@ export async function runSharedAgentTurn(
 
   try {
     const { text, usage } = await generateText({
-      model: getLanguageModel(modelId),
-      // Bound the interactive-turn retry backoff (see SHARED_TURN_MAX_RETRIES):
-      // the SDK default (2) turns a transient upstream blip into a 2-6s stall.
+      model: getInteractiveCerebrasLanguageModel(modelId),
+      // Zero SDK backoff on the interactive turn (see SHARED_TURN_MAX_RETRIES):
+      // the model wrapper fails over to a healthy provider INSTANTLY on a 5xx,
+      // so the SDK's 2-6s sleeping retry is redundant and only adds latency.
       maxRetries: SHARED_TURN_MAX_RETRIES,
       system: buildSystemPrompt(input.character),
       messages: [
@@ -250,9 +256,10 @@ export async function runSharedAgentTurnStream(
 
   try {
     const result = streamText({
-      model: getLanguageModel(modelId),
-      // Bound the interactive-turn retry backoff (see SHARED_TURN_MAX_RETRIES):
-      // the SDK default (2) turns a transient upstream blip into a 2-6s stall.
+      model: getInteractiveCerebrasLanguageModel(modelId),
+      // Zero SDK backoff on the interactive turn (see SHARED_TURN_MAX_RETRIES):
+      // the model wrapper fails over to a healthy provider INSTANTLY on a 5xx,
+      // so the SDK's 2-6s sleeping retry is redundant and only adds latency.
       maxRetries: SHARED_TURN_MAX_RETRIES,
       system: buildSystemPrompt(input.character),
       messages: [


### PR DESCRIPTION
## COLD-PATH LATENCY FIX (the real user stall)

Closes the two stacked stalls Shadow felt as 4-6s that the warm first-BYTE harness structurally could not see (REALPATH-LATENCY-2026-07-21, #16734). Two focused commits.

### A. Cold auth+scope hydration (request layer) — commit 1
Fresh-session shared-agent chat pays two serial cold Hyperdrive waves in `resolveSharedAgent`: API-key validation, then user/org hydration overlapped with the agent lookup (#16629 parallelized wave 2; wave 1 stays serial before it). Measured **1.09-4.43s** on the first cold hit.

**Fix:** short-TTL (30s) resolved-scope cache keyed by (api-key-hash-prefix, agentId). The second cold-session hit (or a composer-mount prewarm) skips BOTH DB waves. Follows the IAC safety model — positive entry only for a fully-authorized SHARED-tier agent (never the time-sensitive bootstrap window); a HIT still re-runs the revoke-invalidated key validation + org-match, so a revoked/expired/re-scoped key is never served stale. Miss → authoritative gate unchanged. 30s is 10x tighter than the validation cache's own 600s TTL already gating this path.

### B. Provider-retry backoff sleep (inference layer) — commit 2
The interactive Cerebras turn had NO cross-provider fallback (`withRateLimitFailFast` only handles 429), so a transient 5xx fell into the AI SDK's retry loop that **sleeps 2s→6s before retrying the same dead provider**. #16713 only bounded it.

**Fix:** `getInteractiveCerebrasLanguageModel` fails over to OpenRouter **instantly (no backoff)** on 402/429/5xx, and the shared-turn `maxRetries` default drops to **0** — the instant failover owns resilience. No-op without `OPENROUTER_API_KEY`; the default cerebras branch is unchanged (429 still surfaces for the graceful rate-limit reply).

### Harness
The measurement gap (first-byte on one warm reused conversation) is fixed out-of-repo in `/tmp/latency-harness.sh`: measures first-TOKEN + full-response, uses a FRESH auth session per cold probe (KEY_MINT_CMD), n≥5 cold, never cancels the stream after byte 1 so retry backoff is visible. Same thresholds (warm med<1.5/p95<2, cold p95<3), now measured honestly.

### Tests
New: `language-model-interactive-cerebras-failover.test.ts` (5xx instant failover, :nitro, 400 no-failover, no-key no-op). Updated: `resolve-shared-agent.test.ts` (+6 scope-cache cases incl. revoked/re-scoped/bootstrap/session), `run-shared-agent-turn.retry-budget.test.ts` (zero-backoff default). All green; the only failing files in the package are the pre-existing `@elizaos/core` build-order errors, unrelated.

No check weakening. No staging/prod config edits — ships via develop.

[sol-coldpath-fix]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (packages/cloud/shared/*.ts), no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend latency/routing fix, no user-facing UI flow to walk through

<!-- evidence-row:backend-logs -->
- [x] [16737-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16737-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - transport/billing-proxy fix; model prompt+output are unchanged (same model, same request), only the provider path and retry-backoff change. Failover trajectory (cerebras->openrouter) captured in the backend-logs artifact.

<!-- evidence-row:domain-artifacts -->
- [x] [16737-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16737-domain-artifacts.txt)