### PR TITLE
chore(registry): add plugin-gauge to third-party

### DIFF
--- a/packages/registry/entries/third-party/plugin-gauge.json
+++ b/packages/registry/entries/third-party/plugin-gauge.json
@@ -1,0 +1,9 @@
+{
+  "package": "plugin-gauge",
+  "repository": "github:CHANGCHINFU/plugin-gauge-x402",
+  "kind": "plugin",
+  "description": "GAUGE: verifiable official-source signals for AI agents via x402 (USDC on Base, no API key). Flood-risk & river anomaly (USGS/NOAA), air quality (AQI/PM2.5), precipitation/drought, agriculture (USDM soil moisture + heat/GDD + crop VHI), power-grid demand & energy inflation (FRED), shipping route disruption + sea-state + live AIS throughput, and SEC-EDGAR corporate distress (8-K material events, late-filing delinquency, Form 4 insider). Free raw reading; paid screening-level records with official thresholds + statistical anomaly + record_hash provenance.",
+  "homepage": "https://github.com/CHANGCHINFU/plugin-gauge-x402#readme",
+  "version": "0.6.0",
+  "tags": ["x402", "usdc", "base", "verifiable", "flood-risk", "environment", "agriculture", "power-grid", "shipping", "sec-edgar", "micropayments", "no-api-key"]
+}


### PR DESCRIPTION
# Relates to

Third-party plugin registry listing — no linked issue. Adds one entry under `packages/registry/entries/third-party/` per the registry README process (replaces the archived `elizaos-plugins/registry` flow).

- [x] Targets `develop`; single new file, zero conflicts.
- [x] `bun install` / `bun run verify` — **N/A**: registry-only JSON addition, no source or build touched. Entry validated against `packages/registry/schema/registry-entry.schema.json` (`package`, `repository`, `kind` all pass; `bun run --cwd packages/registry validate` covers it).
- [x] A reviewer can confirm from the entry file + schema alone, without reading code.

# Sync with develop

- [x] Based on latest `origin/develop`; single new file, zero conflicts.
- [x] `bun run verify` — **N/A** (data-only registry entry); schema-validated instead.

# Risks

Low. Adds one new `entries/third-party/*.json`; no existing files, code, or build touched. A malformed entry is caught by the registry schema / CI validation.

# Background

## What does this PR do?

Adds `packages/registry/entries/third-party/plugin-gauge.json` — a third-party registry listing for the npm package `plugin-gauge` (version 0.6.0).

GAUGE gives ElizaOS agents verifiable, official-source signals via x402 (USDC on Base, no API key): flood-risk / river anomaly (USGS/NOAA), air quality (AQI/PM2.5), precipitation / drought, agriculture (USDM soil moisture + heat/GDD + crop VHI), power-grid demand and energy inflation (FRED), shipping route disruption + sea-state + live AIS throughput, and SEC-EDGAR corporate distress (8-K / late-filing / Form 4). Free raw reading; paid screening-level records carry official thresholds + statistical anomaly + record_hash provenance.

- npm: plugin-gauge 0.6.0 (keyword elizaos; built and type-checked against @elizaos/core ^1.7.0)
- source: github:CHANGCHINFU/plugin-gauge-x402

## What kind of change is this?

Updates — a new third-party registry entry. No code, no breaking change.

# Documentation changes needed?

No. Registry entry only; the plugin's own README lives in its source repo.

# Testing

## Where should a reviewer start?

`packages/registry/entries/third-party/plugin-gauge.json`, validated against `packages/registry/schema/registry-entry.schema.json`.

## Detailed testing steps

`bun run --cwd packages/registry validate` covers this entry. Validated locally: required fields package / repository / kind match the schema patterns; package = plugin-gauge matches the unscoped name pattern and is not the reserved @elizaos scope.

# Evidence Gate

- [x] Before screenshots — N/A - no UI change; registry JSON entry only.
- [x] After screenshots — N/A - no UI change; registry JSON entry only.
- [x] Video walkthrough — N/A - no user-facing flow; single metadata file.
- [x] Backend logs — N/A - no backend/runtime code path changed.
- [x] Frontend logs — N/A - no frontend change.
- [x] Real-LLM trajectory — N/A - no agent/action/provider/prompt/model change; data-only entry.
- [x] Domain artifacts — N/A - no DB / on-chain / generated output; metadata file only.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - data-only registry entry; no code path exercised.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no UI change.
### After
N/A - no UI change.
### Walkthrough video
N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

None. `bun run verify` was intentionally not run because this PR adds only an `entries/third-party/*.json` metadata file (no source or build affected); the entry was validated against the registry JSON Schema, which is the relevant gate for registry PRs.