### PR TITLE
fix(cloud-tts): honor host pre-parsed body on the bare agent server (#16348)

### DIFF
--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -38,6 +38,27 @@ function fakeReq(
   } as unknown as http.IncomingMessage;
 }
 
+/**
+ * Models the bare agent server after `attachJsonBodyIfPresent`
+ * (packages/agent/src/api/runtime-plugin-routes.ts) has already consumed the
+ * stream for a JSON request: `req.body`/`req.rawBody` are populated and the
+ * underlying stream is drained (iterating it yields zero bytes). #16348.
+ */
+function fakeReqPreParsed(
+  parsed: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): http.IncomingMessage {
+  return {
+    headers,
+    body: parsed,
+    rawBody: JSON.stringify(parsed),
+    // Stream already drained upstream → yields nothing on re-read.
+    async *[Symbol.asyncIterator]() {
+      // no chunks
+    },
+  } as unknown as http.IncomingMessage;
+}
+
 function fakeRes(): {
   res: http.ServerResponse;
   state: {
@@ -110,6 +131,41 @@ describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
     expect(upstream.length).toBeGreaterThanOrEqual(1);
     expect(upstream[0].headers["Idempotency-Key"]).toBe("utt-abc");
     expect(upstream[0].body).toMatchObject({ text: "bill me once" });
+  });
+
+  test("honors a host pre-parsed JSON body when the stream is already drained (#16348)", async () => {
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReqPreParsed(
+        { text: "pre-parsed on the bare server" },
+        { "content-type": "application/json" },
+      ),
+      res,
+    );
+
+    expect(state.statusCode).toBe(200);
+    expect(upstream.length).toBeGreaterThanOrEqual(1);
+    expect(upstream[0].body).toMatchObject({
+      text: "pre-parsed on the bare server",
+    });
+  });
+
+  test("pre-parsed body still forwards modelId/voiceId and the idempotency key (#16348)", async () => {
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReqPreParsed(
+        { text: "hi", modelId: "m-9", voiceId: "v-3" },
+        {
+          "content-type": "application/json",
+          "idempotency-key": "utt-preparsed",
+        },
+      ),
+      res,
+    );
+
+    expect(state.statusCode).toBe(200);
+    expect(upstream[0].headers["Idempotency-Key"]).toBe("utt-preparsed");
+    expect(upstream[0].body).toMatchObject({ text: "hi" });
   });
 
   test("no incoming key → no Idempotency-Key header upstream (unchanged shape)", async () => {

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
@@ -89,6 +89,24 @@ function pickBodyString(
 }
 
 async function readRawRequestBody(req: http.IncomingMessage): Promise<Buffer> {
+  // On the bare agent server (packages/agent/src/bin.ts), the host's
+  // `attachJsonBodyIfPresent` already drains and JSON-parses the stream for an
+  // `application/json` request, stashing `req.rawBody`/`req.body` before the
+  // route runs. Re-streaming here would then read zero bytes and 400 a valid
+  // request (#16348). Honor the pre-read body first, mirroring app-core's
+  // `readCompatJsonBody`. The packaged app path re-streams `req` fresh and
+  // leaves these unset, so it still falls through to the drain below.
+  const preRead = req as http.IncomingMessage & {
+    rawBody?: unknown;
+    body?: unknown;
+  };
+  if (typeof preRead.rawBody === "string") {
+    return Buffer.from(preRead.rawBody, "utf8");
+  }
+  if (preRead.body && typeof preRead.body === "object") {
+    return Buffer.from(JSON.stringify(preRead.body), "utf8");
+  }
+
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
     chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);


### PR DESCRIPTION
## What

`POST /api/tts/cloud` with `Content-Type: application/json` returned **400 "Invalid JSON request body"** on the bare agent server (`packages/agent/src/bin.ts`), even for a valid payload.

The host's `attachJsonBodyIfPresent` (`packages/agent/src/api/runtime-plugin-routes.ts`) drains and JSON-parses the stream for `application/json` requests, stashing `req.rawBody` / `req.body` before the runtime plugin route runs. `handleCloudTtsPreviewRoute` then re-streamed `req` via `readRawRequestBody`, read **zero bytes**, and `JSON.parse("")` threw → 400. (The only client workaround was sending JSON under `Content-Type: text/plain` to dodge the host pre-read.)

## Fix

`readRawRequestBody` now honors a host pre-parsed body first — returning `req.rawBody` (or re-serialized `req.body`) when present — mirroring app-core's `readCompatJsonBody` `preParsed` guard. When unset (the packaged app path re-streams `req` fresh via `dispatch-route.ts`), it falls through to the original stream drain unchanged.

**Scope:** plugin-only. `plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts` (+18) and its test (+56). No behavior change on the packaged path.

## Repro-first evidence (before → after)

Two new regression tests model the drained-stream + pre-parsed-`req.body` shape.

**BEFORE fix (unpatched source):** the two new cases FAIL with the exact bug:
```
FAIL  handleCloudTtsPreviewRoute > honors a host pre-parsed JSON body ... (#16348)
FAIL  handleCloudTtsPreviewRoute > pre-parsed body still forwards modelId/voiceId ... (#16348)
AssertionError: expected 400 to be 200
 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
```

**AFTER fix:**
```
✓ src/lib/server-cloud-tts.test.ts (8 tests) 19ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

No regression in the sibling roundtrip suite:
```
✓ __tests__/cloud-tts-roundtrip.test.ts (9 tests) 18ms
 Tests  9 passed (9)
```
`tsc --noEmit` clean for the changed file (0 errors).

## Evidence checklist

<!-- evidence-row:before-screenshots -->
- [x] `N/A - server-side HTTP body-parsing fix, no UI surface changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server-side HTTP body-parsing fix, no UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-visual server route fix; behavior proven by failing-first unit tests (before/after output above).`
<!-- evidence-row:backend-logs -->
- [x] `N/A - real code path exercised by the new server-cloud-tts unit tests (400 to 200 transition shown above); no live cloud key run added.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend change; the fix is in the agent HTTP route.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; pure request-body plumbing.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB/memory/wallet/generated artifacts; TTS upstream call is stubbed in tests.`

Closes #16348
