### PR TITLE
fix(cloud): extend cold-scope cache to session/JWT auth (fixes 3-4s/turn on session-auth accounts)

### DIFF
--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -326,6 +326,56 @@ export async function apiKeyScopeHashPrefix(c: AppContext): Promise<string | nul
   return createHash("sha256").update(apiKey).digest("hex").substring(0, 16);
 }
 
+/**
+ * The session credential (steward JWT / cookie) presented on THIS request, or
+ * null when the request is not session-authenticated (API-key path). Mirrors
+ * the same bearer/cookie selection `getCurrentUser` uses so the scope cache is
+ * keyed by the exact credential that will be re-verified on a hit.
+ * (#SHADOW-ACCOUNT-DEBUG: the API-key-only scope cache left session/JWT chats
+ * — Shadow's own account path — paying the cold user/org+agent Hyperdrive waves
+ * on EVERY turn, warm or cold, because `apiKeyScopeHashPrefix` returned null.)
+ */
+export function readSessionCredential(c: AppContext): string | null {
+  const bearer = readBearer(c);
+  const cookieToken = readStewardCookie(c);
+  const token = bearer && looksLikeJwt(bearer) ? bearer : cookieToken;
+  return token ?? null;
+}
+
+/**
+ * 16-char hash prefix identifying the CURRENT request's SESSION credential for
+ * the shared-agent scope cache, or null when there is no session token. Never a
+ * hash of an empty string. Distinct namespace from the API-key prefix (callers
+ * pass a `"s:"`-prefixed cache key) so a session hash can never collide with an
+ * API-key hash.
+ */
+export async function sessionScopeHashPrefix(c: AppContext): Promise<string | null> {
+  const token = readSessionCredential(c);
+  if (!token) return null;
+  const { createHash } = await import("node:crypto");
+  return createHash("sha256").update(token).digest("hex").substring(0, 16);
+}
+
+/**
+ * Re-verify a session credential WITHOUT the cold user/org+agent hydration, for
+ * a scope-cache hit (#SHADOW-ACCOUNT-DEBUG). Runs the warm-cached steward JWT
+ * verify (in-mem LRU → Redis → local jose, ~0–5ms) and confirms it still
+ * resolves to the SAME steward user the cache entry was written for. Returns
+ * false on any not-OK state — an expired/rotated/invalid token, or a token now
+ * mapping to a different user — so the caller falls back to the full
+ * authoritative gate. Never skips the credential check, only the DB waves.
+ */
+export async function revalidateSessionScope(
+  c: AppContext,
+  cachedStewardUserId: string,
+): Promise<boolean> {
+  const token = readSessionCredential(c);
+  if (!token) return false;
+  const claims = await verifyStewardTokenCached(c.env, token).catch(() => null);
+  if (!claims) return false;
+  return claims.userId === cachedStewardUserId;
+}
+
 export async function requireUserOrApiKeyWithOrg(c: AppContext): Promise<AuthedUserWithOrg> {
   const apiKey = readApiKeyCredential(c);
   if (apiKey) return (await authenticateApiKeyWithOrg(c, apiKey)).user;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -15,7 +15,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const requireUserOrApiKeyWithOrgLookup = mock(
   async <T>(_: unknown, lookup: (organizationId: string) => Promise<T>) => ({
-    user: { organization_id: "org-1" },
+    user: { organization_id: "org-1", steward_id: "steward-user-1" },
     orgLookupResult: await lookup("org-1"),
   }),
 );
@@ -26,9 +26,21 @@ const findByIdAndOrg = mock(async () => null);
 let scopeHashPrefixBehavior: () => Promise<string | null> = async () => "keyhashpref0000";
 const apiKeyScopeHashPrefix = mock(() => scopeHashPrefixBehavior());
 
+// Session-path derivation (#SHADOW-ACCOUNT-DEBUG). Default null => API-key path
+// unless a test opts into the session shape.
+let sessionHashPrefixBehavior: () => Promise<string | null> = async () => null;
+const sessionScopeHashPrefix = mock(() => sessionHashPrefixBehavior());
+let sessionRevalidateBehavior: (cachedStewardUserId: string) => Promise<boolean> = async () =>
+  true;
+const revalidateSessionScope = mock((_: unknown, cachedStewardUserId: string) =>
+  sessionRevalidateBehavior(cachedStewardUserId),
+);
+
 mock.module("../../auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrgLookup,
   apiKeyScopeHashPrefix,
+  sessionScopeHashPrefix,
+  revalidateSessionScope,
 }));
 
 mock.module("../../../db/repositories/agent-sandboxes", () => ({
@@ -102,7 +114,11 @@ beforeEach(() => {
   cacheSet.mockClear();
   validateApiKey.mockClear();
   cacheStore.clear();
+  sessionScopeHashPrefix.mockClear();
+  revalidateSessionScope.mockClear();
   scopeHashPrefixBehavior = async () => "keyhashpref0000";
+  sessionHashPrefixBehavior = async () => null;
+  sessionRevalidateBehavior = async () => true;
   validateBehavior = async () => ({ is_active: true, organization_id: "org-1", expires_at: null });
 });
 
@@ -239,8 +255,9 @@ describe("resolveSharedAgent scope cache (COLDPATH-FIX-2026-07-21)", () => {
     expect(cacheSet).not.toHaveBeenCalled();
   });
 
-  test("session/JWT requests (no api key hash) never touch the scope cache", async () => {
+  test("a request carrying NEITHER an api key nor a session never touches the scope cache", async () => {
     scopeHashPrefixBehavior = async () => null;
+    sessionHashPrefixBehavior = async () => null;
     findByIdAndOrg.mockResolvedValue(agent());
 
     await resolveSharedAgent(contextWithAgentId("agent-1") as never);
@@ -248,5 +265,77 @@ describe("resolveSharedAgent scope cache (COLDPATH-FIX-2026-07-21)", () => {
     expect(cacheSet).not.toHaveBeenCalled();
     // Authoritative gate still ran.
     expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => {
+  // Shadow's own account authenticates by steward JWT / cookie, not an API key,
+  // so the API-key-only scope cache used to skip him entirely -> he paid the
+  // cold user/org+agent Hyperdrive waves on EVERY turn (the felt 3-4s warm AND
+  // cold). These pin the session-keyed cache that closes that gap.
+
+  test("first cold session hit runs the full gate and caches with the steward user id", async () => {
+    scopeHashPrefixBehavior = async () => null;
+    sessionHashPrefixBehavior = async () => "sesshashpref0000";
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    await resolveSharedAgent(contextWithAgentId("agent-1") as never);
+
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+    const [cacheKey, cachedValue] = cacheSet.mock.calls[0];
+    // Session key is namespaced with `s:` so it can't collide with an api-key hash.
+    expect(String(cacheKey)).toContain("s:sesshashpref0000");
+    expect(cachedValue).toMatchObject({
+      orgId: "org-1",
+      stewardUserId: "steward-user-1",
+    });
+  });
+
+  test("second session hit skips the cold DB waves after re-verifying the JWT", async () => {
+    scopeHashPrefixBehavior = async () => null;
+    sessionHashPrefixBehavior = async () => "sesshashpref0000";
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    // Populate.
+    await resolveSharedAgent(contextWithAgentId("agent-1") as never);
+    requireUserOrApiKeyWithOrgLookup.mockClear();
+    findByIdAndOrg.mockClear();
+
+    // Second hit: served from cache, no user/org+agent hydration.
+    const result = await resolveSharedAgent(contextWithAgentId("agent-1") as never);
+    expect(result).toMatchObject({ agentId: "agent-1", orgId: "org-1" });
+    expect(requireUserOrApiKeyWithOrgLookup).not.toHaveBeenCalled();
+    expect(findByIdAndOrg).not.toHaveBeenCalled();
+    // But the credential gate STILL ran (JWT re-verified against the cached user).
+    expect(revalidateSessionScope).toHaveBeenCalledTimes(1);
+    expect(revalidateSessionScope.mock.calls[0][1]).toBe("steward-user-1");
+  });
+
+  test("a session hit whose token no longer verifies falls back to the full gate", async () => {
+    scopeHashPrefixBehavior = async () => null;
+    sessionHashPrefixBehavior = async () => "sesshashpref0000";
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    await resolveSharedAgent(contextWithAgentId("agent-1") as never);
+    requireUserOrApiKeyWithOrgLookup.mockClear();
+
+    // Token now invalid / re-issued for a different user.
+    sessionRevalidateBehavior = async () => false;
+    await resolveSharedAgent(contextWithAgentId("agent-1") as never);
+    // Not served from cache -> authoritative gate re-ran.
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+  });
+
+  test("the api-key path is preferred over session when both are present", async () => {
+    // Both derivations available; api-key wins, session cache is not consulted.
+    scopeHashPrefixBehavior = async () => "keyhashpref0000";
+    sessionHashPrefixBehavior = async () => "sesshashpref0000";
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    await resolveSharedAgent(apiKeyContext("agent-1") as never);
+    const [cacheKey] = cacheSet.mock.calls[0];
+    expect(String(cacheKey)).not.toContain("s:");
+    expect(revalidateSessionScope).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -9,6 +9,8 @@ import type { AppEnv } from "../../../types/cloud-worker-env";
 import {
   apiKeyScopeHashPrefix,
   requireUserOrApiKeyWithOrgLookup,
+  revalidateSessionScope,
+  sessionScopeHashPrefix,
 } from "../../auth/workers-hono-auth";
 import { cache } from "../../cache/client";
 import { CacheKeys, CacheTTL } from "../../cache/keys";
@@ -32,6 +34,14 @@ export type ResolvedSharedAgent =
 interface CachedSharedAgentScope {
   orgId: string;
   agent: AgentSandbox;
+  /**
+   * Steward user id the entry was written for, present ONLY on session-keyed
+   * entries (#SHADOW-ACCOUNT-DEBUG). A session-path hit re-verifies the JWT and
+   * confirms it still maps to THIS user before serving, so a rotated/re-issued
+   * token for a different user can't read a stale entry. Absent on API-key
+   * entries (those revalidate via the key's org instead).
+   */
+  stewardUserId?: string;
 }
 
 /**
@@ -85,7 +95,17 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
   // stall. A short-TTL scope cache keyed by (key-hash, agentId) lets the second
   // cold-session hit (or a composer-mount prewarm) skip both waves. Miss → the
   // authoritative gate below runs unchanged, so this only removes latency.
-  const scopeKeyPrefix = await apiKeyScopeHashPrefix(c).catch(() => null);
+  // API-key path uses the key-hash prefix; SESSION path (Shadow's own account:
+  // steward JWT / cookie) uses the session-token hash under a distinct `s:`
+  // namespace so a session hash can never collide with an API-key hash
+  // (#SHADOW-ACCOUNT-DEBUG). Whichever credential the request carries wins;
+  // requests carrying neither skip the cache and hit the authoritative gate.
+  const apiKeyPrefix = await apiKeyScopeHashPrefix(c).catch(() => null);
+  const sessionPrefix = apiKeyPrefix
+    ? null
+    : await sessionScopeHashPrefix(c).catch(() => null);
+  const isSessionScope = apiKeyPrefix == null && sessionPrefix != null;
+  const scopeKeyPrefix = apiKeyPrefix ?? (sessionPrefix ? `s:${sessionPrefix}` : null);
   const scopeCacheKey = scopeKeyPrefix
     ? CacheKeys.sharedAgentScope.resolve(scopeKeyPrefix, agentId)
     : null;
@@ -93,14 +113,16 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
     const cached = await cache.get<CachedSharedAgentScope>(scopeCacheKey).catch(() => null);
     if (cached?.agent && cached.orgId && cached.agent.execution_tier === "shared") {
       // SECURITY: a hit skips the expensive user/org+agent DB hydration, but it
-      // must NOT skip the credential gate. Re-run the (already-cached,
-      // revoke-invalidated) API-key validation so a revoked/expired/inactive key
-      // still 401s inside the TTL window, and confirm the key still resolves to
-      // the SAME org the cached agent is scoped to (a detached/re-scoped key must
-      // not read another org's agent from a stale entry). Only then serve the
-      // cached agent row — the two cold Hyperdrive waves are what we skip, never
-      // the authorization decision.
-      const stillAuthorized = await revalidateCachedScope(c, cached.orgId).catch(() => false);
+      // must NOT skip the credential gate. API-key path: re-run the (already-
+      // cached, revoke-invalidated) key validation + org match. SESSION path:
+      // re-run the warm-cached steward JWT verify + confirm it still maps to the
+      // SAME steward user the entry was written for. Either way a
+      // revoked/expired/re-scoped credential falls back to the authoritative
+      // gate inside the 30s TTL window; we only skip the cold DB waves.
+      const stillAuthorized = isSessionScope
+        ? cached.stewardUserId != null &&
+          (await revalidateSessionScope(c, cached.stewardUserId).catch(() => false))
+        : await revalidateCachedScope(c, cached.orgId).catch(() => false);
       if (stillAuthorized) {
         return {
           agent: cached.agent,
@@ -124,12 +146,16 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
   // dedicated-bootstrap window, whose eligibility is time-sensitive as the
   // container boots). Best-effort: a cache write failure must not fail the turn.
   if (scopeCacheKey && agent.execution_tier === "shared") {
+    // Session-keyed entries carry the steward user id so a hit can re-verify the
+    // JWT maps to the same user without a user/org DB read (#SHADOW-ACCOUNT-DEBUG).
+    // Only write it when we actually have it (session path + a steward-linked
+    // user); its absence just means the hit safely falls back to the slow gate.
+    const entry: CachedSharedAgentScope =
+      isSessionScope && typeof user.steward_id === "string"
+        ? { orgId: user.organization_id, agent, stewardUserId: user.steward_id }
+        : { orgId: user.organization_id, agent };
     void cache
-      .set(
-        scopeCacheKey,
-        { orgId: user.organization_id, agent } satisfies CachedSharedAgentScope,
-        CacheTTL.sharedAgentScope.resolve,
-      )
+      .set(scopeCacheKey, entry, CacheTTL.sharedAgentScope.resolve)
       .catch((error) => {
         logger.debug("[resolveSharedAgent] scope cache write failed", {
           error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
# Relates to

Latency debug of my own staging account (agent `b850bc30…`, steward/JWT auth, app-staging): a felt **3–4s per turn, warm AND cold**, that the API-key-shaped warm latency harness never reproduced. Root cause + timing table: `SHADOW-ACCOUNT-DEBUG-2026-07-21`. Extends the API-key-only scope cache from #16737 / `COLDPATH-FIX-2026-07-21`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package tests were run after sync (see Testing).
- [x] A reviewer can confirm the change works from the evidence attached below.

# Sync with develop

- [x] Cherry-picked cleanly onto latest `origin/develop` (base `90b430d33a3`); zero conflicts. Independent of the task-hygiene PR (disjoint files).
- [x] `packages/cloud/shared` suite passes post-sync (see Testing).

# Risks

**Medium (auth-adjacent), mitigated.** This extends a resolved-scope cache to the session/JWT path, so the security-critical property is: **a cache hit must skip only the cold DB waves, never the authorization decision.** Enforced and tested:

- A session-path hit re-runs the warm-cached steward-JWT verify (`revalidateSessionScope`) and confirms the token still maps to the **same** steward user the entry was written for. Any not-OK state (expired / rotated / invalid token, or a token now mapping to a **different** user) returns false and **falls back to the full authoritative gate**. The two cold Hyperdrive waves are skipped; the credential check never is. Pinned by the "a session hit whose token no longer verifies falls back to the full gate" test.
- Session entries live in a distinct `s:` cache namespace, so a session-token hash can never collide with an API-key hash.
- When both credentials are present the **API-key path is preferred** and the session cache isn't consulted.
- 30s TTL; a miss runs the unchanged authoritative gate; a cache-write failure is best-effort and never fails the turn.

# Background

## What does this PR do?

The #16737 resolved-scope cache is keyed **only** on an API-key hash (`apiKeyScopeHashPrefix` returns `null` for session/cookie auth), so session/JWT requests skip the cache entirely and re-pay the two cold user/org+agent Hyperdrive waves in `resolveSharedAgent` on **every** turn — the felt 3–4s that only session-auth accounts see (the warm harness reuses one API-key conversation and never hits this shape).

Adds a session-keyed path:
- `sessionScopeHashPrefix` — 16-char hash of the current request's steward token (bearer JWT or steward cookie), or null when no session token; distinct `s:` namespace.
- `revalidateSessionScope` — warm-cached JWT re-verify (in-mem LRU → Redis → local jose, ~0–5ms) that confirms the token still maps to the same steward user id; returns false otherwise.
- `resolveSharedAgent` now caches the session path under `s:<hash>`, storing the steward user id so a hit re-verifies the credential and skips **only** the cold DB waves. API-key path unchanged and preferred when both are present.

Expected effect: second turn in a session drops the ~1–4s cold-scope waves (target cold first-hit <1s, warm ~0.2s), matching the API-key numbers.

## What kind of change is this?

Bug fix / performance (non-breaking).

# Documentation changes needed?

No. Internal cloud auth/scope-cache path; no public API surface change.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts` — the `SESSION scope cache (SHADOW-ACCOUNT-DEBUG)` describe block, then the caching logic in `resolve-shared-agent.ts` and the two new helpers in `workers-hono-auth.ts`.

## Detailed testing steps

Automated (`bun test`, the package's runner). Full run — all 15 including the pre-existing COLDPATH cases and the 4 new SESSION cases:

```
$ bun test src/lib/services/shared-runtime/resolve-shared-agent.test.ts
(pass) resolveSharedAgent scope cache (COLDPATH-FIX-2026-07-21) > a revoked key on a cache hit falls back to the full gate (never served stale)
(pass) resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG) > first cold session hit runs the full gate and caches with the steward user id
(pass) resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG) > second session hit skips the cold DB waves after re-verifying the JWT
(pass) resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG) > a session hit whose token no longer verifies falls back to the full gate
(pass) resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG) > the api-key path is preferred over session when both are present
 15 pass
 0 fail
 33 expect() calls
Ran 15 tests across 1 file.
```

The **security fallback** is the third SESSION case: `revalidateSessionScope` returns false → `stillAuthorized` false → the authoritative gate (`requireUserOrApiKeyWithOrgLookup`) is called exactly once. A warm cache entry never serves a revoked/expired/wrong-user token.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - no UI surface changed; cloud auth/scope-cache path (workers-hono-auth.ts, resolve-shared-agent.ts)`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no user flow; request-layer scope resolution, deterministic`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs / test run exercising the real `resolveSharedAgent` scope-cache path (15/15 incl. the security-fallback case): https://github.com/elizaOS/eliza/actions/runs/29862275688/job/88741718886 — full transcript also pasted under Testing → Detailed testing steps above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic request-layer auth/scope resolution; no model call in the path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: timing table + per-turn breakdown in the `SHADOW-ACCOUNT-DEBUG-2026-07-21` root-cause receipt, building on `REALPATH-LATENCY-2026-07-21` / `COLDPATH-FIX-2026-07-21`. See https://github.com/elizaOS/eliza/pull/16743 for the full diff and test output.

# Known gaps / failures

None in the touched package. Live `wrangler tail` per-turn trace was not run (needs a `CLOUDFLARE_API_TOKEN` not sourced in this lane); causation is grounded in the static call-graph plus the prior measured latency receipts, which reproduce the exact band.