### PR TITLE
feat(plugins): add plugin-serpdive, a SERPdive-backed web search provider

### DIFF
--- a/plugins/plugin-serpdive/README.md
+++ b/plugins/plugin-serpdive/README.md
@@ -1,0 +1,101 @@
+# @elizaos/plugin-serpdive
+
+Adds live web search to an Eliza agent via the [SERPdive](https://serpdive.com) API.
+
+SERPdive returns extracted, answer-ready page content instead of links: each
+result carries the actual text of the page (url, title, date, content),
+already extracted and cleaned for LLM consumption, so agents quote and cite
+straight from the tool output. On a
+[public, replayable 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark),
+SERPdive runs at the same speed as Tavily, feeds the LLM 20.2% fewer tokens,
+and wins 60.7% of decided quality duels against Tavily's default search.
+
+## What it does
+
+Installing this plugin registers a `SerpdiveSearchService`
+(`ServiceType.WEB_SEARCH`) that any other plugin or action can call to search
+the web. It also registers the `"web"` search category so the elizaOS core
+search-dispatch layer routes web queries to this service automatically.
+
+Capabilities exposed through the service:
+
+- **General web search** — extracted page content with optional synthesized answer.
+- **News search** — delegates to general search; SERPdive infers freshness and
+  locale from the query itself (no separate news endpoint).
+- **Image / video search** — delegate to general search; `images` stays empty
+  rather than fabricating entries (SERPdive has no media endpoints).
+- **Suggestions / trending** — derived from unique result titles.
+- **Page info** — fetches a URL and extracts title, description, and raw HTML
+  content (plain fetch, not SERPdive-backed).
+
+No actions are registered by the plugin itself. Other plugins that rely on web
+search call `runtime.getService(ServiceType.WEB_SEARCH)` and invoke the
+service directly.
+
+This plugin is a drop-in alternative to `@elizaos/plugin-web-search`: the
+option shapes match, `searchDepth: "basic" | "advanced"` maps to SERPdive's
+`mako` (fast, key sentences) and `moby` (full page text) models, and a native
+`model` option is available as an escape hatch. Use one web-search provider
+per agent: both register `ServiceType.WEB_SEARCH`.
+
+## Installation
+
+Add the package to your agent:
+
+```bash
+bun add @elizaos/plugin-serpdive
+```
+
+Then include it in your character config:
+
+```typescript
+import { serpdivePlugin } from "@elizaos/plugin-serpdive";
+
+export default {
+    plugins: [serpdivePlugin],
+    // ...
+};
+```
+
+## Configuration
+
+| Environment variable | Required | Description |
+| --- | --- | --- |
+| `SERPDIVE_API_KEY` | Yes (service is inert without it) | SERPdive API key. Free at [serpdive.com/dashboard/keys](https://serpdive.com/dashboard/keys) — 1,000 credits per month, no card required. |
+
+Without a key the plugin boots inert instead of crashing the agent: `search()`
+throws a descriptive, recoverable error until a key is provided.
+
+## Usage
+
+```typescript
+import { ServiceType } from "@elizaos/core";
+
+const search = runtime.getService(ServiceType.WEB_SEARCH);
+
+const response = await search.search("what changed in the EU AI Act this month", {
+    limit: 5,               // hard cap on delivered results (1-10)
+    includeAnswer: true,    // also synthesize a direct answer from the sources
+    searchDepth: "basic",  // "basic" → mako (fast), "advanced" → moby (full pages)
+});
+
+for (const result of response.results) {
+    // result.content is the extracted text of the page, not a snippet
+    console.log(result.title, result.url, result.publishedDate);
+}
+```
+
+Localization is automatic: the language of the query picks where the search
+runs. There is no country or locale parameter.
+
+## Costs
+
+One `mako` search costs 1 credit, one `moby` search 1.5. The synthesized
+answer is included in the price. Failed searches are never billed. Full
+pricing: [serpdive.com](https://serpdive.com/#pricing).
+
+## Links
+
+- [API reference](https://serpdive.com/docs)
+- [Public benchmark](https://github.com/edendalexis/serpdive-benchmark) — replayable end to end
+- [SDK](https://www.npmjs.com/package/serpdive) (zero runtime dependencies)

--- a/plugins/plugin-serpdive/biome.json
+++ b/plugins/plugin-serpdive/biome.json
@@ -1,0 +1,33 @@
+{
+    "root": false,
+    "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+    "assist": { "actions": { "source": { "organizeImports": "on" } } },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "preset": "recommended",
+            "correctness": {
+                "noUnusedVariables": "error"
+            },
+            "suspicious": {
+                "noExplicitAny": "error"
+            },
+            "style": {
+                "useConst": "error"
+            }
+        }
+    },
+    "formatter": {
+        "enabled": true,
+        "indentWidth": 4,
+        "indentStyle": "space",
+        "lineWidth": 100
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+            "trailingCommas": "es5",
+            "semicolons": "always"
+        }
+    }
+}

--- a/plugins/plugin-serpdive/package.json
+++ b/plugins/plugin-serpdive/package.json
@@ -1,0 +1,68 @@
+{
+    "name": "@elizaos/plugin-serpdive",
+    "version": "2.0.3-beta.7",
+    "type": "module",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "eliza-source": {
+                "types": "./src/index.ts",
+                "import": "./src/index.ts",
+                "default": "./src/index.ts"
+            },
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        },
+        "./*.css": "./dist/*.css",
+        "./*": {
+            "types": "./dist/*.d.ts",
+            "eliza-source": {
+                "types": "./src/*.ts",
+                "import": "./src/*.ts",
+                "default": "./src/*.ts"
+            },
+            "import": "./dist/*.js",
+            "default": "./dist/*.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "serpdive": "^0.1.0"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.5.4",
+        "tsup": "^8.5.1",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7"
+    },
+    "scripts": {
+        "test": "vitest run --config ./vitest.config.ts",
+        "build": "tsup --format esm --dts",
+        "dev": "tsup --format esm --dts --watch",
+        "lint": "bunx @biomejs/biome check --write --unsafe .",
+        "lint:fix": "bunx @biomejs/biome check --write src/",
+        "format": "bunx @biomejs/biome format --write .",
+        "format:fix": "bunx @biomejs/biome format --write src/",
+        "typecheck": "tsc --noEmit -p tsconfig.json",
+        "lint:check": "bunx @biomejs/biome check .",
+        "format:check": "bunx @biomejs/biome format ."
+    },
+    "agentConfig": {
+        "pluginType": "elizaos:client:1.0.0",
+        "pluginParameters": {
+            "SERPDIVE_API_KEY": {
+                "type": "string",
+                "description": "SERPdive API key, free at https://serpdive.com/dashboard/keys"
+            }
+        }
+    }
+}

--- a/plugins/plugin-serpdive/src/index.ts
+++ b/plugins/plugin-serpdive/src/index.ts
@@ -1,0 +1,80 @@
+/**
+ * Entry point for the SERPdive plugin.
+ *
+ * Exports the `serpdivePlugin` object and the `"web"` search-category
+ * definition (`WEB_SEARCH_CATEGORY`). Registering the plugin adds the
+ * SERPdive-backed `SerpdiveSearchService` and registers the category with
+ * core's search dispatch (via `runtime.registerSearchCategory`) so web/news
+ * queries route here. Opt-in, and registers no
+ * actions/providers/evaluators/routes.
+ *
+ * Category registration is guarded exactly like plugin-web-search's, so
+ * loading this plugin alongside another web-search provider does not
+ * double-register the "web" category — but only one WEB_SEARCH service is
+ * active at a time, so pick one provider per agent.
+ */
+
+import type { IAgentRuntime, Plugin, SearchCategoryRegistration } from "@elizaos/core";
+import { ServiceType } from "@elizaos/core";
+
+import { SerpdiveSearchService } from "./services/serpdiveSearchService";
+
+export const WEB_SEARCH_CATEGORY: SearchCategoryRegistration = {
+    category: "web",
+    label: "Web",
+    description: "Search current web pages through plugin-serpdive.",
+    contexts: ["knowledge", "browser"],
+    filters: [
+        {
+            name: "model",
+            label: "Model",
+            description:
+                "SERPdive retrieval depth: mako returns the fact-carrying sentences of each page, moby the full page text.",
+            type: "enum",
+            options: [
+                { label: "Mako (fast, key sentences)", value: "mako" },
+                { label: "Moby (full page text)", value: "moby" },
+            ],
+        },
+        {
+            name: "includeAnswer",
+            label: "Include answer",
+            description: "Also return a direct answer synthesized from the sources.",
+            type: "boolean",
+        },
+    ],
+    resultSchemaSummary:
+        "SearchResponse with query, answer, and results containing title/url/description/content where content is the extracted text of the page.",
+    capabilities: ["web", "news", "current-information"],
+    source: "plugin-serpdive",
+    serviceType: ServiceType.WEB_SEARCH,
+};
+
+export function registerWebSearchCategory(runtime: IAgentRuntime): void {
+    try {
+        runtime.getSearchCategory(WEB_SEARCH_CATEGORY.category, {
+            includeDisabled: true,
+        });
+        return;
+    } catch {
+        runtime.registerSearchCategory(WEB_SEARCH_CATEGORY);
+    }
+}
+
+export const serpdivePlugin: Plugin = {
+    name: "serpdive",
+    description:
+        "Web search that returns extracted, answer-ready page content through the SERPdive API",
+    init: async (_config, runtime) => {
+        registerWebSearchCategory(runtime);
+    },
+    async dispose(runtime) {
+        const svc = runtime.getService<SerpdiveSearchService>(SerpdiveSearchService.serviceType);
+        await svc?.stop();
+    },
+    actions: [],
+    providers: [],
+    services: [SerpdiveSearchService],
+};
+
+export default serpdivePlugin;

--- a/plugins/plugin-serpdive/src/services/serpdiveSearchService.test.ts
+++ b/plugins/plugin-serpdive/src/services/serpdiveSearchService.test.ts
@@ -1,0 +1,192 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SerpdiveSearchService } from "./serpdiveSearchService";
+
+const searchMock = vi.hoisted(() => vi.fn());
+// A function expression, not an arrow: the service instantiates the SDK with
+// `new SerpDive(...)`, and arrows are not constructible.
+const serpdiveMock = vi.hoisted(() =>
+    vi.fn(function (this: unknown) {
+        return { search: searchMock };
+    })
+);
+
+vi.mock("serpdive", () => ({
+    SerpDive: serpdiveMock,
+}));
+
+function runtime(settings: Record<string, string | undefined>): IAgentRuntime {
+    return {
+        getSetting: (key: string) => settings[key],
+    } as unknown as IAgentRuntime;
+}
+
+describe("SerpdiveSearchService", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        searchMock.mockReset();
+        serpdiveMock.mockClear();
+    });
+
+    it("starts inert without SERPDIVE_API_KEY and trims configured keys", async () => {
+        // Graceful degradation: missing/blank keys must NOT crash agent boot.
+        const inert = await SerpdiveSearchService.start(runtime({}));
+        await expect(inert.search("anything")).rejects.toThrow(
+            "Web search is not configured: set SERPDIVE_API_KEY to enable it."
+        );
+        const blank = await SerpdiveSearchService.start(runtime({ SERPDIVE_API_KEY: "  " }));
+        await expect(blank.search("eliza")).rejects.toThrow(
+            "Web search is not configured: set SERPDIVE_API_KEY to enable it."
+        );
+        expect(serpdiveMock).not.toHaveBeenCalled();
+
+        await SerpdiveSearchService.start(runtime({ SERPDIVE_API_KEY: "sd_live_test" }));
+        expect(serpdiveMock).toHaveBeenCalledWith({ apiKey: "sd_live_test" });
+
+        serpdiveMock.mockClear();
+        await SerpdiveSearchService.start(runtime({ SERPDIVE_API_KEY: "  sd_live_trim  " }));
+        expect(serpdiveMock).toHaveBeenCalledWith({ apiKey: "sd_live_trim" });
+    });
+
+    it("maps options to the SDK and normalizes the API payload", async () => {
+        searchMock.mockResolvedValue({
+            query: "provider query",
+            model: "moby",
+            response_time_ms: 2641,
+            answer: "the answer",
+            results: [
+                {
+                    url: "https://example.test",
+                    title: "Result",
+                    date: "2026-07-11",
+                    content: "The fact-carrying text of the page.",
+                },
+                {
+                    url: "https://no-title.test",
+                    title: null,
+                    content: "Body without a title.",
+                },
+            ],
+        });
+        const service = await SerpdiveSearchService.start(
+            runtime({ SERPDIVE_API_KEY: "sd_live_test" })
+        );
+
+        const response = await service.search("eliza", {
+            includeAnswer: true,
+            limit: 5,
+            searchDepth: "advanced",
+        });
+
+        // searchDepth "advanced" maps to the moby model; limit to maxResults.
+        expect(searchMock).toHaveBeenCalledWith("eliza", {
+            model: "moby",
+            answer: true,
+            maxResults: 5,
+        });
+
+        expect(response.answer).toBe("the answer");
+        expect(response.query).toBe("provider query");
+        // response_time_ms is converted to Tavily-style seconds.
+        expect(response.responseTime).toBeCloseTo(2.641);
+        expect(response.images).toEqual([]);
+        expect(response.results).toHaveLength(2);
+        expect(response.results[0]).toMatchObject({
+            title: "Result",
+            url: "https://example.test",
+            content: "The fact-carrying text of the page.",
+            description: "The fact-carrying text of the page.",
+            score: 0,
+        });
+        expect(response.results[0]?.publishedDate).toEqual(new Date("2026-07-11"));
+        expect(response.results[1]?.title).toBe("Untitled");
+        expect(response.results[1]?.publishedDate).toBeUndefined();
+    });
+
+    it("defaults to mako with an answer, honors the native model option", async () => {
+        searchMock.mockResolvedValue({ query: "q", results: [] });
+        const service = await SerpdiveSearchService.start(
+            runtime({ SERPDIVE_API_KEY: "sd_live_test" })
+        );
+
+        await service.search("plain");
+        expect(searchMock).toHaveBeenLastCalledWith("plain", { model: "mako", answer: true });
+
+        await service.search("deep", { model: "moby", searchDepth: "basic" });
+        // The native model option wins over searchDepth.
+        expect(searchMock).toHaveBeenLastCalledWith("deep", { model: "moby", answer: true });
+    });
+
+    it("rejects malformed queries and options before touching the network", async () => {
+        const service = await SerpdiveSearchService.start(
+            runtime({ SERPDIVE_API_KEY: "sd_live_test" })
+        );
+
+        await expect(service.search("   ")).rejects.toThrow("search query is required");
+        await expect(service.search("q", { limit: 0 })).rejects.toThrow(
+            "limit must be a positive finite integer"
+        );
+        await expect(
+            service.search("q", { searchDepth: "extreme" as never })
+        ).rejects.toThrow("searchDepth must be basic or advanced");
+        await expect(service.search("q", { model: "orca" as never })).rejects.toThrow(
+            "model must be mako or moby"
+        );
+        expect(searchMock).not.toHaveBeenCalled();
+    });
+
+    it("news, image and video searches delegate to web search without fabricating media", async () => {
+        searchMock.mockResolvedValue({
+            query: "q",
+            results: [
+                { url: "https://a.test", title: "A", content: "a" },
+                { url: "https://b.test", title: "B", content: "b" },
+            ],
+        });
+        const service = await SerpdiveSearchService.start(
+            runtime({ SERPDIVE_API_KEY: "sd_live_test" })
+        );
+
+        const news = await service.searchNews("elections", { freshness: "day", limit: 2 });
+        expect(searchMock).toHaveBeenLastCalledWith("elections", {
+            model: "mako",
+            answer: true,
+            maxResults: 2,
+        });
+        expect(news.images).toEqual([]);
+
+        await service.searchVideos("rocket launch");
+        // Video search biases the query, same approach as plugin-web-search.
+        expect(searchMock).toHaveBeenLastCalledWith(
+            "rocket launch video",
+            expect.objectContaining({ model: "mako" })
+        );
+
+        const images = await service.searchImages("nebula", { limit: 2 });
+        expect(images.images).toEqual([]);
+    });
+
+    it("derives suggestions from unique result titles", async () => {
+        searchMock.mockResolvedValue({
+            query: "q",
+            results: [
+                { url: "https://a.test", title: "Alpha", content: "a" },
+                { url: "https://b.test", title: "alpha", content: "dup, case-insensitive" },
+                { url: "https://c.test", title: "", content: "no title" },
+                { url: "https://d.test", title: "Beta", content: "b" },
+            ],
+        });
+        const service = await SerpdiveSearchService.start(
+            runtime({ SERPDIVE_API_KEY: "sd_live_test" })
+        );
+
+        await expect(service.getSuggestions("query")).resolves.toEqual(["Alpha", "Beta"]);
+        // Suggestions skip the synthesized answer: it costs latency for
+        // nothing here.
+        expect(searchMock).toHaveBeenLastCalledWith("query", {
+            model: "mako",
+            answer: false,
+            maxResults: 5,
+        });
+    });
+});

--- a/plugins/plugin-serpdive/src/services/serpdiveSearchService.ts
+++ b/plugins/plugin-serpdive/src/services/serpdiveSearchService.ts
@@ -1,0 +1,284 @@
+/**
+ * SERPdive-backed `SerpdiveSearchService` — a `ServiceType.WEB_SEARCH`
+ * implementation.
+ *
+ * Wraps the zero-dependency `serpdive` SDK to fulfil the `IWebSearchService`
+ * contract (search / news / images / videos / suggestions / trending /
+ * page-info). SERPdive returns extracted, answer-ready page content instead of
+ * links, so `content` carries the actual text of each page. Degrades
+ * gracefully: without `SERPDIVE_API_KEY` it boots inert and throws a
+ * descriptive error on first use rather than crashing boot.
+ *
+ * Mapping notes, kept deliberately honest:
+ * - `searchDepth` maps to SERPdive's models: "basic" → `mako` (fact-carrying
+ *   sentences, fast), "advanced" → `moby` (full page text). A native `model`
+ *   option wins when provided.
+ * - News search is plain search: SERPdive infers freshness and locale from
+ *   the query itself; there is no separate news endpoint or recency knob, so
+ *   `days`/`freshness` are accepted for compatibility and not forwarded.
+ * - SERPdive returns no images, so image/video search reuse web search and
+ *   `images` stays empty — results are never fabricated.
+ * - `getPageInfo` is a raw fetch + regex scrape (not SERPdive-backed), same
+ *   as plugin-web-search.
+ */
+
+import { type IAgentRuntime, IWebSearchService, logger, ServiceType } from "@elizaos/core";
+import { SerpDive } from "serpdive";
+
+import type {
+    ImageSearchOptions,
+    NewsSearchOptions,
+    SearchOptions,
+    SearchResponse,
+    VideoSearchOptions,
+} from "../types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parsePublishedDate(value: string | undefined): Date | undefined {
+    if (!value) return undefined;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function normalizeApiKey(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function validateSearchQuery(query: unknown): string {
+    if (typeof query !== "string" || !query.trim()) {
+        throw new Error("search query is required");
+    }
+    return query.trim();
+}
+
+function assertOptionalPositiveInteger(value: unknown, name: string): void {
+    if (
+        value !== undefined &&
+        (typeof value !== "number" ||
+            !Number.isFinite(value) ||
+            !Number.isInteger(value) ||
+            value < 1)
+    ) {
+        throw new Error(`${name} must be a positive finite integer`);
+    }
+}
+
+function validateSearchOptions(options?: SearchOptions): void {
+    if (options === undefined) return;
+    if (!isRecord(options)) {
+        throw new Error("search options must be an object");
+    }
+    assertOptionalPositiveInteger(options.limit, "limit");
+    if (options.topic !== undefined && options.topic !== "general" && options.topic !== "news") {
+        throw new Error("topic must be general or news");
+    }
+    if (options.type !== undefined && options.type !== "general" && options.type !== "news") {
+        throw new Error("type must be general or news");
+    }
+    if (
+        options.searchDepth !== undefined &&
+        options.searchDepth !== "basic" &&
+        options.searchDepth !== "advanced"
+    ) {
+        throw new Error("searchDepth must be basic or advanced");
+    }
+    if (options.model !== undefined && options.model !== "mako" && options.model !== "moby") {
+        throw new Error("model must be mako or moby");
+    }
+    if (options.includeAnswer !== undefined && typeof options.includeAnswer !== "boolean") {
+        throw new Error("includeAnswer must be a boolean");
+    }
+}
+
+function pickModel(options?: SearchOptions): "mako" | "moby" {
+    if (options?.model) return options.model;
+    return options?.searchDepth === "advanced" ? "moby" : "mako";
+}
+
+function normalizeResponse(query: string, response: unknown): SearchResponse {
+    const payload = isRecord(response) ? response : {};
+    const rawResults = Array.isArray(payload.results) ? payload.results : [];
+    const results = rawResults.filter(isRecord).map((result) => {
+        const content = typeof result.content === "string" ? result.content : "";
+        return {
+            title: typeof result.title === "string" && result.title ? result.title : "Untitled",
+            url: typeof result.url === "string" ? result.url : "",
+            description: content,
+            content,
+            rawContent: undefined,
+            // SERPdive orders results best-first but publishes no per-result
+            // score; 0 mirrors plugin-web-search's default for absent scores.
+            score: 0,
+            publishedDate: parsePublishedDate(
+                typeof result.date === "string" ? result.date : undefined
+            ),
+        };
+    });
+
+    return {
+        answer: typeof payload.answer === "string" ? payload.answer : undefined,
+        query: typeof payload.query === "string" ? payload.query : query,
+        // The API reports milliseconds; core consumers expect Tavily-style
+        // seconds, so convert.
+        responseTime:
+            typeof payload.response_time_ms === "number" &&
+            Number.isFinite(payload.response_time_ms)
+                ? payload.response_time_ms / 1000
+                : undefined,
+        images: [],
+        results,
+    };
+}
+
+function uniqueResultTitles(response: SearchResponse, limit: number): string[] {
+    const seen = new Set<string>();
+    const titles: string[] = [];
+    for (const result of response.results) {
+        const title = result.title.trim();
+        if (!title || title === "Untitled") continue;
+        const key = title.toLocaleLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        titles.push(title);
+        if (titles.length >= limit) break;
+    }
+    return titles;
+}
+
+export class SerpdiveSearchService extends IWebSearchService {
+    static override serviceType = ServiceType.WEB_SEARCH;
+    override capabilityDescription = "Web search and content discovery capabilities" as const;
+
+    serpdiveClient: SerpDive | undefined;
+    private configured = false;
+
+    static override async start(runtime: IAgentRuntime): Promise<SerpdiveSearchService> {
+        const service = new SerpdiveSearchService(runtime);
+        await service.initialize(runtime);
+        return service;
+    }
+
+    async stop(): Promise<void> {
+        // The SERPdive client is stateless HTTP; nothing to tear down.
+    }
+
+    private async initialize(runtime: IAgentRuntime): Promise<void> {
+        const apiKey = normalizeApiKey(runtime.getSetting("SERPDIVE_API_KEY"));
+        if (!apiKey) {
+            // Degrade gracefully instead of throwing, so the plugin can be
+            // installed unconfigured without crashing agent boot. The service
+            // stays inert and `search()` reports an honest, recoverable error
+            // until a SERPDIVE_API_KEY is provided.
+            this.configured = false;
+            logger.warn(
+                { src: "plugin-serpdive" },
+                "SERPDIVE_API_KEY not set — web search is inert until a key is provided"
+            );
+            return;
+        }
+        this.serpdiveClient = new SerpDive({ apiKey });
+        this.configured = true;
+    }
+
+    async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+        const normalizedQuery = validateSearchQuery(query);
+        validateSearchOptions(options);
+        if (!this.configured || !this.serpdiveClient) {
+            throw new Error("Web search is not configured: set SERPDIVE_API_KEY to enable it.");
+        }
+        try {
+            const response = await this.serpdiveClient.search(normalizedQuery, {
+                model: pickModel(options),
+                answer: options?.includeAnswer ?? true,
+                ...(options?.limit !== undefined ? { maxResults: options.limit } : {}),
+            });
+
+            // The JS SDK returns the API payload verbatim (snake_case fields
+            // included), so it can be normalized directly.
+            return normalizeResponse(normalizedQuery, response);
+        } catch (cause) {
+            const err = cause instanceof Error ? cause : new Error(String(cause));
+            logger.error({ src: "plugin-serpdive", err }, "Web search error");
+            throw err;
+        }
+    }
+
+    async searchNews(query: string, options?: NewsSearchOptions): Promise<SearchResponse> {
+        // SERPdive infers freshness from the query itself; `freshness` is
+        // accepted for provider compatibility but has no knob to forward.
+        return this.search(query, {
+            limit: options?.limit,
+        });
+    }
+
+    async searchImages(query: string, options?: ImageSearchOptions): Promise<SearchResponse> {
+        // No image endpoint: reuse web search. `images` stays empty rather
+        // than fabricating entries.
+        return this.search(validateSearchQuery(query), {
+            limit: options?.limit,
+        });
+    }
+
+    async searchVideos(query: string, options?: VideoSearchOptions): Promise<SearchResponse> {
+        // Same approach as plugin-web-search: no video endpoint, bias the
+        // query and reuse web search.
+        const normalizedQuery = validateSearchQuery(query);
+        return this.search(`${normalizedQuery} video`, {
+            limit: options?.limit,
+        });
+    }
+
+    async getSuggestions(query: string): Promise<string[]> {
+        const response = await this.search(validateSearchQuery(query), {
+            includeAnswer: false,
+            limit: 5,
+        });
+        return uniqueResultTitles(response, 5);
+    }
+
+    async getTrendingSearches(region?: string): Promise<string[]> {
+        const normalizedRegion = typeof region === "string" ? region.trim() : "";
+        const query = normalizedRegion ? `trending news in ${normalizedRegion}` : "trending news";
+        const response = await this.searchNews(query, { limit: 5 });
+        return uniqueResultTitles(response, 5);
+    }
+
+    async getPageInfo(url: string): Promise<{
+        title: string;
+        description: string;
+        content: string;
+        metadata: Record<string, string>;
+        images: string[];
+        links: string[];
+    }> {
+        let parsedUrl: URL;
+        try {
+            parsedUrl = new URL(url);
+        } catch {
+            throw new Error("Invalid page info URL");
+        }
+        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+            throw new Error("Page info URL must use http or https");
+        }
+
+        const response = await fetch(parsedUrl.toString());
+        if (!response.ok) {
+            throw new Error(`Failed to fetch page info: ${response.status} ${response.statusText}`);
+        }
+        const content = await response.text();
+        const title = content.match(/<title[^>]*>(.*?)<\/title>/i)?.[1] ?? url;
+        const description =
+            content.match(/<meta\s+name=["']description["']\s+content=["']([^"']+)/i)?.[1] ?? "";
+        return {
+            title,
+            description,
+            content,
+            metadata: {},
+            images: [],
+            links: [],
+        };
+    }
+}

--- a/plugins/plugin-serpdive/src/types.ts
+++ b/plugins/plugin-serpdive/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Local search option/result types for the SERPdive plugin, extending
+ * `@elizaos/core`'s shared search types (`SearchOptions`/`SearchResponse`) and
+ * re-exporting the image/news/video option types the service accepts. The
+ * option shape deliberately matches plugin-web-search so call sites can swap
+ * web-search providers without changing a line.
+ */
+
+import type {
+    SearchOptions as CoreSearchOptions,
+    SearchResponse as CoreSearchResponse,
+    ImageSearchOptions,
+    NewsSearchOptions,
+    VideoSearchOptions,
+} from "@elizaos/core";
+
+export type SearchResult = {
+    title: string;
+    url: string;
+    description: string;
+    content: string;
+    rawContent?: string;
+    score: number;
+    publishedDate?: Date;
+};
+
+export type SearchImage = {
+    url: string;
+    description?: string;
+};
+
+export type SearchResponse = Omit<CoreSearchResponse, "results"> & {
+    answer?: string;
+    query: string;
+    responseTime?: number;
+    images: SearchImage[];
+    results: SearchResult[];
+};
+
+export interface SearchOptions extends CoreSearchOptions {
+    limit?: number;
+    type?: "news" | "general";
+    topic?: "news" | "general";
+    includeAnswer?: boolean;
+    /**
+     * Kept for drop-in compatibility with plugin-web-search: "basic" maps to
+     * SERPdive's fast `mako` model, "advanced" to the full-page `moby` model.
+     */
+    searchDepth?: "basic" | "advanced";
+    includeImages?: boolean;
+    days?: number;
+    /** SERPdive-native escape hatch; wins over `searchDepth` when set. */
+    model?: "mako" | "moby";
+}
+
+export type { ImageSearchOptions, NewsSearchOptions, VideoSearchOptions };

--- a/plugins/plugin-serpdive/tsconfig.json
+++ b/plugins/plugin-serpdive/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "lib": ["ESNext", "dom"],
+        "module": "Preserve",
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "ignoreDeprecations": "6.0",
+        "forceConsistentCasingInFileNames": false,
+        "allowImportingTsExtensions": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "resolveJsonModule": true,
+        "allowJs": true,
+        "checkJs": false,
+        "noEmitOnError": false,
+        "moduleDetection": "force",
+        "allowArbitraryExtensions": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx", "**/*.e2e.test.ts"]
+}

--- a/plugins/plugin-serpdive/tsup.config.ts
+++ b/plugins/plugin-serpdive/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    sourcemap: true,
+    clean: true,
+    format: ["esm"], // Ensure you're targeting CommonJS
+    external: [
+        "dotenv", // Externalize dotenv to prevent bundling
+        "fs", // Externalize fs to use Node.js built-in module
+        "path", // Externalize other built-ins if necessary
+        "@reflink/reflink",
+        "@node-llama-cpp",
+        "https",
+        "http",
+        "agentkeepalive",
+        "zod",
+        "@elizaos/core",
+        // Add other modules you want to externalize
+    ],
+});

--- a/plugins/plugin-serpdive/vitest.config.ts
+++ b/plugins/plugin-serpdive/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        testTimeout: 30_000,
+    },
+});


### PR DESCRIPTION
# Relates to

Closes #16757

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is purely additive: a new package under
`plugins/plugin-serpdive/`, no existing file touched. The plugin is opt-in,
registers no actions/providers/evaluators/routes, and boots inert without
`SERPDIVE_API_KEY` (honest error on first use instead of crashing agent
boot). Worst case for a user who never installs it: nothing.

# Background

## What does this PR do?

Adds `@elizaos/plugin-serpdive`, a second `ServiceType.WEB_SEARCH` provider,
sibling to `plugin-web-search`. It implements the full `IWebSearchService`
contract (search / news / images / videos / suggestions / trending /
page-info) on the [SERPdive](https://serpdive.com) API, which returns
extracted, answer-ready page content instead of links — each result carries
the actual text of the page.

Structure and behavior deliberately mirror `plugin-web-search`: guarded
`"web"` category registration, graceful degradation without a key, identical
option shapes so call sites swap providers without changes.
`searchDepth: "basic" | "advanced"` maps to SERPdive's `mako`/`moby`
retrieval models, with a native `model` option as escape hatch. No media
endpoints are faked: image/video search reuse web search and `images` stays
empty.

Why a second provider is worth having: search output is LLM input. On a
[public, replayable 1,000-question blind benchmark](https://github.com/edendalexis/serpdive-benchmark),
SERPdive returns **20.2% fewer tokens** than Tavily's default search while
winning **60.7% of decided quality duels**, at the same speed. (Scope note:
the comparison is against Tavily's default/basic tier, the same price class;
Tavily's advanced mode was not tested.) Free tier is 1,000 credits/month, no
card, so reviewers can exercise the plugin without a paid plan. Disclosure: I
maintain SERPdive.

## What kind of change is this?

Feature (non-breaking, additive plugin package).

# Testing

## Where should a reviewer start?

`plugins/plugin-serpdive/src/services/serpdiveSearchService.ts` (the service)
and its test file next to it.

## Detailed testing steps

```bash
cd plugins/plugin-serpdive
bun install
bun run test        # 6 vitest cases
bun run typecheck
```

With a free key: `SERPDIVE_API_KEY=sd_live_... ` then call
`runtime.getService(ServiceType.WEB_SEARCH).search("query")` from any agent —
`results[].content` carries extracted page text.

Evidence from my environment (bun unavailable, see below): the exact test
file passes 6/6 under vitest 4, and `tsc --strict` over the package is clean
against the `IWebSearchService` contract.

## Known gaps / failures

`bun run verify` was not run here: bun is not installable in my sandboxed
environment (network-restricted CI runner). Blocker is environmental, not
code-related. The package's own `test` and `typecheck` scripts were run with
the equivalent npm toolchain (vitest 4, strict tsc) and pass; happy to re-run
anything on request, and CI on this PR will exercise the real thing.
