### PR TITLE
fix(ci): resolve @octokit/core for plugin-agent-orchestrator (Server Tests red)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3000,6 +3000,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/auth": "workspace:*",
+        "@octokit/core": "^7.0.6",
         "@octokit/rest": "^22.0.0",
         "@smithers-orchestrator/engine": "0.28.0",
         "coding-agent-adapters": "0.16.3",

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -72,6 +72,7 @@
     "git-workspace-service": "0.4.5"
   },
   "dependencies": {
+    "@octokit/core": "^7.0.6",
     "@octokit/rest": "^22.0.0",
     "@smithers-orchestrator/engine": "0.28.0",
     "coding-agent-adapters": "0.16.3",


### PR DESCRIPTION
## Problem
`Server Tests` is a standing red on develop HEAD (cc008ff):
```
Cannot find package '@octokit/core' imported from
plugins/plugin-agent-orchestrator/node_modules/@octokit/rest/dist-src/index.js
```
`@octokit/rest@22` imports `@octokit/core`, but in the nested install layout it isn't resolvable at test time.

## Fix
Declare `@octokit/core@^7.0.6` as an explicit dependency of `plugin-agent-orchestrator` so it hoists correctly. `@octokit/core@7.0.6` is **already resolved in bun.lock** (transitively via `@octokit/rest@22.0.1`), so this is a **single-edge lockfile add with zero transitive churn** (2 lines total).

## Relationship to #16744
This is a focused re-cut of the **octokit portion only** of #16744, rebased onto current develop. The **biome portion of #16744 is now obsolete and harmful**: develop already standardized on biome **2.5.4** (devDep + overrides both 2.5.4, consistency check green), so #16744 would silent-revert 14 already-merged formatted test files (#16703) and reintroduce the drift. #16744 should be closed in favor of this.

## Verification
- `@octokit/core@7.0.6` confirmed present in develop's lockfile package table (line ~8032).
- No format/UI-surface changes → no evidence gate, no lint churn, no stale-base revert.

[sol-develop-reds2]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed (dependency + lockfile edge only)

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed (dependency + lockfile edge only)

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed (build/test dep resolution)

<!-- evidence-row:backend-logs -->
- [ ] N/A - fix is a package.json dep declaration; validated by Server Tests going green

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - single-edge @octokit/core lockfile add, zero transitive churn

<!-- evidence-refresh: 20260722T050417Z -->