### PR TITLE
fix(test): pass ElizaError through @elizaos/core mock (Plugin Tests + Windows CI red)

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -57,6 +57,7 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@elizaos/core")>();
 	return {
 		...coreMock,
+		ElizaError: actual.ElizaError,
 		findCodingDelegationActionName: actual.findCodingDelegationActionName,
 		getUserMessageText: actual.getUserMessageText,
 		resolveStateDir: actual.resolveStateDir,

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -197,6 +197,10 @@ function createRepoFixture() {
 		JSON.stringify({
 			name: "@local/plugin-__PLUGIN_NAME__",
 			displayName: "__PLUGIN_DISPLAY_NAME__",
+			// seedGuiViewScaffold validates a semver-pinned biome devDep on the
+			// scaffolded template (matches the repo-canonical pin in root
+			// package.json). scripts/dependencies are auto-created by objectField.
+			devDependencies: { "@biomejs/biome": "2.5.4" },
 		}),
 	);
 	writeFileSync(


### PR DESCRIPTION
## Problem
Both **Plugin Tests (Linux shard 4/4)** and **Windows CI** fail on develop HEAD (cc008ff):
```
[vitest] No "ElizaError" export is defined on the "@elizaos/core" mock.
```
`views-create-scaffold.ts` imports `{ ElizaError }` from `@elizaos/core` and throws it (`requiredStringField`, `requireJsonObject`). The test's `vi.mock("@elizaos/core")` returns a curated object (`...coreMock` + 3 cherry-picked real exports) that **omitted `ElizaError`**, so importing the action-under-test throws at mock-resolve time.

## Fix
Pass the real `ElizaError` class through from `importOriginal()` — same pattern as the sibling `findCodingDelegationActionName` / `getUserMessageText` / `resolveStateDir` passthroughs directly below it. One line, no behavior change (uses the genuine core export).

## Verification
- `ElizaError` confirmed as a real named export of `@elizaos/core` (`packages/core/src/errors.ts` + `index.ts`).
- Not platform-specific: fails identically on Linux and Windows lanes → pure mock gap, not an OS/dep issue.

[sol-develop-reds2]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed (test-mock + fixture only)

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed (test-mock + fixture only)

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed (unit test fix)

<!-- evidence-row:backend-logs -->
- [ ] N/A - test mock passthrough + fixture; validated by Plugin/Windows tests going green

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime code touched (test file only)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - passes real ElizaError through vi.mock + adds biome devDep to fixture

<!-- evidence-refresh: 20260722T050418Z -->