### PR TITLE
fix(cloud): single-flight shared-agent scope hydration (kill demo pile-on wedge)

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -61,27 +61,25 @@ const cacheSet = mock(async (key: string, value: unknown) => {
 // on. Only populates the cache when the loader returns a non-null value (matches
 // the real getOrSet contract the fix depends on for not caching a 404/null scope).
 const inFlight = new Map<string, Promise<unknown>>();
-const cacheGetOrSet = mock(
-  async (key: string, _ttl: number, loader: () => Promise<unknown>) => {
-    if (cacheStore.has(key)) return cacheStore.get(key);
-    const existing = inFlight.get(key);
-    if (existing) return existing;
-    const p = (async () => {
-      const fresh = await loader();
-      // Real getOrSet populates via this.set() on a non-null load — route through
-      // the cacheSet double so existing "cold miss writes the scope once"
-      // assertions still observe the populate through the same mock.
-      if (fresh !== null && fresh !== undefined) await cacheSet(key, fresh);
-      return fresh;
-    })();
-    inFlight.set(key, p);
-    try {
-      return await p;
-    } finally {
-      inFlight.delete(key);
-    }
-  },
-);
+const cacheGetOrSet = mock(async (key: string, _ttl: number, loader: () => Promise<unknown>) => {
+  if (cacheStore.has(key)) return cacheStore.get(key);
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+  const p = (async () => {
+    const fresh = await loader();
+    // Real getOrSet populates via this.set() on a non-null load — route through
+    // the cacheSet double so existing "cold miss writes the scope once"
+    // assertions still observe the populate through the same mock.
+    if (fresh !== null && fresh !== undefined) await cacheSet(key, fresh);
+    return fresh;
+  })();
+  inFlight.set(key, p);
+  try {
+    return await p;
+  } finally {
+    inFlight.delete(key);
+  }
+});
 mock.module("../../cache/client", () => ({
   cache: { get: cacheGet, set: cacheSet, getOrSet: cacheGetOrSet },
 }));
@@ -332,10 +330,12 @@ describe("resolveSharedAgent stampede single-flight (CONTENTION-2026-07-22)", ()
     expect(cacheSet).toHaveBeenCalledTimes(1);
 
     // Restore the default implementation (mockClear keeps impls across tests).
-    requireUserOrApiKeyWithOrgLookup.mockImplementation(async (_c: unknown, lookup: (o: string) => unknown) => ({
-      user: { organization_id: "org-1", steward_id: "steward-user-1" },
-      orgLookupResult: await lookup("org-1"),
-    }));
+    requireUserOrApiKeyWithOrgLookup.mockImplementation(
+      async (_c: unknown, lookup: (o: string) => unknown) => ({
+        user: { organization_id: "org-1", steward_id: "steward-user-1" },
+        orgLookupResult: await lookup("org-1"),
+      }),
+    );
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -55,8 +55,35 @@ const cacheGet = mock(async (key: string) => (cacheStore.has(key) ? cacheStore.g
 const cacheSet = mock(async (key: string, value: unknown) => {
   cacheStore.set(key, value);
 });
+// Single-flight double: an in-process lock so N concurrent misses run the loader
+// EXACTLY ONCE (the real getOrSet uses a distributed SET NX lock). Waiters await
+// the in-flight loader and reuse its result — the property the stampede fix relies
+// on. Only populates the cache when the loader returns a non-null value (matches
+// the real getOrSet contract the fix depends on for not caching a 404/null scope).
+const inFlight = new Map<string, Promise<unknown>>();
+const cacheGetOrSet = mock(
+  async (key: string, _ttl: number, loader: () => Promise<unknown>) => {
+    if (cacheStore.has(key)) return cacheStore.get(key);
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+    const p = (async () => {
+      const fresh = await loader();
+      // Real getOrSet populates via this.set() on a non-null load — route through
+      // the cacheSet double so existing "cold miss writes the scope once"
+      // assertions still observe the populate through the same mock.
+      if (fresh !== null && fresh !== undefined) await cacheSet(key, fresh);
+      return fresh;
+    })();
+    inFlight.set(key, p);
+    try {
+      return await p;
+    } finally {
+      inFlight.delete(key);
+    }
+  },
+);
 mock.module("../../cache/client", () => ({
-  cache: { get: cacheGet, set: cacheSet },
+  cache: { get: cacheGet, set: cacheSet, getOrSet: cacheGetOrSet },
 }));
 
 // validateApiKey double for the cache-HIT re-validation gate.
@@ -111,6 +138,8 @@ beforeEach(() => {
   findByIdAndOrg.mockResolvedValue(null);
   cacheGet.mockClear();
   cacheSet.mockClear();
+  cacheGetOrSet.mockClear();
+  inFlight.clear();
   validateApiKey.mockClear();
   cacheStore.clear();
   sessionScopeHashPrefix.mockClear();
@@ -267,6 +296,49 @@ describe("resolveSharedAgent scope cache (COLDPATH-FIX-2026-07-21)", () => {
   });
 });
 
+describe("resolveSharedAgent stampede single-flight (CONTENTION-2026-07-22)", () => {
+  test("N concurrent cold callers hydrate the scope EXACTLY once", async () => {
+    // Repro of the demo-day audience pile-on: N callers hit the SAME shared
+    // agent's scope with a cold cache at once. Without single-flight all N run
+    // the expensive user/org+agent hydration in parallel and starve the DB pool
+    // (one turn wedged ~8.5s on staging). The fix collapses them to one loader.
+    let resolveGate: (() => void) | null = null;
+    const gateOpened = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    // Make the expensive hydration hang until we release it, so all N callers
+    // are provably in-flight simultaneously before any completes.
+    requireUserOrApiKeyWithOrgLookup.mockImplementation(async (_c, lookup) => {
+      await gateOpened;
+      const a = agent();
+      const orgLookupResult = await lookup((a as { organization_id: string }).organization_id);
+      return { user: { organization_id: "org-1" }, orgLookupResult };
+    });
+    findByIdAndOrg.mockResolvedValue(agent());
+
+    const N = 8;
+    const inflightCalls = Array.from({ length: N }, () =>
+      resolveSharedAgent(apiKeyContext("agent-1") as never),
+    );
+    // All callers have entered; release the single hydration.
+    resolveGate?.();
+    const results = await Promise.all(inflightCalls);
+
+    // Every caller resolves correctly...
+    for (const r of results) expect(r).toMatchObject({ agentId: "agent-1", orgId: "org-1" });
+    // ...but the expensive DB hydration ran ONCE, not N times.
+    expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+    // The scope was populated exactly once.
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+
+    // Restore the default implementation (mockClear keeps impls across tests).
+    requireUserOrApiKeyWithOrgLookup.mockImplementation(async (_c: unknown, lookup: (o: string) => unknown) => ({
+      user: { organization_id: "org-1", steward_id: "steward-user-1" },
+      orgLookupResult: await lookup("org-1"),
+    }));
+  });
+});
+
 describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => {
   // Shadow's own account authenticates by steward JWT / cookie, not an API key,
   // so the API-key-only scope cache used to skip him entirely -> he paid the
@@ -300,6 +372,10 @@ describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => 
     await resolveSharedAgent(contextWithAgentId("agent-1") as never);
     requireUserOrApiKeyWithOrgLookup.mockClear();
     findByIdAndOrg.mockClear();
+    // The populate goes through the single-flight hydration (getOrSet), which
+    // re-runs the credential gate once on the just-hydrated scope (cheap/warm,
+    // strictly safer). Clear it so the assertion below isolates the SECOND hit.
+    revalidateSessionScope.mockClear();
 
     // Second hit: served from cache, no user/org+agent hydration.
     const result = await resolveSharedAgent(contextWithAgentId("agent-1") as never);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -107,28 +107,85 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
   const scopeCacheKey = scopeKeyPrefix
     ? CacheKeys.sharedAgentScope.resolve(scopeKeyPrefix, agentId)
     : null;
+  // A cache HIT reproduces the resolved scope WITHOUT the cold DB waves, but must
+  // STILL run the per-request credential gate (see revalidateResolvedScope). This
+  // is shared by the direct pre-hydration hit below AND by a single-flight waiter
+  // that picks up a scope another concurrent cold caller just populated.
+  const revalidateResolvedScope = async (
+    cached: CachedSharedAgentScope,
+  ): Promise<ResolvedSharedAgent | null> => {
+    if (!(cached?.agent && cached.orgId && cached.agent.execution_tier === "shared")) {
+      return null;
+    }
+    // SECURITY: a hit skips the expensive user/org+agent DB hydration, but it
+    // must NOT skip the credential gate. API-key path: re-run the (already-
+    // cached, revoke-invalidated) key validation + org match. SESSION path:
+    // re-run the warm-cached steward JWT verify + confirm it still maps to the
+    // SAME steward user the entry was written for. Either way a
+    // revoked/expired/re-scoped credential falls back to the authoritative
+    // gate inside the 30s TTL window; we only skip the cold DB waves.
+    const stillAuthorized = isSessionScope
+      ? cached.stewardUserId != null &&
+        (await revalidateSessionScope(c, cached.stewardUserId).catch(() => false))
+      : await revalidateCachedScope(c, cached.orgId).catch(() => false);
+    if (!stillAuthorized) return null;
+    return {
+      agent: cached.agent,
+      agentId,
+      orgId: cached.orgId,
+      agentName: cached.agent.agent_name ?? "Eliza",
+    };
+  };
+
   if (scopeCacheKey) {
     const cached = await cache.get<CachedSharedAgentScope>(scopeCacheKey).catch(() => null);
-    if (cached?.agent && cached.orgId && cached.agent.execution_tier === "shared") {
-      // SECURITY: a hit skips the expensive user/org+agent DB hydration, but it
-      // must NOT skip the credential gate. API-key path: re-run the (already-
-      // cached, revoke-invalidated) key validation + org match. SESSION path:
-      // re-run the warm-cached steward JWT verify + confirm it still maps to the
-      // SAME steward user the entry was written for. Either way a
-      // revoked/expired/re-scoped credential falls back to the authoritative
-      // gate inside the 30s TTL window; we only skip the cold DB waves.
-      const stillAuthorized = isSessionScope
-        ? cached.stewardUserId != null &&
-          (await revalidateSessionScope(c, cached.stewardUserId).catch(() => false))
-        : await revalidateCachedScope(c, cached.orgId).catch(() => false);
-      if (stillAuthorized) {
-        return {
-          agent: cached.agent,
-          agentId,
-          orgId: cached.orgId,
-          agentName: cached.agent.agent_name ?? "Eliza",
-        };
-      }
+    if (cached) {
+      const resolved = await revalidateResolvedScope(cached);
+      if (resolved) return resolved;
+    }
+  }
+
+  // STAMPEDE FIX (CONTENTION-2026-07-22): the scope cache above kills the cold
+  // hydration cost for the SECOND-and-later cold caller, but N concurrent cold
+  // callers (an audience all chatting the SAME shared demo agent at once) ALL
+  // miss simultaneously and stampede `requireUserOrApiKeyWithOrgLookup` +
+  // findByIdAndOrg in parallel, saturating the Hyperdrive/DB connection pool.
+  // Measured: with 8 concurrent turns on one shared agent exactly one turn's
+  // scope-resolve wedged ~8.5-9s (pool-starved) while the rest ran ~1.2s.
+  // Single-flight the expensive hydration so only the FIRST concurrent cold
+  // caller pays the DB waves and populates the scope; the rest poll for the
+  // populated scope (getOrSet singleflight) and then run the SAME per-request
+  // credential gate via revalidateResolvedScope — security is unchanged, only
+  // the redundant parallel DB hydration is collapsed to one. Falls through to
+  // an independent hydration if the lock backend is absent or the holder is
+  // slow past the poll window (getOrSet's own fall-through), so this can never
+  // hang a turn — worst case it degrades to today's stampede behavior.
+  if (scopeCacheKey) {
+    const hydrated = await cache
+      .getOrSet<CachedSharedAgentScope | null>(
+        scopeCacheKey,
+        CacheTTL.sharedAgentScope.resolve,
+        async () => {
+          const { user, orgLookupResult: agent } = await requireUserOrApiKeyWithOrgLookup(
+            c,
+            (orgId) => agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
+          );
+          // Only a settled shared-tier agent is cacheable (never the
+          // time-sensitive dedicated-bootstrap window). A non-cacheable or
+          // not-found result returns null so getOrSet does NOT populate the
+          // cache, and this caller falls through to the authoritative path
+          // below to produce the correct 404 / bootstrap handling.
+          if (!agent || agent.execution_tier !== "shared") return null;
+          return isSessionScope && typeof user.steward_id === "string"
+            ? { orgId: user.organization_id, agent, stewardUserId: user.steward_id }
+            : { orgId: user.organization_id, agent };
+        },
+        { singleflight: true },
+      )
+      .catch(() => null);
+    if (hydrated) {
+      const resolved = await revalidateResolvedScope(hydrated);
+      if (resolved) return resolved;
     }
   }
 


### PR DESCRIPTION
## Problem (Demo Day risk)

Under **N concurrent cold turns on ONE shared agent** — an audience all chatting the same demo agent at once — the scope cache from #16629 does **not** help. All N requests miss the cache simultaneously and stampede `requireUserOrApiKeyWithOrgLookup` + `findByIdAndOrg` in parallel, saturating the Hyperdrive/DB connection pool. The loser's scope-resolve wedges ~8.5-9s.

Ground truth on the receipt conflict: #16629 (merge `9afaeec69`) **IS** an ancestor of staging `f1ae987` — CHAT-LATENCY-2026-07-22 is correct, DEMO-READINESS's "not on staging" note is wrong. But #16629 fixed the *serial second-cold-caller* case, not the *concurrent* stampede. Single-user chat stays ~1.5s; the pile-on is what wedges.

### Repro (headless, staging f1ae987, 8 concurrent SSE turns on one shared agent+conversation)
| metric | before |
|---|---|
| first-text median | ~1.47s |
| first-text **p95 / max** | **8.7s / 9.3s** |
| done max | 11.3-12.1s |
| wall (8 turns) | 11.3-12.1s |
| wedged turns | exactly 1 (open ~8.5-9s, pool-starved) |

Deterministic across two runs. The wedge is entirely in the **pre-header scope-resolve** phase, not the model turn.

## Fix

Single-flight the expensive hydration via the existing `cache.getOrSet(..., { singleflight: true })` primitive, keyed on the same scope key. Only the FIRST concurrent cold caller pays the DB waves and populates the scope; the rest pick up the populated scope and run the **same per-request credential gate** (`revalidateResolvedScope`) a normal cache hit runs.

- **Security unchanged**: every path still validates the credential + org/user match before serving. Waiters that skip hydration still re-verify the API key / steward JWT against the cached org/user. A revoked/re-scoped credential falls through to the authoritative gate.
- **Never hangs a turn**: `getOrSet` falls through to an independent hydration if the lock backend is absent or the holder is slow past the poll window — worst case degrades to today's stampede, never a deadlock.

## Tests

- New stampede regression: **N=8 concurrent cold callers hydrate exactly once** (`requireUserOrApiKeyWithOrgLookup` called 1x, scope populated 1x).
- All existing scope-cache tests green (16/16). One session-cache assertion updated to clear the mock after the populate call (the populate now runs one warm, strictly-safer revalidation via the single-flight path).

## Collision check
No open PR touches `resolve-shared-agent.ts` or the scope stampede (checked 2026-07-22). Branched off fresh `origin/develop` (`d7bb3703d`).

Receipt: `projects/eliza-fleet/CONTENTION-2026-07-22.md`

[sol-contention-fix]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (cloud/shared scope hydration), no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only concurrency fix, covered by deterministic stampede regression test

<!-- evidence-row:backend-logs -->
- [x] [16763-stampede-test-run.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16763-stampede-test-run.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pre-model scope-resolve fix; no model/prompt path changed (wedge is entirely in pre-header hydration)

<!-- evidence-row:domain-artifacts -->
- [x] [16763-stampede-test-run.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16763-stampede-test-run.log)
