### PR TITLE
fix(ci): isolate server tests and octokit runtime deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3015,6 +3015,7 @@
         "@elizaos/auth": "workspace:*",
         "@octokit/core": "^7.0.6",
         "@octokit/rest": "^22.0.0",
+        "universal-user-agent": "^7.0.3",
         "@smithers-orchestrator/engine": "0.28.0",
         "coding-agent-adapters": "0.16.3",
         "drizzle-orm": "^0.45.1",

--- a/packages/app-core/src/api/account-pool-status-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.test.ts
@@ -2,14 +2,10 @@ import { EventEmitter } from "node:events";
 import type http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getPublicAccountPoolStatus } = vi.hoisted(() => ({
-  getPublicAccountPoolStatus: vi.fn(),
-}));
-vi.mock("../services/account-pool-status.js", () => ({
-  getPublicAccountPoolStatus,
-}));
-
 import { handleAccountPoolStatusRoute } from "./account-pool-status-routes";
+
+const getPublicAccountPoolStatus = vi.fn();
+const dependencies = { getPublicAccountPoolStatus };
 
 function response(): http.ServerResponse & {
   body: string;
@@ -70,6 +66,7 @@ describe("GET /api/pool/status", () => {
         res,
         "GET",
         "/api/pool/status",
+        dependencies,
       ),
     ).resolves.toBe(true);
     expect(res.statusCode).toBe(200);
@@ -83,6 +80,7 @@ describe("GET /api/pool/status", () => {
       methodRes,
       "POST",
       "/api/pool/status",
+      dependencies,
     );
     expect(methodRes.statusCode).toBe(405);
 
@@ -93,6 +91,7 @@ describe("GET /api/pool/status", () => {
       errorRes,
       "GET",
       "/api/pool/status",
+      dependencies,
     );
     expect(errorRes.statusCode).toBe(503);
     expect(errorRes.setHeader).toHaveBeenCalledWith("retry-after", "60");

--- a/packages/app-core/src/api/account-pool-status-routes.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.ts
@@ -17,6 +17,14 @@ import { sendJson, sendJsonError } from "./response.js";
 const STATUS_PATH = "/api/pool/status";
 const RETRY_AFTER_SECONDS = 60;
 
+export interface AccountPoolStatusRouteDependencies {
+  getPublicAccountPoolStatus: typeof getPublicAccountPoolStatus;
+}
+
+const DEFAULT_DEPENDENCIES: AccountPoolStatusRouteDependencies = {
+  getPublicAccountPoolStatus,
+};
+
 function publicPoolStatusEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -30,6 +38,7 @@ export async function handleAccountPoolStatusRoute(
   res: http.ServerResponse,
   method: string,
   pathname: string,
+  dependencies: AccountPoolStatusRouteDependencies = DEFAULT_DEPENDENCIES,
 ): Promise<boolean> {
   if (pathname !== STATUS_PATH) return false;
   if (!publicPoolStatusEnabled()) {
@@ -43,7 +52,8 @@ export async function handleAccountPoolStatusRoute(
     return true;
   }
   try {
-    const status: PublicPoolStatus = await getPublicAccountPoolStatus();
+    const status: PublicPoolStatus =
+      await dependencies.getPublicAccountPoolStatus();
     res.setHeader("cache-control", "public, max-age=60");
     sendJson(res, 200, status);
   } catch (error) {

--- a/packages/app-core/src/cli/plugins-cli.test.ts
+++ b/packages/app-core/src/cli/plugins-cli.test.ts
@@ -91,8 +91,9 @@ describe("plugins CLI helpers", () => {
     vi.stubEnv("HOME", home);
     vi.stubEnv("USERPROFILE", home);
 
-    expect(() => validatePluginPath(cwdPluginDir)).not.toThrow();
-    expect(() => validatePluginPath(homePluginDir)).not.toThrow();
+    const boundaries = { cwd, home };
+    expect(() => validatePluginPath(cwdPluginDir, boundaries)).not.toThrow();
+    expect(() => validatePluginPath(homePluginDir, boundaries)).not.toThrow();
   });
 
   it("rejects paths outside cwd and home after resolving dot segments", () => {
@@ -108,7 +109,10 @@ describe("plugins CLI helpers", () => {
     vi.stubEnv("USERPROFILE", home);
 
     expect(() =>
-      validatePluginPath(path.join(cwd, "plugins", "..", "..", "outside")),
+      validatePluginPath(path.join(cwd, "plugins", "..", "..", "outside"), {
+        cwd,
+        home,
+      }),
     ).toThrow("outside allowed boundaries");
   });
 
@@ -126,7 +130,7 @@ describe("plugins CLI helpers", () => {
     vi.stubEnv("HOME", home);
     vi.stubEnv("USERPROFILE", home);
 
-    expect(() => validatePluginPath(symlink)).toThrow(
+    expect(() => validatePluginPath(symlink, { cwd, home })).toThrow(
       "outside allowed boundaries",
     );
   });

--- a/packages/app-core/src/cli/plugins-cli.ts
+++ b/packages/app-core/src/cli/plugins-cli.ts
@@ -24,15 +24,26 @@ import type { Command } from "commander";
 const PLUGIN_NAME_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/i;
 const PLUGIN_VERSION_RE = /^[A-Za-z0-9._+~:-]+$/;
 
+export interface PluginPathBoundaries {
+  home: string;
+  cwd: string;
+}
+
 /** Validate that a resolved plugin path is within allowed boundaries. */
-export function validatePluginPath(resolved: string): void {
+export function validatePluginPath(
+  resolved: string,
+  boundaries: PluginPathBoundaries = {
+    home: os.homedir(),
+    cwd: process.cwd(),
+  },
+): void {
   if (!nodePath.isAbsolute(resolved)) {
     throw new Error(
-      `Plugin path ${resolved} is outside allowed boundaries (must be under ${os.homedir()} or ${process.cwd()})`,
+      `Plugin path ${resolved} is outside allowed boundaries (must be under ${boundaries.home} or ${boundaries.cwd})`,
     );
   }
-  const home = realpathForBoundary(os.homedir());
-  const cwd = realpathForBoundary(process.cwd());
+  const home = realpathForBoundary(boundaries.home);
+  const cwd = realpathForBoundary(boundaries.cwd);
   const target = realpathForBoundary(resolved);
   if (!isWithinBoundary(target, home) && !isWithinBoundary(target, cwd)) {
     throw new Error(

--- a/packages/app-core/test/helpers/live-child-env.test.ts
+++ b/packages/app-core/test/helpers/live-child-env.test.ts
@@ -38,7 +38,14 @@ describe("createLiveRuntimeChildEnv", () => {
     ["whitespace-only", " \t\n"],
   ])("does not preserve a %s Cloud key in Cloud-live mode", (_, cloudKey) => {
     vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "1");
-    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", cloudKey);
+    if (cloudKey === undefined) {
+      // Record the ambient value for `vi.unstubAllEnvs()`, then remove it.
+      // `vi.stubEnv(key, undefined)` leaves an existing CI secret untouched.
+      vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "");
+      delete process.env.ELIZAOS_CLOUD_API_KEY;
+    } else {
+      vi.stubEnv("ELIZAOS_CLOUD_API_KEY", cloudKey);
+    }
 
     const childEnv = createLiveRuntimeChildEnv({
       OPENAI_API_KEY: "selected-provider-key",

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@octokit/core": "^7.0.6",
     "@octokit/rest": "^22.0.0",
+    "universal-user-agent": "^7.0.3",
     "@smithers-orchestrator/engine": "0.29.0",
     "coding-agent-adapters": "0.16.3",
     "drizzle-orm": "^0.45.1",


### PR DESCRIPTION
# Relates to

GitHub Actions [Server Tests job 88918515964](https://github.com/elizaOS/eliza/actions/runs/29918527641/job/88918515964). Issue creation was attempted first, but the available GitHub App returned 403 (issue-write permission unavailable).

# Sync with develop

- [x] Rebases cleanly onto the latest observed `origin/develop` with zero conflicts.
- [ ] `bun run verify` — Bun is unavailable in the repair environment. Focused tests, typechecks, Biome, and the error-policy ratchet were run as detailed below.

# Risks

Low. The runtime changes only add injectable boundaries with production defaults unchanged. The manifest change adds a direct dependency edge already required transitively by `@octokit/core`.

# Background

## What does this PR do?

Fixes all four actionable failures from the linked Server Tests job:

- injects explicit cwd/home boundaries into plugin-path tests instead of relying on `os.homedir()` observing Vitest env stubs
- injects the account-pool status dependency at the route boundary so full-suite module caching cannot bypass the test double
- explicitly deletes an ambient Cloud key when the test case means “missing,” because `vi.stubEnv(key, undefined)` preserves CI secrets
- declares `universal-user-agent` directly for Bun’s isolated workspace layout beside the direct `@octokit/core` dependency

## What kind of change is this?

Bug fix and test-isolation hardening.

# Documentation changes needed?

No project documentation change is required.

# Testing

## Where should a reviewer start?

- `packages/app-core/src/api/account-pool-status-routes.test.ts`
- `packages/app-core/src/cli/plugins-cli.test.ts`
- `packages/app-core/test/helpers/live-child-env.test.ts`
- `plugins/plugin-agent-orchestrator/package.json`

## Detailed testing steps

- app-core targeted tests with `ELIZAOS_CLOUD_API_KEY=ambient-cloud-key`: 13/13 passed
- agent `proactive-interaction-pipeline.test.ts`: 9/9 passed
- app-core typecheck: passed
- agent typecheck: passed
- plugin-agent-orchestrator typecheck: passed
- Biome check for all changed source/manifest files: passed
- error-policy ratchet: passed
- full app-core suite: repaired account-pool test passes; 1364 tests passed and 9 skipped. Two unrelated pre-existing macOS packaging assertions fail: `ffprobe-static` platform gating and `/var` vs `/private/var` realpath normalization.

# Evidence Gate

- [x] Before full-page screenshots: N/A - no UI surface changed.
- [x] After full-page screenshots: N/A - no UI surface changed.
- [x] Video walkthrough: N/A - server CI/test isolation and dependency metadata only.
- [x] Backend logs: N/A - no runtime user flow changed; test output is the relevant execution evidence.
- [x] Frontend logs: N/A - no frontend code changed.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
- [x] Domain artifacts: N/A - no DB, memory, scheduled-task, wallet, or generated-file behavior changed.

## Known gaps / failures

- `bun install` and root `bun run verify` could not run because Bun is absent in this environment.
- The full app-core suite retains two unrelated macOS-only packaging assertion failures described above; all tests associated with the linked CI job pass.
