### PR TITLE
fix(discord): persist durable turns in conversation scope

### DIFF
--- a/plugins/plugin-discord/__tests__/turn-state.test.ts
+++ b/plugins/plugin-discord/__tests__/turn-state.test.ts
@@ -26,6 +26,14 @@ import {
 } from "../turn-state.ts";
 
 const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+const ENTITY_ID = "11111111-2222-3333-4444-555555555555" as UUID;
+const ROOM_ID = "66666666-7777-8888-9999-aaaaaaaaaaaa" as UUID;
+const WORLD_ID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff" as UUID;
+const CONVERSATION = {
+	entityId: ENTITY_ID,
+	roomId: ROOM_ID,
+	worldId: WORLD_ID,
+};
 
 interface Store {
 	runtime: DiscordTurnRuntime;
@@ -96,22 +104,27 @@ describe("durable turn state machine", () => {
 
 	it("claims a fresh turn as RECEIVED then reloads the same record", async () => {
 		const store = makeStore();
-		const claim = await claimDiscordTurn(store.runtime, "msg-1");
+		const claim = await claimDiscordTurn(store.runtime, "msg-1", CONVERSATION);
 		expect(claim.created).toBe(true);
 		expect(claim.record.state).toBe("RECEIVED");
 		expect(claim.record.attempts).toBe(0);
+		expect(store.byId.get(claim.record.id)).toMatchObject(CONVERSATION);
 
 		const reloaded = await loadDiscordTurn(store.runtime, "msg-1");
 		expect(reloaded?.state).toBe("RECEIVED");
 
-		const second = await claimDiscordTurn(store.runtime, "msg-1");
+		const second = await claimDiscordTurn(store.runtime, "msg-1", CONVERSATION);
 		expect(second.created).toBe(false);
 		expect(second.record.state).toBe("RECEIVED");
 	});
 
 	it("advances RECEIVED -> DISPATCHED (attempt++) -> REPLIED", async () => {
 		const store = makeStore();
-		const { record } = await claimDiscordTurn(store.runtime, "msg-2");
+		const { record } = await claimDiscordTurn(
+			store.runtime,
+			"msg-2",
+			CONVERSATION,
+		);
 		const dispatched = await markDiscordTurnDispatched(store.runtime, record);
 		expect(dispatched.state).toBe("DISPATCHED");
 		expect(dispatched.attempts).toBe(1);
@@ -129,7 +142,11 @@ describe("durable turn state machine", () => {
 
 	it("records a terminal FAILED with a reason", async () => {
 		const store = makeStore();
-		const { record } = await claimDiscordTurn(store.runtime, "msg-3");
+		const { record } = await claimDiscordTurn(
+			store.runtime,
+			"msg-3",
+			CONVERSATION,
+		);
 		const failed = await markDiscordTurnFailed(store.runtime, record, "boom");
 		expect(failed.state).toBe("FAILED");
 		expect(failed.failureReason).toBe("boom");
@@ -138,6 +155,7 @@ describe("durable turn state machine", () => {
 	it("decideResume: terminal REPLIED/FAILED are no-ops", () => {
 		const base: DiscordTurnRecord = {
 			id: "x" as UUID,
+			...CONVERSATION,
 			platformMessageId: "m",
 			state: "REPLIED",
 			attempts: 1,
@@ -157,6 +175,7 @@ describe("durable turn state machine", () => {
 	it("decideResume: existing delivered reply reconciles to REPLIED without resend", () => {
 		const record: DiscordTurnRecord = {
 			id: "x" as UUID,
+			...CONVERSATION,
 			platformMessageId: "m",
 			state: "DISPATCHED",
 			attempts: 1,
@@ -172,6 +191,7 @@ describe("durable turn state machine", () => {
 	it("decideResume: resumes when no reply exists and budget remains", () => {
 		const record: DiscordTurnRecord = {
 			id: "x" as UUID,
+			...CONVERSATION,
 			platformMessageId: "m",
 			state: "DISPATCHED",
 			attempts: 1,
@@ -185,6 +205,7 @@ describe("durable turn state machine", () => {
 	it("decideResume: exhausts when attempts reach the bound with no reply", () => {
 		const record: DiscordTurnRecord = {
 			id: "x" as UUID,
+			...CONVERSATION,
 			platformMessageId: "m",
 			state: "DISPATCHED",
 			attempts: DISCORD_TURN_MAX_ATTEMPTS,

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1041,6 +1041,7 @@ export class MessageManager {
 			type = ChannelType.DM;
 			messageServerId = message.channel.id;
 		}
+		const worldId = createUniqueUuid(this.runtime, messageServerId ?? roomId);
 
 		try {
 			let { processedContent, attachments } =
@@ -1157,7 +1158,7 @@ export class MessageManager {
 					? stringToUuid(messageServerId)
 					: undefined,
 				type,
-				worldId: createUniqueUuid(this.runtime, messageServerId ?? roomId),
+				worldId,
 				worldName: message.guild?.name,
 				// Preserve the raw Discord user id in source metadata for role and allowlist checks.
 				userId: message.author.id as UUID,
@@ -1189,7 +1190,11 @@ export class MessageManager {
 					newMessage,
 					message.id,
 				);
-				const claim = await claimDiscordTurn(this.runtime, message.id);
+				const claim = await claimDiscordTurn(this.runtime, message.id, {
+					entityId: newMessage.entityId,
+					roomId: newMessage.roomId,
+					worldId,
+				});
 				turnRecord = claim.record;
 				if (!claim.created) {
 					const deliveredReplyId = newMessage.id

--- a/plugins/plugin-discord/turn-state.ts
+++ b/plugins/plugin-discord/turn-state.ts
@@ -62,6 +62,12 @@ export function isTerminalTurnState(state: DiscordTurnState): boolean {
 export interface DiscordTurnRecord {
 	/** Deterministic UUID derived from the Discord message id. */
 	id: UUID;
+	/** Established Discord participant that owns the inbound message. */
+	entityId: UUID;
+	/** Established Discord channel room that owns the turn. */
+	roomId: UUID;
+	/** Established Discord world that scopes the channel and its memories. */
+	worldId: UUID;
 	/** Raw Discord message id (idempotency key). */
 	platformMessageId: string;
 	state: DiscordTurnState;
@@ -100,11 +106,14 @@ function decodeTurnRecord(memory: Memory): DiscordTurnRecord | null {
 		platformMessageId?: string;
 		state?: DiscordTurnState;
 	};
-	if (!memory.id || !data.platformMessageId || !data.state) {
+	if (!memory.id || !memory.worldId || !data.platformMessageId || !data.state) {
 		return null;
 	}
 	return {
 		id: memory.id,
+		entityId: memory.entityId,
+		roomId: memory.roomId,
+		worldId: memory.worldId,
 		platformMessageId: data.platformMessageId,
 		state: data.state,
 		attempts: typeof data.attempts === "number" ? data.attempts : 0,
@@ -124,9 +133,10 @@ function encodeTurnRecord(
 ): Memory {
 	return {
 		id: record.id,
-		entityId: runtime.agentId,
+		entityId: record.entityId,
 		agentId: runtime.agentId,
-		roomId: record.id,
+		roomId: record.roomId,
+		worldId: record.worldId,
 		content: {
 			text: `discord-turn ${record.platformMessageId} ${record.state}`,
 			source: "discord-turn",
@@ -180,6 +190,9 @@ async function writeDiscordTurn(
 export async function claimDiscordTurn(
 	runtime: DiscordTurnRuntime,
 	platformMessageId: string,
+	conversation: Pick<Memory, "entityId" | "roomId" | "worldId"> & {
+		worldId: UUID;
+	},
 ): Promise<{ record: DiscordTurnRecord; created: boolean }> {
 	const existing = await loadDiscordTurn(runtime, platformMessageId);
 	if (existing) {
@@ -188,6 +201,9 @@ export async function claimDiscordTurn(
 	const now = Date.now();
 	const record: DiscordTurnRecord = {
 		id: discordTurnId(runtime, platformMessageId),
+		entityId: conversation.entityId,
+		roomId: conversation.roomId,
+		worldId: conversation.worldId,
 		platformMessageId,
 		state: "RECEIVED",
 		attempts: 0,


### PR DESCRIPTION
# Relates to

Closes #16778.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; unrelated upstream failures are recorded below.
- [x] A reviewer can confirm the fix from the focused and full Discord test evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `2113424424c`; zero conflicts.
- [x] The exact unrelated `bun run verify` blocker is documented in **Known gaps / failures**.

# Risks

Low. The change only alters the persistence context for Discord durable-turn memories. Existing turn state transitions and IDs are unchanged. A malformed legacy turn row without a world remains unreadable, which matches the prior behavior because the invalid foreign keys prevented those rows from being created successfully.

# Background

## What does this PR do?

It persists Discord durable-turn memories against the inbound message's established entity, room, and world instead of fabricating `entityId = agentId` and `roomId = turnId`.

The zero-key harness job failed all four Discord connector-loop cases before model generation because PostgreSQL rejected the fabricated memory foreign keys. The manager now computes the Discord world once, uses the same value for `ensureConnection`, and passes the real conversation scope into `claimDiscordTurn`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

N/A - the public configuration and connector behavior are unchanged; this repairs an internal persistence contract.

# Testing

## Where should a reviewer start?

Review the `claimDiscordTurn` call in `plugins/plugin-discord/messages.ts` and the persisted-context assertion in `plugins/plugin-discord/__tests__/turn-state.test.ts`.

## Detailed testing steps

```text
bun run --cwd plugins/plugin-discord test
Test Files  66 passed (66)
Tests       716 passed (716)

bun run --cwd plugins/plugin-discord test -- \
  __tests__/turn-state.test.ts \
  __tests__/messages-durable-turn.test.ts \
  __tests__/messages-inbound-idempotency.test.ts
Test Files  3 passed (3)
Tests       22 passed (22)

bun run --cwd plugins/plugin-discord typecheck
PASS

bunx biome check plugins/plugin-discord/turn-state.ts \
  plugins/plugin-discord/messages.ts \
  plugins/plugin-discord/__tests__/turn-state.test.ts
Checked 3 files. No fixes applied.
```

Original failing job: https://github.com/elizaOS/eliza/actions/runs/29918527641/job/88918516070

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Discord memory persistence fix; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Discord memory persistence fix; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow changed; the affected path is the keyless connector harness.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Discord credentials are available in this environment; the linked failing Actions job and manually dispatched keyless harness provide the backend execution logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console behavior, or network request changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, action, provider, or generated response behavior changed; the failure occurs before model generation.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no live Discord database is available; automated turn-state and manager tests inspect the persisted memory's entity, room, and world IDs directly.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed, and the repaired failure is a pre-generation SQL persistence error.

## Backend + frontend logs

Backend failure evidence is in the linked Actions job. It records the rejected `discord_turns` insert with the fabricated turn ID as `room_id`, followed by zero outbound deliveries in all four cases.

Frontend: N/A - no frontend surface is involved.

## Screenshots (before / after) + video walkthrough

N/A - backend-only connector persistence fix with no UI changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun install --ignore-scripts --frozen-lockfile` fails on current `develop` because today's dependency merges changed dependency declarations without a matching frozen lockfile update.
- `bun run verify` stops at `check:biome-version`: current `develop` expects Biome 2.5.5 from the merged dependency group, while repository configs, templates, and lockfiles remain pinned to 2.5.4. This PR does not touch dependency or Biome files.
- The exact keyless harness cannot collect locally on macOS because Vitest resolves `zod` with an undefined named `z` export. The linked Linux CI job loaded the same harness successfully and reached the SQL failure; PR CI is the authoritative rerun. The full Discord unit suite, durability/idempotency tests, typecheck, and formatting all pass locally.
