### PR TITLE
fix: synchronize Biome 2.5.5 and dependency lockfiles

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": true,
   "assist": {
     "actions": {

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@capacitor/core": "8.4.0",
         "@elizaos-benchmarks/lib": "workspace:*",
         "@elizaos/agent": "workspace:*",
@@ -301,7 +301,7 @@
         "pathe": "^2.0.3",
         "postcss": "^8.5.16",
         "rollup-plugin-visualizer": "^7.0.1",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "tailwindcss": "^4.3.1",
         "tesseract.js": "^6.0.1",
         "typescript": "^6.0.3",
@@ -372,7 +372,7 @@
         "playwright-core": "^1.58.2",
         "puppeteer-core": "^24.43.1",
         "react-test-renderer": "^19.2.4",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "tailwindcss": "^4.3.1",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
@@ -399,7 +399,7 @@
         "@elizaos/capacitor-system": "workspace:*",
         "@elizaos/capacitor-talkmode": "workspace:*",
         "@elizaos/capacitor-websiteblocker": "workspace:*",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -434,7 +434,7 @@
         "electrobun": "^1.18.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.8",
         "@typescript/native": "npm:typescript@^7.0.2",
         "rcedit": "5.0.2",
@@ -486,7 +486,7 @@
       "name": "@elizaos/bench-eliza-1-vision-cua-e2e",
       "version": "0.1.0",
       "dependencies": {
-        "sharp": "^0.34.0",
+        "sharp": "^0.35.3",
       },
       "devDependencies": {
         "@elizaos/plugin-computeruse": "workspace:*",
@@ -609,7 +609,7 @@
         "ai": "^6.0.170",
         "drizzle-orm": "^0.45.1",
         "file-type": "^22.0.1",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "music-metadata": "^11.12.3",
         "nanoid": "^5.1.9",
         "stripe": "^22.0.0",
@@ -620,7 +620,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/pg": "^8.16.0",
         "@types/ws": "^8.18.1",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -650,7 +650,7 @@
       "name": "@elizaos/cloud-routing",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.3.12",
@@ -681,7 +681,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.26.0",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "mcp-handler": "^1.0.7",
         "zod": "^4.4.3",
       },
@@ -705,7 +705,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.3.10",
@@ -728,7 +728,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@elizaos/cloud-shared": "workspace:*",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
       },
       "devDependencies": {
         "@types/node": "22.19.2",
@@ -742,15 +742,15 @@
       "version": "1.0.0",
       "dependencies": {
         "@elizaos/cloud-services-common": "workspace:*",
-        "@hono/node-server": "2.0.8",
+        "@hono/node-server": "2.0.10",
         "@upstash/redis": "^1.37.0",
         "discord.js": "^14.26.4",
         "hashring": "^3.2.0",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "ioredis": "^5.10.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/hashring": "^3.2.5",
         "@types/node": "22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -766,12 +766,12 @@
         "@elizaos/cloud-services-common": "workspace:*",
         "@upstash/redis": "^1.37.0",
         "hashring": "^3.2.0",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "ioredis": "^5.10.1",
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/hashring": "^3.2.5",
         "@types/node": "22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -789,13 +789,13 @@
         "pepr": "^1.1.7",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "1.3.14",
-        "@typescript-eslint/parser": "8.64.0",
+        "@typescript-eslint/parser": "8.65.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "esbuild": "0.28.1",
         "ioredis-mock": "^8.13.1",
-        "prettier": "3.9.5",
+        "prettier": "3.9.6",
         "typescript": "5.8.3",
         "uuid": "14.0.0",
       },
@@ -841,7 +841,7 @@
         "exceljs": "^4.4.0",
         "expletives": "^0.1.5",
         "gray-matter": "^4.0.3",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "jose": "^6.0.0",
         "json-schema": "^0.4.0",
         "json5": "^2.2.3",
@@ -862,7 +862,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@cloudflare/workers-types": "^4.20260429.1",
         "@types/node": "^25.6.0",
         "@types/nodemailer": "^8.0.0",
@@ -881,7 +881,7 @@
       "name": "@elizaos/contracts",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.1.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -992,7 +992,7 @@
         "ffmpeg-static": "^5.3.0",
         "ffprobe-static": "^3.1.0",
         "pixelmatch": "^7.2.0",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "tesseract.js": "^6.0.1",
         "zod": "^4.4.3",
       },
@@ -1197,7 +1197,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -1267,13 +1267,13 @@
         "react": "^19.0.0",
         "react-device-detect": "^2.2.3",
         "react-dom": "^19.0.0",
-        "sharp": "^0.33.5",
+        "sharp": "^0.35.3",
         "styled-components": "^6.4.2",
         "tailwind-merge": "^3.0.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@tailwindcss/postcss": "^4.3.1",
         "@types/node": "^22.19.17",
         "@types/react": "^19.0.2",
@@ -1386,7 +1386,7 @@
         "dotenv": "^17.2.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -1423,7 +1423,7 @@
         "dotenv": "^17.2.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -1761,7 +1761,7 @@
         "dotenv": "^17.2.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -1935,7 +1935,7 @@
         "@huggingface/hub": "^2.6.12",
         "@langchain/anthropic": "1.5.1",
         "@langchain/core": "1.1.36",
-        "@langchain/openai": "1.3.1",
+        "@langchain/openai": "1.5.5",
         "@neondatabase/serverless": "^1.0.2",
         "@prb/math": "^4.1.0",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -1962,7 +1962,7 @@
         "@tanstack/react-query": "^5.90.8",
         "@telegram-apps/sdk-react": "^3.3.9",
         "@types/pg": "^8.15.6",
-        "@vercel/analytics": "^1.6.1",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/blob": "2.3.2",
         "@vercel/kv": "^3.0.0",
         "@vercel/postgres": "^0.10.0",
@@ -2192,7 +2192,7 @@
         "@feed/db": "workspace:*",
         "@feed/pack-default": "workspace:*",
         "@feed/shared": "workspace:*",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "xml2js": "^0.6.2",
       },
       "devDependencies": {
@@ -2445,7 +2445,7 @@
         "three": "^0.184.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.3.1",
         "@types/node": "^24.0.0",
@@ -2456,7 +2456,7 @@
         "@vitejs/plugin-react": "^6.0.0",
         "playwright": "^1.59.1",
         "rollup-plugin-visualizer": "^7.0.1",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "tailwindcss": "^4.3.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
@@ -2477,6 +2477,7 @@
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-agent-orchestrator": "workspace:*",
         "@elizaos/plugin-groq": "workspace:*",
         "@elizaos/plugin-local-inference": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -2555,14 +2556,14 @@
         "vite": "^8.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^24.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript/native": "npm:typescript@^7.0.2",
         "playwright": "^1.59.1",
         "rollup-plugin-visualizer": "^7.0.1",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "typescript": "^6.0.3",
         "viem": "^2.48.8",
       },
@@ -2619,7 +2620,7 @@
         "playwright": "^1.59.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "typescript": "^6.0.3",
         "vitest": "^4.0.0",
       },
@@ -2826,7 +2827,7 @@
       },
       "dependencies": {
         "@elizaos/cloud-shared": "workspace:*",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
       },
       "devDependencies": {
         "bun-types": "*",
@@ -2947,7 +2948,7 @@
         "react": "19.2.5",
         "react-dom": "19.2.7",
         "react-plaid-link": "^4.1.1",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "storybook": "^10.0.0",
         "three": "^0.184.0",
         "typescript": "^6.0.3",
@@ -3015,15 +3016,15 @@
         "@elizaos/auth": "workspace:*",
         "@octokit/core": "^7.0.6",
         "@octokit/rest": "^22.0.0",
-        "universal-user-agent": "^7.0.3",
-        "@smithers-orchestrator/engine": "0.28.0",
+        "@smithers-orchestrator/engine": "0.29.0",
         "coding-agent-adapters": "0.16.3",
         "drizzle-orm": "^0.45.1",
         "effect": "^3.21.1",
         "smithers-orchestrator": "0.28.0",
+        "universal-user-agent": "^7.0.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@electric-sql/pglite": "^0.4.0",
         "@elizaos/core": "workspace:*",
         "@elizaos/logger": "workspace:*",
@@ -3052,7 +3053,7 @@
         "fflate": "^0.8.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
@@ -3067,7 +3068,7 @@
         "ai": "^6.0.23",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@elizaos/test-harness": "workspace:*",
         "@types/node": "^25.0.3",
@@ -3125,7 +3126,7 @@
         "react": "^19.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "24.12.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "8.5.1",
@@ -3163,7 +3164,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.1.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -3188,7 +3189,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3203,7 +3204,7 @@
         "@elizaos/ui": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -3234,7 +3235,7 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -3261,7 +3262,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^24.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3282,7 +3283,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3367,7 +3368,7 @@
         "ws": "^8.18.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.12",
         "@types/node": "24.12.2",
         "@types/ws": "^8.5.13",
@@ -3388,7 +3389,7 @@
         "commander": "^15.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@typescript/native": "npm:typescript@^7.0.2",
         "strip-literal": "^3.1.0",
         "typescript": "^6.0.3",
@@ -3399,7 +3400,7 @@
       "name": "@elizaos/plugin-cli-inference",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.0.3",
@@ -3436,7 +3437,7 @@
       "name": "@elizaos/plugin-codex-cli",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.0.3",
@@ -3473,7 +3474,7 @@
         "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.2.22",
         "@types/node": "^24.5.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -3513,7 +3514,7 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -3563,7 +3564,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/test-harness": "workspace:*",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -3578,7 +3579,7 @@
       "name": "@elizaos/plugin-discord-local",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3623,7 +3624,7 @@
         "e2b": "^2.20.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.2.25",
@@ -3639,7 +3640,7 @@
         "node-edge-tts": "^1.0.7",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.2.22",
         "@types/node": "^24.5.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -3656,7 +3657,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.2.22",
         "@types/node": "^24.5.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -3690,7 +3691,7 @@
         "ws": "8.21.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@clack/prompts": "^1.5.1",
         "@types/bun": "^1.3.5",
         "@types/node": "^25.0.3",
@@ -3719,7 +3720,7 @@
       "name": "@elizaos/plugin-embeddings",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -3743,7 +3744,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
@@ -3774,7 +3775,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "esbuild": "^0.28.0",
@@ -3813,7 +3814,7 @@
         "typescript": "^6.0.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "vitest": "^4.0.0",
       },
     },
@@ -3833,7 +3834,7 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -3891,7 +3892,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3915,7 +3916,7 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/test-harness": "workspace:*",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
@@ -3944,7 +3945,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.6.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3960,7 +3961,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -3974,7 +3975,7 @@
         "@google/genai": "^1.5.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@elizaos/test-harness": "workspace:*",
         "@types/node": "^25.0.3",
@@ -3997,7 +3998,7 @@
         "ai": "^6.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/test-harness": "workspace:*",
         "@types/bun": "^1.3.10",
         "@types/node": "^25.0.3",
@@ -4016,7 +4017,7 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/plugin-scheduling": "workspace:*",
         "@types/node": "^25.6.0",
         "@types/react": "^19.0.0",
@@ -4066,7 +4067,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -4086,7 +4087,7 @@
         "lucide-react": "^1.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -4111,7 +4112,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -4127,7 +4128,7 @@
         "typescript": "^6.0.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "vitest": "^4.0.0",
       },
     },
@@ -4139,7 +4140,7 @@
         "@line/bot-sdk": "^11.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -4154,7 +4155,7 @@
         "@linear/sdk": "^86.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -4169,7 +4170,7 @@
         "ai": "^6.0.174",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4193,7 +4194,7 @@
         "ws": "^8.20.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "24.12.2",
         "@types/ws": "^8.18.1",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4213,7 +4214,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.3.14",
@@ -4248,7 +4249,7 @@
         "matrix-js-sdk": "^41.4.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.1.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -4269,7 +4270,7 @@
         "json5": "^2.2.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4341,7 +4342,7 @@
         "uuid": "^14.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "^8.5.1",
@@ -4515,7 +4516,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@capacitor/filesystem": "^8.1.2",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4533,7 +4534,7 @@
       "name": "@elizaos/capacitor-gateway",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@capacitor/core": "^8.3.1",
         "@capacitor/docgen": "^0.3.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4624,7 +4625,7 @@
       "name": "@elizaos/capacitor-mobile-agent-bridge",
       "version": "2.0.3-beta.7",
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@capacitor/core": "^8.3.1",
         "@typescript/native": "npm:typescript@^7.0.2",
         "rollup": "^4.60.2",
@@ -4815,7 +4816,7 @@
         "zod": "^4.4.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.1.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4835,7 +4836,7 @@
         "nostr-tools": "^2.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -4851,7 +4852,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4872,7 +4873,7 @@
         "js-tiktoken": "^1.0.21",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@elizaos/test-harness": "workspace:*",
         "@types/bun": "^1.3.8",
@@ -4896,7 +4897,7 @@
         "ai": "^6.0.30",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/core": "workspace:*",
         "@elizaos/test-harness": "workspace:*",
         "@types/bun": "^1.3.5",
@@ -4919,7 +4920,7 @@
         "unpdf": "^1.4.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.10",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -4965,7 +4966,7 @@
         "drizzle-orm": "0.45.2",
         "lucide-react": "^1.0.0",
         "react-plaid-link": "^4.0.1",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -5071,7 +5072,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.2.25",
@@ -5110,7 +5111,7 @@
         "drizzle-orm": "^0.45.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -5139,7 +5140,7 @@
         "drizzle-orm": "^0.45.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.6",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "^8.5.1",
@@ -5175,7 +5176,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@electric-sql/pglite": "^0.4.5",
         "@types/node": "^25.0.6",
         "@types/react": "^19.0.0",
@@ -5234,7 +5235,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/cross-spawn": "^6.0.6",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -5254,7 +5255,7 @@
         "qrcode": "^1.5.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@types/qrcode": "^1.5.5",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -5279,7 +5280,7 @@
         "@slack/web-api": "^7.15.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.2.25",
@@ -5303,7 +5304,7 @@
         "ws": "^8.18.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.5",
         "@types/node": "^25.0.3",
         "@types/pg": "^8.15.2",
@@ -5341,7 +5342,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "^8.5.1",
@@ -5359,7 +5360,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.6.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "^8.5.1",
@@ -5404,7 +5405,7 @@
         "viem": "^2.48.8",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -5425,7 +5426,7 @@
         "type-detect": "^4.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/config": "latest",
         "@elizaos/test-harness": "workspace:*",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -5441,7 +5442,7 @@
         "telegraf": "4.16.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -5539,7 +5540,7 @@
         "zod": "^4.4.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.1.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -5557,7 +5558,7 @@
         "@twurple/chat": "^8.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.1.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -5611,10 +5612,10 @@
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "jimp": "^1.6.0",
-        "sharp": "^0.34.3",
+        "sharp": "^0.35.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@elizaos/plugin-computeruse": "workspace:*",
         "@types/bun": "^1.3.5",
         "@types/node": "^25.0.3",
@@ -5699,7 +5700,7 @@
         "@tavily/core": "^0.7.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@typescript/native": "npm:typescript@^7.0.2",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
@@ -5731,7 +5732,7 @@
         "qrcode-terminal": "^0.12.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@types/qrcode": "^1.5.5",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -5769,14 +5770,14 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/shared": "workspace:*",
-        "@smithers-orchestrator/engine": "0.28.0",
+        "@smithers-orchestrator/engine": "0.29.0",
         "drizzle-orm": "^0.45.1",
         "effect": "^3.21.1",
         "quickjs-emscripten": "0.32.0",
         "smithers-orchestrator": "0.28.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@electric-sql/pglite": "^0.2.17",
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -5800,7 +5801,7 @@
         "twitter-api-v2": "^1.23.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^22.19.17",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.0.0",
@@ -5839,7 +5840,7 @@
         "@elizaos/core": "workspace:*",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",
@@ -5858,7 +5859,7 @@
         "ai": "^6.0.23",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.10",
         "@types/node": "^25.0.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -5871,79 +5872,79 @@
     },
   },
   "trustedDependencies": [
-    "nx",
-    "esbuild",
-    "ffmpeg-static",
-    "@swc/core",
-    "keccak",
-    "protobufjs",
-    "sharp",
-    "utf-8-validate",
-    "bigint-buffer",
-    "bufferutil",
-    "secp256k1",
     "@elizaos/plugin-starter",
+    "utf-8-validate",
+    "@swc/core",
     "tesseract.js",
+    "protobufjs",
+    "keccak",
+    "secp256k1",
+    "bufferutil",
     "workerd",
-    "electron",
+    "esbuild",
+    "sharp",
     "@biomejs/biome",
+    "electron",
+    "ffmpeg-static",
+    "nx",
+    "bigint-buffer",
   ],
   "patchedDependencies": {
-    "@solana/rpc@5.5.1": "patches/@solana%2Frpc@5.5.1.patch",
-    "@solana/sysvars@5.5.1": "patches/@solana%2Fsysvars@5.5.1.patch",
-    "@solana/rpc-spec@5.5.1": "patches/@solana%2Frpc-spec@5.5.1.patch",
-    "@solana/rpc-subscriptions@5.5.1": "patches/@solana%2Frpc-subscriptions@5.5.1.patch",
-    "@farcaster/quick-auth@0.0.8": "patches/@farcaster%2Fquick-auth@0.0.8.patch",
     "@solana/rpc-subscriptions-spec@5.5.1": "patches/@solana%2Frpc-subscriptions-spec@5.5.1.patch",
-    "@solana/rpc-types@5.5.1": "patches/@solana%2Frpc-types@5.5.1.patch",
-    "@solana/instruction-plans@5.5.1": "patches/@solana%2Finstruction-plans@5.5.1.patch",
-    "@solana/codecs-strings@5.5.1": "patches/@solana%2Fcodecs-strings@5.5.1.patch",
-    "@solana/nominal-types@5.5.1": "patches/@solana%2Fnominal-types@5.5.1.patch",
-    "@solana/rpc-parsed-types@5.5.1": "patches/@solana%2Frpc-parsed-types@5.5.1.patch",
-    "@solana/fast-stable-stringify@5.5.1": "patches/@solana%2Ffast-stable-stringify@5.5.1.patch",
-    "@solana/rpc-spec-types@5.5.1": "patches/@solana%2Frpc-spec-types@5.5.1.patch",
     "@solana/rpc-transformers@5.5.1": "patches/@solana%2Frpc-transformers@5.5.1.patch",
-    "@solana/codecs-numbers@5.5.1": "patches/@solana%2Fcodecs-numbers@5.5.1.patch",
-    "tsup@8.5.1": "patches/tsup@8.5.1.patch",
-    "@vitest/mocker@4.1.5": "patches/@vitest%2Fmocker@4.1.5.patch",
-    "@solana/codecs-core@5.5.1": "patches/@solana%2Fcodecs-core@5.5.1.patch",
-    "@solana/errors@5.5.1": "patches/@solana%2Ferrors@5.5.1.patch",
-    "@solana/offchain-messages@5.5.1": "patches/@solana%2Foffchain-messages@5.5.1.patch",
-    "electrobun@1.18.1": "patches/electrobun@1.18.1.patch",
-    "@capacitor/ios@8.4.1": "patches/@capacitor%2Fios@8.4.1.patch",
-    "@solana/codecs@5.5.1": "patches/@solana%2Fcodecs@5.5.1.patch",
-    "@solana/transactions@5.5.1": "patches/@solana%2Ftransactions@5.5.1.patch",
-    "vitest@4.1.5": "patches/vitest@4.1.5.patch",
-    "@solana/plugin-core@5.5.1": "patches/@solana%2Fplugin-core@5.5.1.patch",
+    "@solana/fast-stable-stringify@5.5.1": "patches/@solana%2Ffast-stable-stringify@5.5.1.patch",
     "@solana/rpc-transport-http@5.5.1": "patches/@solana%2Frpc-transport-http@5.5.1.patch",
-    "@solana/rpc-subscriptions-api@5.5.1": "patches/@solana%2Frpc-subscriptions-api@5.5.1.patch",
-    "@solana/functional@5.5.1": "patches/@solana%2Ffunctional@5.5.1.patch",
-    "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch",
-    "@solana/addresses@5.5.1": "patches/@solana%2Faddresses@5.5.1.patch",
-    "telegraf@4.16.3": "patches/telegraf@4.16.3.patch",
-    "@solana/kit@5.5.1": "patches/@solana%2Fkit@5.5.1.patch",
-    "@solana/assertions@5.5.1": "patches/@solana%2Fassertions@5.5.1.patch",
-    "@solana/codecs-data-structures@5.5.1": "patches/@solana%2Fcodecs-data-structures@5.5.1.patch",
-    "@solana/promises@5.5.1": "patches/@solana%2Fpromises@5.5.1.patch",
-    "@solana/keys@5.5.1": "patches/@solana%2Fkeys@5.5.1.patch",
-    "@solana/transaction-messages@5.5.1": "patches/@solana%2Ftransaction-messages@5.5.1.patch",
-    "@solana/rpc-subscriptions-channel-websocket@5.5.1": "patches/@solana%2Frpc-subscriptions-channel-websocket@5.5.1.patch",
-    "@solana/subscribable@5.5.1": "patches/@solana%2Fsubscribable@5.5.1.patch",
-    "@solana/rpc-api@5.5.1": "patches/@solana%2Frpc-api@5.5.1.patch",
-    "@solana/transaction-confirmation@5.5.1": "patches/@solana%2Ftransaction-confirmation@5.5.1.patch",
-    "@solana/options@5.5.1": "patches/@solana%2Foptions@5.5.1.patch",
-    "@solana/instructions@5.5.1": "patches/@solana%2Finstructions@5.5.1.patch",
-    "@solana/signers@5.5.1": "patches/@solana%2Fsigners@5.5.1.patch",
     "@capacitor/barcode-scanner@3.0.2": "patches/@capacitor%2Fbarcode-scanner@3.0.2.patch",
-    "@solana/accounts@5.5.1": "patches/@solana%2Faccounts@5.5.1.patch",
+    "electrobun@1.18.1": "patches/electrobun@1.18.1.patch",
+    "@solana/transactions@5.5.1": "patches/@solana%2Ftransactions@5.5.1.patch",
+    "@solana/rpc-spec@5.5.1": "patches/@solana%2Frpc-spec@5.5.1.patch",
+    "@solana/codecs-data-structures@5.5.1": "patches/@solana%2Fcodecs-data-structures@5.5.1.patch",
+    "tsup@8.5.1": "patches/tsup@8.5.1.patch",
+    "@solana/codecs-core@5.5.1": "patches/@solana%2Fcodecs-core@5.5.1.patch",
+    "@solana/rpc-spec-types@5.5.1": "patches/@solana%2Frpc-spec-types@5.5.1.patch",
+    "@solana/functional@5.5.1": "patches/@solana%2Ffunctional@5.5.1.patch",
+    "@solana/codecs-numbers@5.5.1": "patches/@solana%2Fcodecs-numbers@5.5.1.patch",
+    "@solana/sysvars@5.5.1": "patches/@solana%2Fsysvars@5.5.1.patch",
+    "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch",
+    "@solana/offchain-messages@5.5.1": "patches/@solana%2Foffchain-messages@5.5.1.patch",
+    "@capacitor/ios@8.4.1": "patches/@capacitor%2Fios@8.4.1.patch",
+    "@solana/rpc-parsed-types@5.5.1": "patches/@solana%2Frpc-parsed-types@5.5.1.patch",
+    "@solana/rpc-subscriptions@5.5.1": "patches/@solana%2Frpc-subscriptions@5.5.1.patch",
+    "@solana/keys@5.5.1": "patches/@solana%2Fkeys@5.5.1.patch",
+    "@solana/transaction-confirmation@5.5.1": "patches/@solana%2Ftransaction-confirmation@5.5.1.patch",
+    "@solana/addresses@5.5.1": "patches/@solana%2Faddresses@5.5.1.patch",
+    "@solana/transaction-messages@5.5.1": "patches/@solana%2Ftransaction-messages@5.5.1.patch",
+    "@solana/promises@5.5.1": "patches/@solana%2Fpromises@5.5.1.patch",
+    "@solana/errors@5.5.1": "patches/@solana%2Ferrors@5.5.1.patch",
+    "@solana/nominal-types@5.5.1": "patches/@solana%2Fnominal-types@5.5.1.patch",
+    "@solana/instructions@5.5.1": "patches/@solana%2Finstructions@5.5.1.patch",
+    "@solana/kit@5.5.1": "patches/@solana%2Fkit@5.5.1.patch",
+    "@solana/rpc-api@5.5.1": "patches/@solana%2Frpc-api@5.5.1.patch",
+    "@solana/rpc-types@5.5.1": "patches/@solana%2Frpc-types@5.5.1.patch",
+    "@solana/signers@5.5.1": "patches/@solana%2Fsigners@5.5.1.patch",
+    "@solana/codecs-strings@5.5.1": "patches/@solana%2Fcodecs-strings@5.5.1.patch",
+    "vitest@4.1.5": "patches/vitest@4.1.5.patch",
     "@solana/programs@5.5.1": "patches/@solana%2Fprograms@5.5.1.patch",
+    "@solana/rpc@5.5.1": "patches/@solana%2Frpc@5.5.1.patch",
+    "@solana/assertions@5.5.1": "patches/@solana%2Fassertions@5.5.1.patch",
+    "@solana/options@5.5.1": "patches/@solana%2Foptions@5.5.1.patch",
+    "@farcaster/quick-auth@0.0.8": "patches/@farcaster%2Fquick-auth@0.0.8.patch",
+    "@solana/subscribable@5.5.1": "patches/@solana%2Fsubscribable@5.5.1.patch",
+    "@solana/accounts@5.5.1": "patches/@solana%2Faccounts@5.5.1.patch",
+    "@solana/instruction-plans@5.5.1": "patches/@solana%2Finstruction-plans@5.5.1.patch",
+    "telegraf@4.16.3": "patches/telegraf@4.16.3.patch",
+    "@vitest/mocker@4.1.5": "patches/@vitest%2Fmocker@4.1.5.patch",
+    "@solana/codecs@5.5.1": "patches/@solana%2Fcodecs@5.5.1.patch",
+    "@solana/plugin-core@5.5.1": "patches/@solana%2Fplugin-core@5.5.1.patch",
+    "@solana/rpc-subscriptions-api@5.5.1": "patches/@solana%2Frpc-subscriptions-api@5.5.1.patch",
+    "@solana/rpc-subscriptions-channel-websocket@5.5.1": "patches/@solana%2Frpc-subscriptions-channel-websocket@5.5.1.patch",
   },
   "overrides": {
     "@ai-sdk/gateway": "3.0.109",
     "@ai-sdk/openai": "3.0.58",
     "@ai-sdk/provider": "3.0.13",
     "@ai-sdk/provider-utils": "4.0.36",
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@clack/prompts": "1.3.0",
     "@cloudflare/workerd-darwin-arm64": "1.20260611.1",
     "@electric-sql/pglite": "^0.4.5",
@@ -6242,23 +6243,23 @@
 
     "@bigmi/core": ["@bigmi/core@0.7.1", "", { "dependencies": { "@noble/hashes": "^1.8.0", "bech32": "^2.0.0", "bitcoinjs-lib": "^7.0.1", "bs58": "^6.0.0", "eventemitter3": "^5.0.4", "zustand": "^5.0.11" } }, "sha512-qG7457V8QlsTmoxuAjmc1h7e259cSfzd6Ifnxg/JJOTo4KNzd1Eb01oHQFK0KUwzqEHm6bQ2mPLQwropNUiFjA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@bitcoinerlab/secp256k1": ["@bitcoinerlab/secp256k1@1.2.0", "", { "dependencies": { "@noble/curves": "^1.7.0" } }, "sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q=="],
 
@@ -7294,7 +7295,7 @@
 
     "@helia/utils": ["@helia/utils@1.4.0", "", { "dependencies": { "@helia/interface": "^5.4.0", "@ipld/dag-cbor": "^9.2.2", "@ipld/dag-json": "^10.2.3", "@ipld/dag-pb": "^4.1.3", "@libp2p/interface": "^2.5.0", "@libp2p/keychain": "^5.2.8", "@libp2p/logger": "^5.1.8", "@libp2p/utils": "^6.5.1", "@multiformats/dns": "^1.0.6", "@multiformats/multiaddr": "^12.4.0", "any-signal": "^4.1.1", "blockstore-core": "^5.0.2", "cborg": "^4.2.6", "interface-blockstore": "^5.3.1", "interface-datastore": "^8.3.1", "interface-store": "^6.0.2", "it-drain": "^3.0.7", "it-filter": "^3.1.1", "it-foreach": "^2.1.1", "it-merge": "^3.0.5", "libp2p": "^2.9.0", "mortice": "^3.0.6", "multiformats": "^13.3.1", "p-defer": "^4.0.1", "progress-events": "^1.0.1", "uint8arrays": "^5.1.0" } }, "sha512-xXwhQbfSQEC5uHd6HVwdGXksZayy5xnYB5aOk0TU1fDnwbaeJz46o/GdWcxkTxnbfGyxqs9hyK5NqHw1B58yAw=="],
 
-    "@hono/node-server": ["@hono/node-server@2.0.8", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA=="],
+    "@hono/node-server": ["@hono/node-server@2.0.10", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@5.4.0", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw=="],
 
@@ -7336,53 +7337,57 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
@@ -7602,7 +7607,7 @@
 
     "@langchain/core": ["@langchain/core@1.1.36", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "@standard-schema/spec": "^1.1.0", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": ">=0.5.0 <1.0.0", "mustache": "^4.2.0", "p-queue": "^6.6.2", "uuid": "^11.1.0", "zod": "^3.25.76 || ^4" } }, "sha512-9NWsdzU3uZD13lJwunXK0t6SIwew+UwcbHggW5yUdaiMmzKeNkDpp1lRD6p49N8+D0Vv4qmQBEKB4Ukh2jfnvw=="],
 
-    "@langchain/openai": ["@langchain/openai@1.3.1", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^6.27.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.1.36" } }, "sha512-6yN3XFRUKUsGREGk4VtCvnMp5NHh2gWujiuWdn/G7cCeHboYrdKLWnwGqopuFOm7Tivv423gtMN1GQ7EJ3kg+g=="],
+    "@langchain/openai": ["@langchain/openai@1.5.5", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^6.41.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.2.2" } }, "sha512-wX7dwb9z4nf5FHXlIl/X2mk08pzonvRHCt1D4+s1zXLP0duYDC95j7dulPIQJ6fmhbyYQc9Ki8mEhY/D1lB8kw=="],
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.68.0", "", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-ip14+pWAv2La3bss4oDDtee2P5xBLDXuvmzhTvkxQMcPA5jCffFsler1TvNt4MyW6pexscj72AEWektyZwU9Yw=="],
 
@@ -8048,7 +8053,7 @@
 
     "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
 
-    "@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
 
     "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
 
@@ -8056,7 +8061,7 @@
 
     "@octokit/oauth-methods": ["@octokit/oauth-methods@4.1.0", "", { "dependencies": { "@octokit/oauth-authorization-url": "^6.0.2", "@octokit/request": "^8.3.1", "@octokit/request-error": "^5.1.0", "@octokit/types": "^13.0.0", "btoa-lite": "^1.0.0" } }, "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw=="],
 
-    "@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
     "@octokit/plugin-enterprise-rest": ["@octokit/plugin-enterprise-rest@6.0.1", "", {}, "sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw=="],
 
@@ -8066,13 +8071,13 @@
 
     "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
 
-    "@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+    "@octokit/request": ["@octokit/request@10.0.10", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w=="],
 
-    "@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
 
     "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
 
-    "@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@openai/codex": ["@openai/codex@0.133.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.133.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.133.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.133.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.133.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.133.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.133.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-Gh42kLLBo/6gpnHmDzUWDVvyS57ekCB1+1Dz0RG2oIl3Lhk1uwrjSj/PwaJWWh4Rw/rUp1RqkwrMugFfFEOlqQ=="],
 
@@ -8910,7 +8915,7 @@
 
     "@smithers-orchestrator/accounts": ["@smithers-orchestrator/accounts@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0" } }, "sha512-imflica+9A5hIBMwP5WLGIuFymC3Of5bVwvqCYa4wM4jTtVFudtRAONybP4cAgU2E9V+5+AT8FUe0ODnRgpKHw=="],
 
-    "@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+    "@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.29.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-M93RlKaI4HwdDKPfcHVJ3PGjzyyZUrohbnfJrlQkwc8NYYNMin6wEIqDbu641ow0uu50jhGayX2mjac6St/QYw=="],
 
     "@smithers-orchestrator/aws": ["@smithers-orchestrator/aws@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0" }, "optionalDependencies": { "@aws-sdk/client-cloudwatch-logs": "^3.700.0", "@aws-sdk/client-codebuild": "^3.700.0", "@aws-sdk/client-ecs": "^3.700.0", "@aws-sdk/client-s3": "^3.700.0" } }, "sha512-pWD6Ql0flidYx2ZFmA4EJD0+M2Wj703jVpExgNPSAxPDStanxcXMDVk5uU17bSiL96k1VL1cUcwMCHH2GoR6jg=="],
 
@@ -8918,23 +8923,23 @@
 
     "@smithers-orchestrator/cloudflare": ["@smithers-orchestrator/cloudflare@0.28.0", "", { "dependencies": { "@smithers-orchestrator/sandbox": "0.28.0" }, "optionalDependencies": { "@cloudflare/sandbox": "^0.12.3" } }, "sha512-A3iBnv2RD9s5rS7jSO4hGdxt2lddhttDwWP38yUsW/knCEVDju6Pv+O9MfuhlpGrmgGpT5nDUjtA8bnBp7St0g=="],
 
-    "@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+    "@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.29.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.29.0", "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/driver": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "@smithers-orchestrator/memory": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/react-reconciler": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-2hhDZsvF23dVBvqmKrPi4Lnyv/XQWctqV3gKKmYnYeWgHQhffmxhVpOFs6DYbpj8v3v6mehEnxNm3o/BlG7YrA=="],
 
     "@smithers-orchestrator/control-plane": ["@smithers-orchestrator/control-plane@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0" } }, "sha512-YD6+PmcU6PdcxfhjVgX3/53TYl9iWDK/PRJvB9D4MqEAQJYPEgMIa8oPkqlyfFd5TCL0PjH0UI8glZWqrBX3ug=="],
 
     "@smithers-orchestrator/daytona": ["@smithers-orchestrator/daytona@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0" }, "optionalDependencies": { "@daytonaio/sdk": "^0.194.0" } }, "sha512-21/IKmRpe9l71UJ92FsXv8joLnU06QtWj9zL3pVC2r1g7n0MrFoAiodVKZVRoS18+6AJFpA8Jj8OFrAdLqJtWg=="],
 
-    "@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+    "@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.29.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-i/+3eT9QoUc+SvZ+mx2pH3MYMduY4hHl4nfFPTfBBleQ4cjgXOZCstNNivYknPoSWR7Jr43gaJWmd70m+kOg7Q=="],
 
-    "@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+    "@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.29.0", "", {}, "sha512-5toOm+xMmPQngclwmIDkanMzaJ3MKIjEvj+3UdCS+5SF/DV8FwAZg8XtHtWahb4QecVuSo+HT4G2baoO7CQbkw=="],
 
-    "@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+    "@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.29.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-O/Sz5OX7sUb1cKfhNytRtS2ypO0heSz2iabLyKqfSBcHO+Z9bHQaREp2WmVPFP/z1Jiv29iKYTqbLAYTstDPGw=="],
 
     "@smithers-orchestrator/electric-proxy": ["@smithers-orchestrator/electric-proxy@0.28.0", "", { "dependencies": { "@smithers-orchestrator/gateway": "0.28.0" }, "bin": { "smithers-electric-proxy": "bin/smithers-electric-proxy.js" } }, "sha512-BLTZAwaRn3TrLTcr5P+nJD0c4TEal2YlYUnNvgdXL3uz6Iyo4uSB5Fc4Op+fcjbKM8QFmFLP2MDMrwOpjCAFvQ=="],
 
-    "@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+    "@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.29.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.29.0", "@smithers-orchestrator/components": "0.29.0", "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/driver": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/react-reconciler": "0.29.0", "@smithers-orchestrator/sandbox": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "@smithers-orchestrator/scorers": "0.29.0", "@smithers-orchestrator/time-travel": "0.29.0", "@smithers-orchestrator/tool-context": "0.29.0", "@smithers-orchestrator/vcs": "0.29.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-6nOftW6viz6AF9YKoLJq2+yIrxRXkW9vUZxGrtUi9gcDf3DYnq18wY8/OIzHvCjnFyXFDHnAdPOqESNC8SxaeQ=="],
 
-    "@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+    "@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.29.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-DUVujdlsNrwFxXxp4FyzwLDhLtIltkLYMJPQs2c+BvMLlmTEve6T6ZBerRIYzIIohWWKEpEtRN4OUFvPwWFI/A=="],
 
     "@smithers-orchestrator/gateway": ["@smithers-orchestrator/gateway@0.28.0", "", { "dependencies": { "@smithers-orchestrator/protocol": "0.28.0" } }, "sha512-W+LLbe+J4iFDSa/dkfsPQSIkOEw2d+eBH4/lkUVNE1+2CODYyJjXSmixnbAhT1dRaDAOVLDDrlurOvaYbKPc0Q=="],
 
@@ -8946,37 +8951,37 @@
 
     "@smithers-orchestrator/gcp": ["@smithers-orchestrator/gcp@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0" }, "optionalDependencies": { "@google-cloud/run": "^2.0.0", "@google-cloud/storage": "^7.0.0" } }, "sha512-xf8cOby9WpcI0uHpD8HQ0TWv8xr242ZcIM/tfmt+b5g0htC+x/a9zgM41OveZsO9NlXQkLOQL47JM6lyBPGuZQ=="],
 
-    "@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+    "@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.29.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.29.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-UV7Ocnx4HVKpUsEV9Kg5ibDm3XGPFshoGG8sn6dqje3lCB4rAuNJAYgPf8CW1lQGEj/FgsV2Zl4iMHEdYltd3A=="],
 
     "@smithers-orchestrator/integrations": ["@smithers-orchestrator/integrations@0.28.0", "", { "dependencies": { "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/engine": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "react": "^19.2.7", "zod": "4.4.3" } }, "sha512-o+skSpsDajKKVwDDsIGlUGK5iHXnyq3Qv/Oz/sK9Ro6RLMvBWZS8gHMN/BhLudXI5hyC+qi7ANoEvYi/+ZZP9Q=="],
 
-    "@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+    "@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.29.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-CFnsAGWIgW28pYUFoqKi7pLs/Hi9VpybqfWktps+rrMKmC5r9mCVKXBKCf5eQzstr7MLTlYo9tlt+0ZHncr4UA=="],
 
-    "@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+    "@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.29.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-56XFCDrFtZBFYhZUc4b4miHSLDKdUcpwErcf7kH3lBmpqq/frFpm+gfM88iJ/oHcHb2TkSp9PlwruYaokvUKyg=="],
 
-    "@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+    "@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.29.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-yVD7haZu2brZvyG3/AkDokXPp39F1Qz4znjWMFWE/oCdeop8/d3nyL5myI6KvogRC04vZi9EiATH1rla4dq7HQ=="],
 
-    "@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+    "@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.29.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-EU4kTP3Hfa9Cufhf+UIgY3vh3t2lfb4iTjz8JCQaZYN5OL+f8X6myg67tTZmjPyDjo3vj4qnC72qIdZlh20HLw=="],
 
-    "@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+    "@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.29.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-l1QrPolrxS48HM6rDTTUf2VX4j0BnSmWLn8tKh1lv+4i3PZ0SKq0bPLwAJyLEbY62zl6K9STysf1n9hE+o9ouA=="],
 
     "@smithers-orchestrator/memory": ["@smithers-orchestrator/memory@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-2Xj1JVNWBtICEU5KtaOk6z/b2x5GqjErDA6K+sbs5aWV1WP+9ALaOgyjvkErvdYx/K6bND1cCo3EVf94b9a2rA=="],
 
-    "@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+    "@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.29.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-akKzI3I5YQVnfIT0AbnBOQ8M7QIGGUHhMntNAp98aTvBOh3+eFFCYn9CDX3yo1FgqA1cyt97Oo73ZC7gUyfedw=="],
 
     "@smithers-orchestrator/openapi": ["@smithers-orchestrator/openapi@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "yaml": "^2.9.0", "zod": "^4.4.3" } }, "sha512-Vb9Gkckirf8f/MOLvGivdP9N49O0NyiczDf/Gu/Y35KIqwrPpXCELvSih1nMF1yFjnhUZg93sWCViiAT/WQIvA=="],
 
     "@smithers-orchestrator/protocol": ["@smithers-orchestrator/protocol@0.28.0", "", {}, "sha512-vTjSaeh3cO2x9+g5VNEWN9xHV4D8Z27ntNzzdvi0L0CACwEwZMqNqWy3VN5Id2N6w+I16abkiQV9lj1GqRjq/g=="],
 
-    "@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+    "@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.29.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.29.0", "@smithers-orchestrator/driver": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-N5hSJLAR+Q8JxmyQw3KazndH9PbVqMBxx3gFNOprG7yluilTokbZDw56pfkGFLwGC9JNUfbXbsPAwVteRfbFyw=="],
 
     "@smithers-orchestrator/review": ["@smithers-orchestrator/review@0.28.0", "", { "dependencies": { "@pierre/diffs": "^1.2.12", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/engine": "0.28.0", "@smithers-orchestrator/gateway-ui": "0.28.0", "effect": "3.21.4", "mermaid": "^11.16.0", "smithers-orchestrator": "0.28.0", "zod": "4.4.3" }, "bin": { "smithers-review": "src/cli/main.ts" } }, "sha512-pIK7862Qs1bHAODEZC/umE4bIh/QvBT315y89i2OcL6GdB4QjvF8h1oWeXbw2rMcAmVOh1pSom8Y7htcHPStWw=="],
 
-    "@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+    "@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.29.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/driver": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "effect": "3.21.4" } }, "sha512-rkH85EnHBDOvKfcQoYREHrT9uEza2Eeg45Y0DqYDdDMFMzjfK9XTXgVmD4vXCVgi7gOSD8DoAAjMTWaKhwOdLg=="],
 
-    "@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+    "@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.29.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "effect": "3.21.4" } }, "sha512-2iPgZyP/zHu2y/+bDY76BX5CY66aiWXp9F2r8R3J311PsiopO6SJaTlgUoCQO5LThYApmYv74HGQ2TvdvAagEA=="],
 
-    "@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+    "@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.29.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.29.0", "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-5TXfVuGCl+WJ0K+ihssEWaJ11Or1SbvKFTZ1kZm3nM0zM4ycKLSchN/FHFrGzVjaRjaPPtMqg9IOFUkZlHzJqA=="],
 
     "@smithers-orchestrator/server": ["@smithers-orchestrator/server@0.28.0", "", { "dependencies": { "@effect/workflow": "^0.18.2", "@smithers-orchestrator/accounts": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/engine": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/gateway": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/integrations": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/protocol": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/ui-styleguide": "0.28.0", "cron-parser": "^5.6.1", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "hono": "^4.12.27", "react": "^19.2.7", "react-dom": "^19.2.7", "ws": "^8.21.0" } }, "sha512-TmERiE30z3bV0uMpg5bR3xxtEsgOsPZhghPXoLfV9Tv3l+vErjNGSIpHZk9BsbCDLWLUKMd5ULzlvANO6+zNFA=="],
 
@@ -8984,9 +8989,9 @@
 
     "@smithers-orchestrator/testing": ["@smithers-orchestrator/testing@0.28.0", "", { "dependencies": { "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/engine": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "koffi": "^2.16.2", "zod": "^4.4.3" } }, "sha512-mnzgscrwVmcl5d53wI3jh+qDerS000rQZu/YaqkDxDO2LB3LmMWzkpUm1fQ0CalnMzjaU6Zht70SRCsSkpdQrA=="],
 
-    "@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+    "@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.29.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "@smithers-orchestrator/vcs": "0.29.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-29HLpGz+G6zWTLDDGNHNdfvxtWwB3yqN9+CnJH2aKEV5juH/nXeewuHp4pilJin//LGxcL5lFzDsxKS8LXUuWw=="],
 
-    "@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+    "@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.29.0", "", { "dependencies": { "ai": "^7.0.10", "zod": "^4.4.3" } }, "sha512-FS9PldpnP8Az/+4d03yDAENBmm3ig8ZBtG+cAPaUF8UcLIVfFBseftlhonuQZtDR521ns9Xnx0H+VhjoQXW+Ng=="],
 
     "@smithers-orchestrator/tui": ["@smithers-orchestrator/tui@0.28.0", "", { "dependencies": { "@opentui/core": "^0.4.2", "@opentui/react": "^0.4.2", "@smithers-orchestrator/gateway-client": "0.28.0", "@smithers-orchestrator/gateway-react": "0.28.0", "react": "^19.2.7", "react-dom": "^19.2.7" }, "bin": { "smithers-mon": "src/index.tsx" } }, "sha512-rk2/iCG4vGz454eLFa8uRvn+7ua6VM5rkApzvQt62U2Pr5Mg/1X2CB1fCjaozE96exTXxosGh/1OmW10QYvQoQ=="],
 
@@ -8996,7 +9001,7 @@
 
     "@smithers-orchestrator/usage": ["@smithers-orchestrator/usage@0.28.0", "", { "dependencies": { "@smithers-orchestrator/accounts": "0.28.0" } }, "sha512-v8UDh41l8Vu67q86N4xRzzSYf9LO1lwbeE6Kc8QopgSyVu/5GYRX7Z5lPPypEoajhtQsWWPovQT2nLY1cwSqcQ=="],
 
-    "@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
+    "@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.29.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.29.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.29.0", "@smithers-orchestrator/jj-darwin-x64": "0.29.0", "@smithers-orchestrator/jj-linux-arm64": "0.29.0", "@smithers-orchestrator/jj-linux-x64": "0.29.0", "@smithers-orchestrator/jj-win32-x64": "0.29.0" } }, "sha512-S+K0ZCDllI2TGqPTnA8glOh/yRa0VC5qjYBOLR0UNr4JE4ichXu31XlIa6Gh1ljUxOECd8k8ahCWhL1PBvBBOw=="],
 
     "@smithers-orchestrator/vercel": ["@smithers-orchestrator/vercel@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0" }, "optionalDependencies": { "@vercel/sandbox": "^2.0.0" } }, "sha512-G8hGAgMmmv61iIbDrYOHgUXry15lOLqdWWAlS8pZz9HN2bkF50D7vmgtzMKL54Ohq6CcjOUtgX2SzkR2RtDGZw=="],
 
@@ -9962,23 +9967,23 @@
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.4", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/type-utils": "8.59.4", "@typescript-eslint/utils": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.4", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.64.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.64.0", "@typescript-eslint/types": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.65.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.64.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.64.0", "@typescript-eslint/types": "^8.64.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.65.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.65.0", "@typescript-eslint/types": "^8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0" } }, "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0" } }, "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.64.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.65.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg=="],
 
     "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.64.0", "", {}, "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.65.0", "", {}, "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.64.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.64.0", "@typescript-eslint/tsconfig-utils": "8.64.0", "@typescript-eslint/types": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.65.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.65.0", "@typescript-eslint/tsconfig-utils": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg=="],
 
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
 
     "@typescript/native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
@@ -10060,7 +10065,9 @@
 
     "@vanilla-extract/sprinkles": ["@vanilla-extract/sprinkles@1.6.5", "", { "peerDependencies": { "@vanilla-extract/css": "^1.0.0" } }, "sha512-HOYidLONR/SeGk8NBAeI64I4gYdsMX9vJmniL13ZcLVwawyK0s2GUENEAcGA+GYLIoeyQB61UqmhqPodJry7zA=="],
 
-    "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
+    "@vectorize-io/hindsight-client": ["@vectorize-io/hindsight-client@0.8.4", "", {}, "sha512-Tk5wRRhRVSZ0FuGcUKqBZIidw/6eS81oTIKV0H5gmzKSM2r2CdoijmOi+NaP0v51rnoxVi0nFEHQXivt0J2+OA=="],
+
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@vercel/backends": ["@vercel/backends@0.8.25", "", { "dependencies": { "@vercel/build-utils": "13.34.0", "@vercel/nft": "1.10.0", "@vercel/static-config": "3.4.0", "execa": "3.2.0", "fs-extra": "11.1.0", "get-port": "5.1.1", "oxc-transform": "0.111.0", "path-to-regexp": "8.3.0", "resolve.exports": "2.0.3", "rolldown": "1.0.0-rc.1", "srvx": "0.11.16", "ts-morph": "12.0.0", "tsx": "4.21.0", "zod": "3.22.4" } }, "sha512-x+Amcl3weuQ0nUk3UcVpdD++jHoHbI1YZDLSJCXVC9iLrtUy1QzSJRb29cWMHtX+ixAjWXhVqd720xcU7PZfTg=="],
 
@@ -10146,7 +10153,7 @@
 
     "@verdaccio/file-locking": ["@verdaccio/file-locking@13.0.1", "", { "dependencies": { "lockfile": "1.0.4" } }, "sha512-SZ9uxnQKppiM+/67xTaaBP4AZ/Q+weUB22ci1gF861icYWhWFu3njA3ofYig/4yNqkYRVEKVAIwnH97BaBEYbg=="],
 
-    "@verdaccio/hooks": ["@verdaccio/hooks@8.0.4", "", { "dependencies": { "@verdaccio/core": "8.1.2", "@verdaccio/logger": "8.0.3", "debug": "4.4.3", "got-cjs": "12.5.4", "handlebars": "4.7.9" } }, "sha512-FJRCe7pH8c1pCqf7BVwKwCtvN63HMQhM6991qQwBS8CgZf86a1TY9TMxW1ICSHqD+jPidtLq+6W2s+bfaiHwJA=="],
+    "@verdaccio/hooks": ["@verdaccio/hooks@8.0.4", "", { "dependencies": { "@verdaccio/core": "8.1.2", "@verdaccio/logger": "8.0.3", "debug": "4.4.3", "got-cjs": "12.5.5", "handlebars": "4.7.9" } }, "sha512-FJRCe7pH8c1pCqf7BVwKwCtvN63HMQhM6991qQwBS8CgZf86a1TY9TMxW1ICSHqD+jPidtLq+6W2s+bfaiHwJA=="],
 
     "@verdaccio/loaders": ["@verdaccio/loaders@8.0.3", "", { "dependencies": { "@verdaccio/core": "8.1.2", "debug": "4.4.3", "lodash": "4.18.1" } }, "sha512-QG7zmQ9YuJgkC63zAMXP0IWafT9wvv/VWx97l0aaWLdXfJqK/l7+B7FgaEK0uZxq92Z+fU6tGaw5h2oe6XIFTg=="],
 
@@ -10534,7 +10541,7 @@
 
     "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
 
-    "bare-fs": ["bare-fs@4.7.2", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg=="],
+    "bare-fs": ["bare-fs@4.7.2", "", { "dependencies": { "bare-events": "^2.5.5", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg=="],
 
     "bare-os": ["bare-os@3.9.2", "", {}, "sha512-h530JsrkYi8518ZfR57GHaLoI5YzXkGGEV0Y+mf4KYPBn4OnNajiznwkDq7FgE+Vnmyss9Utnzi44y7sowiAXA=="],
 
@@ -11758,7 +11765,7 @@
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
-    "got-cjs": ["got-cjs@12.5.4", "", { "dependencies": { "@sindresorhus/is": "4.6.0", "@szmarczak/http-timer": "4.0.6", "@types/responselike": "1.0.0", "cacheable-lookup": "6.1.0", "cacheable-request": "7.0.2", "decompress-response": "^6.0.0", "form-data-encoder": "1.7.2", "get-stream": "^6.0.1", "http2-wrapper": "^2.1.10", "lowercase-keys": "2.0.0", "p-cancelable": "2.1.1", "responselike": "2.0.1" } }, "sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug=="],
+    "got-cjs": ["got-cjs@12.5.5", "", { "dependencies": { "@sindresorhus/is": "4.6.0", "@szmarczak/http-timer": "4.0.6", "@types/responselike": "1.0.0", "cacheable-lookup": "6.1.0", "cacheable-request": "7.0.2", "decompress-response": "^6.0.0", "form-data-encoder": "1.7.2", "get-stream": "^6.0.1", "http2-wrapper": "^2.1.10", "lowercase-keys": "2.0.0", "p-cancelable": "2.1.1", "responselike": "2.0.1" } }, "sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug=="],
 
     "gql.tada": ["gql.tada@1.11.2", "", { "dependencies": { "@0no-co/graphql.web": "^1.3.2", "@0no-co/graphqlsp": "^1.17.3", "@gql.tada/cli-utils": "1.9.2", "@gql.tada/internal": "1.2.1" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "gql-tada": "./bin/cli.js", "gql.tada": "./bin/cli.js" } }, "sha512-oBr7ShA5/TmcwOO7BZgN1SynX2rBU+/ltysB0zXc+NCBF+9YOg6MRzJcTfLjIqDKdcE3LGxpOl0l9hBbxmyzmA=="],
 
@@ -13272,7 +13279,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
@@ -13738,7 +13745,7 @@
 
     "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -14256,7 +14263,7 @@
 
     "universal-github-app-jwt": ["universal-github-app-jwt@1.2.0", "", { "dependencies": { "@types/jsonwebtoken": "^9.0.0", "jsonwebtoken": "^9.0.2" } }, "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g=="],
 
-    "universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
@@ -14748,27 +14755,13 @@
 
     "@electron/get/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
-    "@elizaos/cloud-api/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
-
     "@elizaos/cloud-e2e/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@elizaos/cloud-shared/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
-
-    "@elizaos/cloud-test-mocks/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
-
-    "@elizaos/container-control-plane/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
-
     "@elizaos/example-a2a-server/express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
-
-    "@elizaos/example-clone-ur-crush/sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
     "@elizaos/example-code/@elizaos/plugin-goals": ["@elizaos/plugin-goals@2.0.0-alpha.1", "", { "dependencies": { "@elizaos/core": "workspace:*", "@radix-ui/react-checkbox": "^1.1.4", "@radix-ui/react-collapsible": "^1.1.3", "@radix-ui/react-label": "^2.1.2", "@radix-ui/react-select": "^2.2.2", "@radix-ui/react-separator": "^1.1.2", "@radix-ui/react-slot": "^1.1.2", "class-variance-authority": "^0.7.1" } }, "sha512-KVg0soaLlJy5dxuPDcMEeIFtTINqh2osM3MJcptoqSU01mAFYykWCG67W3e2Y09261yxyo5vJDyd8PYykqLzYA=="],
 
     "@elizaos/example-rest-api-express/express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
-
-    "@elizaos/gateway-discord/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
-
-    "@elizaos/gateway-webhook/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
     "@elizaos/operator/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
@@ -14879,8 +14872,6 @@
     "@feed/e2e/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@feed/engine/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
-
-    "@feed/engine/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
     "@feed/engine/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -15027,6 +15018,8 @@
     "@helia/utils/multiformats": ["multiformats@13.4.2", "", {}, "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ=="],
 
     "@helia/utils/uint8arrays": ["uint8arrays@5.1.1", "", { "dependencies": { "multiformats": "^13.0.0" } }, "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ=="],
+
+    "@huggingface/transformers/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
@@ -15502,25 +15495,41 @@
 
     "@nx/devkit/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "@octokit/auth-app/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+
+    "@octokit/auth-app/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+
+    "@octokit/auth-app/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
     "@octokit/auth-app/lru-cache": ["@wolfy1339/lru-cache@11.0.2-patch.1", "", {}, "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA=="],
 
-    "@octokit/core/@octokit/request": ["@octokit/request@10.0.10", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w=="],
+    "@octokit/auth-app/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
-    "@octokit/core/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+    "@octokit/auth-oauth-app/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
 
-    "@octokit/core/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+    "@octokit/auth-oauth-app/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
-    "@octokit/core/universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+    "@octokit/auth-oauth-app/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
-    "@octokit/graphql/@octokit/request": ["@octokit/request@10.0.10", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w=="],
+    "@octokit/auth-oauth-device/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
 
-    "@octokit/graphql/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+    "@octokit/auth-oauth-device/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
-    "@octokit/graphql/universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+    "@octokit/auth-oauth-device/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
-    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+    "@octokit/auth-oauth-user/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
 
-    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+    "@octokit/auth-oauth-user/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@octokit/auth-oauth-user/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+
+    "@octokit/oauth-methods/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+
+    "@octokit/oauth-methods/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+
+    "@octokit/oauth-methods/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@openai/codex-sdk/@openai/codex": ["@openai/codex@0.144.4", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.4-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.4-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.4-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.4-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.4-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.4-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-DTHzYatlKq9dw55E0/HsbK4tRCEKabuJ10ybbqpsG8gVv/kvwEdg3Z4OI3cvLXKa21xkIa4lkGlZoO/HmqmFFw=="],
 
@@ -16034,15 +16043,135 @@
 
     "@slack/socket-mode/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "@smithers-orchestrator/accounts/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
     "@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
 
+    "@smithers-orchestrator/aws/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
     "@smithers-orchestrator/cli/@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
 
     "@smithers-orchestrator/cli/@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@smithers-orchestrator/cli/@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/components/@smithers-orchestrator/memory": ["@smithers-orchestrator/memory@0.29.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.29.0", "@smithers-orchestrator/errors": "0.29.0", "@smithers-orchestrator/graph": "0.29.0", "@smithers-orchestrator/observability": "0.29.0", "@smithers-orchestrator/scheduler": "0.29.0", "@vectorize-io/hindsight-client": "0.8.4", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-qDtU+76hp7bildezAu6354VI8Ro3BGyOVwPmJd99dAsENNomSbO1zcJPa0nSpnNhk9wnUSZkb0pMamTZKeQUkw=="],
+
+    "@smithers-orchestrator/control-plane/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
     "@smithers-orchestrator/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/memory/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/memory/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/memory/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/memory/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/memory/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/openapi/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/openapi/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/openapi/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
 
     "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -16714,8 +16843,6 @@
 
     "cloud-mcp-smoke/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
 
-    "cloud-mcp-smoke/hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
-
     "coding-agent-adapters/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "compress-commons/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -17190,6 +17317,8 @@
 
     "miller-rabin/bn.js": ["bn.js@4.12.4", "", {}, "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g=="],
 
+    "miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
@@ -17231,6 +17360,8 @@
     "native-run/ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "node-edge-tts/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
@@ -17535,6 +17666,36 @@
     "slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "smithers-orchestrator/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.90.0", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.2", "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/components": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/sandbox": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/scorers": "0.28.0", "@smithers-orchestrator/time-travel": "0.28.0", "@smithers-orchestrator/tool-context": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-socket": "0.2.6", "pg": "^8.22.0" } }, "sha512-LeyEUbl+4geV6LKqfY4ZEDfIjn2h5eG9ThBe1YiLgnFbhY+q05NoXf2TR1xqnpUfyWktZrDyk9NKPgAjvg2Tnw=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
 
     "solc/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -17861,44 +18022,6 @@
     "@elizaos/example-a2a-server/express/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@elizaos/example-a2a-server/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
-
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
     "@elizaos/example-code/@elizaos/plugin-goals/@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA=="],
 
@@ -18436,6 +18559,54 @@
 
     "@helia/interface/@multiformats/multiaddr/uint8arrays": ["uint8arrays@5.1.1", "", { "dependencies": { "multiformats": "^13.0.0" } }, "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ=="],
 
+    "@huggingface/transformers/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@huggingface/transformers/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/types/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
@@ -18752,23 +18923,33 @@
 
     "@nx/devkit/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
-    "@octokit/core/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+    "@octokit/auth-app/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
 
-    "@octokit/core/@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+    "@octokit/auth-app/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
-    "@octokit/core/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+    "@octokit/auth-oauth-app/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
 
-    "@octokit/graphql/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+    "@octokit/auth-oauth-app/@octokit/request/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
 
-    "@octokit/graphql/@octokit/request/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+    "@octokit/auth-oauth-app/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
-    "@octokit/graphql/@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+    "@octokit/auth-oauth-device/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
 
-    "@octokit/graphql/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+    "@octokit/auth-oauth-device/@octokit/request/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
 
-    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+    "@octokit/auth-oauth-device/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
-    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+    "@octokit/auth-oauth-user/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+
+    "@octokit/auth-oauth-user/@octokit/request/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+
+    "@octokit/auth-oauth-user/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "@octokit/oauth-methods/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+
+    "@octokit/oauth-methods/@octokit/request/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+
+    "@octokit/oauth-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "@openai/codex-sdk/@openai/codex/@openai/codex-darwin-arm64": ["@openai/codex@0.144.4-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6J3g498cM2oA7vYIJhpuGJlnIi/M5JdYmjB5BZ1Of5HQ0ziIlplFSvH801oVy9J5TQFp642ODzOu/ZEokDUXsg=="],
 
@@ -18846,9 +19027,9 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
-    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -18992,9 +19173,211 @@
 
     "@sigstore/sign/make-fetch-happen/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
-    "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
 
-    "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/components/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/engine/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/engine/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/engine/@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "@smithers-orchestrator/cli/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/components/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/components/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/components/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/openapi/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/db/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/db/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/db/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/memory": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/react-reconciler": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-upn7Hy2w9vzzak3JZv7EvfwhZcm9Kzc841bScWkVyWPPHoAlR+7r1LKu75Idj2UsntIVzNCZWOB15Z4B856qSQ=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/components/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/components/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-XU6fLe22NSO239S+pdaNw6TrNDiUNazULiXW2wEFqA3YjFxsTHsxvY+f9BANMvC6M46vhFC0JHwg9urD5q0qpQ=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/components/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/components/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/components/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/db/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/db/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/driver/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/driver/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3", "@electric-sql/pglite-age": "0.0.4", "@electric-sql/pglite-pg_hashids": "0.0.4", "@electric-sql/pglite-pg_ivm": "0.0.4", "@electric-sql/pglite-pg_textsearch": "0.0.5", "@electric-sql/pglite-pg_uuidv7": "0.0.4", "@electric-sql/pglite-pgtap": "0.0.4", "@electric-sql/pglite-pgvector": "0.0.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-vAE1JtM3WIMQxB6qZztcy4WvPpqTZ0b4uumbbs+cDgZAIntwh6IbTGHIC9BFkRX3xA8Pki9zY3udcIaL3p/YYA=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.28.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "ai": "^7.0.10", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-60CgrJVfS4lRtuL5S2uzhObtPZJeVHt+GRk2x7Ty1VxeZ/M5/BcToQuEOwVCsPOstvpkwpxcsp9LXiV1HkLh/w=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.28.0", "", { "dependencies": { "@effect/cluster": "^0.59.0", "@effect/rpc": "^0.75.1", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/driver": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4" } }, "sha512-QjDnmJNHCOexRo8MnCG6tl9pZJdoOrcyysJy283D+uP3GgP2SgtjaJ1rrpFdLu3Ee3nAv7uefoIog/Z4JWRG9Q=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.28.0", "", { "dependencies": { "@smithers-orchestrator/agents": "0.28.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-yYTzGRxwTrJhM95MQcFL8hAkZHUnbIu9HnPnLhOapxGAxOjXwBpNv/WtsvjYbIpPMwWggkvTgLcQnpQMYhQD/A=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "@smithers-orchestrator/vcs": "0.28.0", "drizzle-orm": "^0.45.2", "effect": "3.21.4", "picocolors": "^1.1.1" } }, "sha512-wcmdQ+1w4HIwoHWPb9DCu9ciBE1JKtv4r3eX4zaNfCCtgqt1lqP8uliolrzrrXaMEvxfBooFPTGyzF3OhVSr9A=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/tool-context": ["@smithers-orchestrator/tool-context@0.28.0", "", {}, "sha512-m0srLr9iPCvPocPVDAhQTRW9vb0kO/8INSaouMaoavRoZxOSmYNbNBrwIGk7QsbDRNLKjk8UT73DoCWUSS6+2g=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.28.0", "", { "dependencies": { "@effect/platform": "^0.96.2", "@smithers-orchestrator/observability": "0.28.0", "effect": "3.21.4" }, "optionalDependencies": { "@smithers-orchestrator/jj-darwin-arm64": "0.28.0", "@smithers-orchestrator/jj-darwin-x64": "0.28.0", "@smithers-orchestrator/jj-linux-arm64": "0.28.0", "@smithers-orchestrator/jj-linux-x64": "0.28.0", "@smithers-orchestrator/jj-win32-x64": "0.28.0" } }, "sha512-sTHrL+M/6fFLbc/7xCsO3AnKqU8eLowKfU4GvcS9rtCU+47OmCd8pcCJqIYy2c+mra5BxHi5H4kUSmdFEuZDsA=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/graph/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/scheduler/@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.28.0", "", { "dependencies": { "effect": "3.21.4" } }, "sha512-N1b29R3zaFQAnGKFobeTHMOienMmqZbhoXsvOspVmLN/+ALoy00UoyGFSeW5iplYAzaFDnBODyhwx0RTj5BjUg=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.28.0", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.1", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-ofmD5v90zZKYH9kIW04cO+olKtWhFvNLKY2F5ArrOxmNot5ty5WBkW25Umb+6DLZso3mzLh8rqHe+RtlnENenQ=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.28.0", "", { "dependencies": { "@smithers-orchestrator/db": "0.28.0", "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "@smithers-orchestrator/observability": "0.28.0", "@smithers-orchestrator/scheduler": "0.28.0", "effect": "3.21.4", "zod": "^4.4.3" } }, "sha512-D4xf3xurE549uu/nto5VQc8QGVCR6MctzuUW+CJocTnXqYvhHZEzcgdXQm0G1O8zgefssXXW3oAYbK4/bh0OJg=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.28.0", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.2", "@effect/platform-bun": "^0.90.0", "effect": "3.21.4" } }, "sha512-kQrz0pqaJxhC3KXNZldy8jowQ0+8P7ttaucIb+r9FErp1HzbV1hAkVcmBsuCXuFHUovrFJs4Bmu2v6GGckBvuw=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -19544,8 +19927,6 @@
 
     "cloud-mcp-smoke/@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
-    "cloud-mcp-smoke/@modelcontextprotocol/sdk/hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
-
     "coding-agent-adapters/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
     "coding-agent-adapters/pino/thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
@@ -19920,6 +20301,54 @@
 
     "micro/raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
+    "miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "miniflare/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "miniflare/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "miniflare/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "miniflare/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
@@ -19939,6 +20368,54 @@
     "mocha/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -20033,6 +20510,20 @@
     "rollup-plugin-visualizer/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "rollup-plugin-visualizer/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "smithers-orchestrator/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
 
     "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
@@ -20434,8 +20925,6 @@
 
     "@elizaos/example-a2a-server/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "@elizaos/example-clone-ur-crush/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
-
     "@elizaos/example-rest-api-express/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "@elizaos/example-rest-api-express/express/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
@@ -20556,6 +21045,8 @@
 
     "@google-cloud/storage/google-auth-library/gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 
+    "@huggingface/transformers/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
     "@jimp/custom/@jimp/core/file-type/strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
 
     "@jimp/custom/@jimp/core/file-type/token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
@@ -20628,7 +21119,7 @@
 
     "@opentui/core/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
@@ -20736,7 +21227,105 @@
 
     "@sigstore/sign/make-fetch-happen/minipass-fetch/minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
 
-    "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/aws/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/cloudflare/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/daytona/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/gcp/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/components/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "@smithers-orchestrator/integrations/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents/@smithers-orchestrator/driver/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/agents/@smithers-orchestrator/driver/@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "@smithers-orchestrator/graph": "0.28.0", "effect": "3.21.4" } }, "sha512-5yMYz20fo8UMqGrKLDV41G44cfGQE0TjjPyXqLo7jO7PlNDvInjx3DOuem1W/OfiZYwPCdyrvVMF7kfTaVuzCg=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/react-reconciler/@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.28.0", "", {}, "sha512-X6Hd3PPy/7oHyJoE3xD2yyPtlyKO1hchC4QvXRTcJWoHamlpRTzK7xwr5xRzVEz3es2QaIrt0laIJ386Ht16qw=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "@smithers-orchestrator/review/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/components/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "@smithers-orchestrator/server/@smithers-orchestrator/time-travel/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/components/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/agents/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-arm64": ["@smithers-orchestrator/jj-darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-d9SVV+KEeGvIeKjavM/OUSgTuahMz3ajbjcTBO2BBet7Q5rdCKihvUN5ob6n9+fGKABNTWxQpn9KzknMvSTT5w=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-darwin-x64": ["@smithers-orchestrator/jj-darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-wOXpnJJ1oX7bRhQbtQygvva/F9Y04hgCaPyo6OLs9YaBkolXbEyK1YyX9iRQJE0zOlhrzMaPVBnt7b2WQyxzqA=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-arm64": ["@smithers-orchestrator/jj-linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-b7P5amrop0C8zyEvbryTLOYM5A76yLFp358yU/xK7F5BqIFhKNpOYEeXa5slI5p5SwEyv7TgKAth+1btNubmAA=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-linux-x64": ["@smithers-orchestrator/jj-linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-9nnm/YL5lCaNRNCv0GZMW5EiqLPyt7zBIoxYOqpXkXxd0JuEWwHocmxLn0zkDcK5Ynxlj4PZtpOVS4/r56LZ6Q=="],
+
+    "@smithers-orchestrator/testing/@smithers-orchestrator/engine/@smithers-orchestrator/vcs/@smithers-orchestrator/jj-win32-x64": ["@smithers-orchestrator/jj-win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-EPXj/VnW3BAg85t7SLyBTna/KUDLLHoJJWnyyv90z434JweV2bgg1lDUpqt9VPsuj8lu9d631CRfeDRnpw0/og=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/db/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/driver/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@smithers-orchestrator/vercel/@smithers-orchestrator/sandbox/@smithers-orchestrator/scheduler/@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.28.0", "", { "dependencies": { "@smithers-orchestrator/errors": "0.28.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-iMQEfshjBGogRUmZp5+inmXm5XxS/5Rs1K4QrCVldpjj0qwrdJ6rOpTOB7yW1772wFT5JhMFTuCI8uozbh1Frg=="],
+
+    "@snazzah/davey-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@solana/spl-token-group/@solana/codecs/@solana/codecs-core/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
@@ -21070,7 +21659,19 @@
 
     "git-workspace-service/@octokit/rest/@octokit/core/@octokit/graphql": ["@octokit/graphql@7.1.1", "", { "dependencies": { "@octokit/request": "^8.4.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g=="],
 
+    "git-workspace-service/@octokit/rest/@octokit/core/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/core/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/core/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
     "git-workspace-service/@octokit/rest/@octokit/core/before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/core/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
     "googleapis-common/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -21166,7 +21767,19 @@
 
     "lerna/@octokit/rest/@octokit/core/@octokit/graphql": ["@octokit/graphql@7.1.1", "", { "dependencies": { "@octokit/request": "^8.4.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g=="],
 
+    "lerna/@octokit/rest/@octokit/core/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+
+    "lerna/@octokit/rest/@octokit/core/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+
+    "lerna/@octokit/rest/@octokit/core/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
     "lerna/@octokit/rest/@octokit/core/before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
+
+    "lerna/@octokit/rest/@octokit/core/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+
+    "lerna/@octokit/rest/@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "lerna/@octokit/rest/@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
     "mcp-handler/redis/@redis/client/cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
@@ -21188,9 +21801,13 @@
 
     "micro/raw-body/http-errors/toidentifier": ["toidentifier@1.0.0", "", {}, "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="],
 
+    "miniflare/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
     "mocha/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "mocha/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "next/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "normalize-package-data/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
@@ -21448,9 +22065,9 @@
 
     "@solana/spl-token-metadata/@solana/codecs/@solana/options/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
-    "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
-    "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -21480,11 +22097,27 @@
 
     "eliza-multichain-miniapp/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "git-workspace-service/@octokit/rest/@octokit/core/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/core/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "git-workspace-service/@octokit/rest/@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
     "kubernetes-fluent-client/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "kubernetes-fluent-client/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "kubernetes-fluent-client/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "lerna/@octokit/rest/@octokit/core/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+
+    "lerna/@octokit/rest/@octokit/core/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "lerna/@octokit/rest/@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "lerna/@octokit/rest/@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "meow/read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -21582,7 +22215,7 @@
 
     "@serwist/next/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+    "@vercel/backends/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
     "@elizaos/app-core": "workspace:*",
     "@elizaos/agent": "workspace:*",
     "@elizaos/plugin-solana": "2.0.0-alpha.3",
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@types/node": "25.6.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/packages/app-core/biome.json
+++ b/packages/app-core/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": ["../../biome.json"],
   "files": {

--- a/packages/app-core/platforms/electrobun/biome.json
+++ b/packages/app-core/platforms/electrobun/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "extends": ["../../../../biome.json"],
   "files": {
     "includes": ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"]

--- a/packages/cloud/services/operator/bun.lock
+++ b/packages/cloud/services/operator/bun.lock
@@ -183,7 +183,7 @@
 
     "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
 
-    "bare-fs": ["bare-fs@4.5.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA=="],
+    "bare-fs": ["bare-fs@4.5.4", "", { "dependencies": { "bare-events": "^2.5.5", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA=="],
 
     "bare-os": ["bare-os@3.6.2", "", {}, "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A=="],
 

--- a/packages/cloud/shared/biome.json
+++ b/packages/cloud/shared/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/contracts/biome.json
+++ b/packages/contracts/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "*.ts", "!dist", "!node_modules"]
 	},

--- a/packages/core/biome.json
+++ b/packages/core/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"linter": {
 		"rules": {

--- a/packages/elizaos/templates/min-plugin/package.json
+++ b/packages/elizaos/templates/min-plugin/package.json
@@ -29,7 +29,7 @@
     "@elizaos/core": "latest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@types/node": "^25.0.6",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",

--- a/packages/elizaos/templates/min-project/biome.json
+++ b/packages/elizaos/templates/min-project/biome.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "ignoreUnknown": false,
     "includes": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/elizaos/templates/min-project/package.json
+++ b/packages/elizaos/templates/min-project/package.json
@@ -28,7 +28,7 @@
     "@elizaos/core": "latest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@types/node": "^25.0.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/elizaos/templates/plugin/biome.json
+++ b/packages/elizaos/templates/plugin/biome.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "ignoreUnknown": false,
     "includes": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/elizaos/templates/plugin/package.json
+++ b/packages/elizaos/templates/plugin/package.json
@@ -50,7 +50,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@tailwindcss/vite": "^4.3.1",
     "@types/node": "^25.0.3",
     "@types/react-dom": "^19.2.3",

--- a/packages/elizaos/templates/project/apps/app/biome.json
+++ b/packages/elizaos/templates/project/apps/app/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": true,
   "formatter": {
     "indentStyle": "space",

--- a/packages/elizaos/templates/project/apps/app/electrobun/package.json
+++ b/packages/elizaos/templates/project/apps/app/electrobun/package.json
@@ -22,6 +22,6 @@
     "typescript": "^6.0.3",
     "@types/bun": "^1.3.8",
     "vitest": "^4.0.18",
-    "@biomejs/biome": "2.5.4"
+    "@biomejs/biome": "2.5.5"
   }
 }

--- a/packages/elizaos/templates/project/apps/app/package.json
+++ b/packages/elizaos/templates/project/apps/app/package.json
@@ -46,7 +46,7 @@
     "three": "^0.184.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@capacitor/cli": "8.3.1",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.3.1",

--- a/packages/examples/_plugin/biome.json
+++ b/packages/examples/_plugin/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"ignoreUnknown": false,
 		"includes": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/examples/code/biome.json
+++ b/packages/examples/code/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": ["../../../biome.json"],
   "files": {

--- a/packages/examples/elizagotchi/biome.json
+++ b/packages/examples/elizagotchi/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": ["../../../biome.json"],
   "files": {

--- a/packages/examples/next/biome.json
+++ b/packages/examples/next/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": ["../../../biome.json"],
   "files": {

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": ["../../biome.json"],
   "files": {

--- a/plugins/plugin-agent-skills/biome.json
+++ b/plugins/plugin-agent-skills/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "build.ts", "vitest.config.ts"]
 	},

--- a/plugins/plugin-anthropic-proxy/biome.json
+++ b/plugins/plugin-anthropic-proxy/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"includes": [

--- a/plugins/plugin-anthropic/biome.json
+++ b/plugins/plugin-anthropic/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"includes": [

--- a/plugins/plugin-app-control/biome.json
+++ b/plugins/plugin-app-control/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "*.ts", "*.json", "!src/**/*.js", "!src/**/*.js.map"]
 	},

--- a/plugins/plugin-background-runner/biome.json
+++ b/plugins/plugin-background-runner/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["src/**", "__tests__/**", "*.ts", "!dist", "!node_modules", "!.cache", "!.turbo"]
   },

--- a/plugins/plugin-benchmarks/biome.json
+++ b/plugins/plugin-benchmarks/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/plugins/plugin-bluebubbles/biome.json
+++ b/plugins/plugin-bluebubbles/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "__tests__/**", "build.ts", "vitest.config.ts"]
 	},

--- a/plugins/plugin-bluesky/biome.json
+++ b/plugins/plugin-bluesky/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"__tests__/**",

--- a/plugins/plugin-bluesky/bun.lock
+++ b/plugins/plugin-bluesky/bun.lock
@@ -15,7 +15,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "typescript": "^5.9.3",
       },
@@ -43,23 +43,23 @@
 
     "@atproto/xrpc": ["@atproto/xrpc@0.6.12", "", { "dependencies": { "@atproto/lexicon": "^0.4.10", "zod": "^3.23.8" } }, "sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-capacitor-bridge/biome.json
+++ b/plugins/plugin-capacitor-bridge/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "*.ts", "*.json"]
 	},

--- a/plugins/plugin-cli-inference/biome.json
+++ b/plugins/plugin-cli-inference/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-cli/biome.json
+++ b/plugins/plugin-cli/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "*.ts", "vitest.config.ts"]
 	},

--- a/plugins/plugin-codex-cli/biome.json
+++ b/plugins/plugin-codex-cli/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-commands/biome.json
+++ b/plugins/plugin-commands/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["__tests__/**", "src/**", "*.ts", "*.json", "vitest.config.ts"]
 	},

--- a/plugins/plugin-discord-local/biome.json
+++ b/plugins/plugin-discord-local/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "src/**",

--- a/plugins/plugin-discord/biome.json
+++ b/plugins/plugin-discord/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"includes": [

--- a/plugins/plugin-edge-tts/biome.json
+++ b/plugins/plugin-edge-tts/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"src/**",

--- a/plugins/plugin-edge-tts/bun.lock
+++ b/plugins/plugin-edge-tts/bun.lock
@@ -9,30 +9,30 @@
         "node-edge-tts": "^1.0.7",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "typescript": "^5.9.3",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-elizacloud/biome.json
+++ b/plugins/plugin-elizacloud/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"__tests__/**",

--- a/plugins/plugin-embeddings/biome.json
+++ b/plugins/plugin-embeddings/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["**", "!!dist", "!!node_modules"]
   },

--- a/plugins/plugin-facewear/biome.json
+++ b/plugins/plugin-facewear/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"includes": ["**", "!dist", "!native", "!node_modules"]

--- a/plugins/plugin-farcaster/biome.json
+++ b/plugins/plugin-farcaster/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"__tests__/**",

--- a/plugins/plugin-feishu/biome.json
+++ b/plugins/plugin-feishu/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"ignoreUnknown": true,

--- a/plugins/plugin-gitpathologist/biome.json
+++ b/plugins/plugin-gitpathologist/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/plugins/plugin-google-chat/biome.json
+++ b/plugins/plugin-google-chat/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"includes": ["src/**", "__tests__/**", "build.ts", "vitest.config.ts"]

--- a/plugins/plugin-google-genai/biome.json
+++ b/plugins/plugin-google-genai/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": "//",
   "files": {

--- a/plugins/plugin-google/biome.json
+++ b/plugins/plugin-google/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "files": {
     "includes": ["src/**", "__tests__/**", "build.ts", "vitest.config.ts"]

--- a/plugins/plugin-groq/biome.json
+++ b/plugins/plugin-groq/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-hyperliquid/biome.json
+++ b/plugins/plugin-hyperliquid/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"root": false,
 	"files": {
 		"includes": [

--- a/plugins/plugin-imessage/biome.json
+++ b/plugins/plugin-imessage/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-inmemorydb/biome.json
+++ b/plugins/plugin-inmemorydb/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/plugins/plugin-instagram/biome.json
+++ b/plugins/plugin-instagram/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/plugins/plugin-line/biome.json
+++ b/plugins/plugin-line/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-line/bun.lock
+++ b/plugins/plugin-line/bun.lock
@@ -10,7 +10,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^20.0.0",
         "typescript": "^5.6.0",
         "vitest": "^2.0.0",
@@ -18,23 +18,23 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-linear/biome.json
+++ b/plugins/plugin-linear/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-lmstudio/biome.json
+++ b/plugins/plugin-lmstudio/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["**", "!!dist", "!!node_modules"]
   },

--- a/plugins/plugin-local-inference/biome.json
+++ b/plugins/plugin-local-inference/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "*.ts", "*.json"]
 	},

--- a/plugins/plugin-local-storage/biome.json
+++ b/plugins/plugin-local-storage/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"src/**",

--- a/plugins/plugin-matrix/biome.json
+++ b/plugins/plugin-matrix/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/plugins/plugin-matrix/bun.lock
+++ b/plugins/plugin-matrix/bun.lock
@@ -9,7 +9,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.1.0",
         "typescript": "^5.3.0",
         "vitest": "^3.2.4",
@@ -22,23 +22,23 @@
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-mcp/biome.json
+++ b/plugins/plugin-mcp/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/plugins/plugin-mcp/bun.lock
+++ b/plugins/plugin-mcp/bun.lock
@@ -11,7 +11,7 @@
         "json5": "^2.2.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^25.0.3",
         "typescript": "^5.9.3",
       },
@@ -21,23 +21,23 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-native-filesystem/biome.json
+++ b/plugins/plugin-native-filesystem/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": ["src/**", "*.ts", "*.json"]
 	},

--- a/plugins/plugin-native-mobile-agent-bridge/biome.json
+++ b/plugins/plugin-native-mobile-agent-bridge/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "files": {
     "ignoreUnknown": true,

--- a/plugins/plugin-ngrok/biome.json
+++ b/plugins/plugin-ngrok/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["src/**", "*.ts", "!dist", "!node_modules", "!.cache", "!.turbo"]
   },

--- a/plugins/plugin-nostr/biome.json
+++ b/plugins/plugin-nostr/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/plugins/plugin-nostr/bun.lock
+++ b/plugins/plugin-nostr/bun.lock
@@ -10,7 +10,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/node": "^20.0.0",
         "typescript": "^5.3.0",
         "vitest": "^3.2.4",
@@ -18,23 +18,23 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-ollama/biome.json
+++ b/plugins/plugin-ollama/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["**", "!!dist", "!!node_modules"]
   },

--- a/plugins/plugin-openai/biome.json
+++ b/plugins/plugin-openai/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",

--- a/plugins/plugin-openrouter/biome.json
+++ b/plugins/plugin-openrouter/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"*.ts",

--- a/plugins/plugin-pdf/biome.json
+++ b/plugins/plugin-pdf/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"*.ts",

--- a/plugins/plugin-shell/biome.json
+++ b/plugins/plugin-shell/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["**", "!!dist", "!!node_modules"]
   },

--- a/plugins/plugin-shell/bun.lock
+++ b/plugins/plugin-shell/bun.lock
@@ -10,7 +10,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/cross-spawn": "^6.0.6",
         "@types/node": "^25.0.3",
         "typescript": "^5.9.3",
@@ -36,23 +36,23 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.32.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-U9JwTrDvdQ9iWuABVsMLj8nJVwAyQz6QXvgLsVhryhCEPkLsbcP/MXxm+jYcAwLoV8ESbaTTjnD4kuAFa+Hyjg=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 

--- a/plugins/plugin-signal/biome.json
+++ b/plugins/plugin-signal/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/plugins/plugin-sql/src/biome.json
+++ b/plugins/plugin-sql/src/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["**", "!**/*.d.ts", "!**/dist", "!**/node_modules", "!**/.eliza"]
   },

--- a/plugins/plugin-sql/src/package.json
+++ b/plugins/plugin-sql/src/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.5",
-    "@biomejs/biome": "2.5.4",
+    "@biomejs/biome": "2.5.5",
     "@types/node": "^25.0.3",
     "@types/pg": "^8.15.6",
     "@types/ws": "^8.18.1",

--- a/plugins/plugin-suno/biome.json
+++ b/plugins/plugin-suno/biome.json
@@ -1,6 +1,6 @@
 {
     "root": false,
-    "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
     "assist": { "actions": { "source": { "organizeImports": "off" } } },
     "linter": {
         "enabled": true,

--- a/plugins/plugin-telegram-standalone/biome.json
+++ b/plugins/plugin-telegram-standalone/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "src/**",

--- a/plugins/plugin-tunnel/biome.json
+++ b/plugins/plugin-tunnel/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["src/**", "*.ts", "!dist", "!node_modules", "!.cache", "!.turbo"]
   },

--- a/plugins/plugin-twitch/bun.lock
+++ b/plugins/plugin-twitch/bun.lock
@@ -10,7 +10,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.4",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.1.0",
         "typescript": "^5.3.0",
       },
@@ -20,23 +20,23 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/plugins/plugin-wallet/src/chains/evm/biome.json
+++ b/plugins/plugin-wallet/src/chains/evm/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"__tests__/**",

--- a/plugins/plugin-wallet/src/chains/solana/biome.json
+++ b/plugins/plugin-wallet/src/chains/solana/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["**", "!!dist", "!!node_modules"]
   },

--- a/plugins/plugin-web-search/biome.json
+++ b/plugins/plugin-web-search/biome.json
@@ -1,6 +1,6 @@
 {
     "root": false,
-    "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
     "assist": { "actions": { "source": { "organizeImports": "on" } } },
     "linter": {
         "enabled": true,

--- a/plugins/plugin-whatsapp/biome.json
+++ b/plugins/plugin-whatsapp/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "src/**/*.ts",

--- a/plugins/plugin-workflow/biome.json
+++ b/plugins/plugin-workflow/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "src/**",

--- a/plugins/plugin-zai/biome.json
+++ b/plugins/plugin-zai/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"files": {
 		"includes": [
 			"build.ts",


### PR DESCRIPTION
Closes #16783.

## What changed

- Regenerated the root `bun.lock` from the final combined Dependabot manifest state.
- Synchronized Biome 2.5.5 across the root override, schema URLs, templates, plugin-local package metadata, and nested lockfiles.

## Root cause

The independently merged Dependabot PRs updated overlapping manifests without regenerating the combined lockfile. A subsequently generated Biome group updated package manifests but omitted the repository-wide pin surfaces enforced by `check:biome-version`.

## Validation

- `bun install --frozen-lockfile` — passes from a clean checkout after regeneration.
- `bun run check:biome-version` — passes.
- `bun run verify` — proceeds past dependency and Biome gates, then fails on pre-existing type-safety ratchet baseline drift in unrelated production files (`as unknown as`, `?? ""`, `?? []`, `?? {}`, `?? 0`).

## Evidence applicability

- UI screenshots/video: N/A — dependency metadata only.
- Real-LLM trajectories: N/A — no agent/model behavior changes.
- Backend/frontend logs: N/A — no runtime code-path changes.
