### PR TITLE
fix(android): apply no-action-bar theme in Cloud builds

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
@@ -1,4 +1,6 @@
 /** Exercises run mobile build android targets behavior with deterministic app-core test fixtures. */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { resolveAndroidGradleCommandsForTarget } from "./mobile/android-gradle.mjs";
 import {
@@ -8,6 +10,9 @@ import {
 } from "./run-mobile-build.mjs";
 
 const websiteBlockerSettings = "include ':elizaos-capacitor-websiteblocker'";
+const mobileBuildScript = fileURLToPath(
+  new URL("./run-mobile-build.mjs", import.meta.url),
+);
 
 describe("Android mobile build target table", () => {
   it("keeps one descriptor per public Android target", () => {
@@ -59,6 +64,21 @@ describe("Android mobile build target table", () => {
     expect(
       resolveAndroidBuildTarget("android-cloud", { debug: true }).target,
     ).toBe("android-cloud-debug");
+  });
+
+  it("runs the exact mobile CLI through a pre-mutation Android guard", () => {
+    const result = spawnSync(process.execPath, [mobileBuildScript, "android"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZA_PLAY_STORE_BUILD: "1",
+      },
+    });
+
+    expect(result.status).toBe(2);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "Refusing target `android` under ELIZA_PLAY_STORE_BUILD",
+    );
   });
 
   it("fails loudly for unknown public Android targets", () => {

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -6,6 +6,20 @@ import { describe, expect, it } from "vitest";
 import { cloudSafeMainActivityJava } from "./run-mobile-build.mjs";
 
 describe("cloudSafeMainActivityJava", () => {
+  it("installs the splash lifecycle before Capacitor creates the bridge", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app");
+    const splashInstall = source.indexOf(
+      "SplashScreen.installSplashScreen(this);",
+    );
+    const bridgeCreation = source.indexOf(
+      "super.onCreate(savedInstanceState);",
+    );
+
+    expect(source).toContain("import androidx.core.splashscreen.SplashScreen;");
+    expect(splashInstall).toBeGreaterThanOrEqual(0);
+    expect(splashInstall).toBeLessThan(bridgeCreation);
+  });
+
   it("registers the Firebase-safe push plugin after Capacitor creates the bridge", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
     const bridgeCreation = source.indexOf(

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5504,6 +5504,8 @@ import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
+import androidx.core.splashscreen.SplashScreen;
+
 import com.getcapacitor.BridgeActivity;
 
 import ${androidPackage}.BuildConfig;
@@ -5530,6 +5532,12 @@ ${cloudBrandUserAgentMarkerLines()}
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // The launch theme's postSplashScreenTheme is applied only when the
+        // AndroidX splash lifecycle is installed before BridgeActivity builds
+        // the WebView. Otherwise the splash theme keeps a native action bar
+        // over the top of the cloud client for the activity's lifetime.
+        SplashScreen.installSplashScreen(this);
+
         if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true);
         }

--- a/scripts/security/coverage-subprocess-sources.txt
+++ b/scripts/security/coverage-subprocess-sources.txt
@@ -41,3 +41,8 @@ packages/cloud/shared/scripts/run-bun-tests.mjs
 # Workflow policy checker: both contract validation modes are process
 # entrypoints because importing the module immediately reads workflow files.
 packages/scripts/ci-merge-gate-contract.mjs
+
+# The mobile build CLI orchestrates destructive native build phases in a child process.
+# Its focused contract test spawns the exact entrypoint and fails at the
+# sideload-versus-Play policy guard before any platform files are changed.
+packages/app-core/scripts/run-mobile-build.mjs


### PR DESCRIPTION
# Relates to

Supports #16779.

- [x] This PR targets `develop` and is rebased onto current `origin/develop` at `e935a5c526` with zero conflicts.
- [ ] Required CI is rerunning for head `0bc1380224`; the exact focused local checks below are green.
- [x] A reviewer can confirm the physical-device result without reading the code from the evidence below.

# Post-demo current-develop sync

- [x] Rebased onto exact `origin/develop` `e935a5c526d6638d52aa644e4dad96f3c898d3ee`; exact head `0bc13802247d5207278b14da7ee4e0b0ee714cc5`.
- [x] `git range-diff` marks both commits `=` against the prior published series.
- [x] Rebased focused tests 10/10, Biome, error-policy ratchet, and diff check pass; canonical app-core Turbo typecheck passed before the final unrelated personal-assistant-only base advance.
- [x] Fresh CI is running on this exact head. Physical proof remains attributed to the unchanged production patch; exact merged-build device proof follows merge.

# Risks

**Low and Android Cloud-build-only.** The production change affects generated Cloud-only Android `MainActivity` source. It does not alter web, desktop, iOS, Android non-Cloud generation, authentication, provisioning, or runtime selection. The AndroidX splash dependency and identical lifecycle call are already used by the normal Android generator.

The additional coverage repair is test/CI-only: one deterministic subprocess contract test plus one exact-path coverage-manifest entry.

# Background

## What does this PR do?

- Installs the AndroidX splash lifecycle in the generated Cloud-only `MainActivity` before Capacitor creates its bridge.
- Adds a regression test that locks the required import, call, and pre-`super.onCreate` ordering.
- Exercises the exact mobile-build CLI through the existing Play-vs-sideload guard, which exits before SDK/JDK resolution, web build, Capacitor sync, or native writes.
- Registers that exact CLI path under the repository's narrow subprocess-coverage contract because importing the entrypoint starts orchestration.

## Root cause and impact

The Cloud-only Android activity generator kept the launch `Theme.SplashScreen` active because it did not install AndroidX splash handling. On a physical Light Phone III this left an empty native ActionBar over the WebView for the activity lifetime, producing a 168 px black strip and clipping the app top content.

Installing the splash lifecycle before `BridgeActivity` creates the WebView allows `postSplashScreenTheme` to apply normally. This is a generator-level lifecycle fix, not device-specific CSS or an overlay workaround.

## What kind of change is this?

Bug fix plus deterministic regression/coverage proof; no API or protocol change.

# Documentation changes needed?

N/A - this repairs generated native lifecycle behavior and does not change a documented user or developer workflow.

# Testing

## Where should a reviewer start?

Review `cloudSafeMainActivityJava` and its focused regression test, then use the before/after physical LP3 artifacts below. The coverage-only follow-up is isolated in `run-mobile-build-android-targets.test.mjs` and `coverage-subprocess-sources.txt`.

## Detailed physical testing steps

1. Generate the exact Cloud-only Android project.
2. Build and audit the debug APK.
3. Install it in-place over a signed existing build on a physical LP3.
4. Confirm `dumpsys activity top` contains `CapacitorWebView 0,0-1080,1240` and no `ActionBarContainer`.
5. Confirm authenticated Cloud state, live reply, and cold-relaunch persistence.

## Local results on current head

- `bun test packages/app-core/scripts/run-mobile-build-android-targets.test.mjs packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs` — 10 passed
- Exact changed-Vitest coverage runner — 2 files passed, 10 tests passed
- Coverage classifier — no in-process source files; exactly `run-mobile-build.mjs` as subprocess source; exactly the two changed Vitest files
- Biome 2.5.5 on all three changed JavaScript files — passed
- `git diff --check origin/develop...HEAD` — passed
- `bun run audit:error-policy-ratchet` — passed
- Core CI prerequisite build — passed
- Exact Cloud-only post-Gradle audit — passed
- Exact Cloud-only artifact audit — passed
- APK v2 signature and zipalign — passed
- Guarded in-place install and on-device SHA-256 match — passed
- Physical LP3 live production Cloud reply and force-stop/cold relaunch — passed

The physical-device APK was built from source commit `59d873a097ad7b1c97015a7bcffbd1b555779b4a`, whose production generator fix is unchanged and source-equivalent to current PR commit `35de1578af`. Current head `0bc1380224` adds only test/coverage proof around that production fix. The demo freeze is lifted. The proven same-signer install remains unchanged only until this dependency chain merges; an exact merged-build APK hash and physical-device revalidation is the next controlled release step.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshot: [physical LP3 with 168 px native ActionBar clipping the renderer](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-before-actionbar.jpg)

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [full-color full-screen home](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-fullscreen-color.jpg) and [cold-relaunched live Cloud conversation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-cold-relaunch.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough videos: [real Cloud reply MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-live-reply.mp4) and [force-stop plus cold-relaunch MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-cold-relaunch.mp4)

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - this changes generated Android activity lifecycle and test/coverage classification only; it makes no backend request or server-code change.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or request/state behavior changes; Android `dumpsys` native hierarchy proof is recorded in [the physical-device evidence report](https://github.com/elizaOS/eliza/issues/16779#issuecomment-5049310290).

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes; the linked video nevertheless proves the existing production Cloud agent returned the exact live reply `CLOUD READY`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [signed APK hash, renderer stamp, on-device hash match, live reply, and cold-relaunch record](https://github.com/elizaOS/eliza/issues/16779#issuecomment-5049310290).

# Evidence Details

## Before

![Before: blank native ActionBar clips app](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-before-actionbar.jpg)

## After

![After: full 1080x1240 renderer](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-fullscreen-color.jpg)

![After cold relaunch: authentication and reply restored](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-cold-relaunch.jpg)

## Walkthrough video

- [Live production Cloud reply](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-live-reply.mp4)
- [Force-stop and cold relaunch](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16779-lp3-cloud-cold-relaunch.mp4)

## Known gaps / failures

- Required monorepo CI is rerunning for the rebased head; no branch-specific local failure remains.
- Exact merged-build APK SHA revalidation remains required after the LP3 dependency chain merges; no production generator semantics changed after the proven build.
- Device color mode was restored separately through the documented LP3/AOSP secure daltonizer setting and is not part of this code diff.
- This PR does not claim to resolve production provisioning concurrency and does not touch #16640 or #16641.