### PR TITLE
fix(ci): make remote capability live lanes explicit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ on:
   push:
     branches: [develop]
   workflow_dispatch:
+    inputs:
+      remote_capability_live:
+        description: "Run strict remote-capability Cloud and provider live smokes"
+        required: false
+        default: false
+        type: boolean
   schedule:
     # Nightly live smoke for container-backed remote capability plugins.
     - cron: "17 9 * * *"
@@ -897,6 +903,7 @@ jobs:
         id: cloud
         env:
           EVENT_NAME: ${{ github.event_name }}
+          CAPABILITY_LIVE_REQUIRED: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.remote_capability_live) }}
           ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY != '' && secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
           ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED: ${{ vars.ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED != '' && vars.ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED || secrets.ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED }}
         run: |
@@ -919,18 +926,18 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ "${ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED}" = "1" ]; then
+          if [ "${CAPABILITY_LIVE_REQUIRED}" != "true" ]; then
+            echo "::notice::Remote capability cloud sandbox live smoke was not requested for ${EVENT_NAME}."
+            echo "capability_skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "${ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED}" = "1" ]; then
             echo "capability_skip=false" >> "$GITHUB_OUTPUT"
           else
-            if [ "${EVENT_NAME}" = "workflow_dispatch" ] || [ "${EVENT_NAME}" = "schedule" ]; then
-              echo "::error::Remote capability cloud sandbox live smoke is required for ${EVENT_NAME}; set ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED=1 instead of producing a green skip."
-              exit 1
-            fi
-            echo "::notice::Remote capability cloud sandbox live smoke skipped because ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED is not configured."
-            echo "capability_skip=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Remote capability cloud sandbox live smoke is required for ${EVENT_NAME}; set ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED=1 instead of producing a green skip."
+            exit 1
           fi
 
       - name: Checkout
+        id: checkout
         if: steps.cloud.outputs.skip != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -1015,7 +1022,7 @@ jobs:
           retention-days: 7
 
       - name: Prune remote capability cloud report
-        if: always() && steps.cloud.outputs.capability_skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: always() && steps.checkout.outcome == 'success' && steps.cloud.outputs.capability_skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/cloud
 
       - name: Note remote capability cloud live smoke not observed
@@ -1039,25 +1046,22 @@ jobs:
         id: providers
         env:
           EVENT_NAME: ${{ github.event_name }}
+          LIVE_REQUIRED: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.remote_capability_live) }}
           E2B_URL: ${{ secrets.ELIZA_REMOTE_CAPABILITY_E2B_URL }}
           HOME_URL: ${{ secrets.ELIZA_REMOTE_CAPABILITY_HOME_MACHINE_URL }}
           MOBILE_URL: ${{ secrets.ELIZA_REMOTE_CAPABILITY_MOBILE_COMPANION_URL }}
           DESKTOP_URL: ${{ secrets.ELIZA_REMOTE_CAPABILITY_DESKTOP_COMPANION_URL }}
         run: |
-          strict_context=false
-          case "${EVENT_NAME}" in
-            workflow_dispatch|schedule) strict_context=true ;;
-          esac
+          if [ "${LIVE_REQUIRED}" != "true" ]; then
+            echo "::notice::Remote capability provider live smoke was not requested for ${EVENT_NAME}."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ -z "${E2B_URL}${HOME_URL}${MOBILE_URL}${DESKTOP_URL}" ]; then
             message="No remote capability provider endpoints configured"
-            if [ "${strict_context}" = "true" ]; then
-              echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
-              exit 1
-            fi
-            echo "::warning::${message} - skipping optional provider live E2E."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
+            exit 1
           fi
 
           missing_required=()
@@ -1073,17 +1077,14 @@ jobs:
 
           if [ "${#missing_required[@]}" -gt 0 ]; then
             message="Missing required remote capability provider endpoint secrets: ${missing_required[*]}"
-            if [ "${strict_context}" = "true" ]; then
-              echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
-              exit 1
-            fi
-            echo "::warning::${message}. Skipping optional provider live E2E for ${EVENT_NAME}."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
+            exit 1
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout
+        id: checkout
         if: steps.providers.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -1148,7 +1149,7 @@ jobs:
           retention-days: 7
 
       - name: Prune remote capability provider reports
-        if: always() && steps.providers.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: always() && steps.checkout.outcome == 'success' && steps.providers.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/providers
 
       - name: Note provider live smoke not observed

--- a/packages/agent/docs/capability-router-remote-plugins.md
+++ b/packages/agent/docs/capability-router-remote-plugins.md
@@ -995,9 +995,10 @@ The GitHub `Tests` workflow now runs `bun run test:remote-capabilities`,
 `bun run test:remote-capabilities:validate-live-reports:self-test`,
 `bun run test:remote-capabilities:github-live-evidence:self-test`, and
 `bun run test:remote-capabilities:docker` in the server job for pull requests
-and pushes. The live Cloud/provider artifact smokes are observed only on
-`workflow_dispatch` and `schedule`, where the final `test-status` gate treats
-the live jobs as strict. Use
+and pushes. The live Cloud/provider artifact smokes are observed on schedules
+and on manual dispatches that explicitly set `remote_capability_live`; ordinary
+manual runs skip those external-infrastructure smokes. The final `test-status`
+gate treats the live jobs as strict whenever they are requested. Use
 `gh run view <run-id> --json databaseId,event,status,conclusion,jobs | bun run
 test:remote-capabilities:github-live-evidence -` to prove a scheduled/manual
 run actually observed Cloud and provider live smoke, validation, and artifact
@@ -1114,11 +1115,12 @@ an explicit notice and step summary saying the remote capability cloud smoke was
 not observed for that run.
 The workflow also has an optional provider-live job for URL-backed E2B,
 home-machine, mobile-companion, and desktop-companion endpoints. It runs
-`bun run --cwd packages/agent test:remote-capabilities:provider-live` on
-manual/nightly workflows. The preflight allows a full no-secret skip only for
-non-observed workflow events; on manual/nightly runs it fails before setup when
-all provider endpoint secrets are absent or when any required E2B, home-machine,
-or mobile-companion URL secret is missing. Each configured provider must expose
+`bun run --cwd packages/agent test:remote-capabilities:provider-live` on nightly
+workflows and manual workflows with `remote_capability_live` enabled. The
+preflight skips unrequested manual runs before inspecting provider availability;
+on scheduled or explicitly requested manual runs it fails before setup when all
+provider endpoint secrets are absent or when any required E2B, home-machine, or
+mobile-companion URL secret is missing. Each configured provider must expose
 at least one remote action, provider, route, JSON model handler, lifecycle hook,
 event handler, service method, app bridge hook, evaluator, response-handler
 evaluator, response-handler field evaluator, and view through the
@@ -1290,8 +1292,8 @@ packages/agent/src/services/remote-capability-cloud-sandbox.cloud-smoke.test.ts
   moving Cloud live validation onto the reusable endpoint conformance harness.
 - `bun run test:remote-capabilities:live-ci-audit` passes and statically
   enforces that the workflow keeps the Cloud and provider live jobs wired to
-  strict scheduled/manual observation, and that the final `test-status` gate
-  treats observed live runs (`workflow_dispatch` and `schedule`) as strict,
+  strict scheduled or explicitly requested manual observation, and that the
+  final `test-status` gate treats their job results as strict,
   with required provider endpoints, strict
   live report validation, required artifact upload, and matching live report
   directories between smoke producers, validators, and uploaded artifacts. It

--- a/packages/scripts/__tests__/audit-capability-router-live-ci.test.ts
+++ b/packages/scripts/__tests__/audit-capability-router-live-ci.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression coverage for manual remote-capability observation and cleanup
+ * guards in the Tests workflow. The focused assertions complement the broader
+ * mutation script with a conventional unit-test entrypoint for CI coverage.
+ */
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { validateCapabilityRouterLiveCi } from "../audit-capability-router-live-ci";
+
+const workflow = readFileSync(
+  fileURLToPath(
+    new URL("../../../.github/workflows/test.yml", import.meta.url),
+  ),
+  "utf8",
+);
+
+const manualObservationChecks = [
+  "manual remote capability live observation is explicit",
+  "cloud capability live smoke is explicitly configured",
+  "provider live smoke skips when manual observation was not requested",
+];
+
+const cleanupChecks = [
+  "cloud live report prune only runs after checkout-backed live runs",
+  "provider live report prune only runs after checkout-backed live runs",
+];
+
+test("manual dispatch requires explicit remote-capability observation", () => {
+  expect(
+    validateCapabilityRouterLiveCi(workflow, {
+      onlyCheckNames: manualObservationChecks,
+    }),
+  ).toEqual([]);
+
+  const withoutInput = workflow.replace(
+    '      remote_capability_live:\n        description: "Run strict remote-capability Cloud and provider live smokes"\n        required: false\n        default: false\n        type: boolean\n',
+    "",
+  );
+  expect(
+    validateCapabilityRouterLiveCi(withoutInput, {
+      onlyCheckNames: manualObservationChecks,
+    }).map((failure) => failure.name),
+  ).toContain("manual remote capability live observation is explicit");
+});
+
+test("live report cleanup requires a successful checkout", () => {
+  expect(
+    validateCapabilityRouterLiveCi(workflow, { onlyCheckNames: cleanupChecks }),
+  ).toEqual([]);
+
+  const withoutCheckoutGuard = workflow.replaceAll(
+    "steps.checkout.outcome == 'success' && ",
+    "",
+  );
+  expect(
+    validateCapabilityRouterLiveCi(withoutCheckoutGuard, {
+      onlyCheckNames: cleanupChecks,
+    }).map((failure) => failure.name),
+  ).toEqual(cleanupChecks);
+});

--- a/packages/scripts/audit-capability-router-live-ci.self-test.ts
+++ b/packages/scripts/audit-capability-router-live-ci.self-test.ts
@@ -705,6 +705,14 @@ assertFails(
 );
 
 assertFails(
+  "manual remote capability live observation is explicit",
+  workflow.replace(
+    '      remote_capability_live:\n        description: "Run strict remote-capability Cloud and provider live smokes"\n        required: false\n        default: false\n        type: boolean\n',
+    "",
+  ),
+);
+
+assertFails(
   "provider live job is required by ci-ok",
   // Drop `schedule` from strict_results; the check requires both dispatch and
   // schedule to gate the aggregate on the two live jobs.
@@ -741,8 +749,8 @@ assertFails(
 assertFails(
   "cloud capability live smoke is explicitly configured",
   workflow.replace(
-    '            echo "::notice::Remote capability cloud sandbox live smoke skipped because ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED is not configured."\n            echo "capability_skip=true" >> "$GITHUB_OUTPUT"\n          fi\n',
-    "          fi\n",
+    '          if [ "${CAPABILITY_LIVE_REQUIRED}" != "true" ]; then\n            echo "::notice::Remote capability cloud sandbox live smoke was not requested for ${EVENT_NAME}."\n            echo "capability_skip=true" >> "$GITHUB_OUTPUT"\n',
+    '          if [ "${ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED}" = "1" ]; then\n',
   ),
 );
 
@@ -773,7 +781,7 @@ assertFails(
 assertFails(
   "cloud live report prune only runs after checkout-backed live runs",
   workflow.replace(
-    "      - name: Prune remote capability cloud report\n        if: always() && steps.cloud.outputs.capability_skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')\n        run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/cloud",
+    "      - name: Prune remote capability cloud report\n        if: always() && steps.checkout.outcome == 'success' && steps.cloud.outputs.capability_skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')\n        run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/cloud",
     "      - name: Prune remote capability cloud report\n        if: always()\n        run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/cloud",
   ),
 );
@@ -866,18 +874,26 @@ assertFails(
 );
 
 assertFails(
-  "provider live endpoints skip cleanly when absent",
+  "provider live smoke skips when manual observation was not requested",
   workflow.replace(
-    '            echo "::warning::${message} - skipping optional provider live E2E."\n            echo "skip=true" >> "$GITHUB_OUTPUT"\n            exit 0\n',
-    '            echo "::error::No remote capability provider endpoints configured for observed provider live E2E."\n            exit 1\n',
+    '          if [ "${LIVE_REQUIRED}" != "true" ]; then\n            echo "::notice::Remote capability provider live smoke was not requested for ${EVENT_NAME}."\n            echo "skip=true" >> "$GITHUB_OUTPUT"\n            exit 0\n          fi\n\n',
+    "",
   ),
 );
 
 assertFails(
-  "provider live primary endpoint gaps skip cleanly",
+  "provider live endpoints fail observed runs when absent",
   workflow.replace(
-    '            echo "::warning::${message}. Skipping optional provider live E2E for ${EVENT_NAME}."\n            echo "skip=true" >> "$GITHUB_OUTPUT"\n',
-    '            echo "::error::${message}"\n            exit 1\n',
+    '            echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."\n            exit 1\n',
+    '            echo "skip=true" >> "$GITHUB_OUTPUT"\n            exit 0\n',
+  ),
+);
+
+assertFails(
+  "provider live primary endpoint gaps fail observed runs",
+  workflow.replace(
+    '            echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."\n            exit 1\n          else\n',
+    '            echo "skip=true" >> "$GITHUB_OUTPUT"\n          else\n',
   ),
 );
 
@@ -908,7 +924,7 @@ assertFails(
 assertFails(
   "provider live report prune only runs after checkout-backed live runs",
   workflow.replace(
-    "      - name: Prune remote capability provider reports\n        if: always() && steps.providers.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')\n        run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/providers",
+    "      - name: Prune remote capability provider reports\n        if: always() && steps.checkout.outcome == 'success' && steps.providers.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')\n        run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/providers",
     "      - name: Prune remote capability provider reports\n        if: always()\n        run: node packages/scripts/rm-path-recursive.mjs reports/remote-capabilities/providers",
   ),
 );

--- a/packages/scripts/audit-capability-router-live-ci.ts
+++ b/packages/scripts/audit-capability-router-live-ci.ts
@@ -477,6 +477,13 @@ export const checks: Check[] = [
       "ci-ok must fail when cloud-live-e2e or provider-live-e2e are not successful on workflow_dispatch or schedule.",
   },
   {
+    name: "manual remote capability live observation is explicit",
+    pattern:
+      /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*remote_capability_live:[\s\S]{0,300}default:\s*false[\s\S]{0,100}type:\s*boolean/,
+    message:
+      "manual Tests runs must require an explicit remote_capability_live input before observing external capability providers.",
+  },
+  {
     name: "cloud live smoke is observed only on manual or scheduled runs",
     pattern:
       /Remote capability cloud sandbox live smoke[\s\S]{0,300}steps\.cloud\.outputs\.capability_skip != 'true'[\s\S]{0,300}github\.event_name == 'workflow_dispatch' \|\| github\.event_name == 'schedule'[\s\S]{0,300}test:remote-capabilities:cloud-live/,
@@ -496,9 +503,9 @@ export const checks: Check[] = [
   {
     name: "cloud capability live smoke is explicitly configured",
     pattern:
-      /ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED[\s\S]{0,500}capability_skip=false[\s\S]{0,500}Remote capability cloud sandbox live smoke skipped because ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED is not configured[\s\S]{0,200}capability_skip=true/,
+      /CAPABILITY_LIVE_REQUIRED:.*github\.event_name == 'schedule'.*inputs\.remote_capability_live[\s\S]{0,2500}CAPABILITY_LIVE_REQUIRED.*!= "true"[\s\S]{0,300}capability_skip=true[\s\S]{0,300}ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED.*= "1"[\s\S]{0,200}capability_skip=false/,
     message:
-      "cloud capability live smoke must be gated by explicit live capability config.",
+      "cloud capability live smoke must be mandatory on schedules or explicit manual requests and skipped on ordinary manual runs.",
   },
   {
     name: "cloud live report validation is strict",
@@ -517,7 +524,7 @@ export const checks: Check[] = [
   {
     name: "cloud live report prune only runs after checkout-backed live runs",
     pattern:
-      /Prune remote capability cloud report\s*\n\s*if: always\(\) && steps\.cloud\.outputs\.capability_skip != 'true' && \(github\.event_name == 'workflow_dispatch' \|\| github\.event_name == 'schedule'\)\s*\n\s*run: node packages\/scripts\/rm-path-recursive\.mjs reports\/remote-capabilities\/cloud/,
+      /Prune remote capability cloud report\s*\n\s*if: always\(\) && steps\.checkout\.outcome == 'success' && steps\.cloud\.outputs\.capability_skip != 'true' && \(github\.event_name == 'workflow_dispatch' \|\| github\.event_name == 'schedule'\)\s*\n\s*run: node packages\/scripts\/rm-path-recursive\.mjs reports\/remote-capabilities\/cloud/,
     message:
       "cloud live report pruning must not run on no-checkout skip paths.",
   },
@@ -529,21 +536,25 @@ export const checks: Check[] = [
       "provider live smoke must require E2B, home-machine, and mobile-companion endpoints for observed runs.",
   },
   {
-    name: "provider live endpoints skip cleanly when absent",
-    // Same `message=` composition as the cloud skip: the "configured" phrase and
-    // the "skipping optional provider live E2E" warning are separated by the
-    // strict-context fail branch.
+    name: "provider live smoke skips when manual observation was not requested",
     pattern:
-      /No remote capability provider endpoints configured[\s\S]{0,400}skipping optional provider live E2E[\s\S]{0,200}skip=true[\s\S]{0,200}exit 0/,
+      /LIVE_REQUIRED:.*github\.event_name == 'schedule'.*inputs\.remote_capability_live[\s\S]{0,500}LIVE_REQUIRED.*!= "true"[\s\S]{0,300}Remote capability provider live smoke was not requested[\s\S]{0,200}skip=true[\s\S]{0,100}exit 0/,
     message:
-      "provider live runs must skip cleanly when all endpoint secrets are absent.",
+      "provider live runs must skip ordinary manual dispatches before endpoint availability is evaluated.",
   },
   {
-    name: "provider live primary endpoint gaps skip cleanly",
+    name: "provider live endpoints fail observed runs when absent",
     pattern:
-      /Missing required remote capability provider endpoint secrets[\s\S]{0,300}Skipping optional provider live E2E[\s\S]{0,200}skip=true/,
+      /No remote capability provider endpoints configured[\s\S]{0,300}strict \$\{EVENT_NAME\} live lanes must fail instead of greening by skip[\s\S]{0,100}exit 1/,
     message:
-      "provider live runs must skip cleanly when any primary endpoint secret is absent.",
+      "observed provider live runs must fail when all endpoint secrets are absent.",
+  },
+  {
+    name: "provider live primary endpoint gaps fail observed runs",
+    pattern:
+      /Missing required remote capability provider endpoint secrets[\s\S]{0,300}strict \$\{EVENT_NAME\} live lanes must fail instead of greening by skip[\s\S]{0,100}exit 1/,
+    message:
+      "observed provider live runs must fail when any primary endpoint secret is absent.",
   },
   {
     name: "provider live smoke is observed only on manual or scheduled runs",
@@ -569,7 +580,7 @@ export const checks: Check[] = [
   {
     name: "provider live report prune only runs after checkout-backed live runs",
     pattern:
-      /Prune remote capability provider reports\s*\n\s*if: always\(\) && steps\.providers\.outputs\.skip != 'true' && \(github\.event_name == 'workflow_dispatch' \|\| github\.event_name == 'schedule'\)\s*\n\s*run: node packages\/scripts\/rm-path-recursive\.mjs reports\/remote-capabilities\/providers/,
+      /Prune remote capability provider reports\s*\n\s*if: always\(\) && steps\.checkout\.outcome == 'success' && steps\.providers\.outputs\.skip != 'true' && \(github\.event_name == 'workflow_dispatch' \|\| github\.event_name == 'schedule'\)\s*\n\s*run: node packages\/scripts\/rm-path-recursive\.mjs reports\/remote-capabilities\/providers/,
     message:
       "provider live report pruning must not run on no-checkout skip paths.",
   },


### PR DESCRIPTION
Closes #16786

## What changed

- adds a `remote_capability_live` boolean input to the generic `Tests` workflow dispatch
- skips remote-capability Cloud/provider observation on ordinary manual runs
- keeps scheduled and explicitly requested manual observations strict and fail-closed
- guards Cloud/provider report cleanup on successful checkout
- strengthens the live-CI audit and mutation self-test for the new contract
- adds conventional unit coverage for manual dispatch and cleanup guards
- updates the capability-router CI documentation

## Root cause

A generic `workflow_dispatch` was also treated as an unconditional request for three external remote-capability provider endpoints. The repository has none of the required `ELIZA_REMOTE_CAPABILITY_*` secrets configured, so unrelated manual validation failed before checkout. The always-running cleanup then tried to execute a repository script that had never been checked out, adding a misleading `MODULE_NOT_FOUND` failure.

Observed in Actions run 29940557543, job 88993021005.

## Validation

- `bun test packages/scripts/__tests__/audit-capability-router-live-ci.test.ts` — 2 passed
- `bun run test:remote-capabilities:live-ci-audit` — 66 checks passed
- `bun run test:remote-capabilities:live-ci-audit:self-test` — 66 checks passed
- `actionlint .github/workflows/test.yml`
- `biome check` on the changed audit and unit-test files
- `git diff --check origin/develop...HEAD`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only CI change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only CI change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow or UI interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend runtime changed; Actions failure logs and focused audit output are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduler, wallet, chain, media, or generated-file behavior changed.

## Known gaps / failures

- Real remote-provider artifacts are intentionally not produced by this PR because the repository has no configured E2B/home/mobile endpoint secrets. Scheduled and explicitly opted-in manual runs remain strict and will fail until owners configure those real services; ordinary manual test runs no longer claim that observation.