### PR TITLE
fix(workflow): validate assignment test fixture

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
@@ -20,11 +20,26 @@ function workflow(parameters: Record<string, unknown>, type = 'workflows-nodes-b
 }
 
 function assignments(definition: WorkflowDefinition): Array<Record<string, unknown>> {
-  return (
-    definition.nodes[0]?.parameters.assignments as {
-      assignments: Array<Record<string, unknown>>;
-    }
-  ).assignments;
+  const node = definition.nodes[0];
+  if (!node) {
+    throw new Error('Expected the workflow fixture to contain a node');
+  }
+
+  const assignmentGroup = node.parameters.assignments;
+  if (
+    typeof assignmentGroup !== 'object' ||
+    assignmentGroup === null ||
+    !('assignments' in assignmentGroup) ||
+    !Array.isArray(assignmentGroup.assignments) ||
+    !assignmentGroup.assignments.every(
+      (assignment: unknown) =>
+        typeof assignment === 'object' && assignment !== null && !Array.isArray(assignment)
+    )
+  ) {
+    throw new Error('Expected normalized workflow assignments');
+  }
+
+  return assignmentGroup.assignments;
 }
 
 describe('Set/Edit Fields parameter normalization', () => {


### PR DESCRIPTION
Closes #16794.

## Summary

- validate that the workflow fixture contains its expected first node before reading parameters
- validate the normalized assignment group and every assignment record at runtime
- remove the unsafe optional-chain-plus-cast pattern that breaks Biome on `develop`

## Root cause and impact

The test helper used `definition.nodes[0]?.parameters` and then unconditionally dereferenced `.assignments`. Biome correctly reports that the optional chain can yield `undefined` immediately before a throwing access. Because `plugin-workflow` participates in the repository lint graph, the committed failure also blocks unrelated PRs that run lint against `develop`.

The helper now fails closed with explicit fixture-shape errors. No production source or runtime behavior changes.

## Validation

- `bun run --cwd plugins/plugin-workflow lint:check` — passes (113 files)
- `bun test --coverage-reporter=lcov plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts` — passes (4 tests, 11 assertions)
- `bun run --cwd plugins/plugin-workflow typecheck` — passes
- `bun run audit:error-policy-ratchet` — passes; 0 production source files changed
- `git diff --check origin/develop...HEAD` — passes

The repository-wide lint command proceeds past `plugin-workflow`; current `develop` still has a separate pre-existing `plugin-openai` `noUnsafeOptionalChaining` failure. That independent file is deliberately out of scope for this one-file repair.

## Evidence matrix

- Before/after command evidence: included above; the deterministic lint and focused-test outputs are the user-visible artifact for this CI-only change.
- UI screenshots (desktop/mobile): N/A — no UI or shared rendered surface changes.
- Walkthrough video: N/A — no interactive flow changes.
- Frontend console/network logs: N/A — no frontend path changes.
- Backend structured logs: N/A — no backend or production execution path changes.
- Live-LLM trajectory: N/A — no model, prompt, action, provider, or agent behavior changes.
- Domain artifacts: N/A — the change creates no memories, workflows, DB rows, schedules, or external outputs.
