### PR TITLE
fix(openai): guard required tool in shape test

### DIFF
--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -51,9 +51,14 @@ describe("#13111 strict-safe record/map tool args", () => {
       },
     ]) as Record<string, { inputSchema: { jsonSchema: unknown }; strict?: boolean }>;
 
-    expect(toolSet.TASKS?.strict).toBe(false);
-    expect(toolSet.TASKS?.inputSchema.jsonSchema).toEqual(schema);
-    expect((toolSet.TASKS?.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
+    const tasksTool = toolSet.TASKS;
+    if (!tasksTool) {
+      throw new Error("normalizeNativeTools must return the TASKS tool");
+    }
+
+    expect(tasksTool.strict).toBe(false);
+    expect(tasksTool.inputSchema.jsonSchema).toEqual(schema);
+    expect((tasksTool.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
       "action",
     ]);
   });


### PR DESCRIPTION
# Relates to

Regression introduced by #16764. This is a trivial test-only lint repair, so no standalone issue was opened.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and scoped verification were run after sync; exact unrelated root failures are recorded below.
- [x] A reviewer can confirm the change works without reading the code from the command evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a8edf64cb73cefb54d484855a77776e7171cc184`; zero conflicts.
- [x] The affected package passes lint, typecheck, and its focused suite. Root lint advances past plugin-openai and then stops at the unrelated plugin-workflow failure documented below.

# Risks

Low. This changes one test's assertion setup only. Runtime/provider behavior and production code are untouched.

# Background

## What does this PR do?

It binds the required normalized `TASKS` tool once, fails explicitly if normalization omits it, and directly asserts its schema. This removes the unsafe optional-chain-plus-dereference that made plugin-openai's Biome task fail.

## What kind of change is this?

Bug fix (non-breaking, test-only CI repair).

# Documentation changes needed?

No. This does not change a documented API or runtime behavior.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts`, in the test named `preserves an explicitly non-strict tool schema byte-for-byte`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-openai test -- __tests__/record-args-observability.shape.test.ts
bun run --cwd plugins/plugin-openai lint:check
bun run --cwd plugins/plugin-openai typecheck
git diff --check
bun run audit:error-policy-ratchet
bun run lint
```

Observed results:

- Focused shape suite: 1 file passed, 8 tests passed.
- Plugin Biome: 42 files checked, no fixes or errors.
- Plugin typecheck: exit 0.
- Diff check: exit 0.
- Error-policy ratchet: 0 changed production files; no new fallback slop.
- Root lint: plugin-openai passes and Turbo proceeds to the unrelated base failure listed below.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only TypeScript assertion change; no UI surface is affected.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only TypeScript assertion change; no UI surface is affected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user flow or rendered behavior to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend or production runtime path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, response, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, model, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this test-only lint repair produces no domain artifact.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/provider behavior changes; the affected test is a deterministic schema-shape test.

## Backend + frontend logs

N/A - no runtime or UI path changes. The focused Vitest, Biome, and TypeScript results above are the directly affected artifacts.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI or interactive flow changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- `bun install --frozen-lockfile` materialized 9,177 packages and completed repository postinstall, but ended nonzero because the npm registry returned 404 for unrelated `got-cjs@12.5.5`. All dependencies needed for the scoped checks were available.
- `bun run lint` now proceeds past plugin-openai and stops at the existing unrelated `plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts:24` `lint/correctness/noUnsafeOptionalChaining` error.
- Full live-model/UI/native evidence is not applicable because this PR changes only a test guard and does not alter production behavior.
