### PR TITLE
fix(coding-tools): accept full IAgentRuntime in resolveInputPath (develop typecheck green)

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/write.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.test.ts
@@ -215,7 +215,6 @@ describe("WRITE", () => {
     expect(written).toBe("x");
   });
 
-
   it("rejects paths under the blocklist", async () => {
     const result = await writeFileHandler(env.runtime, env.message, undefined, {
       parameters: {

--- a/plugins/plugin-coding-tools/src/lib/path-utils.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.ts
@@ -6,6 +6,8 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+import type { IAgentRuntime } from "@elizaos/core";
+
 const BLOCKED_PATHS = new Set([
   "/dev/zero",
   "/dev/random",
@@ -85,21 +87,30 @@ export function resolveRelativeToCwd(filePath: string, cwd: string): string {
   return isAbsolutePath(filePath) ? filePath : path.resolve(cwd, filePath);
 }
 
+/** Minimal shape of the SessionCwdService this resolver depends on. */
+interface CwdLookup {
+  getCwd(id: string | undefined): string;
+}
+
 /**
  * Resolve a handler's `file_path` input to an absolute path using the
  * conversation's working directory. Owns the SessionCwdService lookup so
  * read/write/edit share one definition; `getCwd` itself defaults to
  * `process.cwd()` when the conversation has no recorded cwd.
+ *
+ * The `runtime` param mirrors core's generic `getService<T>(): T | null`
+ * signature so a full `IAgentRuntime` is assignable here; the resolved
+ * service is narrowed to the {@link CwdLookup} shape internally.
  */
 export function resolveInputPath(
-  runtime: {
-    getService(type: string): { getCwd(id: string | undefined): string } | null;
-  },
+  runtime: Pick<IAgentRuntime, "getService">,
   conversationId: string | undefined,
   filePath: string,
 ): string {
   if (isAbsolutePath(filePath)) return filePath;
-  const cwdService = runtime.getService("CODING_TOOLS_SESSION_CWD");
+  const cwdService = runtime.getService(
+    "CODING_TOOLS_SESSION_CWD",
+  ) as CwdLookup | null;
   const cwd = cwdService?.getCwd(conversationId) ?? process.cwd();
   return path.resolve(cwd, filePath);
 }

--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -51,11 +51,11 @@ describe("#13111 strict-safe record/map tool args", () => {
       },
     ]) as Record<string, { inputSchema: { jsonSchema: unknown }; strict?: boolean }>;
 
-    expect(toolSet.TASKS?.strict).toBe(false);
-    expect(toolSet.TASKS?.inputSchema.jsonSchema).toEqual(schema);
-    expect((toolSet.TASKS?.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
-      "action",
-    ]);
+    const tasks = toolSet.TASKS;
+    if (!tasks) throw new Error("expected TASKS tool in normalized set");
+    expect(tasks.strict).toBe(false);
+    expect(tasks.inputSchema.jsonSchema).toEqual(schema);
+    expect((tasks.inputSchema.jsonSchema as { required?: string[] }).required).toEqual(["action"]);
   });
 
   it("turns additionalProperties:true into a strict entries array", () => {


### PR DESCRIPTION
## What

Clears the develop-side **typecheck red** in `plugin-coding-tools` (found by the merge-triage lanes) plus two biome 2.5.5 stragglers. Surgical, 3 files, +20/-10.

### 1. Root cause: `resolveInputPath` typecheck (the keystone red)
`edit.ts:87`, `read.ts:172`, `write.ts:101` all pass a real `IAgentRuntime` into `resolveInputPath`, but the helper typed its `runtime` param with a **narrow, non-generic** structural shape:

```ts
runtime: { getService(type: string): { getCwd(id) } | null }
```

Core's method is **generic**: `getService<T extends Service>(service): T | null`. A generic method is not assignable to that narrow signature (`Service` has no `getCwd`), so develop failed:

```
src/actions/edit.ts(87,42): error TS2345: Argument of type 'IAgentRuntime' is not
assignable to parameter of type '{ getService(type: string): { getCwd(...) } | null; }'.
```

**Fix:** type the param as `Pick<IAgentRuntime, "getService">` (mirrors core exactly, can't drift) and narrow the resolved service to a local `CwdLookup` interface internally. No behavior change.

### 2. biome 2.5.5 stragglers (surfaced after the lockfile sync #16784/#16796)
- `plugin-openai` `record-args-observability.shape.test.ts`: `noUnsafeOptionalChaining` — guard `TASKS` once with a throw, then use non-optional access; plus a one-line array format.
- `plugin-coding-tools` `write.test.ts`: stray double blank line.

## Local green evidence

`bun install --frozen-lockfile` → **EXIT 0** (lockfile consistent with package.json; confirms biome/lockfile red #1 already resolved on develop by #16784 + #16796).

After building the turbo prereqs (`@elizaos/core#build`, `contracts`, `cloud/routing`, i18n keyword codegen — the deps the `typecheck` turbo task declares):

```
plugin-coding-tools:  tsc --noEmit        -> EXIT 0
plugin-coding-tools:  biome check .        -> EXIT 0
plugin-coding-tools:  vitest run src/lib   -> 67 passed
plugin-openai:        tsc --noEmit         -> EXIT 0
plugin-openai:        biome check .        -> EXIT 0
plugin-openai:        vitest shape test    -> 8 passed
biome version consistency (root)           -> passed
```

Baseline diff proof: on clean develop, `edit/read/write.ts` = **3 TS2345 errors**; with this patch = **0**.

## ⚠️ Separate pre-existing develop red (NOT in this PR — flagging for a dedicated fix)
`packages/benchmarks/claude-subscription-gateway` has **23 biome errors** (11 format, 6 organizeImports, + `noImplicitAnyLet` / `noShadowRestrictedNames` / `noUnusedPrivateClassMembers`). It's a workspace member with `lint:check => biome check .`, so it **gates `bun run lint:check`** in `develop-pr.yml`. Introduced lint-dirty by #16764 (Smithers/benchmark workflow). Autofix touches ~17 files (+140/-125) plus 2 manual code changes — out of scope for this surgical keystone. **Recommend a separate PR.**

## Gate / waiver
- No CI workflow files touched.
- Runner fleet is starved + DISK-FULL; if CI can't run, local green above stands as evidence per the ready-on-green waiver.

Co-authored-by: shadow <shadow@shad0w.xyz>

[sol-develop-green]
