### PR TITLE
fix(claude-subscription-gateway): clear develop Lint + Type Check reds (retired tsgo + biome)

### DIFF
--- a/packages/benchmarks/claude-subscription-gateway/package.json
+++ b/packages/benchmarks/claude-subscription-gateway/package.json
@@ -13,7 +13,7 @@
     "start": "bun src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",

--- a/packages/benchmarks/claude-subscription-gateway/src/audit.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/audit.ts
@@ -4,11 +4,10 @@
  */
 
 import {
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
 } from "./hash-chained-jsonl.js";
-import type { GatewayAuditRecord } from "./types.js";
-import type { JsonObject } from "./types.js";
+import type { GatewayAuditRecord, JsonObject } from "./types.js";
 
 export interface AuditSink {
   append(record: GatewayAuditRecord): void | Promise<void>;
@@ -126,7 +125,9 @@ export class DurableAuditStore implements AuditSink {
     }
     if (logicalOrdinal === cursor.lastOrdinal) {
       if (cursor.lastKey !== logicalKeySha256 || cursor.lastResult === null) {
-        throw new Error("Audit logical ordinal was reused with a different key.");
+        throw new Error(
+          "Audit logical ordinal was reused with a different key.",
+        );
       }
       return cursor.lastResult;
     }
@@ -135,7 +136,8 @@ export class DurableAuditStore implements AuditSink {
     while (true) {
       const candidate = cursor.pending;
       if (candidate !== null) cursor.pending = null;
-      const next = candidate === null ? await this.log.readNext(cursor.stream) : null;
+      const next =
+        candidate === null ? await this.log.readNext(cursor.stream) : null;
       if (candidate === null) {
         if (next === null) {
           cursor.lastResult = false;
@@ -166,7 +168,9 @@ export class DurableAuditStore implements AuditSink {
       }
       this.cursors.set(harness, cursor);
       if (record.logical_key_sha256 !== logicalKeySha256) {
-        throw new Error("Audit logical identity conflicts with its request hash.");
+        throw new Error(
+          "Audit logical identity conflicts with its request hash.",
+        );
       }
       cursor.lastResult = true;
       return true;
@@ -180,7 +184,6 @@ export class DurableAuditStore implements AuditSink {
   close(): Promise<void> {
     return this.log.close();
   }
-
 }
 
 export function toAuditArtifact(record: GatewayAuditRecord): JsonObject {
@@ -191,8 +194,7 @@ export function toAuditArtifact(record: GatewayAuditRecord): JsonObject {
     harness: record.harness,
     transport: record.transport,
     credential_source: record.credentialSource,
-    credential_epoch_hmac_sha256:
-      record.credentialEpochHmacSha256 ?? null,
+    credential_epoch_hmac_sha256: record.credentialEpochHmacSha256 ?? null,
     credential_tier_hmac_sha256: record.credentialTierHmacSha256 ?? null,
     credential_capability_hmac_sha256:
       record.credentialCapabilityHmacSha256 ?? null,

--- a/packages/benchmarks/claude-subscription-gateway/src/claude-completion.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/claude-completion.ts
@@ -758,7 +758,8 @@ export function normalizeResetTimestampMs(value: unknown): number | null {
     return null;
   }
   const milliseconds = value < 1_000_000_000_000 ? value * 1_000 : value;
-  return Number.isSafeInteger(milliseconds) && milliseconds <= 8_640_000_000_000_000
+  return Number.isSafeInteger(milliseconds) &&
+    milliseconds <= 8_640_000_000_000_000
     ? milliseconds
     : null;
 }

--- a/packages/benchmarks/claude-subscription-gateway/src/cli.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/cli.ts
@@ -5,6 +5,7 @@
  */
 
 import { randomBytes, randomUUID } from "node:crypto";
+import type { FileHandle } from "node:fs/promises";
 import {
   chmod,
   open,
@@ -22,18 +23,18 @@ import {
   CLAUDE_AGENT_SDK_VERSION,
   ClaudeSdkCompletionRunner,
 } from "./claude-completion.js";
+import { parseGatewayContentContract } from "./content-attestation.js";
 import {
   type CredentialLeaseBroker,
   RotatingCredentialCompletionRunner,
 } from "./credential-rotation.js";
-import { parseGatewayContentContract } from "./content-attestation.js";
+import { ReplayJournal } from "./replay-journal.js";
 import {
   type ClaudeSubscriptionGatewayHandle,
-  type GatewayStorageGuard,
   GatewayStorageError,
+  type GatewayStorageGuard,
   startClaudeSubscriptionGateway,
 } from "./server.js";
-import { ReplayJournal } from "./replay-journal.js";
 import type { GatewayAuditRecord } from "./types.js";
 
 const PRIVATE_FILE_MODE = 0o600;
@@ -249,7 +250,9 @@ export function parseGatewayCliArguments(
   }
   if (
     contentContractFile !== null &&
-    [readyFile, auditFile, replayFile, hmacKeyFile].includes(contentContractFile)
+    [readyFile, auditFile, replayFile, hmacKeyFile].includes(
+      contentContractFile,
+    )
   ) {
     throw new GatewayCliError(
       "invalid_arguments",
@@ -319,7 +322,10 @@ function makeReadinessDocument(
 async function loadContentContract(target: string) {
   try {
     const fileStat = await stat(target);
-    if (!fileStat.isFile() || (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE) {
+    if (
+      !fileStat.isFile() ||
+      (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE
+    ) {
       throw new TypeError("content contract must be a private regular file");
     }
     const raw = await readFile(target, "utf8");
@@ -396,7 +402,7 @@ async function loadOrCreateHmacKey(target: string): Promise<Buffer> {
     if (!hasErrorCode(error, "ENOENT")) throw error;
   }
   const key = randomBytes(32);
-  let file;
+  let file: FileHandle;
   try {
     file = await open(target, "wx", PRIVATE_FILE_MODE);
   } catch (error: unknown) {
@@ -420,7 +426,10 @@ async function loadOrCreateHmacKey(target: string): Promise<Buffer> {
 
 async function loadHmacKey(target: string): Promise<Buffer> {
   const fileStat = await stat(target);
-  if (!fileStat.isFile() || (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE) {
+  if (
+    !fileStat.isFile() ||
+    (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE
+  ) {
     throw new GatewayCliError(
       "invalid_hmac_key_file",
       "The gateway HMAC key file must be a private regular file.",
@@ -443,17 +452,17 @@ async function loadCanonicalAccountPoolBroker(): Promise<CredentialLeaseBroker> 
     import.meta.url,
   ).href;
   const loaded: unknown = await import(moduleUrl);
-  const constructor =
+  const brokerConstructor =
     typeof loaded === "object" && loaded !== null
       ? Reflect.get(loaded, "AccountPoolBroker")
       : null;
-  if (typeof constructor !== "function") {
+  if (typeof brokerConstructor !== "function") {
     throw new GatewayCliError(
       "account_pool_unavailable",
       "The canonical account-pool broker is unavailable.",
     );
   }
-  const broker: unknown = Reflect.construct(constructor, []);
+  const broker: unknown = Reflect.construct(brokerConstructor, []);
   if (
     typeof broker !== "object" ||
     broker === null ||

--- a/packages/benchmarks/claude-subscription-gateway/src/content-attestation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/content-attestation.ts
@@ -158,10 +158,7 @@ function exactOccurrenceCount(haystack: string, needle: string): number {
   }
 }
 
-function occurrenceCount(
-  contents: readonly string[],
-  needle: string,
-): number {
+function occurrenceCount(contents: readonly string[], needle: string): number {
   return contents.reduce(
     (total, content) => total + exactOccurrenceCount(content, needle),
     0,
@@ -187,10 +184,7 @@ function categoryMatchCounts(
   return Object.fromEntries(
     Object.entries(categories).map(([category, texts]) => [
       category,
-      texts.reduce(
-        (total, text) => total + occurrenceCount(contents, text),
-        0,
-      ),
+      texts.reduce((total, text) => total + occurrenceCount(contents, text), 0),
     ]),
   );
 }
@@ -201,16 +195,16 @@ export function buildGatewayContentAttestation(
   messages: readonly NormalizedChatMessage[],
 ): GatewayContentAttestation {
   const instructionContents = messages
-    .filter((message) =>
-      message.role === "system" || message.role === "developer",
+    .filter(
+      (message) => message.role === "system" || message.role === "developer",
     )
     .map((message) => message.content ?? "");
   const userContents = messages
     .filter((message) => message.role === "user")
     .map((message) => message.content ?? "");
   const generatedContents = messages
-    .filter((message) =>
-      message.role === "assistant" || message.role === "tool",
+    .filter(
+      (message) => message.role === "assistant" || message.role === "tool",
     )
     .map((message) => message.content ?? "");
   const ingressContents = [...instructionContents, ...userContents];
@@ -239,7 +233,10 @@ export function buildGatewayContentAttestation(
       instructionContents,
       contract.systemHint,
     ),
-    systemHintUserOccurrences: occurrenceCount(userContents, contract.systemHint),
+    systemHintUserOccurrences: occurrenceCount(
+      userContents,
+      contract.systemHint,
+    ),
     systemHintGeneratedOccurrences: occurrenceCount(
       generatedContents,
       contract.systemHint,
@@ -259,10 +256,7 @@ export function buildGatewayContentAttestation(
     forbiddenIngressMatchCounts,
     forbiddenIngressMatchTotal: Object.values(
       forbiddenIngressMatchCounts,
-    ).reduce(
-      (total, count) => total + count,
-      0,
-    ),
+    ).reduce((total, count) => total + count, 0),
     forbiddenGeneratedMatchCounts,
     forbiddenGeneratedMatchTotal: Object.values(
       forbiddenGeneratedMatchCounts,

--- a/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
@@ -82,7 +82,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
 
   constructor(options: RotatingCredentialCompletionRunnerOptions) {
     if (options.hmacKey.length < 32) {
-      throw new TypeError("Credential HMAC key must contain at least 32 bytes.");
+      throw new TypeError(
+        "Credential HMAC key must contain at least 32 bytes.",
+      );
     }
     this.inner = options.completionRunner;
     this.broker = options.broker ?? null;
@@ -129,7 +131,10 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
           credentialTierValidator: (subscriptionType) =>
             this.assertTierParity(subscriptionType),
         });
-        const decorated = this.decorateResult(result, `linked:${lease.accountId}`);
+        const decorated = this.decorateResult(
+          result,
+          `linked:${lease.accountId}`,
+        );
         await this.broker?.report({
           leaseId: lease.leaseId,
           ok: true,
@@ -187,10 +192,7 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
       if (!sawRateLimit && lastAuthenticationFailure !== null) {
         throw lastAuthenticationFailure;
       }
-      throw new ClaudeRateLimitError(
-        earliestKnownReset,
-        knownRateLimitType,
-      );
+      throw new ClaudeRateLimitError(earliestKnownReset, knownRateLimitType);
     }
     try {
       const ambient = await this.inner.complete({
@@ -208,11 +210,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
           earliestKnownReset = error.retryAtMs;
           knownRateLimitType = error.rateLimitType;
         }
-        throw new ClaudeRateLimitError(
-          earliestKnownReset,
-          knownRateLimitType,
-          { cause: error },
-        );
+        throw new ClaudeRateLimitError(earliestKnownReset, knownRateLimitType, {
+          cause: error,
+        });
       }
       throw error;
     }
@@ -244,7 +244,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
   }
 
   private hmac(value: string): string {
-    return createHmac("sha256", this.hmacKey).update(value, "utf8").digest("hex");
+    return createHmac("sha256", this.hmacKey)
+      .update(value, "utf8")
+      .digest("hex");
   }
 }
 

--- a/packages/benchmarks/claude-subscription-gateway/src/hash-chained-jsonl.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/hash-chained-jsonl.ts
@@ -6,7 +6,7 @@
 
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { open, type FileHandle } from "node:fs/promises";
+import { type FileHandle, open } from "node:fs/promises";
 import { dirname } from "node:path";
 import { stableJson } from "./canonical.js";
 import type { JsonObject, JsonValue } from "./types.js";
@@ -68,7 +68,9 @@ export class HashChainedJsonl {
       !Number.isSafeInteger(normalized.maxRecordBytes) ||
       normalized.maxRecordBytes <= 0
     ) {
-      throw new TypeError("Hash-chain record limit must be a positive integer.");
+      throw new TypeError(
+        "Hash-chain record limit must be a positive integer.",
+      );
     }
     const file = await open(
       target,
@@ -131,7 +133,8 @@ export class HashChainedJsonl {
     });
     this.appendTail = operation;
     return operation.then(() => {
-      if (appended === null) throw new Error("Hash-chain append did not commit.");
+      if (appended === null)
+        throw new Error("Hash-chain append did not commit.");
       return appended;
     });
   }
@@ -154,7 +157,9 @@ export class HashChainedJsonl {
   async readNext(cursor: HashChainedJsonlCursor): Promise<JsonObject | null> {
     await this.appendTail;
     if (!Number.isSafeInteger(cursor.offset) || cursor.offset < 0) {
-      throw new TypeError("Hash-chain read offset must be a non-negative integer.");
+      throw new TypeError(
+        "Hash-chain read offset must be a non-negative integer.",
+      );
     }
     const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
     while (cursor.pending.length <= this.options.maxRecordBytes) {
@@ -332,7 +337,9 @@ function assertNoReservedFields(
     options.recordHashField,
   ]) {
     if (field in payload) {
-      throw new TypeError(`Hash-chain payload contains reserved field ${field}.`);
+      throw new TypeError(
+        `Hash-chain payload contains reserved field ${field}.`,
+      );
     }
   }
 }

--- a/packages/benchmarks/claude-subscription-gateway/src/index.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/index.ts
@@ -27,6 +27,11 @@ export {
   normalizeResetTimestampMs,
 } from "./claude-completion.js";
 export {
+  buildGatewayContentAttestation,
+  gatewayContentAttestationViolation,
+  parseGatewayContentContract,
+} from "./content-attestation.js";
+export {
   type CredentialBrokerLease,
   type CredentialLeaseBroker,
   CredentialParityError,
@@ -34,29 +39,15 @@ export {
   type RotatingCredentialCompletionRunnerOptions,
 } from "./credential-rotation.js";
 export {
-  buildGatewayContentAttestation,
-  gatewayContentAttestationViolation,
-  parseGatewayContentContract,
-} from "./content-attestation.js";
-export {
   FairHarnessQueue,
   type FairHarnessQueueOptions,
   QueueCapacityError,
   type QueuedResult,
 } from "./fair-queue.js";
 export {
-  GatewayStorageError,
-  type ClaudeSubscriptionGatewayHandle,
-  type GatewayHarnessEnvironment,
-  type GatewayLogger,
-  type GatewayStorageGuard,
-  type StartClaudeSubscriptionGatewayOptions,
-  startClaudeSubscriptionGateway,
-} from "./server.js";
-export {
   HashChainCorruptionError,
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
   type HashChainedJsonlOptions,
 } from "./hash-chained-jsonl.js";
 export {
@@ -70,6 +61,15 @@ export {
   ReplayJournal,
   ReplayMismatchError,
 } from "./replay-journal.js";
+export {
+  type ClaudeSubscriptionGatewayHandle,
+  type GatewayHarnessEnvironment,
+  type GatewayLogger,
+  GatewayStorageError,
+  type GatewayStorageGuard,
+  type StartClaudeSubscriptionGatewayOptions,
+  startClaudeSubscriptionGateway,
+} from "./server.js";
 export type {
   CanonicalChatCompletion,
   CapturedToolCall,

--- a/packages/benchmarks/claude-subscription-gateway/src/logical-request.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/logical-request.ts
@@ -25,7 +25,7 @@ export class LogicalRequestAllocator {
   private readonly nextOrdinalByHarness = new Map<string, number>();
   readonly namespaceSha256: string;
 
-  constructor(private readonly namespace: string) {
+  constructor(readonly namespace: string) {
     if (!SAFE_NAMESPACE_PATTERN.test(namespace)) {
       throw new TypeError(
         "Benchmark namespace must be 1-128 safe identifier characters.",

--- a/packages/benchmarks/claude-subscription-gateway/src/replay-journal.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/replay-journal.ts
@@ -6,8 +6,8 @@
 
 import {
   HashChainCorruptionError,
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
 } from "./hash-chained-jsonl.js";
 import {
   computeLogicalKeySha256,
@@ -42,7 +42,9 @@ export class ReplayMismatchError extends Error {
   readonly statusCode = 409;
 
   constructor() {
-    super("A replay ordinal was reused with different canonical request content.");
+    super(
+      "A replay ordinal was reused with different canonical request content.",
+    );
     this.name = "ReplayMismatchError";
   }
 }
@@ -115,7 +117,8 @@ export class ReplayJournal {
     while (true) {
       const pending = cursor.pending;
       if (pending !== null) cursor.pending = null;
-      const next = pending === null ? await this.log.readNext(cursor.stream) : null;
+      const next =
+        pending === null ? await this.log.readNext(cursor.stream) : null;
       if (pending === null) {
         if (next === null) {
           cursor.lastResult = null;
@@ -236,7 +239,9 @@ interface ParsedJournalRecord {
 
 function parseJournalRecord(record: JsonObject): ParsedJournalRecord {
   if (record.kind !== "completion" || record.journal_schema_version !== 1) {
-    throw new HashChainCorruptionError("Replay journal record kind is invalid.");
+    throw new HashChainCorruptionError(
+      "Replay journal record kind is invalid.",
+    );
   }
   const harness = requiredString(record.harness, "harness");
   const logicalNamespaceSha256 = requiredHash(
@@ -317,7 +322,10 @@ function parseCompletionResult(value: unknown): ClaudeCompletionResult {
           })(),
     resultSubtype: requiredString(value.resultSubtype, "result subtype"),
     terminalReason: nullableString(value.terminalReason, "terminal reason"),
-    subscriptionType: requiredString(value.subscriptionType, "subscription tier"),
+    subscriptionType: requiredString(
+      value.subscriptionType,
+      "subscription tier",
+    ),
     credentialEpochHmacSha256: requiredHash(
       value.credentialEpochHmacSha256,
       "credential epoch",
@@ -410,11 +418,7 @@ function nullableString(value: unknown, label: string): string | null {
 }
 
 function requiredInteger(value: unknown, label: string): number {
-  if (
-    typeof value !== "number" ||
-    !Number.isSafeInteger(value) ||
-    value < 0
-  ) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
     throw new HashChainCorruptionError(`Replay ${label} is invalid.`);
   }
   return value;

--- a/packages/benchmarks/claude-subscription-gateway/src/server.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/server.ts
@@ -19,21 +19,21 @@ import {
   stableJson,
 } from "./canonical.js";
 import {
-  buildGatewayContentAttestation,
-  gatewayContentAttestationViolation,
-} from "./content-attestation.js";
-import {
   CLAUDE_AGENT_SDK_VERSION,
   ClaudeCompletionError,
   ClaudeRateLimitError,
   ClaudeSdkCompletionRunner,
 } from "./claude-completion.js";
+import {
+  buildGatewayContentAttestation,
+  gatewayContentAttestationViolation,
+} from "./content-attestation.js";
 import { FairHarnessQueue, QueueCapacityError } from "./fair-queue.js";
 import {
-  LogicalRequestAllocator,
   type LogicalRequest,
+  LogicalRequestAllocator,
 } from "./logical-request.js";
-import { ReplayJournal, ReplayMismatchError } from "./replay-journal.js";
+import { type ReplayJournal, ReplayMismatchError } from "./replay-journal.js";
 import type {
   ClaudeCompletionResult,
   CompletionFinishReason,
@@ -404,13 +404,8 @@ async function handleRequest(
         ),
       };
     });
-    const {
-      result,
-      serviceMs,
-      created,
-      executionOrigin,
-      responseQueueWaitMs,
-    } = queued.value;
+    const { result, serviceMs, created, executionOrigin, responseQueueWaitMs } =
+      queued.value;
     const finishReason: CompletionFinishReason =
       result.toolCalls.length > 0 ? "tool_calls" : "stop";
     const completionAlreadyAudited =
@@ -726,11 +721,7 @@ interface AuditRecordInput {
     | "pause_control";
   deliveryAttempt: number | null;
   retryAt?: string | null;
-  pauseReason?:
-    | "rate_limit"
-    | "rate_limit_unknown"
-    | "storage_reserve"
-    | null;
+  pauseReason?: "rate_limit" | "rate_limit_unknown" | "storage_reserve" | null;
 }
 
 function makeAuditRecord(input: AuditRecordInput): GatewayAuditRecord {
@@ -781,10 +772,8 @@ function makeAuditRecord(input: AuditRecordInput): GatewayAuditRecord {
     deliveryAttempt: input.deliveryAttempt ?? undefined,
     executionOrigin: input.executionOrigin,
     auditEvent: input.auditEvent,
-    credentialEpochHmacSha256:
-      input.result?.credentialEpochHmacSha256 ?? null,
-    credentialTierHmacSha256:
-      input.result?.credentialTierHmacSha256 ?? null,
+    credentialEpochHmacSha256: input.result?.credentialEpochHmacSha256 ?? null,
+    credentialTierHmacSha256: input.result?.credentialTierHmacSha256 ?? null,
     credentialCapabilityHmacSha256:
       input.result?.credentialCapabilityHmacSha256 ?? null,
     retryAt: input.retryAt ?? null,
@@ -894,7 +883,7 @@ function normalizeHarness(value: string): string {
   return normalized;
 }
 
-function normalizeRequestId(value: string): string {
+function _normalizeRequestId(value: string): string {
   const normalized = value
     .trim()
     .replace(/[^A-Za-z0-9_-]/g, "")

--- a/packages/benchmarks/claude-subscription-gateway/src/types.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/types.ts
@@ -224,9 +224,5 @@ export interface GatewayAuditRecord {
   credentialTierHmacSha256?: string | null;
   credentialCapabilityHmacSha256?: string | null;
   retryAt?: string | null;
-  pauseReason?:
-    | "rate_limit"
-    | "rate_limit_unknown"
-    | "storage_reserve"
-    | null;
+  pauseReason?: "rate_limit" | "rate_limit_unknown" | "storage_reserve" | null;
 }

--- a/packages/benchmarks/claude-subscription-gateway/tests/claude-completion.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/claude-completion.test.ts
@@ -6,7 +6,7 @@ import type { ClaudeAgentSdkModule } from "../src/index.js";
 import {
   assertNoApiBillingEnvironment,
   buildClaudeCodeManagedEnvironment,
-  ClaudeRateLimitError,
+  type ClaudeRateLimitError,
   ClaudeSdkCompletionRunner,
   canonicalizeChatCompletion,
   FORBIDDEN_API_BILLING_ENV_NAMES,

--- a/packages/benchmarks/claude-subscription-gateway/tests/content-attestation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/content-attestation.test.ts
@@ -42,7 +42,9 @@ describe("gateway content attestation", () => {
     });
     expect(proof.forbiddenIngressMatchTotal).toBe(0);
     expect(proof.observedIngressMatchCounts).toEqual({ workspace_paths: 1 });
-    expect(proof.observedInstructionMatchCounts).toEqual({ workspace_paths: 0 });
+    expect(proof.observedInstructionMatchCounts).toEqual({
+      workspace_paths: 0,
+    });
     expect(proof.observedUserMatchCounts).toEqual({ workspace_paths: 1 });
     expect(proof.messageContentManifest).toHaveLength(4);
     const serialized = JSON.stringify(proof);

--- a/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
@@ -3,12 +3,12 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import {
-  canonicalizeChatCompletion,
   type ClaudeCompletionResult,
   ClaudeRateLimitError,
   type CompletionContext,
   type CompletionRunner,
   type CredentialLeaseBroker,
+  canonicalizeChatCompletion,
   RotatingCredentialCompletionRunner,
 } from "../src/index.js";
 
@@ -17,7 +17,10 @@ const HMAC_KEY = Buffer.alloc(32, 7);
 describe("RotatingCredentialCompletionRunner", () => {
   it("rotates linked leases on quota with one stable session key and token-only injection", async () => {
     const leases = [lease("a", "token-a"), lease("b", "token-b"), null];
-    const leaseBroker = vi.fn(async () => leases.shift() ?? null);
+    const leaseBroker = vi.fn(
+      async (_request: Parameters<CredentialLeaseBroker["lease"]>[0]) =>
+        leases.shift() ?? null,
+    );
     const broker: CredentialLeaseBroker = {
       lease: leaseBroker,
       report: vi.fn(async () => ({ ok: true })),
@@ -29,10 +32,7 @@ describe("RotatingCredentialCompletionRunner", () => {
         contexts.push(context);
         context.credentialTierValidator?.("Claude Max");
         if (context.credentialOAuthToken === "token-a") {
-          throw new ClaudeRateLimitError(
-            2_000_000_000_000,
-            "seven_day",
-          );
+          throw new ClaudeRateLimitError(2_000_000_000_000, "seven_day");
         }
         return completionResult();
       },
@@ -136,9 +136,7 @@ describe("RotatingCredentialCompletionRunner", () => {
       broker: null,
       hmacKey: HMAC_KEY,
       expectedTierHmacSha256: expectedTier,
-      expectedCapabilityHmacSha256: hmac(
-        "firstParty:oauth:subscription",
-      ),
+      expectedCapabilityHmacSha256: hmac("firstParty:oauth:subscription"),
     });
 
     await expect(runner.complete(completionContext())).rejects.toMatchObject({

--- a/packages/benchmarks/claude-subscription-gateway/tests/durable-storage.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/durable-storage.test.ts
@@ -1,6 +1,13 @@
 /** Verifies crash repair, committed-corruption rejection, and bounded audit cursor idempotence on real files. */
 
-import { appendFile, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
@@ -6,10 +6,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   type AuditSink,
-  canonicalizeChatCompletion,
-  DurableAuditStore,
   type ClaudeCompletionResult,
   type CompletionRunner,
+  canonicalizeChatCompletion,
+  DurableAuditStore,
   type GatewayAuditRecord,
   LogicalRequestAllocator,
   ReplayJournal,
@@ -22,17 +22,17 @@ describe("gateway replay", () => {
   it("commits the private success before awaiting public audit and HTTP delivery", async () => {
     const directory = await mkdtemp(join(tmpdir(), "gateway-ordering-"));
     const journalPath = join(directory, "responses.jsonl");
-    let enterAudit: (() => void) | null = null;
+    let enterAudit: () => void = () => {};
     const auditEntered = new Promise<void>((resolve) => {
       enterAudit = resolve;
     });
-    let releaseAudit: (() => void) | null = null;
+    let releaseAudit: () => void = () => {};
     const auditReleased = new Promise<void>((resolve) => {
       releaseAudit = resolve;
     });
     const auditSink: AuditSink = {
       append(_record: GatewayAuditRecord) {
-        enterAudit?.();
+        enterAudit();
         return auditReleased;
       },
     };
@@ -40,7 +40,11 @@ describe("gateway replay", () => {
     try {
       const journal = await ReplayJournal.open(journalPath);
       const gateway = await startClaudeSubscriptionGateway({
-        completionRunner: { async complete() { return completionResult(); } },
+        completionRunner: {
+          async complete() {
+            return completionResult();
+          },
+        },
         replayJournal: journal,
         auditSink,
         benchmarkNamespace: "ordering-test",
@@ -59,12 +63,12 @@ describe("gateway replay", () => {
       expect((await readFile(journalPath, "utf8")).trim()).not.toBe("");
       await Promise.resolve();
       expect(delivered).toBe(false);
-      releaseAudit?.();
+      releaseAudit();
       expect((await pendingResponse).status).toBe(200);
       await gateway.close();
       await journal.close();
     } finally {
-      releaseAudit?.();
+      releaseAudit();
       await rm(directory, { recursive: true, force: true });
     }
   });

--- a/packages/benchmarks/claude-subscription-gateway/tests/server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/server.test.ts
@@ -636,16 +636,20 @@ describe("startClaudeSubscriptionGateway", () => {
       request(HERMES_TOKEN),
       request(OPENCLAW_TOKEN),
     ]);
-    expect(responses.map((response) => response.status)).toEqual([429, 429, 429]);
+    expect(responses.map((response) => response.status)).toEqual([
+      429, 429, 429,
+    ]);
     expect(completionCalls).toBe(1);
     expect(handle.auditStore.snapshot()).toHaveLength(3);
     expect(
-      handle.auditStore.snapshot().every(
-        (record) =>
-          record.status === "paused" &&
-          record.pauseReason === "rate_limit" &&
-          record.auditEvent === "pause_control",
-      ),
+      handle.auditStore
+        .snapshot()
+        .every(
+          (record) =>
+            record.status === "paused" &&
+            record.pauseReason === "rate_limit" &&
+            record.auditEvent === "pause_control",
+        ),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## What
Clears the develop-side **Lint** and **Type Check** gate reds carried by `packages/benchmarks/claude-subscription-gateway` (landed by #16764). These block the repo-wide gates for **every** develop PR.

### Lint gate — biome 2.5.5 (23 errors)
- mechanical autofix: format, `organizeImports`, `useImportType` (17 files)
- `cli.ts`: `let file;` → `let file: FileHandle;` (`noImplicitAnyLet`)
- `cli.ts`: rename local `constructor` → `brokerConstructor` (`noShadowRestrictedNames`)
- `logical-request.ts`: drop unused `private readonly` on namespace param (`noUnusedPrivateClassMembers`)

### Type Check gate — retired `tsgo` (was exit 127)
- `package.json`: `typecheck` migrated `tsgo --noEmit` (**RETIRED** → `command not found`, exit 127) → `tsc --noEmit -p tsconfig.json`, matching all 190 other packages. The repo's own `audit-build-typecheck.mjs` flags this package as the **last tsgo holdout**.
- Migrating to `tsc` surfaced 8 real test-file type errors tsgo had tolerated:
  - `credential-rotation.test.ts`: type the `leaseBroker` `vi.fn` param so `.mock.calls[i][0]` is typed (TS2493/TS2532)
  - `replay-server.test.ts`: default `enterAudit`/`releaseAudit` to noop `() => {}` so TS can't narrow them to `null` (TS2349)

## Local green
`tsc --noEmit` → **EXIT 0**; `biome check .` → **EXIT 0** (25 files).

## ⚠️ Known pre-existing (NOT fixed here)
`credential-rotation.test.ts` → "rotates linked leases on quota" **fails on pristine origin/develop too** (expected `exclude: ['a']`, got `['a','b']`) — a rotation-logic-vs-test-expectation mismatch needing product-owner triage. It runs **post-merge**, not in the build-only `develop-pr` gate, so it does **not** block this PR's gates. Flagged for a separate lane.

Co-authored-by: shadow <shadow@shad0w.xyz>

[sol-develop-green]