### PR TITLE
fix(ci): restore claude gateway quality gates

### DIFF
--- a/packages/benchmarks/claude-subscription-gateway/package.json
+++ b/packages/benchmarks/claude-subscription-gateway/package.json
@@ -13,7 +13,7 @@
     "start": "bun src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",

--- a/packages/benchmarks/claude-subscription-gateway/src/audit.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/audit.ts
@@ -4,11 +4,10 @@
  */
 
 import {
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
 } from "./hash-chained-jsonl.js";
-import type { GatewayAuditRecord } from "./types.js";
-import type { JsonObject } from "./types.js";
+import type { GatewayAuditRecord, JsonObject } from "./types.js";
 
 export interface AuditSink {
   append(record: GatewayAuditRecord): void | Promise<void>;
@@ -126,7 +125,9 @@ export class DurableAuditStore implements AuditSink {
     }
     if (logicalOrdinal === cursor.lastOrdinal) {
       if (cursor.lastKey !== logicalKeySha256 || cursor.lastResult === null) {
-        throw new Error("Audit logical ordinal was reused with a different key.");
+        throw new Error(
+          "Audit logical ordinal was reused with a different key.",
+        );
       }
       return cursor.lastResult;
     }
@@ -135,7 +136,8 @@ export class DurableAuditStore implements AuditSink {
     while (true) {
       const candidate = cursor.pending;
       if (candidate !== null) cursor.pending = null;
-      const next = candidate === null ? await this.log.readNext(cursor.stream) : null;
+      const next =
+        candidate === null ? await this.log.readNext(cursor.stream) : null;
       if (candidate === null) {
         if (next === null) {
           cursor.lastResult = false;
@@ -166,7 +168,9 @@ export class DurableAuditStore implements AuditSink {
       }
       this.cursors.set(harness, cursor);
       if (record.logical_key_sha256 !== logicalKeySha256) {
-        throw new Error("Audit logical identity conflicts with its request hash.");
+        throw new Error(
+          "Audit logical identity conflicts with its request hash.",
+        );
       }
       cursor.lastResult = true;
       return true;
@@ -180,7 +184,6 @@ export class DurableAuditStore implements AuditSink {
   close(): Promise<void> {
     return this.log.close();
   }
-
 }
 
 export function toAuditArtifact(record: GatewayAuditRecord): JsonObject {
@@ -191,8 +194,7 @@ export function toAuditArtifact(record: GatewayAuditRecord): JsonObject {
     harness: record.harness,
     transport: record.transport,
     credential_source: record.credentialSource,
-    credential_epoch_hmac_sha256:
-      record.credentialEpochHmacSha256 ?? null,
+    credential_epoch_hmac_sha256: record.credentialEpochHmacSha256 ?? null,
     credential_tier_hmac_sha256: record.credentialTierHmacSha256 ?? null,
     credential_capability_hmac_sha256:
       record.credentialCapabilityHmacSha256 ?? null,

--- a/packages/benchmarks/claude-subscription-gateway/src/claude-completion.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/claude-completion.ts
@@ -758,7 +758,8 @@ export function normalizeResetTimestampMs(value: unknown): number | null {
     return null;
   }
   const milliseconds = value < 1_000_000_000_000 ? value * 1_000 : value;
-  return Number.isSafeInteger(milliseconds) && milliseconds <= 8_640_000_000_000_000
+  return Number.isSafeInteger(milliseconds) &&
+    milliseconds <= 8_640_000_000_000_000
     ? milliseconds
     : null;
 }

--- a/packages/benchmarks/claude-subscription-gateway/src/cli.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/cli.ts
@@ -7,6 +7,7 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import {
   chmod,
+  type FileHandle,
   open,
   readFile,
   rename,
@@ -22,18 +23,18 @@ import {
   CLAUDE_AGENT_SDK_VERSION,
   ClaudeSdkCompletionRunner,
 } from "./claude-completion.js";
+import { parseGatewayContentContract } from "./content-attestation.js";
 import {
   type CredentialLeaseBroker,
   RotatingCredentialCompletionRunner,
 } from "./credential-rotation.js";
-import { parseGatewayContentContract } from "./content-attestation.js";
+import { ReplayJournal } from "./replay-journal.js";
 import {
   type ClaudeSubscriptionGatewayHandle,
-  type GatewayStorageGuard,
   GatewayStorageError,
+  type GatewayStorageGuard,
   startClaudeSubscriptionGateway,
 } from "./server.js";
-import { ReplayJournal } from "./replay-journal.js";
 import type { GatewayAuditRecord } from "./types.js";
 
 const PRIVATE_FILE_MODE = 0o600;
@@ -249,7 +250,9 @@ export function parseGatewayCliArguments(
   }
   if (
     contentContractFile !== null &&
-    [readyFile, auditFile, replayFile, hmacKeyFile].includes(contentContractFile)
+    [readyFile, auditFile, replayFile, hmacKeyFile].includes(
+      contentContractFile,
+    )
   ) {
     throw new GatewayCliError(
       "invalid_arguments",
@@ -319,7 +322,10 @@ function makeReadinessDocument(
 async function loadContentContract(target: string) {
   try {
     const fileStat = await stat(target);
-    if (!fileStat.isFile() || (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE) {
+    if (
+      !fileStat.isFile() ||
+      (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE
+    ) {
       throw new TypeError("content contract must be a private regular file");
     }
     const raw = await readFile(target, "utf8");
@@ -396,7 +402,7 @@ async function loadOrCreateHmacKey(target: string): Promise<Buffer> {
     if (!hasErrorCode(error, "ENOENT")) throw error;
   }
   const key = randomBytes(32);
-  let file;
+  let file: FileHandle;
   try {
     file = await open(target, "wx", PRIVATE_FILE_MODE);
   } catch (error: unknown) {
@@ -420,7 +426,10 @@ async function loadOrCreateHmacKey(target: string): Promise<Buffer> {
 
 async function loadHmacKey(target: string): Promise<Buffer> {
   const fileStat = await stat(target);
-  if (!fileStat.isFile() || (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE) {
+  if (
+    !fileStat.isFile() ||
+    (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE
+  ) {
     throw new GatewayCliError(
       "invalid_hmac_key_file",
       "The gateway HMAC key file must be a private regular file.",
@@ -443,17 +452,17 @@ async function loadCanonicalAccountPoolBroker(): Promise<CredentialLeaseBroker> 
     import.meta.url,
   ).href;
   const loaded: unknown = await import(moduleUrl);
-  const constructor =
+  const accountPoolBrokerConstructor =
     typeof loaded === "object" && loaded !== null
       ? Reflect.get(loaded, "AccountPoolBroker")
       : null;
-  if (typeof constructor !== "function") {
+  if (typeof accountPoolBrokerConstructor !== "function") {
     throw new GatewayCliError(
       "account_pool_unavailable",
       "The canonical account-pool broker is unavailable.",
     );
   }
-  const broker: unknown = Reflect.construct(constructor, []);
+  const broker: unknown = Reflect.construct(accountPoolBrokerConstructor, []);
   if (
     typeof broker !== "object" ||
     broker === null ||

--- a/packages/benchmarks/claude-subscription-gateway/src/content-attestation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/content-attestation.ts
@@ -158,10 +158,7 @@ function exactOccurrenceCount(haystack: string, needle: string): number {
   }
 }
 
-function occurrenceCount(
-  contents: readonly string[],
-  needle: string,
-): number {
+function occurrenceCount(contents: readonly string[], needle: string): number {
   return contents.reduce(
     (total, content) => total + exactOccurrenceCount(content, needle),
     0,
@@ -187,10 +184,7 @@ function categoryMatchCounts(
   return Object.fromEntries(
     Object.entries(categories).map(([category, texts]) => [
       category,
-      texts.reduce(
-        (total, text) => total + occurrenceCount(contents, text),
-        0,
-      ),
+      texts.reduce((total, text) => total + occurrenceCount(contents, text), 0),
     ]),
   );
 }
@@ -201,16 +195,16 @@ export function buildGatewayContentAttestation(
   messages: readonly NormalizedChatMessage[],
 ): GatewayContentAttestation {
   const instructionContents = messages
-    .filter((message) =>
-      message.role === "system" || message.role === "developer",
+    .filter(
+      (message) => message.role === "system" || message.role === "developer",
     )
     .map((message) => message.content ?? "");
   const userContents = messages
     .filter((message) => message.role === "user")
     .map((message) => message.content ?? "");
   const generatedContents = messages
-    .filter((message) =>
-      message.role === "assistant" || message.role === "tool",
+    .filter(
+      (message) => message.role === "assistant" || message.role === "tool",
     )
     .map((message) => message.content ?? "");
   const ingressContents = [...instructionContents, ...userContents];
@@ -239,7 +233,10 @@ export function buildGatewayContentAttestation(
       instructionContents,
       contract.systemHint,
     ),
-    systemHintUserOccurrences: occurrenceCount(userContents, contract.systemHint),
+    systemHintUserOccurrences: occurrenceCount(
+      userContents,
+      contract.systemHint,
+    ),
     systemHintGeneratedOccurrences: occurrenceCount(
       generatedContents,
       contract.systemHint,
@@ -259,10 +256,7 @@ export function buildGatewayContentAttestation(
     forbiddenIngressMatchCounts,
     forbiddenIngressMatchTotal: Object.values(
       forbiddenIngressMatchCounts,
-    ).reduce(
-      (total, count) => total + count,
-      0,
-    ),
+    ).reduce((total, count) => total + count, 0),
     forbiddenGeneratedMatchCounts,
     forbiddenGeneratedMatchTotal: Object.values(
       forbiddenGeneratedMatchCounts,

--- a/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
@@ -82,7 +82,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
 
   constructor(options: RotatingCredentialCompletionRunnerOptions) {
     if (options.hmacKey.length < 32) {
-      throw new TypeError("Credential HMAC key must contain at least 32 bytes.");
+      throw new TypeError(
+        "Credential HMAC key must contain at least 32 bytes.",
+      );
     }
     this.inner = options.completionRunner;
     this.broker = options.broker ?? null;
@@ -111,7 +113,7 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
             providerId: "anthropic-subscription",
             sessionKey: `claude-benchmark:${context.requestId}`,
             strategy: "quota-aware",
-            ...(excluded.length > 0 ? { exclude: excluded } : {}),
+            ...(excluded.length > 0 ? { exclude: [...excluded] } : {}),
           })
         : null;
       if (lease === null) break;
@@ -129,7 +131,10 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
           credentialTierValidator: (subscriptionType) =>
             this.assertTierParity(subscriptionType),
         });
-        const decorated = this.decorateResult(result, `linked:${lease.accountId}`);
+        const decorated = this.decorateResult(
+          result,
+          `linked:${lease.accountId}`,
+        );
         await this.broker?.report({
           leaseId: lease.leaseId,
           ok: true,
@@ -187,10 +192,7 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
       if (!sawRateLimit && lastAuthenticationFailure !== null) {
         throw lastAuthenticationFailure;
       }
-      throw new ClaudeRateLimitError(
-        earliestKnownReset,
-        knownRateLimitType,
-      );
+      throw new ClaudeRateLimitError(earliestKnownReset, knownRateLimitType);
     }
     try {
       const ambient = await this.inner.complete({
@@ -208,11 +210,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
           earliestKnownReset = error.retryAtMs;
           knownRateLimitType = error.rateLimitType;
         }
-        throw new ClaudeRateLimitError(
-          earliestKnownReset,
-          knownRateLimitType,
-          { cause: error },
-        );
+        throw new ClaudeRateLimitError(earliestKnownReset, knownRateLimitType, {
+          cause: error,
+        });
       }
       throw error;
     }
@@ -244,7 +244,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
   }
 
   private hmac(value: string): string {
-    return createHmac("sha256", this.hmacKey).update(value, "utf8").digest("hex");
+    return createHmac("sha256", this.hmacKey)
+      .update(value, "utf8")
+      .digest("hex");
   }
 }
 

--- a/packages/benchmarks/claude-subscription-gateway/src/hash-chained-jsonl.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/hash-chained-jsonl.ts
@@ -6,7 +6,7 @@
 
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { open, type FileHandle } from "node:fs/promises";
+import { type FileHandle, open } from "node:fs/promises";
 import { dirname } from "node:path";
 import { stableJson } from "./canonical.js";
 import type { JsonObject, JsonValue } from "./types.js";
@@ -68,7 +68,9 @@ export class HashChainedJsonl {
       !Number.isSafeInteger(normalized.maxRecordBytes) ||
       normalized.maxRecordBytes <= 0
     ) {
-      throw new TypeError("Hash-chain record limit must be a positive integer.");
+      throw new TypeError(
+        "Hash-chain record limit must be a positive integer.",
+      );
     }
     const file = await open(
       target,
@@ -131,7 +133,8 @@ export class HashChainedJsonl {
     });
     this.appendTail = operation;
     return operation.then(() => {
-      if (appended === null) throw new Error("Hash-chain append did not commit.");
+      if (appended === null)
+        throw new Error("Hash-chain append did not commit.");
       return appended;
     });
   }
@@ -154,7 +157,9 @@ export class HashChainedJsonl {
   async readNext(cursor: HashChainedJsonlCursor): Promise<JsonObject | null> {
     await this.appendTail;
     if (!Number.isSafeInteger(cursor.offset) || cursor.offset < 0) {
-      throw new TypeError("Hash-chain read offset must be a non-negative integer.");
+      throw new TypeError(
+        "Hash-chain read offset must be a non-negative integer.",
+      );
     }
     const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
     while (cursor.pending.length <= this.options.maxRecordBytes) {
@@ -332,7 +337,9 @@ function assertNoReservedFields(
     options.recordHashField,
   ]) {
     if (field in payload) {
-      throw new TypeError(`Hash-chain payload contains reserved field ${field}.`);
+      throw new TypeError(
+        `Hash-chain payload contains reserved field ${field}.`,
+      );
     }
   }
 }

--- a/packages/benchmarks/claude-subscription-gateway/src/index.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/index.ts
@@ -27,6 +27,11 @@ export {
   normalizeResetTimestampMs,
 } from "./claude-completion.js";
 export {
+  buildGatewayContentAttestation,
+  gatewayContentAttestationViolation,
+  parseGatewayContentContract,
+} from "./content-attestation.js";
+export {
   type CredentialBrokerLease,
   type CredentialLeaseBroker,
   CredentialParityError,
@@ -34,29 +39,15 @@ export {
   type RotatingCredentialCompletionRunnerOptions,
 } from "./credential-rotation.js";
 export {
-  buildGatewayContentAttestation,
-  gatewayContentAttestationViolation,
-  parseGatewayContentContract,
-} from "./content-attestation.js";
-export {
   FairHarnessQueue,
   type FairHarnessQueueOptions,
   QueueCapacityError,
   type QueuedResult,
 } from "./fair-queue.js";
 export {
-  GatewayStorageError,
-  type ClaudeSubscriptionGatewayHandle,
-  type GatewayHarnessEnvironment,
-  type GatewayLogger,
-  type GatewayStorageGuard,
-  type StartClaudeSubscriptionGatewayOptions,
-  startClaudeSubscriptionGateway,
-} from "./server.js";
-export {
   HashChainCorruptionError,
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
   type HashChainedJsonlOptions,
 } from "./hash-chained-jsonl.js";
 export {
@@ -70,6 +61,15 @@ export {
   ReplayJournal,
   ReplayMismatchError,
 } from "./replay-journal.js";
+export {
+  type ClaudeSubscriptionGatewayHandle,
+  type GatewayHarnessEnvironment,
+  type GatewayLogger,
+  GatewayStorageError,
+  type GatewayStorageGuard,
+  type StartClaudeSubscriptionGatewayOptions,
+  startClaudeSubscriptionGateway,
+} from "./server.js";
 export type {
   CanonicalChatCompletion,
   CapturedToolCall,

--- a/packages/benchmarks/claude-subscription-gateway/src/logical-request.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/logical-request.ts
@@ -25,7 +25,7 @@ export class LogicalRequestAllocator {
   private readonly nextOrdinalByHarness = new Map<string, number>();
   readonly namespaceSha256: string;
 
-  constructor(private readonly namespace: string) {
+  constructor(namespace: string) {
     if (!SAFE_NAMESPACE_PATTERN.test(namespace)) {
       throw new TypeError(
         "Benchmark namespace must be 1-128 safe identifier characters.",

--- a/packages/benchmarks/claude-subscription-gateway/src/replay-journal.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/replay-journal.ts
@@ -6,8 +6,8 @@
 
 import {
   HashChainCorruptionError,
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
 } from "./hash-chained-jsonl.js";
 import {
   computeLogicalKeySha256,
@@ -42,7 +42,9 @@ export class ReplayMismatchError extends Error {
   readonly statusCode = 409;
 
   constructor() {
-    super("A replay ordinal was reused with different canonical request content.");
+    super(
+      "A replay ordinal was reused with different canonical request content.",
+    );
     this.name = "ReplayMismatchError";
   }
 }
@@ -115,7 +117,8 @@ export class ReplayJournal {
     while (true) {
       const pending = cursor.pending;
       if (pending !== null) cursor.pending = null;
-      const next = pending === null ? await this.log.readNext(cursor.stream) : null;
+      const next =
+        pending === null ? await this.log.readNext(cursor.stream) : null;
       if (pending === null) {
         if (next === null) {
           cursor.lastResult = null;
@@ -236,7 +239,9 @@ interface ParsedJournalRecord {
 
 function parseJournalRecord(record: JsonObject): ParsedJournalRecord {
   if (record.kind !== "completion" || record.journal_schema_version !== 1) {
-    throw new HashChainCorruptionError("Replay journal record kind is invalid.");
+    throw new HashChainCorruptionError(
+      "Replay journal record kind is invalid.",
+    );
   }
   const harness = requiredString(record.harness, "harness");
   const logicalNamespaceSha256 = requiredHash(
@@ -317,7 +322,10 @@ function parseCompletionResult(value: unknown): ClaudeCompletionResult {
           })(),
     resultSubtype: requiredString(value.resultSubtype, "result subtype"),
     terminalReason: nullableString(value.terminalReason, "terminal reason"),
-    subscriptionType: requiredString(value.subscriptionType, "subscription tier"),
+    subscriptionType: requiredString(
+      value.subscriptionType,
+      "subscription tier",
+    ),
     credentialEpochHmacSha256: requiredHash(
       value.credentialEpochHmacSha256,
       "credential epoch",
@@ -410,11 +418,7 @@ function nullableString(value: unknown, label: string): string | null {
 }
 
 function requiredInteger(value: unknown, label: string): number {
-  if (
-    typeof value !== "number" ||
-    !Number.isSafeInteger(value) ||
-    value < 0
-  ) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
     throw new HashChainCorruptionError(`Replay ${label} is invalid.`);
   }
   return value;

--- a/packages/benchmarks/claude-subscription-gateway/src/server.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/server.ts
@@ -19,21 +19,21 @@ import {
   stableJson,
 } from "./canonical.js";
 import {
-  buildGatewayContentAttestation,
-  gatewayContentAttestationViolation,
-} from "./content-attestation.js";
-import {
   CLAUDE_AGENT_SDK_VERSION,
   ClaudeCompletionError,
   ClaudeRateLimitError,
   ClaudeSdkCompletionRunner,
 } from "./claude-completion.js";
+import {
+  buildGatewayContentAttestation,
+  gatewayContentAttestationViolation,
+} from "./content-attestation.js";
 import { FairHarnessQueue, QueueCapacityError } from "./fair-queue.js";
 import {
-  LogicalRequestAllocator,
   type LogicalRequest,
+  LogicalRequestAllocator,
 } from "./logical-request.js";
-import { ReplayJournal, ReplayMismatchError } from "./replay-journal.js";
+import { type ReplayJournal, ReplayMismatchError } from "./replay-journal.js";
 import type {
   ClaudeCompletionResult,
   CompletionFinishReason,
@@ -404,13 +404,8 @@ async function handleRequest(
         ),
       };
     });
-    const {
-      result,
-      serviceMs,
-      created,
-      executionOrigin,
-      responseQueueWaitMs,
-    } = queued.value;
+    const { result, serviceMs, created, executionOrigin, responseQueueWaitMs } =
+      queued.value;
     const finishReason: CompletionFinishReason =
       result.toolCalls.length > 0 ? "tool_calls" : "stop";
     const completionAlreadyAudited =
@@ -726,11 +721,7 @@ interface AuditRecordInput {
     | "pause_control";
   deliveryAttempt: number | null;
   retryAt?: string | null;
-  pauseReason?:
-    | "rate_limit"
-    | "rate_limit_unknown"
-    | "storage_reserve"
-    | null;
+  pauseReason?: "rate_limit" | "rate_limit_unknown" | "storage_reserve" | null;
 }
 
 function makeAuditRecord(input: AuditRecordInput): GatewayAuditRecord {
@@ -781,10 +772,8 @@ function makeAuditRecord(input: AuditRecordInput): GatewayAuditRecord {
     deliveryAttempt: input.deliveryAttempt ?? undefined,
     executionOrigin: input.executionOrigin,
     auditEvent: input.auditEvent,
-    credentialEpochHmacSha256:
-      input.result?.credentialEpochHmacSha256 ?? null,
-    credentialTierHmacSha256:
-      input.result?.credentialTierHmacSha256 ?? null,
+    credentialEpochHmacSha256: input.result?.credentialEpochHmacSha256 ?? null,
+    credentialTierHmacSha256: input.result?.credentialTierHmacSha256 ?? null,
     credentialCapabilityHmacSha256:
       input.result?.credentialCapabilityHmacSha256 ?? null,
     retryAt: input.retryAt ?? null,
@@ -891,18 +880,6 @@ function normalizeHarness(value: string): string {
       400,
     );
   }
-  return normalized;
-}
-
-function normalizeRequestId(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^A-Za-z0-9_-]/g, "")
-    .slice(0, 80);
-  if (!normalized)
-    throw new Error(
-      "[ClaudeSubscriptionGateway] request id factory returned no safe text",
-    );
   return normalized;
 }
 

--- a/packages/benchmarks/claude-subscription-gateway/src/types.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/types.ts
@@ -224,9 +224,5 @@ export interface GatewayAuditRecord {
   credentialTierHmacSha256?: string | null;
   credentialCapabilityHmacSha256?: string | null;
   retryAt?: string | null;
-  pauseReason?:
-    | "rate_limit"
-    | "rate_limit_unknown"
-    | "storage_reserve"
-    | null;
+  pauseReason?: "rate_limit" | "rate_limit_unknown" | "storage_reserve" | null;
 }

--- a/packages/benchmarks/claude-subscription-gateway/tests/claude-completion.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/claude-completion.test.ts
@@ -6,7 +6,7 @@ import type { ClaudeAgentSdkModule } from "../src/index.js";
 import {
   assertNoApiBillingEnvironment,
   buildClaudeCodeManagedEnvironment,
-  ClaudeRateLimitError,
+  type ClaudeRateLimitError,
   ClaudeSdkCompletionRunner,
   canonicalizeChatCompletion,
   FORBIDDEN_API_BILLING_ENV_NAMES,

--- a/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
@@ -2,16 +2,20 @@
 
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, statfs } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  type GatewayReadinessDocument,
   inspectBrokerReadiness,
+  MinimumFreeSpaceGuard,
+  parseGatewayCliArguments,
   runGatewayCli,
   writeAuditJsonl,
+  writeReadinessFile,
 } from "../src/cli.js";
 import {
   buildClaudeCodeManagedEnvironment,
@@ -117,6 +121,156 @@ describe("gateway CLI", () => {
         tool_schema_sha256_by_name: { weather: "e".repeat(64) },
         queue_wait_ms: 12,
         service_ms: 34,
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("parses every lifecycle option and rejects unsafe artifact layouts", () => {
+    const root = join(tmpdir(), "claude-gateway-cli-arguments");
+    const readyFile = join(root, "cohort.ready.json");
+    const auditFile = join(root, "cohort.audit.jsonl");
+    const replayFile = join(root, "cohort.replay.jsonl");
+    const hmacKeyFile = join(root, "cohort.hmac-key");
+    const contentContractFile = join(root, "content-contract.json");
+
+    expect(
+      parseGatewayCliArguments([
+        "--",
+        "--ready-file",
+        readyFile,
+        "--audit-file",
+        auditFile,
+        "--content-contract-file",
+        contentContractFile,
+        "--replay-file",
+        replayFile,
+        "--hmac-key-file",
+        hmacKeyFile,
+        "--benchmark-namespace",
+        "cohort-7",
+        "--storage-root",
+        root,
+        "--minimum-free-bytes",
+        "4096",
+      ]),
+    ).toEqual({
+      readyFile,
+      auditFile,
+      contentContractFile,
+      replayFile,
+      hmacKeyFile,
+      benchmarkNamespace: "cohort-7",
+      storageRoot: root,
+      minimumFreeBytes: 4096,
+    });
+
+    const required = ["--ready-file", readyFile, "--audit-file", auditFile];
+    const invalid: Array<{ argv: string[]; message: string }> = [
+      {
+        argv: ["--ready-file"],
+        message: "Gateway file flags require absolute paths.",
+      },
+      {
+        argv: ["--unsupported", root, ...required],
+        message: "An unsupported gateway lifecycle flag was supplied.",
+      },
+      {
+        argv: ["--ready-file", readyFile, "--audit-file", readyFile],
+        message:
+          "Distinct absolute --ready-file and --audit-file paths are required.",
+      },
+      {
+        argv: [...required, "--replay-file", readyFile],
+        message:
+          "Gateway readiness, audit, replay, and HMAC-key paths must be distinct.",
+      },
+      {
+        argv: [...required, "--content-contract-file", auditFile],
+        message:
+          "The content contract path must be distinct from gateway artifacts.",
+      },
+      {
+        argv: [...required, "--minimum-free-bytes", "-1"],
+        message: "--minimum-free-bytes must be a non-negative safe integer.",
+      },
+      {
+        argv: ["--ready-file", "relative.json", "--audit-file", auditFile],
+        message: "--ready-file must be an absolute path.",
+      },
+    ];
+    for (const scenario of invalid) {
+      expect(() => parseGatewayCliArguments(scenario.argv)).toThrowError(
+        scenario.message,
+      );
+    }
+  });
+
+  it("atomically publishes the complete readiness contract as private JSON", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "claude-gateway-ready-"));
+    const readyFile = join(directory, "cohort.ready.json");
+    const readiness: GatewayReadinessDocument = {
+      schema_version: 1,
+      status: "ready",
+      pid: 42,
+      origin: "http://127.0.0.1:43123",
+      base_url: "http://127.0.0.1:43123/v1",
+      health_url: "http://127.0.0.1:43123/health",
+      transport: {
+        provider: "claude-agent-sdk",
+        sdk_version: "0.3.200",
+        credential_policy: "claude-code-oauth-only",
+        fresh_session_per_request: true,
+        tool_execution: "capture-only",
+        response_modes: ["json", "sse"],
+      },
+      harness_tokens: {
+        eliza: "eliza-private-token",
+        hermes: "hermes-private-token",
+        openclaw: "openclaw-private-token",
+      },
+      credential_readiness: {
+        linked_pool_configured: true,
+        linked_pool_selectable: true,
+        ambient_keychain_required: false,
+      },
+    };
+
+    try {
+      await writeReadinessFile(readyFile, readiness);
+
+      expect(statMode(await stat(readyFile))).toBe(PRIVATE_MODE);
+      expect(await readFile(readyFile, "utf8")).toBe(
+        `${JSON.stringify(readiness)}\n`,
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("checks the real filesystem reserve and fails closed below it", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "claude-gateway-storage-"));
+
+    try {
+      await expect(
+        new MinimumFreeSpaceGuard(
+          join(directory, "not-created"),
+          0,
+        ).assertReady(),
+      ).resolves.toBeUndefined();
+      const fileSystem = await statfs(directory);
+      const availableBytes =
+        BigInt(fileSystem.bavail) * BigInt(fileSystem.bsize);
+      expect(availableBytes).toBeLessThan(BigInt(Number.MAX_SAFE_INTEGER));
+      await expect(
+        new MinimumFreeSpaceGuard(
+          directory,
+          Number(availableBytes) + 1,
+        ).assertReady(),
+      ).rejects.toMatchObject({
+        code: "insufficient_storage",
+        statusCode: 507,
       });
     } finally {
       await rm(directory, { recursive: true, force: true });
@@ -267,6 +421,49 @@ describe("gateway CLI", () => {
       linkedPoolConfigured: true,
       linkedPoolSelectable: false,
     });
+  });
+
+  it("preflights and releases one selectable subscription lease", async () => {
+    const leaseRequests: Array<Parameters<CredentialLeaseBroker["lease"]>[0]> =
+      [];
+    const releasedLeaseIds: string[] = [];
+    const broker: CredentialLeaseBroker = {
+      async lease(request) {
+        leaseRequests.push(request);
+        return {
+          leaseId: "lease-7",
+          providerId: "anthropic-subscription",
+          accountId: "account-7",
+          accessToken: "private-token",
+        };
+      },
+      report: async () => ({ ok: true }),
+      release({ leaseId }) {
+        releasedLeaseIds.push(leaseId);
+      },
+      health: () => ({
+        providers: [
+          {
+            providerId: "anthropic-subscription",
+            total: 2,
+            selectable: 1,
+          },
+        ],
+      }),
+    };
+
+    await expect(inspectBrokerReadiness(broker)).resolves.toEqual({
+      linkedPoolConfigured: true,
+      linkedPoolSelectable: true,
+    });
+    expect(leaseRequests).toEqual([
+      {
+        providerId: "anthropic-subscription",
+        sessionKey: "claude-benchmark:startup-preflight",
+        strategy: "quota-aware",
+      },
+    ]);
+    expect(releasedLeaseIds).toEqual(["lease-7"]);
   });
 });
 

--- a/packages/benchmarks/claude-subscription-gateway/tests/content-attestation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/content-attestation.test.ts
@@ -42,7 +42,9 @@ describe("gateway content attestation", () => {
     });
     expect(proof.forbiddenIngressMatchTotal).toBe(0);
     expect(proof.observedIngressMatchCounts).toEqual({ workspace_paths: 1 });
-    expect(proof.observedInstructionMatchCounts).toEqual({ workspace_paths: 0 });
+    expect(proof.observedInstructionMatchCounts).toEqual({
+      workspace_paths: 0,
+    });
     expect(proof.observedUserMatchCounts).toEqual({ workspace_paths: 1 });
     expect(proof.messageContentManifest).toHaveLength(4);
     const serialized = JSON.stringify(proof);

--- a/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
@@ -3,12 +3,12 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import {
-  canonicalizeChatCompletion,
   type ClaudeCompletionResult,
   ClaudeRateLimitError,
   type CompletionContext,
   type CompletionRunner,
   type CredentialLeaseBroker,
+  canonicalizeChatCompletion,
   RotatingCredentialCompletionRunner,
 } from "../src/index.js";
 
@@ -17,7 +17,9 @@ const HMAC_KEY = Buffer.alloc(32, 7);
 describe("RotatingCredentialCompletionRunner", () => {
   it("rotates linked leases on quota with one stable session key and token-only injection", async () => {
     const leases = [lease("a", "token-a"), lease("b", "token-b"), null];
-    const leaseBroker = vi.fn(async () => leases.shift() ?? null);
+    const leaseBroker = vi.fn<CredentialLeaseBroker["lease"]>(
+      async () => leases.shift() ?? null,
+    );
     const broker: CredentialLeaseBroker = {
       lease: leaseBroker,
       report: vi.fn(async () => ({ ok: true })),
@@ -29,10 +31,7 @@ describe("RotatingCredentialCompletionRunner", () => {
         contexts.push(context);
         context.credentialTierValidator?.("Claude Max");
         if (context.credentialOAuthToken === "token-a") {
-          throw new ClaudeRateLimitError(
-            2_000_000_000_000,
-            "seven_day",
-          );
+          throw new ClaudeRateLimitError(2_000_000_000_000, "seven_day");
         }
         return completionResult();
       },
@@ -136,9 +135,7 @@ describe("RotatingCredentialCompletionRunner", () => {
       broker: null,
       hmacKey: HMAC_KEY,
       expectedTierHmacSha256: expectedTier,
-      expectedCapabilityHmacSha256: hmac(
-        "firstParty:oauth:subscription",
-      ),
+      expectedCapabilityHmacSha256: hmac("firstParty:oauth:subscription"),
     });
 
     await expect(runner.complete(completionContext())).rejects.toMatchObject({

--- a/packages/benchmarks/claude-subscription-gateway/tests/durable-storage.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/durable-storage.test.ts
@@ -1,6 +1,13 @@
 /** Verifies crash repair, committed-corruption rejection, and bounded audit cursor idempotence on real files. */
 
-import { appendFile, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
@@ -6,10 +6,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   type AuditSink,
-  canonicalizeChatCompletion,
-  DurableAuditStore,
   type ClaudeCompletionResult,
   type CompletionRunner,
+  canonicalizeChatCompletion,
+  DurableAuditStore,
   type GatewayAuditRecord,
   LogicalRequestAllocator,
   ReplayJournal,
@@ -18,29 +18,43 @@ import {
 
 const TOKEN = "eliza-replay-token-0000000000000000000000000001";
 
+function deferredSignal(): { wait: Promise<void>; signal: () => void } {
+  let resolveWait: (() => void) | null = null;
+  const wait = new Promise<void>((resolve) => {
+    resolveWait = () => resolve();
+  });
+  return {
+    wait,
+    signal() {
+      if (resolveWait === null) {
+        throw new Error("Deferred signal resolver was not initialized.");
+      }
+      resolveWait();
+    },
+  };
+}
+
 describe("gateway replay", () => {
   it("commits the private success before awaiting public audit and HTTP delivery", async () => {
     const directory = await mkdtemp(join(tmpdir(), "gateway-ordering-"));
     const journalPath = join(directory, "responses.jsonl");
-    let enterAudit: (() => void) | null = null;
-    const auditEntered = new Promise<void>((resolve) => {
-      enterAudit = resolve;
-    });
-    let releaseAudit: (() => void) | null = null;
-    const auditReleased = new Promise<void>((resolve) => {
-      releaseAudit = resolve;
-    });
+    const auditEntered = deferredSignal();
+    const auditReleased = deferredSignal();
     const auditSink: AuditSink = {
       append(_record: GatewayAuditRecord) {
-        enterAudit?.();
-        return auditReleased;
+        auditEntered.signal();
+        return auditReleased.wait;
       },
     };
 
     try {
       const journal = await ReplayJournal.open(journalPath);
       const gateway = await startClaudeSubscriptionGateway({
-        completionRunner: { async complete() { return completionResult(); } },
+        completionRunner: {
+          async complete() {
+            return completionResult();
+          },
+        },
         replayJournal: journal,
         auditSink,
         benchmarkNamespace: "ordering-test",
@@ -55,16 +69,16 @@ describe("gateway replay", () => {
         return response;
       });
 
-      await auditEntered;
+      await auditEntered.wait;
       expect((await readFile(journalPath, "utf8")).trim()).not.toBe("");
       await Promise.resolve();
       expect(delivered).toBe(false);
-      releaseAudit?.();
+      auditReleased.signal();
       expect((await pendingResponse).status).toBe(200);
       await gateway.close();
       await journal.close();
     } finally {
-      releaseAudit?.();
+      auditReleased.signal();
       await rm(directory, { recursive: true, force: true });
     }
   });

--- a/packages/benchmarks/claude-subscription-gateway/tests/server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/server.test.ts
@@ -636,16 +636,20 @@ describe("startClaudeSubscriptionGateway", () => {
       request(HERMES_TOKEN),
       request(OPENCLAW_TOKEN),
     ]);
-    expect(responses.map((response) => response.status)).toEqual([429, 429, 429]);
+    expect(responses.map((response) => response.status)).toEqual([
+      429, 429, 429,
+    ]);
     expect(completionCalls).toBe(1);
     expect(handle.auditStore.snapshot()).toHaveLength(3);
     expect(
-      handle.auditStore.snapshot().every(
-        (record) =>
-          record.status === "paused" &&
-          record.pauseReason === "rate_limit" &&
-          record.auditEvent === "pause_control",
-      ),
+      handle.auditStore
+        .snapshot()
+        .every(
+          (record) =>
+            record.status === "paused" &&
+            record.pauseReason === "rate_limit" &&
+            record.auditEvent === "pause_control",
+        ),
     ).toBe(true);
   });
 


### PR DESCRIPTION
# Relates to

Fixes #16801.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto latest `origin/develop` (`d0cb9c6d72`) with zero conflicts.
- [x] `bun install` and the package quality gates were run after sync. Root verification failures are recorded below with their exact unrelated blockers.
- [x] The command evidence below lets a reviewer confirm the change without reading the implementation.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] Package verification passes post-sync; exact unrelated root blockers are documented under **Known gaps / failures**.

# Risks

Low. The diff is confined to the Claude subscription gateway benchmark. It restores the package's declared TypeScript compiler contract, applies Biome's required formatting/import organization, strengthens strict typing and real CLI contract coverage, and snapshots a mutable lease-exclusion list before passing it across the broker boundary.

# Background

## What does this PR do?

- Replaces the undeclared `tsgo` typecheck command with the package's declared TypeScript 6 `tsc` binary, matching neighboring benchmark packages.
- Clears all 23 Biome errors and five warnings, including dead members, a shadowing identifier, and type-only imports.
- Gives the credential broker an immutable exclusion snapshot so later retries cannot mutate an earlier lease request.
- Makes test synchronization and mocks explicit enough for strict TypeScript without weakening assertions.
- Exercises the real CLI contracts for complete argument validation, atomic private readiness publication, filesystem-reserve enforcement, and selectable account-pool preflight/release. This raises changed-file coverage for `src/cli.ts` from 27.37% to 52.63%.

## What kind of change is this?

Bug fix and CI-quality-gate repair.

# Documentation changes needed?

No. Runtime behavior and user-facing contracts are unchanged; package scripts now match the compiler dependency already declared in `package.json`.

# Testing

## Where should a reviewer start?

Run the four package commands and the changed-file coverage harness below from the repository root. The CLI suite uses real files, filesystem statistics, and broker lifecycle calls; the credential-rotation suite proves successive broker calls receive stable exclusion histories.

## Detailed testing steps

```text
$ bun run --cwd packages/benchmarks/claude-subscription-gateway lint:check
Checked 25 files in 28ms. No fixes applied.

$ bun run --cwd packages/benchmarks/claude-subscription-gateway format:check
Checked 25 files in 18ms. No fixes applied.

$ bun run --cwd packages/benchmarks/claude-subscription-gateway typecheck
$ tsc --noEmit

$ bun run --cwd packages/benchmarks/claude-subscription-gateway test
Test Files  9 passed (9)
Tests       62 passed (62)

$ node packages/scripts/run-changed-vitest-coverage.mjs <the seven changed gateway test files>
Test Files  7 passed (7)
Tests       53 passed (53)
src/cli.ts  52.63% (100/190 lines; threshold 50%)
All nine changed production source files: coverage gate OK

$ git diff --check origin/develop...HEAD
(no output; exit 0)

$ bun run audit:error-policy-ratchet
[error-policy-ratchet] no new fallback-slop in touched files
```

Baseline reproduction before the fix: package lint reported 23 errors and five warnings; package typecheck exited 127 because `tsgo` was not installed. After building the existing core prerequisite used by the CLI test, the baseline package tests were 57/58; the remaining credential-rotation failure exposed the mutable request-array bug fixed here. The initial changed-file run omitted the unchanged CLI suite and reported `src/cli.ts` as missing; running that existing suite alone covered only 27.37%, below the 50% floor. The final package suite is 62/62 and the exact changed-file lane is 53/53 with `src/cli.ts` at 52.63%.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a package-local CI/toolchain and deterministic benchmark test repair with no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production server path is changed; command output above exercises the real package quality gates and loopback test server.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request state is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes; package tests deliberately use injected deterministic completion runners and spend no credits.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent product-domain artifact is produced; the relevant artifacts are the compiler, Biome, 62-test package output, and enforced changed-file coverage output included above.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changes, and this package's normal test contract is deterministic/injected.

## Backend + frontend logs

N/A - no production backend or frontend path changes. The package command logs above are the applicable execution evidence.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio change.

## Known gaps / failures

- Root `bun run lint` advances past this package but fails on existing `plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts:24` (`lint/correctness/noUnsafeOptionalChaining`). That file is outside this PR.
- Root `bun run typecheck` advances past this package but first fails in `@elizaos/plugin-calendar#typecheck`: unresolved `@elizaos/security/kms`, `@elizaos/plugin-remote-manifest` (including `worker-runtime/error`), and `@elizaos/plugin-aosp-local-inference`, plus three existing plugin-coding-tools `getService` shape mismatches. Those packages are outside this PR.
- No live-model run was made because this change does not affect model execution and the package guide explicitly defines the default suite as deterministic and credit-free.
