### PR TITLE
fix(cloud): align staging wrangler.toml realtime flag with live worker (stop next deploy killing realtime voice)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -437,9 +437,11 @@ INFERENCE_PASSTHROUGH_STREAMING = "true"
 # through the identical settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
 
-# Realtime voice is committed default-off. Staging soaks require an explicit
-# deploy/runtime opt-in; production remains explicitly off.
-VOICE_REALTIME_WS_ENABLED = "false"
+# Realtime voice is enabled on staging (proven live E2E 2026-07-22, EOT->first-audio
+# median ~1446ms). The live staging worker already runs true; this keeps the toml in
+# sync so a redeploy from develop does not silently flip realtime OFF. Production
+# remains explicitly off (flag flip there is a separate, gated decision).
+VOICE_REALTIME_WS_ENABLED = "true"
 VOICE_REALTIME_CARTESIA_VOICE_ID = "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4"
 VOICE_REALTIME_ELIZA_ENDPOINT = "https://api-staging.elizacloud.ai"
 VOICE_REALTIME_ELIZA_MODEL = "gemma-4-31b"


### PR DESCRIPTION
## What

One-value change: set `VOICE_REALTIME_WS_ENABLED = "true"` in the **staging** env block of `packages/cloud/api/wrangler.toml` (plus a comment refresh). Production block **unchanged**.

## Why (deploy-config drift, demo T-~21h)

The live `eliza-cloud-api-staging` worker **already runs `VOICE_REALTIME_WS_ENABLED=true`** — realtime streaming voice was proven end-to-end on 2026-07-22 (EOT→first-audio **median ~1446ms**, ~6.8x faster than the old batch path's 9901ms). But `origin/develop`'s wrangler.toml staging block still declared `"false"`.

**The risk:** the staging deploy we *want* (chat fixes + client bundle) would redeploy this stale `false` and **silently flip realtime voice OFF the night before the demo**. This PR makes the toml match the live worker so that can't happen.

## Live-worker evidence (read from CF bindings, acct 23cf6fea…, worker `eliza-cloud-api-staging`)

| Binding | toml (develop, before) | live worker | Action |
|---|---|---|---|
| `VOICE_REALTIME_WS_ENABLED` | `"false"` | **`true`** (plain_text) | **flip toml → `"true"`** |
| `VOICE_REALTIME_CARTESIA_VOICE_ID` | `db6b0ed5-…` | `db6b0ed5-…` | match, no change |
| `VOICE_REALTIME_ELIZA_ENDPOINT` | `https://api-staging.elizacloud.ai` | same (bare origin, correct-by-design — bridge appends agent stream path via `canonicalConversationStreamUrl`, PR #16192) | match, no change |
| `VOICE_REALTIME_ELIZA_MODEL` | `gemma-4-31b` | `gemma-4-31b` | match, no change |
| `DEEPGRAM_API_KEY` / `CARTESIA_API_KEY` / `VOICE_REALTIME_ELIZA_AUTHORIZATION` | secrets (not in toml) | set as secrets | secrets are not managed by toml `vars`; **not touched** — no key material in toml |

`VOICE_REALTIME_WS_ENABLED` is the **only** plaintext staging var that would regress the live worker on a develop deploy. Everything else already matches, so the diff is exactly one value + a comment sync.

## Production block

`[env.production.vars]` also has `VOICE_REALTIME_WS_ENABLED = "false"`, but that is **correct and intentional** — realtime is a staging-only soak; prod stays explicitly off. **Left unchanged.** A prod flag flip is a separate, gated decision (needs explicit owner sign-off) and is out of scope for this PR.

## Rollback

Flip the staging value back to `"false"` (or set `VOICE_REALTIME_WS_ENABLED=0` on the worker) — mint/consent/WS routes fall back to 404 and the client reverts to the batch path automatically (`isVoiceRealtimeWsEnabled` + `isRealtimeVoiceFlagEnabled` both fail closed).

## Tests / Evidence gate

| Row | Status |
|---|---|
| Unit/integration tests | **N/A** — deploy-config only, no code paths changed |
| TOML validity | ✅ parses (`tomllib.load` OK) |
| Diff scope | ✅ 1 value change (`false`→`true`) + comment refresh; staging-only |
| Live-worker parity confirmed | ✅ (table above) |

`wrangler.toml` is **not** a `.github/workflows` file — normal PR rules, no dual-model required.

## Diff

```diff
-# Realtime voice is committed default-off. Staging soaks require an explicit
-# deploy/runtime opt-in; production remains explicitly off.
-VOICE_REALTIME_WS_ENABLED = "false"
+# Realtime voice is enabled on staging (proven live E2E 2026-07-22, EOT->first-audio
+# median ~1446ms). The live staging worker already runs true; this keeps the toml in
+# sync so a redeploy from develop does not silently flip realtime OFF. Production
+# remains explicitly off (flag flip there is a separate, gated decision).
+VOICE_REALTIME_WS_ENABLED = "true"
```

[sol-wrangler-realtime-fix]