### PR TITLE
fix: restore current develop CI baseline

### DIFF
--- a/packages/agent/src/actions/page-action-groups.test.ts
+++ b/packages/agent/src/actions/page-action-groups.test.ts
@@ -71,43 +71,43 @@ async function invoke(
 }
 
 describe("PAGE_DELEGATE workflow alias repair", () => {
-  it.each([
-    "WORKFLOW_CREATE",
-    "CREATE_WORKFLOW",
-  ])("canonicalizes %s to WORKFLOW action=create using the user's request", async (alias) => {
-    let calls = 0;
-    let receivedOptions: HandlerOptions | undefined;
-    const handler: Action["handler"] = async (
-      _runtime,
-      _message,
-      _state,
-      options,
-    ): Promise<ActionResult> => {
-      calls += 1;
-      receivedOptions = options;
-      return {
-        success: true,
-        text: "created",
+  it.each(["WORKFLOW_CREATE", "CREATE_WORKFLOW"])(
+    "canonicalizes %s to WORKFLOW action=create using the user's request",
+    async (alias) => {
+      let calls = 0;
+      let receivedOptions: HandlerOptions | undefined;
+      const handler: Action["handler"] = async (
+        _runtime,
+        _message,
+        _state,
+        options,
+      ): Promise<ActionResult> => {
+        calls += 1;
+        receivedOptions = options;
+        return {
+          success: true,
+          text: "created",
+        };
       };
-    };
-    const runtime = makeRuntime(handler);
+      const runtime = makeRuntime(handler);
 
-    const result = await invoke(runtime, alias, {
-      definition: {
-        nodes: [{ type: "invented", parameters: { value: "wrong" } }],
-      },
-      active: false,
-    });
+      const result = await invoke(runtime, alias, {
+        definition: {
+          nodes: [{ type: "invented", parameters: { value: "wrong" } }],
+        },
+        active: false,
+      });
 
-    expect(result.success).toBe(true);
-    expect(calls).toBe(1);
-    expect(receivedOptions?.parameters).toEqual({
-      action: "create",
-      seedPrompt: CREATE_REQUEST,
-      active: false,
-    });
-    expect(receivedOptions?.parameters).not.toHaveProperty("definition");
-  });
+      expect(result.success).toBe(true);
+      expect(calls).toBe(1);
+      expect(receivedOptions?.parameters).toEqual({
+        action: "create",
+        seedPrompt: CREATE_REQUEST,
+        active: false,
+      });
+      expect(receivedOptions?.parameters).not.toHaveProperty("definition");
+    },
+  );
 
   it("preserves an already-canonical WORKFLOW delegation", async () => {
     let receivedOptions: HandlerOptions | undefined;

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -80,6 +80,15 @@ describe("TRIGGER create — prompt-kind reminders", () => {
     vi.useRealTimers();
   });
 
+  it("rejects creation when triggers are disabled", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    runtime.getSetting = () => "0";
+    const result = await create(runtime, { instructions: "drink water" });
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("TRIGGERS_OFF");
+    expect(createdTasks).toHaveLength(0);
+  });
+
   it("creates a prompt-kind once trigger from delaySeconds with autonomy off", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
     const before = Date.now();
@@ -155,6 +164,14 @@ describe("TRIGGER create — prompt-kind reminders", () => {
     expect(createdTasks).toHaveLength(0);
   });
 
+  it("rejects a trigger with no instructions or message text", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {}, "");
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("MISSING_INSTRUCTIONS");
+    expect(createdTasks).toHaveLength(0);
+  });
+
   it("rejects a sub-minute fractional delayMinutes instead of scheduling 'now'", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
     const result = await create(runtime, {
@@ -188,6 +205,45 @@ describe("TRIGGER create — prompt-kind reminders", () => {
     expect(createdTasks[0].metadata.trigger?.triggerType).toBe("once");
   });
 
+  it("rejects an unbounded relative delay instead of overflowing date math", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "far future reminder",
+      delaySeconds: 367 * 24 * 60 * 60,
+    });
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("INVALID_DELAY");
+    expect(createdTasks).toHaveLength(0);
+  });
+
+  it("rejects an invalid cron expression instead of creating a dead trigger", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "nightly report",
+      triggerType: "cron",
+      cronExpression: "not a cron schedule",
+    });
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("INVALID_CRON");
+    expect(createdTasks).toHaveLength(0);
+  });
+
+  it("creates a recurring prompt trigger from a valid cron expression", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "morning report",
+      triggerType: "cron",
+      cronExpression: "0 9 * * *",
+      wakeMode: "next_autonomy_cycle",
+    });
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0].metadata.trigger?.triggerType).toBe("cron");
+    expect(createdTasks[0].metadata.trigger?.cronExpression).toBe("0 9 * * *");
+    expect(createdTasks[0].metadata.trigger?.wakeMode).toBe(
+      "next_autonomy_cycle",
+    );
+  });
+
   it("dedupes an identical delay-derived reminder (planner retry double-emit)", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
     const first = await create(runtime, {
@@ -213,6 +269,28 @@ describe("TRIGGER create — prompt-kind reminders", () => {
     });
     expect(second?.success).toBe(true);
     expect(second?.data?.duplicateTaskId).toBeDefined();
+    expect(createdTasks).toHaveLength(1);
+  });
+
+  it("enforces the active-trigger limit for the requesting user", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "baseline reminder",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    const saturatedTasks = Array.from({ length: 100 }, (_, index) => ({
+      id: stringToUuid(`saturated-trigger-${index}`),
+      metadata: createdTasks[0].metadata,
+    })) as Task[];
+    vi.mocked(runtime.getTasks).mockResolvedValue(saturatedTasks);
+
+    const result = await create(runtime, {
+      instructions: "one reminder too many",
+      delaySeconds: 120,
+    });
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("LIMIT_REACHED");
     expect(createdTasks).toHaveLength(1);
   });
 });
@@ -241,9 +319,9 @@ describe("TRIGGER create — workflow triggers", () => {
     expect(result?.success).toBe(true);
     const trigger = createdTasks[0].metadata.trigger;
     expect(trigger?.kind).toBe("workflow");
-    expect(
-      trigger?.kind === "workflow" ? trigger.workflowId : undefined,
-    ).toBe("wf-1");
+    expect(trigger?.kind === "workflow" ? trigger.workflowId : undefined).toBe(
+      "wf-1",
+    );
     expect(createdTasks[0].roomId).toBe(AUTONOMY_ROOM_ID);
   });
 });

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -21,19 +21,19 @@ import {
   type ActionExample,
   type ActionResult,
   AUTONOMY_SERVICE_TYPE,
-    type HandlerCallback,
+  type HandlerCallback,
   type HandlerOptions,
   type IAgentRuntime,
   type Memory,
   type State,
   stringToUuid,
-  validateUuid,
   type Task,
   TRIGGER_SCHEMA_VERSION,
   type TriggerConfig,
   type TriggerType,
   type TriggerWakeMode,
   type UUID,
+  validateUuid,
 } from "@elizaos/core";
 
 import {
@@ -344,7 +344,8 @@ async function opCreate(
     delayMs !== undefined
       ? new Date(Date.now() + delayMs).toISOString()
       : undefined;
-  const scheduledAtIso = readString(params.scheduledAtIso) ?? scheduledFromDelay;
+  const scheduledAtIso =
+    readString(params.scheduledAtIso) ?? scheduledFromDelay;
   // A relative delay is one-shot by definition; a contradictory explicit
   // triggerType must not silently drop it.
   const triggerType =

--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -439,6 +439,12 @@ describe("executeTriggerTask", () => {
     expect(handle.promptMessages[0]?.text).toBe(
       'Scheduled trigger "Test Trigger" fired. Do this now: Summarize today\'s calendar',
     );
+    expect(handle.runtime.ensureConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worldId: stringToUuid(`trigger-world:${AGENT_ID}`),
+        source: "trigger-prompt",
+      }),
+    );
 
     // A TriggerRunRecord is appended and runCount incremented, same as workflow.
     const persisted = readTriggerConfig({

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -388,7 +388,8 @@ async function dispatchPrompt(
     await runtime.ensureConnection({
       entityId,
       roomId,
-      worldId: room?.worldId ?? stringToUuid(`trigger-world:${runtime.agentId}`),
+      worldId:
+        room?.worldId ?? stringToUuid(`trigger-world:${runtime.agentId}`),
       roomName: room?.name,
       channelId: room?.channelId,
       messageServerId: room?.messageServerId,

--- a/packages/benchmarks/claude-subscription-gateway/src/audit.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/audit.ts
@@ -4,11 +4,10 @@
  */
 
 import {
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
 } from "./hash-chained-jsonl.js";
-import type { GatewayAuditRecord } from "./types.js";
-import type { JsonObject } from "./types.js";
+import type { GatewayAuditRecord, JsonObject } from "./types.js";
 
 export interface AuditSink {
   append(record: GatewayAuditRecord): void | Promise<void>;
@@ -126,7 +125,9 @@ export class DurableAuditStore implements AuditSink {
     }
     if (logicalOrdinal === cursor.lastOrdinal) {
       if (cursor.lastKey !== logicalKeySha256 || cursor.lastResult === null) {
-        throw new Error("Audit logical ordinal was reused with a different key.");
+        throw new Error(
+          "Audit logical ordinal was reused with a different key.",
+        );
       }
       return cursor.lastResult;
     }
@@ -135,7 +136,8 @@ export class DurableAuditStore implements AuditSink {
     while (true) {
       const candidate = cursor.pending;
       if (candidate !== null) cursor.pending = null;
-      const next = candidate === null ? await this.log.readNext(cursor.stream) : null;
+      const next =
+        candidate === null ? await this.log.readNext(cursor.stream) : null;
       if (candidate === null) {
         if (next === null) {
           cursor.lastResult = false;
@@ -166,7 +168,9 @@ export class DurableAuditStore implements AuditSink {
       }
       this.cursors.set(harness, cursor);
       if (record.logical_key_sha256 !== logicalKeySha256) {
-        throw new Error("Audit logical identity conflicts with its request hash.");
+        throw new Error(
+          "Audit logical identity conflicts with its request hash.",
+        );
       }
       cursor.lastResult = true;
       return true;
@@ -180,7 +184,6 @@ export class DurableAuditStore implements AuditSink {
   close(): Promise<void> {
     return this.log.close();
   }
-
 }
 
 export function toAuditArtifact(record: GatewayAuditRecord): JsonObject {
@@ -191,8 +194,7 @@ export function toAuditArtifact(record: GatewayAuditRecord): JsonObject {
     harness: record.harness,
     transport: record.transport,
     credential_source: record.credentialSource,
-    credential_epoch_hmac_sha256:
-      record.credentialEpochHmacSha256 ?? null,
+    credential_epoch_hmac_sha256: record.credentialEpochHmacSha256 ?? null,
     credential_tier_hmac_sha256: record.credentialTierHmacSha256 ?? null,
     credential_capability_hmac_sha256:
       record.credentialCapabilityHmacSha256 ?? null,

--- a/packages/benchmarks/claude-subscription-gateway/src/claude-completion.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/claude-completion.ts
@@ -758,7 +758,8 @@ export function normalizeResetTimestampMs(value: unknown): number | null {
     return null;
   }
   const milliseconds = value < 1_000_000_000_000 ? value * 1_000 : value;
-  return Number.isSafeInteger(milliseconds) && milliseconds <= 8_640_000_000_000_000
+  return Number.isSafeInteger(milliseconds) &&
+    milliseconds <= 8_640_000_000_000_000
     ? milliseconds
     : null;
 }

--- a/packages/benchmarks/claude-subscription-gateway/src/cli.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/cli.ts
@@ -7,6 +7,7 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import {
   chmod,
+  type FileHandle,
   open,
   readFile,
   rename,
@@ -22,18 +23,18 @@ import {
   CLAUDE_AGENT_SDK_VERSION,
   ClaudeSdkCompletionRunner,
 } from "./claude-completion.js";
+import { parseGatewayContentContract } from "./content-attestation.js";
 import {
   type CredentialLeaseBroker,
   RotatingCredentialCompletionRunner,
 } from "./credential-rotation.js";
-import { parseGatewayContentContract } from "./content-attestation.js";
+import { ReplayJournal } from "./replay-journal.js";
 import {
   type ClaudeSubscriptionGatewayHandle,
-  type GatewayStorageGuard,
   GatewayStorageError,
+  type GatewayStorageGuard,
   startClaudeSubscriptionGateway,
 } from "./server.js";
-import { ReplayJournal } from "./replay-journal.js";
 import type { GatewayAuditRecord } from "./types.js";
 
 const PRIVATE_FILE_MODE = 0o600;
@@ -249,7 +250,9 @@ export function parseGatewayCliArguments(
   }
   if (
     contentContractFile !== null &&
-    [readyFile, auditFile, replayFile, hmacKeyFile].includes(contentContractFile)
+    [readyFile, auditFile, replayFile, hmacKeyFile].includes(
+      contentContractFile,
+    )
   ) {
     throw new GatewayCliError(
       "invalid_arguments",
@@ -319,7 +322,10 @@ function makeReadinessDocument(
 async function loadContentContract(target: string) {
   try {
     const fileStat = await stat(target);
-    if (!fileStat.isFile() || (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE) {
+    if (
+      !fileStat.isFile() ||
+      (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE
+    ) {
       throw new TypeError("content contract must be a private regular file");
     }
     const raw = await readFile(target, "utf8");
@@ -396,7 +402,7 @@ async function loadOrCreateHmacKey(target: string): Promise<Buffer> {
     if (!hasErrorCode(error, "ENOENT")) throw error;
   }
   const key = randomBytes(32);
-  let file;
+  let file: FileHandle;
   try {
     file = await open(target, "wx", PRIVATE_FILE_MODE);
   } catch (error: unknown) {
@@ -420,7 +426,10 @@ async function loadOrCreateHmacKey(target: string): Promise<Buffer> {
 
 async function loadHmacKey(target: string): Promise<Buffer> {
   const fileStat = await stat(target);
-  if (!fileStat.isFile() || (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE) {
+  if (
+    !fileStat.isFile() ||
+    (Number(fileStat.mode) & 0o777) !== PRIVATE_FILE_MODE
+  ) {
     throw new GatewayCliError(
       "invalid_hmac_key_file",
       "The gateway HMAC key file must be a private regular file.",
@@ -443,17 +452,17 @@ async function loadCanonicalAccountPoolBroker(): Promise<CredentialLeaseBroker> 
     import.meta.url,
   ).href;
   const loaded: unknown = await import(moduleUrl);
-  const constructor =
+  const brokerConstructor =
     typeof loaded === "object" && loaded !== null
       ? Reflect.get(loaded, "AccountPoolBroker")
       : null;
-  if (typeof constructor !== "function") {
+  if (typeof brokerConstructor !== "function") {
     throw new GatewayCliError(
       "account_pool_unavailable",
       "The canonical account-pool broker is unavailable.",
     );
   }
-  const broker: unknown = Reflect.construct(constructor, []);
+  const broker: unknown = Reflect.construct(brokerConstructor, []);
   if (
     typeof broker !== "object" ||
     broker === null ||

--- a/packages/benchmarks/claude-subscription-gateway/src/content-attestation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/content-attestation.ts
@@ -158,10 +158,7 @@ function exactOccurrenceCount(haystack: string, needle: string): number {
   }
 }
 
-function occurrenceCount(
-  contents: readonly string[],
-  needle: string,
-): number {
+function occurrenceCount(contents: readonly string[], needle: string): number {
   return contents.reduce(
     (total, content) => total + exactOccurrenceCount(content, needle),
     0,
@@ -187,10 +184,7 @@ function categoryMatchCounts(
   return Object.fromEntries(
     Object.entries(categories).map(([category, texts]) => [
       category,
-      texts.reduce(
-        (total, text) => total + occurrenceCount(contents, text),
-        0,
-      ),
+      texts.reduce((total, text) => total + occurrenceCount(contents, text), 0),
     ]),
   );
 }
@@ -201,16 +195,16 @@ export function buildGatewayContentAttestation(
   messages: readonly NormalizedChatMessage[],
 ): GatewayContentAttestation {
   const instructionContents = messages
-    .filter((message) =>
-      message.role === "system" || message.role === "developer",
+    .filter(
+      (message) => message.role === "system" || message.role === "developer",
     )
     .map((message) => message.content ?? "");
   const userContents = messages
     .filter((message) => message.role === "user")
     .map((message) => message.content ?? "");
   const generatedContents = messages
-    .filter((message) =>
-      message.role === "assistant" || message.role === "tool",
+    .filter(
+      (message) => message.role === "assistant" || message.role === "tool",
     )
     .map((message) => message.content ?? "");
   const ingressContents = [...instructionContents, ...userContents];
@@ -239,7 +233,10 @@ export function buildGatewayContentAttestation(
       instructionContents,
       contract.systemHint,
     ),
-    systemHintUserOccurrences: occurrenceCount(userContents, contract.systemHint),
+    systemHintUserOccurrences: occurrenceCount(
+      userContents,
+      contract.systemHint,
+    ),
     systemHintGeneratedOccurrences: occurrenceCount(
       generatedContents,
       contract.systemHint,
@@ -259,10 +256,7 @@ export function buildGatewayContentAttestation(
     forbiddenIngressMatchCounts,
     forbiddenIngressMatchTotal: Object.values(
       forbiddenIngressMatchCounts,
-    ).reduce(
-      (total, count) => total + count,
-      0,
-    ),
+    ).reduce((total, count) => total + count, 0),
     forbiddenGeneratedMatchCounts,
     forbiddenGeneratedMatchTotal: Object.values(
       forbiddenGeneratedMatchCounts,

--- a/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
@@ -113,7 +113,7 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
             providerId: "anthropic-subscription",
             sessionKey: `claude-benchmark:${context.requestId}`,
             strategy: "quota-aware",
-            ...(excluded.length > 0 ? { exclude: excluded } : {}),
+            ...(excluded.length > 0 ? { exclude: [...excluded] } : {}),
           })
         : null;
       if (lease === null) break;

--- a/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/credential-rotation.ts
@@ -82,7 +82,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
 
   constructor(options: RotatingCredentialCompletionRunnerOptions) {
     if (options.hmacKey.length < 32) {
-      throw new TypeError("Credential HMAC key must contain at least 32 bytes.");
+      throw new TypeError(
+        "Credential HMAC key must contain at least 32 bytes.",
+      );
     }
     this.inner = options.completionRunner;
     this.broker = options.broker ?? null;
@@ -129,7 +131,10 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
           credentialTierValidator: (subscriptionType) =>
             this.assertTierParity(subscriptionType),
         });
-        const decorated = this.decorateResult(result, `linked:${lease.accountId}`);
+        const decorated = this.decorateResult(
+          result,
+          `linked:${lease.accountId}`,
+        );
         await this.broker?.report({
           leaseId: lease.leaseId,
           ok: true,
@@ -187,10 +192,7 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
       if (!sawRateLimit && lastAuthenticationFailure !== null) {
         throw lastAuthenticationFailure;
       }
-      throw new ClaudeRateLimitError(
-        earliestKnownReset,
-        knownRateLimitType,
-      );
+      throw new ClaudeRateLimitError(earliestKnownReset, knownRateLimitType);
     }
     try {
       const ambient = await this.inner.complete({
@@ -208,11 +210,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
           earliestKnownReset = error.retryAtMs;
           knownRateLimitType = error.rateLimitType;
         }
-        throw new ClaudeRateLimitError(
-          earliestKnownReset,
-          knownRateLimitType,
-          { cause: error },
-        );
+        throw new ClaudeRateLimitError(earliestKnownReset, knownRateLimitType, {
+          cause: error,
+        });
       }
       throw error;
     }
@@ -244,7 +244,9 @@ export class RotatingCredentialCompletionRunner implements CompletionRunner {
   }
 
   private hmac(value: string): string {
-    return createHmac("sha256", this.hmacKey).update(value, "utf8").digest("hex");
+    return createHmac("sha256", this.hmacKey)
+      .update(value, "utf8")
+      .digest("hex");
   }
 }
 

--- a/packages/benchmarks/claude-subscription-gateway/src/hash-chained-jsonl.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/hash-chained-jsonl.ts
@@ -6,7 +6,7 @@
 
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { open, type FileHandle } from "node:fs/promises";
+import { type FileHandle, open } from "node:fs/promises";
 import { dirname } from "node:path";
 import { stableJson } from "./canonical.js";
 import type { JsonObject, JsonValue } from "./types.js";
@@ -68,7 +68,9 @@ export class HashChainedJsonl {
       !Number.isSafeInteger(normalized.maxRecordBytes) ||
       normalized.maxRecordBytes <= 0
     ) {
-      throw new TypeError("Hash-chain record limit must be a positive integer.");
+      throw new TypeError(
+        "Hash-chain record limit must be a positive integer.",
+      );
     }
     const file = await open(
       target,
@@ -131,7 +133,8 @@ export class HashChainedJsonl {
     });
     this.appendTail = operation;
     return operation.then(() => {
-      if (appended === null) throw new Error("Hash-chain append did not commit.");
+      if (appended === null)
+        throw new Error("Hash-chain append did not commit.");
       return appended;
     });
   }
@@ -154,7 +157,9 @@ export class HashChainedJsonl {
   async readNext(cursor: HashChainedJsonlCursor): Promise<JsonObject | null> {
     await this.appendTail;
     if (!Number.isSafeInteger(cursor.offset) || cursor.offset < 0) {
-      throw new TypeError("Hash-chain read offset must be a non-negative integer.");
+      throw new TypeError(
+        "Hash-chain read offset must be a non-negative integer.",
+      );
     }
     const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
     while (cursor.pending.length <= this.options.maxRecordBytes) {
@@ -332,7 +337,9 @@ function assertNoReservedFields(
     options.recordHashField,
   ]) {
     if (field in payload) {
-      throw new TypeError(`Hash-chain payload contains reserved field ${field}.`);
+      throw new TypeError(
+        `Hash-chain payload contains reserved field ${field}.`,
+      );
     }
   }
 }

--- a/packages/benchmarks/claude-subscription-gateway/src/index.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/index.ts
@@ -27,6 +27,11 @@ export {
   normalizeResetTimestampMs,
 } from "./claude-completion.js";
 export {
+  buildGatewayContentAttestation,
+  gatewayContentAttestationViolation,
+  parseGatewayContentContract,
+} from "./content-attestation.js";
+export {
   type CredentialBrokerLease,
   type CredentialLeaseBroker,
   CredentialParityError,
@@ -34,29 +39,15 @@ export {
   type RotatingCredentialCompletionRunnerOptions,
 } from "./credential-rotation.js";
 export {
-  buildGatewayContentAttestation,
-  gatewayContentAttestationViolation,
-  parseGatewayContentContract,
-} from "./content-attestation.js";
-export {
   FairHarnessQueue,
   type FairHarnessQueueOptions,
   QueueCapacityError,
   type QueuedResult,
 } from "./fair-queue.js";
 export {
-  GatewayStorageError,
-  type ClaudeSubscriptionGatewayHandle,
-  type GatewayHarnessEnvironment,
-  type GatewayLogger,
-  type GatewayStorageGuard,
-  type StartClaudeSubscriptionGatewayOptions,
-  startClaudeSubscriptionGateway,
-} from "./server.js";
-export {
   HashChainCorruptionError,
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
   type HashChainedJsonlOptions,
 } from "./hash-chained-jsonl.js";
 export {
@@ -70,6 +61,15 @@ export {
   ReplayJournal,
   ReplayMismatchError,
 } from "./replay-journal.js";
+export {
+  type ClaudeSubscriptionGatewayHandle,
+  type GatewayHarnessEnvironment,
+  type GatewayLogger,
+  GatewayStorageError,
+  type GatewayStorageGuard,
+  type StartClaudeSubscriptionGatewayOptions,
+  startClaudeSubscriptionGateway,
+} from "./server.js";
 export type {
   CanonicalChatCompletion,
   CapturedToolCall,

--- a/packages/benchmarks/claude-subscription-gateway/src/logical-request.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/logical-request.ts
@@ -25,7 +25,7 @@ export class LogicalRequestAllocator {
   private readonly nextOrdinalByHarness = new Map<string, number>();
   readonly namespaceSha256: string;
 
-  constructor(private readonly namespace: string) {
+  constructor(namespace: string) {
     if (!SAFE_NAMESPACE_PATTERN.test(namespace)) {
       throw new TypeError(
         "Benchmark namespace must be 1-128 safe identifier characters.",

--- a/packages/benchmarks/claude-subscription-gateway/src/replay-journal.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/replay-journal.ts
@@ -6,8 +6,8 @@
 
 import {
   HashChainCorruptionError,
-  type HashChainedJsonlCursor,
   HashChainedJsonl,
+  type HashChainedJsonlCursor,
 } from "./hash-chained-jsonl.js";
 import {
   computeLogicalKeySha256,
@@ -42,7 +42,9 @@ export class ReplayMismatchError extends Error {
   readonly statusCode = 409;
 
   constructor() {
-    super("A replay ordinal was reused with different canonical request content.");
+    super(
+      "A replay ordinal was reused with different canonical request content.",
+    );
     this.name = "ReplayMismatchError";
   }
 }
@@ -115,7 +117,8 @@ export class ReplayJournal {
     while (true) {
       const pending = cursor.pending;
       if (pending !== null) cursor.pending = null;
-      const next = pending === null ? await this.log.readNext(cursor.stream) : null;
+      const next =
+        pending === null ? await this.log.readNext(cursor.stream) : null;
       if (pending === null) {
         if (next === null) {
           cursor.lastResult = null;
@@ -236,7 +239,9 @@ interface ParsedJournalRecord {
 
 function parseJournalRecord(record: JsonObject): ParsedJournalRecord {
   if (record.kind !== "completion" || record.journal_schema_version !== 1) {
-    throw new HashChainCorruptionError("Replay journal record kind is invalid.");
+    throw new HashChainCorruptionError(
+      "Replay journal record kind is invalid.",
+    );
   }
   const harness = requiredString(record.harness, "harness");
   const logicalNamespaceSha256 = requiredHash(
@@ -317,7 +322,10 @@ function parseCompletionResult(value: unknown): ClaudeCompletionResult {
           })(),
     resultSubtype: requiredString(value.resultSubtype, "result subtype"),
     terminalReason: nullableString(value.terminalReason, "terminal reason"),
-    subscriptionType: requiredString(value.subscriptionType, "subscription tier"),
+    subscriptionType: requiredString(
+      value.subscriptionType,
+      "subscription tier",
+    ),
     credentialEpochHmacSha256: requiredHash(
       value.credentialEpochHmacSha256,
       "credential epoch",
@@ -410,11 +418,7 @@ function nullableString(value: unknown, label: string): string | null {
 }
 
 function requiredInteger(value: unknown, label: string): number {
-  if (
-    typeof value !== "number" ||
-    !Number.isSafeInteger(value) ||
-    value < 0
-  ) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
     throw new HashChainCorruptionError(`Replay ${label} is invalid.`);
   }
   return value;

--- a/packages/benchmarks/claude-subscription-gateway/src/server.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/server.ts
@@ -883,18 +883,6 @@ function normalizeHarness(value: string): string {
   return normalized;
 }
 
-function normalizeRequestId(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^A-Za-z0-9_-]/g, "")
-    .slice(0, 80);
-  if (!normalized)
-    throw new Error(
-      "[ClaudeSubscriptionGateway] request id factory returned no safe text",
-    );
-  return normalized;
-}
-
 function secureEquals(left: string, right: string): boolean {
   const leftBuffer = Buffer.from(left, "utf8");
   const rightBuffer = Buffer.from(right, "utf8");

--- a/packages/benchmarks/claude-subscription-gateway/src/server.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/server.ts
@@ -19,21 +19,21 @@ import {
   stableJson,
 } from "./canonical.js";
 import {
-  buildGatewayContentAttestation,
-  gatewayContentAttestationViolation,
-} from "./content-attestation.js";
-import {
   CLAUDE_AGENT_SDK_VERSION,
   ClaudeCompletionError,
   ClaudeRateLimitError,
   ClaudeSdkCompletionRunner,
 } from "./claude-completion.js";
+import {
+  buildGatewayContentAttestation,
+  gatewayContentAttestationViolation,
+} from "./content-attestation.js";
 import { FairHarnessQueue, QueueCapacityError } from "./fair-queue.js";
 import {
-  LogicalRequestAllocator,
   type LogicalRequest,
+  LogicalRequestAllocator,
 } from "./logical-request.js";
-import { ReplayJournal, ReplayMismatchError } from "./replay-journal.js";
+import { type ReplayJournal, ReplayMismatchError } from "./replay-journal.js";
 import type {
   ClaudeCompletionResult,
   CompletionFinishReason,
@@ -404,13 +404,8 @@ async function handleRequest(
         ),
       };
     });
-    const {
-      result,
-      serviceMs,
-      created,
-      executionOrigin,
-      responseQueueWaitMs,
-    } = queued.value;
+    const { result, serviceMs, created, executionOrigin, responseQueueWaitMs } =
+      queued.value;
     const finishReason: CompletionFinishReason =
       result.toolCalls.length > 0 ? "tool_calls" : "stop";
     const completionAlreadyAudited =
@@ -726,11 +721,7 @@ interface AuditRecordInput {
     | "pause_control";
   deliveryAttempt: number | null;
   retryAt?: string | null;
-  pauseReason?:
-    | "rate_limit"
-    | "rate_limit_unknown"
-    | "storage_reserve"
-    | null;
+  pauseReason?: "rate_limit" | "rate_limit_unknown" | "storage_reserve" | null;
 }
 
 function makeAuditRecord(input: AuditRecordInput): GatewayAuditRecord {
@@ -781,10 +772,8 @@ function makeAuditRecord(input: AuditRecordInput): GatewayAuditRecord {
     deliveryAttempt: input.deliveryAttempt ?? undefined,
     executionOrigin: input.executionOrigin,
     auditEvent: input.auditEvent,
-    credentialEpochHmacSha256:
-      input.result?.credentialEpochHmacSha256 ?? null,
-    credentialTierHmacSha256:
-      input.result?.credentialTierHmacSha256 ?? null,
+    credentialEpochHmacSha256: input.result?.credentialEpochHmacSha256 ?? null,
+    credentialTierHmacSha256: input.result?.credentialTierHmacSha256 ?? null,
     credentialCapabilityHmacSha256:
       input.result?.credentialCapabilityHmacSha256 ?? null,
     retryAt: input.retryAt ?? null,

--- a/packages/benchmarks/claude-subscription-gateway/src/types.ts
+++ b/packages/benchmarks/claude-subscription-gateway/src/types.ts
@@ -224,9 +224,5 @@ export interface GatewayAuditRecord {
   credentialTierHmacSha256?: string | null;
   credentialCapabilityHmacSha256?: string | null;
   retryAt?: string | null;
-  pauseReason?:
-    | "rate_limit"
-    | "rate_limit_unknown"
-    | "storage_reserve"
-    | null;
+  pauseReason?: "rate_limit" | "rate_limit_unknown" | "storage_reserve" | null;
 }

--- a/packages/benchmarks/claude-subscription-gateway/tests/claude-completion.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/claude-completion.test.ts
@@ -6,7 +6,7 @@ import type { ClaudeAgentSdkModule } from "../src/index.js";
 import {
   assertNoApiBillingEnvironment,
   buildClaudeCodeManagedEnvironment,
-  ClaudeRateLimitError,
+  type ClaudeRateLimitError,
   ClaudeSdkCompletionRunner,
   canonicalizeChatCompletion,
   FORBIDDEN_API_BILLING_ENV_NAMES,

--- a/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
@@ -272,7 +272,9 @@ describe("gateway CLI", () => {
 
 const PRIVATE_MODE = 0o600;
 
-function statMode(stats: Awaited<ReturnType<typeof stat>>): number {
+function statMode(
+  stats: NonNullable<Awaited<ReturnType<typeof stat>>>,
+): number {
   return Number(stats.mode) & 0o777;
 }
 

--- a/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
@@ -10,6 +10,8 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   inspectBrokerReadiness,
+  MinimumFreeSpaceGuard,
+  parseGatewayCliArguments,
   runGatewayCli,
   writeAuditJsonl,
 } from "../src/cli.js";
@@ -51,6 +53,105 @@ function withoutApiBillingEnvironment(): NodeJS.ProcessEnv {
 }
 
 describe("gateway CLI", () => {
+  it("parses the complete lifecycle contract and derives private artifact defaults", () => {
+    expect(
+      parseGatewayCliArguments([
+        "--",
+        "--ready-file",
+        "/tmp/gateway.ready",
+        "--audit-file",
+        "/tmp/gateway.audit",
+        "--content-contract-file",
+        "/tmp/gateway.contract",
+        "--benchmark-namespace",
+        "cohort-a",
+        "--storage-root",
+        "/tmp",
+        "--minimum-free-bytes",
+        "4096",
+      ]),
+    ).toEqual({
+      readyFile: "/tmp/gateway.ready",
+      auditFile: "/tmp/gateway.audit",
+      contentContractFile: "/tmp/gateway.contract",
+      replayFile: "/tmp/gateway.audit.responses.jsonl",
+      hmacKeyFile: "/tmp/gateway.audit.responses.jsonl.hmac-key",
+      benchmarkNamespace: "cohort-a",
+      storageRoot: "/tmp",
+      minimumFreeBytes: 4096,
+    });
+  });
+
+  it.each([
+    [[], "invalid_arguments"],
+    [["--ready-file"], "invalid_arguments"],
+    [
+      ["--ready-file", "relative", "--audit-file", "/tmp/audit"],
+      "invalid_arguments",
+    ],
+    [
+      ["--ready-file", "/tmp/same", "--audit-file", "/tmp/same"],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--replay-file",
+        "/tmp/ready",
+      ],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--content-contract-file",
+        "/tmp/audit",
+      ],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--minimum-free-bytes",
+        "-1",
+      ],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--wat",
+        "x",
+      ],
+      "invalid_arguments",
+    ],
+  ])("rejects invalid lifecycle arguments %#", (argv, code) => {
+    expect(() => parseGatewayCliArguments(argv)).toThrow(
+      expect.objectContaining({ code }),
+    );
+  });
+
+  it("checks configured storage reserves without I/O when the threshold is zero", async () => {
+    await expect(
+      new MinimumFreeSpaceGuard("/missing", 0).assertReady(),
+    ).resolves.toBeUndefined();
+    await expect(
+      new MinimumFreeSpaceGuard("/tmp", Number.MAX_SAFE_INTEGER).assertReady(),
+    ).rejects.toThrow("storage reserve is below its required threshold");
+  });
+
   it("projects allowlisted redacted audit fields to private JSONL", async () => {
     const directory = await mkdtemp(join(tmpdir(), "claude-gateway-audit-"));
     const auditFile = join(directory, "cohort.jsonl");

--- a/packages/benchmarks/claude-subscription-gateway/tests/content-attestation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/content-attestation.test.ts
@@ -42,7 +42,9 @@ describe("gateway content attestation", () => {
     });
     expect(proof.forbiddenIngressMatchTotal).toBe(0);
     expect(proof.observedIngressMatchCounts).toEqual({ workspace_paths: 1 });
-    expect(proof.observedInstructionMatchCounts).toEqual({ workspace_paths: 0 });
+    expect(proof.observedInstructionMatchCounts).toEqual({
+      workspace_paths: 0,
+    });
     expect(proof.observedUserMatchCounts).toEqual({ workspace_paths: 1 });
     expect(proof.messageContentManifest).toHaveLength(4);
     const serialized = JSON.stringify(proof);

--- a/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
@@ -3,12 +3,12 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import {
-  canonicalizeChatCompletion,
   type ClaudeCompletionResult,
   ClaudeRateLimitError,
   type CompletionContext,
   type CompletionRunner,
   type CredentialLeaseBroker,
+  canonicalizeChatCompletion,
   RotatingCredentialCompletionRunner,
 } from "../src/index.js";
 
@@ -29,10 +29,7 @@ describe("RotatingCredentialCompletionRunner", () => {
         contexts.push(context);
         context.credentialTierValidator?.("Claude Max");
         if (context.credentialOAuthToken === "token-a") {
-          throw new ClaudeRateLimitError(
-            2_000_000_000_000,
-            "seven_day",
-          );
+          throw new ClaudeRateLimitError(2_000_000_000_000, "seven_day");
         }
         return completionResult();
       },
@@ -136,9 +133,7 @@ describe("RotatingCredentialCompletionRunner", () => {
       broker: null,
       hmacKey: HMAC_KEY,
       expectedTierHmacSha256: expectedTier,
-      expectedCapabilityHmacSha256: hmac(
-        "firstParty:oauth:subscription",
-      ),
+      expectedCapabilityHmacSha256: hmac("firstParty:oauth:subscription"),
     });
 
     await expect(runner.complete(completionContext())).rejects.toMatchObject({

--- a/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/credential-rotation.test.ts
@@ -17,7 +17,10 @@ const HMAC_KEY = Buffer.alloc(32, 7);
 describe("RotatingCredentialCompletionRunner", () => {
   it("rotates linked leases on quota with one stable session key and token-only injection", async () => {
     const leases = [lease("a", "token-a"), lease("b", "token-b"), null];
-    const leaseBroker = vi.fn(async () => leases.shift() ?? null);
+    const leaseBroker = vi.fn(
+      async (_request: Parameters<CredentialLeaseBroker["lease"]>[0]) =>
+        leases.shift() ?? null,
+    );
     const broker: CredentialLeaseBroker = {
       lease: leaseBroker,
       report: vi.fn(async () => ({ ok: true })),

--- a/packages/benchmarks/claude-subscription-gateway/tests/durable-storage.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/durable-storage.test.ts
@@ -1,6 +1,13 @@
 /** Verifies crash repair, committed-corruption rejection, and bounded audit cursor idempotence on real files. */
 
-import { appendFile, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
@@ -22,18 +22,12 @@ describe("gateway replay", () => {
   it("commits the private success before awaiting public audit and HTTP delivery", async () => {
     const directory = await mkdtemp(join(tmpdir(), "gateway-ordering-"));
     const journalPath = join(directory, "responses.jsonl");
-    let enterAudit: (() => void) | null = null;
-    const auditEntered = new Promise<void>((resolve) => {
-      enterAudit = resolve;
-    });
-    let releaseAudit: (() => void) | null = null;
-    const auditReleased = new Promise<void>((resolve) => {
-      releaseAudit = resolve;
-    });
+    const auditEntered = deferred();
+    const auditReleased = deferred();
     const auditSink: AuditSink = {
       append(_record: GatewayAuditRecord) {
-        enterAudit?.();
-        return auditReleased;
+        auditEntered.resolve();
+        return auditReleased.promise;
       },
     };
 
@@ -59,16 +53,16 @@ describe("gateway replay", () => {
         return response;
       });
 
-      await auditEntered;
+      await auditEntered.promise;
       expect((await readFile(journalPath, "utf8")).trim()).not.toBe("");
       await Promise.resolve();
       expect(delivered).toBe(false);
-      releaseAudit?.();
+      auditReleased.resolve();
       expect((await pendingResponse).status).toBe(200);
       await gateway.close();
       await journal.close();
     } finally {
-      releaseAudit?.();
+      auditReleased.resolve();
       await rm(directory, { recursive: true, force: true });
     }
   });
@@ -167,6 +161,14 @@ function request(baseUrl: string, body: unknown): Promise<Response> {
     },
     body: JSON.stringify(body),
   });
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
 }
 
 async function auditRows(path: string): Promise<Record<string, unknown>[]> {

--- a/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/replay-server.test.ts
@@ -6,10 +6,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   type AuditSink,
-  canonicalizeChatCompletion,
-  DurableAuditStore,
   type ClaudeCompletionResult,
   type CompletionRunner,
+  canonicalizeChatCompletion,
+  DurableAuditStore,
   type GatewayAuditRecord,
   LogicalRequestAllocator,
   ReplayJournal,
@@ -40,7 +40,11 @@ describe("gateway replay", () => {
     try {
       const journal = await ReplayJournal.open(journalPath);
       const gateway = await startClaudeSubscriptionGateway({
-        completionRunner: { async complete() { return completionResult(); } },
+        completionRunner: {
+          async complete() {
+            return completionResult();
+          },
+        },
         replayJournal: journal,
         auditSink,
         benchmarkNamespace: "ordering-test",

--- a/packages/benchmarks/claude-subscription-gateway/tests/server.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/server.test.ts
@@ -636,16 +636,20 @@ describe("startClaudeSubscriptionGateway", () => {
       request(HERMES_TOKEN),
       request(OPENCLAW_TOKEN),
     ]);
-    expect(responses.map((response) => response.status)).toEqual([429, 429, 429]);
+    expect(responses.map((response) => response.status)).toEqual([
+      429, 429, 429,
+    ]);
     expect(completionCalls).toBe(1);
     expect(handle.auditStore.snapshot()).toHaveLength(3);
     expect(
-      handle.auditStore.snapshot().every(
-        (record) =>
-          record.status === "paused" &&
-          record.pauseReason === "rate_limit" &&
-          record.auditEvent === "pause_control",
-      ),
+      handle.auditStore
+        .snapshot()
+        .every(
+          (record) =>
+            record.status === "paused" &&
+            record.pauseReason === "rate_limit" &&
+            record.auditEvent === "pause_control",
+        ),
     ).toBe(true);
   });
 

--- a/packages/core/src/__tests__/runtime-component-precedence.test.ts
+++ b/packages/core/src/__tests__/runtime-component-precedence.test.ts
@@ -81,8 +81,9 @@ describe("AgentRuntime component precedence — undeclared collisions (first-win
 		expect(matches).toHaveLength(1);
 		// Incumbent (first) is authoritative.
 		const dup = matches[0];
-		expect(dup).toBeDefined();
-		const result = await dup!.get(runtime, {} as never, {} as never);
+		if (!dup)
+			throw new Error("Expected the duplicate provider to be registered");
+		const result = await dup.get(runtime, {} as never, {} as never);
 		expect(result.text).toBe("first");
 		expect(warn).toHaveBeenCalledTimes(1);
 		expect(warn.mock.calls[0]?.[1]).toMatch(/name collision/i);
@@ -132,8 +133,9 @@ describe("AgentRuntime component precedence — declared override:true supersede
 		const matches = runtime.providers.filter((p) => p.name === "OVR");
 		expect(matches).toHaveLength(1);
 		const ovr = matches[0];
-		expect(ovr).toBeDefined();
-		const result = await ovr!.get(runtime, {} as never, {} as never);
+		if (!ovr)
+			throw new Error("Expected the override provider to be registered");
+		const result = await ovr.get(runtime, {} as never, {} as never);
 		expect(result.text).toBe("second");
 		// Declared override logs at info, never warns.
 		expect(info).toHaveBeenCalled();

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -1490,32 +1490,72 @@ describe("normalizeParamAliases", () => {
 		name: "TRIGGER",
 		description: "",
 		parameters: [
-			{ name: "instructions", required: false, aliases: ["description", "message", "prompt"], schema: { type: "string" } },
-			{ name: "scheduledAtIso", required: false, aliases: ["scheduledFor", "when", "at"], schema: { type: "string" } },
-			{ name: "target", required: false, aliases: ["to", "recipient"], schema: { type: "string" } },
-			{ name: "shared", required: false, aliases: ["dup"], schema: { type: "string" } },
-			{ name: "shared2", required: false, aliases: ["dup"], schema: { type: "string" } },
+			{
+				name: "instructions",
+				required: false,
+				aliases: ["description", "message", "prompt"],
+				schema: { type: "string" },
+			},
+			{
+				name: "scheduledAtIso",
+				required: false,
+				aliases: ["scheduledFor", "when", "at"],
+				schema: { type: "string" },
+			},
+			{
+				name: "target",
+				required: false,
+				aliases: ["to", "recipient"],
+				schema: { type: "string" },
+			},
+			{
+				name: "shared",
+				required: false,
+				aliases: ["dup"],
+				schema: { type: "string" },
+			},
+			{
+				name: "shared2",
+				required: false,
+				aliases: ["dup"],
+				schema: { type: "string" },
+			},
 		],
 		validate: async () => true,
 		handler: async () => ({}),
 	} as unknown as import("@elizaos/core").Action;
 
 	it("renames an alias key to its canonical param", () => {
-		expect(normalizeParamAliases(action, { description: "drink water", scheduledFor: "2026-01-01T00:00:00Z" }))
-			.toEqual({ instructions: "drink water", scheduledAtIso: "2026-01-01T00:00:00Z" });
+		expect(
+			normalizeParamAliases(action, {
+				description: "drink water",
+				scheduledFor: "2026-01-01T00:00:00Z",
+			}),
+		).toEqual({
+			instructions: "drink water",
+			scheduledAtIso: "2026-01-01T00:00:00Z",
+		});
 	});
 
 	it("leaves a declared canonical key untouched", () => {
-		expect(normalizeParamAliases(action, { instructions: "x" })).toEqual({ instructions: "x" });
+		expect(normalizeParamAliases(action, { instructions: "x" })).toEqual({
+			instructions: "x",
+		});
 	});
 
 	it("never clobbers an explicitly-provided canonical value", () => {
-		expect(normalizeParamAliases(action, { instructions: "canon", description: "alias" }))
-			.toEqual({ instructions: "canon", description: "alias" });
+		expect(
+			normalizeParamAliases(action, {
+				instructions: "canon",
+				description: "alias",
+			}),
+		).toEqual({ instructions: "canon", description: "alias" });
 	});
 
 	it("leaves an unknown key to reject (not claimed by any alias)", () => {
-		expect(normalizeParamAliases(action, { totally_unknown: "x" })).toEqual({ totally_unknown: "x" });
+		expect(normalizeParamAliases(action, { totally_unknown: "x" })).toEqual({
+			totally_unknown: "x",
+		});
 	});
 
 	it("leaves an ambiguous alias (two params claim it) to reject", () => {
@@ -1523,7 +1563,10 @@ describe("normalizeParamAliases", () => {
 	});
 
 	it("is a no-op when the action declares no aliases", () => {
-		const noAlias = { ...action, parameters: [{ name: "x", required: false, schema: { type: "string" } }] } as unknown as import("@elizaos/core").Action;
+		const noAlias = {
+			...action,
+			parameters: [{ name: "x", required: false, schema: { type: "string" } }],
+		} as unknown as import("@elizaos/core").Action;
 		expect(normalizeParamAliases(noAlias, { y: "1" })).toEqual({ y: "1" });
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -7,10 +7,10 @@
  * model.
  */
 import { describe, expect, it, vi } from "vitest";
+import { promoteSubactionsToActions } from "../../actions/promote-subactions";
 import { plannerTemplate } from "../../prompts/planner";
 import { type ChatMessage, ModelType } from "../../types/model";
 import { TrajectoryLimitExceeded } from "../limits";
-import { promoteSubactionsToActions } from "../../actions/promote-subactions";
 import {
 	__renderRoutingHintsBlockForTests,
 	PROGRESS_ONLY_ANSWER_REJECT,
@@ -1667,36 +1667,33 @@ describe("v5 planner loop skeleton", () => {
 		"I'm reviewing the conversation history to answer.",
 		"I'll look that up and get back to you.",
 		"Pulling up the info now, one sec.",
-	])(
-		"never surfaces native intent-narration as a refusal: %s (#9874)",
-		async (text) => {
-			// Regression: a native pre-tool/intent-narration text carries no leak
-			// markup and no "thinking through" marker, so a denylist would let it
-			// through and the agent would falsely claim it is doing work it never
-			// did. The positive-allowlist gate (must read as an inability) rejects
-			// it → the loop throws → caller emits the generic apology, never the
-			// phantom action claim.
-			const runtime = {
-				useModel: vi.fn(async () => ({ text, toolCalls: [] })),
-				logger: { warn: vi.fn() },
-			};
+	])("never surfaces native intent-narration as a refusal: %s (#9874)", async (text) => {
+		// Regression: a native pre-tool/intent-narration text carries no leak
+		// markup and no "thinking through" marker, so a denylist would let it
+		// through and the agent would falsely claim it is doing work it never
+		// did. The positive-allowlist gate (must read as an inability) rejects
+		// it → the loop throws → caller emits the generic apology, never the
+		// phantom action claim.
+		const runtime = {
+			useModel: vi.fn(async () => ({ text, toolCalls: [] })),
+			logger: { warn: vi.fn() },
+		};
 
-			await expect(
-				runPlannerLoop({
-					runtime,
-					context: { id: "ctx" },
-					tools: [{ name: "LOOKUP", description: "Lookup current status." }],
-					requireNonTerminalToolCall: true,
-					config: { maxRequiredToolMisses: 1 },
-					executeToolCall: vi.fn(),
-					evaluate: vi.fn(),
-				}),
-			).rejects.toMatchObject({
-				name: "TrajectoryLimitExceeded",
-				kind: "required_tool_misses",
-			});
-		},
-	);
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+	});
 
 	it("does not surface explicit messageToUser intent-narration at required-tool exhaustion (#9874)", async () => {
 		const runtime = {
@@ -3274,8 +3271,7 @@ describe("routing hints — promoted-family fallback", () => {
 				},
 			],
 		};
-		const [createVirtual, deleteVirtual] =
-			promoteSubactionsToActions(parent);
+		const [createVirtual, deleteVirtual] = promoteSubactionsToActions(parent);
 		const ctx = {
 			events: [createVirtual, deleteVirtual].map((action, i) => ({
 				id: `tool-${i}`,
@@ -3287,8 +3283,8 @@ describe("routing hints — promoted-family fallback", () => {
 		expect(block).toContain("# Routing hints");
 		expect(block).toContain("reminders -> TRIGGER_CREATE");
 		// One line for the whole family, not one per virtual.
-		expect(
-			(block ?? "").split("reminders -> TRIGGER_CREATE").length - 1,
-		).toBe(1);
+		expect((block ?? "").split("reminders -> TRIGGER_CREATE").length - 1).toBe(
+			1,
+		);
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1667,33 +1667,36 @@ describe("v5 planner loop skeleton", () => {
 		"I'm reviewing the conversation history to answer.",
 		"I'll look that up and get back to you.",
 		"Pulling up the info now, one sec.",
-	])("never surfaces native intent-narration as a refusal: %s (#9874)", async (text) => {
-		// Regression: a native pre-tool/intent-narration text carries no leak
-		// markup and no "thinking through" marker, so a denylist would let it
-		// through and the agent would falsely claim it is doing work it never
-		// did. The positive-allowlist gate (must read as an inability) rejects
-		// it → the loop throws → caller emits the generic apology, never the
-		// phantom action claim.
-		const runtime = {
-			useModel: vi.fn(async () => ({ text, toolCalls: [] })),
-			logger: { warn: vi.fn() },
-		};
+	])(
+		"never surfaces native intent-narration as a refusal: %s (#9874)",
+		async (text) => {
+			// Regression: a native pre-tool/intent-narration text carries no leak
+			// markup and no "thinking through" marker, so a denylist would let it
+			// through and the agent would falsely claim it is doing work it never
+			// did. The positive-allowlist gate (must read as an inability) rejects
+			// it → the loop throws → caller emits the generic apology, never the
+			// phantom action claim.
+			const runtime = {
+				useModel: vi.fn(async () => ({ text, toolCalls: [] })),
+				logger: { warn: vi.fn() },
+			};
 
-		await expect(
-			runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
-				requireNonTerminalToolCall: true,
-				config: { maxRequiredToolMisses: 1 },
-				executeToolCall: vi.fn(),
-				evaluate: vi.fn(),
-			}),
-		).rejects.toMatchObject({
-			name: "TrajectoryLimitExceeded",
-			kind: "required_tool_misses",
-		});
-	});
+			await expect(
+				runPlannerLoop({
+					runtime,
+					context: { id: "ctx" },
+					tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+					requireNonTerminalToolCall: true,
+					config: { maxRequiredToolMisses: 1 },
+					executeToolCall: vi.fn(),
+					evaluate: vi.fn(),
+				}),
+			).rejects.toMatchObject({
+				name: "TrajectoryLimitExceeded",
+				kind: "required_tool_misses",
+			});
+		},
+	);
 
 	it("does not surface explicit messageToUser intent-narration at required-tool exhaustion (#9874)", async () => {
 		const runtime = {

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -790,9 +790,7 @@ export function normalizeParamAliases(
 	args: Record<string, unknown>,
 ): Record<string, unknown> {
 	const parameters = action.parameters ?? [];
-	const hasAliases = parameters.some(
-		(p) => p.aliases && p.aliases.length > 0,
-	);
+	const hasAliases = parameters.some((p) => p.aliases && p.aliases.length > 0);
 	if (!hasAliases) return args;
 
 	const declaredNames = new Set(parameters.map((p) => p.name));

--- a/packages/core/src/trajectory-utils.llm-input-attestation.test.ts
+++ b/packages/core/src/trajectory-utils.llm-input-attestation.test.ts
@@ -155,24 +155,27 @@ describe("final LLM input substring attestation", () => {
 	it.each([
 		["missing", "unrelated system context"],
 		["duplicate", "expected instruction expected instruction"],
-	])("rejects a %s instruction before invoking the provider", async (_label, systemPrompt) => {
-		const provider = vi.fn(async () => "unreachable");
-		await expect(
-			runWithLlmInputSubstringAttestation("expected instruction", () =>
-				recordLlmCall(
-					null,
-					details({
-						systemPrompt,
-						messages: [{ role: "user", content: "go" }],
-					}),
-					provider,
+	])(
+		"rejects a %s instruction before invoking the provider",
+		async (_label, systemPrompt) => {
+			const provider = vi.fn(async () => "unreachable");
+			await expect(
+				runWithLlmInputSubstringAttestation("expected instruction", () =>
+					recordLlmCall(
+						null,
+						details({
+							systemPrompt,
+							messages: [{ role: "user", content: "go" }],
+						}),
+						provider,
+					),
 				),
-			),
-		).rejects.toMatchObject({
-			code: "LLM_INPUT_SUBSTRING_ATTESTATION_MISMATCH",
-		});
-		expect(provider).not.toHaveBeenCalled();
-	});
+			).rejects.toMatchObject({
+				code: "LLM_INPUT_SUBSTRING_ATTESTATION_MISMATCH",
+			});
+			expect(provider).not.toHaveBeenCalled();
+		},
+	);
 
 	it("rejects a completed scope that never reached a model boundary", async () => {
 		await expect(

--- a/plugins/plugin-coding-tools/src/actions/write.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.test.ts
@@ -215,7 +215,6 @@ describe("WRITE", () => {
     expect(written).toBe("x");
   });
 
-
   it("rejects paths under the blocklist", async () => {
     const result = await writeFileHandler(env.runtime, env.message, undefined, {
       parameters: {

--- a/plugins/plugin-coding-tools/src/lib/path-utils.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.ts
@@ -6,7 +6,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import type { IAgentRuntime } from "@elizaos/core";
+import type { IAgentRuntime, Service } from "@elizaos/core";
 
 const BLOCKED_PATHS = new Set([
   "/dev/zero",
@@ -88,7 +88,7 @@ export function resolveRelativeToCwd(filePath: string, cwd: string): string {
 }
 
 /** Minimal shape of the SessionCwdService this resolver depends on. */
-interface CwdLookup {
+interface CwdLookup extends Service {
   getCwd(id: string | undefined): string;
 }
 
@@ -99,8 +99,7 @@ interface CwdLookup {
  * `process.cwd()` when the conversation has no recorded cwd.
  *
  * The `runtime` param mirrors core's generic `getService<T>(): T | null`
- * signature so a full `IAgentRuntime` is assignable here; the resolved
- * service is narrowed to the {@link CwdLookup} shape internally.
+ * signature so a full `IAgentRuntime` is assignable here.
  */
 export function resolveInputPath(
   runtime: Pick<IAgentRuntime, "getService">,
@@ -108,9 +107,7 @@ export function resolveInputPath(
   filePath: string,
 ): string {
   if (isAbsolutePath(filePath)) return filePath;
-  const cwdService = runtime.getService(
-    "CODING_TOOLS_SESSION_CWD",
-  ) as CwdLookup | null;
+  const cwdService = runtime.getService<CwdLookup>("CODING_TOOLS_SESSION_CWD");
   const cwd = cwdService?.getCwd(conversationId) ?? process.cwd();
   return path.resolve(cwd, filePath);
 }

--- a/plugins/plugin-coding-tools/src/lib/path-utils.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.ts
@@ -6,6 +6,8 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+import type { IAgentRuntime } from "@elizaos/core";
+
 const BLOCKED_PATHS = new Set([
   "/dev/zero",
   "/dev/random",
@@ -85,21 +87,30 @@ export function resolveRelativeToCwd(filePath: string, cwd: string): string {
   return isAbsolutePath(filePath) ? filePath : path.resolve(cwd, filePath);
 }
 
+/** Minimal shape of the SessionCwdService this resolver depends on. */
+interface CwdLookup {
+  getCwd(id: string | undefined): string;
+}
+
 /**
  * Resolve a handler's `file_path` input to an absolute path using the
  * conversation's working directory. Owns the SessionCwdService lookup so
  * read/write/edit share one definition; `getCwd` itself defaults to
  * `process.cwd()` when the conversation has no recorded cwd.
+ *
+ * The `runtime` param mirrors core's generic `getService<T>(): T | null`
+ * signature so a full `IAgentRuntime` is assignable here; the resolved
+ * service is narrowed to the {@link CwdLookup} shape internally.
  */
 export function resolveInputPath(
-  runtime: {
-    getService(type: string): { getCwd(id: string | undefined): string } | null;
-  },
+  runtime: Pick<IAgentRuntime, "getService">,
   conversationId: string | undefined,
   filePath: string,
 ): string {
   if (isAbsolutePath(filePath)) return filePath;
-  const cwdService = runtime.getService("CODING_TOOLS_SESSION_CWD");
+  const cwdService = runtime.getService(
+    "CODING_TOOLS_SESSION_CWD",
+  ) as CwdLookup | null;
   const cwd = cwdService?.getCwd(conversationId) ?? process.cwd();
   return path.resolve(cwd, filePath);
 }

--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -51,11 +51,11 @@ describe("#13111 strict-safe record/map tool args", () => {
       },
     ]) as Record<string, { inputSchema: { jsonSchema: unknown }; strict?: boolean }>;
 
-    expect(toolSet.TASKS?.strict).toBe(false);
-    expect(toolSet.TASKS?.inputSchema.jsonSchema).toEqual(schema);
-    expect((toolSet.TASKS?.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
-      "action",
-    ]);
+    const tasks = toolSet.TASKS;
+    if (!tasks) throw new Error("expected TASKS tool in normalized set");
+    expect(tasks.strict).toBe(false);
+    expect(tasks.inputSchema.jsonSchema).toEqual(schema);
+    expect((tasks.inputSchema.jsonSchema as { required?: string[] }).required).toEqual(["action"]);
   });
 
   it("turns additionalProperties:true into a strict entries array", () => {

--- a/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
@@ -20,11 +20,26 @@ function workflow(parameters: Record<string, unknown>, type = 'workflows-nodes-b
 }
 
 function assignments(definition: WorkflowDefinition): Array<Record<string, unknown>> {
-  return (
-    definition.nodes[0]?.parameters.assignments as {
-      assignments: Array<Record<string, unknown>>;
-    }
-  ).assignments;
+  const node = definition.nodes[0];
+  if (!node) {
+    throw new Error('Expected the workflow fixture to contain a node');
+  }
+
+  const assignmentGroup = node.parameters.assignments;
+  if (
+    typeof assignmentGroup !== 'object' ||
+    assignmentGroup === null ||
+    !('assignments' in assignmentGroup) ||
+    !Array.isArray(assignmentGroup.assignments) ||
+    !assignmentGroup.assignments.every(
+      (assignment: unknown) =>
+        typeof assignment === 'object' && assignment !== null && !Array.isArray(assignment)
+    )
+  ) {
+    throw new Error('Expected normalized workflow assignments');
+  }
+
+  return assignmentGroup.assignments;
 }
 
 describe('Set/Edit Fields parameter normalization', () => {


### PR DESCRIPTION
Closes #16810.

Restores the current develop CI baseline after the Biome 2.5.5 synchronization and overlapping merges. It incorporates the valid portions of #16789 and #16800, fixes the remaining gateway/core/agent formatting and type errors, and preserves generic getService typing without an unsafe cast.

Regression proof:
- Gateway mutable exclusion list: existing test failed before because the first recorded broker call changed from [a] to [a,b]; passing a copy makes the same test pass.
- Gateway CLI lifecycle: adds success and invalid-argument coverage plus storage-reserve boundary coverage. cli.ts line coverage is 62.71%, above the 50% changed-file threshold.
- Gateway package: typecheck passed; 9 test files / 68 tests passed.
- Core planner/execute: 132 tests passed; current-base core lint regressions: 19 tests passed.
- Coding-tools: package typecheck and lib/write tests passed.
- Agent trigger/workflow/OpenAI scoped suites were verified while reviewing the incorporated changes.
- Exact pinned Biome 2.5.5 changed-file check passes.

Evidence applicability: no UI, model, device, audio, or external connector behavior changes; screenshots/video/live-model trajectories are N/A.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - this repairs compile, lint, and deterministic boundary behavior; the real package test and CI logs are linked in checks.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, provider, action, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced by CI/tooling cleanup.