### PR TITLE
fix(agent): format PAGE_DELEGATE alias test

### DIFF
--- a/packages/agent/src/actions/page-action-groups.test.ts
+++ b/packages/agent/src/actions/page-action-groups.test.ts
@@ -71,43 +71,43 @@ async function invoke(
 }
 
 describe("PAGE_DELEGATE workflow alias repair", () => {
-  it.each([
-    "WORKFLOW_CREATE",
-    "CREATE_WORKFLOW",
-  ])("canonicalizes %s to WORKFLOW action=create using the user's request", async (alias) => {
-    let calls = 0;
-    let receivedOptions: HandlerOptions | undefined;
-    const handler: Action["handler"] = async (
-      _runtime,
-      _message,
-      _state,
-      options,
-    ): Promise<ActionResult> => {
-      calls += 1;
-      receivedOptions = options;
-      return {
-        success: true,
-        text: "created",
+  it.each(["WORKFLOW_CREATE", "CREATE_WORKFLOW"])(
+    "canonicalizes %s to WORKFLOW action=create using the user's request",
+    async (alias) => {
+      let calls = 0;
+      let receivedOptions: HandlerOptions | undefined;
+      const handler: Action["handler"] = async (
+        _runtime,
+        _message,
+        _state,
+        options,
+      ): Promise<ActionResult> => {
+        calls += 1;
+        receivedOptions = options;
+        return {
+          success: true,
+          text: "created",
+        };
       };
-    };
-    const runtime = makeRuntime(handler);
+      const runtime = makeRuntime(handler);
 
-    const result = await invoke(runtime, alias, {
-      definition: {
-        nodes: [{ type: "invented", parameters: { value: "wrong" } }],
-      },
-      active: false,
-    });
+      const result = await invoke(runtime, alias, {
+        definition: {
+          nodes: [{ type: "invented", parameters: { value: "wrong" } }],
+        },
+        active: false,
+      });
 
-    expect(result.success).toBe(true);
-    expect(calls).toBe(1);
-    expect(receivedOptions?.parameters).toEqual({
-      action: "create",
-      seedPrompt: CREATE_REQUEST,
-      active: false,
-    });
-    expect(receivedOptions?.parameters).not.toHaveProperty("definition");
-  });
+      expect(result.success).toBe(true);
+      expect(calls).toBe(1);
+      expect(receivedOptions?.parameters).toEqual({
+        action: "create",
+        seedPrompt: CREATE_REQUEST,
+        active: false,
+      });
+      expect(receivedOptions?.parameters).not.toHaveProperty("definition");
+    },
+  );
 
   it("preserves an already-canonical WORKFLOW delegation", async () => {
     let receivedOptions: HandlerOptions | undefined;


### PR DESCRIPTION
Closes #16812

## Summary

- applies the Biome 2.5.5 canonical formatting to the PAGE_DELEGATE workflow alias table test
- keeps the repair to one test file with no runtime or assertion changes
- removes the next unowned fail-fast formatter blocker on exact develop

## Root cause

The file was formatted under Biome 2.5.1, which accepts the existing callback layout. CI now resolves Biome 2.5.5, whose formatter requires the table and callback to use the updated wrapping shape.

## Validation

- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/actions/page-action-groups.test.ts` — 1 file / 4 tests passed
- `bunx @biomejs/biome@2.5.5 check packages/agent/src/actions/page-action-groups.test.ts` — passed
- `git diff --check origin/develop...HEAD` — passed
- `bun run audit:error-policy-ratchet` — passed; zero changed production files
- [Changed-file coverage](https://github.com/elizaOS/eliza/actions/runs/29947065574/job/89015035289) — passed
- [Build](https://github.com/elizaOS/eliza/actions/runs/29947064774/job/89015032616) — passed
- `bun run --cwd packages/agent lint:check` — changed file passes; remaining errors are in files already owned by #16789
- `bun run --cwd packages/agent typecheck` — reports unrelated exact-develop failures; this formatting-only diff adds no TypeScript change

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - the only changed file is a non-rendered test file and this PR changes formatting only; no UI surface changes.`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no rendered UI source or pixels change; the diff is formatting-only in a test file.`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - this PR has no user-visible flow or runtime behavior to demonstrate.`

<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - test-source formatting neither changes nor executes a backend code path; focused Vitest and CI build evidence are linked above.`

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend source, request, response, or client state path changes.`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no production agent action, provider, prompt, model, or runtime behavior changes.`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - formatting a deterministic unit-test table produces no DB, memory, scheduled-task, file, wallet, chain, audio, or device artifact.`

## Evidence Details

<details>
<summary>Focused deterministic proof</summary>

```text
Head: a645fb05ed9becd32a49b674ca542e9def8a91a5
Changed file: packages/agent/src/actions/page-action-groups.test.ts
Vitest: 1 file / 4 tests passed
Biome 2.5.5: passed
git diff --check: passed
error-policy ratchet: passed (zero changed production files)
```

The changed-file coverage and build job links above are the applicable CI artifacts. Runtime, visual, model, device, and domain evidence are non-applicable because this PR changes only whitespace/layout in test source.

</details>
