### PR TITLE
fix(ci): align CodeQL action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,6 +95,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## What changed

Pinned github/codeql-action/analyze to the same 4.37.3 commit already used by init.

## Root cause

Dependabot upgraded only init from 4.37.0 to 4.37.3. CodeQL post-action loaded configuration written by 4.37.3 while analyze still ran 4.37.0.

## Validation

- Both CodeQL action steps resolve to e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 (4.37.3)
- git diff --check
- Full hosted CodeQL lifecycle will run after merge because this workflow triggers on pushes to main, scheduled runs, and manual dispatch rather than develop-targeted PRs

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - workflow-only change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - workflow-only change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - workflow-only change has no interactive user flow.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no application backend code or runtime path changed.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend code or network behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent, prompt, provider, action, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - dependency pin alignment produces no domain artifact.
