### PR TITLE
fix(ci): keep CodeQL action phases aligned

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,6 +95,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
         with:
           category: "/language:${{matrix.language}}"

--- a/packages/scripts/__tests__/codeql-action-version-contract.test.ts
+++ b/packages/scripts/__tests__/codeql-action-version-contract.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Verifies the CodeQL workflow's action phases share one immutable release and
+ * proves the contract rejects the cross-version state that breaks analysis.
+ */
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { assertCodeqlActionVersions } from "../codeql-action-version-contract";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const WORKFLOW_PATH = `${REPOSITORY_ROOT}/.github/workflows/codeql.yml`;
+
+test("all CodeQL action phases use one immutable release", () => {
+  const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+  expect(assertCodeqlActionVersions(workflow)).toMatch(/^[0-9a-f]{40}$/);
+});
+
+test("cross-version CodeQL phases fail the contract", () => {
+  const workflow = `
+    - uses: github/codeql-action/init@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - uses: github/codeql-action/analyze@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  `;
+  expect(() => assertCodeqlActionVersions(workflow)).toThrow(
+    "CodeQL action phases must use one release",
+  );
+});
+
+test("floating CodeQL action tags fail the contract", () => {
+  const workflow = `
+    - uses: github/codeql-action/init@v4
+    - uses: github/codeql-action/analyze@v4
+  `;
+  expect(() => assertCodeqlActionVersions(workflow)).toThrow(
+    "must use an immutable 40-character commit SHA",
+  );
+});

--- a/packages/scripts/codeql-action-version-contract.ts
+++ b/packages/scripts/codeql-action-version-contract.ts
@@ -1,0 +1,57 @@
+/**
+ * Enforces one immutable CodeQL Action release across every workflow phase.
+ * CodeQL persists versioned configuration between initialization and analysis,
+ * so mixing otherwise valid action pins makes the later phase fail at runtime.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const CODEQL_ACTION_PATTERN =
+  /uses:\s*github\/codeql-action\/(init|analyze|upload-sarif)@([^\s#]+)/g;
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export function assertCodeqlActionVersions(workflow: string): string {
+  const phases = [...workflow.matchAll(CODEQL_ACTION_PATTERN)].map((match) => ({
+    phase: match[1],
+    version: match[2],
+  }));
+
+  const requiredPhases = new Set(["init", "analyze"]);
+  for (const { phase } of phases) {
+    requiredPhases.delete(phase);
+  }
+  if (requiredPhases.size > 0) {
+    throw new Error(
+      `CodeQL workflow is missing required phase(s): ${[...requiredPhases].join(", ")}`,
+    );
+  }
+
+  for (const { phase, version } of phases) {
+    if (!COMMIT_SHA_PATTERN.test(version)) {
+      throw new Error(
+        `CodeQL ${phase} must use an immutable 40-character commit SHA; received ${version}`,
+      );
+    }
+  }
+
+  const versions = new Set(phases.map(({ version }) => version));
+  if (versions.size !== 1) {
+    const detail = phases
+      .map(({ phase, version }) => `${phase}@${version}`)
+      .join(", ");
+    throw new Error(`CodeQL action phases must use one release: ${detail}`);
+  }
+
+  return phases[0].version;
+}
+
+if (import.meta.main) {
+  const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+  const workflow = readFileSync(
+    `${repositoryRoot}/.github/workflows/codeql.yml`,
+    "utf8",
+  );
+  const version = assertCodeqlActionVersions(workflow);
+  process.stdout.write(`CodeQL action version contract passed (${version}).\n`);
+}


### PR DESCRIPTION
Closes #16816

## What changed

- aligns CodeQL analysis with the immutable 4.37.3 commit already used by initialization
- adds a reusable contract that requires all CodeQL phases to use one 40-character commit SHA
- adds real-workflow, cross-version mutation, and floating-tag regression tests

## Root cause

The workflow initialized CodeQL with action 4.37.3 but analyzed with 4.37.0. CodeQL stores versioned configuration between phases and rejected the later action with: Loaded a configuration file for version 4.37.3, but running version 4.37.0.

Observed run: https://github.com/elizaOS/eliza/actions/runs/29949960985/job/89024881480

## Validation

- bun test packages/scripts/__tests__/codeql-action-version-contract.test.ts — 3 passed
- bun packages/scripts/codeql-action-version-contract.ts — passed
- actionlint .github/workflows/codeql.yml — passed
- bunx biome check on both new TypeScript files — passed
- git diff --check — passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only security analysis change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only security analysis change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend runtime changed; the failing Actions job and focused validation output are linked above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or generated runtime artifact changed.