### PR TITLE
feat(registry): list plugin-serpdive as a third-party plugin

### DIFF
--- a/packages/registry/entries/third-party/plugin-serpdive.json
+++ b/packages/registry/entries/third-party/plugin-serpdive.json
@@ -1,0 +1,9 @@
+{
+  "package": "plugin-serpdive",
+  "repository": "github:serpdive/plugin-serpdive",
+  "kind": "plugin",
+  "description": "Web search for elizaOS agents through SERPdive: every result carries the extracted, answer-ready content of the page instead of a link or snippet, so agents can quote and cite facts straight from the response. Registers a ServiceType.WEB_SEARCH service and the \"web\" search category, with two retrieval depths (fact-carrying sentences or full page text) and an optional synthesized answer.",
+  "homepage": "https://serpdive.com",
+  "version": "0.1.1",
+  "tags": ["web-search", "search", "serpdive", "rag", "research", "current-information"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1025,6 +1025,52 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "plugin-serpdive": {
+      "git": {
+        "repo": "serpdive/plugin-serpdive",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-serpdive",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Web search for elizaOS agents through SERPdive: every result carries the extracted, answer-ready content of the page instead of a link or snippet, so agents can quote and cite facts straight from the response. Registers a ServiceType.WEB_SEARCH service and the \"web\" search category, with two retrieval depths (fact-carrying sentences or full page text) and an optional synthesized answer.",
+      "homepage": "https://serpdive.com",
+      "topics": [
+        "web-search",
+        "search",
+        "serpdive",
+        "rag",
+        "research",
+        "current-information"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-wallettriage": {
       "git": {
         "repo": "wallettriage/plugin-wallettriage",


### PR DESCRIPTION
Lists [`plugin-serpdive`](https://www.npmjs.com/package/plugin-serpdive) as a third-party plugin, following `packages/registry/README.md` → "Adding a third-party plugin".

This is the follow-up to #16758, which @lalalune closed with a pointer to the third-party guide — thanks for the redirect. The provider now ships as a standalone package instead of living in the monorepo.

**What it does.** Web search for elizaOS agents through [SERPdive](https://serpdive.com): every result carries the extracted, answer-ready content of the page instead of a link or snippet, so an agent can quote and cite facts straight from the response. It registers a `ServiceType.WEB_SEARCH` service and the `"web"` search category, with two retrieval depths (fact-carrying sentences, or full page text) and an optional synthesized answer. Free tier: 1,000 credits/month, no card.

Measured, not asserted: on a [public, replayable 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark) judged blind by an independent model, SERPdive runs at the same speed as Tavily, feeds the LLM 20.2% fewer tokens, and wins 60.7% of decided quality duels against Tavily's default search.

**Checklist from the guide:**

- [x] Published to npm, outside the reserved `@elizaos/*` scope
- [x] `elizaos` in `package.json` keywords (runtime auto-discovery)
- [x] Ships a valid `elizaos.plugin.json` manifest
- [x] Public GitHub repository: https://github.com/serpdive/plugin-serpdive (MIT)
- [x] README with setup steps and the required env var (`SERPDIVE_API_KEY`)
- [x] `@elizaos/core` declared as a `peerDependency` (`^2.0.3-beta.7` — the plugin implements the 2.x web-search contract)

**Verified locally before opening this:**

- `bun run --cwd packages/registry validate` → 26 third-party entries validated
- `bun run --cwd packages/registry generate` → regenerated `generated-registry.json` (the only two files in this diff)
- On the plugin itself: `tsc --noEmit` clean, tsup ESM + types build, 6/6 vitest, biome clean, and a live end-to-end run against the API (plugin init → category registered → `service.search()` → results with extracted page content → clean stop)

Happy to adjust anything — tags, description length, or the entry shape.
