### PR TITLE
fix(ui): make LP3 Home-to-Apps swipe reliable

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -233,6 +233,14 @@ async function touchSwipeLeft(page, testId) {
     stepDelayMs: 16,
   });
 }
+async function touchSlowDragLeft(page, testId) {
+  await touchSwipe(page, `[data-testid="${testId}"]`, -280, 0, {
+    steps: 10,
+    // The complete gesture lasts over a second, keeping release velocity below
+    // the flick path so this certifies the deliberate-drag distance threshold.
+    stepDelayMs: 120,
+  });
+}
 async function touchSwipeRight(page, testId) {
   await touchSwipe(page, `[data-testid="${testId}"]`, 280, 0, {
     steps: 10,
@@ -847,6 +855,20 @@ try {
     `home settle is layout-stable (CLS ${stability.cls.toFixed(4)} ≤ 0.1, ${stability.shiftCount} shifts)`,
   );
 
+  await waitForSurfacePageSettled(mobile, "home");
+
+  // A real finger often performs a deliberate drag rather than a sharp flick.
+  // This ~35%-wide, low-velocity touch path used to reveal Apps and then snap
+  // back because the pager required half the screen; it must now commit.
+  await touchSlowDragLeft(mobile, "home-launcher-home-page");
+  await waitForSurfacePageSettled(mobile, "launcher");
+  assert(
+    (await mobile.getByTestId("home-launcher-surface").getAttribute(
+      "data-page",
+    )) === "launcher",
+    "deliberate one-second thumb drag opens the launcher before half-screen travel",
+  );
+  await touchSwipeRight(mobile, "home-launcher-launcher-page");
   await waitForSurfacePageSettled(mobile, "home");
 
   // Real touch left-swipe on the home half pages the outer rail to the

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -234,12 +234,21 @@ async function touchSwipeLeft(page, testId) {
   });
 }
 async function touchSlowDragLeft(page, testId) {
-  await touchSwipe(page, `[data-testid="${testId}"]`, -280, 0, {
-    steps: 10,
-    // The complete gesture lasts over a second, keeping release velocity below
-    // the flick path so this certifies the deliberate-drag distance threshold.
-    stepDelayMs: 120,
-  });
+  const viewportWidth = page.viewportSize()?.width;
+  if (!viewportWidth) throw new Error("missing viewport width for slow drag");
+  await touchSwipe(
+    page,
+    `[data-testid="${testId}"]`,
+    -viewportWidth * 0.35,
+    0,
+    {
+      steps: 10,
+      // The complete gesture lasts over a second, keeping release velocity below
+      // the flick path. Thirty-five percent is above the production 30% commit
+      // threshold but below the old 50% threshold, so this fails on regression.
+      stepDelayMs: 120,
+    },
+  );
 }
 async function touchSwipeRight(page, testId) {
   await touchSwipe(page, `[data-testid="${testId}"]`, 280, 0, {

--- a/packages/ui/src/hooks/useHorizontalPager.test.tsx
+++ b/packages/ui/src/hooks/useHorizontalPager.test.tsx
@@ -126,7 +126,7 @@ describe("useHorizontalPager — velocity-aware momentum settle (#10717)", () =>
     const { getByTestId, unmount } = render(
       <Harness onPageChange={fastChange} />,
     );
-    // dx = -700 (crosses the 50% distance threshold on the 1024px jsdom
+    // dx = -700 (crosses the distance threshold on the 1024px jsdom
     // viewport → advances even without flick velocity), released in 40ms.
     swipeNext(getByTestId("rail"), 800, 100, 40);
     expect(fastChange).toHaveBeenCalledWith(1);
@@ -135,7 +135,7 @@ describe("useHorizontalPager — velocity-aware momentum settle (#10717)", () =>
 
     const slowChange = vi.fn();
     const { getByTestId: get2 } = render(<Harness onPageChange={slowChange} />);
-    // Same dx = -700 (past the 50% threshold), but released slowly over 1400ms.
+    // Same dx = -700 (past the distance threshold), but released slowly over 1400ms.
     swipeNext(get2("rail"), 800, 100, 1400);
     expect(slowChange).toHaveBeenCalledWith(1);
     const slowMs = settleMsFromRail(get2("rail"));
@@ -157,6 +157,16 @@ describe("useHorizontalPager — velocity-aware momentum settle (#10717)", () =>
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("commits an intentional slow drag after thirty percent of the viewport", () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(<Harness onPageChange={onChange} />);
+    // 330px is just over 30% of jsdom's 1024px viewport, but the 1.2s release
+    // is far below flick velocity. This covers the physical-phone path where a
+    // thumb deliberately drags the pane instead of producing a sharp flick.
+    swipeNext(getByTestId("rail"), 800, 470, 1200);
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
   it("uses a restrained settle under prefers-reduced-motion instead of jumping", () => {
     // The live drag still tracks the finger without a transition. On release,
     // reduced motion uses a short non-bouncy settle so the page does not jump
@@ -176,7 +186,7 @@ describe("useHorizontalPager — velocity-aware momentum settle (#10717)", () =>
       const onChange = vi.fn();
       const { getByTestId } = render(<Harness onPageChange={onChange} />);
       const rail = getByTestId("rail");
-      // Commit a swipe (crosses the 50% distance floor on the 1024px viewport).
+      // Commit a swipe (crosses the distance floor on the 1024px viewport).
       swipeNext(rail, 800, 100, 40);
       expect(onChange).toHaveBeenCalledWith(1);
       expect(settleMsFromRail(rail)).toBe(420);
@@ -570,6 +580,42 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
     });
     expect(rail.style.willChange).toBe("");
     expect(isRailGestureActive()).toBe(false);
+  });
+
+  it("keeps an ambiguous finger start pending until horizontal intent is clear", () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(<Harness onPageChange={onChange} />);
+    const rail = getByTestId("rail");
+    act(() => {
+      clock = 1000;
+      fireEvent.pointerDown(rail, {
+        ...touch,
+        clientX: 800,
+        clientY: 300,
+      });
+      // Equal X/Y travel is neither horizontal nor vertical intent. The pager
+      // must not permanently classify this first thumb jitter as a scroll.
+      fireEvent.pointerMove(rail, {
+        ...touch,
+        clientX: 792,
+        clientY: 308,
+      });
+      expect(isRailGestureActive()).toBe(true);
+
+      clock = 1500;
+      fireEvent.pointerMove(rail, {
+        ...touch,
+        clientX: 430,
+        clientY: 312,
+      });
+      clock = 2200;
+      fireEvent.pointerUp(rail, {
+        ...touch,
+        clientX: 430,
+        clientY: 312,
+      });
+    });
+    expect(onChange).toHaveBeenCalledWith(1);
   });
 
   it("drops the pointerdown promotion after a plain tap (zero-delta settle, no transitionend)", () => {

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -1,7 +1,8 @@
 /**
- * Horizontal paging gesture for the home↔launcher rail: axis-lock, half-viewport
- * commit threshold, and velocity-aware settle so a flick commits early and a
- * slow drag springs back. Tuned for the iOS carousel feel.
+ * Horizontal paging gesture for the home↔launcher rail: recoverable axis-lock,
+ * a deliberate-drag commit threshold, and velocity-aware settle so a flick
+ * commits early while an intentional drag does not require crossing half of a
+ * phone screen.
  */
 import * as React from "react";
 import {
@@ -19,12 +20,11 @@ import { beginRailGesture, endRailGesture } from "../state/rail-gesture-store";
 // module as named PAGER_* overrides (see gestures/constants.ts for why each
 // diverges from the shared defaults); the constants below are pager-only feel.
 const MIN_DISTANCE_THRESHOLD = 64;
-// A slow drag commits the page only once the finger has crossed the halfway
-// point of the viewport; short of that it springs back. This is the iOS
-// carousel feel the user asked for ("past the 50% point if I let go it will
-// animate over"). A fast flick still commits early via the velocity path below,
-// so a quick swipe never has to travel the full 50%.
-const DISTANCE_THRESHOLD_RATIO = 0.5;
+// A slow drag commits after crossing 30% of the viewport. Requiring half the
+// screen made ordinary physical-phone swipes reveal the next page and then snap
+// back; 30% remains deliberate while matching the distance a thumb naturally
+// travels. A fast flick still commits earlier through the velocity path below.
+const DISTANCE_THRESHOLD_RATIO = 0.3;
 const MIN_FLICK_DISTANCE = 48;
 const SETTLE_MS = 460;
 const SETTLE_EASING = "cubic-bezier(0.25, 0.1, 0.25, 1)";
@@ -701,7 +701,17 @@ export function useHorizontalPager<
         const ax = Math.abs(dx);
         const ay = Math.abs(dy);
         if (Math.max(ax, ay) < AXIS_COMMIT_SLOP) return;
-        state.axis = ax > ay * AXIS_DOMINANCE_RATIO ? "horizontal" : "vertical";
+        // A human finger rarely starts on a mathematically straight line. Keep
+        // an ambiguous diagonal pending until one axis actually dominates;
+        // treating every non-horizontal first sample as vertical permanently
+        // cancelled otherwise-valid swipes after only a few pixels of jitter.
+        if (ax > ay * AXIS_DOMINANCE_RATIO) {
+          state.axis = "horizontal";
+        } else if (ay > ax * AXIS_DOMINANCE_RATIO) {
+          state.axis = "vertical";
+        } else {
+          return;
+        }
         // The promotion was armed at pointerdown (so the compositor had the
         // slop window to build the layer before the first tracked frame). A
         // gesture that commits VERTICAL is the home widget list scrolling, not
@@ -711,6 +721,10 @@ export function useHorizontalPager<
         if (state.axis === "vertical") dropRailPromotion();
       }
       if (state.axis !== "horizontal") return;
+
+      // Once horizontal intent is established, keep the WebView from handing a
+      // slightly diagonal continuation to native vertical panning mid-gesture.
+      event.preventDefault();
 
       // Touch pointers are IMPLICITLY captured to the target on pointerdown, so
       // an explicit setPointerCapture is redundant — and on Android WebView it

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -200,6 +200,18 @@ describe("CSS lockdown contract — base.css / styles.css cover body.pwa-standal
     expect(panYBlock?.[0]).toContain("body.pwa-standalone");
   });
 
+  it("pins touch-pan-y to a literal value inside installed shells", () => {
+    // Some bundled WebViews parse Tailwind's custom-property declaration but
+    // resolve its empty slots to `auto`; a literal installed-shell rule keeps
+    // nested notification and launcher scroll regions on the pager contract.
+    const utilityBlock = stylesCss.match(
+      /body\.native \.touch-pan-y,[\s\S]*?touch-action: pan-y;/,
+    );
+    expect(utilityBlock).not.toBeNull();
+    expect(utilityBlock?.[0]).toContain("body.platform-android .touch-pan-y");
+    expect(utilityBlock?.[0]).toContain("body.pwa-standalone .touch-pan-y");
+  });
+
   it("fills #root to the viewport (100dvh) for the installed PWA — full-bleed to the bottom", () => {
     // With the non-fixed body there is no ICB collapse, so `#root` simply fills
     // the viewport (`100dvh`, `100vh` fallback) and the app paints to the true

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -164,6 +164,18 @@ body.pwa-standalone {
   touch-action: pan-y;
 }
 
+/* Native shells can ship an older WebView that accepts Tailwind's custom-
+   property touch-action syntax but resolves its empty custom-property slots to
+   the initial `auto` value. Pin the semantic utility to a literal value in
+   installed shells so nested scroll regions cannot hand horizontal rail drags
+   to the browser and terminate them with `pointercancel`. */
+body.native .touch-pan-y,
+body.platform-ios .touch-pan-y,
+body.platform-android .touch-pan-y,
+body.pwa-standalone .touch-pan-y {
+  touch-action: pan-y;
+}
+
 /* Installed iOS PWAs can report a large viewport (`100lvh`) that reaches the
    physical screen while `100dvh` and `innerHeight` remain collapsed above the
    home indicator. Size `html` to the large viewport so its overflow clip and


### PR DESCRIPTION
# Relates to

Closes #16821.

Depends on #16805: that PR restores the separate Home/Apps rail. This PR fixes the rail's physical touch behavior without rewriting #16805 or #16788.

- [x] This PR targets `develop` and is rebased onto current `origin/develop` (`e935a5c526`) with zero conflicts.
- [x] Dependencies were installed and the scoped verification suite passed; fresh CI is authoritative for repository-wide status.
- [x] A reviewer can confirm the change without reading the code from the physical LP3 evidence below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] Scoped typecheck, tests, Biome, diff check, error-policy ratchet, and UI-determinism ratchet pass on current `develop`.

# Post-demo current-develop sync

- [x] Exact base `b44d5c6c6c1ccae244132d567e408c566ff2fcb2`; exact head `708a0fb87d2d91e13f0d26a8be0abdf249675b63`.
- [x] `git range-diff` marks all three commits `=` against the prior published series.
- [x] Rebased focused suites: 4 files / 85 tests passed; Biome, package typecheck, diff check, error-policy ratchet, and UI-determinism ratchet passed.
- [x] The standalone branch passes the new slow-drag assertion and then encounters the known duplicate launcher topology because #16805 is not yet merged. The combined #16805 + #16822 lane passes the full pager/launcher path; clean `develop` reproduces the same four stale native-tile fixture assertions.
- [x] The combined app audit passed 246/246 views with broken=0 and needs-work=0; OCR broken=0, and mobile Home/Launcher captures were manually reviewed.
- [x] Fresh CI is running on this exact head. The LP3 remains preserved only until the chain merges; exact merged-build same-signer revalidation is next.

# Risks

Low-to-medium interaction risk. The change affects deliberate horizontal pager gestures and installed-shell `touch-pan-y` semantics. Vertical scrolling, notification expansion, composer focus, cold relaunch, and live Cloud chat were exercised on the physical LP3. The literal CSS rule is scoped to installed native/PWA shells and implements the semantics already requested by the existing utility class.

# Background

## What does this PR do?

- Keeps an ambiguous, slightly diagonal finger start pending until one axis clearly dominates.
- Commits a deliberate slow drag after 30% rather than 50% of the viewport while retaining the existing velocity flick path.
- Prevents native scrolling from taking over after horizontal intent locks.
- Pins installed-shell `.touch-pan-y` to literal `touch-action: pan-y` for older bundled WebViews.
- Adds unit, CSS-contract, and real CDP touch regression coverage. The CDP test uses a one-second 35%-width drag and fails against the old 50% hook.

## Root cause

The LP3 bundles Chrome WebView 113. Tailwind 4's generated custom-property `touch-action` form is accepted there but computes to `auto`; the browser claims the drag and emits `pointercancel` after roughly 8 CSS pixels. Desktop/mirror mouse drags therefore passed while a real finger moved the rail slightly and snapped it back.

## What kind of change is this?

Bug fix; no API, protocol, backend, auth, provisioning, or data-model changes.

# Documentation changes needed?

No user documentation change is required. Durable rationale is kept beside the pager constants and installed-shell CSS compatibility rule.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/hooks/useHorizontalPager.ts`, then the installed-shell rule in `packages/ui/src/styles/styles.css` and the physical-device walkthrough below.

## Detailed testing steps

- `bunx vitest run` on the pager hook, HomeLauncherSurface, composed surface, mechanics gate, and installed-shell lockdown: green (85 tests in the integration lane; focused current-`develop` suites also green).
- `packages/ui` typecheck: green.
- Exact Biome and syntax checks: green (only pre-existing CSS suppression warnings).
- `git diff --check`: green.
- `bun run audit:error-policy-ratchet`: green.
- `bun run audit:ui-determinism`: green.
- Real CDP regression: patched 30% hook passes a one-second 35%-viewport drag; temporarily restoring the 50% hook times out waiting for Apps.
- Physical LP3: 3/3 slow short Home→Apps and 3/3 Apps→Home drags passed, plus a post-cold-launch cycle in both directions.
- Physical LP3 live production Cloud chat: `Reply exactly LP3 SWIPE FIX 1548` received `LP3 SWIPE FIX 1548`; composer returned idle.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before physical-LP3 Home screenshot: ![before Home](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-before.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After physical-LP3 screenshots: ![Apps](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-after-apps.jpg) ![Home](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-after-home.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Physical-device slow-short swipe walkthrough: [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-proof.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - this changes only client gesture handling and installed-shell CSS; no backend code path changed.
<!-- evidence-row:frontend-logs -->
- [x] CDP touch-event, computed-style, build-manifest, and state-change log: [frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed; the live model response is included only as end-to-end Cloud/device non-regression proof.
<!-- evidence-row:domain-artifacts -->
- [x] APK/signer/install/cold-relaunch/live-reply device proof: [device-proof.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-device-proof.log). Apple Vision OCR text readout: [ocr.ndjson](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/lp3-pager-e2d1682-ocr.ndjson).

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing code changed. A live production Cloud response on the physical phone passed as a non-regression check.

## Backend + frontend logs

Backend: N/A - no backend path changed.

Frontend/device: the linked logs record the pre-fix `pointercancel`, post-fix computed `pan-y`, six consecutive page commits, exact embedded build manifest, same-signer in-place update, preserved first-install time/auth/history, empty ADB reverse table, and live Cloud reply.

## Screenshots (before / after) + video walkthrough

The release assets linked above were captured from the physical LP3 after rebuilding and installing the exact Cloud APK. The screenshots, MP4, and Apple Vision OCR output were manually reviewed.

## Audio / voice walkthrough

N/A - voice/TTS/STT behavior did not change.

## Known gaps / failures

- Current `develop` still embeds `LauncherSurface` inside Home and does not mount the separate `HomeLauncherSurface`; #16805 must merge first. The full current-`develop` Home fixture later sees duplicate launcher tiles for this known topology, while the new gesture assertion itself passes. This branch deliberately does not absorb or rewrite #16805.
- A prior repository-wide `bun run verify` run stopped at the then-current pre-existing type-safety ratchet baseline (`as unknown as` 84 > 79 and existing `??` totals above baseline). None of this PR's five files adds those patterns; the diff-scoped error-policy and UI-determinism ratchets pass.
- The physical APK proof is commit `e2d1682ede` atop the known #16805/#16788 integration. The two production patches have identical patch IDs on this current-`develop` PR branch; exact post-merge APK revalidation remains required after #16805 lands.

# Deploy Notes

No backend or Cloud deployment. Rebuild/reinstall the same-signature Cloud APK after #16805 and this PR merge, then repeat the short swipe and cold-relaunch check.