### PR TITLE
fix(ci): install Node for CodeQL extraction

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Set up Node.js for TypeScript extraction
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
       - name: Report disk before CodeQL
         shell: bash
         run: |

--- a/packages/scripts/__tests__/codeql-action-version-contract.test.ts
+++ b/packages/scripts/__tests__/codeql-action-version-contract.test.ts
@@ -6,14 +6,44 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { assertCodeqlActionVersions } from "../codeql-action-version-contract";
+import {
+  assertCodeqlActionVersions,
+  assertCodeqlRuntimeSetup,
+} from "../codeql-action-version-contract";
 
 const REPOSITORY_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 const WORKFLOW_PATH = `${REPOSITORY_ROOT}/.github/workflows/codeql.yml`;
 
 test("all CodeQL action phases use one immutable release", () => {
   const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+  expect(assertCodeqlRuntimeSetup(workflow)).toMatch(/^[0-9a-f]{40}$/);
   expect(assertCodeqlActionVersions(workflow)).toMatch(/^[0-9a-f]{40}$/);
+});
+
+test("missing Node.js setup fails the extraction contract", () => {
+  expect(() => assertCodeqlRuntimeSetup("uses: github/codeql-action/init@v4")).toThrow(
+    "must install Node.js before TypeScript extraction",
+  );
+});
+
+test("floating Node.js setup fails the extraction contract", () => {
+  const workflow = `
+    - uses: actions/setup-node@v6
+    - uses: github/codeql-action/init@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  `;
+  expect(() => assertCodeqlRuntimeSetup(workflow)).toThrow(
+    "must use an immutable 40-character commit SHA",
+  );
+});
+
+test("Node.js setup after initialization fails the extraction contract", () => {
+  const workflow = `
+    - uses: github/codeql-action/init@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - uses: actions/setup-node@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  `;
+  expect(() => assertCodeqlRuntimeSetup(workflow)).toThrow(
+    "must install Node.js before initialization",
+  );
 });
 
 test("cross-version CodeQL phases fail the contract", () => {

--- a/packages/scripts/codeql-action-version-contract.ts
+++ b/packages/scripts/codeql-action-version-contract.ts
@@ -10,6 +10,30 @@ import { fileURLToPath } from "node:url";
 const CODEQL_ACTION_PATTERN =
   /uses:\s*github\/codeql-action\/(init|analyze|upload-sarif)@([^\s#]+)/g;
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const SETUP_NODE_PATTERN = /uses:\s*actions\/setup-node@([^\s#]+)/;
+
+export function assertCodeqlRuntimeSetup(workflow: string): string {
+  const setupNode = workflow.match(SETUP_NODE_PATTERN);
+  if (!setupNode) {
+    throw new Error(
+      "CodeQL workflow must install Node.js before TypeScript extraction",
+    );
+  }
+
+  const version = setupNode[1];
+  if (!COMMIT_SHA_PATTERN.test(version)) {
+    throw new Error(
+      `CodeQL Node.js setup must use an immutable 40-character commit SHA; received ${version}`,
+    );
+  }
+
+  const initIndex = workflow.search(/uses:\s*github\/codeql-action\/init@/);
+  if (setupNode.index > initIndex) {
+    throw new Error("CodeQL workflow must install Node.js before initialization");
+  }
+
+  return version;
+}
 
 export function assertCodeqlActionVersions(workflow: string): string {
   const phases = [...workflow.matchAll(CODEQL_ACTION_PATTERN)].map((match) => ({
@@ -52,6 +76,7 @@ if (import.meta.main) {
     `${repositoryRoot}/.github/workflows/codeql.yml`,
     "utf8",
   );
+  assertCodeqlRuntimeSetup(workflow);
   const version = assertCodeqlActionVersions(workflow);
   process.stdout.write(`CodeQL action version contract passed (${version}).\n`);
 }


### PR DESCRIPTION
Closes #16825

## What changed

- installs the repository-pinned Node.js 24.15.0 runtime before CodeQL initialization
- pins actions/setup-node to the established immutable commit used across the repository
- extends the CodeQL contract to reject missing, floating, or late Node.js setup
- adds mutation coverage for every runtime-setup failure mode

## Root cause

After the phase-version mismatch was repaired, the self-hosted CodeQL runner reached TypeScript extraction but could not start Node.js because node was absent from PATH. JavaScript extraction uses an internal autobuild step even with build-mode none, so the workflow must explicitly provision Node on self-hosted runners.

Observed run: https://github.com/elizaOS/eliza/actions/runs/29950810411/job/89027737999

## Validation

- bun test packages/scripts/__tests__/codeql-action-version-contract.test.ts — 6 passed
- bun packages/scripts/codeql-action-version-contract.ts — passed
- actionlint .github/workflows/codeql.yml — passed
- biome check on both TypeScript files — passed
- git diff --check — passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only security analysis change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only security analysis change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend runtime changed; the live failing job is linked above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or generated runtime artifact changed.