### PR TITLE
fix(ci): close Feed external workspaces

### DIFF
--- a/packages/feed/package.json
+++ b/packages/feed/package.json
@@ -7,6 +7,7 @@
     "packages/*",
     "packages/examples/*",
     "tools/*",
+    "../cloud/routing",
     "../contracts",
     "../core",
     "../logger",

--- a/packages/feed/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.test.ts
+++ b/packages/feed/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.test.ts
@@ -27,7 +27,12 @@
  */
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import type {
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
 
 // ─── Mock dispatchAgentChat ───────────────────────────────────────────────────
 // Co-located with the source — this relative path matches exactly what
@@ -468,7 +473,7 @@ describe("DISPATCH_TO_AGENT handler()", () => {
   // ── _callback contract ──────────────────────────────────────────────────
 
   describe("_callback contract (ElizaOS protocol)", () => {
-    it("calls _callback with success result on successful dispatch", async () => {
+    it("calls _callback with successful dispatch content", async () => {
       mockDispatchAgentChat.mockResolvedValue({
         success: true,
         agentId: AGENT_ID,
@@ -478,7 +483,7 @@ describe("DISPATCH_TO_AGENT handler()", () => {
         isLLMFailure: false,
       });
 
-      const callbackFn = mock(async () => []);
+      const callbackFn = mock<HandlerCallback>(async () => []);
       const state = buildState();
 
       await dispatchToAgentAction.handler?.(
@@ -490,14 +495,13 @@ describe("DISPATCH_TO_AGENT handler()", () => {
       );
 
       expect(callbackFn).toHaveBeenCalledTimes(1);
-      const callArg = callbackFn.mock.calls[0]?.[0] as unknown as {
-        content: { success: boolean };
-      };
-      expect(callArg.content.success).toBe(true);
+      const callArg = callbackFn.mock.calls[0]?.[0];
+      expect(callArg?.text).toContain("Dispatched to @bot");
+      expect(callArg?.agentId).toBe(AGENT_ID);
     });
 
     it("calls _callback with failure result on missing fields (error path)", async () => {
-      const callbackFn = mock(async () => []);
+      const callbackFn = mock<HandlerCallback>(async () => []);
       const state = buildState({ actionParams: undefined });
 
       await dispatchToAgentAction.handler?.(
@@ -509,11 +513,8 @@ describe("DISPATCH_TO_AGENT handler()", () => {
       );
 
       expect(callbackFn).toHaveBeenCalledTimes(1);
-      const callArg = callbackFn.mock.calls[0]?.[0] as unknown as {
-        content: { success: boolean; text: string };
-      };
-      expect(callArg.content.success).toBe(false);
-      expect(callArg.content.text).toContain("Missing");
+      const callArg = callbackFn.mock.calls[0]?.[0];
+      expect(callArg?.text).toContain("Missing");
     });
 
     it("calls _callback with failure result when dispatch fails", async () => {
@@ -524,7 +525,7 @@ describe("DISPATCH_TO_AGENT handler()", () => {
         isLLMFailure: false,
       });
 
-      const callbackFn = mock(async () => []);
+      const callbackFn = mock<HandlerCallback>(async () => []);
       const state = buildState();
 
       await dispatchToAgentAction.handler?.(
@@ -536,11 +537,9 @@ describe("DISPATCH_TO_AGENT handler()", () => {
       );
 
       expect(callbackFn).toHaveBeenCalledTimes(1);
-      const callArg = callbackFn.mock.calls[0]?.[0] as unknown as {
-        content: { success: boolean; text: string };
-      };
-      expect(callArg.content.success).toBe(false);
-      expect(callArg.content.text).toContain("Failed");
+      const callArg = callbackFn.mock.calls[0]?.[0];
+      expect(callArg?.text).toContain("Failed");
+      expect(callArg?.agentId).toBe(AGENT_ID);
     });
   });
 
@@ -570,13 +569,14 @@ describe("DISPATCH_TO_AGENT handler()", () => {
     });
 
     it("has agentId and command in parameters schema", () => {
-      const params = dispatchToAgentAction.parameters as Record<
-        string,
-        unknown
-      >;
-      expect(params).toBeDefined();
-      expect(params.agentId).toBeDefined();
-      expect(params.command).toBeDefined();
+      const params = dispatchToAgentAction.parameters;
+      expect(Array.isArray(params)).toBe(true);
+      expect(params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "agentId" }),
+          expect.objectContaining({ name: "command" }),
+        ]),
+      );
     });
   });
 });

--- a/packages/feed/packages/engine/src/__tests__/GameSimulator.test.ts
+++ b/packages/feed/packages/engine/src/__tests__/GameSimulator.test.ts
@@ -53,6 +53,7 @@ describe("GameSimulator - Standalone Engine", () => {
       outcome: true, // YES
       numAgents: 5,
       duration: 30,
+      seed: 42,
     };
     simulator = new GameSimulator(config);
   });

--- a/packages/scripts/__tests__/feed-workspace-closure.test.ts
+++ b/packages/scripts/__tests__/feed-workspace-closure.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Verifies Feed's nested workspace includes the local dependencies required by
+ * every external elizaOS package it links from the repository workspace.
+ */
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PackageManifest {
+  name: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  workspaces?: string[];
+}
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const FEED_ROOT = join(REPOSITORY_ROOT, "packages", "feed");
+
+function readManifest(path: string): PackageManifest {
+  return JSON.parse(readFileSync(path, "utf8")) as PackageManifest;
+}
+
+test("Feed external workspaces form a closed local dependency set", () => {
+  const feedManifest = readManifest(join(FEED_ROOT, "package.json"));
+  const externalManifests = (feedManifest.workspaces ?? [])
+    .filter((workspace) => workspace.startsWith("../"))
+    .map((workspace) => {
+      const path = resolve(FEED_ROOT, workspace, "package.json");
+      return { path, manifest: readManifest(path) };
+    });
+  const availablePackages = new Set(
+    externalManifests.map(({ manifest }) => manifest.name),
+  );
+  const missingDependencies: string[] = [];
+
+  for (const { path, manifest } of externalManifests) {
+    const dependencyGroups = [
+      manifest.dependencies,
+      manifest.devDependencies,
+      manifest.optionalDependencies,
+      manifest.peerDependencies,
+    ];
+    for (const dependencies of dependencyGroups) {
+      for (const [dependency, version] of Object.entries(dependencies ?? {})) {
+        if (
+          version.startsWith("workspace:") &&
+          dependency.startsWith("@elizaos/") &&
+          !availablePackages.has(dependency)
+        ) {
+          missingDependencies.push(
+            `${manifest.name} (${dirname(path)}) requires ${dependency}`,
+          );
+        }
+      }
+    }
+  }
+
+  expect(missingDependencies).toEqual([]);
+});


### PR DESCRIPTION
Closes #16830

## What changed

- adds packages/cloud/routing to the external packages linked by the nested Feed workspace
- adds a workspace-closure regression test for every external elizaOS package Feed includes
- updates the stale dispatch-to-agent callback tests to assert the current top-level Content protocol
- updates the stale action-parameter assertion to validate the current ActionParameter array

## Root cause

Feed links packages/core into its nested workspace. Core gained a workspace dependency on @elizaos/cloud-routing, but Feed did not include that package in its external workspace list. Bun therefore rejected the frozen nested install before tests could start. Once the install reached the unit suite, one test file still asserted legacy callback and parameter-schema shapes even though production already emits the current HandlerCallback Content and ActionParameter array contracts.

Observed initial run: https://github.com/elizaOS/eliza/actions/runs/29954842260/job/89041167988
Observed post-install test run: https://github.com/elizaOS/eliza/actions/runs/29960247825/job/89059291246

## Validation

- bun test packages/scripts/__tests__/feed-workspace-closure.test.ts — passed
- bun install --frozen-lockfile --ignore-scripts from packages/feed — 4,208 packages installed
- bun test packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.test.ts — 30 passed
- biome check on the workspace regression test — passed
- git diff --check — passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - dependency/workflow test repair with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - dependency/workflow test repair with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend runtime changed; failing Actions jobs and successful focused validations are linked above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - production agent behavior is unchanged; only stale unit expectations were aligned with the existing callback and parameter contracts.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or generated runtime artifact changed.