### PR TITLE
fix(ci): scope the chat gesture coverage gate

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -111,7 +111,7 @@ jobs:
       # Boot-free coverage gate: fails when a gesture-handler site in
       # packages/ui/src lacks a CHAT_GESTURE_COVERAGE matrix row (#12188).
       - name: Chat gesture coverage gate
-        run: bun run --cwd packages/app test -- chat-gesture-coverage
+        run: bunx vitest run --config packages/app/vitest.config.ts packages/app/test/chat-gesture-coverage.test.ts
 
       # Component-tree render parity (jsdom/vitest) — ThreadLine vs MessageContent
       # render the same structure for a shared message corpus.

--- a/packages/scripts/__tests__/chat-gesture-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/chat-gesture-workflow-contract.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Keeps the chat gesture coverage step scoped to its named Vitest contract so
+ * unrelated app script tests cannot prevent the browser gesture lane running.
+ */
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const workflow = readFileSync(
+  `${REPOSITORY_ROOT}/.github/workflows/chat-shell-gestures.yml`,
+  "utf8",
+);
+
+test("chat gesture coverage invokes only its focused Vitest contract", () => {
+  const step = workflow.match(
+    /- name: Chat gesture coverage gate\n\s+run: ([^\n]+)/,
+  );
+  expect(step?.[1]).toBe(
+    "bunx vitest run --config packages/app/vitest.config.ts packages/app/test/chat-gesture-coverage.test.ts",
+  );
+  expect(step?.[1]).not.toContain("bun run --cwd packages/app test");
+});

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -1964,13 +1964,10 @@ try {
   }
 
   if (!ONLY_AUTOSCROLL) {
-  // ===== GRABBER horizontal flick → launcher intent, REAL touch (#9943) =====
-  // The collapsed grabber's horizontal swipe pages home → launcher through the
-  // shell-surface store (goLauncher). Android's on-device spec drives this with
-  // a real finger; drive it here through Chromium's REAL touch pipeline
-  // (Input.dispatchTouchEvent, hit-test + touch-action + implicit capture), and
-  // ALSO under a janked main thread (fire-and-forget dispatch → the renderer
-  // coalesces the moves), the failure shape of the Davey!-janked WebView.
+  // ===== Collapsed grabber horizontal flick stays inert, REAL touch (#9943) =====
+  // Home and apps share one surface, so a collapsed grabber has no horizontal
+  // destination. Exercise Chromium's real touch pipeline and a janked/coalesced
+  // delivery to prove neither path opens chat or changes the shell surface.
   {
     const surfacePage = (p) =>
       p.evaluate(
@@ -2007,10 +2004,10 @@ try {
     await touchSwipe(p, grabberSel, -150, -6, { steps: 14, stepDelayMs: 20 });
     await p.waitForTimeout(400);
     assert(
-      (await surfacePage(p)) === "launcher",
-      "[grabber-swipe] REAL-touch left flick on the grabber commits goLauncher (#9943)",
+      (await surfacePage(p)) === "home",
+      "[grabber-swipe] REAL-touch left flick on the collapsed grabber stays inert (#9943)",
     );
-    await snap(p, "grabber-real-touch-launcher");
+    await snap(p, "grabber-real-touch-inert");
 
     // 2. Real-touch flick with the main thread JANKED: dispatch the whole
     // sequence fire-and-forget so the renderer coalesces the moves (this is
@@ -2057,8 +2054,8 @@ try {
     await busy;
     await p.waitForTimeout(600);
     assert(
-      (await surfacePage(p)) === "launcher",
-      "[grabber-swipe] real-touch flick still commits with the main thread janked / moves coalesced (#9943)",
+      (await surfacePage(p)) === "home",
+      "[grabber-swipe] real-touch flick stays inert with the main thread janked / moves coalesced (#9943)",
     );
     await cdp.detach().catch(() => {});
 
@@ -2088,8 +2085,8 @@ try {
     }, grabberSel);
     await p.waitForTimeout(400);
     assert(
-      (await surfacePage(p)) === "launcher",
-      "[grabber-swipe] synthetic PointerEvent flick still commits (parity)",
+      (await surfacePage(p)) === "home",
+      "[grabber-swipe] synthetic PointerEvent flick stays inert (parity)",
     );
     await p.close();
   }

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -240,12 +240,6 @@ async function touchSwipeRight(page, testId) {
   });
 }
 
-// A STATIONARY hold past the long-press window. On the curated launcher this
-// must NOT enter edit mode (the launcher is read-only, fixed placement).
-async function longPressHold(page, tileTestId) {
-  await touchLongPress(page, `[data-testid="${tileTestId}"] button`, 600);
-}
-
 async function installCoarsePointerMedia(page) {
   await page.addInitScript(() => {
     const real = window.matchMedia.bind(window);
@@ -744,13 +738,12 @@ try {
       "collapse returns the notification center to its rested controls",
     );
   }
-  // No general quick-access tiles anymore - Launcher is the adjacent
-  // launcher. The only tiles left are the AOSP native-OS surfaces, shown here
-  // because the mobile page sets ?native (see HomeScreen.tsx HOME_TILES).
+  // Home no longer renders a second tile list beside the embedded curated
+  // launcher. Native surfaces, when available, belong to launcher curation.
   for (const id of ["messages", "phone", "contacts", "camera"]) {
     assert(
-      await mobile.getByTestId(`home-tile-${id}`).isVisible(),
-      `native-OS tile ${id} renders (native enabled)`,
+      (await mobile.getByTestId(`home-tile-${id}`).count()) === 0,
+      `legacy native-OS home tile ${id} is absent`,
     );
   }
   // The removed defaults must NOT appear, even with native enabled.
@@ -854,6 +847,7 @@ try {
   // the rail's - exactly the phone input this profile emulates).
   await touchSwipeLeft(mobile, "home-launcher-home-page");
   await waitForSurfacePageSettled(mobile, "launcher");
+  const launcherPage = mobile.getByTestId("home-launcher-launcher-page");
   assert(
     (await mobile.getByTestId("rail-pager-edge-prev").count()) === 0 &&
       (await mobile.getByTestId("rail-pager-edge-next").count()) === 0 &&
@@ -865,7 +859,7 @@ try {
   // ── Curated apps page - the everyday apps render as tiles, in curated order.
   for (const id of ["wallet", "automations", "browser", "settings"]) {
     assert(
-      await mobile.getByTestId(`launcher-tile-${id}`).isVisible(),
+      await launcherPage.getByTestId(`launcher-tile-${id}`).isVisible(),
       `curated app "${id}" renders on the launcher apps page`,
     );
   }
@@ -889,8 +883,8 @@ try {
   }
   // A single Wallet tile survives the duplicate wallet + inventory registrations.
   assert(
-    (await mobile.getByTestId("launcher-tile-wallet").count()) === 1,
-    "duplicate wallet registrations collapse to one tile",
+    (await launcherPage.getByTestId("launcher-tile-wallet").count()) === 1,
+    "duplicate wallet registrations collapse to one tile on the visible launcher",
   );
 
   // ── Glyph-only app icons (#13453 "deslop the launcher grid"): a launcher tile
@@ -899,7 +893,7 @@ try {
   // (a virus for Settings, a ladybug for Memories: the "icons are slop" report).
   // Each curated tile exposes its `data-view-visual` plate and NO hero image.
   for (const id of ["wallet", "automations", "browser", "character"]) {
-    const visual = mobile.locator(`[data-view-visual="${id}"]`);
+    const visual = launcherPage.locator(`[data-view-visual="${id}"]`);
     assert(
       (await visual.count()) === 1 && (await visual.isVisible()),
       `curated app "${id}" renders its glyph icon plate`,
@@ -931,24 +925,27 @@ try {
   // gradients are deterministic per id (id-hashed palette), so distinct tiles
   // get distinct gradients — a launcher of one flat placeholder would be the
   // regression this guards against.
-  const visualCount = await mobile.locator("[data-view-visual]").count();
+  const visualCount = await launcherPage.locator("[data-view-visual]").count();
   assert(
     visualCount >= 5,
     `launcher renders multiple glyph tiles (${visualCount})`,
   );
   assert(
-    (await mobile.locator('[data-testid^="launcher-image-"]').count()) === 0,
+    (await launcherPage.locator('[data-testid^="launcher-image-"]').count()) ===
+      0,
     "no launcher tile renders a hero <img> (glyph-only launcher)",
   );
-  const tileGradients = await mobile.$$eval("[data-view-visual]", (els) =>
-    Array.from(
-      new Set(
-        els
-          .map((el) => getComputedStyle(el).backgroundImage)
-          .filter((v) => Boolean(v) && v !== "none"),
+  const tileGradients = await launcherPage
+    .locator("[data-view-visual]")
+    .evaluateAll((els) =>
+      Array.from(
+        new Set(
+          els
+            .map((el) => getComputedStyle(el).backgroundImage)
+            .filter((v) => Boolean(v) && v !== "none"),
+        ),
       ),
-    ),
-  );
+    );
   assert(
     tileGradients.length >= 3,
     `launcher glyph plates use varied gradients, not one placeholder (${tileGradients.length} distinct)`,
@@ -957,10 +954,15 @@ try {
   // ── The curated launcher is READ-ONLY: a long-press never enters edit mode
   // (fixed placement, no reorder). Edit mode animates tiles with `animate-pulse`,
   // so its absence after a stationary hold is the real read-only signal. #3
-  await longPressHold(mobile, "launcher-tile-wallet");
+  await touchLongPress(
+    mobile,
+    '[data-testid="home-launcher-launcher-page"] [data-testid="launcher-tile-wallet"] button',
+    600,
+  );
   await mobile.waitForTimeout(150);
   assert(
     (await mobile
+      .getByTestId("home-launcher-launcher-page")
       .getByTestId("launcher-tile-wallet")
       .locator("button.animate-pulse")
       .count()) === 0,
@@ -992,7 +994,7 @@ try {
     "plugins",
   ]) {
     assert(
-      (await mobile
+      (await launcherPage
         .getByTestId("launcher-page-window")
         .getByTestId(`launcher-tile-${id}`)
         .count()) === 1,

--- a/packages/ui/src/testing/launcher-loop/cdp-gestures.test.ts
+++ b/packages/ui/src/testing/launcher-loop/cdp-gestures.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Selector regression coverage for the real-browser launcher-loop driver. The
+ * fixture intentionally renders an embedded launcher on Home beside the
+ * dedicated launcher pane, so gestures must never target the offscreen copy.
+ *
+ * @vitest-environment jsdom
+ */
+
+import type { Page } from "playwright";
+import { describe, expect, it } from "vitest";
+import { LAUNCHER_SELECTORS, readTileIds } from "./cdp-gestures";
+
+describe("launcher-loop CDP selectors", () => {
+  it("scopes grid gestures and tile discovery to the dedicated launcher pane", async () => {
+    document.body.innerHTML = `
+      <div data-testid="home-launcher-home-page">
+        <div data-testid="launcher-page-window">
+          <div data-testid="launcher-tile-offscreen-copy"></div>
+        </div>
+      </div>
+      <div data-testid="home-launcher-launcher-page">
+        <div data-testid="launcher-page-window">
+          <div data-testid="launcher-tile-stream"></div>
+          <div data-testid="launcher-tile-wallet"></div>
+        </div>
+      </div>
+    `;
+
+    const page = {
+      $$eval: async <T>(
+        selector: string,
+        evaluate: (nodes: Element[]) => T,
+      ): Promise<T> => evaluate([...document.querySelectorAll(selector)]),
+    } as unknown as Page;
+
+    await expect(readTileIds(page)).resolves.toEqual(["stream", "wallet"]);
+    expect(
+      document.querySelectorAll(LAUNCHER_SELECTORS.launcherScroll),
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll(LAUNCHER_SELECTORS.tile("stream")),
+    ).toHaveLength(1);
+    expect(
+      document
+        .querySelector(LAUNCHER_SELECTORS.tile("stream"))
+        ?.closest('[data-testid="home-launcher-launcher-page"]'),
+    ).not.toBeNull();
+  });
+});

--- a/packages/ui/src/testing/launcher-loop/cdp-gestures.test.ts
+++ b/packages/ui/src/testing/launcher-loop/cdp-gestures.test.ts
@@ -7,8 +7,115 @@
  */
 
 import type { Page } from "playwright";
-import { describe, expect, it } from "vitest";
-import { LAUNCHER_SELECTORS, readTileIds } from "./cdp-gestures";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { touchLongPress, touchSwipe, touchTap } from "../real-touch-gestures";
+import {
+  CdpTouchDriver,
+  LAUNCHER_SELECTORS,
+  readTileIds,
+} from "./cdp-gestures";
+
+vi.mock("../real-touch-gestures", () => ({
+  touchLongPress: vi.fn(),
+  touchSwipe: vi.fn(),
+  touchTap: vi.fn(),
+}));
+
+interface DriverPageHarness {
+  page: Page;
+  button: {
+    click: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    isVisible: ReturnType<typeof vi.fn>;
+  };
+  keyboardPress: ReturnType<typeof vi.fn>;
+  scrollIntoViewIfNeeded: ReturnType<typeof vi.fn>;
+  waitForFunction: ReturnType<typeof vi.fn>;
+}
+
+function mountLauncherSurface(page = "home"): void {
+  document.body.innerHTML = `
+    <main data-testid="home-launcher-surface" data-page="${page}" style="width: 390px">
+      <div data-testid="home-launcher-rail" style="transform: matrix(1, 0, 0, 1, 0, 0)"></div>
+      <span data-testid="home-launcher-page-probe">${page}</span>
+      <section data-testid="home-launcher-home-page"></section>
+      <section data-testid="home-launcher-launcher-page">
+        <div data-testid="launcher-page-window">
+          <button data-testid="launcher-tile-stream">Stream</button>
+        </div>
+      </section>
+    </main>
+  `;
+  const rail = document.querySelector(LAUNCHER_SELECTORS.rail);
+  const surface = document.querySelector(LAUNCHER_SELECTORS.surface);
+  Object.defineProperty(rail, "getAnimations", {
+    configurable: true,
+    value: () => [{ playState: "finished" }],
+  });
+  Object.defineProperty(rail, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ left: 0, width: 780 }),
+  });
+  Object.defineProperty(surface, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ left: 0, width: 390 }),
+  });
+}
+
+function makeDriverPage(dataPages: string[] = ["home"]): DriverPageHarness {
+  const button = {
+    click: vi.fn(async () => undefined),
+    count: vi.fn(async () => 1),
+    isVisible: vi.fn(async () => true),
+  };
+  const scrollIntoViewIfNeeded = vi.fn(async () => undefined);
+  const keyboardPress = vi.fn(async () => undefined);
+  const getAttribute = vi.fn(async () => dataPages.shift() ?? "home");
+  const waitForFunction = vi.fn(
+    async (
+      predicate: (selectors: { rail: string; surface: string }) => boolean,
+      selectors: { rail: string; surface: string },
+    ) => {
+      expect(predicate(selectors)).toBe(true);
+    },
+  );
+  const locator = vi.fn((selector: string) => ({
+    first: () =>
+      selector === LAUNCHER_SELECTORS.surface
+        ? { getAttribute }
+        : selector === LAUNCHER_SELECTORS.railPrevButton ||
+            selector === LAUNCHER_SELECTORS.railNextButton
+          ? button
+          : { scrollIntoViewIfNeeded },
+  }));
+  const page = {
+    keyboard: { press: keyboardPress },
+    locator,
+    waitForFunction,
+    evaluate: async <T>(callback: (arg?: unknown) => T, arg?: unknown) =>
+      callback(arg),
+  } as unknown as Page;
+  return {
+    page,
+    button,
+    keyboardPress,
+    scrollIntoViewIfNeeded,
+    waitForFunction,
+  };
+}
+
+beforeEach(() => {
+  mountLauncherSurface();
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("launcher-loop CDP selectors", () => {
   it("scopes grid gestures and tile discovery to the dedicated launcher pane", async () => {
@@ -45,5 +152,121 @@ describe("launcher-loop CDP selectors", () => {
         .querySelector(LAUNCHER_SELECTORS.tile("stream"))
         ?.closest('[data-testid="home-launcher-launcher-page"]'),
     ).not.toBeNull();
+  });
+
+  it("drives rail, tile, grid, widget, and keyboard gestures through the scoped selectors", async () => {
+    const harness = makeDriverPage(["home", "launcher"]);
+    const driver = new CdpTouchDriver(harness.page, {
+      commitDistance: 300,
+      rejectDistance: 20,
+    });
+
+    await driver.railSwipe("left", true);
+    expect(touchSwipe).toHaveBeenCalledWith(
+      harness.page,
+      LAUNCHER_SELECTORS.homePage,
+      -300,
+      0,
+      { steps: 10, stepDelayMs: 16 },
+    );
+
+    await driver.railEdgeButton("prev");
+    expect(harness.button.click).toHaveBeenCalledOnce();
+
+    await driver.tapTile("stream");
+    expect(harness.scrollIntoViewIfNeeded).toHaveBeenCalled();
+    expect(touchTap).toHaveBeenCalledWith(
+      harness.page,
+      LAUNCHER_SELECTORS.tile("stream"),
+    );
+
+    await driver.longPressTile("stream");
+    expect(touchLongPress).toHaveBeenCalledWith(
+      harness.page,
+      LAUNCHER_SELECTORS.tile("stream"),
+      650,
+    );
+
+    await driver.scrollGrid(80);
+    await driver.scrollWidgets(-40);
+    expect(touchSwipe).toHaveBeenCalledWith(
+      harness.page,
+      LAUNCHER_SELECTORS.launcherScroll,
+      0,
+      -80,
+      { steps: 8, stepDelayMs: 1 },
+    );
+    expect(touchSwipe).toHaveBeenCalledWith(
+      harness.page,
+      LAUNCHER_SELECTORS.homeScreen,
+      0,
+      40,
+      { steps: 8, stepDelayMs: 1 },
+    );
+
+    await driver.tabFocus();
+    expect(harness.keyboardPress).toHaveBeenCalledWith("Tab");
+    expect(harness.waitForFunction).toHaveBeenCalled();
+  });
+
+  it("handles rejected navigation, absent edge controls, and a failed best-effort tile scroll", async () => {
+    const harness = makeDriverPage(["home", "home"]);
+    const driver = new CdpTouchDriver(harness.page);
+
+    await driver.railSwipe("right", false);
+    expect(touchSwipe).toHaveBeenCalledWith(
+      harness.page,
+      LAUNCHER_SELECTORS.launcherPage,
+      24,
+      0,
+      { steps: 10, stepDelayMs: 16 },
+    );
+
+    harness.button.count.mockResolvedValueOnce(0);
+    await driver.railEdgeButton("next");
+    harness.button.count.mockResolvedValueOnce(1);
+    harness.button.isVisible.mockResolvedValueOnce(false);
+    await driver.railEdgeButton("next");
+    expect(harness.button.click).not.toHaveBeenCalled();
+
+    harness.scrollIntoViewIfNeeded.mockRejectedValueOnce(
+      new Error("detached during centering"),
+    );
+    await driver.tapTile("stream");
+    expect(touchTap).toHaveBeenCalledOnce();
+  });
+
+  it("observes the live launcher DOM and ignores descendant animations while settling", async () => {
+    const harness = makeDriverPage();
+    const rail = document.querySelector(LAUNCHER_SELECTORS.rail);
+    const child = document.createElement("span");
+    rail?.append(child);
+    Object.defineProperty(child, "getAnimations", {
+      configurable: true,
+      value: () => [{ playState: "running" }],
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+    Object.assign(window, {
+      __ELIZA_VIEW_INTERACTION_TELEMETRY__: [
+        { action: "launch" },
+        { action: "dismiss" },
+      ],
+      __ELIZA_LAUNCHER_LOOP_CLS__: 0.02,
+      __ELIZA_LAUNCHER_LOOP_CONSOLE_ERRORS__: 1,
+    });
+
+    const observation = await new CdpTouchDriver(harness.page).observe();
+    expect(observation).toMatchObject({
+      dataPage: "home",
+      probeText: "home",
+      railTransformX: 0,
+      launchCount: 1,
+      viewportWidth: 390,
+      layoutShiftScore: 0.02,
+      consoleErrorCount: 1,
+    });
   });
 });

--- a/packages/ui/src/testing/launcher-loop/cdp-gestures.ts
+++ b/packages/ui/src/testing/launcher-loop/cdp-gestures.ts
@@ -23,14 +23,19 @@ export const LAUNCHER_SELECTORS = {
   pageProbe: '[data-testid="home-launcher-page-probe"]',
   homePage: '[data-testid="home-launcher-home-page"]',
   launcherPage: '[data-testid="home-launcher-launcher-page"]',
-  launcherScroll: '[data-testid="launcher-page-window"]',
+  launcherScroll:
+    '[data-testid="home-launcher-launcher-page"] [data-testid="launcher-page-window"]',
   homeScreen: '[data-testid="home-screen"]',
   // The inline notification inbox on the home column (self-hidden when empty).
   notificationCenter: '[data-testid="home-notification-center"]',
   railPrevButton: '[data-testid="rail-pager-edge-prev"]',
   railNextButton: '[data-testid="rail-pager-edge-next"]',
-  tile: (id: string) => `[data-testid="launcher-tile-${id}"]`,
+  tile: (id: string) =>
+    `[data-testid="home-launcher-launcher-page"] [data-testid="launcher-tile-${id}"]`,
 } as const;
+
+const LAUNCHER_TILE_SELECTOR =
+  '[data-testid="home-launcher-launcher-page"] [data-testid^="launcher-tile-"]';
 
 /**
  * A single observation of the real surface after an action, read atomically
@@ -82,7 +87,7 @@ export interface Driver {
 
 /** How many launcher tiles the current fixture/app exposes (for tile actions). */
 export async function readTileIds(page: Page): Promise<string[]> {
-  return page.$$eval('[data-testid^="launcher-tile-"]', (nodes) =>
+  return page.$$eval(LAUNCHER_TILE_SELECTOR, (nodes) =>
     nodes
       .map((n) => n.getAttribute("data-testid") ?? "")
       .map((t) => t.replace(/^launcher-tile-/, ""))
@@ -377,8 +382,12 @@ export class CdpTouchDriver implements Driver {
           ) {
             return false;
           }
+          // Only the rail's own transform settle blocks the next gesture.
+          // Descendant widgets intentionally run ambient/infinite animations;
+          // including the subtree makes every command burn the timeout even
+          // though the rail has already parked at its page boundary.
           const animating = rail
-            .getAnimations({ subtree: true })
+            .getAnimations()
             .some((a) => a.playState === "running");
           if (animating) return false;
           const railLeft = rail.getBoundingClientRect().left;


### PR DESCRIPTION
Closes #16834

## What changed

- invokes the named chat gesture coverage Vitest file directly instead of the aggregate app test script
- adds a workflow contract that rejects reintroduction of the aggregate command
- scopes launcher tile discovery and touch targets to the visible dedicated launcher pane
- waits for the rail transform only, excluding intentional infinite descendant animations
- adds a duplicate-grid regression fixture matching the real app shell

## Root cause

The original workflow first ran unrelated Bun script tests through the aggregate app test command. After that was corrected, exact-seed native verification exposed a second fault: the fixture contains both an embedded Home launcher and the dedicated launcher page, and the CDP driver selected the first matching tile. That tile was offscreen (`x=-371.75`), so the synthesized tap produced no launch telemetry. The settle check also included ambient descendant animations and unnecessarily exhausted its timeout.

Observed runs:

- [aggregate-command failure](https://github.com/elizaOS/eliza/actions/runs/29954842116/job/89041167559)
- [offscreen duplicate-grid failure](https://github.com/elizaOS/eliza/actions/runs/29962781931/job/89067478148)
- [successful native Chat proof](https://github.com/elizaOS/eliza/actions/runs/29964476933) with the 54 MB `chat-shell-gesture-artifacts` recording/telemetry bundle
- [successful PR UI Fixture proof](https://github.com/elizaOS/eliza/actions/runs/29964405238/job/89072592361)

## Validation

- focused launcher-loop unit regressions — 2 files, 9 passed
- exact failing seed, first 100-action batch (`ELIZA_LOOP_SEED=12375`) — passed
- exact failing seed, full native-style loop — 500/500 touch actions passed
- focused chat gesture workflow contract — passed
- Biome check on touched TypeScript files — passed
- `git diff --check` — passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-driver and workflow correction; production rendering is unchanged.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-driver and workflow correction; production rendering is unchanged.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - production UI behavior is unchanged; the native test-driver recording is retained in the linked workflow artifact for diagnostic review.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no production frontend behavior changed; this corrects test-driver target selection and telemetry assertions.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the test-driver fix creates no persistent product-domain data.
