### PR TITLE
fix(app-control): authenticate view loopback requests

### DIFF
--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -75,6 +75,7 @@ src/
     background.ts                 BACKGROUND action (set color/shader-preset/image/generate, tweak, undo, redo, reset)
     views.ts                      VIEWS action dispatcher
     views-client.ts               ViewsClient — loopback HTTP to /api/views/*
+    views-request-auth.ts         Alias-aware Bearer headers for authenticated view loopback requests
     views-list.ts                 list sub-handler
     views-show.ts                 show/open sub-handler
     views-search.ts               search sub-handler

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -75,6 +75,7 @@ src/
     background.ts                 BACKGROUND action (set color/shader-preset/image/generate, tweak, undo, redo, reset)
     views.ts                      VIEWS action dispatcher
     views-client.ts               ViewsClient — loopback HTTP to /api/views/*
+    views-request-auth.ts         Alias-aware Bearer headers for authenticated view loopback requests
     views-list.ts                 list sub-handler
     views-show.ts                 show/open sub-handler
     views-search.ts               search sub-handler

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -1,11 +1,12 @@
 /**
- * BACKGROUND action tests for plan inference and renderer broadcast payloads.
+ * BACKGROUND action tests for plan inference, renderer delivery, and the
+ * authenticated loopback boundary used by the default emitter and navigator.
  */
 
 import type { IAgentRuntime, Media, Memory } from "@elizaos/core";
 import type { NavigateViewDetail } from "@elizaos/shared/events";
 import { BACKGROUND_APPLY_EVENT as SHARED_BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	BACKGROUND_APPLY_EVENT,
 	type BackgroundApplyPayload,
@@ -14,6 +15,11 @@ import {
 } from "./background.ts";
 
 const runtime = {} as IAgentRuntime;
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
+});
 
 function message(text: string, attachments?: Media[]): Memory {
 	return { content: { text, attachments } } as Memory;
@@ -387,6 +393,60 @@ describe("programmable GLSL shader plan (#10694)", () => {
 describe("BACKGROUND action handler", () => {
 	it("uses the shared background apply event contract", () => {
 		expect(BACKGROUND_APPLY_EVENT).toBe(SHARED_BACKGROUND_APPLY_EVENT);
+	});
+
+	it("authenticates the default broadcast and navigation view routes", async () => {
+		vi.stubEnv("ELIZA_PORT", "3456");
+		vi.stubEnv("ELIZA_API_TOKEN", "background-loopback-token");
+		const fetchMock = vi.fn(
+			async () => ({ ok: true, status: 200 }) as Response,
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const action = createBackgroundAction();
+
+		await action.handler(
+			runtime,
+			message("make the background blue"),
+			undefined,
+			undefined,
+			vi.fn(),
+		);
+		await action.handler(
+			runtime,
+			message("i want to upload my own background image"),
+			undefined,
+			undefined,
+			vi.fn(),
+		);
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"http://127.0.0.1:3456/api/views/events/broadcast",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer background-loopback-token",
+				},
+			}),
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"http://127.0.0.1:3456/api/views/background/navigate",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer background-loopback-token",
+				},
+				body: JSON.stringify({ path: "/background" }),
+			}),
+		);
+		for (const [url, init] of fetchMock.mock.calls) {
+			expect(`${String(url)}\n${String(init?.body ?? "")}`).not.toContain(
+				"background-loopback-token",
+			);
+		}
 	});
 
 	function setup() {

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -41,6 +41,7 @@ import type {
 } from "@elizaos/shared/events";
 import { BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { normalizeActionOptions, readStringOption } from "../params.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 export type {
 	BackgroundApplyOp,
@@ -579,7 +580,7 @@ async function defaultEmit(payload: BackgroundApplyPayload): Promise<void> {
 		`http://127.0.0.1:${port}/api/views/events/broadcast`,
 		{
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify({ type: BACKGROUND_APPLY_EVENT, payload }),
 			signal: AbortSignal.timeout(5_000),
 		},
@@ -641,7 +642,7 @@ async function defaultNavigate(detail: NavigateViewDetail): Promise<void> {
 			};
 	const resp = await fetch(url, {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers: createViewsRequestHeaders(),
 		body,
 		signal: AbortSignal.timeout(5_000),
 	});

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -2,8 +2,8 @@
  * Unit coverage for the SETTINGS action (#14364): param routing, boolean-value
  * parsing, section-token resolution, the delegate/route/readonly/unwired write
  * paths, and the completeness invariant that every built-in settings section has
- * a registry entry. The backend route is exercised through an injected fetch
- * (`SettingsRouteFetch`) so `set` dispatch is asserted without a live server.
+ * a registry entry. Injected fetches cover route selection; the default fetch
+ * path is also exercised to enforce authenticated view-loopback delivery.
  */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
@@ -16,7 +16,7 @@ import {
 	SETTINGS_SECTION_META,
 } from "@elizaos/ui/components/settings/settings-section-meta";
 import { DEFAULT_LOCAL_ASR_AUTO_STOP } from "@elizaos/ui/voice/local-asr-capture";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	createSettingsAction,
 	DEFAULT_VOICE_SETTINGS_PREFS,
@@ -30,6 +30,11 @@ import {
 
 const runtime = {} as IAgentRuntime;
 const message = { content: { text: "" } } as Memory;
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
+});
 
 /** Collect callback replies so we can assert what the user is told. */
 function makeCallback(): { cb: HandlerCallback; texts: string[] } {
@@ -349,6 +354,39 @@ describe("SETTINGS action: list", () => {
 });
 
 describe("SETTINGS action: set on an owned route section", () => {
+	it("authenticates the default appearance broadcast view route", async () => {
+		vi.stubEnv("ELIZA_PORT", "3456");
+		vi.stubEnv("ELIZA_API_TOKEN", "settings-loopback-token");
+		const fetchMock = vi.fn(
+			async () =>
+				({ ok: true, status: 200, json: async () => ({}) }) as Response,
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result } = await invoke({
+			action: "set",
+			section: "appearance",
+			key: "theme",
+			value: "dark",
+		});
+
+		expect(result?.success).toBe(true);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/events/broadcast",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer settings-loopback-token",
+				},
+			}),
+		);
+		const [url, init] = fetchMock.mock.calls[0] ?? [];
+		expect(`${String(url)}\n${String(init?.body ?? "")}`).not.toContain(
+			"settings-loopback-token",
+		);
+	});
+
 	it("dispatches appearance theme mode through the view event broadcast route", async () => {
 		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
 		const { result, texts } = await invoke(

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -51,6 +51,7 @@ import {
 	SETTINGS_SECTION_META,
 } from "@elizaos/ui/components/settings/settings-section-meta";
 import { normalizeActionOptions, readStringOption } from "../params.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 /** The three verbs SETTINGS understands. */
 export type SettingsVerb = "get" | "set" | "list";
@@ -1692,7 +1693,9 @@ async function defaultRouteFetch(
 	const port = resolveServerOnlyPort(process.env);
 	const response = await fetch(`http://127.0.0.1:${port}${request.path}`, {
 		method: request.method,
-		headers: { "Content-Type": "application/json" },
+		headers: request.path.startsWith("/api/views")
+			? createViewsRequestHeaders()
+			: { "Content-Type": "application/json" },
 		body: request.body === undefined ? undefined : JSON.stringify(request.body),
 		signal: AbortSignal.timeout(30_000),
 	});

--- a/plugins/plugin-app-control/src/actions/views-client.ts
+++ b/plugins/plugin-app-control/src/actions/views-client.ts
@@ -9,6 +9,7 @@
 
 import type { ViewCapability, ViewType } from "@elizaos/core";
 import { resolveServerOnlyPort } from "@elizaos/core";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
@@ -298,7 +299,7 @@ export function createViewsClient(): ViewsClient {
 			const url = `${getApiBase()}/api/views${qs}`;
 			const response = await fetch(url, {
 				method: "GET",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 			});
 			if (!response.ok) {
@@ -311,7 +312,7 @@ export function createViewsClient(): ViewsClient {
 		async getCurrentView() {
 			const response = await fetch(`${getApiBase()}/api/views/current`, {
 				method: "GET",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 			});
 			if (!response.ok) {
@@ -326,7 +327,7 @@ export function createViewsClient(): ViewsClient {
 				`${getApiBase()}/api/views/${encodeURIComponent(viewId)}/navigate`,
 				{
 					method: "POST",
-					headers: { "Content-Type": "application/json" },
+					headers: createViewsRequestHeaders(),
 					body: JSON.stringify({ path: opts.path, viewType: opts.viewType }),
 					signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 				},

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Real TCP coverage for app-control view requests crossing a bearer-protected
+ * loopback boundary through the client, show path, and public action handlers.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createBackgroundAction } from "./background.js";
+import { createSettingsAction } from "./settings.js";
+import { createViewsAction } from "./views.js";
+import {
+	createViewsClient,
+	type ViewSummary,
+	type ViewsClient,
+} from "./views-client.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
+import { runViewsShow } from "./views-show.js";
+
+interface CapturedRequest {
+	method: string;
+	pathname: string;
+	authorization: string | undefined;
+	body: string;
+}
+
+interface AuthenticatedViewsServer {
+	port: number;
+	requests: CapturedRequest[];
+}
+
+const ENV_KEYS = [
+	"ELIZA_PORT",
+	"ELIZA_UI_PORT",
+	"ELIZA_API_TOKEN",
+	"ELIZA_API_AUTH_TOKEN",
+] as const;
+
+const SETTINGS_VIEW: ViewSummary = {
+	id: "settings",
+	label: "Settings",
+	path: "/settings",
+	pluginName: "core",
+	available: true,
+	viewType: "gui",
+};
+
+const NOTES_VIEW: ViewSummary = {
+	id: "notes",
+	label: "Notes",
+	path: "/notes",
+	pluginName: "plugin-simple-views",
+	available: true,
+	viewType: "gui",
+};
+
+const servers: http.Server[] = [];
+let previousEnv: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+function sendJson(
+	res: http.ServerResponse,
+	status: number,
+	body: unknown,
+): void {
+	res.statusCode = status;
+	res.setHeader("content-type", "application/json; charset=utf-8");
+	res.end(JSON.stringify(body));
+}
+
+async function readRequestBody(req: http.IncomingMessage): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of req) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startAuthenticatedViewsServer(
+	expectedToken: string,
+): Promise<AuthenticatedViewsServer> {
+	const requests: CapturedRequest[] = [];
+	const server = http.createServer((req, res) => {
+		void (async () => {
+			const url = new URL(req.url ?? "/", "http://127.0.0.1");
+			const body = await readRequestBody(req);
+			const request = {
+				method: req.method ?? "GET",
+				pathname: url.pathname,
+				authorization: req.headers.authorization,
+				body,
+			};
+			requests.push(request);
+
+			if (request.authorization !== `Bearer ${expectedToken}`) {
+				sendJson(res, 401, { error: "Unauthorized" });
+				return;
+			}
+
+			if (request.method === "GET" && request.pathname === "/api/views") {
+				sendJson(res, 200, { views: [SETTINGS_VIEW, NOTES_VIEW] });
+				return;
+			}
+			if (
+				request.method === "GET" &&
+				request.pathname === "/api/views/search"
+			) {
+				sendJson(res, 200, {
+					results: [{ ...SETTINGS_VIEW, _score: 100 }],
+				});
+				return;
+			}
+			if (
+				request.method === "GET" &&
+				request.pathname === "/api/views/current"
+			) {
+				sendJson(res, 200, {
+					currentView: {
+						viewId: "settings",
+						viewPath: "/settings",
+						viewLabel: "Settings",
+						viewType: "gui",
+						updatedAt: "2026-07-22T20:00:00.000Z",
+					},
+				});
+				return;
+			}
+			if (
+				request.method === "POST" &&
+				request.pathname.startsWith("/api/views/") &&
+				request.pathname.endsWith("/navigate")
+			) {
+				sendJson(res, 200, { ok: true });
+				return;
+			}
+			if (
+				request.method === "POST" &&
+				request.pathname.startsWith("/api/views/") &&
+				request.pathname.endsWith("/interact")
+			) {
+				sendJson(res, 200, { success: true, text: "interaction complete" });
+				return;
+			}
+			if (
+				request.method === "POST" &&
+				request.pathname === "/api/views/events/broadcast"
+			) {
+				sendJson(res, 200, { ok: true });
+				return;
+			}
+			sendJson(res, 404, { error: "Not found" });
+		})().catch((error: unknown) => {
+			sendJson(res, 500, {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
+	});
+	servers.push(server);
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	return {
+		port: (server.address() as AddressInfo).port,
+		requests,
+	};
+}
+
+beforeEach(() => {
+	previousEnv = Object.fromEntries(
+		ENV_KEYS.map((key) => [key, process.env[key]]),
+	) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+	for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(async () => {
+	await Promise.all(
+		servers
+			.splice(0)
+			.map(
+				(server) =>
+					new Promise<void>((resolve, reject) =>
+						server.close((error) => (error ? reject(error) : resolve())),
+					),
+			),
+	);
+	for (const key of ENV_KEYS) {
+		const value = previousEnv[key];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+describe("authenticated view loopback requests", () => {
+	it("uses the canonical token, falls back to the legacy key, and omits empty auth", () => {
+		expect(
+			createViewsRequestHeaders({
+				ELIZA_API_TOKEN: " canonical-token ",
+				ELIZA_API_AUTH_TOKEN: "legacy-token",
+			}),
+		).toEqual({
+			"Content-Type": "application/json",
+			Authorization: "Bearer canonical-token",
+		});
+		expect(
+			createViewsRequestHeaders({
+				ELIZA_API_AUTH_TOKEN: " legacy-token ",
+			}),
+		).toEqual({
+			"Content-Type": "application/json",
+			Authorization: "Bearer legacy-token",
+		});
+		expect(createViewsRequestHeaders({})).toEqual({
+			"Content-Type": "application/json",
+		});
+	});
+
+	it("authenticates every ViewsClient route across a real HTTP boundary", async () => {
+		const token = "views-client-test-token";
+		const server = await startAuthenticatedViewsServer(token);
+		process.env.ELIZA_PORT = String(server.port);
+
+		const unauthenticated = await fetch(
+			`http://127.0.0.1:${server.port}/api/views`,
+		);
+		expect(unauthenticated.status).toBe(401);
+
+		process.env.ELIZA_API_TOKEN = token;
+		const client = createViewsClient();
+		await expect(client.listViews()).resolves.toEqual([
+			SETTINGS_VIEW,
+			NOTES_VIEW,
+		]);
+		await expect(client.getCurrentView()).resolves.toMatchObject({
+			viewId: "settings",
+			viewPath: "/settings",
+		});
+		await expect(
+			client.navigate("settings", { path: "/settings", viewType: "gui" }),
+		).resolves.toBe(true);
+
+		const authenticated = server.requests.filter(
+			(request) => request.authorization !== undefined,
+		);
+		expect(
+			authenticated.map(({ method, pathname }) => ({ method, pathname })),
+		).toEqual([
+			{ method: "GET", pathname: "/api/views" },
+			{ method: "GET", pathname: "/api/views/current" },
+			{ method: "POST", pathname: "/api/views/settings/navigate" },
+		]);
+		expect(
+			authenticated.every(
+				(request) => request.authorization === `Bearer ${token}`,
+			),
+		).toBe(true);
+		expect(authenticated[2]?.body).toBe(
+			JSON.stringify({ path: "/settings", viewType: "gui" }),
+		);
+		for (const request of authenticated) {
+			expect(`${request.pathname}\n${request.body}`).not.toContain(token);
+		}
+	});
+
+	it("authenticates the show action's direct navigate path with the legacy key", async () => {
+		const token = "views-show-legacy-token";
+		const server = await startAuthenticatedViewsServer(token);
+		process.env.ELIZA_PORT = String(server.port);
+		process.env.ELIZA_API_AUTH_TOKEN = token;
+
+		const client: ViewsClient = {
+			listViews: async () => [SETTINGS_VIEW],
+			getCurrentView: async () => null,
+			navigate: async () => false,
+		};
+		const result = await runViewsShow({
+			client,
+			message: {
+				entityId: "user-1",
+				roomId: "room-1",
+				agentId: "agent-1",
+				content: { text: "go to settings" },
+			} as never,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.values?.viewId).toBe("settings");
+		expect(server.requests).toHaveLength(1);
+		expect(server.requests[0]).toMatchObject({
+			method: "POST",
+			pathname: "/api/views/settings/navigate",
+			authorization: `Bearer ${token}`,
+		});
+		expect(server.requests[0]?.body).toBe(
+			JSON.stringify({ path: "/settings" }),
+		);
+		expect(
+			`${server.requests[0]?.pathname}\n${server.requests[0]?.body}`,
+		).not.toContain(token);
+	});
+
+	it("authenticates every Node-side views loopback caller", async () => {
+		const token = "all-views-callers-token";
+		const server = await startAuthenticatedViewsServer(token);
+		process.env.ELIZA_PORT = String(server.port);
+		process.env.ELIZA_API_TOKEN = token;
+
+		const runtime = { agentId: "agent-1" } as never;
+		const message = (text: string) =>
+			({
+				entityId: "user-1",
+				roomId: "room-1",
+				agentId: "agent-1",
+				content: { text },
+			}) as never;
+		const viewsAction = createViewsAction({
+			hasOwnerAccess: async () => true,
+		});
+		const invokeViews = async (
+			text: string,
+			options: Record<string, unknown>,
+		) => {
+			const result = await viewsAction.handler(
+				runtime,
+				message(text),
+				undefined,
+				options,
+			);
+			expect(result.success).toBe(true);
+		};
+
+		await invokeViews("open view manager", { action: "manager" });
+		await invokeViews("pin settings", { action: "pin", view: "settings" });
+		await invokeViews("split settings and notes", {
+			action: "split",
+			views: ["settings", "notes"],
+		});
+		await invokeViews("interact with settings", {
+			action: "interact",
+			view: "settings",
+			capability: "get-state",
+		});
+		await invokeViews("broadcast refresh", {
+			action: "broadcast",
+			eventType: "demo:refresh",
+		});
+		await invokeViews("search views settings", {
+			action: "search",
+			query: "settings",
+		});
+
+		const backgroundAction = createBackgroundAction();
+		const backgroundResult = await backgroundAction.handler(
+			runtime,
+			message("make the background green"),
+		);
+		expect(backgroundResult.success).toBe(true);
+		const backgroundNavigateResult = await backgroundAction.handler(
+			runtime,
+			message("i want to upload my own background image"),
+		);
+		expect(backgroundNavigateResult.success).toBe(true);
+
+		const settingsAction = createSettingsAction();
+		const settingsResult = await settingsAction.handler(
+			runtime,
+			message("use dark mode"),
+			undefined,
+			{
+				action: "set",
+				section: "appearance",
+				key: "theme",
+				value: "dark",
+			},
+		);
+		expect(settingsResult.success).toBe(true);
+
+		const paths = server.requests.map((request) => request.pathname);
+		expect(paths).toEqual(
+			expect.arrayContaining([
+				"/api/views/__view-manager__/navigate",
+				"/api/views/settings/navigate",
+				"/api/views/settings/interact",
+				"/api/views/events/broadcast",
+				"/api/views/search",
+				"/api/views/background/navigate",
+			]),
+		);
+		expect(
+			server.requests.every(
+				(request) => request.authorization === `Bearer ${token}`,
+			),
+		).toBe(true);
+		for (const request of server.requests) {
+			expect(`${request.pathname}\n${request.body}`).not.toContain(token);
+		}
+	});
+});

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -1,5 +1,6 @@
 /**
- * Views management tests for create, edit, delete, and follow-up routing flows.
+ * Views management tests for create, edit, delete, follow-up routing, and the
+ * authenticated loopback transport used by direct shell operations.
  */
 
 import {
@@ -233,7 +234,66 @@ describe("view management actions", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		vi.unstubAllGlobals();
+	});
+
+	it("authenticates direct manager and broadcast loopback requests", async () => {
+		vi.stubEnv("ELIZA_API_TOKEN", "views-management-loopback-token");
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+		const { runtime } = createRuntime();
+		const action = createViewsAction({
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		const managerResult = await action.handler(
+			runtime as never,
+			message("open view manager") as never,
+			undefined,
+			{ action: "manager" },
+			vi.fn(),
+		);
+		const broadcastResult = await action.handler(
+			runtime as never,
+			message("broadcast refresh") as never,
+			undefined,
+			{ action: "broadcast", eventType: "demo:refresh" },
+			vi.fn(),
+		);
+
+		expect(managerResult?.success).toBe(true);
+		expect(broadcastResult?.success).toBe(true);
+		expect(globalThis.fetch).toHaveBeenNthCalledWith(
+			1,
+			"http://127.0.0.1:3456/api/views/__view-manager__/navigate",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer views-management-loopback-token",
+				},
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenNthCalledWith(
+			2,
+			"http://127.0.0.1:3456/api/views/events/broadcast",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer views-management-loopback-token",
+				},
+			}),
+		);
+		for (const [url, init] of vi.mocked(globalThis.fetch).mock.calls) {
+			expect(`${String(url)}\n${String(init?.body ?? "")}`).not.toContain(
+				"views-management-loopback-token",
+			);
+		}
 	});
 
 	it("routes active-view mutation follow-ups through VIEWS before direct reply", async () => {

--- a/plugins/plugin-app-control/src/actions/views-request-auth.ts
+++ b/plugins/plugin-app-control/src/actions/views-request-auth.ts
@@ -1,0 +1,21 @@
+/**
+ * Authenticates app-control's loopback view requests with the same API token
+ * the local HTTP boundary validates. The canonical alias-aware token wins;
+ * the plugin's older auth-token variable remains a compatibility fallback.
+ */
+
+import { firstWinningEnvString } from "@elizaos/shared/runtime-env";
+
+type RuntimeEnv = Record<string, string | undefined>;
+
+export function createViewsRequestHeaders(
+	env: RuntimeEnv = process.env,
+): Record<string, string> {
+	const canonicalToken = firstWinningEnvString(env, ["ELIZA_API_TOKEN"])?.value;
+	const legacyToken = env.ELIZA_API_AUTH_TOKEN?.trim();
+	const token = canonicalToken ?? (legacyToken || undefined);
+	return {
+		"Content-Type": "application/json",
+		...(token ? { Authorization: `Bearer ${token}` } : {}),
+	};
+}

--- a/plugins/plugin-app-control/src/actions/views-search.ts
+++ b/plugins/plugin-app-control/src/actions/views-search.ts
@@ -23,6 +23,7 @@ import {
 	type ViewSummary,
 	type ViewsClient,
 } from "./views-client.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 export interface ScoredView {
 	view: ViewSummary;
@@ -85,6 +86,7 @@ async function fetchSemanticSearch(
 		if (viewType) url.searchParams.set("viewType", viewType);
 
 		const resp = await fetch(url.toString(), {
+			headers: createViewsRequestHeaders(),
 			signal: AbortSignal.timeout(5_000),
 		});
 		if (!resp.ok) return null;

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -23,6 +23,7 @@ import { resolveSettingsSectionToken } from "@elizaos/ui/components/settings/set
 import { markViewSwitch } from "../runtime/view-switch-signal.js";
 import { matchViewCommand } from "./view-command-matcher.js";
 import type { ViewSummary, ViewsClient } from "./views-client.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 import { scoreView } from "./views-search.js";
 
 const SHOW_VERBS = [
@@ -377,7 +378,7 @@ async function navigateToView(
 			`${base}/api/views/${encodeURIComponent(view.id)}/navigate${requestedViewType ? `?viewType=${requestedViewType}` : ""}`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({
 					path: view.path,
 					viewType: requestedViewType,

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -37,6 +37,7 @@ import {
 import { runViewsEdit } from "./views-edit.js";
 import { isViewIconRequest, runViewsIcon } from "./views-icon.js";
 import { runViewsList } from "./views-list.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 import { isRollbackRequest, runViewsRollback } from "./views-rollback.js";
 import { runViewsSearch, scoreView } from "./views-search.js";
 import { resolveIntentView, runViewsShow } from "./views-show.js";
@@ -3111,7 +3112,7 @@ async function navigateToPath(
 	try {
 		const resp = await fetch(`${base}/api/views/__view-manager__/navigate`, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify({ path: pathStr }),
 			signal: AbortSignal.timeout(5_000),
 		});
@@ -3150,7 +3151,7 @@ async function navigateViewWithShellAction(
 			`${base}/api/views/${encodeURIComponent(viewId)}/navigate${viewType ? `?viewType=${viewType}` : ""}`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({ action, viewType, alwaysOnTop }),
 				signal: AbortSignal.timeout(5_000),
 			},
@@ -3198,7 +3199,7 @@ async function navigateViewLayout({
 			`${base}/api/views/${encodeURIComponent(viewId)}/navigate${viewType ? `?viewType=${viewType}` : ""}`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({
 					action,
 					views: viewIds,
@@ -3273,7 +3274,7 @@ async function interactWithView(
 			`${base}/api/views/${encodeURIComponent(viewId)}/interact${viewType ? `?viewType=${viewType}` : ""}`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({ capability, params, timeoutMs, viewType }),
 				signal: AbortSignal.timeout(timeoutMs + 1_000),
 			},
@@ -3412,7 +3413,7 @@ async function broadcastViewEvent(
 	try {
 		const resp = await fetch(`${base}/api/views/events/broadcast`, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify({ type: eventType, payload }),
 			signal: AbortSignal.timeout(5_000),
 		});


### PR DESCRIPTION
Closes #16831

## Exact current-develop candidate

- base: `050b26353ab84daed96f3e338862e28471145241`
- production commits: `b7e04485bfcbf91547cdbb4b691e13d80b48d913`, then `17e2bfe48f08c03dcb12bc266cd6364a4a44ed0b`
- head: `17e2bfe48f08c03dcb12bc266cd6364a4a44ed0b`
- tree: `aca7ddc8e270e555016f75dfca1273eda1b4b24b`
- the merge-only head `4de01019bda7070976774cdc846fb0eafa52ecde` is excluded
- stable patch IDs match both pre-rebase commits and `git range-diff` marks both commits `=`; all 13 PR-path blobs are byte-identical

## Summary

- authenticate every `plugin-app-control` `/api/views` loopback request with the configured API Bearer token
- keep canonical alias-aware `ELIZA_API_TOKEN` precedence and the existing `ELIZA_API_AUTH_TOKEN` compatibility fallback
- cover every Node-side `plugin-app-control` `/api/views` caller: client list/current/navigate, direct show, manager/layout/pin/interact/broadcast/search, background, and settings routes
- preserve tokenless local development by omitting `Authorization` when neither token is configured

## Root cause

Several server-side view callers sent only `Content-Type`; fixing only the shared client would have left manager/layout, search, background, settings, interaction, and broadcast paths exposed to the same failure. Cloud and mobile runtimes that require local auth therefore returned HTTP 401 even while the user session and subsequent chat traffic remained healthy. The agent then paraphrased the tool failure as an authentication error.

## Real boundary proof

`views-loopback-auth.integration.test.ts` opens a real ephemeral TCP listener with a Bearer-protected `/api/views` surface. It proves:

1. the same route rejects a raw tokenless request with 401;
2. all `ViewsClient` routes cross the boundary with the exact canonical token;
3. the direct show route crosses it with the compatibility token;
4. public VIEWS manager/layout/pin/interact/broadcast/search handlers cross it authenticated;
5. background navigate/broadcast and settings view routes cross it authenticated;
6. no token appears in a request URL or body;
7. no empty `Authorization` header is synthesized.

## Verification

- exact published head: `17e2bfe48f08c03dcb12bc266cd6364a4a44ed0b`
- synchronized with `origin/develop` at `050b26353ab84daed96f3e338862e28471145241`
- exact changed-test classifier selects the integration plus background, settings, and views-management suites
- changed-suite run: 4 files, 215 tests passed
- enforced changed-source coverage: all 7 production files pass; minimum 73.91%, mean 86.15%
- full `@elizaos/plugin-app-control` suite: 45 files, 1,516 tests passed (current `develop` adds one unrelated file / five tests)
- package typecheck: passed
- package Biome: 110 files checked, passed (current `develop` adds one unrelated file)
- package build: tsup, declaration emit, and Vite view bundle passed
- `audit:error-policy-ratchet`: 7 production files checked, no new empty catches or server console calls
- `git diff --check`: passed

## Evidence matrix

- Before screenshots: N/A — server-side request-header defect with no visual rendering change.
- After screenshots: N/A — server-side request-header defect with no visual rendering change.
- Walkthrough video: N/A — no UI, native shell, gesture, or device behavior changed.
- Backend logs: real TCP test transcript above; manually reviewed a 401 denial followed by authenticated success across every covered GET/POST route family.
- Frontend console/network logs: N/A — no frontend code or browser request path changed.
- Live-LLM trajectory: N/A — no prompt, planner, model, provider, or evaluator behavior changed; the deterministic action transport seam is exercised through real HTTP instead.
- Domain artifact: captured HTTP method/path/header/body records for all affected routes, asserted in the integration test; credential values are intentionally not printed.
- Native/device proof: N/A — this lane intentionally did not touch or reinstall the demo device.

## Security review

- credentials are read only at request construction time
- credentials are not logged, persisted, added to URLs, or copied into request bodies
- canonical token precedence matches the existing app-verification client
- tokenless local mode retains its prior behavior

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side request-header fix with no rendered UI change

<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side request-header fix with no rendered UI change

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI, native shell, gesture, or device behavior changed

<!-- evidence-row:backend-logs -->
- [x] N/A - the affected deterministic loopback client emits no backend log and credentials must not be printed; real TCP 401-to-200 behavior is asserted in the integration test

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, model, provider, or evaluator logic changed; only deterministic HTTP request authentication changed

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, task, wallet, file, audio, or device artifact is produced by this transport fix

