### PR TITLE
fix(cloud): shared-agent conversations 500 + PWA init hang + SW auto-update (3-commit strike)

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -14,9 +14,33 @@
  * Cache is version-keyed (VIEWS_CACHE_NAME, SHELL_CACHE_NAME, ASSETS_CACHE_NAME)
  * so bumping the version strings in a future deploy triggers automatic cleanup
  * of old caches in the `activate` handler.
+ *
+ * PER-DEPLOY VERSIONING (CONVERSATIONS-500-2026-07-22 fix #1): the `BUILD_REV`
+ * token below is REPLACED at build time by the sw-build-rev vite plugin with the
+ * git sha / build timestamp of THIS deploy. That makes `dist/sw.js` byte-change
+ * on every deploy, so the browser's SW byte-diff detects a new worker and runs
+ * install -> skipWaiting -> activate (drop-stale-caches + claim + navigate
+ * windows) automatically. Before this, `public/sw.js` was copied verbatim and
+ * was byte-identical across deploys, so the update machinery below was DEAD CODE
+ * and users needed a manual clear-data ritual to pick up a new renderer. The
+ * cache-name suffixes are derived from BUILD_REV too, so `activate`'s stale-cache
+ * purge drops the PRIOR deploy's caches instead of relying on a hand-bumped -vN.
  */
 
 "use strict";
+
+// Replaced at build time by vite/sw-build-rev-plugin.ts. In the dev/public copy
+// it stays as the literal sentinel, which is fine: dev never installs this SW
+// (registration is PROD-gated) and a missing replacement degrades to a stable
+// suffix rather than breaking the SW.
+const BUILD_REV = "__SW_BUILD_REV__";
+// A short, cache-name-safe suffix derived from the build rev. When the token was
+// not replaced (dev/public copy) fall back to a fixed baseline so cache names
+// stay valid and stable.
+const BUILD_SUFFIX =
+  BUILD_REV && BUILD_REV.indexOf("__SW_BUILD_REV__") === -1
+    ? BUILD_REV.replace(/[^a-zA-Z0-9]/g, "").slice(0, 16) || "dev"
+    : "dev";
 
 // Web Push handler logic (push/notificationclick shaping, deep-link routing,
 // badge helpers) lives in a standalone, unit-tested module. importScripts runs
@@ -31,7 +55,10 @@ try {
   console.warn("[SW] push module unavailable:", err && err.message);
 }
 
-const VIEWS_CACHE_NAME = "elizaos-views-v1";
+// Cache names carry the per-deploy BUILD_SUFFIX so a new deploy's `activate`
+// drops the PRIOR deploy's caches automatically (the -vN literals below are the
+// stable baseline; the suffix makes them deploy-unique without hand-bumping).
+const VIEWS_CACHE_NAME = `elizaos-views-v1-${BUILD_SUFFIX}`;
 // Bump the shell cache to evict any stale precached index/CSS in an installed
 // iOS standalone PWA (Add-to-Home-Screen runs this SW). The network-first shell
 // still updates on reload, but the version bump forces old caches to be dropped
@@ -39,14 +66,14 @@ const VIEWS_CACHE_NAME = "elizaos-views-v1";
 // v5: black launch baseline (theme-color + launch-bg -> #000000; the home
 // background is the black field with the orange ember glow, and boot no
 // longer paints orange). Bump drops any cached prior shell.
-const SHELL_CACHE_NAME = "elizaos-shell-v6";
+const SHELL_CACHE_NAME = `elizaos-shell-v6-${BUILD_SUFFIX}`;
 // Immutable runtime cache for Vite's content-hashed build output (/assets/*).
 // The filename hash IS the cache key's freshness guarantee: any byte change
 // produces a new filename, so cache-first can never serve a stale asset. This
 // insulates a resumed iOS PWA from WKWebView's aggressive HTTP-cache eviction
 // under memory pressure (which otherwise forces a multi-MB re-download of the
 // same immutable bundle). Bump the version to purge the whole cache on deploy.
-const ASSETS_CACHE_NAME = "elizaos-assets-v1";
+const ASSETS_CACHE_NAME = `elizaos-assets-v1-${BUILD_SUFFIX}`;
 const HERO_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h
 // Bound the immutable /assets/* cache so a long-lived install with many deploys
 // can't grow it without limit. Content-hashed assets accumulate across builds;
@@ -257,6 +284,16 @@ self.addEventListener("fetch", (event) => {
 self.addEventListener("message", (event) => {
   const data = event.data;
   if (!data || typeof data !== "object") return;
+
+  // The page (sw-registration.ts) asks a freshly-installed-but-waiting worker to
+  // activate immediately on a deploy. `install` already calls skipWaiting(), so
+  // this is belt-and-suspenders for a worker that was already waiting when the
+  // page loaded — it makes the new renderer take over without a manual reload
+  // (CONVERSATIONS-500-2026-07-22 fix #1).
+  if (data.type === "SKIP_WAITING") {
+    event.waitUntil(self.skipWaiting());
+    return;
+  }
 
   if (data.type === "sw:evict-view") {
     const viewId = typeof data.viewId === "string" ? data.viewId : null;

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -37,6 +37,61 @@ function isElectrobunHost(): boolean {
 }
 
 /**
+ * When a NEW service worker reaches `installed` while an existing controller is
+ * present, a fresh renderer was just deployed. The new SW's own `activate`
+ * already skips-waiting + claims + navigates windows, but wiring the client side
+ * of the update makes the transition immediate and observable: tell the waiting
+ * worker to take over (SKIP_WAITING), then reload once it becomes the controller.
+ * Guarded so the FIRST install (no prior controller) does NOT reload — that is a
+ * normal first paint, not an update (CONVERSATIONS-500-2026-07-22 fix #1).
+ */
+function wireServiceWorkerUpdateReload(
+  registration: ServiceWorkerRegistration,
+): void {
+  let reloading = false;
+  const reloadOnControllerChange = () => {
+    if (reloading) return;
+    reloading = true;
+    // The new worker is now controlling this page → load the new renderer.
+    globalThis.location.reload();
+  };
+
+  const trackInstalling = (worker: ServiceWorker | null) => {
+    if (!worker) return;
+    worker.addEventListener("statechange", () => {
+      // A worker reaching `installed` with an existing controller = an UPDATE
+      // (not the first install). Ask it to activate immediately.
+      if (worker.state === "installed" && navigator.serviceWorker.controller) {
+        try {
+          worker.postMessage({ type: "SKIP_WAITING" });
+        } catch {
+          /* postMessage unsupported — the SW's own skipWaiting still runs */
+        }
+      }
+    });
+  };
+
+  // A worker already waiting at registration time (installed between sessions).
+  if (registration.waiting && navigator.serviceWorker.controller) {
+    try {
+      registration.waiting.postMessage({ type: "SKIP_WAITING" });
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  registration.addEventListener("updatefound", () => {
+    trackInstalling(registration.installing);
+  });
+
+  // Reload exactly once when control passes to the new worker.
+  navigator.serviceWorker.addEventListener(
+    "controllerchange",
+    reloadOnControllerChange,
+  );
+}
+
+/**
  * Register /sw.js with scope "/" in production web builds only.
  * Safe to call unconditionally — bails out when the environment is unsuitable.
  */
@@ -55,6 +110,9 @@ export function registerViewServiceWorker(): void {
       // `.scope` off it would throw and masquerade as a registration error.
       if (!registration) return;
       console.info("[SW] Registered, scope:", registration.scope);
+      // Auto-reload into a new renderer when a deploy ships a new worker
+      // (the per-deploy build rev makes sw.js byte-change so this actually fires).
+      wireServiceWorkerUpdateReload(registration);
     })
     // error-policy:J4 the service worker is a PWA enhancement — the app
     // works without it; the failure is logged for triage

--- a/packages/app/test/sw-build-rev-plugin.test.ts
+++ b/packages/app/test/sw-build-rev-plugin.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests the per-deploy service-worker versioning plugin
+ * (CONVERSATIONS-500-2026-07-22 fix #1): it must stamp a byte-unique build rev
+ * into the emitted `dist/sw.js` so a normal deploy produces a byte-CHANGED sw.js
+ * (the browser's SW byte-diff then detects a new worker and auto-updates).
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveSwBuildRev,
+  swBuildRevPlugin,
+} from "../vite/sw-build-rev-plugin";
+
+const TOKEN = "__SW_BUILD_REV__";
+
+function runCloseBundle(
+  plugin: ReturnType<typeof swBuildRevPlugin>,
+  outDir: string,
+) {
+  // Drive the plugin the way Vite does: configResolved then closeBundle.
+  const info: string[] = [];
+  const warn: string[] = [];
+  const ctx = {
+    info: (m: string) => info.push(m),
+    warn: (m: string) => warn.push(m),
+  };
+  (plugin.configResolved as (c: { build: { outDir: string } }) => void).call(
+    ctx,
+    { build: { outDir } },
+  );
+  (plugin.closeBundle as () => void).call(ctx);
+  return { info, warn };
+}
+
+describe("swBuildRevPlugin", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sw-build-rev-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.GIT_COMMIT;
+    delete process.env.GIT_SHA;
+  });
+
+  it("replaces the __SW_BUILD_REV__ sentinel in dist/sw.js with the env sha", () => {
+    process.env.GIT_COMMIT = "abcdef0123456789";
+    writeFileSync(
+      path.join(dir, "sw.js"),
+      `const BUILD_REV = "${TOKEN}";\n// cache: elizaos-shell-v6-${TOKEN}\n`,
+    );
+
+    runCloseBundle(swBuildRevPlugin(), dir);
+
+    const out = readFileSync(path.join(dir, "sw.js"), "utf8");
+    expect(out).not.toContain(TOKEN);
+    // env sha is truncated to 12 chars.
+    expect(out).toContain("abcdef012345");
+    // ALL occurrences replaced (the const AND the cache-name usage).
+    expect(out.match(/abcdef012345/g)?.length).toBe(2);
+  });
+
+  it("makes two builds at different revs produce BYTE-DIFFERENT sw.js (the whole point)", () => {
+    const template = `const BUILD_REV = "${TOKEN}";\n`;
+
+    process.env.GIT_COMMIT = "1111111111111111";
+    writeFileSync(path.join(dir, "sw.js"), template);
+    runCloseBundle(swBuildRevPlugin(), dir);
+    const first = readFileSync(path.join(dir, "sw.js"), "utf8");
+
+    process.env.GIT_COMMIT = "2222222222222222";
+    writeFileSync(path.join(dir, "sw.js"), template);
+    runCloseBundle(swBuildRevPlugin(), dir);
+    const second = readFileSync(path.join(dir, "sw.js"), "utf8");
+
+    expect(first).not.toBe(second);
+  });
+
+  it("is a no-op when dist/sw.js is absent (secondary single-file build)", () => {
+    // No sw.js written — closeBundle must not throw.
+    expect(() => runCloseBundle(swBuildRevPlugin(), dir)).not.toThrow();
+  });
+
+  it("is idempotent / safe when sw.js has no sentinel (already stamped)", () => {
+    const already = `const BUILD_REV = "deadbeefcafe";\n`;
+    writeFileSync(path.join(dir, "sw.js"), already);
+    runCloseBundle(swBuildRevPlugin(), dir);
+    expect(readFileSync(path.join(dir, "sw.js"), "utf8")).toBe(already);
+  });
+
+  it("resolveSwBuildRev prefers env sha (12 chars) and always returns a non-empty rev", () => {
+    process.env.GIT_COMMIT = "0123456789abcdef";
+    expect(resolveSwBuildRev()).toBe("0123456789ab");
+    delete process.env.GIT_COMMIT;
+    // No env → git or timestamp fallback, but never empty.
+    expect(resolveSwBuildRev().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -51,6 +51,7 @@ import {
   nativeModuleStubPlugin,
 } from "./vite/native-module-stub-plugin.ts";
 import { rendererBuildManifestPlugin } from "./vite/renderer-build-manifest-plugin.ts";
+import { swBuildRevPlugin } from "./vite/sw-build-rev-plugin.ts";
 import { VENDOR_OPTIMIZED_WALLET_TEST } from "./vite/wallet-chunk-matcher.ts";
 import { resolveViteDevServerRuntime } from "./vite-dev-origin.ts";
 
@@ -2189,6 +2190,10 @@ export default defineConfig({
     },
     appShellMetadataPlugin(),
     rendererBuildManifestPlugin(),
+    // Stamp a per-deploy build rev into dist/sw.js so the browser detects a new
+    // service worker on every deploy and auto-runs the update flow (kills the
+    // recurring clear-data ritual — CONVERSATIONS-500-2026-07-22 fix #1).
+    swBuildRevPlugin(),
     appDevWsBasePlugin(),
     elizaCoreBrowserEntryFallbackPlugin(),
     nativeModuleStubPlugin({

--- a/packages/app/vite/sw-build-rev-plugin.ts
+++ b/packages/app/vite/sw-build-rev-plugin.ts
@@ -1,0 +1,89 @@
+/**
+ * Vite plugin: stamp a per-deploy build revision into the emitted service worker.
+ *
+ * THE PROBLEM (CONVERSATIONS-500-2026-07-22 fix #1): `packages/app/public/sw.js`
+ * is copied VERBATIM into `dist/` by Vite (publicDir is not transformed). Its
+ * cache names were hardcoded string literals, so a normal deploy produced a
+ * `dist/sw.js` that was BYTE-IDENTICAL to the installed worker. The browser's SW
+ * update check byte-diffs the fetched `/sw.js` against the installed one, finds
+ * no change, and never installs a new worker — so install/skipWaiting/activate
+ * (drop-stale-caches + clients.claim + navigate-windows) NEVER re-run on deploy.
+ * All the update machinery in sw.js was dead code, and users had to manually
+ * clear site data / reinstall the PWA to pick up a new renderer (the recurring
+ * "clear-data ritual").
+ *
+ * THE FIX: replace the `__SW_BUILD_REV__` sentinel in the emitted `dist/sw.js`
+ * with the git sha (or a build timestamp fallback) of THIS build. Any byte change
+ * to sw.js makes the browser detect a new worker → the existing
+ * install/activate flow runs automatically → the new renderer loads without a
+ * clear-data ritual. sw.js also derives its cache-name suffixes from the rev, so
+ * `activate` purges the prior deploy's caches.
+ *
+ * Runs in `closeBundle` (after publicDir is copied into dist) so it rewrites the
+ * final on-disk `dist/sw.js`. Build-only (`apply: "build"`); dev never installs
+ * the SW (registration is PROD-gated). Idempotent + non-fatal: if `dist/sw.js`
+ * is absent (a secondary single-file build) it no-ops.
+ */
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { Plugin } from "vite";
+
+const SW_BUILD_REV_TOKEN = "__SW_BUILD_REV__";
+
+/**
+ * A stable, deploy-unique revision string: prefer an explicit env sha (CI sets
+ * GIT_COMMIT/GIT_SHA), then `git rev-parse HEAD`, else a build timestamp so the
+ * token is ALWAYS replaced with something byte-unique per build even outside a
+ * git checkout.
+ */
+export function resolveSwBuildRev(): string {
+  const envCommit =
+    process.env.GIT_COMMIT?.trim() || process.env.GIT_SHA?.trim();
+  if (envCommit) return envCommit.slice(0, 12);
+  try {
+    const sha = execSync("git rev-parse --short=12 HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    if (sha) return sha;
+  } catch {
+    /* not a git checkout — fall through to a timestamp */
+  }
+  // Timestamp fallback: always byte-unique per build.
+  return `t${Date.now().toString(36)}`;
+}
+
+export function swBuildRevPlugin(): Plugin {
+  let outDir = "dist";
+  return {
+    name: "sw-build-rev",
+    apply: "build",
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    closeBundle() {
+      const swPath = path.join(outDir, "sw.js");
+      if (!existsSync(swPath)) return; // non-app build (no public sw.js emitted)
+      try {
+        const source = readFileSync(swPath, "utf8");
+        if (!source.includes(SW_BUILD_REV_TOKEN)) {
+          // Already stamped or a sw.js without the sentinel — nothing to do.
+          return;
+        }
+        const rev = resolveSwBuildRev();
+        // Replace ALL occurrences so the marker + any derived usage are stamped.
+        const stamped = source.split(SW_BUILD_REV_TOKEN).join(rev);
+        writeFileSync(swPath, stamped, "utf8");
+        this.info?.(`[sw-build-rev] stamped dist/sw.js build rev=${rev}`);
+      } catch (err) {
+        // Non-fatal: a failed stamp means the SW keeps the sentinel (stable
+        // "dev" suffix) — the app still works, it just won't auto-update on this
+        // build. Surface as a warning so CI can notice, but never fail the build.
+        const message = err instanceof Error ? err.message : String(err);
+        this.warn?.(`[sw-build-rev] failed to stamp dist/sw.js: ${message}`);
+      }
+    },
+  };
+}

--- a/packages/cloud/api/__tests__/shared-agent-conversations-list-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-conversations-list-route.test.ts
@@ -1,0 +1,100 @@
+// Exercises the SHARED-agent conversations LIST route — the exact endpoint the
+// PWA cloud-managed init gate polls (`isCloudProxyPassthroughServing` ->
+// `GET /api/conversations`). Regression guard for CONVERSATIONS-500-2026-07-22:
+// the list route calls `agent.created_at.toISOString()`, so if resolveSharedAgent
+// ever hands back a non-Date `created_at` (as the scope cache did after its JSON
+// round-trip) the route 500s and strands the PWA on "initializing agent". These
+// tests pin the 200 contract for a well-typed resolver result and confirm the
+// route reads `created_at` as a Date.
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realResolveSharedAgent from "@/lib/services/shared-runtime/resolve-shared-agent";
+
+const resolveSharedAgent = mock();
+
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  ...realResolveSharedAgent,
+  resolveSharedAgent,
+}));
+
+const conversationsListRoute = (
+  await import("../v1/eliza/agents/[agentId]/api/conversations/route")
+).default;
+
+afterAll(() => {
+  mock.module(
+    "@/lib/services/shared-runtime/resolve-shared-agent",
+    () => realResolveSharedAgent,
+  );
+});
+
+const AGENT = "69a6249e-0000-4a1a-8a16-19aee293bfea";
+const CREATED = new Date("2026-06-18T12:34:56.000Z");
+const APP_ORIGIN = "https://localhost";
+
+function listConversations(origin?: string): Response | Promise<Response> {
+  const headers: Record<string, string> = {
+    Authorization: "Bearer user-api-key",
+  };
+  if (origin) headers.Origin = origin;
+  return conversationsListRoute.request("/", { method: "GET", headers });
+}
+
+describe("shared agent conversations LIST route (PWA init gate probe)", () => {
+  beforeEach(() => {
+    resolveSharedAgent.mockReset();
+    resolveSharedAgent.mockResolvedValue({
+      agent: {
+        agent_name: "Eliza",
+        created_at: CREATED,
+        execution_tier: "shared",
+      },
+      agentId: AGENT,
+      orgId: "org-1",
+      agentName: "Eliza",
+    });
+  });
+
+  test("GET returns 200 with the canonical single conversation", async () => {
+    const res = await listConversations(APP_ORIGIN);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      conversations: [
+        {
+          id: AGENT,
+          roomId: AGENT,
+          title: "Eliza",
+          createdAt: CREATED.toISOString(),
+          updatedAt: CREATED.toISOString(),
+        },
+      ],
+    });
+  });
+
+  test("GET does NOT 500 when the resolver returns a well-typed Date created_at", async () => {
+    // The defect (CONVERSATIONS-500-2026-07-22) was a string created_at from the
+    // scope cache -> `.toISOString()` threw. With resolveSharedAgent normalizing
+    // dates, the route reads a Date and never 500s.
+    const res = await listConversations(APP_ORIGIN);
+    expect(res.status).not.toBe(500);
+    const body = (await res.json()) as {
+      conversations: Array<{ createdAt: string }>;
+    };
+    // createdAt is a serialized ISO string in the response body.
+    expect(body.conversations[0].createdAt).toBe(CREATED.toISOString());
+  });
+
+  test("GET surfaces the resolver's error status (e.g. 404) instead of masking it", async () => {
+    resolveSharedAgent.mockResolvedValue({
+      error: "Agent not found",
+      status: 404,
+    });
+    const res = await listConversations(APP_ORIGIN);
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "Agent not found",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -100,7 +100,7 @@ mock.module("../../utils/logger", () => ({
 }));
 
 const { resolveSharedAgent } = await import("./resolve-shared-agent");
-const { CacheTTL } = await import("../../cache/keys");
+const { CacheTTL, CacheKeys } = await import("../../cache/keys");
 
 function contextWithAgentId(agentId?: string, headers: Record<string, string> = {}) {
   const lower: Record<string, string> = {};
@@ -484,5 +484,76 @@ describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => 
     const [cacheKey] = cacheSet.mock.calls[0];
     expect(String(cacheKey)).not.toContain("s:");
     expect(revalidateSessionScope).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION (CONVERSATIONS-500-2026-07-22): the real cache client
+  // JSON-serializes on write and JSON-parses on read, so a cached agent row's
+  // `timestamp` columns (Drizzle `Date`s on a live DB hydration) come back as
+  // ISO STRINGS on a cache HIT. The shared-agent conversations route calls
+  // `agent.created_at.toISOString()`, which throws on a string and 500s the
+  // read on EVERY cache hit (the observed "first call 200, then 20/20 = 500").
+  // The module-level in-memory cache double stores by REFERENCE, which hid this
+  // for a year; these tests seed the cache with a JSON-round-tripped entry
+  // (exactly what prod holds) and assert resolveSharedAgent restores the Date
+  // contract before returning.
+  describe("cache-hit Date rehydration", () => {
+    const CREATED = new Date("2026-06-18T12:34:56.000Z");
+
+    // Reproduce what the real cache stores: the object AFTER a JSON round-trip.
+    function jsonRoundTrip<T>(value: T): T {
+      return JSON.parse(JSON.stringify(value)) as T;
+    }
+
+    function seedCacheHit(agentOverrides: Record<string, unknown> = {}) {
+      const key = CacheKeys.sharedAgentScope.resolve("keyhashpref0000", "agent-1");
+      const liveEntry = {
+        orgId: "org-1",
+        agent: agent({ created_at: CREATED, updated_at: CREATED, ...agentOverrides }),
+        firstWrittenAtMs: Date.now(),
+      };
+      // Store the DESERIALIZED shape a real cache.get would return.
+      cacheStore.set(key, jsonRoundTrip(liveEntry));
+    }
+
+    test("a JSON-round-tripped cache hit carries created_at as a string (bug precondition)", () => {
+      const key = CacheKeys.sharedAgentScope.resolve("keyhashpref0000", "agent-1");
+      seedCacheHit();
+      const stored = cacheStore.get(key) as { agent: { created_at: unknown } };
+      // Precondition the fix must survive: the raw cached value is a string,
+      // NOT a Date, so a naive passthrough would 500 the route.
+      expect(typeof stored.agent.created_at).toBe("string");
+      expect(stored.agent.created_at instanceof Date).toBe(false);
+    });
+
+    test("resolveSharedAgent restores created_at to a Date on a cache hit so .toISOString() works", async () => {
+      seedCacheHit();
+
+      const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
+      expect("agent" in result).toBe(true);
+      if (!("agent" in result)) throw new Error("expected a resolved agent");
+
+      // The fix: the agent handed to route consumers has Date timestamps again.
+      expect(result.agent.created_at instanceof Date).toBe(true);
+      // The exact call the conversations route makes must not throw.
+      expect(() => (result.agent.created_at as Date).toISOString()).not.toThrow();
+      expect((result.agent.created_at as Date).toISOString()).toBe(CREATED.toISOString());
+      // Served from cache -> the cold authoritative gate did NOT run.
+      expect(requireUserOrApiKeyWithOrgLookup).not.toHaveBeenCalled();
+    });
+
+    test("updated_at and other timestamp fields are rehydrated too", async () => {
+      seedCacheHit();
+      const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
+      if (!("agent" in result)) throw new Error("expected a resolved agent");
+      expect(result.agent.updated_at instanceof Date).toBe(true);
+    });
+
+    test("a null/absent timestamp field is left untouched (no fabricated Date)", async () => {
+      // deleted_at is nullable; a cache hit must not fabricate a Date for it.
+      seedCacheHit({ deleted_at: null });
+      const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
+      if (!("agent" in result)) throw new Error("expected a resolved agent");
+      expect(result.agent.deleted_at).toBeNull();
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -22,6 +22,51 @@ export type ResolvedSharedAgent =
   | { agent: AgentSandbox; agentId: string; orgId: string; agentName: string };
 
 /**
+ * The `AgentSandbox` timestamp columns Drizzle selects as JS `Date`s. These are
+ * the fields that survive a live DB hydration as `Date` but are lost to `string`
+ * when the agent row round-trips through the scope cache (which JSON-serializes
+ * on write and JSON-parses on read).
+ */
+const AGENT_SANDBOX_DATE_FIELDS = [
+  "created_at",
+  "updated_at",
+  "deleted_at",
+  "claimed_at",
+  "pool_ready_at",
+  "last_backup_at",
+  "last_heartbeat_at",
+  "last_billed_at",
+  "shutdown_warning_sent_at",
+  "scheduled_shutdown_at",
+] as const satisfies ReadonlyArray<keyof AgentSandbox>;
+
+/**
+ * Restore the `AgentSandbox` DATE contract after a scope-cache round-trip
+ * (CONVERSATIONS-500-2026-07-22). The cache client JSON-serializes on write and
+ * JSON-parses on read, so every `timestamp` column that Drizzle hands us as a JS
+ * `Date` on a live DB hydration comes back from cache as an ISO **string**.
+ * Downstream consumers rely on the typed contract — e.g. the shared-agent
+ * conversations route calls `agent.created_at.toISOString()`, which throws
+ * (`string.toISOString is not a function`) and 500s the read on EVERY cache hit
+ * (the exact "first call 200, then all 500" defect). Rehydrating the known date
+ * fields at the cache-read boundary keeps a cache hit byte-for-byte equivalent
+ * to a fresh DB hydration for every caller. Best-effort per field: an absent or
+ * already-`Date` value is left untouched; an unparseable value is left as-is so
+ * we never fabricate a bogus `Date`.
+ */
+function rehydrateCachedAgentDates(agent: AgentSandbox): AgentSandbox {
+  const out = agent as unknown as Record<string, unknown>;
+  for (const field of AGENT_SANDBOX_DATE_FIELDS) {
+    const value = out[field];
+    if (typeof value === "string") {
+      const parsed = new Date(value);
+      if (!Number.isNaN(parsed.getTime())) out[field] = parsed;
+    }
+  }
+  return agent;
+}
+
+/**
  * What the shared-agent SCOPE cache stores (COLDPATH-FIX-2026-07-21): the two
  * facts the cold auth+scope gate produces — the caller's organization id and
  * the org-scoped agent row. Everything else in the success return is derived
@@ -138,11 +183,16 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
         (await revalidateSessionScope(c, cached.stewardUserId).catch(() => false))
       : await revalidateCachedScope(c, cached.orgId).catch(() => false);
     if (!stillAuthorized) return null;
+    // Restore the DATE contract lost to the cache's JSON round-trip before
+    // handing the agent to route consumers (e.g. conversations route calls
+    // `agent.created_at.toISOString()`). Without this a cache hit 500s the read
+    // (CONVERSATIONS-500-2026-07-22).
+    const agent = rehydrateCachedAgentDates(cached.agent);
     return {
-      agent: cached.agent,
+      agent,
       agentId,
       orgId: cached.orgId,
-      agentName: cached.agent.agent_name ?? "Eliza",
+      agentName: agent.agent_name ?? "Eliza",
     };
   };
 

--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -29,6 +29,7 @@ const clientMock = vi.hoisted(() => ({
   hasToken: vi.fn(),
   startAgent: vi.fn(),
   listConversations: vi.fn(),
+  fetch: vi.fn(),
 }));
 
 const persistenceMock = vi.hoisted(() => ({
@@ -199,6 +200,134 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     );
     expect(runningDispatches).toHaveLength(1);
     expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_TIMEOUT" });
+  });
+
+  // ── CONVERSATIONS-500 HARDENING (persistent 5xx must not spin forever) ──
+
+  it("persistent /api/conversations 500 + /api/status canRespond → advances to chat despite the broken list endpoint", async () => {
+    // The exact staging defect: the runtime is UP (/api/status 200 canRespond),
+    // but GET /api/conversations deterministically 500s. The old boolean gate
+    // treated the 500 like a warming 404 and spun forever. Now: after a short
+    // 5xx streak we confirm off /api/status and let the user INTO chat.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+
+    clientMock.listConversations.mockRejectedValue({
+      status: 500,
+      message: "internal_error",
+    });
+    // /api/status through the same passthrough reports a serving runtime.
+    clientMock.fetch.mockResolvedValue({ state: "running", canRespond: true });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    // We fell back to /api/status once the 5xx streak crossed threshold.
+    expect(clientMock.fetch).toHaveBeenCalledWith("/api/status");
+    // And advanced to chat exactly once instead of stranding on the boot screen.
+    const runningDispatches = dispatch.mock.calls.filter(
+      ([e]) => e.type === "AGENT_RUNNING",
+    );
+    expect(runningDispatches).toHaveLength(1);
+    expect(deps.setConnected).toHaveBeenCalledWith(true);
+    // No infinite spinner and no hard error, because status confirmed readiness.
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+
+  it("persistent /api/conversations 500 AND /api/status can't confirm → surfaces an actionable AGENT_ERROR with retry (no infinite spinner)", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+
+    clientMock.listConversations.mockRejectedValue({
+      status: 500,
+      message: "internal_error",
+    });
+    // /api/status also fails to confirm (e.g. also 500 / cannot respond).
+    clientMock.fetch.mockRejectedValue({
+      status: 500,
+      message: "internal_error",
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    // Surfaced a distinct, actionable agent error (not a warming timeout).
+    expect(deps.setStartupError).toHaveBeenCalledTimes(1);
+    const [errState] = deps.setStartupError.mock.calls[0];
+    expect(errState.reason).toBe("agent-error");
+    expect(errState.status).toBe(500);
+    expect(errState.message).toMatch(/chat service returned an error/i);
+    // Dispatched AGENT_ERROR (lands on the error phase → retry UI), never spun
+    // AGENT_RUNNING, and did not keep the user on an infinite "initializing".
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "AGENT_ERROR" }),
+    );
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+    expect(deps.setFirstRunLoading).toHaveBeenCalledWith(false);
+  });
+
+  it("a SINGLE transient 500 that then recovers to serving still advances (no premature error on one blip)", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+
+    let call = 0;
+    clientMock.listConversations.mockImplementation(async () => {
+      call += 1;
+      // One 5xx blip (below the persistent threshold), then it serves.
+      if (call === 1) throw { status: 503, message: "temporarily unavailable" };
+      return { conversations: [] };
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    // A single blip never crossed the streak threshold, so /api/status was not
+    // consulted and no error was surfaced — it simply advanced when serving.
+    expect(clientMock.fetch).not.toHaveBeenCalled();
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+    const runningDispatches = dispatch.mock.calls.filter(
+      ([e]) => e.type === "AGENT_RUNNING",
+    );
+    expect(runningDispatches).toHaveLength(1);
   });
 
   // ── REGRESSION GUARDS (shared-code constraint) ─────────────────────────

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -170,18 +170,55 @@ function isCloudManagedActiveServer(): boolean {
  * booting chat.
  *
  * `listConversations()` issues a real `GET /api/conversations` THROUGH that
- * passthrough (it is NOT short-circuited by any shim), so it is the authoritative
- * "is the warmed runtime actually serving?" signal:
+ * passthrough (it is NOT short-circuited by any shim), so it is a strong
+ * "is the warmed runtime actually serving?" signal — BUT it is not the ONLY
+ * one, and a naive boolean over-trusts it (CONVERSATIONS-500-2026-07-22):
  *   - resolves → the passthrough serves → runtime is live → ready.
- *   - rejects  → still warming (404 "Agent not found") or a transient blip →
- *     keep polling. Both are "not ready yet"; the 401/429 auth cases are already
- *     resolved during the polling-backend phase before starting-runtime, so a
- *     rejection here does not need auth disambiguation.
+ *   - 404 "Agent not found" → still WARMING (container binding the runtime) →
+ *     keep polling.
+ *   - persistent 5xx → the runtime is UP but the conversations-list read is
+ *     ERRORING (e.g. a scope-cache/date defect 500ing the list while /status
+ *     stays 200). Treating this identically to a warming 404 strands a
+ *     genuinely-serving agent on the boot screen until the absolute-max
+ *     deadline. It must be classified distinctly so the warmup can (a) confirm
+ *     readiness off /api/status instead, and (b) surface an actionable error
+ *     rather than an infinite spinner if the whole surface stays broken.
+ * The 401/429 auth cases are already resolved during the polling-backend phase
+ * before starting-runtime, so a rejection here does not need auth disambiguation.
  */
-async function isCloudProxyPassthroughServing(): Promise<boolean> {
+type PassthroughProbe =
+  | { kind: "serving" }
+  | { kind: "warming" }
+  | { kind: "errored"; status: number };
+
+async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
   try {
     await client.listConversations();
-    return true;
+    return { kind: "serving" };
+  } catch (err) {
+    const status = asApiLikeError(err)?.status;
+    // A 5xx means the runtime answered but the list read errored — the agent is
+    // likely UP (that is exactly the shared-agent conversations 500 class). Any
+    // other failure (404 "Agent not found", network/timeout, no status) is
+    // "still warming": keep polling as before.
+    if (typeof status === "number" && status >= 500) {
+      return { kind: "errored", status };
+    }
+    return { kind: "warming" };
+  }
+}
+
+/**
+ * Secondary readiness signal for a cloud-managed agent whose /api/conversations
+ * passthrough is 5xx-ing: does /api/status through the SAME passthrough report a
+ * runtime that can actually respond? A broken list endpoint must not strand a
+ * genuinely-serving agent on the boot screen — if status says `canRespond`, the
+ * agent is ready and the user should be let into chat (CONVERSATIONS-500).
+ */
+async function isCloudProxyStatusReady(): Promise<boolean> {
+  try {
+    const status = await client.fetch<AgentStatus>("/api/status");
+    return status?.state === "running" && status?.canRespond === true;
   } catch {
     return false;
   }
@@ -560,6 +597,28 @@ async function runCloudManagedWarmup(
 ): Promise<void> {
   const started = Date.now();
   let deadline = started + getAgentReadyTimeoutMs();
+  // Count CONSECUTIVE 5xx probes of the conversations passthrough. A persistent
+  // 5xx (runtime up, list read broken) is NOT a warming 404 and must not spin
+  // "initializing agent" forever: after a short streak we (a) confirm readiness
+  // off /api/status so a broken list endpoint can't strand a serving agent, and
+  // (b) if status also can't confirm, surface an actionable error with Retry
+  // instead of an infinite spinner (CONVERSATIONS-500-2026-07-22).
+  let consecutive5xx = 0;
+  // ~5 consecutive 5xx at the 500ms poll cadence (~2.5s of deterministic errors)
+  // is well past any single transient blip and safely distinguishes a real
+  // broken-list-endpoint from a one-off flake before we act on it.
+  const PERSISTENT_5XX_THRESHOLD = 5;
+
+  const advanceReady = async (via: string): Promise<void> => {
+    await hydrateReadyAgentStatus(deps);
+    if (cancelled.current || effectRunRef.current !== effectRunId) return;
+    deps.setConnected(true);
+    deps.setFirstRunLoading(false);
+    logger.info(
+      `[eliza][startup:init] cloud-managed agent ready (${via}); advancing to chat`,
+    );
+    dispatch({ type: "AGENT_RUNNING" });
+  };
 
   logger.info(
     "[eliza][startup:init] cloud-managed agent; waiting on proxy passthrough to warm before declaring ready",
@@ -580,27 +639,68 @@ async function runCloudManagedWarmup(
       return;
     }
 
-    const serving = await isCloudProxyPassthroughServing();
+    const probe = await probeCloudProxyPassthrough();
     if (cancelled.current || effectRunRef.current !== effectRunId) return;
 
-    if (serving) {
+    if (probe.kind === "serving") {
       // The passthrough answers → the warmed runtime is genuinely serving.
-      // Hydrate the full status (model/canRespond) then advance exactly once.
-      await hydrateReadyAgentStatus(deps);
-      if (cancelled.current || effectRunRef.current !== effectRunId) return;
-      deps.setConnected(true);
-      deps.setFirstRunLoading(false);
-      logger.info(
-        "[eliza][startup:init] cloud-managed proxy passthrough is serving; agent ready",
-      );
-      dispatch({ type: "AGENT_RUNNING" });
+      await advanceReady("conversations passthrough serving");
       return;
     }
 
-    // Still warming (or a transient failure). Keep polling and — because the
-    // passthrough not-yet-serving IS the agent still starting — slide the
-    // deadline with an effective "starting" state so the warm window can extend
-    // up to the absolute max instead of tripping the initial timeout.
+    if (probe.kind === "errored") {
+      // The runtime answered but the conversations-list read 5xx'd. The agent is
+      // very likely UP (this is the shared-agent conversations 500 class). Do
+      // NOT treat it as a warming 404.
+      consecutive5xx += 1;
+      if (consecutive5xx >= PERSISTENT_5XX_THRESHOLD) {
+        // Confirm readiness off /api/status so a broken LIST endpoint alone
+        // can't strand a genuinely-serving agent on the boot screen.
+        const statusReady = await isCloudProxyStatusReady();
+        if (cancelled.current || effectRunRef.current !== effectRunId) return;
+        if (statusReady) {
+          logger.warn(
+            `[eliza][startup:init] cloud-managed conversations passthrough is persistently ${probe.status}, but /api/status reports canRespond — advancing to chat despite the broken list endpoint`,
+          );
+          await advanceReady(
+            `status canRespond despite conversations ${probe.status}`,
+          );
+          return;
+        }
+        // Runtime is up (5xx, not 404) but neither the list read nor /status
+        // can confirm it can serve. Surface an ACTIONABLE error with Retry
+        // instead of spinning "initializing agent" to the absolute-max deadline.
+        const errorMessage =
+          "The agent is running but its chat service returned an error.";
+        logger.error(
+          `[eliza][startup:init] cloud-managed conversations passthrough persistently ${probe.status} and /api/status could not confirm readiness; surfacing agent error`,
+        );
+        deps.setStartupError({
+          reason: "agent-error",
+          phase: "initializing-agent",
+          message: errorMessage,
+          detail: `The agent's conversations endpoint responded with a server error (HTTP ${probe.status}) and /api/status could not confirm it can respond. This is a server-side issue, not a slow warmup. Press Retry to try again.`,
+          status: probe.status,
+        });
+        deps.setFirstRunLoading(false);
+        dispatch({ type: "AGENT_ERROR", message: errorMessage });
+        return;
+      }
+      // Below the streak threshold: could still be a transient blip. Keep
+      // polling WITHOUT sliding the deadline (a real 5xx is not "more warmup").
+      deps.setConnected(false);
+      await new Promise<void>((r) => {
+        tidRef.current = setTimeout(r, 500);
+      });
+      continue;
+    }
+
+    // probe.kind === "warming": still warming (404 "Agent not found") or a
+    // transient non-5xx failure. Reset the 5xx streak, keep polling, and —
+    // because the passthrough not-yet-serving IS the agent still starting —
+    // slide the deadline with an effective "starting" state so the warm window
+    // can extend up to the absolute max instead of tripping the initial timeout.
+    consecutive5xx = 0;
     deps.setConnected(false);
     deadline = computeAgentDeadlineExtensions({
       agentWaitStartedAt: started,


### PR DESCRIPTION
## What
Three tightly-scoped fixes for the staging PWA \"initializing agent\" hang Shadow hit live (receipts: projects/eliza-fleet/PWA-INIT-STUCK + CONVERSATIONS-500 in fleet workspace):

1. **fix(cloud): rehydrate cached agent Date fields** — the shared-agent scope cache JSON-round-trips the agent row, so `created_at` returns as ISO **string** on cache HIT; `/api/conversations` calls `.toISOString()` on it → 500 on every hit within TTL (miss=200, hit=500, deterministic). Fix restores Date types at the cache boundary (`rehydrateCachedAgentDates`). Regression test written first: 2 fail without fix → 23/23 with.
2. **fix(cloud-ui): harden cloud-managed warmup gate** — readiness now keys off `/api/status canRespond`; persistent 5xx surfaces as actionable AGENT_ERROR + retry instead of infinite \"initializing agent\". 9/9.
3. **fix(app): version dist/sw.js per deploy** — build rev stamped into the SW so updatefound→SKIP_WAITING→reload fires on every deploy. Ends the clear-data ritual. 5/5, sw-fetch/sw-push green.

## Why not revert 16763/16785
They only widened the window of a latent serialization defect; reverting re-hides the bug and loses the idle-latency win. This fixes the actual contract violation.

## Notes
- No workflow files. Biome clean. All tests green locally (outputs in fleet receipts).
- Touches packages/cloud/shared (deploy path) → merging triggers the staging deploy that clears the live hang.

Co-authored-by: shadow <shadow@shad0w.xyz>