### PR TITLE
fix(evidence): named Metadata type import (fix TS2503 sharp namespace, unblocks #16824)

### DIFF
--- a/packages/evidence/src/vision-qa/image.ts
+++ b/packages/evidence/src/vision-qa/image.ts
@@ -12,6 +12,7 @@
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import type { Metadata } from "sharp";
 import sharp from "sharp";
 import { EvidenceError } from "../errors.ts";
 import type { ImageDimensions } from "./types.ts";
@@ -83,7 +84,7 @@ export async function prepareImage(
   const sourceSha256 = createHash("sha256").update(sourceBytes).digest("hex");
 
   const pipeline = sharp(sourceBytes, { failOn: "error" });
-  let metadata: sharp.Metadata;
+  let metadata: Metadata;
   try {
     metadata = await pipeline.metadata();
   } catch (error) {


### PR DESCRIPTION
## Problem

The develop-wide `typecheck` gate is red on `@elizaos/evidence`:

```
packages/evidence/src/vision-qa/image.ts(86,17): error TS2503: Cannot find namespace 'sharp'.
```

This is byte-identical on develop head (pre-existing), blocks backmerge #16824 (ancestry-only), and pollutes every PR's typecheck cone.

## Root cause (bisect)

Three things aligned to expose a latent fragility — no single code commit is "the" regression:

1. **#16687** introduced `let metadata: sharp.Metadata;` — using the default-import value binding `sharp` as a **type-namespace qualifier**.
2. **sharp 0.35.x** was published within the `^0.34.5` range. CI installs **non-frozen** (`install-command: bun install`, not `--frozen-lockfile` — see `.github/workflows/ci.yaml`), so `sharp` floats from the locked `0.34.5` to **`0.35.3`**. 0.35.x ships a modern `exports` map routing types to `dist/index.d.mts` (ESM dual-package). Under `moduleResolution: "bundler"` the default import then binds **only the value**, so `sharp.Metadata` as a *type* no longer resolves → TS2503. (0.34.5's legacy `export = sharp` / `lib/index.d.ts` did carry the namespace as a type, which is why frozen local installs stay green.)
3. **#16806** activated the per-package `tsc --noEmit` typecheck gate repo-wide, so evidence's now-red typecheck became a required, running check.

Reproduced deterministically: fresh `bun install` on develop head resolves evidence → sharp@0.35.3 → TS2503. With `--frozen-lockfile` (sharp@0.34.5) it's green — which is exactly the "byte-identical but red only in CI" signature.

## Fix (root, no suppressions)

```diff
 import sharp from "sharp";
+import type { Metadata } from "sharp";
...
-  let metadata: sharp.Metadata;
+  let metadata: Metadata;
```

`Metadata` is a **named type export** in both sharp 0.34.5 (namespace member) and 0.35.3 (top-level `export interface Metadata`), so the fix is version-robust across the whole `^0.34.5` float range. **No `ts-ignore`, no `exclude`, no tsconfig weakening.** The runtime `sharp.kernel` value usage in `visual-primitives.mjs` is untouched (it's a value, not a type).

## Verification

Typecheck green across every engine × sharp-version combination:

| engine | sharp 0.34.5 | sharp 0.35.3 (CI) |
|---|---|---|
| TS7 native (CI) | ✅ | ✅ |
| TS 6.0.3 (classic) | ✅ | ✅ |
| TS 5.9.3 | ✅ | ✅ |

Evidence suite: **422 passed / 7 skipped / 0 failed** (incl. `vision-qa/image.test.ts`).

## Segfault note (turbo exit-139)

The exit-139 that trailed the TS2503 in CI did **not** reproduce here. Running the real turbo typecheck cone (35-package dep graph) completed the build tasks with **exit 0** — no segfault. This is consistent with the exit-139 being a **runner OOM artifact** downstream of the type error (turbo/tsc getting OOM-killed on a constrained runner after the failing task), not an independent crash. Recommend the orchestrator confirm the runner memory ceiling; no CI-config change is made in this PR.

Co-authored-by: shadow <shadow@shad0w.xyz>

---

## Evidence

Non-UI, type-only fix: one `.ts` file, +2/-1, no rendered-UI source touched (path is `packages/evidence/`, not app/ui/tui/homepage), no runtime/behavior change. Verification is compiler + unit-suite output, pasted below. All media rows are honest `N/A`.

<!-- evidence-row:before-screenshots -->
- **Before screenshots:** N/A - no UI touched; type-only change to `image.ts` (default-import type-namespace → named type import).

<!-- evidence-row:after-screenshots -->
- **After screenshots:** N/A - no UI touched; no rendered surface in this diff.

<!-- evidence-row:walkthrough-video -->
- **Walkthrough video:** N/A - no user-facing flow; compiler-level type fix.

<!-- evidence-row:backend-logs -->
- **Backend logs:** N/A - no server/runtime code path changed; `sharp.metadata()` call site is byte-identical, only the local variable's *type annotation* changed (`sharp.Metadata` → `Metadata`).

<!-- evidence-row:frontend-logs -->
- **Frontend console/network logs:** N/A - no frontend touched.

<!-- evidence-row:llm-trajectory -->
- **Real-LLM trajectory:** N/A - no agent/LLM behavior changed; this is a build-time typecheck fix.

<!-- evidence-row:domain-artifacts -->
- **Domain artifacts:** typecheck + test output (the artifacts this change produces). CI typecheck run: https://github.com/elizaOS/eliza/actions/runs/29961076288 .
  - Typecheck green across every engine × sharp-version combination — TS7-native (CI default), TS 6.0.3, TS 5.9.3, each against sharp **0.34.5** (frozen lockfile) AND **0.35.3** (CI non-frozen float). Before fix, sharp 0.35.3 → `src/vision-qa/image.ts(86,17): error TS2503: Cannot find namespace 'sharp'.`; after fix → exit 0 in all six combinations.
  - Evidence unit suite (`bun run test` in `packages/evidence`): **422 passed / 7 skipped / 0 failed** (46 files), including `src/vision-qa/image.test.ts` (8 tests) which exercises the patched `prepareImage`.

<!-- evidence-row:ocr-review -->
- **OCR review:** N/A - no image/screenshot output to OCR; the change is a type annotation, and existing OCR-path tests (`src/analyzers/ocr/ocr.test.ts`, 23 tests) remain green in the run above.

