### PR TITLE
fix(ci): run Benchmark Bridge tests from package root

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         include:
           - lane: benchmark-tests
-            command: bunx vitest run --config packages/lifeops-bench/vitest.config.ts --root packages/lifeops-bench --passWithNoTests
+            command: bunx vitest run --config vitest.config.ts --root packages/lifeops-bench --passWithNoTests
           - lane: benchmark-lint
             command: bunx @biomejs/biome check packages/lifeops-bench/src
 
@@ -63,6 +63,9 @@ jobs:
           bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454); packageManager bun@1.4.0-canary.1 is unresolvable (GH+npm 404)
           install-command: bun install --ignore-scripts --no-frozen-lockfile
           install-native-deps: "false"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Run ${{ matrix.lane }} lane
         env:

--- a/packages/lifeops-bench/src/__tests__/native-runtime-routing.test.ts
+++ b/packages/lifeops-bench/src/__tests__/native-runtime-routing.test.ts
@@ -117,25 +117,28 @@ describe("campaign-native Eliza routing", () => {
     );
   });
 
-  it.each(
-    specializedClassifiers,
-  )("%s reaches AgentRuntime.useModel with explicit provenance", (classifier) => {
-    const classifierStart = messageRoute.indexOf(
-      `${classifier}(session.benchmark)`,
-    );
-    expect(classifierStart).toBeGreaterThanOrEqual(0);
-    const metadataStart = messageRoute.indexOf(
-      "const metadata = benchmarkTurnMetadata",
-      classifierStart,
-    );
-    expect(metadataStart).toBeGreaterThan(classifierStart);
-    const branch = messageRoute.slice(classifierStart, metadataStart + 500);
+  it.each(specializedClassifiers)(
+    "%s reaches AgentRuntime.useModel with explicit provenance",
+    (classifier) => {
+      const classifierStart = messageRoute.indexOf(
+        `${classifier}(session.benchmark)`,
+      );
+      expect(classifierStart).toBeGreaterThanOrEqual(0);
+      const metadataStart = messageRoute.indexOf(
+        "const metadata = benchmarkTurnMetadata",
+        classifierStart,
+      );
+      expect(metadataStart).toBeGreaterThan(classifierStart);
+      const branch = messageRoute.slice(classifierStart, metadataStart + 500);
 
-    expect(branch).toContain("runtime.useModel");
-    expect(branch).toContain('nativeRuntimeApi: "useModel"');
-    expect(branch).toMatch(/toolBridge: "runtime_model_(?:native_tools|text)"/);
-    expect(branch).not.toMatch(/\bfetch\s*\(/);
-  });
+      expect(branch).toContain("runtime.useModel");
+      expect(branch).toContain('nativeRuntimeApi: "useModel"');
+      expect(branch).toMatch(
+        /toolBridge: "runtime_model_(?:native_tools|text)"/,
+      );
+      expect(branch).not.toMatch(/\bfetch\s*\(/);
+    },
+  );
 
   it("keeps the generic conversation path on messageService.handleMessage", () => {
     const genericStart = messageRoute.indexOf(

--- a/packages/lifeops-bench/src/subscription-chat-capabilities.test.ts
+++ b/packages/lifeops-bench/src/subscription-chat-capabilities.test.ts
@@ -330,25 +330,26 @@ describe("claudeSubscriptionChatOnlyPlugin", () => {
         },
       ]),
     },
-  ])("fails closed on $label from the lifecycle structured stage", async ({
-    result,
-  }) => {
-    const responseHandler = vi.fn(
-      async (_runtime: IAgentRuntime, _params: GenerateTextParams) => result,
-    );
-    const restricted = claudeSubscriptionChatOnlyPlugin(
-      sourcePluginWithResponseHandler(responseHandler),
-      { lifecycleStructuredResponseTool: true },
-    );
+  ])(
+    "fails closed on $label from the lifecycle structured stage",
+    async ({ result }) => {
+      const responseHandler = vi.fn(
+        async (_runtime: IAgentRuntime, _params: GenerateTextParams) => result,
+      );
+      const restricted = claudeSubscriptionChatOnlyPlugin(
+        sourcePluginWithResponseHandler(responseHandler),
+        { lifecycleStructuredResponseTool: true },
+      );
 
-    await expect(
-      restricted.models?.[ModelType.RESPONSE_HANDLER]?.({} as IAgentRuntime, {
-        prompt: "evaluate",
-        responseSchema: { type: "object" },
-      }),
-    ).rejects.toMatchObject({
-      code: "BENCHMARK_LIFECYCLE_STRUCTURED_RESPONSE_INVALID",
-    });
-    expect(responseHandler).toHaveBeenCalledTimes(1);
-  });
+      await expect(
+        restricted.models?.[ModelType.RESPONSE_HANDLER]?.({} as IAgentRuntime, {
+          prompt: "evaluate",
+          responseSchema: { type: "object" },
+        }),
+      ).rejects.toMatchObject({
+        code: "BENCHMARK_LIFECYCLE_STRUCTURED_RESPONSE_INVALID",
+      });
+      expect(responseHandler).toHaveBeenCalledTimes(1);
+    },
+  );
 });

--- a/packages/lifeops-bench/vitest.config.ts
+++ b/packages/lifeops-bench/vitest.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "vitest/config";
 const fileDir = path.dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = path.resolve(fileDir, "../..");
 const coreSrc = path.join(monorepoRoot, "packages/core/src");
+const loggerSrc = path.join(monorepoRoot, "packages/logger/src");
 const sharedSrc = path.join(monorepoRoot, "packages/shared/src");
 const cloudRoutingSrc = path.join(monorepoRoot, "packages/cloud/routing/src");
 const cloudSdkSrc = path.join(monorepoRoot, "packages/cloud/sdk/src");
@@ -17,12 +18,31 @@ export default defineConfig({
   },
   resolve: {
     alias: [
-      { find: /^@elizaos\/core$/, replacement: path.join(coreSrc, "index.node.ts") },
+      {
+        find: /^@elizaos\/core$/,
+        replacement: path.join(coreSrc, "index.node.ts"),
+      },
       { find: /^@elizaos\/core\/(.+)$/, replacement: path.join(coreSrc, "$1") },
-      { find: /^@elizaos\/shared$/, replacement: path.join(sharedSrc, "index.ts") },
-      { find: /^@elizaos\/shared\/(.+)$/, replacement: path.join(sharedSrc, "$1") },
-      { find: /^@elizaos\/cloud-routing$/, replacement: path.join(cloudRoutingSrc, "index.ts") },
-      { find: /^@elizaos\/cloud-sdk$/, replacement: path.join(cloudSdkSrc, "index.ts") },
+      {
+        find: /^@elizaos\/logger$/,
+        replacement: path.join(loggerSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/shared$/,
+        replacement: path.join(sharedSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/shared\/(.+)$/,
+        replacement: path.join(sharedSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: path.join(cloudRoutingSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/cloud-sdk$/,
+        replacement: path.join(cloudSdkSrc, "index.ts"),
+      },
     ],
   },
 });

--- a/packages/scripts/__tests__/benchmark-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/benchmark-workflow-contract.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Guards the Benchmark Bridge command against resolving its Vitest config
+ * twice beneath the package root before any benchmark tests can run.
+ */
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const WORKFLOW_PATH = `${REPOSITORY_ROOT}/.github/workflows/benchmark-tests.yml`;
+
+test("benchmark Vitest config is relative to its declared root", () => {
+  const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+  expect(workflow).toContain(
+    "bunx vitest run --config vitest.config.ts --root packages/lifeops-bench --passWithNoTests",
+  );
+  expect(workflow).not.toContain(
+    "--config packages/lifeops-bench/vitest.config.ts --root packages/lifeops-bench",
+  );
+  expect(workflow).toContain(
+    "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
+  );
+});


### PR DESCRIPTION
Closes #16839

## Summary

- resolve the Benchmark Bridge Vitest config relative to its declared package root
- generate gitignored shared/core i18n keyword data after the workflow installs with `--ignore-scripts`
- resolve `@elizaos/logger` from workspace source so a clean runner does not require prebuilt dist output
- add a workflow contract that rejects the duplicated config path and requires i18n generation

## Verification

- [rebased native Benchmark Bridge run 29966707958](https://github.com/elizaOS/eliza/actions/runs/29966707958) — success
- `bun test packages/scripts/__tests__/benchmark-workflow-contract.test.ts` — 1 passed
- `bunx vitest run --config vitest.config.ts --root packages/lifeops-bench --passWithNoTests` — 14 files, 152 tests passed
- `actionlint .github/workflows/benchmark-tests.yml`
- `bunx @biomejs/biome check packages/lifeops-bench/vitest.config.ts packages/scripts/__tests__/benchmark-workflow-contract.test.ts`
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or visual behavior changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or visual behavior changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the change only repairs CI test-harness resolution; no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this workflow/config fix does not create persistent domain data.
