### PR TITLE
fix(packaging): align UI React peers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2950,7 +2950,7 @@
         "pngjs": "^7.0.0",
         "postcss": "^8.5.16",
         "react": "19.2.5",
-        "react-dom": "19.2.7",
+        "react-dom": "19.2.5",
         "react-plaid-link": "^4.1.1",
         "sharp": "^0.35.3",
         "storybook": "^10.0.0",
@@ -2970,7 +2970,7 @@
         "@elizaos/capacitor-llama": "workspace:*",
         "llama-cpp-capacitor": "^0.1.5",
         "react": "19.2.5",
-        "react-dom": "19.2.7",
+        "react-dom": "19.2.5",
       },
       "optionalPeers": [
         "@capacitor-community/bluetooth-le",

--- a/packages/scripts/__tests__/ui-react-peer-version-contract.test.ts
+++ b/packages/scripts/__tests__/ui-react-peer-version-contract.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Keeps the published UI package's paired React peers installable together and
+ * aligned with the versions exercised by the root workspace.
+ */
+
+import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+interface PackageManifest {
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  resolutions?: Record<string, string>;
+}
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+const readManifest = async (path: string): Promise<PackageManifest> =>
+  Bun.file(path).json();
+
+test("@elizaos/ui publishes the React pair tested by the workspace", async () => {
+  const root = await readManifest(`${REPOSITORY_ROOT}/package.json`);
+  const ui = await readManifest(`${REPOSITORY_ROOT}/packages/ui/package.json`);
+  const rootReact = root.resolutions?.react;
+  const rootReactDom = root.resolutions?.["react-dom"];
+
+  expect(rootReact).toBeDefined();
+  expect(rootReactDom).toBe(rootReact);
+  expect(ui.peerDependencies?.react).toBe(rootReact);
+  expect(ui.peerDependencies?.["react-dom"]).toBe(rootReactDom);
+  expect(ui.devDependencies?.react).toBe(rootReact);
+  expect(ui.devDependencies?.["react-dom"]).toBe(rootReactDom);
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -354,7 +354,7 @@
     "@elizaos/capacitor-llama": "workspace:*",
     "llama-cpp-capacitor": "^0.1.5",
     "react": "19.2.5",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.5"
   },
   "peerDependenciesMeta": {
     "@capacitor-community/bluetooth-le": {
@@ -486,7 +486,7 @@
     "pngjs": "^7.0.0",
     "postcss": "^8.5.16",
     "react": "19.2.5",
-    "react-dom": "19.2.7",
+    "react-dom": "19.2.5",
     "react-plaid-link": "^4.1.1",
     "sharp": "^0.35.3",
     "storybook": "^10.0.0",


### PR DESCRIPTION
Closes #16847

## Summary

- align `@elizaos/ui` React DOM peer and dev dependencies from 19.2.7 to the workspace React/React DOM pin 19.2.5
- update the Bun lockfile with pinned Bun 1.3.14
- add a contract that keeps the published UI React pair aligned with root resolutions and the versions used by UI development

## Verification

- [native Test Packaging run 29962461718](https://github.com/elizaOS/eliza/actions/runs/29962461718) — success
- rebased Test Packaging run 29966756655 — queued at the current merge candidate
- `bun test packages/scripts/__tests__/ui-react-peer-version-contract.test.ts` — 1 passed, 6 expectations
- `bunx @biomejs/biome check packages/scripts/__tests__/ui-react-peer-version-contract.test.ts`
- `bun install --ignore-scripts --lockfile-only` with Bun 1.3.14
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - package metadata only; no rendered UI behavior changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - package metadata only; no rendered UI behavior changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - dependency metadata only; rendered frontend code is unchanged.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the package metadata fix creates no persistent domain data.
