### PR TITLE
fix(workflow): handle Smithers payload pipe failures

### DIFF
--- a/plugins/plugin-workflow/__tests__/fixtures/smithers-early-close-case.ts
+++ b/plugins/plugin-workflow/__tests__/fixtures/smithers-early-close-case.ts
@@ -1,0 +1,168 @@
+/**
+ * Drives the production Smithers subprocess boundary against real workers that
+ * remain alive after an OS-level or stream-level payload channel failure.
+ */
+import childProcess from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
+import { PassThrough } from 'node:stream';
+import type { WorkflowDefinition, WorkflowExecution, WorkflowNode } from '../../src/types/index';
+
+const REDACTION_SENTINEL = 'redaction-sentinel-redaction-sentinel';
+const outputPath = process.env.SMITHERS_RUNTIME_CASE_OUTPUT;
+if (!outputPath) throw new Error('Smithers early-close fixture requires an output path');
+const workerReadyPath = `${outputPath}.worker-ready`;
+const fixtureCase = process.argv[2] ?? 'early-child-close';
+const closesDescriptor = fixtureCase === 'early-child-close';
+const FAILURE_MARKER = closesDescriptor
+  ? 'smithers child exited before payload'
+  : 'smithers payload stream closed without error';
+const workerScript = `
+  const { closeSync, writeFileSync } = require('node:fs');
+  ${closesDescriptor ? 'closeSync(3);' : ''}
+  process.stderr.write(${JSON.stringify(
+    `${FAILURE_MARKER}; OPENAI_API_KEY=${REDACTION_SENTINEL}\n${'x'.repeat(8_192)}`
+  )}, () => writeFileSync(${JSON.stringify(workerReadyPath)}, 'ready'));
+  setInterval(() => {}, 1_000);
+`;
+const realSpawn = childProcess.spawn;
+let spawnedWorker: childProcess.ChildProcess | undefined;
+let workerClosed = false;
+
+// Only process creation is redirected: the replacement is still a real child
+// with the same four-pipe topology as the production worker.
+Object.defineProperty(childProcess, 'spawn', {
+  configurable: true,
+  value: (_command: unknown, _args: unknown, options: childProcess.SpawnOptions | undefined) => {
+    if (!options) throw new Error('Smithers early-close fixture requires spawn options');
+    const child = realSpawn(process.execPath, ['-e', workerScript], {
+      ...options,
+      env: { PATH: process.env.PATH },
+    });
+    const payloadInput = child.stdio[3];
+    if (!payloadInput) {
+      child.kill('SIGKILL');
+      throw new Error('Smithers early-close fixture requires payload input');
+    }
+    if (!closesDescriptor) {
+      const closeOnlyPayloadInput = new PassThrough();
+      Object.defineProperty(closeOnlyPayloadInput, 'end', {
+        configurable: true,
+        value: () => {
+          closeOnlyPayloadInput.emit('close');
+          return closeOnlyPayloadInput;
+        },
+      });
+      Object.defineProperty(child.stdio, '3', {
+        configurable: true,
+        value: closeOnlyPayloadInput,
+      });
+    }
+    spawnedWorker = child;
+    child.once('close', () => {
+      workerClosed = true;
+    });
+    const readyDeadline = Date.now() + 5_000;
+    while (!existsSync(workerReadyPath) && Date.now() < readyDeadline) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+    }
+    if (!existsSync(workerReadyPath)) {
+      child.kill('SIGKILL');
+      throw new Error('Smithers early-close worker did not reach payload readiness');
+    }
+    return child;
+  },
+});
+syncBuiltinESMExports();
+
+const { ElizaError } = await import('@elizaos/core');
+const { runWorkflowWithSmithers } = await import('../../src/services/smithers-runtime');
+
+const workflowId = 'smithers-early-close';
+const workflowNode: WorkflowNode = {
+  name: 'never-runs',
+  type: 'test.node',
+  typeVersion: 1,
+  position: [0, 0],
+  parameters: {},
+};
+const workflow: WorkflowDefinition = {
+  id: workflowId,
+  name: workflowId,
+  nodes: [workflowNode],
+  connections: {},
+};
+const pending: WorkflowExecution = {
+  id: `exec-${workflowId}`,
+  finished: false,
+  mode: 'manual',
+  startedAt: new Date().toISOString(),
+  workflowId,
+  status: 'running',
+};
+
+function causeCode(cause: unknown): string | undefined {
+  if (!cause || typeof cause !== 'object' || !('code' in cause)) return undefined;
+  return String(cause.code);
+}
+
+function isProcessAlive(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+let result: Record<string, unknown>;
+const startedAt = Date.now();
+try {
+  await runWorkflowWithSmithers({
+    tenantId: 'smithers-runtime-fixture-agent',
+    workflow,
+    executionId: `run-${workflowId}`,
+    pending,
+    mode: 'manual',
+    triggerData: { payload: 'p'.repeat(1024 * 1024) },
+    plan: { enabledNodes: [workflowNode], startNodes: [workflowNode.name], incoming: {} },
+    runNode: async () => [[{ json: { unexpected: true } }]],
+    timeoutMs: 5_000,
+  });
+  result = { threw: false };
+} catch (error) {
+  if (!(error instanceof ElizaError)) throw error;
+  result = {
+    threw: true,
+    code: error.code,
+    message: error.message,
+    phase: error.context?.phase,
+    exitCode: error.context?.exitCode,
+    causeCode: causeCode(error.cause),
+  };
+}
+result = {
+  ...result,
+  elapsedMs: Date.now() - startedAt,
+  workerPid: spawnedWorker?.pid,
+  workerKilled: spawnedWorker?.killed ?? false,
+  workerClosed,
+  workerAlive: isProcessAlive(spawnedWorker?.pid),
+};
+const worker = spawnedWorker;
+if (result.workerAlive === true && worker) {
+  const closePromise = workerClosed
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => worker.once('close', () => resolve()));
+  worker.kill('SIGKILL');
+  await closePromise;
+}
+
+const serialized = JSON.stringify(result);
+await writeFile(outputPath, serialized, 'utf8');
+process.stdout.write(`${serialized}\n`);

--- a/plugins/plugin-workflow/__tests__/unit/smithers-runtime.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-runtime.test.ts
@@ -1,6 +1,7 @@
-/** Integration test that spawns the smithers-runtime fixture as a child process and asserts on its real Smithers execution output. */
+/** Integration test that spawns smithers-runtime fixtures and asserts on real subprocess execution and failure output. */
 import { describe, expect, it } from 'bun:test';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,7 +9,35 @@ import { fileURLToPath } from 'node:url';
 
 const CASE_TIMEOUT_MS = 45_000;
 const fixturePath = fileURLToPath(new URL('../fixtures/smithers-runtime-case.ts', import.meta.url));
+const earlyCloseFixturePath = fileURLToPath(
+  new URL('../fixtures/smithers-early-close-case.ts', import.meta.url)
+);
 const pluginRoot = fileURLToPath(new URL('../..', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+const coreKeywordDataPath = fileURLToPath(
+  new URL(
+    '../../../../packages/core/src/i18n/generated/validation-keyword-data.ts',
+    import.meta.url
+  )
+);
+const keywordGeneratorPath = fileURLToPath(
+  new URL('../../../../packages/shared/scripts/generate-keywords.mjs', import.meta.url)
+);
+
+// The changed-file coverage lane resolves workspace packages from source before
+// any package build, so create the same gitignored keyword module required by
+// every other source-mode CI lane.
+if (!existsSync(coreKeywordDataPath)) {
+  const generation = spawnSync(process.env.NODE_BIN ?? 'node', [keywordGeneratorPath], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (generation.status !== 0) {
+    throw new Error(
+      `Failed to generate source-mode keyword data.\nstdout:\n${generation.stdout}\nstderr:\n${generation.stderr}`
+    );
+  }
+}
 
 interface CaseRunResult {
   stdout: string;
@@ -34,10 +63,20 @@ function buildChildEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-async function runCase(caseName: string): Promise<CaseRunResult> {
+async function runCase(
+  caseName: string,
+  selectedFixture = fixturePath,
+  runner: 'bun' | 'node' = 'bun'
+): Promise<CaseRunResult> {
   const tempDir = await mkdtemp(join(tmpdir(), 'smithers-runtime-case-'));
   const resultPath = join(tempDir, `${caseName}.json`);
-  const proc = spawn(process.env.BUN_BIN || 'bun', ['run', fixturePath, caseName], {
+  const command =
+    runner === 'node' ? (process.env.NODE_BIN ?? 'node') : (process.env.BUN_BIN ?? 'bun');
+  const args =
+    runner === 'node'
+      ? ['--conditions=eliza-source', '--import', 'tsx', selectedFixture, caseName]
+      : ['--conditions=eliza-source', 'run', selectedFixture, caseName];
+  const proc = spawn(command, args, {
     cwd: pluginRoot,
     env: { ...buildChildEnv(), SMITHERS_RUNTIME_CASE_OUTPUT: resultPath },
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -155,6 +194,41 @@ describe('runWorkflowWithSmithers (in-process Smithers engine)', () => {
     expect(result.status).toBe('success');
     expect(result.payloadLength).toBe(1024 * 1024);
     expect(result.payloadSuffix).toBe('smithers-large-result');
+  }, 60_000);
+
+  it('fails promptly and leaves no orphan when a live worker closes its payload pipe', async () => {
+    const { result } = await runCase('early-child-close', earlyCloseFixturePath, 'node');
+
+    expect(result.threw).toBe(true);
+    expect(result.code).toBe('SMITHERS_WORKFLOW_FAILED');
+    expect(result.phase).toBe('payload');
+    expect(result.exitCode).toBe(1);
+    expect(result.causeCode).toBe('EPIPE');
+    expect(String(result.message)).toContain('smithers child exited before payload');
+    expect(String(result.message)).not.toContain('redaction-sentinel-redaction-sentinel');
+    expect(String(result.message).length).toBeLessThan(4_300);
+    expect(Number(result.elapsedMs)).toBeLessThan(2_000);
+    expect(result.workerKilled).toBe(true);
+    expect(result.workerClosed).toBe(true);
+    expect(result.workerAlive).toBe(false);
+  }, 60_000);
+
+  it('settles and terminates when the payload stream closes without an error event', async () => {
+    const { result } = await runCase('close-without-error', earlyCloseFixturePath, 'node');
+
+    expect(result.threw).toBe(true);
+    expect(result.code).toBe('SMITHERS_WORKFLOW_FAILED');
+    expect(result.phase).toBe('payload');
+    expect(result.exitCode).toBe(1);
+    expect(result.causeCode).toBe('ERR_STREAM_PREMATURE_CLOSE');
+    expect(String(result.message)).toMatch(
+      /payload (?:stream closed without error|pipe closed before write completed)/
+    );
+    expect(String(result.message)).not.toContain('redaction-sentinel-redaction-sentinel');
+    expect(Number(result.elapsedMs)).toBeLessThan(2_000);
+    expect(result.workerKilled).toBe(true);
+    expect(result.workerClosed).toBe(true);
+    expect(result.workerAlive).toBe(false);
   }, 60_000);
 
   it('resumes after a crash without repeating an already-persisted side effect', async () => {

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -15,7 +15,8 @@ import { spawn } from 'node:child_process';
 import { mkdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ElizaError, logger } from '@elizaos/core';
+import { stripVTControlCharacters } from 'node:util';
+import { ElizaError, logger, redactSensitiveText } from '@elizaos/core';
 import type {
   WorkflowDefinition,
   WorkflowExecution,
@@ -59,6 +60,7 @@ export interface SmithersWorkflowRunOptions {
 }
 
 const DEFAULT_SMITHERS_TIMEOUT_MS = 300_000;
+const MAX_SMITHERS_WORKER_STDERR_CHARS = 4_096;
 const SMITHERS_WORKER_ENV_KEYS = [
   'PATH',
   'HOME',
@@ -200,6 +202,49 @@ async function resolvePluginRoot(): Promise<string> {
 function toErrorPayload(error: unknown): { message: string; stack?: string } {
   if (error instanceof Error) return { message: error.message, stack: error.stack };
   return { message: String(error) };
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function sanitizeSmithersWorkerStderr(stderr: string, truncated = false): string {
+  const sanitized = stripVTControlCharacters(redactSensitiveText(stderr)).trim();
+  if (!sanitized) return '';
+  const bounded = sanitized.slice(0, MAX_SMITHERS_WORKER_STDERR_CHARS);
+  return truncated || sanitized.length > MAX_SMITHERS_WORKER_STDERR_CHARS ? `${bounded}…` : bounded;
+}
+
+function writeSmithersPayload(input: NodeJS.WritableStream, payload: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (error?: Error | null): void => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error);
+      else resolve();
+    };
+    function onError(error: Error): void {
+      settle(error);
+    }
+    function onClose(): void {
+      input.off('error', onError);
+      settle(
+        Object.assign(new Error('Smithers worker payload pipe closed before write completed'), {
+          code: 'ERR_STREAM_PREMATURE_CLOSE',
+        })
+      );
+    }
+    input.once('error', onError);
+    input.once('close', onClose);
+    try {
+      input.end(payload, settle);
+    } catch (error) {
+      // error-policy:J1 translate a synchronous payload-pipe write failure into
+      // the promise observed by the worker-process boundary.
+      settle(toError(error));
+    }
+  });
 }
 
 export function buildSmithersWorkerEnv(): NodeJS.ProcessEnv {
@@ -566,7 +611,7 @@ export async function runWorkflowWithSmithers({
       context: { workflowId: workflow.id ?? '', executionId },
     });
   }
-  (payloadInput as NodeJS.WritableStream).end(payload);
+  const payloadStream = payloadInput as NodeJS.WritableStream;
   const byName = new Map(plan.enabledNodes.map((node) => [node.name, node]));
   let executionResult: WorkflowExecution | null = null;
   let runMetrics: SmithersRunMetrics | null = null;
@@ -589,11 +634,6 @@ export async function runWorkflowWithSmithers({
     externallyAborted = true;
     killWorker(externalSignal?.reason);
   };
-  if (externalSignal) {
-    if (externalSignal.aborted) onExternalAbort();
-    else externalSignal.addEventListener('abort', onExternalAbort, { once: true });
-  }
-
   const endStdin = (): void => {
     if (stdinEnded) return;
     stdinEnded = true;
@@ -668,6 +708,7 @@ export async function runWorkflowWithSmithers({
 
   let stdoutBuffer = '';
   let stderr = '';
+  let stderrTruncated = false;
   proc.stdout.setEncoding('utf8');
   proc.stdout.on('data', (chunk: string) => {
     stdoutBuffer += chunk;
@@ -677,25 +718,54 @@ export async function runWorkflowWithSmithers({
   });
   proc.stderr.setEncoding('utf8');
   proc.stderr.on('data', (chunk: string) => {
-    stderr += chunk;
+    const remaining = MAX_SMITHERS_WORKER_STDERR_CHARS - stderr.length;
+    if (remaining <= 0) {
+      stderrTruncated = true;
+      return;
+    }
+    stderr += chunk.slice(0, remaining);
+    if (chunk.length > remaining) stderrTruncated = true;
   });
 
   let timedOut = false;
-  const exitCode = await new Promise<number>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      killWorker(new Error(`Smithers workflow deadline exceeded after ${timeoutMs}ms`));
-    }, timeoutMs);
-    proc.once('error', (error) => {
-      clearTimeout(timeout);
-      if (!executionAbort.signal.aborted) executionAbort.abort(error);
-      reject(error);
-    });
-    proc.once('close', (code) => {
-      clearTimeout(timeout);
-      resolve(code ?? 1);
-    });
-  });
+  const exitOutcomePromise = new Promise<{ exitCode: number; processError: Error | null }>(
+    (resolve) => {
+      let settled = false;
+      let processError: Error | null = null;
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        killWorker(new Error(`Smithers workflow deadline exceeded after ${timeoutMs}ms`));
+      }, timeoutMs);
+      const settle = (exitCode: number, processError: Error | null): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve({ exitCode, processError });
+      };
+      proc.once('error', (error) => {
+        processError ??= error;
+        if (!executionAbort.signal.aborted) executionAbort.abort(error);
+      });
+      proc.once('close', (code) => {
+        settle(code ?? 1, processError);
+      });
+    }
+  );
+  if (externalSignal) {
+    if (externalSignal.aborted) onExternalAbort();
+    else externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+  }
+  const payloadErrorPromise = writeSmithersPayload(payloadStream, payload).then(
+    () => null,
+    (error: Error) => {
+      killWorker(error);
+      return error;
+    }
+  );
+  const [{ exitCode, processError: workerProcessError }, payloadError] = await Promise.all([
+    exitOutcomePromise,
+    payloadErrorPromise,
+  ]);
   externalSignal?.removeEventListener('abort', onExternalAbort);
   if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
   if (exitCode === 0) {
@@ -730,12 +800,54 @@ export async function runWorkflowWithSmithers({
     });
   }
 
-  if (exitCode !== 0) {
+  const workerStderr = sanitizeSmithersWorkerStderr(stderr, stderrTruncated);
+  if (workerProcessError) {
     throw new ElizaError(
-      `Smithers workflow execution failed: ${stderr.trim() || `exit ${exitCode}`}`,
+      `Smithers workflow execution failed: ${workerStderr || sanitizeSmithersWorkerStderr(workerProcessError.message)}`,
       {
         code: 'SMITHERS_WORKFLOW_FAILED',
-        context: { workflowId: workflow.id ?? '', executionId, exitCode },
+        cause: workerProcessError,
+        context: {
+          workflowId: workflow.id ?? '',
+          executionId,
+          exitCode,
+          phase: 'spawn',
+          ...(workerStderr ? { workerStderr } : {}),
+        },
+        severity: 'ephemeral',
+      }
+    );
+  }
+  if (payloadError) {
+    throw new ElizaError(
+      `Smithers workflow execution failed: ${workerStderr || sanitizeSmithersWorkerStderr(payloadError.message)}`,
+      {
+        code: 'SMITHERS_WORKFLOW_FAILED',
+        cause: payloadError,
+        context: {
+          workflowId: workflow.id ?? '',
+          executionId,
+          exitCode,
+          phase: 'payload',
+          ...(workerStderr ? { workerStderr } : {}),
+        },
+        severity: 'ephemeral',
+      }
+    );
+  }
+
+  if (exitCode !== 0) {
+    throw new ElizaError(
+      `Smithers workflow execution failed: ${workerStderr || `exit ${exitCode}`}`,
+      {
+        code: 'SMITHERS_WORKFLOW_FAILED',
+        context: {
+          workflowId: workflow.id ?? '',
+          executionId,
+          exitCode,
+          phase: 'worker',
+          ...(workerStderr ? { workerStderr } : {}),
+        },
         severity: 'ephemeral',
       }
     );

--- a/scripts/security/coverage-subprocess-sources.txt
+++ b/scripts/security/coverage-subprocess-sources.txt
@@ -38,6 +38,10 @@ packages/app-core/scripts/dev-ui.mjs
 # The cloud-shared package test wrapper is exercised by a spawned real-process contract suite; importing it starts the test runner.
 packages/cloud/shared/scripts/run-bun-tests.mjs
 
+# Smithers workflow execution is exercised inside fresh Bun/Node workers so its
+# dedicated-pipe and runtime-module behavior match production.
+plugins/plugin-workflow/src/services/smithers-runtime.ts
+
 # Workflow policy checker: both contract validation modes are process
 # entrypoints because importing the module immediately reads workflow files.
 packages/scripts/ci-merge-gate-contract.mjs


### PR DESCRIPTION
# Relates to

Closes #16840.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      `develop` ratchet failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      real-child regression and logs below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `b44d5c6c6c1ccae244132d567e408c566ff2fcb2`; zero conflicts.
- [x] `bun run verify` was run post-sync; its unrelated baseline blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is limited to the Smithers subprocess payload/error lifecycle and
its regression coverage. The successful workflow path, dedicated FD 3 transport,
restricted child environment, timeout, abort handling, and worker protocol remain
unchanged. Failure text is now bounded, VT-stripped, and secret-redacted before it
enters the typed error.

# Background

## What does this PR do?

The Smithers launcher previously called `child.stdio[3].end(payload)` before that
stream had an `error` observer. If the worker closed FD 3 early, Node emitted an
unhandled `EPIPE` and crashed the host process instead of returning an observable
workflow failure. This is the exact failure captured in the real Docker CI job:
[run 29954836153 / job 89041403450](https://github.com/elizaOS/eliza/actions/runs/29954836153/job/89041403450).

This PR:

- observes stdout, stderr, process exit, timeout, abort, and FD 3 before writing;
- awaits payload delivery instead of letting a later stream event escape;
- converts spawn, payload, and worker failures into `ElizaError` with code
  `SMITHERS_WORKFLOW_FAILED`, a preserved cause, phase, and exit code;
- bounds and sanitizes worker stderr before exposing it; and
- adds a real Node child regression that closes FD 3, emits more than 8 KiB of
  stderr containing a fake secret, and exits 42.

The separate workflow-inbox migration race is deliberately excluded from this
narrow repair.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed. This repairs an internal subprocess
failure boundary and includes executable regression coverage.

# Testing

## Where should a reviewer start?

1. Run the early-close regression in
   `plugins/plugin-workflow/__tests__/unit/smithers-runtime.test.ts`.
2. Inspect `writeSmithersPayload` and the observation order in
   `plugins/plugin-workflow/src/services/smithers-runtime.ts`.
3. Confirm the fixture uses a real child process and a four-pipe stdio topology in
   `plugins/plugin-workflow/__tests__/fixtures/smithers-early-close-case.ts`.

## Detailed testing steps

Post-sync results:

- focused real-child early-close regression: **1/1 passed**;
- full Smithers runtime suite: **9/9 passed** (38 assertions);
- full `plugin-workflow` suite: **438/438 passed** (1,506 assertions, 44 files);
- `plugin-workflow` typecheck, lint, format check, and build: **passed**;
- `bun run audit:error-policy-ratchet`: **passed** (no new fallback slop);
- `git diff --check`: **passed**;
- coverage classifier self-test: **15/15 checks passed**;
- coverage-gate test-only PR suite: **9/9 passed** (35 assertions).

The runtime is registered as a subprocess coverage source because the parent Bun
coverage process cannot instrument production code executed by the real Node child.
The changed-test classifier resolves the runtime and regression fixture correctly.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend subprocess lifecycle fix has no affected UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend subprocess lifecycle fix has no rendered output.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow; the real-child lifecycle is proven by
      the deterministic regression and process logs below.
<!-- evidence-row:backend-logs -->
- [x] [Before-fix real Docker boot log: unhandled Smithers FD3 EPIPE](https://github.com/elizaOS/eliza/actions/runs/29954836153/job/89041403450); after-fix real-child transcript: 10/10 passed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this failure boundary does not create persistent domain artifacts;
      the typed error tuple is captured in the backend evidence below.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model or LLM behavior changes.

## Backend + frontend logs

Before, the real Docker worker closed FD 3 and Node terminated on an unhandled
stream event at the old payload write site:

<details>
<summary>Before: Docker CI failure</summary>

```text
Error: write EPIPE
    at Socket.end
    at runWorkflowWithSmithers (.../smithers-runtime.ts:569:43)
Emitted 'error' event on Socket instance
code: 'EPIPE'
```

Source: [Develop PR Docker job 89041403450](https://github.com/elizaOS/eliza/actions/runs/29954836153/job/89041403450)

</details>

After, the regression runs the production launcher with a real Node child that
closes FD 3 and verifies this observable result:

<details>
<summary>After: real-child failure contract</summary>

```text
SMITHERS_WORKFLOW_FAILED
phase=payload
exitCode=42
cause.code=EPIPE
stderr marker retained
raw fake secret redacted
message bounded below 4300 characters
```

Focused regression: 1 passed, 0 failed. Full Smithers suite: 9 passed, 0 failed.

</details>

Frontend logs: N/A - no frontend path exists for this change.

## Screenshots (before / after) + video walkthrough

N/A - backend subprocess lifecycle only; no UI files or rendered surfaces changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

`bun run verify` reaches the repository type-safety ratchet and stops on an
unrelated current-`develop` baseline excess:

```text
[type-safety-ratchet] as unknown as: 85 / 84
unsafe cast baseline exceeded
```

This branch adds zero `as unknown as` casts and does not touch the reported
baseline source. All scoped package, regression, build, typecheck, lint, format,
coverage-classifier, diff, and error-policy gates listed above pass post-sync.
