### PR TITLE
fix(ci): rebaseline hardened app-control view bundle

### DIFF
--- a/packages/benchmarks/view-bundle-size/budgets.json
+++ b/packages/benchmarks/view-bundle-size/budgets.json
@@ -15,9 +15,10 @@
       "gzipBudgetBytes": 4500
     },
     "plugin-app-control": {
-      "measuredRawBytes": 5767,
-      "measuredGzipBytes": 2245,
-      "gzipBudgetBytes": 3000
+      "measuredRawBytes": 10408,
+      "measuredGzipBytes": 3444,
+      "gzipBudgetBytes": 3900,
+      "baselineReason": "Runtime response validation, typed failures, and authenticated cross-platform navigation are part of the shipped view manager; the previous baseline predated that transport hardening."
     },
     "plugin-birdclaw": {
       "measuredRawBytes": 9930,


### PR DESCRIPTION
Closes #16850

## Summary

- records the current app-control view bundle after runtime validation and authenticated transport hardening
- gives that measured bundle 13.2% cross-environment headroom (3,444 → 3,900 bytes gzip)
- documents why the pre-hardening baseline is no longer representative
- leaves every other per-bundle and aggregate ceiling unchanged

## Verification

- `bun test packages/benchmarks/view-bundle-size/metric-schema.test.ts`: 9 passed
- real app-control view build: 10,408 bytes raw / 3,444 bytes gzip
- app-control row passes the real build-and-measure gate at 3,900 bytes
- full local gate could not resolve three unrelated native/xterm workspace packages because this isolated worktree reused a filtered dependency install; native Actions run below is authoritative for all 26 bundles

## Evidence

- UI screenshots/video: N/A — CI budget metadata only; no rendered UI changed
- frontend/backend logs: N/A — no runtime code changed
- live-model trajectories: N/A — no agent/model behavior changed
- domain artifact: native workflow bundle-size dashboard and measurements

<!-- evidence-row:before-screenshots -->
- [ ] N/A - bundle-budget metadata only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - bundle-budget metadata only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [29962932239](https://github.com/elizaOS/eliza/actions/runs/29962932239)
