### PR TITLE
fix(ios): keep Capacitor loopback transport REST-only

### DIFF
--- a/packages/ui/src/api/client-base-capacitor-rest.test.ts
+++ b/packages/ui/src/api/client-base-capacitor-rest.test.ts
@@ -1,0 +1,300 @@
+// @vitest-environment jsdom
+
+/**
+ * Integration coverage for Capacitor's REST-only loopback transport against a
+ * real ephemeral TCP server. The HTTP and SSE paths use no transport mock or model.
+ */
+
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { __resetNetworkStatusForTests, ElizaClient } from "./client-base";
+import type { ApiError } from "./client-types";
+
+interface CapturedRequest {
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+  method: string;
+  path: string;
+}
+
+const requests: CapturedRequest[] = [];
+let server: Server;
+let serverBaseUrl = "";
+
+function stubWindowProtocol(protocol: string): void {
+  const jsdomWindow = window;
+  const location = new Proxy(jsdomWindow.location, {
+    get(target, property) {
+      if (property === "protocol") return protocol;
+      return Reflect.get(target, property, target);
+    },
+  });
+  vi.stubGlobal(
+    "window",
+    new Proxy(jsdomWindow, {
+      get(target, property) {
+        if (property === "location") return location;
+        return Reflect.get(target, property, target);
+      },
+    }),
+  );
+}
+
+function sendJson(
+  response: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): void {
+  response.writeHead(status, {
+    "content-type": "application/json",
+    ...headers,
+  });
+  response.end(JSON.stringify(body));
+}
+
+beforeAll(async () => {
+  server = createServer(async (request, response) => {
+    const bodyChunks: Buffer[] = [];
+    for await (const chunk of request) {
+      bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+    requests.push({
+      body: Buffer.concat(bodyChunks).toString("utf8"),
+      headers: request.headers,
+      method: request.method ?? "GET",
+      path,
+    });
+
+    switch (path) {
+      case "/api/health":
+        sendJson(response, 200, { ok: true, transport: "rest" });
+        return;
+      case "/api/no-content":
+        response.writeHead(204);
+        response.end();
+        return;
+      case "/api/bad-json":
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("not-json");
+        return;
+      case "/api/rate-limited":
+        sendJson(
+          response,
+          429,
+          { error: "slow down", code: "rate_limited", retryAfter: 3 },
+          { "retry-after": "7" },
+        );
+        return;
+      case "/api/progress":
+        sendJson(response, 202, { status: "starting", progress: 0.4 });
+        return;
+      case "/api/conversations/capacitor/messages/stream":
+        response.writeHead(200, {
+          "cache-control": "no-cache",
+          "content-type": "text/event-stream",
+        });
+        response.end(
+          'data: {"type":"status","kind":"running_tool","toolName":"LOOKUP"}\n\n' +
+            'data: {"type":"tool","phase":"call","callId":"call-1","toolName":"LOOKUP","args":{"id":16843}}\n\n' +
+            'data: {"type":"token","text":"Hello "}\n\n' +
+            'data: {"type":"tool","phase":"result","callId":"call-1","toolName":"LOOKUP","result":{"ok":true}}\n\n' +
+            'data: {"type":"token","text":"from iOS"}\n\n' +
+            'data: {"type":"done","fullText":"Hello from iOS","agentName":"Eliza","thought":"REST path verified","usage":{"promptTokens":2,"completionTokens":3,"totalTokens":5,"model":"integration"},"actionResults":[{"actionName":"LOOKUP","success":true}]}\n\n',
+        );
+        return;
+      default:
+        sendJson(response, 404, { error: `unexpected route: ${path}` });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  serverBaseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+beforeEach(() => {
+  requests.length = 0;
+  stubWindowProtocol("capacitor:");
+  __resetNetworkStatusForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  __resetNetworkStatusForTests();
+});
+
+describe("Capacitor REST-only loopback transport", () => {
+  it("stays connected and reaches the authenticated health endpoint without constructing a websocket", async () => {
+    const websocketConstructor = vi.fn(() => {
+      throw new Error("Capacitor must not construct a cleartext WebSocket");
+    });
+    class WebSocketTrap {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+
+      constructor() {
+        websocketConstructor();
+      }
+    }
+    vi.stubGlobal("WebSocket", WebSocketTrap);
+    const client = new ElizaClient(serverBaseUrl, "ios-token");
+    client.setUiLanguage("en-US");
+
+    client.connectWs();
+    const health = await client.fetch<{ ok: boolean; transport: string }>(
+      "/api/health",
+    );
+
+    expect(websocketConstructor).not.toHaveBeenCalled();
+    expect(client.getConnectionState()).toMatchObject({
+      state: "connected",
+      reconnectAttempt: 0,
+      disconnectedAt: null,
+    });
+    expect(health).toEqual({ ok: true, transport: "rest" });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ method: "GET", path: "/api/health" });
+    expect(requests[0].headers.authorization).toBe("Bearer ios-token");
+    expect(requests[0].headers["x-elizaos-client-id"]).toEqual(
+      expect.any(String),
+    );
+    expect(requests[0].headers["x-elizaos-ui-language"]).toBe("en-US");
+  });
+
+  it("preserves JSON, empty, progress, and typed HTTP error semantics over REST", async () => {
+    const client = new ElizaClient(serverBaseUrl, "ios-token");
+
+    await expect(client.fetch("/api/no-content")).resolves.toBeUndefined();
+    await expect(client.fetch("/api/bad-json")).rejects.toMatchObject({
+      kind: "parse",
+      path: "/api/bad-json",
+      status: 200,
+    } satisfies Partial<ApiError>);
+    await expect(client.fetch("/api/rate-limited")).rejects.toMatchObject({
+      kind: "http",
+      path: "/api/rate-limited",
+      status: 429,
+      code: "rate_limited",
+      retryAfter: 3,
+      message: "slow down",
+    } satisfies Partial<ApiError>);
+
+    const progress = await client.fetch<{ status: string; progress: number }>(
+      "/api/progress",
+      undefined,
+      {
+        skipResume: true,
+        on202: (body) => body as { status: string; progress: number },
+      },
+    );
+    expect(progress).toEqual({ status: "starting", progress: 0.4 });
+
+    const allowed = await client.rawRequest("/api/rate-limited", undefined, {
+      allowNonOk: true,
+    });
+    expect(allowed.status).toBe(429);
+    expect(await allowed.json()).toMatchObject({ code: "rate_limited" });
+  });
+
+  it("streams a complete chat turn through the real REST/SSE path", async () => {
+    const client = new ElizaClient(serverBaseUrl, "ios-token");
+    const tokens: Array<[string, string | undefined]> = [];
+    const statuses: unknown[] = [];
+    const tools: unknown[] = [];
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/capacitor/messages/stream",
+      "verify iOS transport",
+      (token, accumulated) => tokens.push([token, accumulated]),
+      "GROUP",
+      undefined,
+      [
+        {
+          data: "aW1hZ2U=",
+          mimeType: "image/png",
+          name: "proof.png",
+          thumbnail: { data: "dGh1bWI=", mimeType: "image/png" },
+        },
+      ],
+      { source: "ios-smoke" },
+      (status) => statuses.push(status),
+      (tool) => tools.push(tool),
+      "ios-message-16843",
+    );
+
+    expect(tokens).toEqual([
+      ["Hello ", "Hello "],
+      ["from iOS", "Hello from iOS"],
+    ]);
+    expect(statuses).toEqual([{ kind: "running_tool", toolName: "LOOKUP" }]);
+    expect(tools).toEqual([
+      {
+        phase: "call",
+        callId: "call-1",
+        toolName: "LOOKUP",
+        args: { id: 16843 },
+      },
+      {
+        phase: "result",
+        callId: "call-1",
+        toolName: "LOOKUP",
+        result: { ok: true },
+      },
+    ]);
+    expect(result).toEqual({
+      text: "Hello from iOS",
+      agentName: "Eliza",
+      completed: true,
+      reasoning: "REST path verified",
+      usage: {
+        promptTokens: 2,
+        completionTokens: 3,
+        totalTokens: 5,
+        model: "integration",
+      },
+      actionResults: [{ actionName: "LOOKUP", success: true }],
+    });
+
+    const streamRequest = requests.find(
+      (request) =>
+        request.path === "/api/conversations/capacitor/messages/stream",
+    );
+    expect(streamRequest).toMatchObject({ method: "POST" });
+    expect(JSON.parse(streamRequest?.body ?? "{}")).toEqual({
+      text: "verify iOS transport",
+      channelType: "GROUP",
+      clientMessageId: "ios-message-16843",
+      streamProtocol: "delta-v2",
+      images: [
+        {
+          data: "aW1hZ2U=",
+          mimeType: "image/png",
+          name: "proof.png",
+          thumbnail: { data: "dGh1bWI=", mimeType: "image/png" },
+        },
+      ],
+      metadata: { source: "ios-smoke" },
+    });
+  });
+});

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -61,6 +61,25 @@ async function flushMicrotasks(): Promise<void> {
   await new Promise<void>((resolve) => queueMicrotask(resolve));
 }
 
+function stubWindowProtocol(protocol: string): void {
+  const jsdomWindow = window;
+  const location = new Proxy(jsdomWindow.location, {
+    get(target, property) {
+      if (property === "protocol") return protocol;
+      return Reflect.get(target, property, target);
+    },
+  });
+  vi.stubGlobal(
+    "window",
+    new Proxy(jsdomWindow, {
+      get(target, property) {
+        if (property === "location") return location;
+        return Reflect.get(target, property, target);
+      },
+    }),
+  );
+}
+
 describe("ElizaClient websocket connection policy", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -127,6 +146,45 @@ describe("ElizaClient websocket connection policy", () => {
       maxReconnectAttempts: 15,
       disconnectedAt: null,
     });
+  });
+
+  it("uses REST-only transport for cleartext ws from a Capacitor origin", () => {
+    const createdUrls = stubWebSocket();
+    const client = new ElizaClient("http://127.0.0.1:31338", "agent-token");
+    stubWindowProtocol("capacitor:");
+
+    client.connectWs();
+
+    expect(window.location.protocol).toBe("capacitor:");
+    expect(createdUrls).toEqual([]);
+    expect(client.getConnectionState()).toEqual({
+      state: "connected",
+      reconnectAttempt: 0,
+      maxReconnectAttempts: 15,
+      disconnectedAt: null,
+    });
+  });
+
+  it("still opens cleartext ws from an HTTP page", () => {
+    const createdUrls = stubWebSocket();
+    const client = new ElizaClient("http://127.0.0.1:31338", "agent-token");
+    stubWindowProtocol("http:");
+
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://127.0.0.1:31338/ws?");
+  });
+
+  it("still opens secure wss from a Capacitor origin", () => {
+    const createdUrls = stubWebSocket();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    stubWindowProtocol("capacitor:");
+
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("wss://agent.example.test/ws?");
   });
 
   it("treats a dedicated cloud agent base as connected without opening a websocket (its /ws is not proxied)", () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -470,10 +470,13 @@ function getInjectedWsBase(): string | undefined {
   return undefined;
 }
 
-function isMixedContentWebSocketBlocked(wsProtocol: "ws:" | "wss:"): boolean {
+function shouldUseRestOnlyForInsecureWebSocket(
+  wsProtocol: "ws:" | "wss:",
+): boolean {
   if (wsProtocol !== "ws:") return false;
   if (typeof window === "undefined") return false;
-  return window.location?.protocol === "https:";
+  const rendererProtocol = window.location?.protocol;
+  return rendererProtocol === "https:" || rendererProtocol === "capacitor:";
 }
 
 // ---------------------------------------------------------------------------
@@ -1387,12 +1390,11 @@ export class ElizaClient {
 
     if (!host) return;
 
-    // WKWebView and browsers on an HTTPS origin block insecure `ws://` as mixed
-    // content before the backend can answer. REST/SSE remains usable in that
-    // remote-host simulator lane, so degrade to connected-over-REST instead of
-    // burning the reconnect budget and surfacing the fatal lost-connection
-    // overlay against a healthy agent.
-    if (isMixedContentWebSocketBlocked(wsProtocol)) {
+    // HTTPS renderers block `ws://` as mixed content. Capacitor's packaged
+    // renderer also cannot use that cleartext WebView socket even though its
+    // native HTTP bridge keeps REST healthy. Both origins therefore use the
+    // same REST-only state instead of reporting a dead backend (#16843).
+    if (shouldUseRestOnlyForInsecureWebSocket(wsProtocol)) {
       this.backoffMs = 500;
       this.reconnectAttempt = 0;
       this.disconnectedAt = null;


### PR DESCRIPTION
Fixes #16843

## Summary

- keep a Capacitor renderer connected over REST/SSE when its remote agent base would derive an insecure `ws://` URL
- preserve the existing WebSocket behavior for normal HTTP pages and for secure `wss://` targets
- prove the fallback with boundary tests plus a real ephemeral TCP HTTP/SSE integration server

## Root cause

The iOS remote-connect smoke runs the packaged WebView at `capacitor://localhost` against a healthy loopback agent at `http://127.0.0.1:31338`. REST health succeeds through the native HTTP path, but the client still tried `ws://127.0.0.1:31338/ws`. The socket never opened, so the UI stayed `disconnected` until the smoke timed out despite the backend being healthy.

The existing HTTPS mixed-content fallback already models this transport correctly: REST/SSE is authoritative and the shell reports connected without opening the unusable cleartext socket. This patch applies that exact policy to the Capacitor renderer protocol only.

## Compatibility boundaries

- `capacitor:` renderer + `http:` agent → REST-only, no WebSocket construction
- `http:` renderer + `http:` agent → unchanged `ws://` connection
- `capacitor:` renderer + `https:` agent → unchanged `wss://` connection
- shared-runtime, dedicated Cloud, local IPC, and iOS in-process rules are unchanged

## Verification

- focused Vitest: **19/19 passed**
- changed-file line coverage: **61.39%** for `packages/ui/src/api/client-base.ts` (required 50%)
- real TCP integration: authenticated REST headers, JSON, 204, typed HTTP error, 202 progress, and full SSE status/tool/token/done flow
- `@elizaos/ui` current-base full package run: **841 files / 8,558 tests passed**; two unrelated base assertions failed (`ViewHeader.test.tsx`, `notifications-boot.test.tsx`; both source files have zero diff from `origin/develop`)
- `@elizaos/ui` typecheck: passed
- `@elizaos/ui` build/runtime-export verification: passed
- exact Biome on all three changed files: passed
- `git diff --check`: passed
- error-policy ratchet: passed (`emptyCatch 6→6`, `serverConsole 0→0`)
- pre-sync exact-head iOS simulator build: **BUILD SUCCEEDED**; staged renderer and local-agent payload verified
  - source commit: `55ff164bfdb41924c1e8e4a010324c150a0fc6c1`
  - base: `ed98b7f2273e2f56cc80d254e0dda8bcdbbdff41`
  - renderer build id: `3f04e048005feab782e66052911b8412279dcb65109b2f4099a75aa9a9f62546`
  - packaged executable SHA-256: `83b940896e2fbad939653d49b0069e341d60df7d7d9e380c6320218cf6b3fafe`
  - functional simulator proof was captured on pre-rebase head `da205705fbc77761332c6c04783ebbfd2d794b33`; all three changed-file Git blobs are byte-identical at the current head
- isolated iPhone 17 Pro simulator `151F2EF9-7B86-4039-9F7B-74D9D914FF36`: onboarding → remote connect → Home → cold relaunch **PASS**; simulator is now shut down

<details>
<summary>Exact on-device transport result</summary>

```json
{
  "webViewOrigin": "capacitor://localhost",
  "webViewProtocol": "capacitor:",
  "clientBaseUrl": "http://127.0.0.1:31338",
  "expectedInsecureWebSocketUrl": "ws://127.0.0.1:31338/ws",
  "webSocketConstructorCalls": [],
  "connectionState": {
    "state": "connected",
    "reconnectAttempt": 0,
    "maxReconnectAttempts": 15,
    "disconnectedAt": null
  },
  "lostBackendOverlayAbsent": true,
  "restHealth": {
    "ok": true,
    "status": 200,
    "url": "http://127.0.0.1:31338/api/health"
  },
  "homeVisible": true,
  "composerVisible": true,
  "onboardingHidden": true,
  "coldRelaunch": {
    "ok": true,
    "homeVisible": true,
    "composerVisible": true,
    "onboardingHidden": true
  }
}
```

</details>

## Latest-develop sync

- rebased source commit: `2ad2f9338eec934a3601fee674cfaa0ad4d8ada4`
- current base: `e935a5c526d6638d52aa644e4dad96f3c898d3ee`
- one-commit range-diff: exact `=`; stable patch id: `b3a9899458ccfac6c90498ff1a23037b7aa69ea8`
- all three changed Git blobs are byte-identical to the already reviewed `55ff164bfd` build
- latest-base focused tests: **19/19 passed**; changed-file coverage: **61.39%**; UI typecheck, exact Biome, build/runtime exports, diff check, and error-policy ratchet passed
- prior CI's unrelated personal-assistant Sharp typecheck is fixed on the new base by merged #16857
- no simulator or physical device was booted, installed, erased, or otherwise mutated during this sync; the prior artifacts remain behavior evidence for the byte-identical transport patch

## Human-verifiable evidence

| Evidence | Result |
| --- | --- |
| Before / wrong behavior | [Develop iOS Simulator Build run 29954842137, job 89042569061](https://github.com/elizaOS/eliza/actions/runs/29954842137/job/89042569061): REST health 200, then 180 disconnected polls with no successful socket. |
| After screenshots + walkthrough video | Captured on the byte-identical pre-rebase patch and manually reviewed; canonical artifacts are linked below. The walkthrough visibly reaches the green **Connected to remote backend** state and survives cold relaunch. |
| Frontend/network evidence | Exact result above proves `capacitor://localhost`, zero WebSocket constructor calls, connected state, REST health 200, and no lost-backend overlay. |
| Backend logs | Real host-agent startup and `/api/health` response were exercised; log attached below. |
| Desktop/mobile matrix | iOS simulator is the affected platform and is proven on a fresh dedicated simulator. Desktop and Android are N/A: both behavior boundaries are regression-tested and production behavior there is unchanged. |
| Live-model trajectory | N/A — this changes transport selection only; no prompt, action, provider, or model behavior changes. The smoke intentionally stops at backend liveness. |
| Domain artifacts | N/A — no persistent domain object is created by transport negotiation. |
| OCR / visual audit | N/A — no component, CSS, copy, or visual layout changed. The exact mobile pixels were still captured and reviewed because the failure was user-visible. |

The protected shared Cloud simulator `00899AA5-6541-4AB6-B818-E2172E9347F3` and physical LP3 were not touched; the isolated evidence simulator is shut down.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16853-before-develop-lost-backend.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16853-ios-capacitor-rest-connected.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16853-ios-capacitor-rest-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [16853-host-agent.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16853-host-agent.log)

<!-- evidence-row:frontend-logs -->
- [x] [16853-comment.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16853-comment.md)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Transport selection only; no prompt, action, provider, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Transport negotiation creates no persistent domain object.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No component, CSS, copy, or layout changed; affected simulator pixels were manually reviewed.


