### PR TITLE
fix(ci): restore personal-assistant sharp typecheck

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/screen-context.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/screen-context.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { logger } from "@elizaos/core";
 import { FRAME_FILE } from "@elizaos/plugin-browser";
+import type sharp from "sharp";
 
 export type LifeOpsScreenFocus =
   | "work"
@@ -130,15 +131,12 @@ const TRANSITION_KEYWORDS = [
   "launchpad",
 ];
 
-type SharpFactory = typeof import("sharp");
-type SharpModuleWithDefault = { default: SharpFactory };
+type SharpFactory = typeof sharp;
 
 let sharpImportPromise: Promise<SharpFactory> | null = null;
 
-function hasDefaultSharpFactory(
-  mod: SharpFactory | SharpModuleWithDefault,
-): mod is SharpModuleWithDefault {
-  return typeof (mod as SharpModuleWithDefault).default === "function";
+function isSharpFactory(value: unknown): value is SharpFactory {
+  return typeof value === "function";
 }
 
 function normalizeText(value: string | null | undefined): string {
@@ -154,9 +152,20 @@ function keywordMatches(text: string, keywords: readonly string[]): string[] {
 }
 
 async function loadSharp(): Promise<SharpFactory> {
-  sharpImportPromise ??= import("sharp").then((mod) =>
-    hasDefaultSharpFactory(mod) ? mod.default : mod,
-  );
+  sharpImportPromise ??= import("sharp").then((mod: unknown) => {
+    if (isSharpFactory(mod)) {
+      return mod;
+    }
+    if (
+      mod !== null &&
+      typeof mod === "object" &&
+      "default" in mod &&
+      isSharpFactory(mod.default)
+    ) {
+      return mod.default;
+    }
+    throw new TypeError("sharp did not expose a callable image factory");
+  });
   return await sharpImportPromise;
 }
 

--- a/plugins/plugin-personal-assistant/test/lifeops-screen-context.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-screen-context.test.ts
@@ -127,4 +127,23 @@ describe("LifeOps screen context", () => {
     expect(summary.width).toBe(2);
     expect(summary.height).toBe(1);
   });
+
+  it("rejects a sharp module without a callable factory", async () => {
+    vi.resetModules();
+    vi.doMock("sharp", () => ({ default: { version: "invalid" } }));
+    const { analyzeLifeOpsScreenBuffer } = await import(
+      "../src/lifeops/screen-context.js"
+    );
+
+    await expect(
+      analyzeLifeOpsScreenBuffer({
+        framePath: "/tmp/frame.png",
+        frameBytes: Buffer.from("image bytes"),
+        ocrText: null,
+        capturedAtMs: 1,
+        sampledAtMs: 2,
+        stale: false,
+      }),
+    ).rejects.toThrow("sharp did not expose a callable image factory");
+  });
 });

--- a/plugins/plugin-personal-assistant/test/lifeops-screen-context.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-screen-context.test.ts
@@ -90,4 +90,41 @@ describe("LifeOps screen context", () => {
     expect(summary.width).toBe(2);
     expect(summary.height).toBe(3);
   });
+
+  it("analyzes images through sharp's callable default export", async () => {
+    vi.resetModules();
+    const pixels = Buffer.from([64, 192]);
+    const pipeline = {
+      rotate: vi.fn(() => pipeline),
+      greyscale: vi.fn(() => pipeline),
+      resize: vi.fn(() => pipeline),
+      raw: vi.fn(() => pipeline),
+      toBuffer: vi.fn(async () => ({
+        data: pixels,
+        info: { width: 2, height: 1 },
+      })),
+    };
+    const sharpFactory = vi.fn(() => pipeline);
+    vi.doMock("sharp", () => ({ default: sharpFactory }));
+    const { analyzeLifeOpsScreenBuffer } = await import(
+      "../src/lifeops/screen-context.js"
+    );
+    const frameBytes = Buffer.from("image bytes");
+
+    const summary = await analyzeLifeOpsScreenBuffer({
+      framePath: "/tmp/frame.png",
+      frameBytes,
+      ocrText: null,
+      capturedAtMs: 1,
+      sampledAtMs: 2,
+      stale: false,
+    });
+
+    expect(sharpFactory).toHaveBeenCalledWith(frameBytes);
+    expect(pipeline.rotate).toHaveBeenCalledOnce();
+    expect(pipeline.greyscale).toHaveBeenCalledOnce();
+    expect(summary.available).toBe(true);
+    expect(summary.width).toBe(2);
+    expect(summary.height).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #16856

## What changed

- types the lazy `sharp` import as the callable factory instead of the module namespace
- validates both direct-callable and ESM-default runtime module shapes before use
- fails explicitly when the optional-dependency boundary exposes no callable factory
- adds regression coverage for the callable default export and invalid module shape

## Root cause

`SharpFactory` was declared as `typeof import("sharp")`, which is a module namespace under the repository's TypeScript configuration. `analyzeImageWithSharp` then invoked that namespace as if it were the callable factory, breaking the current `develop` typecheck.

Observed job: https://github.com/elizaOS/eliza/actions/runs/29962933852/job/89067971366

## Validation

- `bun run --cwd plugins/plugin-personal-assistant typecheck` — passed
- focused screen-context regression — 4 passed
- Biome check on both touched files — passed
- `git diff --check` — passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - type-only optional dependency boundary correction with no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - type-only optional dependency boundary correction with no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changed; this repairs compile-time module typing and is covered by the linked failing Actions job plus focused typecheck.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or generated runtime artifact changed.
