### PR TITLE
fix(ci): remove shared-agent cache unsafe cast

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -120,6 +120,7 @@ function apiKeyContext(agentId?: string) {
 }
 
 function agent(overrides: Record<string, unknown> = {}) {
+  const timestamp = new Date("2026-01-01T00:00:00.000Z");
   return {
     id: "agent-1",
     organization_id: "org-1",
@@ -127,6 +128,16 @@ function agent(overrides: Record<string, unknown> = {}) {
     status: "running",
     bridge_url: null,
     agent_name: "Shared Agent",
+    created_at: timestamp,
+    updated_at: timestamp,
+    deleted_at: null,
+    claimed_at: null,
+    pool_ready_at: null,
+    last_backup_at: null,
+    last_heartbeat_at: null,
+    last_billed_at: null,
+    shutdown_warning_sent_at: null,
+    scheduled_shutdown_at: null,
     ...overrides,
   };
 }
@@ -554,6 +565,22 @@ describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => 
       const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
       if (!("agent" in result)) throw new Error("expected a resolved agent");
       expect(result.agent.deleted_at).toBeNull();
+    });
+
+    test("an invalid cached timestamp fails observably", async () => {
+      seedCacheHit({ last_heartbeat_at: "not-a-timestamp" });
+
+      const error = await resolveSharedAgent(apiKeyContext("agent-1") as never).then(
+        () => null,
+        (cause: unknown) => cause,
+      );
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty("name", "ElizaError");
+      expect(error).toHaveProperty("code", "INVALID_CACHED_AGENT_TIMESTAMP");
+      expect(error).toHaveProperty("context", {
+        field: "last_heartbeat_at",
+        value: "not-a-timestamp",
+      });
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -1,4 +1,5 @@
 // Coordinates cloud service resolve shared agent behavior behind route handlers.
+import { ElizaError } from "@elizaos/core";
 import type { Context } from "hono";
 
 import {
@@ -40,6 +41,36 @@ const AGENT_SANDBOX_DATE_FIELDS = [
   "scheduled_shutdown_at",
 ] as const satisfies ReadonlyArray<keyof AgentSandbox>;
 
+type AgentSandboxDateField = (typeof AGENT_SANDBOX_DATE_FIELDS)[number];
+type CachedAgentSandbox = Omit<AgentSandbox, AgentSandboxDateField> & {
+  [Field in AgentSandboxDateField]: unknown;
+};
+
+function invalidCachedAgentTimestamp(field: AgentSandboxDateField, value: unknown): ElizaError {
+  return new ElizaError("Shared-agent cache contains an invalid timestamp", {
+    code: "INVALID_CACHED_AGENT_TIMESTAMP",
+    context: { field, value },
+    severity: "fatal",
+  });
+}
+
+function rehydrateRequiredCachedDate(value: unknown, field: AgentSandboxDateField): Date {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  throw invalidCachedAgentTimestamp(field, value);
+}
+
+function rehydrateNullableCachedDate(value: unknown, field: AgentSandboxDateField): Date | null {
+  return value === null ? null : rehydrateRequiredCachedDate(value, field);
+}
+
 /**
  * Restore the `AgentSandbox` DATE contract after a scope-cache round-trip
  * (CONVERSATIONS-500-2026-07-22). The cache client JSON-serializes on write and
@@ -49,21 +80,31 @@ const AGENT_SANDBOX_DATE_FIELDS = [
  * conversations route calls `agent.created_at.toISOString()`, which throws
  * (`string.toISOString is not a function`) and 500s the read on EVERY cache hit
  * (the exact "first call 200, then all 500" defect). Rehydrating the known date
- * fields at the cache-read boundary keeps a cache hit byte-for-byte equivalent
- * to a fresh DB hydration for every caller. Best-effort per field: an absent or
- * already-`Date` value is left untouched; an unparseable value is left as-is so
- * we never fabricate a bogus `Date`.
+ * fields at the cache-read boundary keeps a cache hit equivalent to a fresh DB
+ * hydration for every caller. Nullable values and valid `Date`s are preserved;
+ * malformed values fail at this boundary because returning a row that violates
+ * `AgentSandbox` would defer the fault into an unrelated route consumer.
  */
-function rehydrateCachedAgentDates(agent: AgentSandbox): AgentSandbox {
-  const out = agent as unknown as Record<string, unknown>;
-  for (const field of AGENT_SANDBOX_DATE_FIELDS) {
-    const value = out[field];
-    if (typeof value === "string") {
-      const parsed = new Date(value);
-      if (!Number.isNaN(parsed.getTime())) out[field] = parsed;
-    }
-  }
-  return agent;
+function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
+  return {
+    ...agent,
+    created_at: rehydrateRequiredCachedDate(agent.created_at, "created_at"),
+    updated_at: rehydrateRequiredCachedDate(agent.updated_at, "updated_at"),
+    deleted_at: rehydrateNullableCachedDate(agent.deleted_at, "deleted_at"),
+    claimed_at: rehydrateNullableCachedDate(agent.claimed_at, "claimed_at"),
+    pool_ready_at: rehydrateNullableCachedDate(agent.pool_ready_at, "pool_ready_at"),
+    last_backup_at: rehydrateNullableCachedDate(agent.last_backup_at, "last_backup_at"),
+    last_heartbeat_at: rehydrateNullableCachedDate(agent.last_heartbeat_at, "last_heartbeat_at"),
+    last_billed_at: rehydrateNullableCachedDate(agent.last_billed_at, "last_billed_at"),
+    shutdown_warning_sent_at: rehydrateNullableCachedDate(
+      agent.shutdown_warning_sent_at,
+      "shutdown_warning_sent_at",
+    ),
+    scheduled_shutdown_at: rehydrateNullableCachedDate(
+      agent.scheduled_shutdown_at,
+      "scheduled_shutdown_at",
+    ),
+  };
 }
 
 /**
@@ -78,7 +119,7 @@ function rehydrateCachedAgentDates(agent: AgentSandbox): AgentSandbox {
  */
 interface CachedSharedAgentScope {
   orgId: string;
-  agent: AgentSandbox;
+  agent: CachedAgentSandbox;
   /**
    * Steward user id the entry was written for, present ONLY on session-keyed
    * entries (#SHADOW-ACCOUNT-DEBUG). A session-path hit re-verifies the JWT and


### PR DESCRIPTION
Closes #16859

## What changed

- models every JSON-serialized cached timestamp field as an untrusted cache-boundary value
- restores required and nullable dates explicitly without an `AgentSandbox -> Record` double cast
- throws a structured `ElizaError` when cached timestamp data is missing or invalid
- strengthens the resolver fixture with the real timestamp shape and adds malformed-cache regression coverage

## Root cause

The shared-agent cache rehydration added the repository's 85th production `as unknown as` cast after the ratchet baseline was set to 84. The same cast let invalid cache data flow back out under the `AgentSandbox` type, deferring failure into unrelated route consumers.

Observed runs:

- https://github.com/elizaOS/eliza/actions/runs/29962963355
- https://github.com/elizaOS/eliza/actions/runs/29962969850

## Validation

- focused shared-agent resolver suite — 24 passed
- `bun run --cwd packages/cloud/shared typecheck` — passed
- `node packages/scripts/type-safety-ratchet.mjs` — passed at 84/84 without changing the baseline
- Biome check on touched files — passed
- `git diff --check` — passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side cache boundary correction with no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side cache boundary correction with no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend was mutated; focused cache-hit tests exercise valid, nullable, and invalid data paths.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database row, billing record, or migration changed.
