### PR TITLE
fix(agent): migrate plugin schemas before services start

### DIFF
--- a/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
+++ b/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
@@ -256,10 +256,19 @@ describe("mixed plugins — two plugins coexist, one unloads cleanly", () => {
 });
 
 describe("schema-bearing plugin registration", () => {
-  it("runs plugin migrations after a schema plugin registers against a ready adapter", async () => {
+  it("runs plugin migrations before publishing a schema plugin against a ready adapter", async () => {
     const runtime = createTestRuntime();
     installRuntimePluginLifecycle(runtime);
-    const runPluginMigrations = vi.fn(async () => {});
+    const lifecycle: string[] = [];
+    const runPluginMigrations = vi.fn(async () => {
+      lifecycle.push("migration");
+      expect(
+        runtime.plugins.some((plugin) => plugin.name === "schema-ready-plugin"),
+      ).toBe(false);
+      expect(
+        runtime.actions.some((action) => action.name === "SCHEMA_READY_ACTION"),
+      ).toBe(false);
+    });
 
     runtime.registerDatabaseAdapter({
       isReady: async () => true,
@@ -274,6 +283,9 @@ describe("schema-bearing plugin registration", () => {
           id: "text",
         },
       },
+      init: async () => {
+        lifecycle.push("init");
+      },
       actions: [
         {
           name: "SCHEMA_READY_ACTION",
@@ -286,6 +298,7 @@ describe("schema-bearing plugin registration", () => {
       ],
     });
 
+    expect(lifecycle).toEqual(["migration", "init"]);
     expect(runPluginMigrations).toHaveBeenCalledOnce();
     expect(runPluginMigrations).toHaveBeenCalledWith(
       [

--- a/packages/agent/src/runtime/late-plugin-schema.test.ts
+++ b/packages/agent/src/runtime/late-plugin-schema.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Proves late plugin schemas materialize in an isolated PGlite database before the
+ * runtime publishes the plugin or starts services that query those tables.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import {
+  AgentRuntime,
+  createCharacter,
+  InMemoryDatabaseAdapter,
+  type JsonValue,
+  stringToUuid,
+} from "@elizaos/core";
+import { sql } from "drizzle-orm";
+import { pgSchema, text } from "drizzle-orm/pg-core";
+import { drizzle, type PgliteDatabase } from "drizzle-orm/pglite";
+import { afterEach, describe, expect, it } from "vitest";
+import { INBOX_MIGRATION_SERVICE_TYPE } from "../../../../plugins/plugin-inbox/src/inbox/migration.ts";
+import { inboxPlugin } from "../../../../plugins/plugin-inbox/src/plugin.ts";
+import { RuntimeMigrator } from "../../../../plugins/plugin-sql/src/runtime-migrator/runtime-migrator.ts";
+import * as sqlSchema from "../../../../plugins/plugin-sql/src/schema/index.ts";
+import { installRuntimePluginLifecycle } from "./plugin-lifecycle.ts";
+
+const CONCURRENT_SCHEMA_PLUGIN = "concurrent-late-schema-plugin";
+const concurrentSchema = pgSchema("app_concurrent_late");
+const concurrentProbeTable = concurrentSchema.table("probe", {
+  value: text("value").notNull(),
+});
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: () => {
+      if (!resolvePromise) {
+        throw new Error("Deferred promise was not initialized");
+      }
+      resolvePromise();
+    },
+  };
+}
+
+class PGliteMigrationAdapter extends InMemoryDatabaseAdapter {
+  readonly pglite: PGlite;
+  readonly pgliteDb: PgliteDatabase;
+  readonly inboxMigrationEntered = deferred();
+  readonly inboxMigrationRelease = deferred();
+  activeMigrations = 0;
+  maxConcurrentMigrations = 0;
+  migrationBatches: string[][] = [];
+  blockInboxMigration = false;
+
+  constructor(dataDir: string) {
+    super();
+    this.pglite = new PGlite(dataDir, { extensions: { vector } });
+    this.pgliteDb = drizzle(this.pglite);
+    Object.defineProperty(this.db, "execute", {
+      value: this.pgliteDb.execute.bind(this.pgliteDb),
+    });
+  }
+
+  override async initialize(): Promise<void> {
+    await this.pglite.waitReady;
+    await super.initialize();
+  }
+
+  override async runPluginMigrations(
+    plugins: Array<{
+      name: string;
+      schema?: Record<string, JsonValue | object>;
+    }> = [],
+    options?: {
+      verbose?: boolean;
+      force?: boolean;
+      dryRun?: boolean;
+    },
+  ): Promise<void> {
+    this.activeMigrations += 1;
+    this.migrationBatches.push(plugins.map((plugin) => plugin.name));
+    this.maxConcurrentMigrations = Math.max(
+      this.maxConcurrentMigrations,
+      this.activeMigrations,
+    );
+    try {
+      if (
+        this.blockInboxMigration &&
+        plugins.some((plugin) => plugin.name === inboxPlugin.name)
+      ) {
+        this.inboxMigrationEntered.resolve();
+        await this.inboxMigrationRelease.promise;
+      }
+
+      const migrator = new RuntimeMigrator(this.pgliteDb);
+      for (const plugin of plugins) {
+        if (plugin.schema) {
+          await migrator.migrate(plugin.name, plugin.schema, options);
+        }
+      }
+    } finally {
+      this.activeMigrations -= 1;
+    }
+  }
+
+  override async close(): Promise<void> {
+    await super.close();
+    await this.pglite.close();
+  }
+}
+
+describe("late plugin schema ordering", () => {
+  let runtime: AgentRuntime | null = null;
+  let dataDir: string | null = null;
+
+  async function createInitializedRuntime(): Promise<{
+    runtime: AgentRuntime;
+    adapter: PGliteMigrationAdapter;
+  }> {
+    dataDir = await mkdtemp(path.join(tmpdir(), "eliza-late-schema-"));
+    const agentId = stringToUuid("late-schema-integration");
+    const adapter = new PGliteMigrationAdapter(dataDir);
+    await adapter.initialize();
+    runtime = new AgentRuntime({
+      character: createCharacter({
+        id: agentId,
+        name: "LateSchemaIntegration",
+      }),
+      adapter,
+      logLevel: "fatal",
+    });
+    await runtime.registerPlugin({
+      name: "@elizaos/plugin-sql",
+      description: "Real SQL schema for the isolated PGlite runtime.",
+      schema: sqlSchema,
+    });
+    await runtime.initialize();
+    installRuntimePluginLifecycle(runtime);
+    return { runtime, adapter };
+  }
+
+  afterEach(async () => {
+    if (runtime) {
+      for (const pluginName of [
+        "@elizaos/plugin-inbox",
+        CONCURRENT_SCHEMA_PLUGIN,
+      ]) {
+        if (runtime.plugins.some((plugin) => plugin.name === pluginName)) {
+          await runtime.unloadPlugin(pluginName);
+        }
+      }
+      await runtime.stop();
+      await runtime.close();
+      runtime = null;
+    }
+    if (dataDir) {
+      await rm(dataDir, { recursive: true, force: true });
+      dataDir = null;
+    }
+  });
+
+  it("materializes app_inbox before publishing the plugin or starting its migration service", async () => {
+    const harness = await createInitializedRuntime();
+    harness.adapter.blockInboxMigration = true;
+
+    const registration = harness.runtime.registerPlugin(inboxPlugin);
+    await harness.adapter.inboxMigrationEntered.promise;
+    const publishedBeforeSchema = harness.runtime.plugins.some(
+      (plugin) => plugin.name === inboxPlugin.name,
+    );
+    harness.adapter.inboxMigrationRelease.resolve();
+    await registration;
+
+    expect(publishedBeforeSchema).toBe(false);
+    await harness.runtime.getServiceLoadPromise(INBOX_MIGRATION_SERVICE_TYPE);
+
+    const tableRows = await harness.adapter.pgliteDb.execute(sql`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'app_inbox'
+      ORDER BY table_name
+    `);
+    expect(tableRows.rows.map((row) => row.table_name)).toEqual([
+      "life_email_unsubscribes",
+      "life_inbox_triage_entries",
+      "life_inbox_triage_examples",
+    ]);
+    expect(
+      harness.runtime.getServiceRegistrationStatus(
+        INBOX_MIGRATION_SERVICE_TYPE,
+      ),
+    ).toBe("registered");
+  });
+
+  it("serializes concurrent late schema migrations on one adapter", async () => {
+    const harness = await createInitializedRuntime();
+    harness.adapter.migrationBatches.length = 0;
+
+    await Promise.all([
+      harness.runtime.registerPlugin(inboxPlugin),
+      harness.runtime.registerPlugin(inboxPlugin),
+      harness.runtime.registerPlugin({
+        name: CONCURRENT_SCHEMA_PLUGIN,
+        description: "Concurrent migration ordering probe.",
+        schema: { concurrentProbeTable },
+      }),
+    ]);
+    await harness.runtime.getServiceLoadPromise(INBOX_MIGRATION_SERVICE_TYPE);
+
+    const tableRows = await harness.adapter.pgliteDb.execute(sql`
+      SELECT table_schema, table_name
+      FROM information_schema.tables
+      WHERE (table_schema = 'app_inbox' AND table_name = 'life_inbox_triage_entries')
+         OR (table_schema = 'app_concurrent_late' AND table_name = 'probe')
+      ORDER BY table_schema, table_name
+    `);
+    expect(tableRows.rows).toEqual([
+      {
+        table_schema: "app_concurrent_late",
+        table_name: "probe",
+      },
+      {
+        table_schema: "app_inbox",
+        table_name: "life_inbox_triage_entries",
+      },
+    ]);
+    expect(harness.adapter.maxConcurrentMigrations).toBe(1);
+    expect(harness.adapter.migrationBatches).toEqual([
+      ["@elizaos/plugin-inbox"],
+      [CONCURRENT_SCHEMA_PLUGIN],
+    ]);
+    expect(
+      harness.runtime.plugins.filter(
+        (plugin) => plugin.name === "@elizaos/plugin-inbox",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/agent/src/runtime/plugin-lifecycle.ts
+++ b/packages/agent/src/runtime/plugin-lifecycle.ts
@@ -19,6 +19,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type {
   AgentContext,
   AgentRuntime,
+  IDatabaseAdapter,
   Plugin,
   PluginEventRegistration,
   PluginModelRegistration,
@@ -143,6 +144,11 @@ const pluginRegistrationContext =
 const pluginServiceStartContext =
   new AsyncLocalStorage<RuntimePluginServiceStartCapture>();
 const serviceClassOwners = new WeakMap<RuntimeServiceClass, string>();
+const pluginMigrationQueues = new WeakMap<IDatabaseAdapter, Promise<void>>();
+const pluginMigrationsInFlight = new WeakMap<
+  IDatabaseAdapter,
+  Map<string, Promise<void>>
+>();
 
 function getRuntimePrivateState(runtime: AgentRuntime): RuntimePrivateState {
   return runtime as AgentRuntime & RuntimePrivateState;
@@ -609,7 +615,7 @@ async function migratePluginSchemasIfReady(
   runtime: AgentRuntime,
   plugin: Plugin,
 ): Promise<void> {
-  if (!plugin.schema || typeof runtime.runPluginMigrations !== "function") {
+  if (!plugin.schema) {
     return;
   }
 
@@ -617,25 +623,10 @@ async function migratePluginSchemasIfReady(
   if (!adapter || typeof adapter.runPluginMigrations !== "function") {
     return;
   }
+  const runPluginMigrations = adapter.runPluginMigrations.bind(adapter);
 
   if (typeof adapter.isReady === "function") {
-    let ready = false;
-    try {
-      ready = await adapter.isReady();
-    } catch (error) {
-      runtime.logger.debug(
-        {
-          src: "plugin-lifecycle",
-          agentId: runtime.agentId,
-          plugin: plugin.name,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "Skipping plugin schema migration because database readiness check failed",
-      );
-      return;
-    }
-
-    if (!ready) {
+    if (!(await adapter.isReady())) {
       runtime.logger.debug(
         {
           src: "plugin-lifecycle",
@@ -648,7 +639,50 @@ async function migratePluginSchemasIfReady(
     }
   }
 
-  await runtime.runPluginMigrations();
+  const isProduction = process.env.NODE_ENV === "production";
+  const activeMigrations = pluginMigrationsInFlight.get(adapter);
+  const existingMigration = activeMigrations?.get(plugin.name);
+  if (existingMigration) {
+    await existingMigration;
+    return;
+  }
+
+  const previous = pluginMigrationQueues.get(adapter);
+  // error-policy:J5 the registration that owns a failed migration observes its
+  // rejection; the next registration only waits for that adapter's queue slot.
+  const readyForTurn = previous
+    ? previous.catch(() => undefined)
+    : Promise.resolve();
+  const turn = readyForTurn.then(() =>
+    runPluginMigrations([{ name: plugin.name, schema: plugin.schema }], {
+      verbose: !isProduction,
+      force: process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS === "true",
+      dryRun: false,
+    }),
+  );
+  pluginMigrationQueues.set(adapter, turn);
+  const migrationsByPlugin =
+    activeMigrations ?? new Map<string, Promise<void>>();
+  if (!activeMigrations) {
+    pluginMigrationsInFlight.set(adapter, migrationsByPlugin);
+  }
+  migrationsByPlugin.set(plugin.name, turn);
+  try {
+    await turn;
+  } finally {
+    if (pluginMigrationQueues.get(adapter) === turn) {
+      pluginMigrationQueues.delete(adapter);
+    }
+    if (migrationsByPlugin.get(plugin.name) === turn) {
+      migrationsByPlugin.delete(plugin.name);
+    }
+    if (
+      migrationsByPlugin.size === 0 &&
+      pluginMigrationsInFlight.get(adapter) === migrationsByPlugin
+    ) {
+      pluginMigrationsInFlight.delete(adapter);
+    }
+  }
 }
 
 /**
@@ -703,7 +737,11 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
   const baseRegisterPlugin = runtime.registerPlugin.bind(runtime);
   const baseUnloadPlugin = runtime.unloadPlugin?.bind(runtime);
   runtime.registerPlugin = (async (plugin: Plugin) => {
-    await baseRegisterPlugin(plugin);
+    if (runtime.plugins.some((registered) => registered.name === plugin.name)) {
+      await baseRegisterPlugin(plugin);
+      return;
+    }
+    let registeredHere = false;
     try {
       // #12087 Item 1: gate this plugin's sensitive providers (SECRETS_STATUS,
       // walletPortfolio, shellHistory, …) at the moment it registers, not via a
@@ -715,12 +753,20 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
       // covered by the boot pass are unaffected.
       applyPluginRoleGating([plugin]);
       await migratePluginSchemasIfReady(runtime, plugin);
+      if (
+        runtime.plugins.some((registered) => registered.name === plugin.name)
+      ) {
+        await baseRegisterPlugin(plugin);
+        return;
+      }
+      await baseRegisterPlugin(plugin);
+      registeredHere = runtime.plugins.includes(plugin);
       await registerPluginViews(plugin);
       registerViewScopedActions(runtime, plugin.name, plugin.views ?? []);
     } catch (error) {
       unregisterPluginViews(plugin.name);
       unregisterViewScopedActions(runtime, plugin.name);
-      if (baseUnloadPlugin) {
+      if (baseUnloadPlugin && registeredHere) {
         await baseUnloadPlugin(plugin.name);
       }
       throw error;
@@ -960,6 +1006,10 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
   }
 
   runtime.registerPlugin = (async (plugin: Plugin) => {
+    if (runtime.plugins.some((registered) => registered.name === plugin.name)) {
+      await originalRegisterPlugin(plugin);
+      return;
+    }
     const pluginsBefore = new Set(runtime.plugins);
     const routesBefore = new Set(runtime.routes);
     const capture: RuntimePluginRegistrationCapture = {
@@ -968,6 +1018,13 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
     };
 
     try {
+      await migratePluginSchemasIfReady(runtime, plugin);
+      if (
+        runtime.plugins.some((registered) => registered.name === plugin.name)
+      ) {
+        await originalRegisterPlugin(plugin);
+        return;
+      }
       await pluginRegistrationContext.run(capture, async () => {
         await originalRegisterPlugin(plugin);
       });
@@ -977,7 +1034,6 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
         pluginsBefore,
         routesBefore,
       );
-      await migratePluginSchemasIfReady(runtime, plugin);
       if (
         capture.ownership.registeredPlugin ||
         capture.ownership.actions.length > 0 ||

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -31,6 +31,7 @@ import {
   type ElizaCapabilityRouter,
   type EventPayload,
   type IAgentRuntime,
+  type IDatabaseAdapter,
   type Plugin,
   type PluginCallAppBridgeResult,
   type PluginOwnership,
@@ -2422,6 +2423,44 @@ describe("remote plugin adapter", () => {
       message:
         'Remote plugin "remote-demo" route "POST /remote/demo" would collide with an existing runtime route.',
     });
+  });
+
+  it("migrates a remote plugin schema before publishing its runtime surface", async () => {
+    let runtime: IAgentRuntime;
+    const runPluginMigrations = vi.fn(
+      async (
+        plugins: Parameters<
+          NonNullable<IDatabaseAdapter["runPluginMigrations"]>
+        >[0],
+      ) => {
+        expect(
+          runtime.plugins.some((plugin) => plugin.name === "@remote/demo"),
+        ).toBe(false);
+        expect(plugins).toEqual([
+          {
+            name: "@remote/demo",
+            schema: remoteModule.schema,
+          },
+        ]);
+      },
+    );
+    runtime = makeLifecycleRuntime(
+      makeRouter({ callLifecycle: async () => ({ ok: true }) }),
+      runPluginMigrations,
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, { modules: [remoteModule] }),
+    ).resolves.toMatchObject({
+      registered: [expect.objectContaining({ name: "@remote/demo" })],
+      skipped: [],
+    });
+
+    expect(runPluginMigrations).toHaveBeenCalledOnce();
+    expect(runtime.plugins.map((plugin) => plugin.name)).toEqual([
+      "@remote/demo",
+    ]);
+    await runtime.unloadPlugin("@remote/demo");
   });
 
   it("unloads remote plugins missing from the next manifest", async () => {
@@ -5155,7 +5194,10 @@ function makeExecutableRuntime(router: ElizaCapabilityRouter): IAgentRuntime {
   return runtime;
 }
 
-function makeLifecycleRuntime(router: ElizaCapabilityRouter): IAgentRuntime {
+function makeLifecycleRuntime(
+  router: ElizaCapabilityRouter,
+  runPluginMigrations?: NonNullable<IDatabaseAdapter["runPluginMigrations"]>,
+): IAgentRuntime {
   const runtime = makeRuntime(router, {
     plugins: [],
     actions: [],
@@ -5179,6 +5221,14 @@ function makeLifecycleRuntime(router: ElizaCapabilityRouter): IAgentRuntime {
       error: vi.fn(),
       info: vi.fn(),
     },
+    ...(runPluginMigrations
+      ? {
+          adapter: {
+            isReady: async () => true,
+            runPluginMigrations,
+          },
+        }
+      : {}),
   } as never);
   runtime.registerAction = (action) => {
     runtime.actions.push(action);


### PR DESCRIPTION
# Relates to

Fixes #16851.

This is the narrow schema-ordering extraction from @lalalune's broader draft #16311. It intentionally carries none of that draft's health, scheduling, or service-supervision scope.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`e935a5c526d6638d52aa644e4dad96f3c898d3ee`) with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync. The exact unrelated `develop` ratchet failure is recorded below.
- [x] A reviewer can confirm the ordering contract from the real PGlite database evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `e935a5c526d6638d52aa644e4dad96f3c898d3ee`; zero conflicts.
- [x] `bun run verify` reaches the type-safety ratchet and stops on the same 85-vs-84 unsafe-cast count reproduced in a clean detached worktree at exact `origin/develop`. This PR's sole production file adds no unsafe cast. See **Known gaps / failures**.

# Risks

Low-to-medium. This changes only late plugin registration on an already initialized runtime. A schema-bearing plugin now waits for its own DDL before publication/service start. Migrations are serialized per adapter, concurrent registration of the same plugin joins one in-flight migration, and any migration failure still rejects registration before components are published. Initial boot behavior while an adapter reports not-ready is unchanged.

# Background

## What does this PR do?

- Moves late-plugin schema migration ahead of base plugin registration, which is the point that eagerly initializes services.
- Sends only the incoming plugin's real schema to the adapter instead of re-running every registered plugin migration.
- Serializes migration work per adapter and deduplicates simultaneous registrations of the same plugin name.
- Preserves fail-closed rollback and propagates readiness/migration failures.
- Adds a real isolated PGlite regression using the actual inbox plugin, actual `RuntimeMigrator`, and actual `InboxMigrationService`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This repairs an internal lifecycle ordering invariant and adds executable regression coverage; no public API or operator workflow changes.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/runtime/late-plugin-schema.test.ts` for the real database proof.
2. `packages/agent/src/runtime/plugin-lifecycle.ts` for the schema-before-publication boundary and per-adapter queue.
3. The failing production Docker log: https://github.com/elizaOS/eliza/actions/runs/29954836153/job/89041403450

## Detailed testing steps

- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/runtime/late-plugin-schema.test.ts packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts packages/agent/src/services/remote-plugin-adapter.test.ts` — 3 files passed, 52 tests passed, 3 intentional environment skips.
- `bun run --cwd plugins/plugin-inbox test` — 21 files passed / 1 intentionally skipped; 166 tests passed / 2 skipped.
- `bun run --cwd plugins/plugin-inbox lint:check && bun run --cwd plugins/plugin-inbox format:check && bun run --cwd plugins/plugin-inbox typecheck && bun run --cwd plugins/plugin-inbox build` — pass.
- `bun run --cwd packages/agent lint:check && bun run --cwd packages/agent format:check && bun run --cwd packages/agent typecheck && bun run --cwd packages/agent build` — pass (lint reports only pre-existing warnings in untouched files).
- Changed-file coverage — `packages/agent/src/runtime/plugin-lifecycle.ts` 65.23%, required floor 50%; pass.
- `bun run audit:error-policy-ratchet` and `git diff --check` — pass.
- Full agent package matrix — the pre-rebase exact-equivalent commit completed 347/347 test-file batches. On rebased head `e9e213d617`, all 52 affected lifecycle tests passed and 52 additional serial agent-package batches passed before the redundant full sweep was stopped after every required focused, package, coverage, and ratchet gate had completed; fresh GitHub CI is the canonical full gate.

## Post-rebase verification

- Remote head: `e9e213d617b5f48deb7593bf795eea356d267c4f`.
- Base: `e935a5c526d6638d52aa644e4dad96f3c898d3ee`.
- `git range-diff ed98b7f..8852aea e935a5c..e9e213d` reports exact `=` semantic identity; the four changed paths have no develop-side overlap.
- Real PGlite/focused lifecycle: 3 files passed, 52 tests passed, 3 intentional environment skips.
- Actual inbox package: 21 files passed / 1 intentionally skipped, 166 tests passed / 2 skipped.
- Changed-file coverage: `plugin-lifecycle.ts` 65.23% (50% required).
- `@elizaos/agent` and `@elizaos/plugin-inbox` lint/format/typecheck/build: pass.
- Error-policy ratchet, lane-coverage ratchet, `git diff --check`: pass.
- Type-safety ratchet is the same repository baseline failure on the branch and clean detached base: 85 `as unknown as` casts vs baseline 84; this PR changes none of the listed files and adds no unsafe cast.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or rendered surface changes; this is a headless runtime/database ordering fix.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or rendered surface changes; this is a headless runtime/database ordering fix.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing interaction to record; the real database lifecycle is proven below.
<!-- evidence-row:backend-logs -->
- [x] The [production Docker job](https://github.com/elizaOS/eliza/actions/runs/29954836153/job/89041403450) shows `InboxMigrationService` issuing its `ALTER TABLE` before plugin-sql creates the inbox schema; the post-fix real PGlite run shows migration completion before publication and service registration.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or bundle changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, model, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the isolated PGlite database is intentionally ephemeral; its table inventory, service state, migration batches, and concurrency maximum are reproduced and asserted inline below rather than mutating a durable user database.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM/model/action/provider/prompt path changes.

## Backend + frontend logs

Before, the production Docker smoke at develop SHA `3def4a82d3947bfaf1eab668ced6050a90cf1898` logged the inbox migration service attempting to alter `app_inbox.life_inbox_triage_entries`; the relation did not exist. Only afterward did plugin-sql execute the inbox plugin's schema statements. [Run](https://github.com/elizaOS/eliza/actions/runs/29954836153) / [exact job](https://github.com/elizaOS/eliza/actions/runs/29954836153/job/89041403450).

After, the deterministic barrier in the real PGlite test observes:

```text
publishedBeforeSchema = false
migrationBatches = [["@elizaos/plugin-inbox"], ["concurrent-late-schema-plugin"]]
maxConcurrentMigrations = 1
InboxMigrationService status = registered
```

Frontend logs: N/A - no frontend path changes.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface is changed or exercised.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Domain artifacts

The real PGlite query after registration returns the persisted inbox tables:

```text
app_inbox.life_email_unsubscribes
app_inbox.life_inbox_triage_entries
app_inbox.life_inbox_triage_examples
app_concurrent_late.probe
```

Two simultaneous registrations of `@elizaos/plugin-inbox` produce exactly one inbox migration batch and one published plugin. A concurrent second schema plugin produces its own table, and the observed maximum number of adapter migrations in flight is one.

## Known gaps / failures

- `bun run verify` stops at the repository type-safety ratchet: current `origin/develop` contains 85 `as unknown as` casts while `scripts/security/type-safety-baseline.json` permits 84. I reproduced the identical count and file list in a clean detached worktree at exact base `e935a5c526d6638d52aa644e4dad96f3c898d3ee`; this PR's only production diff contains none.
- Changed Vitest coverage emits the existing parse warning for untouched `packages/agent/src/external-modules.d.ts`, excludes that declaration file, exits successfully, and enforces the changed production file at 65.23%.
- UI, frontend, LLM, native/device, audio, and deployment evidence are N/A because this PR only changes a headless runtime/database lifecycle boundary.

# Deploy Notes

No manual migration or deployment step. The lifecycle runs each late plugin's existing declared schema through the active adapter before starting that plugin.
