### PR TITLE
fix(coding-tools): gate PowerShell recursive deletes

### DIFF
--- a/packages/elizaos/src/__tests__/template-biome-contract.test.ts
+++ b/packages/elizaos/src/__tests__/template-biome-contract.test.ts
@@ -11,11 +11,26 @@ const templatesRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../templates",
 );
+const repositoryManifestPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../package.json",
+);
 
 function readJson(relativePath: string): Record<string, unknown> {
   return JSON.parse(
     readFileSync(path.join(templatesRoot, relativePath), "utf8"),
   );
+}
+
+const repositoryManifest = JSON.parse(
+  readFileSync(repositoryManifestPath, "utf8"),
+) as {
+  devDependencies?: Record<string, unknown>;
+};
+const pinnedBiomeVersion =
+  repositoryManifest.devDependencies?.["@biomejs/biome"];
+if (typeof pinnedBiomeVersion !== "string") {
+  throw new TypeError("The repository must pin @biomejs/biome");
 }
 
 describe("standalone template Biome contract", () => {
@@ -29,13 +44,15 @@ describe("standalone template Biome contract", () => {
         $schema: string;
       };
 
-      expect(manifest.devDependencies["@biomejs/biome"]).toBe("2.5.5");
+      expect(manifest.devDependencies["@biomejs/biome"]).toBe(
+        pinnedBiomeVersion,
+      );
       expect(manifest.scripts.lint).toMatch(/^biome check\b/);
       expect(manifest.scripts["lint:check"]).toMatch(/^biome check\b/);
       expect(manifest.scripts.lint).not.toContain("||");
       expect(manifest.scripts["lint:check"]).not.toContain("||");
       expect(config.$schema).toBe(
-        "https://biomejs.dev/schemas/2.5.5/schema.json",
+        `https://biomejs.dev/schemas/${pinnedBiomeVersion}/schema.json`,
       );
     });
   }

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -57,6 +57,36 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+async function createRecursiveDeleteCommand(): Promise<{
+  command: string;
+  target: string;
+}> {
+  const target = await fs.mkdtemp(
+    path.join(os.tmpdir(), "coding-tools-destructive-gate-"),
+  );
+  const quotedTarget =
+    process.platform === "win32"
+      ? `'${target.replaceAll("'", "''")}'`
+      : `'${target.replaceAll("'", "'\\''")}'`;
+  return {
+    target,
+    command:
+      process.platform === "win32"
+        ? `Remove-Item -LiteralPath ${quotedTarget} -Recurse -Force`
+        : `rm -rf ${quotedTarget}`,
+  };
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    // error-policy:J3 filesystem probe; a missing path is the explicit signal.
+    return false;
+  }
+}
+
 interface RuntimeOptions {
   blockedPaths?: string;
   shellTimeoutMs?: number;
@@ -1943,37 +1973,44 @@ describe("platform-aware canned resource commands", () => {
 
 describe("destructive-bulk confirm gate", () => {
   it("blocks an unconfirmed recursive delete with needs_confirmation", async () => {
+    const { command, target } = await createRecursiveDeleteCommand();
     const { runtime } = await makeRuntime();
-    const result = await shellAction.handler?.(
-      runtime,
-      makeMessage(undefined, "clean up the old projects"),
-      undefined,
-      { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
-    );
-    expect(result.success).toBe(false);
-    expect(result.text).toContain("needs_confirmation");
-    expect(result.text).toContain("confirm=true");
-    const data = result.data as Record<string, unknown> | undefined;
-    expect(data?.destructive_reason).toBe("recursive delete");
+    try {
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "clean up the old projects"),
+        undefined,
+        { command },
+      );
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("needs_confirmation");
+      expect(result.text).toContain("confirm=true");
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?.destructive_reason).toBe("recursive delete");
+      expect(await pathExists(target)).toBe(true);
+    } finally {
+      await fs.rm(target, { recursive: true, force: true });
+    }
   });
 
   it("runs the same command when confirm=true", async () => {
+    const { command, target } = await createRecursiveDeleteCommand();
     const { runtime } = await makeRuntime();
     const result = await shellAction.handler?.(
       runtime,
       makeMessage(undefined, "yes do it"),
       undefined,
       {
-        command: "rm -rf /tmp/coding-tools-gate-test-nonexistent",
+        command,
         confirm: true,
       },
     );
-    // The path does not exist; rm -rf exits 0 on nonexistent targets — the
-    // point is the gate let it through to real execution.
     expect(result.success).toBe(true);
+    expect(await pathExists(target)).toBe(false);
   });
 
   it("is exempt on the coding sub-agent path (task briefs carry confirmation)", async () => {
+    const { command, target } = await createRecursiveDeleteCommand();
     process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
     try {
       const { runtime } = await makeRuntime();
@@ -1981,15 +2018,18 @@ describe("destructive-bulk confirm gate", () => {
         runtime,
         makeMessage(undefined, "build step"),
         undefined,
-        { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+        { command },
       );
       expect(result.success).toBe(true);
+      expect(await pathExists(target)).toBe(false);
     } finally {
       delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+      await fs.rm(target, { recursive: true, force: true });
     }
   });
 
   it("honors the ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0 escape hatch", async () => {
+    const { command, target } = await createRecursiveDeleteCommand();
     process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM = "0";
     try {
       const { runtime } = await makeRuntime();
@@ -1997,11 +2037,13 @@ describe("destructive-bulk confirm gate", () => {
         runtime,
         makeMessage(undefined, "clean up"),
         undefined,
-        { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+        { command },
       );
       expect(result.success).toBe(true);
+      expect(await pathExists(target)).toBe(false);
     } finally {
       delete process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM;
+      await fs.rm(target, { recursive: true, force: true });
     }
   });
 
@@ -2011,7 +2053,7 @@ describe("destructive-bulk confirm gate", () => {
       runtime,
       makeMessage(undefined, "whats here"),
       undefined,
-      { command: "ls /tmp" },
+      { command: 'node -e "process.exit(0)"' },
     );
     expect(result.success).toBe(true);
   });

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -16,6 +16,17 @@ describe("classifyDestructiveCommand — fires", () => {
     expect(classifyDestructiveCommand("rm -fr build").destructive).toBe(true);
     expect(classifyDestructiveCommand("rm -R cache").destructive).toBe(true);
   });
+  it.each([
+    ["Remove-Item -LiteralPath C:\\temp\\old -Recurse -Force"],
+    ["remove-item C:\\temp\\old -Rec -Force"],
+    ["ri -R C:\\temp\\old"],
+    ["rmdir -Recurse C:\\temp\\old"],
+  ])("PowerShell recursive delete: %s", (command) => {
+    const verdict = classifyDestructiveCommand(command);
+    expect(verdict.destructive).toBe(true);
+    expect(verdict.reason).toBe("recursive delete");
+    expect(verdict.targets).toContain("C:\\temp\\old");
+  });
   it("recursive rm hidden behind a chain", () => {
     const v = classifyDestructiveCommand("ls && rm -rf ./data");
     expect(v.destructive).toBe(true);
@@ -56,6 +67,7 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     ["ls -la /tmp"],
     ["rm single-file.txt"],
     ["rm -f one-exact-file.log"],
+    ["Remove-Item one-exact-file.log"],
     ["git rm old.ts"],
     ["df -h / && du -sh /home"],
     ["grep -r pattern src/"],

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -18,6 +18,15 @@ export interface DestructiveVerdict {
 
 const RECURSIVE_RM_FLAG = /^-[a-z]*[rR][a-z]*$/;
 const FORCE_ONLY_FLAG = /^-[a-z]*f[a-z]*$/;
+const POWERSHELL_RECURSE_FLAG = /^-(?:r|re|rec|recu|recur|recurs|recurse)$/i;
+const POWERSHELL_REMOVE_ITEM_BINS = new Set([
+  "remove-item",
+  "del",
+  "erase",
+  "rd",
+  "ri",
+  "rmdir",
+]);
 const DESTRUCTIVE_BINS = new Set(["mkfs", "shred", "wipefs"]);
 const DROP_SQL = /\bdrop\s+(database|table|schema)\s+(\S+)/i;
 
@@ -75,7 +84,7 @@ export function classifyDestructiveCommand(
       /^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[i] as string)
     )
       i += 1;
-    const bin = (argv[i] ?? "").split("/").pop() ?? "";
+    const bin = (argv[i] ?? "").split(/[\\/]/).pop()?.toLowerCase() ?? "";
     const rest = argv.slice(i + 1);
 
     if (bin === "rm") {
@@ -92,6 +101,16 @@ export function classifyDestructiveCommand(
           destructive: true,
           reason: "forced glob delete",
           targets: paths,
+        };
+      }
+    }
+    if (POWERSHELL_REMOVE_ITEM_BINS.has(bin)) {
+      const recursive = rest.some((arg) => POWERSHELL_RECURSE_FLAG.test(arg));
+      if (recursive) {
+        return {
+          destructive: true,
+          reason: "recursive delete",
+          targets: rest.filter((arg) => !arg.startsWith("-")),
         };
       }
     }


### PR DESCRIPTION
Closes #16867.

## What changed

- recognize PowerShell `Remove-Item` recursive deletes and common aliases/parameter abbreviations in the chat-path destructive confirmation classifier
- normalize executable names case-insensitively and across Windows/POSIX path separators
- replace POSIX-only destructive-gate action fixtures with real platform-native recursive deletes against temporary directories
- assert that unconfirmed deletes preserve the target, while confirmed, coding-subagent, and explicit opt-out paths really delete it
- replace the ordinary `ls /tmp` fixture with a real cross-platform Node command

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `vitest run src/lib/destructive-gate.test.ts src/actions/bash.test.ts` — 99 passed
- `bun run --cwd plugins/plugin-coding-tools test` — 382 passed
- `bun run --cwd plugins/plugin-coding-tools typecheck`
- `bun run --cwd plugins/plugin-coding-tools lint:check`
- `bun run audit:error-policy-ratchet`
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or visual behavior changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or visual behavior changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - CLI/runtime shell policy only; no backend service behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - temporary filesystem targets are created and inspected within the real command tests, then removed.
