### PR TITLE
fix(ci): provision LifeOps live prerequisites

### DIFF
--- a/.github/workflows/lifeops-bench.yml
+++ b/.github/workflows/lifeops-bench.yml
@@ -14,8 +14,9 @@
 # top-level `report.md` / `report.json`) as a 30-day artifact, and posts a
 # side-by-side summary as a PR comment after all matrix legs complete.
 #
-# Required secrets (job is skipped, NOT failed, when missing):
-#   CEREBRAS_API_KEY  — eval/judge/teacher provider (gpt-oss-120b)
+# Required secrets (job is skipped, NOT failed, when either is missing):
+#   CEREBRAS_API_KEY  — simulated user and agent model provider
+#   ANTHROPIC_API_KEY — live benchmark judge
 
 name: LifeOps Benchmark
 
@@ -73,9 +74,10 @@ jobs:
         id: gate
         env:
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -z "${CEREBRAS_API_KEY:-}" ]; then
-            echo "[lifeops-bench] CEREBRAS_API_KEY not configured — skipping benchmark."
+          if [ -z "${CEREBRAS_API_KEY:-}" ] || [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "[lifeops-bench] CEREBRAS_API_KEY and ANTHROPIC_API_KEY are both required — skipping benchmark."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -113,6 +115,12 @@ jobs:
         run: |
           cd packages/benchmarks/lifeops-bench
           pip install -e .
+
+      - name: Install and verify Hermes agent
+        if: steps.gate.outputs.skip != 'true' && matrix.agent == 'hermes'
+        env:
+          AGENT_INSTALL_TIMEOUT_SECONDS: "900"
+        run: python packages/benchmarks/lib/agent_install.py --agents hermes
 
       - name: Type/build check (lifeops + training + scenario-runner + core)
         if: steps.gate.outputs.skip != 'true'
@@ -162,6 +170,7 @@ jobs:
         id: run
         env:
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ELIZA_BENCH_AGENT: ${{ matrix.agent }}
           ELIZA_BENCH_LIMIT: ${{ inputs.limit || '25' }}
         run: |

--- a/packages/scripts/__tests__/lifeops-benchmark-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/lifeops-benchmark-workflow-contract.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the live LifeOps benchmark's provider and external-agent prerequisites.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/lifeops-bench.yml", import.meta.url),
+  "utf8",
+);
+
+function extractStep(name: string): string {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = workflow.match(
+    new RegExp(
+      `^      - name: ${escaped}\\n(?<body>[\\s\\S]*?)(?=^      - (?:name|uses): |$(?![\\s\\S]))`,
+      "m",
+    ),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+  return match.groups.body;
+}
+
+describe("LifeOps benchmark workflow prerequisites", () => {
+  test("skips unless both live provider secrets are configured", () => {
+    const gate = extractStep("Check secrets");
+    expect(gate).toContain(
+      "CEREBRAS_API_KEY: $" + "{{ secrets.CEREBRAS_API_KEY }}",
+    );
+    expect(gate).toContain(
+      "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
+    );
+    expect(gate).toContain('[ -z "$' + '{CEREBRAS_API_KEY:-}" ] ||');
+    expect(gate).toContain('[ -z "$' + '{ANTHROPIC_API_KEY:-}" ]');
+
+    const run = extractStep("Run lifeops multi-agent bench (matrix leg)");
+    expect(run).toContain(
+      "CEREBRAS_API_KEY: $" + "{{ secrets.CEREBRAS_API_KEY }}",
+    );
+    expect(run).toContain(
+      "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
+    );
+  });
+
+  test("installs and verifies Hermes before its matrix leg runs", () => {
+    const install = extractStep("Install and verify Hermes agent");
+    expect(install).toContain("matrix.agent == 'hermes'");
+    expect(install).toContain('AGENT_INSTALL_TIMEOUT_SECONDS: "900"');
+    expect(install).toContain(
+      "python packages/benchmarks/lib/agent_install.py --agents hermes",
+    );
+    expect(
+      workflow.indexOf("- name: Install and verify Hermes agent"),
+    ).toBeLessThan(
+      workflow.indexOf("- name: Run lifeops multi-agent bench (matrix leg)"),
+    );
+  });
+});


### PR DESCRIPTION
Closes #16869.

## What changed

- gate the live LifeOps benchmark on both required provider secrets: Cerebras for simulated-user/agent calls and Anthropic for the judge
- pass both secrets to the benchmark process
- install and verify Hermes-agent through the repository-owned installer before the Hermes matrix leg
- give the external agent installation a bounded 900-second subprocess timeout
- add a workflow contract that pins the secret gate, benchmark environment, Hermes condition/command, and step ordering

## Verification

- `bun test packages/scripts/__tests__/lifeops-benchmark-workflow-contract.test.ts` — 2 passed, 10 expectations
- `actionlint .github/workflows/lifeops-bench.yml`
- `bunx @biomejs/biome check packages/scripts/__tests__/lifeops-benchmark-workflow-contract.test.ts`
- `bun run audit:error-policy-ratchet`
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or visual behavior changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or visual behavior changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - workflow prerequisite handling only; no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the fix prevents an unconfigured live benchmark from starting; it does not change model prompts or outputs.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - prerequisite gating and agent installation create no persistent product-domain data.
