### PR TITLE
fix(lint): clear develop-wide biome drift blocking every PR gate

### DIFF
--- a/packages/agent/src/actions/page-action-groups.test.ts
+++ b/packages/agent/src/actions/page-action-groups.test.ts
@@ -71,43 +71,43 @@ async function invoke(
 }
 
 describe("PAGE_DELEGATE workflow alias repair", () => {
-  it.each([
-    "WORKFLOW_CREATE",
-    "CREATE_WORKFLOW",
-  ])("canonicalizes %s to WORKFLOW action=create using the user's request", async (alias) => {
-    let calls = 0;
-    let receivedOptions: HandlerOptions | undefined;
-    const handler: Action["handler"] = async (
-      _runtime,
-      _message,
-      _state,
-      options,
-    ): Promise<ActionResult> => {
-      calls += 1;
-      receivedOptions = options;
-      return {
-        success: true,
-        text: "created",
+  it.each(["WORKFLOW_CREATE", "CREATE_WORKFLOW"])(
+    "canonicalizes %s to WORKFLOW action=create using the user's request",
+    async (alias) => {
+      let calls = 0;
+      let receivedOptions: HandlerOptions | undefined;
+      const handler: Action["handler"] = async (
+        _runtime,
+        _message,
+        _state,
+        options,
+      ): Promise<ActionResult> => {
+        calls += 1;
+        receivedOptions = options;
+        return {
+          success: true,
+          text: "created",
+        };
       };
-    };
-    const runtime = makeRuntime(handler);
+      const runtime = makeRuntime(handler);
 
-    const result = await invoke(runtime, alias, {
-      definition: {
-        nodes: [{ type: "invented", parameters: { value: "wrong" } }],
-      },
-      active: false,
-    });
+      const result = await invoke(runtime, alias, {
+        definition: {
+          nodes: [{ type: "invented", parameters: { value: "wrong" } }],
+        },
+        active: false,
+      });
 
-    expect(result.success).toBe(true);
-    expect(calls).toBe(1);
-    expect(receivedOptions?.parameters).toEqual({
-      action: "create",
-      seedPrompt: CREATE_REQUEST,
-      active: false,
-    });
-    expect(receivedOptions?.parameters).not.toHaveProperty("definition");
-  });
+      expect(result.success).toBe(true);
+      expect(calls).toBe(1);
+      expect(receivedOptions?.parameters).toEqual({
+        action: "create",
+        seedPrompt: CREATE_REQUEST,
+        active: false,
+      });
+      expect(receivedOptions?.parameters).not.toHaveProperty("definition");
+    },
+  );
 
   it("preserves an already-canonical WORKFLOW delegation", async () => {
     let receivedOptions: HandlerOptions | undefined;

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -46,9 +46,9 @@ describe("fetchAnthropicOAuthProfile", () => {
       _input,
       init,
     ) => {
-      expect((init?.headers as Record<string, string>).Authorization).toBe(
-        "Bearer access-token",
-      );
+      expect(
+        (init?.headers as Record<string, string> | undefined)?.Authorization,
+      ).toBe("Bearer access-token");
       return Response.json({
         account: { uuid: "account-1", email: "person@example.com" },
         organization: { uuid: "organization-1" },
@@ -95,13 +95,14 @@ describe("fetchAnthropicOAuthProfile", () => {
       },
       "anthropic_oauth.profile_request_failed",
     ],
-  ] as Array<
-    [string, () => Promise<Response>, string]
-  >)("surfaces %s instead of fabricating an empty profile", async (_name, fetchImpl, code) => {
-    await expect(
-      fetchAnthropicOAuthProfile("access-token", fetchImpl as typeof fetch),
-    ).rejects.toMatchObject({ code });
-  });
+  ] as Array<[string, () => Promise<Response>, string]>)(
+    "surfaces %s instead of fabricating an empty profile",
+    async (_name, fetchImpl, code) => {
+      await expect(
+        fetchAnthropicOAuthProfile("access-token", fetchImpl as typeof fetch),
+      ).rejects.toMatchObject({ code });
+    },
+  );
 });
 
 function useTempElizaHome(): string {

--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -51,11 +51,11 @@ describe("#13111 strict-safe record/map tool args", () => {
       },
     ]) as Record<string, { inputSchema: { jsonSchema: unknown }; strict?: boolean }>;
 
-    expect(toolSet.TASKS?.strict).toBe(false);
-    expect(toolSet.TASKS?.inputSchema.jsonSchema).toEqual(schema);
-    expect((toolSet.TASKS.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
-      "action",
-    ]);
+    const tasks = toolSet.TASKS;
+    if (!tasks) throw new Error("expected TASKS tool in normalized set");
+    expect(tasks.strict).toBe(false);
+    expect(tasks.inputSchema.jsonSchema).toEqual(schema);
+    expect((tasks.inputSchema.jsonSchema as { required?: string[] }).required).toEqual(["action"]);
   });
 
   it("turns additionalProperties:true into a strict entries array", () => {

--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -53,7 +53,7 @@ describe("#13111 strict-safe record/map tool args", () => {
 
     expect(toolSet.TASKS?.strict).toBe(false);
     expect(toolSet.TASKS?.inputSchema.jsonSchema).toEqual(schema);
-    expect((toolSet.TASKS?.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
+    expect((toolSet.TASKS.inputSchema.jsonSchema as { required?: string[] }).required).toEqual([
       "action",
     ]);
   });

--- a/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
@@ -21,7 +21,7 @@ function workflow(parameters: Record<string, unknown>, type = 'workflows-nodes-b
 
 function assignments(definition: WorkflowDefinition): Array<Record<string, unknown>> {
   return (
-    definition.nodes[0]?.parameters.assignments as {
+    definition.nodes[0].parameters.assignments as {
       assignments: Array<Record<string, unknown>>;
     }
   ).assignments;

--- a/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts
@@ -20,8 +20,12 @@ function workflow(parameters: Record<string, unknown>, type = 'workflows-nodes-b
 }
 
 function assignments(definition: WorkflowDefinition): Array<Record<string, unknown>> {
+  const node = definition.nodes[0];
+  if (!node) {
+    throw new Error('workflow definition has no nodes');
+  }
   return (
-    definition.nodes[0].parameters.assignments as {
+    node.parameters.assignments as {
       assignments: Array<Record<string, unknown>>;
     }
   ).assignments;


### PR DESCRIPTION
## Why

The lint lane was red on `develop` for any PR whose turbo cache missed these packages, failing the **Develop PR Gate** across the open-PR queue. This PR originally corrected four files; develop commit `4979e6e92c` has since landed its own (differently-shaped) fixes for three of them, so this PR is now **rescoped to the one remaining file**:

- `packages/auth/src/oauth-flow.test.ts:49` — `correctness/noUnsafeOptionalChaining`: `(init?.headers as Record<…>).Authorization` throws if the chain short-circuits — still present on `develop` head, plus formatter drift on the `it.each` block in the same file.

## What

Test-file-only, behavior-preserving corrections to `packages/auth/src/oauth-flow.test.ts`:

- Keep the header chain fully optional: `(init?.headers as Record<string, string> | undefined)?.Authorization` — identical pass/fail semantics (`undefined` ≠ expected header string).
- `biome format` reflow of the `it.each(...)` call.

**Rescope note:** the three other files this PR previously touched — `plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts`, `plugins/plugin-workflow/__tests__/unit/setNodeParameters.test.ts`, `packages/agent/src/actions/page-action-groups.test.ts` — were fixed on `develop` by `4979e6e92c` with a different (guard-based) shape. This branch now carries them **byte-identical to `develop`**, so the merge is conflict-free and the squash lands only the auth change.

Verified against pinned biome **2.5.5** with develop's root + nested biome configs: all four files on this branch check clean; develop's current `oauth-flow.test.ts` fails with 2 errors (lint + format) — full log attached below.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - lint-only change to a test file; no UI surface touched.`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - lint-only change to a test file; no UI surface touched.`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing behavior change; the deliverable is a clean biome check, proven by the attached log.`

<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no runtime code touched; test-file-only lint fix.`

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no UI change.`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/prompt/model behavior change.`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: biome 2.5.5 verification log (branch files clean; develop's pre-fix `oauth-flow.test.ts` fails as control): https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16876-biome-check.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
