### PR TITLE
fix(elizaos): derive template Biome contract from the root pin

### DIFF
--- a/packages/elizaos/src/__tests__/template-biome-contract.test.ts
+++ b/packages/elizaos/src/__tests__/template-biome-contract.test.ts
@@ -1,16 +1,60 @@
 /**
  * Keeps standalone app scaffolds on the repository's pinned, fail-closed Biome validation contract.
+ * The expected version is derived from the monorepo root package.json pin so a routine Biome bump
+ * cannot break this contract, while a template that drifts from the root pin still fails.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const templatesRoot = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../templates",
-);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const templatesRoot = path.resolve(testDir, "../../templates");
+
+// Walk up from the test file to the monorepo root (the first package.json declaring
+// workspaces) so the contract follows the canonical pin wherever the repo is checked out.
+function findRepoRootPackageJson(startDir: string): Record<string, unknown> {
+  let dir = startDir;
+  while (true) {
+    const candidate = path.join(dir, "package.json");
+    if (existsSync(candidate)) {
+      const parsed = JSON.parse(readFileSync(candidate, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      if (parsed.workspaces !== undefined) {
+        return parsed;
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(
+        `Could not locate monorepo root package.json above ${startDir}`,
+      );
+    }
+    dir = parent;
+  }
+}
+
+function canonicalBiomeVersion(): string {
+  const rootManifest = findRepoRootPackageJson(testDir) as {
+    devDependencies?: Record<string, string>;
+  };
+  const version = rootManifest.devDependencies?.["@biomejs/biome"];
+  if (version === undefined) {
+    throw new Error(
+      "Root package.json is missing the @biomejs/biome devDependency pin",
+    );
+  }
+  // The root pin must be an exact version; a range would make the contract ambiguous.
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+      `Root @biomejs/biome pin must be an exact version, got "${version}"`,
+    );
+  }
+  return version;
+}
 
 function readJson(relativePath: string): Record<string, unknown> {
   return JSON.parse(
@@ -19,6 +63,8 @@ function readJson(relativePath: string): Record<string, unknown> {
 }
 
 describe("standalone template Biome contract", () => {
+  const biomeVersion = canonicalBiomeVersion();
+
   for (const templateRoot of ["min-project", "plugin", "project/apps/app"]) {
     it(`${templateRoot} pins Biome and exposes strict lint commands`, () => {
       const manifest = readJson(`${templateRoot}/package.json`) as {
@@ -29,13 +75,13 @@ describe("standalone template Biome contract", () => {
         $schema: string;
       };
 
-      expect(manifest.devDependencies["@biomejs/biome"]).toBe("2.5.4");
+      expect(manifest.devDependencies["@biomejs/biome"]).toBe(biomeVersion);
       expect(manifest.scripts.lint).toMatch(/^biome check\b/);
       expect(manifest.scripts["lint:check"]).toMatch(/^biome check\b/);
       expect(manifest.scripts.lint).not.toContain("||");
       expect(manifest.scripts["lint:check"]).not.toContain("||");
       expect(config.$schema).toBe(
-        "https://biomejs.dev/schemas/2.5.4/schema.json",
+        `https://biomejs.dev/schemas/${biomeVersion}/schema.json`,
       );
     });
   }


### PR DESCRIPTION
# Relates to

Follow-up to #16784 (Biome 2.5.5 lockfile/pin sync). That PR was admin-merged (b5a378d66b6) with a known defect left unfixed: `packages/elizaos/src/__tests__/template-biome-contract.test.ts` still hard-asserted `2.5.4` (version pin + `schemas/2.5.4` URL) while the merged templates pin `2.5.5` — all 3 tests in the file were red on `develop` tip with `expected '2.5.5' to be '2.5.4'`. No open PR owned the fix.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branched directly from `origin/develop` tip `8557162cbda`).
- [x] Scoped `bun run --cwd packages/elizaos typecheck` and `lint:check` pass (see Testing). Full repo-wide `bun run verify` not run for this one-test-file change; the touched package's typecheck + lint are green (recorded in Known gaps).
- [x] A reviewer can confirm the change works without reading the code, from the before/after test output below.

# Sync with develop

- [x] Branched from the latest `origin/develop` (`8557162cbda`); zero conflicts.
- [x] Package-scoped verify passes post-sync (`tsc --noEmit` clean; `biome check` clean on the touched file).

# Risks

**Low.** Single test file changed; no runtime, template, or build code touched. Worst case is a false-green if the root pin and templates drift together — which is exactly the intended contract (they must move together).

# Background

## What does this PR do?

Fixes the live-red `template-biome-contract.test.ts` suite on `develop` by deriving the expected Biome version from the canonical pin — the monorepo root `package.json` `devDependencies["@biomejs/biome"]` — instead of a hard-coded string. The root manifest is located robustly by walking up from the test file to the first `package.json` declaring `workspaces`, so the test works from any checkout/worktree location. Both the template `devDependencies` pin and the `biome.json` `$schema` URL are asserted against the derived version.

It stays a real contract test:
- A template pin that drifts from the root pin still fails (verified by hand: temporarily setting the `plugin` template back to `2.5.4` fails with `expected '2.5.4' to be '2.5.5'`).
- If the root pin is ever not an exact `x.y.z` version, the suite throws at collection instead of asserting against an ambiguous range.

Future Biome bumps that update root + templates together can no longer re-break this test.

## What kind of change is this?

Bug fix (repairs a red test on `develop`; non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/__tests__/template-biome-contract.test.ts` — then run:

```bash
bun run --cwd packages/elizaos vitest run src/__tests__/template-biome-contract.test.ts
```

## Detailed testing steps

1. On `develop` tip (`8557162cbda`), the suite fails 3/3 (before output below).
2. With this branch, the suite passes 3/3 (after output below).
3. Drift check: change any template's `@biomejs/biome` pin (or `$schema` URL) away from the root pin — the suite fails again, proving the contract is still enforced.
4. `bun run --cwd packages/elizaos typecheck` — clean. `bunx biome check` on the test file — clean. `bun run --cwd packages/elizaos lint:check` — clean (one pre-existing `biome migrate` info, no errors).

<details>
<summary>BEFORE — develop tip 8557162cbda: 3/3 failed</summary>

```
 RUN  v4.1.5 .../packages/elizaos

 ❯ src/__tests__/template-biome-contract.test.ts (3 tests | 3 failed) 29ms
     × min-project pins Biome and exposes strict lint commands 14ms
     × plugin pins Biome and exposes strict lint commands 10ms
     × project/apps/app pins Biome and exposes strict lint commands 4ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/__tests__/template-biome-contract.test.ts > standalone template Biome contract > min-project pins Biome and exposes strict lint commands
 FAIL  src/__tests__/template-biome-contract.test.ts > standalone template Biome contract > plugin pins Biome and exposes strict lint commands
 FAIL  src/__tests__/template-biome-contract.test.ts > standalone template Biome contract > project/apps/app pins Biome and exposes strict lint commands
AssertionError: expected '2.5.5' to be '2.5.4' // Object.is equality

Expected: "2.5.4"
Received: "2.5.5"

 ❯ src/__tests__/template-biome-contract.test.ts:32:58
     30|       };
     31|
     32|       expect(manifest.devDependencies["@biomejs/biome"]).toBe("2.5.4");
       |                                                          ^
     33|       expect(manifest.scripts.lint).toMatch(/^biome check\b/);
     34|       expect(manifest.scripts["lint:check"]).toMatch(/^biome check\b/);

 Test Files  1 failed (1)
      Tests  3 failed (3)
   Duration  333ms

error: "vitest" exited with code 1
```

</details>

<details>
<summary>AFTER — this branch: 3/3 passed + drift check</summary>

```
 RUN  v4.1.5 .../packages/elizaos

 ✓ src/__tests__/template-biome-contract.test.ts (3 tests) 7ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  232ms
```

Drift check (template `plugin` pin temporarily set to 2.5.4, then reverted):

```
 ❯ src/__tests__/template-biome-contract.test.ts (3 tests | 1 failed) 16ms
AssertionError: expected '2.5.4' to be '2.5.5' // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

Biome on the touched file:

```
$ bunx biome check packages/elizaos/src/__tests__/template-biome-contract.test.ts
Checked 1 file in 127ms. No fixes applied.
```

</details>

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; no UI surface is rendered or affected. The "before" state is the red vitest run attached above.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no UI surface is rendered or affected. The "after" state is the green vitest run attached above.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow exists for a vitest contract test; the complete flow is the two terminal runs pasted above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server code path exists or fires; the change is a static contract test over template JSON files. Full vitest runner output (the only relevant execution log) is attached in the details blocks above.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code, no requests, no state change; test-only diff.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; static file-contract test only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: before/after vitest output plus the manual drift-check run (test fails again when a template pin diverges) are attached inline above — these are the artifacts this change produces.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - test-only change; the vitest runner output above is the complete execution log.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT change.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run for this single-test-file diff; the touched package's `typecheck` and `lint:check` both pass, and `bunx biome check` on the changed file is clean. Not a blocker: no other package is touched.
- `lint:check` prints one pre-existing informational notice (`biome migrate` suggestion for a template config); zero errors, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
