### PR TITLE
fix(ci): stop app-real-e2e reporting green while its only job fails

### DIFF
--- a/.github/workflows/app-real-e2e.yml
+++ b/.github/workflows/app-real-e2e.yml
@@ -49,7 +49,12 @@ jobs:
     name: Browser-driven real app e2e (nightly)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
-    continue-on-error: true
+    # NOTE: `continue-on-error` intentionally lives on the e2e run step below, NOT
+    # here at the job level. Job-level soft-fail resolves the whole run to
+    # `success` even when the only job fails — a vacuous green that hid a real
+    # browser-e2e failure (#16722). The lane stays advisory (a failed nightly
+    # still ends green, exactly as before), but the true outcome is now surfaced
+    # in the job summary + a warning annotation so `success` can't be misread.
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -76,6 +81,10 @@ jobs:
           bunx playwright install --with-deps chromium
 
       - name: Run browser-driven real app e2e
+        id: e2e
+        # Step-level soft-fail keeps the nightly advisory (the job/run still ends
+        # green on failure), while the report step below records the real result.
+        continue-on-error: true
         run: |
           set -euo pipefail
           # streaming-visible-text.live.e2e launches a real browser via
@@ -89,3 +98,30 @@ jobs:
           echo "Using ELIZA_CHROME_PATH=$ELIZA_CHROME_PATH"
           export ELIZA_CHROME_PATH
           bun run --cwd packages/app-core test:app-real-e2e
+
+      - name: Report real app e2e outcome
+        if: always()
+        env:
+          E2E_OUTCOME: ${{ steps.e2e.outcome }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## App Real E2E (browser-driven, nightly · advisory)"
+            echo ""
+            echo "- Suite: \`packages/app-core\` \`test:app-real-e2e\`"
+            echo "- Trigger: \`${{ github.event_name }}\` · Ref: \`${{ github.ref }}\`"
+            echo "- Real e2e step outcome: \`${E2E_OUTCOME}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # This lane is advisory: the run stays green regardless, but a failed
+          # e2e must be visible, not silently masked by the green checkmark.
+          if [ "${E2E_OUTCOME}" = "failure" ]; then
+            # Annotation to stdout (GitHub surfaces `::warning::` on the run);
+            # human-readable line to the summary.
+            echo "::warning title=App Real E2E failed (advisory)::The browser-driven real app e2e suite FAILED (advisory nightly; run stays green). Inspect the 'Run browser-driven real app e2e' step."
+            echo "❌ **Real e2e FAILED** — advisory, so the run is green, but the suite did not pass." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${E2E_OUTCOME}" = "success" ]; then
+            echo "✅ **Real e2e passed.**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            # skipped / cancelled — surface it rather than implying a pass.
+            echo "⚠️ **Real e2e did not run to a pass/fail** (outcome: \`${E2E_OUTCOME}\`)." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
# Relates to

Closes #16722. Implements the issue's **option 3** (behavior-preserving); gating semantics and options 1/2 are left for owner sign-off.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `actionlint` (incl. shellcheck on the `run:` blocks) passes on the changed workflow; `git diff --check` clean; YAML parses.

# Risks

Low, and one-directional toward honesty. The lane stays **advisory** exactly as before — a failed nightly e2e still resolves the run to `success`, and it never gated PRs (`schedule` + `workflow_dispatch` only, never `pull_request`). The only behavioral change beyond surfacing the true outcome: a **setup/infra** failure (checkout, install, browser-driver install) now hard-fails the job instead of being masked — which is correct, since a nightly that never ran the suite should not report green.

# Background

## What does this PR do?

`app-real-e2e.yml` carried `continue-on-error: true` at the **job** level on its single job. Because it's the workflow's only job, a job failure resolves the whole run to `success` — a vacuous green that hid a real browser-e2e failure (run [#29733684389](https://github.com/elizaOS/eliza/actions/runs/29733684389): run conclusion `success`, only job `failure`).

- Moved `continue-on-error: true` from the job onto the **e2e run step** (with `id: e2e`), so the step can still soft-fail (advisory intent preserved) but the job's conclusion is no longer force-masked.
- Added an `if: always()` **report step** that reads `steps.e2e.outcome`, writes the true result to `$GITHUB_STEP_SUMMARY`, and emits a `::warning::` annotation when the suite failed.

Net: `success` can no longer be silently misread as "e2e passed" — the real outcome is visible on every run, while the lane's non-blocking nature is untouched.

## What kind of change is this?

CI correctness (removes a fails-open / vacuous-green pattern; #13620 umbrella).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The diff is one workflow file. Trace the three parts: (1) job-level `continue-on-error` removed with a comment explaining why; (2) `continue-on-error: true` + `id: e2e` on the run step; (3) the `always()` report step mapping `failure`/`success`/other → summary line + annotation.

## Detailed testing steps

Static validation only (a workflow-correctness change): `actionlint` passes (it runs shellcheck on the `run:` scripts too), the YAML parses, and `git diff --check` is clean. The outcome-branch logic is a straight `steps.e2e.outcome` switch — `failure` → warning annotation + ❌ summary, `success` → ✅ summary, `skipped`/`cancelled` → ⚠️ "did not run to a pass/fail" (never implies a pass).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - CI workflow-correctness change; no rendered product surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - CI workflow-correctness change; no rendered product surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; the change is a nightly CI workflow's failure-reporting.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no runtime/server code changed; the artifact is the workflow's own summary/annotation, validated by actionlint + the outcome-branch logic in the diff.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows; the artifact is the corrected run conclusion + job summary.`

# Evidence Details

The defect is only observable on a real failing nightly run (the reproduction the issue cites, run #29733684389, shows run `success` / job `failure`). It cannot be reproduced in a PR context (the workflow never triggers on `pull_request`). The fix is validated statically: `actionlint`/shellcheck clean, and the report step's branch logic is a deterministic map from `steps.e2e.outcome`.

## Known gaps / failures

Options 1 and 2 from the issue (hard-fail the core e2e job, or split the soft-failing exploratory work into its own job) change whether the lane is advisory at all — that's a gating decision reserved for owner sign-off. This PR takes the conservative, behavior-preserving option 3. The Security Advisory Gate on this PR requires the `claude-review` bot, which currently errors on fork PRs — a pre-existing infra blocker unrelated to this change.

[stan-cloud]
