### PR TITLE
fix(ci): stabilize cloud audit paint sampling

### DIFF
--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -23,9 +23,96 @@ import {
   parseMinimalismBaseline,
   parseNavigationTabPaths,
   parseRgb,
+  readReadableCharsWithNavigationRetry,
   resolveAuditStrictFlags,
   type VerdictFinding,
 } from "../ui-smoke/aesthetic-audit-rules";
+
+describe("readReadableCharsWithNavigationRetry", () => {
+  it("retries a measurement when navigation replaces the execution context", async () => {
+    const samples = [
+      () =>
+        Promise.reject(
+          new Error(
+            "Execution context was destroyed, most likely because of a navigation",
+          ),
+        ),
+      () => Promise.resolve(158),
+    ];
+    const waits: number[] = [];
+
+    await expect(
+      readReadableCharsWithNavigationRetry(
+        () => samples.shift()?.() ?? Promise.resolve(0),
+        async (delayMs) => {
+          waits.push(delayMs);
+        },
+      ),
+    ).resolves.toBe(158);
+    expect(waits).toEqual([100]);
+  });
+
+  it("preserves a successful zero so a genuinely blank page stays broken", async () => {
+    const waits: number[] = [];
+
+    await expect(
+      readReadableCharsWithNavigationRetry(
+        async () => 0,
+        async (delayMs) => {
+          waits.push(delayMs);
+        },
+      ),
+    ).resolves.toBe(0);
+    expect(waits).toEqual([]);
+  });
+
+  it("waits for a transient blank paint to regain the required readability", async () => {
+    const samples = [0, 0, 85];
+    const waits: number[] = [];
+
+    await expect(
+      readReadableCharsWithNavigationRetry(
+        async () => samples.shift() ?? 0,
+        async (delayMs) => {
+          waits.push(delayMs);
+        },
+        { minimumReadableChars: 10 },
+      ),
+    ).resolves.toBe(85);
+    expect(waits).toEqual([100, 100]);
+  });
+
+  it("returns zero after the bounded retry when the page remains blank", async () => {
+    const waits: number[] = [];
+
+    await expect(
+      readReadableCharsWithNavigationRetry(
+        async () => 0,
+        async (delayMs) => {
+          waits.push(delayMs);
+        },
+        { attempts: 3, minimumReadableChars: 10 },
+      ),
+    ).resolves.toBe(0);
+    expect(waits).toEqual([100, 100]);
+  });
+
+  it("surfaces non-navigation evaluation failures without retrying", async () => {
+    let waits = 0;
+
+    await expect(
+      readReadableCharsWithNavigationRetry(
+        async () => {
+          throw new Error("Target page has been closed");
+        },
+        async () => {
+          waits += 1;
+        },
+      ),
+    ).rejects.toThrow("Target page has been closed");
+    expect(waits).toBe(0);
+  });
+});
 
 describe("findRemoteBundleDeclaration", () => {
   it("distinguishes in-process app-shell pages from production bundles", () => {

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -30,6 +30,54 @@ export interface RemoteBundleDeclaration {
   componentExport: string;
 }
 
+const TRANSIENT_PAGE_EVALUATION_ERROR =
+  /execution context was destroyed|cannot find context with specified id|because of a navigation/i;
+
+/**
+ * Retries a DOM measurement only when Playwright reports that navigation
+ * replaced its execution context. A successful zero remains zero so genuinely
+ * blank pages still fail the audit; infrastructure errors surface immediately.
+ */
+export async function readReadableCharsWithNavigationRetry(
+  read: () => Promise<number>,
+  wait: (delayMs: number) => Promise<void>,
+  options: {
+    attempts?: number;
+    delayMs?: number;
+    minimumReadableChars?: number;
+  } = {},
+): Promise<number> {
+  const attempts = options.attempts ?? 4;
+  const delayMs = options.delayMs ?? 100;
+  const minimumReadableChars = options.minimumReadableChars ?? 0;
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error(
+      "readable-character retry attempts must be a positive integer",
+    );
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const readableChars = await read();
+      if (readableChars >= minimumReadableChars || attempt === attempts) {
+        return readableChars;
+      }
+      await wait(delayMs);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !TRANSIENT_PAGE_EVALUATION_ERROR.test(message) ||
+        attempt === attempts
+      ) {
+        throw error;
+      }
+      await wait(delayMs);
+    }
+  }
+
+  throw new Error("readable-character measurement exhausted its retry budget");
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -8,6 +8,7 @@ import { expect, test } from "@playwright/test";
 import {
   type AestheticVerdictDebt,
   evaluateStrictGate,
+  readReadableCharsWithNavigationRetry,
 } from "./aesthetic-audit-rules";
 import {
   collectBlueColors,
@@ -573,23 +574,27 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
         // react-query settle). Non-fatal: a page that never paints is recorded
         // as a `broken` finding, not a walk abort.
         const readPaint = async (): Promise<number> =>
-          page
-            .evaluate(
-              () => document.body.innerText.trim().replace(/\s+/g, " ").length,
-            )
-            .catch(() => 0);
-        let readableChars = await readPaint();
+          page.evaluate(
+            () => document.body.innerText.trim().replace(/\s+/g, " ").length,
+          );
+        const readPaintAfterNavigation = (minimumReadableChars = 0) =>
+          readReadableCharsWithNavigationRetry(
+            readPaint,
+            (delayMs) => page.waitForTimeout(delayMs),
+            { minimumReadableChars },
+          );
+        let readableChars = await readPaintAfterNavigation();
         for (
           let attempt = 0;
           attempt < 15 && readableChars < 10;
           attempt += 1
         ) {
           await page.waitForTimeout(1000);
-          readableChars = await readPaint();
+          readableChars = await readPaintAfterNavigation();
         }
         // Let late skeleton → content transitions settle before sampling.
         await page.waitForTimeout(750);
-        readableChars = await readPaint();
+        readableChars = await readPaintAfterNavigation(10);
 
         const restPath = path.join(shotDir, `${auditCase.slug}.png`);
         let buffer = await page.screenshot({ path: restPath, fullPage: false });


### PR DESCRIPTION
## Summary

- retry DOM readability samples when Playwright navigation replaces the execution context
- require the post-settle sample to regain the established readability floor for a bounded interval
- preserve a successful zero after retries so genuinely blank pages still fail
- add regression coverage for navigation errors, transient blank paints, persistent blanks, and unrelated browser failures

Fixes #16872

## Verification

- `bun test packages/app/test/audit/aesthetic-audit-rules.test.ts` — 63 passed
- `bunx biome check <three touched files>` — passed
- `bun run audit:error-policy-ratchet` — passed
- strict `bun run --cwd packages/app audit:cloud` — 86 passed; broken=0; needs-work=0
- `bun run --cwd packages/app audit:app` — 246 passed; broken=0; needs-work=0; OCR 244 views / broken=0
- package-only typecheck could not resolve prebuilt app-core/native bridge dists in the isolated worktree; current-head CI runs the canonical workspace pipeline

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - no rendered UI source changed. The failed artifact was manually reviewed and showed populated mobile pages despite recorded zeros: https://github.com/elizaOS/eliza/actions/runs/29966664895

<!-- evidence-row:after-screenshots -->
N/A - no product pixels changed; fresh local Cloud and app audits recaptured every surface and reported zero broken views.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing interaction changed; the automated route walkthroughs covered 86 Cloud cases and 246 app cases.

<!-- evidence-row:backend-logs -->
N/A - no backend code path changed.

<!-- evidence-row:frontend-logs -->
N/A - no frontend product behavior changed; local strict audit summaries reported zero broken and zero needs-work across both matrices.

<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, action, provider, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
N/A - audit measurement-only change; local reports, screenshots, manual-review stubs, and OCR output were generated and reviewed but excluded from git by policy.