### PR TITLE
feat: composeState provider budget defends interactive latency, not just hangs

### DIFF
--- a/packages/core/src/__tests__/compose-state-provider-budget.test.ts
+++ b/packages/core/src/__tests__/compose-state-provider-budget.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Per-provider composeState time budgets: a provider that exceeds its declared
+ * `timeoutMs` degrades to an empty contribution for the turn while composition
+ * proceeds with every other provider's output. Uses a real in-memory
+ * AgentRuntime with synthetic providers; no database or model.
+ */
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory, Provider, UUID } from "../types";
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ENTITY_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+
+function makeMessage(id: string): Memory {
+	return {
+		id: id as UUID,
+		entityId: ENTITY_ID,
+		roomId: ROOM_ID,
+		content: { text: "gm" },
+	};
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("composeState per-provider time budget", () => {
+	it("truncates a provider that exceeds its declared timeoutMs and keeps the fast ones", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-truncation" } as Character,
+		});
+		const slow: Provider = {
+			name: "SLOW_NETWORK",
+			timeoutMs: 300,
+			get: async () => {
+				await sleep(1_500);
+				return { text: "SLOW_RESULT_MUST_NOT_APPEAR", values: {}, data: {} };
+			},
+		};
+		const fast: Provider = {
+			name: "FAST_LOCAL",
+			get: async () => ({ text: "FAST_RESULT_PRESENT", values: {}, data: {} }),
+		};
+		runtime.registerProvider(slow);
+		runtime.registerProvider(fast);
+
+		const start = Date.now();
+		const state = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+			null,
+			false,
+			true,
+		);
+		const elapsed = Date.now() - start;
+
+		expect(state.text).toContain("FAST_RESULT_PRESENT");
+		expect(state.text).not.toContain("SLOW_RESULT_MUST_NOT_APPEAR");
+		// Compose returns at the slow provider's budget, not its full runtime.
+		expect(elapsed).toBeLessThan(1_400);
+	});
+
+	it("honors a declared budget larger than the elapsed work", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-headroom" } as Character,
+		});
+		const withinBudget: Provider = {
+			name: "WITHIN_BUDGET",
+			timeoutMs: 2_000,
+			get: async () => {
+				await sleep(400);
+				return { text: "WITHIN_BUDGET_PRESENT", values: {}, data: {} };
+			},
+		};
+		runtime.registerProvider(withinBudget);
+
+		const state = await runtime.composeState(
+			makeMessage("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+			null,
+			false,
+			true,
+		);
+		expect(state.text).toContain("WITHIN_BUDGET_PRESENT");
+	});
+
+	it("ignores sub-floor timeoutMs declarations instead of racing at unusable budgets", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-floor" } as Character,
+		});
+		const declaredTooLow: Provider = {
+			name: "FLOOR_GUARDED",
+			// Below the 250ms floor — the runtime default applies instead, so
+			// this ordinary-speed provider must not be truncated.
+			timeoutMs: 1,
+			get: async () => {
+				await sleep(50);
+				return { text: "FLOOR_GUARDED_PRESENT", values: {}, data: {} };
+			},
+		};
+		runtime.registerProvider(declaredTooLow);
+
+		const state = await runtime.composeState(
+			makeMessage("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+			null,
+			false,
+			true,
+		);
+		expect(state.text).toContain("FLOOR_GUARDED_PRESENT");
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -336,7 +336,21 @@ const DEFAULT_FAST_SERVICE_STOP_TIMEOUT_MS = 500;
 // recent and in-flight turns while bounding memory.
 const STATE_CACHE_LIMIT = 512;
 const PROVIDERS_PROMPT_MARKER = "__ELIZA_PROMPT_SEGMENT_PROVIDERS__";
-const COMPOSE_STATE_PROVIDER_TIMEOUT_MS = 30_000;
+// Per-provider composeState budget. The old fixed 30s value only guarded
+// against infinite hangs — a provider doing synchronous network could hold
+// every message turn hostage for tens of seconds and still count as healthy
+// (a registry refetch measured 10.9s on a live turn). The default defends
+// interactive latency; a provider with legitimately slow, turn-blocking work
+// declares its own `timeoutMs`. On expiry the provider degrades to an empty
+// contribution for the turn and composition proceeds.
+const COMPOSE_STATE_PROVIDER_TIMEOUT_MS = (() => {
+	const raw = Number.parseInt(
+		process.env.ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS ?? "",
+		10,
+	);
+	if (Number.isFinite(raw) && raw >= 250) return raw;
+	return 3_000;
+})();
 
 export function calculateProviderOverlaps(
 	timings: readonly {
@@ -4293,6 +4307,10 @@ export class AgentRuntime implements IAgentRuntime {
 				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 				let timedOut = false;
 				const providerRuntime: IAgentRuntime = this;
+				const providerBudgetMs =
+					typeof provider.timeoutMs === "number" && provider.timeoutMs >= 250
+						? provider.timeoutMs
+						: COMPOSE_STATE_PROVIDER_TIMEOUT_MS;
 				try {
 					const result = await Promise.race([
 						withProviderStep(providerRuntime, provider.name, () =>
@@ -4306,12 +4324,12 @@ export class AgentRuntime implements IAgentRuntime {
 										src: "agent",
 										agentId: this.agentId,
 										provider: provider.name,
-										timeoutMs: COMPOSE_STATE_PROVIDER_TIMEOUT_MS,
+										timeoutMs: providerBudgetMs,
 									},
 									"Provider timed out during state composition",
 								);
 								resolve({ text: "", values: {}, data: {} });
-							}, COMPOSE_STATE_PROVIDER_TIMEOUT_MS);
+							}, providerBudgetMs);
 						}),
 					]);
 					const endedAt = Date.now();

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -732,6 +732,17 @@ export interface Provider {
 	cacheScope?: CacheScope;
 
 	/**
+	 * Per-provider composeState time budget in milliseconds. When the budget
+	 * elapses the provider's contribution degrades to empty for that turn and
+	 * composition proceeds — a slow provider must never hold the message turn
+	 * hostage. Overrides the runtime default
+	 * (`ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS`); declare a higher budget only for
+	 * providers whose work is legitimately slow AND worth blocking the turn
+	 * for (e.g. corpus retrieval).
+	 */
+	timeoutMs?: number;
+
+	/**
 	 * Whether plugin registration should install this provider into the runtime.
 	 *
 	 * Defaults to true. Set to false for plugin-owned providers that are


### PR DESCRIPTION
## Why chat latency keeps coming back

Every latency fix so far (#16785 server caches, #16873 provider caches, the earlier cold-path chain) is a *point* fix — and nothing stops the next plugin from adding a blocking `await fetch()` inside a provider. The runtime's existing per-provider timeout is **30 seconds**: it prevents infinite hangs, not slow turns. A provider burning 10.9s on a registry refetch (measured live, pre-#16873) sailed under it as 'healthy'.

## What this does

- Default per-provider composeState budget drops to **3s**, env-tunable via `ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS` (250ms floor) — deployments can tighten to their UX bar without code changes.
- New optional `Provider.timeoutMs` for providers whose work is legitimately slow AND worth blocking the turn for (e.g. corpus retrieval) — sub-floor declarations are ignored.
- On expiry the provider degrades to an empty contribution for that turn (same shape its own error paths already produce) and composition proceeds; the existing timeout error log fires with the actual budget.

Complements Sol's #16820 (browser-level latency E2E gate): that *detects* regressions in CI, this *bounds* them at runtime — no future provider can hold a message turn hostage.

## Verification

- New `compose-state-provider-budget.test.ts` (3 tests, real in-memory AgentRuntime): over-budget provider truncated at its declared budget with fast providers preserved and compose returning at the budget, not the provider's runtime; declared headroom honored; sub-floor declarations ignored.
- Neighboring composeState suites green: provider-hook, refresh-providers, role-gate, trajectory-recording, register-provider — 18/18.
- Direct runtime repro: slow provider (1.5s work, 300ms budget) → compose returns in 310ms, contribution empty, timeout logged.
- Note for reviewers: while validating this I found stale compiled `.js` shadows in `packages/core/src` (incl. `runtime.js`) that made vitest silently test stale code until `bun run clean:stale-js` — the existing build guard catches it, but local vitest runs do not.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - core runtime latency-bound change, no UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - core runtime change, no UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - behavior fully captured by the deterministic test suite`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend involved`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: timeout log line + direct-repro timing quoted in Verification
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model-behavior change; compose-time bounding only`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: test output (3/3 new + 18/18 neighboring) in Verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)