### PR TITLE
fix(views): pass runtime to server interactions

### DIFF
--- a/packages/agent/src/api/views-routes.activate.test.ts
+++ b/packages/agent/src/api/views-routes.activate.test.ts
@@ -121,6 +121,7 @@ describe("POST /api/views/:id/activate", () => {
     expect(serverInteract).toHaveBeenCalledWith(
       "click-element",
       expect.objectContaining({ elementId: "send-it" }),
+      { runtime: ctx.runtime },
     );
     // A view-updated event is broadcast.
     expect(broadcastWs).toHaveBeenCalledWith(

--- a/packages/agent/src/api/views-routes.interact-coverage.test.ts
+++ b/packages/agent/src/api/views-routes.interact-coverage.test.ts
@@ -8,6 +8,7 @@
  */
 import type http from "node:http";
 import { Readable } from "node:stream";
+import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { viewActionAffinityMap } from "../runtime/view-action-affinity.ts";
 import {
@@ -55,11 +56,14 @@ const REFERENCE_VIEWS = [
   { id: "settings", label: "Settings" },
 ];
 let lastOpenedViewId: string | null = null;
+let lastInteractionRuntime: IAgentRuntime | undefined;
 
 async function referenceServerInteract(
   capability: string,
   params?: Record<string, unknown>,
+  context?: { runtime?: IAgentRuntime },
 ): Promise<unknown> {
+  lastInteractionRuntime = context?.runtime;
   if (capability === "list-views") {
     return { views: REFERENCE_VIEWS };
   }
@@ -79,6 +83,7 @@ function makeCtx(
   method: "POST",
   pathname: string,
   body: Record<string, unknown> | null,
+  runtime?: IAgentRuntime,
 ): {
   ctx: ViewsRouteContext;
   json: ReturnType<typeof vi.fn>;
@@ -101,6 +106,7 @@ function makeCtx(
     json,
     error,
     broadcastWs,
+    runtime,
   };
   return { ctx, json, error, broadcastWs };
 }
@@ -110,6 +116,7 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
     registerBuiltinViews();
     clearCurrentViewState();
     lastOpenedViewId = null;
+    lastInteractionRuntime = undefined;
 
     // (a) reference view: capabilities + a headless serverInteract, mirroring
     // the plugin-app-control views-manager declaration.
@@ -231,6 +238,22 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
     // The dispatched result is the reference view list — proves the round-trip
     // returned real serverInteract output, not just "did not throw".
     expect(payload.result.views).toEqual(REFERENCE_VIEWS);
+  });
+
+  it("passes the owning runtime through the direct interact route", async () => {
+    const runtime = { agentId: "runtime-owner" } as unknown as IAgentRuntime;
+    const { ctx, json, error } = makeCtx(
+      "POST",
+      "/api/views/views-manager-ref/interact",
+      { capability: "list-views" },
+      runtime,
+    );
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(lastInteractionRuntime).toBe(runtime);
   });
 
   it("dispatches open-view with params and mutates server-side state", async () => {

--- a/packages/agent/src/api/views-routes.runtime-service.real-server.test.ts
+++ b/packages/agent/src/api/views-routes.runtime-service.real-server.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Proves every server-side view interaction reaches the service owned by the
+ * request's runtime. A real loopback HTTP server drives direct and activation
+ * routes, while the planner action uses the same registered stateful view.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { type Action, type IAgentRuntime, Service } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearActiveViewContext } from "../runtime/view-action-affinity.ts";
+import {
+  __resetViewScopedActionRegistryForTests,
+  buildViewScopedAction,
+} from "../runtime/view-scoped-actions.ts";
+import {
+  registerPluginViews,
+  unregisterPluginViews,
+} from "./views-registry.ts";
+import {
+  clearCurrentViewState,
+  handleViewsRoutes,
+  setViewsBroadcastWs,
+} from "./views-routes.ts";
+
+const TEST_PLUGIN = "@test/runtime-owned-view";
+const VIEW_ID = "runtime-owned-records";
+const SERVICE_TYPE = "runtime-owned-records";
+
+class RuntimeOwnedRecordsService extends Service {
+  static override serviceType = SERVICE_TYPE;
+  override capabilityDescription = "Stores records for a runtime-owned view.";
+
+  readonly records = new Map<string, string>();
+  activeRecordId: string | null = null;
+
+  override async stop(): Promise<void> {}
+
+  create(id: string, value: string): void {
+    this.records.set(id, value);
+    this.activeRecordId = id;
+  }
+
+  update(id: string, value: string): void {
+    if (!this.records.has(id)) throw new Error(`Record "${id}" not found.`);
+    this.records.set(id, value);
+  }
+
+  delete(id: string): void {
+    if (!this.records.delete(id)) throw new Error(`Record "${id}" not found.`);
+    if (this.activeRecordId === id) this.activeRecordId = null;
+  }
+}
+
+function requireService(context?: {
+  runtime?: IAgentRuntime;
+}): RuntimeOwnedRecordsService {
+  const service =
+    context?.runtime?.getService<RuntimeOwnedRecordsService>(SERVICE_TYPE);
+  if (!service) throw new Error("Owning runtime service is unavailable.");
+  return service;
+}
+
+function stringParam(
+  params: Record<string, unknown> | undefined,
+  key: string,
+): string {
+  const value = params?.[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${key} is required.`);
+  }
+  return value;
+}
+
+function jsonResponder(
+  res: http.ServerResponse,
+  data: unknown,
+  status = 200,
+): void {
+  if (res.headersSent) return;
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(data));
+}
+
+function errorResponder(
+  res: http.ServerResponse,
+  message: string,
+  status = 500,
+): void {
+  jsonResponder(res, { error: message }, status);
+}
+
+function makeRuntime(service: RuntimeOwnedRecordsService): IAgentRuntime {
+  const actions: Action[] = [];
+  return {
+    agentId: "runtime-owner",
+    actions,
+    getService: (serviceType: string) =>
+      serviceType === SERVICE_TYPE ? service : null,
+    emitEvent: async () => {},
+    registerAction: (action: Action) => {
+      if (!actions.some((candidate) => candidate.name === action.name)) {
+        actions.push(action);
+      }
+    },
+    unregisterAction: (name: string) => {
+      const index = actions.findIndex((action) => action.name === name);
+      if (index < 0) return false;
+      actions.splice(index, 1);
+      return true;
+    },
+  } as unknown as IAgentRuntime;
+}
+
+async function startViewsServer(runtime: IAgentRuntime): Promise<{
+  baseUrl: string;
+  server: http.Server;
+}> {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const handled = await handleViewsRoutes({
+      req,
+      res,
+      method: req.method ?? "GET",
+      pathname: url.pathname,
+      url,
+      json: jsonResponder,
+      error: errorResponder,
+      broadcastWs: vi.fn(),
+      runtime,
+    });
+    if (!handled && !res.headersSent) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, server };
+}
+
+async function postJson(
+  baseUrl: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+let server: http.Server | null = null;
+
+beforeEach(async () => {
+  clearCurrentViewState();
+  clearActiveViewContext();
+  __resetViewScopedActionRegistryForTests();
+  setViewsBroadcastWs(() => {});
+});
+
+afterEach(async () => {
+  unregisterPluginViews(TEST_PLUGIN);
+  clearCurrentViewState();
+  clearActiveViewContext();
+  setViewsBroadcastWs(null);
+  __resetViewScopedActionRegistryForTests();
+  vi.restoreAllMocks();
+  if (server) {
+    server.closeIdleConnections?.();
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) =>
+      server?.close((error) => (error ? reject(error) : resolve())),
+    );
+    server = null;
+  }
+});
+
+describe("runtime-owned view interactions over the real HTTP route", () => {
+  it("keeps CRUD on one runtime service across interact, activate, and planner paths", async () => {
+    const service = new RuntimeOwnedRecordsService();
+    const runtime = makeRuntime(service);
+    const scopedAction = {
+      name: "VIEW_RUNTIME_OWNED_RECORDS_DELETE_ACTIVE",
+      description: "Delete the active runtime-owned record.",
+      steps: [{ kind: "agent-click" as const, target: "delete-active" }],
+    };
+
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "Stateful view used to prove runtime service ownership.",
+        views: [
+          {
+            id: VIEW_ID,
+            label: "Runtime-owned records",
+            path: "/runtime-owned-records",
+            surface: { capabilities: ["agent-surface"] },
+            capabilities: [
+              { id: "create-record", description: "Create a record." },
+              { id: "update-record", description: "Update a record." },
+              { id: "delete-record", description: "Delete a record." },
+            ],
+            scopedActions: [scopedAction],
+            serverInteract: async (capability, params, context) => {
+              const owned = requireService(context);
+              if (capability === "create-record") {
+                owned.create(
+                  stringParam(params, "id"),
+                  stringParam(params, "value"),
+                );
+              } else if (capability === "update-record") {
+                owned.update(
+                  stringParam(params, "id"),
+                  stringParam(params, "value"),
+                );
+              } else if (capability === "delete-record") {
+                owned.delete(stringParam(params, "id"));
+              } else if (capability === "click-element") {
+                const id = owned.activeRecordId;
+                if (!id) throw new Error("No active record.");
+                owned.update(id, "activated");
+              } else if (capability === "agent-click") {
+                if (stringParam(params, "id") !== "delete-active") {
+                  throw new Error("Unknown agent element.");
+                }
+                const id = owned.activeRecordId;
+                if (!id) throw new Error("No active record.");
+                owned.delete(id);
+              }
+              return {
+                success: true,
+                records: Object.fromEntries(owned.records),
+              };
+            },
+          },
+        ],
+      },
+      process.cwd(),
+      runtime,
+    );
+
+    const started = await startViewsServer(runtime);
+    server = started.server;
+
+    const created = await postJson(
+      started.baseUrl,
+      `/api/views/${VIEW_ID}/interact`,
+      {
+        capability: "create-record",
+        params: { id: "record-1", value: "draft" },
+      },
+    );
+    expect(created.success).toBe(true);
+    expect(service.records.get("record-1")).toBe("draft");
+
+    await postJson(started.baseUrl, `/api/views/${VIEW_ID}/interact`, {
+      capability: "update-record",
+      params: { id: "record-1", value: "saved" },
+    });
+    expect(service.records.get("record-1")).toBe("saved");
+
+    await postJson(started.baseUrl, `/api/views/${VIEW_ID}/activate`, {
+      elementId: "activate-current",
+    });
+    expect(service.records.get("record-1")).toBe("activated");
+
+    await postJson(started.baseUrl, `/api/views/${VIEW_ID}/navigate`, {});
+    const action = buildViewScopedAction(VIEW_ID, scopedAction);
+    const deleted = await action.handler(runtime, {} as never);
+    expect(deleted?.success).toBe(true);
+    expect(service.records.size).toBe(0);
+  });
+});

--- a/packages/agent/src/api/views-routes.runtime-service.real-server.test.ts
+++ b/packages/agent/src/api/views-routes.runtime-service.real-server.test.ts
@@ -144,13 +144,24 @@ async function postJson(
   baseUrl: string,
   path: string,
   body: Record<string, unknown>,
+  expectedStatus = 200,
 ): Promise<Record<string, unknown>> {
   const response = await fetch(`${baseUrl}${path}`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
-  expect(response.status).toBe(200);
+  expect(response.status).toBe(expectedStatus);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+async function getJson(
+  baseUrl: string,
+  path: string,
+  expectedStatus = 200,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(`${baseUrl}${path}`);
+  expect(response.status).toBe(expectedStatus);
   return (await response.json()) as Record<string, unknown>;
 }
 
@@ -247,6 +258,108 @@ describe("runtime-owned view interactions over the real HTTP route", () => {
     const started = await startViewsServer(runtime);
     server = started.server;
 
+    const platform = await getJson(started.baseUrl, "/api/views/platform-info");
+    expect(platform).toMatchObject({
+      dynamicLoadingAllowed: true,
+      prebuiltOnly: false,
+    });
+
+    const list = await getJson(started.baseUrl, "/api/views");
+    expect(list.views).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: VIEW_ID, builtin: false }),
+      ]),
+    );
+
+    const detail = await getJson(started.baseUrl, `/api/views/${VIEW_ID}`);
+    expect(detail).toMatchObject({
+      id: VIEW_ID,
+      label: "Runtime-owned records",
+    });
+
+    const search = await getJson(
+      started.baseUrl,
+      "/api/views/search?q=runtime-owned&limit=1",
+    );
+    expect(search).toMatchObject({ query: "runtime-owned" });
+    expect(search.results).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: VIEW_ID })]),
+    );
+
+    const missing = await getJson(
+      started.baseUrl,
+      "/api/views/missing-runtime-view",
+      404,
+    );
+    expect(missing.error).toBe('View "missing-runtime-view" not found');
+
+    const hero = await fetch(`${started.baseUrl}/api/views/${VIEW_ID}/hero`);
+    expect(hero.status).toBe(200);
+    expect(hero.headers.get("content-type")).toContain("image/svg+xml");
+    expect(await hero.text()).toContain("Runtime-owned records");
+
+    const broadcast = await postJson(
+      started.baseUrl,
+      "/api/views/events/broadcast",
+      { type: "runtime-records:refresh", payload: { source: "test" } },
+    );
+    expect(broadcast).toEqual({
+      ok: true,
+      type: "runtime-records:refresh",
+      payload: { source: "test" },
+    });
+
+    const invalidBroadcast = await postJson(
+      started.baseUrl,
+      "/api/views/events/broadcast",
+      { payload: { source: "test" } },
+      400,
+    );
+    expect(invalidBroadcast.error).toBe('Missing required field "type"');
+
+    const emptySearch = await getJson(started.baseUrl, "/api/views/search?q=");
+    expect(emptySearch).toEqual({ results: [], query: "" });
+
+    const malformedView = await getJson(
+      started.baseUrl,
+      "/api/views/%E0%A4%A",
+      400,
+    );
+    expect(malformedView.error).toBe("Malformed view id");
+
+    const missingResultId = await postJson(
+      started.baseUrl,
+      "/api/views/interact-result",
+      {},
+      400,
+    );
+    expect(missingResultId.error).toBe(
+      "Missing requestId in interact-result body",
+    );
+
+    const undeclared = await postJson(
+      started.baseUrl,
+      `/api/views/${VIEW_ID}/interact`,
+      { capability: "undeclared-record-operation" },
+      400,
+    );
+    expect(undeclared.error).toContain("is not declared");
+
+    const missingUpdate = await postJson(
+      started.baseUrl,
+      `/api/views/${VIEW_ID}/interact`,
+      {
+        capability: "update-record",
+        params: { id: "missing-record", value: "cannot-save" },
+      },
+    );
+    expect(missingUpdate).toMatchObject({
+      success: false,
+      error: 'Record "missing-record" not found.',
+      result: { success: false },
+    });
+    expect(service.records.size).toBe(0);
+
     const created = await postJson(
       started.baseUrl,
       `/api/views/${VIEW_ID}/interact`,
@@ -264,15 +377,55 @@ describe("runtime-owned view interactions over the real HTTP route", () => {
     });
     expect(service.records.get("record-1")).toBe("saved");
 
-    await postJson(started.baseUrl, `/api/views/${VIEW_ID}/activate`, {
+    const navigated = await postJson(
+      started.baseUrl,
+      `/api/views/${VIEW_ID}/navigate`,
+      { payload: { recordId: "record-1" } },
+    );
+    expect(navigated).toMatchObject({
+      ok: true,
+      viewId: VIEW_ID,
+      payload: { recordId: "record-1" },
+    });
+
+    const current = await getJson(started.baseUrl, "/api/views/current");
+    expect(current.currentView).toMatchObject({ viewId: VIEW_ID });
+    expect(current.justSwitched).toBe(true);
+
+    const elements = await postJson(
+      started.baseUrl,
+      `/api/views/${VIEW_ID}/elements`,
+      {
+        elements: [
+          {
+            id: "activate-current",
+            role: "button",
+            label: "Activate current record",
+          },
+        ],
+      },
+    );
+    expect(elements).toMatchObject({ accepted: true, count: 1 });
+
+    const activated = await postJson(
+      started.baseUrl,
+      `/api/views/${VIEW_ID}/activate`,
+      { elementId: "activate-current" },
+    );
+    expect(activated).toMatchObject({
+      ok: true,
       elementId: "activate-current",
+      element: { label: "Activate current record" },
     });
     expect(service.records.get("record-1")).toBe("activated");
 
-    await postJson(started.baseUrl, `/api/views/${VIEW_ID}/navigate`, {});
     const action = buildViewScopedAction(VIEW_ID, scopedAction);
     const deleted = await action.handler(runtime, {} as never);
     expect(deleted?.success).toBe(true);
     expect(service.records.size).toBe(0);
+
+    await expect(action.handler(runtime, {} as never)).rejects.toThrow(
+      "No active record.",
+    );
   });
 });

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -1145,6 +1145,7 @@ export async function handleViewsRoutes(
       broadcastWs: ctx.broadcastWs,
       broadcastWsToClientId: ctx.broadcastWsToClientId,
       clientId: resolveTargetViewClientId(id, req, body),
+      runtime: ctx.runtime ?? undefined,
     });
 
     json(res, {
@@ -1254,7 +1255,9 @@ export async function handleViewsRoutes(
 
     if (typeof entry.serverInteract === "function") {
       try {
-        const result = await entry.serverInteract(capability, params);
+        const result = await entry.serverInteract(capability, params, {
+          runtime: ctx.runtime ?? undefined,
+        });
         ctx.broadcastWs?.({
           type: "view:event",
           viewEventType: `view:${id}:updated`,
@@ -1367,6 +1370,7 @@ interface ViewInteractTransport {
   broadcastWs?: (payload: object) => void;
   broadcastWsToClientId?: (clientId: string, payload: object) => number;
   clientId?: string | null;
+  runtime?: IAgentRuntime;
 }
 
 /**
@@ -1396,7 +1400,9 @@ export async function dispatchViewInteract(
 
   if (typeof entry.serverInteract === "function") {
     try {
-      const result = await entry.serverInteract(capability, params);
+      const result = await entry.serverInteract(capability, params, {
+        runtime: transport.runtime,
+      });
       transport.broadcastWs?.({
         type: "view:event",
         viewEventType: `view:${viewId}:updated`,

--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -46,9 +46,11 @@ const INTERACTIVE_VIEW_ID = "settings_fixture";
 function makeInteractiveView(id: string, mountedIds: Set<string>) {
   const filled: Record<string, string> = {};
   const clicked: string[] = [];
+  const interactionRuntimes: Array<IAgentRuntime | undefined> = [];
   return {
     filled,
     clicked,
+    interactionRuntimes,
     view: {
       id,
       label: `${id} view`,
@@ -79,7 +81,9 @@ function makeInteractiveView(id: string, mountedIds: Set<string>) {
       serverInteract: async (
         capability: string,
         params?: Record<string, unknown>,
+        context?: { runtime?: IAgentRuntime },
       ) => {
+        interactionRuntimes.push(context?.runtime);
         const targetId = typeof params?.id === "string" ? params.id : "";
         if (!mountedIds.has(targetId)) {
           return { ok: false, id: targetId, reason: "element not found" };
@@ -223,18 +227,17 @@ describe("view-scoped action handler drives the interact protocol", () => {
       INTERACTIVE_VIEW_ID,
       settings.view.scopedActions[0],
     );
-    const result = await action.handler(
-      {} as IAgentRuntime,
-      fakeMessage,
-      undefined,
-      { parameters: { provider: "anthropic" } },
-    );
+    const runtime = { agentId: "runtime-owner" } as unknown as IAgentRuntime;
+    const result = await action.handler(runtime, fakeMessage, undefined, {
+      parameters: { provider: "anthropic" },
+    });
 
     expect(result?.success).toBe(true);
     // The fill drove the real serverInteract with the resolved param value…
     expect(settings.filled["provider-select"]).toBe("anthropic");
     // …and the click step ran.
     expect(settings.clicked).toContain("save-button");
+    expect(settings.interactionRuntimes).toEqual([runtime, runtime, runtime]);
     // The step trace is reported for observability.
     expect(result?.data?.steps).toEqual([
       "agent-focus:provider-select",

--- a/packages/agent/src/runtime/view-scoped-actions.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.ts
@@ -171,7 +171,7 @@ export function buildViewScopedAction(
       return getActiveViewContext()?.viewId === viewId;
     },
     handler: async (
-      _runtime: IAgentRuntime,
+      runtime: IAgentRuntime,
       _message: Memory,
       _state?: State,
       options?: unknown,
@@ -235,7 +235,7 @@ export function buildViewScopedAction(
           viewId,
           capability,
           stepParams,
-          broadcastWs ? { broadcastWs } : {},
+          { ...(broadcastWs ? { broadcastWs } : {}), runtime },
           SCOPED_ACTION_STEP_TIMEOUT_MS,
         );
 

--- a/packages/core/src/types/plugin.test.ts
+++ b/packages/core/src/types/plugin.test.ts
@@ -7,8 +7,9 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { Route } from "./plugin";
-import { assertPublicRouteIntent } from "./plugin";
+import type { Route, ViewDeclaration } from "./plugin";
+import { assertPublicRouteIntent, collapseViewDeclarations } from "./plugin";
+import type { IAgentRuntime } from "./runtime";
 
 const READ_REASON = "Read-only public surface for unauthenticated clients.";
 const WRITE_REASON =
@@ -107,5 +108,27 @@ describe("assertPublicRouteIntent — private routes are unaffected", () => {
 	it("accepts a private GET route", () => {
 		const route: Route = { type: "GET", path: "/api/plugin/read" };
 		expect(() => assertPublicRouteIntent(route)).not.toThrow();
+	});
+});
+
+describe("ViewDeclaration server interactions", () => {
+	it("preserves a runtime-aware handler when declarations are collapsed", async () => {
+		const service = { owner: "runtime-owner" };
+		const runtime = {
+			getService: (serviceType: string) =>
+				serviceType === "runtime-owned" ? service : null,
+		} as IAgentRuntime;
+		const view: ViewDeclaration = {
+			id: "runtime-owned-view",
+			label: "Runtime-owned view",
+			serverInteract: async (_capability, _params, context) =>
+				context?.runtime?.getService("runtime-owned"),
+		};
+
+		const [collapsed] = collapseViewDeclarations([view]);
+		expect(collapsed.serverInteract).toBe(view.serverInteract);
+		expect(
+			await collapsed.serverInteract?.("read-owner", undefined, { runtime }),
+		).toBe(service);
 	});
 });

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1015,11 +1015,13 @@ export interface ViewDeclaration {
 	/**
 	 * Optional backend capability handler for operations that do not require a
 	 * mounted UI surface. The view route invokes this before falling back to the
-	 * frontend `view:interact` WebSocket round-trip.
+	 * frontend `view:interact` WebSocket round-trip. Runtime context keeps
+	 * service-backed handlers scoped to the agent that owns the request.
 	 */
 	serverInteract?: (
 		capability: string,
 		params?: Record<string, unknown>,
+		context?: { runtime?: IAgentRuntime },
 	) => Promise<unknown>;
 	/** Allow this view to be pinned as a desktop tab. Default true. */
 	desktopTabEnabled?: boolean;


### PR DESCRIPTION
Closes #16883

## What changed

- Extend `PluginView.serverInteract` with an optional interaction context containing the owning `IAgentRuntime`.
- Pass the exact runtime through direct `/api/views/:id/interact`, `/activate`, and planner-scoped view actions.
- Preserve declared-capability checks, structured failure results, targeted frontend fallback, and view-update broadcasts.
- Add a real loopback HTTP regression with a registered stateful view and runtime-owned service. It creates and updates through `/interact`, mutates through `/activate`, and deletes through the real view-scoped action path.

## Why

Stateful views resolve services from the runtime that owns the request. The shared broker previously invoked `serverInteract(capability, params)` with no runtime, so a view could register and render correctly while every state mutation failed as service unavailable. This is the shared prerequisite for #16871; the feature PR must rebase onto this fix before it is mergeable.

## Impact

The change is additive for plugin authors: existing two-argument handlers continue to work, while stateful handlers can consume `context.runtime`. No rendered UI, persisted schema, prompt, model, or default plugin behavior changes.

## Verification

- Exact head `759257b585fbe628606b0c2c74d305b6dc0235d5` on merge-base `b14a3c55b86957ad05b8c628176f1d842ba4bd51`.
- Exact-head focused runtime suites: agent 4 files / 31 tests and core 1 file / 15 tests pass (46/46 total), including the real loopback stateful-service regression.
- Changed-file coverage passes: `views-routes.ts` 51.49%, `view-scoped-actions.ts` 88.00%, and `plugin.ts` 72.22% (70.57% mean; 50% required). [Exact-head CI coverage transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16884-pr16884-759257b585-changed-file-coverage.log).
- Production files are byte-identical to the previously live-evidenced head; the rebased head adds focused lifecycle coverage only.
- Broader stacked feature verification: 5 files / 47 tests pass.
- Core typecheck passes.
- Biome: all 7 changed files pass.
- Error-policy ratchet passes with no new empty catches or server console calls.
- `git diff --check` passes.
- Exact foundation + opt-in QA plugin live server: ready, responsive, 27 plugins loaded / 0 failed.
- Live HTTP CRUD: note create revision 7, event create revision 8, both deletes complete at revision 10 with zero remaining notes/events.
- Full agent typecheck currently reports unrelated account-contract and plugin-agent-orchestrator drift in untouched files; core typecheck and all changed-path tests are green.

<details>
<summary>Live HTTP broker artifact</summary>

```json
{
  "note": {
    "success": true,
    "requestId": "0fa590a5-e9c8-4502-ab26-a5d752c0e1ef",
    "revision": 7
  },
  "event": {
    "success": true,
    "requestId": "52a9a4ae-235c-43f4-9140-7932b8c4a9af",
    "revision": 8
  },
  "after": {
    "revision": 10,
    "noteCount": 0,
    "eventCount": 0
  }
}
```

</details>

<!-- evidence-row:before-screenshots -->
- [ ] N/A - shared server transport only; no rendered pixels change.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - shared server transport only; no rendered pixels change.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible interaction or animation changes.

<!-- evidence-row:backend-logs -->
- [x] [16884-pr16884-759257b585-runtime-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16884-pr16884-759257b585-runtime-tests.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network-client behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model-selection, or response-grammar behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [16884-pr16884-live-http-domain-artifact.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16884-pr16884-live-http-domain-artifact.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text changed.

