### PR TITLE
test(ui): non-blocking startup hydration invariant — first usable load (first-5 strike F2 port)

### DIFF
--- a/packages/ui/src/state/startup-phase-hydrate.nonblocking.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.nonblocking.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression: runHydrating() must reach HYDRATION_COMPLETE without blocking on
+ * slow/hanging shell-decoration work (first-5 strike F2, ported from
+ * milady-ai/milady#2209).
+ *
+ * On cloud containers getWalletAddresses() was measured at 1.3–12.4 s
+ * (staging median 7.8 s, probe evidence in
+ * projects/eliza-fleet/F5-FIRSTLOAD-2026-07-22.md). eliza's runHydrating
+ * already runs wallet/avatar/autonomy-replay AFTER dispatching
+ * HYDRATION_COMPLETE (decorateShellAfterReady, #15178) — this test pins that
+ * invariant so a future refactor cannot quietly re-await any of them on the
+ * ready critical path. Every decoration dependency hangs FOREVER here; the
+ * dashboard must still become interactive.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StartupEvent } from "./startup-coordinator";
+
+const hangForever = () => new Promise<never>(() => {});
+
+const clientMock = vi.hoisted(() => {
+  const hang = () => new Promise<never>(() => {});
+  return {
+    connectWs: vi.fn(),
+    getBaseUrl: vi.fn(() => "http://127.0.0.1:31337"),
+    // The hangers — must NOT block hydration:
+    getWalletAddresses: vi.fn(() => hang()),
+    getConfig: vi.fn(() => hang()),
+    getStreamSettings: vi.fn(() => hang()),
+  };
+});
+
+vi.mock("../api", () => ({ client: clientMock }));
+vi.mock("../components/apps/load-apps-catalog", () => ({
+  prefetchAppsCatalog: vi.fn(async () => undefined),
+}));
+
+import { type HydratingDeps, runHydrating } from "./startup-phase-hydrate";
+
+function makeDeps(): HydratingDeps {
+  return {
+    setStartupError: vi.fn(),
+    setFirstRunLoading: vi.fn(),
+    hydrateInitialConversationState: vi.fn(async () => null),
+    requestGreetingWhenRunningRef: { current: vi.fn(async () => undefined) },
+    loadWorkbench: vi.fn(async () => {}),
+    loadPlugins: vi.fn(async () => {}),
+    loadSkills: vi.fn(async () => {}),
+    loadCharacter: vi.fn(async () => {}),
+    loadWalletConfig: vi.fn(async () => {}),
+    loadInventory: vi.fn(async () => {}),
+    loadUpdateStatus: vi.fn(async () => {}),
+    checkExtensionStatus: vi.fn(async () => {}),
+    pollCloudCredits: vi.fn(),
+    // Autonomy replay hangs forever — must NOT block hydration.
+    fetchAutonomyReplay: vi.fn(() => hangForever()),
+    setSelectedVrmIndex: vi.fn(),
+    setWalletAddresses: vi.fn(),
+    setTab: vi.fn(),
+    setTabRaw: vi.fn(),
+    initialTabSetRef: { current: false },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  window.history.replaceState(null, "", "/");
+});
+
+describe("runHydrating — non-blocking first-load (F2)", () => {
+  it("dispatches HYDRATION_COMPLETE even when wallet, config, stream settings, and autonomy replay all hang forever", async () => {
+    const deps = makeDeps();
+    const events: StartupEvent[] = [];
+
+    // Must resolve quickly. If any hanging decoration is awaited before
+    // HYDRATION_COMPLETE, this rejects on the timeout instead.
+    await Promise.race([
+      runHydrating(deps, (event) => events.push(event), { current: false }),
+      new Promise((_resolve, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                "runHydrating blocked on non-critical shell decoration",
+              ),
+            ),
+          3_000,
+        ),
+      ),
+    ]);
+
+    expect(events).toContainEqual({ type: "HYDRATION_COMPLETE" });
+  });
+
+  it("defers the wallet fetch off the ready critical path but still kicks it off", async () => {
+    const deps = makeDeps();
+    const events: StartupEvent[] = [];
+
+    await runHydrating(deps, (event) => events.push(event), {
+      current: false,
+    });
+
+    expect(events).toContainEqual({ type: "HYDRATION_COMPLETE" });
+    // The fetch was started (background decoration)…
+    expect(clientMock.getWalletAddresses).toHaveBeenCalledTimes(1);
+    // …but since it never resolves, the setter must not have run by the time
+    // hydration completed — proving the await is NOT on the critical path.
+    expect(deps.setWalletAddresses).not.toHaveBeenCalled();
+  });
+
+  it("does not await the autonomy replay before completing hydration", async () => {
+    const deps = makeDeps();
+    const events: StartupEvent[] = [];
+
+    await runHydrating(deps, (event) => events.push(event), {
+      current: false,
+    });
+
+    expect(events).toContainEqual({ type: "HYDRATION_COMPLETE" });
+    expect(deps.fetchAutonomyReplay).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What & why

Ports the non-blocking-startup regression contract from **milady-ai/milady#2209**
(wrong repo — the demo deploys from here) to `elizaOS/eliza`.

**The milady _code_ fix is not needed on this repo.** eliza's
`runHydrating()` already runs every shell-decoration fetch
(`getWalletAddresses`, `getConfig`, `getStreamSettings`, `fetchAutonomyReplay`)
inside `decorateShellAfterReady()`, fired **after** `dispatch({ type: "HYDRATION_COMPLETE" })`
(the #15178 lineage; last touch #16292). The serial-await structure milady#2209
targeted does not exist on this path.

So this PR lands the durable piece: a **regression test** that pins that
deferral so a future refactor cannot silently re-await a slow decoration call
on the ready critical path (the exact regression class milady#2209 fixed).

`packages/ui/src/state/startup-phase-hydrate.nonblocking.test.ts` — hangs every
non-critical dependency forever and proves:
- `HYDRATION_COMPLETE` still fires (<3s);
- the wallet fetch is kicked off but its setter never runs before completion →
  proves it's off the critical path;
- autonomy replay is invoked but never awaited pre-completion.

## Where the demo stall actually is (receipts)

A live staging startup-trace (`window.__ELIZA_STARTUP_TRACE__`, #9565) shows the
canary's ~13.6s post-login stall is **not** in the hydrate window:

| coordinator mark | at (ms) |
|---|---:|
| first-run-required | 1763 |
| **starting-runtime** | **14195** |
| hydrating | 14208 |
| ready | 18365 |

The 12.4s cost is `first-run-required → starting-runtime` (login/session establish
+ agent-base resolution), and `hydrating → ready` (~4s) is dominated by the
post-ready agent-base fetch waterfall + lazy chunk loads — not the awaits
milady#2209 removed. Full decomposition + follow-up levers in
`projects/eliza-fleet/F2-PORT-2026-07-22.md`.

## Test evidence

```
bun run test -- src/state/startup-phase-hydrate
 ✓ …nonblocking.test.ts (3)     <-- new
 Test Files  6 passed (6)   Tests  37 passed (37)
biome check …nonblocking.test.ts → clean
```

Reference: milady-ai/milady#2209
Part of the first-5-minutes demo strike (F2 port).

Co-authored-by: shadow <shadow@shad0w.xyz>
