### PR TITLE
feat(embeddings): flag-gated local-primary restore for lean-chat cloud agents

### DIFF
--- a/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
@@ -3,7 +3,7 @@
  * minimal conversational seed is kept while heavy coding/browser/orchestrator/
  * local-inference/wallet/workflow surfaces are force-dropped even when config
  * allow-lists or env request them, and elizacloud stays for a cloud agent.
- * Deterministic — env-driven over an in-memory ElizaConfig, no live model.
+ * Deterministic - env-driven over an in-memory ElizaConfig, no live model.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -22,6 +22,8 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_ENABLED",
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS",
+  "ELIZAOS_CLOUD_USE_EMBEDDINGS",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -106,9 +108,42 @@ describe("collectPluginNames lean-chat plugin set (#8434)", () => {
     expect(names.has("@elizaos/plugin-workflow")).toBe(false);
   });
 
+  it("restores local-primary embeddings for lean-chat when ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1 (opt-in, default OFF)", () => {
+    // Local-primary restore (sol-emb-restore): local gte-small is 17–48ms vs the
+    // cloud ~250ms round-trip, so an opt-in flag re-keeps plugin-local-inference
+    // in a lean-chat agent so it wins TEXT_EMBEDDING. Default OFF (asserted by
+    // the force-exclude test above); when ON it keeps the local embedder AND
+    // yields the cloud embedding slot so both don't register.
+    process.env.ELIZA_PLUGIN_SET = "lean-chat";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS = "1";
+    const names = collectPluginNames(emptyConfig);
+    expect(names.has("@elizaos/plugin-local-inference")).toBe(true);
+    // Cloud embedding slot yielded so plugin-elizacloud doesn't also register.
+    expect(process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
+    // The rest of the lean exclusions still hold - only local-inference is kept.
+    expect(names.has("@elizaos/plugin-shell")).toBe(false);
+    expect(names.has("@elizaos/plugin-coding-tools")).toBe(false);
+    expect(names.has("@elizaos/plugin-wallet")).toBe(false);
+  });
+
+  it("honors an explicit cloud-embeddings pin over the local-primary opt-in", () => {
+    // If an operator has deliberately pinned ELIZAOS_CLOUD_USE_EMBEDDINGS=true
+    // (a dedicated cloud agent whose 1536-dim store must stay consistent), the
+    // opt-in must NOT override it - local stays excluded and cloud keeps the
+    // slot. This protects the #9911 hot-flip-recall-degradation class.
+    process.env.ELIZA_PLUGIN_SET = "lean-chat";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS = "1";
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "true";
+    const names = collectPluginNames(emptyConfig);
+    expect(names.has("@elizaos/plugin-local-inference")).toBe(false);
+    expect(process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("true");
+  });
+
   it("keeps plugin-elizacloud for a lean CLOUD agent (cloud serves models + 1536 embeddings)", () => {
     // A lean dedicated cloud agent drops local-inference but MUST keep
-    // elizacloud — that is the inference + 1536-embedding provider for the
+    // elizacloud - that is the inference + 1536-embedding provider for the
     // cloud chat path. Dropping both would leave the agent with no model.
     process.env.ELIZA_PLUGIN_SET = "lean-chat";
     process.env.ELIZAOS_CLOUD_ENABLED = "true";

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -792,7 +792,42 @@ export function collectPluginNames(
   // gitpathologist .git auto-detect, config allow-list) added them, so a
   // lean-chat agent is guaranteed minimal. (#8434)
   if (leanChat) {
+    // OPT-IN local-primary embeddings for lean-chat cloud agents.
+    //
+    // #8762 excluded @elizaos/plugin-local-inference from lean-chat entirely
+    // because on a cloud container the on-device gte-small GGUF (a) ran
+    // 1.5-98s/batch on the contended CPU and (b) emitted 384-dim vectors into
+    // a 1536-dim column, dropping every insert. That was the right default at
+    // the time. But local gte-small is now measured at 17-48ms/embed on the
+    // live VPS, 10-20x faster than the cloud OpenAI round-trip (~250ms), so
+    // for a cloud agent whose store is re-provisioned at gte-small's 384-dim
+    // width, local-primary is a strict win on the always-on recall hot path.
+    //
+    // Gated behind ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS (default OFF): a hot flip
+    // for EXISTING 1536-dim agents would degrade recall until re-embedded
+    // (#9911 failure class), so this stays opt-in and rolls out per-agent with
+    // a backfill. When the flag is set, keep plugin-local-inference loaded so
+    // it can win the TEXT_EMBEDDING registration, and signal the cloud plugin
+    // to yield the slot (ELIZAOS_CLOUD_USE_EMBEDDINGS=false unless the operator
+    // explicitly pinned it true) so the two providers don't both register.
+    const localEmbeddingsOptIn =
+      readAliasedEnv("ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS") === "1" &&
+      process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS?.trim().toLowerCase() !== "true";
     for (const name of LEAN_CHAT_EXCLUDED_PLUGINS) {
+      if (localEmbeddingsOptIn && name === "@elizaos/plugin-local-inference") {
+        // Keep the local embedder; ensure it wins TEXT_EMBEDDING over cloud.
+        pluginsToLoad.add(name);
+        track(
+          name,
+          "lean-chat local-primary embeddings (ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1)",
+        );
+        // Yield the cloud embedding slot so plugin-elizacloud does not also
+        // register TEXT_EMBEDDING (registerCloudEmbeddingModels checks this).
+        if (!process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS) {
+          process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
+        }
+        continue;
+      }
       pluginsToLoad.delete(name);
     }
   }

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -180,7 +180,7 @@ describe("managed Eliza environment", () => {
       agentSandboxId: "cloud-agent-1",
     });
 
-    // Local agent-state on the persistent volume — no shared-DB hot path.
+    // Local agent-state on the persistent volume - no shared-DB hot path.
     expect(result.environmentVars.ELIZA_AGENT_LOCAL_STATE).toBe("1");
     expect(result.environmentVars.PGLITE_DATA_DIR).toBe("/root/.eliza/.pgdata");
     // Lean chat plugin set for fast cold-start.
@@ -210,7 +210,7 @@ describe("managed Eliza environment", () => {
     // The provisioning Worker/daemon carries its OWN DATABASE_URL in process env,
     // which spreads in via existingEnv. If it leaks through, the agent's
     // resolveEffectiveDbProvider selects Postgres and silently overrides
-    // ELIZA_AGENT_LOCAL_STATE=1 — forcing every local-state agent back onto the
+    // ELIZA_AGENT_LOCAL_STATE=1 - forcing every local-state agent back onto the
     // shared Railway DB (the latency + blast-radius regression #8779 had to
     // restore the strip for). The strip is THE mechanism; guard it directly.
     const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
@@ -236,7 +236,7 @@ describe("managed Eliza environment", () => {
     // the cloud TEXT_EMBEDDING handler EMIT 1536-wide vectors. plugin-sql does NOT
     // read these vars; the storage column is sized at boot by the model-length
     // probe (runtime.ensureEmbeddingDimension). Both must agree on 1536 or the boot
-    // probe snaps the column to a width the handler's output won't match —
+    // probe snaps the column to a width the handler's output won't match -
     // re-introducing "Skipping embedding insert: dimension mismatch" (#8769).
     const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
 
@@ -296,6 +296,35 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
     expect(result.ELIZAOS_CLOUD_LARGE_MODEL).toBeTruthy();
   });
 
+  test("local-primary embedding opt-in yields cloud embeddings and uses 384-dim hints", async () => {
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const result = applyManagedAgentInferenceEnvDefaults({
+      ELIZA_PLUGIN_SET: "lean-chat",
+      ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "1",
+    });
+
+    expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
+    expect(result.EMBEDDING_DIMENSION).toBe("384");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
+    // Keep the fallback URL available for rollback/mobile/no-model paths; the
+    // use-embeddings flag is what prevents cloud from registering primary.
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_URL).toBeTruthy();
+  });
+
+  test("explicit cloud-embedding pin wins over local-primary opt-in", async () => {
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const result = applyManagedAgentInferenceEnvDefaults({
+      ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "1",
+      ELIZAOS_CLOUD_USE_EMBEDDINGS: "true",
+    });
+
+    expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
+    expect(result.EMBEDDING_DIMENSION).toBe("1536");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+  });
+
   test("preserves explicit per-agent overrides", async () => {
     const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
 
@@ -343,7 +372,7 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
     expect(healed.ELIZAOS_CLOUD_SMALL_MODEL).toBeTruthy();
     expect(healed.ELIZAOS_CLOUD_LARGE_MODEL).toBeTruthy();
     // ...and the stored env is preserved verbatim (no key rotation, no DB strip,
-    // no state flip — the whole point of the narrow helper).
+    // no state flip - the whole point of the narrow helper).
     expect(healed.DATABASE_URL).toBe("postgres://agent/own-db");
     expect(healed.ELIZA_API_TOKEN).toBe("agent_existingtoken");
     expect(healed.ELIZAOS_CLOUD_API_KEY).toBe("sk-existing");

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
@@ -17,8 +17,8 @@ const DEV_ELIZA_APP_ORIGINS = [
 ] as const;
 /**
  * Platform-reserved env keys for the managed agent path. Aliases the shared
- * {@link RESERVED_PLATFORM_ENV_KEYS} denylist — single source of truth, also
- * enforced on the Apps deploy path — and stays a named export for existing
+ * {@link RESERVED_PLATFORM_ENV_KEYS} denylist - single source of truth, also
+ * enforced on the Apps deploy path - and stays a named export for existing
  * importers (the agent environment route).
  */
 export const RESERVED_MANAGED_ELIZA_ENV_KEYS = RESERVED_PLATFORM_ENV_KEYS;
@@ -184,31 +184,45 @@ export function mergeManagedPublicBaseUrl(
 /**
  * The cloud-managed inference defaults: the embedding endpoint + the cloud
  * embedding handler's OUTPUT dimensions, and the Cerebras-direct small/large
- * model pins. Pure and single-source-of-truth — both the provision path (via
+ * model pins. Pure and single-source-of-truth - both the provision path (via
  * prepareManagedElizaBaseEnvironment) and the blue/green fleet-upgrade path
  * (eliza-sandbox.ts) backfill these onto an agent's stored env so an agent
- * provisioned BEFORE these pins landed heals on upgrade (#8434). Returns ONLY
- * these 5 keys; an explicit per-agent value always wins.
+ * provisioned BEFORE these pins landed heals on upgrade (#8434). An explicit
+ * per-agent value always wins.
+ *
+ * Local-primary restore: when a managed lean-chat agent opts in with
+ * ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1, keep cloud text generation defaults but
+ * stop pinning the cloud embedding handler as primary. The local gte-small
+ * handler emits 384-d vectors, so the managed defaults also move the embedding
+ * dimension hints to 384 for that agent. This is deliberately per-agent and
+ * flag-gated: existing 1536-d stores must be re-embedded/backfilled before the
+ * flag is enabled or recall can degrade (#9911 class).
  *
  * NOTE on dimensions: EMBEDDING_DIMENSION / ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS
  * set the width of the vectors the plugin-elizacloud TEXT_EMBEDDING handler
- * EMITS (1536). They do NOT size the plugin-sql storage column — plugin-sql
- * never reads either var. The storage column width is decided at boot by
- * runtime.ensureEmbeddingDimension(), which probes the registered cloud
- * embedding handler's actual vector length and snaps the column to dim1536.
- * That probe must run before bundled docs are seeded; that boot ordering was
- * the real no-memory bug (#8769) — fixed in packages/agent/src/runtime/eliza.ts,
- * not here. Keeping these env pins ensures the handler emits 1536-wide vectors
- * for the probe to detect.
+ * EMITS when cloud embeddings are enabled (1536 by default, 384 for the
+ * local-primary opt-in so all probes/storage hints agree). They do NOT size the
+ * plugin-sql storage column - plugin-sql never reads either var. The storage
+ * column width is decided at boot by runtime.ensureEmbeddingDimension(), which
+ * probes the registered embedding handler's actual vector length and snaps the
+ * column to that dimension. That probe must run before bundled docs are seeded;
+ * that boot ordering was the real no-memory bug (#8769) - fixed in
+ * packages/agent/src/runtime/eliza.ts, not here.
  */
 export function applyManagedAgentInferenceEnvDefaults(
   existingEnv: Record<string, string>,
 ): Record<string, string> {
+  const localPrimaryEmbeddings =
+    existingEnv.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS === "1" &&
+    existingEnv.ELIZAOS_CLOUD_USE_EMBEDDINGS?.trim().toLowerCase() !== "true";
+  const embeddingDimension = localPrimaryEmbeddings ? "384" : "1536";
   return {
+    ...(localPrimaryEmbeddings ? { ELIZAOS_CLOUD_USE_EMBEDDINGS: "false" } : {}),
     ELIZAOS_CLOUD_EMBEDDING_URL:
       existingEnv.ELIZAOS_CLOUD_EMBEDDING_URL ?? resolveCloudApiBaseUrl(),
-    EMBEDDING_DIMENSION: existingEnv.EMBEDDING_DIMENSION ?? "1536",
-    ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS: existingEnv.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS ?? "1536",
+    EMBEDDING_DIMENSION: existingEnv.EMBEDDING_DIMENSION ?? embeddingDimension,
+    ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS:
+      existingEnv.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS ?? embeddingDimension,
     ELIZAOS_CLOUD_SMALL_MODEL:
       existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
     ELIZAOS_CLOUD_LARGE_MODEL:
@@ -224,8 +238,8 @@ export async function prepareManagedElizaBaseEnvironment(
   // (RESERVED_MANAGED_ELIZA_ENV_KEYS); the sandbox layer
   // (computeManagedAgentDbEnv in eliza-sandbox.ts) is the SOLE authority on the
   // agent's DB env. Strip any inherited value here so the control-plane's OWN
-  // DATABASE_URL — which the cloud Worker / provisioning daemon carries in its
-  // process env and which spreads in through params.existingEnv — cannot leak
+  // DATABASE_URL - which the cloud Worker / provisioning daemon carries in its
+  // process env and which spreads in through params.existingEnv - cannot leak
   // into the agent and silently override ELIZA_AGENT_LOCAL_STATE=1. That leak
   // forced every "local-state" agent onto the remote shared Railway Postgres
   // (~166ms/query x dozens of serial reads+writes per turn = the dominant
@@ -251,7 +265,7 @@ export async function prepareManagedElizaBaseEnvironment(
       ELIZA_API_TOKEN: apiToken,
       ELIZA_ALLOW_WS_QUERY_TOKEN: "1",
       ELIZA_ALLOWED_ORIGINS: mergeManagedAllowedOrigins(existingEnv.ELIZA_ALLOWED_ORIGINS),
-      // Public web UI on by default — users access it via the agent
+      // Public web UI on by default - users access it via the agent
       // subdomain (https://<agent-id>.elizacloud.ai), gated by
       // ELIZA_API_TOKEN at the agent-router. Set ELIZA_UI_ENABLE=false in
       // existingEnv to opt out per-agent.
@@ -259,19 +273,17 @@ export async function prepareManagedElizaBaseEnvironment(
       ELIZAOS_CLOUD_API_KEY: agentApiKey,
       ELIZAOS_CLOUD_ENABLED: "true",
       ELIZAOS_CLOUD_BASE_URL: resolveCloudApiBaseUrl(),
-      // Cloud-managed inference defaults: pin embeddings to the elizacloud Worker
-      // base (whose POST /embeddings serves 1536-dim text-embedding-3-small —
-      // without it the plugin falls back to the Cerebras/BitRouter text base with
-      // no /embeddings route → 503), pin BOTH embedding-output dimensions to 1536
-      // so the cloud TEXT_EMBEDDING handler EMITS 1536-wide vectors (these vars
-      // size the handler's output, NOT the plugin-sql storage column — plugin-sql
-      // ignores them; the column width is set at boot by the model-length probe,
-      // ensureEmbeddingDimension, see applyManagedAgentInferenceEnvDefaults above
-      // and the #8769 boot-order fix in packages/agent/src/runtime/eliza.ts), and
-      // pin the healthy Cerebras-direct small/large models so the container never
-      // resolves a tier to the `:nitro` default. Shared single-source helper so
-      // the fleet-upgrade path re-applies the same defaults (#8434). Each value
-      // still honors an explicit per-agent override in existingEnv.
+      // Cloud-managed inference defaults: by default pin embeddings to the
+      // elizacloud Worker base (whose POST /embeddings serves 1536-dim
+      // text-embedding-3-small - without it the plugin falls back to the
+      // Cerebras/BitRouter text base with no /embeddings route -> 503), pin
+      // BOTH embedding-output dimensions to the handler's output width, and pin
+      // the healthy Cerebras-direct small/large models so the container never
+      // resolves a tier to the `:nitro` default. For the explicit
+      // ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1 rollout lane, the helper yields the
+      // cloud embedding slot and uses 384-dim hints so local gte-small,
+      // ensureEmbeddingDimension, and storage agree. Each value still honors an
+      // explicit per-agent override in existingEnv.
       ...applyManagedAgentInferenceEnvDefaults(existingEnv),
       // New managed agents keep agent-state in a LOCAL in-container DB (PGlite on
       // the persistent /root/.eliza volume) instead of the shared cloud Postgres;
@@ -279,7 +291,7 @@ export async function prepareManagedElizaBaseEnvironment(
       // This removes the shared-Postgres connection hot path that caused the
       // "too many clients" incident (#8696). The flag is read at container-create
       // time (eliza-sandbox.ts): only agents PROVISIONED with it set go local, so
-      // existing agents keep their shared-DB state untouched — a forward cutover
+      // existing agents keep their shared-DB state untouched - a forward cutover
       // with no migration. Set ELIZA_AGENT_LOCAL_STATE=0 to provision a new agent
       // on the shared DB instead. PGLITE_DATA_DIR is pinned under the persistent
       // mount so local state survives container restarts.
@@ -289,7 +301,7 @@ export async function prepareManagedElizaBaseEnvironment(
       // browser/orchestrator) for fast cold-start (#8434). Override per agent by
       // pinning ELIZA_PLUGIN_SET to another value at create.
       ELIZA_PLUGIN_SET: existingEnv.ELIZA_PLUGIN_SET ?? "lean-chat",
-      // Lean Postgres pool — only applies to agents still on the SHARED DB
+      // Lean Postgres pool - only applies to agents still on the SHARED DB
       // (existing agents, or new agents provisioned with ELIZA_AGENT_LOCAL_STATE=0).
       // The default per-agent pool (max 20 / min 2) exhausts the server's
       // max_connections at scale (50 idle agents × min 2 = 100). Cap bursts at 8


### PR DESCRIPTION
## Why

Cloud dedicated agents have been silently paying ~250ms-5s per embedding round-trip since June. Forensics:

- **#8664** (`3132514e67c`, Jun 19) pinned managed agents to the elizacloud Worker embedding route (OpenAI text-embedding-3-small, 1536-dim) to fix a real 404->503.
- **#8762** (`cf614e9bca9`, Jun 20) excluded `@elizaos/plugin-local-inference` from lean-chat entirely, because gte-small ran 1.5-98s/batch on then-contended container CPU and its 384-dim output was dropped against 1536-dim columns.
- **#16630/#16701** (Jul 20) restored runtime local-primary ordering, but every managed agent boots `ELIZA_PLUGIN_SET=lean-chat`, so the #8762 exclusion strips the local embedder before runtime ordering matters. Verified live on staging: `/api/runtime` shows `pinnedEmbeddingProvider=elizaOSCloud`, `dim1536`.

The #8762 premise no longer holds: local gte-small now measures **17-48ms/embed** on live VPS containers, 10-20x faster than the cloud round-trip (synchronous PATCH re-embeds measured at 1.7-5.1s on staging).

## What

`ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1` (**default OFF**, zero behavior change without the flag) opts a lean-chat cloud agent into local-primary embeddings:

- **plugin-collector**: keeps `@elizaos/plugin-local-inference` in the lean-chat set for opted-in agents and yields the cloud TEXT_EMBEDDING slot (`ELIZAOS_CLOUD_USE_EMBEDDINGS=false`) unless the operator explicitly pinned it `true`.
- **managed-eliza-config**: `applyManagedAgentInferenceEnvDefaults` emits 384-dim hints + the yield flag for opted-in agents so the local handler, the `ensureEmbeddingDimension` boot probe, and storage agree. The Worker URL pin (#8664) is retained as rollback/mobile/no-model fallback.

## Rollout safety

- Per-agent, migration-based: existing 1536-dim stores must be re-embedded before flipping (avoids the #9911 recall-degradation class). Audited corpora are tiny (staging central PG: 4 embeddings; 11 sampled dedicated agents: 290 memories total; ~0.7s backfill per agent at 48ms/embed).
- Explicit `ELIZAOS_CLOUD_USE_EMBEDDINGS=true` always wins over the opt-in.
- Ops tooling (re-embed backfill script + embedding provider/latency canary probe) lives fleet-side.

## Tests

- lean-chat collector: default-off exclusion unchanged, opt-in keeps local + yields cloud, explicit cloud pin wins
- managed-config: default 1536 path byte-identical, opt-in emits 384 + yield, per-agent overrides preserved (19 pass)