### PR TITLE
ci: defer heavy promotion PR workflows

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -19,7 +19,7 @@ on:
       - "packages/lifeops-bench/**"
       - ".github/workflows/benchmark-tests.yml"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/lifeops-bench/**"
       - ".github/workflows/benchmark-tests.yml"

--- a/.github/workflows/browser-real-bench.yml
+++ b/.github/workflows/browser-real-bench.yml
@@ -18,7 +18,7 @@ on:
     - cron: "0 10 * * *"
   workflow_dispatch: {}
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "plugins/plugin-browser/src/benchmark/**"
       - "plugins/plugin-browser/vitest.real.config.ts"
@@ -29,7 +29,7 @@ on:
 
 concurrency:
   group: browser-real-bench-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lifeops-bench-manifest.yml
+++ b/.github/workflows/lifeops-bench-manifest.yml
@@ -21,7 +21,7 @@ name: LifeOps Action Manifest Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "plugins/plugin-personal-assistant/**"
       - "plugins/plugin-contacts/**"
@@ -38,7 +38,7 @@ on:
 
 concurrency:
   group: lifeops-bench-manifest-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lifeops-bench-multi-tier.yml
+++ b/.github/workflows/lifeops-bench-multi-tier.yml
@@ -20,7 +20,7 @@ name: LifeOps Benchmark — Multi-Tier
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/**"
       - "plugins/plugin-training/**"
@@ -45,7 +45,7 @@ on:
 
 concurrency:
   group: lifeops-bench-multi-tier-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lifeops-bench-python.yml
+++ b/.github/workflows/lifeops-bench-python.yml
@@ -27,7 +27,7 @@ name: LifeOpsBench (Python)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/lifeops-bench/**"
       - "packages/benchmarks/eliza-adapter/eliza_adapter/lifeops_bench.py"
@@ -70,7 +70,7 @@ on:
 
 concurrency:
   group: lifeops-bench-python-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lifeops-bench.yml
+++ b/.github/workflows/lifeops-bench.yml
@@ -21,7 +21,7 @@ name: LifeOps Benchmark
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "plugins/plugin-personal-assistant/**"
       - "plugins/plugin-training/**"
@@ -47,7 +47,7 @@ on:
 
 concurrency:
   group: lifeops-bench-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lifeops-quality-bench.yml
+++ b/.github/workflows/lifeops-quality-bench.yml
@@ -22,7 +22,7 @@ name: lifeops-quality-bench
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/lifeops-quality/**"
       - "plugins/plugin-inbox/src/inbox/**"
@@ -38,7 +38,7 @@ on:
 
 concurrency:
   group: lifeops-quality-bench-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: "canary"

--- a/.github/workflows/loadperf.yml
+++ b/.github/workflows/loadperf.yml
@@ -5,7 +5,7 @@ on:
     # Daily at 09:17 UTC, after the normal nightly lanes have had time to settle.
     - cron: "17 9 * * *"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - ".github/workflows/loadperf.yml"
       - "packages/benchmarks/loadperf/**"
@@ -29,7 +29,7 @@ on:
 
 concurrency:
   group: loadperf-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/local-inference-bench.yml
+++ b/.github/workflows/local-inference-bench.yml
@@ -26,7 +26,7 @@ on:
     # 04:30 UTC Sunday — weekly eliza-1 model publish window.
     - cron: "30 4 * * 0"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/scripts/benchmark/**"
       - ".github/workflows/local-inference-bench.yml"
@@ -54,7 +54,7 @@ on:
 
 concurrency:
   group: local-inference-bench-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write

--- a/.github/workflows/local-inference-matrix.yml
+++ b/.github/workflows/local-inference-matrix.yml
@@ -35,7 +35,7 @@ on:
         type: boolean
         default: false
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/app-core/src/services/local-inference/**"
       - "packages/scripts/local-inference-ablation.mjs"
@@ -46,7 +46,7 @@ on:
 
 concurrency:
   group: local-inference-matrix-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -2,7 +2,7 @@ name: Markdown Links
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
     paths:
       - "**/*.md"
       - "scripts/check-markdown-links.mjs"

--- a/.github/workflows/memperf.yml
+++ b/.github/workflows/memperf.yml
@@ -13,7 +13,7 @@ name: memperf
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/memperf/**"
       - "plugins/plugin-local-inference/src/services/memory-arbiter.ts"
@@ -26,7 +26,7 @@ on:
 
 concurrency:
   group: memperf-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   harness-gate:

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: standalone
   pull_request:
-    branches: [main]
+    branches: [develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/mobile-resource-workbench.yml
+++ b/.github/workflows/mobile-resource-workbench.yml
@@ -25,7 +25,7 @@ on:
     # 05:30 UTC — after the nightly publish window, like local-inference-bench.
     - cron: "30 5 * * *"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/mobile-resource/**"
       - ".github/workflows/mobile-resource-workbench.yml"
@@ -50,7 +50,7 @@ on:
 
 concurrency:
   group: mobile-resource-workbench-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   harness-smoke:

--- a/.github/workflows/recall-bench.yml
+++ b/.github/workflows/recall-bench.yml
@@ -18,7 +18,7 @@ name: recall-bench
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/recall-bench/**"
       - "packages/benchmarks/registry/**"
@@ -34,7 +34,7 @@ on:
 
 concurrency:
   group: recall-bench-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   recall-gate:

--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -47,7 +47,7 @@ name: Terraform — Apps Data Plane (Hetzner)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/**"
       - ".github/workflows/terraform-apps-data-plane.yml"

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -27,7 +27,7 @@ name: Terraform — Apps Shared (Hetzner)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/cloud/infra/cloud/terraform/hetzner/apps-shared/**"
       - ".github/workflows/terraform-apps-shared.yml"

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -29,7 +29,7 @@ name: Terraform — Control Plane (Hetzner)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/cloud/infra/cloud/terraform/hetzner/control-plane/**"
       - ".github/workflows/terraform-control-plane.yml"

--- a/.github/workflows/terraform-pages-domains.yml
+++ b/.github/workflows/terraform-pages-domains.yml
@@ -2,7 +2,7 @@ name: Terraform — Cloudflare Pages Domains
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
     paths:
       - "packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/**"
       - "packages/cloud/infra/tests/terraform-static.test.ts"

--- a/.github/workflows/view-bundle-size.yml
+++ b/.github/workflows/view-bundle-size.yml
@@ -16,7 +16,7 @@ name: view-bundle-size
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       # Plugin source (where view components live) + the view-bundle build/config
       # + the gate itself. Scheduled runs below are the catch-all for drift.
@@ -34,7 +34,7 @@ on:
 
 concurrency:
   group: view-bundle-size-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   size-gate:

--- a/.github/workflows/voice-bench-smoke.yml
+++ b/.github/workflows/voice-bench-smoke.yml
@@ -14,6 +14,7 @@ name: Voice Benchmark Smoke
 
 on:
   push:
+    branches: [main]
     paths:
       - "packages/benchmarks/voicebench/**"
       - "packages/benchmarks/voicebench-quality/**"
@@ -22,7 +23,7 @@ on:
       - "scripts/bench-voice.mjs"
       - ".github/workflows/voice-bench-smoke.yml"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "packages/benchmarks/voicebench/**"
       - "packages/benchmarks/voicebench-quality/**"
@@ -39,7 +40,7 @@ on:
 
 concurrency:
   group: voice-bench-smoke-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default to least privilege. Override per-job where needed.
 permissions:

--- a/.github/workflows/voice-workbench.yml
+++ b/.github/workflows/voice-workbench.yml
@@ -19,6 +19,7 @@ name: Voice Workbench
 
 on:
   push:
+    branches: [main]
     paths:
       - "plugins/plugin-local-inference/src/services/voice/voice-scenario.ts"
       - "plugins/plugin-local-inference/src/services/voice/e2e-harness.ts"
@@ -39,7 +40,7 @@ on:
       - "packages/shared/src/voice/owner-inference.ts"
       - ".github/workflows/voice-workbench.yml"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "plugins/plugin-local-inference/src/services/voice/voice-scenario.ts"
       - "plugins/plugin-local-inference/src/services/voice/e2e-harness.ts"
@@ -66,7 +67,7 @@ on:
 
 concurrency:
   group: voice-workbench-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The long-lived `develop` -> `main` promotion PR is synchronized after every develop merge. Heavy non-required workflows targeting PR base `main` then rerun against the cumulative promotion diff, producing repeated queue fan-out during hackathon mode.

## What changed

- retarget 22 benchmark/performance/plan workflows from PR base `main` to feature PR base `develop`
- preserve all existing path filters, schedule triggers, manual dispatch, jobs, scripts, assertions, and matrices
- constrain the two broad voice benchmark push triggers to `main`
- scope existing concurrency cancellation to pull-request events, preserving schedule/manual/push runs

## Explicitly preserved

- no required check changed
- no check semantics or thresholds weakened
- no Cloud CF, security, gitleaks, stale-base, Windows CI, core Tests/Quality, or zero-key workflow changed
- promotion to `main` still receives the already-validated develop commits; nightly/manual coverage remains available

## Validation

- `git diff --check`
- all 159 workflow YAML files parsed successfully
- diff scope verified as workflow YAML only
- model 1 implementation/review: Codex
- model 2 independent review: PASS, no blocking findings

## Rollback

Revert commit `61163a995ec` to restore all previous triggers and concurrency settings.

## Merge gate

**DUAL-MODEL REVIEW REQUIRED: COMPLETE (2/2 PASS)**

**SHADOW EYEBALL REQUIRED BEFORE MERGE**

**NO SELF-MERGE**
