### PR TITLE
fix(android): persist opted-in LP3 color mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "dev:cloud:web": "bun run --cwd packages/app dev",
     "build:cloud": "bun run --cwd packages/cloud/api build",
     "build:android:cloud": "node packages/app-core/scripts/run-mobile-build.mjs android-cloud",
+    "build:android:lp3-cloud:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 node packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:system": "node packages/app-core/scripts/run-mobile-build.mjs android-system",
     "test:cloud": "node packages/scripts/test-cloud-run.mjs",
     "test:cloud:helpers:self-test": "node packages/scripts/test-cloud-run-helpers.self-test.mjs",

--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -88,6 +88,78 @@ renderer reads this via
 and the `RuntimeSettingsSection` hides the Local picker option so users
 cannot try to provision an on-device agent that physically isn't there.
 
+## `build:android:lp3-cloud:debug` — direct LP3 Cloud APK
+
+```bash
+bun run --cwd packages/app build:android:lp3-cloud:debug
+```
+
+This explicit direct-distribution variant keeps the Cloud-only renderer but
+adds the Light Phone III display-color guard from issue #16888. It is not a
+Play artifact: the build preserves a `specialUse` foreground service, boot
+receiver, and `WRITE_SECURE_SETTINGS` solely when
+`ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1`. Ordinary `android-cloud` and
+`android-cloud-debug` builds strip the components, Java sources, and all three
+policy permissions.
+
+The build flag alone cannot activate the guard. On a Light/TLP301 device, the
+operator must grant the declared privileged permission, then send the explicit
+enable command as the debuggable app's own UID. The unexported receiver stores
+the opt-in in device-protected private preferences:
+
+```bash
+adb shell pm grant ai.elizaos.app android.permission.WRITE_SECURE_SETTINGS
+adb shell am start -W -n ai.elizaos.app/.MainActivity
+adb shell dumpsys activity activities | grep topResumedActivity
+adb shell run-as ai.elizaos.app am broadcast \
+  -n ai.elizaos.app/ai.elizaos.app.Lp3ColorPolicyBootReceiver \
+  -a ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY
+```
+
+Confirm that `topResumedActivity` names `ai.elizaos.app/.MainActivity` before
+sending `ENABLE`. Android 12+ can deny a foreground-service start from a custom
+background broadcast. If that happens, the receiver keeps the durable opt-in
+but logcat records `foreground guard start failed`; bring MainActivity to the
+foreground and send `SYNC_LP3_COLOR_POLICY`, or let the next boot/package
+replacement retry through its platform exemption. Never treat the preference
+write alone as proof that the guard is running.
+
+Verify the service, repair result, and final SettingsProvider state before
+calling the device durable:
+
+```bash
+adb logcat -d -s ElizaLp3Color:I '*:S'
+adb shell dumpsys activity services ai.elizaos.app | grep Lp3ColorPolicyService
+adb shell settings get secure accessibility_display_daltonizer_enabled
+adb shell settings get secure accessibility_display_daltonizer
+```
+
+The final two values must be `0` and `-1`. Reboot the device and repeat those
+checks; the boot receiver plus observer are what prove persistence beyond the
+one-time repair.
+
+To disable it cleanly, send the matching same-UID command:
+
+```bash
+adb shell run-as ai.elizaos.app am broadcast \
+  -n ai.elizaos.app/ai.elizaos.app.Lp3ColorPolicyBootReceiver \
+  -a ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY
+```
+
+`SYNC_LP3_COLOR_POLICY` re-evaluates the existing private opt-in without
+changing it. `run-as` requires a debuggable direct build and makes the sender
+the app UID; ordinary apps cannot reach the unexported receiver. The private
+state survives reboot and in-place update, but correctly disappears on app
+data clear or uninstall. Unknown actions are ignored.
+
+When all gates pass, a low-importance ongoing notification makes the lifecycle
+honest and lets the service observe only Android's two daltonizer keys. It
+writes `accessibility_display_daltonizer_enabled=0` and
+`accessibility_display_daltonizer=-1` only when either value is wrong.
+`BOOT_COMPLETED` and package-replacement delivery reapply the same gate; a
+force-stopped Android app cannot receive boot broadcasts until the user
+launches it again, by platform design.
+
 ## `build:android` — sideload-only debug
 
 ```bash

--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -7,6 +7,9 @@ apply plugin: 'com.android.application'
 // project lives outside the eliza tree and the relative walk overshoots.
 // Keep the variable name and single definition, or that pin silently misses.
 def elizaRepoRoot = rootProject.projectDir.toPath().resolve('../../../..').normalize().toFile()
+def lp3ColorPolicyBuildEnabled = ['1', 'true', 'yes'].contains(
+    (System.getenv('ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED') ?: 'false').toLowerCase()
+)
 
 def resolveElizaVoiceArm64SourceDir = {
     def fromProp = project.findProperty("eliza.mtp.android.libdir")
@@ -39,6 +42,9 @@ android {
         buildConfig true
     }
     defaultConfig {
+        // Direct-distribution LP3 builds opt in explicitly. Runtime device,
+        // operator, and privileged-permission gates still apply independently.
+        buildConfigField "boolean", "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED", "${lp3ColorPolicyBuildEnabled}"
         buildConfigField "boolean", "ELIZA_ANDROID_SMS_GATEWAY_ENABLED", "${['1', 'true', 'yes'].contains((System.getenv('ELIZA_ANDROID_SMS_GATEWAY_ENABLED') ?: 'false').toLowerCase())}"
         buildConfigField "String", "ELIZA_ANDROID_SMS_GATEWAY_SECRET", "\"\""
         buildConfigField "String", "ELIZA_ANDROID_SMS_GATEWAY_WEBHOOK_URL", "\"https://api.elizacloud.ai/api/webhooks/blooio/local?bridge=bluebubbles\""
@@ -73,6 +79,22 @@ android {
             cmake {
                 arguments "-DELIZAVOICE_FFI_INCLUDE_DIR=${new File(elizaRepoRoot, 'plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include').absolutePath}"
             }
+        }
+    }
+
+    // The LP3 production sources live outside src/main so every ordinary APK
+    // and AAB excludes them. The explicit flag attaches them only to the debug
+    // source set; release variants cannot see the Java or manifest overlay.
+    sourceSets {
+        test.java.srcDir file('../lp3-color-policy/src/test/java')
+        if (lp3ColorPolicyBuildEnabled) {
+            debug.java.srcDir file('../lp3-color-policy/src/debug/java')
+            debug.manifest.srcFile file('../lp3-color-policy/src/debug/AndroidManifest.xml')
+            // Release artifacts cannot see the policy, but release unit tests
+            // still compile the shared policy contract outside the main APK.
+            testRelease.java.srcDir file('../lp3-color-policy/src/debug/java')
+        } else {
+            test.java.srcDir file('../lp3-color-policy/src/debug/java')
         }
     }
 

--- a/packages/app-core/platforms/android/lp3-color-policy/src/debug/AndroidManifest.xml
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/debug/AndroidManifest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Direct-debug-only LP3 color persistence overlay. Gradle attaches this source
+  set only when ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED is explicit; ordinary
+  debug, release, AOSP, ordinary Cloud/Play, and whitelabel artifacts cannot
+  merge it.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
+    <application>
+        <service
+            android:name=".Lp3ColorPolicyService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Maintain the operator-selected full-color display state on Light Phone III" />
+        </service>
+
+        <receiver
+            android:name=".Lp3ColorPolicyBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY" />
+                <action android:name="ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY" />
+                <action android:name="ai.elizaos.app.action.SYNC_LP3_COLOR_POLICY" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicy.java
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicy.java
@@ -1,0 +1,206 @@
+/**
+ * Decides whether the direct-distribution Light Phone III color guard may run
+ * and repairs only Android's two daltonizer settings. Android lifecycle and
+ * SettingsProvider adapters live in the service so this policy remains a
+ * deterministic JVM-testable boundary.
+ */
+package ai.elizaos.app;
+
+final class Lp3ColorPolicy {
+    static final String TARGET_MANUFACTURER = "Light";
+    static final String TARGET_MODEL = "TLP301";
+    static final int COLOR_CORRECTION_DISABLED = 0;
+    static final int COLOR_CORRECTION_MODE_DISABLED = -1;
+    static final String ACTION_BOOT_COMPLETED = "android.intent.action.BOOT_COMPLETED";
+    static final String ACTION_MY_PACKAGE_REPLACED =
+        "android.intent.action.MY_PACKAGE_REPLACED";
+    static final String ACTION_ENABLE = "ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY";
+    static final String ACTION_DISABLE = "ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY";
+    static final String ACTION_SYNC = "ai.elizaos.app.action.SYNC_LP3_COLOR_POLICY";
+
+    enum Decision {
+        BUILD_DISABLED,
+        WRONG_DEVICE,
+        OPTED_OUT,
+        MISSING_PERMISSION,
+        ELIGIBLE
+    }
+
+    enum Outcome {
+        BUILD_DISABLED,
+        WRONG_DEVICE,
+        OPTED_OUT,
+        MISSING_PERMISSION,
+        ALREADY_CORRECT,
+        REPAIRED
+    }
+
+    enum OperatorCommand {
+        ENABLE,
+        DISABLE,
+        SYNC,
+        NONE
+    }
+
+    interface State {
+        boolean buildEnabled();
+
+        String manufacturer();
+
+        String model();
+
+        boolean optedIn();
+
+        boolean hasWriteSecureSettings();
+
+        int colorCorrectionEnabled();
+
+        int colorCorrectionMode();
+
+        boolean writeColorCorrectionEnabled(int value);
+
+        boolean writeColorCorrectionMode(int value);
+    }
+
+    interface Scheduler {
+        void remove(Runnable task);
+
+        void postDelayed(Runnable task, long delayMillis);
+    }
+
+    interface OptInWriter {
+        boolean commit(boolean enabled);
+    }
+
+    static final class Debouncer {
+        private final Scheduler scheduler;
+        private final Runnable task;
+        private final long delayMillis;
+
+        Debouncer(Scheduler scheduler, Runnable task, long delayMillis) {
+            this.scheduler = scheduler;
+            this.task = task;
+            this.delayMillis = delayMillis;
+        }
+
+        void request() {
+            scheduler.remove(task);
+            scheduler.postDelayed(task, delayMillis);
+        }
+
+        void cancel() {
+            scheduler.remove(task);
+        }
+    }
+
+    static final class SettingsWriteException extends IllegalStateException {
+        SettingsWriteException(String setting, int value) {
+            super("SettingsProvider rejected " + setting + "=" + value);
+        }
+    }
+
+    static final class SettingsReadbackException extends IllegalStateException {
+        SettingsReadbackException(int enabled, int mode) {
+            super(
+                "SettingsProvider readback mismatch: "
+                    + "accessibility_display_daltonizer_enabled="
+                    + enabled
+                    + ", accessibility_display_daltonizer="
+                    + mode
+            );
+        }
+    }
+
+    private Lp3ColorPolicy() {}
+
+    static Decision decide(
+            boolean buildEnabled,
+            String manufacturer,
+            String model,
+            boolean optedIn,
+            boolean hasWriteSecureSettings) {
+        if (!buildEnabled) return Decision.BUILD_DISABLED;
+        if (!isTargetDevice(manufacturer, model)) return Decision.WRONG_DEVICE;
+        if (!optedIn) return Decision.OPTED_OUT;
+        if (!hasWriteSecureSettings) return Decision.MISSING_PERMISSION;
+        return Decision.ELIGIBLE;
+    }
+
+    static boolean isTargetDevice(String manufacturer, String model) {
+        return TARGET_MANUFACTURER.equalsIgnoreCase(trim(manufacturer))
+            && TARGET_MODEL.equalsIgnoreCase(trim(model));
+    }
+
+    static boolean acceptsTrigger(String action) {
+        return ACTION_BOOT_COMPLETED.equals(action)
+            || ACTION_MY_PACKAGE_REPLACED.equals(action)
+            || ACTION_ENABLE.equals(action)
+            || ACTION_DISABLE.equals(action)
+            || ACTION_SYNC.equals(action);
+    }
+
+    static OperatorCommand operatorCommand(String action) {
+        if (ACTION_ENABLE.equals(action)) return OperatorCommand.ENABLE;
+        if (ACTION_DISABLE.equals(action)) return OperatorCommand.DISABLE;
+        if (ACTION_SYNC.equals(action)) return OperatorCommand.SYNC;
+        return OperatorCommand.NONE;
+    }
+
+    static boolean shouldKeepStickyRestart(boolean initialized, Decision decision) {
+        return initialized && decision == Decision.ELIGIBLE;
+    }
+
+    static void persistOptIn(OptInWriter writer, boolean enabled) {
+        if (!writer.commit(enabled)) {
+            throw new IllegalStateException("Could not persist LP3 color policy opt-in");
+        }
+    }
+
+    static Outcome reconcile(State state) {
+        Decision decision = decide(
+            state.buildEnabled(),
+            state.manufacturer(),
+            state.model(),
+            state.optedIn(),
+            state.hasWriteSecureSettings()
+        );
+        if (decision != Decision.ELIGIBLE) return Outcome.valueOf(decision.name());
+
+        int initialEnabled = state.colorCorrectionEnabled();
+        int initialMode = state.colorCorrectionMode();
+        boolean repaired = false;
+        if (initialEnabled != COLOR_CORRECTION_DISABLED) {
+            if (!state.writeColorCorrectionEnabled(COLOR_CORRECTION_DISABLED)) {
+                throw new SettingsWriteException(
+                    "accessibility_display_daltonizer_enabled",
+                    COLOR_CORRECTION_DISABLED
+                );
+            }
+            repaired = true;
+        }
+        if (initialMode != COLOR_CORRECTION_MODE_DISABLED) {
+            if (!state.writeColorCorrectionMode(COLOR_CORRECTION_MODE_DISABLED)) {
+                throw new SettingsWriteException(
+                    "accessibility_display_daltonizer",
+                    COLOR_CORRECTION_MODE_DISABLED
+                );
+            }
+            repaired = true;
+        }
+        if (repaired) {
+            int finalEnabled = state.colorCorrectionEnabled();
+            int finalMode = state.colorCorrectionMode();
+            if (
+                finalEnabled != COLOR_CORRECTION_DISABLED
+                    || finalMode != COLOR_CORRECTION_MODE_DISABLED
+            ) {
+                throw new SettingsReadbackException(finalEnabled, finalMode);
+            }
+        }
+        return repaired ? Outcome.REPAIRED : Outcome.ALREADY_CORRECT;
+    }
+
+    private static String trim(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyBootReceiver.java
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyBootReceiver.java
@@ -1,0 +1,39 @@
+/**
+ * Reconciles the direct-distribution LP3 color service at boot, package
+ * replacement, and explicit same-UID operator commands. Its device-protected
+ * private preference survives reboot and in-place updates without creating a
+ * cross-app control surface.
+ */
+package ai.elizaos.app;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public final class Lp3ColorPolicyBootReceiver extends BroadcastReceiver {
+    private static final String TAG = "ElizaLp3Color";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent == null ? null : intent.getAction();
+        if (!Lp3ColorPolicy.acceptsTrigger(action)) return;
+        try {
+            Lp3ColorPolicy.OperatorCommand command = Lp3ColorPolicy.operatorCommand(action);
+            if (command == Lp3ColorPolicy.OperatorCommand.ENABLE) {
+                Lp3ColorPolicyService.setOptedIn(context, true);
+            } else if (command == Lp3ColorPolicy.OperatorCommand.DISABLE) {
+                Lp3ColorPolicyService.setOptedIn(context, false);
+            }
+            Lp3ColorPolicyService.sync(context, action);
+        } catch (RuntimeException error) {
+            // error-policy:J1 Android receiver boundary — private preference
+            // persistence must be observable; an operator command that cannot
+            // be committed must never appear successful in logcat.
+            Log.e(TAG, "[Lp3ColorPolicy] operator command failed; action=" + action, error);
+            context.getApplicationContext().stopService(
+                new Intent(context, Lp3ColorPolicyService.class)
+            );
+        }
+    }
+}

--- a/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyService.java
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyService.java
@@ -1,0 +1,394 @@
+/**
+ * Keeps an explicitly opted-in Light Phone III in full color while LightOS is
+ * running. This direct-distribution-only foreground service observes the
+ * SettingsProvider keys that the stock launcher rewrites and delegates all
+ * repair decisions to {@link Lp3ColorPolicy}.
+ */
+package ai.elizaos.app;
+
+import android.Manifest;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
+import android.database.ContentObserver;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+public final class Lp3ColorPolicyService extends Service {
+    static final String PREFERENCES_NAME = "lp3_color_policy";
+    static final String OPT_IN_PREFERENCE = "enabled";
+    private static final String TAG = "ElizaLp3Color";
+    private static final String CHANNEL_ID = "lp3_color_policy";
+    private static final int NOTIFICATION_ID = 31;
+    private static final long REPAIR_DEBOUNCE_MILLIS = 150L;
+    private static final String DALTONIZER_ENABLED =
+        "accessibility_display_daltonizer_enabled";
+    private static final String DALTONIZER_MODE = "accessibility_display_daltonizer";
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private ContentObserver settingsObserver;
+    private Lp3ColorPolicy.Debouncer repairDebouncer;
+    private boolean foregroundStarted;
+    private boolean initialized;
+
+    /**
+     * Reconciles the private persistent opt-in with the service lifecycle. The
+     * same-UID commands are the explicit activation path; boot delivery uses
+     * the same device, permission, and preference gates.
+     */
+    static void sync(Context context, String trigger) {
+        Context appContext = context.getApplicationContext();
+        Lp3ColorPolicy.Decision decision;
+        try {
+            decision = currentDecision(appContext);
+        } catch (RuntimeException error) {
+            // error-policy:J1 Android receiver boundary — SettingsProvider or
+            // package-state failures must be visible and must not start a guard
+            // whose eligibility could not be established.
+            Log.e(TAG, "[Lp3ColorPolicy] eligibility read failed; trigger=" + trigger, error);
+            appContext.stopService(new Intent(appContext, Lp3ColorPolicyService.class));
+            return;
+        }
+
+        if (decision != Lp3ColorPolicy.Decision.ELIGIBLE) {
+            logInactiveDecision(trigger, decision);
+            appContext.stopService(new Intent(appContext, Lp3ColorPolicyService.class));
+            return;
+        }
+
+        Intent serviceIntent = new Intent(appContext, Lp3ColorPolicyService.class);
+        try {
+            appContext.startForegroundService(serviceIntent);
+            Log.i(TAG, "[Lp3ColorPolicy] foreground guard requested; trigger=" + trigger);
+        } catch (IllegalStateException | SecurityException error) {
+            // error-policy:J1 Android receiver boundary — background FGS
+            // denial is an observable durability failure, never a silent boot
+            // success. specialUse is legal from BOOT_COMPLETED, but OEM policy
+            // may still deny the start.
+            Log.e(TAG, "[Lp3ColorPolicy] foreground guard start failed; trigger=" + trigger, error);
+        }
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Lp3ColorPolicy.Decision decision;
+        try {
+            decision = currentDecision(this);
+        } catch (RuntimeException error) {
+            // error-policy:J1 Android service boundary — a service whose
+            // eligibility cannot be established must stop before foreground
+            // or observer setup.
+            Log.e(TAG, "[Lp3ColorPolicy] service eligibility read failed", error);
+            stopAndRemoveNotification();
+            return;
+        }
+        if (decision != Lp3ColorPolicy.Decision.ELIGIBLE) {
+            logInactiveDecision("service-create", decision);
+            stopAndRemoveNotification();
+            return;
+        }
+
+        try {
+            ensureNotificationChannel();
+            Notification notification = buildNotification();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                );
+            } else {
+                startForeground(NOTIFICATION_ID, notification);
+            }
+            foregroundStarted = true;
+            registerSettingsObserver();
+            initialized = reconcileAtBoundary("service-create");
+        } catch (RuntimeException error) {
+            // error-policy:J1 Android service boundary — notification/FGS or
+            // SettingsProvider failures make persistence unavailable, so stop
+            // instead of leaving a misleading ongoing notification.
+            Log.e(TAG, "[Lp3ColorPolicy] service initialization failed", error);
+            stopAndRemoveNotification();
+        }
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (!initialized) {
+            Log.e(TAG, "[Lp3ColorPolicy] refusing sticky restart before successful initialization");
+            stopAndRemoveNotification();
+            return START_NOT_STICKY;
+        }
+        Lp3ColorPolicy.Decision decision;
+        try {
+            decision = currentDecision(this);
+        } catch (RuntimeException error) {
+            // error-policy:J1 Android sticky-restart boundary — a restored
+            // process must re-establish every gate before it can remain alive.
+            Log.e(TAG, "[Lp3ColorPolicy] service restart eligibility read failed", error);
+            stopAndRemoveNotification();
+            return START_NOT_STICKY;
+        }
+        if (!Lp3ColorPolicy.shouldKeepStickyRestart(initialized, decision)) {
+            logInactiveDecision("service-start", decision);
+            stopAndRemoveNotification();
+            return START_NOT_STICKY;
+        }
+        if (repairDebouncer != null) repairDebouncer.request();
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        initialized = false;
+        if (repairDebouncer != null) {
+            repairDebouncer.cancel();
+            repairDebouncer = null;
+        }
+        if (settingsObserver != null) {
+            getContentResolver().unregisterContentObserver(settingsObserver);
+            settingsObserver = null;
+        }
+        if (foregroundStarted) {
+            stopForeground(STOP_FOREGROUND_REMOVE);
+            foregroundStarted = false;
+        }
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager != null) manager.cancel(NOTIFICATION_ID);
+        super.onDestroy();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void registerSettingsObserver() {
+        ContentResolver resolver = getContentResolver();
+        repairDebouncer = new Lp3ColorPolicy.Debouncer(
+            new Lp3ColorPolicy.Scheduler() {
+                @Override
+                public void remove(Runnable task) {
+                    handler.removeCallbacks(task);
+                }
+
+                @Override
+                public void postDelayed(Runnable task, long delayMillis) {
+                    handler.postDelayed(task, delayMillis);
+                }
+            },
+            () -> reconcileAtBoundary("settings-change"),
+            REPAIR_DEBOUNCE_MILLIS
+        );
+        settingsObserver = new ContentObserver(handler) {
+            @Override
+            public void onChange(boolean selfChange) {
+                Lp3ColorPolicy.Debouncer debouncer = repairDebouncer;
+                if (debouncer != null) debouncer.request();
+            }
+        };
+        resolver.registerContentObserver(
+            Settings.Secure.getUriFor(DALTONIZER_ENABLED),
+            false,
+            settingsObserver
+        );
+        resolver.registerContentObserver(
+            Settings.Secure.getUriFor(DALTONIZER_MODE),
+            false,
+            settingsObserver
+        );
+    }
+
+    private boolean reconcileAtBoundary(String trigger) {
+        try {
+            Lp3ColorPolicy.Outcome outcome = Lp3ColorPolicy.reconcile(new AndroidState(this));
+            if (outcome == Lp3ColorPolicy.Outcome.REPAIRED) {
+                Log.i(TAG, "[Lp3ColorPolicy] restored full color; trigger=" + trigger);
+                return true;
+            }
+            if (outcome == Lp3ColorPolicy.Outcome.ALREADY_CORRECT) {
+                Log.d(TAG, "[Lp3ColorPolicy] color state already correct; trigger=" + trigger);
+                return true;
+            }
+            logInactiveDecision(trigger, Lp3ColorPolicy.Decision.valueOf(outcome.name()));
+            stopAndRemoveNotification();
+            return false;
+        } catch (RuntimeException error) {
+            // error-policy:J1 ContentObserver/service boundary — a rejected
+            // secure-setting write is terminal for this service instance and
+            // is surfaced in logcat for the operator.
+            Log.e(TAG, "[Lp3ColorPolicy] color repair failed; trigger=" + trigger, error);
+            stopAndRemoveNotification();
+            return false;
+        }
+    }
+
+    private void stopAndRemoveNotification() {
+        initialized = false;
+        if (repairDebouncer != null) {
+            repairDebouncer.cancel();
+            repairDebouncer = null;
+        }
+        if (settingsObserver != null) {
+            getContentResolver().unregisterContentObserver(settingsObserver);
+            settingsObserver = null;
+        }
+        if (foregroundStarted) {
+            stopForeground(STOP_FOREGROUND_REMOVE);
+            foregroundStarted = false;
+        }
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager != null) manager.cancel(NOTIFICATION_ID);
+        stopSelf();
+    }
+
+    private void ensureNotificationChannel() {
+        NotificationChannel channel = new NotificationChannel(
+            CHANNEL_ID,
+            "LP3 color guard",
+            NotificationManager.IMPORTANCE_LOW
+        );
+        channel.setDescription("Keeps an explicitly opted-in Light Phone III in full color");
+        channel.setShowBadge(false);
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager == null) {
+            throw new IllegalStateException("NotificationManager unavailable");
+        }
+        manager.createNotificationChannel(channel);
+    }
+
+    private Notification buildNotification() {
+        Intent launchIntent = new Intent(this, MainActivity.class);
+        launchIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+            this,
+            31,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Eliza display color")
+            .setContentText("Keeping this Light Phone III in full color")
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .build();
+    }
+
+    private static Lp3ColorPolicy.Decision currentDecision(Context context) {
+        AndroidState state = new AndroidState(context);
+        return Lp3ColorPolicy.decide(
+            state.buildEnabled(),
+            state.manufacturer(),
+            state.model(),
+            state.optedIn(),
+            state.hasWriteSecureSettings()
+        );
+    }
+
+    static boolean isOptedIn(Context context) {
+        return preferences(context).getBoolean(OPT_IN_PREFERENCE, false);
+    }
+
+    static void setOptedIn(Context context, boolean enabled) {
+        Lp3ColorPolicy.persistOptIn(
+            value -> preferences(context).edit().putBoolean(OPT_IN_PREFERENCE, value).commit(),
+            enabled
+        );
+    }
+
+    private static SharedPreferences preferences(Context context) {
+        Context storageContext = context.createDeviceProtectedStorageContext();
+        return storageContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+    }
+
+    private static void logInactiveDecision(String trigger, Lp3ColorPolicy.Decision decision) {
+        String message = "[Lp3ColorPolicy] guard inactive; trigger=" + trigger + "; reason=" + decision;
+        if (decision == Lp3ColorPolicy.Decision.MISSING_PERMISSION) {
+            Log.e(TAG, message + "; grant android.permission.WRITE_SECURE_SETTINGS");
+        } else {
+            Log.i(TAG, message);
+        }
+    }
+
+    private static final class AndroidState implements Lp3ColorPolicy.State {
+        private final Context context;
+        private final ContentResolver resolver;
+
+        AndroidState(Context context) {
+            this.context = context;
+            this.resolver = context.getContentResolver();
+        }
+
+        @Override
+        public boolean buildEnabled() {
+            return BuildConfig.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED;
+        }
+
+        @Override
+        public String manufacturer() {
+            return Build.MANUFACTURER;
+        }
+
+        @Override
+        public String model() {
+            return Build.MODEL;
+        }
+
+        @Override
+        public boolean optedIn() {
+            return isOptedIn(context);
+        }
+
+        @Override
+        public boolean hasWriteSecureSettings() {
+            return context.checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS)
+                == PackageManager.PERMISSION_GRANTED;
+        }
+
+        @Override
+        public int colorCorrectionEnabled() {
+            return Settings.Secure.getInt(
+                resolver,
+                DALTONIZER_ENABLED,
+                Lp3ColorPolicy.COLOR_CORRECTION_DISABLED
+            );
+        }
+
+        @Override
+        public int colorCorrectionMode() {
+            return Settings.Secure.getInt(
+                resolver,
+                DALTONIZER_MODE,
+                Lp3ColorPolicy.COLOR_CORRECTION_MODE_DISABLED
+            );
+        }
+
+        @Override
+        public boolean writeColorCorrectionEnabled(int value) {
+            return Settings.Secure.putInt(resolver, DALTONIZER_ENABLED, value);
+        }
+
+        @Override
+        public boolean writeColorCorrectionMode(int value) {
+            return Settings.Secure.putInt(resolver, DALTONIZER_MODE, value);
+        }
+    }
+}

--- a/packages/app-core/platforms/android/lp3-color-policy/src/test/java/ai/elizaos/app/Lp3ColorPolicyTest.java
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/test/java/ai/elizaos/app/Lp3ColorPolicyTest.java
@@ -1,0 +1,431 @@
+/**
+ * Exercises the LP3 color guard with deterministic settings and scheduler
+ * fakes; Android services and the physical panel are verified separately.
+ */
+package ai.elizaos.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class Lp3ColorPolicyTest {
+    @Test
+    public void receiverAcceptsOnlyBootPackageReplaceAndExplicitCommands() {
+        assertTrue(Lp3ColorPolicy.acceptsTrigger("android.intent.action.BOOT_COMPLETED"));
+        assertTrue(
+            Lp3ColorPolicy.acceptsTrigger("android.intent.action.MY_PACKAGE_REPLACED")
+        );
+        assertTrue(
+            Lp3ColorPolicy.acceptsTrigger(
+                "ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY"
+            )
+        );
+        assertTrue(
+            Lp3ColorPolicy.acceptsTrigger(
+                "ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY"
+            )
+        );
+        assertTrue(
+            Lp3ColorPolicy.acceptsTrigger(
+                "ai.elizaos.app.action.SYNC_LP3_COLOR_POLICY"
+            )
+        );
+        assertFalse(Lp3ColorPolicy.acceptsTrigger(null));
+        assertFalse(Lp3ColorPolicy.acceptsTrigger("android.intent.action.SCREEN_ON"));
+    }
+
+    @Test
+    public void operatorCommandsCannotAliasBootOrUnknownActions() {
+        assertEquals(
+            Lp3ColorPolicy.OperatorCommand.ENABLE,
+            Lp3ColorPolicy.operatorCommand(Lp3ColorPolicy.ACTION_ENABLE)
+        );
+        assertEquals(
+            Lp3ColorPolicy.OperatorCommand.DISABLE,
+            Lp3ColorPolicy.operatorCommand(Lp3ColorPolicy.ACTION_DISABLE)
+        );
+        assertEquals(
+            Lp3ColorPolicy.OperatorCommand.SYNC,
+            Lp3ColorPolicy.operatorCommand(Lp3ColorPolicy.ACTION_SYNC)
+        );
+        assertEquals(
+            Lp3ColorPolicy.OperatorCommand.NONE,
+            Lp3ColorPolicy.operatorCommand(Lp3ColorPolicy.ACTION_BOOT_COMPLETED)
+        );
+        assertEquals(
+            Lp3ColorPolicy.OperatorCommand.NONE,
+            Lp3ColorPolicy.operatorCommand(null)
+        );
+    }
+
+    @Test
+    public void privateOptInCommitFailureStopsBeforeAnySuccessCanBeReported() {
+        List<Boolean> attempted = new ArrayList<>();
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            () ->
+                Lp3ColorPolicy.persistOptIn(
+                    enabled -> {
+                        attempted.add(enabled);
+                        return false;
+                    },
+                    false
+                )
+        );
+        assertEquals("Could not persist LP3 color policy opt-in", error.getMessage());
+        assertEquals(List.of(false), attempted);
+    }
+
+    @Test
+    public void stickyNullIntentRestartRequiresPriorInitializationAndCurrentEligibility() {
+        assertTrue(
+            Lp3ColorPolicy.shouldKeepStickyRestart(
+                true,
+                Lp3ColorPolicy.Decision.ELIGIBLE
+            )
+        );
+        assertFalse(
+            Lp3ColorPolicy.shouldKeepStickyRestart(
+                false,
+                Lp3ColorPolicy.Decision.ELIGIBLE
+            )
+        );
+        assertFalse(
+            Lp3ColorPolicy.shouldKeepStickyRestart(
+                true,
+                Lp3ColorPolicy.Decision.MISSING_PERMISSION
+            )
+        );
+    }
+
+    @Test
+    public void disabledBuildNeverReadsOrWritesSecureSettings() {
+        FakeState state = eligibleState();
+        state.buildEnabled = false;
+
+        assertEquals(Lp3ColorPolicy.Outcome.BUILD_DISABLED, Lp3ColorPolicy.reconcile(state));
+        assertEquals(0, state.secureReads);
+        assertEquals(List.of(), state.writes);
+    }
+
+    @Test
+    public void nonLightPhoneNeverReadsOrWritesSecureSettings() {
+        FakeState state = eligibleState();
+        state.model = "Pixel 10";
+
+        assertEquals(Lp3ColorPolicy.Outcome.WRONG_DEVICE, Lp3ColorPolicy.reconcile(state));
+        assertEquals(0, state.secureReads);
+        assertEquals(List.of(), state.writes);
+    }
+
+    @Test
+    public void optedOutDeviceNeverReadsOrWritesSecureSettings() {
+        FakeState state = eligibleState();
+        state.optedIn = false;
+
+        assertEquals(Lp3ColorPolicy.Outcome.OPTED_OUT, Lp3ColorPolicy.reconcile(state));
+        assertEquals(0, state.secureReads);
+        assertEquals(List.of(), state.writes);
+    }
+
+    @Test
+    public void missingPermissionNeverReadsOrWritesSecureSettings() {
+        FakeState state = eligibleState();
+        state.hasPermission = false;
+
+        assertEquals(
+            Lp3ColorPolicy.Outcome.MISSING_PERMISSION,
+            Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(0, state.secureReads);
+        assertEquals(List.of(), state.writes);
+    }
+
+    @Test
+    public void optOutAndPermissionRevokeMakeTheNextReconcileIneligible() {
+        FakeState optedOut = eligibleState();
+        assertEquals(
+            Lp3ColorPolicy.Outcome.ALREADY_CORRECT,
+            Lp3ColorPolicy.reconcile(optedOut)
+        );
+        optedOut.optedIn = false;
+        assertEquals(Lp3ColorPolicy.Outcome.OPTED_OUT, Lp3ColorPolicy.reconcile(optedOut));
+        assertEquals(2, optedOut.secureReads);
+
+        FakeState revoked = eligibleState();
+        assertEquals(
+            Lp3ColorPolicy.Outcome.ALREADY_CORRECT,
+            Lp3ColorPolicy.reconcile(revoked)
+        );
+        revoked.hasPermission = false;
+        assertEquals(
+            Lp3ColorPolicy.Outcome.MISSING_PERMISSION,
+            Lp3ColorPolicy.reconcile(revoked)
+        );
+        assertEquals(2, revoked.secureReads);
+    }
+
+    @Test
+    public void repairsBothDaltonizerSettingsInSafeOrder() {
+        FakeState state = eligibleState();
+        state.enabled = 1;
+        state.mode = 0;
+
+        assertEquals(Lp3ColorPolicy.Outcome.REPAIRED, Lp3ColorPolicy.reconcile(state));
+        assertEquals(List.of("enabled=0", "mode=-1"), state.writes);
+    }
+
+    @Test
+    public void repairsOnlyTheMismatchedSetting() {
+        FakeState state = eligibleState();
+        state.enabled = 0;
+        state.mode = 0;
+
+        assertEquals(Lp3ColorPolicy.Outcome.REPAIRED, Lp3ColorPolicy.reconcile(state));
+        assertEquals(List.of("mode=-1"), state.writes);
+    }
+
+    @Test
+    public void correctStateAndObserverReplayDoNotWrite() {
+        FakeState state = eligibleState();
+
+        assertEquals(
+            Lp3ColorPolicy.Outcome.ALREADY_CORRECT,
+            Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(
+            Lp3ColorPolicy.Outcome.ALREADY_CORRECT,
+            Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(List.of(), state.writes);
+    }
+
+    @Test
+    public void rejectedSettingsWriteFailsLoudly() {
+        FakeState state = eligibleState();
+        state.enabled = 1;
+        state.acceptEnabledWrite = false;
+
+        Lp3ColorPolicy.SettingsWriteException error = assertThrows(
+            Lp3ColorPolicy.SettingsWriteException.class,
+            () -> Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(
+            "SettingsProvider rejected accessibility_display_daltonizer_enabled=0",
+            error.getMessage()
+        );
+    }
+
+    @Test
+    public void rejectedSecondWriteSurfacesAfterTheSafeFirstWrite() {
+        FakeState state = eligibleState();
+        state.enabled = 1;
+        state.mode = 0;
+        state.acceptModeWrite = false;
+
+        Lp3ColorPolicy.SettingsWriteException error = assertThrows(
+            Lp3ColorPolicy.SettingsWriteException.class,
+            () -> Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(
+            "SettingsProvider rejected accessibility_display_daltonizer=-1",
+            error.getMessage()
+        );
+        assertEquals(List.of("enabled=0", "mode=-1"), state.writes);
+        assertEquals(0, state.enabled);
+        assertEquals(0, state.mode);
+    }
+
+    @Test
+    public void successfulWritesMustPassFinalReadback() {
+        FakeState state = eligibleState();
+        state.enabled = 1;
+        state.retainEnabledWrite = false;
+
+        Lp3ColorPolicy.SettingsReadbackException error = assertThrows(
+            Lp3ColorPolicy.SettingsReadbackException.class,
+            () -> Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(
+            "SettingsProvider readback mismatch: "
+                + "accessibility_display_daltonizer_enabled=1, "
+                + "accessibility_display_daltonizer=-1",
+            error.getMessage()
+        );
+        assertEquals(List.of("enabled=0"), state.writes);
+    }
+
+    @Test
+    public void retainedModeMismatchAlsoFailsFinalReadback() {
+        FakeState state = eligibleState();
+        state.enabled = 1;
+        state.mode = 0;
+        state.retainModeWrite = false;
+
+        Lp3ColorPolicy.SettingsReadbackException error = assertThrows(
+            Lp3ColorPolicy.SettingsReadbackException.class,
+            () -> Lp3ColorPolicy.reconcile(state)
+        );
+        assertEquals(
+            "SettingsProvider readback mismatch: "
+                + "accessibility_display_daltonizer_enabled=0, "
+                + "accessibility_display_daltonizer=0",
+            error.getMessage()
+        );
+        assertEquals(List.of("enabled=0", "mode=-1"), state.writes);
+    }
+
+    @Test
+    public void debounceKeepsOnlyTheLatestRepairRequest() {
+        FakeScheduler scheduler = new FakeScheduler();
+        int[] repairs = {0};
+        Lp3ColorPolicy.Debouncer debouncer = new Lp3ColorPolicy.Debouncer(
+            scheduler,
+            () -> repairs[0] += 1,
+            150L
+        );
+
+        debouncer.request();
+        debouncer.request();
+        debouncer.request();
+
+        assertEquals(1, scheduler.pending.size());
+        assertEquals(150L, scheduler.lastDelayMillis);
+        scheduler.runPending();
+        assertEquals(1, repairs[0]);
+
+        debouncer.request();
+        debouncer.cancel();
+        scheduler.runPending();
+        assertEquals(1, repairs[0]);
+    }
+
+    @Test
+    public void observerBurstAndOwnWriteCallbacksConvergeWithoutALoop() {
+        FakeState state = eligibleState();
+        state.enabled = 1;
+        state.mode = 0;
+        FakeScheduler scheduler = new FakeScheduler();
+        int[] reconciliations = {0};
+        Lp3ColorPolicy.Debouncer debouncer = new Lp3ColorPolicy.Debouncer(
+            scheduler,
+            () -> {
+                reconciliations[0] += 1;
+                Lp3ColorPolicy.reconcile(state);
+            },
+            150L
+        );
+
+        debouncer.request();
+        debouncer.request();
+        debouncer.request();
+        scheduler.runPending();
+        assertEquals(1, reconciliations[0]);
+        assertEquals(List.of("enabled=0", "mode=-1"), state.writes);
+
+        debouncer.request();
+        debouncer.request();
+        scheduler.runPending();
+        assertEquals(2, reconciliations[0]);
+        assertEquals(List.of("enabled=0", "mode=-1"), state.writes);
+        assertEquals(6, state.secureReads);
+    }
+
+    private static FakeState eligibleState() {
+        return new FakeState();
+    }
+
+    private static final class FakeState implements Lp3ColorPolicy.State {
+        boolean buildEnabled = true;
+        String manufacturer = " Light ";
+        String model = "tlp301";
+        boolean optedIn = true;
+        boolean hasPermission = true;
+        int enabled = 0;
+        int mode = -1;
+        boolean acceptEnabledWrite = true;
+        boolean acceptModeWrite = true;
+        boolean retainEnabledWrite = true;
+        boolean retainModeWrite = true;
+        int secureReads;
+        final List<String> writes = new ArrayList<>();
+
+        @Override
+        public boolean buildEnabled() {
+            return buildEnabled;
+        }
+
+        @Override
+        public String manufacturer() {
+            return manufacturer;
+        }
+
+        @Override
+        public String model() {
+            return model;
+        }
+
+        @Override
+        public boolean optedIn() {
+            return optedIn;
+        }
+
+        @Override
+        public boolean hasWriteSecureSettings() {
+            return hasPermission;
+        }
+
+        @Override
+        public int colorCorrectionEnabled() {
+            secureReads += 1;
+            return enabled;
+        }
+
+        @Override
+        public int colorCorrectionMode() {
+            secureReads += 1;
+            return mode;
+        }
+
+        @Override
+        public boolean writeColorCorrectionEnabled(int value) {
+            writes.add("enabled=" + value);
+            if (acceptEnabledWrite && retainEnabledWrite) enabled = value;
+            return acceptEnabledWrite;
+        }
+
+        @Override
+        public boolean writeColorCorrectionMode(int value) {
+            writes.add("mode=" + value);
+            if (acceptModeWrite && retainModeWrite) mode = value;
+            return acceptModeWrite;
+        }
+    }
+
+    private static final class FakeScheduler implements Lp3ColorPolicy.Scheduler {
+        final List<Runnable> pending = new ArrayList<>();
+        long lastDelayMillis;
+
+        @Override
+        public void remove(Runnable task) {
+            pending.removeIf(candidate -> candidate == task);
+        }
+
+        @Override
+        public void postDelayed(Runnable task, long delayMillis) {
+            pending.add(task);
+            lastDelayMillis = delayMillis;
+        }
+
+        void runPending() {
+            List<Runnable> snapshot = List.copyOf(pending);
+            pending.clear();
+            for (Runnable task : snapshot) task.run();
+        }
+    }
+}

--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -2,6 +2,8 @@
  * Proves that LP3 color persistence is an explicit direct-build delta and that
  * ordinary Cloud/Play transforms remove every component and permission.
  */
+
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,6 +29,7 @@ import {
 } from "./run-mobile-build.mjs";
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const mobileBuildScriptPath = path.join(scriptsDir, "run-mobile-build.mjs");
 const androidRoot = path.resolve(scriptsDir, "../platforms/android");
 const manifestPath = path.join(androidRoot, "app/src/main/AndroidManifest.xml");
 const gradlePath = path.join(androidRoot, "app/build.gradle");
@@ -62,6 +65,24 @@ function stripManifest(xml, policy) {
 }
 
 describe("LP3 direct Cloud build flag", () => {
+  it("rejects the LP3 flag at the real process boundary before building", () => {
+    const result = spawnSync("node", [mobileBuildScriptPath, "android-cloud"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+      },
+      timeout: 15_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "restricted to the canonical android-cloud-debug",
+    );
+  });
+
   it("accepts only explicit truthy values", () => {
     expect(isAndroidLp3ColorPolicyEnabled({})).toBe(false);
     expect(

--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -1,0 +1,331 @@
+/**
+ * Proves that LP3 color persistence is an explicit direct-build delta and that
+ * ordinary Cloud/Play transforms remove every component and permission.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  hasAndroidPermissionRequest,
+  removeAndroidPermissionRequests,
+  removeApplicationComponentClassBlock,
+} from "./mobile/android-manifest.mjs";
+import {
+  ANDROID_CLOUD_STRIPPED_COMPONENTS,
+  ANDROID_CLOUD_STRIPPED_JAVA_FILES,
+  ANDROID_CLOUD_STRIPPED_PERMISSIONS,
+  ANDROID_LP3_COLOR_POLICY_COMPONENTS,
+  ANDROID_LP3_COLOR_POLICY_JAVA_FILES,
+  ANDROID_LP3_COLOR_POLICY_PERMISSIONS,
+  enforceAndroidLp3ColorPolicyBuildPolicy,
+  isAndroidLp3ColorPolicyEnabled,
+  resolveAndroidCloudStripPolicy,
+  resolveAndroidLp3ColorPolicyBuildEnv,
+} from "./run-mobile-build.mjs";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const androidRoot = path.resolve(scriptsDir, "../platforms/android");
+const manifestPath = path.join(androidRoot, "app/src/main/AndroidManifest.xml");
+const gradlePath = path.join(androidRoot, "app/build.gradle");
+const debugManifestPath = path.join(
+  androidRoot,
+  "lp3-color-policy/src/debug/AndroidManifest.xml",
+);
+const servicePath = path.join(
+  androidRoot,
+  "lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyService.java",
+);
+const readmePath = path.join(androidRoot, "README.md");
+const repoRoot = path.resolve(scriptsDir, "../../..");
+const aospManifestPath = path.join(
+  repoRoot,
+  "packages/os/android/vendor/eliza/manifests/aosp-assistant-full-control.json",
+);
+const privappPermissionsPath = path.join(
+  repoRoot,
+  "packages/os/android/vendor/eliza/permissions/privapp-permissions-ai.elizaos.app.xml",
+);
+const distroValidatorPath = path.join(
+  repoRoot,
+  "packages/scripts/distro-android/validate.mjs",
+);
+
+function stripManifest(xml, policy) {
+  let stripped = xml;
+  for (const component of policy.components) {
+    stripped = removeApplicationComponentClassBlock(stripped, component);
+  }
+  return removeAndroidPermissionRequests(stripped, policy.permissions);
+}
+
+describe("LP3 direct Cloud build flag", () => {
+  it("accepts only explicit truthy values", () => {
+    expect(isAndroidLp3ColorPolicyEnabled({})).toBe(false);
+    expect(
+      isAndroidLp3ColorPolicyEnabled({
+        ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "0",
+      }),
+    ).toBe(false);
+    expect(
+      isAndroidLp3ColorPolicyEnabled({
+        ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: " true ",
+      }),
+    ).toBe(true);
+    expect(
+      isAndroidLp3ColorPolicyEnabled({
+        ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "YES",
+      }),
+    ).toBe(true);
+  });
+
+  it("normalizes the passed build environment without consulting process.env", () => {
+    const original = process.env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED;
+    process.env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED = "1";
+    try {
+      const disabled = resolveAndroidLp3ColorPolicyBuildEnv({
+        ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "0",
+      });
+      expect(disabled.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED).toBe("0");
+      expect(resolveAndroidCloudStripPolicy(disabled).components).toContain(
+        "Lp3ColorPolicyService",
+      );
+
+      process.env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED = "0";
+      const enabled = resolveAndroidLp3ColorPolicyBuildEnv({
+        ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "yes",
+      });
+      expect(enabled.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED).toBe("1");
+      expect(resolveAndroidCloudStripPolicy(enabled).components).not.toContain(
+        "Lp3ColorPolicyService",
+      );
+    } finally {
+      if (original === undefined) {
+        delete process.env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED;
+      } else {
+        process.env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED = original;
+      }
+    }
+  });
+
+  it("keeps policy files inside the ordinary Cloud strip set", () => {
+    for (const component of ANDROID_LP3_COLOR_POLICY_COMPONENTS) {
+      expect(ANDROID_CLOUD_STRIPPED_COMPONENTS).toContain(component);
+    }
+    for (const permission of ANDROID_LP3_COLOR_POLICY_PERMISSIONS) {
+      expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).toContain(permission);
+    }
+    for (const file of ANDROID_LP3_COLOR_POLICY_JAVA_FILES) {
+      expect(ANDROID_CLOUD_STRIPPED_JAVA_FILES).toContain(file);
+    }
+  });
+
+  it("rejects the LP3 flag outside the dedicated direct debug lane", () => {
+    const enabled = { ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1" };
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud",
+        env: enabled,
+      }),
+    ).toThrow("restricted to the canonical android-cloud-debug");
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-sms-gateway",
+        env: enabled,
+      }),
+    ).toThrow("restricted to the canonical android-cloud-debug");
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android",
+        env: enabled,
+      }),
+    ).toThrow("restricted to the canonical android-cloud-debug");
+  });
+
+  it("rejects Play signals even on the debug target", () => {
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: {
+          ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+          ELIZA_PLAY_STORE_BUILD: "1",
+        },
+      }),
+    ).toThrow("restricted to the canonical android-cloud-debug");
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: {
+          ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+          ELIZA_BUILD_VARIANT: "STORE",
+        },
+      }),
+    ).toThrow("restricted to the canonical android-cloud-debug");
+  });
+
+  it("rejects app-dir and whitelabel variants", () => {
+    const enabled = { ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1" };
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: { ...enabled, ELIZA_ANDROID_USE_APP_DIR: "1" },
+      }),
+    ).toThrow("app-dir");
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: enabled,
+        appId: "com.example.whitelabel",
+      }),
+    ).toThrow("whitelabel");
+  });
+
+  it("allows only the explicit direct debug target and keeps disabled builds unchanged", () => {
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: { ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "yes" },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      enforceAndroidLp3ColorPolicyBuildPolicy({
+        targetName: "android-cloud",
+        env: {},
+      }),
+    ).not.toThrow();
+  });
+
+  it("preserves only the exact LP3 delta when the direct flag is enabled", () => {
+    const normal = resolveAndroidCloudStripPolicy({});
+    const direct = resolveAndroidCloudStripPolicy({
+      ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+    });
+
+    for (const component of ANDROID_LP3_COLOR_POLICY_COMPONENTS) {
+      expect(normal.components).toContain(component);
+      expect(direct.components).not.toContain(component);
+    }
+    for (const permission of ANDROID_LP3_COLOR_POLICY_PERMISSIONS) {
+      expect(normal.permissions).toContain(permission);
+      expect(direct.permissions).not.toContain(permission);
+    }
+    for (const file of ANDROID_LP3_COLOR_POLICY_JAVA_FILES) {
+      expect(normal.javaFiles).toContain(file);
+      expect(direct.javaFiles).not.toContain(file);
+    }
+
+    expect(direct.components).toContain("ElizaAgentService");
+    expect(direct.permissions).toContain("MANAGE_APP_OPS_MODES");
+    expect(direct.javaFiles).toContain("ElizaAgentService.java");
+  });
+
+  it("removes the entire LP3 delta from a normal Cloud manifest", () => {
+    const manifest = fs.readFileSync(manifestPath, "utf8");
+    const normal = stripManifest(manifest, resolveAndroidCloudStripPolicy({}));
+
+    for (const component of ANDROID_LP3_COLOR_POLICY_COMPONENTS) {
+      expect(normal).not.toContain(component);
+    }
+    for (const permission of ANDROID_LP3_COLOR_POLICY_PERMISSIONS) {
+      const full = `android.permission.${permission}`;
+      expect(hasAndroidPermissionRequest(normal, full)).toBe(false);
+    }
+  });
+
+  it("keeps the canonical platform manifest free of direct-only components", () => {
+    const manifest = fs.readFileSync(manifestPath, "utf8");
+    for (const component of ANDROID_LP3_COLOR_POLICY_COMPONENTS) {
+      expect(manifest).not.toContain(component);
+    }
+    expect(manifest).not.toContain("android.permission.WRITE_SECURE_SETTINGS");
+  });
+
+  it("keeps direct-only Java out of ordinary sideload, system, and manual Gradle sources", () => {
+    const ordinaryMainRoot = path.join(
+      androidRoot,
+      "app/src/main/java/ai/elizaos/app",
+    );
+    const isolatedTemplateRoot = path.join(
+      androidRoot,
+      "lp3-color-policy/src/debug/java/ai/elizaos/app",
+    );
+    for (const file of ANDROID_LP3_COLOR_POLICY_JAVA_FILES) {
+      expect(fs.existsSync(path.join(ordinaryMainRoot, file))).toBe(false);
+      expect(fs.existsSync(path.join(isolatedTemplateRoot, file))).toBe(true);
+    }
+  });
+
+  it("declares the guarded specialUse boot contract", () => {
+    const manifest = fs.readFileSync(debugManifestPath, "utf8");
+    const gradle = fs.readFileSync(gradlePath, "utf8");
+    const receiverStart = manifest.indexOf(
+      'android:name=".Lp3ColorPolicyBootReceiver"',
+    );
+    const receiverBlock = manifest.slice(
+      receiverStart,
+      manifest.indexOf("</receiver>", receiverStart),
+    );
+
+    expect(manifest).toContain("Lp3ColorPolicyService");
+    expect(manifest).toContain('android:foregroundServiceType="specialUse"');
+    expect(manifest).toContain("android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE");
+    expect(manifest).toContain("Lp3ColorPolicyBootReceiver");
+    expect(manifest).not.toMatch(
+      /Lp3ColorPolicy(?:Service|BootReceiver)[\s\S]{0,160}directBootAware/,
+    );
+    expect(manifest).toContain("android.intent.action.BOOT_COMPLETED");
+    expect(manifest).toContain("android.intent.action.MY_PACKAGE_REPLACED");
+    expect(manifest).toContain("ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY");
+    expect(manifest).toContain(
+      "ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY",
+    );
+    expect(manifest).toContain("ai.elizaos.app.action.SYNC_LP3_COLOR_POLICY");
+    expect(receiverBlock).toContain('android:exported="false"');
+    expect(receiverBlock).not.toContain("android:permission=");
+    expect(gradle).toContain(
+      'buildConfigField "boolean", "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED"',
+    );
+    expect(gradle).toContain("debug.java.srcDir");
+    expect(gradle).toContain("debug.manifest.srcFile");
+    expect(gradle).toContain("testRelease.java.srcDir");
+    expect(gradle).not.toContain("release.java.srcDir");
+  });
+
+  it("keeps runtime opt-in private and writable only through same-UID commands", () => {
+    const service = fs.readFileSync(servicePath, "utf8");
+    const readme = fs.readFileSync(readmePath, "utf8");
+
+    expect(service).toContain('PREFERENCES_NAME = "lp3_color_policy"');
+    expect(service).toContain('OPT_IN_PREFERENCE = "enabled"');
+    expect(service).toContain("createDeviceProtectedStorageContext");
+    expect(service).toContain("Context.MODE_PRIVATE");
+    expect(service).not.toContain("Settings.System");
+    expect(service).toContain("if (!initialized)");
+    expect(service).toContain("return START_NOT_STICKY");
+    expect(readme).toContain("adb shell run-as ai.elizaos.app am broadcast");
+    expect(readme).toContain("ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY");
+    expect(readme).toContain("ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY");
+  });
+
+  it("does not grant the direct-only permission to generic AOSP builds", () => {
+    const aospManifest = JSON.parse(fs.readFileSync(aospManifestPath, "utf8"));
+    const privappPermissions = fs.readFileSync(privappPermissionsPath, "utf8");
+    const validator = fs.readFileSync(distroValidatorPath, "utf8");
+
+    expect(aospManifest.privilegedPermissions).not.toContain(
+      "android.permission.WRITE_SECURE_SETTINGS",
+    );
+    expect(aospManifest.playStorePolicy.mustStripPermissions).toContain(
+      "android.permission.WRITE_SECURE_SETTINGS",
+    );
+    expect(aospManifest.playStorePolicy.mustStripComponents).toEqual(
+      expect.arrayContaining(ANDROID_LP3_COLOR_POLICY_COMPONENTS),
+    );
+    expect(privappPermissions).not.toContain(
+      '<permission name="android.permission.WRITE_SECURE_SETTINGS" />',
+    );
+    expect(validator).not.toContain("android.permission.WRITE_SECURE_SETTINGS");
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1931,6 +1931,7 @@ function injectBuildConfigAospField(content) {
 
 function androidSmsGatewayBuildConfigFieldLines() {
   return [
+    `        buildConfigField "boolean", "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED", "\${['1', 'true', 'yes'].contains((System.getenv('ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED') ?: 'false').toLowerCase())}"`,
     `        buildConfigField "boolean", "ELIZA_ANDROID_SMS_GATEWAY_ENABLED", "\${['1', 'true', 'yes'].contains((System.getenv('ELIZA_ANDROID_SMS_GATEWAY_ENABLED') ?: 'false').toLowerCase())}"`,
     `        buildConfigField "String", "ELIZA_ANDROID_SMS_GATEWAY_SECRET", "\\"${escapeJavaString(process.env.ELIZA_ANDROID_SMS_GATEWAY_SECRET ?? "")}\\""`,
     `        buildConfigField "String", "ELIZA_ANDROID_SMS_GATEWAY_WEBHOOK_URL", "\\"${escapeJavaString(process.env.ELIZA_ANDROID_SMS_GATEWAY_WEBHOOK_URL ?? "https://api.elizacloud.ai/api/webhooks/blooio/local?bridge=bluebubbles")}\\""`,
@@ -5266,6 +5267,23 @@ function ensureIosFullBunEngineArtifact({ buildTarget = null } = {}) {
 // components.
 //
 // Components deleted from the manifest (and from app/src/main/java/...):
+export const ANDROID_LP3_COLOR_POLICY_COMPONENTS = [
+  "Lp3ColorPolicyService",
+  "Lp3ColorPolicyBootReceiver",
+];
+
+export const ANDROID_LP3_COLOR_POLICY_PERMISSIONS = [
+  "WRITE_SECURE_SETTINGS",
+  "RECEIVE_BOOT_COMPLETED",
+  "FOREGROUND_SERVICE_SPECIAL_USE",
+];
+
+export const ANDROID_LP3_COLOR_POLICY_JAVA_FILES = [
+  "Lp3ColorPolicy.java",
+  "Lp3ColorPolicyService.java",
+  "Lp3ColorPolicyBootReceiver.java",
+];
+
 export const ANDROID_CLOUD_STRIPPED_COMPONENTS = [
   "ElizaAgentService",
   "ElizaDialActivity",
@@ -5291,6 +5309,7 @@ export const ANDROID_CLOUD_STRIPPED_COMPONENTS = [
   "ElizaCameraActivity",
   "ElizaClockActivity",
   "ElizaCalendarActivity",
+  ...ANDROID_LP3_COLOR_POLICY_COMPONENTS,
 ];
 
 // Permissions removed from the manifest. Anything that triggers a Play
@@ -5332,6 +5351,7 @@ export const ANDROID_CLOUD_STRIPPED_PERMISSIONS = [
   "BIND_ACCESSIBILITY_SERVICE",
   "BIND_NOTIFICATION_LISTENER_SERVICE",
   "BIND_DEVICE_ADMIN",
+  "WRITE_SECURE_SETTINGS",
 ];
 
 // Some kept Capacitor plugins can reintroduce source-stripped permissions via
@@ -5378,7 +5398,81 @@ export const ANDROID_CLOUD_STRIPPED_JAVA_FILES = [
   "ElizaRespondViaMessageService.java",
   "ElizaSmsComposeActivity.java",
   "ElizaSmsReceiver.java",
+  ...ANDROID_LP3_COLOR_POLICY_JAVA_FILES,
 ];
+
+export function isAndroidLp3ColorPolicyEnabled(env = process.env) {
+  return ["1", "true", "yes"].includes(
+    String(env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED ?? "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
+export function resolveAndroidLp3ColorPolicyBuildEnv(env = process.env) {
+  return {
+    ...env,
+    ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: isAndroidLp3ColorPolicyEnabled(env)
+      ? "1"
+      : "0",
+  };
+}
+
+export function enforceAndroidLp3ColorPolicyBuildPolicy({
+  targetName,
+  env = process.env,
+  appId = APP.appId,
+}) {
+  if (!isAndroidLp3ColorPolicyEnabled(env)) return;
+  const playSignaled =
+    env.ELIZA_PLAY_STORE_BUILD === "1" ||
+    String(env.ELIZA_BUILD_VARIANT ?? "").toLowerCase() === "store";
+  const nonCanonicalTree =
+    env.ELIZA_ANDROID_USE_APP_DIR === "1" || appId !== "ai.elizaos.app";
+  if (
+    targetName !== "android-cloud-debug" ||
+    playSignaled ||
+    nonCanonicalTree
+  ) {
+    throw new Error(
+      "[mobile-build] ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED is restricted to " +
+        "the canonical android-cloud-debug direct-distribution lane; it is " +
+        "forbidden for release, Play, SMS gateway, sideload, AOSP, app-dir, " +
+        "and whitelabel targets.",
+    );
+  }
+}
+
+export function resolveAndroidCloudStripPolicy(env = process.env) {
+  if (!isAndroidLp3ColorPolicyEnabled(env)) {
+    return {
+      components: ANDROID_CLOUD_STRIPPED_COMPONENTS,
+      permissions: ANDROID_CLOUD_STRIPPED_PERMISSIONS,
+      mergerRemovedPermissions:
+        ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS,
+      javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES,
+    };
+  }
+
+  const allowedComponents = new Set(ANDROID_LP3_COLOR_POLICY_COMPONENTS);
+  const allowedPermissions = new Set(ANDROID_LP3_COLOR_POLICY_PERMISSIONS);
+  const allowedJavaFiles = new Set(ANDROID_LP3_COLOR_POLICY_JAVA_FILES);
+  return {
+    components: ANDROID_CLOUD_STRIPPED_COMPONENTS.filter(
+      (component) => !allowedComponents.has(component),
+    ),
+    permissions: ANDROID_CLOUD_STRIPPED_PERMISSIONS.filter(
+      (permission) => !allowedPermissions.has(permission),
+    ),
+    mergerRemovedPermissions:
+      ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS.filter(
+        (permission) => !allowedPermissions.has(permission),
+      ),
+    javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
+      (file) => !allowedJavaFiles.has(file),
+    ),
+  };
+}
 
 // Java sources that survive the cloud strip but are rewritten (or deleted) by
 // rewriteCloudJavaSources() so that the android-cloud tree compiles without
@@ -5977,8 +6071,10 @@ function stripAndroidCloudNativePlugins() {
   );
 }
 
-function auditAndroidCloudSource(phase) {
+function auditAndroidCloudSource(phase, { env = process.env } = {}) {
   const failures = [];
+  const lp3ColorPolicyEnabled = isAndroidLp3ColorPolicyEnabled(env);
+  const stripPolicy = resolveAndroidCloudStripPolicy(env);
   const manifestPath = path.join(
     androidDir,
     "app",
@@ -5991,12 +6087,12 @@ function auditAndroidCloudSource(phase) {
     if (xml.includes("ElizaAgentService")) {
       failures.push("AndroidManifest.xml still references ElizaAgentService");
     }
-    for (const component of ANDROID_CLOUD_STRIPPED_COMPONENTS) {
+    for (const component of stripPolicy.components) {
       if (xml.includes(component)) {
         failures.push(`AndroidManifest.xml still references ${component}`);
       }
     }
-    for (const perm of ANDROID_CLOUD_STRIPPED_PERMISSIONS) {
+    for (const perm of stripPolicy.permissions) {
       const full = `android.permission.${perm}`;
       if (hasAndroidPermissionRequest(xml, full)) {
         failures.push(`AndroidManifest.xml still requests ${full}`);
@@ -6019,6 +6115,45 @@ function auditAndroidCloudSource(phase) {
     }
     if (!xml.includes('android:name="android.app.shortcuts"')) {
       failures.push("AndroidManifest.xml does not register @xml/shortcuts");
+    }
+  }
+
+  const lp3DebugRoot = path.join(
+    platformsDir,
+    "android",
+    "lp3-color-policy",
+    "src",
+    "debug",
+  );
+  if (lp3ColorPolicyEnabled) {
+    const lp3ManifestPath = path.join(lp3DebugRoot, "AndroidManifest.xml");
+    if (!fs.existsSync(lp3ManifestPath)) {
+      failures.push("LP3 direct-debug manifest overlay is missing");
+    } else {
+      const lp3Manifest = stripXmlComments(
+        fs.readFileSync(lp3ManifestPath, "utf8"),
+      );
+      for (const component of ANDROID_LP3_COLOR_POLICY_COMPONENTS) {
+        if (!lp3Manifest.includes(component)) {
+          failures.push(
+            `LP3 direct-debug manifest is missing component ${component}`,
+          );
+        }
+      }
+      for (const permission of ANDROID_LP3_COLOR_POLICY_PERMISSIONS) {
+        const full = `android.permission.${permission}`;
+        if (!hasAndroidPermissionRequest(lp3Manifest, full)) {
+          failures.push(
+            `LP3 direct-debug manifest is missing permission ${full}`,
+          );
+        }
+      }
+    }
+    const lp3JavaRoot = path.join(lp3DebugRoot, "java", "ai", "elizaos", "app");
+    for (const file of ANDROID_LP3_COLOR_POLICY_JAVA_FILES) {
+      if (!fs.existsSync(path.join(lp3JavaRoot, file))) {
+        failures.push(`LP3 direct-debug Java source is missing: ${file}`);
+      }
     }
   }
 
@@ -6051,8 +6186,13 @@ function auditAndroidCloudSource(phase) {
   }
 
   const javaRoot = path.join(androidDir, "app", "src", "main", "java");
+  const forbiddenJavaFiles = new Set(stripPolicy.javaFiles);
   walkFiles(javaRoot, (filePath) => {
     const base = path.basename(filePath);
+    if (forbiddenJavaFiles.has(base)) {
+      failures.push(path.relative(androidDir, filePath));
+      return;
+    }
     if (base === "ElizaAgentService.java") {
       failures.push(path.relative(androidDir, filePath));
       return;
@@ -6283,8 +6423,9 @@ function auditAndroidSystemSource(
  *
  * Idempotent: safe to re-run on an already-stripped tree.
  */
-function stripAndroidForCloud() {
+function stripAndroidForCloud({ env = process.env } = {}) {
   const androidPackage = APP.appId;
+  const stripPolicy = resolveAndroidCloudStripPolicy(env);
 
   // 1. Strip manifest components, permissions, and BootReceiver/SMS/etc.
   const manifestPath = path.join(
@@ -6298,23 +6439,20 @@ function stripAndroidForCloud() {
     let xml = fs.readFileSync(manifestPath, "utf8");
     const original = xml;
 
-    for (const component of ANDROID_CLOUD_STRIPPED_COMPONENTS) {
+    for (const component of stripPolicy.components) {
       xml = removeApplicationComponentBlock(
         xml,
         `${androidPackage}.${component}`,
       );
       xml = removeApplicationComponentClassBlock(xml, component);
     }
-    xml = removeXmlCommentsContaining(xml, ANDROID_CLOUD_STRIPPED_COMPONENTS);
+    xml = removeXmlCommentsContaining(xml, stripPolicy.components);
     xml = ensureManifestApplicationClosedBeforeTopLevelEntries(xml);
 
-    xml = removeAndroidPermissionRequests(
-      xml,
-      ANDROID_CLOUD_STRIPPED_PERMISSIONS,
-    );
+    xml = removeAndroidPermissionRequests(xml, stripPolicy.permissions);
     xml = ensureAndroidPermissionRemovalMarkers(
       xml,
-      ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS,
+      stripPolicy.mergerRemovedPermissions,
     );
     xml = applyAndroidCleartextPolicy(xml, { allowCleartext: false });
 
@@ -6346,7 +6484,7 @@ function stripAndroidForCloud() {
   let removedJavaCount = 0;
   for (const root of javaRoots) {
     if (!fs.existsSync(root)) continue;
-    for (const file of ANDROID_CLOUD_STRIPPED_JAVA_FILES) {
+    for (const file of stripPolicy.javaFiles) {
       const target = path.join(root, file);
       if (fs.existsSync(target)) {
         fs.rmSync(target);
@@ -6546,9 +6684,9 @@ const ANDROID_SOURCE_AUDITS = Object.freeze({
 
 const ANDROID_ARTIFACT_AUDITS = Object.freeze({
   sideload: ({ javaHome }) => auditAndroidSideloadArtifact({ javaHome }),
-  cloud: ({ javaHome }) => auditAndroidCloudArtifact({ javaHome }),
-  cloudDebug: ({ javaHome }) =>
-    auditAndroidCloudArtifact({ debug: true, javaHome }),
+  cloud: ({ env, javaHome }) => auditAndroidCloudArtifact({ env, javaHome }),
+  cloudDebug: ({ env, javaHome }) =>
+    auditAndroidCloudArtifact({ debug: true, env, javaHome }),
   smsGateway: ({ androidSdkRoot, javaHome }) =>
     auditAndroidSmsGatewayArtifact({ androidSdkRoot, javaHome }),
   system: ({ javaHome }) => auditAndroidSystemArtifact({ javaHome }),
@@ -6630,11 +6768,19 @@ export async function runAndroidBuild(
   targetName,
   { debug = false, env = process.env } = {},
 ) {
+  const resolvedEnv = resolveAndroidLp3ColorPolicyBuildEnv(env);
   const target = resolveAndroidBuildTarget(targetName, { debug });
-  runAndroidTargetPhase(target, ANDROID_PREFLIGHTS, "preflightKey", { env });
+  enforceAndroidLp3ColorPolicyBuildPolicy({
+    targetName: target.target,
+    env: resolvedEnv,
+    appId: APP.appId,
+  });
+  runAndroidTargetPhase(target, ANDROID_PREFLIGHTS, "preflightKey", {
+    env: resolvedEnv,
+  });
 
-  const sdk = resolveAndroidSdkRoot(env);
-  const jdk = resolveJavaHome(env);
+  const sdk = resolveAndroidSdkRoot(resolvedEnv);
+  const jdk = resolveJavaHome(resolvedEnv);
   if (!sdk)
     throw new Error(
       "Android SDK not found. Set ANDROID_SDK_ROOT or ANDROID_HOME.",
@@ -6644,7 +6790,7 @@ export async function runAndroidBuild(
     target,
     ANDROID_AFTER_TOOLCHAIN,
     "afterToolchainResolvedKey",
-    { env },
+    { env: resolvedEnv },
   );
 
   await buildWeb(target.webTarget);
@@ -6667,23 +6813,26 @@ export async function runAndroidBuild(
       ...target.agentRuntime,
     });
   }
-  runAndroidTargetPhase(target, ANDROID_SOURCE_STRIPS, "stripSourceKey");
+  runAndroidTargetPhase(target, ANDROID_SOURCE_STRIPS, "stripSourceKey", {
+    env: resolvedEnv,
+  });
   runAndroidTargetPhase(
     target,
     ANDROID_SOURCE_AUDITS,
     "auditSourceKey",
     "pre-gradle",
+    { env: resolvedEnv },
   );
 
   const buildEnv = createAndroidBuildEnv(target, {
     androidSdkRoot: sdk,
-    env,
+    env: resolvedEnv,
     javaHome: jdk,
   });
   const { buildArgs, metadataArgs } = resolveAndroidGradleCommands(
     target.target,
     {
-      env,
+      env: resolvedEnv,
       settingsGradle: readAndroidSettingsGradle(),
     },
   );
@@ -6700,6 +6849,7 @@ export async function runAndroidBuild(
     ANDROID_SOURCE_AUDITS,
     "auditSourceKey",
     "post-gradle",
+    { env: resolvedEnv },
   );
   const artifact = runAndroidTargetPhase(
     target,
@@ -6707,6 +6857,7 @@ export async function runAndroidBuild(
     "artifactAuditKey",
     {
       androidSdkRoot: sdk,
+      env: resolvedEnv,
       javaHome: jdk,
     },
   );
@@ -6843,6 +6994,149 @@ function listAndroidArtifactEntries(artifact, javaHome) {
   return result.stdout.split(/\r?\n/);
 }
 
+function auditAndroidArtifactDexLp3Policy(
+  artifact,
+  entries,
+  javaHome,
+  { debug, expectedPresent },
+) {
+  const dexEntries = entries.filter((entry) =>
+    /(^|\/)classes\d*\.dex$/.test(entry),
+  );
+  if (dexEntries.length === 0) {
+    throw new Error(
+      `[mobile-build] Android artifact has no classes*.dex entries: ${artifact}`,
+    );
+  }
+
+  const extractionDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "eliza-lp3-dex-audit-"),
+  );
+  try {
+    const jar = resolveJarTool(javaHome);
+    const extraction = spawnSync(jar, ["xf", artifact, ...dexEntries], {
+      cwd: extractionDir,
+      encoding: "utf8",
+    });
+    if (extraction.status !== 0) {
+      throw new Error(
+        `[mobile-build] Could not extract DEX for LP3 policy audit: ${
+          extraction.stderr ||
+          extraction.stdout ||
+          `jar exited with ${extraction.status}`
+        }`,
+      );
+    }
+    const dexBuffers = dexEntries.map((entry) =>
+      fs.readFileSync(path.join(extractionDir, entry)),
+    );
+    const packagePath = APP.appId.replaceAll(".", "/");
+    const classNames =
+      expectedPresent && !debug
+        ? ANDROID_LP3_COLOR_POLICY_COMPONENTS
+        : ANDROID_LP3_COLOR_POLICY_JAVA_FILES.map((file) =>
+            file.replace(/\.java$/, ""),
+          );
+    const findings = classNames.filter((className) => {
+      const marker = Buffer.from(`${packagePath}/${className}`, "utf8");
+      return dexBuffers.some((dex) => dex.includes(marker));
+    });
+    if (expectedPresent && findings.length !== classNames.length) {
+      const missing = classNames.filter((name) => !findings.includes(name));
+      throw new Error(
+        "[mobile-build] opted-in LP3 artifact DEX is missing policy classes:\n" +
+          missing.map((name) => `  - ${APP.appId}.${name}`).join("\n"),
+      );
+    }
+    if (!expectedPresent && findings.length > 0) {
+      throw new Error(
+        "[mobile-build] normal Cloud artifact DEX still contains LP3 policy classes:\n" +
+          findings.map((name) => `  - ${APP.appId}.${name}`).join("\n"),
+      );
+    }
+  } finally {
+    fs.rmSync(extractionDir, { force: true, recursive: true });
+  }
+}
+
+function findAndroidManifestElementBlock(
+  manifestText,
+  elementName,
+  qualifiedName,
+) {
+  const lines = manifestText.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(\s*)E: (\S+)/);
+    if (!match || match[2] !== elementName) continue;
+    const indent = match[1].length;
+    let end = index + 1;
+    while (end < lines.length) {
+      const nextElement = lines[end].match(/^(\s*)E: /);
+      if (nextElement && nextElement[1].length <= indent) break;
+      end += 1;
+    }
+    const block = lines.slice(index, end).join("\n");
+    if (block.includes(qualifiedName)) return block;
+  }
+  return null;
+}
+
+function assertAndroidLp3ColorPolicyManifest(manifestText) {
+  const serviceName = `${APP.appId}.Lp3ColorPolicyService`;
+  const receiverName = `${APP.appId}.Lp3ColorPolicyBootReceiver`;
+  const service = findAndroidManifestElementBlock(
+    manifestText,
+    "service",
+    serviceName,
+  );
+  const receiver = findAndroidManifestElementBlock(
+    manifestText,
+    "receiver",
+    receiverName,
+  );
+  if (!service) {
+    throw new Error(
+      `[mobile-build] opted-in LP3 artifact is missing ${serviceName}`,
+    );
+  }
+  if (!receiver) {
+    throw new Error(
+      `[mobile-build] opted-in LP3 artifact is missing ${receiverName}`,
+    );
+  }
+  if (!/android:exported[^\n]*(?:0x0|false)/.test(service)) {
+    throw new Error(
+      `[mobile-build] opted-in LP3 service must be android:exported=false`,
+    );
+  }
+  if (!/android:exported[^\n]*(?:0x0|false)/.test(receiver)) {
+    throw new Error(
+      `[mobile-build] opted-in LP3 receiver must be android:exported=false`,
+    );
+  }
+  if (
+    !/android:foregroundServiceType[^\n]*0x40000000/.test(service) ||
+    !service.includes("android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE")
+  ) {
+    throw new Error(
+      `[mobile-build] opted-in LP3 service is missing its specialUse foreground contract`,
+    );
+  }
+  for (const action of [
+    "android.intent.action.BOOT_COMPLETED",
+    "android.intent.action.MY_PACKAGE_REPLACED",
+    "ai.elizaos.app.action.ENABLE_LP3_COLOR_POLICY",
+    "ai.elizaos.app.action.DISABLE_LP3_COLOR_POLICY",
+    "ai.elizaos.app.action.SYNC_LP3_COLOR_POLICY",
+  ]) {
+    if (!receiver.includes(action)) {
+      throw new Error(
+        `[mobile-build] opted-in LP3 receiver is missing action ${action}`,
+      );
+    }
+  }
+}
+
 /**
  * Positive assertion that an installable APK actually ships the web renderer
  * (and, for local builds, the on-device agent). Without this, a sync that
@@ -6885,7 +7179,13 @@ function assertAndroidArtifactShipsWebPayload(
   }
 }
 
-function auditAndroidCloudArtifact({ debug = false, javaHome } = {}) {
+function auditAndroidCloudArtifact({
+  debug = false,
+  env = process.env,
+  javaHome,
+} = {}) {
+  const lp3ColorPolicyEnabled = isAndroidLp3ColorPolicyEnabled(env);
+  const stripPolicy = resolveAndroidCloudStripPolicy(env);
   const artifact = debug ? findAndroidCloudDebugApk() : findAndroidCloudAab();
   if (!artifact) {
     throw new Error(
@@ -6904,16 +7204,15 @@ function auditAndroidCloudArtifact({ debug = false, javaHome } = {}) {
         offenders.map((entry) => `  - ${entry}`).join("\n"),
     );
   }
-  const aapt = resolveAndroidBuildTool(resolveAndroidSdkRoot(), "aapt");
+  const aapt = resolveAndroidBuildTool(resolveAndroidSdkRoot(env), "aapt");
   if (!aapt) {
     throw new Error(
       "[mobile-build] Could not find aapt under Android SDK build-tools for android-cloud artifact audit.",
     );
   }
   const badging = dumpAndroidArtifactBadging(aapt, artifact);
-  const permissionOffenders = ANDROID_CLOUD_STRIPPED_PERMISSIONS.filter(
-    (perm) =>
-      badging.includes(`uses-permission: name='android.permission.${perm}'`),
+  const permissionOffenders = stripPolicy.permissions.filter((perm) =>
+    badging.includes(`uses-permission: name='android.permission.${perm}'`),
   );
   if (permissionOffenders.length > 0) {
     throw new Error(
@@ -6923,6 +7222,35 @@ function auditAndroidCloudArtifact({ debug = false, javaHome } = {}) {
           .join("\n"),
     );
   }
+  const manifestText = dumpAndroidArtifactManifest(aapt, artifact);
+  for (const component of stripPolicy.components) {
+    if (manifestText.includes(`${APP.appId}.${component}`)) {
+      throw new Error(
+        `[mobile-build] android-cloud artifact still declares stripped component ${component}`,
+      );
+    }
+  }
+  if (lp3ColorPolicyEnabled) {
+    const missingPermissions = ANDROID_LP3_COLOR_POLICY_PERMISSIONS.filter(
+      (permission) =>
+        !badging.includes(
+          `uses-permission: name='android.permission.${permission}'`,
+        ),
+    );
+    if (missingPermissions.length > 0) {
+      throw new Error(
+        "[mobile-build] opted-in LP3 artifact is missing required permissions:\n" +
+          missingPermissions
+            .map((permission) => `  - android.permission.${permission}`)
+            .join("\n"),
+      );
+    }
+    assertAndroidLp3ColorPolicyManifest(manifestText);
+  }
+  auditAndroidArtifactDexLp3Policy(artifact, entries, javaHome, {
+    debug,
+    expectedPresent: lp3ColorPolicyEnabled,
+  });
   // Cloud is a thin client (no on-device agent), but it must still ship the
   // renderer — a web-less cloud APK is just as broken as a web-less sideload.
   assertAndroidArtifactShipsWebPayload(artifact, entries, {
@@ -6930,7 +7258,7 @@ function auditAndroidCloudArtifact({ debug = false, javaHome } = {}) {
     label: "android-cloud",
   });
   console.log(
-    `[mobile-build] android-cloud artifact audit passed: ${artifact}`,
+    `[mobile-build] android-cloud${lp3ColorPolicyEnabled ? " LP3 direct" : ""} artifact audit passed: ${artifact}`,
   );
   return artifact;
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -114,6 +114,7 @@
     "build:android:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android",
     "build:android:cloud": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud",
     "build:android:cloud:debug": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
+    "build:android:lp3-cloud:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:system": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-system",
     "preflight:android:sideload": "node scripts/mobile-release-preflight.mjs --platform=android --sideload",
     "preflight:android:store": "node scripts/mobile-release-preflight.mjs --platform=android --store",

--- a/packages/os/android/vendor/eliza/manifests/aosp-assistant-full-control.json
+++ b/packages/os/android/vendor/eliza/manifests/aosp-assistant-full-control.json
@@ -155,7 +155,9 @@
       "ElizaVoiceInteractionService",
       "ElizaVoiceInteractionSessionService",
       "ElizaRecognitionService",
-      "ElizaVoiceInputMethodService"
+      "ElizaVoiceInputMethodService",
+      "Lp3ColorPolicyService",
+      "Lp3ColorPolicyBootReceiver"
     ],
     "mustStripPermissions": [
       "android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION",
@@ -169,7 +171,8 @@
       "android.permission.INJECT_EVENTS",
       "android.permission.REAL_GET_TASKS",
       "android.permission.BIND_ACCESSIBILITY_SERVICE",
-      "android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+      "android.permission.BIND_NOTIFICATION_LISTENER_SERVICE",
+      "android.permission.WRITE_SECURE_SETTINGS"
     ],
     "mustStripPlugins": [
       "@elizaos/capacitor-agent",

--- a/scripts/security/coverage-subprocess-sources.txt
+++ b/scripts/security/coverage-subprocess-sources.txt
@@ -28,6 +28,10 @@ packages/eliza-hub/services/merge-steward/src/cli.js
 # at module evaluation; its importable bootstrap policies carry unit coverage.
 packages/app-core/src/runtime/dev-server.ts
 
+# The mobile build orchestrator mutates a staged native tree and launches the
+# platform toolchain; its contract suite also drives the real CLI rejection path.
+packages/app-core/scripts/run-mobile-build.mjs
+
 # ACP stdio entrypoint is exercised via spawned runtime contract tests; importing it in-process starts the protocol server.
 packages/examples/code/src/acp.ts
 


### PR DESCRIPTION
Refs #16888

## Summary

- add a dedicated direct-distribution LP3 Cloud debug build lane guarded by `ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1`;
- persist an explicit operator opt-in in device-protected private storage and maintain full color only on `Light` / `TLP301` devices with `WRITE_SECURE_SETTINGS`;
- observe only the two daltonizer settings, debounce launcher rewrites, write mismatches only, verify readback, and stop observably on opt-out, permission loss, wrong device, or failure;
- keep every policy class, component, action, and restricted permission out of ordinary Cloud and release artifacts.

This does not touch `light_mode`, SurfaceFlinger, Qualcomm display properties, auth/app data, or networking.

## Safety boundary

- The implementation lives in an external debug-only source set. Canonical `app/src/main` contains no policy code or components.
- The build flag is accepted only by the dedicated `android-cloud-debug` direct-distribution command and is rejected for release, Play, SMS, AOSP, app-dir, sideload, and whitelabel targets.
- Runtime activation requires all of: compile-time lane enabled, exact `Light` / `TLP301`, granted privileged permission, and explicit same-UID operator opt-in.
- The service and receiver are unexported. Operator enable/disable/sync commands are same-UID only.
- The persistent foreground service uses the Android `specialUse` contract and a visible low-importance notification.

## Source and test evidence

Exact base: `050b26353ab84daed96f3e338862e28471145241`

Exact head: `9751207dbc6b232ee62fd62d9c9151d902eb3098`

- `git range-diff f23365e0fd^! 9751207dbc^!`: exact `=`
- focused mobile-build suite: **43 passed, 0 failed, 134 assertions**
- Android JVM policy tests, flag unset: debug + release variants, **1,063 tasks, BUILD SUCCESSFUL**
- Android JVM policy tests, flag set: debug + release variants, **1,063 tasks, BUILD SUCCESSFUL**
- Biome: passed
- `xmllint` / `jq`: passed
- `git diff --check`: passed
- error-policy ratchet: passed, zero new production fallback slop
- independent source review: passed for source-set isolation, opt-in/device/permission gates, exact settings boundary, boot/package-replace behavior, debounce/no-loop behavior, and failure handling

## Exact artifact isolation matrix

| Build | SHA-256 | Result |
| --- | --- | --- |
| Dedicated LP3 Cloud debug | `ccb855f86d4db8f13d564c1d0e028fc28e888fb7f5aad13b2cd72eafe8cbb4db` | `ai.elizaos.app`; v2 signer cert `afa5afb6ba582f67222548872292341df0bf6d625f705904858b81051dde91f4`; `WRITE_SECURE_SETTINGS`, boot receiver, unexported foreground service, private operator actions, `specialUse` subtype, and policy bytecode present (`classes17.dex`). Canonical post-Gradle LP3 artifact audit passed. |
| Ordinary Cloud debug, flag unset | `1210915a76eada7da62393142acd20bb0e1223c4502daf32e1dc880da0b90d9b` | Same package and signer; exact policy permission, classes, components, actions, subtype, and DEX markers absent. Canonical ordinary Cloud artifact audit passed. |
| Raw release with malicious flag set | `a5f9a83d39583c8869b32cd8a6d55eeff5f69a63d96e2c96b91bdbfdc73ff352` | **1,330 tasks, BUILD SUCCESSFUL**; exact policy permission, classes, components, actions, subtype, and DEX markers absent. This proves the debug source set cannot leak into release even when the environment flag is set. |

The dedicated and ordinary debug artifacts use the same ElizaOS debug signer already proven against the current physical LP3 install. No device mutation was performed for this source/isolation proof.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - this source/isolation PR intentionally does not mutate the protected LP3; before pixels belong to the user-approved composed-APK proof.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the exact composed APK must pass review and user approval before an in-place install and after screenshot are allowed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - HOME relaunch, process restart, and reboot video will be captured from the exact reviewed composed APK, not from an isolated build that would overwrite current demo behavior.
<!-- evidence-row:backend-logs -->
- [x] N/A - this policy has no backend path; native Gradle, manifest, signer, and DEX audit results are recorded in the exact artifact matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - this policy changes no frontend state or network path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this policy changes no model, action, provider, prompt, planner, or evaluator behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the three exact APK artifacts remain local and unhashed installation is forbidden; their SHA-256, signer, manifest, and DEX outcomes are recorded above pending the composed-device proof.

## Human-verifiable evidence status

- Real LP3 install / HOME relaunch / process restart / reboot video: **pending the deliberately composed APK** that also carries the already-proven pager and WebView touch chain. Installing this isolated artifact now would overwrite newer demo behavior and provide weaker evidence.
- Device logs and before/after secure-setting reads: **pending the same composed exact-SHA install**.
- Screenshots: **N/A for source isolation**; physical full-color before/after evidence will be attached with the composed-device proof.
- Backend/frontend network logs: **N/A**; this policy has no network or backend path.
- Live-model trajectory: **N/A**; no model, action, prompt, or agent behavior changes.

The post-review device gate is: verify signer and composed manifest/DEX, install in place with `adb install -r` only, grant the privileged permission, opt in through the private same-UID command, prove launcher rewrite repair, then prove HOME relaunch, process restart, real reboot, preserved auth/data, and final full-color pixels.
