### PR TITLE
fix(cloud): model the shared-agent scope cache's serialized dates instead of casting through unknown

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -127,6 +127,10 @@ function agent(overrides: Record<string, unknown> = {}) {
     status: "running",
     bridge_url: null,
     agent_name: "Shared Agent",
+    // `created_at` / `updated_at` are NOT NULL columns — a real Drizzle row (and
+    // its cache round-trip) always carries them, so the fixture must too.
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
     ...overrides,
   };
 }
@@ -554,6 +558,48 @@ describe("resolveSharedAgent SESSION scope cache (SHADOW-ACCOUNT-DEBUG)", () => 
       const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
       if (!("agent" in result)) throw new Error("expected a resolved agent");
       expect(result.agent.deleted_at).toBeNull();
+    });
+
+    test("an already-Date cached timestamp passes through unchanged (idempotent)", async () => {
+      // The cache always JSON-round-trips, but rehydration must be idempotent:
+      // a value that is already a Date is returned as-is (the `instanceof Date`
+      // passthrough), never re-parsed. Seed a LIVE Date (no round-trip).
+      const key = CacheKeys.sharedAgentScope.resolve("keyhashpref0000", "agent-1");
+      cacheStore.set(key, {
+        orgId: "org-1",
+        agent: agent({ created_at: CREATED, updated_at: CREATED }),
+        firstWrittenAtMs: Date.now(),
+      });
+      const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
+      if (!("agent" in result)) throw new Error("expected a resolved agent");
+      expect(result.agent.created_at instanceof Date).toBe(true);
+      expect((result.agent.created_at as Date).toISOString()).toBe(CREATED.toISOString());
+    });
+
+    test("an unparseable cached timestamp fails closed: the poisoned hit is dropped and the authoritative gate re-hydrates", async () => {
+      // A truncated/garbled cache value deserializes a timestamp column to a
+      // string `new Date()` rejects. The fix must NOT leak that string into a
+      // `Date` field (the pre-fix passthrough did, then the route 500s on
+      // `.toISOString()`): it fails closed, drops the entry to a MISS, and lets
+      // the authoritative DB hydration re-populate a clean, Date-typed row.
+      const key = CacheKeys.sharedAgentScope.resolve("keyhashpref0000", "agent-1");
+      const poisoned = jsonRoundTrip({
+        orgId: "org-1",
+        agent: agent({ created_at: CREATED, updated_at: CREATED }),
+        firstWrittenAtMs: Date.now(),
+      }) as { agent: Record<string, unknown> };
+      poisoned.agent.created_at = "not-a-real-timestamp";
+      cacheStore.set(key, poisoned);
+      findByIdAndOrg.mockResolvedValue(agent({ created_at: CREATED, updated_at: CREATED }));
+
+      const result = await resolveSharedAgent(apiKeyContext("agent-1") as never);
+
+      // The poisoned entry was NOT served: the cold authoritative gate ran.
+      expect(requireUserOrApiKeyWithOrgLookup).toHaveBeenCalledTimes(1);
+      if (!("agent" in result)) throw new Error("expected a resolved agent");
+      // The re-hydrated row carries a real Date, never the poisoned string.
+      expect(result.agent.created_at instanceof Date).toBe(true);
+      expect(() => (result.agent.created_at as Date).toISOString()).not.toThrow();
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -41,29 +41,83 @@ const AGENT_SANDBOX_DATE_FIELDS = [
 ] as const satisfies ReadonlyArray<keyof AgentSandbox>;
 
 /**
- * Restore the `AgentSandbox` DATE contract after a scope-cache round-trip
- * (CONVERSATIONS-500-2026-07-22). The cache client JSON-serializes on write and
- * JSON-parses on read, so every `timestamp` column that Drizzle hands us as a JS
- * `Date` on a live DB hydration comes back from cache as an ISO **string**.
- * Downstream consumers rely on the typed contract — e.g. the shared-agent
- * conversations route calls `agent.created_at.toISOString()`, which throws
- * (`string.toISOString is not a function`) and 500s the read on EVERY cache hit
- * (the exact "first call 200, then all 500" defect). Rehydrating the known date
- * fields at the cache-read boundary keeps a cache hit byte-for-byte equivalent
- * to a fresh DB hydration for every caller. Best-effort per field: an absent or
- * already-`Date` value is left untouched; an unparseable value is left as-is so
- * we never fabricate a bogus `Date`.
+ * The `AgentSandbox` as the scope cache actually holds it: the client
+ * JSON-serializes on write and JSON-parses on read, so every `timestamp` column
+ * comes back as an ISO **string** (nulls stay null). Model that shape directly
+ * — deriving each date field's cached type as `<original> | string` so the
+ * per-column nullability (`created_at`/`updated_at` are NOT NULL, the rest are
+ * nullable) carries over exactly — instead of pretending a cached row is still a
+ * fully-typed `AgentSandbox` and casting through `unknown` to touch its fields.
  */
-function rehydrateCachedAgentDates(agent: AgentSandbox): AgentSandbox {
-  const out = agent as unknown as Record<string, unknown>;
-  for (const field of AGENT_SANDBOX_DATE_FIELDS) {
-    const value = out[field];
-    if (typeof value === "string") {
-      const parsed = new Date(value);
-      if (!Number.isNaN(parsed.getTime())) out[field] = parsed;
-    }
+type CachedAgentSandbox = Omit<AgentSandbox, (typeof AGENT_SANDBOX_DATE_FIELDS)[number]> & {
+  [K in (typeof AGENT_SANDBOX_DATE_FIELDS)[number]]: AgentSandbox[K] | string;
+};
+
+/** A cached timestamp column that JSON-parsed to a value `new Date()` rejects. */
+class SharedAgentCacheDateError extends Error {
+  constructor(field: string, value: string) {
+    super(
+      `shared-agent scope cache holds an unparseable ${field} timestamp: ${JSON.stringify(value)}`,
+    );
+    this.name = "SharedAgentCacheDateError";
   }
-  return agent;
+}
+
+/** Revive a NOT-NULL cached timestamp column; throws on unparseable input. */
+function reviveRequiredCachedDate(value: Date | string, field: string): Date {
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new SharedAgentCacheDateError(field, value);
+  return parsed;
+}
+
+/** Revive a nullable cached timestamp column; throws on unparseable input. */
+function reviveNullableCachedDate(
+  value: Date | string | null | undefined,
+  field: string,
+): Date | null {
+  // Absent (undefined) or explicit null → the column is genuinely empty, not
+  // corrupt. Only a present, non-empty string that `new Date()` rejects is
+  // invalid data worth failing closed on.
+  if (value == null) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new SharedAgentCacheDateError(field, value);
+  return parsed;
+}
+
+/**
+ * Restore the `AgentSandbox` DATE contract after a scope-cache round-trip
+ * (CONVERSATIONS-500-2026-07-22). Downstream consumers rely on the typed
+ * contract — e.g. the shared-agent conversations route calls
+ * `agent.created_at.toISOString()`, which throws (`string.toISOString is not a
+ * function`) and 500s the read on EVERY cache hit (the "first call 200, then
+ * all 500" defect). Each known date column is revived through a typed helper so
+ * a cache hit is byte-for-byte equivalent to a fresh DB hydration, with no
+ * dynamic-key mutation and no cast. An already-`Date`/null value passes through;
+ * an unparseable string FAILS CLOSED (throws) rather than leaking a `string`
+ * into a `Date` field — the caller drops the poisoned entry to a cache miss.
+ */
+function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
+  return {
+    ...agent,
+    created_at: reviveRequiredCachedDate(agent.created_at, "created_at"),
+    updated_at: reviveRequiredCachedDate(agent.updated_at, "updated_at"),
+    deleted_at: reviveNullableCachedDate(agent.deleted_at, "deleted_at"),
+    claimed_at: reviveNullableCachedDate(agent.claimed_at, "claimed_at"),
+    pool_ready_at: reviveNullableCachedDate(agent.pool_ready_at, "pool_ready_at"),
+    last_backup_at: reviveNullableCachedDate(agent.last_backup_at, "last_backup_at"),
+    last_heartbeat_at: reviveNullableCachedDate(agent.last_heartbeat_at, "last_heartbeat_at"),
+    last_billed_at: reviveNullableCachedDate(agent.last_billed_at, "last_billed_at"),
+    shutdown_warning_sent_at: reviveNullableCachedDate(
+      agent.shutdown_warning_sent_at,
+      "shutdown_warning_sent_at",
+    ),
+    scheduled_shutdown_at: reviveNullableCachedDate(
+      agent.scheduled_shutdown_at,
+      "scheduled_shutdown_at",
+    ),
+  };
 }
 
 /**
@@ -78,7 +132,9 @@ function rehydrateCachedAgentDates(agent: AgentSandbox): AgentSandbox {
  */
 interface CachedSharedAgentScope {
   orgId: string;
-  agent: AgentSandbox;
+  // Holds the JSON-round-tripped shape, not a live `AgentSandbox`: the date
+  // columns are ISO strings on read (rehydrated at the read boundary below).
+  agent: CachedAgentSandbox;
   /**
    * Steward user id the entry was written for, present ONLY on session-keyed
    * entries (#SHADOW-ACCOUNT-DEBUG). A session-path hit re-verifies the JWT and
@@ -186,8 +242,19 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
     // Restore the DATE contract lost to the cache's JSON round-trip before
     // handing the agent to route consumers (e.g. conversations route calls
     // `agent.created_at.toISOString()`). Without this a cache hit 500s the read
-    // (CONVERSATIONS-500-2026-07-22).
-    const agent = rehydrateCachedAgentDates(cached.agent);
+    // (CONVERSATIONS-500-2026-07-22). A poisoned entry (unparseable cached
+    // timestamp) fails closed: drop it to a MISS so the authoritative DB
+    // hydration re-populates it, never serve a row that violates AgentSandbox.
+    let agent: AgentSandbox;
+    try {
+      agent = rehydrateCachedAgentDates(cached.agent);
+    } catch (error) {
+      logger.warn(
+        "[resolveSharedAgent] dropping scope-cache hit with an invalid cached timestamp",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return null;
+    }
     return {
       agent,
       agentId,


### PR DESCRIPTION
# Relates to

Closes #16859.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `tsgo --noEmit` clean on `packages/cloud/shared`; biome clean on both changed files; `git diff --check` clean; the changed suite passes 25/25.

# Risks

Low. The rehydration is a pure boundary transform with identical behavior for well-formed entries (the only path prod ever produces): every existing `resolve-shared-agent` test passes unchanged. The one behavioral delta is stricter and safer — a corrupt cached timestamp now fails closed to a cache miss instead of leaking a `string` into a `Date` field.

# Background

## What does this PR do?

`rehydrateCachedAgentDates` (resolve-shared-agent.ts) cast the cached agent row to `Record<string, unknown>` via `as unknown as` so it could mutate its timestamp columns by dynamic key — the double cast the type-safety ratchet flagged (`as unknown as: 85 / 84` at filing time; the offending cast is this one).

- Replaced the cast with an explicit **`CachedAgentSandbox`** model: the date columns are typed as the `string | Date | null` they actually are after the cache client's JSON round-trip, with per-column nullability **derived** from `AgentSandbox` (`created_at`/`updated_at` stay NOT NULL, the other eight stay nullable). Each column is revived through a small typed helper — no dynamic-key mutation, no cast.
- The cache's stored-agent field is retyped to `CachedAgentSandbox` (it never held a live `AgentSandbox` — a real `AgentSandbox` is still assignable on write, since `Date ⊆ string | Date | null`).
- **Fail closed on invalid data**: an unparseable cached timestamp throws; the read boundary catches it, logs a warning, and drops the poisoned entry to a **cache miss** so the authoritative DB hydration re-populates a clean row — never returning an object that violates `AgentSandbox` (which is what 500s the conversations route on `.toISOString()`).

## What kind of change is this?

Bug fix (type safety + fail-closed cache-boundary hardening).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`resolve-shared-agent.test.ts` → the `cache-hit Date rehydration` block. New/expanded coverage per the acceptance criteria: valid ISO strings restore to `Date`, an already-`Date`/`null` value passes through unchanged (idempotent), and an **unparseable** timestamp fails closed — the poisoned hit is dropped and the authoritative gate re-hydrates (asserted by the cold gate running + the result carrying a real `Date`). The fixture now sets `created_at`/`updated_at` because they are NOT NULL columns a real Drizzle row always carries.

## Detailed testing steps

None: automated tests are acceptable. Changed suite: **25 pass / 0 fail** (CI-pinned bun, `--conditions=eliza-source`). `tsgo --noEmit` clean on `packages/cloud/shared`. Type-safety ratchet: `as unknown as` drops **83 → 82** with this change (the ratchet even reports "baseline can shrink 84 → 82"); the baseline is left untouched, satisfying "remove the cast without raising the baseline."

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - type-safety + cache-boundary fix in .ts; no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - type-safety + cache-boundary fix in .ts; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; behavior pinned by the resolve-shared-agent test lane.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the defect (cache-hit 500 on .toISOString()) reproduces only against a live scope cache; the deterministic reproduction (JSON-round-tripped + poisoned cache entries) lives in the changed suite.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; scope-cache date rehydration only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows; the artifact is the Date-typed agent handed to route consumers, asserted per lane.`

# Evidence Details

The stricter fail-closed path is the load-bearing new behavior and is asserted directly: a cache entry whose `created_at` deserializes to `"not-a-real-timestamp"` must NOT be served — the test proves the cold authoritative gate runs (the entry was dropped to a miss) and the re-hydrated row carries a real `Date`.

## Known gaps / failures

The `type-safety-ratchet` lane is currently red on `develop` for a **separate, pre-existing** metric — `?? "" (core/agent/app-core): 591 / 590` — spread across `core`/`agent` files unrelated to the shared-agent cache. This PR does not touch that metric (its diff adds zero `?? ""`), so that overage will still show until it is addressed on its own; it is out of scope for the cast removal this issue asked for. The `as unknown as` metric this issue is about passes with this change (82 / 84). The Security Advisory Gate requires the `claude-review` bot, which currently errors on fork PRs — a pre-existing infra blocker.

[stan-cloud]
