### PR TITLE
test(coding-tools): fix Windows CI — gate destructive-confirm pass-through cases to POSIX

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1942,6 +1942,8 @@ describe("platform-aware canned resource commands", () => {
 });
 
 describe("destructive-bulk confirm gate", () => {
+  // The BLOCK path never executes anything, so it is platform-independent
+  // and runs everywhere (including Windows).
   it("blocks an unconfirmed recursive delete with needs_confirmation", async () => {
     const { runtime } = await makeRuntime();
     const result = await shellAction.handler?.(
@@ -1957,62 +1959,76 @@ describe("destructive-bulk confirm gate", () => {
     expect(data?.destructive_reason).toBe("recursive delete");
   });
 
-  it("runs the same command when confirm=true", async () => {
-    const { runtime } = await makeRuntime();
-    const result = await shellAction.handler?.(
-      runtime,
-      makeMessage(undefined, "yes do it"),
-      undefined,
-      {
-        command: "rm -rf /tmp/coding-tools-gate-test-nonexistent",
-        confirm: true,
-      },
-    );
-    // The path does not exist; rm -rf exits 0 on nonexistent targets — the
-    // point is the gate let it through to real execution.
-    expect(result.success).toBe(true);
-  });
+  // The PASS-THROUGH cases below actually execute the command on the host
+  // shell. On Windows that shell is PowerShell (resolveHostShell()), where
+  // `rm -rf <path>` is Remove-Item with an unknown `-rf` parameter and
+  // `ls /tmp` probes a path that may not exist — both exit non-zero, so
+  // `result.success` is false for shell-dialect reasons, not gate reasons
+  // (the suite-wide describeIfPosix rationale at the top of this file).
+  // The gate decision itself is platform-independent and covered on all
+  // platforms by the block test above + destructive-gate.test.ts; the
+  // execution-shaped assertions run on the POSIX lanes.
+  const describePassThroughIfPosix =
+    process.platform === "win32" ? describe.skip : describe;
 
-  it("is exempt on the coding sub-agent path (task briefs carry confirmation)", async () => {
-    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
-    try {
+  describePassThroughIfPosix("pass-through execution (POSIX shell)", () => {
+    it("runs the same command when confirm=true", async () => {
       const { runtime } = await makeRuntime();
       const result = await shellAction.handler?.(
         runtime,
-        makeMessage(undefined, "build step"),
+        makeMessage(undefined, "yes do it"),
         undefined,
-        { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+        {
+          command: "rm -rf /tmp/coding-tools-gate-test-nonexistent",
+          confirm: true,
+        },
       );
+      // The path does not exist; rm -rf exits 0 on nonexistent targets — the
+      // point is the gate let it through to real execution.
       expect(result.success).toBe(true);
-    } finally {
-      delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-    }
-  });
+    });
 
-  it("honors the ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0 escape hatch", async () => {
-    process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM = "0";
-    try {
+    it("is exempt on the coding sub-agent path (task briefs carry confirmation)", async () => {
+      process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
+      try {
+        const { runtime } = await makeRuntime();
+        const result = await shellAction.handler?.(
+          runtime,
+          makeMessage(undefined, "build step"),
+          undefined,
+          { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+        );
+        expect(result.success).toBe(true);
+      } finally {
+        delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+      }
+    });
+
+    it("honors the ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0 escape hatch", async () => {
+      process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM = "0";
+      try {
+        const { runtime } = await makeRuntime();
+        const result = await shellAction.handler?.(
+          runtime,
+          makeMessage(undefined, "clean up"),
+          undefined,
+          { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+        );
+        expect(result.success).toBe(true);
+      } finally {
+        delete process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM;
+      }
+    });
+
+    it("never gates ordinary commands", async () => {
       const { runtime } = await makeRuntime();
       const result = await shellAction.handler?.(
         runtime,
-        makeMessage(undefined, "clean up"),
+        makeMessage(undefined, "whats here"),
         undefined,
-        { command: "rm -rf /tmp/coding-tools-gate-test-nonexistent" },
+        { command: "ls /tmp" },
       );
       expect(result.success).toBe(true);
-    } finally {
-      delete process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM;
-    }
-  });
-
-  it("never gates ordinary commands", async () => {
-    const { runtime } = await makeRuntime();
-    const result = await shellAction.handler?.(
-      runtime,
-      makeMessage(undefined, "whats here"),
-      undefined,
-      { command: "ls /tmp" },
-    );
-    expect(result.success).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## What

The **windows (framework-packages)** shard is red on the develop head: 8 failing tests (4 cases x2 via `bash-regression-lane.test.ts`'s composition import), all in the `destructive-bulk confirm gate` suite added by #16709's merge train.

## Root cause: shell dialect, not the gate

Every failing case is one that **executes the command after the gate lets it through**, asserting `result.success === true`. On Windows `resolveHostShell()` routes to `powershell.exe -Command`, where:

- `rm -rf <path>` is PowerShell's `Remove-Item` alias with an unknown `-rf` parameter → non-zero exit
- `ls /tmp` probes a path that may not exist on the runner → non-zero exit

So `result.success` is `false` for shell-dialect reasons the file's own suite-wide comment already documents (`describeIfPosix` at the top: this suite pins the *bash* output shape; per-platform expected values are explicitly out of scope for the Windows lane).

The gate **decision** logic (classify → block/pass) is pure and platform-independent.

## Fix (test-only, mirrors the file's existing pattern)

- The **block** case (`blocks an unconfirmed recursive delete with needs_confirmation`) never spawns a process → stays running on **all** platforms including Windows (it was already passing there).
- The four **pass-through/execution** cases (`confirm=true` runs, coding sub-agent exemption, `ELIZA_SHELL_DESTRUCTIVE_CONFIRM=0` escape hatch, ordinary-command non-gating) move under a `describePassThroughIfPosix` block with a comment explaining exactly why.

Windows coverage of the gate is not weakened: the block test + `destructive-gate.test.ts` (pure classifier suite) still run everywhere.

## Verification

- Local POSIX run: `bash.test.ts` **77 pass / 0 fail** (includes all 5 gate cases)
- Windows repro reasoned from the failing-job assertions (`expected false to be true` at exactly the 4 execution-shaped `expect(result.success).toBe(true)` sites; the block case passed in the same run) — the same failure signature across both shard runs on the head SHA
- biome clean

Part of clearing the real reds on develop head `951a2faa6` (ratchet red is #16906; the remaining Windows core-runtime/app-and-cli failures are pre-existing test-drift on stale heads that the current develop head has already superseded — receipts in the lane deliverable).

🌞 [sol-develop-green-now]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only CI fix, no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only CI fix, no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible behavior; the deliverable is a green Windows shard

<!-- evidence-row:backend-logs -->
- [x] [16909-posix-suite-pass.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16909-posix-suite-pass.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path in this change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model in the loop; deterministic vitest suites

<!-- evidence-row:domain-artifacts -->
- [x] [16909-windows-framework-failures.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16909-windows-framework-failures.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots to OCR
