### PR TITLE
perf(cloud): stale-while-revalidate the org-balance gate hint to take the balance re-read off the chat hot path

### DIFF
--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -304,7 +304,8 @@ export const CacheTTL = {
    */
   inference: {
     authContext: 300, // 5 min - backstop only; revoke paths invalidate explicitly (fail-closed)
-    orgBalance: 15, // 15 seconds - optimistic-billing gate hint, kept tight to bound drift
+    orgBalance: 15, // 15 seconds - FRESHNESS window: getGateBalanceUsd serves a hint older than this stale-while-revalidate (background refresh) instead of blocking on an authoritative read
+    orgBalanceStale: 300, // 5 min - PHYSICAL KV lifetime so a stale hint can be served + background-refreshed; over-admit stays bounded by the debit settler's lowerOrgBalanceHint + top-up invalidate, exactly as before
     pendingCharge: 3600, // 60 min - sweep window = TTL - grace(20m) = 40m, survives cron hiccups
   },
   /**

--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
@@ -234,7 +234,12 @@ export async function writeOrgBalanceHint(
     balanceUsd,
     balanceAt,
   };
-  await cache.set(CacheKeys.inference.orgBalance(orgId), hint, CacheTTL.inference.orgBalance);
+  // Physical lifetime is orgBalanceStale (5m): the hint must survive past the
+  // orgBalance freshness window so getGateBalanceUsd can serve it stale-while-
+  // revalidate. `balanceAt` is the freshness clock the reader checks; the debit
+  // settler (lowerOrgBalanceHint) and top-ups (invalidateOrgBalanceHint) still
+  // keep the served value correct on writes.
+  await cache.set(CacheKeys.inference.orgBalance(orgId), hint, CacheTTL.inference.orgBalanceStale);
 }
 
 /** Drop the org-balance gate hint so the next request re-reads it fresh. */

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -221,6 +221,31 @@ describe("getGateBalanceUsd", () => {
     expect(freshBalanceCalls).toBe(1); // hint served, no 2nd DB read
     expect((await readOrgBalanceHint(org))?.balanceUsd).toBe(33);
   });
+  test("stale hint is served immediately AND triggers a background revalidation", async () => {
+    const org = uid("org");
+    freshBalanceUsd = 77;
+    // A hint older than the orgBalance freshness window (15s).
+    await writeOrgBalanceHint(org, 42, Date.now() - 20_000);
+    const bal = await getGateBalanceUsd(org);
+    expect(bal).toBe(42); // served the STALE value without blocking on a DB read
+    // Revalidation runs off the hot path; let the background task settle.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(freshBalanceCalls).toBe(1); // authoritative refresh happened in the background
+    expect((await readOrgBalanceHint(org))?.balanceUsd).toBe(77); // hint now fresh
+  });
+  test("concurrent stale reads dedupe to a single revalidation", async () => {
+    const org = uid("org");
+    freshBalanceUsd = 88;
+    await writeOrgBalanceHint(org, 42, Date.now() - 20_000);
+    const results = await Promise.all([
+      getGateBalanceUsd(org),
+      getGateBalanceUsd(org),
+      getGateBalanceUsd(org),
+    ]);
+    expect(results).toEqual([42, 42, 42]); // all served the stale value
+    await new Promise((r) => setTimeout(r, 25));
+    expect(freshBalanceCalls).toBe(1); // in-flight guard collapsed 3 reads to 1 DB refresh
+  });
 });
 
 describe("writePendingInferenceCharge + durable backstop", () => {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -118,15 +118,59 @@ export function isPendingInferenceCharge(value: unknown): value is PendingInfere
   );
 }
 
+// De-dupes background revalidations: while one authoritative refresh for an org
+// is in flight, concurrent stale reads skip scheduling another (no read
+// stampede). Module-scoped, so it is per-isolate best-effort — correctness never
+// depends on the refresh completing (see getGateBalanceUsd).
+const balanceRevalidationInFlight = new Set<string>();
+
 /**
- * Read the gate balance for an org. Uses the short-lived KV hint when present;
- * on a miss reads a FRESH authoritative balance and caches the hint. The
- * fast-vs-safe decision is therefore made on a number at most `orgBalance` TTL
- * old (plus KV lag), which the threshold must account for.
+ * Best-effort background revalidation of the org-balance hint. Reads the
+ * authoritative balance and writes it as the fresh hint, off the request's hot
+ * path. Not awaited and not durable: if the isolate is torn down before it
+ * finishes, the hint stays stale and the next stale read simply reschedules —
+ * money-safety does not depend on it (the debit settler + top-up invalidation
+ * keep the served value correct regardless).
+ */
+function scheduleOrgBalanceRevalidation(organizationId: string): void {
+  if (balanceRevalidationInFlight.has(organizationId)) return;
+  balanceRevalidationInFlight.add(organizationId);
+  void (async () => {
+    try {
+      const fresh = await creditsService.getOrganizationBalanceUsd(organizationId);
+      await writeOrgBalanceHint(organizationId, fresh, Date.now());
+    } catch (error) {
+      logger.warn("[InferenceBilling] org-balance revalidation failed", {
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      balanceRevalidationInFlight.delete(organizationId);
+    }
+  })();
+}
+
+/**
+ * Read the gate balance for an org, stale-while-revalidate. Serves the KV hint
+ * whenever one exists; if it is older than the `orgBalance` freshness window it
+ * is still returned immediately and an authoritative refresh is scheduled in the
+ * background. Only a full miss (no hint within the physical `orgBalanceStale`
+ * lifetime) blocks on the authoritative read. This keeps the human-paced first
+ * call of each turn off the ~200-500ms balance re-read that a hard 15s TTL
+ * forced, without widening the over-admit window: every optimistic charge still
+ * lands in the durable pending-charge ledger, the debit settler lowers the hint
+ * after each settle, and top-ups invalidate it — so a drained org is corrected
+ * on its first settle exactly as before, not after the stale window.
  */
 export async function getGateBalanceUsd(organizationId: string): Promise<number> {
   const hint = await readOrgBalanceHint(organizationId);
-  if (hint) return hint.balanceUsd;
+  if (hint) {
+    const freshnessMs = CacheTTL.inference.orgBalance * 1000;
+    if (Date.now() - hint.balanceAt > freshnessMs) {
+      scheduleOrgBalanceRevalidation(organizationId);
+    }
+    return hint.balanceUsd;
+  }
   const fresh = await creditsService.getOrganizationBalanceUsd(organizationId);
   await writeOrgBalanceHint(organizationId, fresh, Date.now());
   return fresh;


### PR DESCRIPTION
Stale-while-revalidate the org-balance gate hint so the first human-paced call of every chat turn stops blocking ~200–500ms on an authoritative `creditsService.getOrganizationBalanceUsd` read — the dominant reducible chunk of the ~500ms gateway preforward on a warm turn.

**What changed (read path only):** `getGateBalanceUsd` serves the KV hint whenever one exists; if it's older than the `orgBalance` freshness window (15s) it's still returned immediately and an in-flight-deduped background refresh is scheduled. Only a full miss (no hint within the new `orgBalanceStale` 5m physical lifetime) blocks on the authoritative read.

**Over-admit stays bounded exactly as before:** every optimistic charge still lands in the durable pending-charge ledger, the debit settler still lowers the hint after each settle (`lowerOrgBalanceHint`, unchanged), and top-ups still invalidate it — so a drained org is corrected on its first settle, not after the stale window. No write/invalidation path changed.

**Tests:** +2 (stale-serve-triggers-revalidation, concurrent-reads-dedupe-to-one) on top of the existing 30 fast-path tests → 32/32 green. Typecheck clean on the touched files.

**⚠️ Money-path — needs @0xSolace review before merge** per `packages/cloud` discipline (owner review, no solo-merge). I implemented + tested the mechanism and preserved the invariants; please confirm the background-refresh-vs-concurrent-debit edge from inside the subsystem. Measured win: warm ttreply ~1290ms → ~900–1000ms combined with the merged #16873 + the identity-cluster memo.

Evidence rows — UI/video/frontend/trajectory: `N/A - cloud billing hot-path latency, no model or UI change`. Backend: x-eliza-preforward-ms decomposition + the 32/32 test run (discussion #14308).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
