### PR TITLE
fix(agent): serialize plugin register, unload, and reload lifecycles

### DIFF
--- a/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
+++ b/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
@@ -11,14 +11,144 @@
  * for substring inclusion (`.includes(path)`) rather than exact equality.
  */
 
-import type { Plugin } from "@elizaos/core";
+import { type IAgentRuntime, type Plugin, Service } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+import { getView } from "../api/views-registry.ts";
 import { installRuntimePluginLifecycle } from "../runtime/plugin-lifecycle.ts";
-import { createTestRuntime } from "./plugin-lifecycle-test-utils.ts";
+import {
+  createTestRuntime,
+  type TestRuntime,
+} from "./plugin-lifecycle-test-utils.ts";
 
 /** Returns true if the runtime has a registered route whose path includes the given segment. */
 function hasRoutePath(routes: { path: string }[], segment: string): boolean {
   return routes.some((r) => r.path.includes(segment));
+}
+
+type LifecycleRaceFixture = {
+  plugin: Plugin;
+  actionName: string;
+  routePath: string;
+  serviceType: string;
+  viewId: string;
+};
+
+type InspectableRuntime = TestRuntime & {
+  getPluginOwnership: (pluginName: string) => {
+    registeredPlugin?: Plugin;
+  } | null;
+};
+
+function makeLifecycleRaceFixture(
+  pluginName: string,
+  version: string,
+  init?: Plugin["init"],
+): LifecycleRaceFixture {
+  const token = `${pluginName}-${version}`;
+  const actionName = token.replaceAll("-", "_").toUpperCase();
+  const routePath = `/api/${token}`;
+  const serviceType = `${token}-service`;
+  const viewId = `${token}-view`;
+
+  class LifecycleRaceService extends Service {
+    static override serviceType = serviceType;
+    override capabilityDescription = `Service for ${token}.`;
+
+    static override async start(
+      runtime: IAgentRuntime,
+    ): Promise<LifecycleRaceService> {
+      return new LifecycleRaceService(runtime);
+    }
+
+    override async stop(): Promise<void> {}
+  }
+
+  return {
+    actionName,
+    routePath,
+    serviceType,
+    viewId,
+    plugin: {
+      name: pluginName,
+      description: `Lifecycle race fixture ${token}.`,
+      init,
+      actions: [
+        {
+          name: actionName,
+          description: "Lifecycle race action.",
+          examples: [],
+          similes: [],
+          validate: async () => true,
+          handler: async () => ({ success: true }),
+        },
+      ],
+      routes: [
+        {
+          type: "GET",
+          path: routePath,
+          rawPath: true,
+          handler: async (_req, res) => {
+            res.json({ ok: true });
+          },
+        },
+      ],
+      services: [LifecycleRaceService],
+      views: [{ id: viewId, label: `Lifecycle ${version}` }],
+    },
+  };
+}
+
+function expectFixtureComponentsAbsent(
+  runtime: TestRuntime,
+  fixture: LifecycleRaceFixture,
+): void {
+  expect(
+    runtime.actions.some((action) => action.name === fixture.actionName),
+  ).toBe(false);
+  expect(hasRoutePath(runtime.routes, fixture.routePath)).toBe(false);
+  expect(runtime.hasService(fixture.serviceType)).toBe(false);
+  expect(getView(fixture.viewId)).toBeUndefined();
+}
+
+function expectFixturePresent(
+  runtime: InspectableRuntime,
+  fixture: LifecycleRaceFixture,
+): void {
+  expect(
+    runtime.plugins.filter((plugin) => plugin.name === fixture.plugin.name),
+  ).toEqual([fixture.plugin]);
+  expect(
+    runtime.actions.some((action) => action.name === fixture.actionName),
+  ).toBe(true);
+  expect(hasRoutePath(runtime.routes, fixture.routePath)).toBe(true);
+  expect(runtime.hasService(fixture.serviceType)).toBe(true);
+  expect(getView(fixture.viewId)).toMatchObject({
+    pluginName: fixture.plugin.name,
+  });
+  expect(
+    runtime.getPluginOwnership(fixture.plugin.name)?.registeredPlugin,
+  ).toBe(fixture.plugin);
+}
+
+function expectPluginAbsent(
+  runtime: InspectableRuntime,
+  fixture: LifecycleRaceFixture,
+): void {
+  expect(
+    runtime.plugins.some((plugin) => plugin.name === fixture.plugin.name),
+  ).toBe(false);
+  expectFixtureComponentsAbsent(runtime, fixture);
+  expect(runtime.getPluginOwnership(fixture.plugin.name)).toBeNull();
+}
+
+function installFallbackLifecycle(runtime: TestRuntime): void {
+  const internal = runtime as TestRuntime & {
+    __elizaPluginLifecycleInstalled?: boolean;
+    __elizaPluginViewSyncInstalled?: boolean;
+  };
+  delete internal.__elizaPluginLifecycleInstalled;
+  delete internal.__elizaPluginViewSyncInstalled;
+  installRuntimePluginLifecycle(runtime);
 }
 
 /**
@@ -394,7 +524,186 @@ describe("schema-bearing plugin registration", () => {
     ).toBe(false);
     expect(hasRoutePath(runtime.routes, "/api/schema-failure")).toBe(false);
   });
+
+  it("shares one failed registration across concurrent same-name callers", async () => {
+    const runtime = createTestRuntime();
+    installRuntimePluginLifecycle(runtime);
+    const runPluginMigrations = vi.fn(async () => {});
+    const initEntered = Promise.withResolvers<void>();
+    const initRelease = Promise.withResolvers<void>();
+
+    runtime.registerDatabaseAdapter({
+      isReady: async () => true,
+      runPluginMigrations,
+    } as never);
+
+    const plugin: Plugin = {
+      name: "concurrent-failure-plugin",
+      description: "plugin whose owner registration fails after publishing",
+      schema: {
+        widgets: {
+          id: "text",
+        },
+      },
+      init: async () => {
+        initEntered.resolve();
+        await initRelease.promise;
+        throw new Error("init failed");
+      },
+      actions: [
+        {
+          name: "CONCURRENT_FAILURE_ACTION",
+          description: "action",
+          examples: [],
+          similes: [],
+          validate: async () => true,
+          handler: async () => ({ success: true }),
+        },
+      ],
+      routes: [
+        {
+          type: "GET",
+          path: "/api/concurrent-failure",
+          rawPath: true,
+          handler: async (_req, res) => {
+            res.json({ ok: true });
+          },
+        },
+      ],
+      views: [
+        {
+          id: "concurrent-failure-view",
+          label: "Concurrent failure",
+        },
+      ],
+    };
+
+    const ownerRegistration = runtime.registerPlugin(plugin);
+    await initEntered.promise;
+    const duplicateRegistration = runtime.registerPlugin(plugin);
+    initRelease.resolve();
+
+    const results = await Promise.allSettled([
+      ownerRegistration,
+      duplicateRegistration,
+    ]);
+
+    expect(results).toHaveLength(2);
+    for (const result of results) {
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.reason).toBeInstanceOf(Error);
+        expect((result.reason as Error).message).toBe("init failed");
+      }
+    }
+    expect(runPluginMigrations).toHaveBeenCalledOnce();
+    expect(runtime.plugins.some((entry) => entry.name === plugin.name)).toBe(
+      false,
+    );
+    expect(
+      runtime.actions.some(
+        (action) => action.name === "CONCURRENT_FAILURE_ACTION",
+      ),
+    ).toBe(false);
+    expect(hasRoutePath(runtime.routes, "/api/concurrent-failure")).toBe(false);
+    expect(getView("concurrent-failure-view")).toBeUndefined();
+
+    await runtime.registerPlugin({
+      ...plugin,
+      init: async () => {},
+    });
+
+    expect(runPluginMigrations).toHaveBeenCalledTimes(2);
+    expect(runtime.plugins.some((entry) => entry.name === plugin.name)).toBe(
+      true,
+    );
+    expect(
+      runtime.actions.some(
+        (action) => action.name === "CONCURRENT_FAILURE_ACTION",
+      ),
+    ).toBe(true);
+    expect(hasRoutePath(runtime.routes, "/api/concurrent-failure")).toBe(true);
+    expect(getView("concurrent-failure-view")).toMatchObject({
+      pluginName: plugin.name,
+    });
+
+    await runtime.unloadPlugin(plugin.name);
+    expect(getView("concurrent-failure-view")).toBeUndefined();
+  });
 });
+
+for (const mode of [
+  {
+    label: "core lifecycle plus view sync",
+    install: installRuntimePluginLifecycle,
+  },
+  {
+    label: "agent fallback lifecycle",
+    install: installFallbackLifecycle,
+  },
+] as const) {
+  describe(`${mode.label} operation ordering`, () => {
+    it("queues unload behind in-flight init and leaves no resurrected state", async () => {
+      const runtime = createTestRuntime() as InspectableRuntime;
+      await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+      mode.install(runtime);
+      const initEntered = Promise.withResolvers<void>();
+      const initRelease = Promise.withResolvers<void>();
+      const fixture = makeLifecycleRaceFixture(
+        `concurrent-unload-${mode.label.replaceAll(" ", "-")}`,
+        "initial",
+        async () => {
+          initEntered.resolve();
+          await initRelease.promise;
+        },
+      );
+
+      const registration = runtime.registerPlugin(fixture.plugin);
+      await initEntered.promise;
+      const unload = runtime.unloadPlugin(fixture.plugin.name);
+      initRelease.resolve();
+      await Promise.all([registration, unload]);
+
+      expectPluginAbsent(runtime, fixture);
+
+      const retry = makeLifecycleRaceFixture(fixture.plugin.name, "retry");
+      await runtime.registerPlugin(retry.plugin);
+      expectFixturePresent(runtime, retry);
+      await runtime.unloadPlugin(retry.plugin.name);
+      expectPluginAbsent(runtime, retry);
+    });
+
+    it("queues reload behind in-flight init and keeps exactly one replacement", async () => {
+      const runtime = createTestRuntime() as InspectableRuntime;
+      await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+      mode.install(runtime);
+      const initEntered = Promise.withResolvers<void>();
+      const initRelease = Promise.withResolvers<void>();
+      const pluginName = `concurrent-reload-${mode.label.replaceAll(" ", "-")}`;
+      const initial = makeLifecycleRaceFixture(
+        pluginName,
+        "initial",
+        async () => {
+          initEntered.resolve();
+          await initRelease.promise;
+        },
+      );
+      const replacement = makeLifecycleRaceFixture(pluginName, "replacement");
+
+      const registration = runtime.registerPlugin(initial.plugin);
+      await initEntered.promise;
+      const reload = runtime.reloadPlugin(replacement.plugin);
+      initRelease.resolve();
+      await Promise.all([registration, reload]);
+
+      expectFixtureComponentsAbsent(runtime, initial);
+      expectFixturePresent(runtime, replacement);
+
+      await runtime.unloadPlugin(pluginName);
+      expectPluginAbsent(runtime, replacement);
+    });
+  });
+}
 
 describe("dispose error handling", () => {
   it("a plugin whose dispose hook throws does not corrupt the runtime state", async () => {

--- a/packages/agent/src/runtime/plugin-lifecycle.ts
+++ b/packages/agent/src/runtime/plugin-lifecycle.ts
@@ -149,6 +149,15 @@ const pluginMigrationsInFlight = new WeakMap<
   IDatabaseAdapter,
   Map<string, Promise<void>>
 >();
+type PluginLifecycleLane = {
+  tail: Promise<void>;
+  joinableRegistration: Promise<void> | null;
+  pendingOperations: number;
+};
+const pluginLifecycleLanes = new WeakMap<
+  AgentRuntime,
+  Map<string, PluginLifecycleLane>
+>();
 
 function getRuntimePrivateState(runtime: AgentRuntime): RuntimePrivateState {
   return runtime as AgentRuntime & RuntimePrivateState;
@@ -161,6 +170,94 @@ function getPluginOwnershipStore(
     runtime.__elizaPluginOwnership = new Map();
   }
   return runtime.__elizaPluginOwnership;
+}
+
+function getPluginLifecycleLane(
+  runtime: AgentRuntime,
+  pluginName: string,
+): {
+  lane: PluginLifecycleLane;
+  lanes: Map<string, PluginLifecycleLane>;
+} {
+  let lanes = pluginLifecycleLanes.get(runtime);
+  if (!lanes) {
+    lanes = new Map();
+    pluginLifecycleLanes.set(runtime, lanes);
+  }
+  let lane = lanes.get(pluginName);
+  if (!lane) {
+    lane = {
+      tail: Promise.resolve(),
+      joinableRegistration: null,
+      pendingOperations: 0,
+    };
+    lanes.set(pluginName, lane);
+  }
+  return { lane, lanes };
+}
+
+function enqueuePluginLifecycleOperation<T>(
+  runtime: AgentRuntime,
+  pluginName: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const { lane, lanes } = getPluginLifecycleLane(runtime, pluginName);
+  lane.pendingOperations += 1;
+  const result = lane.tail.then(operation);
+  lane.tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  void lane.tail.then(() => {
+    lane.pendingOperations -= 1;
+    if (lane.pendingOperations === 0 && lanes.get(pluginName) === lane) {
+      lanes.delete(pluginName);
+    }
+    if (lanes.size === 0 && pluginLifecycleLanes.get(runtime) === lanes) {
+      pluginLifecycleLanes.delete(runtime);
+    }
+  });
+  return result;
+}
+
+function registerPluginOnce(
+  runtime: AgentRuntime,
+  pluginName: string,
+  register: () => Promise<void>,
+): Promise<void> {
+  const { lane } = getPluginLifecycleLane(runtime, pluginName);
+  if (lane.joinableRegistration) {
+    return lane.joinableRegistration;
+  }
+  const registration = enqueuePluginLifecycleOperation(
+    runtime,
+    pluginName,
+    register,
+  );
+  lane.joinableRegistration = registration;
+  void registration.then(
+    () => {
+      if (lane.joinableRegistration === registration) {
+        lane.joinableRegistration = null;
+      }
+    },
+    () => {
+      if (lane.joinableRegistration === registration) {
+        lane.joinableRegistration = null;
+      }
+    },
+  );
+  return registration;
+}
+
+function enqueuePluginLifecycleMutation<T>(
+  runtime: AgentRuntime,
+  pluginName: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const { lane } = getPluginLifecycleLane(runtime, pluginName);
+  lane.joinableRegistration = null;
+  return enqueuePluginLifecycleOperation(runtime, pluginName, operation);
 }
 
 function getOwnershipTarget(
@@ -282,6 +379,41 @@ function pushUniqueService(
     return;
   }
   items.push(next);
+}
+
+function snapshotPluginServiceClasses(
+  runtime: AgentRuntime,
+  plugin: Plugin,
+): Map<ServiceTypeName, Set<RuntimeServiceClass>> {
+  const privateState = getRuntimePrivateState(runtime);
+  const snapshot = new Map<ServiceTypeName, Set<RuntimeServiceClass>>();
+  for (const serviceClass of plugin.services ?? []) {
+    const serviceType = serviceClass.serviceType as ServiceTypeName;
+    snapshot.set(
+      serviceType,
+      new Set(privateState.serviceTypes.get(serviceType) ?? []),
+    );
+  }
+  return snapshot;
+}
+
+function trackPluginServiceClasses(
+  runtime: AgentRuntime,
+  ownership: RuntimePluginOwnership,
+  before: Map<ServiceTypeName, Set<RuntimeServiceClass>>,
+): void {
+  const privateState = getRuntimePrivateState(runtime);
+  for (const serviceClass of ownership.plugin.services ?? []) {
+    const serviceType = serviceClass.serviceType as ServiceTypeName;
+    const previousClasses = before.get(serviceType);
+    if (
+      !previousClasses?.has(serviceClass) &&
+      privateState.serviceTypes.get(serviceType)?.includes(serviceClass)
+    ) {
+      serviceClassOwners.set(serviceClass, ownership.pluginName);
+      pushUniqueService(ownership.services, { serviceType, serviceClass });
+    }
+  }
 }
 
 function createEmptyOwnership(plugin: Plugin): RuntimePluginOwnership {
@@ -736,12 +868,13 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
 
   const baseRegisterPlugin = runtime.registerPlugin.bind(runtime);
   const baseUnloadPlugin = runtime.unloadPlugin?.bind(runtime);
-  runtime.registerPlugin = (async (plugin: Plugin) => {
+  const registerPluginOperation = async (plugin: Plugin): Promise<void> => {
     if (runtime.plugins.some((registered) => registered.name === plugin.name)) {
       await baseRegisterPlugin(plugin);
       return;
     }
     let registeredHere = false;
+    const servicesBefore = snapshotPluginServiceClasses(runtime, plugin);
     try {
       // #12087 Item 1: gate this plugin's sensitive providers (SECRETS_STATUS,
       // walletPortfolio, shellHistory, …) at the moment it registers, not via a
@@ -761,6 +894,10 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
       }
       await baseRegisterPlugin(plugin);
       registeredHere = runtime.plugins.includes(plugin);
+      const ownership = runtime.getPluginOwnership?.(plugin.name);
+      if (ownership) {
+        trackPluginServiceClasses(runtime, ownership, servicesBefore);
+      }
       await registerPluginViews(plugin);
       registerViewScopedActions(runtime, plugin.name, plugin.views ?? []);
     } catch (error) {
@@ -771,30 +908,31 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
       }
       throw error;
     }
-  }) as typeof runtime.registerPlugin;
+  };
+  runtime.registerPlugin = ((plugin: Plugin) =>
+    registerPluginOnce(runtime, plugin.name, () =>
+      registerPluginOperation(plugin),
+    )) as typeof runtime.registerPlugin;
 
   if (baseUnloadPlugin) {
-    runtime.unloadPlugin = async (pluginName: string) => {
+    const unloadPluginOperation = async (pluginName: string) => {
       const ownership = await baseUnloadPlugin(pluginName);
       unregisterPluginViews(pluginName);
       unregisterViewScopedActions(runtime, pluginName);
       return ownership as RuntimePluginOwnership | null;
     };
-  }
+    runtime.unloadPlugin = (pluginName: string) =>
+      enqueuePluginLifecycleMutation(runtime, pluginName, () =>
+        unloadPluginOperation(pluginName),
+      );
 
-  const baseReloadPlugin = runtime.reloadPlugin?.bind(runtime);
-  if (baseReloadPlugin) {
-    runtime.reloadPlugin = async (plugin: Plugin) => {
-      unregisterPluginViews(plugin.name);
-      await baseReloadPlugin(plugin);
-      // #12087 Item 1: re-gate providers on reload (a reloaded plugin object has
-      // fresh, un-wrapped provider.get functions).
-      applyPluginRoleGating([plugin]);
-      await registerPluginViews(plugin);
-      // registerViewScopedActions reconciles: it unregisters this plugin's
-      // previous scoped actions before registering the reloaded set.
-      registerViewScopedActions(runtime, plugin.name, plugin.views ?? []);
-    };
+    if (runtime.reloadPlugin) {
+      runtime.reloadPlugin = (plugin: Plugin) =>
+        enqueuePluginLifecycleMutation(runtime, plugin.name, async () => {
+          await unloadPluginOperation(plugin.name);
+          await registerPluginOperation(plugin);
+        });
+    }
   }
 }
 
@@ -1005,7 +1143,7 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
     }) as typeof privateState._runServiceStart;
   }
 
-  runtime.registerPlugin = (async (plugin: Plugin) => {
+  const registerPluginOperation = async (plugin: Plugin): Promise<void> => {
     if (runtime.plugins.some((registered) => registered.name === plugin.name)) {
       await originalRegisterPlugin(plugin);
       return;
@@ -1016,6 +1154,7 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
       ownership: createEmptyOwnership(plugin),
       adapterBefore: runtime.adapter,
     };
+    const servicesBefore = snapshotPluginServiceClasses(runtime, plugin);
 
     try {
       await migratePluginSchemasIfReady(runtime, plugin);
@@ -1034,6 +1173,7 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
         pluginsBefore,
         routesBefore,
       );
+      trackPluginServiceClasses(runtime, capture.ownership, servicesBefore);
       if (
         capture.ownership.registeredPlugin ||
         capture.ownership.actions.length > 0 ||
@@ -1061,6 +1201,7 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
         pluginsBefore,
         routesBefore,
       );
+      trackPluginServiceClasses(runtime, capture.ownership, servicesBefore);
       await teardownPluginOwnership(runtimeWithLifecycle, capture.ownership, {
         allowAdapterUnload: true,
         removeOwnership: true,
@@ -1068,9 +1209,15 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
       });
       throw error;
     }
-  }) as typeof runtime.registerPlugin;
+  };
+  runtime.registerPlugin = ((plugin: Plugin) =>
+    registerPluginOnce(runtime, plugin.name, () =>
+      registerPluginOperation(plugin),
+    )) as typeof runtime.registerPlugin;
 
-  runtimeWithLifecycle.unloadPlugin = async (pluginName: string) => {
+  const unloadPluginOperation = async (
+    pluginName: string,
+  ): Promise<RuntimePluginOwnership | null> => {
     const ownership =
       getPluginOwnershipStore(runtimeWithLifecycle).get(pluginName);
     if (!ownership) {
@@ -1082,19 +1229,16 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
     });
     return ownership;
   };
-
-  runtimeWithLifecycle.reloadPlugin = async (plugin: Plugin) => {
-    const existingOwnership = getPluginOwnershipStore(runtimeWithLifecycle).get(
-      plugin.name,
+  runtimeWithLifecycle.unloadPlugin = (pluginName: string) =>
+    enqueuePluginLifecycleMutation(runtime, pluginName, () =>
+      unloadPluginOperation(pluginName),
     );
-    if (existingOwnership) {
-      unregisterPluginViews(plugin.name);
-      await teardownPluginOwnership(runtimeWithLifecycle, existingOwnership, {
-        removeOwnership: true,
-      });
-    }
-    await runtime.registerPlugin(plugin);
-  };
+
+  runtimeWithLifecycle.reloadPlugin = (plugin: Plugin) =>
+    enqueuePluginLifecycleMutation(runtime, plugin.name, async () => {
+      await unloadPluginOperation(plugin.name);
+      await registerPluginOperation(plugin);
+    });
 
   runtimeWithLifecycle.applyPluginConfig = async (
     pluginName: string,


### PR DESCRIPTION
Closes #16910.

## Root cause

#16862 correctly moved late plugin schema migration ahead of publication, but its
register-only single-flight did not order `unloadPlugin` or `reloadPlugin`
against an initialization already in flight. An unload could therefore return
before initialization settled, after which the original registration could
publish the plugin and resurrect its actions, routes, services, views, and
ownership.

## Fix

- Add one FIFO lifecycle lane per runtime and plugin name.
- Let concurrent register callers join the same registration while making
  unload and reload clear joinability and queue behind the active operation.
- Keep a rejected operation observable to its caller without poisoning later
  operations in the lane.
- Compose reload from captured internal unload/register operations so neither
  the core-plus-view-sync path nor the fallback path re-enters its own public
  queue.
- Track declared service classes precisely enough for failed, unloaded, and
  reloaded registrations to stop and remove only their owned services.
- Add real-runtime regressions for register→unload and register→reload races in
  both lifecycle modes, including full plugin/action/route/service/view/
  ownership cleanup, clean retry, and exactly-one-replacement assertions.

## Scope

Exactly two files:

- `packages/agent/src/runtime/plugin-lifecycle.ts`
- `packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts`

Diff: 487 insertions, 34 deletions. No Cloud, image, mobile, simulator, or device
mutation is included.

## Sync and extraction proof

- Original merged base containing #16862: `b44d5c6c6c1ccae244132d567e408c566ff2fcb2`
- First clean extraction: `39fd39327c40dd7e540f540515769cb92a9e68f7`
- Current `develop` base: `32b336f757463caa2b679e392ede1b86b21dd543`
- Final head: `298fda949f87d7a7c57c47baf642df0725041397`
- Range-diff: `1: 39fd39327c = 1: 298fda949f`
- Stable patch ID before/after rebase:
  `400e808d63fd6e434bb0488dd3e9474ec373dffc`
- Final two file blobs are byte-identical to the independently reviewed preserved
  source candidate.

## Validation

| Gate | Result |
| --- | --- |
| Register→unload/reload adversarial races, normal + fallback paths | 40/40 passed across 10 consecutive runs |
| Lifecycle + leak + late-schema + remote-adapter focused suite | 68 passed, 3 intentional skips |
| Inbox regression suite | 166 passed, 2 intentional skips |
| Role-gating + remote-forwarder companion suite | 38/38 passed |
| `packages/agent` typecheck | Passed |
| `packages/agent` build | Passed |
| Full agent Biome + exact changed-file Biome | Passed |
| Changed-file coverage | `plugin-lifecycle.ts` 80.25%; 50% gate passed |
| `git diff --check` | Passed |
| Error-policy ratchet | Passed; empty catches 0→0, server console 0→0 |
| Plugin lane-coverage audit | Passed |
| Independent review | Two independent GO verdicts; no P1/P2 findings |

The coverage runner printed the repository's known non-fatal parser warning for
`packages/agent/src/external-modules.d.ts`; it excluded that declaration file,
generated LCOV successfully, and the changed production source passed at
80.25%.

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Real runtime/domain state | Attached in deterministic assertions: after queued unload, plugin/action/route/service/view/ownership are all absent; retry succeeds; queued reload leaves exactly one replacement |
| Backend structured logs | N/A — this changes in-process lifecycle ordering and does not add a transport or deployed backend path |
| Frontend console/network logs | N/A — no frontend or network behavior changed |
| Desktop screenshots | N/A — no visual surface changed |
| Mobile screenshots | N/A — no visual surface changed |
| Video walkthrough | N/A — the regression is a blocked-promise concurrency race proven by deterministic runtime tests, not a user-driven UI flow |
| Real-LLM trajectory | N/A — no prompt, action selection, model, or agent-response behavior changed |
| Device/simulator capture | N/A — no native or platform code changed; device mutation is explicitly outside #16910 |
| Security review | Two independent reviewers inspected queue ordering, rejection recovery, non-reentrant reload, service ownership, cleanup, and both lifecycle modes |

## Rollout safety

This PR does not deploy, promote an image, or touch an LP3. The launch canary
image should include this fix only after review, merge, and the separate
digest-pinned rollout gate.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no visual surface changed; desktop and mobile before screenshots are not applicable.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no visual surface changed; desktop and mobile after screenshots are not applicable.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the regression is a blocked-promise concurrency race proven by deterministic runtime tests, not a user-driven UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - this changes in-process lifecycle ordering and does not add a transport or deployed backend path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action selection, model, or agent-response behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head real-runtime lifecycle assertions](https://github.com/elizaOS/eliza/blob/298fda949f87d7a7c57c47baf642df0725041397/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts#L646-L704) — after queued unload, plugin/action/route/service/view/ownership are all absent; retry succeeds; queued reload leaves exactly one replacement.
