### PR TITLE
fix(type-safety): re-green the ratchet empty-fallback budget (?? [] regression from #16915)

### DIFF
--- a/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
+++ b/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
@@ -705,6 +705,39 @@ for (const mode of [
   });
 }
 
+describe("service-less plugin — explicit absent-services branch", () => {
+  it("registers and unloads a plugin that declares NO services (services key absent)", async () => {
+    // Pins the #9940-style explicit branch in snapshot/trackPluginServiceClasses:
+    // an absent `services` array is a distinct state, not an empty iteration,
+    // and the register/unload cycle must behave identically either way.
+    const runtime = createTestRuntime();
+    const plugin: Plugin = {
+      name: "no-services-plugin",
+      description: "plugin without a services key",
+      actions: [
+        {
+          name: "NO_SERVICES_ACTION",
+          description: "action",
+          examples: [],
+          similes: [],
+          validate: async () => true,
+          handler: async () => ({ success: true }),
+        },
+      ],
+    };
+
+    await runtime.registerPlugin(plugin);
+    expect(runtime.actions.some((a) => a.name === "NO_SERVICES_ACTION")).toBe(
+      true,
+    );
+
+    await runtime.unloadPlugin("no-services-plugin");
+    expect(runtime.actions.some((a) => a.name === "NO_SERVICES_ACTION")).toBe(
+      false,
+    );
+  });
+});
+
 describe("dispose error handling", () => {
   it("a plugin whose dispose hook throws does not corrupt the runtime state", async () => {
     const plugin: Plugin = {

--- a/packages/agent/src/runtime/plugin-lifecycle.ts
+++ b/packages/agent/src/runtime/plugin-lifecycle.ts
@@ -387,11 +387,16 @@ function snapshotPluginServiceClasses(
 ): Map<ServiceTypeName, Set<RuntimeServiceClass>> {
   const privateState = getRuntimePrivateState(runtime);
   const snapshot = new Map<ServiceTypeName, Set<RuntimeServiceClass>>();
-  for (const serviceClass of plugin.services ?? []) {
+  // "Plugin declares no services" is a distinct absent state (#9940): branch
+  // on it explicitly instead of defaulting into an empty iteration.
+  if (!plugin.services) return snapshot;
+  for (const serviceClass of plugin.services) {
     const serviceType = serviceClass.serviceType as ServiceTypeName;
+    // `new Set(undefined)` is a valid empty Set, so the map miss needs no
+    // empty-array default.
     snapshot.set(
       serviceType,
-      new Set(privateState.serviceTypes.get(serviceType) ?? []),
+      new Set(privateState.serviceTypes.get(serviceType)),
     );
   }
   return snapshot;
@@ -403,7 +408,8 @@ function trackPluginServiceClasses(
   before: Map<ServiceTypeName, Set<RuntimeServiceClass>>,
 ): void {
   const privateState = getRuntimePrivateState(runtime);
-  for (const serviceClass of ownership.plugin.services ?? []) {
+  if (!ownership.plugin.services) return;
+  for (const serviceClass of ownership.plugin.services) {
     const serviceType = serviceClass.serviceType as ServiceTypeName;
     const previousClasses = before.get(serviceType);
     if (


### PR DESCRIPTION
## What

The **Format + Type Safety Ratchet** went red again on the current develop head: `?? []` (core/agent/app-core empty-fallback budget) is **588 > 586 baseline**. The +2 are the snapshot/track helpers #16915 added to `packages/agent/src/runtime/plugin-lifecycle.ts`.

(This supersedes the merge attempt of #16906 — develop has since absorbed equivalent fixes for the original two regressions via #16860 and the lint sweep, so the only remaining ratchet red is this one.)

## Fix (behavior-identical, no baseline edits)

- `for (const s of plugin.services ?? [])` (x2): a plugin declaring no services is a distinct absent state (#9940 rule) — branch on it explicitly with an early return instead of defaulting into an empty iteration.
- `new Set(privateState.serviceTypes.get(t) ?? [])`: `new Set(undefined)` is already a valid empty Set, so the map-miss default is dropped outright.

The #16915 serialize-mutations logic is untouched.

## Verification

Local ratchet on this branch (same script CI runs):
```
[type-safety-ratchet] `?? []` (core/agent/app-core): 585 / 586   <-- below baseline (+1 headroom)
[type-safety-ratchet] baseline can shrink: as unknown as 84 -> 81, non-null (!) 488 -> 478, ?? [] 586 -> 585
```
All kinds at/below baseline → the job goes green.

Touched suite re-run green: `plugin-smoke-lifecycle.test.ts` (the #16915 coverage for exactly these helpers) — **13 pass / 0 fail**. biome clean.

🌞 [sol-develop-green-now]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI-gate type-safety fix, no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI-gate type-safety fix, no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible behavior change; ratchet counts are the deliverable

<!-- evidence-row:backend-logs -->
- [x] [16923-lifecycle-suite-13pass.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16923-lifecycle-suite-13pass.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path in this change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model in the loop; deterministic AST count gate

<!-- evidence-row:domain-artifacts -->
- [x] [16923-ratchet-after-green.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16923-ratchet-after-green.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots to OCR
