### PR TITLE
perf(cloud): defer the shared-tier billing tail off the chat response path (2.3s → ~0.7s)

### DIFF
--- a/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
+++ b/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
@@ -103,7 +103,15 @@ describe("agent bridge runtime routing", () => {
       result: { text: "pong" },
     });
     expect(deadControlPlaneFetch).not.toHaveBeenCalled();
-    expect(bridge).toHaveBeenCalledWith("agent-1", "org-1", rpcRequest);
+    // 4th arg: the Workers executionCtx that defers the shared-turn billing
+    // tail — this fixture has none, so the route degrades to undefined
+    // (inline settlement).
+    expect(bridge).toHaveBeenCalledWith(
+      "agent-1",
+      "org-1",
+      rpcRequest,
+      undefined,
+    );
   });
 
   test("stream ignores stale control-plane env and uses sandbox service", async () => {

--- a/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
@@ -92,12 +92,16 @@ describe("shared agent messages route", () => {
       text: "hello",
       agentName: "Eliza",
     });
+    // 6th arg: the Workers executionCtx that defers the billing tail — the
+    // Hono test harness has none, so the route degrades to undefined (inline
+    // settlement).
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
       AGENT,
       ORG,
       AGENT,
       "say hi",
       "Eliza",
+      undefined,
     );
   });
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -1,6 +1,7 @@
 // Handles v1 cloud API v1 eliza agents agentid api conversations conversationid messages route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { InsufficientCreditsError } from "@/lib/api/errors";
+import type { BridgeExecutionContext } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import {
@@ -69,6 +70,16 @@ app.post("/", async (c) => {
       origin,
     );
   }
+  // Workers only: pass an executionCtx so the shared turn defers its billing
+  // tail off the response path via waitUntil. Hono's executionCtx getter
+  // THROWS outside a Worker (tests, Node) — degrade to undefined there so the
+  // turn settles inline, preserving fully-synchronous behavior.
+  let executionCtx: BridgeExecutionContext | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
   let result: { text: string; agentName: string };
   try {
     result = await sharedRestMessageSend(
@@ -77,6 +88,7 @@ app.post("/", async (c) => {
       conversationId,
       text,
       r.agentName,
+      executionCtx,
     );
   } catch (error) {
     // error-policy:J1 route boundary translates bridge/billing failures to HTTP responses.

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
@@ -3,7 +3,10 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { errorToResponse, ValidationError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
+import type {
+  BridgeExecutionContext,
+  BridgeRequest,
+} from "@/lib/services/eliza-sandbox";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -57,10 +60,22 @@ async function __hono_POST(
     }
 
     const rpcRequest = parsed.data as BridgeRequest;
+    // Workers only: hand the bridge an executionCtx so the shared-tier turn can
+    // defer its billing tail (billUsage → settle → analytics → audit) off the
+    // response path via waitUntil. Hono's executionCtx getter THROWS outside a
+    // Worker (tests, Node) — degrade to undefined there so the bridge settles
+    // inline, preserving fully-synchronous behavior.
+    let executionCtx: BridgeExecutionContext | undefined;
+    try {
+      executionCtx = _ctx?.executionCtx;
+    } catch {
+      executionCtx = undefined;
+    }
     const response = await elizaSandboxService.bridge(
       agentId,
       user.organization_id,
       rpcRequest,
+      executionCtx,
     );
 
     return applyCorsHeaders(Response.json(response), CORS_METHODS);

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-turn-deferred-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-turn-deferred-billing.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Deferred billing-tail proof for the SHARED-runtime agent turn.
+ *
+ * bridgeSharedMessageSend returns the reply as soon as the turn ran and history
+ * persisted; the billing tail (billUsage → settleReservation → analytics →
+ * audit, ~1.7s of cross-region RTT) runs via executionCtx.waitUntil OFF the
+ * response path. These tests drive the REAL bridgeSharedMessageSend against a
+ * spy reservation and a capturing waitUntil to prove the money invariants
+ * survive the deferral:
+ *   (a) the reply resolves while billUsage is still in flight,
+ *   (b) the deferred task still settles the hold at billing.totalCost,
+ *   (c) a billUsage throw still refunds the hold (reconcile(0)) — deferred,
+ *   (d) without an executionCtx the tail runs inline (pre-deferral behavior),
+ *   (e) the degraded path refunds synchronously and never uses waitUntil.
+ */
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { describe, expect, mock, test } from "bun:test";
+
+const aiBillingActual = await import("../ai-billing");
+const runTurnActual = await import("../shared-runtime/run-shared-agent-turn");
+
+// A reservation whose reconcile() records every settle amount.
+const reconcileCalls: number[] = [];
+const makeReservation = () => ({
+  reservedAmount: 0.01,
+  reconcile: mock(async (actualCost: number) => {
+    reconcileCalls.push(actualCost);
+    return null;
+  }),
+});
+let reservation = makeReservation();
+
+// Controllable seams: the turn result and the billUsage behavior.
+let turnImpl: () => unknown = () => ({
+  degraded: false,
+  reply: "hi there",
+  history: [],
+  model: "openai/gpt-oss-120b",
+});
+let billUsageImpl: () => Promise<{ totalCost: number }> = async () => ({ totalCost: 0.0042 });
+
+mock.module("../ai-billing", () => ({
+  ...aiBillingActual,
+  reserveCredits: mock(async () => reservation),
+  billUsage: mock(async () => billUsageImpl()),
+  recordUsageAnalytics: mock(async () => null),
+}));
+
+mock.module("../shared-runtime/run-shared-agent-turn", () => ({
+  ...runTurnActual,
+  // Keep the model billable so a reservation is actually taken.
+  resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
+  runSharedAgentTurn: mock(async () => turnImpl()),
+}));
+
+const { ElizaSandboxService } = await import("../eliza-sandbox");
+
+type BridgeCallable = {
+  bridgeSharedMessageSend: (
+    rec: Record<string, unknown>,
+    rpc: { jsonrpc: string; id: number; method: string; params: { text: string } },
+    executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+  ) => Promise<{ result?: { text?: string } }>;
+  buildSharedRuntimeCharacter: (...args: unknown[]) => Promise<unknown>;
+  loadSharedRuntimeHistory: (...args: unknown[]) => Promise<unknown>;
+  saveSharedRuntimeHistory: (...args: unknown[]) => Promise<unknown>;
+};
+
+function makeService(): BridgeCallable {
+  const svc = new ElizaSandboxService() as unknown as BridgeCallable;
+  // Private seams the turn path calls before/after runSharedAgentTurn.
+  svc.buildSharedRuntimeCharacter = mock(async () => ({
+    name: "Eliza",
+    model: "openai/gpt-oss-120b",
+    system: "",
+    bio: [],
+  })) as never;
+  svc.loadSharedRuntimeHistory = mock(async () => []) as never;
+  svc.saveSharedRuntimeHistory = mock(async () => undefined) as never;
+  return svc;
+}
+
+/** executionCtx spy that captures every promise handed to waitUntil. */
+function makeExecutionCtx() {
+  const captured: Promise<unknown>[] = [];
+  return {
+    captured,
+    waitUntil: (p: Promise<unknown>) => {
+      captured.push(p);
+    },
+  };
+}
+
+function reset() {
+  reconcileCalls.length = 0;
+  reservation = makeReservation();
+  turnImpl = () => ({
+    degraded: false,
+    reply: "hi there",
+    history: [],
+    model: "openai/gpt-oss-120b",
+  });
+  billUsageImpl = async () => ({ totalCost: 0.0042 });
+}
+
+const REC = {
+  id: "00000000-0000-4000-8000-00000000b1e0",
+  organization_id: "00000000-0000-4000-8000-00000000b1e1",
+  user_id: "00000000-0000-4000-8000-00000000b1e2",
+  execution_tier: "shared",
+  agent_name: "Eliza",
+};
+const RPC = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "message.send",
+  params: { text: "hello" },
+};
+
+describe("bridgeSharedMessageSend — billing tail deferred via executionCtx.waitUntil", () => {
+  test("reply resolves BEFORE the billing tail; deferred task settles at billing.totalCost", async () => {
+    reset();
+    // Gate billUsage so we can prove the reply did not wait for it.
+    let releaseBill: (() => void) | undefined;
+    const billGate = new Promise<void>((resolve) => {
+      releaseBill = resolve;
+    });
+    billUsageImpl = async () => {
+      await billGate;
+      return { totalCost: 0.0042 };
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    // (a) resolves while billUsage is still blocked on the gate.
+    const response = await svc.bridgeSharedMessageSend(REC, RPC, ctx);
+    expect(response.result?.text).toBe("hi there");
+    expect(ctx.captured).toHaveLength(1);
+    expect(reservation.reconcile).not.toHaveBeenCalled();
+
+    // (b) the deferred task still settles the hold, at the billed cost.
+    releaseBill?.();
+    await ctx.captured[0];
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
+  test("billUsage throwing in the deferred task refunds the hold (reconcile(0)) without failing the reply", async () => {
+    reset();
+    billUsageImpl = async () => {
+      throw new Error("cross-region billing write failed");
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageSend(REC, RPC, ctx);
+    expect(response.result?.text).toBe("hi there");
+    expect(ctx.captured).toHaveLength(1);
+
+    // The waitUntil promise must resolve (never reject — Workers would log an
+    // unhandled rejection) and must have refunded the hold exactly once.
+    await ctx.captured[0];
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0]);
+  });
+
+  test("without an executionCtx the tail runs inline: settled by the time the reply resolves", async () => {
+    reset();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageSend(REC, RPC);
+    expect(response.result?.text).toBe("hi there");
+    // Pre-deferral behavior preserved for tests / non-Worker callers.
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
+  test("degraded turn refunds synchronously and never touches waitUntil", async () => {
+    reset();
+    turnImpl = () => ({
+      degraded: true,
+      reply: "degraded reply",
+      history: [],
+      model: "openai/gpt-oss-120b",
+    });
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    await svc.bridgeSharedMessageSend(REC, RPC, ctx);
+    expect(ctx.captured).toHaveLength(0);
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -37,6 +37,7 @@ import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { settleOffResponsePath } from "../utils/settle-off-response-path";
 import { withTimeout } from "../utils/with-timeout";
 import {
   computeStateHash,
@@ -363,6 +364,14 @@ export interface BridgeRequest {
   method: string;
   params?: Record<string, unknown>;
 }
+
+/**
+ * Structural subset of the Cloudflare Workers `ExecutionContext` the shared-tier
+ * bridge needs to defer its post-reply billing tail off the response path.
+ * Routes pass `c.executionCtx`; non-Worker callers (tests, Node) omit it and
+ * the tail runs inline, preserving fully-synchronous settlement.
+ */
+export type BridgeExecutionContext = { waitUntil(promise: Promise<unknown>): void };
 
 /**
  * JSON-RPC error code for a shared-runtime turn rejected by the credit
@@ -2545,6 +2554,7 @@ export class ElizaSandboxService {
   private async bridgeSharedMessageSend(
     rec: AgentSandbox,
     rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
   ): Promise<BridgeResponse> {
     const params = rpc.params && typeof rpc.params === "object" ? rpc.params : {};
     const text = typeof params.text === "string" ? params.text : "";
@@ -2616,7 +2626,10 @@ export class ElizaSandboxService {
     // (it runs OUTSIDE the inner billing try/catch) — would otherwise propagate
     // without ever refunding, stranding the hold and over-charging the org.
     // settleReservation is idempotent (reservationSettled), so refunding here
-    // never double-refunds a turn that already settled on a normal path.
+    // never double-refunds a turn that already settled on a normal path. The
+    // deferred billing tail below owns its own settle-or-refund end-to-end, so
+    // this catch never races it: by the time the tail is registered, every
+    // throw it can produce is contained inside the tail's own try/catch.
     try {
       const turn = await runSharedAgentTurn({
         character,
@@ -2634,40 +2647,66 @@ export class ElizaSandboxService {
       } else {
         await this.saveSharedRuntimeHistory(rec.id, channelId, turn.history);
         if (billingContext) {
-          try {
-            const billing = await billUsage(
-              billingContext,
-              this.sharedRuntimeBillingUsage(turn, estimatedInputTokens),
-            );
-            const settlement = await settleReservation(billing.totalCost);
-            const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-              type: "chat",
-              content: turn.reply,
-              prompt: text,
-            });
-            if (usageRecord) {
-              await aiBillingRecordsService
-                .record({
-                  context: billingContext,
-                  billing,
-                  usageRecord,
-                  idempotencyKey,
-                  reconciliation: settlement,
-                })
-                .catch((error) => {
-                  logger.error("[shared-runtime] AI billing audit record failed", {
-                    error: error instanceof Error ? error.message : String(error),
-                    agentId: rec.id,
+          // The reply is final once the turn ran and history persisted, but the
+          // billing tail (billUsage → settleReservation → analytics → audit) is
+          // ~1.7s of cross-region Worker→DB RTT. On a Worker, defer it via
+          // executionCtx.waitUntil so it completes off the response path;
+          // without an executionCtx (tests, non-Worker callers) it runs inline,
+          // exactly as before. The deferred task ALWAYS settles the hold:
+          // success settles at billing.totalCost, any failure refunds via the
+          // idempotent settleReservation(0), and a refund throw is contained
+          // and logged (never an unhandled waitUntil rejection) — the #11169
+          // sweep-credit-reservations cron backstops a hold stranded by a
+          // dropped waitUntil or a failed refund.
+          await settleOffResponsePath(executionCtx, async () => {
+            try {
+              const billing = await billUsage(
+                billingContext,
+                this.sharedRuntimeBillingUsage(turn, estimatedInputTokens),
+              );
+              const settlement = await settleReservation(billing.totalCost);
+              const usageRecord = await recordUsageAnalytics(billingContext, billing, {
+                type: "chat",
+                content: turn.reply,
+                prompt: text,
+              });
+              if (usageRecord) {
+                await aiBillingRecordsService
+                  .record({
+                    context: billingContext,
+                    billing,
+                    usageRecord,
+                    idempotencyKey,
+                    reconciliation: settlement,
+                  })
+                  .catch((error) => {
+                    logger.error("[shared-runtime] AI billing audit record failed", {
+                      error: error instanceof Error ? error.message : String(error),
+                      agentId: rec.id,
+                    });
                   });
-                });
+              }
+            } catch (error) {
+              // error-policy:J1 deferred-settlement boundary — the response may
+              // already be gone, so the refund is the handling: settle(0) is
+              // idempotent, and a refund failure is logged for the cron sweep.
+              try {
+                await settleReservation(0);
+              } catch (refundError) {
+                logger.error(
+                  "[shared-runtime] deferred billing refund failed; sweep-credit-reservations will reclaim the hold",
+                  {
+                    error: refundError instanceof Error ? refundError.message : String(refundError),
+                    agentId: rec.id,
+                  },
+                );
+              }
+              logger.error("[shared-runtime] billing failed", {
+                error: error instanceof Error ? error.message : String(error),
+                agentId: rec.id,
+              });
             }
-          } catch (error) {
-            await settleReservation(0);
-            logger.error("[shared-runtime] billing failed", {
-              error: error instanceof Error ? error.message : String(error),
-              agentId: rec.id,
-            });
-          }
+          });
         }
       }
 
@@ -2952,7 +2991,12 @@ export class ElizaSandboxService {
 
   // Bridge
 
-  async bridge(agentId: string, orgId: string, rpc: BridgeRequest): Promise<BridgeResponse> {
+  async bridge(
+    agentId: string,
+    orgId: string,
+    rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
+  ): Promise<BridgeResponse> {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec) {
       // Bootstrap window: a freshly-created dedicated agent whose container is
@@ -2962,7 +3006,7 @@ export class ElizaSandboxService {
       // yet "running", so re-resolve by id+org.)
       const bootstrap = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
       if (bootstrap && isDedicatedBootstrapWindow(bootstrap)) {
-        return this.bridgeSharedBootstrap(bootstrap, rpc);
+        return this.bridgeSharedBootstrap(bootstrap, rpc, executionCtx);
       }
       logger.warn("[agent-sandbox] Bridge call to non-running sandbox", {
         agentId,
@@ -2981,7 +3025,7 @@ export class ElizaSandboxService {
           return await this.bridgeSharedStatus(rec, rpc);
         }
         if (rpc.method === "message.send") {
-          return await this.bridgeSharedMessageSend(rec, rpc);
+          return await this.bridgeSharedMessageSend(rec, rpc, executionCtx);
         }
         return {
           jsonrpc: "2.0",
@@ -3038,13 +3082,14 @@ export class ElizaSandboxService {
   private async bridgeSharedBootstrap(
     rec: AgentSandbox,
     rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
   ): Promise<BridgeResponse> {
     try {
       if (rpc.method === "status.get" || rpc.method === "heartbeat") {
         return await this.bridgeSharedStatus(rec, rpc);
       }
       if (rpc.method === "message.send") {
-        return await this.bridgeSharedMessageSend(rec, rpc);
+        return await this.bridgeSharedMessageSend(rec, rpc, executionCtx);
       }
       return {
         jsonrpc: "2.0",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -18,7 +18,7 @@
  */
 
 import { InsufficientCreditsError } from "../../api/errors";
-import type { BridgeRequest } from "../eliza-sandbox";
+import type { BridgeExecutionContext, BridgeRequest } from "../eliza-sandbox";
 // Namespace import (resolved at call-time, not captured at module-eval) so the
 // adapter always reads the *current* eliza-sandbox export. Under bun's
 // process-global `mock.module`, a sibling test file can import this module
@@ -361,6 +361,7 @@ export async function sharedRestMessageSend(
   conversationId: string,
   text: string,
   agentName: string,
+  executionCtx?: BridgeExecutionContext,
 ): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
@@ -368,7 +369,9 @@ export async function sharedRestMessageSend(
     method: "message.send",
     params: { text, roomId: conversationId },
   };
-  const response = await elizaSandbox.elizaSandboxService.bridge(agentId, orgId, rpc);
+  // executionCtx (Workers only) lets the bridge defer the post-reply billing
+  // tail off the response path; without it the turn settles inline as before.
+  const response = await elizaSandbox.elizaSandboxService.bridge(agentId, orgId, rpc, executionCtx);
   if (response.error) {
     // A credit-reserve rejection is a permanent add-credits condition, not a
     // transient bridge failure — surface it typed so the route boundary can


### PR DESCRIPTION
## The biggest hosted-latency win — shared-tier 2.3s → ~0.7s
**⚠️ MONEY-PATH — @0xSolace review required before merge** (packages/cloud discipline: owner review, no solo-merge). I implemented + tested it and preserved every invariant; the credit-settlement timing change needs your eyes from inside the subsystem.

Measured decomposition of a warm shared-tier chat turn (Server-Timing `cloud_worker` ≈ 98% of the 2.3s): the model is only **~290ms (13%)**. **~1.66s (72%)** is the post-reply billing/persistence tail — `billUsage` (195ms) → `settleReservation` reconcile txn (527-578ms, ≥5 statements × ~100ms BOS→Railway-us-west RTT) → `recordUsageAnalytics` (371ms) → `aiBillingRecords` (519ms) — **all sequentially `await`ed BEFORE the response returns**.

## Change (read the diff — surgical)
Return the reply as soon as `runSharedAgentTurn` + `saveSharedRuntimeHistory` complete; move the entire billing tail into a deferred task via a new `settleOffResponsePath` helper: **`executionCtx.waitUntil` on Workers, inline `await` when there's no ctx** (so every existing caller/test keeps fully-synchronous behavior — no bare non-awaited promise anywhere). `executionCtx` is threaded as an optional trailing param down the exact chain (route → `bridge()`/`sharedRestMessageSend()` → `bridgeSharedMessageSend()`), extracted with the repo's throw-safe `try { c.executionCtx } catch {}` guard (copied from the provision route). Applies to both the bridge JSON-RPC route and the mobile/web REST messages route.

## Invariants preserved
1. `reserveCredits` still runs **before** the model call (gate), untouched.
2. `settleReservation` runs for **every** turn: the deferred task always ends in a settle — `totalCost` on success, idempotent `settleReservation(0)` refund inside its own catch on any billing throw; a refund-throw is itself caught+logged citing the every-minute `sweep-credit-reservations` cron (the #11169 backstop for a dropped `waitUntil`), so the `waitUntil` promise never rejects or carries an unsettled hold.
3. The #11169 refund guard still covers `runSharedAgentTurn`/`saveSharedRuntimeHistory` throws (synchronous, before the return).
4. Degraded path `settleReservation(0)` stays synchronous. Reserve/settle amounts + `idempotencyKey` byte-identical.

## Risk flags for your review
- Settlement now lands ~1.7s **after** the response — a burst could briefly read a stale balance at the next reserve gate (the same window `settleOffResponsePath` / the chat-completions routes already accept).
- `waitUntil` hard-drop (isolate eviction) strands the hold until the every-minute sweep cron reclaims it — bounded, existing #11169 backstop, but worth your eyes.
- Behavioral nuance: a refund-path throw inside the tail no longer turns a successful turn into a 500 — the user now gets the reply and the failure is logged (believed strictly better, but it is a change).
- `bridgeSharedMessageStream` (SSE) still settles inline — out of scope, same deferral applies later.

## Tests (run by me): **51 pass, 0 fail**
New `eliza-sandbox-shared-turn-deferred-billing.test.ts` (4/4): reply resolves while billUsage is gated; awaiting the captured `waitUntil` settles at `totalCost`; billUsage-throw refunds deferred without rejecting; no-ctx settles inline before the reply; degraded refunds synchronously (waitUntil never called). Plus refund-guard 2/2, route suites 6/6, adjacent adapter/bridge/settle 39/39. Typecheck + biome clean; error-policy ratchet clean.

**Follow-up (specced, NOT in this PR — needs your money-path review):** the reconcile txn itself can collapse to one CTE (saving another ~420-470ms), matching the `reserveAndDeductCredits` house pattern — one trap is it must DROP `ON CONFLICT DO NOTHING` so a unique-violation aborts atomically (per the #10846 design). Full CTE in the latency report #16917.

Evidence rows: UI/video/frontend `N/A - cloud backend latency`. Backend: the InferenceTiming decomposition (#16917) + the 51-test run above. Trajectory `N/A - no model-behavior change`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
