### PR TITLE
fix(ci): stub optional wallet peers in UI fixture

### DIFF
--- a/packages/ui/src/cloud/__e2e__/optional-wallet-peer-stub.ts
+++ b/packages/ui/src/cloud/__e2e__/optional-wallet-peer-stub.ts
@@ -1,0 +1,42 @@
+/**
+ * Esbuild resolver for wallet connector peers that are intentionally absent
+ * from the cloud settings fixture. The fixture never exercises wallet
+ * connections, but wagmi keeps optional connector imports in its module graph.
+ */
+
+import type { Plugin } from "esbuild";
+
+export const optionalWalletPeers = [
+  "@base-org/account",
+  "@coinbase/wallet-sdk",
+  "@metamask/connect-evm",
+  "@safe-global/safe-apps-provider",
+  "@safe-global/safe-apps-sdk",
+  "@walletconnect/ethereum-provider",
+  "cbw-sdk",
+  "porto",
+] as const;
+
+const escapedPeers = optionalWalletPeers.map((peer) =>
+  peer.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+);
+const optionalWalletPeerPattern = new RegExp(
+  `^(?:${escapedPeers.join("|")})(?:/.*)?$`,
+);
+
+export const optionalWalletPeerStubPlugin: Plugin = {
+  name: "optional-wallet-peer-stub",
+  setup(pluginBuild) {
+    pluginBuild.onResolve({ filter: optionalWalletPeerPattern }, (args) => ({
+      path: args.path,
+      namespace: "optional-wallet-peer-stub",
+    }));
+    pluginBuild.onLoad(
+      { filter: /.*/, namespace: "optional-wallet-peer-stub" },
+      () => ({
+        contents: "export default {};",
+        loader: "js",
+      }),
+    );
+  },
+};

--- a/packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs
+++ b/packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs
@@ -38,6 +38,7 @@ import { chromium } from "playwright";
 import postcss from "postcss";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createSiweMessage } from "viem/siwe";
+import { optionalWalletPeerStubPlugin } from "./optional-wallet-peer-stub.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const uiSrc = resolve(here, "../..");
@@ -274,26 +275,6 @@ const elizaSourceAliasPlugin = {
   },
 };
 
-// Optional wallet-connector deps that wagmi lazily requires but which are not
-// installed (and never execute in this harness) — stub them inert.
-const optionalDepStubPlugin = {
-  name: "optional-dep-stub",
-  setup(pluginBuild) {
-    const filter = /^(@metamask\/connect-evm|@base-org\/account|@safe-global\/safe-apps-sdk|@safe-global\/safe-apps-provider|cbw-sdk|porto(\/.*)?)$/;
-    pluginBuild.onResolve({ filter }, (args) => ({
-      path: args.path,
-      namespace: "optional-dep-stub",
-    }));
-    pluginBuild.onLoad(
-      { filter: /.*/, namespace: "optional-dep-stub" },
-      () => ({
-        contents: "export default {};",
-        loader: "js",
-      }),
-    );
-  },
-};
-
 const bundle = await build({
   entryPoints: [join(here, "slop-removal-fixture.tsx")],
   bundle: true,
@@ -311,7 +292,11 @@ const bundle = await build({
     "import.meta.env": "globalThis.__VITE_ENV__",
   },
   tsconfig: bareTsconfig,
-  plugins: [elizaSourceAliasPlugin, nodeStubPlugin, optionalDepStubPlugin],
+  plugins: [
+    elizaSourceAliasPlugin,
+    nodeStubPlugin,
+    optionalWalletPeerStubPlugin,
+  ],
   write: false,
 });
 const js = bundle.outputFiles[0].text;

--- a/packages/ui/src/cloud/__tests__/optional-wallet-peer-stub.test.ts
+++ b/packages/ui/src/cloud/__tests__/optional-wallet-peer-stub.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Verifies that the cloud settings fixture can bundle wagmi's complete
+ * connector graph without installing optional wallet SDKs it never executes.
+ */
+
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+import {
+  optionalWalletPeerStubPlugin,
+  optionalWalletPeers,
+} from "../__e2e__/optional-wallet-peer-stub";
+
+describe("optional wallet peer fixture stubs", () => {
+  it("resolves every absent wallet connector peer", async () => {
+    const result = await build({
+      stdin: {
+        contents: optionalWalletPeers
+          .map((peer) => `import "${peer}";`)
+          .join("\n"),
+        resolveDir: process.cwd(),
+      },
+      bundle: true,
+      format: "esm",
+      platform: "browser",
+      plugins: [optionalWalletPeerStubPlugin],
+      write: false,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.outputFiles).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #16931

## Summary

- move the cloud fixture optional wallet-peer resolver into a typed reusable esbuild plugin
- cover Coinbase Wallet SDK and WalletConnect Ethereum Provider, the two unresolved optional peers breaking the Actions bundle
- add a focused build regression that resolves every intentionally absent wallet peer

## Verification

- real bun run --cwd packages/ui test:slop-removal-e2e: all checks passed through PGlite migration, cloud API, SIWE, fixture bundling, routing, desktop/mobile browser assertions, and screenshots
- focused resolver regression: 1 pass
- package typecheck: pass
- bun run verify: 573/573 Turbo tasks and all retained root audits pass
- git diff --check

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - CI fixture harness change; no rendered product UI changed

<!-- evidence-row:after-screenshots -->
N/A - CI fixture harness change; no rendered product UI changed

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing flow changed

<!-- evidence-row:backend-logs -->
N/A - no production backend behavior changed

<!-- evidence-row:frontend-logs -->
N/A - no production frontend behavior changed

<!-- evidence-row:llm-trajectory -->
N/A - no agent, prompt, action, or model behavior changed

<!-- evidence-row:domain-artifacts -->
N/A - no domain output changed