### PR TITLE
fix(core): boot-grace missing task workers and auto-resume healed orphan pauses

### DIFF
--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -359,6 +359,10 @@ describe("TaskService tick re-arm", () => {
 		(runtime as { serverless: boolean }).serverless = true;
 		service = (await TaskService.start(runtime)) as TaskService;
 
+		// Step past the boot grace window: inside it a missing worker is treated
+		// as "not registered yet" and skipped silently, not healed.
+		vi.setSystemTime(T0 + 61_000);
+
 		// A genuinely invalid row (bad preflight) still rejects the tick; the
 		// orphaned missing-worker row is healed away and absent from the failures.
 		await expect(service.runDueTasks()).rejects.toMatchObject({
@@ -574,10 +578,17 @@ describe("TaskService orphaned-task self-heal (missing worker)", () => {
 
 		service = (await TaskService.start(runtime)) as TaskService;
 
-		// First tick heals it: paused=true, ONE diagnostic (the tick's
-		// TASK_TICK_FAILED does NOT fire because failures[] is empty after heal).
-		await vi.advanceTimersByTimeAsync(1_000);
+		// Inside the 60s boot grace the missing worker is "not registered yet":
+		// no pause, no delete, no diagnostic.
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(tasks.get("orphan-r")?.metadata?.paused).toBeUndefined();
+
+		// First tick past the grace heals it: paused=true, ONE diagnostic (the
+		// tick's TASK_TICK_FAILED does NOT fire because failures[] is empty after
+		// heal).
+		await vi.advanceTimersByTimeAsync(60_000);
 		expect(tasks.get("orphan-r")?.metadata?.paused).toBe(true);
+		expect(tasks.get("orphan-r")?.metadata?.orphanedNoWorker).toBe(true);
 		const reportError = runtime.reportError as ReturnType<typeof vi.fn>;
 		const callsAfterFirst = reportError.mock.calls.length;
 		expect(callsAfterFirst).toBe(0);
@@ -602,7 +613,12 @@ describe("TaskService orphaned-task self-heal (missing worker)", () => {
 
 		service = (await TaskService.start(runtime)) as TaskService;
 
-		await vi.advanceTimersByTimeAsync(1_000);
+		// Inside the boot grace the one-shot is left alone (its plugin may just
+		// not have registered yet — deleting here would destroy a healthy task).
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(tasks.has("orphan-1")).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(60_000);
 		// One-shot with no worker is deleted (keeping it = re-fail every tick).
 		expect(tasks.has("orphan-1")).toBe(false);
 		const reportError = runtime.reportError as ReturnType<typeof vi.fn>;
@@ -630,7 +646,7 @@ describe("TaskService orphaned-task self-heal (missing worker)", () => {
 
 		service = (await TaskService.start(runtime)) as TaskService;
 
-		await vi.advanceTimersByTimeAsync(1_000);
+		await vi.advanceTimersByTimeAsync(61_000);
 		const reportError = runtime.reportError as ReturnType<typeof vi.fn>;
 		const afterFirst = reportError.mock.calls.length;
 		// The heal failure surfaces (once) via the tick's TASK_TICK_FAILED.
@@ -639,5 +655,88 @@ describe("TaskService orphaned-task self-heal (missing worker)", () => {
 		// It must NOT keep re-narrating on every subsequent 1s tick.
 		await vi.advanceTimersByTimeAsync(30_000);
 		expect(reportError.mock.calls.length).toBe(afterFirst);
+	});
+
+	it("never quarantines during the boot grace window when the worker registers late", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		// Repeat task exists at boot; its plugin registers the worker 10s later
+		// (real boot ordering: TaskService's 1s tick starts before every plugin
+		// has registered its workers).
+		tasks.set("late-worker", {
+			id: "late-worker" as UUID,
+			name: "LATE_WORKER",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			metadata: { updateInterval: 30_000, updatedAt: T0 },
+		});
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		// 10 ticks with no worker: silently skipped, never paused, never errored.
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(tasks.get("late-worker")?.metadata?.paused).toBeUndefined();
+		expect(
+			(runtime.reportError as ReturnType<typeof vi.fn>).mock.calls.length,
+		).toBe(0);
+
+		// Worker registers late; the task then runs normally on its interval.
+		workers.set("LATE_WORKER", { name: "LATE_WORKER", execute });
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(execute).toHaveBeenCalled();
+		expect(tasks.get("late-worker")?.metadata?.paused).not.toBe(true);
+	});
+
+	it("auto-resumes an orphan-paused repeat task when its worker re-registers", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		// A row a PREVIOUS boot orphan-paused (orphanedNoWorker marker). This
+		// build registers the worker again (redeploy restored the plugin).
+		tasks.set("healed", {
+			id: "healed" as UUID,
+			name: "HEALED_WORKER",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			metadata: {
+				updateInterval: 10_000,
+				updatedAt: T0,
+				paused: true,
+				orphanedNoWorker: true,
+				lastError:
+					"No worker registered for task HEALED_WORKER (orphan auto-paused)",
+			},
+		});
+		workers.set("HEALED_WORKER", { name: "HEALED_WORKER", execute });
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		// First tick resumes it (clears paused + marker); it then runs when due.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(tasks.get("healed")?.metadata?.paused).toBe(false);
+		expect(tasks.get("healed")?.metadata?.orphanedNoWorker).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(execute).toHaveBeenCalled();
+	});
+
+	it("never auto-resumes an operator-paused task (no orphanedNoWorker marker)", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		tasks.set("op-paused", {
+			id: "op-paused" as UUID,
+			name: "OP_PAUSED",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			// Operator paused via API — no orphan marker. Must stay paused even
+			// though the worker is registered.
+			metadata: { updateInterval: 5_000, updatedAt: T0, paused: true },
+		});
+		workers.set("OP_PAUSED", { name: "OP_PAUSED", execute });
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(tasks.get("op-paused")?.metadata?.paused).toBe(true);
+		expect(execute).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -62,8 +62,26 @@ export class TaskService extends Service {
 	 * so a transient getTasks/update failure can't re-narrate on the next tick.
 	 */
 	private quarantinedOrphans = new Set<string>();
+	/**
+	 * Service construction time (epoch-ms). A missing worker inside
+	 * {@link TaskService.ORPHAN_GRACE_MS} of this moment is treated as "not
+	 * registered YET" (boot ordering: the 1s tick can start before every plugin
+	 * has registered its workers), not as an orphan. WHY: without the grace, a
+	 * healthy task whose plugin registers a beat later was wrongly quarantined —
+	 * repeat tasks auto-paused, one-shots DELETED — and the first tick emitted
+	 * the TASK_WORKER_MISSING diagnostic that painted red system lines into the
+	 * owner's chat view on every boot.
+	 */
+	private readonly startedAt = Date.now();
 	/** Set true in stop(). runTick returns immediately when true (daemon may call runTick after unregister). */
 	private stopped = false;
+	/**
+	 * Boot grace window (ms) during which a missing worker is skipped silently
+	 * instead of quarantined. 60s comfortably covers slow plugin boots (remote
+	 * capability sync, late schema migrations) while still healing a genuinely
+	 * orphaned row within the first minute of steady-state.
+	 */
+	private static readonly ORPHAN_GRACE_MS = 60_000;
 	static serviceType = ServiceType.TASK;
 	capabilityDescription = "The agent is able to schedule and execute tasks";
 
@@ -225,7 +243,22 @@ export class TaskService extends Service {
 		for (const task of tasks) {
 			const context = { taskId: task.id, taskName: task.name };
 			const metadata = task.metadata as TaskMetadata | undefined;
-			if (task.tags?.includes("repeat") && metadata?.paused) continue;
+			if (task.tags?.includes("repeat") && metadata?.paused) {
+				// Heal in BOTH directions: a repeat task WE paused for a missing
+				// worker (orphanedNoWorker marker) must resume once a redeploy
+				// re-registers that worker. Without this, the paused check here (which
+				// runs before the worker lookup) stranded healed tasks paused forever.
+				// Operator-paused tasks (no marker) are never touched.
+				if (
+					metadata.orphanedNoWorker === true &&
+					task.id &&
+					this.runtime.getTaskWorker(task.name)
+				) {
+					await this.resumeHealedOrphanTask(task, metadata);
+				}
+				// Resumed or not, skip this tick; a resumed task runs when next due.
+				continue;
+			}
 			if (!task.id) {
 				errors.push(
 					new ElizaError("Scheduled task is missing an id", {
@@ -239,6 +272,14 @@ export class TaskService extends Service {
 
 			const worker = this.runtime.getTaskWorker(task.name);
 			if (!worker) {
+				// Boot ordering: the tick can run before every plugin has registered
+				// its workers. Inside the grace window a missing worker is "not
+				// registered YET" — skip silently (no error, no heal). Quarantining
+				// here wrongly paused/DELETED healthy tasks and emitted the
+				// TASK_WORKER_MISSING noise seen on every staging boot.
+				if (Date.now() - this.startedAt < TaskService.ORPHAN_GRACE_MS) {
+					continue;
+				}
 				// Orphaned task: no worker registered in THIS build. Self-heal instead
 				// of re-erroring every 1s tick (the TASK_WORKER_MISSING → TASK_TICK_FAILED
 				// loop that narrated into chat 9×). Emit the diagnostic ONCE per orphan.
@@ -329,6 +370,10 @@ export class TaskService extends Service {
 						metadata: {
 							...task.metadata,
 							paused: true,
+							// Marks the pause as OURS so validateTasks can auto-resume it
+							// when the worker re-registers. Operator pauses lack this flag
+							// and are never auto-resumed.
+							orphanedNoWorker: true,
 							lastError: `No worker registered for task ${task.name} (orphan auto-paused)`,
 							updatedAt: Date.now(),
 						},
@@ -368,6 +413,55 @@ export class TaskService extends Service {
 			);
 		}
 		this.quarantinedOrphans.add(task.id);
+	}
+
+	/**
+	 * Resume a repeat task that quarantineOrphanTask paused (orphanedNoWorker
+	 * marker) now that its worker is registered again (plugin reloaded / build
+	 * redeployed). Clears the pause + marker + lastError and drops the in-memory
+	 * quarantine mark so a FUTURE disappearance re-heals and re-diagnoses once.
+	 * Best-effort: a failed resume write is logged and retried on the next tick
+	 * (the task simply stays paused until the write succeeds).
+	 */
+	private async resumeHealedOrphanTask(
+		task: Task,
+		metadata: TaskMetadata,
+	): Promise<void> {
+		if (!task.id) return;
+		try {
+			await this.runtime.updateTask(task.id, {
+				metadata: {
+					...metadata,
+					paused: false,
+					orphanedNoWorker: false,
+					lastError: undefined,
+					updatedAt: Date.now(),
+				},
+			});
+			this.quarantinedOrphans.delete(task.id);
+			this.runtime.logger.info(
+				{
+					src: "plugin:basic-capabilities:service:task",
+					agentId: this.runtime.agentId,
+					taskId: task.id,
+					taskName: task.name,
+				},
+				"Orphan-paused task auto-resumed (worker registered again)",
+			);
+		} catch (cause) {
+			// Logged only — resume is retried on the next tick; failing the whole
+			// tick over a resume write would recreate the noise this path removes.
+			this.runtime.logger.warn(
+				{
+					src: "plugin:basic-capabilities:service:task",
+					agentId: this.runtime.agentId,
+					taskId: task.id,
+					taskName: task.name,
+					err: cause,
+				},
+				"Failed to auto-resume orphan-paused task; will retry next tick",
+			);
+		}
 	}
 
 	private invalidScheduleField(task: Task): string | undefined {

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -88,6 +88,8 @@ export interface TaskMetadata {
 	notAfter?: number;
 	/** Optional. If true, the scheduler skips this task. WHY: operators pause/resume via API without deleting the task. */
 	paused?: boolean;
+	/** Optional. Set by the scheduler when IT paused a repeat task because no worker was registered (orphan self-heal). Distinguishes scheduler pauses (auto-resumed when the worker re-registers) from operator pauses (never auto-resumed). */
+	orphanedNoWorker?: boolean;
 	/** Optional. Consecutive failure count; reset to 0 on success. WHY: drive backoff and auto-pause after maxFailures. */
 	failureCount?: number;
 	/** Optional. Auto-pause after this many consecutive failures. undefined = 5. Any value <= 0 (use 0 or -1, not Infinity; JSON loses it) = never auto-pause — for critical heartbeats that must survive failure storms. WHY: prevent infinite retry storms; operators can resume after fixing. */


### PR DESCRIPTION
## Problem

Shadow's staging screenshot (2026-07-22 22:43) showed repeated red system lines — `Scheduled task X skipped: TASK_WORKER_MISSING` — polluting the chat view on his dedicated agent.

#16742 already stopped the 1s re-error loop and quieted the codes out of chat narration (QUIET_ERROR_CODES + orphan self-heal). But the noise came back because there is a **second root cause: boot ordering.**

TaskService's tick starts before every plugin has registered its task workers (plugin registration got slower/more async after the schema-migration serialization in #16862, but the race has always existed). On every boot the first ticks see legitimate tasks as "orphans":

- the TASK_WORKER_MISSING diagnostic fires (once per row, but on EVERY boot for MANY rows = the screenshot)
- worse, the self-heal is **destructive when mistaken**: healthy repeat tasks get auto-paused, healthy one-shot tasks get **deleted** — just because their plugin registered a beat late

And the pause was **permanent**: the `paused repeat is skipped` check in `validateTasks` runs before the worker lookup, so the existing "worker is back → unquarantine" path could never reach a paused row. A single mis-heal stranded the task until an operator noticed.

## Fix (scheduler layer, two changes)

1. **60s boot grace window.** A missing worker within 60s of TaskService start is treated as "not registered YET": skipped silently — no error, no heal. Past the grace, the existing quarantine self-heal applies unchanged.
2. **Auto-resume healed orphans.** `quarantineOrphanTask` now stamps its pause with `metadata.orphanedNoWorker: true`. When the worker re-registers (redeploy restored the plugin), `validateTasks` clears the pause + marker and the task resumes on its normal cadence. Operator pauses (no marker) are never auto-resumed.

## Tests

`packages/core` — task.test.ts (24 passed, includes 3 new + 2 hardened):

- late-registering worker inside the grace: never paused, never errored, runs once registered
- one-shot survives the grace window instead of being deleted at t+1s
- orphan heal still pauses (repeat) / deletes (one-shot) past the grace
- healed orphan auto-resumes when its worker re-registers, then runs
- operator-paused row (no marker) stays paused forever
- quarantine-failure diagnostic still emits at most once

```
✓ src/services/task.test.ts (24 tests) 50ms
✓ src/providers/recent-errors.test.ts (8 tests)
✓ src/runtime-report-error.test.ts (6 tests)
✓ src/services/task-scheduler.test.ts (7 tests)
Test Files 4 passed — Tests 45 passed
tsc --noEmit: clean · biome: clean
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - core scheduler change (packages/core task service), no UI surface.`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - core scheduler change, no UI surface.`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - internal scheduler boot-ordering fix; no user-visible flow.`

<!-- evidence-row:backend-logs -->
- [x] Backend logs: CI execution of the real scheduler path on this head — `src/services/task.test.ts` 24/24 passed (includes the 3 new boot-grace/auto-resume tests + 2 hardened): [16934-core-task-vitest-coverage.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16934-core-task-vitest-coverage.log) (verbatim excerpt of green job https://github.com/elizaOS/eliza/actions/runs/29984196253/job/89132361943 on head 314cbf2).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no frontend surface.`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic scheduler-layer fix (boot grace + orphan-pause auto-resume); no agent/prompt/model behavior change, no model call in the fix path.`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: vitest + coverage-gate transcript on head 314cbf2 — [16934-core-task-vitest-coverage.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16934-core-task-vitest-coverage.log): Tests 24 passed (24); coverage 68.89% `task.ts`, 100.00% `types/task.ts`, mean 84.44% ≥ 50% threshold, coverage gate OK.

## Merge

**ready-on-freeze-lift** — queued behind the merge freeze; do not merge while the freeze is active.

> Update 2026-07-23: the Discussion #14308 develop merge hold is lifted (lalalune 05:16Z; sol-critical-merge 05:26Z), so the note above no longer blocks. Evidence rows attached 2026-07-23 from this head's green CI coverage job.

Follow-up to #16742. Adjacent: #16862 (schema migration serialization made the boot registration window wider/more visible).
