### PR TITLE
fix(sql): defer search objects until core schema

### DIFF
--- a/plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts
@@ -15,6 +15,7 @@ import {
   type World,
 } from "@elizaos/core";
 import { sql } from "drizzle-orm";
+import { pgTable, text } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/pglite";
 import { v4 } from "uuid";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -94,6 +95,28 @@ describe("message-search production DDL guard", () => {
 
     await runSqlPluginMigration("pglite");
 
+    expect(await messageSearchColumnExists()).toBe(true);
+  });
+
+  it("defers search objects when an app schema migrates before the core SQL schema", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS;
+
+    const migrationService = new DatabaseMigrationService({
+      databaseBackend: "pglite",
+    });
+    await migrationService.initializeWithDatabase(db);
+    migrationService.registerSchema("early-app-plugin", {
+      earlyAppRecords: pgTable("early_app_records", {
+        id: text("id").primaryKey(),
+      }),
+    });
+
+    await migrationService.runAllPluginMigrations();
+    expect(await messageSearchColumnExists()).toBe(false);
+
+    migrationService.registerSchema(sqlPlugin.name, sqlPlugin.schema ?? {});
+    await migrationService.runAllPluginMigrations();
     expect(await messageSearchColumnExists()).toBe(true);
   });
 

--- a/plugins/plugin-sql/src/message-search.ts
+++ b/plugins/plugin-sql/src/message-search.ts
@@ -44,6 +44,19 @@ export function usesWebsearchSyntax(value: string): boolean {
   return value.includes('"') || /(^|\s)-(?=\S)/.test(value) || /(^|\s)or(?=\s|$)/i.test(value);
 }
 
+/**
+ * Plugin schemas may migrate before the core SQL schema during boot. Search
+ * objects are a post-migration optimization and must wait for their table
+ * instead of turning an otherwise valid early plugin migration into a crash.
+ */
+export async function messageSearchTableExists(db: DrizzleDatabase): Promise<boolean> {
+  const result = await db.execute(sql`
+    SELECT to_regclass('memories') AS table_name
+  `);
+  const row = result.rows[0] as { table_name?: unknown } | undefined;
+  return typeof row?.table_name === "string";
+}
+
 // Accent-folding map: each accented Latin letter → its ASCII base. `from` and
 // `to` are equal length; the three trailing chars in `from` (straight/curly
 // apostrophe, backtick) have no `to` counterpart and are therefore deleted by

--- a/plugins/plugin-sql/src/migration-service.ts
+++ b/plugins/plugin-sql/src/migration-service.ts
@@ -7,7 +7,7 @@
  * Security across all tables once every migration succeeds.
  */
 import { type IDatabaseAdapter, logger, type Plugin } from "@elizaos/core";
-import { applyMessageSearchObjects } from "./message-search";
+import { applyMessageSearchObjects, messageSearchTableExists } from "./message-search";
 import { migrateToEntityRLS } from "./migrations";
 import { applyEntityRLSToAllTables, applyRLSToNewTables, installRLSFunctions } from "./rls";
 import { RuntimeMigrator } from "./runtime-migrator";
@@ -141,8 +141,14 @@ export class DatabaseMigrationService {
       // Install the message full-text/trigram search objects on the migrated
       // `memories` table (#13534). Idempotent; runs after the table exists so the
       // GIN expression indexes can be created.
-      if (shouldApplyMessageSearchObjects(this.databaseBackend)) {
+      const shouldInstallSearchObjects = shouldApplyMessageSearchObjects(this.databaseBackend);
+      if (shouldInstallSearchObjects && (await messageSearchTableExists(this.db))) {
         await applyMessageSearchObjects(this.db);
+      } else if (shouldInstallSearchObjects) {
+        logger.info(
+          { src: "plugin:sql", table: "memories" },
+          "[MessageSearch] deferring search-object install until the core SQL schema is migrated"
+        );
       } else {
         logger.warn(
           {


### PR DESCRIPTION
Closes #16933

## Summary

- defer message-search post-migration DDL until the core `memories` table exists
- retain the later automatic install once the SQL core schema is registered
- cover the exact app-schema-before-core-schema boot order with real PGlite

## Verification

- focused real PGlite suite — 5/5 passed
- plugin SQL typecheck — passed
- Biome on all three changed files — passed
- `bun run verify` — 575/575 Turbo tasks, retained audits passed, 28 dist consumers passed
- source entrypoint under the Build Agent Image smoke environment reached `/api/health`; early app migration deferred search DDL, core SQL migration created `memories`, then search objects installed
- repository Docker smoke preparation completed, but local Docker Desktop failed before any image layer with an infrastructure metadata-database I/O error (`/var/lib/desktop-containerd/.../meta.db`); a fresh isolated buildx builder reproduced the same daemon error. Existing user containers were preserved and the task-scoped builder was removed.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - backend migration ordering only; no visual surface changed.

<!-- evidence-row:after-screenshots -->
N/A - backend migration ordering only; no visual surface changed.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing interactive flow changed.

<!-- evidence-row:backend-logs -->
N/A - the manually reviewed local source-boot excerpt is included below; no durable external log artifact was produced.

<!-- evidence-row:frontend-logs -->
N/A - backend migration ordering only; no frontend path changed.

<!-- evidence-row:llm-trajectory -->
N/A - migration ordering does not alter model, prompt, action, provider, or planner behavior.

<!-- evidence-row:domain-artifacts -->
N/A - the real PGlite schema assertions are committed as the regression test; no external domain artifact applies.

<details><summary>Manually reviewed real source boot path</summary>

```text
[PLUGIN:SQL] Migration completed successfully (pluginName=eliza)
[MessageSearch] deferring search-object install until the core SQL schema is available (table=memories)
[PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=167)
[MessageSearch] full-text search objects applied
API server listening
SOURCE_BOOT_HEALTHY
```

The original failure was reproduced with its nested database cause: `relation "memories" does not exist`.
</details>

The real PGlite regression inspects both phases: the early app-only migration completes before `memories` exists; after registering the core SQL schema and rerunning migrations, `memories.message_search_document` exists.