### PR TITLE
docs(plugin-trajectory-logger): point evidence guidance at inline PR attachments

### DIFF
--- a/plugins/plugin-trajectory-logger/AGENTS.md
+++ b/plugins/plugin-trajectory-logger/AGENTS.md
@@ -135,7 +135,7 @@ Add a typed `fetch` wrapper to `src/api-client.ts` following the `readJson<T>` p
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-trajectory-logger/CLAUDE.md
+++ b/plugins/plugin-trajectory-logger/CLAUDE.md
@@ -135,7 +135,7 @@ Add a typed `fetch` wrapper to `src/api-client.ts` following the `readJson<T>` p
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 


### PR DESCRIPTION
# Relates to

Closes #16946 (LifeOps MVP workstream 9 — doc-driven development).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched from `origin/develop` at `ee5ffb6d757`).
- [x] `bun install` and `bun run verify` were run after sync (output below).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Branched directly off the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync (output in Evidence Details).

# Risks

Low. Two-line, docs-only change to a byte-identical guide pair
(`plugins/plugin-trajectory-logger/CLAUDE.md` + `AGENTS.md`). No code, no
build outputs, no runtime behavior touched.

# Background

## What does this PR do?

The evidence-and-e2e-mandate block in the `plugin-trajectory-logger` guide
pair was the one pair missed by the workstream-9 sweep: line 138 still told
agents to commit evidence artifacts under the retired `.github/issue-evidence/`
directory — a path that (a) no longer exists on `develop` and (b)
`scripts/check-pr-evidence.mjs` now refuses to count as evidence
(`RETIRED_REPO_EVIDENCE_RE`) and rejects files added under. An agent following
the guide verbatim produced a PR the evidence gate fails.

This replaces line 138 in both files with the exact swept wording every
sibling guide uses (verbatim from `packages/docs/CLAUDE.md:163`):

Before:

> ``Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**``

After:

> ``Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**``

The pair stays byte-identical, as enforced by
`scripts/assert-agents-claude-identical.mjs` (wired into `bun run verify` via
`check:agents-claude`).

## What kind of change is this?

Documentation fix (guide-pair text only).

# Documentation changes needed?

This PR *is* the documentation change. No further docs updates required —
after it, `git grep "issue-evidence" -- '**/CLAUDE.md' '**/AGENTS.md'` is
empty repo-wide (proof below). The only remaining non-guide grep hits on
`develop` are `scripts/check-pr-evidence.test.mjs` rejection-test fixtures
(must stay) and historical research/benchmark docs that describe the
retirement itself.

# Testing

## Where should a reviewer start?

The two-line diff, then the three command outputs in Evidence Details:
the empty guide grep, the pair-identity assertion, and `bun run verify`.

## Detailed testing steps

None: the mechanical checks below are the acceptance criteria from #16946.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - docs-only guide text change` (no UI surface).
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - docs-only guide text change` (no UI surface).
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - docs-only guide text change` (no user flow).
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - docs-only guide text change`; the relevant check output
      (`assert-agents-claude-identical`, `verify`) is pasted inline below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - docs-only guide text change` (no frontend).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - docs-only guide text change` (no agent/action/provider/prompt/model behavior touched).
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - docs-only guide text change`; the changed guide
      lines ARE the domain artifact and are fully visible in the two-line diff
      plus the acceptance-criteria command outputs pasted below.

# Evidence Details

## Real LLM-call trajectory

`N/A - docs-only guide text change` (no agent/action/provider/prompt/model change).

## Backend + frontend logs

`N/A - docs-only guide text change`. Acceptance-criteria command outputs, run at the PR head:

<details>
<summary>Acceptance criterion 1 — guide grep is empty repo-wide (exit 1 = zero hits)</summary>

```
$ git rev-parse HEAD
27c5465b5f6ea5a85694c0c555e6ff656673bd8e

$ git grep -n "issue-evidence" -- '**/CLAUDE.md' '**/AGENTS.md'; echo "exit: $?"
exit: 1
```

</details>

<details>
<summary>Acceptance criterion 2 — CLAUDE.md/AGENTS.md pair byte-identical</summary>

```
$ node scripts/assert-agents-claude-identical.mjs
[assert-agents-claude-identical] PASS: 297 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
exit: 0
```

</details>

<details>
<summary>bun run verify (root, post-sync)</summary>

```
$ flock /tmp/eliza-verify.lock -c "bun run verify"
$ node scripts/assert-agents-claude-identical.mjs
[assert-agents-claude-identical] PASS: 297 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
...
 Tasks:    575 successful, 575 total
...
[typecheck:dist] checked 28 dist-path consumer config(s)
verify exit: 0
```

</details>

Acceptance criterion 3 — the replacement line is byte-for-byte the swept wording
from `packages/docs/CLAUDE.md:163`:

```
$ grep -n "Artifacts →" packages/docs/CLAUDE.md plugins/plugin-trajectory-logger/CLAUDE.md plugins/plugin-trajectory-logger/AGENTS.md
plugins/plugin-trajectory-logger/CLAUDE.md:138:Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
plugins/plugin-trajectory-logger/AGENTS.md:138:Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
packages/docs/CLAUDE.md:163:Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
```

## Screenshots (before / after) + video walkthrough

### Before

`N/A - docs-only guide text change`

### After

`N/A - docs-only guide text change`

### Walkthrough video

`N/A - docs-only guide text change`

## Audio / voice walkthrough

`N/A - docs-only guide text change` (no voice/TTS/STT surface).

## Known gaps / failures

None. All four acceptance criteria from #16946 are met; every N/A row above is
docs-only scoped with the reason stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
