### PR TITLE
test: cover request-local model usage capture

### DIFF
--- a/packages/agent/src/runtime/prompt-optimization.usage.test.ts
+++ b/packages/agent/src/runtime/prompt-optimization.usage.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Model-usage capture tests use real AgentRuntime event dispatch to prove
+ * request-local accounting under concurrent and nested asynchronous turns.
+ */
+
+import { AgentRuntime, EventType, ModelType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { withModelUsageCapture } from "./prompt-optimization.ts";
+
+function createRuntime(): AgentRuntime {
+  return new AgentRuntime({ logLevel: "fatal" });
+}
+
+async function emitUsage(
+  runtime: AgentRuntime,
+  provider: string,
+  prompt: number,
+  completion: number,
+): Promise<void> {
+  await runtime.emitEvent(EventType.MODEL_USED, {
+    runtime,
+    provider,
+    type: ModelType.TEXT_LARGE,
+    tokens: {
+      prompt,
+      completion,
+      total: prompt + completion,
+    },
+  });
+}
+
+describe("withModelUsageCapture", () => {
+  it("normalizes SDK cache tokens and aggregates every model call", async () => {
+    const runtime = createRuntime();
+
+    const captured = await withModelUsageCapture(runtime, async () => {
+      await runtime.emitEvent(EventType.MODEL_USED, {
+        runtime,
+        provider: "openai",
+        model: "gpt-test",
+        type: ModelType.TEXT_LARGE,
+        tokens: {
+          prompt: 80,
+          completion: 20,
+          total: 100,
+          cached: 64,
+        },
+      });
+      await runtime.emitEvent([EventType.MODEL_USED], {
+        runtime,
+        source: "anthropic",
+        modelName: "claude-test",
+        type: ModelType.TEXT_LARGE,
+        usageEstimated: true,
+        tokens: {
+          prompt: 40,
+          total: 50,
+          cache_creation_input_tokens: 12,
+        },
+      });
+      return "complete";
+    });
+
+    expect(captured).toEqual({
+      result: "complete",
+      usage: {
+        promptTokens: 120,
+        completionTokens: 30,
+        totalTokens: 150,
+        cacheReadInputTokens: 64,
+        cacheCreationInputTokens: 12,
+        cachedInputTokens: 64,
+        model: "claude-test",
+        provider: "anthropic",
+        isEstimated: true,
+        llmCalls: 2,
+      },
+    });
+  });
+
+  it("isolates overlapping turns on the same runtime", async () => {
+    const runtime = createRuntime();
+    let arrived = 0;
+    let release!: () => void;
+    const bothArrived = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const capture = async (
+      provider: string,
+      prompt: number,
+      completion: number,
+    ) =>
+      withModelUsageCapture(runtime, async () => {
+        arrived += 1;
+        if (arrived === 2) release();
+        await bothArrived;
+        await emitUsage(runtime, provider, prompt, completion);
+        return provider;
+      });
+
+    const [first, second] = await Promise.all([
+      capture("provider-a", 101, 11),
+      capture("provider-b", 202, 22),
+    ]);
+
+    expect(first).toMatchObject({
+      result: "provider-a",
+      usage: {
+        promptTokens: 101,
+        completionTokens: 11,
+        totalTokens: 112,
+        provider: "provider-a",
+        llmCalls: 1,
+      },
+    });
+    expect(second).toMatchObject({
+      result: "provider-b",
+      usage: {
+        promptTokens: 202,
+        completionTokens: 22,
+        totalTokens: 224,
+        provider: "provider-b",
+        llmCalls: 1,
+      },
+    });
+  });
+
+  it("includes nested calls in the outer capture without leaking outward", async () => {
+    const runtime = createRuntime();
+
+    const outer = await withModelUsageCapture(runtime, async () => {
+      await emitUsage(runtime, "outer-before", 10, 1);
+      const inner = await withModelUsageCapture(runtime, async () => {
+        await emitUsage(runtime, "inner", 20, 2);
+        return "inner-result";
+      });
+      await emitUsage(runtime, "outer-after", 30, 3);
+      return inner;
+    });
+
+    expect(outer.result).toMatchObject({
+      result: "inner-result",
+      usage: {
+        promptTokens: 20,
+        completionTokens: 2,
+        totalTokens: 22,
+        provider: "inner",
+        llmCalls: 1,
+      },
+    });
+    expect(outer.usage).toMatchObject({
+      promptTokens: 60,
+      completionTokens: 6,
+      totalTokens: 66,
+      provider: "outer-after",
+      llmCalls: 3,
+    });
+
+    const subsequent = await withModelUsageCapture(runtime, async () => "next");
+    expect(subsequent).toEqual({ result: "next", usage: null });
+  });
+
+  it("ignores model events that contain no usage fields", async () => {
+    const runtime = createRuntime();
+
+    const captured = await withModelUsageCapture(runtime, async () => {
+      await runtime.emitEvent(EventType.MODEL_USED, {
+        runtime,
+        provider: "empty",
+        type: ModelType.TEXT_LARGE,
+        tokens: {},
+      });
+    });
+
+    expect(captured.usage).toBeNull();
+  });
+
+  it("propagates request failures and leaves the next capture clean", async () => {
+    const runtime = createRuntime();
+
+    await expect(
+      withModelUsageCapture(runtime, async () => {
+        await emitUsage(runtime, "failed-turn", 99, 9);
+        throw new Error("request failed");
+      }),
+    ).rejects.toThrow("request failed");
+
+    const next = await withModelUsageCapture(runtime, async () => {
+      await emitUsage(runtime, "next-turn", 7, 3);
+      return "ok";
+    });
+    expect(next).toMatchObject({
+      result: "ok",
+      usage: {
+        promptTokens: 7,
+        completionTokens: 3,
+        totalTokens: 10,
+        provider: "next-turn",
+        llmCalls: 1,
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #16896.

## Why

The post-merge coverage run for #16916 correctly reported `packages/agent/src/runtime/prompt-optimization.ts` at 14.24% total-file coverage. The behavior was covered indirectly through chat-route tests, but the request-local usage-capture contract needs direct regression coverage.

## What

Adds five tests against real `AgentRuntime` event dispatch:

- OpenAI-style `tokens.cached` normalization plus multi-call aggregation;
- concurrent captures on the same runtime remain request-local;
- nested capture includes inner events in the outer total without leaking afterward;
- model events with no usage fields remain explicit `null`;
- a failed request cannot pollute the following capture.

No production code changes.

## Validation

- focused Vitest: **5/5 passed**
- `bun run --cwd packages/agent typecheck`: passed
- Biome: passed
- `bun run audit:test-realness`: passed, **0 regressions**

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-only backend/runtime follow-up with no rendered UI change`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test-only backend/runtime follow-up with no rendered UI change`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-visible behavior changed`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [the real provider benchmark log exercised by the implementation this test protects](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16916-provider-latency-final.log).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or behavior changed`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [the eight-turn live production trace for the implementation this test protects](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16916-full-flow-live-final-v2.json).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - test-only follow-up; the underlying provider and embedding artifacts are attached to #16916`.
