### PR TITLE
fix(ui): pill tap steps ONE state to the input bar — no thread jump, no keyboard

### DIFF
--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -1476,8 +1476,13 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
         await page.keyboard.press("ArrowUp").catch(() => undefined);
       } else {
         const pill = page.getByTestId("chat-pill");
-        if (await pill.isVisible({ timeout: 3_000 }).catch(() => false))
+        if (await pill.isVisible({ timeout: 3_000 }).catch(() => false)) {
+          // A pill tap steps only to the INPUT bar; the grabber tap then
+          // reveals the thread (the deliberate two-step).
           await pill.click().catch(() => undefined);
+          await grabber.focus().catch(() => undefined);
+          await page.keyboard.press("ArrowUp").catch(() => undefined);
+        }
       }
       await expect(overlay).toHaveAttribute("data-open", "true", {
         timeout: 10_000,

--- a/packages/ui/src/components/shell/ChatOverlay.fuzz.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.fuzz.test.tsx
@@ -695,26 +695,25 @@ describe("ChatOverlay — seeded random fuzz", () => {
   }
 });
 
-// ── The two reported bugs, pinned ────────────────────────────────────────────
-describe("ChatOverlay — bug (a): a single pill tap opens to half", () => {
-  it("ONE tap on the pill opens the chat to half (no blink-back, no second tap)", () => {
+// ── The reported bugs, pinned ────────────────────────────────────────────────
+describe("ChatOverlay — pill tap steps ONE state to the input bar", () => {
+  it("ONE tap on the pill forms the INPUT bar — never the thread, never the keyboard", () => {
     render(<ChatOverlay controller={makeController()} />);
     gotoPill();
     tap(pill(), 400); // a single tap
-    expect(detentOf()).toBe("half");
-    expect(variantOf()).toBe("open");
-    expect(document.activeElement).toBe(input()); // keyboard raised on first tap
-    assertInvariants("bug-a-single-tap");
+    expect(detentOf()).toBe("collapsed");
+    // No keyboard pop and no half jump: the thread reveal (grabber tap) and
+    // composer focus (composer tap) are each their own deliberate gesture.
+    expect(document.activeElement).not.toBe(input());
+    assertInvariants("pill-tap-single-step");
   });
 
-  it("repeated open/collapse via the pill always reaches half on the very next tap", () => {
+  it("repeated collapse/tap cycles always land back on the input bar", () => {
     render(<ChatOverlay controller={makeController()} />);
     for (let i = 0; i < 5; i++) {
       gotoPill();
       tap(pill(), 400);
-      expect(detentOf(), `cycle ${i}`).toBe("half");
-      // back to the pill for the next cycle
-      flickDown(grabber() as Element);
+      expect(detentOf(), `cycle ${i}`).toBe("collapsed");
     }
   });
 });
@@ -802,11 +801,14 @@ describe("ChatOverlay — bug (b): keyboard dismiss restores prior state", () =>
     assertInvariants("bug-b-grabber-input");
   });
 
-  it("pill tap → half, then dismissing the keyboard keeps the chat open at half", () => {
+  it("pill tap → input → grabber tap → half; a keyboard dismiss keeps the deliberate open", () => {
     render(<ChatOverlay controller={makeController()} />);
     gotoPill();
-    tap(pill(), 400); // opens to half + raises keyboard (bug a)
+    tap(pill(), 400); // step 1: form the input bar (no keyboard, no thread)
+    expect(detentOf()).toBe("collapsed");
+    tap(grabber() as Element, 180); // step 2: reveal the thread
     expect(detentOf()).toBe("half");
+    focusReal(); // step 3: composer tap raises the keyboard
     fireEvent.pointerDown(document.body); // dismiss keyboard
     expect(detentOf()).toBe("half"); // deliberate open survives (bug b)
     assertInvariants("bug-ab-pill-then-dismiss");

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -2300,11 +2300,12 @@ describe("ChatOverlay", () => {
     expect(pill.getAttribute("tabindex")).toBeNull();
   });
 
-  it("opens the chat to HALF on a SINGLE pill tap (not the bare input bar)", () => {
-    // Regression: a tap on the pill used to land on the bare input bar (the
-    // chat "blinked" without opening) and needed a SECOND tap to reach half.
-    // With a conversation to show, ONE tap must open straight to half — exactly
-    // like a flick-up.
+  it("steps a pill tap to the INPUT bar — never the thread detent, never the keyboard", () => {
+    // A pill tap is ONE step up the continuum: it forms the bare input bar.
+    // Even with a conversation to show it must NOT jump to half (the grabber
+    // tap reveals the thread) and must NOT focus the composer (a composer tap
+    // raises the keyboard) — the sheet never lurches taller or pops a keyboard
+    // the user didn't ask for.
     render(<ChatOverlay controller={makeController()} />);
     const sheet = screen.getByTestId("chat-sheet");
     const grabber = screen.getByTestId("chat-sheet-grabber");
@@ -2316,21 +2317,22 @@ describe("ChatOverlay", () => {
     // pull-gesture binding is the single tap authority (onPointerUp → onTap).
     fireEvent.pointerDown(pill, { clientY: 400, pointerId: 1 });
     fireEvent.pointerUp(pill, { clientY: 400, pointerId: 1 });
-    expect(sheet.getAttribute("data-detent")).toBe("half");
+    expect(sheet.getAttribute("data-detent")).toBe("collapsed");
+    expect(sheet.getAttribute("data-chat-state")).toBe("INPUT");
     const textarea = screen.getByTestId("chat-composer-textarea");
     expect(textarea).toBeTruthy();
-    // The pill tap must focus the composer (so iOS raises the keyboard on the
-    // first tap) and clear the `inert` it carried while pilled — without that,
-    // the composer silently refuses keyboard input until a second tap.
-    expect(document.activeElement).toBe(textarea);
+    // No keyboard: the composer is present but NOT focused.
+    expect(document.activeElement).not.toBe(textarea);
+    // The formed input bar is interactive — leaving the pill state cleared the
+    // `inert` the content carried while pilled.
     expect(screen.getByTestId("chat-content").hasAttribute("inert")).toBe(
       false,
     );
   });
 
-  it("opens a thread-less pill tap to the bare input bar (nothing to open into)", () => {
-    // With no conversation yet there's no thread to reveal, so a pill tap forms
-    // the input bar (and raises the keyboard) rather than an empty half sheet.
+  it("steps a thread-less pill tap to the same INPUT bar (no keyboard)", () => {
+    // No conversation changes nothing: the tap forms the input bar and leaves
+    // the keyboard down — focusing is the composer tap's job.
     render(<ChatOverlay controller={makeController({ messages: [] })} />);
     const sheet = screen.getByTestId("chat-sheet");
     const grabber = screen.getByTestId("chat-sheet-grabber");
@@ -2341,14 +2343,15 @@ describe("ChatOverlay", () => {
     fireEvent.pointerDown(pill, { clientY: 400, pointerId: 1 });
     fireEvent.pointerUp(pill, { clientY: 400, pointerId: 1 });
     expect(sheet.getAttribute("data-detent")).toBe("collapsed");
-    expect(document.activeElement).toBe(
+    expect(document.activeElement).not.toBe(
       screen.getByTestId("chat-composer-textarea"),
     );
   });
 
   it("opens the pill on keyboard activation (Enter)", () => {
     // Keyboard users still open the pill via onKeyDown even though the native
-    // onClick was removed in favour of the gesture binding.
+    // onClick was removed in favour of the gesture binding. Activation matches
+    // a tap: one step to the INPUT bar.
     render(<ChatOverlay controller={makeController()} />);
     const sheet = screen.getByTestId("chat-sheet");
     const grabber = screen.getByTestId("chat-sheet-grabber");
@@ -2357,7 +2360,7 @@ describe("ChatOverlay", () => {
     fireEvent.pointerUp(grabber, { clientY: 380, pointerId: 1 });
     expect(sheet.getAttribute("data-detent")).toBe("pill");
     fireEvent.keyDown(screen.getByTestId("chat-pill"), { key: "Enter" });
-    expect(sheet.getAttribute("data-detent")).toBe("half");
+    expect(sheet.getAttribute("data-detent")).toBe("collapsed");
   });
 
   it("flicks UP from the pill to recover the input", () => {
@@ -3439,8 +3442,8 @@ describe("ChatOverlay single-thread (no chat swipe, #13531)", () => {
     expect(sheet.getAttribute("data-detent")).toBe("pill");
     expect(sheet.getAttribute("data-chat-state")).toBe("CLOSED");
 
-    // pill → back: a tap on the pill leaves the CLOSED/pill state (it reveals the
-    // composer, or the thread when there's history to show).
+    // pill → back: a tap on the pill leaves the CLOSED/pill state (it re-forms
+    // the bare input bar; thread reveal and keyboard are later gestures).
     const grabber = screen.getByTestId("chat-sheet-grabber");
     fireEvent.pointerDown(grabber, { clientY: 780, pointerId: 35 });
     fireEvent.pointerUp(grabber, { clientY: 780, pointerId: 35 });

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -752,6 +752,20 @@ function PillHandle({
           onOpen();
         }
       }}
+      // A touch tap opens the INPUT bar in the pointerup that precedes this
+      // touchend — by the time the browser dispatches its compat mouse events
+      // (mousedown/click), the composer textarea has already formed under the
+      // same coordinates, and the synthetic click would focus it and pop the
+      // keyboard the pill tap deliberately leaves down. preventDefault() on
+      // touchend suppresses the compat sequence; the gesture itself runs on
+      // pointer events and is unaffected. Unconditional: a touchend only
+      // reaches this handle when the touch STARTED on it (touch events retarget
+      // to their touchstart element), i.e. while it was the pilled handle —
+      // the render that formed the input has already flipped `pilled` false by
+      // the time this fires, so the prop cannot gate it.
+      onTouchEnd={(e) => {
+        if (e.cancelable) e.preventDefault();
+      }}
       {...binding}
       tabIndex={pilled ? undefined : -1}
       aria-hidden={pilled ? undefined : true}
@@ -4129,61 +4143,25 @@ export function ChatOverlay({
   // openProgress → 1 directly so the open never depends on that effect's timing.
   const openFromPill = React.useCallback(() => {
     draggingRef.current = false;
-    // A pill tap OPENS the chat. With a conversation to show, go straight to the
-    // HALF detent — a tap reveals the thread/loader exactly like a flick-up, so a
-    // SINGLE tap always opens the chat (never the old "tap lands on a bare input
-    // bar, tap again to actually open" two-step). Mark it deliberately open so
-    // dismissing the keyboard then KEEPS it at half (preFocusCollapsedRef gates
-    // that). With no thread yet, there's nothing to open into — just form the
-    // bare input bar, and treat a later keyboard dismiss as a re-collapse.
-    if (hasRevealableThread) {
-      goToDetent("half");
-      preFocusCollapsedRef.current = false;
-    } else {
-      setMode("input");
-      preFocusCollapsedRef.current = true;
-      detentHaptic();
-    }
+    // A pill tap steps ONE state up the continuum: it forms the bare input bar,
+    // nothing more. It must NOT jump to a thread detent and must NOT raise the
+    // keyboard — revealing the thread (grabber tap) and focusing the composer
+    // (composer tap) are each their own deliberate next gesture, so the sheet
+    // never lurches taller or pops a keyboard the user didn't ask for. Because
+    // nothing is focused, a later keyboard dismiss reads as a re-collapse.
+    setMode("input");
+    preFocusCollapsedRef.current = true;
+    detentHaptic();
     if (reduce) {
       stopOpenProgressAnimation();
       openProgress.set(1);
     } else animateOpenProgress(1);
-    // Raise the keyboard on the SAME tap that opens the pill. While pilled, the
-    // composer content is `inert`, and React only clears that on the next
-    // render — too late for iOS WebKit, which honors focus() only synchronously
-    // inside the originating user gesture AND only on a non-inert element. So
-    // clear inert imperatively now and focus immediately; otherwise the first
-    // tap opens a composer that silently refuses keyboard input until a second
-    // tap (the reported "chat input doesn't accept text on iOS" bug). Suppress
-    // the focus→expand: the target detent is already set above, and letting
-    // expand run would clobber preFocusCollapsedRef with the (pre-render, still
-    // pilled) sheet state and treat this deliberate open as a re-collapse.
-    contentRef.current?.removeAttribute("inert");
-    suppressExpandOnFocusRef.current = true;
     // A stale thread-focus intent (queued by an earlier maximize/settle whose
-    // sheetOpen edge never consumed it) would fire on THIS open's sheetOpen
-    // flip and steal focus from the composer the very tap just focused —
-    // breaking the grabber's two-step keyboard dismiss. This open's focus
-    // target is explicitly the composer, so void any queued intent.
+    // sheetOpen edge never consumed it) would fire on the NEXT open and steal
+    // focus the user never requested — this tap's endpoint is the unfocused
+    // input bar, so void any queued intent.
     focusThreadRef.current = false;
-    inputRef.current?.focus();
-    // If the synchronous focus did NOT land (blocked by the platform), disarm
-    // the suppress flag now — a stranded flag would silently swallow the next
-    // genuine focus→expand.
-    if (
-      typeof document !== "undefined" &&
-      document.activeElement !== inputRef.current
-    ) {
-      suppressExpandOnFocusRef.current = false;
-    }
-  }, [
-    openProgress,
-    reduce,
-    hasRevealableThread,
-    goToDetent,
-    stopOpenProgressAnimation,
-    animateOpenProgress,
-  ]);
+  }, [openProgress, reduce, stopOpenProgressAnimation, animateOpenProgress]);
 
   // --- Pull gesture --------------------------------------------------------
   // The grabber is the draggable handle. A live drag sets the threadHeight motion
@@ -4689,7 +4667,8 @@ export function ChatOverlay({
       // INPUT → PILL: collapse the input away into a pill at the bottom.
       collapseToPill();
     },
-    // A tap (no drag) on the handle. A tap on the PILL brings the input back.
+    // A tap (no drag) on the handle. A tap on the PILL brings the input back —
+    // one step only: no thread detent, no keyboard (openFromPill).
     // When OPEN, the grabber acts as a disclosure toggle: tap once to close.
     // When COLLAPSED, tap opens the thread or its loader; thread-less chats focus
     // the composer because there is nothing above the input to reveal.

--- a/packages/ui/src/components/shell/__e2e__/CHAT_SHEET_STATE_MATRIX.md
+++ b/packages/ui/src/components/shell/__e2e__/CHAT_SHEET_STATE_MATRIX.md
@@ -32,7 +32,7 @@ Continuous motion values: `threadHeight` (px, finger-tracked), `openProgress`
 ### From PILL
 | Gesture | Result |
 | --- | --- |
-| Tap | HALF when a thread exists (single tap always opens the chat), else INPUT + keyboard. |
+| Tap | INPUT — forms the bare input bar, one step up the continuum. Never a thread detent, never the keyboard: revealing the thread (grabber tap) and raising the keyboard (composer tap) are each their own deliberate next gesture. A later keyboard dismiss re-collapses. |
 | Flick up (short) | HALF when a thread exists, else INPUT. |
 | Held drag up, released anywhere | One continuum: first 120px morphs pill→input (`openProgress`), excess flows into the thread height. Release: < 64px of thread → INPUT; ≥ half+64 → FULL; between → HALF or free rest; a long haul (≥ 80% of the screen) → **MAXIMIZED**. |
 | Slow drag up < half the pill morph (`openProgress` < 0.5) | springs back to PILL. |

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -15,7 +15,8 @@
  *       the PILL, with per-step geometry sampling (monotonic height, pill
  *       crossfade, edge-to-edge box, fixed-width text column). Detent rules:
  *       pill nudge springs back · pill drag past half-morph rests at INPUT ·
- *       short input pull springs back · pill tap → HALF · grabber tap → INPUT.
+ *       short input pull springs back · pill tap → INPUT (no keyboard) ·
+ *       grabber tap steps INPUT → HALF → INPUT.
  *       Full matrix: CHAT_SHEET_STATE_MATRIX.md.
  *   - AUTOSCROLL, per input type: tail follows at bottom, a single >80px
  *       streamed growth remains pinned, reading-scrollback is not yanked, and
@@ -963,7 +964,7 @@ async function runContinuumSuite(p, pointer, tag) {
   );
   await snap(p, `${tag}-continuum-back-to-pill`);
 
-  // -- Detent rules: pill tap → HALF; open + grabber tap → INPUT -------------
+  // -- Detent rules: pill tap → INPUT (no keyboard); grabber taps step -------
   if (pointer === "mouse") {
     await p.getByTestId("chat-pill").click();
   } else {
@@ -971,12 +972,19 @@ async function runContinuumSuite(p, pointer, tag) {
   }
   await p.waitForTimeout(SETTLE);
   assert(
-    (await detent(p)) === "half",
-    `[${tag}-continuum] pill tap opens straight to HALF`,
+    (await detent(p)) === "collapsed" && (await variant(p)) === "closed",
+    `[${tag}-continuum] pill tap steps ONE state to the INPUT bar (never the thread detent)`,
   );
-  // The pill tap also focused the composer (keyboard up), so the FIRST grabber
-  // tap dismisses the keyboard and keeps the sheet at its detent; the SECOND
-  // collapses to the input bar — the designed two-step.
+  // The pill tap must NOT raise the keyboard: the composer stays unfocused
+  // until the user taps it deliberately.
+  assert(
+    (await p.evaluate(
+      () => document.activeElement?.getAttribute("data-testid"),
+    )) !== "chat-composer-textarea",
+    `[${tag}-continuum] pill tap leaves the keyboard down (composer unfocused)`,
+  );
+  // Grabber taps then step the disclosure: INPUT → HALF reveals the thread; a
+  // tap on the open sheet (no keyboard up) collapses back to INPUT.
   const grabberTap = async () => {
     if (pointer === "mouse") await p.getByTestId("chat-sheet-grabber").click();
     else await touchTap(p, testIdSelector("chat-sheet-grabber"));
@@ -985,12 +993,12 @@ async function runContinuumSuite(p, pointer, tag) {
   await grabberTap();
   assert(
     (await detent(p)) === "half",
-    `[${tag}-continuum] first grabber tap (keyboard up) dismisses the keyboard, stays HALF`,
+    `[${tag}-continuum] grabber tap from INPUT reveals the thread at HALF`,
   );
   await grabberTap();
   assert(
     (await detent(p)) === "collapsed" && (await variant(p)) === "closed",
-    `[${tag}-continuum] second grabber tap collapses the open sheet to INPUT`,
+    `[${tag}-continuum] grabber tap on the open sheet collapses to INPUT`,
   );
   await snap(p, `${tag}-continuum-final-input`);
 }
@@ -2763,7 +2771,7 @@ try {
 
   // PILL: pull DOWN from the input collapses the whole chat into a small pill at
   // the bottom (input hidden). Slow-drag and flick both pill it; the composer
-  // stays mounted but hidden + inert. (A pill TAP opens the chat — see PILL-TAP.)
+  // stays mounted but hidden + inert. (A pill TAP re-forms the input — see PILL-TAP.)
   {
     const p = await ctrl();
     attachConsole(p, sink);
@@ -2811,12 +2819,12 @@ try {
     await p.close();
   }
 
-  // ── PILL TAP opens the chat to HALF (regression for the reported bug): a real
-  // TAP (pointerdown+up, no move) routes through the gesture's onDrag(0) → onTap
-  // path. It must open the chat in ONE tap straight to the HALF detent (the
-  // conversation is visible) — NOT blink to a bare input bar that needs a second
-  // tap. Assert the detent is half/open AND the content actually formed (opacity
-  // ~1), not just a detent label with a stuck-at-0 morph.
+  // ── PILL TAP steps ONE state to the INPUT bar: a real TAP (pointerdown+up,
+  // no move) routes through the gesture's onDrag(0) → onTap path. It must form
+  // the bare input bar — never jump to a thread detent, never raise the
+  // keyboard (thread reveal is the grabber tap; keyboard is the composer tap).
+  // Assert the detent is collapsed AND the input actually formed (opacity ~1),
+  // not just a detent label with a stuck-at-0 morph (the old "bad state").
   {
     const p = await ctrl();
     attachConsole(p, sink);
@@ -2834,14 +2842,19 @@ try {
       .evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
     assert(
       openedOpacity > 0.9,
-      `PILL-TAP: tap animates pill → chat, content fully formed (opacity ${openedOpacity})`,
+      `PILL-TAP: tap animates pill → input, content fully formed (opacity ${openedOpacity})`,
     );
     assert(
-      (await detent(p)) === "half",
-      `PILL-TAP: a SINGLE tap opens the chat to half (got ${await detent(p)})`,
+      (await detent(p)) === "collapsed",
+      `PILL-TAP: a tap steps to the INPUT bar, not a thread detent (got ${await detent(p)})`,
     );
-    assert((await variant(p)) === "open", "PILL-TAP: the chat is open after one tap");
-    await snap(p, "state-pill-tap-opened");
+    assert(
+      (await p.evaluate(
+        () => document.activeElement?.getAttribute("data-testid"),
+      )) !== "chat-composer-textarea",
+      "PILL-TAP: the tap does not raise the keyboard (composer unfocused)",
+    );
+    await snap(p, "state-pill-tap-input");
     await p.close();
   }
 


### PR DESCRIPTION
## Problem

From the collapsed PILL, a tap on the handle jumped straight to the HALF detent (when a thread existed) and force-focused the composer, popping the keyboard. Per design direction, a pill tap must step exactly ONE state up the continuum: form the bare input bar — no thread reveal, no keyboard.

## Change

- `openFromPill` now sets `mode="input"` only: no `goToDetent("half")`, no synchronous composer `focus()`, no inert-clearing/focus-suppression machinery (all deleted). One detent haptic; a later keyboard dismiss reads as a re-collapse (`preFocusCollapsedRef = true`).
- **Touch structural fix:** after the pointerup that forms the input bar, the browser's compat mouse events (synthesized post-`touchend`) landed on the composer textarea that now sits under the tap point — focusing it and re-opening to HALF via focus-to-expand. The pill handle now `preventDefault()`s `touchend`; the gesture runs on pointer events and is unaffected. (Unconditional: by the time `touchend` fires, the render already flipped `pilled` false, so the prop cannot gate it.)
- The disclosure staircase is unchanged and now uniform: PILL —tap→ INPUT —grabber tap→ HALF —grabber tap→ INPUT; composer tap raises the keyboard; flick up from pill still throws open (HALF with a thread).
- `CHAT_SHEET_STATE_MATRIX.md` From-PILL row updated; walkthrough journey's dormant pill branch now does the two-step.

## Evidence

- **Real-browser e2e (Playwright chromium, desktop mouse + mobile touch):** `bun run --cwd packages/ui test:chat-sheet-e2e` — **PASSED** (72 screenshots). New/updated assertions: `pill tap steps ONE state to the INPUT bar (never the thread detent)`, `pill tap leaves the keyboard down (composer unfocused)`, `grabber tap from INPUT reveals the thread at HALF`, `grabber tap on the open sheet collapses to INPUT`, PILL-TAP suite (`got collapsed`, composer unfocused, content formed opacity 1). Screenshot artifacts: `state-pill-tap-input.png`, `*-continuum-final-input.png`.
- **Unit/component:** all 53 shell test files green (904 passed / 7 skipped), including the rewritten pill-tap contracts in `ChatOverlay.test.tsx` + `ChatOverlay.fuzz.test.tsx` (single tap, repeated cycles, Enter activation, keyboard-dismiss-keeps-deliberate-open, 6-seed adversarial walks).
- **Typecheck + biome:** clean.
- Video walkthrough: N/A — every transition is covered by the e2e gesture suites above (mouse + real CDP touch), which screenshot each state.
- Real-LLM trajectories: N/A — pure UI gesture/state change; no agent/action/prompt/model behavior touched.
- Backend logs: N/A — renderer-only change in @elizaos/ui; no server code path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)