### PR TITLE
feat(ui): cover Documents/Files/Memories/Automations in the builtin-view mutation ratchet and add a baseline-completeness sweep

### DIFF
--- a/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
@@ -9,15 +9,20 @@
  * prompt-spec names, so a renamed/deleted action fails this test instead of
  * silently passing against a hand-maintained list — the drift class that
  * mis-filed #14365/#14366/#14367.
+ *
+ * The completeness sweep (#16944) walks the real pages directory, so a new
+ * mutating shell page fails here until it is baseline-mapped or exempted.
  */
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { collectRegisteredActionInventory } from "../../../prompts/scripts/registered-action-inventory.js";
 import {
   BUILTIN_VIEW_MUTATION_BASELINE,
+  SHELL_PAGE_SWEEP_EXEMPTIONS,
   validateBuiltinViewMutationCoverage,
+  validateShellPageSweepCompleteness,
 } from "./builtin-view-action-ratchet";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -48,6 +53,31 @@ function readRepoSource(sourcePath: string): string {
   return readFileSync(path.join(repoRoot, sourcePath), "utf8");
 }
 
+const PAGES_DIR = "packages/ui/src/components/pages";
+
+/**
+ * Enumerates every shell page module the completeness sweep must account for:
+ * .ts/.tsx sources under the pages directory, recursive, minus tests, stories,
+ * and the Playwright __e2e__ harness.
+ */
+function collectShellPageFiles(relDir: string = PAGES_DIR): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(path.join(repoRoot, relDir))) {
+    const rel = `${relDir}/${entry}`;
+    if (statSync(path.join(repoRoot, rel)).isDirectory()) {
+      if (entry === "__e2e__") continue;
+      out.push(...collectShellPageFiles(rel));
+      continue;
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue;
+    if (/\.(test|stories)\.(ts|tsx)$/.test(entry) || entry.endsWith(".d.ts")) {
+      continue;
+    }
+    out.push(rel);
+  }
+  return out;
+}
+
 describe("builtin view action ratchet (#14369)", () => {
   it("passes for the current builtin mutation baseline", () => {
     const result = validateBuiltinViewMutationCoverage({
@@ -65,7 +95,22 @@ describe("builtin view action ratchet (#14369)", () => {
         }),
         expect.objectContaining({
           viewId: "plugins-page",
-          semanticActions: ["APP", "SETTINGS", "PLUGIN", "SECRETS", "RUNTIME"],
+          semanticActions: [
+            "APP",
+            "SETTINGS",
+            "PLUGIN",
+            "SECRETS",
+            "RUNTIME",
+            "CONNECTOR",
+          ],
+        }),
+        expect.objectContaining({
+          viewId: "memories",
+          semanticActions: ["MEMORY"],
+        }),
+        expect.objectContaining({
+          viewId: "automations",
+          semanticActions: ["SCHEDULED_TASKS", "TRIGGER"],
         }),
         expect.objectContaining({
           viewId: "logs",
@@ -101,6 +146,38 @@ describe("builtin view action ratchet (#14369)", () => {
     ]);
   });
 
+  it.each(["documents", "files", "memories", "automations", "triggers"])(
+    "fails when the %s view gains an unmapped local mutation",
+    (viewId) => {
+      const entry = BUILTIN_VIEW_MUTATION_BASELINE.find(
+        (candidate) => candidate.viewId === viewId,
+      );
+      if (!entry) throw new Error(`${viewId} baseline entry missing`);
+      // Real page sources plus one synthetic local-only handler on the first
+      // file — the exact regression class the ratchet exists to catch.
+      const injected = `${readRepoSource(entry.sourceFiles[0])}
+        export function InjectedLocalOnlyButton() {
+          return <button onClick={() => window.localStorage.setItem("x", "1")}>Local only</button>;
+        }
+      `;
+      const readSource = (sourcePath: string) =>
+        sourcePath === entry.sourceFiles[0]
+          ? injected
+          : readRepoSource(sourcePath);
+
+      const result = validateBuiltinViewMutationCoverage({
+        baseline: [entry],
+        readSource,
+        registeredActions: REGISTERED_ACTIONS,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.findings).toEqual([
+        expect.objectContaining({ viewId, code: "new-local-mutation" }),
+      ]);
+    },
+  );
+
   it("fails when a non-exempt builtin mapping references an unregistered action", () => {
     const result = validateBuiltinViewMutationCoverage({
       baseline: [
@@ -120,6 +197,107 @@ describe("builtin view action ratchet (#14369)", () => {
       expect.objectContaining({
         viewId: "synthetic",
         code: "missing-semantic-action",
+      }),
+    ]);
+  });
+});
+
+describe("shell page baseline-completeness sweep (#16944)", () => {
+  const realPageFiles = collectShellPageFiles();
+
+  it("accounts for every real shell page module", () => {
+    const result = validateShellPageSweepCompleteness({
+      pageFiles: realPageFiles,
+      readSource: readRepoSource,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(result.ok).toBe(true);
+    // The sweep only means something if it actually enumerated the shell
+    // pages: guard against the walk silently returning an empty/near-empty
+    // list (wrong dir, over-aggressive filters).
+    expect(realPageFiles.length).toBeGreaterThan(50);
+    const mutating = result.inventory.filter((row) => row.mutationSites > 0);
+    expect(mutating.length).toBeGreaterThan(30);
+    for (const row of mutating) {
+      expect(row.coveredBy != null || row.exempt).toBe(true);
+    }
+  });
+
+  it("fails with an actionable message when an unlisted mutating page ships", () => {
+    const syntheticPage = `${PAGES_DIR}/BrandNewLocalOnlyView.tsx`;
+    const result = validateShellPageSweepCompleteness({
+      pageFiles: [...realPageFiles, syntheticPage],
+      readSource: (sourcePath) =>
+        sourcePath === syntheticPage
+          ? '<button onClick={() => window.localStorage.setItem("x", "1")}>Local only</button>'
+          : readRepoSource(sourcePath),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        sourceFile: syntheticPage,
+        code: "unmapped-mutating-page",
+        message: expect.stringContaining("BUILTIN_VIEW_MUTATION_BASELINE"),
+      }),
+    ]);
+  });
+
+  it("fails when an exemption points at a file the sweep no longer sees", () => {
+    const result = validateShellPageSweepCompleteness({
+      pageFiles: realPageFiles,
+      exemptions: [
+        ...SHELL_PAGE_SWEEP_EXEMPTIONS,
+        { sourceFile: `${PAGES_DIR}/DeletedView.tsx`, reason: "gone" },
+      ],
+      readSource: readRepoSource,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        sourceFile: `${PAGES_DIR}/DeletedView.tsx`,
+        code: "stale-exemption",
+      }),
+    ]);
+  });
+
+  it("fails when an exempt file stops mutating (exemption must be removed)", () => {
+    const exemptFile = SHELL_PAGE_SWEEP_EXEMPTIONS[0].sourceFile;
+    const result = validateShellPageSweepCompleteness({
+      pageFiles: realPageFiles,
+      readSource: (sourcePath) =>
+        sourcePath === exemptFile
+          ? "export const nowInert = true;"
+          : readRepoSource(sourcePath),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        sourceFile: exemptFile,
+        code: "stale-exemption",
+      }),
+    ]);
+  });
+
+  it("fails when a file is both baseline-covered and exempt", () => {
+    const covered = "packages/ui/src/components/pages/FilesView.tsx";
+    const result = validateShellPageSweepCompleteness({
+      pageFiles: realPageFiles,
+      exemptions: [
+        ...SHELL_PAGE_SWEEP_EXEMPTIONS,
+        { sourceFile: covered, reason: "double-booked" },
+      ],
+      readSource: readRepoSource,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        sourceFile: covered,
+        code: "conflicting-exemption",
       }),
     ]);
   });

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -6,6 +6,14 @@
  * a semantic agent action. Third-party plugin views use the generic
  * agent-surface bridge and are audited elsewhere; this file tracks only the
  * first-party pages bundled into the shell.
+ *
+ * Two checks compose the ratchet (#14369 shipped the first, #16944 the second):
+ * the per-view coverage validator pins each baseline entry's mutation-site
+ * count and verifies its semantic actions against the live registered-action
+ * inventory, and the shell-page completeness sweep walks every module under
+ * `packages/ui/src/components/pages` and fails when a mutating page is neither
+ * claimed by a baseline entry nor exempt with a reason — so a brand-new
+ * mutating view cannot ship un-ratcheted.
  */
 
 export interface BuiltinViewMutationBaselineEntry {
@@ -53,11 +61,21 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "packages/ui/src/components/pages/PluginsView.tsx",
       "packages/ui/src/components/pages/PluginCard.tsx",
       "packages/ui/src/components/pages/PluginConfigForm.tsx",
+      "packages/ui/src/components/pages/plugin-view-connectors.tsx",
+      "packages/ui/src/components/pages/plugin-view-modal.tsx",
+      "packages/ui/src/components/pages/plugin-view-dialogs.tsx",
     ],
-    semanticActions: ["APP", "SETTINGS", "PLUGIN", "SECRETS", "RUNTIME"],
-    maxMutationSites: 14,
+    semanticActions: [
+      "APP",
+      "SETTINGS",
+      "PLUGIN",
+      "SECRETS",
+      "RUNTIME",
+      "CONNECTOR",
+    ],
+    maxMutationSites: 62,
     notes:
-      "Plugin enable/config/reorder/setup flows are covered by app/settings/plugin/secrets/runtime actions; the count ratchets local-only control growth.",
+      "Plugin enable/config/reorder/setup flows are covered by app/settings/plugin/secrets/runtime actions; connector setup dialogs (plugin-view-connectors) pair with CONNECTOR. The count ratchets local-only control growth.",
   },
   {
     viewId: "settings",
@@ -65,6 +83,8 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "packages/ui/src/components/pages/SettingsView.tsx",
       "packages/ui/src/components/pages/ConfigPageView.tsx",
       "packages/ui/src/components/pages/PluginConfigForm.tsx",
+      "packages/ui/src/components/pages/config-page-sections.tsx",
+      "packages/ui/src/components/pages/SecretsView.tsx",
     ],
     semanticActions: [
       "SETTINGS",
@@ -74,7 +94,7 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "PLUGIN",
       "SECRETS",
     ],
-    maxMutationSites: 18,
+    maxMutationSites: 32,
     notes:
       "Settings sections delegate to SETTINGS or to the dedicated action that owns the section.",
   },
@@ -121,11 +141,13 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "packages/ui/src/components/pages/DatabasePageView.tsx",
       "packages/ui/src/components/pages/DatabaseView.tsx",
       "packages/ui/src/components/pages/SqlEditorPanel.tsx",
+      "packages/ui/src/components/pages/database-utils.tsx",
+      "packages/ui/src/components/pages/MediaGalleryView.tsx",
     ],
     semanticActions: [],
-    maxMutationSites: 15,
+    maxMutationSites: 26,
     exemptReason:
-      "developer diagnostic view; SQL/editor controls are not MVP chat mutations",
+      "developer diagnostic view; SQL/editor/media-table browsing controls are not MVP chat mutations",
   },
   {
     viewId: "trajectories",
@@ -136,6 +158,157 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
     semanticActions: [],
     maxMutationSites: 12,
     exemptReason: "read-only trajectory inspection view",
+  },
+  {
+    viewId: "documents",
+    sourceFiles: [
+      "packages/ui/src/components/pages/DocumentsView.tsx",
+      "packages/ui/src/components/pages/documents-detail.tsx",
+      "packages/ui/src/components/pages/KnowledgeView.tsx",
+    ],
+    semanticActions: ["OWNER_DOCUMENTS", "DOCUMENT"],
+    maxMutationSites: 17,
+    notes:
+      "Knowledge-hub upload/delete/tag controls have DOCUMENT (core CRUD) and OWNER_DOCUMENTS (personal-assistant portal) as chat twins, per the builtin-views relatedActions mapping.",
+  },
+  {
+    viewId: "files",
+    sourceFiles: ["packages/ui/src/components/pages/FilesView.tsx"],
+    semanticActions: ["FILES"],
+    maxMutationSites: 10,
+    notes:
+      "File browser upload/delete/rename controls pair with the FILES action (packages/agent/src/actions/files.ts).",
+  },
+  {
+    viewId: "memories",
+    sourceFiles: [
+      "packages/ui/src/components/pages/MemoryViewerView.tsx",
+      "packages/ui/src/components/pages/MemoryDetailPanel.tsx",
+    ],
+    semanticActions: ["MEMORY"],
+    maxMutationSites: 21,
+    notes:
+      "Memory browse/prune controls pair with MEMORY (op create|search|update|delete, packages/agent/src/actions/memories.ts).",
+  },
+  {
+    viewId: "automations",
+    sourceFiles: [
+      "packages/ui/src/components/pages/AutomationsFeed.tsx",
+      "packages/ui/src/components/pages/TaskEditor.tsx",
+      "packages/ui/src/components/pages/ScheduledTaskEditor.tsx",
+      "packages/ui/src/components/pages/WorkflowEditor.tsx",
+      "packages/ui/src/components/pages/WorkflowGraphViewer.tsx",
+    ],
+    semanticActions: ["SCHEDULED_TASKS", "TRIGGER"],
+    maxMutationSites: 71,
+    notes:
+      "Automations feed plus its task/workflow editors all write ScheduledTask records through the one scheduler; SCHEDULED_TASKS is the umbrella twin and TRIGGER pairs the trigger steps inside workflow editing.",
+  },
+  {
+    viewId: "triggers",
+    sourceFiles: [
+      "packages/ui/src/components/pages/TriggersView.tsx",
+      "packages/ui/src/components/pages/TriggerForm.tsx",
+    ],
+    semanticActions: ["TRIGGER"],
+    maxMutationSites: 66,
+    notes:
+      "Trigger editor (mounted as a detached desktop shell window via app-core DetachedShellRoot) pairs with the TRIGGER action (packages/agent/src/actions/trigger.ts).",
+  },
+  {
+    viewId: "skills",
+    sourceFiles: [
+      "packages/ui/src/components/pages/SkillsView.tsx",
+      "packages/ui/src/components/pages/skill-marketplace.tsx",
+      "packages/ui/src/components/pages/skill-detail-panel.tsx",
+    ],
+    semanticActions: ["SKILL", "USE_SKILL"],
+    maxMutationSites: 56,
+    notes:
+      "Skill install/toggle/uninstall and marketplace flows pair with SKILL (manage) and USE_SKILL (invoke) from plugin-agent-skills.",
+  },
+  {
+    viewId: "browser",
+    sourceFiles: [
+      "packages/ui/src/components/pages/BrowserWorkspaceView.tsx",
+      "packages/ui/src/components/pages/BrowserTabSwitcher.tsx",
+    ],
+    semanticActions: ["BROWSER"],
+    maxMutationSites: 23,
+    notes:
+      "Browser workspace navigation/tab controls pair with the BROWSER action (plugin-browser); wallet-consent prompts are owner-in-the-loop by design and stay counted here.",
+  },
+  {
+    viewId: "relationships",
+    sourceFiles: [
+      "packages/ui/src/components/pages/RelationshipsView.tsx",
+      "packages/ui/src/components/pages/RelationshipsGraphPanel.tsx",
+      "packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx",
+      "packages/ui/src/components/pages/relationships/RelationshipsPersonPanels.tsx",
+      "packages/ui/src/components/pages/relationships/RelationshipsCandidateMergesPanel.tsx",
+      "packages/ui/src/components/pages/relationships/RelationshipsActivityFeed.tsx",
+      "packages/ui/src/components/pages/relationships/RelationshipsSidebar.tsx",
+    ],
+    semanticActions: ["ENTITY", "CONTACT"],
+    maxMutationSites: 29,
+    notes:
+      "Relationship workspace person edits and merge approvals go through EntityStore/RelationshipStore; ENTITY (personal-assistant) and CONTACT (agent contact CRUD) are the chat twins.",
+  },
+  {
+    viewId: "chat",
+    sourceFiles: ["packages/ui/src/components/pages/ChatView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 4,
+    exemptReason:
+      "the chat surface IS the semantic channel; its composer/attachment controls are how users reach every action, not mutations needing a chat twin",
+  },
+  {
+    viewId: "launcher",
+    sourceFiles: ["packages/ui/src/components/pages/Launcher.tsx"],
+    semanticActions: [],
+    maxMutationSites: 3,
+    exemptReason:
+      "read-only launcher grid; tile taps navigate to views (VIEWS action drives the same navigation) and mutate no domain state",
+  },
+  {
+    viewId: "native-os-apps",
+    sourceFiles: ["packages/ui/src/components/pages/ElizaOsAppsView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 48,
+    exemptReason:
+      "AOSP-fork native OS surfaces (dialer, SMS, contacts) driven through the native-plugins bridge; device telephony affordances, not agent-domain mutations",
+  },
+  {
+    viewId: "camera",
+    sourceFiles: ["packages/ui/src/components/pages/CameraPageView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 4,
+    exemptReason:
+      "native camera preview surface (AOSP home tile); capture/switch controls are device affordances, not agent-domain mutations",
+  },
+  {
+    viewId: "cloud-dashboard",
+    sourceFiles: ["packages/ui/src/components/pages/ElizaCloudDashboard.tsx"],
+    semanticActions: [],
+    maxMutationSites: 15,
+    exemptReason:
+      "cloud billing surface; Stripe checkout, top-up, and spend-limit changes are deliberately owner-in-the-loop consent flows, never agent-drivable (reads pair with CLOUD_ACCOUNT_STATUS)",
+  },
+  {
+    viewId: "pendant-transcript",
+    sourceFiles: ["packages/ui/src/components/pages/PendantTranscriptView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 7,
+    exemptReason:
+      "device-local BLE pendant capture surface; segments live in a browser-local optimistic cache, not agent domain state",
+  },
+  {
+    viewId: "release-center",
+    sourceFiles: ["packages/ui/src/components/pages/ReleaseCenterView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 13,
+    exemptReason:
+      "operator update surface (runtime/desktop update check + apply); the update lifecycle is owner-driven infrastructure with no chat-mutation twin",
   },
 ] as const satisfies readonly BuiltinViewMutationBaselineEntry[];
 
@@ -213,5 +386,146 @@ export function validateBuiltinViewMutationCoverage(args: {
     ok: findings.length === 0,
     coverage,
     findings,
+  };
+}
+
+export interface ShellPageSweepExemption {
+  sourceFile: string;
+  reason: string;
+}
+
+/**
+ * Page modules excluded from the completeness sweep. Reserved for files that
+ * are not mounted view surfaces at all — anything a user can actually reach
+ * belongs in BUILTIN_VIEW_MUTATION_BASELINE (mapped or exempt-with-reason)
+ * where its mutation-site count is also ratcheted.
+ */
+export const SHELL_PAGE_SWEEP_EXEMPTIONS = [
+  {
+    sourceFile: "packages/ui/src/components/pages/documents-upload.tsx",
+    reason:
+      "UploadZone is not imported by any mounted surface (DocumentsView uses documents-upload.helpers directly); exercised only by its own dnd test — dead-module candidate, tracked in #16944",
+  },
+  {
+    sourceFile: "packages/ui/src/components/pages/plugin-view-sidebar.tsx",
+    reason:
+      "ConnectorSidebar is not imported by any mounted surface (PluginsView renders plugin-view-connectors instead) — dead-module candidate, tracked in #16944",
+  },
+] as const satisfies readonly ShellPageSweepExemption[];
+
+export interface ShellPageSweepFinding {
+  sourceFile: string;
+  code:
+    | "unmapped-mutating-page"
+    | "missing-source"
+    | "stale-exemption"
+    | "conflicting-exemption";
+  message: string;
+}
+
+export interface ShellPageSweepInventoryRow {
+  sourceFile: string;
+  mutationSites: number;
+  /** viewId of the baseline entry that claims the file, or null. */
+  coveredBy: string | null;
+  exempt: boolean;
+}
+
+export interface ShellPageSweepResult {
+  ok: boolean;
+  findings: ShellPageSweepFinding[];
+  inventory: ShellPageSweepInventoryRow[];
+}
+
+/**
+ * Baseline-completeness sweep (#16944): every enumerated shell page module
+ * with at least one mutation site must be claimed by a baseline entry's
+ * sourceFiles or carry an explicit exemption. The caller enumerates
+ * `pageFiles` (the test walks packages/ui/src/components/pages) so this stays
+ * pure and testable against synthetic inventories. Exemptions are themselves
+ * ratcheted: one that points at a deleted file, a file the baseline already
+ * claims, or a file with no mutation sites left fails as stale/conflicting so
+ * the list cannot rot into silent grandfathering.
+ */
+export function validateShellPageSweepCompleteness(args: {
+  pageFiles: readonly string[];
+  baseline?: readonly BuiltinViewMutationBaselineEntry[];
+  exemptions?: readonly ShellPageSweepExemption[];
+  readSource: (path: string) => string | null | undefined;
+}): ShellPageSweepResult {
+  const baseline: readonly BuiltinViewMutationBaselineEntry[] =
+    args.baseline ?? BUILTIN_VIEW_MUTATION_BASELINE;
+  const exemptions: readonly ShellPageSweepExemption[] =
+    args.exemptions ?? SHELL_PAGE_SWEEP_EXEMPTIONS;
+
+  const coveredBy = new Map<string, string>();
+  for (const entry of baseline) {
+    for (const sourceFile of entry.sourceFiles) {
+      coveredBy.set(sourceFile, entry.viewId);
+    }
+  }
+  const exemptionByFile = new Map(
+    exemptions.map((exemption) => [exemption.sourceFile, exemption]),
+  );
+
+  const findings: ShellPageSweepFinding[] = [];
+  const inventory: ShellPageSweepInventoryRow[] = [];
+  const pageFileSet = new Set(args.pageFiles);
+
+  for (const sourceFile of args.pageFiles) {
+    const source = args.readSource(sourceFile);
+    if (source == null) {
+      findings.push({
+        sourceFile,
+        code: "missing-source",
+        message: `${sourceFile}: enumerated shell page could not be read`,
+      });
+      continue;
+    }
+    const mutationSites = countBuiltinViewMutationSites(source);
+    const claimedBy = coveredBy.get(sourceFile) ?? null;
+    const exempt = exemptionByFile.has(sourceFile);
+    inventory.push({ sourceFile, mutationSites, coveredBy: claimedBy, exempt });
+
+    if (exempt && claimedBy != null) {
+      findings.push({
+        sourceFile,
+        code: "conflicting-exemption",
+        message: `${sourceFile}: listed both in the '${claimedBy}' baseline entry and in SHELL_PAGE_SWEEP_EXEMPTIONS; keep exactly one source of truth`,
+      });
+      continue;
+    }
+    if (mutationSites > 0 && claimedBy == null && !exempt) {
+      findings.push({
+        sourceFile,
+        code: "unmapped-mutating-page",
+        message: `${sourceFile}: ${mutationSites} mutation site(s) but no baseline coverage — add it to a BUILTIN_VIEW_MUTATION_BASELINE entry with semantic actions (or an exemptReason), or add a SHELL_PAGE_SWEEP_EXEMPTIONS entry explaining why it is not a mounted view surface`,
+      });
+    }
+  }
+
+  for (const exemption of exemptions) {
+    if (!pageFileSet.has(exemption.sourceFile)) {
+      findings.push({
+        sourceFile: exemption.sourceFile,
+        code: "stale-exemption",
+        message: `${exemption.sourceFile}: SHELL_PAGE_SWEEP_EXEMPTIONS entry points at a file the sweep did not enumerate; remove the stale exemption`,
+      });
+      continue;
+    }
+    const source = args.readSource(exemption.sourceFile);
+    if (source != null && countBuiltinViewMutationSites(source) === 0) {
+      findings.push({
+        sourceFile: exemption.sourceFile,
+        code: "stale-exemption",
+        message: `${exemption.sourceFile}: exempt file no longer contains mutation sites; remove the exemption`,
+      });
+    }
+  }
+
+  return {
+    ok: findings.length === 0,
+    findings,
+    inventory,
   };
 }


### PR DESCRIPTION
## What

Extends the #14369 builtin-view mutation ratchet (`packages/ui/src/testing/builtin-view-action-ratchet.ts`) so it covers **every** first-party mutating shell page, and adds a **baseline-completeness sweep** so an unlisted mutating page fails the suite instead of staying invisible to the ratchet.

## Why

The ratchet only inspected the 9 views enumerated in `BUILTIN_VIEW_MUTATION_BASELINE`. Documents, Files, Memories, Automations — and a dozen other mutating shell pages — were never scanned, so a brand-new local-only mutation in any of them (or in any future page) shipped without failing the ratchet. That is exactly the regression class the ws6 acceptance bar targets: "a ratchet asserts **every** builtin view mutation maps to a registered action."

## How

**1. Baseline coverage extended from 9 to 24 views.** Every mapped semantic action is validated against the live `collectRegisteredActionInventory` scan (a renamed/deleted action fails the test loudly). New mapped entries (max = observed mutation-site count, pinned):

| viewId | sourceFiles (sites) | semanticActions | max |
| --- | --- | --- | --- |
| `documents` | DocumentsView (7), documents-detail (10), KnowledgeView (0) | `OWNER_DOCUMENTS`, `DOCUMENT` | 17 |
| `files` | FilesView (10) | `FILES` | 10 |
| `memories` | MemoryViewerView (21), MemoryDetailPanel (0) | `MEMORY` | 21 |
| `automations` | AutomationsFeed (11), TaskEditor (16), ScheduledTaskEditor (6), WorkflowEditor (25), WorkflowGraphViewer (13) | `SCHEDULED_TASKS`, `TRIGGER` | 71 |
| `triggers` | TriggersView (22), TriggerForm (44) — detached desktop shell window | `TRIGGER` | 66 |
| `skills` | SkillsView (25), skill-marketplace (16), skill-detail-panel (15) | `SKILL`, `USE_SKILL` | 56 |
| `browser` | BrowserWorkspaceView (16), BrowserTabSwitcher (7) | `BROWSER` | 23 |
| `relationships` | RelationshipsView + graph panel + relationships/* (29 total) | `ENTITY`, `CONTACT` | 29 |

New exempt-with-reason entries (each still count-ratcheted via `maxMutationSites`): `chat` (the chat surface IS the semantic channel), `launcher` (read-only navigation grid), `native-os-apps` (AOSP dialer/SMS/contacts device surfaces), `camera` (native preview), `cloud-dashboard` (Stripe checkout / spend limits are deliberately owner-in-the-loop consent flows), `pendant-transcript` (browser-local BLE cache), `release-center` (owner-driven update lifecycle; no chat twin exists).

Updated entries: `plugins-page` gains its connector/modal/dialog sub-components + the `CONNECTOR` action (max 14 → 62); `settings` gains `config-page-sections` + `SecretsView` (18 → 32); `database` (exempt diagnostic) gains `database-utils` + `MediaGalleryView` (15 → 26).

**2. Completeness sweep** (`validateShellPageSweepCompleteness`): the test walks the real `packages/ui/src/components/pages` tree (recursive; minus tests/stories/`__e2e__`) and fails when a module with ≥1 `MUTATION_SITE_RE` hit is neither claimed by a baseline entry's `sourceFiles` nor listed in `SHELL_PAGE_SWEEP_EXEMPTIONS`. Exemptions are themselves ratcheted: an exemption pointing at a deleted file, a no-longer-mutating file, or a file the baseline already claims fails as `stale-exemption` / `conflicting-exemption`, so the list cannot rot into grandfathering.

**3. No grandfathering.** Only two files are sweep-exempt, both because they are **not mounted anywhere** (verified by repo-wide import search): `documents-upload.tsx` (`UploadZone` — DocumentsView imports `documents-upload.helpers` directly; only its own dnd test imports the component) and `plugin-view-sidebar.tsx` (`ConnectorSidebar` — PluginsView renders `plugin-view-connectors` instead). Both exemption reasons name them dead-module candidates; the sweep forces the exemption out the moment either is deleted or re-mounted.

## Evidence

### 1. Red run — a covered page gains an unmapped local mutation (synthetic `onClick` appended to the real `FilesView.tsx` on disk)

<details><summary>vitest output (1 failed): <code>files: observed 11 mutation sites exceeds baseline 10</code></summary>

```
 FAIL  src/testing/builtin-view-action-ratchet.test.ts > builtin view action ratchet (#14369) > passes for the current builtin mutation baseline
AssertionError: expected [ { viewId: 'files', …(2) } ] to deeply equal []
- []
+ [
+   {
+     "code": "new-local-mutation",
+     "message": "files: observed 11 mutation sites exceeds baseline 10; add a semantic action mapping or deliberately update the baseline",
+     "viewId": "files",
+   },
+ ]
 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

The suite also carries this permanently as a parameterized test: `fails when the documents|files|memories|automations|triggers view gains an unmapped local mutation`.

</details>

### 2. Red run — synthetic unlisted mutating page (`BrandNewLocalOnlyView.tsx` actually created on disk in the pages dir)

<details><summary>vitest output (5 failed) with the actionable message</summary>

```
 FAIL  src/testing/builtin-view-action-ratchet.test.ts > shell page baseline-completeness sweep (#16944) > accounts for every real shell page module
AssertionError: expected [ { …(3) } ] to deeply equal []
- []
+ [
+   {
+     "code": "unmapped-mutating-page",
+     "message": "packages/ui/src/components/pages/BrandNewLocalOnlyView.tsx: 1 mutation site(s) but no baseline coverage — add it to a BUILTIN_VIEW_MUTATION_BASELINE entry with semantic actions (or an exemptReason), or add a SHELL_PAGE_SWEEP_EXEMPTIONS entry explaining why it is not a mounted view surface",
+     "sourceFile": "packages/ui/src/components/pages/BrandNewLocalOnlyView.tsx",
+   },
+ ]
 Test Files  1 failed (1)
      Tests  5 failed | 8 passed (13)
```

(The other 4 failures are the sweep's negative tests correctly seeing the extra on-disk file; all 13 pass once the synthetic file is removed.)

</details>

### 3. Green runs — ratchet suite + full packages/ui suite

<details><summary>ratchet suite: 13 passed; full packages/ui suite: 850 files / 8644 tests passed</summary>

```
 RUN  v4.1.5 .../packages/ui
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

```
 Test Files  850 passed (850)
      Tests  8644 passed | 7 skipped (8651)
   Duration  208.95s
```

`bun run typecheck` (packages/ui, after building `@elizaos/cloud-routing` dts) and `bunx biome check` on both touched files: clean.

</details>

### Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change (ratchet + sweep in packages/ui/src/testing), no rendered UI delta`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change, no rendered UI delta`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - test-only change, no rendered UI delta; the observable output is the vitest red/green runs quoted above`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server code touched`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no runtime code touched; test-only change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectories: `N/A - no agent/action/provider/prompt/model behavior change; this pins static view->action mappings validated against the live registered-action inventory`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the ratchet's own script output IS the artifact — the two red runs and the green sweep run are quoted verbatim in the Evidence section above (§1 `files: observed 11 mutation sites exceeds baseline 10`, §2 `unmapped-mutating-page` for the synthetic on-disk view, §3 `13 passed` + full packages/ui `8644 tests passed`); the green sweep asserts every mutating page module in the real inventory satisfies `coveredBy != null || exempt` (40+ mutating modules enumerated; guard asserts >50 files walked and >30 mutating). Separate file attachment `N/A - script output quoted inline in this PR body`.

Closes #16944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

