### PR TITLE
fix(tts): make server-side ELIZA_TTS_DEBUG actually emit through the structured logger

### DIFF
--- a/packages/shared/src/utils/tts-debug.test.ts
+++ b/packages/shared/src/utils/tts-debug.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Server-side `ttsDebug` emission through the real structured logger: the
+ * `ELIZA_TTS_DEBUG` flag gates output, and entries are observed via the
+ * logger's global listener stream — no logger mocking.
+ */
+import { addLogListener, type LogEntry } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isTtsDebugEnabled, ttsDebug, ttsDebugTextPreview } from "./tts-debug";
+
+// The logger freezes its level at module init and the repo test setup defaults
+// LOG_LEVEL to "error", which would gate the info-level tts lines (and their
+// listener delivery) off before this suite could observe them. vi.hoisted runs
+// before the imports above evaluate, so the logger initializes at "info" —
+// the production default this diagnostic is documented against.
+vi.hoisted(() => {
+  process.env.LOG_LEVEL = "info";
+});
+
+const prevFlag = process.env.ELIZA_TTS_DEBUG;
+
+function restoreFlag(): void {
+  if (prevFlag === undefined) delete process.env.ELIZA_TTS_DEBUG;
+  else process.env.ELIZA_TTS_DEBUG = prevFlag;
+}
+
+describe("ttsDebug (server flavor)", () => {
+  let entries: LogEntry[] = [];
+  let unsubscribe: (() => void) | null = null;
+
+  const ttsEntries = () =>
+    entries.filter((entry) => entry.msg.includes("[eliza][tts]"));
+
+  beforeEach(() => {
+    entries = [];
+    unsubscribe = addLogListener((entry) => entries.push(entry));
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = null;
+    restoreFlag();
+  });
+
+  it("emits nothing when ELIZA_TTS_DEBUG is unset", () => {
+    delete process.env.ELIZA_TTS_DEBUG;
+    expect(isTtsDebugEnabled()).toBe(false);
+    ttsDebug("server:cloud-tts:proxy", { textChars: 5 });
+    expect(ttsEntries()).toHaveLength(0);
+  });
+
+  it("emits nothing for falsy flag values", () => {
+    for (const value of ["0", "false", "off", "no", "", "  "]) {
+      process.env.ELIZA_TTS_DEBUG = value;
+      expect(isTtsDebugEnabled()).toBe(false);
+      ttsDebug("server:cloud-tts:proxy");
+    }
+    expect(ttsEntries()).toHaveLength(0);
+  });
+
+  it("recognizes every documented truthy variant", () => {
+    for (const value of ["1", "true", "yes", "on", " TRUE ", "On"]) {
+      process.env.ELIZA_TTS_DEBUG = value;
+      expect(isTtsDebugEnabled()).toBe(true);
+    }
+  });
+
+  it("emits an info-level entry carrying phase and detail when enabled", () => {
+    process.env.ELIZA_TTS_DEBUG = "1";
+    ttsDebug("server:cloud-tts:proxy", {
+      textChars: 11,
+      preview: "hello world",
+    });
+
+    // The logger mirrors each line into the in-memory buffer from two spots
+    // (direct write + adze listener), so assert on presence, not count.
+    const hits = ttsEntries();
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0]?.msg).toContain("[eliza][tts] server:cloud-tts:proxy");
+    expect(hits[0]?.msg).toContain("hello world");
+    expect(hits[0]?.msg).toContain("textChars");
+    // 30 = info: the operator opted in, so lines must be visible at the
+    // default LOG_LEVEL rather than hiding behind debug.
+    expect(hits[0]?.level).toBe(30);
+  });
+
+  it("emits a phase-only entry when no detail is passed", () => {
+    process.env.ELIZA_TTS_DEBUG = "true";
+    ttsDebug("server:local-tts:request");
+
+    const hits = ttsEntries();
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0]?.msg.trim()).toBe("[eliza][tts] server:local-tts:request");
+  });
+});
+
+describe("ttsDebugTextPreview", () => {
+  it("collapses newlines and whitespace into one line", () => {
+    expect(ttsDebugTextPreview("hello\nworld\r\n  again")).toBe(
+      "hello↵ world↵ again",
+    );
+  });
+
+  it("truncates long text with an ellipsis at the default cap", () => {
+    const long = "a".repeat(200);
+    const preview = ttsDebugTextPreview(long);
+    expect(preview).toBe(`${"a".repeat(160)}…`);
+  });
+
+  it("honors a custom cap and leaves short text untouched", () => {
+    expect(ttsDebugTextPreview("short text", 20)).toBe("short text");
+    expect(ttsDebugTextPreview("abcdefghij", 4)).toBe("abcd…");
+  });
+});

--- a/packages/shared/src/utils/tts-debug.ts
+++ b/packages/shared/src/utils/tts-debug.ts
@@ -1,25 +1,31 @@
 /// <reference types="vite/client" />
 
 /**
- * TTS pipeline tracing (opt-in). Prefix: `[eliza][tts]`.
+ * Server-side TTS pipeline tracing (opt-in). Prefix: `[eliza][tts]`.
  * Never pass secrets in `detail`. With debug on, `preview` fields may contain
  * user-visible spoken text — disable in shared logs / production.
  *
- * Playback phases (browser console): `play:web-audio:start|end` (ElevenLabs /
- * cloud MP3), `speakBrowser:enter`, `play:browser:web-speech:enqueued`,
- * `play:browser:speechSynthesis:start|end|error`, `play:talkmode:dispatch|speak-failed`,
- * `play:browser:no-synth`. Server logs: `server:cloud-tts:*` (includes optional
+ * `ttsDebug` emits straight through the structured logger at `info` level, so
+ * setting the env flag is sufficient on every server host (bare agent server,
+ * app-core API, packaged desktop) — no per-host wiring exists to forget
+ * (#16347). Info level is deliberate: the operator opted in explicitly, so the
+ * lines must be visible at the default `LOG_LEVEL` rather than hiding behind
+ * `debug`.
+ *
+ * Server phases: `server:cloud-tts:*` (Eliza Cloud proxy, includes optional
  * `messageId`, `clipSegment`, `hearingFull` when the client sends
- * `x-elizaos-tts-*` headers on `/api/tts/cloud`), ChatView: `chat:*`.
+ * `x-elizaos-tts-*` headers on `/api/tts/cloud`) and `server:local-tts:*`
+ * (on-device synthesis via `/api/tts/local-inference`).
  *
  * Enable with:
- * - **Node / API:** `ELIZA_TTS_DEBUG=1` (or `true`, `yes`, `on`) — logs appear in the API
- *   terminal / `[api]` aggregator only for **server** routes (e.g. `server:cloud-tts:*`).
- * - **Renderer (WebView / browser):** same env is mirrored via Vite `define` in
- *   `apps/app/vite.config.ts` when you start dev with `ELIZA_TTS_DEBUG=1`. Those lines
- *   go to the **renderer** JavaScript console (Electrobun: Web Inspector on the window),
- *   not `LOG_LEVEL` on the API process alone.
+ * - **Node / API:** `ELIZA_TTS_DEBUG=1` (or `true`, `yes`, `on`) — lines appear
+ *   in the API terminal / `[api]` aggregator.
+ * - **Renderer (WebView / browser):** the renderer flavor lives in
+ *   `packages/ui/src/utils/tts-debug.ts` and logs to the JavaScript console;
+ *   the same env is mirrored via Vite `define` in `apps/app/vite.config.ts`.
  */
+import { logger } from "@elizaos/core";
+
 function ttsDebugEnabled(): boolean {
   const truthy = (raw: string | undefined | null): boolean => {
     if (raw == null) return false;
@@ -63,23 +69,17 @@ export function ttsDebugTextPreview(
 }
 
 /**
- * Sink for TTS debug output. Set by the host app (e.g. pino on the server,
- * Web Inspector in the renderer). Null disables debug output.
+ * Emit one TTS trace line through the structured logger when
+ * `ELIZA_TTS_DEBUG` is set; a no-op otherwise.
  */
-let _ttsSink:
-  | ((phase: string, detail?: Record<string, unknown>) => void)
-  | null = null;
-
-export function setTtsDebugSink(
-  sink: ((phase: string, detail?: Record<string, unknown>) => void) | null,
-): void {
-  _ttsSink = sink;
-}
-
 export function ttsDebug(
   phase: string,
   detail?: Record<string, unknown>,
 ): void {
-  if (!ttsDebugEnabled() || !_ttsSink) return;
-  _ttsSink(phase, detail);
+  if (!ttsDebugEnabled()) return;
+  if (detail && Object.keys(detail).length > 0) {
+    logger.info(detail, `[eliza][tts] ${phase}`);
+  } else {
+    logger.info(`[eliza][tts] ${phase}`);
+  }
 }

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts
@@ -3,13 +3,26 @@
  * real node req/res fakes and a stubbed upstream fetch. Pins the #16425
  * contract — the client's per-utterance Idempotency-Key is forwarded upstream
  * so the cloud route can replay the direct attempt's committed reservation —
- * plus the handler's auth/validation/success/error envelope.
+ * plus the handler's auth/validation/success/error envelope and the #16347
+ * `ELIZA_TTS_DEBUG` contract (phases observably emitted on the structured
+ * logger when the flag is set, silent otherwise).
  */
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type http from "node:http";
+import { addLogListener, type LogEntry } from "@elizaos/core";
 import { handleCloudTtsPreviewRoute } from "./server-cloud-tts";
 
+// The logger freezes its level at module init and the repo test setup defaults
+// LOG_LEVEL to "error", which would gate the info-level tts lines (and their
+// listener delivery) off. vi.hoisted runs before the imports above evaluate,
+// so the logger initializes at "info" — the production default the
+// ELIZA_TTS_DEBUG diagnostic is documented against.
+vi.hoisted(() => {
+  process.env.LOG_LEVEL = "info";
+});
+
 const prevApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+const prevTtsDebug = process.env.ELIZA_TTS_DEBUG;
 const realFetch = globalThis.fetch;
 
 interface CapturedUpstream {
@@ -115,6 +128,8 @@ afterAll(() => {
   globalThis.fetch = realFetch;
   if (prevApiKey === undefined) delete process.env.ELIZAOS_CLOUD_API_KEY;
   else process.env.ELIZAOS_CLOUD_API_KEY = prevApiKey;
+  if (prevTtsDebug === undefined) delete process.env.ELIZA_TTS_DEBUG;
+  else process.env.ELIZA_TTS_DEBUG = prevTtsDebug;
 });
 
 describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
@@ -221,5 +236,82 @@ describe("handleCloudTtsPreviewRoute (/api/tts/cloud proxy)", () => {
     expect(JSON.parse(String(state.body))).toMatchObject({
       error: "Insufficient credits",
     });
+  });
+});
+
+// #16347: server-side ELIZA_TTS_DEBUG must actually emit — entries observed on
+// the real structured logger's listener stream, driven through the real route.
+describe("ELIZA_TTS_DEBUG tracing on /api/tts/cloud", () => {
+  let entries: LogEntry[] = [];
+  let unsubscribe: (() => void) | null = null;
+
+  const ttsLines = () =>
+    entries.filter((entry) => entry.msg.includes("[eliza][tts]"));
+
+  beforeEach(() => {
+    entries = [];
+    unsubscribe?.();
+    unsubscribe = addLogListener((entry) => entries.push(entry));
+  });
+
+  afterAll(() => {
+    unsubscribe?.();
+  });
+
+  test("successful proxy emits proxy → upstream-ok → success phases", async () => {
+    process.env.ELIZA_TTS_DEBUG = "1";
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReq(JSON.stringify({ text: "trace me please" }), {
+        "x-elizaos-tts-message-id": "msg-42",
+      }),
+      res,
+    );
+
+    expect(state.statusCode).toBe(200);
+    const phases = ttsLines().map((entry) => entry.msg);
+    expect(
+      phases.some((m) => m.includes("[eliza][tts] server:cloud-tts:proxy")),
+    ).toBe(true);
+    expect(
+      phases.some((m) =>
+        m.includes("[eliza][tts] server:cloud-tts:upstream-ok"),
+      ),
+    ).toBe(true);
+    expect(
+      phases.some((m) => m.includes("[eliza][tts] server:cloud-tts:success")),
+    ).toBe(true);
+    // Client correlation header and spoken-text preview ride along.
+    expect(phases.some((m) => m.includes("msg-42"))).toBe(true);
+    expect(phases.some((m) => m.includes("trace me please"))).toBe(true);
+  });
+
+  test("missing cloud key emits a reject phase with the reason", async () => {
+    process.env.ELIZA_TTS_DEBUG = "1";
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReq(JSON.stringify({ text: "hi" })),
+      res,
+    );
+
+    expect(state.statusCode).toBe(401);
+    const reject = ttsLines().find((entry) =>
+      entry.msg.includes("server:cloud-tts:reject"),
+    );
+    expect(reject).toBeDefined();
+    expect(reject?.msg).toContain("no_api_key");
+  });
+
+  test("flag unset → the same successful request emits zero tts lines", async () => {
+    delete process.env.ELIZA_TTS_DEBUG;
+    const { res, state } = fakeRes();
+    await handleCloudTtsPreviewRoute(
+      fakeReq(JSON.stringify({ text: "silent run" })),
+      res,
+    );
+
+    expect(state.statusCode).toBe(200);
+    expect(ttsLines()).toHaveLength(0);
   });
 });

--- a/plugins/plugin-elizacloud/src/lib/tts-debug.ts
+++ b/plugins/plugin-elizacloud/src/lib/tts-debug.ts
@@ -1,5 +1,6 @@
 /**
- * TTS debug logging. Implementation moved to
- * `@elizaos/shared/elizacloud/tts-debug`.
+ * TTS debug logging. Implementation lives in `@elizaos/shared`
+ * (`packages/shared/src/utils/tts-debug.ts`), which emits through the
+ * structured logger whenever `ELIZA_TTS_DEBUG` is set (#16347).
  */
 export { isTtsDebugEnabled, ttsDebug, ttsDebugTextPreview } from "@elizaos/shared";

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
@@ -6,8 +6,18 @@
 
 import * as http from "node:http";
 import { Socket } from "node:net";
-import { ModelType } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { addLogListener, type LogEntry, ModelType } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The logger freezes its level at module init and the repo test setup defaults
+// LOG_LEVEL to "error", which would gate the info-level tts lines (and their
+// listener delivery) off. vi.hoisted runs before the imports above evaluate,
+// so the logger initializes at "info" — the production default the
+// ELIZA_TTS_DEBUG diagnostic is documented against.
+vi.hoisted(() => {
+	process.env.LOG_LEVEL = "info";
+});
+
 import type { CompatRuntimeState } from "./compat-helpers";
 import {
 	handleLocalInferenceTtsRoute,
@@ -255,5 +265,119 @@ describe("local inference TTS route", () => {
 
 		expect(aborted).toBe(true);
 		expect(out.bodyBuffer().length).toBe(0);
+	});
+});
+
+// #16347: with ELIZA_TTS_DEBUG set the route traces `server:local-tts:*`
+// through the real structured logger; entries observed via the listener
+// stream, silent when the flag is unset.
+describe("ELIZA_TTS_DEBUG tracing on /api/tts/local-inference", () => {
+	const prevFlag = process.env.ELIZA_TTS_DEBUG;
+	let entries: LogEntry[] = [];
+	let unsubscribe: (() => void) | null = null;
+
+	const ttsLines = () =>
+		entries.filter((entry) => entry.msg.includes("[eliza][tts]"));
+
+	const listen = () => {
+		entries = [];
+		unsubscribe?.();
+		unsubscribe = addLogListener((entry) => entries.push(entry));
+	};
+
+	afterEach(() => {
+		unsubscribe?.();
+		unsubscribe = null;
+		if (prevFlag === undefined) delete process.env.ELIZA_TTS_DEBUG;
+		else process.env.ELIZA_TTS_DEBUG = prevFlag;
+	});
+
+	it("traces request and success phases on a successful synthesis", async () => {
+		process.env.ELIZA_TTS_DEBUG = "1";
+		listen();
+		const useModel = vi.fn().mockResolvedValue(wavBytes());
+		const state: CompatRuntimeState = {
+			current: { useModel } as unknown as CompatRuntimeState["current"],
+		};
+		const out = fakeRes();
+
+		await handleLocalInferenceTtsRoute(
+			fakeReq({ text: "Trace this line", voiceId: "narrator" }),
+			out.res,
+			state,
+		);
+
+		expect(out.status()).toBe(200);
+		const msgs = ttsLines().map((entry) => entry.msg);
+		expect(
+			msgs.some((m) => m.includes("[eliza][tts] server:local-tts:request")),
+		).toBe(true);
+		expect(
+			msgs.some((m) => m.includes("[eliza][tts] server:local-tts:success")),
+		).toBe(true);
+		expect(msgs.some((m) => m.includes("Trace this line"))).toBe(true);
+		expect(msgs.some((m) => m.includes("narrator"))).toBe(true);
+	});
+
+	it("traces a reject phase when synthesis fails", async () => {
+		process.env.ELIZA_TTS_DEBUG = "1";
+		listen();
+		const useModel = vi.fn().mockRejectedValue(new Error("kokoro exploded"));
+		const state: CompatRuntimeState = {
+			current: { useModel } as unknown as CompatRuntimeState["current"],
+		};
+		const out = fakeRes();
+
+		await handleLocalInferenceTtsRoute(
+			fakeReq({ text: "Hello" }),
+			out.res,
+			state,
+		);
+
+		expect(out.res.statusCode).toBe(502);
+		const reject = ttsLines().find((entry) =>
+			entry.msg.includes("server:local-tts:reject"),
+		);
+		expect(reject).toBeDefined();
+		expect(reject?.msg).toContain("synthesis_failed");
+		expect(reject?.msg).toContain("kokoro exploded");
+	});
+
+	it("traces a reject phase when the runtime is unavailable", async () => {
+		process.env.ELIZA_TTS_DEBUG = "1";
+		listen();
+		const state: CompatRuntimeState = { current: null };
+		const out = fakeRes();
+
+		await handleLocalInferenceTtsRoute(
+			fakeReq({ text: "Hello" }),
+			out.res,
+			state,
+		);
+
+		expect(out.res.statusCode).toBe(503);
+		const reject = ttsLines().find((entry) =>
+			entry.msg.includes("server:local-tts:reject"),
+		);
+		expect(reject?.msg).toContain("runtime_unavailable");
+	});
+
+	it("stays silent when the flag is unset", async () => {
+		delete process.env.ELIZA_TTS_DEBUG;
+		listen();
+		const useModel = vi.fn().mockResolvedValue(wavBytes());
+		const state: CompatRuntimeState = {
+			current: { useModel } as unknown as CompatRuntimeState["current"],
+		};
+		const out = fakeRes();
+
+		await handleLocalInferenceTtsRoute(
+			fakeReq({ text: "Quiet run" }),
+			out.res,
+			state,
+		);
+
+		expect(out.status()).toBe(200);
+		expect(ttsLines()).toHaveLength(0);
 	});
 });

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
@@ -6,11 +6,14 @@
  * drives the TEXT_TO_SPEECH model over the platform provider chain
  * (`eliza-local-inference` → capacitor → device-bridge → AOSP) and returns the
  * first provider's audio. The sanitizer and `normalizeAudioBytes` are exported
- * as pure helpers for the route-contract fuzz tests.
+ * as pure helpers for the route-contract fuzz tests. With `ELIZA_TTS_DEBUG`
+ * set, the handler traces `server:local-tts:*` phases through the structured
+ * logger, mirroring the cloud proxy's `server:cloud-tts:*` tracing.
  */
 
 import type http from "node:http";
 import { type AgentRuntime, ModelType } from "@elizaos/core";
+import { ttsDebug, ttsDebugTextPreview } from "@elizaos/shared";
 import {
 	type CompatRuntimeState,
 	ensureRouteAuthorized,
@@ -219,11 +222,20 @@ export async function handleLocalInferenceTtsRoute(
 
 	const runtime = state.current;
 	if (!runtime) {
+		ttsDebug("server:local-tts:reject", { reason: "runtime_unavailable" });
 		sendJson(res, 503, {
 			error: "Local inference TEXT_TO_SPEECH is not available",
 		});
 		return true;
 	}
+
+	const ttsPreview = ttsDebugTextPreview(text);
+	ttsDebug("server:local-tts:request", {
+		textChars: text.length,
+		preview: ttsPreview,
+		...(ttsRequest.voice ? { voice: ttsRequest.voice } : {}),
+		...(ttsRequest.modelId ? { modelId: ttsRequest.modelId } : {}),
+	});
 
 	const abortController = new AbortController();
 	let completed = false;
@@ -243,20 +255,35 @@ export async function handleLocalInferenceTtsRoute(
 			abortController.signal,
 		);
 		if (bytes.length === 0) {
+			ttsDebug("server:local-tts:reject", {
+				reason: "empty_audio",
+				preview: ttsPreview,
+			});
 			sendJson(res, 502, {
 				error: "Local inference TEXT_TO_SPEECH returned empty audio",
 			});
 			return true;
 		}
 		completed = true;
+		const contentType = sniffAudioContentType(bytes);
+		ttsDebug("server:local-tts:success", {
+			bytes: bytes.byteLength,
+			contentType,
+			preview: ttsPreview,
+		});
 		res.writeHead(200, {
-			"Content-Type": sniffAudioContentType(bytes),
+			"Content-Type": contentType,
 			"Cache-Control": "no-store",
 			"Content-Length": String(bytes.byteLength),
 		});
 		res.end(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
 	} catch (err) {
 		if (!clientClosed && !abortController.signal.aborted && !isClosed(res)) {
+			ttsDebug("server:local-tts:reject", {
+				reason: "synthesis_failed",
+				error: err instanceof Error ? err.message : String(err),
+				preview: ttsPreview,
+			});
 			sendJson(res, 502, {
 				error: `Local inference TTS error: ${err instanceof Error ? err.message : String(err)}`,
 			});


### PR DESCRIPTION
# Relates to

Closes #16347 (server-side `ELIZA_TTS_DEBUG` is a dead diagnostic: no production code installs a ttsDebug sink).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync (verify exit 0, output below).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`521cdc8fe90`); zero conflicts.
- [x] `bun run verify` passes post-sync (exit 0; run under `flock /tmp/eliza-verify.lock`).

# Risks

Low. `ttsDebug` was provably a no-op on every server host (its sink was never installed), so the only behavior change is that an **explicitly opt-in** flag now does what its documentation always claimed. With `ELIZA_TTS_DEBUG` unset (the default everywhere), the emission path is byte-for-byte a no-op — proven by the negative-control server run below and by flag-off tests in all three suites. The deleted `setTtsDebugSink` export had zero callers repo-wide.

# Background

## What does this PR do?

Server-side `ELIZA_TTS_DEBUG` was a dead diagnostic: `ttsDebug` in `@elizaos/shared` only emitted through a sink installed via `setTtsDebugSink()`, and no production code ever called it. Booting any server with `ELIZA_TTS_DEBUG=1` produced zero `[tts]` lines while the cloud TTS proxy's call sites traced into the void — operators believed tracing was on and got silence.

Per the error-handling doctrine (no half-alive diagnostics), this wires the real thing instead of deleting the flag:

- **`packages/shared/src/utils/tts-debug.ts`** — `ttsDebug` now emits straight through the structured logger (`logger.info(detail, "[eliza][tts] <phase>")`) whenever the flag is set. No per-host sink wiring exists to forget: the bare agent server, the app-core API, and the packaged desktop all trace from the same module. The dead `setTtsDebugSink` API is removed. Info level is deliberate: the operator opted in explicitly, so lines must be visible at the default `LOG_LEVEL` rather than hiding behind `debug`.
- **`plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts`** — the local TTS path (`POST /api/tts/local-inference`) now traces `server:local-tts:request|success|reject` phases, mirroring the cloud proxy's `server:cloud-tts:*`, so both server TTS paths are observable under the flag.
- **`plugins/plugin-elizacloud/src/lib/tts-debug.ts`** — header updated to describe the real mechanism.

The renderer flavor (`packages/ui/src/utils/tts-debug.ts`, Vite define) already worked and is untouched.

## What kind of change is this?

Bug fix (non-breaking; dead diagnostic made real).

# Documentation changes needed?

None beyond the file headers updated in this diff — `packages/shared/src/utils/tts-debug.ts` is itself the documentation of the flag and now describes the actual mechanism and both server phase families.

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/tts-debug.ts` (the 3-line emission core), then the live server logs in Evidence Details — a real bare-agent boot with the flag on shows the full `server:cloud-tts:*` trace against the real Eliza Cloud upstream, and a second boot with the flag off shows zero lines for the same requests.

## Detailed testing steps

Emission is asserted on the structured logger's **real** listener stream (`addLogListener`), driven through the real route handlers — no logger mocks:

- `packages/shared/src/utils/tts-debug.test.ts` (new): flag-off silence, falsy/truthy flag variants (`0/false/off/no` vs `1/true/yes/on`), info-level entry carrying phase + detail, phase-only entries, preview collapsing/truncation.
- `plugins/plugin-elizacloud/src/lib/server-cloud-tts.test.ts`: successful proxy emits `proxy → upstream-ok → success` with the client correlation header (`x-elizaos-tts-message-id`) and spoken-text preview riding along; missing cloud key emits `reject (no_api_key)`; the same successful request with the flag unset emits **zero** tts lines.
- `plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts`: `request`+`success` on synthesis (incl. voice hint), `reject (synthesis_failed)` carrying the error message, `reject (runtime_unavailable)`, and flag-off silence.

The repo test setup pins `LOG_LEVEL=error`, which would gate info-level lines off before the listener sees them; the three suites use `vi.hoisted` to set `LOG_LEVEL=info` before the logger module initializes (the production default this diagnostic is documented against).

Full suites at the branch head: `packages/shared` **1293 passed** (114 files), `plugin-elizacloud` **390 passed** (47 files), `plugin-local-inference` **2607 passed** (253 files). Root `bun run verify` exit 0.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-side logging diagnostic only; no UI surface changed` (renderer tts-debug module untouched).
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-side logging diagnostic only; no UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable output is server log lines, pasted inline below`.
<!-- evidence-row:backend-logs -->
- [x] [16958-tts-debug-flag-on-server.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16958-tts-debug-flag-on-server.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change; requests were driven via curl and shown with HTTP status + payload below`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change; the change is a logging emission path, exercised directly over HTTP below`.
<!-- evidence-row:domain-artifacts -->
- [x] [16958-tts-debug-trace-lines.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16958-tts-debug-trace-lines.log)

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior change` — this PR changes where an opt-in diagnostic writes; no prompt, model call, or action path is touched.

## Backend + frontend logs

Booted the **bare agent server** (`packages/agent/src/bin.ts serve`) from this branch (freshly built via `turbo build --filter=@elizaos/agent...`) with `ELIZA_TTS_DEBUG=1`, `LOG_LEVEL=info`, and a real Eliza Cloud API key, then drove real HTTP requests with curl.

**`POST /api/tts/cloud`** — full trace through the structured logger, including the fan-out across all four upstream URL candidates and the client correlation headers:

```
Info  [eliza][tts] server:cloud-tts:proxy (textChars=79, preview=Server side TTS debug tracing is now alive for issue sixteen three forty seven., modelId=eleven_flash_v2_5, voiceId=EXAVITQu4vr4xnSDxMaL, urlCandidates=4, messageId=evidence-16347, clipSegment=1/1)
Info  [eliza][tts] server:cloud-tts:upstream-retry (urlIndex=0, status=503, preview=Server side TTS debug tracing is now alive for issue sixteen three forty seven., messageId=evidence-16347, clipSegment=1/1)
Info  [eliza][tts] server:cloud-tts:upstream-retry (urlIndex=1, status=404, preview=Server side TTS debug tracing is now alive for issue sixteen three forty seven., messageId=evidence-16347, clipSegment=1/1)
Info  [eliza][tts] server:cloud-tts:upstream-retry (urlIndex=2, status=503, preview=Server side TTS debug tracing is now alive for issue sixteen three forty seven., messageId=evidence-16347, clipSegment=1/1)
Info  [eliza][tts] server:cloud-tts:upstream-retry (urlIndex=3, status=404, preview=Server side TTS debug tracing is now alive for issue sixteen three forty seven., messageId=evidence-16347, clipSegment=1/1)
Info  [eliza][tts] server:cloud-tts:reject (reason=upstream_failed, lastStatus=404, preview=Server side TTS debug tracing is now alive for issue sixteen three forty seven., messageId=evidence-16347, clipSegment=1/1)
```

The 503s are the **real** Eliza Cloud voice service answering during the capture window — verified by direct curl against `https://elizacloud.ai/api/v1/voice/tts` with the same key:

```
{"error":"Voice service is temporarily unavailable due to high demand. Please try again in a few moments.","type":"service_unavailable","retryAfter":"5 minutes"}
```

(retried for 30+ minutes; still 503 — see Known gaps). This is precisely the operator scenario the flag exists for — diagnosing *why* TTS fails — and the previously-dead diagnostic now tells the whole story: which candidate URLs were tried, each upstream status, and the final reject reason, correlated to the client's message id. The `upstream-ok`/`success` phases on a 200 upstream are pinned by the route-level tests (real handler + real logger listener, stubbed upstream `fetch`).

**No cloud key present** (separate boot without the key):

```
Info  [eliza][tts] server:cloud-tts:reject (reason=no_api_key, messageId=evidence-16347)
```

**`POST /api/tts/local-inference`** (no on-device synthesizer staged on this box — real reject path, `HTTP 502 {"error":"Local inference TTS error: No handler found for delegate type: TEXT_TO_SPEECH"}`):

```
Info  [eliza][tts] server:local-tts:request (textChars=66, preview=Local inference tracing check for issue sixteen three forty seven.)
Info  [eliza][tts] server:local-tts:reject (reason=synthesis_failed, error=No handler found for delegate type: TEXT_TO_SPEECH, preview=Local inference tracing check for issue sixteen three forty seven.)
```

**Negative control** — second server boot from the same branch with `ELIZA_TTS_DEBUG` **unset**, same two requests (`/api/tts/cloud` + `/api/tts/local-inference`, both answered): `grep -c 'eliza..tts'` over the full server log = **0**.

<details>
<summary>bun run verify (root, post-sync)</summary>

```
$ flock /tmp/eliza-verify.lock -c "bun run verify"
...
verify_exit=0
```

Full suites at branch head:

```
packages/shared:            Test Files 114 passed | Tests 1293 passed
plugin-elizacloud:          Test Files 47 passed, 1 skipped | Tests 390 passed, 3 skipped
plugin-local-inference:     Test Files 253 passed | Tests 2607 passed, 2 skipped
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - server-side logging diagnostic; no UI surface` (the "before" behavior is the absence of any `[eliza][tts]` line — reproduced in the issue and by the pre-fix boot in #16347).

### After

`N/A - server-side logging diagnostic; no UI surface` (the "after" is the log excerpts above).

### Walkthrough video

`N/A - no user flow; observable output is the server log stream shown above`.

## Audio / voice walkthrough

`N/A - no synthesis behavior change` — this PR does not alter TTS output, voice routing, or audio bytes; it makes the existing opt-in trace flag emit. A live audio-success capture was additionally blocked by the Eliza Cloud voice-service outage during the evidence window (real 503 shown above).

## Known gaps / failures

- The live `server:cloud-tts:upstream-ok`/`success` phases could not be captured against the real upstream because `elizacloud.ai/api/v1/voice/tts` returned `503 service_unavailable ("high demand")` for the entire 30+ minute evidence window (direct curl with the same key confirms; the outage is upstream infra, unrelated to this diff). Those two phases fire from the same three-line emission core proven live above, and are pinned end-to-end by `server-cloud-tts.test.ts` ("successful proxy emits proxy → upstream-ok → success phases") against the real handler and real logger listener stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


