### PR TITLE
feat(scenarios): view-chat live scenarios for SETTINGS voice and DOCUMENT delete

### DIFF
--- a/packages/core/src/runtime/default-contexts.ts
+++ b/packages/core/src/runtime/default-contexts.ts
@@ -66,10 +66,14 @@ export const DEFAULT_CONTEXT_DEFINITIONS: readonly ContextDefinition[] =
 		{
 			id: "documents",
 			label: "Documents",
+			// "delete" must stay in both descriptions: the DOCUMENT action owns
+			// document deletion, and a Stage-1 inventory that only advertises
+			// save/search/recall makes models refuse "delete that document" as
+			// unsupported instead of classifying into this context (#16942).
 			description:
-				"Read, write, edit, search, and list stored documents. Use whenever the user asks to save findings, notes, summaries, files, or any persisted text artifact, or to search and recall prior documents and uploaded files.",
+				"Read, write, edit, delete, search, and list stored documents. Use whenever the user asks to save findings, notes, summaries, files, or any persisted text artifact, to search and recall prior documents and uploaded files, or to remove a stored document.",
 			descriptionCompressed:
-				"Stored documents/notes/uploads: save, search, recall",
+				"Stored documents/notes/uploads: save, search, recall, delete",
 			sensitivity: "personal",
 			cacheScope: "agent",
 			subcontexts: ["knowledge", "research"],

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -225,11 +225,11 @@ const KNOWN_UNCOVERED: readonly string[] = [
   "SHARE_TRANSCRIPT",
   // New workflow code-eval action (#8914); no deterministic keyless scenario yet.
   "EVAL_CODE",
-  // App-control agent/model switchers + settings surface; dispatched through
-  // dashboard affordances, no deterministic keyless scenarios yet.
+  // App-control agent/model switchers; dispatched through dashboard
+  // affordances, no deterministic keyless scenarios yet. (SETTINGS left this
+  // baseline with deterministic-settings-voice-actions, #16942.)
   "AGENT_SWITCH",
   "MODEL_SWITCH",
-  "SETTINGS",
   // Local-inference management action; no deterministic keyless scenario yet.
   "LOCAL_INFERENCE",
   // Facewear owns smartglasses connection/runtime actions. The device-facing
@@ -281,6 +281,7 @@ const COVERED_ACTIONS: readonly string[] = [
   "BROWSER_SCREENSHOT",
   "BROWSER_TYPE",
   "BROWSER_WAIT",
+  "DOCUMENT",
   "FILE",
   "GENERATE_MEDIA",
   "GIT_PATHOLOGY",
@@ -308,6 +309,7 @@ const COVERED_ACTIONS: readonly string[] = [
   "SKILL_UNINSTALL",
   "SHELL",
   "SCHEDULED_TASKS",
+  "SETTINGS",
   "STREAM",
   "TODO",
   "USE_SKILL",
@@ -797,6 +799,8 @@ const PROSE_ONLY_LLM_SCENARIOS: Record<string, string> = {
     "live-only real-LLM followups-restraint check; asserts the live reply withholds widgets, routing no action. Keyless gating proof: the chat-widget unit + fixture e2e suites in packages/ui.",
   "live-chat-widgets-form-roundtrip":
     "live-only real-LLM chat-widget form roundtrip; widget emission/interaction is judged from the live reply with no deterministic ACTION_PLANNER fixture. Keyless gating proof: the chat-widget unit + fixture e2e suites in packages/ui.",
+  "live-document-delete":
+    "live-only real-LLM counterpart of deterministic-document-actions (#16942); the live model routes DOCUMENT list/delete (owner wall included) with no deterministic ACTION_PLANNER fixture, so it cannot satisfy STRICT_LLM_ROUTING's fixture contract. The deterministic twin pins the delete payload contract on the keyless lane.",
   "live-experience-delete-by-topic":
     "live-only real-LLM EXPERIENCE deletion flow; the live model routes EXPERIENCE with no deterministic ACTION_PLANNER fixture, so it cannot satisfy STRICT_LLM_ROUTING's fixture contract. Keyless gating proof: the experience service unit suites.",
   "live-help-knowledge":
@@ -815,7 +819,11 @@ const PROSE_ONLY_LLM_SCENARIOS: Record<string, string> = {
  * Covered actions that are not yet strict natural-language routed. This
  * baseline may only shrink as actions move to STRICT_LLM_ROUTED_ACTIONS.
  */
-const DIRECT_ONLY_COVERED_ACTIONS: readonly string[] = ["BACKGROUND"];
+const DIRECT_ONLY_COVERED_ACTIONS: readonly string[] = [
+  "BACKGROUND",
+  "DOCUMENT",
+  "SETTINGS",
+];
 
 function collectActionNames(plugin: Plugin): string[] {
   return sorted(

--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -13,6 +13,15 @@ catalog with `SCENARIO_USE_LLM_PROXY=1` and
   named-color and hex color set, programmable GLSL shader presets (natural
   phrasing + explicit `preset` param), a live-shader uniform tweak, undo, redo,
   and reset — asserting the exact ordered `background:apply` broadcast ledger.
+- `deterministic-settings-voice-actions` covers the real `SETTINGS` voice
+  section: continuous-chat on/off, silence window, RMS threshold, and the
+  invalid-mode / out-of-range rejections — asserting the exact ordered
+  `PUT /api/config` persisted-prefs ledger and matching `voice-settings:apply`
+  broadcast ledger, including the #14910 twin-default seeding.
+- `deterministic-document-actions` covers the real core `DOCUMENT` handler and
+  DocumentService DB state: list, an owner-only mutation-wall refusal for a
+  USER-granted non-owner, the owner delete (document actually gone), and the
+  not-found / missing-id rejections.
 - `deterministic-generated-app-routes` covers a generated app loaded through the
   real AppRegistryService and app-manager routes: registry persistence,
   catalog tile data, generated hero SVG, `/api/apps/:slug/*` package routing,

--- a/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
@@ -84,9 +84,10 @@ function shouldHandle(url: URL | null): url is URL {
       // SETTINGS routes owned sections through their own backend endpoints
       // (e.g. permissions shell toggle → PUT /api/permissions/shell,
       // auto-training toggle → POST /api/training/auto/config,
-      // local backups → POST /api/backups).
+      // local backups → POST /api/backups, voice prefs → GET/PUT /api/config).
       url.pathname.startsWith("/api/permissions") ||
       url.pathname.startsWith("/api/backups") ||
+      url.pathname.startsWith("/api/config") ||
       url.pathname.startsWith("/api/training/auto/config"))
   );
 }

--- a/packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts
@@ -1,0 +1,351 @@
+/**
+ * Keyless catalog coverage for the core DOCUMENT umbrella action's delete
+ * contract (#16942). Runs on the pr-deterministic lane; live-document-delete
+ * proves a real model routes the same path from natural phrasing.
+ *
+ * Exercises the real DOCUMENT handler and DocumentService end to end against
+ * real DB state: a seeded global document is listed, a non-owner delete is
+ * refused by the owner-only mutation wall (the document must survive), the
+ * owner delete succeeds (the document must actually be gone), and the
+ * not-found / missing-id rejections are pinned. The guest room's account maps
+ * to a second entity that is NOT the executor-configured canonical owner
+ * (ELIZA_ADMIN_ENTITY_ID); the seed makes it a connector-admin (ADMIN) via
+ * the roles whitelist + a stamped connector identity, matching
+ * live-document-delete's fixture, so the wall is exercised with the real
+ * roles.ts resolution against the strongest non-owner tier it admits,
+ * nothing mocked.
+ */
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { setConnectorAdminWhitelist, stringToUuid } from "@elizaos/core";
+import type {
+  CapturedAction,
+  ScenarioContext,
+  ScenarioTurnExecution,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  DocumentService,
+  documentsPlugin,
+} from "../../../core/src/features/documents/index";
+
+const SCENARIO_ID = "deterministic-document-actions";
+const DOCUMENT_TITLE = "Quarterly Onboarding Guide";
+const DOCUMENT_CONTENT = [
+  "# Quarterly Onboarding Guide",
+  "",
+  "Welcome aboard. Week one covers workstation setup, security training,",
+  "and the deployment checklist. The onboarding buddy roster rotates on the",
+  "first Monday of each quarter.",
+].join("\n");
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * The real AgentRuntime handed to seeds/checks via ScenarioContext (typed
+ * `unknown` in the schema package to keep it dependency-free), plus the
+ * plugin-registration surface the seed uses. Never a hand-built partial.
+ */
+type ScenarioRuntime = IAgentRuntime & {
+  plugins?: Array<{ name: string }>;
+  registerPlugin: (plugin: unknown) => Promise<void>;
+  getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// The seed learns the content-addressed document id only at runtime, after the
+// turn objects are already constructed — so the delete turns share these
+// mutable parameter records and the seed fills in `documentId` before any turn
+// runs.
+let seededDocumentId: UUID | null = null;
+const guestDeleteParams: JsonRecord = { action: "delete" };
+const ownerDeleteParams: JsonRecord = { action: "delete" };
+
+// Stable platform id stamped onto the guest entity + whitelisted so the guest
+// resolves as connector-admin (ADMIN). Entity metadata survives message
+// processing (merged per source key); world-metadata role grants do not.
+const GUEST_STABLE_ID = `${SCENARIO_ID}-guest-admin`;
+
+function getDocumentService(ctx: ScenarioContext): DocumentService | null {
+  const runtime = ctx.runtime as ScenarioRuntime;
+  const service = runtime.getService<DocumentService>(
+    DocumentService.serviceType,
+  );
+  return service ?? null;
+}
+
+function findDocumentCall(
+  execution: ScenarioTurnExecution,
+): CapturedAction | null {
+  return (
+    execution.actionsCalled.find(
+      (candidate) => candidate.actionName === "DOCUMENT",
+    ) ?? null
+  );
+}
+
+function expectDocumentTurn(
+  execution: ScenarioTurnExecution,
+  expected: {
+    success: boolean;
+    subaction: string;
+    values?: JsonRecord;
+  },
+): string | undefined {
+  const action = findDocumentCall(execution);
+  if (!action) {
+    return `expected DOCUMENT action, saw ${execution.actionsCalled.map((candidate) => candidate.actionName).join(", ") || "none"}`;
+  }
+  if (action.result?.success !== expected.success) {
+    return `expected DOCUMENT result.success=${expected.success}, saw ${JSON.stringify(action.result)}`;
+  }
+  const data = isRecord(action.result?.data) ? action.result.data : {};
+  if (data.subaction !== expected.subaction) {
+    return `expected DOCUMENT subaction=${expected.subaction}, saw ${JSON.stringify(data.subaction)}`;
+  }
+  const values = isRecord(action.result?.values) ? action.result.values : {};
+  for (const [key, expectedValue] of Object.entries(expected.values ?? {})) {
+    if (JSON.stringify(values[key]) !== JSON.stringify(expectedValue)) {
+      return `expected DOCUMENT values.${key}=${JSON.stringify(expectedValue)}, saw ${JSON.stringify(values[key])}`;
+    }
+  }
+  return undefined;
+}
+
+function expectSeededDocumentListed(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const structural = expectDocumentTurn(execution, {
+    success: true,
+    subaction: "list",
+  });
+  if (structural) return structural;
+  const action = findDocumentCall(execution);
+  const values = isRecord(action?.result?.values) ? action.result.values : {};
+  const documents = Array.isArray(values.documents) ? values.documents : [];
+  const ids = documents
+    .filter(isRecord)
+    .map((document) => document.id)
+    .filter((id): id is string => typeof id === "string");
+  if (!seededDocumentId) return "seeded document id was not recorded";
+  if (!ids.includes(seededDocumentId)) {
+    return `expected the seeded document ${seededDocumentId} in the list, saw ${JSON.stringify(ids)}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  id: "deterministic-document-actions",
+  lane: "pr-deterministic",
+  title: "Deterministic DOCUMENT delete contract with owner-only wall",
+  domain: "scenario-runner",
+  tags: ["pr", "deterministic", "zero-cost", "documents", "delete"],
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "client_chat",
+      title: "Document Owner",
+    },
+    {
+      id: "guest",
+      account: `${SCENARIO_ID}:guest`,
+      source: "client_chat",
+      title: "Document Guest",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "register the core documents plugin",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as ScenarioRuntime;
+        const registered = (runtime.plugins ?? []).some(
+          (plugin) => plugin.name === documentsPlugin.name,
+        );
+        if (!registered) await runtime.registerPlugin(documentsPlugin);
+        await runtime.getServiceLoadPromise?.(DocumentService.serviceType);
+        return runtime.getService(DocumentService.serviceType)
+          ? undefined
+          : "documents service did not start";
+      },
+    },
+    {
+      type: "custom",
+      name: "seed one global document through the real service",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as ScenarioRuntime;
+        const service = getDocumentService(ctx);
+        if (!service) return "documents service was not available";
+        if (!ctx.primaryRoomId || !ctx.primaryUserId) {
+          return "primary room/user were not set by the executor";
+        }
+        const room = await runtime.getRoom(ctx.primaryRoomId as UUID);
+        if (!room?.worldId) return "primary room world was not created";
+        const stored = await service.addDocument({
+          worldId: room.worldId,
+          roomId: ctx.primaryRoomId as UUID,
+          entityId: ctx.primaryUserId as UUID,
+          clientDocumentId: stringToUuid(`${SCENARIO_ID}:doc`) as UUID,
+          contentType: "text/markdown",
+          originalFilename: "quarterly-onboarding-guide.md",
+          content: DOCUMENT_CONTENT,
+          scope: "global",
+          addedBy: ctx.primaryUserId as UUID,
+          addedByRole: "OWNER",
+          addedFrom: "import",
+          metadata: { title: DOCUMENT_TITLE },
+        });
+        seededDocumentId = stored.clientDocumentId as UUID;
+        guestDeleteParams.documentId = seededDocumentId;
+        ownerDeleteParams.documentId = seededDocumentId;
+        return undefined;
+      },
+    },
+    {
+      type: "custom",
+      name: "whitelist the guest entity as a connector admin",
+      // An ungranted entity resolves to GUEST; the whitelist makes it ADMIN,
+      // pinning that even the strongest non-owner tier is refused by the
+      // owner-only mutation wall, mirroring live-document-delete's fixture.
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as ScenarioRuntime;
+        const guestId = stringToUuid(
+          `scenario-account:${SCENARIO_ID}:guest`,
+        ) as UUID;
+        setConnectorAdminWhitelist(runtime, { telegram: [GUEST_STABLE_ID] });
+        const entity = (await runtime.getEntitiesByIds([guestId]))[0] ?? null;
+        if (!entity) return "guest entity was not created by the executor";
+        entity.metadata = {
+          ...entity.metadata,
+          telegram: { userId: GUEST_STABLE_ID },
+        };
+        await runtime.updateEntities([entity]);
+        return undefined;
+      },
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "clear the connector-admin whitelist",
+      // The pr-deterministic lane shares one runtime across scenarios; a
+      // lingering whitelist could leak ADMIN into a later scenario's entities.
+      apply: (ctx) => {
+        setConnectorAdminWhitelist(ctx.runtime as ScenarioRuntime, undefined);
+        return undefined;
+      },
+    },
+  ],
+  turns: [
+    {
+      kind: "action",
+      name: "owner lists stored documents",
+      text: "what documents do I have stored?",
+      actionName: "DOCUMENT",
+      room: "main",
+      options: { parameters: { action: "list" } },
+      assertTurn: expectSeededDocumentListed,
+    },
+    {
+      kind: "action",
+      name: "non-owner delete is refused by the mutation wall",
+      text: "delete the quarterly onboarding guide document",
+      actionName: "DOCUMENT",
+      room: "guest",
+      options: { parameters: guestDeleteParams },
+      responseIncludesAny: [
+        "Only the owner can edit or delete global and owner-private documents.",
+      ],
+      assertTurn: (execution) =>
+        expectDocumentTurn(execution, {
+          success: false,
+          subaction: "delete",
+          values: { error: "forbidden" },
+        }),
+    },
+    {
+      kind: "action",
+      name: "document survives the refused delete",
+      text: "what documents do I have stored?",
+      actionName: "DOCUMENT",
+      room: "main",
+      options: { parameters: { action: "list" } },
+      assertTurn: expectSeededDocumentListed,
+    },
+    {
+      kind: "action",
+      name: "owner delete removes the document",
+      text: "delete that onboarding document",
+      actionName: "DOCUMENT",
+      room: "main",
+      options: { parameters: ownerDeleteParams },
+      assertTurn: (execution) => {
+        const structural = expectDocumentTurn(execution, {
+          success: true,
+          subaction: "delete",
+        });
+        if (structural) return structural;
+        const action = findDocumentCall(execution);
+        const values = isRecord(action?.result?.values)
+          ? action.result.values
+          : {};
+        return values.documentId === seededDocumentId
+          ? undefined
+          : `expected values.documentId=${seededDocumentId}, saw ${JSON.stringify(values.documentId)}`;
+      },
+    },
+    {
+      kind: "action",
+      name: "deleting the same document again reports not found",
+      text: "delete that onboarding document again",
+      actionName: "DOCUMENT",
+      room: "main",
+      options: { parameters: ownerDeleteParams },
+      assertTurn: (execution) =>
+        expectDocumentTurn(execution, {
+          success: false,
+          subaction: "delete",
+          values: { error: "not_found" },
+        }),
+    },
+    {
+      kind: "action",
+      name: "delete without any id is rejected",
+      text: "delete the document",
+      actionName: "DOCUMENT",
+      room: "main",
+      options: { parameters: { action: "delete" } },
+      responseIncludesAny: ["I need a valid document id to delete."],
+      assertTurn: (execution) =>
+        expectDocumentTurn(execution, {
+          success: false,
+          subaction: "delete",
+          values: { error: "invalid_id" },
+        }),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "DOCUMENT",
+      status: "success",
+      minCount: 3,
+    },
+    {
+      type: "custom",
+      name: "seeded document is actually gone from the store",
+      predicate: async (ctx) => {
+        const service = getDocumentService(ctx);
+        if (!service) return "documents service was not available";
+        if (!seededDocumentId) return "seeded document id was not recorded";
+        const remaining = await service.getDocumentById(seededDocumentId);
+        return remaining
+          ? `expected ${seededDocumentId} to be deleted, but it still exists`
+          : undefined;
+      },
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/deterministic-settings-voice-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-settings-voice-actions.scenario.ts
@@ -1,0 +1,303 @@
+/**
+ * Keyless catalog coverage for the SETTINGS voice section and its payload
+ * contract (#16942). Runs on the pr-deterministic lane; settings-voice-toggle
+ * (plugins/plugin-app-control/test/scenarios) proves a real model drives the
+ * same path from natural phrasing.
+ *
+ * Exercises the real SETTINGS handler end to end against the loopback config
+ * API: continuous-chat on, silence window, RMS threshold, continuous-chat off,
+ * plus the invalid-mode and out-of-range rejections. The final checks pin the
+ * exact ordered `PUT /api/config` persisted-prefs ledger and the matching
+ * `voice-settings:apply` broadcast ledger — including the #14910 twin
+ * invariant that a write seeding an empty voice config persists exactly the
+ * defaults the Voice settings UI applies (silenceMs 650, speechRmsThreshold
+ * 0.003) — proving the emitted payload contract, not just handler success.
+ */
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { VOICE_SETTINGS_APPLY_EVENT } from "@elizaos/shared";
+import {
+  jsonResponse,
+  readAppControlHttpRequests,
+  registerAppControlHttpHandler,
+  resetAppControlHttpLoopback,
+} from "./_helpers/app-control-http-loopback";
+
+type JsonRecord = Record<string, unknown>;
+
+function toRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+// Stateful stand-in for the real config route so consecutive writes prove
+// cumulative state: each turn's PUT must preserve what earlier turns persisted.
+let configState: { messages: JsonRecord } = { messages: {} };
+
+function voiceConfigWrites(): unknown[] {
+  return readAppControlHttpRequests(
+    (request) => request.method === "PUT" && request.pathname === "/api/config",
+  ).map((request) => request.body ?? null);
+}
+
+function voiceApplyBroadcasts(): unknown[] {
+  return readAppControlHttpRequests(
+    (request) =>
+      request.method === "POST" &&
+      request.pathname === "/api/views/events/broadcast" &&
+      toRecord(request.body).type === VOICE_SETTINGS_APPLY_EVENT,
+  ).map((request) => toRecord(request.body).payload ?? null);
+}
+
+function expectSettingsTurn(
+  execution: ScenarioTurnExecution,
+  expected: { success: boolean; responseText: string },
+): string | undefined {
+  if (execution.responseText !== expected.responseText) {
+    return `expected responseText=${JSON.stringify(expected.responseText)}, saw ${JSON.stringify(execution.responseText)}`;
+  }
+  const action = execution.actionsCalled.find(
+    (candidate) => candidate.actionName === "SETTINGS",
+  );
+  if (!action) {
+    return `expected SETTINGS action, saw ${execution.actionsCalled.map((candidate) => candidate.actionName).join(", ") || "none"}`;
+  }
+  if (action.result?.success !== expected.success) {
+    return `expected SETTINGS result.success=${expected.success}, saw ${JSON.stringify(action.result)}`;
+  }
+  return undefined;
+}
+
+// #14910 twin invariant defaults (see DEFAULT_VOICE_SETTINGS_PREFS in
+// plugins/plugin-app-control/src/actions/settings.ts).
+const TWIN_DEFAULT_SILENCE_MS = 650;
+const TWIN_DEFAULT_RMS = 0.003;
+
+// The exact prefs each successful write must persist AND broadcast, in turn
+// order: on → silence 1200 → rms 0.008 → off. Rejected turns write nothing.
+const EXPECTED_PREFS_LEDGER = [
+  {
+    continuous: "always-on",
+    vadAutoStop: {
+      silenceMs: TWIN_DEFAULT_SILENCE_MS,
+      speechRmsThreshold: TWIN_DEFAULT_RMS,
+    },
+  },
+  {
+    continuous: "always-on",
+    vadAutoStop: { silenceMs: 1200, speechRmsThreshold: TWIN_DEFAULT_RMS },
+  },
+  {
+    continuous: "always-on",
+    vadAutoStop: { silenceMs: 1200, speechRmsThreshold: 0.008 },
+  },
+  {
+    continuous: "off",
+    vadAutoStop: { silenceMs: 1200, speechRmsThreshold: 0.008 },
+  },
+];
+
+export default scenario({
+  id: "deterministic-settings-voice-actions",
+  lane: "pr-deterministic",
+  title: "Deterministic SETTINGS voice-section payload contract",
+  domain: "scenario-runner",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "app-control",
+    "settings",
+    "voice",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: ["@elizaos/plugin-app-control"],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "register config + broadcast loopback API",
+      apply: () => {
+        resetAppControlHttpLoopback();
+        configState = { messages: {} };
+        registerAppControlHttpHandler((request) => {
+          if (request.method === "GET" && request.pathname === "/api/config") {
+            return jsonResponse(configState);
+          }
+          if (request.method === "PUT" && request.pathname === "/api/config") {
+            configState = {
+              messages: toRecord(toRecord(request.body).messages),
+            };
+            return jsonResponse({ ok: true });
+          }
+          if (
+            request.method === "POST" &&
+            request.pathname === "/api/views/events/broadcast"
+          ) {
+            return jsonResponse({ ok: true, delivered: 1 });
+          }
+          return undefined;
+        });
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "client_chat",
+      title: "Deterministic Settings Voice Catalog",
+    },
+  ],
+  turns: [
+    {
+      kind: "action",
+      name: "turn on continuous voice chat",
+      text: "turn on continuous voice chat",
+      actionName: "SETTINGS",
+      options: {
+        action: "set",
+        section: "voice",
+        key: "continuous",
+        value: "always-on",
+      },
+      assertTurn: (execution) =>
+        expectSettingsTurn(execution, {
+          success: true,
+          responseText:
+            "Voice settings updated: continuous chat is always-on, silence is 650ms, speech threshold is 0.003.",
+        }),
+    },
+    {
+      kind: "action",
+      name: "set voice silence window to 1200ms",
+      text: "set voice silence to 1200ms",
+      actionName: "SETTINGS",
+      options: {
+        action: "set",
+        section: "voice",
+        key: "silence-ms",
+        value: "1200",
+      },
+      assertTurn: (execution) =>
+        expectSettingsTurn(execution, {
+          success: true,
+          responseText:
+            "Voice settings updated: continuous chat is always-on, silence is 1200ms, speech threshold is 0.003.",
+        }),
+    },
+    {
+      kind: "action",
+      name: "set voice speech threshold to 0.008",
+      text: "make the voice end-of-turn threshold 0.008",
+      actionName: "SETTINGS",
+      options: {
+        action: "set",
+        section: "voice",
+        key: "rms",
+        value: "0.008",
+      },
+      assertTurn: (execution) =>
+        expectSettingsTurn(execution, {
+          success: true,
+          responseText:
+            "Voice settings updated: continuous chat is always-on, silence is 1200ms, speech threshold is 0.008.",
+        }),
+    },
+    {
+      kind: "action",
+      name: "turn continuous voice chat off",
+      text: "turn off hands-free voice",
+      actionName: "SETTINGS",
+      options: {
+        action: "set",
+        section: "voice",
+        key: "continuous",
+        value: "off",
+      },
+      assertTurn: (execution) =>
+        expectSettingsTurn(execution, {
+          success: true,
+          responseText:
+            "Voice settings updated: continuous chat is off, silence is 1200ms, speech threshold is 0.008.",
+        }),
+    },
+    {
+      kind: "action",
+      name: "reject an unknown continuous-chat mode",
+      text: "set voice continuous to sometimes",
+      actionName: "SETTINGS",
+      options: {
+        action: "set",
+        section: "voice",
+        key: "continuous",
+        value: "sometimes",
+      },
+      assertTurn: (execution) =>
+        expectSettingsTurn(execution, {
+          success: false,
+          responseText:
+            "I couldn't change voice continuous: provide value=off|vad-gated|always-on for voice continuous chat.",
+        }),
+    },
+    {
+      kind: "action",
+      name: "reject an out-of-range silence window",
+      text: "set voice silence to 50ms",
+      actionName: "SETTINGS",
+      options: {
+        action: "set",
+        section: "voice",
+        key: "silence-ms",
+        value: "50",
+      },
+      assertTurn: (execution) =>
+        expectSettingsTurn(execution, {
+          success: false,
+          responseText:
+            "I couldn't change voice silence-ms: silenceMs must be between 300 and 3000.",
+        }),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "SETTINGS",
+      status: "success",
+      minCount: 4,
+    },
+    {
+      type: "custom",
+      name: "PUT /api/config persisted-prefs ledger is exact and ordered",
+      predicate: () => {
+        const expected = EXPECTED_PREFS_LEDGER.map((prefs) => ({
+          messages: { voice: prefs },
+        }));
+        const actual = voiceConfigWrites();
+        return JSON.stringify(actual) === JSON.stringify(expected)
+          ? undefined
+          : `expected voice config write ledger ${JSON.stringify(expected)}, saw ${JSON.stringify(actual)}`;
+      },
+    },
+    {
+      type: "custom",
+      name: "voice-settings:apply broadcast ledger mirrors the persisted prefs",
+      predicate: () => {
+        const actual = voiceApplyBroadcasts();
+        return JSON.stringify(actual) === JSON.stringify(EXPECTED_PREFS_LEDGER)
+          ? undefined
+          : `expected voice-settings:apply ledger ${JSON.stringify(EXPECTED_PREFS_LEDGER)}, saw ${JSON.stringify(actual)}`;
+      },
+    },
+    {
+      type: "custom",
+      name: "cleanup config loopback",
+      predicate: () => {
+        resetAppControlHttpLoopback();
+        return undefined;
+      },
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/live-document-delete.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-document-delete.scenario.ts
@@ -1,0 +1,369 @@
+/**
+ * Live-model proof for the view-chat DOCUMENT delete acceptance bar (#16942):
+ * "delete that document" in natural phrasing must make a REAL model route the
+ * semantic DOCUMENT action with a delete op — never a raw selector
+ * (`agent-fill`/`agent-click`) on the Knowledge view — and the stored document
+ * must actually be gone from the real DocumentService afterwards (state
+ * assertion, not reply phrasing). A non-owner turn first attempts the same
+ * delete and must be refused by the owner-only mutation wall while the
+ * document survives. deterministic-document-actions pins the same payload
+ * contract keyless on the PR lane.
+ *
+ * The guest room's account maps to a second entity that is NOT the
+ * executor-configured canonical owner (ELIZA_ADMIN_ENTITY_ID). The seed makes
+ * it a connector-admin (ADMIN) via the roles whitelist + a stamped connector
+ * identity on the entity — the strongest non-owner tier the role system
+ * admits. An ungranted entity resolves to GUEST and never even sees the
+ * documents context (defense in depth hides the action before the wall can
+ * fire), and world-metadata role grants do not survive message processing
+ * (each turn re-upserts the world with fresh metadata), so the whitelist is
+ * the durable non-owner fixture. Even as ADMIN the handler's owner-only
+ * mutation wall must refuse the delete, exercising the real roles.ts
+ * resolution end to end.
+ */
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { setConnectorAdminWhitelist, stringToUuid } from "@elizaos/core";
+import type {
+  CapturedAction,
+  ScenarioContext,
+  ScenarioTurnExecution,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  DocumentService,
+  documentsPlugin,
+} from "../../../core/src/features/documents/index";
+
+const SCENARIO_ID = "live-document-delete";
+const DOCUMENT_TITLE = "Quarterly Onboarding Guide";
+const DOCUMENT_CONTENT = [
+  "# Quarterly Onboarding Guide",
+  "",
+  "Welcome aboard. Week one covers workstation setup, security training,",
+  "and the deployment checklist. The onboarding buddy roster rotates on the",
+  "first Monday of each quarter.",
+].join("\n");
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * The real AgentRuntime handed to seeds/checks via ScenarioContext (typed
+ * `unknown` in the schema package to keep it dependency-free), plus the
+ * plugin-registration surface the seed uses. Never a hand-built partial.
+ */
+type ScenarioRuntime = IAgentRuntime & {
+  plugins?: Array<{ name: string }>;
+  registerPlugin: (plugin: unknown) => Promise<void>;
+  getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+let seededDocumentId: UUID | null = null;
+
+// Stable platform id stamped onto the guest entity + whitelisted so the guest
+// resolves as connector-admin (ADMIN). Entity metadata survives message
+// processing (it is merged per source key), unlike world-metadata role grants
+// which each processed message clobbers.
+const GUEST_STABLE_ID = `${SCENARIO_ID}-guest-admin`;
+
+function getDocumentService(ctx: ScenarioContext): DocumentService | null {
+  const runtime = ctx.runtime as ScenarioRuntime;
+  const service = runtime.getService<DocumentService>(
+    DocumentService.serviceType,
+  );
+  return service ?? null;
+}
+
+function actionParams(action: CapturedAction): JsonRecord {
+  const envelope = isRecord(action.parameters) ? action.parameters : {};
+  return isRecord(envelope.parameters) ? envelope.parameters : envelope;
+}
+
+function documentCalls(execution: ScenarioTurnExecution): CapturedAction[] {
+  return execution.actionsCalled.filter(
+    (candidate) => candidate.actionName === "DOCUMENT",
+  );
+}
+
+function resultValues(action: CapturedAction): JsonRecord {
+  return isRecord(action.result?.values) ? action.result.values : {};
+}
+
+function resultData(action: CapturedAction): JsonRecord {
+  return isRecord(action.result?.data) ? action.result.data : {};
+}
+
+// The raw-selector negative the acceptance bar names: the Knowledge view's
+// delete control must be reached through the semantic DOCUMENT action, never
+// the generic synthetic-DOM bridge.
+function noSyntheticDomFallback(ctx: {
+  actionsCalled: CapturedAction[];
+}): string | undefined {
+  for (const call of ctx.actionsCalled) {
+    if (call.actionName === "VIEWS") {
+      return `expected no VIEWS synthetic-DOM fallback, saw VIEWS with ${JSON.stringify(actionParams(call))}`;
+    }
+    const capability = actionParams(call).capability;
+    if (capability === "agent-fill" || capability === "agent-click") {
+      return `expected no agent-fill/agent-click, saw capability=${String(capability)}`;
+    }
+  }
+  return undefined;
+}
+
+function expectListWithSeededDocument(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const listCall = documentCalls(execution).find(
+    (call) => resultData(call).subaction === "list",
+  );
+  if (!listCall) {
+    return `expected a DOCUMENT list call, saw ${execution.actionsCalled.map((candidate) => candidate.actionName).join(", ") || "none"}`;
+  }
+  if (listCall.result?.success !== true) {
+    return `expected DOCUMENT list success=true, saw ${JSON.stringify(listCall.result)}`;
+  }
+  const documents = Array.isArray(resultValues(listCall).documents)
+    ? (resultValues(listCall).documents as unknown[])
+    : [];
+  const ids = documents
+    .filter(isRecord)
+    .map((document) => document.id)
+    .filter((id): id is string => typeof id === "string");
+  if (!seededDocumentId) return "seeded document id was not recorded";
+  if (!ids.includes(seededDocumentId)) {
+    return `expected the seeded document ${seededDocumentId} in the list, saw ${JSON.stringify(ids)}`;
+  }
+  return noSyntheticDomFallback({ actionsCalled: execution.actionsCalled });
+}
+
+// The model may legitimately re-list before deleting inside the same turn, so
+// the delete expectation searches all DOCUMENT calls for the delete op instead
+// of assuming the turn produced exactly one call.
+function findDeleteCall(
+  execution: ScenarioTurnExecution,
+): CapturedAction | null {
+  return (
+    documentCalls(execution).find(
+      (call) => resultData(call).subaction === "delete",
+    ) ?? null
+  );
+}
+
+function expectRefusedDelete(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const deleteCall = findDeleteCall(execution);
+  if (!deleteCall) {
+    return `expected a DOCUMENT delete attempt, saw ${
+      execution.actionsCalled
+        .map(
+          (candidate) =>
+            `${candidate.actionName}:${String(resultData(candidate).subaction ?? "")}`,
+        )
+        .join(", ") || "none"
+    }`;
+  }
+  if (deleteCall.result?.success !== false) {
+    return `expected the non-owner delete to fail, saw ${JSON.stringify(deleteCall.result)}`;
+  }
+  const error = resultValues(deleteCall).error;
+  if (error !== "forbidden") {
+    return `expected values.error="forbidden", saw ${JSON.stringify(error)}`;
+  }
+  return noSyntheticDomFallback({ actionsCalled: execution.actionsCalled });
+}
+
+function expectOwnerDeleteSucceeded(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const deleteCall = findDeleteCall(execution);
+  if (!deleteCall) {
+    return `expected a DOCUMENT delete call, saw ${
+      execution.actionsCalled
+        .map(
+          (candidate) =>
+            `${candidate.actionName}:${String(resultData(candidate).subaction ?? "")}`,
+        )
+        .join(", ") || "none"
+    }`;
+  }
+  if (deleteCall.result?.success !== true) {
+    return `expected DOCUMENT delete success=true, saw ${JSON.stringify(deleteCall.result)}`;
+  }
+  const documentId = resultValues(deleteCall).documentId;
+  if (documentId !== seededDocumentId) {
+    return `expected values.documentId=${seededDocumentId}, saw ${JSON.stringify(documentId)}`;
+  }
+  return noSyntheticDomFallback({ actionsCalled: execution.actionsCalled });
+}
+
+export default scenario({
+  id: "live-document-delete",
+  lane: "live-only",
+  title: "Real LLM routes 'delete that document' to DOCUMENT with owner wall",
+  domain: "documents",
+  tags: ["live", "real-llm", "documents", "views-chat-integration", "mvp"],
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "client_chat",
+      title: "Document Owner",
+    },
+    {
+      id: "guest",
+      account: `${SCENARIO_ID}:guest`,
+      source: "client_chat",
+      title: "Document Guest",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "register the core documents plugin",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as ScenarioRuntime;
+        const registered = (runtime.plugins ?? []).some(
+          (plugin) => plugin.name === documentsPlugin.name,
+        );
+        if (!registered) await runtime.registerPlugin(documentsPlugin);
+        await runtime.getServiceLoadPromise?.(DocumentService.serviceType);
+        return runtime.getService(DocumentService.serviceType)
+          ? undefined
+          : "documents service did not start";
+      },
+    },
+    {
+      type: "custom",
+      name: "seed one global document through the real service",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as ScenarioRuntime;
+        const service = getDocumentService(ctx);
+        if (!service) return "documents service was not available";
+        if (!ctx.primaryRoomId || !ctx.primaryUserId) {
+          return "primary room/user were not set by the executor";
+        }
+        const room = await runtime.getRoom(ctx.primaryRoomId as UUID);
+        if (!room?.worldId) return "primary room world was not created";
+        const stored = await service.addDocument({
+          worldId: room.worldId,
+          roomId: ctx.primaryRoomId as UUID,
+          entityId: ctx.primaryUserId as UUID,
+          clientDocumentId: stringToUuid(`${SCENARIO_ID}:doc`) as UUID,
+          contentType: "text/markdown",
+          originalFilename: "quarterly-onboarding-guide.md",
+          content: DOCUMENT_CONTENT,
+          scope: "global",
+          addedBy: ctx.primaryUserId as UUID,
+          addedByRole: "OWNER",
+          addedFrom: "import",
+          metadata: { title: DOCUMENT_TITLE },
+        });
+        seededDocumentId = stored.clientDocumentId as UUID;
+        return undefined;
+      },
+    },
+    {
+      type: "custom",
+      name: "whitelist the guest entity as a connector admin",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as ScenarioRuntime;
+        const guestId = stringToUuid(
+          `scenario-account:${SCENARIO_ID}:guest`,
+        ) as UUID;
+        setConnectorAdminWhitelist(runtime, { telegram: [GUEST_STABLE_ID] });
+        const entity = (await runtime.getEntitiesByIds([guestId]))[0] ?? null;
+        if (!entity) return "guest entity was not created by the executor";
+        entity.metadata = {
+          ...entity.metadata,
+          telegram: { userId: GUEST_STABLE_ID },
+        };
+        await runtime.updateEntities([entity]);
+        return undefined;
+      },
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "clear the connector-admin whitelist",
+      apply: (ctx) => {
+        setConnectorAdminWhitelist(ctx.runtime as ScenarioRuntime, undefined);
+        return undefined;
+      },
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "non-owner lists the stored documents",
+      room: "guest",
+      text: "What documents are stored right now?",
+      expectedActions: ["DOCUMENT"],
+      assertTurn: expectListWithSeededDocument,
+    },
+    {
+      kind: "message",
+      name: "non-owner delete is refused by the mutation wall",
+      room: "guest",
+      text: `Delete the ${DOCUMENT_TITLE} document.`,
+      expectedActions: ["DOCUMENT"],
+      assertTurn: expectRefusedDelete,
+    },
+    {
+      kind: "message",
+      name: "owner lists the stored documents",
+      room: "main",
+      text: "What documents do I have stored?",
+      expectedActions: ["DOCUMENT"],
+      assertTurn: expectListWithSeededDocument,
+    },
+    {
+      kind: "message",
+      name: "owner deletes the document by natural phrasing",
+      room: "main",
+      text: "Delete that onboarding guide document.",
+      expectedActions: ["DOCUMENT"],
+      assertTurn: expectOwnerDeleteSucceeded,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "DOCUMENT",
+      status: "success",
+      minCount: 3,
+    },
+    {
+      type: "selectedActionArguments",
+      actionName: "DOCUMENT",
+      includesAll: [/delete/i],
+    },
+    {
+      type: "custom",
+      // Survival across the refused non-owner delete is proven by turn
+      // ordering: the owner list turn re-observed the document AFTER the
+      // guest refusal. By final-check time the owner delete has run, so the
+      // document must be gone from the real store.
+      name: "seeded document is actually gone from the store",
+      predicate: async (ctx) => {
+        if (!seededDocumentId) return "seeded document id was not recorded";
+        const service = getDocumentService(ctx);
+        if (!service) return "documents service was not available";
+        const remaining = await service.getDocumentById(seededDocumentId);
+        return remaining
+          ? `expected ${seededDocumentId} to be deleted by the owner turn, but it still exists`
+          : undefined;
+      },
+    },
+    {
+      type: "custom",
+      name: "no synthetic-DOM (VIEWS/agent-fill/agent-click) fallback was used",
+      predicate: noSyntheticDomFallback,
+    },
+  ],
+});

--- a/plugins/plugin-app-control/test/scenarios/settings-voice-toggle.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-voice-toggle.scenario.ts
@@ -1,0 +1,232 @@
+/**
+ * Live-model SETTINGS voice scenario (MVP workstream 6 acceptance bar, #16942):
+ * natural "turn on voice" phrasing must make a REAL model select the semantic
+ * SETTINGS action and drive the voice section's own write path — never a raw
+ * selector (`agent-fill`/`agent-click`) on the Settings surface. The loopback
+ * captures the exact `PUT /api/config` persisted voice prefs and the
+ * `voice-settings:apply` broadcast the running shell consumes, so every check
+ * is on behavior, not on the model's phrasing. The persisted payload is pinned
+ * to the #14910 twin defaults (silenceMs 650, speechRmsThreshold 0.003) so a
+ * chat-issued voice write can never diverge from what the Voice settings UI
+ * seeds. deterministic-settings-voice-actions pins the same payload contract
+ * keyless on the PR lane.
+ */
+
+import { VOICE_SETTINGS_APPLY_EVENT } from "@elizaos/shared";
+import type {
+	CapturedAction,
+	ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+	jsonResponse,
+	readAppControlHttpRequests,
+	registerAppControlHttpHandler,
+	resetAppControlHttpLoopback,
+} from "../../../../packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback";
+
+type JsonRecord = Record<string, unknown>;
+
+function toRecord(value: unknown): JsonRecord {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as JsonRecord)
+		: {};
+}
+
+// The stateful stand-in for the real config route: GET serves it, PUT replaces
+// `messages`, so the second turn's write proves cumulative state (the silence
+// change must preserve the continuous mode the first turn persisted).
+let configState: { messages: JsonRecord } = { messages: {} };
+
+function voiceConfigWrites(): unknown[] {
+	return readAppControlHttpRequests(
+		(request) =>
+			request.method === "PUT" && request.pathname === "/api/config",
+	).map((request) => request.body ?? null);
+}
+
+function voiceApplyBroadcasts(): unknown[] {
+	return readAppControlHttpRequests(
+		(request) =>
+			request.method === "POST" &&
+			request.pathname === "/api/views/events/broadcast" &&
+			toRecord(request.body).type === VOICE_SETTINGS_APPLY_EVENT,
+	).map((request) => toRecord(request.body).payload ?? null);
+}
+
+function actionParams(action: CapturedAction): JsonRecord {
+	const envelope = toRecord(action.parameters);
+	return toRecord(envelope.parameters ?? envelope);
+}
+
+// The raw-selector negative the acceptance bar names: the builtin Settings
+// surface must be driven semantically, never through the generic synthetic-DOM
+// bridge.
+function noSyntheticDomFallback(ctx: ScenarioContext): string | undefined {
+	for (const call of ctx.actionsCalled) {
+		if (call.actionName === "VIEWS") {
+			return `expected no VIEWS synthetic-DOM fallback, saw VIEWS with ${JSON.stringify(actionParams(call))}`;
+		}
+		const capability = actionParams(call).capability;
+		if (capability === "agent-fill" || capability === "agent-click") {
+			return `expected no agent-fill/agent-click, saw capability=${String(capability)}`;
+		}
+	}
+	return undefined;
+}
+
+// #14910 twin invariant: a chat-write that seeds an empty voice config must
+// persist exactly the defaults the Voice settings UI applies.
+const TWIN_DEFAULT_RMS = 0.003;
+const TWIN_DEFAULT_SILENCE_MS = 650;
+
+const EXPECTED_PREFS_LEDGER = [
+	{
+		continuous: "always-on",
+		vadAutoStop: {
+			silenceMs: TWIN_DEFAULT_SILENCE_MS,
+			speechRmsThreshold: TWIN_DEFAULT_RMS,
+		},
+	},
+	{
+		continuous: "always-on",
+		vadAutoStop: { silenceMs: 1200, speechRmsThreshold: TWIN_DEFAULT_RMS },
+	},
+];
+
+function expectSettingsSuccess(execution: {
+	actionsCalled: CapturedAction[];
+}): string | undefined {
+	const action = execution.actionsCalled.find(
+		(candidate) => candidate.actionName === "SETTINGS",
+	);
+	if (!action) {
+		return `expected the model to route to SETTINGS, saw ${execution.actionsCalled.map((candidate) => candidate.actionName).join(", ") || "none"}`;
+	}
+	if (action.result?.success !== true) {
+		return `expected SETTINGS result.success=true, saw ${JSON.stringify(action.result)}`;
+	}
+	return undefined;
+}
+
+export default scenario({
+	lane: "live-only",
+	id: "settings-voice-toggle",
+	title: "SETTINGS action turns on continuous voice via the config route",
+	domain: "app-control",
+	tags: ["app-control", "settings", "set", "voice", "mvp"],
+	isolation: "per-scenario",
+	requires: {
+		plugins: ["@elizaos/plugin-app-control"],
+	},
+	seed: [
+		{
+			type: "custom",
+			name: "register config + broadcast loopback API",
+			apply: () => {
+				resetAppControlHttpLoopback();
+				configState = { messages: {} };
+				registerAppControlHttpHandler((request) => {
+					if (
+						request.method === "GET" &&
+						request.pathname === "/api/config"
+					) {
+						return jsonResponse(configState);
+					}
+					if (
+						request.method === "PUT" &&
+						request.pathname === "/api/config"
+					) {
+						configState = {
+							messages: toRecord(toRecord(request.body).messages),
+						};
+						return jsonResponse({ ok: true });
+					}
+					if (
+						request.method === "POST" &&
+						request.pathname === "/api/views/events/broadcast"
+					) {
+						return jsonResponse({ ok: true, delivered: 1 });
+					}
+					return undefined;
+				});
+				return undefined;
+			},
+		},
+	],
+	rooms: [
+		{
+			id: "main",
+			source: "client_chat",
+			title: "Settings Voice Toggle",
+		},
+	],
+	turns: [
+		{
+			kind: "message",
+			name: "user-turns-on-continuous-voice",
+			text: "Turn on continuous voice chat so it's always on.",
+			expectedActions: ["SETTINGS"],
+			assertTurn: expectSettingsSuccess,
+		},
+		{
+			kind: "message",
+			name: "user-sets-voice-silence-window",
+			// "window" is deliberately avoided: it is a strong VIEWS retrieval
+			// keyword (detached windows), and the acceptance bar's canonical
+			// phrasing for this write is "set voice silence to 1200ms".
+			text: "Update my voice settings: set the end-of-turn silence to 1200 ms.",
+			expectedActions: ["SETTINGS"],
+			assertTurn: expectSettingsSuccess,
+		},
+	],
+	finalChecks: [
+		{
+			type: "selectedAction",
+			actionName: "SETTINGS",
+		},
+		{
+			type: "actionCalled",
+			actionName: "SETTINGS",
+			status: "success",
+			minCount: 2,
+		},
+		{
+			type: "custom",
+			name: "SETTINGS persisted the exact voice prefs through PUT /api/config",
+			predicate: () => {
+				const expected = EXPECTED_PREFS_LEDGER.map((prefs) => ({
+					messages: { voice: prefs },
+				}));
+				const actual = voiceConfigWrites();
+				return JSON.stringify(actual) === JSON.stringify(expected)
+					? undefined
+					: `expected voice config write ledger ${JSON.stringify(expected)}, saw ${JSON.stringify(actual)}`;
+			},
+		},
+		{
+			type: "custom",
+			name: "voice-settings:apply broadcasts mirror the persisted prefs in order",
+			predicate: () => {
+				const actual = voiceApplyBroadcasts();
+				return JSON.stringify(actual) ===
+					JSON.stringify(EXPECTED_PREFS_LEDGER)
+					? undefined
+					: `expected voice-settings:apply ledger ${JSON.stringify(EXPECTED_PREFS_LEDGER)}, saw ${JSON.stringify(actual)}`;
+			},
+		},
+		{
+			type: "custom",
+			name: "no synthetic-DOM (VIEWS/agent-fill/agent-click) fallback was used",
+			predicate: noSyntheticDomFallback,
+		},
+		{
+			type: "custom",
+			name: "cleanup config loopback",
+			predicate: () => {
+				resetAppControlHttpLoopback();
+				return undefined;
+			},
+		},
+	],
+});


### PR DESCRIPTION
Closes #16942 — the two missing view-chat acceptance-bar scenarios from MVP workstream 6 (`packages/docs/ongoing-development/mvp/MVP.md`, View-chat row): **"turn on voice" → SETTINGS voice section** and **"delete that document" → DOCUMENT action**. Both are proven with a live model driving the real runtime, both are pinned keyless on the PR lane, and the raw-selector negative (no `agent-fill`/`agent-click`, no `VIEWS` synthetic-DOM fallback) is asserted on every live turn. All evidence below was re-captured on this branch's base (`a71c622ac20`, current `develop` tip at capture time).

## What ships

**Live-only scenarios (real model, real state mutation):**
- `plugins/plugin-app-control/test/scenarios/settings-voice-toggle.scenario.ts` (app-control shard of `live-scenarios.yml`) — natural "Turn on continuous voice chat so it's always on." / "Update my voice settings: set the end-of-turn silence to 1200 ms." must make a real model select the semantic `SETTINGS` action and drive the voice section's own write path. A stateful loopback stands in for `/api/config`; final checks pin the **exact ordered `PUT /api/config` persisted-prefs ledger** and the **exact `voice-settings:apply` broadcast ledger**, including the #14910 twin invariant (a write seeding an empty voice config persists exactly the Voice-UI defaults `silenceMs 650` / `speechRmsThreshold 0.003`). Zero `VIEWS`/`agent-fill`/`agent-click` allowed.
- `packages/scenario-runner/test/scenarios/live-document-delete.scenario.ts` — seeds a real global document through `DocumentService`, then: a **whitelisted connector-admin (ADMIN) non-owner** lists it and attempts the delete → the owner-only mutation wall refuses (`values.error="forbidden"`); a follow-up owner list re-observes the document (survival proof); the owner's "Delete that onboarding guide document." routes `DOCUMENT action=delete`; the final check asserts the document is **actually gone from the store** (service read, not reply phrasing). Zero `VIEWS`/`agent-fill`/`agent-click` allowed.

**Deterministic keyless twins (pr-deterministic lane, every PR):**
- `deterministic-settings-voice-actions` — the real SETTINGS handler end to end: continuous on / silence 1200 / rms 0.008 / off with exact write + broadcast ledgers, plus byte-exact invalid-mode and out-of-range rejection replies.
- `deterministic-document-actions` — the real DOCUMENT handler against real DB state: list, ADMIN non-owner refused (`forbidden`, document survives a real re-list), owner delete (document gone via `getDocumentById → null`), `not_found` and `invalid_id` rejections.

**Supporting changes:**
- `packages/core/src/runtime/default-contexts.ts` — the `documents` context description now includes **delete**. The live scenario exposed a real gap: the Stage-1 inventory advertised only "save, search, recall", so models refused "delete that document" as unsupported instead of classifying into the documents context (reproduced twice, fixed, and re-proven live — see below).
- `_helpers/app-control-http-loopback.ts` — the loopback additionally captures `/api/config` (the route the SETTINGS voice section writes through). No behavior change for existing scenarios: every registered handler is an exact-path match and unmatched requests still pass through to the real fetch.
- `deterministic-action-coverage.test.ts` — `SETTINGS` leaves the shrink-only `KNOWN_UNCOVERED` baseline; `SETTINGS` + `DOCUMENT` enter `COVERED_ACTIONS` and the direct-only baseline; `live-document-delete` classified in `PROSE_ONLY_LLM_SCENARIOS` (live model routes it; no deterministic ACTION_PLANNER fixture — the twins gate the keyless lane). 17/17 gate tests pass.
- Scenario catalog README rows for the two new twins.

## What hand-reading the failed trajectories surfaced (and how each was fixed)

1. **CLI planner mode** — with `ELIZA_CHAT_VIA_CLI=claude` the planner must run in text-planner mode (`ELIZA_PLANNER_NATIVE_TOOLS=0`): `claude --print` cannot honor native tool schemas, and the cli-inference plugin registers its clean-routing ACTION_PLANNER only in that mode. The first run's model narrated "I don't have a tool…" with SETTINGS sitting right in the tools array.
2. **"window" is a VIEWS keyword** — "set the voice silence *window*…" retrieval-collided with VIEWS (detached windows) and SETTINGS was never offered to the planner (toolSearch returned `["VIEWS"]` only). The turn now uses the acceptance bar's canonical phrasing.
3. **GUEST never reaches the wall** — an ungranted second entity resolves to GUEST and the `documents` context (`minRole: USER`) is hidden before the wall can fire (defense in depth working as designed). The permission-wall turn therefore models the **strongest non-owner tier**: a connector-admin (ADMIN) via the roles whitelist + a stamped connector identity on the entity. World-metadata role grants were tried first and do **not** survive message processing (each processed turn re-upserts the world with fresh metadata — verified empirically with a diagnostic scenario); entity metadata does survive (merged per source key), so the whitelist is the durable fixture.
4. **Stage-1 refused deletes it should classify** — with the `documents` context advertised as "save, search, recall", the model (twice) replied "there's no document-management tool… to delete stored documents" instead of emitting the classification JSON. Adding `delete` to the context description fixed it; the very next live run routed the ADMIN delete straight into the wall.

## Evidence (all artifacts opened and reviewed by hand)

### Live runs — real model via `ELIZA_CHAT_VIA_CLI=claude` (subscription CLI, provider `cli`), `ELIZA_PLANNER_NATIVE_TOOLS=0`

**`settings-voice-toggle` — PASSED (1/1, 34.6s; all 6 final checks green)**

Decisive planner outputs from the recorded trajectories (quoted verbatim):

```
== "Turn on continuous voice chat so it's always on."
PLANNER: {"action":"SETTINGS","params":{"action":"set","section":"voice","key":"continuous","value":"always-on"}}
== "Update my voice settings: set the end-of-turn silence to 1200 ms."
PLANNER: {"action":"SETTINGS","params":{"action":"set","section":"voice","key":"silence-ms","value":"1200"}}
```

Captured domain artifacts (loopback ledgers, asserted exactly by final checks):

```
PUT /api/config #1: {"messages":{"voice":{"continuous":"always-on","vadAutoStop":{"silenceMs":650,"speechRmsThreshold":0.003}}}}
PUT /api/config #2: {"messages":{"voice":{"continuous":"always-on","vadAutoStop":{"silenceMs":1200,"speechRmsThreshold":0.003}}}}
voice-settings:apply broadcasts: the same two payloads, in order
```

Both turns `SETTINGS success=true` with handler replies "Voice settings updated: continuous chat is always-on, silence is 650ms/1200ms, speech threshold is 0.003." Zero `VIEWS`/`agent-fill`/`agent-click` calls in the run (asserted).

**`live-document-delete` — PASSED (1/1, 70.0s; all 4 final checks green)**

Per-turn decisive lines (report + trajectories, quoted verbatim; `user_role` lines are from the recorded Stage-1 prompts):

```
guest (user_role: ADMIN)  "What documents are stored right now?"
  PLANNER: {"action":"DOCUMENT","params":{"action":"list"}}
  result:  success=true, list includes "Quarterly Onboarding Guide (2895df5a-f9a4-53ed-a2e7-540095ca1bd5)"
guest (user_role: ADMIN)  "Delete the Quarterly Onboarding Guide document."
  PLANNER: {"action":"DOCUMENT","params":{"action":"delete","id":"2895df5a-f9a4-53ed-a2e7-540095ca1bd5","title":"Quarterly Onboarding Guide"}}
  result:  success=false, values.error="forbidden", reply "Only the owner can edit or delete global and owner-private documents."
owner (user_role: OWNER)  "What documents do I have stored?"
  PLANNER: {"action":"DOCUMENT","params":{"action":"list","limit":50}}
  result:  success=true — the document SURVIVED the refused non-owner delete
owner (user_role: OWNER)  "Delete that onboarding guide document."
  PLANNER: {"action":"DOCUMENT","params":{"action":"delete","documentId":"2895df5a-…","id":"2895df5a-…","title":"Quarterly Onboarding Guide"}}
  result:  success=true, "Deleted document 2895df5a-f9a4-53ed-a2e7-540095ca1bd5."
final check: service.getDocumentById(2895df5a-…) → null (domain artifact actually gone)
```

Zero `VIEWS`/`agent-fill`/`agent-click` calls in the run (asserted per turn and in final checks).

### Deterministic twins (keyless, strict LLM proxy) — same base

```
| deterministic-document-actions       | passed | 248ms |
| deterministic-settings-voice-actions | passed |  61ms |
Totals: 2 passed, 0 failed, 0 skipped of 2
```

Backend structured logs on the real code path (excerpt from the runner log):

```
Info [SettingsAction] set section=voice key=continuous value=null
Info [SettingsAction] set section=voice key=silence-ms value=null
Info [SettingsAction] set section=voice key=rms value=null
Info [eliza-scenarios] ✓ deterministic-document-actions passed
Info [eliza-scenarios] ✓ deterministic-settings-voice-actions passed
```

Full pr-deterministic lane (40 scenarios, run twice — before and after the core context-description change): **38 passed / 2 failed** both times. Both failures (`deterministic-seeded-fact-recall`, `deterministic-workflow-actions-routes`) reproduce byte-identically on a clean `origin/develop` checkout (`git stash -u` A/B run) and are pre-existing, unrelated breakage.

### Gates
- `deterministic-action-coverage.test.ts`: 17/17 passed (on this exact tree).
- scenario-runner unit suite: 34 files / 278 tests passed.
- `bun run verify` (root typecheck + lint, incl. the diff-scoped test-realness gate): passed, exit 0.
- Core `context-gates` tests: 15/15 passed after the documents-context description change.

### Evidence rows (per repo Definition of Done)
- Video walkthrough: **N/A — headless scenario lane** (no UI surface; the domain artifacts are the loopback ledgers and DB state above).
- Before/after full-page screenshots (desktop + mobile): **N/A — headless scenario lane**.
- Frontend console/network logs: **N/A — headless scenario lane** (the network artifact is the captured loopback request ledger, asserted exactly).
- Real-LLM trajectories: recorded by the scenario runner (`--run-dir` trajectories + run viewer + JSON reports), hand-read; decisive lines quoted verbatim above.
- Live lane: `settings-voice-toggle` is picked up automatically by the nightly `live-scenarios.yml` app-control shard once merged; `live-document-delete` sits beside the other scenario-runner live-only rows (`background-live`, `live-experience-delete-by-topic`). A pre-merge `workflow_dispatch` with `SCENARIO_FILTER` cannot exercise these ids — the filter routes only the EA shard, whose `SCENARIO_ROOT` (`packages/test/scenarios`) does not contain them, and the app-control shard only runs with an empty filter — so the pre-merge live proof is the recorded runs above; the nightly enforcing run covers `settings-voice-toggle` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - headless scenario lane; no UI surface is touched (test scenarios + a prompt-text context description).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - headless scenario lane; no UI surface is touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - headless scenario lane; the user flow is chat turns whose full transcript, planner outputs, and handler replies are quoted verbatim above from the recorded runs.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: structured `[SettingsAction] set section=voice key=…` / `[eliza-scenarios] ✓` runner-log lines quoted in the Deterministic twins section above; full captured runner log from this tree: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-det-both-runner.log (regenerated deterministically by `bun run --cwd packages/scenario-runner test:deterministic:e2e`).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - headless scenario lane; the network artifact is the captured loopback request ledger (PUT /api/config bodies + voice-settings:apply broadcasts), asserted exactly and quoted above.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: live-model trajectories (provider `cli`, `ELIZA_CHAT_VIA_CLI=claude`): [live-voice-trajectories.tar.gz](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-voice-trajectories.tar.gz), [live-document-trajectories.tar.gz](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-document-trajectories.tar.gz); scenario-runner JSON reports: [voice](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-voice-scenario-report.json), [document](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-document-delete-scenario-report.json). Hand-read; decisive planner outputs and Stage-1 `user_role` lines quoted verbatim above. Recorded artifacts: [settings-voice-toggle report — passed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-voice-report.json), [live-document-delete report — passed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-doc-report.json), full native trajectories + run viewer: [voice run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-voice-run.zip) / [document run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-doc-run.zip).
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the exact `PUT /api/config` persisted voice-prefs ledger + `voice-settings:apply` broadcast ledger (quoted above), and the DocumentService store state — document survives the refused non-owner delete (re-list), `getDocumentById → null` after the owner delete. Reports: [voice](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-voice-scenario-report.json), [document](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-document-delete-scenario-report.json), [deterministic twins](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-deterministic-twins-report.json). Recorded in the run reports: [live document run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-live-doc-report.json) / [deterministic twins](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16963-det-both-report.json).


