### PR TITLE
fix: expose exact Cerebras chat latency

### DIFF
--- a/.github/workflows/cerebras-chat-flow-live.yml
+++ b/.github/workflows/cerebras-chat-flow-live.yml
@@ -1,0 +1,124 @@
+name: Cerebras Chat Flow Live
+
+# Manual real-model evidence for the complete local AgentRuntime chat path. The
+# credential stays in the staging environment; reports contain only synthetic
+# prompts, outputs, timing spans, token usage, and provider/cache telemetry.
+on:
+  workflow_dispatch:
+    inputs:
+      samples:
+        description: Measured turns after warmup
+        required: true
+        default: "30"
+        type: choice
+        options:
+          - "10"
+          - "30"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cerebras-chat-flow-live-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  live:
+    name: Gemma 4 31B full runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: staging
+    env:
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      ELIZA_CEREBRAS_CHAT_MODEL: gemma-4-31b
+      ELIZA_CEREBRAS_CHAT_SAMPLES: ${{ inputs.samples }}
+      ELIZA_CEREBRAS_CHAT_WARMUPS: "3"
+      ELIZA_PROVIDER_LATENCY_SAMPLES: ${{ inputs.samples }}
+      ELIZA_PROVIDER_LATENCY_WARMUPS: "3"
+      ELIZA_PROVIDER_LATENCY_REPORT: ${{ github.workspace }}/reports/provider-latency.json
+      ELIZA_CEREBRAS_CHAT_REPORT: ${{ github.workspace }}/reports/cerebras-gemma-4-chat-flow.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Install workspace
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Generate source-mode keyword data
+        run: node packages/shared/scripts/generate-keywords.mjs
+
+      - name: Validate benchmark helpers
+        run: bunx vitest run packages/agent/scripts/cerebras-chat-flow-latency.test.ts --coverage.enabled=false
+
+      - name: Measure every provider in parallel and max-cached
+        run: |
+          mkdir -p reports
+          bun run --cwd packages/core perf:providers > reports/provider-latency.log
+
+      - name: Measure live Cerebras Gemma 4 production chat flow
+        run: bun run --cwd packages/agent perf:cerebras-chat > reports/cerebras-gemma-4-chat-flow.log
+
+      - name: Publish exact latency summary
+        run: |
+          node --input-type=module - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          import { readFileSync } from "node:fs";
+          const chat = JSON.parse(readFileSync(process.env.ELIZA_CEREBRAS_CHAT_REPORT, "utf8"));
+          const providers = JSON.parse(
+            readFileSync(process.env.ELIZA_PROVIDER_LATENCY_REPORT, "utf8"),
+          );
+          const metric = (value) =>
+            `${value.p50} / ${value.p90 ?? "—"} / ${value.p95} ms`;
+          console.log("## Cerebras Gemma 4 31B full AgentRuntime telemetry");
+          console.log("");
+          console.log(`Commit: ${process.env.GITHUB_SHA}`);
+          console.log("");
+          console.log(`Model: \`${chat.model}\``);
+          console.log("");
+          console.log(`Successful live turns: ${chat.samples}/${chat.samples}`);
+          console.log("");
+          console.log("| metric | p50 / p90 / p95 |");
+          console.log("| --- | ---: |");
+          console.log(`| wall | ${metric(chat.wallMs)} |`);
+          console.log(`| TTFT | ${metric(chat.derivedHistograms.timeToFirstTokenMs)} |`);
+          console.log(`| first visible | ${metric(chat.derivedHistograms.timeToFirstVisibleMs)} |`);
+          console.log(`| delivered | ${metric(chat.derivedHistograms.timeToReplyMs)} |`);
+          console.log(`| finalized | ${metric(chat.derivedHistograms.timeToResponseFinalizedMs)} |`);
+          for (const [stage, values] of Object.entries(chat.stageHistograms)) {
+            console.log(`| ${stage} | ${metric(values)} |`);
+          }
+          console.log("");
+          console.log("## Provider composition");
+          console.log("");
+          console.log(`Providers: ${providers.providerCount}`);
+          console.log("");
+          console.log(
+            `Fresh parallel compose p50/p95: ${providers.freshComposeWallMs.p50} / ${providers.freshComposeWallMs.p95} ms`,
+          );
+          console.log("");
+          console.log(
+            `Max-cached compose p50/p95: ${providers.maxCachedComposeWallMs.p50} / ${providers.maxCachedComposeWallMs.p95} ms`,
+          );
+          console.log("");
+          console.log(
+            `Cached providers per sample: ${providers.cachedProvidersPerSample.p50}/${providers.providerCount}`,
+          );
+          NODE
+
+      - name: Upload live telemetry
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cerebras-gemma-4-chat-flow-${{ github.sha }}
+          path: reports/
+          if-no-files-found: error
+          retention-days: 30

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -37,6 +37,7 @@
     "build:mobile": "bun run scripts/build-mobile-bundle.mjs",
     "build:ios-bun": "bun run scripts/build-mobile-bundle.mjs --target=ios",
     "build:ios-jsc": "bun run scripts/build-mobile-bundle.mjs --target=ios-jsc",
+    "perf:cerebras-chat": "bun run scripts/cerebras-chat-flow-latency.ts",
     "verify:mobile-workspace-resolution": "bun run scripts/build-mobile-bundle.mjs --verify-workspace-resolution",
     "build:docker-dist": "bun run build:dist",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/agent/scripts/cerebras-chat-flow-latency.test.ts
+++ b/packages/agent/scripts/cerebras-chat-flow-latency.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Validates the deterministic statistics and proof checks used by the live
+ * Cerebras chat-flow harness; provider execution remains in the live lane.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  distribution,
+  percentile,
+  verifyProofResponse,
+} from "./cerebras-chat-flow-latency";
+
+describe("Cerebras chat-flow latency helpers", () => {
+  it("uses nearest-rank percentiles and reports the full distribution", () => {
+    const samples = [9, 1, 5, 3, 7];
+    expect(
+      percentile(
+        [...samples].sort((a, b) => a - b),
+        95,
+      ),
+    ).toBe(9);
+    expect(distribution(samples)).toEqual({
+      count: 5,
+      min: 1,
+      p50: 5,
+      p90: 9,
+      p95: 9,
+      p99: 9,
+      max: 9,
+      mean: 5,
+    });
+  });
+
+  it("accepts punctuation around a distinct proof and rejects stale output", () => {
+    expect(() =>
+      verifyProofResponse('"SPEED-S-4".', "SPEED-S-4"),
+    ).not.toThrow();
+    expect(() => verifyProofResponse("SPEED-S-3", "SPEED-S-4")).toThrow(
+      "did not contain the requested proof",
+    );
+  });
+});

--- a/packages/agent/scripts/cerebras-chat-flow-latency.ts
+++ b/packages/agent/scripts/cerebras-chat-flow-latency.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env bun
+/**
+ * Measures the complete production chat path against Cerebras Gemma 4 31B.
+ *
+ * A real PGLite-backed AgentRuntime processes every turn through providers,
+ * model routing, streaming, persistence, delivery, and lifecycle events. The
+ * report retains synthetic prompts and outputs so reviewers can verify that
+ * each live response was distinct rather than served by a fabricated fallback.
+ */
+import { randomUUID } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import {
+  buildInferenceTimingDevPayload,
+  ChannelType,
+  createMessageMemory,
+  type InferenceFlowStage,
+  type InferenceHistogramSummary,
+  inferenceTimingRegistry,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { createTestRuntime } from "@elizaos/core/testing";
+import openaiPlugin from "../../../plugins/plugin-openai/index.ts";
+import { generateChatResponse } from "../src/api/chat-routes.ts";
+
+const DEFAULT_MODEL = "gemma-4-31b";
+const DEFAULT_SAMPLES = 30;
+const DEFAULT_WARMUPS = 3;
+
+export interface Distribution {
+  count: number;
+  min: number;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  max: number;
+  mean: number;
+}
+
+function rounded(value: number): number {
+  return Math.round(value * 1_000) / 1_000;
+}
+
+export function percentile(
+  sortedSamples: readonly number[],
+  percent: number,
+): number {
+  if (sortedSamples.length === 0) {
+    throw new Error("Cannot take a percentile of an empty sample");
+  }
+  const rank = Math.ceil((percent / 100) * sortedSamples.length);
+  return sortedSamples[
+    Math.min(sortedSamples.length - 1, Math.max(0, rank - 1))
+  ] as number;
+}
+
+export function distribution(samples: readonly number[]): Distribution {
+  if (samples.length === 0) {
+    throw new Error("Cannot summarize an empty latency sample");
+  }
+  const sorted = [...samples].sort((left, right) => left - right);
+  return {
+    count: sorted.length,
+    min: rounded(sorted[0] as number),
+    p50: rounded(percentile(sorted, 50)),
+    p90: rounded(percentile(sorted, 90)),
+    p95: rounded(percentile(sorted, 95)),
+    p99: rounded(percentile(sorted, 99)),
+    max: rounded(sorted.at(-1) as number),
+    mean: rounded(
+      sorted.reduce((sum, sample) => sum + sample, 0) / sorted.length,
+    ),
+  };
+}
+
+export function verifyProofResponse(response: string, proof: string): void {
+  const normalized = response.toUpperCase().replace(/[^A-Z0-9-]/g, "");
+  if (!normalized.includes(proof.toUpperCase())) {
+    throw new Error(
+      `Live model response did not contain the requested proof ${proof}: ${JSON.stringify(response)}`,
+    );
+  }
+}
+
+function positiveIntegerSetting(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function stageHistograms(
+  flows: ReturnType<typeof buildInferenceTimingDevPayload>["flows"],
+): Partial<Record<InferenceFlowStage, Distribution>> {
+  const samples = new Map<InferenceFlowStage, number[]>();
+  for (const flow of flows) {
+    for (const stage of flow.stages) {
+      const values = samples.get(stage.stage) ?? [];
+      values.push(stage.totalMs);
+      samples.set(stage.stage, values);
+    }
+  }
+  return Object.fromEntries(
+    [...samples.entries()].map(([stage, values]) => [
+      stage,
+      distribution(values),
+    ]),
+  );
+}
+
+function configuredModelEnvironment(model: string): void {
+  process.env.ELIZA_PROVIDER = "cerebras";
+  process.env.CEREBRAS_BASE_URL =
+    process.env.CEREBRAS_BASE_URL?.trim() || "https://api.cerebras.ai/v1";
+  process.env.CEREBRAS_MODEL = model;
+  process.env.CEREBRAS_SMALL_MODEL = model;
+  process.env.CEREBRAS_LARGE_MODEL = model;
+  process.env.ELIZA_INFERENCE_TIMING = "0";
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.CEREBRAS_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("CEREBRAS_API_KEY is required for live latency evidence");
+  }
+  const model = process.env.ELIZA_CEREBRAS_CHAT_MODEL?.trim() || DEFAULT_MODEL;
+  const sampleCount = positiveIntegerSetting(
+    "ELIZA_CEREBRAS_CHAT_SAMPLES",
+    DEFAULT_SAMPLES,
+  );
+  const warmupCount = positiveIntegerSetting(
+    "ELIZA_CEREBRAS_CHAT_WARMUPS",
+    DEFAULT_WARMUPS,
+  );
+  configuredModelEnvironment(model);
+
+  const { runtime, cleanup } = await createTestRuntime({
+    characterName: "CerebrasLatencyAudit",
+    plugins: [openaiPlugin],
+  });
+  try {
+    const worldId = randomUUID() as UUID;
+    const roomId = randomUUID() as UUID;
+    const entityId = randomUUID() as UUID;
+    await runtime.ensureWorldExists({
+      id: worldId,
+      name: "Cerebras latency audit",
+      agentId: runtime.agentId,
+    });
+    await runtime.ensureConnection({
+      entityId,
+      roomId,
+      worldId,
+      worldName: "Cerebras latency audit",
+      userName: "Latency auditor",
+      name: "Latency auditor",
+      source: "cerebras_latency_audit",
+      channelId: roomId,
+      type: ChannelType.DM,
+    });
+    await runtime.ensureParticipantInRoom(runtime.agentId, roomId);
+
+    const runTurn = async (index: number, warmup: boolean) => {
+      const proof = `SPEED-${warmup ? "W" : "S"}-${index}`;
+      const prompt = `Reply with exactly ${proof} and no other text.`;
+      const message = createMessageMemory({
+        id: randomUUID() as UUID,
+        entityId,
+        roomId,
+        content: {
+          text: prompt,
+          source: "client_chat",
+          channelType: ChannelType.DM,
+        },
+      });
+      const streamed: string[] = [];
+      const startedAt = performance.now();
+      const result = await generateChatResponse(
+        runtime,
+        message as Memory,
+        runtime.character.name,
+        {
+          onChunk: (chunk) => {
+            streamed.push(chunk);
+          },
+        },
+      );
+      const wallMs = performance.now() - startedAt;
+      verifyProofResponse(result.text, proof);
+      verifyProofResponse(streamed.join(""), proof);
+      return {
+        index,
+        proof,
+        prompt,
+        output: result.text,
+        wallMs: rounded(wallMs),
+        streamedCharacters: streamed.join("").length,
+        outputCharacters: result.text.length,
+        usage: result.usage,
+        failureKind: result.failureKind ?? null,
+      };
+    };
+
+    for (let index = 0; index < warmupCount; index += 1) {
+      await runTurn(index, true);
+    }
+    inferenceTimingRegistry.reset();
+
+    const turns = [];
+    for (let index = 0; index < sampleCount; index += 1) {
+      turns.push(await runTurn(index, false));
+    }
+    const telemetry = buildInferenceTimingDevPayload(sampleCount);
+    if (telemetry.turns.length !== sampleCount) {
+      throw new Error(
+        `Expected ${sampleCount} timed turns, observed ${telemetry.turns.length}`,
+      );
+    }
+    if (turns.some((turn) => turn.usage.llmCalls !== 1)) {
+      throw new Error(
+        "Every benchmark turn must make exactly one live LLM call",
+      );
+    }
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      runtime: "AgentRuntime + plugin-sql/PGLite + plugin-openai",
+      endpoint: process.env.CEREBRAS_BASE_URL,
+      model,
+      reasoningEffort: "omitted (Gemma 4 has no reasoning-effort control)",
+      embeddingMode:
+        "plugin-openai deterministic local token/bigram feature hashing (Cerebras exposes no embedding endpoint)",
+      execution:
+        "production generateChatResponse path with streaming, persistence, and distinct proof validation",
+      warmups: warmupCount,
+      samples: sampleCount,
+      registeredProviders: runtime.providers.map((provider) => provider.name),
+      wallMs: distribution(turns.map((turn) => turn.wallMs)),
+      stageHistograms: stageHistograms(telemetry.flows),
+      derivedHistograms: telemetry.derivedHistograms satisfies Record<
+        string,
+        InferenceHistogramSummary
+      >,
+      spanHistograms: telemetry.spanHistograms,
+      providerTelemetry: telemetry.providers,
+      turns,
+      inferenceTurns: telemetry.turns,
+      flows: telemetry.flows,
+    };
+    const json = `${JSON.stringify(report, null, 2)}\n`;
+    const reportPath = process.env.ELIZA_CEREBRAS_CHAT_REPORT?.trim();
+    if (reportPath) await writeFile(reportPath, json, "utf8");
+    process.stdout.write(json);
+  } finally {
+    await cleanup();
+  }
+}
+
+// error-policy:J1 CLI boundary translates failure into a non-zero process.
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    process.stderr.write(
+      `Cerebras chat-flow latency audit failed: ${
+        error instanceof Error ? error.stack : String(error)
+      }\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/core/scripts/provider-latency-report.test.ts
+++ b/packages/core/scripts/provider-latency-report.test.ts
@@ -5,6 +5,8 @@
  * established by the operator benchmark rather than this structural gate.
  */
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -25,12 +27,17 @@ describe("provider latency report process", () => {
 			import.meta.dirname,
 			"provider-latency-report.ts",
 		);
+		const reportDirectory = mkdtempSync(
+			path.join(tmpdir(), "provider-latency-report-"),
+		);
+		const reportPath = path.join(reportDirectory, "report.json");
 		const result = spawnSync("bun", [script], {
 			cwd: path.resolve(import.meta.dirname, "../../.."),
 			encoding: "utf8",
 			env: {
 				...process.env,
 				ELIZA_LOG_LEVEL: "fatal",
+				ELIZA_PROVIDER_LATENCY_REPORT: reportPath,
 				ELIZA_PROVIDER_LATENCY_SAMPLES: "1",
 				ELIZA_PROVIDER_LATENCY_WARMUPS: "1",
 			},
@@ -46,6 +53,10 @@ describe("provider latency report process", () => {
 		const report = JSON.parse(
 			result.stdout.slice(jsonStart, jsonEnd + 2),
 		) as ProviderLatencyReport;
+		expect(
+			JSON.parse(readFileSync(reportPath, "utf8")) as ProviderLatencyReport,
+		).toEqual(report);
+		rmSync(reportDirectory, { recursive: true });
 
 		expect(report.samples).toBe(1);
 		expect(report.providerCount).toBeGreaterThanOrEqual(20);

--- a/packages/core/scripts/provider-latency-report.ts
+++ b/packages/core/scripts/provider-latency-report.ts
@@ -8,6 +8,7 @@
  * time and observed concurrency.
  */
 import { randomUUID } from "node:crypto";
+import { writeFile } from "node:fs/promises";
 import {
 	InferenceTurnTimer,
 	runWithInferenceTiming,
@@ -178,7 +179,12 @@ async function main(): Promise<void> {
 			effectiveParallelism: distribution(concurrencySamples),
 			providers,
 		};
-		process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+		const serialized = `${JSON.stringify(output, null, 2)}\n`;
+		const reportPath = process.env.ELIZA_PROVIDER_LATENCY_REPORT;
+		if (reportPath) {
+			await writeFile(reportPath, serialized, "utf8");
+		}
+		process.stdout.write(serialized);
 	} finally {
 		await cleanup();
 	}

--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -119,6 +119,18 @@ describe("exclusive inference flow breakdown", () => {
 					durationMs: 80,
 				},
 				{
+					name: "message:ingress:persistence",
+					startMs: 10,
+					endMs: 15,
+					durationMs: 5,
+				},
+				{
+					name: "message:lifecycle:run-started",
+					startMs: 15,
+					endMs: 20,
+					durationMs: 5,
+				},
+				{
 					name: "composeState",
 					startMs: 20,
 					endMs: 50,
@@ -167,6 +179,18 @@ describe("exclusive inference flow breakdown", () => {
 					durationMs: 2,
 				},
 				{
+					name: "message:delivery:persistence",
+					startMs: 85,
+					endMs: 88,
+					durationMs: 3,
+				},
+				{
+					name: "message:lifecycle:run-ended",
+					startMs: 88,
+					endMs: 90,
+					durationMs: 2,
+				},
+				{
 					name: "chat:response-finalization",
 					startMs: 90,
 					endMs: 95,
@@ -196,7 +220,16 @@ describe("exclusive inference flow breakdown", () => {
 		).toBe(2);
 		expect(
 			flow.stages.find((stage) => stage.stage === "planner-overhead")?.totalMs,
+		).toBeUndefined();
+		expect(
+			flow.stages.find((stage) => stage.stage === "message-ingress")?.totalMs,
 		).toBe(5);
+		expect(
+			flow.stages.find((stage) => stage.stage === "message-delivery")?.totalMs,
+		).toBe(3);
+		expect(
+			flow.stages.find((stage) => stage.stage === "message-lifecycle")?.totalMs,
+		).toBe(7);
 		expect(
 			flow.stages.find((stage) => stage.stage === "unattributed")?.totalMs,
 		).toBe(15);

--- a/packages/core/src/inference-timing.ts
+++ b/packages/core/src/inference-timing.ts
@@ -103,6 +103,9 @@ export const INFERENCE_FLOW_STAGES = [
 	"evaluators",
 	"planner-overhead",
 	"response-finalization",
+	"message-ingress",
+	"message-delivery",
+	"message-lifecycle",
 	"message-service-overhead",
 	"unattributed",
 ] as const;
@@ -136,8 +139,11 @@ const FLOW_STAGE_PRIORITY: readonly InferenceFlowStage[] = [
 	"evaluators",
 	"providers",
 	"document-augmentation",
-	"planner-overhead",
 	"response-finalization",
+	"message-ingress",
+	"message-delivery",
+	"message-lifecycle",
+	"planner-overhead",
 	"message-service-overhead",
 ];
 
@@ -176,6 +182,15 @@ function classifyInferenceSpan(name: string): InferenceFlowStage | null {
 	if (normalized === "message:planner") return "planner-overhead";
 	if (normalized === "chat:response-finalization") {
 		return "response-finalization";
+	}
+	if (normalized.startsWith("message:ingress:")) {
+		return "message-ingress";
+	}
+	if (normalized.startsWith("message:delivery:")) {
+		return "message-delivery";
+	}
+	if (normalized.startsWith("message:lifecycle:")) {
+		return "message-lifecycle";
 	}
 	if (
 		normalized === "chat:message-service" ||

--- a/packages/core/src/services/message.mute-drop.test.ts
+++ b/packages/core/src/services/message.mute-drop.test.ts
@@ -46,6 +46,7 @@ function makeRuntime(seed: {
 		stateCache: new Map(),
 		turnControllers: new TurnControllerRegistry(),
 		emitEvent,
+		reportError: vi.fn(),
 		useModel,
 		getService: () => null,
 		getSetting: () => undefined,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8132,10 +8132,6 @@ export function hasTextGenerationHandler(runtime: IAgentRuntime): boolean {
  * Tracks the latest response ID per agent+room to handle message superseding
  */
 const latestResponseIds = new Map<string, Map<string, string>>();
-// Sub-agent completions emit follow-up evaluators (URL verification, attachment
-// routing, transcript stripping) that legitimately take >5s; 30s gives them
-// room without indefinitely blocking response finalization.
-const DEFAULT_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS = 30_000;
 const INFERENCE_TIMING_LOG_TYPE = "inference_timing";
 const INFERENCE_TIMING_LOG_RETENTION = 4_096;
 const INFERENCE_TIMING_LOG_SWEEP_INTERVAL = 64;
@@ -8226,61 +8222,25 @@ function clearLatestResponseId(
 	}
 }
 
-function resolvePostDeliverySideEffectTimeoutMs(): number {
-	const raw = process.env.ELIZA_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS?.trim();
-	if (!raw) return DEFAULT_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS;
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed <= 0) {
-		return DEFAULT_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS;
-	}
-	return Math.max(100, parsed);
-}
-
 async function runPostDeliverySideEffect(
-	runtime: Pick<IAgentRuntime, "logger" | "agentId">,
+	runtime: Pick<IAgentRuntime, "agentId" | "reportError">,
 	label: string,
 	task: () => Promise<unknown>,
 ): Promise<void> {
-	const timeoutMs = resolvePostDeliverySideEffectTimeoutMs();
-	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 	try {
-		const result = await Promise.race([
-			Promise.resolve()
-				.then(task)
-				.then(() => "completed" as const),
-			new Promise<"timed_out">((resolve) => {
-				timeoutHandle = setTimeout(() => resolve("timed_out"), timeoutMs);
-				(timeoutHandle as { unref?: () => void }).unref?.();
-			}),
-		]);
-		if (result === "timed_out") {
-			runtime.logger.warn(
-				{
-					src: "service:message",
-					agentId: runtime.agentId,
-					label,
-					timeoutMs,
-				},
-				"Post-delivery side effect timed out",
-			);
-		}
+		await task();
 	} catch (err) {
-		runtime.logger.warn(
-			{
-				src: "service:message",
-				agentId: runtime.agentId,
-				label,
-				err: err instanceof Error ? err.message : String(err),
-			},
-			"Post-delivery side effect failed",
-		);
-	} finally {
-		if (timeoutHandle) clearTimeout(timeoutHandle);
+		// error-policy:J1 Detached background-task boundary reports failures
+		// without converting them into a successful user-visible operation.
+		runtime.reportError("MessageService.postDeliverySideEffect", err, {
+			agentId: runtime.agentId,
+			label,
+		});
 	}
 }
 
 function detachPostDeliverySideEffect(
-	runtime: Pick<IAgentRuntime, "logger" | "agentId">,
+	runtime: Pick<IAgentRuntime, "agentId" | "reportError">,
 	label: string,
 	task: () => Promise<unknown>,
 ): void {
@@ -9668,16 +9628,20 @@ export class DefaultMessageService implements IMessageService {
 						});
 
 					// Emit run started event
-					await runtime.emitEvent(EventType.RUN_STARTED, {
-						runtime,
-						source: "messageHandler",
-						runId,
-						messageId: message.id,
-						roomId: message.roomId,
-						entityId: message.entityId,
-						startTime,
-						status: "started",
-					} as RunEventPayload);
+					await runWithInferenceTiming(inferenceTimer, () =>
+						timeInferenceSpan("message:lifecycle:run-started", () =>
+							runtime.emitEvent(EventType.RUN_STARTED, {
+								runtime,
+								source: "messageHandler",
+								runId,
+								messageId: message.id,
+								roomId: message.roomId,
+								entityId: message.entityId,
+								startTime,
+								status: "started",
+							} as RunEventPayload),
+						),
+					);
 
 					const timeoutPromise = new Promise<never>((_, reject) => {
 						timeoutId = setTimeout(async () => {
@@ -9966,48 +9930,58 @@ export class DefaultMessageService implements IMessageService {
 			{ src: "service:message" },
 			"Saving message to memory",
 		);
-		let memoryToQueue: Memory;
+		await timeInferenceSpan("message:ingress:persistence", async () => {
+			let memoryToQueue: Memory;
 
-		// The document augmentation envelope
-		// (`<contextual_documents>...</contextual_documents>` + `<user_request>`)
-		// is a model-facing wrapper added just for this turn's LLM prompt. Persist
-		// and embed the clean user text so the stored memory does not echo raw
-		// wrapper XML back into the user's chat bubble or re-enter context as
-		// history on later turns. `message` (used downstream this turn) keeps its
-		// wrap.
-		const persistableMessage = stripAugmentationForPersistence(message);
+			// The document augmentation envelope
+			// (`<contextual_documents>...</contextual_documents>` + `<user_request>`)
+			// is a model-facing wrapper added just for this turn's LLM prompt. Persist
+			// and embed the clean user text so the stored memory does not echo raw
+			// wrapper XML back into the user's chat bubble or re-enter context as
+			// history on later turns. `message` (used downstream this turn) keeps its
+			// wrap.
+			const persistableMessage = stripAugmentationForPersistence(message);
 
-		if (message.id) {
-			const existingMemory = await runtime.getMemoryById(message.id);
-			if (existingMemory) {
-				runtime.logger.debug(
-					{ src: "service:message" },
-					"Memory already exists, skipping creation",
-				);
-				memoryToQueue = existingMemory;
+			if (message.id) {
+				const existingMemory = await runtime.getMemoryById(message.id);
+				if (existingMemory) {
+					runtime.logger.debug(
+						{ src: "service:message" },
+						"Memory already exists, skipping creation",
+					);
+					memoryToQueue = existingMemory;
+				} else {
+					const createdMemoryId = await runtime.createMemory(
+						persistableMessage,
+						"messages",
+					);
+					memoryToQueue = { ...persistableMessage, id: createdMemoryId };
+				}
+				await runtime.queueEmbeddingGeneration(memoryToQueue, "high");
 			} else {
-				const createdMemoryId = await runtime.createMemory(
+				const memoryId = await runtime.createMemory(
 					persistableMessage,
 					"messages",
 				);
-				memoryToQueue = { ...persistableMessage, id: createdMemoryId };
+				message.id = memoryId;
+				memoryToQueue = { ...persistableMessage, id: memoryId };
+				await runtime.queueEmbeddingGeneration(memoryToQueue, "normal");
 			}
-			await runtime.queueEmbeddingGeneration(memoryToQueue, "high");
-		} else {
-			const memoryId = await runtime.createMemory(
-				persistableMessage,
-				"messages",
-			);
-			message.id = memoryId;
-			memoryToQueue = { ...persistableMessage, id: memoryId };
-			await runtime.queueEmbeddingGeneration(memoryToQueue, "normal");
-		}
+		});
+
+		// Participant state and room are independent reads. Resolving them together
+		// also lets mute evaluation reuse this room instead of fetching it once to
+		// discover the world and again before should-respond routing.
+		const [agentUserState, room] = await Promise.all([
+			timeInferenceSpan("message:ingress:participant-state", () =>
+				runtime.getParticipantUserState(message.roomId, runtime.agentId),
+			),
+			timeInferenceSpan("message:ingress:room", () =>
+				runtime.getRoom(message.roomId),
+			),
+		]);
 
 		// Check if LLM is off by default
-		const agentUserState = await runtime.getParticipantUserState(
-			message.roomId,
-			runtime.agentId,
-		);
 		const defLllmOff = parseBooleanFromText(
 			String(runtime.getSetting("BASIC_CAPABILITIES_DEFLLMOFF") || ""),
 		);
@@ -10036,11 +10010,18 @@ export class DefaultMessageService implements IMessageService {
 			runtime,
 			message,
 		);
-		const muteState = await resolveEffectiveMuteState(runtime, {
-			roomIds: [message.roomId],
-			primaryParticipantState: agentUserState,
-			...(message.worldId ? { worldId: message.worldId } : {}),
-		});
+		const muteState = await timeInferenceSpan(
+			"message:ingress:mute-state",
+			() =>
+				resolveEffectiveMuteState(runtime, {
+					roomIds: [message.roomId],
+					primaryRoom: room,
+					primaryParticipantState: agentUserState,
+					...(message.worldId || room?.worldId
+						? { worldId: message.worldId ?? room?.worldId }
+						: {}),
+				}),
+		);
 		if (muteState.muted) {
 			runtime.logger.debug(
 				{
@@ -10181,15 +10162,12 @@ export class DefaultMessageService implements IMessageService {
 			});
 		}
 
-		// Room context for shouldRespond (fetch before compose so providers see
-		// post-attachment and post-incoming-hook message state).
-		const room = await runtime.getRoom(message.roomId);
-
 		// Process attachments before state composition / incoming hooks
 		if (message.content.attachments && message.content.attachments.length > 0) {
-			message.content.attachments = await this.processAttachments(
-				runtime,
-				message.content.attachments,
+			const attachments = message.content.attachments;
+			message.content.attachments = await timeInferenceSpan(
+				"message:ingress:attachments",
+				() => this.processAttachments(runtime, attachments),
 			);
 			if (message.id) {
 				await runtime.updateMemory({
@@ -10207,13 +10185,15 @@ export class DefaultMessageService implements IMessageService {
 		const preIncomingHookText =
 			typeof message.content?.text === "string" ? message.content.text : "";
 
-		await runtime.applyPipelineHooks(
-			"incoming_before_compose",
-			incomingPipelineHookContext(message, {
-				roomId: message.roomId,
-				responseId,
-				runId,
-			}),
+		await timeInferenceSpan("message:ingress:hooks", () =>
+			runtime.applyPipelineHooks(
+				"incoming_before_compose",
+				incomingPipelineHookContext(message, {
+					roomId: message.roomId,
+					responseId,
+					runId,
+				}),
+			),
 		);
 
 		const postIncomingHookText =
@@ -10243,15 +10223,17 @@ export class DefaultMessageService implements IMessageService {
 		const autonomyMode =
 			typeof metadata?.autonomyMode === "string" ? metadata.autonomyMode : null;
 
-		await runtime.applyPipelineHooks(
-			"pre_should_respond",
-			preShouldRespondPipelineHookContext(message, {
-				roomId: message.roomId,
-				responseId,
-				runId,
-				state,
-				isAutonomous,
-			}),
+		await timeInferenceSpan("message:ingress:pre-respond-hooks", () =>
+			runtime.applyPipelineHooks(
+				"pre_should_respond",
+				preShouldRespondPipelineHookContext(message, {
+					roomId: message.roomId,
+					responseId,
+					runId,
+					state,
+					isAutonomous,
+				}),
+			),
 		);
 
 		let shouldRespondToMessage = true;
@@ -10735,30 +10717,39 @@ export class DefaultMessageService implements IMessageService {
 						{ src: "service:message", memoryId: responseMemory.id },
 						"Saving response to memory",
 					);
-					await runtime.createMemory(responseMemory, "messages");
+					await timeInferenceSpan("message:delivery:persistence", () =>
+						runtime.createMemory(responseMemory, "messages"),
+					);
 
-					await this.emitMessageSent(
-						runtime,
-						responseMemory,
-						message.content.source ?? "messageHandler",
+					await timeInferenceSpan("message:delivery:event", () =>
+						this.emitMessageSent(
+							runtime,
+							responseMemory,
+							message.content.source ?? "messageHandler",
+						),
 					);
 				}
 			}
 
 			if (responseContent) {
+				const deliverableResponseContent = responseContent;
 				if (mode === "simple") {
 					// Keep content hooks and DB write before delivery so the wire
 					// response and stored memory match. Do not put MESSAGE_SENT
 					// handlers or post-turn evaluators before the callback; they are
 					// side effects and must not stall user-visible streaming.
-					await runtime.applyPipelineHooks(
-						"outgoing_before_deliver",
-						outgoingPipelineHookContext(responseContent, {
-							source: "simple",
-							roomId: message.roomId,
-							message,
-							responseId: responseContent.responseId ?? responseMessages[0]?.id,
-						}),
+					await timeInferenceSpan("message:delivery:hooks", () =>
+						runtime.applyPipelineHooks(
+							"outgoing_before_deliver",
+							outgoingPipelineHookContext(deliverableResponseContent, {
+								source: "simple",
+								roomId: message.roomId,
+								message,
+								responseId:
+									deliverableResponseContent.responseId ??
+									responseMessages[0]?.id,
+							}),
+						),
 					);
 					if (responseMessages.length > 0) {
 						for (const responseMemory of responseMessages) {
@@ -10768,9 +10759,7 @@ export class DefaultMessageService implements IMessageService {
 							) {
 								continue;
 							}
-							if (responseContent) {
-								responseMemory.content = responseContent;
-							}
+							responseMemory.content = deliverableResponseContent;
 							if (shouldSkipResponseMemoryPersistence(responseMemory)) {
 								runtime.logger.debug(
 									{ src: "service:message", memoryId: responseMemory.id },
@@ -10782,7 +10771,9 @@ export class DefaultMessageService implements IMessageService {
 								{ src: "service:message", memoryId: responseMemory.id },
 								"Saving response to memory",
 							);
-							await runtime.createMemory(responseMemory, "messages");
+							await timeInferenceSpan("message:delivery:persistence", () =>
+								runtime.createMemory(responseMemory, "messages"),
+							);
 
 							detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
 								this.emitMessageSent(
@@ -10794,10 +10785,10 @@ export class DefaultMessageService implements IMessageService {
 						}
 					}
 					if (callback) {
-						if (responseContent) {
-							await callback(responseContent);
-							markInference(INFERENCE_MARKS.replyDelivered);
-						}
+						await timeInferenceSpan("message:delivery:callback", () =>
+							callback(deliverableResponseContent),
+						);
+						markInference(INFERENCE_MARKS.replyDelivered);
 					}
 				}
 			}
@@ -10862,13 +10853,15 @@ export class DefaultMessageService implements IMessageService {
 				inReplyTo: createUniqueUuid(runtime, message.id),
 			};
 
-			await runtime.applyPipelineHooks(
-				"outgoing_before_deliver",
-				outgoingPipelineHookContext(terminalContent, {
-					source: "excluded",
-					roomId: message.roomId,
-					message,
-				}),
+			await timeInferenceSpan("message:delivery:hooks", () =>
+				runtime.applyPipelineHooks(
+					"outgoing_before_deliver",
+					outgoingPipelineHookContext(terminalContent, {
+						source: "excluded",
+						roomId: message.roomId,
+						message,
+					}),
+				),
 			);
 
 			const terminalMemory: Memory = {
@@ -10879,11 +10872,15 @@ export class DefaultMessageService implements IMessageService {
 				roomId: message.roomId,
 				createdAt: Date.now(),
 			};
-			await runtime.createMemory(terminalMemory, "messages");
-			await this.emitMessageSent(
-				runtime,
-				terminalMemory,
-				message.content.source ?? "messageHandler",
+			await timeInferenceSpan("message:delivery:persistence", () =>
+				runtime.createMemory(terminalMemory, "messages"),
+			);
+			await timeInferenceSpan("message:delivery:event", () =>
+				this.emitMessageSent(
+					runtime,
+					terminalMemory,
+					message.content.source ?? "messageHandler",
+				),
 			);
 			runtime.logger.debug(
 				{ src: "service:message", memoryId: terminalMemory.id },
@@ -10894,7 +10891,9 @@ export class DefaultMessageService implements IMessageService {
 				callback &&
 				!(terminalAction === "IGNORE" && isVoiceChannelMessage(message))
 			) {
-				await callback(terminalContent);
+				await timeInferenceSpan("message:delivery:callback", () =>
+					callback(terminalContent),
+				);
 			}
 		}
 
@@ -10940,14 +10939,21 @@ export class DefaultMessageService implements IMessageService {
 		let roomName = entityName;
 
 		if (!isDM) {
-			const roomDatas = await runtime.getRoomsByIds([message.roomId]);
+			const roomDatas = await timeInferenceSpan(
+				"message:lifecycle:log-context-room",
+				() => runtime.getRoomsByIds([message.roomId]),
+			);
 			if (roomDatas?.length) {
 				const roomData = roomDatas[0];
 				if (roomData.name) {
 					roomName = roomData.name;
 				}
 				if (roomData.worldId) {
-					const worldData = await runtime.getWorld(roomData.worldId);
+					const worldId = roomData.worldId;
+					const worldData = await timeInferenceSpan(
+						"message:lifecycle:log-context-world",
+						() => runtime.getWorld(worldId),
+					);
 					if (worldData) {
 						roomName = `${worldData.name}-${roomName}`;
 					}
@@ -10986,18 +10992,20 @@ export class DefaultMessageService implements IMessageService {
 		};
 
 		// Emit run ended event
-		await runtime.emitEvent(EventType.RUN_ENDED, {
-			runtime,
-			source: "messageHandler",
-			runId,
-			messageId: message.id,
-			roomId: message.roomId,
-			entityId: message.entityId,
-			startTime,
-			status: "completed",
-			endTime: Date.now(),
-			duration: Date.now() - startTime,
-		} as RunEventPayload);
+		await timeInferenceSpan("message:lifecycle:run-ended", () =>
+			runtime.emitEvent(EventType.RUN_ENDED, {
+				runtime,
+				source: "messageHandler",
+				runId,
+				messageId: message.id,
+				roomId: message.roomId,
+				entityId: message.entityId,
+				startTime,
+				status: "completed",
+				endTime: Date.now(),
+				duration: Date.now() - startTime,
+			} as RunEventPayload),
+		);
 
 		return {
 			didRespond,

--- a/packages/core/src/services/message/mute-state.test.ts
+++ b/packages/core/src/services/message/mute-state.test.ts
@@ -99,6 +99,23 @@ describe("resolveEffectiveMuteState", () => {
 		).toEqual({ muted: true, scope: "room", roomId: ROOM_ID });
 	});
 
+	it("reuses a preloaded primary room for room and world mute checks", async () => {
+		const primaryRoom = room(ROOM_ID);
+		const { runtime } = makeRuntime({
+			worlds: [world()],
+		});
+		runtime.getRoom = async () => {
+			throw new Error("primary room must not be fetched again");
+		};
+		expect(
+			await resolveEffectiveMuteState(runtime, {
+				roomIds: [ROOM_ID],
+				primaryRoom,
+				primaryParticipantState: "MUTED",
+			}),
+		).toEqual({ muted: true, scope: "room", roomId: ROOM_ID });
+	});
+
 	it("keeps a timed mute active before its ISO expiry", async () => {
 		const untilIso = new Date(Date.now() + 60_000).toISOString();
 		const { runtime } = makeRuntime({

--- a/packages/core/src/services/message/mute-state.ts
+++ b/packages/core/src/services/message/mute-state.ts
@@ -81,21 +81,22 @@ export function roomMuteActive(
  * inherit the mute (e.g. a Discord thread's parent channel). `worldId` may be
  * passed when the caller already knows it (connectors derive it without a DB
  * read); otherwise it is read from the first room record. Likewise
- * `primaryParticipantState` lets a caller that already fetched the first
- * room's participant state skip the refetch — the message pipeline reads it
- * for its LLM-off check just before this resolver runs.
+ * `primaryRoom` and `primaryParticipantState` let a caller that already fetched
+ * the first room's environment reuse both records — the message pipeline needs
+ * them for should-respond and its LLM-off check immediately around this gate.
  */
 export async function resolveEffectiveMuteState(
 	runtime: IAgentRuntime,
 	args: {
 		roomIds: readonly UUID[];
 		worldId?: UUID;
+		primaryRoom?: Room | null;
 		primaryParticipantState?: ParticipantUserState;
 	},
 	now: number = Date.now(),
 ): Promise<EffectiveMuteState> {
 	let worldId = args.worldId;
-	let primaryRoom: Room | null | undefined;
+	let primaryRoom = args.primaryRoom;
 
 	for (const roomId of args.roomIds) {
 		const state =
@@ -103,7 +104,10 @@ export async function resolveEffectiveMuteState(
 				? args.primaryParticipantState
 				: await runtime.getParticipantUserState(roomId, runtime.agentId);
 		if (state !== "MUTED") continue;
-		const room = await runtime.getRoom(roomId);
+		const room =
+			roomId === args.roomIds[0] && primaryRoom !== undefined
+				? primaryRoom
+				: await runtime.getRoom(roomId);
 		if (roomId === args.roomIds[0]) primaryRoom = room;
 		const untilIso = readMuteUntilIso(
 			room?.metadata as Record<string, unknown> | undefined,


### PR DESCRIPTION
Closes #16957.

## Why

The prior full-flow report left about 50 ms labeled only as
`message-service-overhead`. That residual was too broad to diagnose, and the
existing detached post-delivery helper still contained a 30-second
`Promise.race` that did not cancel its task.

This change makes the remaining local work exact, removes a redundant room
read from the hot path, and adds a reproducible 30-turn live benchmark for the
fast Cerebras `gemma-4-31b` path.

## Runtime changes

- Splits the former message-service residual into exclusive
  `message-ingress`, `message-delivery`, `message-lifecycle`, and true residual
  `message-service-overhead` stages.
- Times incoming persistence, participant/room/mute resolution, attachment
  processing, pipeline hooks, outgoing persistence/events/callbacks, and run
  lifecycle bookkeeping individually.
- Resolves participant state and room concurrently.
- Reuses the preloaded primary room during mute resolution, removing the common
  duplicate room read without regressing timed or room-level mute behavior.
- Removes the 30-second post-delivery `Promise.race`. The task was already
  detached and the race never cancelled it; failures now surface through
  `runtime.reportError`.

## Live Cerebras benchmark

Adds `bun run --cwd packages/agent perf:cerebras-chat`, backed by a real
PGLite `AgentRuntime`, plugin-openai in Cerebras mode, production
`generateChatResponse`, streaming, persistence, delivery, and lifecycle
events.

The benchmark:

- pins `gemma-4-31b`;
- performs 3 warmups and 30 measured turns by default;
- requires a distinct `SPEED-S-N` proof from every final and streamed response;
- requires exactly one live LLM call per turn;
- writes raw prompts/outputs, usage, TTFT, first-visible, delivered/finalized,
  exclusive stage histograms, raw spans/flows, and provider/cache telemetry;
- fails fast when the Cerebras credential is missing;
- adds no artificial 30-second response timeout.

The manual `Cerebras Chat Flow Live` workflow uses the staging
`CEREBRAS_API_KEY`, runs the full-runtime benchmark and all-provider benchmark,
and uploads the exact JSON/log reports. It is intentionally dispatched from
`develop` after merge because new workflow files cannot be manually dispatched
until they exist on the default branch.

## Local all-provider telemetry

Real `AgentRuntime` + plugin-sql/PGLite, all 24 providers selected together,
3 warmups, 30 measured samples:

- fresh parallel compose: p50 **27.474 ms**, p95 **73.493 ms**, max
  **81.494 ms**
- max-cached compose: p50 **0.086 ms**, p95 **0.133 ms**, one isolated max
  **8.126 ms**
- cache coverage: **24/24 providers on every sample**
- effective parallelism: p50 **7.85x**, p95 **10.78x**

The fresh run was captured immediately after a full 253-workspace build and is
CPU/noise sensitive. The clean GitHub runner report will be the comparison
artifact. In this local sample the highest fresh p95 contributors were
ATTACHMENTS 67.384 ms, WORLD 62.498 ms, ACTIONS 55.949 ms, FACTS 39.412 ms,
RECENT_MESSAGES 39.267 ms, and DOCUMENTS 30.050 ms. Their overlap is why the
wall time is far below their sum.

## Validation

- `bun run verify`: **575/575 Turbo tasks passed** on the rebased commit;
  build/typecheck, lint, compiler-model, dependency, secret-leak, script,
  test-realness, and 28/28 dist-path consumer gates passed.
- Focused changed-path suite: **49/49 passed**.
- Core typecheck passed.
- Provider benchmark process test proves all-provider execution, warm cache
  coverage, clean report-file output, and parallelism.
- `actionlint .github/workflows/cerebras-chat-flow-live.yml` passed.
- `git diff --check` passed.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend runtime, benchmark, and telemetry changes only; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend runtime, benchmark, and telemetry changes only; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [16967-provider-latency-final.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16967-provider-latency-final.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend production behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] [16916-full-flow-live-final-v2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16916-full-flow-live-final-v2.json)

<!-- evidence-row:domain-artifacts -->
- [x] [16967-provider-latency-final.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16967-provider-latency-final.json)

