### PR TITLE
fix(ci): actionable checker diagnostics + PR-base-aware test-realness audit

### DIFF
--- a/packages/scripts/__tests__/test-realness-audit.test.ts
+++ b/packages/scripts/__tests__/test-realness-audit.test.ts
@@ -321,12 +321,50 @@ describe("test-realness-audit", () => {
     const result = spawnSync(
       "node",
       [SCRIPT_PATH, "--repo-root", root, "--check"],
-      { encoding: "utf8" },
+      { encoding: "utf8", env: { ...process.env, GITHUB_BASE_REF: "" } },
     );
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("diff-scoped ratchet could not run");
-    expect(result.stderr).toContain("Ensure CI fetches origin/develop");
+    expect(result.stderr).toContain("Ensure CI fetches the PR base branch");
+  });
+
+  test("resolveBaseRef honors GITHUB_BASE_REF over the develop default (#16908)", () => {
+    const root = makeRepo();
+    git(root, "init", "--quiet", "--initial-branch=develop");
+    git(root, "config", "user.email", "audit@test");
+    git(root, "config", "user.name", "audit");
+    write(root, "README.md", "base\n");
+    git(root, "add", "README.md");
+    git(root, "commit", "--quiet", "-m", "init");
+    git(root, "branch", "main");
+
+    // A promotion PR targeting main must diff against main, not develop.
+    expect(audit.resolveBaseRef(root, { GITHUB_BASE_REF: "main" })).toBe(
+      "main",
+    );
+    // Local/push runs (no base ref in the environment) keep the develop default.
+    expect(audit.resolveBaseRef(root, {})).toBe("develop");
+    expect(audit.resolveBaseRef(root, { GITHUB_BASE_REF: "  " })).toBe(
+      "develop",
+    );
+  });
+
+  test("a declared but unfetched base ref skips rather than silently diffing develop (#16908)", () => {
+    const root = makeRepo();
+    git(root, "init", "--quiet", "--initial-branch=develop");
+    git(root, "config", "user.email", "audit@test");
+    git(root, "config", "user.name", "audit");
+    write(root, "README.md", "base\n");
+    git(root, "add", "README.md");
+    git(root, "commit", "--quiet", "-m", "init");
+
+    // GITHUB_BASE_REF names a branch this checkout never fetched: the audit
+    // must return null (reported as a fetch problem in --check) instead of
+    // falling back to develop and producing a wrong-base regression list.
+    expect(
+      audit.resolveBaseRef(root, { GITHUB_BASE_REF: "release/next" }),
+    ).toBeNull();
   });
 
   test("--check rejects a source archive without a verifiable Git index", () => {

--- a/packages/scripts/test-realness-audit.mjs
+++ b/packages/scripts/test-realness-audit.mjs
@@ -624,7 +624,7 @@ export function collectDiffScopedFailures(regressions) {
 export function collectDiffScopedGateFailures(diffScoped) {
   if (diffScoped.skipped) {
     return [
-      `diff-scoped ratchet could not run: ${diffScoped.reason}. Ensure CI fetches origin/develop before running --check.`,
+      `diff-scoped ratchet could not run: ${diffScoped.reason}. Ensure CI fetches the PR base branch (GITHUB_BASE_REF, falling back to origin/develop) before running --check.`,
     ];
   }
   return diffScoped.failures;
@@ -810,8 +810,22 @@ function git(repoRoot, argv, { allowFailure = false } = {}) {
   }
 }
 
-function resolveBaseRef(repoRoot) {
-  const candidates = ["origin/develop", "develop"];
+export function resolveBaseRef(repoRoot, env = process.env) {
+  // The PR's ACTUAL base branch comes first (#16908): GitHub Actions exports
+  // GITHUB_BASE_REF on pull_request events. Hardcoding origin/develop made a
+  // promotion PR to main diff against develop, "changing" every develop-side
+  // test and producing false regression verdicts no promotion PR could avoid.
+  // Same audit semantics, right comparison base — develop stays the fallback
+  // for local runs and push events where GITHUB_BASE_REF is empty.
+  const baseBranch = String(env.GITHUB_BASE_REF ?? "").trim();
+  // When the event declares a base branch, ONLY that branch is a valid
+  // comparison base — falling back to develop would silently reintroduce the
+  // wrong-base diff. An unresolvable declared base returns null, which the
+  // --check path reports as an explicit fetch problem rather than a bogus
+  // regression list.
+  const candidates = baseBranch
+    ? [`origin/${baseBranch}`, baseBranch]
+    : ["origin/develop", "develop"];
   for (const ref of candidates) {
     if (
       git(repoRoot, ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
@@ -856,7 +870,7 @@ function collectBaseFindingsForChangedFiles(repoRoot, base, files) {
 }
 
 function diffScopedCheck(result, repoRoot) {
-  const baseRef = resolveBaseRef(repoRoot);
+  const baseRef = resolveBaseRef(repoRoot, process.env);
   if (!baseRef) {
     return {
       skipped: true,

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -570,6 +570,19 @@ export function runSelfTest() {
   }
 
   {
+    // A body written without ANY template markers (prose-only evidence notes,
+    // the #16925/#16913 failure shape) reports every required row missing —
+    // the CLI layer keys its "template was removed" hint off this shape.
+    const { ok, findings } = evaluatePrEvidence(
+      "Evidence rows: UI/video/frontend N/A - cloud backend latency.",
+    );
+    if (ok) failures.push("marker-free body should fail");
+    if (!findings.every((finding) => finding.status === "missing")) {
+      failures.push("marker-free body should report every row missing");
+    }
+  }
+
+  {
     // An overflow-release (pr-evidence-N) screenshot satisfies a UI-file surface
     // PR identically to a primary-release one — the storage location moved, the
     // gate did not.
@@ -607,7 +620,7 @@ export function runSelfTest() {
     for (const failure of failures) console.error(`  - ${failure}`);
     process.exit(1);
   }
-  console.log("check-pr-evidence self-test passed (13 cases).");
+  console.log("check-pr-evidence self-test passed (14 cases).");
 }
 
 function main() {
@@ -653,6 +666,28 @@ function main() {
 
   if (!allOk) {
     const bad = findings.filter((finding) => finding.status !== "ok");
+    const requiredIds = new Set(REQUIRED_EVIDENCE_ROWS.map(({ id }) => id));
+    const allRequiredMissing = findings
+      .filter((finding) => requiredIds.has(finding.id))
+      .every((finding) => finding.status === "missing");
+    if (allRequiredMissing) {
+      console.error(
+        `\nNO evidence-row markers found in the PR body. The gate locates each row
+by its HTML marker (\`<!-- evidence-row:<id> -->\`) from the PR template —
+prose like "Evidence rows: N/A - backend only" cannot be matched without them.
+This usually means the PR template section was deleted or the body was written
+from scratch.
+
+Fix in one command (uploads/patches rows AND re-adds the missing markers):
+  node scripts/pr-evidence.mjs rows <pr> \\
+    --row before-screenshots="N/A - <reason>" --row after-screenshots="N/A - <reason>" \\
+    --row walkthrough-video="N/A - <reason>" --row backend-logs=<file-or-url> \\
+    --row frontend-logs="N/A - <reason>" --row llm-trajectory="N/A - <reason>" \\
+    --row domain-artifacts="N/A - <reason>"
+Or copy the \`<!-- evidence-row:* -->\` block from .github/pull_request_template.md
+into the PR description and fill each row.`,
+      );
+    }
     console.error(
       `\nEvidence gate FAILED: ${bad.length} row(s) need attention, ${retiredEvidenceFiles.length} retired repo evidence file(s) changed.
 

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -623,6 +623,28 @@ export function runSelfTest() {
   console.log("check-pr-evidence self-test passed (14 cases).");
 }
 
+// The diagnostic for a PR body carrying NONE of the template's evidence-row
+// markers (the #16925/#16913 failure shape). The --row flags are generated
+// from REQUIRED_EVIDENCE_ROWS so the hint can never drift from the rows the
+// gate actually enforces.
+export function markerFreeBodyHint() {
+  const rowFlags = REQUIRED_EVIDENCE_ROWS.map(
+    ({ id }) => `    --row ${id}=<file|url|"N/A - <reason>">`,
+  ).join(" \\\n");
+  return `NO evidence-row markers found in the PR body. The gate locates each row
+by its HTML marker (\`<!-- evidence-row:<id> -->\`) from the PR template —
+prose like "Evidence rows: N/A - backend only" cannot be matched without them.
+This usually means the PR template section was deleted or the body was written
+from scratch.
+
+Fix in one command (uploads/patches rows AND re-adds the missing markers; each
+row takes a local file, an existing URL, or an "N/A - <reason>" string):
+  node scripts/pr-evidence.mjs rows <pr> \\
+${rowFlags}
+Or copy the \`<!-- evidence-row:* -->\` block from .github/pull_request_template.md
+into the PR description and fill each row.`;
+}
+
 function main() {
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
@@ -671,22 +693,7 @@ function main() {
       .filter((finding) => requiredIds.has(finding.id))
       .every((finding) => finding.status === "missing");
     if (allRequiredMissing) {
-      console.error(
-        `\nNO evidence-row markers found in the PR body. The gate locates each row
-by its HTML marker (\`<!-- evidence-row:<id> -->\`) from the PR template —
-prose like "Evidence rows: N/A - backend only" cannot be matched without them.
-This usually means the PR template section was deleted or the body was written
-from scratch.
-
-Fix in one command (uploads/patches rows AND re-adds the missing markers):
-  node scripts/pr-evidence.mjs rows <pr> \\
-    --row before-screenshots="N/A - <reason>" --row after-screenshots="N/A - <reason>" \\
-    --row walkthrough-video="N/A - <reason>" --row backend-logs=<file-or-url> \\
-    --row frontend-logs="N/A - <reason>" --row llm-trajectory="N/A - <reason>" \\
-    --row domain-artifacts="N/A - <reason>"
-Or copy the \`<!-- evidence-row:* -->\` block from .github/pull_request_template.md
-into the PR description and fill each row.`,
-      );
+      console.error(`\n${markerFreeBodyHint()}`);
     }
     console.error(
       `\nEvidence gate FAILED: ${bad.length} row(s) need attention, ${retiredEvidenceFiles.length} retired repo evidence file(s) changed.

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -22,6 +22,7 @@ import {
   isChecked,
   isRowSatisfied,
   isRowSatisfiedForContext,
+  markerFreeBodyHint,
   parseLabels,
   REQUIRED_EVIDENCE_ROWS,
   requiresSurfaceArtifacts,
@@ -222,6 +223,20 @@ describe("check-pr-evidence parser", () => {
     assert.equal(ok, false);
     assert.equal(findings.length, REQUIRED_EVIDENCE_ROWS.length);
     assert.ok(findings.every((finding) => finding.status === "missing"));
+  });
+
+  it("marker-free hint names the marker mechanism and one --row flag per required row", () => {
+    // The hint is the fix instruction shown on the #16925/#16913 shape; a row
+    // list that drifted from REQUIRED_EVIDENCE_ROWS would tell authors to
+    // patch the wrong rows — the exact misdiagnosis class the hint exists to
+    // prevent.
+    const hint = markerFreeBodyHint();
+    assert.match(hint, /NO evidence-row markers found/);
+    assert.match(hint, /<!-- evidence-row:<id> -->/);
+    assert.match(hint, /pr-evidence\.mjs rows/);
+    for (const { id } of REQUIRED_EVIDENCE_ROWS) {
+      assert.ok(hint.includes(`--row ${id}=`), `hint must offer --row ${id}=…`);
+    }
   });
 });
 

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -210,6 +210,19 @@ describe("check-pr-evidence parser", () => {
     assert.equal(ok, false);
     assert.ok(findings.every((finding) => finding.status === "missing"));
   });
+
+  it("reports a prose-only body (template markers deleted) as all-missing", () => {
+    // The #16925/#16913 failure shape: an agent-authored body that talks about
+    // evidence in prose but carries none of the template's HTML markers. The
+    // gate cannot match prose — every required row is missing, and the CLI
+    // keys its "re-add the markers" hint off this exact all-missing shape.
+    const { ok, findings } = evaluatePrEvidence(
+      "Evidence rows: UI/video/frontend `N/A - cloud backend latency`. Backend: 51-test run above.",
+    );
+    assert.equal(ok, false);
+    assert.equal(findings.length, REQUIRED_EVIDENCE_ROWS.length);
+    assert.ok(findings.every((finding) => finding.status === "missing"));
+  });
 });
 
 describe("check-pr-evidence row primitives", () => {

--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -138,8 +138,24 @@ END {
   if (fail && ENVIRON["COVERAGE_GATE_ENFORCE"] == "1") {
     if (missing_count > 0) {
       print "coverage gate FAILED (changed source missing from LCOV)"
+      print ""
+      print "How to fix: a MISSING file was changed by this PR but no changed unit"
+      print "test executed a single line of it. Add or update a Bun/Vitest unit test"
+      print "that imports and exercises the file (the gate only runs tests CHANGED in"
+      print "this PR — pre-existing passing tests do not count). If coverage"
+      print "collection genuinely cannot instrument the file, see"
+      print "scripts/security/coverage-lcov-excluded.txt (reviewed manifest)."
     } else {
       print "coverage gate FAILED (enforcement enabled)"
+      print ""
+      printf "How to fix: every BELOW file needs >=%d%% of its lines executed by the\n", threshold
+      print "unit tests CHANGED in this PR. Extend the changed test file(s) to cover"
+      print "the untested branches of each BELOW file; per-file percentage is the"
+      print "BEST single lane, and complementary hits within the Bun lane are"
+      print "union-merged, so splitting cases across changed test files also works."
+      print "Reproduce locally: run the changed test with"
+      print "  bun test <changed-test> --coverage --coverage-reporter=lcov"
+      print "and inspect the LCOV record for the BELOW file."
     }
     exit 1
   }

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -155,6 +155,10 @@ try {
     assert.match(result.stdout, /100\.00% packages\/demo\/src\/covered\.ts/);
     assert.match(result.stdout, /MISSING: packages\/demo\/src\/missing\.ts/);
     assert.match(result.stdout, /changed source missing from LCOV/);
+    // The MISSING verdict must carry its remediation text — an unexplained
+    // failure is the tooling defect this hint was added to fix.
+    assert.match(result.stdout, /How to fix: a MISSING file was changed/);
+    assert.match(result.stdout, /coverage-lcov-excluded\.txt/);
   });
 
   assertGate("prefers the longest matching changed path", () => {
@@ -292,6 +296,13 @@ try {
         result.stdout,
         /BELOW: packages\/agent\/src\/runtime\/eliza\.ts/,
       );
+      // The BELOW verdict must carry its remediation text, quoting the active
+      // threshold and the changed-tests-only rule.
+      assert.match(
+        result.stdout,
+        /How to fix: every BELOW file needs >=50% of its lines/,
+      );
+      assert.match(result.stdout, /unit tests CHANGED in this PR/);
     },
   );
 


### PR DESCRIPTION
## Why

The "Develop PR Gate" + "check-pr-evidence" + "coverage on changed files" cluster failed every legitimate PR tonight (#16925, #16913, #16924; the first two were merged by human order over the reds). Diagnosis of all six failing runs shows the checks computed the right verdicts but explained them so poorly that authors could not see what to fix, plus one genuine checker bug (#16908). This PR fixes the tooling, never the thresholds.

## Root causes (from the failing run logs)

- **check-pr-evidence** failed #16925/#16913 with seven bare `missing` lines. Both PR bodies discussed evidence in prose ("Evidence rows: UI/video/frontend N/A - cloud backend latency") but deleted the template's `<!-- evidence-row:* -->` HTML markers, which are the only thing the parser can match. Nothing in the output said that.
- **coverage on changed files** failed all three PRs correctly (files below the 50% per-file floor) but never explained that only tests *changed in the PR* are executed, what the floor is, or how to reproduce locally.
- **Develop PR Gate** is a pure aggregate; it was red only because the two component checks above were red. No bug there.
- **audit:test-realness** (#16908) hardcodes `origin/develop` as the diff base, so a promotion PR to `main` sees 48 develop-side test files as "touched" and fails with unavoidable false regression verdicts.

## Changes (scripts only, no workflow YAML, no threshold changes)

1. `scripts/check-pr-evidence.mjs`: when every required row is `missing` (the marker-free body shape), print a dedicated diagnostic explaining the marker mechanism and the exact `pr-evidence.mjs rows` command that re-adds them. Self-test extended to 14 cases; suite extended to 49.
2. `scripts/security/coverage-gate.awk`: BELOW and MISSING failures now print how-to-fix text (changed-tests-only rule, per-file floor, best-lane aggregation, local repro command). Pass/fail criteria byte-identical.
3. `packages/scripts/test-realness-audit.mjs` (#16908): `resolveBaseRef` honors `GITHUB_BASE_REF`; a declared-but-unfetched base skips with an explicit fetch error instead of silently diffing develop; local/push runs keep the develop default. Two new vitest cases.

## Verification (all run locally)

- `node scripts/check-pr-evidence.mjs --self-test` → 14 cases pass
- `node --test scripts/check-pr-evidence.test.mjs` → 49/49
- `node scripts/security/coverage-gate.self-test.mjs` → all cases pass (incl. new-message paths, exit codes unchanged)
- `node scripts/security/coverage-changed-files.self-test.mjs` → pass
- `npx vitest run packages/scripts/__tests__/test-realness-audit.test.ts` → 19/19
- `node packages/scripts/test-realness-audit.mjs --check` on this checkout → exit 0, `diffScoped=checked base=origin/develop`
- Changed-file coverage (same lanes CI runs): check-pr-evidence.mjs **73.08%**, test-realness-audit.mjs **69.33%**, threshold 50% → gate OK
- biome clean on all touched files

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - CI checker scripts, no UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - CI checker scripts, no UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - CLI tooling; behavior fully covered by the 49-case node:test suite + 14-case self-test quoted above`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server involved; the artifact is the local gate runs in the Verification section (self-tests, 19/19 vitest, coverage-gate OK at 73.08%/69.33%)`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend involved`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model/runtime behavior change; CI checker scripts only`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the domain artifacts are the new checker error messages, reproduced verbatim in the linked deliverable and testable via --self-test`

Fixes #16908

[sol-ci-fixer]
