### PR TITLE
perf(cloud): defer shared-tier SSE billing tail off the stream done path

### DIFF
--- a/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
+++ b/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
@@ -141,7 +141,15 @@ describe("agent bridge runtime routing", () => {
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toContain("event: done");
     expect(deadControlPlaneFetch).not.toHaveBeenCalled();
-    expect(bridgeStream).toHaveBeenCalledWith("agent-1", "org-1", rpcRequest);
+    // 4th arg: the Workers executionCtx that defers the shared-turn billing
+    // tail — this fixture has none, so the route degrades to undefined
+    // (inline settlement). Mirrors the bridge (non-stream) assertion above.
+    expect(bridgeStream).toHaveBeenCalledWith(
+      "agent-1",
+      "org-1",
+      rpcRequest,
+      undefined,
+    );
     expect(bridge).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -141,6 +141,17 @@ app.post("/", async (c) => {
   }
 
   const conversationId = c.req.param("conversationId") ?? r.agentId;
+  // Workers only: pass an executionCtx so the shared turn defers its billing
+  // tail off the SSE `done` path via waitUntil. Hono's executionCtx getter
+  // THROWS outside a Worker (tests, Node) — degrade to undefined there so the
+  // turn settles inline, preserving fully-synchronous behavior. Mirrors the
+  // non-stream POST .../messages route.
+  let executionCtx: CanonicalScopedStreamRequest["executionCtx"];
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
   return handleCanonicalScopedAgentStream({
     agentId: r.agentId,
     orgId: r.orgId,
@@ -152,6 +163,7 @@ app.post("/", async (c) => {
       scope: scopeMs,
       body: bodyMs,
     },
+    ...(executionCtx ? { executionCtx } : {}),
   } satisfies CanonicalScopedStreamRequest);
 });
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -130,11 +130,23 @@ async function __hono_POST(
 
     const rpcRequest = parsed.data as BridgeRequest;
 
+    // Workers only: pass an executionCtx so a shared-tier turn defers its
+    // billing tail off the SSE `done` path via waitUntil. Hono's executionCtx
+    // getter THROWS outside a Worker (tests, Node) — degrade to undefined
+    // there so the turn settles inline, preserving synchronous behavior.
+    let executionCtx: Parameters<typeof elizaSandboxService.bridgeStream>[3];
+    try {
+      executionCtx = _ctx?.executionCtx;
+    } catch {
+      executionCtx = undefined;
+    }
+
     // Get the raw SSE stream from the sandbox
     const upstreamResponse = await elizaSandboxService.bridgeStream(
       agentId,
       user.organization_id,
       rpcRequest,
+      executionCtx,
     );
 
     if (!upstreamResponse?.body) {

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
@@ -196,6 +196,56 @@ describe("bridgeSharedMessageStream — billing tail deferred via executionCtx.w
     expect(reconcileCalls).toEqual([0.0042]);
   });
 
+  test("client cancel between last token and `done` frame never refunds a delivered turn", async () => {
+    reset();
+    // Gate the parts iterator between the text-delta and the finish part so the
+    // test can cancel the response stream while the turn is still "delivering".
+    let releaseFinish: (() => void) | undefined;
+    const finishGate = new Promise<void>((resolve) => {
+      releaseFinish = resolve;
+    });
+    streamTurnImpl = () => ({
+      model: "openai/gpt-oss-120b",
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta", text: "hi there" } as const;
+        await finishGate;
+        yield { type: "finish", text: "hi there" } as const;
+      })(),
+    });
+    // Gate billUsage so the deferred tail provably cannot settle before the
+    // stream's catch runs — pre-fix, the catch's settle(0) always won this race.
+    let releaseBill: (() => void) | undefined;
+    const billGate = new Promise<void>((resolve) => {
+      releaseBill = resolve;
+    });
+    billUsageImpl = async () => {
+      await billGate;
+      return { totalCost: 0.0042 };
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+    await reader.read(); // the chunk frame
+    await reader.cancel(); // client disconnects; the later `done` enqueue throws
+    releaseFinish?.();
+
+    // Let the start() continuation run: history persists, the tail registers,
+    // the `done` enqueue throws into the stream catch.
+    while (ctx.captured.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    releaseBill?.();
+    await ctx.captured[0];
+
+    // The reply was fully generated and persisted — the hold must settle at the
+    // billed cost exactly once, never refund via the stream catch.
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
   test("nav-intent turn refunds synchronously and never touches waitUntil", async () => {
     reset();
     streamTurnImpl = () => ({

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Deferred billing-tail proof for the SHARED-runtime SSE stream turn.
+ *
+ * bridgeSharedMessageStream emits the `done` SSE frame as soon as the last
+ * token arrived and history persisted; the billing tail (billUsage →
+ * settleReservation → analytics → audit, ~4 serial cross-region Worker→DB
+ * round-trips ≈ 1.5-2s) runs via executionCtx.waitUntil OFF the stream path —
+ * the same #8759 deferral the non-stream send already has. These tests drive
+ * the REAL bridgeSharedMessageStream against a spy reservation and a capturing
+ * waitUntil to prove the money invariants survive the deferral:
+ *   (a) the `done` frame flushes while billUsage is still in flight,
+ *   (b) the deferred task still settles the hold at billing.totalCost,
+ *   (c) a billUsage throw still refunds the hold (reconcile(0)) — deferred,
+ *   (d) without an executionCtx the tail runs inline (pre-deferral behavior),
+ *   (e) a nav-intent turn refunds synchronously and never uses waitUntil.
+ */
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { describe, expect, mock, test } from "bun:test";
+
+const aiBillingActual = await import("../ai-billing");
+const runTurnActual = await import("../shared-runtime/run-shared-agent-turn");
+
+import type { SharedAgentTurnStreamPart } from "../shared-runtime/run-shared-agent-turn";
+
+// A reservation whose reconcile() records every settle amount.
+const reconcileCalls: number[] = [];
+const makeReservation = () => ({
+  reservedAmount: 0.01,
+  reconcile: mock(async (actualCost: number) => {
+    reconcileCalls.push(actualCost);
+    return null;
+  }),
+});
+let reservation = makeReservation();
+
+function makeParts(finalText: string): AsyncIterable<SharedAgentTurnStreamPart> {
+  return (async function* () {
+    yield { type: "text-delta", text: finalText } as const;
+    yield { type: "finish", text: finalText } as const;
+  })();
+}
+
+// Controllable seams: the stream turn result and the billUsage behavior.
+let streamTurnImpl: () => unknown = () => ({
+  model: "openai/gpt-oss-120b",
+  degraded: false,
+  parts: makeParts("hi there"),
+});
+let billUsageImpl: () => Promise<{ totalCost: number }> = async () => ({ totalCost: 0.0042 });
+
+mock.module("../ai-billing", () => ({
+  ...aiBillingActual,
+  reserveCredits: mock(async () => reservation),
+  billUsage: mock(async () => billUsageImpl()),
+  recordUsageAnalytics: mock(async () => null),
+}));
+
+mock.module("../shared-runtime/run-shared-agent-turn", () => ({
+  ...runTurnActual,
+  // Keep the model billable so a reservation is actually taken.
+  resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
+  runSharedAgentTurnStream: mock(async () => streamTurnImpl()),
+}));
+
+const { ElizaSandboxService } = await import("../eliza-sandbox");
+
+type StreamCallable = {
+  bridgeSharedMessageStream: (
+    rec: Record<string, unknown>,
+    rpc: { jsonrpc: string; id: number; method: string; params: { text: string } },
+    executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+  ) => Promise<Response>;
+  buildSharedRuntimeCharacter: (...args: unknown[]) => Promise<unknown>;
+  loadSharedRuntimeHistory: (...args: unknown[]) => Promise<unknown>;
+  saveSharedRuntimeHistory: (...args: unknown[]) => Promise<unknown>;
+};
+
+function makeService(): StreamCallable {
+  const svc = new ElizaSandboxService() as unknown as StreamCallable;
+  // Private seams the turn path calls before/after runSharedAgentTurnStream.
+  svc.buildSharedRuntimeCharacter = mock(async () => ({
+    name: "Eliza",
+    model: "openai/gpt-oss-120b",
+    system: "",
+    bio: [],
+  })) as never;
+  svc.loadSharedRuntimeHistory = mock(async () => []) as never;
+  svc.saveSharedRuntimeHistory = mock(async () => undefined) as never;
+  return svc;
+}
+
+/** executionCtx spy that captures every promise handed to waitUntil. */
+function makeExecutionCtx() {
+  const captured: Promise<unknown>[] = [];
+  return {
+    captured,
+    waitUntil: (p: Promise<unknown>) => {
+      captured.push(p);
+    },
+  };
+}
+
+async function drainSse(response: Response): Promise<string> {
+  return await response.text();
+}
+
+function reset() {
+  reconcileCalls.length = 0;
+  reservation = makeReservation();
+  streamTurnImpl = () => ({
+    model: "openai/gpt-oss-120b",
+    degraded: false,
+    parts: makeParts("hi there"),
+  });
+  billUsageImpl = async () => ({ totalCost: 0.0042 });
+}
+
+const REC = {
+  id: "00000000-0000-4000-8000-00000000c1e0",
+  organization_id: "00000000-0000-4000-8000-00000000c1e1",
+  user_id: "00000000-0000-4000-8000-00000000c1e2",
+  execution_tier: "shared",
+  agent_name: "Eliza",
+};
+const RPC = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "message.send",
+  params: { text: "hello" },
+};
+
+describe("bridgeSharedMessageStream — billing tail deferred via executionCtx.waitUntil", () => {
+  test("`done` frame flushes BEFORE the billing tail; deferred task settles at billing.totalCost", async () => {
+    reset();
+    // Gate billUsage so we can prove the stream completed without waiting on it.
+    let releaseBill: (() => void) | undefined;
+    const billGate = new Promise<void>((resolve) => {
+      releaseBill = resolve;
+    });
+    billUsageImpl = async () => {
+      await billGate;
+      return { totalCost: 0.0042 };
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    // (a) the full SSE body (including `done`) drains while billUsage is still
+    // blocked on the gate — the stream never awaited the billing tail.
+    const body = await drainSse(response);
+    expect(body).toContain("event: done");
+    expect(body).toContain("hi there");
+    expect(ctx.captured).toHaveLength(1);
+    expect(reservation.reconcile).not.toHaveBeenCalled();
+
+    // (b) the deferred task still settles the hold, at the billed cost.
+    releaseBill?.();
+    await ctx.captured[0];
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
+  test("billUsage throwing in the deferred task refunds the hold (reconcile(0)) without failing the stream", async () => {
+    reset();
+    billUsageImpl = async () => {
+      throw new Error("cross-region billing write failed");
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    const body = await drainSse(response);
+    expect(body).toContain("event: done");
+    expect(ctx.captured).toHaveLength(1);
+
+    // The waitUntil promise must resolve (never reject — Workers would log an
+    // unhandled rejection) and must have refunded the hold exactly once.
+    await ctx.captured[0];
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0]);
+  });
+
+  test("without an executionCtx the tail runs inline: settled by the time the stream drains", async () => {
+    reset();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC);
+    const body = await drainSse(response);
+    expect(body).toContain("event: done");
+    // Pre-deferral behavior preserved for tests / non-Worker callers.
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
+  test("nav-intent turn refunds synchronously and never touches waitUntil", async () => {
+    reset();
+    streamTurnImpl = () => ({
+      model: "nav-intent",
+      degraded: false,
+      parts: makeParts("Opening settings."),
+      navIntent: {
+        viewId: "settings",
+        label: "Settings",
+        reply: "Opening settings.",
+      },
+    });
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    await drainSse(response);
+    expect(ctx.captured).toHaveLength(0);
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2819,6 +2819,14 @@ export class ElizaSandboxService {
         start: async (controller) => {
           let reply = "";
           let finished = false;
+          // Once the billing tail is registered it owns settlement end-to-end
+          // (success settles at totalCost, failure refunds). The stream catch
+          // below must then leave the reservation alone: a client cancel makes
+          // the `done` enqueue throw AFTER registration, and racing a
+          // settle(0) against the deferred tail's settle(totalCost) would turn
+          // a fully-delivered, persisted reply into an unbilled one depending
+          // on which write lands first.
+          let billingTailOwnsSettlement = false;
           try {
             for await (const part of parts) {
               if (part.type === "text-delta") {
@@ -2866,6 +2874,7 @@ export class ElizaSandboxService {
                 // contained and logged (never an unhandled waitUntil rejection)
                 // — the #11169 sweep-credit-reservations cron backstops a hold
                 // stranded by a dropped waitUntil or a failed refund.
+                billingTailOwnsSettlement = true;
                 await settleOffResponsePath(executionCtx, async () => {
                   try {
                     const billing = await billUsage(
@@ -2949,8 +2958,12 @@ export class ElizaSandboxService {
             }
           } catch (error) {
             // error-policy:J1 stream boundary translation — partial SSE streams
-            // cannot become HTTP errors, so emit a terminal error frame.
-            await settleReservation(0);
+            // cannot become HTTP errors, so emit a terminal error frame. The
+            // refund only runs while the reservation is still this scope's to
+            // settle — once the billing tail is registered it owns the hold.
+            if (!billingTailOwnsSettlement) {
+              await settleReservation(0);
+            }
             logger.warn("[shared-runtime] stream failed", {
               error: error instanceof Error ? error.message : String(error),
               agentId: rec.id,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2737,6 +2737,7 @@ export class ElizaSandboxService {
   private async bridgeSharedMessageStream(
     rec: AgentSandbox,
     rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
   ): Promise<Response> {
     const params = rpc.params && typeof rpc.params === "object" ? rpc.params : {};
     const text = typeof params.text === "string" ? params.text : "";
@@ -2850,46 +2851,78 @@ export class ElizaSandboxService {
               if (turn.navIntent) {
                 await settleReservation(0);
               } else if (billingContext) {
-                try {
-                  const billing = await billUsage(
-                    billingContext,
-                    this.sharedRuntimeBillingUsageForReply(
-                      finalReply,
-                      part.usage,
-                      estimatedInputTokens,
-                    ),
-                  );
-                  const settlement = await settleReservation(billing.totalCost);
-                  const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-                    type: "chat",
-                    content: finalReply,
-                    prompt: text,
-                  });
-                  if (usageRecord) {
-                    await aiBillingRecordsService
-                      .record({
-                        context: billingContext,
-                        billing,
-                        usageRecord,
-                        idempotencyKey,
-                        reconciliation: settlement,
-                      })
-                      .catch((error) => {
-                        logger.error("[shared-runtime] AI billing audit record failed", {
-                          error: error instanceof Error ? error.message : String(error),
-                          agentId: rec.id,
+                // The reply is final once the last token arrived and history
+                // persisted, but the billing tail (billUsage → settleReservation
+                // → analytics → audit) is ~4 serial cross-region Worker→DB
+                // round-trips (~1.5-2s) that previously ran INLINE before the
+                // `done` SSE frame — the exact firstText≈1.4s / done≈4s gap
+                // measured on staging. Same deferral the non-stream send got
+                // (#8759 / settleOffResponsePath): on a Worker the tail runs via
+                // executionCtx.waitUntil OFF the `done` path; without an
+                // executionCtx (tests, non-Worker callers) it runs inline,
+                // exactly as before. The deferred task ALWAYS settles the hold:
+                // success settles at billing.totalCost, any failure refunds via
+                // the idempotent settleReservation(0), and a refund throw is
+                // contained and logged (never an unhandled waitUntil rejection)
+                // — the #11169 sweep-credit-reservations cron backstops a hold
+                // stranded by a dropped waitUntil or a failed refund.
+                await settleOffResponsePath(executionCtx, async () => {
+                  try {
+                    const billing = await billUsage(
+                      billingContext,
+                      this.sharedRuntimeBillingUsageForReply(
+                        finalReply,
+                        part.usage,
+                        estimatedInputTokens,
+                      ),
+                    );
+                    const settlement = await settleReservation(billing.totalCost);
+                    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
+                      type: "chat",
+                      content: finalReply,
+                      prompt: text,
+                    });
+                    if (usageRecord) {
+                      await aiBillingRecordsService
+                        .record({
+                          context: billingContext,
+                          billing,
+                          usageRecord,
+                          idempotencyKey,
+                          reconciliation: settlement,
+                        })
+                        .catch((error) => {
+                          logger.error("[shared-runtime] AI billing audit record failed", {
+                            error: error instanceof Error ? error.message : String(error),
+                            agentId: rec.id,
+                          });
                         });
-                      });
+                    }
+                  } catch (error) {
+                    // error-policy:J1 deferred-settlement boundary — the `done`
+                    // frame may already be flushed, so the refund is the
+                    // handling: settle(0) is idempotent, and a refund failure is
+                    // logged for the cron sweep.
+                    try {
+                      await settleReservation(0);
+                    } catch (refundError) {
+                      logger.error(
+                        "[shared-runtime] deferred billing refund failed; sweep-credit-reservations will reclaim the hold",
+                        {
+                          error:
+                            refundError instanceof Error
+                              ? refundError.message
+                              : String(refundError),
+                          agentId: rec.id,
+                        },
+                      );
+                    }
+                    logger.error("[shared-runtime] billing failed", {
+                      error: error instanceof Error ? error.message : String(error),
+                      agentId: rec.id,
+                    });
                   }
-                } catch (error) {
-                  // error-policy:J1 billing boundary translation — the user got
-                  // the reply, but a failed meter write must release the hold.
-                  await settleReservation(0);
-                  logger.error("[shared-runtime] billing failed", {
-                    error: error instanceof Error ? error.message : String(error),
-                    agentId: rec.id,
-                  });
-                }
+                });
               }
               // Attach a VIEWS navigation handoff for a deterministic nav turn so
               // the PWA opens the view (findViewActionHandoff → navigate event in
@@ -4251,7 +4284,12 @@ export class ElizaSandboxService {
     }
   }
 
-  async bridgeStream(agentId: string, orgId: string, rpc: BridgeRequest): Promise<Response | null> {
+  async bridgeStream(
+    agentId: string,
+    orgId: string,
+    rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
+  ): Promise<Response | null> {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec) {
       logger.warn("[agent-sandbox] Bridge stream to non-running sandbox", {
@@ -4266,7 +4304,7 @@ export class ElizaSandboxService {
     const fallbackText = this.buildBridgeNoReplyFallbackText(params);
 
     if (rec.execution_tier === "shared") {
-      const response = await this.bridgeSharedMessageStream(rec, rpc);
+      const response = await this.bridgeSharedMessageStream(rec, rpc, executionCtx);
       return response ?? (fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null);
     }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical scoped SSE handler — executionCtx threading contract.
+ *
+ * The shared-tier billing-tail deferral (#8759 pattern for the SSE path) only
+ * works if the Worker executionCtx handed to handleCanonicalScopedAgentStream
+ * actually reaches elizaSandboxService.bridgeStream — dropping the parameter
+ * anywhere along the chain silently reverts every turn to inline billing with
+ * no failing behavior. These tests drive the REAL handler against a captured
+ * bridgeStream to pin the pass-through (and its absence for non-Worker
+ * callers, who must keep the inline-settle behavior).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const bridgeStream = mock(
+  async (
+    _agentId: string,
+    _orgId: string,
+    _rpc: unknown,
+    _executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+  ): Promise<Response | null> =>
+    new Response("event: done\ndata: {}\n\n", {
+      headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+    }),
+);
+
+mock.module("../eliza-sandbox", () => ({
+  elizaSandboxService: { bridgeStream },
+}));
+
+const { handleCanonicalScopedAgentStream } = await import("./canonical-scoped-stream");
+
+const BASE = {
+  agentId: "00000000-0000-4000-8000-00000000a9e0",
+  orgId: "00000000-0000-4000-8000-00000000a9e1",
+  conversationId: "00000000-0000-4000-8000-00000000a9e2",
+  body: { text: "hello" },
+};
+
+describe("handleCanonicalScopedAgentStream — executionCtx threading", () => {
+  test("threads the caller's executionCtx to bridgeStream (deferral seam)", async () => {
+    bridgeStream.mockClear();
+    const executionCtx = { waitUntil: (_p: Promise<unknown>) => undefined };
+
+    const res = await handleCanonicalScopedAgentStream({ ...BASE, executionCtx });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    const call = bridgeStream.mock.calls[0];
+    expect(call?.[0]).toBe(BASE.agentId);
+    expect(call?.[1]).toBe(BASE.orgId);
+    // The SAME executionCtx object must arrive as the 4th argument — the
+    // shared-tier turn hands its billing tail to exactly this waitUntil.
+    expect(call?.[3]).toBe(executionCtx);
+  });
+
+  test("no executionCtx (tests, non-Worker callers): bridgeStream receives undefined", async () => {
+    bridgeStream.mockClear();
+
+    const res = await handleCanonicalScopedAgentStream({ ...BASE });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    expect(bridgeStream.mock.calls[0]?.[3]).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -7,7 +7,7 @@
 
 import { InsufficientCreditsError } from "../../api/errors";
 import { logger } from "../../utils/logger";
-import type { BridgeRequest } from "../eliza-sandbox";
+import type { BridgeExecutionContext, BridgeRequest } from "../eliza-sandbox";
 import { elizaSandboxService } from "../eliza-sandbox";
 import { applyCorsHeaders } from "../proxy/cors";
 
@@ -27,6 +27,12 @@ export interface CanonicalScopedStreamRequest {
   body: unknown;
   origin?: string | null;
   timings?: Record<string, number>;
+  /**
+   * Workers only: lets the shared-tier turn defer its billing tail off the
+   * SSE `done` path via executionCtx.waitUntil (see bridgeSharedMessageStream).
+   * Absent (tests, non-Worker callers) the tail settles inline as before.
+   */
+  executionCtx?: BridgeExecutionContext;
 }
 
 function nowMs(): number {
@@ -90,7 +96,12 @@ export async function handleCanonicalScopedAgentStream(
   let upstream: Response | null;
   const bridgeStartedAt = nowMs();
   try {
-    upstream = await elizaSandboxService.bridgeStream(request.agentId, request.orgId, rpc);
+    upstream = await elizaSandboxService.bridgeStream(
+      request.agentId,
+      request.orgId,
+      rpc,
+      request.executionCtx,
+    );
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {
     timings.bridge = elapsedMs(bridgeStartedAt);


### PR DESCRIPTION
## Why

Cloud chat still feels 2-3s. Measured the DB geometry + per-turn round-trips:

**Geometry (measured 2026-07-23):**
- Railway PG origin: us-west (Railway proxy `switchback.proxy.rlwy.net`, SF/us-west region, PG 18.4)
- Worker: Cloudflare (staging worker placement seen at ORD; prod has smart placement)
- Per-query RTT from a cross-region client on an ESTABLISHED connection: **~162ms** (10x `SELECT 1`, 162-179ms). Worker(ORD)->Hyperdrive->Railway(us-west) per-query RTT is the same order: every serial DB round-trip on the turn path costs real wall-clock.

**Per-turn DB timeline for a shared-tier SSE chat turn (the PWA hot path):**

| # | Query | Serial/parallel | When |
|---|---|---|---|
| 1 | scope resolve (auth+org+agent) | serial | pre-turn (KV scope cache #COLDPATH already absorbs warm case) |
| 2 | `findRunningSandbox` | serial | bridgeStream |
| 3 | character lookup + history read | **parallel** (Promise.all) | pre-model |
| 4 | `reserveCredits` (atomic CTE: FOR UPDATE + insert) | serial | pre-model |
| 5 | model inference (Cerebras) | — | ~1-2.5s |
| 6 | history upsert | serial | post-last-token |
| 7 | `billUsage` -> calculateCost (pricing read, in-memory cached) | serial | **was inline before `done`** |
| 8 | `reservation.reconcile` (settlement lookup + UPDATE + refund txn, in a write txn) | serial | **was inline before `done`** |
| 9 | `recordUsageAnalytics` (usage_records insert, staging mean 4.6ms exec + RTT) | serial | **was inline before `done`** |
| 10 | `aiBillingRecords.record` (audit insert) | serial | **was inline before `done`** |

Steps 7-10 are ~4+ serial cross-region round-trips ≈ **1.5-2s of pure RTT after the reply text is already final**. That matches the staging measurement (CHAT-LATENCY-MEASURE-2026-07-22): firstText ~1.4-1.7s but `done` ~4-4.8s.

The **non-stream** send already fixed this exact shape with `settleOffResponsePath` + `executionCtx.waitUntil` (#8759 pattern; see the existing deferred-billing tests). The SSE stream path — which is what the PWA actually uses — never got it.

## What

- `bridgeSharedMessageStream` / `bridgeStream` accept an optional `BridgeExecutionContext`; the billing tail (billUsage -> settle -> analytics -> audit) runs via `settleOffResponsePath`: deferred through `waitUntil` on a Worker, inline (byte-identical behavior) without one.
- `canonical-scoped-stream` threads an optional `executionCtx` to `bridgeStream` (voice + REST SSE both route through it).
- Both HTTP SSE routes pass their Worker executionCtx with the same throw-safe degrade the non-stream route uses.

## Money invariants (tested against the REAL `bridgeSharedMessageStream`)

- `done` frame flushes while billUsage is still in flight; the deferred task settles the hold at `billing.totalCost`.
- A billUsage throw refunds the hold (idempotent `reconcile(0)`), contained so waitUntil never sees an unhandled rejection.
- No executionCtx -> tail runs inline, settled by the time the stream drains (pre-deferral behavior for tests/non-Worker callers).
- Nav-intent turns still refund synchronously, never touch waitUntil.
- `sweep-credit-reservations` cron remains the backstop for a dropped waitUntil.

## Expected impact

~1.5-2s off every shared-tier chat turn's `done` latency. First-token timing unchanged; the socket now closes when the reply does instead of after the billing writes.

## Tests

- NEW `eliza-sandbox-shared-stream-deferred-billing.test.ts` (4 tests, mirrors the non-stream deferral proof)
- Existing `eliza-sandbox-shared-turn-deferred-billing` + `-refund` suites: pass
- `shared-agent-messages-stream.test.ts` (route pass-through contract): 18 pass
- `tsc --noEmit` clean for cloud/shared + cloud/api; biome clean

[sol-db-rtt]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only billing-path change in cloud Worker code; no UI surface modified

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only billing-path change in cloud Worker code; no UI surface modified

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only; the observable behavior is SSE frame timing vs billing settlement, proven by the attached timeline transcript and test logs

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no client change; the SSE frame contract (chunk/done payloads and order) is byte-identical to before

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/model/action behavior change; the model call is untouched — only the post-reply billing tail moves off the done path

<!-- evidence-row:backend-logs -->
- [x] [16976-backend-test-logs.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16976-backend-test-logs.log)

<!-- evidence-row:domain-artifacts -->
- [x] [16976-domain-artifact-stream-billing-timeline.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16976-domain-artifact-stream-billing-timeline.log)
