### PR TITLE
feat(cloud): push character onto claimed warm-pool container at claim time

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-provision-warm-pool-character-push.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-provision-warm-pool-character-push.test.ts
@@ -1,0 +1,252 @@
+/**
+ * POST /api/v1/eliza/agents/[agentId]/provision — warm-pool post-claim
+ * character push (the SECOND claim site; the create-route site is pinned by
+ * eliza-agents-warm-pool-character-push.test.ts).
+ *
+ * A pool container boots GENERIC (no ELIZA_AGENT_CHARACTER_JSON), so after a
+ * successful `claimWarmContainer` the provision route pushes the user's
+ * character onto the RUNNING container before responding. This pins the same
+ * contract at this site:
+ *   - a successful claim invokes the push with the claimed row and responds
+ *     200 source=warm_pool;
+ *   - a push FAILURE does not fail the claim — still 200 source=warm_pool, no
+ *     cold job enqueued, and the stable `warm_pool.character_push_failed`
+ *     event carries error context;
+ *   - a claim fallthrough (null) never invokes the push and degrades to the
+ *     202 async job path.
+ *
+ * Mocks only the module boundaries the handler imports; the route logic is
+ * real. Harness modeled on eliza-agents-warm-pool-character-push.test.ts.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+}));
+
+const getAgentForWrite = mock(async (): Promise<unknown> => null);
+const provision = mock(async () => ({ success: false, error: "unused" }));
+const pushClaimedWarmContainerCharacter = mock(
+  async (_rec: Record<string, unknown>) =>
+    ({ pushed: true, agentName: "alpha" }) as {
+      pushed: boolean;
+      agentName?: string;
+    },
+);
+
+const enqueueAgentProvisionOnce = mock(async () => ({
+  job: {
+    id: "job-1",
+    status: "pending",
+    estimated_completion_at: new Date("2026-07-23T00:01:30.000Z"),
+  },
+  created: true,
+}));
+const triggerImmediate = mock(async () => undefined);
+
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 100,
+}));
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+
+type LoggerMeta = {
+  event?: string;
+  agentId?: string;
+  orgId?: string;
+  error?: string;
+};
+const loggerInfo = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+const loggerWarn = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+const loggerError = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+
+const claimWarmContainer = mock(async (): Promise<unknown> => null);
+const countReadyPoolEntriesForImage = mock(async () => 0);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    claimWarmContainer,
+    countReadyPoolEntriesForImage,
+  },
+}));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    getAgentForWrite,
+    provision,
+    pushClaimedWarmContainerCharacter,
+  },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvisionOnce, triggerImmediate },
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: (h: { code?: string }) => ({
+    success: false,
+    code: h.code ?? "worker_unavailable",
+  }),
+}));
+
+mock.module("@/lib/security/outbound-url", () => ({
+  assertSafeOutboundUrl: mock(async () => undefined),
+}));
+
+mock.module("@/lib/config/containers-env", () => ({
+  containersEnv: {
+    warmPoolEnabled: () => true,
+    defaultAgentImage: () => "ghcr.io/example/agent:pinned",
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: loggerInfo, warn: loggerWarn, error: loggerError },
+}));
+
+const { default: provisionRoute } = await import(
+  "../v1/eliza/agents/[agentId]/provision/route"
+);
+
+const app = new Hono();
+app.route("/api/v1/eliza/agents/:agentId/provision", provisionRoute);
+
+const AGENT_ID = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+
+function pendingAgent() {
+  return {
+    id: AGENT_ID,
+    agent_name: "alpha",
+    organization_id: "org-1",
+    status: "pending",
+    execution_tier: "dedicated-always",
+    bridge_url: null,
+    health_url: null,
+    agent_config: { name: "alpha", system: "You are alpha." },
+    character_id: null,
+    updated_at: new Date("2026-07-23T00:00:00.000Z"),
+  };
+}
+
+function claimedRow() {
+  return {
+    id: AGENT_ID,
+    agent_name: "alpha",
+    agent_config: { name: "alpha", system: "You are alpha." },
+    status: "running",
+    execution_tier: "dedicated-always",
+    node_id: "node-1",
+    container_name: `agent-${AGENT_ID}`,
+    bridge_port: 21060,
+    web_ui_port: 3000,
+    headscale_ip: "100.64.0.11",
+    bridge_url: "http://100.64.0.11:3000",
+    health_url: "http://100.64.0.11:3000/api",
+    sandbox_id: `agent-${AGENT_ID}`,
+    environment_vars: { ELIZA_API_TOKEN: "agent_pool_live" },
+  };
+}
+
+async function postProvision() {
+  return app.fetch(
+    new Request(
+      `https://api.example.test/api/v1/eliza/agents/${AGENT_ID}/provision`,
+      { method: "POST" },
+    ),
+  );
+}
+
+function pushFailedEvents() {
+  return loggerWarn.mock.calls.filter(
+    (c) =>
+      (c[1] as LoggerMeta | undefined)?.event ===
+      "warm_pool.character_push_failed",
+  );
+}
+
+describe("POST /api/v1/eliza/agents/[agentId]/provision — warm-pool post-claim character push", () => {
+  beforeEach(() => {
+    getAgentForWrite.mockReset();
+    getAgentForWrite.mockResolvedValue(pendingAgent());
+    claimWarmContainer.mockReset();
+    pushClaimedWarmContainerCharacter.mockReset();
+    pushClaimedWarmContainerCharacter.mockResolvedValue({
+      pushed: true,
+      agentName: "alpha",
+    });
+    enqueueAgentProvisionOnce.mockClear();
+    triggerImmediate.mockClear();
+    countReadyPoolEntriesForImage.mockReset();
+    countReadyPoolEntriesForImage.mockResolvedValue(0);
+    loggerWarn.mockClear();
+    loggerInfo.mockClear();
+  });
+
+  test("successful claim: push invoked with the claimed row, 200 source=warm_pool", async () => {
+    claimWarmContainer.mockResolvedValue(claimedRow());
+
+    const res = await postProvision();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { source?: string; success?: boolean };
+    expect(body.success).toBe(true);
+    expect(body.source).toBe("warm_pool");
+
+    expect(pushClaimedWarmContainerCharacter).toHaveBeenCalledTimes(1);
+    const arg = pushClaimedWarmContainerCharacter.mock
+      .calls[0]?.[0] as unknown as {
+      id?: string;
+      agent_config?: { name?: string };
+      bridge_url?: string;
+    };
+    expect(arg?.id).toBe(AGENT_ID);
+    expect(arg?.agent_config?.name).toBe("alpha");
+    expect(arg?.bridge_url).toBe("http://100.64.0.11:3000");
+
+    // Warm path — no cold job, no failure event.
+    expect(enqueueAgentProvisionOnce).not.toHaveBeenCalled();
+    expect(pushFailedEvents()).toHaveLength(0);
+  });
+
+  test("push failure does NOT fail the claim: still 200 source=warm_pool + failure event", async () => {
+    claimWarmContainer.mockResolvedValue(claimedRow());
+    pushClaimedWarmContainerCharacter.mockRejectedValue(
+      new Error("Warm-claim character push failed: HTTP 503"),
+    );
+
+    const res = await postProvision();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { source?: string; success?: boolean };
+    expect(body.success).toBe(true);
+    expect(body.source).toBe("warm_pool");
+    expect(enqueueAgentProvisionOnce).not.toHaveBeenCalled();
+
+    const events = pushFailedEvents();
+    expect(events).toHaveLength(1);
+    const meta = events[0]?.[1] as LoggerMeta;
+    expect(meta.agentId).toBe(AGENT_ID);
+    expect(meta.error).toContain("HTTP 503");
+  });
+
+  test("claim fallthrough (null): push never invoked, degrades to 202 async job", async () => {
+    claimWarmContainer.mockResolvedValue(null);
+
+    const res = await postProvision();
+
+    expect(res.status).toBe(202);
+    expect(enqueueAgentProvisionOnce).toHaveBeenCalledTimes(1);
+    expect(pushClaimedWarmContainerCharacter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/__tests__/eliza-agents-warm-pool-character-push.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-warm-pool-character-push.test.ts
@@ -1,0 +1,282 @@
+/**
+ * POST /api/v1/eliza/agents — warm-pool post-claim character push.
+ *
+ * A warm pool container boots GENERIC (agent-warm-pool-creator provisions with
+ * `environment_vars: {}` — no ELIZA_AGENT_CHARACTER_JSON), so after
+ * `claimWarmContainer` transfers the DB row the RUNNING container would answer
+ * as the default Eliza. The create route now calls
+ * `elizaSandboxService.pushClaimedWarmContainerCharacter(claimed)` after a
+ * successful claim, BEFORE responding 201.
+ *
+ * This pins:
+ *   - a successful claim invokes the push with the claimed row (the user's
+ *     character) and still responds 201 source=warm_pool;
+ *   - a push FAILURE does not fail the claim — still 201 source=warm_pool,
+ *     no cold-path job enqueued, and the stable
+ *     `warm_pool.character_push_failed` event is emitted;
+ *   - an empty-pool fallthrough (claim null) never invokes the push.
+ *
+ * Mocks only the module boundaries the handler imports; the route logic is
+ * real. Harness modeled on eliza-agents-warm-pool-empty-on-claim.test.ts.
+ * [sol-warmpool]
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+const createAgent = mock();
+const updateAgentEnvironment = mock(async () => undefined);
+const listAgents = mock(async () => []);
+const pushClaimedWarmContainerCharacter = mock(
+  async (_rec: Record<string, unknown>) =>
+    ({ pushed: true, agentName: "alpha" }) as {
+      pushed: boolean;
+      agentName?: string;
+    },
+);
+
+const enqueueAgentProvision = mock(async () => ({
+  id: "job-1",
+  status: "pending",
+  estimated_completion_at: new Date("2026-07-23T00:01:30.000Z"),
+}));
+const triggerImmediate = mock(async () => undefined);
+
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 100,
+}));
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+const prepareManagedElizaEnvironment = mock(async () => ({
+  changed: false,
+  environmentVars: {},
+}));
+
+type LoggerMeta = {
+  event?: string;
+  agentId?: string;
+  orgId?: string;
+  error?: string;
+};
+const loggerInfo = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+const loggerWarn = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+const loggerError = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+
+const claimWarmContainer = mock(async (): Promise<unknown> => null);
+const listByOrganization = mock(async () => []);
+const countReadyPoolEntriesForImage = mock(async () => 0);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    claimWarmContainer,
+    listByOrganization,
+    countReadyPoolEntriesForImage,
+  },
+}));
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    findByIdInOrganizationForWrite: mock(async () => undefined),
+    findByIdsInOrganization: mock(async () => []),
+  },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+class AgentQuotaExceededError extends Error {}
+class AgentImageNotAllowedError extends Error {}
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    createAgent,
+    updateAgentEnvironment,
+    listAgents,
+    pushClaimedWarmContainerCharacter,
+  },
+  AgentQuotaExceededError,
+  AgentImageNotAllowedError,
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision, triggerImmediate },
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: (h: { code?: string }) => ({
+    success: false,
+    code: h.code ?? "worker_unavailable",
+  }),
+}));
+
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  prepareManagedElizaEnvironment,
+}));
+
+// Force a dedicated (eager, non-custom) tier so the create reaches the
+// warm-pool claim block, and enable the pool.
+mock.module("@/lib/services/shared-runtime/agent-tier", () => ({
+  getAgentTier: () => "dedicated-always",
+  tierProvisionsEagerly: () => true,
+}));
+
+mock.module("@/lib/config/containers-env", () => ({
+  containersEnv: {
+    warmPoolEnabled: () => true,
+    defaultAgentImage: () => "ghcr.io/example/agent:pinned",
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: loggerInfo, warn: loggerWarn, error: loggerError },
+}));
+
+const { default: agentsRoute } = await import("../v1/eliza/agents/route");
+
+const app = new Hono();
+app.route("/api/v1/eliza/agents", agentsRoute);
+
+const AGENT_ID = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+
+function pendingAgent() {
+  return {
+    id: AGENT_ID,
+    agent_name: "alpha",
+    organization_id: "org-1",
+    status: "pending",
+    execution_tier: "dedicated-always",
+    created_at: new Date("2026-07-23T00:00:00.000Z"),
+    agent_config: { name: "alpha", system: "You are alpha." },
+    character_id: null,
+  };
+}
+
+function claimedRow() {
+  return {
+    id: AGENT_ID,
+    agent_name: "alpha",
+    agent_config: { name: "alpha", system: "You are alpha." },
+    status: "running",
+    execution_tier: "dedicated-always",
+    node_id: "node-1",
+    container_name: `agent-${AGENT_ID}`,
+    bridge_port: 21060,
+    web_ui_port: 3000,
+    headscale_ip: "100.64.0.11",
+    bridge_url: "http://100.64.0.11:3000",
+    health_url: "http://100.64.0.11:3000/api",
+    sandbox_id: `agent-${AGENT_ID}`,
+    environment_vars: { ELIZA_API_TOKEN: "agent_pool_live" },
+  };
+}
+
+async function postCreate(body: unknown) {
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/eliza/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function pushFailedEvents() {
+  return loggerWarn.mock.calls.filter(
+    (c) =>
+      (c[1] as LoggerMeta | undefined)?.event ===
+      "warm_pool.character_push_failed",
+  );
+}
+
+describe("POST /api/v1/eliza/agents — warm-pool post-claim character push", () => {
+  beforeEach(() => {
+    createAgent.mockReset();
+    claimWarmContainer.mockReset();
+    pushClaimedWarmContainerCharacter.mockReset();
+    pushClaimedWarmContainerCharacter.mockResolvedValue({
+      pushed: true,
+      agentName: "alpha",
+    });
+    enqueueAgentProvision.mockClear();
+    triggerImmediate.mockClear();
+    countReadyPoolEntriesForImage.mockReset();
+    countReadyPoolEntriesForImage.mockResolvedValue(0);
+    loggerWarn.mockClear();
+    loggerInfo.mockClear();
+  });
+
+  test("successful claim: push invoked with the claimed row, 201 source=warm_pool", async () => {
+    createAgent.mockResolvedValue({ agent: pendingAgent(), idempotent: false });
+    claimWarmContainer.mockResolvedValue(claimedRow());
+
+    const res = await postCreate({ agentName: "alpha", alwaysOn: true });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { source?: string };
+    expect(body.source).toBe("warm_pool");
+
+    // Push happened exactly once, with the claimed row (the user's character
+    // travels via its agent_config/agent_name).
+    expect(pushClaimedWarmContainerCharacter).toHaveBeenCalledTimes(1);
+    const arg = pushClaimedWarmContainerCharacter.mock
+      .calls[0]?.[0] as unknown as {
+      id?: string;
+      agent_config?: { name?: string };
+      bridge_url?: string;
+    };
+    expect(arg?.id).toBe(AGENT_ID);
+    expect(arg?.agent_config?.name).toBe("alpha");
+    expect(arg?.bridge_url).toBe("http://100.64.0.11:3000");
+
+    // Warm path — no cold job, no failure event.
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(pushFailedEvents()).toHaveLength(0);
+  });
+
+  test("push failure does NOT fail the claim: still 201 source=warm_pool + failure event", async () => {
+    createAgent.mockResolvedValue({ agent: pendingAgent(), idempotent: false });
+    claimWarmContainer.mockResolvedValue(claimedRow());
+    pushClaimedWarmContainerCharacter.mockRejectedValue(
+      new Error("Warm-claim character push failed: HTTP 503"),
+    );
+
+    const res = await postCreate({ agentName: "alpha", alwaysOn: true });
+
+    // The claim survives the push failure.
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { source?: string; success?: boolean };
+    expect(body.success).toBe(true);
+    expect(body.source).toBe("warm_pool");
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+
+    // The degrade is observable via the stable event, with error context.
+    const events = pushFailedEvents();
+    expect(events).toHaveLength(1);
+    const meta = events[0]?.[1] as LoggerMeta;
+    expect(meta.agentId).toBe(AGENT_ID);
+    expect(meta.error).toContain("HTTP 503");
+  });
+
+  test("empty-pool fallthrough (claim null): push is never invoked", async () => {
+    createAgent.mockResolvedValue({ agent: pendingAgent(), idempotent: false });
+    claimWarmContainer.mockResolvedValue(null);
+
+    const res = await postCreate({ agentName: "alpha", alwaysOn: true });
+
+    // Degraded to the async cold path.
+    expect(res.status).toBe(202);
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+    expect(pushClaimedWarmContainerCharacter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -188,6 +188,36 @@ async function __hono_POST(
             orgId: user.organization_id,
             poolNodeId: claimed.node_id,
           });
+          // Post-claim character apply: the pool container booted GENERIC (no
+          // ELIZA_AGENT_CHARACTER_JSON), so push the user's character onto the
+          // live runtime via the container's PUT /api/character. Bounded (10s)
+          // and NON-FATAL: on failure the claim still succeeds (the row's
+          // agent_config applies on the next container restart) and
+          // `warm_pool.character_push_failed` keeps the miss observable.
+          try {
+            const push =
+              await elizaSandboxService.pushClaimedWarmContainerCharacter(
+                claimed,
+              );
+            if (push.pushed) {
+              logger.info("[agent-api] Warm pool character push applied", {
+                agentId,
+                orgId: user.organization_id,
+                agentName: push.agentName,
+              });
+            }
+          } catch (pushErr) {
+            logger.warn(
+              "[agent-api] Warm pool character push failed; claim kept (character applies on next restart)",
+              {
+                event: "warm_pool.character_push_failed",
+                agentId,
+                orgId: user.organization_id,
+                error:
+                  pushErr instanceof Error ? pushErr.message : String(pushErr),
+              },
+            );
+          }
           return applyCorsHeaders(
             Response.json({
               success: true,

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -544,6 +544,39 @@ app.post("/", async (c) => {
             orgId: user.organization_id,
             poolNodeId: claimed.node_id,
           });
+          // Post-claim character apply: the pool container booted GENERIC (no
+          // ELIZA_AGENT_CHARACTER_JSON), so without this push the running
+          // container answers as the default Eliza even though the DB row now
+          // carries the user's character. The push is bounded (10s) and
+          // NON-FATAL: on failure the claim still succeeds — the row's
+          // agent_config is authoritative, so the character applies on the
+          // next container restart — and the stable
+          // `warm_pool.character_push_failed` event makes a persistently
+          // broken push path observable in aggregate.
+          try {
+            const push =
+              await elizaSandboxService.pushClaimedWarmContainerCharacter(
+                claimed,
+              );
+            if (push.pushed) {
+              logger.info("[agent-api] Warm pool character push applied", {
+                agentId: agent.id,
+                orgId: user.organization_id,
+                agentName: push.agentName,
+              });
+            }
+          } catch (pushErr) {
+            logger.warn(
+              "[agent-api] Warm pool character push failed; claim kept (character applies on next restart)",
+              {
+                event: "warm_pool.character_push_failed",
+                agentId: agent.id,
+                orgId: user.organization_id,
+                error:
+                  pushErr instanceof Error ? pushErr.message : String(pushErr),
+              },
+            );
+          }
           return c.json(
             {
               success: true,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -9,6 +9,7 @@ import {
   selectPrunableBackupIds,
 } from "../../lib/services/agent-backup-diff";
 import { AGENT_MANAGED_DISCORD_KEY } from "../../lib/services/eliza-agent-config";
+import { mergeWarmClaimEnvironmentVars } from "../../lib/services/warm-claim-character-push";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import { getObjectText, offloadJsonField } from "../../lib/storage/object-store";
 import { logger } from "../../lib/utils/logger";
@@ -1183,6 +1184,18 @@ export class AgentSandboxesRepository {
         .update(agentSandboxes)
         .set({
           status: "running",
+          // Container-boot-coupled env transfer: the pool container is ALREADY
+          // RUNNING with the pool row's ELIZA_API_TOKEN (its inbound API auth
+          // boundary), and the pool row is deleted in this same transaction.
+          // Without carrying that token onto the user's row, every
+          // authenticated call to the claimed container (character push,
+          // bridge proxy, web UI gate) fails 401 against a token the container
+          // never saw. User-provided env keys are preserved; only the keys the
+          // container was booted with are overridden.
+          environment_vars: mergeWarmClaimEnvironmentVars(
+            userRow.environment_vars as Record<string, string> | null,
+            pool.environment_vars as Record<string, string> | null,
+          ),
           node_id: pool.node_id,
           container_name: pool.container_name,
           bridge_port: pool.bridge_port,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -100,6 +100,10 @@ import {
   runWakeRestoreIntegrityGate,
   type WakeRestoreIntegrityFailure,
 } from "./wake-restore-integrity";
+import {
+  buildWarmClaimCharacterPayload,
+  WARM_CLAIM_CHARACTER_PUSH_TIMEOUT_MS,
+} from "./warm-claim-character-push";
 
 export interface CreateAgentParams {
   organizationId: string;
@@ -2987,6 +2991,55 @@ export class ElizaSandboxService {
       return this.buildSharedRuntimeCharacter(bootstrap);
     }
     return null;
+  }
+
+  /**
+   * Post-claim character apply (warm pool). A pool container boots GENERIC
+   * (no ELIZA_AGENT_CHARACTER_JSON — agent-warm-pool-creator provisions with
+   * empty env), so after `claimWarmContainer` transfers the DB row the RUNNING
+   * container would still answer as the default Eliza. This pushes the user's
+   * character onto the live runtime via the container's own
+   * `PUT /api/character` route (which applies it in-memory, persists it to the
+   * agent DB so it survives restarts, and journals character history) — no
+   * container restart, no cold boot.
+   *
+   * Bounded and non-fatal by contract: the CALLER treats a failure as
+   * "claim still succeeds, character applies on next container restart"
+   * (the row's agent_config feeds ensureRuntimeAgentStarted / the env path on
+   * any subsequent boot). Throws on failure so the caller can log the
+   * `warm_pool.character_push_failed` event with context.
+   */
+  async pushClaimedWarmContainerCharacter(
+    rec: Pick<
+      AgentSandbox,
+      | "id"
+      | "agent_name"
+      | "agent_config"
+      | "environment_vars"
+      | "bridge_url"
+      | "health_url"
+      | "node_id"
+      | "bridge_port"
+      | "web_ui_port"
+      | "headscale_ip"
+      | "sandbox_id"
+    >,
+  ): Promise<{ pushed: boolean; agentName?: string }> {
+    const payload = buildWarmClaimCharacterPayload(rec.agent_config, rec.agent_name);
+    if (!payload) return { pushed: false };
+
+    const res = await this.fetchAgentApi(rec, "/api/character", {
+      method: "PUT",
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(WARM_CLAIM_CHARACTER_PUSH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      // error-policy: enrich with a bounded body excerpt; a failed body read
+      // must never mask the HTTP status.
+      const text = await res.text().catch(() => "");
+      throw new Error(`Warm-claim character push failed: HTTP ${res.status} ${text.slice(0, 200)}`);
+    }
+    return { pushed: true, agentName: String(payload.name) };
   }
 
   // Bridge

--- a/packages/cloud/shared/src/lib/services/warm-claim-character-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-character-push.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Warm-pool claim → character push payload builder + boot-coupled env merge.
+ *
+ * The push payload must satisfy the agent's STRICT `PUT /api/character`
+ * CharacterSchema (unknown keys rejected at parse time), so the builder is the
+ * single seam that keeps a loose user `agent_config` (plugins, settings,
+ * secrets, connectors, ...) from 422-ing the push — or worse, from leaking
+ * secrets to an HTTP surface that never needs them. The env merge pins that a
+ * claimed container's boot credentials (ELIZA_API_TOKEN et al) follow the
+ * container onto the user row, or every authenticated call after the claim
+ * checks the wrong token. [sol-warmpool]
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildWarmClaimCharacterPayload,
+  mergeWarmClaimEnvironmentVars,
+} from "./warm-claim-character-push";
+
+describe("buildWarmClaimCharacterPayload", () => {
+  test("projects a full agent_config down to exactly the strict schema's keys", () => {
+    const payload = buildWarmClaimCharacterPayload(
+      {
+        name: "Nyx",
+        username: "nyx",
+        system: "You are Nyx.",
+        bio: ["Nyx is a night owl."],
+        topics: ["astronomy"],
+        adjectives: ["nocturnal"],
+        style: { all: ["terse"], chat: ["lowercase"], post: [] },
+        postExamples: ["gm from the dark side"],
+        // Keys the strict schema REJECTS — must all be dropped.
+        plugins: ["@elizaos/plugin-sql"],
+        settings: { secrets: { OPENAI_API_KEY: "sk-REDACT" } },
+        secrets: { token: "nope" },
+        connectors: { discord: { token: "nope" } },
+        knowledge: ["doc.md"],
+        id: "some-uuid",
+      },
+      "fallback-name",
+    );
+
+    expect(payload).toEqual({
+      name: "Nyx",
+      username: "nyx",
+      system: "You are Nyx.",
+      bio: ["Nyx is a night owl."],
+      adjectives: ["nocturnal"],
+      topics: ["astronomy"],
+      // Empty `post` array dropped, non-empty kept.
+      style: { all: ["terse"], chat: ["lowercase"] },
+      postExamples: ["gm from the dark side"],
+    });
+    // Secrets must NEVER ride along on the push.
+    expect(JSON.stringify(payload)).not.toContain("sk-REDACT");
+  });
+
+  test("falls back to agent_name when the config has no name", () => {
+    const payload = buildWarmClaimCharacterPayload({}, "Bnancy");
+    expect(payload).toEqual({ name: "Bnancy" });
+  });
+
+  test("returns null when there is no name anywhere (nothing to push)", () => {
+    expect(buildWarmClaimCharacterPayload({}, null)).toBeNull();
+    expect(buildWarmClaimCharacterPayload(undefined, "   ")).toBeNull();
+    expect(buildWarmClaimCharacterPayload(null, undefined)).toBeNull();
+  });
+
+  test("string bio is wrapped into the array form the schema accepts", () => {
+    const payload = buildWarmClaimCharacterPayload({ name: "A", bio: "one-liner" }, null);
+    expect(payload?.bio).toEqual(["one-liner"]);
+  });
+
+  test("oversized fields are truncated instead of 422-ing the whole push", () => {
+    const payload = buildWarmClaimCharacterPayload(
+      {
+        name: "N".repeat(300),
+        username: "u".repeat(90),
+        system: "s".repeat(20_000),
+        adjectives: ["a".repeat(250)],
+      },
+      null,
+    );
+    if (!payload) throw new Error("expected a payload");
+    expect((payload.name as string).length).toBe(100);
+    expect((payload.username as string).length).toBe(50);
+    expect((payload.system as string).length).toBe(10_000);
+    expect((payload.adjectives as string[])[0]?.length).toBe(100);
+  });
+
+  test("strict-form messageExamples pass through with unknown content keys stripped", () => {
+    const payload = buildWarmClaimCharacterPayload(
+      {
+        name: "A",
+        messageExamples: [
+          {
+            examples: [
+              {
+                name: "{{user1}}",
+                content: { text: "hi", extraneous: "drop-me" },
+              },
+              {
+                name: "A",
+                content: { text: "hello", actions: ["REPLY"] },
+              },
+            ],
+          },
+        ],
+      },
+      null,
+    );
+    expect(payload?.messageExamples).toEqual([
+      {
+        examples: [
+          { name: "{{user1}}", content: { text: "hi" } },
+          { name: "A", content: { text: "hello", actions: ["REPLY"] } },
+        ],
+      },
+    ]);
+  });
+
+  test("legacy [[{user,content}]] messageExamples are omitted (boot path normalises later)", () => {
+    const payload = buildWarmClaimCharacterPayload(
+      {
+        name: "A",
+        messageExamples: [[{ user: "u", content: { text: "hi" } }]],
+      },
+      null,
+    );
+    expect(payload).not.toBeNull();
+    expect(payload?.messageExamples).toBeUndefined();
+  });
+});
+
+describe("mergeWarmClaimEnvironmentVars", () => {
+  test("pool boot-coupled keys override; user keys otherwise win/persist", () => {
+    const merged = mergeWarmClaimEnvironmentVars(
+      {
+        ELIZA_API_TOKEN: "agent_user_stale",
+        MY_CUSTOM_SECRET: "keep-me",
+      },
+      {
+        ELIZA_API_TOKEN: "agent_pool_live",
+        JWT_SECRET: "pool-jwt",
+        AGENT_SERVER_SHARED_SECRET: "pool-shared",
+        SOME_POOL_ONLY_KEY: "must-not-leak",
+      },
+    );
+    expect(merged).toEqual({
+      // The container is RUNNING with the pool token — it must win.
+      ELIZA_API_TOKEN: "agent_pool_live",
+      JWT_SECRET: "pool-jwt",
+      AGENT_SERVER_SHARED_SECRET: "pool-shared",
+      MY_CUSTOM_SECRET: "keep-me",
+    });
+  });
+
+  test("null/absent pool env leaves the user env untouched", () => {
+    expect(mergeWarmClaimEnvironmentVars({ A: "1" }, null)).toEqual({ A: "1" });
+    expect(mergeWarmClaimEnvironmentVars(null, null)).toEqual({});
+  });
+});

--- a/packages/cloud/shared/src/lib/services/warm-claim-character-push.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-character-push.ts
@@ -1,0 +1,192 @@
+/**
+ * Warm-pool claim → character push payload builder.
+ *
+ * A warm pool container boots GENERIC (HetznerPoolContainerCreator provisions
+ * it with `environment_vars: {}` — no ELIZA_AGENT_CHARACTER_JSON), so after a
+ * claim the RUNNING container would answer as the default Eliza preset even
+ * though the DB row now carries the user's agent_name / agent_config /
+ * character_id. The fix is a post-claim runtime push: the container's own
+ * `PUT /api/character` route (packages/agent character-routes.ts) applies
+ * name/system/bio/style/examples to the live runtime, persists them to the
+ * agent's DB (updateAgent metadata) and journals character history — no
+ * restart, no cold boot.
+ *
+ * That route validates with the agent's STRICT CharacterSchema
+ * (packages/agent/src/config/character-schema.ts): unknown keys are rejected
+ * at parse time and fields carry max lengths. `agent_config` is a loose
+ * user-supplied blob (plugins, settings, secrets, connectors, ...), so this
+ * builder projects it down to EXACTLY the schema's accepted shape:
+ *
+ *   - whitelist: name, username, system, bio, adjectives, topics, style,
+ *     messageExamples, postExamples (everything else — plugins, settings,
+ *     secrets, connectors, knowledge — is dropped; secrets must NEVER ride
+ *     along on this call anyway);
+ *   - length caps mirrored from the schema (name 100, username 50,
+ *     system 10000, adjective/topic items 100) via slice, so an oversized
+ *     field degrades to a truncated push instead of a 422 that would forfeit
+ *     the whole character;
+ *   - messageExamples are included ONLY when they already match the strict
+ *     `[{ examples: [{ name, content: { text, actions? } }] }]` group form
+ *     (extra content keys are stripped); the legacy `[[{user,content}]]` form
+ *     is omitted — the boot-time env path normalises it on the next restart.
+ *
+ * Returns null when there is no name to push (no config name and no
+ * agent_name), in which case the caller skips the push entirely.
+ */
+
+/**
+ * Boot-coupled env keys: values the RUNNING pool container was started with
+ * that MUST follow the container onto the claimed user row, or every
+ * authenticated call to it (the character push below, the bridge proxy, the
+ * agent-router web UI gate) checks the wrong credential:
+ *
+ *   - ELIZA_API_TOKEN — the container's inbound API auth boundary
+ *     (getAgentApiToken reads the ROW's value and the container validates its
+ *     own process env's value; they must be the same token);
+ *   - JWT_SECRET — per-container session secret generated at boot;
+ *   - AGENT_SERVER_SHARED_SECRET — the X-Server-Token gateway secret the
+ *     container booted with.
+ *
+ * Everything else on the user's row (their BYO secrets, managed cloud keys)
+ * is preserved untouched.
+ */
+const WARM_CLAIM_BOOT_COUPLED_ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "JWT_SECRET",
+  "AGENT_SERVER_SHARED_SECRET",
+] as const;
+
+/**
+ * Merge a claimed pool row's boot-coupled env keys onto the user row's env.
+ * User keys win everywhere EXCEPT the boot-coupled set, where the container's
+ * actual boot values are authoritative (the container is already running with
+ * them and cannot be told otherwise without a restart).
+ */
+export function mergeWarmClaimEnvironmentVars(
+  userEnv: Record<string, string> | null | undefined,
+  poolEnv: Record<string, string> | null | undefined,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...(userEnv ?? {}) };
+  for (const key of WARM_CLAIM_BOOT_COUPLED_ENV_KEYS) {
+    const value = poolEnv?.[key];
+    if (typeof value === "string" && value.trim()) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+const NAME_MAX = 100;
+const USERNAME_MAX = 50;
+const SYSTEM_MAX = 10_000;
+const LIST_ITEM_MAX = 100;
+
+/** Bounded timeout for the post-claim character push HTTP call. */
+export const WARM_CLAIM_CHARACTER_PUSH_TIMEOUT_MS = 10_000;
+
+function cleanStringArray(value: unknown, itemMax?: number): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value
+    .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+    .map((v) => (itemMax !== undefined ? v.slice(0, itemMax) : v));
+  return items.length > 0 ? items : undefined;
+}
+
+type MessageExampleGroup = {
+  examples: Array<{ name: string; content: { text: string; actions?: string[] } }>;
+};
+
+/**
+ * Accept message examples ONLY in the strict group form the agent's
+ * CharacterSchema validates; strip unknown content keys. Any structural
+ * mismatch returns undefined (omit the field) rather than risking a 422.
+ */
+function sanitizeMessageExampleGroups(value: unknown): MessageExampleGroup[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const groups: MessageExampleGroup[] = [];
+  for (const rawGroup of value) {
+    if (!rawGroup || typeof rawGroup !== "object" || Array.isArray(rawGroup)) return undefined;
+    const rawExamples = (rawGroup as { examples?: unknown }).examples;
+    if (!Array.isArray(rawExamples) || rawExamples.length === 0) return undefined;
+    const examples: MessageExampleGroup["examples"] = [];
+    for (const rawExample of rawExamples) {
+      if (!rawExample || typeof rawExample !== "object") return undefined;
+      const name = (rawExample as { name?: unknown }).name;
+      const content = (rawExample as { content?: unknown }).content;
+      const text =
+        content && typeof content === "object" ? (content as { text?: unknown }).text : undefined;
+      if (typeof name !== "string" || !name.trim()) return undefined;
+      if (typeof text !== "string" || !text.trim()) return undefined;
+      const rawActions = (content as { actions?: unknown }).actions;
+      const actions = Array.isArray(rawActions)
+        ? rawActions.filter((a): a is string => typeof a === "string" && a.length > 0)
+        : undefined;
+      examples.push({
+        name,
+        content: { text, ...(actions && actions.length > 0 ? { actions } : {}) },
+      });
+    }
+    groups.push({ examples });
+  }
+  return groups.length > 0 ? groups : undefined;
+}
+
+/**
+ * Project a claimed sandbox row's agent_config (+ agent_name fallback) into a
+ * payload the container's strict `PUT /api/character` accepts. Null ⇒ nothing
+ * to push (no name available at all).
+ */
+export function buildWarmClaimCharacterPayload(
+  agentConfig: unknown,
+  agentName?: string | null,
+): Record<string, unknown> | null {
+  const config =
+    agentConfig && typeof agentConfig === "object" && !Array.isArray(agentConfig)
+      ? (agentConfig as Record<string, unknown>)
+      : {};
+
+  const name =
+    typeof config.name === "string" && config.name.trim()
+      ? config.name.trim()
+      : (agentName?.trim() ?? "");
+  if (!name) return null;
+
+  const payload: Record<string, unknown> = { name: name.slice(0, NAME_MAX) };
+
+  if (typeof config.username === "string" && config.username.trim()) {
+    payload.username = config.username.trim().slice(0, USERNAME_MAX);
+  }
+  if (typeof config.system === "string" && config.system.trim()) {
+    payload.system = config.system.slice(0, SYSTEM_MAX);
+  }
+
+  const bio =
+    typeof config.bio === "string" && config.bio.trim()
+      ? [config.bio]
+      : cleanStringArray(config.bio);
+  if (bio) payload.bio = bio;
+
+  const adjectives = cleanStringArray(config.adjectives, LIST_ITEM_MAX);
+  if (adjectives) payload.adjectives = adjectives;
+
+  const topics = cleanStringArray(config.topics, LIST_ITEM_MAX);
+  if (topics) payload.topics = topics;
+
+  if (config.style && typeof config.style === "object" && !Array.isArray(config.style)) {
+    const rawStyle = config.style as Record<string, unknown>;
+    const style: Record<string, string[]> = {};
+    for (const key of ["all", "chat", "post"] as const) {
+      const items = cleanStringArray(rawStyle[key]);
+      if (items) style[key] = items;
+    }
+    if (Object.keys(style).length > 0) payload.style = style;
+  }
+
+  const postExamples = cleanStringArray(config.postExamples);
+  if (postExamples) payload.postExamples = postExamples;
+
+  const messageExamples = sanitizeMessageExampleGroups(config.messageExamples);
+  if (messageExamples) payload.messageExamples = messageExamples;
+
+  return payload;
+}


### PR DESCRIPTION
## The gap

The warm pool is ~90% built on develop: replenish runs as a real phase in the provisioning-worker daemon (`processPoolReplenishCycle` → `WarmPoolManager.replenish`), and claim-first is wired into both the create and provision routes (atomic `claimWarmContainer` with `FOR UPDATE SKIP LOCKED`, Neon branch transfer, null-node guard, empty-pool observability), behind `WARM_POOL_ENABLED` (default off).

The one remaining gap was **character-push-on-claim**: pool containers boot generic via `HetznerPoolContainerCreator` (`environment_vars: {}` — no `ELIZA_AGENT_CHARACTER_JSON`). `claimWarmContainer` transfers `agent_name` / `agent_config` / `character_id` onto the DB row, but nothing informed the RUNNING container. **A claimed container answered as the default Eliza.**

## The fix — runtime push, no restart

Chosen mechanism: the container's own **`PUT /api/character`** route (packages/agent character-routes.ts). It applies the character to the live runtime in-memory, persists it to the agent DB via `updateAgent` (survives restarts), and journals character history. Milliseconds, vs. seconds-to-minutes for an env-push + restart — and no restart-window flakiness on the claim's critical path.

- **`elizaSandboxService.pushClaimedWarmContainerCharacter(claimed)`** — PUTs the projected character through the existing authenticated `fetchAgentApi` transport (agent-router in Worker runtime, trusted docker URL / safe bridge endpoint otherwise). Bounded at 10s.
- **`warm-claim-character-push.ts`** — projects the loose user `agent_config` down to EXACTLY the agent's strict `CharacterSchema` shape: whitelisted keys only (name/username/system/bio/adjectives/topics/style/messageExamples/postExamples), schema length caps mirrored via slice so an oversized field truncates instead of 422-ing the whole push, and plugins/settings/**secrets**/connectors dropped — no secret ever rides along to this HTTP surface. Strict-form `messageExamples` pass through (unknown content keys stripped); the legacy `[[{user,content}]]` form is omitted and normalises on the next boot via the env path.
- **Both claim sites** (create route + provision route) invoke the push after a successful claim, before responding 201. **Failure is non-fatal by contract**: claim still succeeds — the row's `agent_config` is authoritative and applies on the next container restart — and the stable **`warm_pool.character_push_failed`** event makes a persistently broken push path observable in aggregate (mirrors `warm_pool.claim_failed` / `warm_pool.empty_on_claim`).
- **Boot-coupled env transfer in `claimWarmContainer`**: the pool row's `ELIZA_API_TOKEN` / `JWT_SECRET` / `AGENT_SERVER_SHARED_SECRET` now carry onto the user's row (`mergeWarmClaimEnvironmentVars`). The container is RUNNING with those boot values; without the transfer, every authenticated call to the claimed container (this push, the bridge proxy, the agent-router web UI gate) reads the row's token, checks a credential the container never saw, and 401s. All other user env keys are preserved untouched.

## Tests

- `warm-claim-character-push.test.ts` (9): strict projection (secrets/plugins/connectors dropped, secret string provably absent from payload), name fallback to `agent_name`, null when nothing to push, string-bio wrapping, truncation-not-422, strict/legacy messageExamples handling, boot-coupled env merge (pool token wins, user keys persist, pool-only keys don't leak).
- `eliza-agents-warm-pool-character-push.test.ts` (3, route-level, same harness as the empty-on-claim pin): push invoked once with the claimed row on a successful claim (201 `source=warm_pool`); push failure does NOT fail the claim (still 201, no cold job, failure event with error context); empty-pool fallthrough never invokes the push.
- Existing warm-pool / create-route suites stay green (32 pass across the 5 touched-area files). `tsc --noEmit` clean on cloud/shared + cloud/api; biome clean on all changed files.

Does not touch `preferSharedCloudTier`, no workflow changes.

## Staging flip runbook

1. Set `WARM_POOL_ENABLED=true` and `WARM_POOL_MIN_SIZE=3` on the provisioning-worker AND the API env.
2. Wait one replenish cycle; confirm pool rows reach `running`/`unclaimed` with non-null `node_id`.
3. Create an agent with a real character; expect 201 `source=warm_pool`, then `warm_pool character push applied` in API logs.
4. Measure claim→first-turn; verify the first reply speaks AS the user's character (not default Eliza).
5. Watch `warm_pool.character_push_failed` / `warm_pool.empty_on_claim` / `warm_pool.claim_failed` for aggregate regressions.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cloud provisioning change; no UI surface modified

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only cloud provisioning change; no UI surface modified

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only; the observable behavior is DB-row transfer + an authenticated PUT to the container, proven by the attached live-DB transcript and test logs. The staging flip runbook in the PR description covers the live first-reply verification

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no client change; the create/provision response contract is unchanged (201/200 source=warm_pool)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/model/action change in this repo's runtime; the push transports character config to the container's existing PUT /api/character route

<!-- evidence-row:backend-logs -->
- [x] [16977-backend-test-logs.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16977-backend-test-logs.log)

<!-- evidence-row:domain-artifacts -->
- [x] [16977-domain-artifact-live-claim.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16977-domain-artifact-live-claim.log)
