### PR TITLE
fix(app-control): humanize settings route failures in chat replies

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	createSettingsAction,
 	DEFAULT_VOICE_SETTINGS_PREFS,
+	humanizeSettingsRouteFailure,
 	parseBooleanValue,
 	parseSettingsRequest,
 	resolveSectionId,
@@ -2173,6 +2174,94 @@ describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 			expect(result?.success).toBe(false);
 			expect(texts.join(" ")).toContain(cap.reason);
 		}
+	});
+});
+
+describe("humanizeSettingsRouteFailure: user-facing route failure copy", () => {
+	it("maps 401 to a retryable session message with no raw path/status internals", () => {
+		const copy = humanizeSettingsRouteFailure(
+			"/api/views/settings/navigate",
+			401,
+			null,
+		);
+		expect(copy).toContain("isn't authenticated right now");
+		expect(copy).toContain("try that again");
+		expect(copy).not.toContain("/api/views");
+		expect(copy).not.toContain("401");
+	});
+
+	it("maps 403 the same as 401 (auth class)", () => {
+		expect(humanizeSettingsRouteFailure("/api/x", 403, "Forbidden")).toContain(
+			"isn't authenticated",
+		);
+	});
+
+	it("maps 404 to a capability-missing message", () => {
+		expect(humanizeSettingsRouteFailure("/api/x", 404, null)).toContain(
+			"isn't available in this app version",
+		);
+	});
+
+	it("maps 5xx to a transient retry message and keeps a descriptive server detail", () => {
+		const copy = humanizeSettingsRouteFailure(
+			"/api/update/status",
+			503,
+			"registry unreachable while refreshing",
+		);
+		expect(copy).toContain("temporary error");
+		expect(copy).toContain("try that again");
+		expect(copy).toContain("registry unreachable while refreshing");
+	});
+
+	it("drops boilerplate status-text bodies on 5xx (no signal beyond the code)", () => {
+		const copy = humanizeSettingsRouteFailure(
+			"/api/x",
+			500,
+			"Internal Server Error",
+		);
+		expect(copy).toContain("temporary error");
+		expect(copy).not.toContain("Internal Server Error");
+	});
+
+	it("prefers a descriptive server error verbatim for other client errors", () => {
+		expect(
+			humanizeSettingsRouteFailure("/api/x", 422, "choose stable or beta"),
+		).toBe("choose stable or beta");
+	});
+
+	it("falls back to the technical path/status only when nothing better exists", () => {
+		expect(humanizeSettingsRouteFailure("/api/x", 400, null)).toBe(
+			"the request failed (HTTP 400 on /api/x)",
+		);
+	});
+
+	it("default route fetch narrates a 401 as a retryable session hiccup, not raw internals", async () => {
+		// The QA-reported class: settings-open toast reading "Authentication
+		// error: … route … returned 401". The reply must carry the human copy.
+		vi.stubEnv("ELIZA_PORT", "3456");
+		const fetchMock = vi.fn(
+			async () =>
+				({
+					ok: false,
+					status: 401,
+					json: async () => ({ error: "Unauthorized" }),
+				}) as unknown as Response,
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result, texts } = await invoke({
+			action: "set",
+			section: "appearance",
+			key: "theme",
+			value: "dark",
+		});
+
+		expect(result?.success).toBe(false);
+		const joined = texts.join(" ");
+		expect(joined).toContain("isn't authenticated right now");
+		expect(joined).toContain("try that again");
+		expect(joined).not.toContain("returned 401");
+		expect(joined).not.toContain("/api/views");
 	});
 });
 

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -1687,6 +1687,43 @@ export function parseSettingsRequest(
 	};
 }
 
+/**
+ * Turns a failed settings-route response into copy a person can act on. The
+ * raw `route <path> returned <status>` internals used to flow verbatim into
+ * the chat reply ("I couldn't change …: route /api/views/settings/navigate
+ * returned 401"), which reads as a scary internal error even when the failure
+ * is a transient auth/session hiccup the user can simply retry (the class
+ * behind the "Authentication error: please reopen settings" QA report,
+ * 2026-07-22). Auth and transient server failures get retry-first phrasing;
+ * a server-provided error message is preferred when it is actually
+ * descriptive; the technical path/status fallback only remains for
+ * unclassified client errors with no server detail.
+ */
+export function humanizeSettingsRouteFailure(
+	path: string,
+	status: number,
+	serverDetail: string | null,
+): string {
+	const detail = serverDetail?.trim() ?? "";
+	// Boilerplate status-text bodies carry no more signal than the code itself.
+	const terse =
+		!detail ||
+		/^(unauthorized|forbidden|not found|bad request|internal server error|bad gateway|service unavailable|gateway timeout)\.?$/i.test(
+			detail,
+		);
+	if (status === 401 || status === 403) {
+		return "the app session isn't authenticated right now — try that again in a moment, and reopen the app if it keeps happening";
+	}
+	if (status === 404) {
+		return "that settings surface isn't available in this app version";
+	}
+	if (status === 408 || status === 429 || status >= 500) {
+		const base = `the app hit a temporary error (HTTP ${status}) — try that again in a moment`;
+		return terse ? base : `${base} (${detail})`;
+	}
+	return terse ? `the request failed (HTTP ${status} on ${path})` : detail;
+}
+
 async function defaultRouteFetch(
 	request: SettingsRouteRequest,
 ): Promise<SettingsRouteOutcome> {
@@ -1706,11 +1743,14 @@ async function defaultRouteFetch(
 		unknown
 	> | null;
 	if (!response.ok) {
-		const detail =
-			parsed && typeof parsed.error === "string"
-				? parsed.error
-				: `route ${request.path} returned ${response.status}`;
-		return { ok: false, detail };
+		return {
+			ok: false,
+			detail: humanizeSettingsRouteFailure(
+				request.path,
+				response.status,
+				parsed && typeof parsed.error === "string" ? parsed.error : null,
+			),
+		};
 	}
 	return { ok: true, data: parsed };
 }


### PR DESCRIPTION
## Problem

Shadow's QA (2026-07-22, settings-open flow): the agent narrated raw internals to the user as an error toast:

> Authentication error: please reopen settings from an authenticated session / `I couldn't change ...: route /api/views/settings/navigate returned 401`

The transport class behind the 401 was fixed by #16836 (view loopback auth), but the narration seam remained: any failed settings loopback route still leaks `route <path> returned <status>` verbatim into a user-facing chat reply.

## Fix

New `humanizeSettingsRouteFailure(path, status, serverDetail)` in `defaultRouteFetch`:

- **401/403** → "the app session isn't authenticated right now — try that again in a moment, and reopen the app if it keeps happening" (retry affordance for the transient class)
- **404** → "that settings surface isn't available in this app version"
- **408/429/5xx** → "the app hit a temporary error (HTTP N) — try that again in a moment", keeping a descriptive server detail and dropping boilerplate status-text bodies ("Internal Server Error")
- **other 4xx** → prefer the server's descriptive error verbatim; technical path/status fallback only when nothing better exists

## Scope

Frontend/narration only — no route, API, or auth behavior changes. The injectable `routeFetch` seam is unchanged.

## Tests

8 new tests: each status class, boilerplate-body suppression, descriptive-detail passthrough, and an end-to-end default-fetch 401 asserting the chat reply carries the human copy and NOT `returned 401` / the raw path.

`settings.test.ts`: 115/115 pass.

Evidence: Shadow QA reports 2026-07-22, `projects/eliza-fleet/UX-STRIKE-2026-07-23.md`.

[sol-ux-strike]

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - narration-string change in plugin-app-control action code (.ts); no rendered-UI source file in the diff`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - narration-string change in plugin-app-control action code (.ts); no rendered-UI source file in the diff`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no visual surface changed; behavior is chat-reply copy, pinned by unit tests`

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no backend/route change; the injectable routeFetch seam and all HTTP behavior are untouched`

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no frontend network behavior change; copy-only mapping of already-received statuses`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic string mapping, no model in the loop; end-to-end 401 reply asserted in settings.test.ts`

<!-- evidence-row:domain-artifacts -->
N/A - domain proof is embedded in the PR tests/artifacts; see the Tests section above and changed test files in this PR.