### PR TITLE
fix(ui): staged human copy for provisioning + cold-boot waits

### DIFF
--- a/packages/ui/src/api/client-cloud-provision-wait-copy.test.ts
+++ b/packages/ui/src/api/client-cloud-provision-wait-copy.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit coverage for the provisioning/cold-boot wait narration
+ * (`describeProvisioningWait` / `describeAgentWakeWait`): the staged copy that
+ * replaced the raw `Status: pending...` / `(status) — Ns elapsed...` internals
+ * (the "static spinner during a 30s+ provision" QA class, 2026-07-22). Pure
+ * functions, no harness.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  describeAgentWakeWait,
+  describeProvisioningWait,
+} from "./client-cloud";
+
+describe("describeProvisioningWait", () => {
+  it("never leaks a raw backend job status token", () => {
+    for (const status of [
+      "pending",
+      "in_progress",
+      "processing",
+      "retrying",
+      undefined,
+    ]) {
+      for (const elapsed of [0, 25_000, 70_000]) {
+        const copy = describeProvisioningWait(status, elapsed);
+        expect(copy).not.toMatch(/status:/i);
+        expect(copy).not.toContain("in_progress");
+        expect(copy).not.toContain("pending");
+      }
+    }
+  });
+
+  it("stages queued vs active work early in the wait", () => {
+    expect(describeProvisioningWait(undefined, 2_000)).toBe(
+      "Getting your agent's environment ready…",
+    );
+    expect(describeProvisioningWait("queued", 2_000)).toBe(
+      "Getting your agent's environment ready…",
+    );
+    expect(describeProvisioningWait("in_progress", 2_000)).toBe(
+      "Starting your agent…",
+    );
+    expect(describeProvisioningWait("retrying", 2_000)).toBe(
+      "Starting your agent…",
+    );
+  });
+
+  it("advances to reassurance copy past the typical-wait threshold", () => {
+    expect(describeProvisioningWait("in_progress", 25_000)).toContain(
+      "usually takes under a minute",
+    );
+    expect(describeProvisioningWait("queued", 25_000)).toContain(
+      "Waiting for a sandbox slot",
+    );
+  });
+
+  it("names elapsed time on a long (degraded) wait, bucketed to 30s steps", () => {
+    // Bucketing: consumers seed one chat turn per unique status text, so the
+    // long-wait copy must NOT change every 2s poll tick.
+    expect(describeProvisioningWait("in_progress", 61_000)).toBe(
+      describeProvisioningWait("in_progress", 89_000),
+    );
+    expect(describeProvisioningWait("in_progress", 61_000)).toContain(
+      "about 60s in",
+    );
+    expect(describeProvisioningWait("in_progress", 95_000)).toContain(
+      "about 90s in",
+    );
+  });
+});
+
+describe("describeAgentWakeWait", () => {
+  it("uses stable expectation-setting copy for the first minute", () => {
+    expect(describeAgentWakeWait(5_000)).toBe(describeAgentWakeWait(55_000));
+    expect(describeAgentWakeWait(5_000)).toContain("cold boot");
+  });
+
+  it("advances by minute buckets on a long wait (no per-tick counter)", () => {
+    expect(describeAgentWakeWait(65_000)).toBe(describeAgentWakeWait(115_000));
+    expect(describeAgentWakeWait(65_000)).toContain("about 1 minute in");
+    expect(describeAgentWakeWait(125_000)).toContain("about 2 minutes in");
+  });
+
+  it("never leaks a raw backend status token", () => {
+    for (const elapsed of [0, 30_000, 61_000, 200_000]) {
+      expect(describeAgentWakeWait(elapsed)).not.toMatch(
+        /\((?:pending|unknown|stopped)\)/,
+      );
+    }
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3187,7 +3187,8 @@ ElizaClient.prototype.provisionCloudSandbox = async (options) => {
   }
 
   // Step 3: Poll job status
-  const deadline = Date.now() + 120_000;
+  const startedAt = Date.now();
+  const deadline = startedAt + 120_000;
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, 2000));
 
@@ -3221,11 +3222,55 @@ ElizaClient.prototype.provisionCloudSandbox = async (options) => {
       throw new Error(`Provisioning failed: ${error ?? "Unknown error"}`);
     }
 
-    onProgress?.("provisioning", `Status: ${status ?? "pending"}...`);
+    onProgress?.(
+      "provisioning",
+      describeProvisioningWait(status, Date.now() - startedAt),
+    );
   }
 
   throw new Error("Provisioning timed out after 2 minutes");
 };
+
+// Elapsed-time thresholds for the provisioning wait narration. A dedicated
+// provision typically lands in ~30-45s (PROVISIONING-SLOW-2026-07-22 traces:
+// create→first-turn 34-44s typical), so past ~20s the copy reassures rather
+// than repeats, and past ~60s it names the elapsed time so a degraded-mode
+// wait never looks frozen.
+const PROVISION_WAIT_REASSURE_MS = 20_000;
+const PROVISION_WAIT_LONG_MS = 60_000;
+
+/**
+ * Human copy for one provisioning-wait poll tick. The raw
+ * `Status: ${status}...` narration leaked backend job states ("pending",
+ * "in_progress") to the user and never changed across a 30s+ wait — the
+ * "static spinner" class from the 2026-07-22 QA reports. Instead: map the
+ * real job status to a staged step (getting things ready → starting up), and
+ * advance the copy with elapsed time so a long wait visibly progresses.
+ * Exported for unit tests.
+ */
+export function describeProvisioningWait(
+  status: string | undefined,
+  elapsedMs: number,
+): string {
+  if (elapsedMs >= PROVISION_WAIT_LONG_MS) {
+    // Bucketed to 30s steps: consumers (the first-run conductor) seed one
+    // chat turn per unique status text, so a per-tick counter would spam a
+    // new bubble every poll. A 30s step still visibly advances a long wait.
+    const bucket = Math.floor(elapsedMs / 30_000) * 30;
+    return `Still working — about ${bucket}s in. Almost there…`;
+  }
+  const active =
+    normalizeCloudJobStatus(status) === "processing" ||
+    normalizeCloudJobStatus(status) === "retrying";
+  if (elapsedMs >= PROVISION_WAIT_REASSURE_MS) {
+    return active
+      ? "Starting your agent — this usually takes under a minute…"
+      : "Waiting for a sandbox slot — this usually takes under a minute…";
+  }
+  return active
+    ? "Starting your agent…"
+    : "Getting your agent's environment ready…";
+}
 
 // Dedicated cold-boot wait defaults. A dedicated container cold-starts in
 // ~5 minutes (#8621, measured live 2026-06-19); the generic 202-retry budget in
@@ -3312,12 +3357,25 @@ export async function waitForCloudAgentRunning(
         )}s. It may still be booting — try again in a minute.`,
       );
     }
-    onProgress?.(
-      "starting",
-      `Starting your agent (${lastStatus}) — ${Math.round(elapsedMs / 1000)}s elapsed...`,
-    );
+    onProgress?.("starting", describeAgentWakeWait(elapsedMs));
     await new Promise((r) => setTimeout(r, pollIntervalMs));
   }
+}
+
+/**
+ * Human copy for one cold-boot wake poll tick. The old narration leaked the
+ * raw backend status (`Starting your agent (pending) — 35s elapsed...`) and
+ * changed every poll, which spams consumers that seed one chat turn per
+ * unique status text (the first-run conductor). Staged, minute-bucketed copy
+ * instead: it advances visibly on a long wait without a per-tick counter.
+ * Exported for unit tests.
+ */
+export function describeAgentWakeWait(elapsedMs: number): string {
+  if (elapsedMs < 60_000) {
+    return "Starting your agent — a cold boot can take a few minutes…";
+  }
+  const minutes = Math.floor(elapsedMs / 60_000);
+  return `Still starting your agent — about ${minutes} minute${minutes === 1 ? "" : "s"} in. Cold boots can take a few minutes…`;
 }
 
 /**


### PR DESCRIPTION
## Problem

Shadow's QA (2026-07-22): a ~30s dedicated provision shows no meaningful progress. The two wait loops narrated raw backend state to the user:

- provision job poll: `Status: pending...` / `Status: in_progress...` — static across the whole wait
- cold-boot wake poll: `Starting your agent (unknown) — 35s elapsed...` — leaks internal status tokens and changes every 5s tick (which spams consumers that seed one chat turn per unique status text, e.g. the first-run conductor)

Measured context: typical dedicated provision create→first-turn is 34-44s, degraded modes 291-503s (PROVISIONING-SLOW-2026-07-22 traces).

## Fix

Two exported pure helpers drive the per-tick narration:

**`describeProvisioningWait(status, elapsedMs)`** — staged by REAL job status via the existing `normalizeCloudJobStatus`:
- queued → "Getting your agent's environment ready…"
- processing/retrying → "Starting your agent…"
- past 20s → reassurance copy ("usually takes under a minute")
- past 60s → elapsed-time copy bucketed to 30s steps (visibly advances, never per-tick spam)

**`describeAgentWakeWait(elapsedMs)`** — expectation-setting cold-boot copy for the first minute, then minute-bucketed "Still starting — about N minutes in".

## Scope

Narration strings only. No control-flow, polling-interval, timeout, or API changes. Error paths untouched.

## Tests

New `client-cloud-provision-wait-copy.test.ts` (7 tests): staging, bucket stability (same string within a bucket → no turn spam), no raw status token leakage. Existing provision-sandbox + connect-mock-cloud suites: 18/18 pass.

Evidence: Shadow QA 2026-07-22, PROVISIONING-SLOW-2026-07-22.md, `projects/eliza-fleet/UX-STRIKE-2026-07-23.md`.

[sol-ux-strike]

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - progress-copy change in packages/ui/src/api/client-cloud.ts (.ts API client); no rendered-UI source file (.tsx/css) in the diff`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - progress-copy change in a .ts API client; the strings flow through the existing onProgress seam unchanged`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no visual surface changed; staged copy pinned by unit tests including bucket stability`

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no backend change; polling cadence, timeouts, and API calls untouched`

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no network behavior change; narration strings only`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic elapsed-time/status mapping, no model in the loop`

<!-- evidence-row:domain-artifacts -->
N/A - domain proof is embedded in the PR tests/artifacts; see the Tests section above and changed test files in this PR.