### PR TITLE
fix(ui): collapse double-persisted assistant replies at render time

### DIFF
--- a/packages/ui/src/state/conversation-message-filter.test.ts
+++ b/packages/ui/src/state/conversation-message-filter.test.ts
@@ -4,7 +4,12 @@
  */
 import { describe, expect, it } from "vitest";
 import type { ConversationMessage } from "../api";
-import { shouldKeepConversationMessage } from "./conversation-message-filter";
+import {
+  ASSISTANT_DUPLICATE_WINDOW_MS,
+  dedupeDoubledAssistantMessages,
+  filterRenderableConversationMessages,
+  shouldKeepConversationMessage,
+} from "./conversation-message-filter";
 
 function msg(partial: Partial<ConversationMessage>): ConversationMessage {
   return {
@@ -50,5 +55,106 @@ describe("shouldKeepConversationMessage", () => {
         msg({ text: "", blocks: [{ type: "text", text: "x" }] }),
       ),
     ).toBe(true);
+  });
+});
+
+describe("dedupeDoubledAssistantMessages", () => {
+  const T = 1_700_000_000_000;
+
+  it("collapses adjacent identical assistant turns inside the window (double-persist class)", () => {
+    const result = dedupeDoubledAssistantMessages([
+      msg({ id: "u1", role: "user", text: "hi", timestamp: T }),
+      msg({ id: "a1", text: "hello there", timestamp: T + 100 }),
+      msg({ id: "a2", text: "hello there", timestamp: T + 600 }),
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("keeps identical assistant turns outside the window (intentional repeat)", () => {
+    const input = [
+      msg({ id: "a1", text: "sure", timestamp: T }),
+      msg({
+        id: "a2",
+        text: "sure",
+        timestamp: T + ASSISTANT_DUPLICATE_WINDOW_MS + 1,
+      }),
+    ];
+    expect(dedupeDoubledAssistantMessages(input)).toBe(input);
+  });
+
+  it("keeps identical assistant turns separated by another turn (adjacency required)", () => {
+    const input = [
+      msg({ id: "a1", text: "yes", timestamp: T }),
+      msg({ id: "u1", role: "user", text: "really?", timestamp: T + 200 }),
+      msg({ id: "a2", text: "yes", timestamp: T + 400 }),
+    ];
+    expect(dedupeDoubledAssistantMessages(input)).toBe(input);
+  });
+
+  it("never collapses turns carrying attachments or blocks", () => {
+    const withMedia = [
+      msg({
+        id: "a1",
+        text: "here",
+        timestamp: T,
+        attachments: [{ id: "x", url: "/m.png", contentType: "image" }],
+      }),
+      msg({
+        id: "a2",
+        text: "here",
+        timestamp: T + 100,
+        attachments: [{ id: "y", url: "/n.png", contentType: "image" }],
+      }),
+    ];
+    expect(dedupeDoubledAssistantMessages(withMedia)).toBe(withMedia);
+  });
+
+  it("never collapses duplicate USER turns (user may send the same text twice)", () => {
+    const input = [
+      msg({ id: "u1", role: "user", text: "ok", timestamp: T }),
+      msg({ id: "u2", role: "user", text: "ok", timestamp: T + 100 }),
+    ];
+    expect(dedupeDoubledAssistantMessages(input)).toBe(input);
+  });
+
+  it("returns the SAME array reference when nothing collapses (render-path referential equality)", () => {
+    const input = [
+      msg({ id: "a1", text: "one", timestamp: T }),
+      msg({ id: "a2", text: "two", timestamp: T + 100 }),
+    ];
+    expect(dedupeDoubledAssistantMessages(input)).toBe(input);
+  });
+
+  it("matches on trimmed text (whitespace-only differences are the same reply)", () => {
+    const result = dedupeDoubledAssistantMessages([
+      msg({ id: "a1", text: "hello", timestamp: T }),
+      msg({ id: "a2", text: " hello \n", timestamp: T + 300 }),
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["a1"]);
+  });
+});
+
+describe("filterRenderableConversationMessages", () => {
+  const T = 1_700_000_000_000;
+
+  it("applies both the render filter and the duplicate collapse", () => {
+    const result = filterRenderableConversationMessages([
+      msg({ id: "u1", role: "user", text: "hi", timestamp: T }),
+      msg({ id: "empty", text: "  ", timestamp: T + 10 }),
+      msg({ id: "a1", text: "hey", timestamp: T + 20 }),
+      msg({ id: "a2", text: "hey", timestamp: T + 400 }),
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("collapses a double-persist even when an empty placeholder sits between the copies", () => {
+    // The empty turn is filtered first, which makes the two copies adjacent —
+    // exactly the shape a swallowed-then-retried stream leaves behind.
+    const result = filterRenderableConversationMessages([
+      msg({ id: "a1", text: "done", timestamp: T }),
+      msg({ id: "ph", text: "", timestamp: T + 50 }),
+      msg({ id: "a2", text: "done", timestamp: T + 900 }),
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["a1"]);
   });
 });

--- a/packages/ui/src/state/conversation-message-filter.ts
+++ b/packages/ui/src/state/conversation-message-filter.ts
@@ -2,6 +2,8 @@
  * Decides which conversation messages render in the transcript: user turns
  * always show; assistant turns show only with visible text, structured blocks,
  * or media (image-only replies carry empty text but populated attachments).
+ * Also collapses back-to-back duplicate assistant turns (same text, near-same
+ * timestamp) so a backend double-persist never paints twice.
  */
 import type { ConversationMessage } from "../api";
 
@@ -20,8 +22,67 @@ export function shouldKeepConversationMessage(
   return Boolean(message.blocks?.length);
 }
 
+/**
+ * Two adjacent assistant turns within this window and with identical text are
+ * treated as one double-persisted reply. 2s is far below any real "the agent
+ * said the same thing twice on purpose" gap and comfortably above the write
+ * jitter of the duplicate-persist class (the double-message QA report,
+ * 2026-07-22).
+ */
+export const ASSISTANT_DUPLICATE_WINDOW_MS = 2_000;
+
+function isPlainTextAssistantTurn(message: ConversationMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    message.text.trim().length > 0 &&
+    !message.attachments?.length &&
+    !message.blocks?.length
+  );
+}
+
+/**
+ * Render-side guard against the backend double-persist class: the same
+ * assistant reply stored twice within milliseconds shows up as two identical
+ * consecutive bubbles. This collapses the later copy when two ADJACENT
+ * assistant turns carry identical text and land within
+ * `ASSISTANT_DUPLICATE_WINDOW_MS` of each other.
+ *
+ * Defense-in-depth only — the persist bug is fixed server-side in its own
+ * lane; this keeps a not-yet-deployed or regressed backend from ever painting
+ * the duplicate. Deliberately narrow so it can never eat a real reply:
+ * plain-text turns only (attachments/blocks always render), adjacency required
+ * (any turn in between means real conversation flow), and an intentional
+ * repeat ("say that again") arrives seconds later, outside the window.
+ */
+export function dedupeDoubledAssistantMessages(
+  messages: ConversationMessage[],
+): ConversationMessage[] {
+  if (messages.length < 2) return messages;
+  let changed = false;
+  const next: ConversationMessage[] = [];
+  for (const message of messages) {
+    const prev = next[next.length - 1];
+    if (
+      prev &&
+      isPlainTextAssistantTurn(prev) &&
+      isPlainTextAssistantTurn(message) &&
+      prev.id !== message.id &&
+      prev.text.trim() === message.text.trim() &&
+      Math.abs(message.timestamp - prev.timestamp) <
+        ASSISTANT_DUPLICATE_WINDOW_MS
+    ) {
+      changed = true;
+      continue;
+    }
+    next.push(message);
+  }
+  return changed ? next : messages;
+}
+
 export function filterRenderableConversationMessages(
   messages: ConversationMessage[],
 ): ConversationMessage[] {
-  return messages.filter((message) => shouldKeepConversationMessage(message));
+  return dedupeDoubledAssistantMessages(
+    messages.filter((message) => shouldKeepConversationMessage(message)),
+  );
 }


### PR DESCRIPTION
## Problem

Shadow's QA (2026-07-22): identical assistant replies painting twice (double messages). The backend double-persist is being fixed in its own lane; until that deploys everywhere (and against future regressions), the transcript should never paint the duplicate.

## Fix

`dedupeDoubledAssistantMessages` inside `filterRenderableConversationMessages` (the single render filter all thread loads route through): collapse the LATER copy when two **adjacent** assistant turns carry identical (trimmed) text and land within **2s** of each other.

Deliberately narrow so it can never eat a real reply:
- plain-text assistant turns only — turns with attachments or A2UI blocks always render
- adjacency required — any turn in between means real conversation flow
- 2s window — an intentional "say that again" repeat arrives seconds later, outside it
- user turns are never touched (users may legitimately send the same text twice)
- returns the SAME array reference when nothing collapses (render-path referential equality preserved, no extra re-renders)

Applied at the filter seam, so it covers initial load, cache merge, around-window jumps, older-page loads, and prefetch uniformly — and composes with the existing empty-placeholder filter (a swallowed-then-retried stream leaves `reply, empty placeholder, reply`; the placeholder filters out first, making the copies adjacent).

## Scope

Render path only. No store mutations, no API changes, nothing is deleted server-side.

## Tests

9 new tests: collapse inside the window, keep outside the window, adjacency requirement, media/blocks exemption, user-turn exemption, referential equality, trimmed-text matching, and the composed placeholder-between-copies case. Full filter suite 14/14; adjacent loader suites 18/18.

Evidence: Shadow QA 2026-07-22, `projects/eliza-fleet/UX-STRIKE-2026-07-23.md`.

[sol-ux-strike]

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - pure render-filter change in packages/ui/src/state/conversation-message-filter.ts (.ts state module); no rendered-UI source file (.tsx/css) in the diff`

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no component/style change; the transcript renders through the same filter seam`

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no visual surface changed; collapse semantics pinned by 9 unit tests`

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - render path only; no store mutations, no API calls, nothing deleted server-side`

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no network behavior change; pure function over already-loaded messages`

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic dedupe of double-persisted rows, no model in the loop`

<!-- evidence-row:domain-artifacts -->
N/A - domain proof is embedded in the PR tests/artifacts; see the Tests section above and changed test files in this PR.