### PR TITLE
fix(core): gate native evaluator on terminal action results

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -13,6 +13,7 @@ import { type ChatMessage, ModelType } from "../../types/model";
 import { TrajectoryLimitExceeded } from "../limits";
 import {
 	__renderRoutingHintsBlockForTests,
+	actionResultToPlannerToolResult,
 	PROGRESS_ONLY_ANSWER_REJECT,
 	PROGRESS_ONLY_REPLY_OPENERS_PATTERN,
 	parsePlannerOutput,
@@ -2744,12 +2745,12 @@ describe("v5 planner loop skeleton", () => {
 
 describe("v5 planner loop — evaluator gate", () => {
 	// Conservative gate: when a successful tool drained the queue and the most
-	// recent planner output supplied an EXPLICIT `messageToUser` field, the
+	// recent planner output supplied an EXPLICIT `messageToUser` field, or the
+	// drained action result explicitly owns a verified terminal reply, the
 	// planner loop synthesizes a FINISH evaluator output and skips the
-	// evaluator's full LLM call. The six tests below pin the fire/withhold
-	// contract — including the discriminator that native-mode tool-call returns
-	// (which fall back to `text`) do NOT trigger the gate, because `text` can
-	// be a pre-tool thought rather than a final answer.
+	// evaluator's full LLM call. The tests below pin both fire paths and every
+	// conservative withhold condition. Native free text remains ambiguous
+	// because it can be a pre-tool thought rather than a final answer.
 
 	function plannerJsonWith(opts: {
 		messageToUser?: string;
@@ -2993,6 +2994,239 @@ describe("v5 planner loop — evaluator gate", () => {
 
 		expect(evaluate).toHaveBeenCalledTimes(1);
 		expect(result.finalMessage).toBe("Status: ok.");
+	});
+
+	it("SKIPS in native-mode when the action owns a terminal canonical result", async () => {
+		const runtime = {
+			useModel: plannerNativeWith({
+				text: "I should change the setting.",
+				toolCalls: [
+					{
+						id: "settings-1",
+						name: "SETTINGS",
+						arguments: {
+							action: "set",
+							section: "permissions",
+							key: "shell",
+							value: "off",
+						},
+					},
+				],
+			}),
+		};
+		const reply = "Shell access is off.";
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: reply,
+			userFacingText: reply,
+			verifiedUserFacing: true,
+			turnComplete: true,
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "should not be called",
+		}));
+		const recordedStages: RecordedStage[] = [];
+		const recorder: TrajectoryRecorder = {
+			startTrajectory: vi.fn(() => "trj-native-action-owned"),
+			recordStage: vi.fn(
+				async (_trajectoryId: string, stage: RecordedStage) => {
+					recordedStages.push(stage);
+				},
+			),
+			endTrajectory: vi.fn(async () => undefined),
+			load: vi.fn(async () => null),
+			list: vi.fn(async () => []),
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+			recorder,
+			trajectoryId: "trj-native-action-owned",
+		});
+
+		expect(evaluate).not.toHaveBeenCalled();
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(reply);
+		expect(result.evaluator?.thought).toContain("action-owned");
+		expect(
+			recordedStages.find((stage) => stage.kind === "evaluation")?.evaluation
+				?.reason,
+		).toBe("action_terminal_result");
+	});
+
+	it("preserves action-owned completion through the canonical planner-result mapping", () => {
+		const result = actionResultToPlannerToolResult({
+			success: true,
+			text: "Settings updated.",
+			userFacingText: "Settings updated.",
+			verifiedUserFacing: true,
+			turnComplete: true,
+		});
+
+		expect(result).toMatchObject({
+			success: true,
+			userFacingText: "Settings updated.",
+			verifiedUserFacing: true,
+			turnComplete: true,
+		});
+	});
+
+	it("WITHHOLDS an action-owned completion while another native tool remains queued", async () => {
+		const runtime = {
+			useModel: plannerNativeWith({
+				toolCalls: [
+					{ id: "settings-1", name: "SETTINGS", arguments: {} },
+					{ id: "lookup-1", name: "LOOKUP", arguments: {} },
+				],
+			}),
+		};
+		const executeToolCall = vi.fn(async (toolCall: { name: string }) =>
+			toolCall.name === "SETTINGS"
+				? {
+						success: true,
+						text: "Settings updated.",
+						userFacingText: "Settings updated.",
+						verifiedUserFacing: true,
+						turnComplete: true,
+					}
+				: { success: true, text: "Lookup complete." },
+		);
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "NEXT_RECOMMENDED" as const,
+				thought: "The queued lookup still needs to run.",
+				recommendedToolCallId: "lookup-1",
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "FINISH" as const,
+				thought: "All queued work is complete.",
+				messageToUser: "Settings updated and lookup complete.",
+			});
+
+		await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		expect(evaluate).toHaveBeenCalledTimes(2);
+	});
+
+	it("WITHHOLDS when an action-owned completion follows another executed tool", async () => {
+		const runtime = {
+			useModel: plannerNativeWith({
+				toolCalls: [
+					{ id: "lookup-1", name: "LOOKUP", arguments: {} },
+					{ id: "settings-1", name: "SETTINGS", arguments: {} },
+				],
+			}),
+		};
+		const executeToolCall = vi.fn(async (toolCall: { name: string }) =>
+			toolCall.name === "SETTINGS"
+				? {
+						success: true,
+						text: "Settings updated.",
+						userFacingText: "Settings updated.",
+						verifiedUserFacing: true,
+						turnComplete: true,
+					}
+				: { success: true, text: "Lookup complete." },
+		);
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "NEXT_RECOMMENDED" as const,
+				thought: "Run the queued settings action.",
+				recommendedToolCallId: "settings-1",
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "FINISH" as const,
+				thought: "The evaluator combines both completed operations.",
+				messageToUser: "Lookup complete and settings updated.",
+			});
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		expect(evaluate).toHaveBeenCalledTimes(2);
+		expect(result.finalMessage).toBe("Lookup complete and settings updated.");
+		expect(result.evaluator?.thought).toContain("combines both");
+	});
+
+	it("WITHHOLDS an action-owned completion without canonical user-facing text", async () => {
+		const runtime = {
+			useModel: plannerNativeWith({
+				toolCalls: [{ id: "settings-1", name: "SETTINGS", arguments: {} }],
+			}),
+		};
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "The evaluator supplies the missing reply.",
+			messageToUser: "Settings updated.",
+		}));
+
+		await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi.fn(async () => ({
+				success: true,
+				text: "internal diagnostic",
+				verifiedUserFacing: true,
+				turnComplete: true,
+			})),
+			evaluate,
+		});
+
+		expect(evaluate).toHaveBeenCalledTimes(1);
+	});
+
+	it("WITHHOLDS when the action explicitly marks the turn incomplete", async () => {
+		const runtime = {
+			useModel: plannerJsonWith({
+				messageToUser: "This planner reply is premature.",
+				toolCalls: [{ name: "LOOKUP", args: {} }],
+			}),
+		};
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "The evaluator respects the action-owned disclaimer.",
+			messageToUser: "Lookup complete.",
+		}));
+
+		await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi.fn(async () => ({
+				success: true,
+				text: "Lookup partial.",
+				userFacingText: "Lookup partial.",
+				verifiedUserFacing: true,
+				turnComplete: false,
+			})),
+			evaluate,
+		});
+
+		expect(evaluate).toHaveBeenCalledTimes(1);
 	});
 
 	it("WITHHOLDS on tool failure — evaluator IS called", async () => {

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -161,6 +161,9 @@ export function projectActionResultForClipboard(
 			? { verifiedUserFacing: result.verifiedUserFacing }
 			: {}),
 		...(safeActionName ? { data: { actionName: safeActionName } } : {}),
+		...(result.turnComplete !== undefined
+			? { turnComplete: result.turnComplete }
+			: {}),
 		...(result.continueChain !== undefined
 			? { continueChain: result.continueChain }
 			: {}),
@@ -569,6 +572,7 @@ function actionResultToStreamingResult(
 			options.suppressData && result.values !== undefined
 				? sensitiveActionResultMarker(result.values)
 				: result.values,
+		turnComplete: result.turnComplete,
 		continueChain: result.continueChain,
 	} as ToolCall["result"];
 }

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -988,18 +988,19 @@ async function runPlannerLoopIterations(
 			continue;
 		}
 
-		// Conservative gate (PR #7514): when a successful tool drained the queue
-		// and the just-completed planner call gave us a clean explicit
-		// `messageToUser`, synthesize a FINISH and skip the in-loop evaluator.
-		// Falls through on any ambiguity. See `tryGateEvaluator` doc-comment.
+		// Conservative gate (PR #7514): once a successful tool drains the queue,
+		// synthesize FINISH only from a clean explicit planner reply or a verified
+		// action-owned completion. Falls through on any ambiguity. See
+		// `tryGateEvaluator` for the full contract.
 		const gateStartedAt = Date.now();
-		const gated = tryGateEvaluator({
+		const gatedDecision = tryGateEvaluator({
 			trajectory,
 			failures,
 			lastPlannerExplicitMessageToUser,
 			lastPlannerExplicitCompleted,
 		});
-		if (gated) {
+		if (gatedDecision) {
+			const { output: gated, reason } = gatedDecision;
 			trajectory.evaluatorOutputs.push(gated);
 			trajectory.context = appendEvaluationEvent({
 				context: trajectory.context,
@@ -1014,6 +1015,7 @@ async function runPlannerLoopIterations(
 				startedAt: gateStartedAt,
 				endedAt: Date.now(),
 				output: gated,
+				reason,
 				logger: params.runtime.logger,
 			});
 			return {
@@ -1939,10 +1941,10 @@ function compactText(value: string, maxLength: number): string {
  * Synthesized recorder stage for the gated path. Emits a `kind: "evaluation"`
  * entry so the recorder timeline shows the iteration's outcome on the same
  * slot a model-produced evaluation would have occupied. The stage carries
- * `gated: true`, `llmCallSkipped: true`, and `reason: "explicit_terminal_reply"`
- * so replay/debug tools can distinguish gated decisions from real evaluator
- * calls without a string-match against the thought marker. No `model` block
- * is included — no LLM call happened.
+ * `gated: true`, `llmCallSkipped: true`, and a reason that distinguishes an
+ * explicit planner reply from a terminal action-owned result. Replay/debug
+ * tools can therefore identify both fast paths without string-matching the
+ * thought marker. No `model` block is included because no LLM call happened.
  */
 async function recordGatedEvaluationStage(args: {
 	recorder?: TrajectoryRecorder;
@@ -3746,11 +3748,15 @@ function diagnosticFailureReason(
  *   1. The just-completed tool result is `success: true`.
  *   2. The plan queue is drained — no tools remain to evaluate.
  *   3. No failures have accumulated (no recent error to investigate).
- *   4. The most-recent planner output supplied an EXPLICIT `messageToUser`
- *      field in its structured output (NOT a fallback inferred from a stray
- *      `text` on a native tool-call return — that path can carry a pre-tool
- *      thought rather than a final answer, which would be unsafe to surface).
- *   5. That `messageToUser` is not a tool/function-syntax leak (the evaluator's
+ *   4. One side owns a complete user reply:
+ *      - this is the turn's only executed tool and the action returned
+ *        `turnComplete:true`, `verifiedUserFacing:true`, and non-empty
+ *        `userFacingText` after seeing the real tool outcome; or
+ *      - the most-recent planner output supplied an EXPLICIT `messageToUser`
+ *        field (not a fallback inferred from native free text).
+ *      `turnComplete:false` is an explicit action-owned disclaimer and always
+ *      falls through to the evaluator.
+ *   5. The selected reply is not a tool/function-syntax leak (the evaluator's
  *      own prompt rules say leaked syntax should force CONTINUE; we honor the
  *      same constraint by reusing `isUnsafeUserVisibleText`).
  *   6. The planner did NOT explicitly set `completed: false` on this output.
@@ -3769,37 +3775,81 @@ function diagnosticFailureReason(
  * the decision in the context event stream, `trajectory.evaluatorOutputs` still
  * gets the entry, and the loop's return value still carries `evaluator` in the
  * shape consumers (`subPlannerResultToPlannerToolResult` in `services/message.ts`)
- * read — `success` and `messageToUser`. Recorder stage entries for "evaluation"
- * are NOT emitted in the gated case; the recorder timeline shows tool stages
- * only for that iteration.
+ * read — `success` and `messageToUser`. The recorder receives a synthesized
+ * evaluation stage whose reason distinguishes planner-owned replies from
+ * action-owned terminal results.
  *
  * Cost win: roughly 50% of LLM calls on "tool-then-explicit-reply" turns where
  * the planner committed a `messageToUser` field at plan-time. Native-mode
- * native-tool-call returns without an explicit `messageToUser` field do NOT
- * trigger the gate — those calls remain on the full evaluator path.
+ * native-tool-call returns without that field remain ambiguous; actions that
+ * truly own a single-operation turn can instead set `turnComplete:true` after
+ * execution. The gate requires both a drained queue and exactly one executed
+ * tool, so it never replaces the evaluator on a native parallel-call batch.
  */
+type GatedEvaluatorDecision = {
+	output: EvaluatorOutput;
+	reason: "explicit_terminal_reply" | "action_terminal_result";
+};
+
 function tryGateEvaluator(args: {
 	trajectory: PlannerTrajectory;
 	failures: readonly FailureLike[];
 	lastPlannerExplicitMessageToUser: string | undefined;
 	lastPlannerExplicitCompleted: boolean | undefined;
-}): EvaluatorOutput | null {
+}): GatedEvaluatorDecision | null {
 	const latestStep = args.trajectory.steps[args.trajectory.steps.length - 1];
 	const latestResult = latestStep?.result;
 	if (latestResult?.success !== true) return null;
 	if (args.trajectory.plannedQueue.length > 0) return null;
 	if (args.failures.length > 0) return null;
-	const message = args.lastPlannerExplicitMessageToUser?.trim();
-	if (!message) return null;
-	if (isUnsafeUserVisibleText(message)) return null;
 	// Precondition 6: respect the planner's own completion disclaimer.
 	if (args.lastPlannerExplicitCompleted === false) return null;
+	if (
+		latestResult.turnComplete === true &&
+		completedToolStepCount(args.trajectory) !== 1
+	) {
+		return null;
+	}
 
+	return selectGatedEvaluatorReply(latestResult, args);
+}
+
+function completedToolStepCount(trajectory: PlannerTrajectory): number {
+	return [...trajectory.archivedSteps, ...trajectory.steps].filter(
+		(step) => step.toolCall && step.result,
+	).length;
+}
+
+function selectGatedEvaluatorReply(
+	latestResult: PlannerToolResult,
+	args: { lastPlannerExplicitMessageToUser: string | undefined },
+): GatedEvaluatorDecision | null {
+	if (latestResult.turnComplete === true) {
+		const message = latestResult.userFacingText?.trim();
+		if (latestResult.verifiedUserFacing !== true || !message) return null;
+		if (isUnsafeUserVisibleText(message)) return null;
+		return {
+			reason: "action_terminal_result",
+			output: {
+				success: true,
+				decision: "FINISH",
+				thought: ACTION_RESULT_GATED_EVALUATOR_THOUGHT,
+				messageToUser: message,
+			},
+		};
+	}
+	if (latestResult.turnComplete === false) return null;
+
+	const message = args.lastPlannerExplicitMessageToUser?.trim();
+	if (!message || isUnsafeUserVisibleText(message)) return null;
 	return {
-		success: true,
-		decision: "FINISH",
-		thought: GATED_EVALUATOR_THOUGHT,
-		messageToUser: message,
+		reason: "explicit_terminal_reply",
+		output: {
+			success: true,
+			decision: "FINISH",
+			thought: GATED_EVALUATOR_THOUGHT,
+			messageToUser: message,
+		},
 	};
 }
 
@@ -3808,6 +3858,9 @@ function tryGateEvaluator(args: {
  * cheaply. */
 export const GATED_EVALUATOR_THOUGHT =
 	"Gated FINISH: queue drained successfully with a clean planner messageToUser; evaluator LLM call skipped.";
+
+export const ACTION_RESULT_GATED_EVALUATOR_THOUGHT =
+	"Gated FINISH: queue drained successfully with a terminal action-owned userFacingText; evaluator LLM call skipped.";
 
 const TERMINAL_TOOL_CALL_FINISH_THOUGHT =
 	"Terminal FINISH: planner ended the loop with a terminal tool call; evaluator LLM call skipped.";
@@ -4195,6 +4248,7 @@ export function actionResultToPlannerToolResult(
 		verifiedUserFacing: result.verifiedUserFacing,
 		data: Object.keys(data).length > 0 ? data : undefined,
 		error: result.error,
+		turnComplete: result.turnComplete,
 		continueChain: result.continueChain,
 	};
 	if (options.summary) {

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -140,6 +140,19 @@ export interface PlannerToolResult {
 	summary?: string;
 	data?: Record<string, unknown>;
 	error?: unknown;
+	/**
+	 * Action-owned completion signal that is honored only for a single executed
+	 * tool after the plan queue drains and the successful result carries verified
+	 * canonical user-facing text. It never discards already-queued calls or
+	 * replaces evaluation of a multi-tool turn. `false` explicitly requires
+	 * evaluation, while omission delegates completion to the planner/evaluator.
+	 */
+	turnComplete?: boolean;
+	/**
+	 * Explicit chain-control override. `false` unconditionally aborts the
+	 * remaining planner queue, including for legacy failure and fire-and-forget
+	 * results. It is distinct from the conservative `turnComplete` fast path.
+	 */
 	continueChain?: boolean;
 }
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6227,6 +6227,9 @@ function collectPreviousActionResults(
 					? { verifiedUserFacing: step.result.verifiedUserFacing }
 					: {}),
 				data: { actionName },
+				...(step.result.turnComplete !== undefined
+					? { turnComplete: step.result.turnComplete }
+					: {}),
 				...(step.result.continueChain !== undefined
 					? { continueChain: step.result.continueChain }
 					: {}),
@@ -6276,6 +6279,9 @@ function collectPreviousActionResults(
 			},
 			...(values ? { values } : {}),
 			...(error !== undefined ? { error } : {}),
+			...(step.result.turnComplete !== undefined
+				? { turnComplete: step.result.turnComplete }
+				: {}),
 			...(step.result.continueChain !== undefined
 				? { continueChain: step.result.continueChain }
 				: {}),

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -873,7 +873,23 @@ export interface ActionResult {
 	/** Error information if the action failed */
 	error?: string | Error;
 
-	/** Whether to continue the action chain (for chained actions) */
+	/**
+	 * Declares that this result fully answers a single-operation turn. The
+	 * planner may skip its in-loop evaluator only when this was the turn's sole
+	 * executed tool, no planned tools remain, the result succeeded, and it
+	 * supplies safe canonical `userFacingText` via `verifiedUserFacing`. Unlike
+	 * `continueChain: false`, this does not discard already-queued tool calls.
+	 * Set `false` to explicitly require evaluation; omit it when the action has
+	 * no opinion about whether the overall turn is complete.
+	 */
+	turnComplete?: boolean;
+
+	/**
+	 * Explicit chain-control override. `false` aborts the remaining planner queue
+	 * and returns immediately, including for legacy failure and fire-and-forget
+	 * actions that do not own a complete user reply. Prefer `turnComplete` for the
+	 * safe single-operation evaluator fast path.
+	 */
 	continueChain?: boolean;
 
 	/** Optional cleanup function to execute after action completion */

--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -4,7 +4,7 @@ Gives an Eliza agent the ability to launch, close, list, scaffold, and verify El
 
 ## Purpose / role
 
-This plugin registers three actions, one natural-language shortcut set, two evaluators, one provider, and four services. It exposes those capabilities to any Eliza agent that loads it; it is opt-in (not default-enabled). All runtime communication with the Eliza dashboard happens over loopback HTTP (`/api/apps/*`, `/api/views/*`) discovered via `resolveServerOnlyPort`.
+This plugin registers four actions, one natural-language shortcut set, two evaluators, one provider, and four services. It exposes those capabilities to any Eliza agent that loads it; it is opt-in (not default-enabled). All runtime communication with the Eliza dashboard happens over loopback HTTP (`/api/apps/*`, `/api/views/*`) discovered via `resolveServerOnlyPort`.
 
 ## Plugin surface
 
@@ -15,6 +15,7 @@ This plugin registers three actions, one natural-language shortcut set, two eval
 | `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
 | `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `icon`, `rollback`, `delete`/`remove`. Create/edit/icon/rollback/delete are owner-gated; read modes are open. `rollback` resets a created/edited view-or-plugin workdir to the pre-edit git snapshot taken before the coding agent ran (#8915) and re-registers it via `load-from-directory`. |
 | `BACKGROUND` | `src/actions/background.ts` | Change the unified app background from chat. Ops: `set` (color name/hex, a named **programmable GLSL shader** preset — `aurora`/`lava`/`plasma`/`waves`/`nebula` — plus relative uniform tweaks like *slower*/*brighter*/*bigger* (#10694), an uploaded image attachment, or a generated image from a prompt), `undo`, `redo`, `reset`. The action names a preset id + uniform patch only; the GLSL source lives in `@elizaos/ui` (`backgrounds/shader-presets.ts`) where `useBackgroundApplyChannel` resolves id→source, validates it, and `ProgrammableShaderBackground` renders it via three.js with a compile-validate + frame-watchdog + context-loss-recovery + reduced-motion + color-field fallback. Broadcasts a `background:apply` view event via `POST /api/views/events/broadcast`; the renderer applies it to the shared `BackgroundConfig` store. Drives the SAME background as the `/background` view — there is no separate homescreen-scene surface. |
+| `SETTINGS` | `src/actions/settings.ts` | Describe, list, and change built-in settings; mutations use the same semantic routes as the UI. Successful list/set results own canonical reply text and declare a single-operation turn complete once the plan queue is drained, avoiding a redundant evaluator model call on native function-calling backends without suppressing multi-tool evaluation. Owner-gated. |
 
 ### Evaluators
 
@@ -73,6 +74,7 @@ src/
     app-create.ts                 create sub-handler (multi-turn scaffold + coding agent)
     scaffold-env.ts               shared template/plugins-dir resolution + coding-dispatch preflight for the create flows
     background.ts                 BACKGROUND action (set color/shader-preset/image/generate, tweak, undo, redo, reset)
+    settings.ts                   SETTINGS action (list/get/set built-in settings)
     views.ts                      VIEWS action dispatcher
     views-client.ts               ViewsClient — loopback HTTP to /api/views/*
     views-request-auth.ts         Alias-aware Bearer headers for authenticated view loopback requests

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -4,7 +4,7 @@ Gives an Eliza agent the ability to launch, close, list, scaffold, and verify El
 
 ## Purpose / role
 
-This plugin registers three actions, one natural-language shortcut set, two evaluators, one provider, and four services. It exposes those capabilities to any Eliza agent that loads it; it is opt-in (not default-enabled). All runtime communication with the Eliza dashboard happens over loopback HTTP (`/api/apps/*`, `/api/views/*`) discovered via `resolveServerOnlyPort`.
+This plugin registers four actions, one natural-language shortcut set, two evaluators, one provider, and four services. It exposes those capabilities to any Eliza agent that loads it; it is opt-in (not default-enabled). All runtime communication with the Eliza dashboard happens over loopback HTTP (`/api/apps/*`, `/api/views/*`) discovered via `resolveServerOnlyPort`.
 
 ## Plugin surface
 
@@ -15,6 +15,7 @@ This plugin registers three actions, one natural-language shortcut set, two eval
 | `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
 | `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `icon`, `rollback`, `delete`/`remove`. Create/edit/icon/rollback/delete are owner-gated; read modes are open. `rollback` resets a created/edited view-or-plugin workdir to the pre-edit git snapshot taken before the coding agent ran (#8915) and re-registers it via `load-from-directory`. |
 | `BACKGROUND` | `src/actions/background.ts` | Change the unified app background from chat. Ops: `set` (color name/hex, a named **programmable GLSL shader** preset — `aurora`/`lava`/`plasma`/`waves`/`nebula` — plus relative uniform tweaks like *slower*/*brighter*/*bigger* (#10694), an uploaded image attachment, or a generated image from a prompt), `undo`, `redo`, `reset`. The action names a preset id + uniform patch only; the GLSL source lives in `@elizaos/ui` (`backgrounds/shader-presets.ts`) where `useBackgroundApplyChannel` resolves id→source, validates it, and `ProgrammableShaderBackground` renders it via three.js with a compile-validate + frame-watchdog + context-loss-recovery + reduced-motion + color-field fallback. Broadcasts a `background:apply` view event via `POST /api/views/events/broadcast`; the renderer applies it to the shared `BackgroundConfig` store. Drives the SAME background as the `/background` view — there is no separate homescreen-scene surface. |
+| `SETTINGS` | `src/actions/settings.ts` | Describe, list, and change built-in settings; mutations use the same semantic routes as the UI. Successful list/set results own canonical reply text and declare a single-operation turn complete once the plan queue is drained, avoiding a redundant evaluator model call on native function-calling backends without suppressing multi-tool evaluation. Owner-gated. |
 
 ### Evaluators
 
@@ -73,6 +74,7 @@ src/
     app-create.ts                 create sub-handler (multi-turn scaffold + coding agent)
     scaffold-env.ts               shared template/plugins-dir resolution + coding-dispatch preflight for the create flows
     background.ts                 BACKGROUND action (set color/shader-preset/image/generate, tweak, undo, redo, reset)
+    settings.ts                   SETTINGS action (list/get/set built-in settings)
     views.ts                      VIEWS action dispatcher
     views-client.ts               ViewsClient — loopback HTTP to /api/views/*
     views-request-auth.ts         Alias-aware Bearer headers for authenticated view loopback requests

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -323,6 +323,10 @@ describe("SETTINGS action: list", () => {
 	it("lists writable sections with how each is written", async () => {
 		const { result } = await invoke({ action: "list" });
 		expect(result?.success).toBe(true);
+		expect(result?.userFacingText).toBe(result?.text);
+		expect(result?.verifiedUserFacing).toBe(true);
+		expect(result?.turnComplete).toBe(true);
+		expect(result?.continueChain).toBeUndefined();
 		expect(result).toBeDefined();
 		if (!result) throw new Error("Expected SETTINGS list result");
 		const sections = (
@@ -402,6 +406,10 @@ describe("SETTINGS action: set on an owned route section", () => {
 			},
 		});
 		expect(result?.success).toBe(true);
+		expect(result?.userFacingText).toBe(result?.text);
+		expect(result?.verifiedUserFacing).toBe(true);
+		expect(result?.turnComplete).toBe(true);
+		expect(result?.continueChain).toBeUndefined();
 		expect(result?.values).toMatchObject({
 			section: "appearance",
 			key: "theme",
@@ -2184,6 +2192,10 @@ describe("SETTINGS action: get and validate", () => {
 	it("reports a section's write capability on get", async () => {
 		const { result } = await invoke({ action: "get", section: "permissions" });
 		expect(result?.success).toBe(true);
+		expect(result?.userFacingText).toBeUndefined();
+		expect(result?.verifiedUserFacing).toBeUndefined();
+		expect(result?.turnComplete).toBeUndefined();
+		expect(result?.continueChain).toBeUndefined();
 		expect(result?.data).toMatchObject({
 			section: "permissions",
 			capability: "route",

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -1859,6 +1859,9 @@ async function handleSet(
 	return {
 		success: true,
 		text: reply,
+		userFacingText: reply,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			section: request.sectionId,
 			key: keyName,
@@ -2122,6 +2125,9 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 				return {
 					success: true,
 					text: reply,
+					userFacingText: reply,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					data: { sections: listing },
 				};
 			}


### PR DESCRIPTION
Fixes #16889

## Root cause

Native function-calling does not carry a trustworthy post-action `messageToUser`. Adding anticipatory planner prose, as originally proposed, would let text produced before dispatch falsely certify that the action succeeded and that the turn is complete. The existing `continueChain` flag cannot serve as that certificate either: it is a legacy immediate chain-abort signal, so using it for evaluator gating can truncate a queued batch.

## Architecture

This change adds an explicit, provider-independent `turnComplete` result contract owned by the action:

- `true` makes the result eligible for terminal gating; `false` vetoes gating; absent delegates to normal evaluation.
- Eligibility additionally requires exactly one executed tool in the turn, a successful latest result, a drained planned queue, no accumulated failure, planner completion not explicitly false, and non-empty canonical `userFacingText` marked `verifiedUserFacing`.
- Multi-tool batches are counted across active and archived planner steps, so the last tool cannot accidentally become terminal merely because the queue just drained.
- Failed, partial, ambiguous, unsafe, missing-output, queued, and explicitly incomplete turns retain the model-backed evaluator.
- The existing text/XML planner-owned gate and `continueChain` behavior remain intact.
- Gated trajectories record `action_terminal_result` with `llmCallSkipped: true` and no model attribution.

`SETTINGS` opts in only for successful list/set operations whose returned text describes the actual completed result. Its GET/capability-description path and every failure remain evaluator-backed.

## Exact-head validation

Validated commit: `269ce9fd975a38aaee837c128d9e7e6dcb821077`, rebased onto `0d0e53fe9592036da2d1b51b8e4dfe1a6437498c`.

- Core regression suite: **5 files, 254 tests passed**.
- App-control SETTINGS suite: **1 file, 107 tests passed**.
- `@elizaos/core` and `@elizaos/plugin-app-control` TypeScript checks: passed.
- Biome check on all eight changed TypeScript files: passed.
- `CLAUDE.md` / `AGENTS.md` package pair: byte-identical.
- CI build, lint, typecheck, changed-file coverage, security, gitleaks, environment audit, test-integrity, and stale-base checks: passed.
- Root `bun run verify` preflight passed and then stopped on an untouched baseline formatter failure in `packages/import-conversations/src/parsers/fixtures/chatgpt-export/conversations.json`; this branch does not change that package or fixture.

## Live-model trajectories

### Native function-calling control on exact head

Run: `issue-16889-native-final2-269ce9` through Eliza Cloud's OpenAI-compatible native function-calling route.

- Scenario: `settings-shell-toggle`.
- Result: **1 passed, 0 failed**, 28.793 s scenario duration.
- Planner: one `ACTION_PLANNER` iteration with `toolChoice=required` and one native `SETTINGS` call.
- Dispatch: `set permissions.shell=false`, successful.
- Canonical result: `Shell access is off. The agent can no longer run shell commands.`
- Structural proof: `verifiedUserFacing=true`, `turnComplete=true`.
- Evaluation: synthetic `FINISH`, `gated=true`, `llmCallSkipped=true`, `reason=action_terminal_result`, 3 ms.
- Model stages: exactly two (message handler + planner); there is no evaluator-model stage.
- Metrics: one planner iteration, one executed tool, zero tool failures, zero evaluator failures, 8,583 ms trajectory latency.
- Loopback PUT, selected-action, exact-response, and action-called assertions: all passed.
- Native export: 2/2 rows passed strict privacy attestation, with zero redactions and zero residuals.
- The generated run viewer was opened and manually reviewed at both the stage table and raw native-row levels.

A first exact-head attempt did not dispatch SETTINGS: after an empty completion retry, the upstream model selected `REPLY` while claiming SETTINGS text. The scenario correctly failed rather than accepting that response. The successful rerun above is the primary evidence.

### Text/XML parser control

The same scenario also passed through the Claude SDK text-tool route with native tool exposure disabled. The model emitted text JSON, the parser resolved it to `SETTINGS`, the action returned the same verified terminal result, and the evaluator was skipped for the same structural reason. This confirms that the contract is provider-independent rather than coupled to one native tool-call envelope.

## Evidence artifacts

- [Exact-head scenario report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-report.json)
- [Exact-head native boundary rows](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-native.jsonl)
- [Exact-head native manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-native.manifest.json)
- [Exact-head privacy attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-native.privacy-attestation.json)
- [Exact-head runtime log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-runner.log)
- [Exact-head trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-tj-888edb8d3374b9.json)
- [Text-tool control log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-runner.stdout.log)
- [Text-tool control trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-tj-5b6d59e8930409.json)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - runtime planner/evaluator contract only; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - runtime planner/evaluator contract only; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or audio behavior changed; the generated trajectory viewer was manually inspected

<!-- evidence-row:backend-logs -->
- [x] [16983-runner.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-runner.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend, browser client, or network-client code changed

<!-- evidence-row:llm-trajectory -->
- [x] [16983-tj-888edb8d3374b9.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16983-tj-888edb8d3374b9.json)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the scenario asserts an in-memory loopback settings endpoint and creates no persistent domain record

<!-- evidence-row:ocr-review -->
- [ ] N/A - no product UI screenshot evidence applies to this runtime-only change
