### PR TITLE
fix(ci): run Cerebras telemetry without deploy approval

### DIFF
--- a/.github/workflows/cerebras-chat-flow-live.yml
+++ b/.github/workflows/cerebras-chat-flow-live.yml
@@ -1,8 +1,9 @@
 name: Cerebras Chat Flow Live
 
 # Manual real-model evidence for the complete local AgentRuntime chat path. The
-# credential stays in the staging environment; reports contain only synthetic
-# prompts, outputs, timing spans, token usage, and provider/cache telemetry.
+# credential uses the repository's established benchmark secret; reports
+# contain only synthetic prompts, outputs, timing spans, token usage, and
+# provider/cache telemetry.
 on:
   workflow_dispatch:
     inputs:
@@ -27,7 +28,6 @@ jobs:
     name: Gemma 4 31B full runtime
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    environment: staging
     env:
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
       ELIZA_CEREBRAS_CHAT_MODEL: gemma-4-31b


### PR DESCRIPTION
Follow-up to #16957 and #16978.

The telemetry-only workflow was incorrectly bound to the protected staging deployment environment. That made a benchmark require deployment approval and blocked the triggering reviewer under GitHub self-review protection. Existing Cerebras benchmark workflows use the repository CEREBRAS_API_KEY secret without an environment because they do not deploy anything. This aligns the new full-runtime telemetry workflow with that established pattern.

Validation: actionlint passed; CI Bun pin contract 6/6 passed; git diff --check passed.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow-only change; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow-only change; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - workflow-only change

<!-- evidence-row:backend-logs -->
- [x] The blocked run is https://github.com/elizaOS/eliza/actions/runs/29993785413 and shows the staging approval failure mode.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this change only unblocks the live run; the resulting trajectory will be posted after merge

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - workflow configuration only