### PR TITLE
fix(ci): keep dev preparation inside build outputs

### DIFF
--- a/packages/agent/src/build-config.test.ts
+++ b/packages/agent/src/build-config.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Guards the agent's production emit boundary against traversing into sibling
+ * workspace sources, which would leave JavaScript beside their TypeScript.
+ */
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+interface BuildConfig {
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+describe("agent build configuration", () => {
+  it("resolves app-manager declarations from its build output", async () => {
+    const configPath = fileURLToPath(
+      new URL("../tsconfig.build.json", import.meta.url),
+    );
+    const config = JSON.parse(
+      await readFile(configPath, "utf8"),
+    ) as BuildConfig;
+
+    expect(
+      config.compilerOptions?.paths?.["@elizaos/plugin-app-manager"],
+    ).toEqual(["../../plugins/plugin-app-manager/dist/index.d.ts"]);
+  });
+});

--- a/packages/agent/tsconfig.build.json
+++ b/packages/agent/tsconfig.build.json
@@ -26,7 +26,7 @@
         "../../plugins/plugin-browser/dist/index.d.ts"
       ],
       "@elizaos/plugin-app-manager": [
-        "../../plugins/plugin-app-manager/src/index.ts"
+        "../../plugins/plugin-app-manager/dist/index.d.ts"
       ],
       "@elizaos/plugin-elizacloud": ["./src/external-modules.d.ts"]
     },

--- a/packages/cloud-ui/src/build-config.test.ts
+++ b/packages/cloud-ui/src/build-config.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Guards declaration emit against following workspace aliases back into source
+ * trees, where TypeScript can leave ignored JavaScript beside TypeScript files.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+interface BuildConfig {
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+describe("cloud UI build boundary", () => {
+  test("resolves workspace dependencies through built declarations", () => {
+    const config = JSON.parse(
+      readFileSync(new URL("../tsconfig.build.json", import.meta.url), "utf8"),
+    ) as BuildConfig;
+    const targets = Object.values(config.compilerOptions?.paths ?? {}).flat();
+
+    expect(targets).not.toHaveLength(0);
+    expect(targets.every((target) => target.includes("/dist/"))).toBe(true);
+    expect(targets.every((target) => !target.includes("/src/"))).toBe(true);
+  });
+});

--- a/packages/cloud-ui/tsconfig.build.json
+++ b/packages/cloud-ui/tsconfig.build.json
@@ -9,7 +9,11 @@
     "rootDir": "./src",
     "rewriteRelativeImportExtensions": true,
     "stripInternal": true,
-    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "paths": {
+      "@elizaos/ui": ["../ui/dist/index.d.ts"],
+      "@elizaos/ui/*": ["../ui/dist/*"]
+    }
   },
   "exclude": [
     "src/**/*.stories.ts",

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -529,9 +529,7 @@ function pluginIsRegistered(runtime: AgentRuntime, name: string): boolean {
 
 async function loadRequiredPlugin(pkg: string): Promise<Plugin | null> {
   if (pkg === "@elizaos/plugin-app-control") {
-    const mod = (await import(
-      "../../../plugins/plugin-app-control/src/index.ts"
-    )) as {
+    const mod = (await import("@elizaos/plugin-app-control")) as {
       appAction?: Action;
       appControlPlugin?: Plugin;
       backgroundAction?: Action;
@@ -562,24 +560,6 @@ async function loadRequiredPlugin(pkg: string): Promise<Plugin | null> {
         mod.appControlPlugin?.responseHandlerEvaluators,
     };
   }
-  if (pkg === "@elizaos/plugin-hyperliquid") {
-    const mod = (await import(
-      "../../../plugins/plugin-hyperliquid/src/plugin.ts"
-    )) as {
-      hyperliquidPlugin?: Plugin;
-    };
-    return mod.hyperliquidPlugin ?? null;
-  }
-  if (pkg === "@elizaos/plugin-anthropic-proxy") {
-    const mod = (await import(
-      "../../../plugins/plugin-anthropic-proxy/index.ts"
-    )) as {
-      default?: Plugin;
-      anthropicProxyPlugin?: Plugin;
-    };
-    return mod.default ?? mod.anthropicProxyPlugin ?? null;
-  }
-
   const mod = (await import(pkg)) as Record<string, unknown>;
   const isPlugin = (value: unknown): value is Plugin => {
     if (value === null || typeof value !== "object") return false;

--- a/packages/scenario-runner/src/scenario-pr-workflow.test.ts
+++ b/packages/scenario-runner/src/scenario-pr-workflow.test.ts
@@ -585,9 +585,8 @@ describe("scenario PR workflow contract", () => {
     expect(deterministicScenarioReadme).toContain(
       "runtime currently removes `UPDATE_ENTITY`",
     );
-    expect(scenarioExecutor).toContain(
-      "../../../plugins/plugin-app-control/src/index.ts",
-    );
+    expect(scenarioExecutor).toContain('@elizaos/plugin-app-control"');
+    expect(scenarioExecutor).not.toContain("../../../plugins/");
     expect(scenarioExecutor).toContain(
       "actions: [\n        mod.appAction,\n        mod.backgroundAction,\n        mod.viewsAction,\n        mod.settingsAction,\n      ]",
     );


### PR DESCRIPTION
Closes #16959

## What changed
- Make cloud-ui declaration emit resolve UI types from `packages/ui/dist` instead of traversing UI/core sources.
- Make scenario-runner load workspace plugins through package exports instead of sibling `src` paths.
- Make agent declaration emit resolve app-manager from its built declarations.
- Add regression tests for all three build boundaries.

## Verification
- `bun run dev:prepare`: 116/116 tasks successful; stale-source guard clean.
- Real `bun run dev` boot: ready=true, canRespond=true, runtime/database/coordinator=ok, plugins=29 loaded/0 failed, deferred boot complete.
- Focused regressions: 3 files, 13 tests passed.
- `bun run build`: 175/175 tasks successful; 26/26 view bundles; stale-source guard clean.
- `bun run verify`: 575/575 tasks successful; test-realness regressions=0; 28 dist consumers passed.

## Evidence
- before-screenshots: N/A - CI/runtime build-boundary repair has no visual surface.
- after-screenshots: N/A - CI/runtime build-boundary repair has no visual surface.
- walkthrough-video: N/A - no user-facing interaction changed.
- backend-logs: Failed run [29988448438 job 89145968849](https://github.com/elizaOS/eliza/actions/runs/29988448438/job/89145968849) timed out after `dev:prepare` emitted ignored JavaScript beside TypeScript. Local after-fix boot reached the full healthy state listed above.
- frontend-logs: N/A - frontend behavior was not changed; Vite only consumes the prepared workspace.
- llm-trajectory: N/A - no model, prompt, action, provider, or evaluator behavior changed.
- domain-artifacts: N/A - no persistent product-domain artifact is produced by this CI build-boundary change.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI/runtime build-boundary repair has no visual surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI/runtime build-boundary repair has no visual surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction changed.

<!-- evidence-row:backend-logs -->
- [x] [89145968849](https://github.com/elizaOS/eliza/actions/runs/29988448438/job/89145968849)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - frontend behavior was not changed; Vite only consumes the prepared workspace.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent product-domain artifact is produced by this CI build-boundary change.
