### PR TITLE
fix(ci): benchmark Cerebras with production semantics

### DIFF
--- a/.github/workflows/cerebras-chat-flow-live.yml
+++ b/.github/workflows/cerebras-chat-flow-live.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
+      # Match deployed runtime semantics: production keeps trajectory persistence
+      # opt-in, so diagnostic file flushes cannot inflate the request hot path.
+      NODE_ENV: production
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
       ELIZA_CEREBRAS_CHAT_MODEL: gemma-4-31b
       ELIZA_CEREBRAS_CHAT_SAMPLES: ${{ inputs.samples }}


### PR DESCRIPTION
## What

Runs the live Cerebras full-runtime latency benchmark with `NODE_ENV=production`. Production keeps JSON trajectory persistence opt-in, so synchronous diagnostic file flushes do not contaminate the request hot path.

## Why

The first successful 30-turn run on develop isolated `message-service-overhead` at p50 23ms / p95 51.693ms. The dominant uninstrumented gap between RESPONSE_HANDLER completion and evaluators was p50 16ms / p95 44ms / max 73ms; source inspection confirms the non-production default enables awaited JSON trajectory stage persistence in that gap. This follow-up makes the benchmark match deployed runtime semantics before the final comparison.

Closes no issue; follow-up evidence for #16957 and #16978.

## Validation

- `actionlint .github/workflows/cerebras-chat-flow-live.yml`
- `bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts` (6/6)
- `git diff --check`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only benchmark semantics; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only benchmark semantics; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow-only benchmark semantics; no interactive product flow changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact-merge production run and structured job logs](https://github.com/elizaOS/eliza/actions/runs/29995416024)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Thirty-turn live Cerebras trajectory artifact `8559045096`](https://github.com/elizaOS/eliza/actions/runs/29995416024/artifacts/8559045096)
<!-- evidence-row:domain-artifacts -->
- [x] [Manually reviewed benchmark findings and artifact provenance](https://github.com/elizaOS/eliza/issues/16957#issuecomment-5056973419)
