### PR TITLE
test(agent): pin service-less plugin lifecycle through the snapshot/track pass

### DIFF
--- a/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
+++ b/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
@@ -747,3 +747,35 @@ describe("dispose error handling", () => {
     );
   });
 });
+
+describe("service-class snapshot with a service-less plugin (#16808)", () => {
+  // PR #16808 replaced `plugin.services ?? []` iteration in
+  // snapshotPluginServiceClasses/trackPluginServiceClasses with early
+  // returns. A plugin without a `services` array must still register and
+  // unload cleanly through the serialized lifecycle (the tracking pass is a
+  // no-op for it) and must not disturb another plugin's service ownership.
+  it("registers and unloads a service-less plugin without touching service state", async () => {
+    const runtime = createTestRuntime() as InspectableRuntime;
+    await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+    installRuntimePluginLifecycle(runtime);
+    const withService = makeLifecycleRaceFixture("ratchet-guard-plugin", "v1");
+    const serviceLess = makeSyntheticSkillsPlugin();
+
+    await runtime.registerPlugin(withService.plugin);
+    expect(runtime.hasService(withService.serviceType)).toBe(true);
+
+    await runtime.registerPlugin(serviceLess);
+    expect(serviceLess.services).toBeUndefined();
+    expect(runtime.actions.some((a) => a.name === "USE_SKILL")).toBe(true);
+    // The service-less registration must not have perturbed the other
+    // plugin's service registration.
+    expect(runtime.hasService(withService.serviceType)).toBe(true);
+
+    await runtime.unloadPlugin(serviceLess.name);
+    expect(runtime.actions.some((a) => a.name === "USE_SKILL")).toBe(false);
+    expect(runtime.hasService(withService.serviceType)).toBe(true);
+
+    await runtime.unloadPlugin(withService.plugin.name);
+    expect(runtime.hasService(withService.serviceType)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Test-only: adds a service-less-plugin lifecycle smoke test to `packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts`. A plugin without a `services` array must register and unload cleanly through the serialized lifecycle (`snapshotPluginServiceClasses` / `trackPluginServiceClasses` early-return on `!plugin.services`, landed in #16808 / 8ee057a5f6) and must not disturb another plugin's service ownership.

## Why

Carries forward the unique remaining value of #16928 (author @0xSolace). That PR's core `plugin-lifecycle.ts` change was superseded line-for-line by #16808 on develop, which left #16928 in an unresolvable both-modified conflict from a fork branch; this PR keeps only its additive smoke test, rebased onto current develop (`c68f37a955`). Develop's `plugin-smoke-lifecycle.test.ts` previously had no service-less-plugin coverage of the snapshot/track pass.

## Evidence

- The identical test body already ran green on #16928's head `7d1dfe363f` (Lint / typecheck / build / Develop PR Gate / Test Integrity / coverage / security all success).
- No production code touched — single test-file addition, appended describe block only; the base file content is byte-identical to develop's.
- CI on this PR re-runs the suite against current develop.

Supersedes and closes the remaining scope of #16928. Credit: 0xSolace (co-authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:domain-artifacts -->
- [x] [17002-vitest-plugin-smoke-lifecycle.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17002-vitest-plugin-smoke-lifecycle.log)

<!-- evidence-row:backend-logs -->
- [x] [17002-vitest-plugin-smoke-lifecycle.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17002-vitest-plugin-smoke-lifecycle.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change, no UI flow to record

<!-- evidence-row:ocr-review -->
- [ ] N/A - test-only change, no screenshots

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/prompt/model behavior change; pins existing lifecycle behavior
