### PR TITLE
fix(cloud): keep cli-session create alive across relogin navigation

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -93,6 +93,7 @@ describe("ElizaClient direct Cloud auth served from a cloud web host", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: expect.stringContaining("sessionId"),
+        keepalive: true,
       }),
     );
     expect(result).toEqual(
@@ -194,7 +195,7 @@ describe("ElizaClient direct Cloud auth served from localhost dev (port-shift)",
     // agent API, whose default-deny gate 401s the unlisted /api/auth/* path.
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://api-staging.elizacloud.ai/api/auth/cli-session",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({ method: "POST", keepalive: true }),
     );
     expect(fetchSpy).not.toHaveBeenCalledWith(
       "/api/auth/cli-session",

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -2905,6 +2905,11 @@ ElizaClient.prototype.cloudLoginDirect = async function (
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId }),
+        // The staged sign-out→sign-in can navigate through the cloud auth return
+        // route while this POST is settling. Keep the session-create request out
+        // of the document lifecycle so a successful server-side session is not
+        // reported as an AbortError and abandoned by the polling path.
+        keepalive: true,
       },
     );
     if (!res.ok) {


### PR DESCRIPTION
## Summary
Fixes the residual cli-session relogin navigation race tracked in #16900.

The web `cloudLoginDirect` path now creates `/api/auth/cli-session` with `keepalive: true`. The F5 failure shows the app navigating through sign-out/sign-in return paths while the session-create POST is still settling, so Chromium reports the request as `net::ERR_ABORTED` and the poll path never observes the authenticated session. Keeping the POST outside the document lifecycle preserves the server-side session create across expected navigations.

Native/Capacitor already uses `CapacitorHttp`, so this only changes the browser fetch path.

## Tests
- `bun x vitest run packages/ui/src/api/client-cloud-direct-auth-web.test.ts --coverage.enabled=false` in `/mnt/HC_Volume_106234565/eliza-workers/eliza`: 6 passed

Note: the isolated worktree cannot currently run the test because its symlinked deps are missing `file-type`; canonical checkout run above passed against the same test file.

[sol-orch]

Fixes #16900

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual auth transport lifecycle change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-visual auth transport lifecycle change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-visual auth transport lifecycle change

<!-- evidence-row:backend-logs -->
- [ ] N/A - browser-side fetch option only; no backend changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - browser fetch option unit-only change; no new visual surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - auth transport lifecycle fix; no LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts; focused unit regression covers fetch keepalive contract
