### PR TITLE
fix(ui): suppress duplicate chat websocket echo

### DIFF
--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -667,9 +667,27 @@ export function bindReadyPhase(
       const d = depsRef.current;
       if (!d) return;
       if (cid === d.activeConversationIdRef.current)
-        d.setConversationMessages((prev: ConversationMessage[]) =>
-          prev.some((m) => m.id === msg.id) ? prev : [...prev, msg],
-        );
+        d.setConversationMessages((prev: ConversationMessage[]) => {
+          if (prev.some((m) => m.id === msg.id)) return prev;
+          if (
+            msg.role === "assistant" &&
+            msg.source === MESSAGE_SOURCE_CLIENT_CHAT
+          ) {
+            const normalizedIncoming = msg.text.replace(/\s+/g, " ").trim();
+            if (
+              normalizedIncoming &&
+              prev.some(
+                (m) =>
+                  m.role === "assistant" &&
+                  m.id.startsWith("temp-resp-") &&
+                  m.text.replace(/\s+/g, " ").trim() === normalizedIncoming,
+              )
+            ) {
+              return prev;
+            }
+          }
+          return [...prev, msg];
+        });
       else
         d.setUnreadConversations(
           (prev: Set<string>) => new Set([...prev, cid]),

--- a/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
@@ -79,6 +79,80 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
     window.removeEventListener(VOICE_CONTROL_EVENT, voiceHandler);
   }
 
+  it("does not append a client-chat proactive echo when the streamed temp assistant already has the same text", () => {
+    const deps = makeDeps();
+    deps.activeConversationIdRef.current = "conv-1";
+    let messages = [
+      { id: "temp-user-1", role: "user", text: "hi", timestamp: 1 },
+      {
+        id: "temp-resp-1",
+        role: "assistant",
+        text: "hello there",
+        timestamp: 1,
+      },
+    ];
+    deps.setConversationMessages = vi.fn((updater) => {
+      messages = typeof updater === "function" ? updater(messages) : updater;
+    });
+    const cleanup = bindReadyPhase({ current: deps });
+
+    clientMock.handlers.get("proactive-message")?.({
+      conversationId: "conv-1",
+      message: {
+        id: "server-assistant-1",
+        role: "assistant",
+        text: " hello   there ",
+        timestamp: 2,
+        source: "client_chat",
+      },
+    });
+
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.id)).toEqual([
+      "temp-user-1",
+      "temp-resp-1",
+    ]);
+
+    teardown(cleanup);
+  });
+
+  it("appends distinct proactive assistant messages that do not match the streamed temp assistant", () => {
+    const deps = makeDeps();
+    deps.activeConversationIdRef.current = "conv-1";
+    let messages = [
+      { id: "temp-user-1", role: "user", text: "hi", timestamp: 1 },
+      {
+        id: "temp-resp-1",
+        role: "assistant",
+        text: "hello there",
+        timestamp: 1,
+      },
+    ];
+    deps.setConversationMessages = vi.fn((updater) => {
+      messages = typeof updater === "function" ? updater(messages) : updater;
+    });
+    const cleanup = bindReadyPhase({ current: deps });
+
+    clientMock.handlers.get("proactive-message")?.({
+      conversationId: "conv-1",
+      message: {
+        id: "server-assistant-1",
+        role: "assistant",
+        text: "different answer",
+        timestamp: 2,
+        source: "client_chat",
+      },
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "temp-user-1",
+      "temp-resp-1",
+      "server-assistant-1",
+    ]);
+
+    teardown(cleanup);
+  });
+
   it("re-dispatches a START_TRANSCRIPTION voice-control agent_event to the shell", () => {
     const cleanup = bindReadyPhase({ current: makeDeps() });
 


### PR DESCRIPTION
## Summary
- suppress client-chat proactive WS assistant echoes when the active streamed temp assistant already has the same normalized text
- keep distinct proactive assistant messages appending normally
- add regression coverage for the duplicate visible web-chat bubble path

## Incident verification
- investigated staging user shadow+demo@shad0w.xyz / org 22700f87-40d6-4313-82cc-9acbccc693eb on image sha-39d18c4
- container-local transcript for the demo conversation had one persisted assistant row per user turn, so the observed pairs were a UI/live echo duplicate, not duplicate assistant persistence
- PR #16863 only silences trigger action callback acks, and does not cover ordinary web-chat full-reply duplicates

## Test
- NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" ../../node_modules/.bin/vitest run --config vitest.config.ts src/state/startup-phase-hydrate.voice-control.test.ts

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure state-module change in packages/ui/src/state/startup-phase-hydrate.ts (.ts, no .tsx/css in diff); duplicate bubble only reproducible in a live streamed session against the old code

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no component/style change; suppression semantics pinned by 6/6 unit tests in startup-phase-hydrate.voice-control.test.ts

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual surface changed; guard is a narrow WS-echo suppression at the proactive-message handler

<!-- evidence-row:backend-logs -->
- [x] [17009-staging-db-evidence.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17009-staging-db-evidence.log)

<!-- evidence-row:frontend-logs -->
- [x] [17009-vitest-startup-phase-hydrate.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17009-vitest-startup-phase-hydrate.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic client-side dedupe of a WS echo; no model in the loop

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - server-vs-client verdict + staging DB proof attached in backend-logs row; full incident report in eliza-fleet DOUBLE-MSG-2026-07-23.md