### PR TITLE
perf(cloud): reduce billing and sandbox DB round trips

### DIFF
--- a/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
+++ b/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
@@ -141,7 +141,15 @@ describe("agent bridge runtime routing", () => {
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toContain("event: done");
     expect(deadControlPlaneFetch).not.toHaveBeenCalled();
-    expect(bridgeStream).toHaveBeenCalledWith("agent-1", "org-1", rpcRequest);
+    // 4th arg: the Workers executionCtx that defers the shared-turn billing
+    // tail — this fixture has none, so the route degrades to undefined
+    // (inline settlement). Mirrors the bridge (non-stream) assertion above.
+    expect(bridgeStream).toHaveBeenCalledWith(
+      "agent-1",
+      "org-1",
+      rpcRequest,
+      undefined,
+    );
     expect(bridge).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -155,6 +155,7 @@ app.post("/", async (c) => {
   return handleCanonicalScopedAgentStream({
     agentId: r.agentId,
     orgId: r.orgId,
+    agent: r.agent,
     conversationId,
     ...("userId" in r ? { userId: r.userId } : {}),
     body: raw,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -141,6 +141,17 @@ app.post("/", async (c) => {
   }
 
   const conversationId = c.req.param("conversationId") ?? r.agentId;
+  // Workers only: pass an executionCtx so the shared turn defers its billing
+  // tail off the SSE `done` path via waitUntil. Hono's executionCtx getter
+  // THROWS outside a Worker (tests, Node) — degrade to undefined there so the
+  // turn settles inline, preserving fully-synchronous behavior. Mirrors the
+  // non-stream POST .../messages route.
+  let executionCtx: CanonicalScopedStreamRequest["executionCtx"];
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
   return handleCanonicalScopedAgentStream({
     agentId: r.agentId,
     orgId: r.orgId,
@@ -152,6 +163,7 @@ app.post("/", async (c) => {
       scope: scopeMs,
       body: bodyMs,
     },
+    ...(executionCtx ? { executionCtx } : {}),
   } satisfies CanonicalScopedStreamRequest);
 });
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -130,11 +130,23 @@ async function __hono_POST(
 
     const rpcRequest = parsed.data as BridgeRequest;
 
+    // Workers only: pass an executionCtx so a shared-tier turn defers its
+    // billing tail off the SSE `done` path via waitUntil. Hono's executionCtx
+    // getter THROWS outside a Worker (tests, Node) — degrade to undefined
+    // there so the turn settles inline, preserving synchronous behavior.
+    let executionCtx: Parameters<typeof elizaSandboxService.bridgeStream>[3];
+    try {
+      executionCtx = _ctx?.executionCtx;
+    } catch {
+      executionCtx = undefined;
+    }
+
     // Get the raw SSE stream from the sandbox
     const upstreamResponse = await elizaSandboxService.bridgeStream(
       agentId,
       user.organization_id,
       rpcRequest,
+      executionCtx,
     );
 
     if (!upstreamResponse?.body) {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -702,6 +702,18 @@ export class AgentSandboxesRepository {
       .set({ ...data, updated_at: new Date() })
       .where(eq(agentSandboxes.id, id))
       .returning();
+    if (r && data.status !== undefined) {
+      void import("../../lib/services/shared-runtime/resolve-shared-agent")
+        .then(({ invalidateSharedAgentRunningSandbox }) =>
+          invalidateSharedAgentRunningSandbox(r.id, r.organization_id),
+        )
+        .catch((error) => {
+          logger.debug("[agent-sandboxes] running sandbox cache invalidation failed", {
+            id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    }
     return r;
   }
 

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -50,6 +50,8 @@ export const CacheKeys = {
   sharedAgentScope: {
     resolve: (keyHashPrefix: string, agentId: string) =>
       `shared-agent-scope:${keyHashPrefix}:${agentId}:v1`,
+    runningSandbox: (agentId: string, orgId: string) =>
+      `shared-agent-scope:running-sandbox:${orgId}:${agentId}:v1`,
   },
   /**
    * Inference hot-path caches (#9899). The IAC entry collapses auth + org +
@@ -277,6 +279,7 @@ export const CacheTTL = {
    */
   sharedAgentScope: {
     resolve: 30,
+    runningSandbox: 30,
     /**
      * SLIDING-TTL CAP (COLDPATH-FIX-2026-07-22): a validated scope-cache hit
      * refreshes the entry's TTL back to `resolve` so an ACTIVE conversation

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -901,6 +901,45 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
     PGLITE_TIMEOUT,
   );
 
+
+  test(
+    "concurrent settle attempts claim exactly one reconciliation row",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("9");
+      const reservationId = await insertReservation(1.0);
+
+      const [first, second] = await Promise.all([
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0.4,
+          description: "concurrent chat completion settle a",
+          metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        }),
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0.4,
+          description: "concurrent chat completion settle b",
+          metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        }),
+      ]);
+
+      expect([first.adjustmentType, second.adjustmentType].sort()).toEqual(["none", "refund"]);
+      expect(await getBalance()).toBeCloseTo(9.6, 6);
+      expect(await countByType("refund")).toBe(1);
+      expect(await settlementRowsForReservation(reservationId)).toEqual([
+        {
+          amount: "0.600000",
+          type: "refund",
+          stripe_payment_intent_id: `recon:${reservationId}:refund`,
+        },
+      ]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
   test(
     "sweep ignores ambiguous pre-marker reservations",
     async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
@@ -196,6 +196,56 @@ describe("bridgeSharedMessageStream — billing tail deferred via executionCtx.w
     expect(reconcileCalls).toEqual([0.0042]);
   });
 
+  test("client cancel between last token and `done` frame never refunds a delivered turn", async () => {
+    reset();
+    // Gate the parts iterator between the text-delta and the finish part so the
+    // test can cancel the response stream while the turn is still "delivering".
+    let releaseFinish: (() => void) | undefined;
+    const finishGate = new Promise<void>((resolve) => {
+      releaseFinish = resolve;
+    });
+    streamTurnImpl = () => ({
+      model: "openai/gpt-oss-120b",
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta", text: "hi there" } as const;
+        await finishGate;
+        yield { type: "finish", text: "hi there" } as const;
+      })(),
+    });
+    // Gate billUsage so the deferred tail provably cannot settle before the
+    // stream's catch runs — pre-fix, the catch's settle(0) always won this race.
+    let releaseBill: (() => void) | undefined;
+    const billGate = new Promise<void>((resolve) => {
+      releaseBill = resolve;
+    });
+    billUsageImpl = async () => {
+      await billGate;
+      return { totalCost: 0.0042 };
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+    await reader.read(); // the chunk frame
+    await reader.cancel(); // client disconnects; the later `done` enqueue throws
+    releaseFinish?.();
+
+    // Let the start() continuation run: history persists, the tail registers,
+    // the `done` enqueue throws into the stream catch.
+    while (ctx.captured.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    releaseBill?.();
+    await ctx.captured[0];
+
+    // The reply was fully generated and persisted — the hold must settle at the
+    // billed cost exactly once, never refund via the stream catch.
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
   test("nav-intent turn refunds synchronously and never touches waitUntil", async () => {
     reset();
     streamTurnImpl = () => ({

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Deferred billing-tail proof for the SHARED-runtime SSE stream turn.
+ *
+ * bridgeSharedMessageStream emits the `done` SSE frame as soon as the last
+ * token arrived and history persisted; the billing tail (billUsage →
+ * settleReservation → analytics → audit, ~4 serial cross-region Worker→DB
+ * round-trips ≈ 1.5-2s) runs via executionCtx.waitUntil OFF the stream path —
+ * the same #8759 deferral the non-stream send already has. These tests drive
+ * the REAL bridgeSharedMessageStream against a spy reservation and a capturing
+ * waitUntil to prove the money invariants survive the deferral:
+ *   (a) the `done` frame flushes while billUsage is still in flight,
+ *   (b) the deferred task still settles the hold at billing.totalCost,
+ *   (c) a billUsage throw still refunds the hold (reconcile(0)) — deferred,
+ *   (d) without an executionCtx the tail runs inline (pre-deferral behavior),
+ *   (e) a nav-intent turn refunds synchronously and never uses waitUntil.
+ */
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { describe, expect, mock, test } from "bun:test";
+
+const aiBillingActual = await import("../ai-billing");
+const runTurnActual = await import("../shared-runtime/run-shared-agent-turn");
+
+import type { SharedAgentTurnStreamPart } from "../shared-runtime/run-shared-agent-turn";
+
+// A reservation whose reconcile() records every settle amount.
+const reconcileCalls: number[] = [];
+const makeReservation = () => ({
+  reservedAmount: 0.01,
+  reconcile: mock(async (actualCost: number) => {
+    reconcileCalls.push(actualCost);
+    return null;
+  }),
+});
+let reservation = makeReservation();
+
+function makeParts(finalText: string): AsyncIterable<SharedAgentTurnStreamPart> {
+  return (async function* () {
+    yield { type: "text-delta", text: finalText } as const;
+    yield { type: "finish", text: finalText } as const;
+  })();
+}
+
+// Controllable seams: the stream turn result and the billUsage behavior.
+let streamTurnImpl: () => unknown = () => ({
+  model: "openai/gpt-oss-120b",
+  degraded: false,
+  parts: makeParts("hi there"),
+});
+let billUsageImpl: () => Promise<{ totalCost: number }> = async () => ({ totalCost: 0.0042 });
+
+mock.module("../ai-billing", () => ({
+  ...aiBillingActual,
+  reserveCredits: mock(async () => reservation),
+  billUsage: mock(async () => billUsageImpl()),
+  recordUsageAnalytics: mock(async () => null),
+}));
+
+mock.module("../shared-runtime/run-shared-agent-turn", () => ({
+  ...runTurnActual,
+  // Keep the model billable so a reservation is actually taken.
+  resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
+  runSharedAgentTurnStream: mock(async () => streamTurnImpl()),
+}));
+
+const { ElizaSandboxService } = await import("../eliza-sandbox");
+
+type StreamCallable = {
+  bridgeSharedMessageStream: (
+    rec: Record<string, unknown>,
+    rpc: { jsonrpc: string; id: number; method: string; params: { text: string } },
+    executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+  ) => Promise<Response>;
+  buildSharedRuntimeCharacter: (...args: unknown[]) => Promise<unknown>;
+  loadSharedRuntimeHistory: (...args: unknown[]) => Promise<unknown>;
+  saveSharedRuntimeHistory: (...args: unknown[]) => Promise<unknown>;
+};
+
+function makeService(): StreamCallable {
+  const svc = new ElizaSandboxService() as unknown as StreamCallable;
+  // Private seams the turn path calls before/after runSharedAgentTurnStream.
+  svc.buildSharedRuntimeCharacter = mock(async () => ({
+    name: "Eliza",
+    model: "openai/gpt-oss-120b",
+    system: "",
+    bio: [],
+  })) as never;
+  svc.loadSharedRuntimeHistory = mock(async () => []) as never;
+  svc.saveSharedRuntimeHistory = mock(async () => undefined) as never;
+  return svc;
+}
+
+/** executionCtx spy that captures every promise handed to waitUntil. */
+function makeExecutionCtx() {
+  const captured: Promise<unknown>[] = [];
+  return {
+    captured,
+    waitUntil: (p: Promise<unknown>) => {
+      captured.push(p);
+    },
+  };
+}
+
+async function drainSse(response: Response): Promise<string> {
+  return await response.text();
+}
+
+function reset() {
+  reconcileCalls.length = 0;
+  reservation = makeReservation();
+  streamTurnImpl = () => ({
+    model: "openai/gpt-oss-120b",
+    degraded: false,
+    parts: makeParts("hi there"),
+  });
+  billUsageImpl = async () => ({ totalCost: 0.0042 });
+}
+
+const REC = {
+  id: "00000000-0000-4000-8000-00000000c1e0",
+  organization_id: "00000000-0000-4000-8000-00000000c1e1",
+  user_id: "00000000-0000-4000-8000-00000000c1e2",
+  execution_tier: "shared",
+  agent_name: "Eliza",
+};
+const RPC = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "message.send",
+  params: { text: "hello" },
+};
+
+describe("bridgeSharedMessageStream — billing tail deferred via executionCtx.waitUntil", () => {
+  test("`done` frame flushes BEFORE the billing tail; deferred task settles at billing.totalCost", async () => {
+    reset();
+    // Gate billUsage so we can prove the stream completed without waiting on it.
+    let releaseBill: (() => void) | undefined;
+    const billGate = new Promise<void>((resolve) => {
+      releaseBill = resolve;
+    });
+    billUsageImpl = async () => {
+      await billGate;
+      return { totalCost: 0.0042 };
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    // (a) the full SSE body (including `done`) drains while billUsage is still
+    // blocked on the gate — the stream never awaited the billing tail.
+    const body = await drainSse(response);
+    expect(body).toContain("event: done");
+    expect(body).toContain("hi there");
+    expect(ctx.captured).toHaveLength(1);
+    expect(reservation.reconcile).not.toHaveBeenCalled();
+
+    // (b) the deferred task still settles the hold, at the billed cost.
+    releaseBill?.();
+    await ctx.captured[0];
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
+  test("billUsage throwing in the deferred task refunds the hold (reconcile(0)) without failing the stream", async () => {
+    reset();
+    billUsageImpl = async () => {
+      throw new Error("cross-region billing write failed");
+    };
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    const body = await drainSse(response);
+    expect(body).toContain("event: done");
+    expect(ctx.captured).toHaveLength(1);
+
+    // The waitUntil promise must resolve (never reject — Workers would log an
+    // unhandled rejection) and must have refunded the hold exactly once.
+    await ctx.captured[0];
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0]);
+  });
+
+  test("without an executionCtx the tail runs inline: settled by the time the stream drains", async () => {
+    reset();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC);
+    const body = await drainSse(response);
+    expect(body).toContain("event: done");
+    // Pre-deferral behavior preserved for tests / non-Worker callers.
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0.0042]);
+  });
+
+  test("nav-intent turn refunds synchronously and never touches waitUntil", async () => {
+    reset();
+    streamTurnImpl = () => ({
+      model: "nav-intent",
+      degraded: false,
+      parts: makeParts("Opening settings."),
+      navIntent: {
+        viewId: "settings",
+        label: "Settings",
+        reply: "Opening settings.",
+      },
+    });
+    const ctx = makeExecutionCtx();
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC, ctx);
+    await drainSse(response);
+    expect(ctx.captured).toHaveLength(0);
+    expect(reservation.reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcileCalls).toEqual([0]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -4,7 +4,7 @@
 
 import { sql } from "drizzle-orm";
 import { type SqlExecutor, sqlRows } from "../../db/execute-helpers";
-import { dbWrite, writeTransaction } from "../../db/helpers";
+import { dbWrite } from "../../db/helpers";
 import {
   appsRepository,
   type CreditPack,
@@ -1189,30 +1189,21 @@ export class CreditsService {
     | { kind: "no_reservation_row" }
   > {
     const { organizationId, reservationTransactionId, actualCost, description, metadata } = params;
+    const normalizedActualCost = Math.max(actualCost, 0);
+    const inputMetadata = JSON.stringify(metadata ?? {});
 
-    const existingSettlementIds = async (executor: SqlExecutor): Promise<string[]> => {
-      const rows = await sqlRows<{ id: string }>(
-        executor,
-        sql`
-          SELECT id
-          FROM credit_transactions
-          WHERE metadata->>'reservation_transaction_id' = ${reservationTransactionId}
-            AND organization_id = ${organizationId}
-          ORDER BY created_at ASC
-        `,
-      );
-      return rows.map((row) => row.id);
-    };
-
-    const result = await writeTransaction(async (tx) => {
-      const reservationRows = await sqlRows<{
-        id: string;
-        amount: string | number;
-        settled_at: Date | string | null;
-      }>(
-        tx,
-        sql`
-          SELECT id, amount, settled_at
+    const rows = await sqlRows<{
+      reservation_found: boolean | string | number | null;
+      claimed: boolean | string | number | null;
+      reserved_amount: string | number | null;
+      new_balance: string | number | null;
+      settlement_ids: string[] | null;
+      adjustment_type: CreditReconciliationResult["adjustmentType"] | null;
+    }>(
+      dbWrite,
+      sql`
+        WITH reservation AS (
+          SELECT id, organization_id, amount::numeric AS amount, settled_at
           FROM credit_transactions
           WHERE id = ${reservationTransactionId}
             AND organization_id = ${organizationId}
@@ -1225,300 +1216,198 @@ export class CreditsService {
               )
             )
           LIMIT 1
-        `,
-      );
-      const reservation = reservationRows[0];
-      if (!reservation) {
-        return { kind: "no_reservation_row" as const };
-      }
-
-      const reservedAmount = Math.abs(parseNumeric(reservation.amount, "reservation_amount"));
-
-      if (reservation.settled_at !== null) {
-        return {
-          kind: "handled" as const,
-          claimed: false,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: await existingSettlementIds(tx),
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const preexistingSettlementIds = await existingSettlementIds(tx);
-      if (preexistingSettlementIds.length > 0) {
-        const markedRows = await sqlRows<{ id: string }>(
-          tx,
-          sql`
-            UPDATE credit_transactions
-            SET settled_at = NOW()
-            WHERE id = ${reservationTransactionId}
-              AND organization_id = ${organizationId}
-              AND type = 'debit'
-              AND (
-                metadata->>'type' = 'reservation'
-                OR (
-                  metadata->>'type' = 'app_chat_reservation'
-                  AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
-                )
-              )
-              AND settled_at IS NULL
-            RETURNING id
-          `,
-        );
-        return {
-          kind: "handled" as const,
-          claimed: markedRows.length > 0,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: preexistingSettlementIds,
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const claimedRows = await sqlRows<{
-        id: string;
-        amount: string | number;
-      }>(
-        tx,
-        sql`
-          UPDATE credit_transactions
+        ),
+        reservation_values AS (
+          SELECT
+            id,
+            organization_id,
+            ABS(amount)::numeric AS reserved_amount,
+            ${String(normalizedActualCost)}::numeric AS actual_cost,
+            (ABS(amount)::numeric - ${String(normalizedActualCost)}::numeric) AS difference,
+            settled_at
+          FROM reservation
+        ),
+        existing_settlements AS (
+          SELECT COALESCE(array_agg(ct.id ORDER BY ct.created_at ASC), ARRAY[]::uuid[]) AS ids
+          FROM credit_transactions ct
+          WHERE ct.metadata->>'reservation_transaction_id' = ${reservationTransactionId}
+            AND ct.organization_id = ${organizationId}
+        ),
+        claim AS (
+          UPDATE credit_transactions ct
           SET settled_at = NOW()
-          WHERE id = ${reservationTransactionId}
-            AND organization_id = ${organizationId}
-            AND type = 'debit'
+          FROM reservation_values rv
+          WHERE ct.id = rv.id
+            AND rv.settled_at IS NULL
+            AND NOT EXISTS (SELECT 1 FROM existing_settlements es WHERE cardinality(es.ids) > 0)
+            AND ct.settled_at IS NULL
+          RETURNING ct.id
+        ),
+        mark_preexisting AS (
+          UPDATE credit_transactions ct
+          SET settled_at = NOW()
+          FROM reservation_values rv
+          WHERE ct.id = rv.id
+            AND rv.settled_at IS NULL
+            AND EXISTS (SELECT 1 FROM existing_settlements es WHERE cardinality(es.ids) > 0)
+            AND ct.settled_at IS NULL
+          RETURNING ct.id
+        ),
+        mutation_plan AS (
+          SELECT
+            rv.*,
+            CASE
+              WHEN NOT EXISTS (SELECT 1 FROM claim) THEN 'none'
+              WHEN ABS(rv.difference) < ${String(EPSILON)}::numeric THEN 'none'
+              WHEN rv.difference > 0 THEN 'refund'
+              ELSE 'overage'
+            END AS phase,
+            CASE
+              WHEN NOT EXISTS (SELECT 1 FROM claim) THEN 0::numeric
+              WHEN ABS(rv.difference) < ${String(EPSILON)}::numeric THEN 0::numeric
+              ELSE ABS(rv.difference)::numeric
+            END AS amount
+          FROM reservation_values rv
+        ),
+        org AS (
+          SELECT o.id, o.credit_balance::numeric AS current_balance
+          FROM organizations o
+          JOIN mutation_plan mp ON mp.organization_id = o.id
+          WHERE mp.phase IN ('refund', 'overage')
+          FOR UPDATE
+        ),
+        org_update AS (
+          UPDATE organizations o
+          SET credit_balance = CASE
+                WHEN mp.phase = 'refund' THEN org.current_balance + mp.amount
+                WHEN mp.phase = 'overage' THEN org.current_balance - mp.amount
+                ELSE org.current_balance
+              END,
+              updated_at = NOW()
+          FROM org, mutation_plan mp
+          WHERE o.id = org.id
             AND (
-              metadata->>'type' = 'reservation'
-              OR (
-                metadata->>'type' = 'app_chat_reservation'
-                AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
-              )
+              mp.phase = 'refund'
+              OR (mp.phase = 'overage' AND org.current_balance >= mp.amount)
             )
-            AND settled_at IS NULL
-          RETURNING id, amount
-        `,
-      );
-      const claimed = claimedRows[0];
-      if (!claimed) {
-        return {
-          kind: "handled" as const,
-          claimed: false,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: await existingSettlementIds(tx),
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const claimedReservedAmount = Math.abs(parseNumeric(claimed.amount, "reservation_amount"));
-      const normalizedActualCost = Math.max(actualCost, 0);
-      const difference = claimedReservedAmount - normalizedActualCost;
-      const baseMetadata = {
-        ...metadata,
-        reservation_transaction_id: reservationTransactionId,
-        reserved: claimedReservedAmount,
-        actual: normalizedActualCost,
-      };
-
-      if (Math.abs(difference) < EPSILON) {
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [],
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      if (difference > 0) {
-        const refundMetadata = JSON.stringify({
-          ...baseMetadata,
-          type: "reconciliation_refund",
-        });
-        const refundRows = await sqlRows<{
-          id: string | null;
-          new_balance: string | number | null;
-        }>(
-          tx,
-          sql`
-            WITH org AS (
-              SELECT id, credit_balance::numeric AS current_balance
-              FROM organizations
-              WHERE id = ${organizationId}
-              FOR UPDATE
-            ),
-            updated AS (
-              UPDATE organizations AS o
-              SET credit_balance = org.current_balance + ${String(difference)}::numeric,
-                  updated_at = NOW()
-              FROM org
-              WHERE o.id = org.id
-              RETURNING o.credit_balance AS new_balance
-            ),
-            inserted AS (
-              INSERT INTO credit_transactions (
-                organization_id,
-                amount,
-                type,
-                description,
-                metadata,
-                stripe_payment_intent_id,
-                created_at
-              )
-              SELECT
-                org.id,
-                ${String(difference)}::numeric,
-                'refund',
-                ${`${description} (refund)`},
-                ${refundMetadata}::jsonb,
-                ${`recon:${reservationTransactionId}:refund`},
-                NOW()
-              FROM org
-              WHERE EXISTS (SELECT 1 FROM updated)
-              ON CONFLICT (stripe_payment_intent_id) DO NOTHING
-              RETURNING id
-            )
-            SELECT
-              (SELECT id FROM inserted) AS id,
-              (SELECT new_balance FROM updated) AS new_balance
-          `,
-        );
-        const refund = refundRows[0];
-        if (!refund?.id) {
-          throw new Error("[CreditsService] Reservation refund settlement did not insert a row");
-        }
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          newBalance: parseNumeric(refund.new_balance, "new_balance"),
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [refund.id],
-            adjustmentType: "refund" as const,
-          },
-        };
-      }
-
-      const overage = -difference;
-      const overageMetadata = JSON.stringify({
-        ...baseMetadata,
-        type: "reconciliation_overage",
-      });
-      const overageRows = await sqlRows<{
-        id: string | null;
-        debited: boolean | string | number | null;
-        new_balance: string | number | null;
-      }>(
-        tx,
-        sql`
-          WITH org AS (
-            SELECT id, credit_balance::numeric AS current_balance
-            FROM organizations
-            WHERE id = ${organizationId}
-            FOR UPDATE
-          ),
-          updated AS (
-            UPDATE organizations AS o
-            SET credit_balance = org.current_balance - ${String(overage)}::numeric,
-                updated_at = NOW()
-            FROM org
-            WHERE o.id = org.id
-              AND org.current_balance >= ${String(overage)}::numeric
-            RETURNING o.credit_balance AS new_balance
-          ),
-          inserted AS (
-            INSERT INTO credit_transactions (
-              organization_id,
-              amount,
-              type,
-              description,
-              metadata,
-              stripe_payment_intent_id,
-              created_at
-            )
-            SELECT
-              org.id,
-              ${String(-overage)}::numeric,
-              'debit',
-              ${`${description} (overage)`},
-              ${overageMetadata}::jsonb,
-              ${`recon:${reservationTransactionId}:overage`},
-              NOW()
-            FROM org
-            WHERE EXISTS (SELECT 1 FROM updated)
-            ON CONFLICT (stripe_payment_intent_id) DO NOTHING
-            RETURNING id
+          RETURNING o.credit_balance AS new_balance
+        ),
+        inserted AS (
+          INSERT INTO credit_transactions (
+            organization_id,
+            amount,
+            type,
+            description,
+            metadata,
+            stripe_payment_intent_id,
+            created_at
           )
           SELECT
-            EXISTS(SELECT 1 FROM updated) AS debited,
-            (SELECT id FROM inserted) AS id,
-            (SELECT new_balance FROM updated) AS new_balance
-        `,
-      );
-      const overageRow = overageRows[0];
-      if (!isPgTrue(overageRow?.debited)) {
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [],
-            adjustmentType: "uncollected_overage" as const,
-          },
-        };
-      }
-      if (!overageRow?.id) {
-        throw new Error("[CreditsService] Reservation overage settlement did not insert a row");
-      }
-      return {
-        kind: "handled" as const,
-        claimed: true,
-        newBalance: parseNumeric(overageRow.new_balance, "new_balance"),
-        balanceDecreaseMetadata: {
-          ...baseMetadata,
-          type: "reconciliation_overage",
-        },
-        result: {
-          reservedAmount: claimedReservedAmount,
-          actualCost: normalizedActualCost,
-          reservationTransactionId,
-          settlementTransactionIds: [overageRow.id],
-          adjustmentType: "overage" as const,
-        },
-      };
-    });
+            mp.organization_id,
+            CASE WHEN mp.phase = 'refund' THEN mp.amount ELSE -mp.amount END,
+            CASE WHEN mp.phase = 'refund' THEN 'refund' ELSE 'debit' END,
+            CASE
+              WHEN mp.phase = 'refund' THEN ${`${description} (refund)`}
+              ELSE ${`${description} (overage)`}
+            END,
+            (
+              ${inputMetadata}::jsonb ||
+              jsonb_build_object(
+                'reservation_transaction_id', ${reservationTransactionId},
+                'reserved', mp.reserved_amount,
+                'actual', mp.actual_cost,
+                'type', CASE
+                  WHEN mp.phase = 'refund' THEN 'reconciliation_refund'
+                  ELSE 'reconciliation_overage'
+                END
+              )
+            ),
+            CASE
+              WHEN mp.phase = 'refund' THEN ${`recon:${reservationTransactionId}:refund`}
+              ELSE ${`recon:${reservationTransactionId}:overage`}
+            END,
+            NOW()
+          FROM mutation_plan mp
+          WHERE mp.phase IN ('refund', 'overage')
+            AND EXISTS (SELECT 1 FROM org_update)
+          ON CONFLICT (stripe_payment_intent_id) DO NOTHING
+          RETURNING id
+        )
+        SELECT
+          EXISTS(SELECT 1 FROM reservation) AS reservation_found,
+          EXISTS(SELECT 1 FROM claim) OR EXISTS(SELECT 1 FROM mark_preexisting) AS claimed,
+          (SELECT reserved_amount FROM reservation_values) AS reserved_amount,
+          (SELECT new_balance FROM org_update) AS new_balance,
+          CASE
+            WHEN EXISTS(SELECT 1 FROM inserted) THEN (SELECT array_agg(id ORDER BY id) FROM inserted)
+            ELSE (SELECT ids FROM existing_settlements)
+          END AS settlement_ids,
+          CASE
+            WHEN NOT EXISTS(SELECT 1 FROM reservation) THEN NULL
+            WHEN NOT EXISTS(SELECT 1 FROM claim) THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mark_preexisting) THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'none') THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'refund')
+              THEN CASE WHEN EXISTS(SELECT 1 FROM inserted) THEN 'refund' ELSE 'none' END
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'overage')
+              THEN CASE WHEN EXISTS(SELECT 1 FROM org_update) THEN 'overage' ELSE 'uncollected_overage' END
+            ELSE 'none'
+          END AS adjustment_type
+      `,
+    );
 
-    if (result.kind !== "handled" || !result.claimed) {
-      return result;
+    const row = rows[0];
+    if (!row || !isPgTrue(row.reservation_found)) {
+      return { kind: "no_reservation_row" };
     }
 
-    await CacheInvalidation.onCreditMutation(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate credit mutation cache:", error);
-    });
-    invalidateOrganizationCache(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate org cache:", error);
-    });
-    if (result.balanceDecreaseMetadata && result.newBalance !== undefined) {
-      this.notifyBalanceDecrease(organizationId, result.newBalance, result.balanceDecreaseMetadata);
+    const reservedAmount = parseNumeric(row.reserved_amount, "reservation_amount");
+    const adjustmentType = row.adjustment_type ?? "none";
+    const settlementTransactionIds = row.settlement_ids ?? [];
+    const result: CreditReconciliationResult = {
+      reservedAmount,
+      actualCost: normalizedActualCost,
+      reservationTransactionId,
+      settlementTransactionIds,
+      adjustmentType,
+    };
+    const handled = {
+      kind: "handled" as const,
+      claimed: isPgTrue(row.claimed),
+      ...(row.new_balance !== null && row.new_balance !== undefined
+        ? { newBalance: parseNumeric(row.new_balance, "new_balance") }
+        : {}),
+      ...(adjustmentType === "overage"
+        ? {
+            balanceDecreaseMetadata: {
+              ...metadata,
+              reservation_transaction_id: reservationTransactionId,
+              reserved: reservedAmount,
+              actual: normalizedActualCost,
+              type: "reconciliation_overage",
+            },
+          }
+        : {}),
+      result,
+    };
+
+    if (handled.claimed) {
+      await CacheInvalidation.onCreditMutation(organizationId).catch((error) => {
+        logger.error("[CreditsService] Failed to invalidate credit mutation cache:", error);
+      });
+      invalidateOrganizationCache(organizationId).catch((error) => {
+        logger.error("[CreditsService] Failed to invalidate org cache:", error);
+      });
+      if (handled.balanceDecreaseMetadata && handled.newBalance !== undefined) {
+        this.notifyBalanceDecrease(
+          organizationId,
+          handled.newBalance,
+          handled.balanceDecreaseMetadata,
+        );
+      }
     }
-    return result;
+
+    return handled;
   }
 
   async markReservationSettled(params: {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1450,6 +1450,51 @@ describe("ElizaSandboxService recoverDisconnected", () => {
   });
 });
 
+
+describe("ElizaSandboxService bridgeStream scope-cache reuse", () => {
+  test("uses the already-resolved running agent row without re-querying findRunningSandbox", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      execution_tier: "shared",
+      status: "running",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => {
+        throw new Error("findRunningSandbox should not run when the stream route passes resolvedAgent");
+      },
+    );
+    const service = new ElizaSandboxService();
+    const sharedSpy = spyOn(service as never, "bridgeSharedMessageStream" as never).mockResolvedValue(
+      new Response("event: done\ndata: {}\n\n", {
+        headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+      }) as never,
+    );
+
+    try {
+      const res = await service.bridgeStream(
+        sandbox.id,
+        sandbox.organization_id,
+        {
+          jsonrpc: "2.0",
+          id: "bridge-cache-test",
+          method: "message.send",
+          params: { text: "hello", roomId: "room-1" },
+        },
+        undefined,
+        sandbox,
+      );
+
+      expect(res?.status).toBe(200);
+      expect(findSpy).not.toHaveBeenCalled();
+      expect(sharedSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      findSpy.mockRestore();
+      sharedSpy.mockRestore();
+    }
+  });
+});
+
 describe("ElizaSandboxService heartbeat", () => {
   // Pins the behaviour the probeBridgeHealth() extraction must preserve on the
   // prod-critical heartbeat path: grace-window hysteresis and the exact DB

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2819,6 +2819,14 @@ export class ElizaSandboxService {
         start: async (controller) => {
           let reply = "";
           let finished = false;
+          // Once the billing tail is registered it owns settlement end-to-end
+          // (success settles at totalCost, failure refunds). The stream catch
+          // below must then leave the reservation alone: a client cancel makes
+          // the `done` enqueue throw AFTER registration, and racing a
+          // settle(0) against the deferred tail's settle(totalCost) would turn
+          // a fully-delivered, persisted reply into an unbilled one depending
+          // on which write lands first.
+          let billingTailOwnsSettlement = false;
           try {
             for await (const part of parts) {
               if (part.type === "text-delta") {
@@ -2866,6 +2874,7 @@ export class ElizaSandboxService {
                 // contained and logged (never an unhandled waitUntil rejection)
                 // — the #11169 sweep-credit-reservations cron backstops a hold
                 // stranded by a dropped waitUntil or a failed refund.
+                billingTailOwnsSettlement = true;
                 await settleOffResponsePath(executionCtx, async () => {
                   try {
                     const billing = await billUsage(
@@ -2949,8 +2958,12 @@ export class ElizaSandboxService {
             }
           } catch (error) {
             // error-policy:J1 stream boundary translation — partial SSE streams
-            // cannot become HTTP errors, so emit a terminal error frame.
-            await settleReservation(0);
+            // cannot become HTTP errors, so emit a terminal error frame. The
+            // refund only runs while the reservation is still this scope's to
+            // settle — once the billing tail is registered it owns the hold.
+            if (!billingTailOwnsSettlement) {
+              await settleReservation(0);
+            }
             logger.warn("[shared-runtime] stream failed", {
               error: error instanceof Error ? error.message : String(error),
               agentId: rec.id,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -84,6 +84,7 @@ import {
   type SandboxProvider,
 } from "./sandbox-provider";
 import { isDedicatedBootstrapWindow } from "./shared-runtime/dedicated-bootstrap";
+import { getCachedSharedAgentRunningSandbox } from "./shared-runtime/resolve-shared-agent";
 import {
   type RunSharedAgentTurnResult,
   resolveSharedAgentTurnModel,
@@ -4302,8 +4303,15 @@ export class ElizaSandboxService {
     orgId: string,
     rpc: BridgeRequest,
     executionCtx?: BridgeExecutionContext,
+    resolvedAgent?: AgentSandbox,
   ): Promise<Response | null> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec =
+      resolvedAgent?.id === agentId &&
+      resolvedAgent.organization_id === orgId &&
+      resolvedAgent.status === "running"
+        ? resolvedAgent
+        : (await getCachedSharedAgentRunningSandbox(agentId, orgId)) ??
+          (await agentSandboxesRepository.findRunningSandbox(agentId, orgId));
     if (!rec) {
       logger.warn("[agent-sandbox] Bridge stream to non-running sandbox", {
         agentId,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2737,6 +2737,7 @@ export class ElizaSandboxService {
   private async bridgeSharedMessageStream(
     rec: AgentSandbox,
     rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
   ): Promise<Response> {
     const params = rpc.params && typeof rpc.params === "object" ? rpc.params : {};
     const text = typeof params.text === "string" ? params.text : "";
@@ -2850,46 +2851,78 @@ export class ElizaSandboxService {
               if (turn.navIntent) {
                 await settleReservation(0);
               } else if (billingContext) {
-                try {
-                  const billing = await billUsage(
-                    billingContext,
-                    this.sharedRuntimeBillingUsageForReply(
-                      finalReply,
-                      part.usage,
-                      estimatedInputTokens,
-                    ),
-                  );
-                  const settlement = await settleReservation(billing.totalCost);
-                  const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-                    type: "chat",
-                    content: finalReply,
-                    prompt: text,
-                  });
-                  if (usageRecord) {
-                    await aiBillingRecordsService
-                      .record({
-                        context: billingContext,
-                        billing,
-                        usageRecord,
-                        idempotencyKey,
-                        reconciliation: settlement,
-                      })
-                      .catch((error) => {
-                        logger.error("[shared-runtime] AI billing audit record failed", {
-                          error: error instanceof Error ? error.message : String(error),
-                          agentId: rec.id,
+                // The reply is final once the last token arrived and history
+                // persisted, but the billing tail (billUsage → settleReservation
+                // → analytics → audit) is ~4 serial cross-region Worker→DB
+                // round-trips (~1.5-2s) that previously ran INLINE before the
+                // `done` SSE frame — the exact firstText≈1.4s / done≈4s gap
+                // measured on staging. Same deferral the non-stream send got
+                // (#8759 / settleOffResponsePath): on a Worker the tail runs via
+                // executionCtx.waitUntil OFF the `done` path; without an
+                // executionCtx (tests, non-Worker callers) it runs inline,
+                // exactly as before. The deferred task ALWAYS settles the hold:
+                // success settles at billing.totalCost, any failure refunds via
+                // the idempotent settleReservation(0), and a refund throw is
+                // contained and logged (never an unhandled waitUntil rejection)
+                // — the #11169 sweep-credit-reservations cron backstops a hold
+                // stranded by a dropped waitUntil or a failed refund.
+                await settleOffResponsePath(executionCtx, async () => {
+                  try {
+                    const billing = await billUsage(
+                      billingContext,
+                      this.sharedRuntimeBillingUsageForReply(
+                        finalReply,
+                        part.usage,
+                        estimatedInputTokens,
+                      ),
+                    );
+                    const settlement = await settleReservation(billing.totalCost);
+                    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
+                      type: "chat",
+                      content: finalReply,
+                      prompt: text,
+                    });
+                    if (usageRecord) {
+                      await aiBillingRecordsService
+                        .record({
+                          context: billingContext,
+                          billing,
+                          usageRecord,
+                          idempotencyKey,
+                          reconciliation: settlement,
+                        })
+                        .catch((error) => {
+                          logger.error("[shared-runtime] AI billing audit record failed", {
+                            error: error instanceof Error ? error.message : String(error),
+                            agentId: rec.id,
+                          });
                         });
-                      });
+                    }
+                  } catch (error) {
+                    // error-policy:J1 deferred-settlement boundary — the `done`
+                    // frame may already be flushed, so the refund is the
+                    // handling: settle(0) is idempotent, and a refund failure is
+                    // logged for the cron sweep.
+                    try {
+                      await settleReservation(0);
+                    } catch (refundError) {
+                      logger.error(
+                        "[shared-runtime] deferred billing refund failed; sweep-credit-reservations will reclaim the hold",
+                        {
+                          error:
+                            refundError instanceof Error
+                              ? refundError.message
+                              : String(refundError),
+                          agentId: rec.id,
+                        },
+                      );
+                    }
+                    logger.error("[shared-runtime] billing failed", {
+                      error: error instanceof Error ? error.message : String(error),
+                      agentId: rec.id,
+                    });
                   }
-                } catch (error) {
-                  // error-policy:J1 billing boundary translation — the user got
-                  // the reply, but a failed meter write must release the hold.
-                  await settleReservation(0);
-                  logger.error("[shared-runtime] billing failed", {
-                    error: error instanceof Error ? error.message : String(error),
-                    agentId: rec.id,
-                  });
-                }
+                });
               }
               // Attach a VIEWS navigation handoff for a deterministic nav turn so
               // the PWA opens the view (findViewActionHandoff → navigate event in
@@ -4251,7 +4284,12 @@ export class ElizaSandboxService {
     }
   }
 
-  async bridgeStream(agentId: string, orgId: string, rpc: BridgeRequest): Promise<Response | null> {
+  async bridgeStream(
+    agentId: string,
+    orgId: string,
+    rpc: BridgeRequest,
+    executionCtx?: BridgeExecutionContext,
+  ): Promise<Response | null> {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec) {
       logger.warn("[agent-sandbox] Bridge stream to non-running sandbox", {
@@ -4266,7 +4304,7 @@ export class ElizaSandboxService {
     const fallbackText = this.buildBridgeNoReplyFallbackText(params);
 
     if (rec.execution_tier === "shared") {
-      const response = await this.bridgeSharedMessageStream(rec, rpc);
+      const response = await this.bridgeSharedMessageStream(rec, rpc, executionCtx);
       return response ?? (fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null);
     }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -18,6 +18,7 @@ const bridgeStream = mock(
     _orgId: string,
     _rpc: unknown,
     _executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+    _resolvedAgent?: unknown,
   ): Promise<Response | null> =>
     new Response("event: done\ndata: {}\n\n", {
       headers: { "Content-Type": "text/event-stream; charset=utf-8" },
@@ -52,6 +53,17 @@ describe("handleCanonicalScopedAgentStream — executionCtx threading", () => {
     // The SAME executionCtx object must arrive as the 4th argument — the
     // shared-tier turn hands its billing tail to exactly this waitUntil.
     expect(call?.[3]).toBe(executionCtx);
+  });
+
+  test("threads the resolved agent row to bridgeStream so the stream path skips findRunningSandbox", async () => {
+    bridgeStream.mockClear();
+    const agent = { id: BASE.agentId, organization_id: BASE.orgId, status: "running" };
+
+    const res = await handleCanonicalScopedAgentStream({ ...BASE, agent: agent as never });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    expect(bridgeStream.mock.calls[0]?.[4]).toBe(agent);
   });
 
   test("no executionCtx (tests, non-Worker callers): bridgeStream receives undefined", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical scoped SSE handler — executionCtx threading contract.
+ *
+ * The shared-tier billing-tail deferral (#8759 pattern for the SSE path) only
+ * works if the Worker executionCtx handed to handleCanonicalScopedAgentStream
+ * actually reaches elizaSandboxService.bridgeStream — dropping the parameter
+ * anywhere along the chain silently reverts every turn to inline billing with
+ * no failing behavior. These tests drive the REAL handler against a captured
+ * bridgeStream to pin the pass-through (and its absence for non-Worker
+ * callers, who must keep the inline-settle behavior).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const bridgeStream = mock(
+  async (
+    _agentId: string,
+    _orgId: string,
+    _rpc: unknown,
+    _executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+  ): Promise<Response | null> =>
+    new Response("event: done\ndata: {}\n\n", {
+      headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+    }),
+);
+
+mock.module("../eliza-sandbox", () => ({
+  elizaSandboxService: { bridgeStream },
+}));
+
+const { handleCanonicalScopedAgentStream } = await import("./canonical-scoped-stream");
+
+const BASE = {
+  agentId: "00000000-0000-4000-8000-00000000a9e0",
+  orgId: "00000000-0000-4000-8000-00000000a9e1",
+  conversationId: "00000000-0000-4000-8000-00000000a9e2",
+  body: { text: "hello" },
+};
+
+describe("handleCanonicalScopedAgentStream — executionCtx threading", () => {
+  test("threads the caller's executionCtx to bridgeStream (deferral seam)", async () => {
+    bridgeStream.mockClear();
+    const executionCtx = { waitUntil: (_p: Promise<unknown>) => undefined };
+
+    const res = await handleCanonicalScopedAgentStream({ ...BASE, executionCtx });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    const call = bridgeStream.mock.calls[0];
+    expect(call?.[0]).toBe(BASE.agentId);
+    expect(call?.[1]).toBe(BASE.orgId);
+    // The SAME executionCtx object must arrive as the 4th argument — the
+    // shared-tier turn hands its billing tail to exactly this waitUntil.
+    expect(call?.[3]).toBe(executionCtx);
+  });
+
+  test("no executionCtx (tests, non-Worker callers): bridgeStream receives undefined", async () => {
+    bridgeStream.mockClear();
+
+    const res = await handleCanonicalScopedAgentStream({ ...BASE });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    expect(bridgeStream.mock.calls[0]?.[3]).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -7,7 +7,7 @@
 
 import { InsufficientCreditsError } from "../../api/errors";
 import { logger } from "../../utils/logger";
-import type { BridgeRequest } from "../eliza-sandbox";
+import type { BridgeExecutionContext, BridgeRequest } from "../eliza-sandbox";
 import { elizaSandboxService } from "../eliza-sandbox";
 import { applyCorsHeaders } from "../proxy/cors";
 
@@ -27,6 +27,12 @@ export interface CanonicalScopedStreamRequest {
   body: unknown;
   origin?: string | null;
   timings?: Record<string, number>;
+  /**
+   * Workers only: lets the shared-tier turn defer its billing tail off the
+   * SSE `done` path via executionCtx.waitUntil (see bridgeSharedMessageStream).
+   * Absent (tests, non-Worker callers) the tail settles inline as before.
+   */
+  executionCtx?: BridgeExecutionContext;
 }
 
 function nowMs(): number {
@@ -90,7 +96,12 @@ export async function handleCanonicalScopedAgentStream(
   let upstream: Response | null;
   const bridgeStartedAt = nowMs();
   try {
-    upstream = await elizaSandboxService.bridgeStream(request.agentId, request.orgId, rpc);
+    upstream = await elizaSandboxService.bridgeStream(
+      request.agentId,
+      request.orgId,
+      rpc,
+      request.executionCtx,
+    );
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {
     timings.bridge = elapsedMs(bridgeStartedAt);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -5,6 +5,7 @@
  * SSE/CORS response shape used by HTTP routes and in-process voice turns.
  */
 
+import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import { InsufficientCreditsError } from "../../api/errors";
 import { logger } from "../../utils/logger";
 import type { BridgeExecutionContext, BridgeRequest } from "../eliza-sandbox";
@@ -22,6 +23,7 @@ const STREAM_HEADERS = {
 export interface CanonicalScopedStreamRequest {
   agentId: string;
   orgId: string;
+  agent?: AgentSandbox;
   conversationId: string;
   userId?: string;
   body: unknown;
@@ -101,6 +103,7 @@ export async function handleCanonicalScopedAgentStream(
       request.orgId,
       rpc,
       request.executionCtx,
+      request.agent,
     );
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -85,7 +85,7 @@ function rehydrateNullableCachedDate(value: unknown, field: AgentSandboxDateFiel
  * malformed values fail at this boundary because returning a row that violates
  * `AgentSandbox` would defer the fault into an unrelated route consumer.
  */
-function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
+export function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
   return {
     ...agent,
     created_at: rehydrateRequiredCachedDate(agent.created_at, "created_at"),
@@ -117,7 +117,7 @@ function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
  * time-sensitive dedicated-bootstrap window, whose eligibility flips as the
  * container boots.
  */
-interface CachedSharedAgentScope {
+export interface CachedSharedAgentScope {
   orgId: string;
   agent: CachedAgentSandbox;
   /**
@@ -164,6 +164,50 @@ async function revalidateCachedScope(c: Context<AppEnv>, cachedOrgId: string): P
   // The key must still be scoped to the org the cached agent belongs to. A
   // detach/re-scope changes organization_id, so a stale cross-org read fails here.
   return validated.organization_id === cachedOrgId;
+}
+
+export async function cacheSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+  agent: AgentSandbox,
+): Promise<void> {
+  if (agent.execution_tier !== "shared" || agent.status !== "running") return;
+  await cache
+    .set(
+      CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId),
+      agent,
+      CacheTTL.sharedAgentScope.runningSandbox,
+    )
+    .catch((error) => {
+      logger.debug("[resolveSharedAgent] running sandbox cache write failed", {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
+export async function getCachedSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+): Promise<AgentSandbox | null> {
+  const cached = await cache
+    .get<CachedAgentSandbox>(CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId))
+    .catch(() => null);
+  if (!cached) return null;
+  const agent = rehydrateCachedAgentDates(cached);
+  return agent.execution_tier === "shared" && agent.status === "running" ? agent : null;
+}
+
+export async function invalidateSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+): Promise<void> {
+  await cache.del(CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId)).catch((error) => {
+    logger.debug("[resolveSharedAgent] running sandbox cache invalidation failed", {
+      agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 /**
@@ -352,6 +396,7 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
         error: error instanceof Error ? error.message : String(error),
       });
     });
+    void cacheSharedAgentRunningSandbox(agentId, user.organization_id, agent);
   }
 
   return { agent, agentId, orgId: user.organization_id, agentName: agent.agent_name ?? "Eliza" };


### PR DESCRIPTION
## Summary
- collapse reservation reconciliation from a multi-statement write transaction into one Postgres CTE round trip
- preserve first-claim/idempotency semantics, legacy keyed settlement behavior, refund/overage accounting, org/cache invalidation, and balance-decrease notifications
- reuse the resolved shared-agent row/running-sandbox scope cache on the canonical stream path so bridgeStream does not issue a redundant findRunningSandbox query
- add bounded running-sandbox cache TTL plus invalidation on sandbox status updates

## Tests
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts`
- `bun test packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts --timeout 120000` currently blocked locally by existing PGlite bootstrap issue: `Cannot find module '@elizaos/core' from plugins/plugin-sql/src/index.ts`; non-DB cases pass, PGlite guard fails before DB assertions can run
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts --timeout 120000` currently blocked locally by same plugin-sql/core resolution issue; canonical stream tests pass

## Notes
- Based on #16976 so this can ride on top of the billing-tail deferral seam.
