### PR TITLE
perf(cloud): reduce billing and sandbox DB round trips

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -155,6 +155,7 @@ app.post("/", async (c) => {
   return handleCanonicalScopedAgentStream({
     agentId: r.agentId,
     orgId: r.orgId,
+    agent: r.agent,
     conversationId,
     ...("userId" in r ? { userId: r.userId } : {}),
     body: raw,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1,6 +1,18 @@
 // Persists agent sandboxes records for cloud services through the shared DB boundary.
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gte, inArray, isNotNull, lt, ne, notInArray, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  lt,
+  ne,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import {
   applyBackupDelta,
   type BackupChainNode,
@@ -11,9 +23,15 @@ import {
 import { AGENT_MANAGED_DISCORD_KEY } from "../../lib/services/eliza-agent-config";
 import { mergeWarmClaimEnvironmentVars } from "../../lib/services/warm-claim-character-push";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
-import { getObjectText, offloadJsonField } from "../../lib/storage/object-store";
+import {
+  getObjectText,
+  offloadJsonField,
+} from "../../lib/storage/object-store";
 import { logger } from "../../lib/utils/logger";
-import { decryptAgentBackupStateData, encryptAgentBackupStateData } from "../crypto/agent-backups";
+import {
+  decryptAgentBackupStateData,
+  encryptAgentBackupStateData,
+} from "../crypto/agent-backups";
 import { ensureAgentSandboxSchema } from "../ensure-agent-sandbox-schema";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -45,7 +63,10 @@ export type {
   NewAgentSandboxBackup,
 };
 
-export type AgentSandboxBackupMetadata = Omit<StoredAgentSandboxBackup, "state_data">;
+export type AgentSandboxBackupMetadata = Omit<
+  StoredAgentSandboxBackup,
+  "state_data"
+>;
 
 const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   memories: [],
@@ -82,12 +103,16 @@ export async function hydrateAgentSandboxBackup(
   let stateData = backup.state_data;
   if (backup.state_data_storage === "r2") {
     if (!backup.state_data_key) {
-      throw new Error(`Agent sandbox backup ${backup.id} is missing state_data_key`);
+      throw new Error(
+        `Agent sandbox backup ${backup.id} is missing state_data_key`,
+      );
     }
 
     const raw = await getObjectText(backup.state_data_key);
     if (!raw) {
-      throw new Error(`Agent sandbox backup payload not found: ${backup.state_data_key}`);
+      throw new Error(
+        `Agent sandbox backup payload not found: ${backup.state_data_key}`,
+      );
     }
 
     stateData = JSON.parse(raw) as AgentBackupStoredStateData;
@@ -159,22 +184,38 @@ export class AgentSandboxesRepository {
     return r?.organizationId;
   }
 
-  async findByIdAndOrg(id: string, orgId: string): Promise<AgentSandbox | undefined> {
+  async findByIdAndOrg(
+    id: string,
+    orgId: string,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbRead
       .select()
       .from(agentSandboxes)
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.organization_id, orgId)))
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.organization_id, orgId),
+        ),
+      )
       .limit(1);
     return r;
   }
 
-  async findByIdAndOrgForWrite(id: string, orgId: string): Promise<AgentSandbox | undefined> {
+  async findByIdAndOrgForWrite(
+    id: string,
+    orgId: string,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbWrite
       .select()
       .from(agentSandboxes)
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.organization_id, orgId)))
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.organization_id, orgId),
+        ),
+      )
       .limit(1);
     return r;
   }
@@ -198,7 +239,9 @@ export class AgentSandboxesRepository {
     return r;
   }
 
-  async findLatestByCharacterId(characterId: string): Promise<AgentSandbox | undefined> {
+  async findLatestByCharacterId(
+    characterId: string,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbRead
       .select()
@@ -239,7 +282,10 @@ export class AgentSandboxesRepository {
       })
       .from(agentSandboxes)
       .where(
-        and(eq(agentSandboxes.status, "running"), ne(agentSandboxes.execution_tier, "shared")),
+        and(
+          eq(agentSandboxes.status, "running"),
+          ne(agentSandboxes.execution_tier, "shared"),
+        ),
       );
   }
 
@@ -553,7 +599,10 @@ export class AgentSandboxesRepository {
       .limit(limit);
   }
 
-  async findRunningSandbox(id: string, orgId: string): Promise<AgentSandbox | undefined> {
+  async findRunningSandbox(
+    id: string,
+    orgId: string,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     // Use dbWrite (primary) for fresh read-after-write data from the VPS worker.
     const [r] = await dbWrite
@@ -696,13 +745,31 @@ export class AgentSandboxesRepository {
       });
   }
 
-  async update(id: string, data: Partial<NewAgentSandbox>): Promise<AgentSandbox | undefined> {
+  async update(
+    id: string,
+    data: Partial<NewAgentSandbox>,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbWrite
       .update(agentSandboxes)
       .set({ ...data, updated_at: new Date() })
       .where(eq(agentSandboxes.id, id))
       .returning();
+    if (r && data.status !== undefined) {
+      void import("../../lib/services/shared-runtime/resolve-shared-agent")
+        .then(({ invalidateSharedAgentRunningSandbox }) =>
+          invalidateSharedAgentRunningSandbox(r.id, r.organization_id),
+        )
+        .catch((error) => {
+          logger.debug(
+            "[agent-sandboxes] running sandbox cache invalidation failed",
+            {
+              id,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        });
+    }
     return r;
   }
 
@@ -812,7 +879,9 @@ export class AgentSandboxesRepository {
    * multi-second re-probe is never clobbered. Returns undefined when the CAS
    * matched nothing.
    */
-  async markRunningFromProvisioning(id: string): Promise<AgentSandbox | undefined> {
+  async markRunningFromProvisioning(
+    id: string,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbWrite
       .update(agentSandboxes)
@@ -847,7 +916,12 @@ export class AgentSandboxesRepository {
     await ensureAgentSandboxSchema();
     const r = await dbWrite
       .delete(agentSandboxes)
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.organization_id, orgId)))
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.organization_id, orgId),
+        ),
+      )
       .returning({ id: agentSandboxes.id });
     return r.length > 0;
   }
@@ -874,7 +948,8 @@ export class AgentSandboxesRepository {
       isNotNull(agentSandboxes.node_id),
       sql`${agentSandboxes.node_id} <> ''`,
     ];
-    if (filter.image) conditions.push(eq(agentSandboxes.docker_image, filter.image));
+    if (filter.image)
+      conditions.push(eq(agentSandboxes.docker_image, filter.image));
     const [row] = await dbRead
       .select({ count: sql<number>`count(*)::int` })
       .from(agentSandboxes)
@@ -886,7 +961,10 @@ export class AgentSandboxesRepository {
    * Count pool entries by status — including not-yet-ready ones (still
    * provisioning). Used to size in-flight replenish work.
    */
-  async countAllPoolEntries(): Promise<{ ready: number; provisioning: number }> {
+  async countAllPoolEntries(): Promise<{
+    ready: number;
+    provisioning: number;
+  }> {
     await ensureAgentSandboxSchema();
     const [ready] = await dbRead
       .select({ count: sql<number>`count(*)::int` })
@@ -951,7 +1029,9 @@ export class AgentSandboxesRepository {
    * Used by the create path's per-org quota (#11023). Best-effort read; the
    * authoritative check runs under the advisory lock inside createAgent.
    */
-  async countNonTerminalByOrganization(organizationId: string): Promise<number> {
+  async countNonTerminalByOrganization(
+    organizationId: string,
+  ): Promise<number> {
     await ensureAgentSandboxSchema();
     const [row] = await dbRead
       .select({ count: sql<number>`count(*)::int` })
@@ -1043,7 +1123,12 @@ export class AgentSandboxesRepository {
     return dbRead
       .select()
       .from(agentSandboxes)
-      .where(and(eq(agentSandboxes.pool_status, "unclaimed"), eq(agentSandboxes.status, "running")))
+      .where(
+        and(
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          eq(agentSandboxes.status, "running"),
+        ),
+      )
       .orderBy(agentSandboxes.pool_ready_at);
   }
 
@@ -1051,7 +1136,9 @@ export class AgentSandboxesRepository {
    * Pool rows that started provisioning but never became ready. Used to
    * reap stuck containers so the pool replenisher can retry.
    */
-  async findStuckPoolProvisioning(staleThresholdMs: number): Promise<AgentSandbox[]> {
+  async findStuckPoolProvisioning(
+    staleThresholdMs: number,
+  ): Promise<AgentSandbox[]> {
     await ensureAgentSandboxSchema();
     const cutoff = new Date(Date.now() - staleThresholdMs);
     return dbRead
@@ -1168,13 +1255,18 @@ export class AgentSandboxesRepository {
       // Pool claim is for fresh provisions only. If the user's row already
       // has a database, fall through to the existing provision flow which
       // will reuse it. Likewise if it's already running.
-      if (userRow.database_status === "ready" || userRow.database_uri) return null;
+      if (userRow.database_status === "ready" || userRow.database_uri)
+        return null;
       if (userRow.status === "running") return null;
 
       if (params.expectedUpdatedAt) {
         const expectedMs = new Date(params.expectedUpdatedAt).getTime();
         const currentMs = userRow.updated_at?.getTime() ?? Number.NaN;
-        if (Number.isFinite(expectedMs) && Number.isFinite(currentMs) && expectedMs !== currentMs) {
+        if (
+          Number.isFinite(expectedMs) &&
+          Number.isFinite(currentMs) &&
+          expectedMs !== currentMs
+        ) {
           return null;
         }
       }
@@ -1247,7 +1339,12 @@ export class AgentSandboxesRepository {
     await ensureAgentSandboxSchema();
     const r = await dbWrite
       .delete(agentSandboxes)
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.pool_status, "unclaimed")))
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+        ),
+      )
       .returning({ id: agentSandboxes.id });
     return r.length > 0;
   }
@@ -1262,7 +1359,12 @@ export class AgentSandboxesRepository {
         pool_ready_at: new Date(),
         updated_at: new Date(),
       })
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.pool_status, "unclaimed")))
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+        ),
+      )
       .returning();
     return r;
   }
@@ -1271,12 +1373,18 @@ export class AgentSandboxesRepository {
 
   async createBackup(data: NewAgentSandboxBackup): Promise<AgentSandboxBackup> {
     const insertData = await prepareAgentBackupInsertData(data);
-    const [r] = await dbWrite.insert(agentSandboxBackups).values(insertData).returning();
+    const [r] = await dbWrite
+      .insert(agentSandboxBackups)
+      .values(insertData)
+      .returning();
     if (!r) throw new Error("Failed to create backup");
     return await hydrateAgentSandboxBackup(r);
   }
 
-  async listBackups(sandboxRecordId: string, limit = 10): Promise<AgentSandboxBackup[]> {
+  async listBackups(
+    sandboxRecordId: string,
+    limit = 10,
+  ): Promise<AgentSandboxBackup[]> {
     const rows = await dbRead
       .select()
       .from(agentSandboxBackups)
@@ -1312,7 +1420,9 @@ export class AgentSandboxesRepository {
       .limit(limit);
   }
 
-  async getLatestBackup(sandboxRecordId: string): Promise<AgentSandboxBackup | undefined> {
+  async getLatestBackup(
+    sandboxRecordId: string,
+  ): Promise<AgentSandboxBackup | undefined> {
     const [r] = await dbRead
       .select()
       .from(agentSandboxBackups)
@@ -1345,7 +1455,9 @@ export class AgentSandboxesRepository {
     return r ? await hydrateAgentSandboxBackup(r) : undefined;
   }
 
-  async getBackupById(backupId: string): Promise<AgentSandboxBackup | undefined> {
+  async getBackupById(
+    backupId: string,
+  ): Promise<AgentSandboxBackup | undefined> {
     const r = await getStoredBackupById(backupId);
     return r ? await hydrateAgentSandboxBackup(r) : undefined;
   }
@@ -1356,7 +1468,9 @@ export class AgentSandboxesRepository {
    * which does its own budgeted download + decrypt — hydrating here would
    * decrypt the payload eagerly and bypass the verifier's byte budget.
    */
-  async getStoredBackupById(backupId: string): Promise<StoredAgentSandboxBackup | undefined> {
+  async getStoredBackupById(
+    backupId: string,
+  ): Promise<StoredAgentSandboxBackup | undefined> {
     return getStoredBackupById(backupId);
   }
 
@@ -1382,7 +1496,11 @@ export class AgentSandboxesRepository {
    */
   async stampBackupVerification(
     backupId: string,
-    outcome: { status: "verified" | "failed"; verifiedAt: Date; error: string | null },
+    outcome: {
+      status: "verified" | "failed";
+      verifiedAt: Date;
+      error: string | null;
+    },
   ): Promise<void> {
     await dbWrite
       .update(agentSandboxBackups)
@@ -1433,7 +1551,9 @@ export class AgentSandboxesRepository {
    * need state to restore (provision auto-restore, `restore()`) MUST go through
    * here so incrementals are transparently materialized.
    */
-  async getReconstructedBackupState(backupId: string): Promise<AgentBackupStateData | undefined> {
+  async getReconstructedBackupState(
+    backupId: string,
+  ): Promise<AgentBackupStateData | undefined> {
     const targetStored = await getStoredBackupById(backupId);
     if (!targetStored) return undefined;
     const chain: AgentSandboxBackup[] = [];
@@ -1441,13 +1561,17 @@ export class AgentSandboxesRepository {
     let chainBytes = 0;
     let cursor: StoredAgentSandboxBackup | undefined = targetStored;
     while (cursor) {
-      if (seen.has(cursor.id)) throw new Error(`Backup chain cycle at ${cursor.id}`);
+      if (seen.has(cursor.id))
+        throw new Error(`Backup chain cycle at ${cursor.id}`);
       seen.add(cursor.id);
       if (cursor.sandbox_record_id !== targetStored.sandbox_record_id) {
-        throw new Error(`Backup chain row ${cursor.id} crosses sandbox boundary`);
+        throw new Error(
+          `Backup chain row ${cursor.id} crosses sandbox boundary`,
+        );
       }
       chainBytes +=
-        cursor.size_bytes ?? Buffer.byteLength(JSON.stringify(cursor.state_data), "utf8");
+        cursor.size_bytes ??
+        Buffer.byteLength(JSON.stringify(cursor.state_data), "utf8");
       if (chainBytes > MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES) {
         throw new Error(
           `Backup chain for ${backupId} exceeds ${MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES} bytes`,
@@ -1465,7 +1589,10 @@ export class AgentSandboxesRepository {
       }
       const parentBackupId = cursor.parent_backup_id;
       cursor = await getStoredBackupById(parentBackupId);
-      if (!cursor) throw new Error(`Backup chain references missing backup ${parentBackupId}`);
+      if (!cursor)
+        throw new Error(
+          `Backup chain references missing backup ${parentBackupId}`,
+        );
     }
     chain.reverse();
     let state: AgentBackupStateData | undefined;
@@ -1473,8 +1600,12 @@ export class AgentSandboxesRepository {
       if (row.backup_kind === "full") {
         state = requireBackupStateData(row.state_data, row.id);
       } else {
-        if (!state) throw new Error(`Incremental ${row.id} reached before a full backup`);
-        state = applyBackupDelta(state, requireBackupDelta(row.state_data, row.id));
+        if (!state)
+          throw new Error(`Incremental ${row.id} reached before a full backup`);
+        state = applyBackupDelta(
+          state,
+          requireBackupDelta(row.state_data, row.id),
+        );
       }
     }
     return state;

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -13,13 +13,18 @@ export const CacheKeys = {
       `analytics:overview:${orgId}:${timeRange}:v1`,
     breakdown: (orgId: string, dimension: string, range: string) =>
       `analytics:breakdown:${orgId}:${dimension}:${range}:v1`,
-    stats: (orgId: string, dateRange: string) => `analytics:stats:${orgId}:${dateRange}:v1`,
+    stats: (orgId: string, dateRange: string) =>
+      `analytics:stats:${orgId}:${dateRange}:v1`,
     userBreakdown: (orgId: string, params: string) =>
       `analytics:userbreakdown:${orgId}:${params}:v1`,
     projections: (orgId: string, daysAhead: number) =>
       `analytics:projections:${orgId}:${daysAhead}:v1`,
-    timeSeries: (orgId: string, granularity: string, start: string, end: string) =>
-      `analytics:timeseries:${orgId}:${granularity}:${start}:${end}:v1`,
+    timeSeries: (
+      orgId: string,
+      granularity: string,
+      start: string,
+      end: string,
+    ) => `analytics:timeseries:${orgId}:${granularity}:${start}:${end}:v1`,
     providerBreakdown: (orgId: string, start: string, end: string) =>
       `analytics:provider:${orgId}:${start}:${end}:v1`,
     modelBreakdown: (orgId: string, start: string, end: string) =>
@@ -50,6 +55,8 @@ export const CacheKeys = {
   sharedAgentScope: {
     resolve: (keyHashPrefix: string, agentId: string) =>
       `shared-agent-scope:${keyHashPrefix}:${agentId}:v1`,
+    runningSandbox: (agentId: string, orgId: string) =>
+      `shared-agent-scope:running-sandbox:${orgId}:${agentId}:v1`,
   },
   /**
    * Inference hot-path caches (#9899). The IAC entry collapses auth + org +
@@ -99,35 +106,43 @@ export const CacheKeys = {
     byStewardId: (stewardId: string) => `user:steward:${stewardId}:v1`,
     withOrg: (id: string) => `user:with-org:${id}:v1`,
     byEmailWithOrg: (email: string) => `user:email-with-org:${email}:v1`,
-    byStewardIdWithOrg: (stewardId: string) => `user:steward-with-org:${stewardId}:v1`,
+    byStewardIdWithOrg: (stewardId: string) =>
+      `user:steward-with-org:${stewardId}:v1`,
     byWalletAddress: (address: string) => `user:wallet:${address}:v1`,
-    byWalletAddressWithOrg: (address: string) => `user:wallet-with-org:${address}:v1`,
+    byWalletAddressWithOrg: (address: string) =>
+      `user:wallet-with-org:${address}:v1`,
     pattern: () => `user:*`,
   },
   identity: {
-    resolve: (platform: string, platformId: string) => `identity:${platform}:${platformId}`,
+    resolve: (platform: string, platformId: string) =>
+      `identity:${platform}:${platformId}`,
   },
   memory: {
     item: (orgId: string, memoryId: string) => `memory:${orgId}:${memoryId}:v1`,
-    roomRecent: (orgId: string, roomId: string) => `memory:${orgId}:room:${roomId}:recent:v1`,
+    roomRecent: (orgId: string, roomId: string) =>
+      `memory:${orgId}:room:${roomId}:recent:v1`,
     roomContext: (orgId: string, roomId: string, depth: number) =>
       `memory:${orgId}:room:${roomId}:context:${depth}:v1`,
-    search: (orgId: string, queryHash: string) => `memory:${orgId}:search:${queryHash}:v1`,
+    search: (orgId: string, queryHash: string) =>
+      `memory:${orgId}:search:${queryHash}:v1`,
     conversationContext: (orgId: string, convId: string, depth: number) =>
       `memory:${orgId}:conv:${convId}:${depth}:v1`,
     conversationSummary: (orgId: string, convId: string) =>
       `memory:${orgId}:conv:${convId}:summary:v1`,
     patterns: (orgId: string, analysisType: string) =>
       `memory:${orgId}:patterns:${analysisType}:v1`,
-    topics: (orgId: string, timeRange: string) => `memory:${orgId}:topics:${timeRange}:v1`,
+    topics: (orgId: string, timeRange: string) =>
+      `memory:${orgId}:topics:${timeRange}:v1`,
     orgPattern: (orgId: string) => `memory:${orgId}:*`,
-    roomPattern: (orgId: string, roomId: string) => `memory:${orgId}:room:${roomId}:*`,
+    roomPattern: (orgId: string, roomId: string) =>
+      `memory:${orgId}:room:${roomId}:*`,
   },
   agent: {
     roomContext: (roomId: string) => `agent:room:${roomId}:context:v1`,
     characterData: (agentId: string) => `agent:${agentId}:character:v1`,
     userSession: (entityId: string) => `agent:user:${entityId}:session:v1`,
-    agentList: (orgId: string, filterHash: string) => `agent:list:${orgId}:${filterHash}:v1`,
+    agentList: (orgId: string, filterHash: string) =>
+      `agent:list:${orgId}:${filterHash}:v1`,
     agentStats: (agentId: string) => `agent:stats:${agentId}:v1`,
   },
   container: {
@@ -163,7 +178,8 @@ export const CacheKeys = {
   codeAgent: {
     session: (sessionId: string) => `code_agent:session:${sessionId}:v1`,
     list: (orgId: string) => `code_agent:list:${orgId}:v1`,
-    analytics: (orgId: string, range: string) => `code_agent:analytics:${orgId}:${range}:v1`,
+    analytics: (orgId: string, range: string) =>
+      `code_agent:analytics:${orgId}:${range}:v1`,
     pattern: (orgId: string) => `code_agent:*:${orgId}:*`,
   },
   /**
@@ -172,7 +188,8 @@ export const CacheKeys = {
    */
   admin: {
     /** Cache admin status by wallet address (isAdmin + role) */
-    status: (walletAddress: string) => `admin:status:${walletAddress.toLowerCase()}:v1`,
+    status: (walletAddress: string) =>
+      `admin:status:${walletAddress.toLowerCase()}:v1`,
     pattern: () => `admin:*`,
   },
   /**
@@ -184,13 +201,16 @@ export const CacheKeys = {
     items: (orgId: string, userId: string, filterHash: string) =>
       `gallery:items:${orgId}:${userId}:${filterHash}:v1`,
     /** Cache gallery stats by org/user */
-    stats: (orgId: string, userId: string) => `gallery:stats:${orgId}:${userId}:v1`,
+    stats: (orgId: string, userId: string) =>
+      `gallery:stats:${orgId}:${userId}:v1`,
     /** Cache collections by org/user */
-    collections: (orgId: string, userId: string) => `gallery:collections:${orgId}:${userId}:v1`,
+    collections: (orgId: string, userId: string) =>
+      `gallery:collections:${orgId}:${userId}:v1`,
     /** Pattern for invalidating all gallery cache for an org */
     orgPattern: (orgId: string) => `gallery:*:${orgId}:*`,
     /** Pattern for invalidating all gallery cache for a user */
-    userPattern: (orgId: string, userId: string) => `gallery:*:${orgId}:${userId}:*`,
+    userPattern: (orgId: string, userId: string) =>
+      `gallery:*:${orgId}:${userId}:*`,
   },
   /**
    * MCP cache keys
@@ -230,11 +250,15 @@ export const CacheKeys = {
     user: (address: string) => `wallet-auth:user:${address}:v1`,
   },
   userMetrics: {
-    overview: (rangeDays?: number) => `user-metrics:overview:${rangeDays ?? 30}d:v1`,
-    daily: (start: string, end: string) => `user-metrics:daily:${start}:${end}:v1`,
-    retention: (start: string, end: string) => `user-metrics:retention:${start}:${end}:v1`,
+    overview: (rangeDays?: number) =>
+      `user-metrics:overview:${rangeDays ?? 30}d:v1`,
+    daily: (start: string, end: string) =>
+      `user-metrics:daily:${start}:${end}:v1`,
+    retention: (start: string, end: string) =>
+      `user-metrics:retention:${start}:${end}:v1`,
     activeUsers: (range: string) => `user-metrics:active:${range}:v1`,
-    signups: (start: string, end: string) => `user-metrics:signups:${start}:${end}:v1`,
+    signups: (start: string, end: string) =>
+      `user-metrics:signups:${start}:${end}:v1`,
     pattern: () => `user-metrics:*`,
   },
 } as const;
@@ -277,6 +301,7 @@ export const CacheTTL = {
    */
   sharedAgentScope: {
     resolve: 30,
+    runningSandbox: 30,
     /**
      * SLIDING-TTL CAP (COLDPATH-FIX-2026-07-22): a validated scope-cache hit
      * refreshes the entry's TTL back to `resolve` so an ACTIVE conversation

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -11,7 +11,14 @@
  * the cent. They fail loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
@@ -26,7 +33,9 @@ const ORG_ID = "00000000-0000-0000-0000-0000000000d4";
 const USER_ID = "00000000-0000-0000-0000-0000000000e5";
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
-let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let closeDb:
+  | typeof import("../../../db/client").closeDatabaseConnectionsForTests
+  | undefined;
 let creditsService: typeof import("../credits").creditsService;
 let pgliteReady = true;
 
@@ -38,7 +47,9 @@ async function getBalance(): Promise<number> {
 }
 
 async function seedOrg(balance: string): Promise<void> {
-  await dbWrite.execute(`DELETE FROM credit_transactions WHERE organization_id = '${ORG_ID}';`);
+  await dbWrite.execute(
+    `DELETE FROM credit_transactions WHERE organization_id = '${ORG_ID}';`,
+  );
   await dbWrite.execute(`DELETE FROM organizations WHERE id = '${ORG_ID}';`);
   await dbWrite.execute(
     `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '${balance}');`,
@@ -146,7 +157,13 @@ async function getReservationSettledAt(id: string): Promise<string | null> {
 
 async function settlementRowsForReservation(
   id: string,
-): Promise<Array<{ amount: string; type: string; stripe_payment_intent_id: string | null }>> {
+): Promise<
+  Array<{
+    amount: string;
+    type: string;
+    stripe_payment_intent_id: string | null;
+  }>
+> {
   const res = await dbWrite.execute(
     `SELECT amount, type, stripe_payment_intent_id
      FROM credit_transactions
@@ -160,7 +177,10 @@ async function settlementRowsForReservation(
   }>;
 }
 
-async function insertLegacySettlementForReservation(id: string, amount: number): Promise<string> {
+async function insertLegacySettlementForReservation(
+  id: string,
+  amount: number,
+): Promise<string> {
   const res = await dbWrite.execute(
     `INSERT INTO credit_transactions (
       organization_id,
@@ -187,7 +207,8 @@ async function insertLegacySettlementForReservation(id: string, amount: number):
 
 beforeAll(async () => {
   try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } =
+      await import("../../../db/client"));
     ({ creditsService } = await import("../credits"));
 
     // organizations carries the full column set that the real reconcile path
@@ -258,7 +279,10 @@ beforeAll(async () => {
     }
   } catch (error) {
     pgliteReady = false;
-    console.warn("[credits-reconcile] PGlite unavailable, skipping DB cases:", error);
+    console.warn(
+      "[credits-reconcile] PGlite unavailable, skipping DB cases:",
+      error,
+    );
   }
 }, PGLITE_TIMEOUT);
 
@@ -298,8 +322,12 @@ describe("CreditsService.reconcile", () => {
       const refundRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'refund';`,
       );
-      expect(Number((refundRow.rows[0] as { amount: string }).amount)).toBeCloseTo(0.6, 6);
-      expect((refundRow.rows[0] as { id: string }).id).toBe(result.settlementTransactionIds[0]);
+      expect(
+        Number((refundRow.rows[0] as { amount: string }).amount),
+      ).toBeCloseTo(0.6, 6);
+      expect((refundRow.rows[0] as { id: string }).id).toBe(
+        result.settlementTransactionIds[0],
+      );
     },
     PGLITE_TIMEOUT,
   );
@@ -329,8 +357,12 @@ describe("CreditsService.reconcile", () => {
       const debitRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'debit';`,
       );
-      expect(Number((debitRow.rows[0] as { amount: string }).amount)).toBeCloseTo(-0.6, 6);
-      expect((debitRow.rows[0] as { id: string }).id).toBe(result.settlementTransactionIds[0]);
+      expect(
+        Number((debitRow.rows[0] as { amount: string }).amount),
+      ).toBeCloseTo(-0.6, 6);
+      expect((debitRow.rows[0] as { id: string }).id).toBe(
+        result.settlementTransactionIds[0],
+      );
     },
     PGLITE_TIMEOUT,
   );
@@ -454,8 +486,12 @@ describe("CreditsService.reconcile", () => {
       const refundRow = await dbWrite.execute(
         `SELECT id, amount FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'refund';`,
       );
-      expect(Number((refundRow.rows[0] as { amount: string }).amount)).toBeCloseTo(1.0, 6);
-      expect((refundRow.rows[0] as { id: string }).id).toBe(result.settlementTransactionIds[0]);
+      expect(
+        Number((refundRow.rows[0] as { amount: string }).amount),
+      ).toBeCloseTo(1.0, 6);
+      expect((refundRow.rows[0] as { id: string }).id).toBe(
+        result.settlementTransactionIds[0],
+      );
     },
     PGLITE_TIMEOUT,
   );
@@ -586,7 +622,9 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
       expect(await countByType("refund")).toBe(1);
       expect(await countTransactions()).toBe(1);
       // Both invocations report the SAME settlement transaction.
-      expect(second.settlementTransactionIds).toEqual(first.settlementTransactionIds);
+      expect(second.settlementTransactionIds).toEqual(
+        first.settlementTransactionIds,
+      );
     },
     PGLITE_TIMEOUT,
   );
@@ -611,7 +649,9 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
       expect(await getBalance()).toBeCloseTo(19.4, 6);
       expect(await countByType("debit")).toBe(1);
       expect(await countTransactions()).toBe(1);
-      expect(second.settlementTransactionIds).toEqual(first.settlementTransactionIds);
+      expect(second.settlementTransactionIds).toEqual(
+        first.settlementTransactionIds,
+      );
     },
     PGLITE_TIMEOUT,
   );
@@ -667,7 +707,9 @@ describe("CreditsService.reserve idempotency key (#16425)", () => {
         idempotencyKey: "utt-1",
       });
 
-      expect(replay.reservationTransactionId).toBe(first.reservationTransactionId);
+      expect(replay.reservationTransactionId).toBe(
+        first.reservationTransactionId,
+      );
       // One upfront deduction, not two: balance = 10 - 0.5, one transaction row.
       expect(await getBalance()).toBeCloseTo(9.5, 6);
       expect(await countTransactions()).toBe(1);
@@ -703,7 +745,9 @@ describe("CreditsService.reserve idempotency key (#16425)", () => {
         idempotencyKey: "utt-2",
       });
 
-      expect(replay.reservationTransactionId).toBe(first.reservationTransactionId);
+      expect(replay.reservationTransactionId).toBe(
+        first.reservationTransactionId,
+      );
       expect(replay.reservedAmount).toBeCloseTo(0.4, 6);
       expect(await getBalance()).toBeCloseTo(9.6, 6);
 
@@ -719,7 +763,9 @@ describe("CreditsService.reserve idempotency key (#16425)", () => {
     async () => {
       if (!pgliteReady) return;
       await seedOrg("10");
-      await dbWrite.execute(`DELETE FROM credit_transactions WHERE organization_id = '${ORG_B}';`);
+      await dbWrite.execute(
+        `DELETE FROM credit_transactions WHERE organization_id = '${ORG_B}';`,
+      );
       await dbWrite.execute(`DELETE FROM organizations WHERE id = '${ORG_B}';`);
       await dbWrite.execute(
         `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_B}', '10');`,
@@ -784,14 +830,20 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
         reservedAmount: 1.0,
         actualCost: 0.4,
         description: "chat completion settle",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
       const second = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 1.0,
         actualCost: 0,
         description: "late duplicate refund attempt",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
 
       expect(first.adjustmentType).toBe("refund");
@@ -826,7 +878,10 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       const res = await dbWrite.execute(
         `SELECT amount, metadata FROM credit_transactions WHERE id = '${reservation.reservationTransactionId}';`,
       );
-      const row = res.rows[0] as { amount: string; metadata: Record<string, unknown> | string };
+      const row = res.rows[0] as {
+        amount: string;
+        metadata: Record<string, unknown> | string;
+      };
       const metadata =
         typeof row.metadata === "string"
           ? (JSON.parse(row.metadata) as Record<string, unknown>)
@@ -853,7 +908,10 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
         reservedAmount: 1.0,
         actualCost: 1.0,
         description: "chat completion exact settle",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
 
       expect(result.adjustmentType).toBe("none");
@@ -876,14 +934,20 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
         reservedAmount: 0.4,
         actualCost: 1.0,
         description: "chat completion overage settle",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
       const second = await creditsService.reconcile({
         organizationId: ORG_ID,
         reservedAmount: 0.4,
         actualCost: 1.0,
         description: "duplicate overage settle",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
 
       expect(first.adjustmentType).toBe("overage");
@@ -895,6 +959,53 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
           amount: "-0.600000",
           type: "debit",
           stripe_payment_intent_id: `recon:${reservationId}:overage`,
+        },
+      ]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent settle attempts claim exactly one reconciliation row",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("9");
+      const reservationId = await insertReservation(1.0);
+
+      const [first, second] = await Promise.all([
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0.4,
+          description: "concurrent chat completion settle a",
+          metadata: {
+            user_id: USER_ID,
+            reservation_transaction_id: reservationId,
+          },
+        }),
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0.4,
+          description: "concurrent chat completion settle b",
+          metadata: {
+            user_id: USER_ID,
+            reservation_transaction_id: reservationId,
+          },
+        }),
+      ]);
+
+      expect([first.adjustmentType, second.adjustmentType].sort()).toEqual([
+        "none",
+        "refund",
+      ]);
+      expect(await getBalance()).toBeCloseTo(9.6, 6);
+      expect(await countByType("refund")).toBe(1);
+      expect(await settlementRowsForReservation(reservationId)).toEqual([
+        {
+          amount: "0.600000",
+          type: "refund",
+          stripe_payment_intent_id: `recon:${reservationId}:refund`,
         },
       ]);
     },
@@ -928,7 +1039,10 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       if (!pgliteReady) return;
       await seedOrg("9.6");
       const reservationId = await insertReservation(1.0, 25 * 60 * 1000);
-      const legacySettlementId = await insertLegacySettlementForReservation(reservationId, 0.6);
+      const legacySettlementId = await insertLegacySettlementForReservation(
+        reservationId,
+        0.6,
+      );
 
       const stats = await creditsService.sweepStaleReservations({
         graceMs: 20 * 60 * 1000,
@@ -955,7 +1069,10 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
         reservedAmount: 1.0,
         actualCost: 0.2,
         description: "late waitUntil settle after legacy keyed settle",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
 
       expect(late.adjustmentType).toBe("none");
@@ -991,7 +1108,10 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
         reservedAmount: 1.0,
         actualCost: 0.2,
         description: "late waitUntil settle after sweep",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        metadata: {
+          user_id: USER_ID,
+          reservation_transaction_id: reservationId,
+        },
       });
 
       expect(late.adjustmentType).toBe("none");
@@ -1080,7 +1200,9 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       expect(settlements).toHaveLength(1);
       expect(settlements[0]?.type).toBe("refund");
       expect(Number(settlements[0]?.amount)).toBeCloseTo(0.5, 6);
-      expect(settlements[0]?.stripe_payment_intent_id).toBe(`reconcile-refund:${reservationId}`);
+      expect(settlements[0]?.stripe_payment_intent_id).toBe(
+        `reconcile-refund:${reservationId}`,
+      );
       expect(await countByType("refund")).toBe(1);
     },
     PGLITE_TIMEOUT,
@@ -1100,14 +1222,18 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       // real app-credits-lane proof for markup math and late-settle dedup lives
       // in app-chat-sweep-double-refund.test.ts.
       await seedOrg("8.2"); // org had 10, paid the 1.8 hold
-      const reservationId = await insertAppChatReservation(1.8, 25 * 60 * 1000, {
-        estimated_cost: 1.0,
-        reserved_amount: 1.5,
-        totalCost: 1.8,
-        baseCost: 1.5,
-        creatorMarkup: 0.3,
-        markupPercentage: 20,
-      });
+      const reservationId = await insertAppChatReservation(
+        1.8,
+        25 * 60 * 1000,
+        {
+          estimated_cost: 1.0,
+          reserved_amount: 1.5,
+          totalCost: 1.8,
+          baseCost: 1.5,
+          creatorMarkup: 0.3,
+          markupPercentage: 20,
+        },
+      );
 
       const stats = await creditsService.sweepStaleReservations({
         graceMs: 20 * 60 * 1000,
@@ -1131,10 +1257,14 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
     async () => {
       if (!pgliteReady) return;
       await seedOrg("8.2");
-      const reservationId = await insertAppChatReservation(1.8, 25 * 60 * 1000, {
-        estimated_cost: null,
-        reserved_amount: null,
-      });
+      const reservationId = await insertAppChatReservation(
+        1.8,
+        25 * 60 * 1000,
+        {
+          estimated_cost: null,
+          reserved_amount: null,
+        },
+      );
 
       const stats = await creditsService.sweepStaleReservations({
         graceMs: 20 * 60 * 1000,
@@ -1242,8 +1372,12 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         metadata: { payment_intent_id: "pi_3" },
       });
 
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_3")).toBeCloseTo(50, 6);
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_none")).toBe(0);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_3"),
+      ).toBeCloseTo(50, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_none"),
+      ).toBe(0);
       // Balance clawed the full $50 across the two partials.
       expect(await getBalance()).toBeCloseTo(50, 6);
     },
@@ -1265,14 +1399,17 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         stripePaymentIntentId: "stripe:dispute:dp_r1",
         metadata: { payment_intent_id: "pi_r1" },
       });
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r1")).toBeCloseTo(10, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r1"),
+      ).toBeCloseTo(10, 6);
 
       // Platform wins the dispute: funds_reinstated writes a `refund` row
       // (mirrors handleChargeDisputeFundsReinstated in stripe-event.ts).
       await creditsService.refundCredits({
         organizationId: ORG_ID,
         amount: 10,
-        description: "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r1",
+        description:
+          "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r1",
         stripePaymentIntentId: "stripe:dispute:dp_r1:reinstated",
         metadata: {
           payment_intent_id: "pi_r1",
@@ -1282,7 +1419,9 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
 
       // The tally nets to 0 so a later charge.refunded claws the FULL refund
       // delta instead of under-clawing by the reinstated amount.
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r1")).toBeCloseTo(0, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r1"),
+      ).toBeCloseTo(0, 6);
 
       // An ordinary (non-reinstatement) refund tagged with the same payment
       // intent must NOT reduce the tally.
@@ -1292,7 +1431,9 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         description: "unrelated refund",
         metadata: { payment_intent_id: "pi_r1" },
       });
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r1")).toBeCloseTo(0, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r1"),
+      ).toBeCloseTo(0, 6);
 
       // Balance: 100 - 10 (clawback) + 10 (reinstatement) + 5 (refund) = 105.
       expect(await getBalance()).toBeCloseTo(105, 6);
@@ -1317,7 +1458,8 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
       const reinstatement = {
         organizationId: ORG_ID,
         amount: 10,
-        description: "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r2",
+        description:
+          "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r2",
         stripePaymentIntentId: "stripe:dispute:dp_r2:reinstated",
         metadata: {
           payment_intent_id: "pi_r2",
@@ -1325,7 +1467,9 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         },
       };
       const first = await creditsService.refundCredits(reinstatement);
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r2")).toBeCloseTo(0, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r2"),
+      ).toBeCloseTo(0, 6);
       expect(first.newBalance).toBeCloseTo(100, 6);
 
       // Stripe re-delivers the webhook: the same `:reinstated` idempotency key
@@ -1336,7 +1480,9 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
       const second = await creditsService.refundCredits(reinstatement);
       expect(second.transaction.id).toBe(first.transaction.id);
       expect(second.newBalance).toBeCloseTo(100, 6);
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r2")).toBeCloseTo(0, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r2"),
+      ).toBeCloseTo(0, 6);
       expect(await getBalance()).toBeCloseTo(100, 6);
     },
     PGLITE_TIMEOUT,
@@ -1363,14 +1509,17 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
       await creditsService.refundCredits({
         organizationId: ORG_ID,
         amount: 4,
-        description: "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r3",
+        description:
+          "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r3",
         stripePaymentIntentId: "stripe:dispute:dp_r3:reinstated",
         metadata: {
           payment_intent_id: "pi_r3",
           source: "charge.dispute.funds_reinstated",
         },
       });
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r3")).toBeCloseTo(6, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r3"),
+      ).toBeCloseTo(6, 6);
 
       // Later charge.refunded for the full $10: clawbackForReversal computes
       // toClaw = min(10, grant) - 6 = 4 — exactly the reinstated portion.
@@ -1382,7 +1531,9 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         stripePaymentIntentId: "stripe:refund:ch_r3:1000",
         metadata: { payment_intent_id: "pi_r3" },
       });
-      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r3")).toBeCloseTo(10, 6);
+      expect(
+        await creditsService.getClawedBackUsdForPaymentIntent("pi_r3"),
+      ).toBeCloseTo(10, 6);
 
       // Balance: 100 - 10 + 4 - 4 = 90 — the org holds exactly what the fiat
       // flows imply (grant refunded in full, only $4 was ever reinstated).

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -4,7 +4,7 @@
 
 import { sql } from "drizzle-orm";
 import { type SqlExecutor, sqlRows } from "../../db/execute-helpers";
-import { dbWrite, writeTransaction } from "../../db/helpers";
+import { dbWrite } from "../../db/helpers";
 import {
   appsRepository,
   type CreditPack,
@@ -16,9 +16,15 @@ import {
 } from "../../db/repositories";
 import { CacheInvalidation } from "../cache/invalidation";
 import { invalidateOrganizationCache } from "../cache/organizations-cache";
-import { canSendLowCreditsEmail, markLowCreditsEmailSent } from "../email/utils/rate-limiter";
+import {
+  canSendLowCreditsEmail,
+  markLowCreditsEmailSent,
+} from "../email/utils/rate-limiter";
 import { calculateCost, getProviderFromModel } from "../pricing";
-import { PROVIDER_DEFAULT_MAX_RETRIES, PROVIDER_MAX_BACKOFF_DELAY_MS } from "../providers/_http";
+import {
+  PROVIDER_DEFAULT_MAX_RETRIES,
+  PROVIDER_MAX_BACKOFF_DELAY_MS,
+} from "../providers/_http";
 import { logger } from "../utils/logger";
 import { getRouteTimeoutMs } from "../utils/request-timeout";
 import type { PricingBillingSource } from "./ai-pricing-definitions";
@@ -65,7 +71,8 @@ const SWEEP_PROVIDERS_PER_REQUEST = 2;
 const SWEEP_SETTLE_MARGIN_MS = 20 * 60 * 1000;
 export const RESERVATION_SWEEP_GRACE_MS =
   SWEEP_PROVIDERS_PER_REQUEST *
-    ((PROVIDER_DEFAULT_MAX_RETRIES + 1) * getRouteTimeoutMs(SWEEP_MAX_ROUTE_DURATION_SECONDS) +
+    ((PROVIDER_DEFAULT_MAX_RETRIES + 1) *
+      getRouteTimeoutMs(SWEEP_MAX_ROUTE_DURATION_SECONDS) +
       PROVIDER_DEFAULT_MAX_RETRIES * PROVIDER_MAX_BACKOFF_DELAY_MS) +
   SWEEP_SETTLE_MARGIN_MS;
 
@@ -209,12 +216,24 @@ interface ClawbackMutationRow extends CreditMutationRow {
   already_processed: boolean | string | number | null;
 }
 
-function isPgTrue(value: boolean | string | number | null | undefined): boolean {
-  return value === true || value === 1 || value === "1" || value === "t" || value === "true";
+function isPgTrue(
+  value: boolean | string | number | null | undefined,
+): boolean {
+  return (
+    value === true ||
+    value === 1 ||
+    value === "1" ||
+    value === "t" ||
+    value === "true"
+  );
 }
 
-function parseNumeric(value: string | number | null | undefined, fieldName: string): number {
-  const parsed = typeof value === "number" ? value : Number.parseFloat(String(value ?? ""));
+function parseNumeric(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  const parsed =
+    typeof value === "number" ? value : Number.parseFloat(String(value ?? ""));
   if (!Number.isFinite(parsed)) {
     throw new Error(`[CreditsService] Invalid numeric ${fieldName}`);
   }
@@ -241,7 +260,9 @@ function parseNumeric(value: string | number | null | undefined, fieldName: stri
  *    about, so we throw and let the caller SKIP the charge rather than fire an
  *    unvalidatable auto-top-up.
  */
-function parseAutoTopUpThreshold(value: string | number | null | undefined): number {
+function parseAutoTopUpThreshold(
+  value: string | number | null | undefined,
+): number {
   if (value === null || value === undefined) {
     return 0;
   }
@@ -255,13 +276,17 @@ function parseAutoTopUpThreshold(value: string | number | null | undefined): num
   return parsed;
 }
 
-function parseMetadata(value: CreditMutationRow["metadata"]): Record<string, unknown> {
+function parseMetadata(
+  value: CreditMutationRow["metadata"],
+): Record<string, unknown> {
   if (!value) {
     return {};
   }
   if (typeof value === "string") {
     const parsed = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
   }
   return value;
 }
@@ -286,15 +311,27 @@ function metadataNumber(value: unknown): number | null {
  * this helper because their estimates are in base-cost units and must use the
  * app-credits settle lane for markup and creator-earnings reconciliation.
  */
-function staleHoldSettleCost(reservedAmount: number, metadata: Record<string, unknown>): number {
+function staleHoldSettleCost(
+  reservedAmount: number,
+  metadata: Record<string, unknown>,
+): number {
   const estimate =
-    metadataNumber(metadata.estimated_cost) ?? metadataNumber(metadata.estimatedCost);
+    metadataNumber(metadata.estimated_cost) ??
+    metadataNumber(metadata.estimatedCost);
   return estimate ?? reservedAmount;
 }
 
 function toCreditTransaction(row: CreditMutationRow): CreditTransaction {
-  if (!row.id || !row.organization_id || !row.amount || !row.type || !row.created_at) {
-    throw new Error("[CreditsService] Credit mutation did not return a transaction row");
+  if (
+    !row.id ||
+    !row.organization_id ||
+    !row.amount ||
+    !row.type ||
+    !row.created_at
+  ) {
+    throw new Error(
+      "[CreditsService] Credit mutation did not return a transaction row",
+    );
   }
 
   return {
@@ -306,7 +343,10 @@ function toCreditTransaction(row: CreditMutationRow): CreditTransaction {
     description: row.description,
     metadata: parseMetadata(row.metadata),
     stripe_payment_intent_id: row.stripe_payment_intent_id,
-    created_at: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
+    created_at:
+      row.created_at instanceof Date
+        ? row.created_at
+        : new Date(row.created_at),
     settled_at:
       row.settled_at == null
         ? null
@@ -492,24 +532,34 @@ export class CreditsService {
   async getTransactionByStripePaymentIntent(
     paymentIntentId: string,
   ): Promise<CreditTransaction | undefined> {
-    return await creditTransactionsRepository.findByStripePaymentIntent(paymentIntentId);
+    return await creditTransactionsRepository.findByStripePaymentIntent(
+      paymentIntentId,
+    );
   }
 
   async listTransactionsByOrganization(
     organizationId: string,
     limit?: number,
   ): Promise<CreditTransaction[]> {
-    return await creditTransactionsRepository.listByOrganization(organizationId, limit);
+    return await creditTransactionsRepository.listByOrganization(
+      organizationId,
+      limit,
+    );
   }
 
   async listTransactionsByOrganizationAndType(
     organizationId: string,
     type: string,
   ): Promise<CreditTransaction[]> {
-    return await creditTransactionsRepository.listByOrganizationAndType(organizationId, type);
+    return await creditTransactionsRepository.listByOrganizationAndType(
+      organizationId,
+      type,
+    );
   }
 
-  async createTransaction(data: NewCreditTransaction): Promise<CreditTransaction> {
+  async createTransaction(
+    data: NewCreditTransaction,
+  ): Promise<CreditTransaction> {
     return await creditTransactionsRepository.create(data);
   }
 
@@ -517,7 +567,14 @@ export class CreditsService {
     transaction: CreditTransaction;
     newBalance: number;
   }> {
-    const { organizationId, amount, description, metadata, stripePaymentIntentId, db } = params;
+    const {
+      organizationId,
+      amount,
+      description,
+      metadata,
+      stripePaymentIntentId,
+      db,
+    } = params;
 
     // IDEMPOTENCY: If stripePaymentIntentId is provided, check for existing transaction
     // This prevents race conditions when both synchronous and webhook calls try to add credits
@@ -609,7 +666,9 @@ export class CreditsService {
     // aborts the whole atomic statement, and the caller retries into this
     // check). Callers that pass no key keep the exact previous behavior. (#10846)
     if (stripePaymentIntentId) {
-      const existing = await this.getTransactionByStripePaymentIntent(stripePaymentIntentId);
+      const existing = await this.getTransactionByStripePaymentIntent(
+        stripePaymentIntentId,
+      );
       if (existing) {
         return {
           success: true,
@@ -719,7 +778,10 @@ export class CreditsService {
         reason: "org_not_found",
       };
     } else if (!row.id) {
-      const currentBalance = parseNumeric(row.current_balance, "current_balance");
+      const currentBalance = parseNumeric(
+        row.current_balance,
+        "current_balance",
+      );
       result = {
         success: false,
         newBalance: currentBalance,
@@ -741,7 +803,10 @@ export class CreditsService {
       // Invalidate organization cache if balance changed
       if (result.success) {
         invalidateOrganizationCache(organizationId).catch((error) => {
-          logger.error("[CreditsService] Failed to invalidate org cache:", error);
+          logger.error(
+            "[CreditsService] Failed to invalidate org cache:",
+            error,
+          );
         });
         // Invalidate balance cache immediately after successful deduction
         await CacheInvalidation.onCreditMutation(organizationId);
@@ -756,7 +821,10 @@ export class CreditsService {
               tokens_consumed: tokens_consumed || 0,
             })
             .catch((error) => {
-              logger.error("[CreditsService] Failed to track session usage:", error);
+              logger.error(
+                "[CreditsService] Failed to track session usage:",
+                error,
+              );
             });
         }
 
@@ -785,11 +853,19 @@ export class CreditsService {
       logger.error("[CreditsService] Failed to check auto top-up:", error);
     });
     this.queueLowCreditsEmail(organizationId, newBalance).catch((error) => {
-      logger.error("[CreditsService] Failed to queue low credits email:", error);
+      logger.error(
+        "[CreditsService] Failed to queue low credits email:",
+        error,
+      );
     });
-    this.notifyWaifuCredits(organizationId, newBalance, metadata).catch((error) => {
-      logger.error("[CreditsService] Failed to notify waifu credit webhook:", error);
-    });
+    this.notifyWaifuCredits(organizationId, newBalance, metadata).catch(
+      (error) => {
+        logger.error(
+          "[CreditsService] Failed to notify waifu credit webhook:",
+          error,
+        );
+      },
+    );
   }
 
   /**
@@ -887,7 +963,10 @@ export class CreditsService {
         );
       });
     } catch (error) {
-      logger.error(`[CreditsService] Error checking auto top-up for org ${organizationId}:`, error);
+      logger.error(
+        `[CreditsService] Error checking auto top-up for org ${organizationId}:`,
+        error,
+      );
     }
   }
 
@@ -896,7 +975,10 @@ export class CreditsService {
     currentBalance: number,
   ): Promise<void> {
     try {
-      const threshold = parseInt(process.env.LOW_CREDITS_THRESHOLD || "1000", 10);
+      const threshold = parseInt(
+        process.env.LOW_CREDITS_THRESHOLD || "1000",
+        10,
+      );
 
       if (currentBalance <= 0 || currentBalance > threshold) {
         return;
@@ -947,7 +1029,13 @@ export class CreditsService {
     transaction: CreditTransaction;
     newBalance: number;
   }> {
-    const { organizationId, amount, description, metadata, stripePaymentIntentId } = params;
+    const {
+      organizationId,
+      amount,
+      description,
+      metadata,
+      stripePaymentIntentId,
+    } = params;
 
     if (amount <= 0) {
       throw new Error("Refund amount must be positive");
@@ -1113,7 +1201,9 @@ export class CreditsService {
       throw new Error("Organization not found");
     }
     if (!row.id) {
-      const existing = await this.getTransactionByStripePaymentIntent(params.stripePaymentIntentId);
+      const existing = await this.getTransactionByStripePaymentIntent(
+        params.stripePaymentIntentId,
+      );
       const org = await organizationsRepository.findById(params.organizationId);
       if (existing && org) {
         const metadata = parseMetadata(existing.metadata);
@@ -1125,7 +1215,9 @@ export class CreditsService {
           alreadyProcessed: true,
         };
       }
-      throw new Error("[CreditsService] Clawback did not return a transaction row");
+      throw new Error(
+        "[CreditsService] Clawback did not return a transaction row",
+      );
     }
 
     const result = {
@@ -1156,7 +1248,9 @@ export class CreditsService {
    * a refund that follows a won dispute would see the stale dispute clawback
    * as "already clawed" and under-claw by that amount. (#11155)
    */
-  async getClawedBackUsdForPaymentIntent(paymentIntentId: string): Promise<number> {
+  async getClawedBackUsdForPaymentIntent(
+    paymentIntentId: string,
+  ): Promise<number> {
     const rows = await sqlRows<{ total: string | number | null }>(
       dbWrite,
       sql`
@@ -1188,31 +1282,28 @@ export class CreditsService {
       }
     | { kind: "no_reservation_row" }
   > {
-    const { organizationId, reservationTransactionId, actualCost, description, metadata } = params;
+    const {
+      organizationId,
+      reservationTransactionId,
+      actualCost,
+      description,
+      metadata,
+    } = params;
+    const normalizedActualCost = Math.max(actualCost, 0);
+    const inputMetadata = JSON.stringify(metadata ?? {});
 
-    const existingSettlementIds = async (executor: SqlExecutor): Promise<string[]> => {
-      const rows = await sqlRows<{ id: string }>(
-        executor,
-        sql`
-          SELECT id
-          FROM credit_transactions
-          WHERE metadata->>'reservation_transaction_id' = ${reservationTransactionId}
-            AND organization_id = ${organizationId}
-          ORDER BY created_at ASC
-        `,
-      );
-      return rows.map((row) => row.id);
-    };
-
-    const result = await writeTransaction(async (tx) => {
-      const reservationRows = await sqlRows<{
-        id: string;
-        amount: string | number;
-        settled_at: Date | string | null;
-      }>(
-        tx,
-        sql`
-          SELECT id, amount, settled_at
+    const rows = await sqlRows<{
+      reservation_found: boolean | string | number | null;
+      claimed: boolean | string | number | null;
+      reserved_amount: string | number | null;
+      new_balance: string | number | null;
+      settlement_ids: string[] | null;
+      adjustment_type: CreditReconciliationResult["adjustmentType"] | null;
+    }>(
+      dbWrite,
+      sql`
+        WITH reservation AS (
+          SELECT id, organization_id, amount::numeric AS amount, settled_at
           FROM credit_transactions
           WHERE id = ${reservationTransactionId}
             AND organization_id = ${organizationId}
@@ -1225,300 +1316,206 @@ export class CreditsService {
               )
             )
           LIMIT 1
-        `,
-      );
-      const reservation = reservationRows[0];
-      if (!reservation) {
-        return { kind: "no_reservation_row" as const };
-      }
-
-      const reservedAmount = Math.abs(parseNumeric(reservation.amount, "reservation_amount"));
-
-      if (reservation.settled_at !== null) {
-        return {
-          kind: "handled" as const,
-          claimed: false,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: await existingSettlementIds(tx),
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const preexistingSettlementIds = await existingSettlementIds(tx);
-      if (preexistingSettlementIds.length > 0) {
-        const markedRows = await sqlRows<{ id: string }>(
-          tx,
-          sql`
-            UPDATE credit_transactions
-            SET settled_at = NOW()
-            WHERE id = ${reservationTransactionId}
-              AND organization_id = ${organizationId}
-              AND type = 'debit'
-              AND (
-                metadata->>'type' = 'reservation'
-                OR (
-                  metadata->>'type' = 'app_chat_reservation'
-                  AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
-                )
-              )
-              AND settled_at IS NULL
-            RETURNING id
-          `,
-        );
-        return {
-          kind: "handled" as const,
-          claimed: markedRows.length > 0,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: preexistingSettlementIds,
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const claimedRows = await sqlRows<{
-        id: string;
-        amount: string | number;
-      }>(
-        tx,
-        sql`
-          UPDATE credit_transactions
+        ),
+        reservation_values AS (
+          SELECT
+            id,
+            organization_id,
+            ABS(amount)::numeric AS reserved_amount,
+            ${String(normalizedActualCost)}::numeric AS actual_cost,
+            (ABS(amount)::numeric - ${String(normalizedActualCost)}::numeric) AS difference,
+            settled_at
+          FROM reservation
+        ),
+        existing_settlements AS (
+          SELECT COALESCE(array_agg(ct.id ORDER BY ct.created_at ASC), ARRAY[]::uuid[]) AS ids
+          FROM credit_transactions ct
+          WHERE ct.metadata->>'reservation_transaction_id' = ${reservationTransactionId}
+            AND ct.organization_id = ${organizationId}
+        ),
+        claim AS (
+          UPDATE credit_transactions ct
           SET settled_at = NOW()
-          WHERE id = ${reservationTransactionId}
-            AND organization_id = ${organizationId}
-            AND type = 'debit'
+          FROM reservation_values rv
+          WHERE ct.id = rv.id
+            AND rv.settled_at IS NULL
+            AND NOT EXISTS (SELECT 1 FROM existing_settlements es WHERE cardinality(es.ids) > 0)
+            AND ct.settled_at IS NULL
+          RETURNING ct.id
+        ),
+        mark_preexisting AS (
+          UPDATE credit_transactions ct
+          SET settled_at = NOW()
+          FROM reservation_values rv
+          WHERE ct.id = rv.id
+            AND rv.settled_at IS NULL
+            AND EXISTS (SELECT 1 FROM existing_settlements es WHERE cardinality(es.ids) > 0)
+            AND ct.settled_at IS NULL
+          RETURNING ct.id
+        ),
+        mutation_plan AS (
+          SELECT
+            rv.*,
+            CASE
+              WHEN NOT EXISTS (SELECT 1 FROM claim) THEN 'none'
+              WHEN ABS(rv.difference) < ${String(EPSILON)}::numeric THEN 'none'
+              WHEN rv.difference > 0 THEN 'refund'
+              ELSE 'overage'
+            END AS phase,
+            CASE
+              WHEN NOT EXISTS (SELECT 1 FROM claim) THEN 0::numeric
+              WHEN ABS(rv.difference) < ${String(EPSILON)}::numeric THEN 0::numeric
+              ELSE ABS(rv.difference)::numeric
+            END AS amount
+          FROM reservation_values rv
+        ),
+        org AS (
+          SELECT o.id, o.credit_balance::numeric AS current_balance
+          FROM organizations o
+          JOIN mutation_plan mp ON mp.organization_id = o.id
+          WHERE mp.phase IN ('refund', 'overage')
+          FOR UPDATE
+        ),
+        org_update AS (
+          UPDATE organizations o
+          SET credit_balance = CASE
+                WHEN mp.phase = 'refund' THEN org.current_balance + mp.amount
+                WHEN mp.phase = 'overage' THEN org.current_balance - mp.amount
+                ELSE org.current_balance
+              END,
+              updated_at = NOW()
+          FROM org, mutation_plan mp
+          WHERE o.id = org.id
             AND (
-              metadata->>'type' = 'reservation'
-              OR (
-                metadata->>'type' = 'app_chat_reservation'
-                AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
-              )
+              mp.phase = 'refund'
+              OR (mp.phase = 'overage' AND org.current_balance >= mp.amount)
             )
-            AND settled_at IS NULL
-          RETURNING id, amount
-        `,
-      );
-      const claimed = claimedRows[0];
-      if (!claimed) {
-        return {
-          kind: "handled" as const,
-          claimed: false,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: await existingSettlementIds(tx),
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const claimedReservedAmount = Math.abs(parseNumeric(claimed.amount, "reservation_amount"));
-      const normalizedActualCost = Math.max(actualCost, 0);
-      const difference = claimedReservedAmount - normalizedActualCost;
-      const baseMetadata = {
-        ...metadata,
-        reservation_transaction_id: reservationTransactionId,
-        reserved: claimedReservedAmount,
-        actual: normalizedActualCost,
-      };
-
-      if (Math.abs(difference) < EPSILON) {
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [],
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      if (difference > 0) {
-        const refundMetadata = JSON.stringify({
-          ...baseMetadata,
-          type: "reconciliation_refund",
-        });
-        const refundRows = await sqlRows<{
-          id: string | null;
-          new_balance: string | number | null;
-        }>(
-          tx,
-          sql`
-            WITH org AS (
-              SELECT id, credit_balance::numeric AS current_balance
-              FROM organizations
-              WHERE id = ${organizationId}
-              FOR UPDATE
-            ),
-            updated AS (
-              UPDATE organizations AS o
-              SET credit_balance = org.current_balance + ${String(difference)}::numeric,
-                  updated_at = NOW()
-              FROM org
-              WHERE o.id = org.id
-              RETURNING o.credit_balance AS new_balance
-            ),
-            inserted AS (
-              INSERT INTO credit_transactions (
-                organization_id,
-                amount,
-                type,
-                description,
-                metadata,
-                stripe_payment_intent_id,
-                created_at
-              )
-              SELECT
-                org.id,
-                ${String(difference)}::numeric,
-                'refund',
-                ${`${description} (refund)`},
-                ${refundMetadata}::jsonb,
-                ${`recon:${reservationTransactionId}:refund`},
-                NOW()
-              FROM org
-              WHERE EXISTS (SELECT 1 FROM updated)
-              ON CONFLICT (stripe_payment_intent_id) DO NOTHING
-              RETURNING id
-            )
-            SELECT
-              (SELECT id FROM inserted) AS id,
-              (SELECT new_balance FROM updated) AS new_balance
-          `,
-        );
-        const refund = refundRows[0];
-        if (!refund?.id) {
-          throw new Error("[CreditsService] Reservation refund settlement did not insert a row");
-        }
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          newBalance: parseNumeric(refund.new_balance, "new_balance"),
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [refund.id],
-            adjustmentType: "refund" as const,
-          },
-        };
-      }
-
-      const overage = -difference;
-      const overageMetadata = JSON.stringify({
-        ...baseMetadata,
-        type: "reconciliation_overage",
-      });
-      const overageRows = await sqlRows<{
-        id: string | null;
-        debited: boolean | string | number | null;
-        new_balance: string | number | null;
-      }>(
-        tx,
-        sql`
-          WITH org AS (
-            SELECT id, credit_balance::numeric AS current_balance
-            FROM organizations
-            WHERE id = ${organizationId}
-            FOR UPDATE
-          ),
-          updated AS (
-            UPDATE organizations AS o
-            SET credit_balance = org.current_balance - ${String(overage)}::numeric,
-                updated_at = NOW()
-            FROM org
-            WHERE o.id = org.id
-              AND org.current_balance >= ${String(overage)}::numeric
-            RETURNING o.credit_balance AS new_balance
-          ),
-          inserted AS (
-            INSERT INTO credit_transactions (
-              organization_id,
-              amount,
-              type,
-              description,
-              metadata,
-              stripe_payment_intent_id,
-              created_at
-            )
-            SELECT
-              org.id,
-              ${String(-overage)}::numeric,
-              'debit',
-              ${`${description} (overage)`},
-              ${overageMetadata}::jsonb,
-              ${`recon:${reservationTransactionId}:overage`},
-              NOW()
-            FROM org
-            WHERE EXISTS (SELECT 1 FROM updated)
-            ON CONFLICT (stripe_payment_intent_id) DO NOTHING
-            RETURNING id
+          RETURNING o.credit_balance AS new_balance
+        ),
+        inserted AS (
+          INSERT INTO credit_transactions (
+            organization_id,
+            amount,
+            type,
+            description,
+            metadata,
+            stripe_payment_intent_id,
+            created_at
           )
           SELECT
-            EXISTS(SELECT 1 FROM updated) AS debited,
-            (SELECT id FROM inserted) AS id,
-            (SELECT new_balance FROM updated) AS new_balance
-        `,
+            mp.organization_id,
+            CASE WHEN mp.phase = 'refund' THEN mp.amount ELSE -mp.amount END,
+            CASE WHEN mp.phase = 'refund' THEN 'refund' ELSE 'debit' END,
+            CASE
+              WHEN mp.phase = 'refund' THEN ${`${description} (refund)`}
+              ELSE ${`${description} (overage)`}
+            END,
+            (
+              ${inputMetadata}::jsonb ||
+              jsonb_build_object(
+                'reservation_transaction_id', ${reservationTransactionId},
+                'reserved', mp.reserved_amount,
+                'actual', mp.actual_cost,
+                'type', CASE
+                  WHEN mp.phase = 'refund' THEN 'reconciliation_refund'
+                  ELSE 'reconciliation_overage'
+                END
+              )
+            ),
+            CASE
+              WHEN mp.phase = 'refund' THEN ${`recon:${reservationTransactionId}:refund`}
+              ELSE ${`recon:${reservationTransactionId}:overage`}
+            END,
+            NOW()
+          FROM mutation_plan mp
+          WHERE mp.phase IN ('refund', 'overage')
+            AND EXISTS (SELECT 1 FROM org_update)
+          ON CONFLICT (stripe_payment_intent_id) DO NOTHING
+          RETURNING id
+        )
+        SELECT
+          EXISTS(SELECT 1 FROM reservation) AS reservation_found,
+          EXISTS(SELECT 1 FROM claim) OR EXISTS(SELECT 1 FROM mark_preexisting) AS claimed,
+          (SELECT reserved_amount FROM reservation_values) AS reserved_amount,
+          (SELECT new_balance FROM org_update) AS new_balance,
+          CASE
+            WHEN EXISTS(SELECT 1 FROM inserted) THEN (SELECT array_agg(id ORDER BY id) FROM inserted)
+            ELSE (SELECT ids FROM existing_settlements)
+          END AS settlement_ids,
+          CASE
+            WHEN NOT EXISTS(SELECT 1 FROM reservation) THEN NULL
+            WHEN NOT EXISTS(SELECT 1 FROM claim) THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mark_preexisting) THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'none') THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'refund')
+              THEN CASE WHEN EXISTS(SELECT 1 FROM inserted) THEN 'refund' ELSE 'none' END
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'overage')
+              THEN CASE WHEN EXISTS(SELECT 1 FROM org_update) THEN 'overage' ELSE 'uncollected_overage' END
+            ELSE 'none'
+          END AS adjustment_type
+      `,
+    );
+
+    const row = rows[0];
+    if (!row || !isPgTrue(row.reservation_found)) {
+      return { kind: "no_reservation_row" };
+    }
+
+    const reservedAmount = parseNumeric(
+      row.reserved_amount,
+      "reservation_amount",
+    );
+    const adjustmentType = row.adjustment_type ?? "none";
+    const settlementTransactionIds = row.settlement_ids ?? [];
+    const result: CreditReconciliationResult = {
+      reservedAmount,
+      actualCost: normalizedActualCost,
+      reservationTransactionId,
+      settlementTransactionIds,
+      adjustmentType,
+    };
+    const handled = {
+      kind: "handled" as const,
+      claimed: isPgTrue(row.claimed),
+      ...(row.new_balance !== null && row.new_balance !== undefined
+        ? { newBalance: parseNumeric(row.new_balance, "new_balance") }
+        : {}),
+      ...(adjustmentType === "overage"
+        ? {
+            balanceDecreaseMetadata: {
+              ...metadata,
+              reservation_transaction_id: reservationTransactionId,
+              reserved: reservedAmount,
+              actual: normalizedActualCost,
+              type: "reconciliation_overage",
+            },
+          }
+        : {}),
+      result,
+    };
+
+    if (handled.claimed) {
+      await CacheInvalidation.onCreditMutation(organizationId).catch(
+        (error) => {
+          logger.error(
+            "[CreditsService] Failed to invalidate credit mutation cache:",
+            error,
+          );
+        },
       );
-      const overageRow = overageRows[0];
-      if (!isPgTrue(overageRow?.debited)) {
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [],
-            adjustmentType: "uncollected_overage" as const,
-          },
-        };
+      invalidateOrganizationCache(organizationId).catch((error) => {
+        logger.error("[CreditsService] Failed to invalidate org cache:", error);
+      });
+      if (handled.balanceDecreaseMetadata && handled.newBalance !== undefined) {
+        this.notifyBalanceDecrease(
+          organizationId,
+          handled.newBalance,
+          handled.balanceDecreaseMetadata,
+        );
       }
-      if (!overageRow?.id) {
-        throw new Error("[CreditsService] Reservation overage settlement did not insert a row");
-      }
-      return {
-        kind: "handled" as const,
-        claimed: true,
-        newBalance: parseNumeric(overageRow.new_balance, "new_balance"),
-        balanceDecreaseMetadata: {
-          ...baseMetadata,
-          type: "reconciliation_overage",
-        },
-        result: {
-          reservedAmount: claimedReservedAmount,
-          actualCost: normalizedActualCost,
-          reservationTransactionId,
-          settlementTransactionIds: [overageRow.id],
-          adjustmentType: "overage" as const,
-        },
-      };
-    });
-
-    if (result.kind !== "handled" || !result.claimed) {
-      return result;
     }
 
-    await CacheInvalidation.onCreditMutation(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate credit mutation cache:", error);
-    });
-    invalidateOrganizationCache(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate org cache:", error);
-    });
-    if (result.balanceDecreaseMetadata && result.newBalance !== undefined) {
-      this.notifyBalanceDecrease(organizationId, result.newBalance, result.balanceDecreaseMetadata);
-    }
-    return result;
+    return handled;
   }
 
   async markReservationSettled(params: {
@@ -1557,7 +1554,10 @@ export class CreditsService {
     }
 
     await CacheInvalidation.onCreditMutation(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate credit mutation cache:", error);
+      logger.error(
+        "[CreditsService] Failed to invalidate credit mutation cache:",
+        error,
+      );
     });
     invalidateOrganizationCache(organizationId).catch((error) => {
       logger.error("[CreditsService] Failed to invalidate org cache:", error);
@@ -1581,7 +1581,13 @@ export class CreditsService {
     description: string;
     metadata?: Record<string, unknown>;
   }): Promise<CreditReconciliationResult> {
-    const { organizationId, reservedAmount, actualCost, description, metadata } = params;
+    const {
+      organizationId,
+      reservedAmount,
+      actualCost,
+      description,
+      metadata,
+    } = params;
     const difference = reservedAmount - actualCost;
     const reservationTxId =
       typeof metadata?.reservation_transaction_id === "string"
@@ -1607,14 +1613,17 @@ export class CreditsService {
           break;
         } catch (error) {
           if (attempt === MAX_RETRIES) {
-            logger.error("[Credits] Reservation reconciliation failed after retries", {
-              organizationId,
-              reserved: reservedAmount,
-              actual: actualCost,
-              reservationTransactionId: reservationTxId,
-              difference,
-              error: error instanceof Error ? error.message : "Unknown error",
-            });
+            logger.error(
+              "[Credits] Reservation reconciliation failed after retries",
+              {
+                organizationId,
+                reserved: reservedAmount,
+                actual: actualCost,
+                reservationTransactionId: reservationTxId,
+                difference,
+                error: error instanceof Error ? error.message : "Unknown error",
+              },
+            );
             return {
               reservedAmount,
               actualCost,
@@ -1629,7 +1638,9 @@ export class CreditsService {
             reservationTransactionId: reservationTxId,
             error: error instanceof Error ? error.message : "Unknown error",
           });
-          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * attempt));
+          await new Promise((resolve) =>
+            setTimeout(resolve, RETRY_DELAY_MS * attempt),
+          );
         }
       }
     }
@@ -1728,7 +1739,9 @@ export class CreditsService {
             typeof metadata?.reservation_transaction_id === "string"
               ? metadata.reservation_transaction_id
               : null,
-          settlementTransactionIds: overageResult.transaction ? [overageResult.transaction.id] : [],
+          settlementTransactionIds: overageResult.transaction
+            ? [overageResult.transaction.id]
+            : [],
           adjustmentType: "overage",
         };
       } catch (error) {
@@ -1757,7 +1770,9 @@ export class CreditsService {
           organizationId,
           error: error instanceof Error ? error.message : "Unknown error",
         });
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * attempt));
+        await new Promise((resolve) =>
+          setTimeout(resolve, RETRY_DELAY_MS * attempt),
+        );
       }
     }
 
@@ -1827,7 +1842,9 @@ export class CreditsService {
       stats.scanned += rows.length;
 
       for (const row of rows) {
-        const reservedAmount = Math.abs(parseNumeric(row.amount, "reservation_amount"));
+        const reservedAmount = Math.abs(
+          parseNumeric(row.amount, "reservation_amount"),
+        );
         const reservationMetadata = parseMetadata(row.metadata);
         const description = (row.description ?? "Credit reservation").replace(
           /\s+\(reserved\)$/,
@@ -1846,7 +1863,8 @@ export class CreditsService {
           // over-refunded the markup and left unbacked redeemable earnings.
           if (
             reservationMetadata.type === "app_chat_reservation" &&
-            reservationMetadata.settlement_marker === APP_CHAT_RESERVATION_SETTLEMENT_MARKER
+            reservationMetadata.settlement_marker ===
+              APP_CHAT_RESERVATION_SETTLEMENT_MARKER
           ) {
             await this.sweepAppChatReservation(
               { id: row.id, description, organizationId: row.organization_id },
@@ -1855,7 +1873,10 @@ export class CreditsService {
             );
             continue;
           }
-          const actualCost = staleHoldSettleCost(reservedAmount, reservationMetadata);
+          const actualCost = staleHoldSettleCost(
+            reservedAmount,
+            reservationMetadata,
+          );
           const settlement = await this.reconcileReservationTransaction({
             organizationId: row.organization_id,
             reservationTransactionId: row.id,
@@ -1926,9 +1947,14 @@ export class CreditsService {
     reservationMetadata: Record<string, unknown>,
     stats: ReservationSweepStats,
   ): Promise<void> {
-    const appId = typeof reservationMetadata.appId === "string" ? reservationMetadata.appId : null;
+    const appId =
+      typeof reservationMetadata.appId === "string"
+        ? reservationMetadata.appId
+        : null;
     const userId =
-      typeof reservationMetadata.userId === "string" ? reservationMetadata.userId : null;
+      typeof reservationMetadata.userId === "string"
+        ? reservationMetadata.userId
+        : null;
     // What was actually debited, in BASE-cost space (the route's buffered base
     // estimate). `reserved_amount`/`baseCost` are both written by the app-chat
     // deduct; the hold row's `amount` is markup-inclusive and must NOT be used
@@ -1938,12 +1964,15 @@ export class CreditsService {
       metadataNumber(reservationMetadata.baseCost);
     if (!appId || !userId || reservedBaseCost === null) {
       stats.skipped++;
-      logger.error("[Credits] Stale app-chat reservation is missing reconcile inputs — skipping", {
-        reservationTransactionId: row.id,
-        hasAppId: appId !== null,
-        hasUserId: userId !== null,
-        hasReservedBaseCost: reservedBaseCost !== null,
-      });
+      logger.error(
+        "[Credits] Stale app-chat reservation is missing reconcile inputs — skipping",
+        {
+          reservationTransactionId: row.id,
+          hasAppId: appId !== null,
+          hasUserId: userId !== null,
+          hasReservedBaseCost: reservedBaseCost !== null,
+        },
+      );
       return;
     }
     const assumedActualBaseCost =
@@ -1970,7 +1999,9 @@ export class CreditsService {
           ? reservationMetadata.creator_user_id
           : null;
     const appName =
-      typeof reservationMetadata.appName === "string" ? reservationMetadata.appName : appId;
+      typeof reservationMetadata.appName === "string"
+        ? reservationMetadata.appName
+        : appId;
     const app =
       currentApp ??
       (storedCreatorUserId || markupPercentage === 0
@@ -2084,7 +2115,8 @@ export class CreditsService {
     }
     if (
       params.estimatedCostMultiplier !== undefined &&
-      (!Number.isFinite(params.estimatedCostMultiplier) || params.estimatedCostMultiplier < 0)
+      (!Number.isFinite(params.estimatedCostMultiplier) ||
+        params.estimatedCostMultiplier < 0)
     ) {
       throw new Error("reserve() estimatedCostMultiplier must be non-negative");
     }
@@ -2101,7 +2133,8 @@ export class CreditsService {
       model = params.model;
       const provider = params.provider ?? getProviderFromModel(params.model);
       const estimatedInputTokens = params.estimatedInputTokens ?? 0;
-      const estimatedOutputTokens = params.estimatedOutputTokens ?? DEFAULT_OUTPUT_TOKENS;
+      const estimatedOutputTokens =
+        params.estimatedOutputTokens ?? DEFAULT_OUTPUT_TOKENS;
 
       const { totalCost } = await calculateCost(
         params.model,
@@ -2163,10 +2196,16 @@ export class CreditsService {
         available: result.newBalance,
         reason: result.reason,
       });
-      throw new InsufficientCreditsError(reservedAmount, result.newBalance, result.reason);
+      throw new InsufficientCreditsError(
+        reservedAmount,
+        result.newBalance,
+        result.reason,
+      );
     }
     if (!result.transaction) {
-      throw new Error("[Credits] Reservation did not return a credit transaction");
+      throw new Error(
+        "[Credits] Reservation did not return a credit transaction",
+      );
     }
     const reservationTransactionId = result.transaction.id;
 
@@ -2177,7 +2216,8 @@ export class CreditsService {
     // that was actually deducted.
     if (idempotencyMarker) {
       const originalReserved = Number(
-        (result.transaction.metadata as { reserved_amount?: unknown } | null)?.reserved_amount,
+        (result.transaction.metadata as { reserved_amount?: unknown } | null)
+          ?.reserved_amount,
       );
       if (Number.isFinite(originalReserved) && originalReserved > 0) {
         reservedAmount = originalReserved;
@@ -2226,7 +2266,9 @@ export class CreditsService {
     return await creditPacksRepository.findById(id);
   }
 
-  async getCreditPackByStripePriceId(stripePriceId: string): Promise<CreditPack | undefined> {
+  async getCreditPackByStripePriceId(
+    stripePriceId: string,
+  ): Promise<CreditPack | undefined> {
     return await creditPacksRepository.findByStripePriceId(stripePriceId);
   }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -21,7 +21,10 @@ import { decryptField, encryptField } from "../../db/crypto/field-crypto";
 import { resetKmsClientForTests } from "../../db/crypto/kms-client";
 import * as realHelpersNs from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
-import type { AgentSandbox, AgentSandboxBackup } from "../../db/repositories/agent-sandboxes";
+import type {
+  AgentSandbox,
+  AgentSandboxBackup,
+} from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import type { DockerNode } from "../../db/repositories/docker-nodes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
@@ -50,9 +53,16 @@ const KMS_TEST_COORDS = {
 // verify — the shape a corrupt / wrong-key snapshot surfaces as.
 async function realAeadDecryptError(): Promise<Error> {
   resetKmsClientForTests();
-  const enc = await encryptField(KMS_TEST_ORG, '{"memories":[]}', KMS_TEST_COORDS);
+  const enc = await encryptField(
+    KMS_TEST_ORG,
+    '{"memories":[]}',
+    KMS_TEST_COORDS,
+  );
   try {
-    await decryptField(enc, { ...KMS_TEST_COORDS, rowId: "00000000-0000-4000-8000-0000000000bb" });
+    await decryptField(enc, {
+      ...KMS_TEST_COORDS,
+      rowId: "00000000-0000-4000-8000-0000000000bb",
+    });
   } catch (e) {
     if (e instanceof Error) return e;
   }
@@ -65,14 +75,20 @@ async function realAeadDecryptError(): Promise<Error> {
 // gone, and decrypt of the older ciphertext can no longer find it.
 async function realKeyRotatedAwayError(): Promise<Error> {
   resetKmsClientForTests();
-  const enc = await encryptField(KMS_TEST_ORG, '{"memories":[]}', KMS_TEST_COORDS);
+  const enc = await encryptField(
+    KMS_TEST_ORG,
+    '{"memories":[]}',
+    KMS_TEST_COORDS,
+  );
   resetKmsClientForTests();
   try {
     await decryptField(enc, KMS_TEST_COORDS);
   } catch (e) {
     if (e instanceof Error) return e;
   }
-  throw new Error("expected a real KeyNotFoundError after the key was rotated away");
+  throw new Error(
+    "expected a real KeyNotFoundError after the key was rotated away",
+  );
 }
 
 // `executeUpgrade()`'s blue/green swap runs inside `dbWrite.transaction(...)`.
@@ -84,13 +100,16 @@ async function realKeyRotatedAwayError(): Promise<Error> {
 // repositories used elsewhere in this file are all `spyOn`-stubbed, so they
 // never touch this swapped `dbWrite`. The override is restored in `afterAll` so
 // it cannot leak into other files in the shared single-process run.
-type UpgradeTx = { execute: (query: unknown) => Promise<{ rows: Array<{ id: string }> }> };
+type UpgradeTx = {
+  execute: (query: unknown) => Promise<{ rows: Array<{ id: string }> }>;
+};
 // VALUE snapshot taken at module evaluation, while no mock is installed:
 // `db/helpers` re-exports `dbWrite` from `db/client`, so bun's module mocks
 // patch the SHARED live binding — building the restore (or this override's
 // spread) from the live namespace after a mock landed would capture the mock.
 const realHelpers = { ...realHelpersNs };
-let upgradeTransactionImpl: (<T>(fn: (tx: UpgradeTx) => Promise<T>) => Promise<T>) | null = null;
+let upgradeTransactionImpl:
+  (<T>(fn: (tx: UpgradeTx) => Promise<T>) => Promise<T>) | null = null;
 const upgradeDbWrite = {
   ...(realHelpers.dbWrite as unknown as Record<string, unknown>),
   transaction: <T>(fn: (tx: UpgradeTx) => Promise<T>): Promise<T> => {
@@ -128,7 +147,10 @@ const reactivateBillingSpy = spyOn(
 ).mockResolvedValue(undefined);
 
 const originalFetch = globalThis.fetch;
-const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "WebSocketPair",
+);
 
 function restoreWebSocketPair(): void {
   if (originalWebSocketPair) {
@@ -144,7 +166,9 @@ function fetchUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
-function fetchHeaders(headers: HeadersInit | undefined): Record<string, string> {
+function fetchHeaders(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
   if (!headers) return {};
   if (headers instanceof Headers) return Object.fromEntries(headers.entries());
   if (Array.isArray(headers)) return Object.fromEntries(headers);
@@ -267,7 +291,8 @@ describe("resolveSandboxContainerLaunchConfig", () => {
 
 describe("buildAgentSandboxInsertValues", () => {
   test("derives trusted storage fields while rejecting caller-owned internal config", async () => {
-    const { buildAgentSandboxInsertValues } = await import("./eliza-sandbox.ts?actual");
+    const { buildAgentSandboxInsertValues } =
+      await import("./eliza-sandbox.ts?actual");
 
     expect(
       buildAgentSandboxInsertValues({
@@ -307,22 +332,31 @@ describe("ElizaSandboxService state restore auth", () => {
       headers: Record<string, string>;
       body: string;
     }> = [];
-    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
-      requests.push({
-        url: fetchUrl(input),
-        headers: fetchHeaders(init?.headers),
-        body: String(init?.body ?? ""),
-      });
-      return Response.json({ ok: true });
-    });
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push({
+          url: fetchUrl(input),
+          headers: fetchHeaders(init?.headers),
+          body: String(init?.body ?? ""),
+        });
+        return Response.json({ ok: true });
+      },
+    );
 
     const sandbox = customSandbox();
     await (
       new ElizaSandboxService() as unknown as {
         pushState: (
           bridgeUrl: string,
-          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
-          options: { trusted: true; authRec: Pick<AgentSandbox, "id" | "environment_vars"> },
+          state: {
+            memories: unknown[];
+            config: Record<string, unknown>;
+            workspaceFiles: object;
+          },
+          options: {
+            trusted: true;
+            authRec: Pick<AgentSandbox, "id" | "environment_vars">;
+          },
         ) => Promise<void>;
       }
     ).pushState(
@@ -349,16 +383,22 @@ describe("ElizaSandboxService state restore auth", () => {
   test("keeps legacy bridge URL restores unauthenticated when no sandbox record is supplied", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const requests: Array<{ headers: Record<string, string> }> = [];
-    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      requests.push({ headers: fetchHeaders(init?.headers) });
-      return Response.json({ ok: true });
-    });
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push({ headers: fetchHeaders(init?.headers) });
+        return Response.json({ ok: true });
+      },
+    );
 
     await (
       new ElizaSandboxService() as unknown as {
         pushState: (
           bridgeUrl: string,
-          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          state: {
+            memories: unknown[];
+            config: Record<string, unknown>;
+            workspaceFiles: object;
+          },
           options?: { trusted?: boolean },
         ) => Promise<void>;
       }
@@ -431,7 +471,8 @@ describe("ElizaSandboxService bridge status", () => {
   test("reports web-only custom agents as running through the router origin in Workers", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = customSandbox();
-    const requests: Array<{ url: string; headers: Record<string, string> }> = [];
+    const requests: Array<{ url: string; headers: Record<string, string> }> =
+      [];
     const findRunningSandboxSpy = spyOn(
       agentSandboxesRepository,
       "findRunningSandbox",
@@ -440,17 +481,19 @@ describe("ElizaSandboxService bridge status", () => {
       value: class WebSocketPair {},
       configurable: true,
     });
-    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = fetchUrl(input);
-      requests.push({ url, headers: fetchHeaders(init?.headers) });
-      if (url === "https://eliza-production-1.elizacloud.ai/api/agents") {
-        return new Response("{}", { status: 404 });
-      }
-      if (url === "https://eliza-production-1.elizacloud.ai/") {
-        return new Response("<!doctype html>", { status: 200 });
-      }
-      return new Response("not found", { status: 404 });
-    });
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = fetchUrl(input);
+        requests.push({ url, headers: fetchHeaders(init?.headers) });
+        if (url === "https://eliza-production-1.elizacloud.ai/api/agents") {
+          return new Response("{}", { status: 404 });
+        }
+        if (url === "https://eliza-production-1.elizacloud.ai/") {
+          return new Response("<!doctype html>", { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
 
     try {
       const response = await runWithCloudBindings(
@@ -459,12 +502,16 @@ describe("ElizaSandboxService bridge status", () => {
           AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
         },
         () =>
-          new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
-            jsonrpc: "2.0",
-            id: "status-check",
-            method: "status.get",
-            params: {},
-          }),
+          new ElizaSandboxService().bridge(
+            sandbox.id,
+            sandbox.organization_id,
+            {
+              jsonrpc: "2.0",
+              id: "status-check",
+              method: "status.get",
+              params: {},
+            },
+          ),
       );
 
       expect(response).toEqual({
@@ -526,10 +573,14 @@ describe("ElizaSandboxService shared runtime bridge", () => {
         agentSandboxesRepository,
         "findRunningSandbox",
       ).mockResolvedValue(sandbox);
-      const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
-      const historyUpsertSpy = spyOn(sharedRuntimeHistoryRepository, "upsert").mockResolvedValue(
-        undefined,
-      );
+      const historyGetSpy = spyOn(
+        sharedRuntimeHistoryRepository,
+        "get",
+      ).mockResolvedValue([]);
+      const historyUpsertSpy = spyOn(
+        sharedRuntimeHistoryRepository,
+        "upsert",
+      ).mockResolvedValue(undefined);
 
       try {
         const response = await runWithCloudBindings(
@@ -538,12 +589,16 @@ describe("ElizaSandboxService shared runtime bridge", () => {
             OPENAI_API_KEY: "",
           },
           () =>
-            new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
-              jsonrpc: "2.0",
-              id: "shared-turn",
-              method: "message.send",
-              params: { text: "hello" },
-            }),
+            new ElizaSandboxService().bridge(
+              sandbox.id,
+              sandbox.organization_id,
+              {
+                jsonrpc: "2.0",
+                id: "shared-turn",
+                method: "message.send",
+                params: { text: "hello" },
+              },
+            ),
         );
 
         expect(response).toEqual({
@@ -578,10 +633,14 @@ describe("ElizaSandboxService shared runtime bridge", () => {
         agentSandboxesRepository,
         "findRunningSandbox",
       ).mockResolvedValue(sandbox);
-      const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
-      const historyUpsertSpy = spyOn(sharedRuntimeHistoryRepository, "upsert").mockResolvedValue(
-        undefined,
-      );
+      const historyGetSpy = spyOn(
+        sharedRuntimeHistoryRepository,
+        "get",
+      ).mockResolvedValue([]);
+      const historyUpsertSpy = spyOn(
+        sharedRuntimeHistoryRepository,
+        "upsert",
+      ).mockResolvedValue(undefined);
 
       try {
         const response = await runWithCloudBindings(
@@ -590,16 +649,22 @@ describe("ElizaSandboxService shared runtime bridge", () => {
             OPENAI_API_KEY: "",
           },
           () =>
-            new ElizaSandboxService().bridgeStream(sandbox.id, sandbox.organization_id, {
-              jsonrpc: "2.0",
-              id: "shared-stream-turn",
-              method: "message.send",
-              params: { text: " hello " },
-            }),
+            new ElizaSandboxService().bridgeStream(
+              sandbox.id,
+              sandbox.organization_id,
+              {
+                jsonrpc: "2.0",
+                id: "shared-stream-turn",
+                method: "message.send",
+                params: { text: " hello " },
+              },
+            ),
         );
 
         expect(response).toBeInstanceOf(Response);
-        expect(response?.headers.get("content-type")).toContain("text/event-stream");
+        expect(response?.headers.get("content-type")).toContain(
+          "text/event-stream",
+        );
         const body = await response?.text();
         expect(body).toContain("event: chunk");
         expect(body).toContain("no shared model configured");
@@ -621,10 +686,14 @@ describe("ElizaSandboxService shared runtime bridge", () => {
       agentSandboxesRepository,
       "findRunningSandbox",
     ).mockResolvedValue(sandbox);
-    const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
-    const historyUpsertSpy = spyOn(sharedRuntimeHistoryRepository, "upsert").mockResolvedValue(
-      undefined,
-    );
+    const historyGetSpy = spyOn(
+      sharedRuntimeHistoryRepository,
+      "get",
+    ).mockResolvedValue([]);
+    const historyUpsertSpy = spyOn(
+      sharedRuntimeHistoryRepository,
+      "upsert",
+    ).mockResolvedValue(undefined);
 
     try {
       const response = await runWithCloudBindings(
@@ -633,12 +702,16 @@ describe("ElizaSandboxService shared runtime bridge", () => {
           OPENAI_API_KEY: "",
         },
         () =>
-          new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
-            jsonrpc: "2.0",
-            id: "shared-nav-turn",
-            method: "message.send",
-            params: { text: "open settings" },
-          }),
+          new ElizaSandboxService().bridge(
+            sandbox.id,
+            sandbox.organization_id,
+            {
+              jsonrpc: "2.0",
+              id: "shared-nav-turn",
+              method: "message.send",
+              params: { text: "open settings" },
+            },
+          ),
       );
 
       expect(response).toMatchObject({
@@ -742,19 +815,27 @@ describe("ElizaSandboxService wake", () => {
         return Response.json({ ok: true });
       });
       const originalFindByIdAndOrg = agentSandboxesRepository.findByIdAndOrg;
-      const originalFindByIdAndOrgForWrite = agentSandboxesRepository.findByIdAndOrgForWrite;
-      const originalTrySetProvisioning = agentSandboxesRepository.trySetProvisioning;
+      const originalFindByIdAndOrgForWrite =
+        agentSandboxesRepository.findByIdAndOrgForWrite;
+      const originalTrySetProvisioning =
+        agentSandboxesRepository.trySetProvisioning;
       const originalGetLatestBackup = agentSandboxesRepository.getLatestBackup;
       const originalGetBackupById = agentSandboxesRepository.getBackupById;
-      const originalGetLatestStoredBackup = agentSandboxesRepository.getLatestStoredBackup;
-      const originalStampBackupVerification = agentSandboxesRepository.stampBackupVerification;
+      const originalGetLatestStoredBackup =
+        agentSandboxesRepository.getLatestStoredBackup;
+      const originalStampBackupVerification =
+        agentSandboxesRepository.stampBackupVerification;
       const originalGetReconstructedBackupState =
         agentSandboxesRepository.getReconstructedBackupState;
-      agentSandboxesRepository.findByIdAndOrg = mock(async () => sleepingSandbox);
+      agentSandboxesRepository.findByIdAndOrg = mock(
+        async () => sleepingSandbox,
+      );
       // executeWake reads from the PRIMARY via getAgentForWrite →
       // findByIdAndOrgForWrite; provision() (called next) reads via
       // findByIdAndOrg. Stub both so neither touches the unmigrated test DB.
-      agentSandboxesRepository.findByIdAndOrgForWrite = mock(async () => sleepingSandbox);
+      agentSandboxesRepository.findByIdAndOrgForWrite = mock(
+        async () => sleepingSandbox,
+      );
       agentSandboxesRepository.trySetProvisioning = mock(async () => ({
         ...sleepingSandbox,
         status: "provisioning",
@@ -763,25 +844,31 @@ describe("ElizaSandboxService wake", () => {
       // The wake hands provision the gate-validated backup as an explicit
       // from-backup override, so provision fetches it by id, not "latest".
       agentSandboxesRepository.getBackupById = mock(async () => backup);
-      agentSandboxesRepository.getLatestStoredBackup = mock(async () => storedBackup);
+      agentSandboxesRepository.getLatestStoredBackup = mock(
+        async () => storedBackup,
+      );
       agentSandboxesRepository.stampBackupVerification = mock(async () => {});
       agentSandboxesRepository.getReconstructedBackupState = mock(async () => ({
         memories: [],
         config: {},
         workspaceFiles: {},
       }));
-      const createForAgentSpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      const createForAgentSpy = spyOn(
+        apiKeysService,
+        "createForAgent",
+      ).mockResolvedValue({
         id: "22222222-2222-4222-8222-222222222222",
         plainKey: "eliza_test_agent_key",
         prefix: "eliza_test",
       });
-      const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-        async (_id, data) => ({
-          ...sleepingSandbox,
-          ...data,
-          updated_at: now,
-        }),
-      );
+      const updateSpy = spyOn(
+        agentSandboxesRepository,
+        "update",
+      ).mockImplementation(async (_id, data) => ({
+        ...sleepingSandbox,
+        ...data,
+        updated_at: now,
+      }));
 
       try {
         const result = await new ElizaSandboxService(provider).executeWake(
@@ -801,13 +888,18 @@ describe("ElizaSandboxService wake", () => {
         );
       } finally {
         agentSandboxesRepository.findByIdAndOrg = originalFindByIdAndOrg;
-        agentSandboxesRepository.findByIdAndOrgForWrite = originalFindByIdAndOrgForWrite;
-        agentSandboxesRepository.trySetProvisioning = originalTrySetProvisioning;
+        agentSandboxesRepository.findByIdAndOrgForWrite =
+          originalFindByIdAndOrgForWrite;
+        agentSandboxesRepository.trySetProvisioning =
+          originalTrySetProvisioning;
         agentSandboxesRepository.getLatestBackup = originalGetLatestBackup;
         agentSandboxesRepository.getBackupById = originalGetBackupById;
-        agentSandboxesRepository.getLatestStoredBackup = originalGetLatestStoredBackup;
-        agentSandboxesRepository.stampBackupVerification = originalStampBackupVerification;
-        agentSandboxesRepository.getReconstructedBackupState = originalGetReconstructedBackupState;
+        agentSandboxesRepository.getLatestStoredBackup =
+          originalGetLatestStoredBackup;
+        agentSandboxesRepository.stampBackupVerification =
+          originalStampBackupVerification;
+        agentSandboxesRepository.getReconstructedBackupState =
+          originalGetReconstructedBackupState;
         createForAgentSpy.mockRestore();
         updateSpy.mockRestore();
       }
@@ -887,8 +979,14 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
       if (url === "https://runtime.example/api/agents") {
         return Response.json({ error: "Not found" }, { status: 404 });
       }
-      if (url === "https://runtime.example/api/restore" && opts.restoreHttpStatus) {
-        return Response.json({ error: "restore rejected" }, { status: opts.restoreHttpStatus });
+      if (
+        url === "https://runtime.example/api/restore" &&
+        opts.restoreHttpStatus
+      ) {
+        return Response.json(
+          { error: "restore rejected" },
+          { status: opts.restoreHttpStatus },
+        );
       }
       return Response.json({ ok: true });
     });
@@ -897,7 +995,8 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
       findById: agentSandboxesRepository.findById,
       trySetProvisioning: agentSandboxesRepository.trySetProvisioning,
       getBackupById: agentSandboxesRepository.getBackupById,
-      getReconstructedBackupState: agentSandboxesRepository.getReconstructedBackupState,
+      getReconstructedBackupState:
+        agentSandboxesRepository.getReconstructedBackupState,
     };
     agentSandboxesRepository.findByIdAndOrg = mock(async () => rec);
     agentSandboxesRepository.findById = mock(async () => rec);
@@ -912,14 +1011,22 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
       return { memories: [], config: {}, workspaceFiles: {} };
     });
     agentSandboxesRepository.getReconstructedBackupState = reconstructMock;
-    const createForAgentSpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+    const createForAgentSpy = spyOn(
+      apiKeysService,
+      "createForAgent",
+    ).mockResolvedValue({
       id: "22222222-2222-4222-8222-222222222222",
       plainKey: "eliza_test_agent_key",
       prefix: "eliza_test",
     });
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => ({ ...rec, ...data, updated_at: rec.updated_at }),
-    );
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => ({
+      ...rec,
+      ...data,
+      updated_at: rec.updated_at,
+    }));
     const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups");
     return {
       svc: new ElizaSandboxService(provider),
@@ -932,7 +1039,8 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
       restore: () => {
         agentSandboxesRepository.findByIdAndOrg = originals.findByIdAndOrg;
         agentSandboxesRepository.findById = originals.findById;
-        agentSandboxesRepository.trySetProvisioning = originals.trySetProvisioning;
+        agentSandboxesRepository.trySetProvisioning =
+          originals.trySetProvisioning;
         agentSandboxesRepository.getBackupById = originals.getBackupById;
         agentSandboxesRepository.getReconstructedBackupState =
           originals.getReconstructedBackupState;
@@ -1004,7 +1112,9 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
 
       expect(result.success).toBe(false);
       if (result.success) throw new Error("expected provision failure");
-      expect(result.error).toBe(`Restore backup ${FROM_BACKUP_ID} not found for this agent`);
+      expect(result.error).toBe(
+        `Restore backup ${FROM_BACKUP_ID} not found for this agent`,
+      );
       // Rejected before any state was read or touched.
       expect(h.reconstructMock).not.toHaveBeenCalled();
       expect(h.pruneSpy).not.toHaveBeenCalled();
@@ -1030,12 +1140,14 @@ describe("ElizaSandboxService sleep", () => {
     globalThis.fetch = mock(async () => {
       throw new Error("snapshot unavailable");
     });
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      rec,
-    );
-    const latestBackupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(rec);
+    const latestBackupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
     const createBackupSpy = spyOn(agentSandboxesRepository, "createBackup");
     const updateSpy = spyOn(agentSandboxesRepository, "update");
 
@@ -1121,7 +1233,8 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
     });
 
     const originalFindByIdAndOrg = agentSandboxesRepository.findByIdAndOrg;
-    const originalTrySetProvisioning = agentSandboxesRepository.trySetProvisioning;
+    const originalTrySetProvisioning =
+      agentSandboxesRepository.trySetProvisioning;
     const originalFindById = agentSandboxesRepository.findById;
     const originalGetLatestBackup = agentSandboxesRepository.getLatestBackup;
     // No snapshot to restore — keeps the success path free of the backup-restore
@@ -1133,29 +1246,40 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
       status: "provisioning",
     }));
     // markError re-reads via findById for the returned record.
-    agentSandboxesRepository.findById = mock(async () => ({ ...rec, status: "error" }));
+    agentSandboxesRepository.findById = mock(async () => ({
+      ...rec,
+      status: "error",
+    }));
     // Direct property override (not spyOn) so it lands on the SAME singleton the
     // ?actual eliza-sandbox module holds — matching the other stubs above.
     const originalUpdate = agentSandboxesRepository.update;
-    const updateSpy = mock(async (_id: string, data: Record<string, unknown>) => ({
-      ...rec,
-      ...data,
-      updated_at: now,
-    }));
+    const updateSpy = mock(
+      async (_id: string, data: Record<string, unknown>) => ({
+        ...rec,
+        ...data,
+        updated_at: now,
+      }),
+    );
     agentSandboxesRepository.update =
       updateSpy as unknown as typeof agentSandboxesRepository.update;
     // prepareManagedElizaEnvironment mints an agent API key via createForAgent,
     // whose revoke path calls dbWrite.delete — unsupported by this file's
     // transaction-only dbWrite swap. Stub it like the wake suite does so
     // provision() reaches the guard without touching a real DB.
-    const createForAgentSpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+    const createForAgentSpy = spyOn(
+      apiKeysService,
+      "createForAgent",
+    ).mockResolvedValue({
       id: "22222222-2222-4222-8222-222222222222",
       plainKey: "eliza_test_agent_key",
       prefix: "eliza_test",
     });
 
     try {
-      const result = await new ElizaSandboxService(provider).provision(rec.id, rec.organization_id);
+      const result = await new ElizaSandboxService(provider).provision(
+        rec.id,
+        rec.organization_id,
+      );
       return { result, create, stop, updateSpy };
     } finally {
       agentSandboxesRepository.findByIdAndOrg = originalFindByIdAndOrg;
@@ -1170,16 +1294,17 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
   test.skipIf(process.platform === "win32")(
     "docker-backed handle with EMPTY nodeId: no running+null row, non-retryable, container stopped",
     async () => {
-      const { result, create, stop, updateSpy } = await runProvisionWithMetadata({
-        // Docker-backed by provider tag, but the strict guard fails (empty
-        // nodeId) so dockerMeta is undefined — the exact C1b drift.
-        provider: "docker",
-        nodeId: "",
-        hostname: "host-1",
-        containerName: "agent-e06bb509",
-        bridgePort: 21060,
-        webUiPort: 3000,
-      });
+      const { result, create, stop, updateSpy } =
+        await runProvisionWithMetadata({
+          // Docker-backed by provider tag, but the strict guard fails (empty
+          // nodeId) so dockerMeta is undefined — the exact C1b drift.
+          provider: "docker",
+          nodeId: "",
+          hostname: "host-1",
+          containerName: "agent-e06bb509",
+          bridgePort: 21060,
+          webUiPort: 3000,
+        });
 
       // Provision fails (not a fabricated success).
       expect(result.success).toBe(false);
@@ -1197,9 +1322,9 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
       if (!errorUpdate) {
         throw new Error("Expected the empty-node attribution error update");
       }
-      expect((errorUpdate[1] as { error_message?: string }).error_message).toContain(
-        "provision attribution guard:",
-      );
+      expect(
+        (errorUpdate[1] as { error_message?: string }).error_message,
+      ).toContain("provision attribution guard:");
 
       // Non-retryable: the guard message matches none of the port-collision
       // retry patterns, so create() ran exactly once (no retry loop).
@@ -1214,12 +1339,13 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
   test.skipIf(process.platform === "win32")(
     "docker-backed handle with MISSING fields (type-guard miss): same refusal",
     async () => {
-      const { result, create, stop, updateSpy } = await runProvisionWithMetadata({
-        // Provider tag present but hostname/containerName absent => strict guard
-        // fails => dockerMeta undefined, yet it IS docker-backed.
-        provider: "docker",
-        nodeId: "node-1",
-      });
+      const { result, create, stop, updateSpy } =
+        await runProvisionWithMetadata({
+          // Provider tag present but hostname/containerName absent => strict guard
+          // fails => dockerMeta undefined, yet it IS docker-backed.
+          provider: "docker",
+          nodeId: "node-1",
+        });
 
       expect(result.success).toBe(false);
       for (const call of updateSpy.mock.calls) {
@@ -1230,11 +1356,13 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
       );
       expect(errorUpdate).toBeDefined();
       if (!errorUpdate) {
-        throw new Error("Expected the incomplete-metadata attribution error update");
+        throw new Error(
+          "Expected the incomplete-metadata attribution error update",
+        );
       }
-      expect((errorUpdate[1] as { error_message?: string }).error_message).toContain(
-        "provision attribution guard:",
-      );
+      expect(
+        (errorUpdate[1] as { error_message?: string }).error_message,
+      ).toContain("provision attribution guard:");
       expect(create).toHaveBeenCalledTimes(1);
       expect(stop).toHaveBeenCalledTimes(1);
     },
@@ -1269,13 +1397,13 @@ describe("ElizaSandboxService provision — node attribution guard (C1b)", () =>
 
 describe("ElizaSandboxService snapshot — endpoint capability", () => {
   test("a 404 from /api/snapshot (V2 image) returns the unsupported sentinel, not a hard failure", async () => {
-    const { ElizaSandboxService, SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import(
-      "./eliza-sandbox.ts?actual"
-    );
+    const { ElizaSandboxService, SNAPSHOT_ENDPOINT_UNSUPPORTED } =
+      await import("./eliza-sandbox.ts?actual");
     const rec = customSandbox();
-    const findRunningSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
-      rec,
-    );
+    const findRunningSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(rec);
     const createBackupSpy = spyOn(agentSandboxesRepository, "createBackup");
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       const url = fetchUrl(input);
@@ -1285,7 +1413,11 @@ describe("ElizaSandboxService snapshot — endpoint capability", () => {
       return new Response("{}", { status: 200 });
     });
     try {
-      const res = await new ElizaSandboxService().snapshot(rec.id, rec.organization_id, "auto");
+      const res = await new ElizaSandboxService().snapshot(
+        rec.id,
+        rec.organization_id,
+        "auto",
+      );
       expect(res).toEqual({
         success: false,
         error: SNAPSHOT_ENDPOINT_UNSUPPORTED,
@@ -1307,9 +1439,10 @@ describe("ElizaSandboxService recoverDisconnected", () => {
   test("recovers a reachable disconnected agent via guarded compare-and-set", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = disconnectedSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
-      async () => sandbox,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockImplementation(async () => sandbox);
     const casSpy = spyOn(
       agentSandboxesRepository,
       "markReconnectedFromDisconnected",
@@ -1338,13 +1471,18 @@ describe("ElizaSandboxService recoverDisconnected", () => {
       error_message: null,
       previous_image_digest: "sha256:old",
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
-      async () => sandbox,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockImplementation(async () => sandbox);
     const casSpy = spyOn(
       agentSandboxesRepository,
       "markReconnectedFromDisconnected",
-    ).mockImplementation(async () => ({ ...sandbox, status: "running", error_message: null }));
+    ).mockImplementation(async () => ({
+      ...sandbox,
+      status: "running",
+      error_message: null,
+    }));
     globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
 
     try {
@@ -1364,9 +1502,10 @@ describe("ElizaSandboxService recoverDisconnected", () => {
   test("does NOT revive when the row left disconnected mid-probe (CAS loses -> gone)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = disconnectedSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
-      async () => sandbox,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockImplementation(async () => sandbox);
     // Probe succeeds, but the agent was deleted/stopped/re-provisioned during the
     // probe → guarded update matches 0 rows. Must report "gone", never resurrect.
     const casSpy = spyOn(
@@ -1391,14 +1530,18 @@ describe("ElizaSandboxService recoverDisconnected", () => {
   test("reports unreachable without writing when the bridge does not answer", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = disconnectedSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
-      async () => sandbox,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockImplementation(async () => sandbox);
     const casSpy = spyOn(
       agentSandboxesRepository,
       "markReconnectedFromDisconnected",
     ).mockImplementation(async () => undefined);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(undefined);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(undefined);
     globalThis.fetch = mock(async () => new Response("nope", { status: 502 }));
 
     try {
@@ -1419,12 +1562,13 @@ describe("ElizaSandboxService recoverDisconnected", () => {
 
   test("reports gone (and never probes) when the row is no longer disconnected", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
-      async () => ({
-        ...customSandbox(),
-        status: "running",
-      }),
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockImplementation(async () => ({
+      ...customSandbox(),
+      status: "running",
+    }));
     const casSpy = spyOn(
       agentSandboxesRepository,
       "markReconnectedFromDisconnected",
@@ -1450,6 +1594,56 @@ describe("ElizaSandboxService recoverDisconnected", () => {
   });
 });
 
+describe("ElizaSandboxService bridgeStream scope-cache reuse", () => {
+  test("uses the already-resolved running agent row without re-querying findRunningSandbox", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      execution_tier: "shared",
+      status: "running",
+    };
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => {
+      throw new Error(
+        "findRunningSandbox should not run when the stream route passes resolvedAgent",
+      );
+    });
+    const service = new ElizaSandboxService();
+    const sharedSpy = spyOn(
+      service as never,
+      "bridgeSharedMessageStream" as never,
+    ).mockResolvedValue(
+      new Response("event: done\ndata: {}\n\n", {
+        headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+      }) as never,
+    );
+
+    try {
+      const res = await service.bridgeStream(
+        sandbox.id,
+        sandbox.organization_id,
+        {
+          jsonrpc: "2.0",
+          id: "bridge-cache-test",
+          method: "message.send",
+          params: { text: "hello", roomId: "room-1" },
+        },
+        undefined,
+        sandbox,
+      );
+
+      expect(res?.status).toBe(200);
+      expect(findSpy).not.toHaveBeenCalled();
+      expect(sharedSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      findSpy.mockRestore();
+      sharedSpy.mockRestore();
+    }
+  });
+});
+
 describe("ElizaSandboxService heartbeat", () => {
   // Pins the behaviour the probeBridgeHealth() extraction must preserve on the
   // prod-critical heartbeat path: grace-window hysteresis and the exact DB
@@ -1463,18 +1657,23 @@ describe("ElizaSandboxService heartbeat", () => {
       ...customSandbox(),
       last_heartbeat_at: new Date(Date.now() - 30_000),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
     globalThis.fetch = mock(async () => {
       throw new Error("fetch failed");
     });
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).not.toHaveBeenCalled();
     } finally {
@@ -1490,22 +1689,33 @@ describe("ElizaSandboxService heartbeat", () => {
       ...customSandbox(),
       last_heartbeat_at: new Date(Date.now() - 200_000),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(undefined);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(undefined);
     globalThis.fetch = mock(async () => {
       throw new Error("fetch failed");
     });
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.status).toBe("disconnected");
       // last_heartbeat_at is bumped ONLY on success — its age is the liveness clock.
       expect(Object.hasOwn(patch, "last_heartbeat_at")).toBe(false);
@@ -1519,12 +1729,14 @@ describe("ElizaSandboxService heartbeat", () => {
   test("probe that succeeds on a retry bumps last_heartbeat_at and leaves status alone", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = customSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
     let calls = 0;
     globalThis.fetch = mock(async () => {
       calls += 1;
@@ -1533,11 +1745,17 @@ describe("ElizaSandboxService heartbeat", () => {
     });
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(true);
       expect(calls).toBe(2); // retry semantics preserved
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.last_heartbeat_at).toBeInstanceOf(Date);
       expect(patch.status).toBeUndefined();
     } finally {
@@ -1549,13 +1767,18 @@ describe("ElizaSandboxService heartbeat", () => {
   test("terminal database liveness failure enqueues a bounded restart", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = customSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentRestartOnce",
+    ).mockImplementation(
       async () =>
         ({
           created: true,
@@ -1579,10 +1802,16 @@ describe("ElizaSandboxService heartbeat", () => {
     );
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.error_count).toBe(1);
       expect(String(patch.error_message)).toContain("[db-liveness-restart]");
       expect(enqueueSpy).toHaveBeenCalledWith({
@@ -1603,13 +1832,18 @@ describe("ElizaSandboxService heartbeat", () => {
       ...customSandbox(),
       last_heartbeat_at: new Date(Date.now() - 30_000),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentRestartOnce",
+    ).mockImplementation(
       async () =>
         ({
           created: true,
@@ -1630,7 +1864,10 @@ describe("ElizaSandboxService heartbeat", () => {
     );
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).not.toHaveBeenCalled();
       expect(enqueueSpy).not.toHaveBeenCalled();
@@ -1648,13 +1885,18 @@ describe("ElizaSandboxService heartbeat", () => {
       error_count: 9,
       error_message: "tailnet reconciliation failures",
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentRestartOnce",
+    ).mockImplementation(
       async () =>
         ({
           created: true,
@@ -1676,10 +1918,16 @@ describe("ElizaSandboxService heartbeat", () => {
     );
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(enqueueSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.error_count).toBe(1);
     } finally {
       findSpy.mockRestore();
@@ -1695,13 +1943,18 @@ describe("ElizaSandboxService heartbeat", () => {
       error_count: 1,
       error_message: `[db-liveness-restart] count=1 at=${new Date().toISOString()} reason=PGlite is closed`,
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentRestartOnce",
+    ).mockImplementation(
       async () =>
         ({
           created: true,
@@ -1723,7 +1976,10 @@ describe("ElizaSandboxService heartbeat", () => {
     );
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).not.toHaveBeenCalled();
       expect(enqueueSpy).not.toHaveBeenCalled();
@@ -1741,13 +1997,18 @@ describe("ElizaSandboxService heartbeat", () => {
       error_count: 3,
       error_message: `[db-liveness-restart] count=3 at=${new Date(Date.now() - 20 * 60_000).toISOString()} reason=PGlite is closed`,
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () => sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentRestartOnce",
+    ).mockImplementation(
       async () =>
         ({
           created: true,
@@ -1769,10 +2030,16 @@ describe("ElizaSandboxService heartbeat", () => {
     );
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.status).toBe("error");
       expect(patch.error_count).toBe(3);
       expect(String(patch.error_message)).toContain("budget-exhausted");
@@ -1798,13 +2065,20 @@ describe("ElizaSandboxService heartbeat", () => {
       error_count: 3,
       error_message: "unrelated launch failures",
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async (agentId) => (agentId === exhausted.id ? exhausted : fresh),
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async (agentId) =>
+      agentId === exhausted.id ? exhausted : fresh,
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async () => undefined as never,
-    );
-    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockImplementation(
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async () => undefined as never);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentRestartOnce",
+    ).mockImplementation(
       async () =>
         ({
           created: true,
@@ -1827,7 +2101,10 @@ describe("ElizaSandboxService heartbeat", () => {
 
     try {
       await expect(
-        new ElizaSandboxService().heartbeat(exhausted.id, exhausted.organization_id),
+        new ElizaSandboxService().heartbeat(
+          exhausted.id,
+          exhausted.organization_id,
+        ),
       ).resolves.toBe(false);
       await expect(
         new ElizaSandboxService().heartbeat(fresh.id, fresh.organization_id),
@@ -1893,7 +2170,10 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
 
   // One SSH client mock serving both node-side commands the reconcile issues:
   // docker health inspect and the in-container `tailscale ip -4`.
-  function mockNodeSsh(opts: { health: string | Error; tailscaleIp: string | Error }) {
+  function mockNodeSsh(opts: {
+    health: string | Error;
+    tailscaleIp: string | Error;
+  }) {
     const exec = mock(async (cmd: string) => {
       if (cmd.includes("docker inspect")) {
         if (opts.health instanceof Error) throw opts.health;
@@ -1930,13 +2210,18 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
   test("(a) heartbeat: docker-healthy + new IP + repaired probe 200 → stays running with repaired columns", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = staleIpSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
-      sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(nodeRecord());
     // tailscale CLI prints the v4 line first; the parser must take the 100.x line.
     const { getClientSpy } = mockNodeSsh({
       health: "healthy",
@@ -1945,10 +2230,16 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
     fetchAliveOnlyOnNewIp();
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(true);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [id, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [id, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(id).toBe(sandbox.id);
       expect(patch.headscale_ip).toBe(NEW_IP);
       expect(patch.bridge_url).toBe(REPAIRED_BRIDGE);
@@ -1967,21 +2258,35 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
   test("(b) heartbeat: docker NOT healthy → disconnected (dead containers still self-heal via reprovision)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = staleIpSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
-      sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
-    const { exec, getClientSpy } = mockNodeSsh({ health: "unhealthy", tailscaleIp: NEW_IP });
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(nodeRecord());
+    const { exec, getClientSpy } = mockNodeSsh({
+      health: "unhealthy",
+      tailscaleIp: NEW_IP,
+    });
     fetchAllDead();
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.status).toBe("disconnected");
       expect(patch.headscale_ip).toBeUndefined();
       // A dead container short-circuits — no IP resolve is attempted on it.
@@ -2000,21 +2305,35 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
   test("(c) heartbeat: docker-healthy but the resolved IP equals the stored one → genuinely unreachable → disconnected", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = staleIpSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
-      sandbox,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
-    const { getClientSpy } = mockNodeSsh({ health: "healthy", tailscaleIp: OLD_IP });
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({
+      health: "healthy",
+      tailscaleIp: OLD_IP,
+    });
     fetchAllDead();
 
     try {
-      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      const ok = await new ElizaSandboxService().heartbeat(
+        sandbox.id,
+        sandbox.organization_id,
+      );
       expect(ok).toBe(false);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.status).toBe("disconnected");
       expect(patch.headscale_ip).toBeUndefined();
     } finally {
@@ -2029,16 +2348,25 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     // error_count evolves across cycles the way the ratchet writes it.
     let errorCount = 0;
-    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
-      async () => staleIpSandbox({ error_count: errorCount }),
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockImplementation(async () =>
+      staleIpSandbox({ error_count: errorCount }),
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(nodeRecord());
     const { getClientSpy } = mockNodeSsh({
       health: "healthy",
-      tailscaleIp: new Error("docker exec failed: container has no tailscale binary reachable"),
+      tailscaleIp: new Error(
+        "docker exec failed: container has no tailscale binary reachable",
+      ),
     });
     fetchAllDead();
 
@@ -2053,7 +2381,10 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
         );
         expect(ok).toBe(false);
         expect(updateSpy).toHaveBeenCalledTimes(1);
-        const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+        const [, patch] = updateSpy.mock.calls[0] as [
+          string,
+          Record<string, unknown>,
+        ];
         expect(patch.error_count).toBe(expected);
         expect(patch.status).toBeUndefined();
         errorCount = expected;
@@ -2066,7 +2397,10 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
       );
       expect(ok).toBe(false);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(patch.status).toBe("disconnected");
     } finally {
       findSpy.mockRestore();
@@ -2079,16 +2413,26 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
   test("(e) recoverDisconnected: repaired IP + live re-probe → recovered with columns updated, no reprovision", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = staleIpSandbox({ status: "disconnected" });
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(sandbox);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(sandbox);
     const casSpy = spyOn(
       agentSandboxesRepository,
       "markReconnectedFromDisconnected",
     ).mockResolvedValue({ ...sandbox, status: "running" });
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
-    const { getClientSpy } = mockNodeSsh({ health: "healthy", tailscaleIp: NEW_IP });
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({
+      health: "healthy",
+      tailscaleIp: NEW_IP,
+    });
     fetchAliveOnlyOnNewIp();
 
     try {
@@ -2100,7 +2444,10 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
       expect(casSpy).toHaveBeenCalledTimes(1);
       expect(casSpy.mock.calls[0]).toEqual([sandbox.id, "disconnected"]);
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [id, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      const [id, patch] = updateSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
       expect(id).toBe(sandbox.id);
       expect(patch.headscale_ip).toBe(NEW_IP);
       expect(patch.bridge_url).toBe(REPAIRED_BRIDGE);
@@ -2116,16 +2463,26 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
   test("(f) recoverDisconnected: repaired IP still dead → unreachable (reprovision path), nothing written", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = staleIpSandbox({ status: "disconnected" });
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(sandbox);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(sandbox);
     const casSpy = spyOn(
       agentSandboxesRepository,
       "markReconnectedFromDisconnected",
     ).mockResolvedValue(undefined);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
-    const { getClientSpy } = mockNodeSsh({ health: "healthy", tailscaleIp: NEW_IP });
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined as never);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({
+      health: "healthy",
+      tailscaleIp: NEW_IP,
+    });
     fetchAllDead();
 
     try {
@@ -2170,13 +2527,18 @@ describe("ElizaSandboxService.executeResume", () => {
   test("an already-running agent is a no-op — never re-provisioned", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const svc = new ElizaSandboxService();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      resumeRow("running"),
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(resumeRow("running"));
     const provisionSpy = spyOn(svc, "provision");
     try {
       const res = await svc.executeResume(RESUME_AGENT, RESUME_ORG);
-      expect(res).toEqual({ success: true, containerStarted: true, reprovisioned: false });
+      expect(res).toEqual({
+        success: true,
+        containerStarted: true,
+        reprovisioned: false,
+      });
       // Re-provisioning a live agent would needlessly rebuild its container.
       expect(provisionSpy).not.toHaveBeenCalled();
     } finally {
@@ -2187,13 +2549,20 @@ describe("ElizaSandboxService.executeResume", () => {
   test("a stopped agent is resumed by delegating to provision()", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const svc = new ElizaSandboxService();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      resumeRow("stopped"),
-    );
-    const provisionSpy = spyOn(svc, "provision").mockResolvedValue({ success: true } as never);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(resumeRow("stopped"));
+    const provisionSpy = spyOn(svc, "provision").mockResolvedValue({
+      success: true,
+    } as never);
     try {
       const res = await svc.executeResume(RESUME_AGENT, RESUME_ORG);
-      expect(res).toEqual({ success: true, containerStarted: true, reprovisioned: true });
+      expect(res).toEqual({
+        success: true,
+        containerStarted: true,
+        reprovisioned: true,
+      });
       expect(provisionSpy).toHaveBeenCalledTimes(1);
       expect(provisionSpy).toHaveBeenCalledWith(RESUME_AGENT, RESUME_ORG);
     } finally {
@@ -2204,9 +2573,10 @@ describe("ElizaSandboxService.executeResume", () => {
   test("an unknown agent returns not-found without provisioning", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const svc = new ElizaSandboxService();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      undefined,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(undefined);
     const provisionSpy = spyOn(svc, "provision");
     try {
       const res = await svc.executeResume(RESUME_AGENT, RESUME_ORG);
@@ -2221,9 +2591,10 @@ describe("ElizaSandboxService.executeResume", () => {
   test("a provision failure during resume is surfaced, not swallowed", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const svc = new ElizaSandboxService();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      resumeRow("stopped"),
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(resumeRow("stopped"));
     const provisionSpy = spyOn(svc, "provision").mockResolvedValue({
       success: false,
       error: "no capacity",
@@ -2256,9 +2627,10 @@ describe("ElizaSandboxService deletion-state guards (resume/wake/restart)", () =
     test(`executeResume bails on ${status} (not-found, no provision)`, async () => {
       const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
       const svc = new ElizaSandboxService();
-      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-        row(status),
-      );
+      const findSpy = spyOn(
+        agentSandboxesRepository,
+        "findByIdAndOrgForWrite",
+      ).mockResolvedValue(row(status));
       const provisionSpy = spyOn(svc, "provision");
       try {
         const res = await svc.executeResume(AGENT, ORG);
@@ -2273,9 +2645,10 @@ describe("ElizaSandboxService deletion-state guards (resume/wake/restart)", () =
     test(`executeWake bails on ${status} (not-found, no provision)`, async () => {
       const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
       const svc = new ElizaSandboxService();
-      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-        row(status),
-      );
+      const findSpy = spyOn(
+        agentSandboxesRepository,
+        "findByIdAndOrgForWrite",
+      ).mockResolvedValue(row(status));
       const provisionSpy = spyOn(svc, "provision");
       try {
         const res = await svc.executeWake(AGENT, ORG);
@@ -2290,9 +2663,10 @@ describe("ElizaSandboxService deletion-state guards (resume/wake/restart)", () =
     test(`executeRestart bails on ${status} before shutdown/provision`, async () => {
       const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
       const svc = new ElizaSandboxService();
-      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-        row(status),
-      );
+      const findSpy = spyOn(
+        agentSandboxesRepository,
+        "findByIdAndOrgForWrite",
+      ).mockResolvedValue(row(status));
       const shutdownSpy = spyOn(svc, "shutdown");
       const provisionSpy = spyOn(svc, "provision");
       try {
@@ -2329,7 +2703,8 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       agentId: string,
       orgId: string,
     ): Promise<
-      { ok: true; sandboxId: string | null; status: string } | { ok: false; error: string }
+      | { ok: true; sandboxId: string | null; status: string }
+      | { ok: false; error: string }
     >;
     commitAgentRowDelete(agentId: string, orgId: string): Promise<unknown>;
     runBoundedSandboxStop(sandboxId: string): Promise<unknown>;
@@ -2342,7 +2717,11 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
 
   test("(a) teardown timeout → delete still proceeds (row deleted) + leak warning, no phantom 'handled'", async () => {
     const svc = await makeSvc();
-    const deletedSandbox = { ...customSandbox(), id: AGENT, organization_id: ORG };
+    const deletedSandbox = {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+    };
     const prepare = spyOn(svc, "prepareAgentDelete").mockResolvedValue({
       ok: true,
       sandboxId: SANDBOX_ID,
@@ -2350,15 +2729,22 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     });
     // Timed-out teardown is reported as the { error, timedOut } shape.
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
-      error: new Error("agent-delete stop sandbox-e06bb509 timed out after 120000ms"),
+      error: new Error(
+        "agent-delete stop sandbox-e06bb509 timed out after 120000ms",
+      ),
       timedOut: true,
     });
     const commit = spyOn(svc, "commitAgentRowDelete").mockResolvedValue({
       success: true,
       deletedSandbox,
     });
-    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
-    const historySpy = spyOn(sharedRuntimeHistoryRepository, "deleteByAgent").mockResolvedValue(0);
+    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(
+      undefined as never,
+    );
+    const historySpy = spyOn(
+      sharedRuntimeHistoryRepository,
+      "deleteByAgent",
+    ).mockResolvedValue(0);
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
     try {
       const res = (await svc.deleteAgent(AGENT, ORG)) as {
@@ -2394,12 +2780,17 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     });
     // Bounded (non-timeout) failure with a non-ignorable message.
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
-      error: new Error("docker stop -> daemon hung; docker rm -f -> daemon hung"),
+      error: new Error(
+        "docker stop -> daemon hung; docker rm -f -> daemon hung",
+      ),
     });
     const commit = spyOn(svc, "commitAgentRowDelete");
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
     try {
-      const res = (await svc.deleteAgent(AGENT, ORG)) as { success: boolean; error?: string };
+      const res = (await svc.deleteAgent(AGENT, ORG)) as {
+        success: boolean;
+        error?: string;
+      };
       expect(res.success).toBe(false);
       expect(res.error).toBe("Failed to delete sandbox");
       // Critically: the row delete is never attempted when the container may
@@ -2415,7 +2806,11 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
 
   test("(c) an ignorable 'already gone' failure → info + delete proceeds (row deleted)", async () => {
     const svc = await makeSvc();
-    const deletedSandbox = { ...customSandbox(), id: AGENT, organization_id: ORG };
+    const deletedSandbox = {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+    };
     const prepare = spyOn(svc, "prepareAgentDelete").mockResolvedValue({
       ok: true,
       sandboxId: SANDBOX_ID,
@@ -2428,8 +2823,13 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       success: true,
       deletedSandbox,
     });
-    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
-    const historySpy = spyOn(sharedRuntimeHistoryRepository, "deleteByAgent").mockResolvedValue(0);
+    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(
+      undefined as never,
+    );
+    const historySpy = spyOn(
+      sharedRuntimeHistoryRepository,
+      "deleteByAgent",
+    ).mockResolvedValue(0);
     const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
     try {
@@ -2455,20 +2855,34 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
   test("the bounded teardown runs OUTSIDE the row-delete phase (sequenced, not nested)", async () => {
     const svc = await makeSvc();
     const order: string[] = [];
-    const prepare = spyOn(svc, "prepareAgentDelete").mockImplementation(async () => {
-      order.push("prepare");
-      return { ok: true, sandboxId: SANDBOX_ID, status: "running" };
-    });
-    const stop = spyOn(svc, "runBoundedSandboxStop").mockImplementation(async () => {
-      order.push("teardown");
-      return null;
-    });
-    const commit = spyOn(svc, "commitAgentRowDelete").mockImplementation(async () => {
-      order.push("commit");
-      return { success: true, deletedSandbox: { ...customSandbox(), id: AGENT } };
-    });
-    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
-    const historySpy = spyOn(sharedRuntimeHistoryRepository, "deleteByAgent").mockResolvedValue(0);
+    const prepare = spyOn(svc, "prepareAgentDelete").mockImplementation(
+      async () => {
+        order.push("prepare");
+        return { ok: true, sandboxId: SANDBOX_ID, status: "running" };
+      },
+    );
+    const stop = spyOn(svc, "runBoundedSandboxStop").mockImplementation(
+      async () => {
+        order.push("teardown");
+        return null;
+      },
+    );
+    const commit = spyOn(svc, "commitAgentRowDelete").mockImplementation(
+      async () => {
+        order.push("commit");
+        return {
+          success: true,
+          deletedSandbox: { ...customSandbox(), id: AGENT },
+        };
+      },
+    );
+    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(
+      undefined as never,
+    );
+    const historySpy = spyOn(
+      sharedRuntimeHistoryRepository,
+      "deleteByAgent",
+    ).mockResolvedValue(0);
     try {
       await svc.deleteAgent(AGENT, ORG);
       // Teardown must happen between the precheck txn and the row-delete txn,
@@ -2565,22 +2979,28 @@ describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
   const DB = "postgres://shared.example/railway";
 
   test("local-state agent gets ELIZA_MANAGED_DATABASE_URL and NO DATABASE_URL", async () => {
-    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const { computeManagedAgentDbEnv } =
+      await import("./eliza-sandbox.ts?actual");
     const env = computeManagedAgentDbEnv({ ELIZA_AGENT_LOCAL_STATE: "1" }, DB);
     expect(env.DATABASE_URL).toBeUndefined();
     expect(env.ELIZA_MANAGED_DATABASE_URL).toBe(DB);
   });
 
   test("existing agent (no flag) keeps the shared DATABASE_URL injection", async () => {
-    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const { computeManagedAgentDbEnv } =
+      await import("./eliza-sandbox.ts?actual");
     const env = computeManagedAgentDbEnv({}, DB);
     expect(env.DATABASE_URL).toBe(DB);
     expect(env.ELIZA_MANAGED_DATABASE_URL).toBeUndefined();
   });
 
   test("caller-supplied DATABASE_URL is preserved; managed exposed separately", async () => {
-    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
-    const env = computeManagedAgentDbEnv({ DATABASE_URL: "postgres://own.example/db" }, DB);
+    const { computeManagedAgentDbEnv } =
+      await import("./eliza-sandbox.ts?actual");
+    const env = computeManagedAgentDbEnv(
+      { DATABASE_URL: "postgres://own.example/db" },
+      DB,
+    );
     // dbEnv never clobbers the caller's DATABASE_URL (it is spread first in create()).
     expect(env.DATABASE_URL).toBeUndefined();
     expect(env.ELIZA_MANAGED_DATABASE_URL).toBe(DB);
@@ -2590,7 +3010,8 @@ describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
   // (eliza-sandbox.ts) — the whole locality design depends on this spread order,
   // which the pure-function tests above don't exercise.
   test("create() merge: a caller DATABASE_URL survives while the shared DB rides ELIZA_MANAGED_DATABASE_URL", async () => {
-    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const { computeManagedAgentDbEnv } =
+      await import("./eliza-sandbox.ts?actual");
     const callerEnv = { DATABASE_URL: "postgres://own.example/db" };
     const merged = { ...callerEnv, ...computeManagedAgentDbEnv(callerEnv, DB) };
     expect(merged.DATABASE_URL).toBe("postgres://own.example/db");
@@ -2598,7 +3019,8 @@ describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
   });
 
   test("create() merge: a local-state agent ends with NO DATABASE_URL and the shared DB on the managed key", async () => {
-    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const { computeManagedAgentDbEnv } =
+      await import("./eliza-sandbox.ts?actual");
     const callerEnv = { ELIZA_AGENT_LOCAL_STATE: "1" };
     const merged = { ...callerEnv, ...computeManagedAgentDbEnv(callerEnv, DB) };
     expect(merged.DATABASE_URL).toBeUndefined();
@@ -2607,7 +3029,10 @@ describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
 });
 
 describe("buildRuntimeBootstrapAgent persona seed", () => {
-  type BootstrapRec = Pick<AgentSandbox, "id" | "agent_name" | "agent_config" | "environment_vars">;
+  type BootstrapRec = Pick<
+    AgentSandbox,
+    "id" | "agent_name" | "agent_config" | "environment_vars"
+  >;
   type BootstrapAgent = {
     name: string;
     system: string;
@@ -2710,7 +3135,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
         agentId: AGENT,
         volumePath: "/var/lib/eliza/agent-blue-1",
         dockerImage: "ghcr.io/example/bnancy:latest",
-        imageDigest: "sha256:bluebluebluebluebluebluebluebluebluebluebluebluebluebluebluebl01",
+        imageDigest:
+          "sha256:bluebluebluebluebluebluebluebluebluebluebluebluebluebluebluebl01",
       },
     };
   }
@@ -2725,11 +3151,15 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       bridge_url: "https://live-bridge.example",
       health_url: "https://live-bridge.example/health",
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(runningRow);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(runningRow);
     // trySetProvisioning returns undefined: someone else holds the lock.
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(
-      undefined,
-    );
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue(undefined);
     const create = mock(async () => providerHandle());
     const provider: SandboxProvider = {
       create,
@@ -2761,12 +3191,14 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       bridge_url: null,
       health_url: null,
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(
-      provisioningRow,
-    );
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(
-      undefined,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(provisioningRow);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue(undefined);
     const create = mock(async () => providerHandle());
     const provider: SandboxProvider = {
       create,
@@ -2788,36 +3220,48 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   test("(3) UNIQUE (port TOCTOU) on attempt 1 → ghost stop + retry → attempt 2 succeeds", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
-    );
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
     // The status-write is the row that races on the (node_id, bridge_port)
     // UNIQUE constraint. Fail it with a PG 23505 once, then succeed.
     let statusWrites = 0;
     const finalRow: AgentSandbox = { ...row, status: "running" };
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") {
-          statusWrites += 1;
-          if (statusWrites === 1) {
-            throw new Error('duplicate key value violates unique constraint "23505"');
-          }
-          return finalRow;
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") {
+        statusWrites += 1;
+        if (statusWrites === 1) {
+          throw new Error(
+            'duplicate key value violates unique constraint "23505"',
+          );
         }
-        // Environment-vars persistence write (managedEnvironment.changed) — pass through.
-        return { ...row, ...data };
+        return finalRow;
+      }
+      // Environment-vars persistence write (managedEnvironment.changed) — pass through.
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     // ensureRuntimeAgentStarted hits the runtime over HTTP — no-op it so the
     // retry path under test is the row-write, not the runtime bring-up.
@@ -2830,7 +3274,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(true);
@@ -2859,26 +3307,40 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       ...provisioningReadyRow(),
       docker_image: "ghcr.io/elizaos/eliza:sha-stale",
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
-    );
-    const finalRow: AgentSandbox = { ...row, status: "running", docker_image: configuredImage };
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") return finalRow;
-        return { ...row, ...data };
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
+    const finalRow: AgentSandbox = {
+      ...row,
+      status: "running",
+      docker_image: configuredImage,
+    };
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") return finalRow;
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -2895,8 +3357,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     } as SandboxProvider);
 
     try {
-      const res = await runWithCloudBindings({ ELIZA_AGENT_IMAGE: configuredImage }, () =>
-        svc.provision(AGENT, ORG),
+      const res = await runWithCloudBindings(
+        { ELIZA_AGENT_IMAGE: configuredImage },
+        () => svc.provision(AGENT, ORG),
       );
       expect(res.success).toBe(true);
       expect(create.mock.calls[0]?.[0]).toMatchObject({
@@ -2921,26 +3384,36 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       ...provisioningReadyRow(),
       docker_image: customImage,
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
-    );
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
     const finalRow: AgentSandbox = { ...row, status: "running" };
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") return finalRow;
-        return { ...row, ...data };
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") return finalRow;
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -2957,8 +3430,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     } as SandboxProvider);
 
     try {
-      const res = await runWithCloudBindings({ ELIZA_AGENT_IMAGE: configuredImage }, () =>
-        svc.provision(AGENT, ORG),
+      const res = await runWithCloudBindings(
+        { ELIZA_AGENT_IMAGE: configuredImage },
+        () => svc.provision(AGENT, ORG),
       );
       expect(res.success).toBe(true);
       expect(create.mock.calls[0]?.[0]).toMatchObject({
@@ -2978,35 +3452,50 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   test("(4) a NON-unique post-create error → markError, NO retry (one create), failure", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue({
       ...row,
       status: "error",
     });
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") {
-          // A non-retryable write failure (NOT a unique violation).
-          throw new Error("connection terminated unexpectedly");
-        }
-        return { ...row, ...data };
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") {
+        // A non-retryable write failure (NOT a unique violation).
+        throw new Error("connection terminated unexpectedly");
+      }
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     const markErrorSpy = spyOn(
-      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      svc as unknown as {
+        markError: (rec: AgentSandbox, msg: string) => Promise<void>;
+      },
       "markError",
     ).mockResolvedValue(undefined);
     const ensureStartedSpy = spyOn(
@@ -3018,7 +3507,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(false);
@@ -3044,37 +3537,54 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   test("(5) UNIQUE on every attempt → exhaustion → 'Provisioning failed after 3 attempts'", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue({
       ...row,
       status: "error",
     });
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
-    );
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
     let statusWrites = 0;
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") {
-          statusWrites += 1;
-          throw new Error("duplicate key value violates unique constraint (port collision)");
-        }
-        return { ...row, ...data };
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") {
+        statusWrites += 1;
+        throw new Error(
+          "duplicate key value violates unique constraint (port collision)",
+        );
+      }
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     let markedMessage = "";
     const markErrorSpy = spyOn(
-      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      svc as unknown as {
+        markError: (rec: AgentSandbox, msg: string) => Promise<void>;
+      },
       "markError",
     ).mockImplementation(async (_rec, msg) => {
       markedMessage = msg;
@@ -3088,7 +3598,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(false);
@@ -3120,22 +3634,34 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
     const finalRow: AgentSandbox = { ...row, status: "running" };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -3146,7 +3672,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     reactivateBillingSpy.mockClear();
     try {
       const res = await svc.provision(AGENT, ORG);
@@ -3154,7 +3684,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(res.sandboxRecord).toBe(finalRow);
       // The fix: provision() re-enters billing for the just-provisioned agent.
       expect(reactivateBillingSpy).toHaveBeenCalledTimes(1);
-      expect(reactivateBillingSpy).toHaveBeenCalledWith(AGENT, expect.any(Date));
+      expect(reactivateBillingSpy).toHaveBeenCalledWith(
+        AGENT,
+        expect.any(Date),
+      );
       expect(create).toHaveBeenCalledTimes(1);
     } finally {
       findSpy.mockRestore();
@@ -3179,12 +3712,14 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       bridge_url: null,
       health_url: null,
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(
-      provisioningRow,
-    );
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(
-      undefined,
-    );
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(provisioningRow);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue(undefined);
     const provider: SandboxProvider = {
       create: mock(async () => providerHandle()),
       stop: mock(async () => {}),
@@ -3224,27 +3759,39 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
     const order: string[] = [];
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(backup);
     const reconstructedSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") order.push("status-running");
-        return { ...row, ...data };
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") order.push("status-running");
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -3304,36 +3851,56 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       content_hash: null,
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue({
       ...row,
       status: "error",
     });
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(backup);
     const reconstructedSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(0);
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(0);
     let runningWrites = 0;
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => {
-        if (data.status === "running") runningWrites += 1;
-        return { ...row, ...data };
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => {
+      if (data.status === "running") runningWrites += 1;
+      return { ...row, ...data };
+    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
       },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const svc = new ElizaSandboxService();
     const markErrorSpy = spyOn(
-      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      svc as unknown as {
+        markError: (rec: AgentSandbox, msg: string) => Promise<void>;
+      },
       "markError",
     ).mockResolvedValue(undefined);
     const ensureStartedSpy = spyOn(
@@ -3391,24 +3958,39 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
     const finalRow: AgentSandbox = { ...row, status: "running" };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
     // The org DEK that encrypted the snapshot is gone (memory backend restart).
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockRejectedValue(
-      new KeyNotFoundError(orgKey(ORG, "dek"), 1),
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockRejectedValue(new KeyNotFoundError(orgKey(ORG, "dek"), 1));
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(1);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(1);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
@@ -3425,7 +4007,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       // Fresh boot: the provision SUCCEEDS instead of bricking.
@@ -3477,25 +4063,42 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       content_hash: null,
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(backup);
     const reconstructedSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockRejectedValue(aeadError);
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(2);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(2);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
@@ -3545,32 +4148,50 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   test("(12) a transient (non-crypto) backup-read failure propagates — provision fails, snapshot NOT discarded", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue({
       ...row,
       status: "error",
     });
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
     // A DB blip, NOT a crypto failure — must NOT degrade.
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockRejectedValue(
-      new Error("connection terminated unexpectedly"),
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockRejectedValue(new Error("connection terminated unexpectedly"));
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(0);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) => ({ ...row, ...data }));
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
     );
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(0);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => ({ ...row, ...data }),
-    );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
     const svc = new ElizaSandboxService();
     const markErrorSpy = spyOn(
-      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      svc as unknown as {
+        markError: (rec: AgentSandbox, msg: string) => Promise<void>;
+      },
       "markError",
     ).mockResolvedValue(undefined);
     const ensureStartedSpy = spyOn(
@@ -3582,7 +4203,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       // A transient failure fails the provision (the resume job retries), rather
@@ -3622,7 +4247,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   // shape, not a hand-rolled string.
   test("(13) restore push rejected 401 (dead/rotated container) degrades to a fresh boot on the first attempt", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const row: AgentSandbox = { ...provisioningReadyRow(), execution_tier: "dedicated-lazy" };
+    const row: AgentSandbox = {
+      ...provisioningReadyRow(),
+      execution_tier: "dedicated-lazy",
+    };
     const finalRow: AgentSandbox = { ...row, status: "running" };
     const backup: AgentSandboxBackup = {
       id: "66666666-6666-4666-8666-666666666666",
@@ -3637,29 +4265,48 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       content_hash: null,
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(backup);
     const reconstructedSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(1);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(1);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
     const svc = new ElizaSandboxService();
     const markErrorSpy = spyOn(
-      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      svc as unknown as {
+        markError: (rec: AgentSandbox, msg: string) => Promise<void>;
+      },
       "markError",
     ).mockResolvedValue(undefined);
     const ensureStartedSpy = spyOn(
@@ -3679,14 +4326,20 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       // Fresh boot: the provision SUCCEEDS instead of bricking the agent.
       expect(res.success).toBe(true);
       expect(res.sandboxRecord).toBe(finalRow);
       // The restore POST really went to the new container's bridge.
-      expect(restoreCalls).toEqual(["https://runtime-blue.example/api/restore"]);
+      expect(restoreCalls).toEqual([
+        "https://runtime-blue.example/api/restore",
+      ]);
       // Degrade on FIRST detection: one create, no retry burn, no ghost
       // cleanup of the healthy container, no markError.
       expect(create).toHaveBeenCalledTimes(1);
@@ -3720,7 +4373,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   // real pushState throw shape.
   test("(14) restore push rejected 404 on a non-custom tier degrades to a fresh boot", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const row: AgentSandbox = { ...provisioningReadyRow(), execution_tier: "dedicated-lazy" };
+    const row: AgentSandbox = {
+      ...provisioningReadyRow(),
+      execution_tier: "dedicated-lazy",
+    };
     const finalRow: AgentSandbox = { ...row, status: "running" };
     const backup: AgentSandboxBackup = {
       id: "77777777-7777-4777-8777-777777777777",
@@ -3735,42 +4391,66 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       content_hash: null,
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(backup);
     const reconstructedSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(1);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(1);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
     const svc = new ElizaSandboxService();
     const markErrorSpy = spyOn(
-      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      svc as unknown as {
+        markError: (rec: AgentSandbox, msg: string) => Promise<void>;
+      },
       "markError",
     ).mockResolvedValue(undefined);
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
       "ensureRuntimeAgentStarted",
     ).mockResolvedValue(null);
-    globalThis.fetch = (async () => new Response("Not Found", { status: 404 })) as typeof fetch;
+    globalThis.fetch = (async () =>
+      new Response("Not Found", { status: 404 })) as typeof fetch;
     const create = mock(async () => providerHandle());
     const stop = mock(async () => {});
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(true);
@@ -3815,25 +4495,42 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       content_hash: null,
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(backup);
     const reconstructedSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(0);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const pruneSpy = spyOn(
+      agentSandboxesRepository,
+      "pruneBackups",
+    ).mockResolvedValue(0);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const infoLogSpy = spyOn(logger, "info").mockImplementation(() => {});
     const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
     const svc = new ElizaSandboxService();
@@ -3841,7 +4538,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
       "ensureRuntimeAgentStarted",
     ).mockResolvedValue(null);
-    globalThis.fetch = (async () => new Response("Not Found", { status: 404 })) as typeof fetch;
+    globalThis.fetch = (async () =>
+      new Response("Not Found", { status: 404 })) as typeof fetch;
     const create = mock(async () => providerHandle());
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
@@ -3883,22 +4581,36 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     // so the job retries instead of permanently failing.
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue(row);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(
       async (_id, data) => ({ ...row, ...data }) as AgentSandbox,
     );
     const stop = mock(async () => {});
     const create = mock(async () => providerHandle());
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -3926,7 +4638,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       // The container handle IS persisted (so the reconciler can find the row),
       // and NO write flips it to `running` (only a confirmed re-probe may).
       const persistWrite = updateSpy.mock.calls.find(
-        ([, data]) => (data as { sandbox_id?: string }).sandbox_id === "sandbox-blue-1",
+        ([, data]) =>
+          (data as { sandbox_id?: string }).sandbox_id === "sandbox-blue-1",
       );
       expect(persistWrite).toBeDefined();
       const flippedRunning = updateSpy.mock.calls.some(
@@ -3952,13 +4665,25 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
   test("(9b) transport_unresolved docker handle without node_id fails closed instead of preserving an orphan handle", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue({
       ...row,
       status: "provisioning",
     });
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue(row);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(
       async (_id, data) => ({ ...row, ...data }) as AgentSandbox,
     );
     const stop = mock(async () => {});
@@ -3971,11 +4696,13 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
         containerName: "agent-blue-1",
       },
     }));
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -4001,7 +4728,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(stop).toHaveBeenCalledTimes(1);
       expect(
         updateSpy.mock.calls.some(
-          ([, data]) => (data as { sandbox_id?: string }).sandbox_id === "sandbox-blue-1",
+          ([, data]) =>
+            (data as { sandbox_id?: string }).sandbox_id === "sandbox-blue-1",
         ),
       ).toBe(false);
       const errorWrite = updateSpy.mock.calls.find(
@@ -4011,9 +4739,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       if (!errorWrite) {
         throw new Error("Expected the failed-provision error write");
       }
-      expect(String((errorWrite[1] as { error_message?: string }).error_message)).toContain(
-        "provision attribution guard:",
-      );
+      expect(
+        String((errorWrite[1] as { error_message?: string }).error_message),
+      ).toContain("provision attribution guard:");
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();
@@ -4040,19 +4768,31 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       headscale_ip: "100.64.0.42",
     };
     const finalRow: AgentSandbox = { ...row, status: "running" };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(row);
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
-      undefined,
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue(row);
+    const backupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackup",
+    ).mockResolvedValue(undefined);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(async (_id, data) =>
+      data.status === "running" ? finalRow : { ...row, ...data },
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
     const create = mock(async () => providerHandle());
     const stop = mock(async () => {});
     const healthInputs: Array<{ sandboxId: string }> = [];
@@ -4088,7 +4828,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       if (!runningWrite) {
         throw new Error("Expected the adopted sandbox running write");
       }
-      expect((runningWrite[1] as { sandbox_id?: string }).sandbox_id).toBe("sandbox-blue-1");
+      expect((runningWrite[1] as { sandbox_id?: string }).sandbox_id).toBe(
+        "sandbox-blue-1",
+      );
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();
@@ -4114,20 +4856,37 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       web_ui_port: 4444,
       headscale_ip: "100.64.0.42",
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(row);
-    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(row);
+    const lockSpy = spyOn(
+      agentSandboxesRepository,
+      "trySetProvisioning",
+    ).mockResolvedValue(row);
+    const findByIdSpy = spyOn(
+      agentSandboxesRepository,
+      "findById",
+    ).mockResolvedValue(row);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(
       async (_id, data) => ({ ...row, ...data }) as AgentSandbox,
     );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      },
+    );
     const create = mock(async () => providerHandle());
     const stop = mock(async () => {});
-    const healthInputs: Array<{ sandboxId: string; metadata?: Record<string, unknown> }> = [];
+    const healthInputs: Array<{
+      sandboxId: string;
+      metadata?: Record<string, unknown>;
+    }> = [];
     const svc = new ElizaSandboxService();
     const ensureStartedSpy = spyOn(
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
@@ -4141,7 +4900,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       stop,
       checkHealth: async () => true,
       checkHealthDetailed: async (handle) => {
-        healthInputs.push({ sandboxId: handle.sandboxId, metadata: handle.metadata });
+        healthInputs.push({
+          sandboxId: handle.sandboxId,
+          metadata: handle.metadata,
+        });
         return { ready: true, verdict: "ready" as const };
       },
     } as unknown as SandboxProvider);
@@ -4167,7 +4929,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
         },
       ]);
       expect(
-        updateSpy.mock.calls.some(([, data]) => (data as { status?: string }).status === "running"),
+        updateSpy.mock.calls.some(
+          ([, data]) => (data as { status?: string }).status === "running",
+        ),
       ).toBe(false);
       const errorWrite = updateSpy.mock.calls.find(
         ([, data]) => (data as { status?: string }).status === "error",
@@ -4176,9 +4940,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       if (!errorWrite) {
         throw new Error("Expected the invalid-adoption error write");
       }
-      expect(String((errorWrite[1] as { error_message?: string }).error_message)).toContain(
-        "provision attribution guard:",
-      );
+      expect(
+        String((errorWrite[1] as { error_message?: string }).error_message),
+      ).toContain("provision attribution guard:");
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();
@@ -4196,7 +4960,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
 // precise crypto-vs-transient distinction the degrade path keys on.
 describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)", () => {
   test("classifies a real KeyNotFoundError (memory-KMS key rotated away) as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    const { isUnrecoverableSnapshotError } =
+      await import("./eliza-sandbox.ts?actual");
     const err = await realKeyRotatedAwayError();
     // The exact prod incident: the memory backend restart orphaned the key.
     expect(err).toBeInstanceOf(KeyNotFoundError);
@@ -4204,14 +4969,16 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
   });
 
   test("classifies a real AeadError (auth-tag failure) as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    const { isUnrecoverableSnapshotError } =
+      await import("./eliza-sandbox.ts?actual");
     const err = await realAeadDecryptError();
     expect(err.name).toBe("AeadError");
     expect(isUnrecoverableSnapshotError(err)).toBe(true);
   });
 
   test("classifies permanent snapshot HTTP rejections (401/403/404/410) as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    const { isUnrecoverableSnapshotError } =
+      await import("./eliza-sandbox.ts?actual");
     // The exact HQ 14308 incident string, as pushState throws it (status +
     // first 200 bytes of the response body).
     expect(
@@ -4219,23 +4986,44 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
         new Error('State restore failed: HTTP 401 {"error":"Unauthorized"}'),
       ),
     ).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 403 "))).toBe(true);
     expect(
-      isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 404 Not Found")),
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 403 "),
+      ),
     ).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 410 Gone"))).toBe(
-      true,
-    );
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 404 Not Found"),
+      ),
+    ).toBe(true);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 410 Gone"),
+      ),
+    ).toBe(true);
     // fetchSnapshotState's shape (no body suffix). Its 404 is mapped to the
     // SNAPSHOT_ENDPOINT_UNSUPPORTED sentinel before ever surfacing, but the
     // auth statuses surface verbatim.
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 401"))).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 403"))).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("Snapshot fetch failed: HTTP 401"),
+      ),
+    ).toBe(true);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("Snapshot fetch failed: HTTP 403"),
+      ),
+    ).toBe(true);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("Snapshot fetch failed: HTTP 410"),
+      ),
+    ).toBe(true);
   });
 
   test("does NOT classify transient snapshot HTTP failures — those must retry", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    const { isUnrecoverableSnapshotError } =
+      await import("./eliza-sandbox.ts?actual");
     // 5xx (container mid-boot / overloaded), 408 (timeout), 429 (throttled):
     // all can heal on the next attempt, so degrading would discard restorable
     // state.
@@ -4245,21 +5033,44 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
       ),
     ).toBe(false);
     expect(
-      isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 502 Bad Gateway")),
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 502 Bad Gateway"),
+      ),
     ).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 503 "))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 408 "))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 429 "))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 500"))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 503"))).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 503 "),
+      ),
+    ).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 408 "),
+      ),
+    ).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 429 "),
+      ),
+    ).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("Snapshot fetch failed: HTTP 500"),
+      ),
+    ).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("Snapshot fetch failed: HTTP 503"),
+      ),
+    ).toBe(false);
   });
 
   test("matches only this file's snapshot throw shapes — anchored, exact status", async () => {
-    const { isUnrecoverableSnapshotError, SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import(
-      "./eliza-sandbox.ts?actual"
-    );
+    const { isUnrecoverableSnapshotError, SNAPSHOT_ENDPOINT_UNSUPPORTED } =
+      await import("./eliza-sandbox.ts?actual");
     // Network-level fetch failures carry no HTTP status and must propagate.
-    expect(isUnrecoverableSnapshotError(new TypeError("fetch failed"))).toBe(false);
+    expect(isUnrecoverableSnapshotError(new TypeError("fetch failed"))).toBe(
+      false,
+    );
     // A message that merely EMBEDS the wrapper (e.g. the markError re-wrap) is
     // not the raw restore-path error the degrade classifies.
     expect(
@@ -4271,18 +5082,25 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
     ).toBe(false);
     // The "image has no snapshot endpoint" sentinel is a benign skip elsewhere,
     // never a degrade.
-    expect(isUnrecoverableSnapshotError(new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("Sandbox is not running"))).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED)),
+    ).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(new Error("Sandbox is not running")),
+    ).toBe(false);
   });
 
   test("does NOT classify transient / non-crypto failures as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    const { isUnrecoverableSnapshotError } =
+      await import("./eliza-sandbox.ts?actual");
     // A DB/network blip, a base Steward KmsError (HTTP 5xx transient), and
     // non-Errors must all propagate — degrading on them would discard state a
     // retry would have restored.
-    expect(isUnrecoverableSnapshotError(new Error("connection terminated unexpectedly"))).toBe(
-      false,
-    );
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("connection terminated unexpectedly"),
+      ),
+    ).toBe(false);
     expect(
       isUnrecoverableSnapshotError(
         new KmsError("Steward KMS decrypt failed (503 Service Unavailable)"),
@@ -4302,7 +5120,8 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
 // HTTP 404/410 are permanently lost and safe to prune.
 describe("isPermanentlyLostSnapshot (prune-vs-preserve gating)", () => {
   test("classifies crypto-loss shapes (KeyNotFoundError / AeadError) as permanently lost", async () => {
-    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
+    const { isPermanentlyLostSnapshot } =
+      await import("./eliza-sandbox.ts?actual");
     const keyGone = await realKeyRotatedAwayError();
     expect(keyGone).toBeInstanceOf(KeyNotFoundError);
     expect(isPermanentlyLostSnapshot(keyGone)).toBe(true);
@@ -4312,42 +5131,67 @@ describe("isPermanentlyLostSnapshot (prune-vs-preserve gating)", () => {
   });
 
   test("classifies HTTP 404/410 (snapshot gone) as permanently lost — safe to prune", async () => {
-    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 404 Not Found"))).toBe(
-      true,
-    );
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 410 Gone"))).toBe(true);
-    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
+    const { isPermanentlyLostSnapshot } =
+      await import("./eliza-sandbox.ts?actual");
+    expect(
+      isPermanentlyLostSnapshot(
+        new Error("State restore failed: HTTP 404 Not Found"),
+      ),
+    ).toBe(true);
+    expect(
+      isPermanentlyLostSnapshot(
+        new Error("State restore failed: HTTP 410 Gone"),
+      ),
+    ).toBe(true);
+    expect(
+      isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 410")),
+    ).toBe(true);
   });
 
   test("does NOT classify auth 401/403 as permanently lost — recoverable, must PRESERVE the chain (#15274)", async () => {
-    const { isPermanentlyLostSnapshot, isUnrecoverableSnapshotError } = await import(
-      "./eliza-sandbox.ts?actual"
-    );
+    const { isPermanentlyLostSnapshot, isUnrecoverableSnapshotError } =
+      await import("./eliza-sandbox.ts?actual");
     // The exact HQ 14308 incident string. It IS unrecoverable-for-this-provision
     // (degrade to fresh boot) but NOT permanently lost: PR #15263 shows the 401
     // was a healthy container missing the agent token, which a corrected resume
     // restores. Pruning here = silent permanent data loss.
-    const auth401 = new Error('State restore failed: HTTP 401 {"error":"Unauthorized"}');
+    const auth401 = new Error(
+      'State restore failed: HTTP 401 {"error":"Unauthorized"}',
+    );
     expect(isUnrecoverableSnapshotError(auth401)).toBe(true);
     expect(isPermanentlyLostSnapshot(auth401)).toBe(false);
     const auth403 = new Error("State restore failed: HTTP 403 ");
     expect(isUnrecoverableSnapshotError(auth403)).toBe(true);
     expect(isPermanentlyLostSnapshot(auth403)).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 401"))).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 403"))).toBe(false);
+    expect(
+      isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 401")),
+    ).toBe(false);
+    expect(
+      isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 403")),
+    ).toBe(false);
   });
 
   test("does NOT classify transient / non-matching errors as permanently lost", async () => {
-    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
+    const { isPermanentlyLostSnapshot } =
+      await import("./eliza-sandbox.ts?actual");
     // Transient HTTP and network/DB errors were never unrecoverable to begin
     // with; they must never prune.
     expect(
-      isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 500 Internal Server Error")),
+      isPermanentlyLostSnapshot(
+        new Error("State restore failed: HTTP 500 Internal Server Error"),
+      ),
     ).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 503 "))).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("connection terminated unexpectedly"))).toBe(false);
-    expect(isPermanentlyLostSnapshot(new TypeError("fetch failed"))).toBe(false);
+    expect(
+      isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 503 ")),
+    ).toBe(false);
+    expect(
+      isPermanentlyLostSnapshot(
+        new Error("connection terminated unexpectedly"),
+      ),
+    ).toBe(false);
+    expect(isPermanentlyLostSnapshot(new TypeError("fetch failed"))).toBe(
+      false,
+    );
     expect(isPermanentlyLostSnapshot("AEAD decrypt failed")).toBe(false);
     expect(isPermanentlyLostSnapshot(null)).toBe(false);
     expect(isPermanentlyLostSnapshot(undefined)).toBe(false);
@@ -4367,8 +5211,10 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   const AGENT = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
   const ORG = "22222222-2222-4222-8222-222222222222";
   const DOCKER_IMAGE = "ghcr.io/elizaos/eliza-agent:latest";
-  const FROM_DIGEST = "sha256:0000000000000000000000000000000000000000000000000000000000000aaa";
-  const TO_DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111bbb";
+  const FROM_DIGEST =
+    "sha256:0000000000000000000000000000000000000000000000000000000000000aaa";
+  const TO_DIGEST =
+    "sha256:1111111111111111111111111111111111111111111111111111111111111bbb";
 
   function runtimeHealthResponse(
     body: Record<string, unknown> = {
@@ -4414,7 +5260,10 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   }
 
   // A genuine DockerSandboxMetadata for blue — isDockerSandboxMetadata() passes.
-  function blueMetadata(imageDigest: string | null, previousVpnNodeId?: string) {
+  function blueMetadata(
+    imageDigest: string | null,
+    previousVpnNodeId?: string,
+  ) {
     return {
       provider: "docker" as const,
       nodeId: "node-new",
@@ -4455,7 +5304,9 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     const stop = mock(async () => {});
     const stopOnSpecificNode = mock(async () => {});
     Object.assign(provider, { create, checkHealth, stop, stopOnSpecificNode });
-    globalThis.fetch = mock(async () => runtimeHealthResponse()) as unknown as typeof fetch;
+    globalThis.fetch = mock(async () =>
+      runtimeHealthResponse(),
+    ) as unknown as typeof fetch;
     return {
       provider: provider as unknown as SandboxProvider,
       create,
@@ -4472,8 +5323,14 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   test("(a) blue health-check FAILS → blue torn down, row stays on OLD, rolled-back error", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
     const { provider, create, checkHealth, stop } = await makeDockerProvider({
       create: async () => blueHandle(TO_DIGEST),
       checkHealth: async () => false, // blue never comes up
@@ -4512,9 +5369,16 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   test("(b) blue digest MISMATCH → blue torn down, NO swap", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
-    const WRONG_DIGEST = "sha256:dededededededededededededededededededededededededededededede0000";
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
+    const WRONG_DIGEST =
+      "sha256:dededededededededededededededededededededededededededededede0000";
     const { provider, create, checkHealth, stop } = await makeDockerProvider({
       create: async () => blueHandle(WRONG_DIGEST), // healthy but wrong image
       checkHealth: async () => true,
@@ -4551,12 +5415,19 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   test("(b2) blue runtime readiness gate FAILS → blue torn down, NO snapshot or swap", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
-    const { provider, create, checkHealth, stop, stopOnSpecificNode } = await makeDockerProvider({
-      create: async () => blueHandle(TO_DIGEST),
-      checkHealth: async () => true,
-    });
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
+    const { provider, create, checkHealth, stop, stopOnSpecificNode } =
+      await makeDockerProvider({
+        create: async () => blueHandle(TO_DIGEST),
+        checkHealth: async () => true,
+      });
     const healthFetch = mock(async () =>
       runtimeHealthResponse({
         ready: false,
@@ -4581,7 +5452,13 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       return false as never;
     };
     try {
-      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      const res = await svc.executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
       expect(res.success).toBe(false);
       expect(res.error).toContain("Blue runtime readiness gate failed");
       expect(res.error).toContain("ready=false");
@@ -4605,12 +5482,19 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   test("(c) happy path → atomic swap writes blue's node/container/bridge + image_digest=toDigest", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
-    const { provider, create, checkHealth, stop, stopOnSpecificNode } = await makeDockerProvider({
-      create: async () => blueHandle(TO_DIGEST),
-      checkHealth: async () => true,
-    });
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
+    const { provider, create, checkHealth, stop, stopOnSpecificNode } =
+      await makeDockerProvider({
+        create: async () => blueHandle(TO_DIGEST),
+        checkHealth: async () => true,
+      });
     const svc = new ElizaSandboxService(provider);
     // Pin the lifecycle lock + the FOR-UPDATE read to a no-op / unchanged row so
     // the CAS guard passes and control reaches the UPDATE.
@@ -4620,7 +5504,9 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     ).mockResolvedValue(undefined);
     const readSpy = spyOn(
       svc as unknown as {
-        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+        getAgentForLifecycleMutation: (
+          ...a: unknown[]
+        ) => Promise<AgentSandbox | undefined>;
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(agent);
@@ -4646,7 +5532,13 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       return fn(tx);
     };
     try {
-      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      const res = await svc.executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
       expect(res.success).toBe(true);
       expect(res.newNodeId).toBe("node-new");
       expect(res.newContainerName).toBe("agent-new-1");
@@ -4666,7 +5558,9 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       expect(params).toContain(DOCKER_IMAGE); // previous_docker_image (agent.docker_image is null → dockerImage)
       // Success clears the upgrade-exhaustion marker: a row frozen for a prior
       // target re-arms the moment a swap onto a new target lands (#15358).
-      const updateSql = new PgDialect().sqlToQuery(executedSql as SQL).sql.toLowerCase();
+      const updateSql = new PgDialect()
+        .sqlToQuery(executedSql as SQL)
+        .sql.toLowerCase();
       expect(updateSql).toContain("error_message = null");
       // The old container is best-effort torn down on its specific node; the
       // blue is the live one and is NOT stopped.
@@ -4687,8 +5581,14 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const { headscaleIntegration } = await import("./headscale-integration");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
     const { provider, create, stopOnSpecificNode } = await makeDockerProvider({
       create: async () => blueHandle(TO_DIGEST, "old-live-node-7"),
       checkHealth: async () => true,
@@ -4700,7 +5600,9 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     ).mockResolvedValue(undefined);
     const readSpy = spyOn(
       svc as unknown as {
-        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+        getAgentForLifecycleMutation: (
+          ...a: unknown[]
+        ) => Promise<AgentSandbox | undefined>;
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(agent);
@@ -4713,11 +5615,12 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     // Event order: the old node's by-id deletion must come AFTER the swap
     // commit AND after old-container teardown started — never before.
     const events: string[] = [];
-    const removeSpy = spyOn(headscaleIntegration, "removeVpnNodeById").mockImplementation(
-      async (id: string) => {
-        events.push(`vpn-delete:${id}`);
-      },
-    );
+    const removeSpy = spyOn(
+      headscaleIntegration,
+      "removeVpnNodeById",
+    ).mockImplementation(async (id: string) => {
+      events.push(`vpn-delete:${id}`);
+    });
     stopOnSpecificNode.mockImplementation(async () => {
       events.push("old-teardown");
     });
@@ -4731,17 +5634,26 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       return fn(tx);
     };
     try {
-      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      const res = await svc.executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
       expect(res.success).toBe(true);
       // Blue was provisioned in preserve mode.
       const createConfig = create.mock.calls[0]?.[0] as
-        | { reclaimStaleVpnNode?: boolean }
-        | undefined;
+        { reclaimStaleVpnNode?: boolean } | undefined;
       expect(createConfig?.reclaimStaleVpnNode).toBe(false);
       // The preserved node was deleted exactly once, by id, after the swap.
       expect(removeSpy).toHaveBeenCalledTimes(1);
       expect(removeSpy).toHaveBeenCalledWith("old-live-node-7");
-      expect(events).toEqual(["swap-commit", "old-teardown", "vpn-delete:old-live-node-7"]);
+      expect(events).toEqual([
+        "swap-commit",
+        "old-teardown",
+        "vpn-delete:old-live-node-7",
+      ]);
     } finally {
       findSpy.mockRestore();
       nodeSpy.mockRestore();
@@ -4756,13 +5668,22 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const { headscaleIntegration } = await import("./headscale-integration");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
     const { provider, stop } = await makeDockerProvider({
       create: async () => blueHandle(TO_DIGEST, "old-live-node-7"),
       checkHealth: async () => false, // blue never comes up → rollback
     });
-    const removeSpy = spyOn(headscaleIntegration, "removeVpnNodeById").mockResolvedValue(undefined);
+    const removeSpy = spyOn(
+      headscaleIntegration,
+      "removeVpnNodeById",
+    ).mockResolvedValue(undefined);
     try {
       const res = await new ElizaSandboxService(provider).executeUpgrade(
         AGENT,
@@ -4787,16 +5708,25 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   test("(c2) pre-upgrade snapshot failure → blue torn down, NO swap", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
-    const { provider, create, checkHealth, stop, stopOnSpecificNode } = await makeDockerProvider({
-      create: async () => blueHandle(TO_DIGEST),
-      checkHealth: async () => true,
-    });
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
+    const { provider, create, checkHealth, stop, stopOnSpecificNode } =
+      await makeDockerProvider({
+        create: async () => blueHandle(TO_DIGEST),
+        checkHealth: async () => true,
+      });
     const svc = new ElizaSandboxService(provider);
     const snapshotSpy = spyOn(
       svc as unknown as {
-        snapshot: (...a: unknown[]) => Promise<{ success: boolean; error?: string }>;
+        snapshot: (
+          ...a: unknown[]
+        ) => Promise<{ success: boolean; error?: string }>;
       },
       "snapshot",
     ).mockResolvedValue({ success: false, error: "manifest missing" });
@@ -4806,7 +5736,13 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       return false as never;
     };
     try {
-      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      const res = await svc.executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
       expect(res.success).toBe(false);
       expect(res.error).toContain("Pre-upgrade snapshot failed");
       expect(res.error).toContain("manifest missing");
@@ -4827,12 +5763,19 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   test("(d) CAS guard: row moved under us → returns false → throws 'changed during upgrade', tears down orphaned blue", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const agent = liveAgentRow();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
-    const { provider, create, checkHealth, stop, stopOnSpecificNode } = await makeDockerProvider({
-      create: async () => blueHandle(TO_DIGEST),
-      checkHealth: async () => true,
-    });
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
+    const { provider, create, checkHealth, stop, stopOnSpecificNode } =
+      await makeDockerProvider({
+        create: async () => blueHandle(TO_DIGEST),
+        checkHealth: async () => true,
+      });
     const svc = new ElizaSandboxService(provider);
     const lockSpy = spyOn(
       svc as unknown as { lockLifecycle: (...a: unknown[]) => Promise<void> },
@@ -4847,7 +5790,9 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     };
     const readSpy = spyOn(
       svc as unknown as {
-        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+        getAgentForLifecycleMutation: (
+          ...a: unknown[]
+        ) => Promise<AgentSandbox | undefined>;
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(movedRow);
@@ -4868,7 +5813,13 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       return fn(tx);
     };
     try {
-      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      const res = await svc.executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
       expect(res.success).toBe(false);
       expect(res.error).toContain("Agent changed during upgrade");
       // The guard short-circuits BEFORE the UPDATE — never writes a stale swap.
@@ -4892,10 +5843,19 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
   // Shared driver for the CAS docker_image-leg cases (#15358): run a full
   // executeUpgrade with the given row at BOTH the pre-provision read and the
   // in-transaction CAS read, and report whether the swap UPDATE was issued.
-  async function runSwapWithRow(agentRow: AgentSandbox, casRow: AgentSandbox = agentRow) {
+  async function runSwapWithRow(
+    agentRow: AgentSandbox,
+    casRow: AgentSandbox = agentRow,
+  ) {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agentRow);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agentRow);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(oldNode());
     const { provider, stop } = await makeDockerProvider({
       create: async () => blueHandle(TO_DIGEST),
       checkHealth: async () => true,
@@ -4907,12 +5867,16 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     ).mockResolvedValue(undefined);
     const readSpy = spyOn(
       svc as unknown as {
-        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+        getAgentForLifecycleMutation: (
+          ...a: unknown[]
+        ) => Promise<AgentSandbox | undefined>;
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(casRow);
     const snapshotSpy = spyOn(
-      svc as unknown as { snapshot: (...a: unknown[]) => Promise<{ success: boolean }> },
+      svc as unknown as {
+        snapshot: (...a: unknown[]) => Promise<{ success: boolean }>;
+      },
       "snapshot",
     ).mockResolvedValue({ success: true });
     let executedSql: unknown;
@@ -4926,7 +5890,13 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       return fn(tx);
     };
     try {
-      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      const res = await svc.executeUpgrade(
+        AGENT,
+        ORG,
+        TO_DIGEST,
+        DOCKER_IMAGE,
+        FROM_DIGEST,
+      );
       return { res, executedSql, stop };
     } finally {
       findSpy.mockRestore();
@@ -4969,7 +5939,10 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       ...liveAgentRow(),
       docker_image: "ghcr.io/acme/custom-agent:latest",
     };
-    const { res, executedSql, stop } = await runSwapWithRow(liveAgentRow(), movedRow);
+    const { res, executedSql, stop } = await runSwapWithRow(
+      liveAgentRow(),
+      movedRow,
+    );
     expect(res.success).toBe(false);
     expect(res.error).toContain("Agent changed during upgrade");
     // No UPDATE was issued and the orphaned blue is stopped.
@@ -4989,8 +5962,10 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
   const ORG = "22222222-2222-4222-8222-222222222222";
   const DOCKER_IMAGE = "ghcr.io/elizaos/eliza-agent:latest";
   // The agent currently runs on the post-upgrade digest; rollback targets PREV.
-  const CURRENT_DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111bbb";
-  const PREV_DIGEST = "sha256:0000000000000000000000000000000000000000000000000000000000000aaa";
+  const CURRENT_DIGEST =
+    "sha256:1111111111111111111111111111111111111111111111111111111111111bbb";
+  const PREV_DIGEST =
+    "sha256:0000000000000000000000000000000000000000000000000000000000000aaa";
 
   // A live fleet agent that HAS a persisted rollback target.
   function upgradedAgentRow(): AgentSandbox {
@@ -5071,8 +6046,14 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
 
   test("no previous_image_digest → refuses, never touches the live agent", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const agent: AgentSandbox = { ...upgradedAgentRow(), previous_image_digest: null };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
+    const agent: AgentSandbox = {
+      ...upgradedAgentRow(),
+      previous_image_digest: null,
+    };
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
     const { provider, create } = await makeDockerProvider({
       create: async () => blueHandle(PREV_DIGEST),
       checkHealth: async () => true,
@@ -5095,26 +6076,41 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
 
   test("happy path with empty persisted image ref → restores pre-upgrade snapshot then swaps back onto PREV_DIGEST", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const agent: AgentSandbox = { ...upgradedAgentRow(), previous_docker_image: "" };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
-    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(curNode());
+    const agent: AgentSandbox = {
+      ...upgradedAgentRow(),
+      previous_docker_image: "",
+    };
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(agent);
+    const nodeSpy = spyOn(
+      dockerNodesRepository,
+      "findByNodeId",
+    ).mockResolvedValue(curNode());
     // The pre-upgrade restore point + its reconstruction.
     const preUpgradeBackup = {
       id: "backup-preupgrade-1",
       sandbox_record_id: AGENT,
       snapshot_type: "pre-upgrade",
     } as unknown as AgentSandboxBackup;
-    const byTypeSpy = spyOn(agentSandboxesRepository, "getLatestBackupByType").mockResolvedValue(
-      preUpgradeBackup,
-    );
+    const byTypeSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestBackupByType",
+    ).mockResolvedValue(preUpgradeBackup);
     const reconstructSpy = spyOn(
       agentSandboxesRepository,
       "getReconstructedBackupState",
-    ).mockResolvedValue({ memories: [], config: { restored: true }, workspaceFiles: {} });
-    const { provider, create, checkHealth, stop, stopOnSpecificNode } = await makeDockerProvider({
-      create: async () => blueHandle(PREV_DIGEST),
-      checkHealth: async () => true,
+    ).mockResolvedValue({
+      memories: [],
+      config: { restored: true },
+      workspaceFiles: {},
     });
+    const { provider, create, checkHealth, stop, stopOnSpecificNode } =
+      await makeDockerProvider({
+        create: async () => blueHandle(PREV_DIGEST),
+        checkHealth: async () => true,
+      });
     const svc = new ElizaSandboxService(provider);
     // The pre-cutover state push lands on blue's /api/restore — stub the private
     // pushState so the test stays offline; assert it received blue's bridge URL.
@@ -5128,7 +6124,9 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
     ).mockResolvedValue(undefined);
     const readSpy = spyOn(
       svc as unknown as {
-        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+        getAgentForLifecycleMutation: (
+          ...a: unknown[]
+        ) => Promise<AgentSandbox | undefined>;
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(agent);
@@ -5143,7 +6141,12 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
       return fn(tx);
     };
     try {
-      const res = await svc.executeDowngrade(AGENT, ORG, DOCKER_IMAGE, CURRENT_DIGEST);
+      const res = await svc.executeDowngrade(
+        AGENT,
+        ORG,
+        DOCKER_IMAGE,
+        CURRENT_DIGEST,
+      );
       expect(res.success).toBe(true);
       expect(res.newNodeId).toBe("node-rb");
       expect(res.newContainerName).toBe("agent-rb-1");
@@ -5185,7 +6188,8 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
 // returns exactly the bound params in order (same introspection the enqueue
 // tests use).
 function sqlBoundParams(query: unknown): unknown[] {
-  if (!query || typeof query !== "object" || !("queryChunks" in query)) return [];
+  if (!query || typeof query !== "object" || !("queryChunks" in query))
+    return [];
   return new PgDialect().sqlToQuery(query as SQL).params;
 }
 
@@ -5196,10 +6200,14 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
       ...customSandbox(),
       agent_config: { system: "old system", temperature: 0.7 },
     };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      existing,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(existing);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(
       async (_id, updates) => ({ ...existing, ...updates }) as AgentSandbox,
     );
     try {
@@ -5223,10 +6231,14 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
 
   test("updateAgentProfile returns undefined for an unknown/foreign agent and writes nothing", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      undefined,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(undefined);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(undefined);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined);
     try {
       const result = await new ElizaSandboxService().updateAgentProfile(
         "dddddddd-9999-4999-8999-999999999999",
@@ -5244,10 +6256,14 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
   test("updateAgentProfile with no edits returns the row untouched without writing", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const existing = customSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
-      existing,
-    );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(existing);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrgForWrite",
+    ).mockResolvedValue(existing);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(existing);
     try {
       const result = await new ElizaSandboxService().updateAgentProfile(
         existing.id,
@@ -5265,8 +6281,14 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
   test("updateAgentEnvironment writes through the at-rest encryption boundary (org-scoped read, repo update)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const existing = customSandbox();
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(existing);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(existing);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockImplementation(
       async (_id, updates) => ({ ...existing, ...updates }) as AgentSandbox,
     );
     try {
@@ -5285,7 +6307,9 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
       if (!result) {
         throw new Error("Expected the updated sandbox environment row");
       }
-      expect((result.environment_vars as Record<string, string>).MY_FLAG).toBe("on");
+      expect((result.environment_vars as Record<string, string>).MY_FLAG).toBe(
+        "on",
+      );
     } finally {
       findSpy.mockRestore();
       updateSpy.mockRestore();
@@ -5294,8 +6318,14 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
 
   test("updateAgentEnvironment returns undefined for an unknown agent and writes nothing", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(undefined);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(undefined);
+    const findSpy = spyOn(
+      agentSandboxesRepository,
+      "findByIdAndOrg",
+    ).mockResolvedValue(undefined);
+    const updateSpy = spyOn(
+      agentSandboxesRepository,
+      "update",
+    ).mockResolvedValue(undefined);
     try {
       const result = await new ElizaSandboxService().updateAgentEnvironment(
         "dddddddd-9999-4999-8999-999999999999",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -45,7 +45,10 @@ import {
   incrementalChainDepth,
   planIncrementalBackup,
 } from "./agent-backup-diff";
-import { decryptAgentEnvVars, encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
+import {
+  decryptAgentEnvVars,
+  encryptAgentEnvVarsForStorage,
+} from "./agent-env-crypto";
 import {
   type AIUsage,
   type BillingContext,
@@ -57,7 +60,10 @@ import {
 } from "./ai-billing";
 import { aiBillingRecordsService } from "./ai-billing-records";
 import { apiKeysService } from "./api-keys";
-import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
+import {
+  imageRequiresDigestPin,
+  isCodingContainerImageAllowed,
+} from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
 import { shellQuote } from "./docker-sandbox-utils";
@@ -84,6 +90,7 @@ import {
   type SandboxProvider,
 } from "./sandbox-provider";
 import { isDedicatedBootstrapWindow } from "./shared-runtime/dedicated-bootstrap";
+import { getCachedSharedAgentRunningSandbox } from "./shared-runtime/resolve-shared-agent";
 import {
   type RunSharedAgentTurnResult,
   resolveSharedAgentTurnModel,
@@ -191,7 +198,9 @@ export class AgentQuotaExceededError extends Error {
  * and column defaults cannot drift between paths. `environmentVars` is expected
  * storage-ready (already passed through `encryptAgentEnvVarsForStorage`).
  */
-export function buildAgentSandboxInsertValues(params: CreateAgentParams): NewAgentSandbox {
+export function buildAgentSandboxInsertValues(
+  params: CreateAgentParams,
+): NewAgentSandbox {
   const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
   const agentConfig = params.characterId
     ? withReusedElizaCharacterOwnership(sanitizedConfig)
@@ -281,7 +290,12 @@ export function assertAgentImageAllowed(dockerImage: string | undefined): void {
     });
     throw new AgentImageNotAllowedError(dockerImage, "not_allowlisted");
   }
-  if (imageRequiresDigestPin(dockerImage, containersEnv.requireDigestPinnedImages())) {
+  if (
+    imageRequiresDigestPin(
+      dockerImage,
+      containersEnv.requireDigestPinnedImages(),
+    )
+  ) {
     logger.warn("[agent-sandbox] docker image rejected: digest pin required", {
       image: dockerImage,
     });
@@ -298,7 +312,9 @@ function resolveManagedProvisionDockerImage(
   // reprovision they must follow the operator's current image so recovery does
   // not replay an old broken sha tag forever.
   if (!storedImage) return configuredImage;
-  return imageRepo(storedImage) === imageRepo(configuredImage) ? configuredImage : storedImage;
+  return imageRepo(storedImage) === imageRepo(configuredImage)
+    ? configuredImage
+    : storedImage;
 }
 
 /**
@@ -344,8 +360,7 @@ export type ProvisionResult =
  * default latest-backup auto-restore.
  */
 export type ProvisionRestoreOverride =
-  | { kind: "from-backup"; backupId: string }
-  | { kind: "fresh-boot" };
+  { kind: "from-backup"; backupId: string } | { kind: "fresh-boot" };
 
 export type DeleteAgentResult =
   | { success: true; deletedSandbox: AgentSandbox }
@@ -358,9 +373,7 @@ export type DeleteAgentResult =
  * hard cap and was abandoned (see `runBoundedSandboxStop`).
  */
 export type BoundedSandboxStopResult =
-  | null
-  | { error: unknown }
-  | { error: unknown; timedOut: true };
+  null | { error: unknown } | { error: unknown; timedOut: true };
 
 export interface BridgeRequest {
   jsonrpc: "2.0";
@@ -375,7 +388,9 @@ export interface BridgeRequest {
  * Routes pass `c.executionCtx`; non-Worker callers (tests, Node) omit it and
  * the tail runs inline, preserving fully-synchronous settlement.
  */
-export type BridgeExecutionContext = { waitUntil(promise: Promise<unknown>): void };
+export type BridgeExecutionContext = {
+  waitUntil(promise: Promise<unknown>): void;
+};
 
 /**
  * JSON-RPC error code for a shared-runtime turn rejected by the credit
@@ -429,7 +444,8 @@ export interface SnapshotResult {
  * against such an agent is a no-op, not a failure, so the snapshot job treats
  * this exactly like "Sandbox is not running": skip without burning retries.
  */
-export const SNAPSHOT_ENDPOINT_UNSUPPORTED = "Snapshot endpoint not supported by agent image";
+export const SNAPSHOT_ENDPOINT_UNSUPPORTED =
+  "Snapshot endpoint not supported by agent image";
 
 const MAX_BACKUPS = 10;
 const SHARED_RUNTIME_HISTORY_MAX_MESSAGES = 40;
@@ -475,7 +491,12 @@ type LifecycleTx = Parameters<Parameters<Database["transaction"]>[0]>[0];
 /** Columns the tailnet-IP reconcile path reads to locate and repair an agent. */
 type ReconcilableSandbox = Pick<
   AgentSandbox,
-  "id" | "node_id" | "container_name" | "environment_vars" | "bridge_url" | "headscale_ip"
+  | "id"
+  | "node_id"
+  | "container_name"
+  | "environment_vars"
+  | "bridge_url"
+  | "headscale_ip"
 >;
 
 /** Outcome of a stale-tailnet-IP reconcile attempt (see reconcileStaleTailnetIp). */
@@ -489,11 +510,14 @@ function digestPinnedImageRef(imageRef: string, digest: string): string {
   if (imageRef.includes("@sha256:")) return imageRef;
   const lastColon = imageRef.lastIndexOf(":");
   const lastSlash = imageRef.lastIndexOf("/");
-  const withoutTag = lastColon > lastSlash ? imageRef.slice(0, lastColon) : imageRef;
+  const withoutTag =
+    lastColon > lastSlash ? imageRef.slice(0, lastColon) : imageRef;
   return `${withoutTag}@${digest}`;
 }
 
-function isDockerSandboxMetadata(value: unknown): value is DockerSandboxMetadata {
+function isDockerSandboxMetadata(
+  value: unknown,
+): value is DockerSandboxMetadata {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -560,17 +584,21 @@ type AgentNetworkTarget = Pick<
   | "sandbox_id"
 >;
 
-type AgentApiTarget = AgentNetworkTarget & Pick<AgentSandbox, "environment_vars">;
+type AgentApiTarget = AgentNetworkTarget &
+  Pick<AgentSandbox, "environment_vars">;
 
 type AgentFetchTarget = {
   url: string;
   forwardedHost?: string;
 };
 
-const AGENT_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+const AGENT_ID_RE =
+  /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 class AgentRouterConfigurationError extends Error {
-  constructor(variable: "AGENT_ROUTER_ORIGIN_HOST" | "ELIZA_CLOUD_AGENT_BASE_DOMAIN") {
+  constructor(
+    variable: "AGENT_ROUTER_ORIGIN_HOST" | "ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+  ) {
     super(`Worker agent routing requires a valid ${variable}`);
     this.name = "AgentRouterConfigurationError";
   }
@@ -608,7 +636,8 @@ export function computeManagedAgentDbEnv(
   dbUri: string,
 ): Record<string, string> {
   const callerSuppliedDatabaseUrl =
-    typeof callerEnv.DATABASE_URL === "string" && callerEnv.DATABASE_URL.trim().length > 0;
+    typeof callerEnv.DATABASE_URL === "string" &&
+    callerEnv.DATABASE_URL.trim().length > 0;
   const wantsLocalState = callerEnv.ELIZA_AGENT_LOCAL_STATE === "1";
   return callerSuppliedDatabaseUrl || wantsLocalState
     ? { ELIZA_MANAGED_DATABASE_URL: dbUri }
@@ -674,9 +703,12 @@ const SNAPSHOT_HTTP_ERROR_SHAPE =
  */
 export function isUnrecoverableSnapshotError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
+  if (error.name === "AeadError" || error.name === "KeyNotFoundError")
+    return true;
   const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
-  return match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
+  return (
+    match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]))
+  );
 }
 
 /**
@@ -698,9 +730,13 @@ export function isUnrecoverableSnapshotError(error: unknown): boolean {
  */
 export function isPermanentlyLostSnapshot(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
+  if (error.name === "AeadError" || error.name === "KeyNotFoundError")
+    return true;
   const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
-  return match !== null && PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
+  return (
+    match !== null &&
+    PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]))
+  );
 }
 
 export class ElizaSandboxService {
@@ -724,7 +760,9 @@ export class ElizaSandboxService {
     return this._providerPromise;
   }
 
-  private getAgentApiToken(rec: Pick<AgentSandbox, "id" | "environment_vars">): string | undefined {
+  private getAgentApiToken(
+    rec: Pick<AgentSandbox, "id" | "environment_vars">,
+  ): string | undefined {
     const envVars = rec.environment_vars as Record<string, string> | null;
     const apiToken =
       envVars?.ELIZA_API_TOKEN?.trim() ||
@@ -739,7 +777,9 @@ export class ElizaSandboxService {
     return apiToken;
   }
 
-  private getAgentJsonHeaders(rec: Pick<AgentSandbox, "id" | "environment_vars">) {
+  private getAgentJsonHeaders(
+    rec: Pick<AgentSandbox, "id" | "environment_vars">,
+  ) {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
@@ -753,9 +793,12 @@ export class ElizaSandboxService {
   }
 
   private getRuntimeAgentsFromBody(body: unknown): RuntimeAgentSummary[] {
-    const root = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+    const root =
+      body && typeof body === "object" ? (body as Record<string, unknown>) : {};
     const data =
-      root.data && typeof root.data === "object" ? (root.data as Record<string, unknown>) : {};
+      root.data && typeof root.data === "object"
+        ? (root.data as Record<string, unknown>)
+        : {};
     const rawAgents = Array.isArray(root.agents)
       ? root.agents
       : Array.isArray(data.agents)
@@ -777,7 +820,9 @@ export class ElizaSandboxService {
           status: typeof agent.status === "string" ? agent.status : undefined,
         };
       })
-      .filter((agent): agent is RuntimeAgentSummary => Boolean(agent?.id || agent?.name));
+      .filter((agent): agent is RuntimeAgentSummary =>
+        Boolean(agent?.id || agent?.name),
+      );
   }
 
   private isRuntimeAgentReady(agent: RuntimeAgentSummary | undefined): boolean {
@@ -786,7 +831,9 @@ export class ElizaSandboxService {
     return status === "active" || status === "running" || status === "ready";
   }
 
-  private selectRuntimeAgent(agents: RuntimeAgentSummary[]): RuntimeAgentSummary | undefined {
+  private selectRuntimeAgent(
+    agents: RuntimeAgentSummary[],
+  ): RuntimeAgentSummary | undefined {
     return agents.find((agent) => this.isRuntimeAgentReady(agent)) ?? agents[0];
   }
 
@@ -816,16 +863,26 @@ export class ElizaSandboxService {
     }
     return {
       supported: true,
-      agents: this.getRuntimeAgentsFromBody(await agentsRes.json().catch(() => ({}))),
+      agents: this.getRuntimeAgentsFromBody(
+        await agentsRes.json().catch(() => ({})),
+      ),
     };
   }
 
   private buildRuntimeBootstrapAgent(
-    rec: Pick<AgentSandbox, "id" | "agent_name" | "agent_config" | "environment_vars">,
+    rec: Pick<
+      AgentSandbox,
+      "id" | "agent_name" | "agent_config" | "environment_vars"
+    >,
   ) {
     const rawConfig =
-      rec.agent_config && typeof rec.agent_config === "object" && !Array.isArray(rec.agent_config)
-        ? ({ ...(rec.agent_config as Record<string, unknown>) } as Record<string, unknown>)
+      rec.agent_config &&
+      typeof rec.agent_config === "object" &&
+      !Array.isArray(rec.agent_config)
+        ? ({ ...(rec.agent_config as Record<string, unknown>) } as Record<
+            string,
+            unknown
+          >)
         : {};
     const rawName =
       typeof rawConfig.name === "string" && rawConfig.name.trim()
@@ -839,19 +896,28 @@ export class ElizaSandboxService {
       rawConfig.settings &&
       typeof rawConfig.settings === "object" &&
       !Array.isArray(rawConfig.settings)
-        ? ({ ...(rawConfig.settings as Record<string, unknown>) } as Record<string, unknown>)
+        ? ({ ...(rawConfig.settings as Record<string, unknown>) } as Record<
+            string,
+            unknown
+          >)
         : {};
     const rawSecrets =
       rawSettings.secrets &&
       typeof rawSettings.secrets === "object" &&
       !Array.isArray(rawSettings.secrets)
-        ? ({ ...(rawSettings.secrets as Record<string, unknown>) } as Record<string, unknown>)
+        ? ({ ...(rawSettings.secrets as Record<string, unknown>) } as Record<
+            string,
+            unknown
+          >)
         : {};
     const environmentVars =
       rec.environment_vars && typeof rec.environment_vars === "object"
         ? (rec.environment_vars as Record<string, string>)
         : {};
-    const secrets = mergeRuntimeAgentSecretsFromEnv({ rawSecrets, environmentVars });
+    const secrets = mergeRuntimeAgentSecretsFromEnv({
+      rawSecrets,
+      environmentVars,
+    });
     const settings = {
       ...rawSettings,
       secrets,
@@ -881,13 +947,17 @@ export class ElizaSandboxService {
           ? rawConfig.bio
           : [`${rawName} is a helpful Eliza Cloud agent.`],
       topics:
-        Array.isArray(rawConfig.topics) && rawConfig.topics.length > 0 ? rawConfig.topics : [],
+        Array.isArray(rawConfig.topics) && rawConfig.topics.length > 0
+          ? rawConfig.topics
+          : [],
       adjectives:
         Array.isArray(rawConfig.adjectives) && rawConfig.adjectives.length > 0
           ? rawConfig.adjectives
           : [],
       style:
-        rawConfig.style && typeof rawConfig.style === "object" && !Array.isArray(rawConfig.style)
+        rawConfig.style &&
+        typeof rawConfig.style === "object" &&
+        !Array.isArray(rawConfig.style)
           ? rawConfig.style
           : undefined,
       plugins,
@@ -965,7 +1035,10 @@ export class ElizaSandboxService {
     const createRes = await this.fetchAgentApi(rec, "/api/agents", {
       method: "POST",
       body: JSON.stringify({
-        agent: this.buildRuntimeBootstrapAgent({ ...rec, environment_vars: pooledEnv }),
+        agent: this.buildRuntimeBootstrapAgent({
+          ...rec,
+          environment_vars: pooledEnv,
+        }),
       }),
       signal: AbortSignal.timeout(60_000),
     });
@@ -973,9 +1046,14 @@ export class ElizaSandboxService {
       throw new Error(`Runtime agent create returned HTTP ${createRes.status}`);
     }
 
-    const body = (await createRes.json().catch(() => ({}))) as Record<string, unknown>;
+    const body = (await createRes.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
     const data =
-      body.data && typeof body.data === "object" ? (body.data as Record<string, unknown>) : {};
+      body.data && typeof body.data === "object"
+        ? (body.data as Record<string, unknown>)
+        : {};
     const runtimeAgentId = typeof data.id === "string" ? data.id : undefined;
     if (!runtimeAgentId) {
       throw new Error("Runtime agent create response was missing data.id");
@@ -1012,7 +1090,8 @@ export class ElizaSandboxService {
 
     const afterStart = await this.listRuntimeAgents(rec);
     const started =
-      afterStart.agents.find((agent) => agent.id === runtimeAgentId) ?? afterStart.agents[0];
+      afterStart.agents.find((agent) => agent.id === runtimeAgentId) ??
+      afterStart.agents[0];
     if (!this.isRuntimeAgentReady(started)) {
       throw new Error("Runtime agent did not become active after start");
     }
@@ -1020,7 +1099,11 @@ export class ElizaSandboxService {
   }
 
   private stableBridgeUuid(raw: string): string {
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(raw)) {
+    if (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        raw,
+      )
+    ) {
       return raw;
     }
     const hash = crypto.createHash("sha256").update(raw).digest("hex");
@@ -1040,7 +1123,10 @@ export class ElizaSandboxService {
     return this.stableBridgeUuid(raw);
   }
 
-  private stableBridgeChannelId(agentId: string, params: Record<string, unknown>): string {
+  private stableBridgeChannelId(
+    agentId: string,
+    params: Record<string, unknown>,
+  ): string {
     const raw =
       typeof params.roomId === "string" && params.roomId.trim()
         ? params.roomId.trim()
@@ -1071,7 +1157,10 @@ export class ElizaSandboxService {
 
     // Caller-supplied env can carry BYO secrets — encrypt them before the row
     // is inserted (#11332), mirroring updateAgentEnvironment.
-    if (params.environmentVars && Object.keys(params.environmentVars).length > 0) {
+    if (
+      params.environmentVars &&
+      Object.keys(params.environmentVars).length > 0
+    ) {
       params = {
         ...params,
         environmentVars: await encryptAgentEnvVarsForStorage(
@@ -1098,7 +1187,9 @@ export class ElizaSandboxService {
       // uses and refuse past the cap.
       const cap = params.maxNonTerminalAgents;
       return dbWrite.transaction(async (tx) => {
-        await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
+        await tx.execute(
+          elizaAgentCreateAdvisoryLockSql(params.organizationId),
+        );
         await assertOrgAgentQuota(tx, params.organizationId, cap);
 
         const [created] = await tx
@@ -1143,7 +1234,11 @@ export class ElizaSandboxService {
       // (#11023 residual). Enforce the same per-org ceiling, still under the
       // org advisory lock.
       if (params.maxNonTerminalAgents !== undefined) {
-        await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
+        await assertOrgAgentQuota(
+          tx,
+          params.organizationId,
+          params.maxNonTerminalAgents,
+        );
       }
 
       const [created] = await tx
@@ -1155,7 +1250,9 @@ export class ElizaSandboxService {
     });
   }
 
-  async createCodingContainerAgent(params: CreateAgentParams & { dockerImage: string }): Promise<{
+  async createCodingContainerAgent(
+    params: CreateAgentParams & { dockerImage: string },
+  ): Promise<{
     agent: AgentSandbox;
     idempotent: boolean;
   }> {
@@ -1165,7 +1262,10 @@ export class ElizaSandboxService {
       // Coding-container env carries caller secrets (tokens, provider keys) —
       // encrypt them before the row is inserted (#11332).
       environmentVars: params.environmentVars
-        ? await encryptAgentEnvVarsForStorage(params.organizationId, params.environmentVars)
+        ? await encryptAgentEnvVarsForStorage(
+            params.organizationId,
+            params.environmentVars,
+          )
         : params.environmentVars,
     };
 
@@ -1182,7 +1282,9 @@ export class ElizaSandboxService {
       // quota count below would not be atomic without the org lock. Taking the
       // org lock first everywhere gives a strict org→image lock order, so this
       // path and createAgent (org lock only) can never deadlock. (#11023)
-      await tx.execute(elizaAgentCreateAdvisoryLockSql(createParams.organizationId));
+      await tx.execute(
+        elizaAgentCreateAdvisoryLockSql(createParams.organizationId),
+      );
       await tx.execute(
         elizaCodingContainerImageAdvisoryLockSql(
           createParams.organizationId,
@@ -1228,7 +1330,8 @@ export class ElizaSandboxService {
         .insert(agentSandboxes)
         .values(buildAgentSandboxInsertValues(createParams))
         .returning();
-      if (!created) throw new Error("Failed to create coding-container agent record");
+      if (!created)
+        throw new Error("Failed to create coding-container agent record");
       return { agent: created, idempotent: false };
     });
   }
@@ -1252,7 +1355,10 @@ export class ElizaSandboxService {
     // the materialization paths (provision / fleet upgrade / runtime
     // bootstrap) decrypt, so the running agent still sees real values.
     return agentSandboxesRepository.update(rec.id, {
-      environment_vars: await encryptAgentEnvVarsForStorage(orgId, environmentVars),
+      environment_vars: await encryptAgentEnvVarsForStorage(
+        orgId,
+        environmentVars,
+      ),
     });
   }
 
@@ -1268,14 +1374,22 @@ export class ElizaSandboxService {
     orgId: string,
     input: { agentName?: string; agentConfig?: Record<string, unknown> },
   ): Promise<AgentSandbox | undefined> {
-    const rec = await agentSandboxesRepository.findByIdAndOrgForWrite(agentId, orgId);
+    const rec = await agentSandboxesRepository.findByIdAndOrgForWrite(
+      agentId,
+      orgId,
+    );
     if (!rec) return undefined;
 
-    const updates: { agent_name?: string; agent_config?: Record<string, unknown> } = {};
+    const updates: {
+      agent_name?: string;
+      agent_config?: Record<string, unknown>;
+    } = {};
     if (input.agentName !== undefined) updates.agent_name = input.agentName;
     if (input.agentConfig !== undefined) {
       const existing =
-        rec.agent_config && typeof rec.agent_config === "object" && !Array.isArray(rec.agent_config)
+        rec.agent_config &&
+        typeof rec.agent_config === "object" &&
+        !Array.isArray(rec.agent_config)
           ? (rec.agent_config as Record<string, unknown>)
           : {};
       updates.agent_config = { ...existing, ...input.agentConfig };
@@ -1293,7 +1407,10 @@ export class ElizaSandboxService {
     return agentSandboxesRepository.listByOrganization(orgId);
   }
 
-  async deleteAgent(agentId: string, orgId: string): Promise<DeleteAgentResult> {
+  async deleteAgent(
+    agentId: string,
+    orgId: string,
+  ): Promise<DeleteAgentResult> {
     // Phase 1 — short transaction: take the lifecycle lock, validate
     // preconditions, and capture the fields needed for teardown. We deliberately
     // do NOT run the container teardown inside this transaction: provider.stop()
@@ -1328,7 +1445,8 @@ export class ElizaSandboxService {
       const stop = await this.runBoundedSandboxStop(sandboxId);
 
       if (stop) {
-        const errorMessage = stop.error instanceof Error ? stop.error.message : String(stop.error);
+        const errorMessage =
+          stop.error instanceof Error ? stop.error.message : String(stop.error);
         if ("timedOut" in stop) {
           // HONEST LIMITATION: there is currently NO automatic reclaimer — no
           // orphan-sweep / node-reconcile job that lists actual containers on a
@@ -1345,11 +1463,14 @@ export class ElizaSandboxService {
             { sandboxId, status: precheck.status, error: errorMessage },
           );
         } else if (this.isIgnorableSandboxStopError(stop.error)) {
-          logger.info("[agent-sandbox] Sandbox already absent during delete cleanup", {
-            sandboxId,
-            status: precheck.status,
-            error: errorMessage,
-          });
+          logger.info(
+            "[agent-sandbox] Sandbox already absent during delete cleanup",
+            {
+              sandboxId,
+              status: precheck.status,
+              error: errorMessage,
+            },
+          );
         } else {
           logger.warn("[agent-sandbox] Stop failed during delete", {
             sandboxId,
@@ -1384,18 +1505,25 @@ export class ElizaSandboxService {
       // orphaned forever after the agent is gone. A failure here leaves stale
       // rows but never un-deletes the (already gone) sandbox.
       try {
-        const removed = await sharedRuntimeHistoryRepository.deleteByAgent(agentId);
+        const removed =
+          await sharedRuntimeHistoryRepository.deleteByAgent(agentId);
         if (removed > 0) {
-          logger.info("[agent-sandbox] Cleaned up shared-runtime history after delete", {
-            agentId,
-            channelsRemoved: removed,
-          });
+          logger.info(
+            "[agent-sandbox] Cleaned up shared-runtime history after delete",
+            {
+              agentId,
+              channelsRemoved: removed,
+            },
+          );
         }
       } catch (err) {
-        logger.warn("[agent-sandbox] Failed to clean up shared-runtime history", {
-          agentId,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        logger.warn(
+          "[agent-sandbox] Failed to clean up shared-runtime history",
+          {
+            agentId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
       }
     }
 
@@ -1422,12 +1550,23 @@ export class ElizaSandboxService {
       const rec = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
       if (!rec) return { ok: false as const, error: "Agent not found" };
 
-      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(
+        tx,
+        agentId,
+        orgId,
+      );
       if (rec.status === "provisioning" || hasActiveProvisionJob) {
-        return { ok: false as const, error: "Agent provisioning is in progress" };
+        return {
+          ok: false as const,
+          error: "Agent provisioning is in progress",
+        };
       }
 
-      return { ok: true as const, sandboxId: rec.sandbox_id, status: rec.status };
+      return {
+        ok: true as const,
+        sandboxId: rec.sandbox_id,
+        status: rec.status,
+      };
     });
   }
 
@@ -1436,14 +1575,21 @@ export class ElizaSandboxService {
    * the lifecycle lock, re-validates (a concurrent provision could have started
    * while the out-of-transaction teardown ran), then deletes the sandbox row.
    */
-  private async commitAgentRowDelete(agentId: string, orgId: string): Promise<DeleteAgentResult> {
+  private async commitAgentRowDelete(
+    agentId: string,
+    orgId: string,
+  ): Promise<DeleteAgentResult> {
     return dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, orgId);
 
       const rec = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
       if (!rec) return { success: false, error: "Agent not found" } as const;
 
-      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(
+        tx,
+        agentId,
+        orgId,
+      );
       if (rec.status === "provisioning" || hasActiveProvisionJob) {
         return {
           success: false,
@@ -1472,7 +1618,9 @@ export class ElizaSandboxService {
    * or `{ error, timedOut: true }` when the teardown hit the hard cap (in which
    * case the container is abandoned and leaks — there is no reclaimer).
    */
-  private async runBoundedSandboxStop(sandboxId: string): Promise<BoundedSandboxStopResult> {
+  private async runBoundedSandboxStop(
+    sandboxId: string,
+  ): Promise<BoundedSandboxStopResult> {
     return withTimeout(
       (async (): Promise<null | { error: unknown }> => {
         try {
@@ -1532,19 +1680,28 @@ export class ElizaSandboxService {
     // HTTP request context. Best-effort: a failure here leaves an orphan
     // row but does not un-delete the (already gone) sandbox.
     const characterId = result.deletedSandbox.character_id;
-    if (characterId && !reusesExistingElizaCharacter(result.deletedSandbox.agent_config)) {
+    if (
+      characterId &&
+      !reusesExistingElizaCharacter(result.deletedSandbox.agent_config)
+    ) {
       try {
         await userCharactersRepository.delete(characterId);
-        logger.info("[agent-sandbox] Cleaned up linked character after delete", {
-          agentId,
-          characterId,
-        });
+        logger.info(
+          "[agent-sandbox] Cleaned up linked character after delete",
+          {
+            agentId,
+            characterId,
+          },
+        );
       } catch (charErr) {
-        logger.warn("[agent-sandbox] Linked character cleanup failed after delete", {
-          agentId,
-          characterId,
-          error: charErr instanceof Error ? charErr.message : String(charErr),
-        });
+        logger.warn(
+          "[agent-sandbox] Linked character cleanup failed after delete",
+          {
+            agentId,
+            characterId,
+            error: charErr instanceof Error ? charErr.message : String(charErr),
+          },
+        );
       }
     }
 
@@ -1576,7 +1733,8 @@ export class ElizaSandboxService {
     restoreOverride?: ProvisionRestoreOverride,
   ): Promise<ProvisionResult> {
     let rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
-    if (!rec) return { success: false, error: "Agent not found" } as ProvisionResult;
+    if (!rec)
+      return { success: false, error: "Agent not found" } as ProvisionResult;
 
     const previousStatus = rec.status;
     const lock = await agentSandboxesRepository.trySetProvisioning(rec.id);
@@ -1610,7 +1768,10 @@ export class ElizaSandboxService {
       }
       dbUri = db.connectionUri!;
       // DB assignment updates the row but doesn't return the full record; re-fetch to avoid stale data
-      const refreshed = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+      const refreshed = await agentSandboxesRepository.findByIdAndOrg(
+        agentId,
+        orgId,
+      );
       if (refreshed) {
         rec = refreshed;
       }
@@ -1622,7 +1783,9 @@ export class ElizaSandboxService {
       userId: rec.user_id,
       sandboxId: agentId,
     });
-    const containerLaunch = resolveSandboxContainerLaunchConfig(rec.agent_config);
+    const containerLaunch = resolveSandboxContainerLaunchConfig(
+      rec.agent_config,
+    );
 
     if (managedEnvironment.changed) {
       const updatedEnvRecord = await agentSandboxesRepository.update(rec.id, {
@@ -1645,7 +1808,9 @@ export class ElizaSandboxService {
     // Solution: Retry loop catches unique constraint errors, cleans up ghost container, and retries.
     const MAX_PROVISION_ATTEMPTS = 3;
     let lastError: string = "Unknown error";
-    const provisionDockerImage = resolveManagedProvisionDockerImage(rec.docker_image);
+    const provisionDockerImage = resolveManagedProvisionDockerImage(
+      rec.docker_image,
+    );
 
     // Materialize the stored env for the container: BYO secrets are encrypted
     // at rest (#11332); compatibility plaintext values pass through unchanged. A
@@ -1658,7 +1823,8 @@ export class ElizaSandboxService {
         (rec.environment_vars as Record<string, string>) ?? {},
       );
     } catch (envError) {
-      const message = envError instanceof Error ? envError.message : String(envError);
+      const message =
+        envError instanceof Error ? envError.message : String(envError);
       await this.markError(rec, `Environment decryption failed: ${message}`);
       return {
         success: false,
@@ -1677,10 +1843,13 @@ export class ElizaSandboxService {
             : null;
         if (retryHandle) {
           handle = retryHandle;
-          logger.info("[agent-sandbox] Re-probing persisted provisioning container before create", {
-            agentId: rec.id,
-            sandboxId: handle.sandboxId,
-          });
+          logger.info(
+            "[agent-sandbox] Re-probing persisted provisioning container before create",
+            {
+              agentId: rec.id,
+              sandboxId: handle.sandboxId,
+            },
+          );
         } else {
           // 2. Sandbox (via provider)
           const callerEnv = materializedEnv;
@@ -1693,7 +1862,9 @@ export class ElizaSandboxService {
           // the caller did NOT supply one do we inject the managed URL as
           // DATABASE_URL — the normal managed-agent path, byte-identical to before.
           const dbEnv = computeManagedAgentDbEnv(callerEnv, dbUri);
-          handle = await (await this.getProvider()).create({
+          handle = await (
+            await this.getProvider()
+          ).create({
             agentId: rec.id,
             agentName: rec.agent_name ?? "CloudAgent",
             organizationId: rec.organization_id,
@@ -1746,7 +1917,9 @@ export class ElizaSandboxService {
               verdict: "not_ready" as const,
             };
 
-        const dockerMeta = isDockerSandboxMetadata(handle.metadata) ? handle.metadata : undefined;
+        const dockerMeta = isDockerSandboxMetadata(handle.metadata)
+          ? handle.metadata
+          : undefined;
 
         if (!health.ready) {
           if (health.verdict === "transport_unresolved") {
@@ -1762,7 +1935,11 @@ export class ElizaSandboxService {
             //       collision, and tearing down the very container we preserved.
             // Without this write the leave-and-reconcile path is defeated for
             // exactly the SSH-transport-blip case it exists for.
-            await this.persistContainerHandleForRetry(rec.id, handle, dockerMeta);
+            await this.persistContainerHandleForRetry(
+              rec.id,
+              handle,
+              dockerMeta,
+            );
             throw new SandboxTransportUnresolvedError(
               "Sandbox readiness probe could not reach the container (SSH transport unresolved); " +
                 "leaving the container in place for retry/reconciliation",
@@ -1835,7 +2012,9 @@ export class ElizaSandboxService {
         // failure still flips the row out of 'running' via the catch below
         // (ghost cleanup → retry or markError), so 'running' never sticks on a
         // failed provision.
-        const updateData: Parameters<typeof agentSandboxesRepository.update>[1] = {
+        const updateData: Parameters<
+          typeof agentSandboxesRepository.update
+        >[1] = {
           status: "running",
           sandbox_id: handle.sandboxId,
           bridge_url: handle.bridgeUrl,
@@ -1846,11 +2025,16 @@ export class ElizaSandboxService {
 
         if (dockerMeta) {
           if (dockerMeta.nodeId) updateData.node_id = dockerMeta.nodeId;
-          if (dockerMeta.containerName) updateData.container_name = dockerMeta.containerName;
-          if (dockerMeta.bridgePort) updateData.bridge_port = dockerMeta.bridgePort;
-          if (dockerMeta.webUiPort) updateData.web_ui_port = dockerMeta.webUiPort;
-          if (dockerMeta.headscaleIp) updateData.headscale_ip = dockerMeta.headscaleIp;
-          if (dockerMeta.dockerImage) updateData.docker_image = dockerMeta.dockerImage;
+          if (dockerMeta.containerName)
+            updateData.container_name = dockerMeta.containerName;
+          if (dockerMeta.bridgePort)
+            updateData.bridge_port = dockerMeta.bridgePort;
+          if (dockerMeta.webUiPort)
+            updateData.web_ui_port = dockerMeta.webUiPort;
+          if (dockerMeta.headscaleIp)
+            updateData.headscale_ip = dockerMeta.headscaleIp;
+          if (dockerMeta.dockerImage)
+            updateData.docker_image = dockerMeta.dockerImage;
           // Always overwrite the digest (including null) so a re-provision
           // onto a different image clears any stale value. The reconciler
           // treats null as "unknown, wait until probe succeeds before
@@ -1858,7 +2042,10 @@ export class ElizaSandboxService {
           updateData.image_digest = dockerMeta.imageDigest;
         }
 
-        const updated = await agentSandboxesRepository.update(rec.id, updateData);
+        const updated = await agentSandboxesRepository.update(
+          rec.id,
+          updateData,
+        );
 
         // Re-enter the billable set on every successful provision. A
         // credit-suspended agent (billing_status='suspended') that a user tops
@@ -1867,7 +2054,10 @@ export class ElizaSandboxService {
         // free dedicated compute forever. The service-key resume/restart routes
         // already reactivate; do it here so ALL provision paths re-enter billing.
         // Idempotent + exempt-guarded (ne billing_status 'exempt').
-        await agentBillingRepository.reactivateSandboxBillingAfterFunding(rec.id, new Date());
+        await agentBillingRepository.reactivateSandboxBillingAfterFunding(
+          rec.id,
+          new Date(),
+        );
 
         // 5. Restore from backup (reconstructs incrementals back to a full).
         //
@@ -1887,9 +2077,13 @@ export class ElizaSandboxService {
         // markError. A transient DB/IO/network/5xx error is rethrown so the
         // provision fails and the resume job retries rather than silently
         // discarding recoverable state.
-        let backup: Awaited<ReturnType<typeof agentSandboxesRepository.getLatestBackup>>;
+        let backup: Awaited<
+          ReturnType<typeof agentSandboxesRepository.getLatestBackup>
+        >;
         let restoreState: Awaited<
-          ReturnType<typeof agentSandboxesRepository.getReconstructedBackupState>
+          ReturnType<
+            typeof agentSandboxesRepository.getReconstructedBackupState
+          >
         >;
         if (restoreOverride?.kind === "fresh-boot") {
           // Explicit opt-in (wake forceFreshBoot): the caller accepted the
@@ -1897,14 +2091,19 @@ export class ElizaSandboxService {
           // chain stays intact for a later explicit restore.
           backup = undefined;
           restoreState = undefined;
-          logger.warn("[agent-sandbox] Backup restore skipped: explicit fresh boot requested", {
-            agentId: rec.id,
-          });
+          logger.warn(
+            "[agent-sandbox] Backup restore skipped: explicit fresh boot requested",
+            {
+              agentId: rec.id,
+            },
+          );
         } else {
           try {
             backup =
               restoreOverride?.kind === "from-backup"
-                ? await agentSandboxesRepository.getBackupById(restoreOverride.backupId)
+                ? await agentSandboxesRepository.getBackupById(
+                    restoreOverride.backupId,
+                  )
                 : await agentSandboxesRepository.getLatestBackup(rec.id);
             if (restoreOverride?.kind === "from-backup") {
               // Cross-sandbox ids are rejected here as defense in depth; the
@@ -1916,7 +2115,9 @@ export class ElizaSandboxService {
               }
             }
             restoreState = backup
-              ? await agentSandboxesRepository.getReconstructedBackupState(backup.id)
+              ? await agentSandboxesRepository.getReconstructedBackupState(
+                  backup.id,
+                )
               : undefined;
           } catch (error) {
             // An explicitly-requested backup must NEVER silently degrade to a
@@ -1937,7 +2138,8 @@ export class ElizaSandboxService {
               authRec: rec,
             });
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
+            const message =
+              error instanceof Error ? error.message : String(error);
             if (
               rec.execution_tier === "custom" &&
               message.startsWith("State restore failed: HTTP 404")
@@ -1958,16 +2160,23 @@ export class ElizaSandboxService {
               // than degrading (#15603 B6).
               throw error;
             } else if (isUnrecoverableSnapshotError(error)) {
-              await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
+              await this.degradeUnrecoverableSnapshot(
+                rec.id,
+                backup?.id,
+                error,
+              );
             } else {
               throw error;
             }
           }
         } else if (backup) {
-          logger.warn("[agent-sandbox] Backup restore skipped: reconstructed state was null", {
-            agentId: rec.id,
-            backupId: backup.id,
-          });
+          logger.warn(
+            "[agent-sandbox] Backup restore skipped: reconstructed state was null",
+            {
+              agentId: rec.id,
+              backupId: backup.id,
+            },
+          );
         }
 
         logger.info("[agent-sandbox] Provisioned", {
@@ -2007,19 +2216,27 @@ export class ElizaSandboxService {
           };
         }
 
-        logger.warn("[agent-sandbox] Post-create failure, cleaning up container", {
-          agentId: rec.id,
-          sandboxId: handle.sandboxId,
-          attempt,
-          error: msg,
-        });
-
-        await (await this.getProvider()).stop(handle.sandboxId).catch((stopErr) => {
-          logger.error("[agent-sandbox] Ghost container cleanup failed", {
+        logger.warn(
+          "[agent-sandbox] Post-create failure, cleaning up container",
+          {
+            agentId: rec.id,
             sandboxId: handle.sandboxId,
-            error: stopErr instanceof Error ? stopErr.message : String(stopErr),
+            attempt,
+            error: msg,
+          },
+        );
+
+        await (
+          await this.getProvider()
+        )
+          .stop(handle.sandboxId)
+          .catch((stopErr) => {
+            logger.error("[agent-sandbox] Ghost container cleanup failed", {
+              sandboxId: handle.sandboxId,
+              error:
+                stopErr instanceof Error ? stopErr.message : String(stopErr),
+            });
           });
-        });
 
         // Check if it's a unique constraint error (port collision) -> retry
         const isUniqueConstraintError =
@@ -2054,7 +2271,14 @@ export class ElizaSandboxService {
 
   private async getSafeBridgeEndpoint(
     sandboxOrBridgeUrl:
-      | Pick<AgentSandbox, "bridge_url" | "node_id" | "bridge_port" | "headscale_ip" | "sandbox_id">
+      | Pick<
+          AgentSandbox,
+          | "bridge_url"
+          | "node_id"
+          | "bridge_port"
+          | "headscale_ip"
+          | "sandbox_id"
+        >
       | string,
     path: string,
     options?: { trusted?: boolean },
@@ -2064,14 +2288,22 @@ export class ElizaSandboxService {
         return new URL(path, sandboxOrBridgeUrl).toString();
       }
 
-      return (await assertSafeOutboundUrl(new URL(path, sandboxOrBridgeUrl).toString())).toString();
+      return (
+        await assertSafeOutboundUrl(
+          new URL(path, sandboxOrBridgeUrl).toString(),
+        )
+      ).toString();
     }
 
-    const dockerBridgeBaseUrl = await this.getTrustedDockerBridgeBaseUrl(sandboxOrBridgeUrl);
+    const dockerBridgeBaseUrl =
+      await this.getTrustedDockerBridgeBaseUrl(sandboxOrBridgeUrl);
     if (
       dockerBridgeBaseUrl &&
       sandboxOrBridgeUrl.bridge_url &&
-      this.matchesTrustedDockerBridge(sandboxOrBridgeUrl.bridge_url, dockerBridgeBaseUrl)
+      this.matchesTrustedDockerBridge(
+        sandboxOrBridgeUrl.bridge_url,
+        dockerBridgeBaseUrl,
+      )
     ) {
       return new URL(path, dockerBridgeBaseUrl).toString();
     }
@@ -2085,7 +2317,9 @@ export class ElizaSandboxService {
     }
 
     return (
-      await assertSafeOutboundUrl(new URL(path, sandboxOrBridgeUrl.bridge_url).toString())
+      await assertSafeOutboundUrl(
+        new URL(path, sandboxOrBridgeUrl.bridge_url).toString(),
+      )
     ).toString();
   }
 
@@ -2117,7 +2351,8 @@ export class ElizaSandboxService {
     options: { allowPort: boolean },
   ): string {
     const raw = value?.trim();
-    if (!raw || raw.startsWith("//")) throw new AgentRouterConfigurationError(variable);
+    if (!raw || raw.startsWith("//"))
+      throw new AgentRouterConfigurationError(variable);
 
     let parsed: URL;
     try {
@@ -2318,7 +2553,8 @@ export class ElizaSandboxService {
     }
 
     const host =
-      sandbox.headscale_ip || (await dockerNodesRepository.findByNodeId(sandbox.node_id))?.hostname;
+      sandbox.headscale_ip ||
+      (await dockerNodesRepository.findByNodeId(sandbox.node_id))?.hostname;
     if (!host) {
       return null;
     }
@@ -2334,7 +2570,8 @@ export class ElizaSandboxService {
     }
 
     const host =
-      sandbox.headscale_ip || (await dockerNodesRepository.findByNodeId(sandbox.node_id))?.hostname;
+      sandbox.headscale_ip ||
+      (await dockerNodesRepository.findByNodeId(sandbox.node_id))?.hostname;
     if (!host) {
       return null;
     }
@@ -2359,7 +2596,10 @@ export class ElizaSandboxService {
       return false;
     }
 
-    if (candidate.protocol !== "http:" || !this.isAgentPrivateBridgeHost(candidate.hostname)) {
+    if (
+      candidate.protocol !== "http:" ||
+      !this.isAgentPrivateBridgeHost(candidate.hostname)
+    ) {
       return false;
     }
 
@@ -2381,8 +2621,12 @@ export class ElizaSandboxService {
     );
   }
 
-  private isLegacyDockerSandboxId(sandboxId: string | null | undefined): boolean {
-    return typeof sandboxId === "string" && /^agent-[0-9a-f-]{36}$/i.test(sandboxId);
+  private isLegacyDockerSandboxId(
+    sandboxId: string | null | undefined,
+  ): boolean {
+    return (
+      typeof sandboxId === "string" && /^agent-[0-9a-f-]{36}$/i.test(sandboxId)
+    );
   }
 
   private isAgentPrivateBridgeHost(hostname: string): boolean {
@@ -2390,7 +2634,9 @@ export class ElizaSandboxService {
       return false;
     }
 
-    const [first, second] = hostname.split(".").map((part) => Number.parseInt(part, 10));
+    const [first, second] = hostname
+      .split(".")
+      .map((part) => Number.parseInt(part, 10));
     // CGNAT (100.64.0.0/10)
     if (first === 100 && second >= 64 && second <= 127) return true;
     // RFC1918: 10.0.0.0/8
@@ -2427,7 +2673,8 @@ export class ElizaSandboxService {
     if (typeof value === "string" && value.trim()) return [value.trim()];
     if (!Array.isArray(value)) return [];
     return value.filter(
-      (item): item is string => typeof item === "string" && item.trim().length > 0,
+      (item): item is string =>
+        typeof item === "string" && item.trim().length > 0,
     );
   }
 
@@ -2482,7 +2729,11 @@ export class ElizaSandboxService {
     turn: RunSharedAgentTurnResult,
     estimatedInputTokens: number,
   ): AIUsage {
-    return this.sharedRuntimeBillingUsageForReply(turn.reply, turn.usage, estimatedInputTokens);
+    return this.sharedRuntimeBillingUsageForReply(
+      turn.reply,
+      turn.usage,
+      estimatedInputTokens,
+    );
   }
 
   private sharedRuntimeBillingUsageForReply(
@@ -2502,11 +2753,16 @@ export class ElizaSandboxService {
     };
   }
 
-  private async buildSharedRuntimeCharacter(rec: AgentSandbox): Promise<SharedAgentCharacter> {
+  private async buildSharedRuntimeCharacter(
+    rec: AgentSandbox,
+  ): Promise<SharedAgentCharacter> {
     const config = this.nestedBridgeRecord(rec.agent_config) ?? {};
     const configCharacter = this.nestedBridgeRecord(config.character) ?? config;
     const linkedCharacter = rec.character_id
-      ? await userCharactersRepository.findByIdInOrganization(rec.character_id, rec.organization_id)
+      ? await userCharactersRepository.findByIdInOrganization(
+          rec.character_id,
+          rec.organization_id,
+        )
       : undefined;
     const linkedSettings = this.nestedBridgeRecord(linkedCharacter?.settings);
 
@@ -2541,7 +2797,10 @@ export class ElizaSandboxService {
     };
   }
 
-  private async bridgeSharedStatus(rec: AgentSandbox, rpc: BridgeRequest): Promise<BridgeResponse> {
+  private async bridgeSharedStatus(
+    rec: AgentSandbox,
+    rpc: BridgeRequest,
+  ): Promise<BridgeResponse> {
     return {
       jsonrpc: "2.0",
       id: rpc.id,
@@ -2560,7 +2819,8 @@ export class ElizaSandboxService {
     rpc: BridgeRequest,
     executionCtx?: BridgeExecutionContext,
   ): Promise<BridgeResponse> {
-    const params = rpc.params && typeof rpc.params === "object" ? rpc.params : {};
+    const params =
+      rpc.params && typeof rpc.params === "object" ? rpc.params : {};
     const text = typeof params.text === "string" ? params.text : "";
     if (!text.trim()) {
       return {
@@ -2577,7 +2837,9 @@ export class ElizaSandboxService {
     ]);
     const billingModel = resolveSharedAgentTurnModel(character.model);
     const estimatedInputTokens = billingModel
-      ? estimateInputTokens(this.sharedRuntimeBillingPrompt(character, history, text))
+      ? estimateInputTokens(
+          this.sharedRuntimeBillingPrompt(character, history, text),
+        )
       : 0;
     const idempotencyKey = `shared-runtime:${rec.id}:${channelId}:${crypto.randomUUID()}`;
     const requestId = `shared-runtime-${crypto.randomUUID()}`;
@@ -2609,7 +2871,11 @@ export class ElizaSandboxService {
     };
     if (billingContext) {
       try {
-        reservation = await reserveCredits(billingContext, estimatedInputTokens, 500);
+        reservation = await reserveCredits(
+          billingContext,
+          estimatedInputTokens,
+          500,
+        );
       } catch (error) {
         if (error instanceof InsufficientCreditsError) {
           return {
@@ -2669,11 +2935,15 @@ export class ElizaSandboxService {
                 this.sharedRuntimeBillingUsage(turn, estimatedInputTokens),
               );
               const settlement = await settleReservation(billing.totalCost);
-              const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-                type: "chat",
-                content: turn.reply,
-                prompt: text,
-              });
+              const usageRecord = await recordUsageAnalytics(
+                billingContext,
+                billing,
+                {
+                  type: "chat",
+                  content: turn.reply,
+                  prompt: text,
+                },
+              );
               if (usageRecord) {
                 await aiBillingRecordsService
                   .record({
@@ -2684,10 +2954,16 @@ export class ElizaSandboxService {
                     reconciliation: settlement,
                   })
                   .catch((error) => {
-                    logger.error("[shared-runtime] AI billing audit record failed", {
-                      error: error instanceof Error ? error.message : String(error),
-                      agentId: rec.id,
-                    });
+                    logger.error(
+                      "[shared-runtime] AI billing audit record failed",
+                      {
+                        error:
+                          error instanceof Error
+                            ? error.message
+                            : String(error),
+                        agentId: rec.id,
+                      },
+                    );
                   });
               }
             } catch (error) {
@@ -2700,7 +2976,10 @@ export class ElizaSandboxService {
                 logger.error(
                   "[shared-runtime] deferred billing refund failed; sweep-credit-reservations will reclaim the hold",
                   {
-                    error: refundError instanceof Error ? refundError.message : String(refundError),
+                    error:
+                      refundError instanceof Error
+                        ? refundError.message
+                        : String(refundError),
                     agentId: rec.id,
                   },
                 );
@@ -2728,7 +3007,9 @@ export class ElizaSandboxService {
           // A deterministic navigation turn carries a VIEWS handoff so callers
           // that surface `actionResults` (the PWA) open the view. Omitted for
           // normal chat turns, so their result shape is unchanged.
-          ...(turn.navIntent ? { actionResults: [navIntentActionResult(turn.navIntent)] } : {}),
+          ...(turn.navIntent
+            ? { actionResults: [navIntentActionResult(turn.navIntent)] }
+            : {}),
         },
       };
     } catch (settleError) {
@@ -2743,10 +3024,13 @@ export class ElizaSandboxService {
     rpc: BridgeRequest,
     executionCtx?: BridgeExecutionContext,
   ): Promise<Response> {
-    const params = rpc.params && typeof rpc.params === "object" ? rpc.params : {};
+    const params =
+      rpc.params && typeof rpc.params === "object" ? rpc.params : {};
     const text = typeof params.text === "string" ? params.text : "";
     if (!text.trim()) {
-      return this.createBridgeSseErrorResponse("message.send requires params.text");
+      return this.createBridgeSseErrorResponse(
+        "message.send requires params.text",
+      );
     }
 
     const channelId = this.stableBridgeChannelId(rec.id, params);
@@ -2756,7 +3040,9 @@ export class ElizaSandboxService {
     ]);
     const billingModel = resolveSharedAgentTurnModel(character.model);
     const estimatedInputTokens = billingModel
-      ? estimateInputTokens(this.sharedRuntimeBillingPrompt(character, history, text))
+      ? estimateInputTokens(
+          this.sharedRuntimeBillingPrompt(character, history, text),
+        )
       : 0;
     const idempotencyKey = `shared-runtime:${rec.id}:${channelId}:${crypto.randomUUID()}`;
     const requestId = `shared-runtime-${crypto.randomUUID()}`;
@@ -2788,7 +3074,11 @@ export class ElizaSandboxService {
     };
     if (billingContext) {
       try {
-        reservation = await reserveCredits(billingContext, estimatedInputTokens, 500);
+        reservation = await reserveCredits(
+          billingContext,
+          estimatedInputTokens,
+          500,
+        );
       } catch (error) {
         // error-policy:J1 boundary translation — no SSE bytes exist before credit
         // reservation, so the HTTP route can still return the canonical 402.
@@ -2814,7 +3104,9 @@ export class ElizaSandboxService {
       const parts = turn.parts;
       if (!parts) {
         await settleReservation(0);
-        return this.createBridgeSseErrorResponse("Shared runtime stream did not start");
+        return this.createBridgeSseErrorResponse(
+          "Shared runtime stream did not start",
+        );
       }
 
       const messageId = crypto.randomUUID();
@@ -2855,9 +3147,17 @@ export class ElizaSandboxService {
               const nextHistory: SharedTurnMessage[] = [
                 ...history,
                 { role: "user", content: text.trim(), createdAt: sentAt },
-                { role: "assistant", content: finalReply, createdAt: sentAt + 1 },
+                {
+                  role: "assistant",
+                  content: finalReply,
+                  createdAt: sentAt + 1,
+                },
               ];
-              await this.saveSharedRuntimeHistory(rec.id, channelId, nextHistory);
+              await this.saveSharedRuntimeHistory(
+                rec.id,
+                channelId,
+                nextHistory,
+              );
               // A deterministic navigation turn ran NO model, so it must not be
               // billed — just refund the upfront hold. Only real LLM turns meter.
               if (turn.navIntent) {
@@ -2889,12 +3189,18 @@ export class ElizaSandboxService {
                         estimatedInputTokens,
                       ),
                     );
-                    const settlement = await settleReservation(billing.totalCost);
-                    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-                      type: "chat",
-                      content: finalReply,
-                      prompt: text,
-                    });
+                    const settlement = await settleReservation(
+                      billing.totalCost,
+                    );
+                    const usageRecord = await recordUsageAnalytics(
+                      billingContext,
+                      billing,
+                      {
+                        type: "chat",
+                        content: finalReply,
+                        prompt: text,
+                      },
+                    );
                     if (usageRecord) {
                       await aiBillingRecordsService
                         .record({
@@ -2905,10 +3211,16 @@ export class ElizaSandboxService {
                           reconciliation: settlement,
                         })
                         .catch((error) => {
-                          logger.error("[shared-runtime] AI billing audit record failed", {
-                            error: error instanceof Error ? error.message : String(error),
-                            agentId: rec.id,
-                          });
+                          logger.error(
+                            "[shared-runtime] AI billing audit record failed",
+                            {
+                              error:
+                                error instanceof Error
+                                  ? error.message
+                                  : String(error),
+                              agentId: rec.id,
+                            },
+                          );
                         });
                     }
                   } catch (error) {
@@ -2931,7 +3243,8 @@ export class ElizaSandboxService {
                       );
                     }
                     logger.error("[shared-runtime] billing failed", {
-                      error: error instanceof Error ? error.message : String(error),
+                      error:
+                        error instanceof Error ? error.message : String(error),
                       agentId: rec.id,
                     });
                   }
@@ -2949,7 +3262,9 @@ export class ElizaSandboxService {
                   }
                 : { messageId, text: finalReply };
               controller.enqueue(
-                encoder.encode(`event: done\ndata: ${JSON.stringify(doneData)}\n\n`),
+                encoder.encode(
+                  `event: done\ndata: ${JSON.stringify(doneData)}\n\n`,
+                ),
               );
             }
             if (!finished) {
@@ -3025,14 +3340,20 @@ export class ElizaSandboxService {
     agentId: string,
     orgId: string,
   ): Promise<SharedAgentCharacter | null> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
     if (rec && rec.execution_tier === "shared") {
       return this.buildSharedRuntimeCharacter(rec);
     }
     // Bootstrap window: a freshly-created dedicated agent (not yet "running", so
     // findRunningSandbox misses it) is served by the in-Worker shared runtime
     // until its container boots — return the same character the shared turn uses.
-    const bootstrap = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    const bootstrap = await agentSandboxesRepository.findByIdAndOrg(
+      agentId,
+      orgId,
+    );
     if (bootstrap && isDedicatedBootstrapWindow(bootstrap)) {
       return this.buildSharedRuntimeCharacter(bootstrap);
     }
@@ -3071,7 +3392,10 @@ export class ElizaSandboxService {
       | "sandbox_id"
     >,
   ): Promise<{ pushed: boolean; agentName?: string }> {
-    const payload = buildWarmClaimCharacterPayload(rec.agent_config, rec.agent_name);
+    const payload = buildWarmClaimCharacterPayload(
+      rec.agent_config,
+      rec.agent_name,
+    );
     if (!payload) return { pushed: false };
 
     const res = await this.fetchAgentApi(rec, "/api/character", {
@@ -3083,7 +3407,9 @@ export class ElizaSandboxService {
       // error-policy: enrich with a bounded body excerpt; a failed body read
       // must never mask the HTTP status.
       const text = await res.text().catch(() => "");
-      throw new Error(`Warm-claim character push failed: HTTP ${res.status} ${text.slice(0, 200)}`);
+      throw new Error(
+        `Warm-claim character push failed: HTTP ${res.status} ${text.slice(0, 200)}`,
+      );
     }
     return { pushed: true, agentName: String(payload.name) };
   }
@@ -3096,14 +3422,20 @@ export class ElizaSandboxService {
     rpc: BridgeRequest,
     executionCtx?: BridgeExecutionContext,
   ): Promise<BridgeResponse> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
     if (!rec) {
       // Bootstrap window: a freshly-created dedicated agent whose container is
       // still provisioning is served by the in-Worker shared runtime so the user
       // can chat immediately; the client hands off to the dedicated subdomain
       // once it reports running. (findRunningSandbox misses it since it is not
       // yet "running", so re-resolve by id+org.)
-      const bootstrap = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+      const bootstrap = await agentSandboxesRepository.findByIdAndOrg(
+        agentId,
+        orgId,
+      );
       if (bootstrap && isDedicatedBootstrapWindow(bootstrap)) {
         return this.bridgeSharedBootstrap(bootstrap, rpc, executionCtx);
       }
@@ -3134,10 +3466,13 @@ export class ElizaSandboxService {
       }
 
       if (!rec.bridge_url) {
-        logger.warn("[agent-sandbox] Bridge call to running sandbox without bridge URL", {
-          agentId,
-          method: rpc.method,
-        });
+        logger.warn(
+          "[agent-sandbox] Bridge call to running sandbox without bridge URL",
+          {
+            agentId,
+            method: rpc.method,
+          },
+        );
         return {
           jsonrpc: "2.0",
           id: rpc.id,
@@ -3209,7 +3544,10 @@ export class ElizaSandboxService {
     }
   }
 
-  private async bridgeStatus(rec: AgentSandbox, rpc: BridgeRequest): Promise<BridgeResponse> {
+  private async bridgeStatus(
+    rec: AgentSandbox,
+    rpc: BridgeRequest,
+  ): Promise<BridgeResponse> {
     const runtimeAgents = await this.listRuntimeAgents(rec);
     if (runtimeAgents.supported) {
       const agent = this.selectRuntimeAgent(runtimeAgents.agents);
@@ -3254,9 +3592,14 @@ export class ElizaSandboxService {
     };
   }
 
-  private async bridgeMessageSend(rec: AgentSandbox, rpc: BridgeRequest): Promise<BridgeResponse> {
+  private async bridgeMessageSend(
+    rec: AgentSandbox,
+    rpc: BridgeRequest,
+  ): Promise<BridgeResponse> {
     const params =
-      rpc.params && typeof rpc.params === "object" ? (rpc.params as Record<string, unknown>) : {};
+      rpc.params && typeof rpc.params === "object"
+        ? (rpc.params as Record<string, unknown>)
+        : {};
     const text = typeof params.text === "string" ? params.text : "";
     if (!text.trim()) {
       return {
@@ -3330,7 +3673,10 @@ export class ElizaSandboxService {
   // central-channel polling per failed turn. Strict callers (the e2e chat
   // scripts) reject on the propagated `failureKind` instead (#15616).
   private bridgeResponseHasText(response: BridgeResponse): boolean {
-    return typeof response.result?.text === "string" && response.result.text.trim().length > 0;
+    return (
+      typeof response.result?.text === "string" &&
+      response.result.text.trim().length > 0
+    );
   }
 
   /**
@@ -3339,7 +3685,9 @@ export class ElizaSandboxService {
    * issue, rate limit, credit exhaustion, no provider). Surface it so callers
    * can tell a genuine model reply from a canned failure (#15616).
    */
-  private extractBridgeFailureKind(body: Record<string, unknown>): string | undefined {
+  private extractBridgeFailureKind(
+    body: Record<string, unknown>,
+  ): string | undefined {
     return typeof body.failureKind === "string" && body.failureKind.trim()
       ? body.failureKind.trim()
       : undefined;
@@ -3380,11 +3728,14 @@ export class ElizaSandboxService {
     }
     // Parse envelope; cloud-agent returns valid JSON-RPC on both 200 and 500.
     const body = (await res.json().catch((error) => {
-      logger.warn("[agent-sandbox] Failed to parse native bridge JSON-RPC body", {
-        agentId: rec.id,
-        status: res.status,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[agent-sandbox] Failed to parse native bridge JSON-RPC body",
+        {
+          agentId: rec.id,
+          status: res.status,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     })) as {
       jsonrpc?: string;
@@ -3436,14 +3787,18 @@ export class ElizaSandboxService {
       };
     }
 
-    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const body = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
     const failureKind = this.extractBridgeFailureKind(body);
     return {
       jsonrpc: "2.0",
       id: rpc.id,
       result: {
         text: this.extractBridgeMessageText(body) ?? "",
-        agentName: typeof body.agentName === "string" ? body.agentName : undefined,
+        agentName:
+          typeof body.agentName === "string" ? body.agentName : undefined,
         conversationId,
         transport: "conversation-rest",
         ...(failureKind ? { failureKind } : {}),
@@ -3456,7 +3811,8 @@ export class ElizaSandboxService {
     rpc: BridgeRequest,
     params: Record<string, unknown>,
   ): Promise<BridgeResponse> {
-    const runtimeAgent = (await this.ensureRuntimeAgentStarted(rec)) ?? undefined;
+    const runtimeAgent =
+      (await this.ensureRuntimeAgentStarted(rec)) ?? undefined;
     if (!runtimeAgent?.id) {
       return {
         jsonrpc: "2.0",
@@ -3465,7 +3821,11 @@ export class ElizaSandboxService {
       };
     }
 
-    const sessionId = await this.createBridgeMessagingSession(rec, runtimeAgent.id, params);
+    const sessionId = await this.createBridgeMessagingSession(
+      rec,
+      runtimeAgent.id,
+      params,
+    );
     const res = await this.fetchAgentApi(
       rec,
       `/api/messaging/sessions/${encodeURIComponent(sessionId)}/messages`,
@@ -3483,8 +3843,15 @@ export class ElizaSandboxService {
       };
     }
 
-    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-    const agentText = await this.waitForBridgeSessionAgentReply(rec, sessionId, runtimeAgent.id);
+    const body = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const agentText = await this.waitForBridgeSessionAgentReply(
+      rec,
+      sessionId,
+      runtimeAgent.id,
+    );
     return {
       jsonrpc: "2.0",
       id: rpc.id,
@@ -3504,7 +3871,8 @@ export class ElizaSandboxService {
     rpc: BridgeRequest,
     params: Record<string, unknown>,
   ): Promise<BridgeResponse> {
-    const runtimeAgent = (await this.ensureRuntimeAgentStarted(rec)) ?? undefined;
+    const runtimeAgent =
+      (await this.ensureRuntimeAgentStarted(rec)) ?? undefined;
     if (!runtimeAgent?.id) {
       return {
         jsonrpc: "2.0",
@@ -3519,7 +3887,9 @@ export class ElizaSandboxService {
       `/api/messaging/central-channels/${encodeURIComponent(channelId)}/messages`,
       {
         method: "POST",
-        body: JSON.stringify(this.buildBridgeCentralChannelMessageBody(params, runtimeAgent.id)),
+        body: JSON.stringify(
+          this.buildBridgeCentralChannelMessageBody(params, runtimeAgent.id),
+        ),
         signal: AbortSignal.timeout(60_000),
       },
     );
@@ -3537,7 +3907,10 @@ export class ElizaSandboxService {
       };
     }
 
-    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const body = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
     const data = this.nestedBridgeRecord(body.data) ?? {};
     const agentText = await this.waitForBridgeCentralChannelAgentReply(
       rec,
@@ -3555,7 +3928,11 @@ export class ElizaSandboxService {
         channelId,
         transport: "central-channel",
         messageId:
-          typeof data.id === "string" ? data.id : typeof body.id === "string" ? body.id : undefined,
+          typeof data.id === "string"
+            ? data.id
+            : typeof body.id === "string"
+              ? body.id
+              : undefined,
       },
     };
   }
@@ -3565,9 +3942,15 @@ export class ElizaSandboxService {
     rpc: BridgeRequest,
     params: Record<string, unknown>,
   ): Promise<BridgeResponse> {
-    const { body, status } = await this.requestBridgeOpenAiChatCompletion(rec, params);
+    const { body, status } = await this.requestBridgeOpenAiChatCompletion(
+      rec,
+      params,
+    );
     if (status === 404) {
-      throw new BridgeRouteUnavailableError("OpenAI chat compatibility API is unavailable", status);
+      throw new BridgeRouteUnavailableError(
+        "OpenAI chat compatibility API is unavailable",
+        status,
+      );
     }
     if (status < 200 || status >= 300) {
       return {
@@ -3575,7 +3958,9 @@ export class ElizaSandboxService {
         id: rpc.id,
         error: {
           code: -32000,
-          message: this.extractBridgeErrorMessage(body) ?? `Bridge returned HTTP ${status}`,
+          message:
+            this.extractBridgeErrorMessage(body) ??
+            `Bridge returned HTTP ${status}`,
         },
       };
     }
@@ -3601,20 +3986,29 @@ export class ElizaSandboxService {
       body: JSON.stringify(this.buildBridgeOpenAiChatBody(params)),
       signal: AbortSignal.timeout(120_000),
     });
-    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const body = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
     return { status: res.status, body };
   }
 
-  private buildBridgeOpenAiChatBody(params: Record<string, unknown>): Record<string, unknown> {
+  private buildBridgeOpenAiChatBody(
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
     const text = typeof params.text === "string" ? params.text : "";
     const roomId =
-      typeof params.roomId === "string" && params.roomId.trim() ? params.roomId.trim() : "default";
+      typeof params.roomId === "string" && params.roomId.trim()
+        ? params.roomId.trim()
+        : "default";
     const userId =
       typeof params.userId === "string" && params.userId.trim()
         ? params.userId.trim()
         : this.stableBridgeUserId(params);
     const source =
-      typeof params.source === "string" && params.source.trim() ? params.source.trim() : "cloud";
+      typeof params.source === "string" && params.source.trim()
+        ? params.source.trim()
+        : "cloud";
 
     return {
       model: "eliza",
@@ -3629,7 +4023,9 @@ export class ElizaSandboxService {
     };
   }
 
-  private buildBridgeNoReplyFallbackText(params: Record<string, unknown>): string | null {
+  private buildBridgeNoReplyFallbackText(
+    params: Record<string, unknown>,
+  ): string | null {
     const text = typeof params.text === "string" ? params.text.trim() : "";
     if (!text) return null;
 
@@ -3648,9 +4044,13 @@ export class ElizaSandboxService {
     params: Record<string, unknown>,
   ): Promise<string> {
     const source =
-      typeof params.source === "string" && params.source.trim() ? params.source : "cloud";
+      typeof params.source === "string" && params.source.trim()
+        ? params.source
+        : "cloud";
     const roomId =
-      typeof params.roomId === "string" && params.roomId.trim() ? params.roomId : "default";
+      typeof params.roomId === "string" && params.roomId.trim()
+        ? params.roomId
+        : "default";
     const res = await this.fetchAgentApi(rec, "/api/conversations", {
       method: "POST",
       body: JSON.stringify({
@@ -3661,7 +4061,10 @@ export class ElizaSandboxService {
     });
     if (!res.ok) {
       if (res.status === 404) {
-        throw new BridgeRouteUnavailableError("Conversation API is unavailable", res.status);
+        throw new BridgeRouteUnavailableError(
+          "Conversation API is unavailable",
+          res.status,
+        );
       }
       throw new Error(`Bridge conversation create returned HTTP ${res.status}`);
     }
@@ -3671,7 +4074,9 @@ export class ElizaSandboxService {
     };
     const conversationId = body.conversation?.id;
     if (typeof conversationId !== "string" || !conversationId.trim()) {
-      throw new Error("Bridge conversation create response was missing conversation.id");
+      throw new Error(
+        "Bridge conversation create response was missing conversation.id",
+      );
     }
     return conversationId;
   }
@@ -3693,7 +4098,9 @@ export class ElizaSandboxService {
               : "cloud",
           roomId: typeof params.roomId === "string" ? params.roomId : undefined,
           sender:
-            params.sender && typeof params.sender === "object" && !Array.isArray(params.sender)
+            params.sender &&
+            typeof params.sender === "object" &&
+            !Array.isArray(params.sender)
               ? params.sender
               : undefined,
         },
@@ -3701,13 +4108,20 @@ export class ElizaSandboxService {
       signal: AbortSignal.timeout(15_000),
     });
     if (res.status === 404) {
-      throw new BridgeRouteUnavailableError("Messaging sessions API is unavailable", res.status);
+      throw new BridgeRouteUnavailableError(
+        "Messaging sessions API is unavailable",
+        res.status,
+      );
     }
     if (!res.ok) {
       throw new Error(`Bridge session create returned HTTP ${res.status}`);
     }
-    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-    const sessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
+    const body = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const sessionId =
+      typeof body.sessionId === "string" ? body.sessionId : undefined;
     if (!sessionId) {
       throw new Error("Bridge session create response was missing sessionId");
     }
@@ -3720,16 +4134,21 @@ export class ElizaSandboxService {
     const body: Record<string, unknown> = {
       text: typeof params.text === "string" ? params.text : "",
       source:
-        typeof params.source === "string" && params.source.trim() ? params.source.trim() : "cloud",
+        typeof params.source === "string" && params.source.trim()
+          ? params.source.trim()
+          : "cloud",
       metadata: {
         ...(params.metadata &&
         typeof params.metadata === "object" &&
         !Array.isArray(params.metadata)
           ? (params.metadata as Record<string, unknown>)
           : {}),
-        bridgeRoomId: typeof params.roomId === "string" ? params.roomId : undefined,
+        bridgeRoomId:
+          typeof params.roomId === "string" ? params.roomId : undefined,
         bridgeSender:
-          params.sender && typeof params.sender === "object" && !Array.isArray(params.sender)
+          params.sender &&
+          typeof params.sender === "object" &&
+          !Array.isArray(params.sender)
             ? params.sender
             : undefined,
       },
@@ -3747,10 +4166,14 @@ export class ElizaSandboxService {
     return body;
   }
 
-  private buildBridgeSessionMessageBody(params: Record<string, unknown>): Record<string, unknown> {
+  private buildBridgeSessionMessageBody(
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
     return {
       content: typeof params.text === "string" ? params.text : "",
-      attachments: Array.isArray(params.attachments) ? params.attachments : undefined,
+      attachments: Array.isArray(params.attachments)
+        ? params.attachments
+        : undefined,
       metadata: {
         ...(params.metadata &&
         typeof params.metadata === "object" &&
@@ -3761,7 +4184,8 @@ export class ElizaSandboxService {
           typeof params.source === "string" && params.source.trim()
             ? params.source.trim()
             : "cloud",
-        bridgeRoomId: typeof params.roomId === "string" ? params.roomId : undefined,
+        bridgeRoomId:
+          typeof params.roomId === "string" ? params.roomId : undefined,
       },
     };
   }
@@ -3771,11 +4195,15 @@ export class ElizaSandboxService {
     runtimeAgentId: string,
   ): Record<string, unknown> {
     const metadata =
-      params.metadata && typeof params.metadata === "object" && !Array.isArray(params.metadata)
+      params.metadata &&
+      typeof params.metadata === "object" &&
+      !Array.isArray(params.metadata)
         ? { ...(params.metadata as Record<string, unknown>) }
         : {};
     const sender =
-      params.sender && typeof params.sender === "object" && !Array.isArray(params.sender)
+      params.sender &&
+      typeof params.sender === "object" &&
+      !Array.isArray(params.sender)
         ? (params.sender as Record<string, unknown>)
         : {};
     const displayName =
@@ -3802,10 +4230,13 @@ export class ElizaSandboxService {
         channelType: "DM",
         targetUserId: runtimeAgentId,
         user_display_name: displayName,
-        bridgeRoomId: typeof params.roomId === "string" ? params.roomId : undefined,
+        bridgeRoomId:
+          typeof params.roomId === "string" ? params.roomId : undefined,
       },
       source_type:
-        typeof params.source === "string" && params.source.trim() ? params.source.trim() : "cloud",
+        typeof params.source === "string" && params.source.trim()
+          ? params.source.trim()
+          : "cloud",
     };
   }
 
@@ -3815,7 +4246,9 @@ export class ElizaSandboxService {
 
     const root = body as Record<string, unknown>;
     const data =
-      root.data && typeof root.data === "object" ? (root.data as Record<string, unknown>) : {};
+      root.data && typeof root.data === "object"
+        ? (root.data as Record<string, unknown>)
+        : {};
     const result =
       root.result && typeof root.result === "object"
         ? (root.result as Record<string, unknown>)
@@ -3866,7 +4299,10 @@ export class ElizaSandboxService {
     );
   }
 
-  private bridgeMessageIdMatches(value: unknown, runtimeAgentId?: string): boolean {
+  private bridgeMessageIdMatches(
+    value: unknown,
+    runtimeAgentId?: string,
+  ): boolean {
     return (
       typeof runtimeAgentId === "string" &&
       runtimeAgentId.length > 0 &&
@@ -3881,19 +4317,39 @@ export class ElizaSandboxService {
       : null;
   }
 
-  private isBridgeAgentMessage(message: Record<string, unknown>, runtimeAgentId?: string): boolean {
-    if (message.isAgent === true || message.fromAgent === true || message.isBot === true) {
+  private isBridgeAgentMessage(
+    message: Record<string, unknown>,
+    runtimeAgentId?: string,
+  ): boolean {
+    if (
+      message.isAgent === true ||
+      message.fromAgent === true ||
+      message.isBot === true
+    ) {
       return true;
     }
-    if (message.isAgent === false || message.fromAgent === false || message.isBot === false) {
+    if (
+      message.isAgent === false ||
+      message.fromAgent === false ||
+      message.isBot === false
+    ) {
       return false;
     }
-    const sourceType = this.normalizeBridgeRole(message.sourceType ?? message.source_type);
+    const sourceType = this.normalizeBridgeRole(
+      message.sourceType ?? message.source_type,
+    );
     if (sourceType === "agent_response") {
       return true;
     }
 
-    for (const key of ["role", "type", "senderType", "senderRole", "authorRole", "messageType"]) {
+    for (const key of [
+      "role",
+      "type",
+      "senderType",
+      "senderRole",
+      "authorRole",
+      "messageType",
+    ]) {
       const value = message[key];
       if (this.bridgeRoleIsAgent(value)) return true;
       if (this.bridgeRoleIsUser(value)) return false;
@@ -3902,9 +4358,17 @@ export class ElizaSandboxService {
     for (const key of ["sender", "author", "from", "entity", "metadata"]) {
       const nested = this.nestedBridgeRecord(message[key]);
       if (!nested) continue;
-      if (nested.isAgent === true || nested.fromAgent === true || nested.isBot === true)
+      if (
+        nested.isAgent === true ||
+        nested.fromAgent === true ||
+        nested.isBot === true
+      )
         return true;
-      if (nested.isAgent === false || nested.fromAgent === false || nested.isBot === false) {
+      if (
+        nested.isAgent === false ||
+        nested.fromAgent === false ||
+        nested.isBot === false
+      ) {
         return false;
       }
       for (const nestedKey of ["role", "type", "senderType", "authorRole"]) {
@@ -3912,13 +4376,27 @@ export class ElizaSandboxService {
         if (this.bridgeRoleIsAgent(nestedValue)) return true;
         if (this.bridgeRoleIsUser(nestedValue)) return false;
       }
-      for (const nestedIdKey of ["id", "entityId", "agentId", "runtimeAgentId", "senderId"]) {
-        if (this.bridgeMessageIdMatches(nested[nestedIdKey], runtimeAgentId)) return true;
+      for (const nestedIdKey of [
+        "id",
+        "entityId",
+        "agentId",
+        "runtimeAgentId",
+        "senderId",
+      ]) {
+        if (this.bridgeMessageIdMatches(nested[nestedIdKey], runtimeAgentId))
+          return true;
       }
     }
 
-    for (const idKey of ["entityId", "agentId", "runtimeAgentId", "senderId", "authorId"]) {
-      if (this.bridgeMessageIdMatches(message[idKey], runtimeAgentId)) return true;
+    for (const idKey of [
+      "entityId",
+      "agentId",
+      "runtimeAgentId",
+      "senderId",
+      "authorId",
+    ]) {
+      if (this.bridgeMessageIdMatches(message[idKey], runtimeAgentId))
+        return true;
     }
 
     return false;
@@ -3962,15 +4440,27 @@ export class ElizaSandboxService {
     return null;
   }
 
-  private extractBridgeMessageText(message: Record<string, unknown>): string | null {
-    for (const key of ["text", "fullText", "content", "message", "body", "reply", "response"]) {
+  private extractBridgeMessageText(
+    message: Record<string, unknown>,
+  ): string | null {
+    for (const key of [
+      "text",
+      "fullText",
+      "content",
+      "message",
+      "body",
+      "reply",
+      "response",
+    ]) {
       const text = this.extractBridgeTextValue(message[key]);
       if (text) return text;
     }
     return null;
   }
 
-  private extractBridgeErrorMessage(body: Record<string, unknown>): string | null {
+  private extractBridgeErrorMessage(
+    body: Record<string, unknown>,
+  ): string | null {
     const error = this.nestedBridgeRecord(body.error);
     if (error) {
       const message = this.extractBridgeTextValue(error.message);
@@ -3978,10 +4468,15 @@ export class ElizaSandboxService {
       const text = this.extractBridgeTextValue(error);
       if (text) return text;
     }
-    return this.extractBridgeTextValue(body.message) ?? this.extractBridgeTextValue(body);
+    return (
+      this.extractBridgeTextValue(body.message) ??
+      this.extractBridgeTextValue(body)
+    );
   }
 
-  private extractOpenAiChatCompletionText(body: Record<string, unknown>): string | null {
+  private extractOpenAiChatCompletionText(
+    body: Record<string, unknown>,
+  ): string | null {
     const choices = Array.isArray(body.choices) ? body.choices : [];
     for (const choice of choices) {
       const choiceRecord = this.nestedBridgeRecord(choice);
@@ -4003,7 +4498,8 @@ export class ElizaSandboxService {
     runtimeAgentId?: string,
   ): Promise<string | null> {
     for (let attempt = 0; attempt < 24; attempt++) {
-      if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 2_500));
+      if (attempt > 0)
+        await new Promise((resolve) => setTimeout(resolve, 2_500));
       const res = await this.fetchAgentApi(
         rec,
         `/api/messaging/sessions/${encodeURIComponent(sessionId)}/messages?limit=20`,
@@ -4017,7 +4513,8 @@ export class ElizaSandboxService {
       const messages = this.getBridgeMessages(body);
       for (const message of messages.toReversed()) {
         const record = this.nestedBridgeRecord(message);
-        if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId)) continue;
+        if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId))
+          continue;
         const text = this.extractBridgeMessageText(record);
         if (text) return text;
       }
@@ -4032,7 +4529,8 @@ export class ElizaSandboxService {
     runtimeAgentId?: string,
   ): Promise<string | null> {
     for (let attempt = 0; attempt < 20; attempt++) {
-      if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 2_500));
+      if (attempt > 0)
+        await new Promise((resolve) => setTimeout(resolve, 2_500));
       const res = await this.fetchAgentApi(
         rec,
         `/api/messaging/central-channels/${encodeURIComponent(channelId)}/messages?limit=30`,
@@ -4046,7 +4544,8 @@ export class ElizaSandboxService {
       const messages = this.getBridgeMessages(body);
       for (const message of messages.toReversed()) {
         const record = this.nestedBridgeRecord(message);
-        if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId)) continue;
+        if (!record || !this.isBridgeAgentMessage(record, runtimeAgentId))
+          continue;
         const text = this.extractBridgeMessageText(record);
         if (text) return text;
       }
@@ -4132,15 +4631,22 @@ export class ElizaSandboxService {
     body?: string | null,
     query?: string,
   ): Promise<Response | null> {
-    if (!ElizaSandboxService.ALLOWED_WORKFLOW_PATH_PATTERNS.some((re) => re.test(workflowPath))) {
+    if (
+      !ElizaSandboxService.ALLOWED_WORKFLOW_PATH_PATTERNS.some((re) =>
+        re.test(workflowPath),
+      )
+    ) {
       logger.warn("[agent-sandbox] Rejected workflow proxy: invalid path", {
         agentId,
         workflowPath,
       });
-      return new Response(JSON.stringify({ error: "Invalid workflow endpoint" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Invalid workflow endpoint" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     let sanitizedQuery = "";
@@ -4155,13 +4661,19 @@ export class ElizaSandboxService {
       sanitizedQuery = filtered.toString();
     }
 
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
     if (!rec) {
-      logger.warn("[agent-sandbox] Workflow proxy: sandbox not found or not running", {
-        agentId,
-        orgId,
-        workflowPath,
-      });
+      logger.warn(
+        "[agent-sandbox] Workflow proxy: sandbox not found or not running",
+        {
+          agentId,
+          orgId,
+          workflowPath,
+        },
+      );
       return null;
     }
     if (!rec.bridge_url) {
@@ -4212,10 +4724,13 @@ export class ElizaSandboxService {
         agentId,
         walletPath,
       });
-      return new Response(JSON.stringify({ error: "Invalid wallet endpoint" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Invalid wallet endpoint" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Sanitize query parameters
@@ -4231,13 +4746,19 @@ export class ElizaSandboxService {
       sanitizedQuery = filtered.toString();
     }
 
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
     if (!rec) {
-      logger.warn("[agent-sandbox] Wallet proxy: sandbox not found or not running", {
-        agentId,
-        orgId,
-        walletPath,
-      });
+      logger.warn(
+        "[agent-sandbox] Wallet proxy: sandbox not found or not running",
+        {
+          agentId,
+          orgId,
+          walletPath,
+        },
+      );
       return null;
     }
     if (!rec.bridge_url) {
@@ -4287,10 +4808,13 @@ export class ElizaSandboxService {
         agentId,
         schedulePath,
       });
-      return new Response(JSON.stringify({ error: "Invalid schedule endpoint" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Invalid schedule endpoint" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     let sanitizedQuery = "";
@@ -4298,20 +4822,28 @@ export class ElizaSandboxService {
       const params = new URLSearchParams(query);
       const filtered = new URLSearchParams();
       for (const [key, value] of params) {
-        if (ElizaSandboxService.ALLOWED_LIFEOPS_SCHEDULE_QUERY_PARAMS.has(key)) {
+        if (
+          ElizaSandboxService.ALLOWED_LIFEOPS_SCHEDULE_QUERY_PARAMS.has(key)
+        ) {
           filtered.set(key, value);
         }
       }
       sanitizedQuery = filtered.toString();
     }
 
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
     if (!rec) {
-      logger.warn("[agent-sandbox] Schedule proxy: sandbox not found or not running", {
-        agentId,
-        orgId,
-        schedulePath,
-      });
+      logger.warn(
+        "[agent-sandbox] Schedule proxy: sandbox not found or not running",
+        {
+          agentId,
+          orgId,
+          schedulePath,
+        },
+      );
       return null;
     }
     if (!rec.bridge_url) {
@@ -4355,8 +4887,15 @@ export class ElizaSandboxService {
     orgId: string,
     rpc: BridgeRequest,
     executionCtx?: BridgeExecutionContext,
+    resolvedAgent?: AgentSandbox,
   ): Promise<Response | null> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec =
+      resolvedAgent?.id === agentId &&
+      resolvedAgent.organization_id === orgId &&
+      resolvedAgent.status === "running"
+        ? resolvedAgent
+        : ((await getCachedSharedAgentRunningSandbox(agentId, orgId)) ??
+          (await agentSandboxesRepository.findRunningSandbox(agentId, orgId)));
     if (!rec) {
       logger.warn("[agent-sandbox] Bridge stream to non-running sandbox", {
         agentId,
@@ -4366,19 +4905,31 @@ export class ElizaSandboxService {
     }
 
     const params =
-      rpc.params && typeof rpc.params === "object" ? (rpc.params as Record<string, unknown>) : {};
+      rpc.params && typeof rpc.params === "object"
+        ? (rpc.params as Record<string, unknown>)
+        : {};
     const fallbackText = this.buildBridgeNoReplyFallbackText(params);
 
     if (rec.execution_tier === "shared") {
-      const response = await this.bridgeSharedMessageStream(rec, rpc, executionCtx);
-      return response ?? (fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null);
+      const response = await this.bridgeSharedMessageStream(
+        rec,
+        rpc,
+        executionCtx,
+      );
+      return (
+        response ??
+        (fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null)
+      );
     }
 
     if (!rec.bridge_url) {
-      logger.warn("[agent-sandbox] Bridge stream to running sandbox without bridge URL", {
-        agentId,
-        method: rpc.method,
-      });
+      logger.warn(
+        "[agent-sandbox] Bridge stream to running sandbox without bridge URL",
+        {
+          agentId,
+          method: rpc.method,
+        },
+      );
       return null;
     }
 
@@ -4395,35 +4946,50 @@ export class ElizaSandboxService {
       );
       if (res.ok) return this.normalizeBridgeSseResponse(res);
       if (res.status !== 404) {
-        logger.warn("[agent-sandbox] Bridge stream conversation request failed", {
-          agentId,
-          status: res.status,
-        });
+        logger.warn(
+          "[agent-sandbox] Bridge stream conversation request failed",
+          {
+            agentId,
+            status: res.status,
+          },
+        );
       }
     } catch (error) {
       if (!(error instanceof BridgeRouteUnavailableError)) {
-        logger.warn("[agent-sandbox] Bridge stream conversation request failed", {
-          agentId,
-          method: rpc.method,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.warn(
+          "[agent-sandbox] Bridge stream conversation request failed",
+          {
+            agentId,
+            method: rpc.method,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     }
 
     try {
       return await this.bridgeOpenAiChatCompletionSse(rec, params);
     } catch (error) {
-      logger.warn("[agent-sandbox] Bridge stream compatibility request failed", {
-        agentId,
-        method: rpc.method,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[agent-sandbox] Bridge stream compatibility request failed",
+        {
+          agentId,
+          method: rpc.method,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
     }
 
     try {
-      const centralResponse = await this.bridgeCentralChannelMessageSend(rec, rpc, params);
+      const centralResponse = await this.bridgeCentralChannelMessageSend(
+        rec,
+        rpc,
+        params,
+      );
       if (this.bridgeResponseHasText(centralResponse)) {
-        return this.createBridgeSseTextResponse(centralResponse.result!.text as string);
+        return this.createBridgeSseTextResponse(
+          centralResponse.result!.text as string,
+        );
       }
       if (centralResponse.error) {
         return this.createBridgeSseErrorResponse(centralResponse.error.message);
@@ -4432,11 +4998,14 @@ export class ElizaSandboxService {
         return this.createBridgeSseTextResponse(fallbackText);
       }
     } catch (error) {
-      logger.warn("[agent-sandbox] Bridge stream central-channel request failed", {
-        agentId,
-        method: rpc.method,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[agent-sandbox] Bridge stream central-channel request failed",
+        {
+          agentId,
+          method: rpc.method,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
     }
 
     if (fallbackText) {
@@ -4450,11 +5019,15 @@ export class ElizaSandboxService {
     rec: AgentSandbox,
     params: Record<string, unknown>,
   ): Promise<Response | null> {
-    const { body, status } = await this.requestBridgeOpenAiChatCompletion(rec, params);
+    const { body, status } = await this.requestBridgeOpenAiChatCompletion(
+      rec,
+      params,
+    );
     if (status === 404) return null;
     if (status < 200 || status >= 300) {
       return this.createBridgeSseErrorResponse(
-        this.extractBridgeErrorMessage(body) ?? `Bridge returned HTTP ${status}`,
+        this.extractBridgeErrorMessage(body) ??
+          `Bridge returned HTTP ${status}`,
       );
     }
 
@@ -4504,11 +5077,18 @@ export class ElizaSandboxService {
       if (lfBreak === -1 && crlfBreak === -1) return null;
       if (lfBreak === -1) return { index: crlfBreak, length: 4 };
       if (crlfBreak === -1) return { index: lfBreak, length: 2 };
-      return lfBreak < crlfBreak ? { index: lfBreak, length: 2 } : { index: crlfBreak, length: 4 };
+      return lfBreak < crlfBreak
+        ? { index: lfBreak, length: 2 }
+        : { index: crlfBreak, length: 4 };
     };
-    const emitFrame = (frame: string, controller: TransformStreamDefaultController<string>) => {
+    const emitFrame = (
+      frame: string,
+      controller: TransformStreamDefaultController<string>,
+    ) => {
       if (!frame.trim()) return;
-      const dataLine = frame.split(/\r?\n/).find((line) => line.startsWith("data:"));
+      const dataLine = frame
+        .split(/\r?\n/)
+        .find((line) => line.startsWith("data:"));
       if (!dataLine) {
         controller.enqueue(`${frame}\n\n`);
         return;
@@ -4517,7 +5097,10 @@ export class ElizaSandboxService {
         const data = JSON.parse(dataLine.slice(5).trimStart());
         if (data?.type === "token") {
           const delta = typeof data.text === "string" ? data.text : "";
-          accumulated = typeof data.fullText === "string" ? data.fullText : accumulated + delta;
+          accumulated =
+            typeof data.fullText === "string"
+              ? data.fullText
+              : accumulated + delta;
           controller.enqueue(
             `event: chunk\ndata: ${JSON.stringify({
               messageId,
@@ -4533,7 +5116,8 @@ export class ElizaSandboxService {
           controller.enqueue(
             `event: done\ndata: ${JSON.stringify({
               messageId,
-              text: typeof data.fullText === "string" ? data.fullText : accumulated,
+              text:
+                typeof data.fullText === "string" ? data.fullText : accumulated,
             })}\n\n`,
           );
           return;
@@ -4572,13 +5156,16 @@ export class ElizaSandboxService {
   }
 
   private createBridgeSseErrorResponse(message: string): Response {
-    return new Response(`event: error\ndata: ${JSON.stringify({ message })}\n\n`, {
-      status: 200,
-      headers: {
-        "Content-Type": "text/event-stream; charset=utf-8",
-        "Cache-Control": "no-cache, no-transform",
+    return new Response(
+      `event: error\ndata: ${JSON.stringify({ message })}\n\n`,
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache, no-transform",
+        },
       },
-    });
+    );
   }
 
   // Snapshots
@@ -4588,8 +5175,12 @@ export class ElizaSandboxService {
     orgId: string,
     type: AgentBackupSnapshotType = "manual",
   ): Promise<SnapshotResult> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
-    if (!rec?.bridge_url) return { success: false, error: "Sandbox is not running" };
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
+    if (!rec?.bridge_url)
+      return { success: false, error: "Sandbox is not running" };
 
     let stateData: AgentBackupStateData;
     let sizeBytes: number;
@@ -4646,12 +5237,17 @@ export class ElizaSandboxService {
     sizeBytes: number,
   ): Promise<NewAgentSandboxBackup> {
     const contentHash = computeStateHash(stateData);
-    const latest = await agentSandboxesRepository.getLatestBackup(sandboxRecordId);
+    const latest =
+      await agentSandboxesRepository.getLatestBackup(sandboxRecordId);
     if (latest) {
       try {
-        const baseState = await agentSandboxesRepository.getReconstructedBackupState(latest.id);
+        const baseState =
+          await agentSandboxesRepository.getReconstructedBackupState(latest.id);
         if (baseState) {
-          const all = await agentSandboxesRepository.listBackups(sandboxRecordId, 1000);
+          const all = await agentSandboxesRepository.listBackups(
+            sandboxRecordId,
+            1000,
+          );
           const nodes = all.map((b) => ({
             id: b.id,
             backupKind: b.backup_kind,
@@ -4659,7 +5255,11 @@ export class ElizaSandboxService {
             createdAtMs: b.created_at.getTime(),
           }));
           const chainDepth = incrementalChainDepth(nodes, latest.id);
-          const plan = planIncrementalBackup({ base: baseState, next: stateData, chainDepth });
+          const plan = planIncrementalBackup({
+            base: baseState,
+            next: stateData,
+            chainDepth,
+          });
           if (plan.kind === "incremental") {
             return {
               sandbox_record_id: sandboxRecordId,
@@ -4674,10 +5274,13 @@ export class ElizaSandboxService {
           }
         }
       } catch (error) {
-        logger.warn("[agent-sandbox] Incremental planning failed; storing full backup", {
-          sandboxRecordId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.warn(
+          "[agent-sandbox] Incremental planning failed; storing full backup",
+          {
+            sandboxRecordId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     }
     return {
@@ -4690,7 +5293,11 @@ export class ElizaSandboxService {
     };
   }
 
-  async restore(agentId: string, orgId: string, backupId?: string): Promise<SnapshotResult> {
+  async restore(
+    agentId: string,
+    orgId: string,
+    backupId?: string,
+  ): Promise<SnapshotResult> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
     if (!rec) return { success: false, error: "Agent not found" };
 
@@ -4705,7 +5312,9 @@ export class ElizaSandboxService {
     }
 
     if (rec.status !== "running" && backupId) {
-      const latestBackup = await agentSandboxesRepository.getLatestBackup(rec.id);
+      const latestBackup = await agentSandboxesRepository.getLatestBackup(
+        rec.id,
+      );
       if (!latestBackup || backup.id !== latestBackup.id) {
         return {
           success: false,
@@ -4715,7 +5324,8 @@ export class ElizaSandboxService {
     }
 
     if (rec.status === "running" && rec.bridge_url) {
-      const restoreState = await agentSandboxesRepository.getReconstructedBackupState(backup.id);
+      const restoreState =
+        await agentSandboxesRepository.getReconstructedBackupState(backup.id);
       if (!restoreState) {
         return {
           success: false,
@@ -4727,7 +5337,9 @@ export class ElizaSandboxService {
     }
 
     const prov = await this.provision(agentId, orgId);
-    return prov.success ? { success: true, backup } : { success: false, error: prov.error };
+    return prov.success
+      ? { success: true, backup }
+      : { success: false, error: prov.error };
   }
 
   async listBackups(
@@ -4736,13 +5348,18 @@ export class ElizaSandboxService {
     limit?: number,
   ): Promise<AgentSandboxBackupMetadata[]> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
-    return rec ? agentSandboxesRepository.listBackupMetadata(rec.id, limit) : [];
+    return rec
+      ? agentSandboxesRepository.listBackupMetadata(rec.id, limit)
+      : [];
   }
 
   // Heartbeat
 
   async heartbeat(agentId: string, orgId: string): Promise<boolean> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec = await agentSandboxesRepository.findRunningSandbox(
+      agentId,
+      orgId,
+    );
     if (!rec?.bridge_url) return false;
 
     const probe = await this.probeBridgeHealthDetailed(rec);
@@ -4763,11 +5380,14 @@ export class ElizaSandboxService {
         : Date.now();
       const downForMs = Date.now() - lastOkMs;
       if (downForMs < HEARTBEAT_DISCONNECT_AFTER_MS) {
-        logger.warn("[agent-sandbox] Heartbeat miss within grace window, keeping running", {
-          agentId,
-          downForMs,
-          reason: probe.reason,
-        });
+        logger.warn(
+          "[agent-sandbox] Heartbeat miss within grace window, keeping running",
+          {
+            agentId,
+            downForMs,
+            reason: probe.reason,
+          },
+        );
         return false;
       }
       // Past-grace miss: before disconnecting (which reprovisions — destroying
@@ -4808,12 +5428,15 @@ export class ElizaSandboxService {
           return false;
         }
       }
-      logger.warn("[agent-sandbox] Heartbeat failed past grace window, marking disconnected", {
-        agentId,
-        downForMs,
-        reason: probe.reason,
-        reconcileOutcome: reconcile.outcome,
-      });
+      logger.warn(
+        "[agent-sandbox] Heartbeat failed past grace window, marking disconnected",
+        {
+          agentId,
+          downForMs,
+          reason: probe.reason,
+          reconcileOutcome: reconcile.outcome,
+        },
+      );
       await agentSandboxesRepository.update(rec.id, {
         status: "disconnected",
       });
@@ -4862,7 +5485,9 @@ export class ElizaSandboxService {
     };
     for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
       if (attempt > 0) {
-        await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS),
+        );
       }
       try {
         const res = await fetch(endpoint, {
@@ -4880,17 +5505,22 @@ export class ElizaSandboxService {
           kind: "unreachable",
           reason: error instanceof Error ? error.message : String(error),
         };
-        logger.debug("[agent-sandbox] Bridge health probe attempt failed, retrying", {
-          agentId: rec.id,
-          attempt,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.debug(
+          "[agent-sandbox] Bridge health probe attempt failed, retrying",
+          {
+            agentId: rec.id,
+            attempt,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     }
     return lastFailure;
   }
 
-  private async classifyBridgeHealthResponse(res: Response): Promise<BridgeHealthProbeResult> {
+  private async classifyBridgeHealthResponse(
+    res: Response,
+  ): Promise<BridgeHealthProbeResult> {
     let payload: AgentRuntimeHealthPayload | null = null;
     try {
       payload = (await res.clone().json()) as AgentRuntimeHealthPayload;
@@ -4914,7 +5544,8 @@ export class ElizaSandboxService {
       };
     }
     const transient =
-      databaseLiveness?.status === "transient_error" || payload?.database === "transient_error";
+      databaseLiveness?.status === "transient_error" ||
+      payload?.database === "transient_error";
     if (transient) {
       return {
         ok: false,
@@ -4961,14 +5592,23 @@ export class ElizaSandboxService {
     // barred from automatic recovery after three failures over its lifetime.
     const markerAge = marker.at === null ? null : now - marker.at;
     const markerActive =
-      markerAge !== null && markerAge >= 0 && markerAge < DB_LIVENESS_RESTART_BUDGET_WINDOW_MS;
+      markerAge !== null &&
+      markerAge >= 0 &&
+      markerAge < DB_LIVENESS_RESTART_BUDGET_WINDOW_MS;
     const count = markerActive ? marker.count : 0;
-    if (markerActive && markerAge !== null && markerAge < DB_LIVENESS_RESTART_COOLDOWN_MS) {
-      logger.warn("[agent-sandbox] Terminal database liveness failure inside restart cooldown", {
-        agentId: rec.id,
-        count,
-        reason,
-      });
+    if (
+      markerActive &&
+      markerAge !== null &&
+      markerAge < DB_LIVENESS_RESTART_COOLDOWN_MS
+    ) {
+      logger.warn(
+        "[agent-sandbox] Terminal database liveness failure inside restart cooldown",
+        {
+          agentId: rec.id,
+          count,
+          reason,
+        },
+      );
       return;
     }
     if (count >= DB_LIVENESS_RESTART_BUDGET) {
@@ -4977,11 +5617,14 @@ export class ElizaSandboxService {
         error_count: count,
         error_message: `${DB_LIVENESS_RESTART_MARKER} budget-exhausted count=${count} at=${new Date(now).toISOString()} reason=${reason}`,
       });
-      logger.error("[agent-sandbox] Terminal database liveness restart budget exhausted", {
-        agentId: rec.id,
-        count,
-        reason,
-      });
+      logger.error(
+        "[agent-sandbox] Terminal database liveness restart budget exhausted",
+        {
+          agentId: rec.id,
+          count,
+          reason,
+        },
+      );
       return;
     }
 
@@ -4996,13 +5639,16 @@ export class ElizaSandboxService {
       organizationId: rec.organization_id,
       userId: rec.user_id,
     });
-    logger.warn("[agent-sandbox] Enqueued restart for terminal database liveness failure", {
-      agentId: rec.id,
-      jobId: result.job.id,
-      created: result.created,
-      count: nextCount,
-      reason,
-    });
+    logger.warn(
+      "[agent-sandbox] Enqueued restart for terminal database liveness failure",
+      {
+        agentId: rec.id,
+        jobId: result.job.id,
+        created: result.created,
+        count: nextCount,
+        reason,
+      },
+    );
   }
 
   /**
@@ -5026,11 +5672,14 @@ export class ElizaSandboxService {
         node.ssh_user,
       );
     } catch (error) {
-      logger.debug("[agent-sandbox] Failed to resolve docker node for reconcile", {
-        agentId: rec.id,
-        nodeId: rec.node_id,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.debug(
+        "[agent-sandbox] Failed to resolve docker node for reconcile",
+        {
+          agentId: rec.id,
+          nodeId: rec.node_id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
   }
@@ -5041,7 +5690,9 @@ export class ElizaSandboxService {
    * from a live one whose stored tailnet IP went stale (must be repaired, not
    * destroyed).
    */
-  private async isContainerDockerHealthy(rec: ReconcilableSandbox): Promise<boolean> {
+  private async isContainerDockerHealthy(
+    rec: ReconcilableSandbox,
+  ): Promise<boolean> {
     if (!rec.container_name) return false;
     const ssh = await this.getNodeSshForAgent(rec);
     if (!ssh) return false;
@@ -5056,10 +5707,13 @@ export class ElizaSandboxService {
       ).trim();
       return status === "healthy";
     } catch (error) {
-      logger.debug("[agent-sandbox] Docker health inspect failed during reconcile", {
-        agentId: rec.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.debug(
+        "[agent-sandbox] Docker health inspect failed during reconcile",
+        {
+          agentId: rec.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return false;
     }
   }
@@ -5070,7 +5724,9 @@ export class ElizaSandboxService {
    * registered with, so it reflects the post-restart node key/IP — unlike the
    * stored headscale_ip, which is a provision-time snapshot.
    */
-  private async resolveCurrentAgentTailnetIp(rec: ReconcilableSandbox): Promise<string | null> {
+  private async resolveCurrentAgentTailnetIp(
+    rec: ReconcilableSandbox,
+  ): Promise<string | null> {
     if (!rec.container_name) return null;
     const ssh = await this.getNodeSshForAgent(rec);
     if (!ssh) return null;
@@ -5088,10 +5744,13 @@ export class ElizaSandboxService {
         .find((line) => line.startsWith("100."));
       return ip && isIP(ip) === 4 ? ip : null;
     } catch (error) {
-      logger.debug("[agent-sandbox] Current tailnet IP resolve failed during reconcile", {
-        agentId: rec.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.debug(
+        "[agent-sandbox] Current tailnet IP resolve failed during reconcile",
+        {
+          agentId: rec.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
   }
@@ -5111,12 +5770,14 @@ export class ElizaSandboxService {
   private async reconcileStaleTailnetIp(
     rec: ReconcilableSandbox,
   ): Promise<TailnetIpReconcileResult> {
-    if (!(await this.isContainerDockerHealthy(rec))) return { outcome: "container-dead" };
+    if (!(await this.isContainerDockerHealthy(rec)))
+      return { outcome: "container-dead" };
     const currentIp = await this.resolveCurrentAgentTailnetIp(rec);
     if (!currentIp) return { outcome: "ip-unresolvable" };
     // Same IP as stored = nothing to repair: the miss is genuine
     // unreachability at the correct address, so the dead-agent path applies.
-    if (!rec.bridge_url || currentIp === rec.headscale_ip) return { outcome: "unrepairable" };
+    if (!rec.bridge_url || currentIp === rec.headscale_ip)
+      return { outcome: "unrepairable" };
 
     let bridgeUrl: string;
     try {
@@ -5126,16 +5787,22 @@ export class ElizaSandboxService {
     } catch (error) {
       // error-policy:J4 a malformed stored bridge_url cannot be repaired in
       // place; degrade to the existing disconnect → reprovision self-heal.
-      logger.warn("[agent-sandbox] Stored bridge_url unparsable during reconcile", {
-        agentId: rec.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[agent-sandbox] Stored bridge_url unparsable during reconcile",
+        {
+          agentId: rec.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return { outcome: "unrepairable" };
     }
 
     // Only a live answer on the repaired address proves the new IP is the
     // container we think it is — never persist an unverified repair.
-    const reachable = await this.probeBridgeHealth({ ...rec, bridge_url: bridgeUrl });
+    const reachable = await this.probeBridgeHealth({
+      ...rec,
+      bridge_url: bridgeUrl,
+    });
     if (!reachable) return { outcome: "unrepairable" };
     return { outcome: "repaired", headscaleIp: currentIp, bridgeUrl };
   }
@@ -5187,14 +5854,17 @@ export class ElizaSandboxService {
       }
       const rawFailedPlugins = health.plugins?.failed ?? 0;
       const failedPlugins =
-        typeof rawFailedPlugins === "number" ? rawFailedPlugins : Number(rawFailedPlugins);
+        typeof rawFailedPlugins === "number"
+          ? rawFailedPlugins
+          : Number(rawFailedPlugins);
       if (!Number.isFinite(failedPlugins)) {
         failures.push(`plugins.failed=${String(rawFailedPlugins)}`);
       } else if (failedPlugins > 0) {
         failures.push(`plugins.failed=${failedPlugins}`);
       }
       const startupError =
-        typeof health.startup?.lastError === "string" && health.startup.lastError.trim()
+        typeof health.startup?.lastError === "string" &&
+        health.startup.lastError.trim()
           ? health.startup.lastError.trim()
           : null;
       if (startupError) {
@@ -5235,7 +5905,8 @@ export class ElizaSandboxService {
     orgId: string,
   ): Promise<"recovered" | "unreachable" | "gone"> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
-    if (!rec || (rec.status !== "disconnected" && rec.status !== "error")) return "gone";
+    if (!rec || (rec.status !== "disconnected" && rec.status !== "error"))
+      return "gone";
     const recoverableStatus = rec.status;
     const reachable = await this.probeBridgeHealth(rec);
     if (!reachable) {
@@ -5250,10 +5921,11 @@ export class ElizaSandboxService {
       // Same guarded CAS as the plain recovery flip below: only revive a row
       // that is STILL in the probed recoverable status, then persist the
       // repaired ingress columns on the now-running row.
-      const revived = await agentSandboxesRepository.markReconnectedFromDisconnected(
-        rec.id,
-        recoverableStatus,
-      );
+      const revived =
+        await agentSandboxesRepository.markReconnectedFromDisconnected(
+          rec.id,
+          recoverableStatus,
+        );
       if (!revived) return "gone";
       await agentSandboxesRepository.update(rec.id, {
         headscale_ip: reconcile.headscaleIp,
@@ -5269,10 +5941,11 @@ export class ElizaSandboxService {
     // bridge_url) / provisioning during the multi-second probe. Only flip it if
     // it is STILL disconnected with a live bridge — otherwise we'd resurrect a
     // being-deleted agent or wedge a stopped one at `running` with a dead bridge.
-    const restored = await agentSandboxesRepository.markReconnectedFromDisconnected(
-      rec.id,
-      recoverableStatus,
-    );
+    const restored =
+      await agentSandboxesRepository.markReconnectedFromDisconnected(
+        rec.id,
+        recoverableStatus,
+      );
     if (!restored) return "gone";
     logger.info("[agent-sandbox] Recovered agent back to running", {
       agentId,
@@ -5310,7 +5983,9 @@ export class ElizaSandboxService {
       sandboxId: rec.sandbox_id,
       bridgeUrl: rec.bridge_url ?? "",
       healthUrl: rec.health_url ?? "",
-      metadata: rec.headscale_ip ? { headscaleIp: rec.headscale_ip } : undefined,
+      metadata: rec.headscale_ip
+        ? { headscaleIp: rec.headscale_ip }
+        : undefined,
     };
 
     let healthy = false;
@@ -5321,10 +5996,13 @@ export class ElizaSandboxService {
     } catch (error) {
       // A probe that throws is "no signal" — leave the row for the next pass,
       // never condemn or resurrect on an errored probe.
-      logger.debug("[agent-sandbox] Stuck-provisioning re-probe threw; leaving row", {
-        agentId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.debug(
+        "[agent-sandbox] Stuck-provisioning re-probe threw; leaving row",
+        {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return "unresolved";
     }
 
@@ -5332,7 +6010,9 @@ export class ElizaSandboxService {
 
     // Guarded CAS: only flip if still `provisioning` with a live container and
     // no active provision job racing it (see markRunningFromProvisioning).
-    const flipped = await agentSandboxesRepository.markRunningFromProvisioning(rec.id);
+    const flipped = await agentSandboxesRepository.markRunningFromProvisioning(
+      rec.id,
+    );
     if (!flipped) return "gone";
     logger.info(
       "[agent-sandbox] Reconciled wedged provisioning row to running (container re-probed healthy)",
@@ -5343,7 +6023,10 @@ export class ElizaSandboxService {
 
   // Shutdown
 
-  async shutdown(agentId: string, orgId: string): Promise<{ success: boolean; error?: string }> {
+  async shutdown(
+    agentId: string,
+    orgId: string,
+  ): Promise<{ success: boolean; error?: string }> {
     let snapshotAgentId: string | null = null;
     let preShutdownSnapshot: {
       stateData: AgentBackupStateData;
@@ -5353,13 +6036,15 @@ export class ElizaSandboxService {
 
     const snapshotSource = await this.getAgentForWrite(agentId, orgId);
     if (snapshotSource?.status === "running" && snapshotSource.bridge_url) {
-      preShutdownSnapshot = await this.fetchSnapshotState(snapshotSource).catch((error) => {
-        logger.warn("[agent-sandbox] Pre-shutdown backup fetch failed", {
-          agentId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return null;
-      });
+      preShutdownSnapshot = await this.fetchSnapshotState(snapshotSource).catch(
+        (error) => {
+          logger.warn("[agent-sandbox] Pre-shutdown backup fetch failed", {
+            agentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        },
+      );
     }
 
     const result = await dbWrite.transaction(async (tx) => {
@@ -5368,7 +6053,11 @@ export class ElizaSandboxService {
       const rec = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
       if (!rec) return { success: false, error: "Agent not found" } as const;
 
-      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(
+        tx,
+        agentId,
+        orgId,
+      );
       if (rec.status === "provisioning" || hasActiveProvisionJob) {
         return {
           success: false,
@@ -5417,12 +6106,14 @@ export class ElizaSandboxService {
     });
 
     if (result.success && snapshotAgentId) {
-      await agentSandboxesRepository.pruneBackups(snapshotAgentId, MAX_BACKUPS).catch((error) => {
-        logger.warn("[agent-sandbox] Backup pruning failed after shutdown", {
-          agentId,
-          error: error instanceof Error ? error.message : String(error),
+      await agentSandboxesRepository
+        .pruneBackups(snapshotAgentId, MAX_BACKUPS)
+        .catch((error) => {
+          logger.warn("[agent-sandbox] Backup pruning failed after shutdown", {
+            agentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
       logger.info("[agent-sandbox] Shutdown complete", { agentId });
     }
 
@@ -5451,7 +6142,11 @@ export class ElizaSandboxService {
           error: "Agent not found",
         } as const;
 
-      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(
+        tx,
+        agentId,
+        orgId,
+      );
       if (rec.status === "provisioning" || hasActiveProvisionJob) {
         return {
           success: false,
@@ -5459,7 +6154,8 @@ export class ElizaSandboxService {
           error: "Agent provisioning is in progress",
         } as const;
       }
-      if (rec.status === "stopped") return { success: true, containerStopped: true } as const;
+      if (rec.status === "stopped")
+        return { success: true, containerStopped: true } as const;
 
       let containerStopped = false;
       if (rec.sandbox_id) {
@@ -5469,10 +6165,13 @@ export class ElizaSandboxService {
         } catch (e) {
           if (this.isIgnorableSandboxStopError(e)) {
             containerStopped = true;
-            logger.info("[agent-sandbox] Sandbox already absent during suspend", {
-              sandboxId: rec.sandbox_id,
-              error: e instanceof Error ? e.message : String(e),
-            });
+            logger.info(
+              "[agent-sandbox] Sandbox already absent during suspend",
+              {
+                sandboxId: rec.sandbox_id,
+                error: e instanceof Error ? e.message : String(e),
+              },
+            );
           } else {
             return {
               success: false,
@@ -5585,8 +6284,13 @@ export class ElizaSandboxService {
     // Primary read: replica lag must not turn a real sleep into a no-op.
     const rec = await this.getAgentForWrite(agentId, orgId);
     if (!rec || this.isAwaitingDeletion(rec.status))
-      return { success: false, containerRemoved: false, error: "Agent not found" };
-    if (rec.status === "sleeping") return { success: true, containerRemoved: true };
+      return {
+        success: false,
+        containerRemoved: false,
+        error: "Agent not found",
+      };
+    if (rec.status === "sleeping")
+      return { success: true, containerRemoved: true };
     if (rec.status === "provisioning") {
       return {
         success: false,
@@ -5608,10 +6312,13 @@ export class ElizaSandboxService {
         });
         backupId = backup.id;
       } catch (error) {
-        logger.warn("[agent-sandbox] Sleep snapshot fetch failed; checking latest durable backup", {
-          agentId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.warn(
+          "[agent-sandbox] Sleep snapshot fetch failed; checking latest durable backup",
+          {
+            agentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     }
     if (!backupId) {
@@ -5619,10 +6326,13 @@ export class ElizaSandboxService {
       if (existing) {
         backupId = existing.id;
       } else {
-        logger.error("[agent-sandbox] Sleep aborted: no durable backup available", {
-          agentId,
-          sandboxRecordId: rec.id,
-        });
+        logger.error(
+          "[agent-sandbox] Sleep aborted: no durable backup available",
+          {
+            agentId,
+            sandboxRecordId: rec.id,
+          },
+        );
         return {
           success: false,
           containerRemoved: false,
@@ -5669,14 +6379,20 @@ export class ElizaSandboxService {
       web_ui_port: null,
       last_backup_at: new Date(),
     });
-    await agentSandboxesRepository.pruneBackups(rec.id, MAX_BACKUPS).catch((error) => {
-      logger.warn("[agent-sandbox] Backup pruning failed after sleep", {
-        agentId,
-        error: error instanceof Error ? error.message : String(error),
+    await agentSandboxesRepository
+      .pruneBackups(rec.id, MAX_BACKUPS)
+      .catch((error) => {
+        logger.warn("[agent-sandbox] Backup pruning failed after sleep", {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
       });
-    });
 
-    logger.info("[agent-sandbox] Sleep complete", { agentId, backupId, containerRemoved });
+    logger.info("[agent-sandbox] Sleep complete", {
+      agentId,
+      backupId,
+      containerRemoved,
+    });
     return { success: true, containerRemoved, backupId };
   }
 
@@ -5729,14 +6445,25 @@ export class ElizaSandboxService {
     }
 
     if (opts?.forceFreshBoot) {
-      logger.warn("[agent-sandbox] Wake with explicit forceFreshBoot: restore skipped by user", {
+      logger.warn(
+        "[agent-sandbox] Wake with explicit forceFreshBoot: restore skipped by user",
+        {
+          agentId,
+        },
+      );
+      const provisionResult = await this.provision(agentId, orgId, {
+        kind: "fresh-boot",
+      });
+      if (!provisionResult.success) {
+        return {
+          success: false,
+          reprovisioned: true,
+          error: provisionResult.error,
+        };
+      }
+      logger.info("[agent-sandbox] Wake complete (explicit fresh boot)", {
         agentId,
       });
-      const provisionResult = await this.provision(agentId, orgId, { kind: "fresh-boot" });
-      if (!provisionResult.success) {
-        return { success: false, reprovisioned: true, error: provisionResult.error };
-      }
-      logger.info("[agent-sandbox] Wake complete (explicit fresh boot)", { agentId });
       return { success: true, reprovisioned: true, freshBoot: true };
     }
 
@@ -5777,9 +6504,17 @@ export class ElizaSandboxService {
         ? (await agentSandboxesRepository.getLatestStoredBackup(rec.id))?.id
         : (gate.backupId ?? undefined);
 
-    const provisionResult = await this.provision(agentId, orgId, restoreOverride);
+    const provisionResult = await this.provision(
+      agentId,
+      orgId,
+      restoreOverride,
+    );
     if (!provisionResult.success) {
-      return { success: false, reprovisioned: true, error: provisionResult.error };
+      return {
+        success: false,
+        reprovisioned: true,
+        error: provisionResult.error,
+      };
     }
 
     logger.info("[agent-sandbox] Wake complete", {
@@ -5839,10 +6574,13 @@ export class ElizaSandboxService {
           error: "Agent not found",
         };
       }
-      logger.warn("[agent-sandbox] Shutdown during restart returned error, continuing", {
-        agentId,
-        error: shutdownResult.error,
-      });
+      logger.warn(
+        "[agent-sandbox] Shutdown during restart returned error, continuing",
+        {
+          agentId,
+          error: shutdownResult.error,
+        },
+      );
     }
 
     const provisionResult = await this.provision(agentId, orgId);
@@ -5948,7 +6686,10 @@ export class ElizaSandboxService {
     // The reconciler already selects them by digest drift; the blue/green swap
     // re-provisions on the target image+digest, so moving a fleet-managed agent
     // to the current default is safe regardless of its current tag.
-    if (agent.docker_image && imageRepo(agent.docker_image) !== imageRepo(dockerImage)) {
+    if (
+      agent.docker_image &&
+      imageRepo(agent.docker_image) !== imageRepo(dockerImage)
+    ) {
       // Refusal before any container work: old container is untouched and live.
       return {
         success: false,
@@ -6030,10 +6771,13 @@ export class ElizaSandboxService {
       try {
         await provider.stop(blueHandle.sandboxId);
       } catch (err) {
-        logger.warn("[agent-sandbox] Failed to tear down unhealthy blue during upgrade rollback", {
-          agentId,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        logger.warn(
+          "[agent-sandbox] Failed to tear down unhealthy blue during upgrade rollback",
+          {
+            agentId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+        );
       }
       return {
         success: false,
@@ -6044,7 +6788,9 @@ export class ElizaSandboxService {
       };
     }
 
-    const blueMeta = isDockerSandboxMetadata(blueHandle.metadata) ? blueHandle.metadata : undefined;
+    const blueMeta = isDockerSandboxMetadata(blueHandle.metadata)
+      ? blueHandle.metadata
+      : undefined;
     if (!blueMeta) {
       try {
         await provider.stop(blueHandle.sandboxId);
@@ -6067,10 +6813,13 @@ export class ElizaSandboxService {
     }
     if (blueMeta.imageDigest && blueMeta.imageDigest !== toDigest) {
       await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after digest mismatch", {
-          agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after digest mismatch",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
@@ -6087,10 +6836,13 @@ export class ElizaSandboxService {
     });
     if (!runtimeHealth.success) {
       await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after runtime readiness failure", {
-          agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after runtime readiness failure",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
@@ -6106,16 +6858,23 @@ export class ElizaSandboxService {
     // back. A missing/partial snapshot blocks the upgrade: swapping images
     // without a verified full-agent restore point is the data-loss class this
     // path is designed to prevent.
-    const preUpgradeSnapshot = await this.snapshot(agentId, orgId, "pre-upgrade").catch((err) => ({
+    const preUpgradeSnapshot = await this.snapshot(
+      agentId,
+      orgId,
+      "pre-upgrade",
+    ).catch((err) => ({
       success: false,
       error: err instanceof Error ? err.message : String(err),
     }));
     if (!preUpgradeSnapshot.success) {
       await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after pre-upgrade snapshot failure", {
-          agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after pre-upgrade snapshot failure",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
@@ -6129,7 +6888,11 @@ export class ElizaSandboxService {
     try {
       const swapped = await dbWrite.transaction(async (tx) => {
         await this.lockLifecycle(tx, agentId, orgId);
-        const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
+        const current = await this.getAgentForLifecycleMutation(
+          tx,
+          agentId,
+          orgId,
+        );
         if (!current) return false;
         if (
           current.status !== "running" ||
@@ -6149,7 +6912,8 @@ export class ElizaSandboxService {
           // (#15358). Mirror the selection/pre-provision semantics — abandon
           // only on a real repo change; the digest/node/container/sandbox legs
           // above still detect every other concurrent mutation.
-          (current.docker_image && imageRepo(current.docker_image) !== imageRepo(dockerImage))
+          (current.docker_image &&
+            imageRepo(current.docker_image) !== imageRepo(dockerImage))
         ) {
           return false;
         }
@@ -6182,15 +6946,21 @@ export class ElizaSandboxService {
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      logger.error("[agent-sandbox] Atomic swap UPDATE failed; tearing down orphaned blue", {
-        agentId,
-        err: errMsg,
-      });
-      await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after atomic swap UPDATE failure", {
+      logger.error(
+        "[agent-sandbox] Atomic swap UPDATE failed; tearing down orphaned blue",
+        {
           agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+          err: errMsg,
+        },
+      );
+      await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after atomic swap UPDATE failure",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
@@ -6286,7 +7056,10 @@ export class ElizaSandboxService {
     // Same fleet-managed-vs-custom distinction as the upgrade path (#15101):
     // a rollback of a default-family agent must not be refused just because its
     // tag differs from the target.
-    if (agent.docker_image && imageRepo(agent.docker_image) !== imageRepo(dockerImage)) {
+    if (
+      agent.docker_image &&
+      imageRepo(agent.docker_image) !== imageRepo(dockerImage)
+    ) {
       return {
         success: false,
         error: "Agent uses a custom docker image; refusing fleet rollback",
@@ -6361,10 +7134,13 @@ export class ElizaSandboxService {
 
     if (!(await provider.checkHealth(blueHandle))) {
       await provider.stop(blueHandle.sandboxId).catch((err) =>
-        logger.warn("[agent-sandbox] Failed to tear down unhealthy blue during rollback", {
-          agentId,
-          err: err instanceof Error ? err.message : String(err),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down unhealthy blue during rollback",
+          {
+            agentId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+        ),
       );
       return {
         success: false,
@@ -6374,7 +7150,9 @@ export class ElizaSandboxService {
       };
     }
 
-    const blueMeta = isDockerSandboxMetadata(blueHandle.metadata) ? blueHandle.metadata : undefined;
+    const blueMeta = isDockerSandboxMetadata(blueHandle.metadata)
+      ? blueHandle.metadata
+      : undefined;
     if (!blueMeta) {
       await provider.stop(blueHandle.sandboxId).catch((err) =>
         logger.warn(
@@ -6394,10 +7172,13 @@ export class ElizaSandboxService {
     }
     if (blueMeta.imageDigest && blueMeta.imageDigest !== toDigest) {
       await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after rollback digest mismatch", {
-          agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after rollback digest mismatch",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
@@ -6410,14 +7191,16 @@ export class ElizaSandboxService {
     // Restore the pre-upgrade state onto blue BEFORE cutover. A rollback that
     // cannot replay the verified restore point is not a rollback, so fail
     // loudly and leave the current image serving traffic.
-    const preUpgradeBackup = await agentSandboxesRepository.getLatestBackupByType(
-      agent.id,
-      "pre-upgrade",
-    );
-    if (preUpgradeBackup) {
-      const restoreState = await agentSandboxesRepository.getReconstructedBackupState(
-        preUpgradeBackup.id,
+    const preUpgradeBackup =
+      await agentSandboxesRepository.getLatestBackupByType(
+        agent.id,
+        "pre-upgrade",
       );
+    if (preUpgradeBackup) {
+      const restoreState =
+        await agentSandboxesRepository.getReconstructedBackupState(
+          preUpgradeBackup.id,
+        );
       if (restoreState) {
         try {
           await this.pushState(blueHandle.bridgeUrl, restoreState, {
@@ -6425,12 +7208,17 @@ export class ElizaSandboxService {
             authRec: agent,
           });
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
+          const message =
+            error instanceof Error ? error.message : String(error);
           await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-            logger.warn("[agent-sandbox] Failed to tear down blue after rollback restore failure", {
-              agentId,
-              err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-            }),
+            logger.warn(
+              "[agent-sandbox] Failed to tear down blue after rollback restore failure",
+              {
+                agentId,
+                err:
+                  stopErr instanceof Error ? stopErr.message : String(stopErr),
+              },
+            ),
           );
           return {
             success: false,
@@ -6441,10 +7229,13 @@ export class ElizaSandboxService {
         }
       } else {
         await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-          logger.warn("[agent-sandbox] Failed to tear down blue after empty rollback restore", {
-            agentId,
-            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-          }),
+          logger.warn(
+            "[agent-sandbox] Failed to tear down blue after empty rollback restore",
+            {
+              agentId,
+              err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+            },
+          ),
         );
         return {
           success: false,
@@ -6455,23 +7246,31 @@ export class ElizaSandboxService {
       }
     } else {
       await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after missing rollback snapshot", {
-          agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after missing rollback snapshot",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
         oldNodeId,
         oldContainerName,
-        error: "No pre-upgrade snapshot found; refusing rollback without restore point",
+        error:
+          "No pre-upgrade snapshot found; refusing rollback without restore point",
       };
     }
 
     try {
       const swapped = await dbWrite.transaction(async (tx) => {
         await this.lockLifecycle(tx, agentId, orgId);
-        const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
+        const current = await this.getAgentForLifecycleMutation(
+          tx,
+          agentId,
+          orgId,
+        );
         if (!current) return false;
         if (
           current.status !== "running" ||
@@ -6484,7 +7283,8 @@ export class ElizaSandboxService {
           // pin drift within the fleet repo (an empty or tag/digest-pinned
           // docker_image on the same repo is still the fleet image — #15101,
           // #15358). `dockerImage` here is the recorded rollback ref.
-          (current.docker_image && imageRepo(current.docker_image) !== imageRepo(dockerImage))
+          (current.docker_image &&
+            imageRepo(current.docker_image) !== imageRepo(dockerImage))
         ) {
           return false;
         }
@@ -6524,10 +7324,13 @@ export class ElizaSandboxService {
         },
       );
       await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
-        logger.warn("[agent-sandbox] Failed to tear down blue after rollback swap UPDATE failure", {
-          agentId,
-          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
-        }),
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue after rollback swap UPDATE failure",
+          {
+            agentId,
+            err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          },
+        ),
       );
       return {
         success: false,
@@ -6598,7 +7401,8 @@ export class ElizaSandboxService {
       return {
         success: true,
         status: rec.status,
-        message: "Logs unavailable: sandbox provider does not implement fetchLogs.",
+        message:
+          "Logs unavailable: sandbox provider does not implement fetchLogs.",
       };
     }
 
@@ -6631,7 +7435,11 @@ export class ElizaSandboxService {
 
   // Private helpers
 
-  private async lockLifecycle(tx: LifecycleTx, agentId: string, orgId: string): Promise<void> {
+  private async lockLifecycle(
+    tx: LifecycleTx,
+    agentId: string,
+    orgId: string,
+  ): Promise<void> {
     await tx.execute(elizaProvisionAdvisoryLockSql(orgId, agentId));
   }
 
@@ -6787,12 +7595,18 @@ export class ElizaSandboxService {
     // error-policy:J6 best-effort — a failed prune only means we warn + degrade
     // again next boot, never that we fail to boot fresh, so it must not throw
     // out of the provision.
-    await agentSandboxesRepository.pruneBackups(agentId, 0).catch((pruneErr) => {
-      logger.warn("[agent-sandbox] Failed to drop orphaned snapshot after degrade", {
-        agentId,
-        error: pruneErr instanceof Error ? pruneErr.message : String(pruneErr),
+    await agentSandboxesRepository
+      .pruneBackups(agentId, 0)
+      .catch((pruneErr) => {
+        logger.warn(
+          "[agent-sandbox] Failed to drop orphaned snapshot after degrade",
+          {
+            agentId,
+            error:
+              pruneErr instanceof Error ? pruneErr.message : String(pruneErr),
+          },
+        );
       });
-    });
   }
 
   private async markError(rec: AgentSandbox, msg: string) {
@@ -6810,7 +7624,9 @@ export class ElizaSandboxService {
    * exists turns Docker's "already in use" into a cleanup path that removes the
    * very container the retry was meant to save.
    */
-  private buildProvisioningRetryHandle(rec: AgentSandbox): SandboxHandle | null {
+  private buildProvisioningRetryHandle(
+    rec: AgentSandbox,
+  ): SandboxHandle | null {
     if (!rec.sandbox_id || !rec.bridge_url || !rec.health_url) return null;
     const hasDockerFleetColumns = Boolean(
       rec.node_id || rec.container_name || rec.bridge_port || rec.web_ui_port,
@@ -6867,25 +7683,33 @@ export class ElizaSandboxService {
     }
 
     try {
-      const updateData: Parameters<typeof agentSandboxesRepository.update>[1] = {
-        sandbox_id: handle.sandboxId,
-        bridge_url: handle.bridgeUrl,
-        health_url: handle.healthUrl,
-      };
+      const updateData: Parameters<typeof agentSandboxesRepository.update>[1] =
+        {
+          sandbox_id: handle.sandboxId,
+          bridge_url: handle.bridgeUrl,
+          health_url: handle.healthUrl,
+        };
       if (dockerMeta) {
         if (dockerMeta.nodeId) updateData.node_id = dockerMeta.nodeId;
-        if (dockerMeta.containerName) updateData.container_name = dockerMeta.containerName;
-        if (dockerMeta.bridgePort) updateData.bridge_port = dockerMeta.bridgePort;
+        if (dockerMeta.containerName)
+          updateData.container_name = dockerMeta.containerName;
+        if (dockerMeta.bridgePort)
+          updateData.bridge_port = dockerMeta.bridgePort;
         if (dockerMeta.webUiPort) updateData.web_ui_port = dockerMeta.webUiPort;
-        if (dockerMeta.headscaleIp) updateData.headscale_ip = dockerMeta.headscaleIp;
-        if (dockerMeta.dockerImage) updateData.docker_image = dockerMeta.dockerImage;
+        if (dockerMeta.headscaleIp)
+          updateData.headscale_ip = dockerMeta.headscaleIp;
+        if (dockerMeta.dockerImage)
+          updateData.docker_image = dockerMeta.dockerImage;
         updateData.image_digest = dockerMeta.imageDigest;
       }
       await agentSandboxesRepository.update(agentId, updateData);
     } catch (error) {
       logger.warn(
         "[agent-sandbox] Failed to persist container handle for transport-unresolved retry",
-        { agentId, error: error instanceof Error ? error.message : String(error) },
+        {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
       );
     }
   }
@@ -6960,7 +7784,11 @@ export class ElizaSandboxService {
     const res =
       typeof sandboxOrBridgeUrl === "string"
         ? await fetch(
-            await this.getSafeBridgeEndpoint(sandboxOrBridgeUrl, "/api/restore", options),
+            await this.getSafeBridgeEndpoint(
+              sandboxOrBridgeUrl,
+              "/api/restore",
+              options,
+            ),
             {
               ...requestInit,
               headers: options?.authRec
@@ -6968,7 +7796,11 @@ export class ElizaSandboxService {
                 : { "Content-Type": "application/json" },
             },
           )
-        : await this.fetchAgentApi(sandboxOrBridgeUrl, "/api/restore", requestInit);
+        : await this.fetchAgentApi(
+            sandboxOrBridgeUrl,
+            "/api/restore",
+            requestInit,
+          );
     if (!res.ok) {
       // error-policy:J6 best-effort read of the restore error body to enrich
       // the error we throw next; a failed body read must not mask the status.
@@ -6979,7 +7811,9 @@ export class ElizaSandboxService {
         });
         return "";
       });
-      throw new Error(`State restore failed: HTTP ${res.status} ${text.slice(0, 200)}`);
+      throw new Error(
+        `State restore failed: HTTP ${res.status} ${text.slice(0, 200)}`,
+      );
     }
   }
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -18,6 +18,7 @@ const bridgeStream = mock(
     _orgId: string,
     _rpc: unknown,
     _executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+    _resolvedAgent?: unknown,
   ): Promise<Response | null> =>
     new Response("event: done\ndata: {}\n\n", {
       headers: { "Content-Type": "text/event-stream; charset=utf-8" },
@@ -28,7 +29,8 @@ mock.module("../eliza-sandbox", () => ({
   elizaSandboxService: { bridgeStream },
 }));
 
-const { handleCanonicalScopedAgentStream } = await import("./canonical-scoped-stream");
+const { handleCanonicalScopedAgentStream } =
+  await import("./canonical-scoped-stream");
 
 const BASE = {
   agentId: "00000000-0000-4000-8000-00000000a9e0",
@@ -42,7 +44,10 @@ describe("handleCanonicalScopedAgentStream — executionCtx threading", () => {
     bridgeStream.mockClear();
     const executionCtx = { waitUntil: (_p: Promise<unknown>) => undefined };
 
-    const res = await handleCanonicalScopedAgentStream({ ...BASE, executionCtx });
+    const res = await handleCanonicalScopedAgentStream({
+      ...BASE,
+      executionCtx,
+    });
 
     expect(res.status).toBe(200);
     expect(bridgeStream).toHaveBeenCalledTimes(1);
@@ -52,6 +57,24 @@ describe("handleCanonicalScopedAgentStream — executionCtx threading", () => {
     // The SAME executionCtx object must arrive as the 4th argument — the
     // shared-tier turn hands its billing tail to exactly this waitUntil.
     expect(call?.[3]).toBe(executionCtx);
+  });
+
+  test("threads the resolved agent row to bridgeStream so the stream path skips findRunningSandbox", async () => {
+    bridgeStream.mockClear();
+    const agent = {
+      id: BASE.agentId,
+      organization_id: BASE.orgId,
+      status: "running",
+    };
+
+    const res = await handleCanonicalScopedAgentStream({
+      ...BASE,
+      agent: agent as never,
+    });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    expect(bridgeStream.mock.calls[0]?.[4]).toBe(agent);
   });
 
   test("no executionCtx (tests, non-Worker callers): bridgeStream receives undefined", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -5,6 +5,7 @@
  * SSE/CORS response shape used by HTTP routes and in-process voice turns.
  */
 
+import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import { InsufficientCreditsError } from "../../api/errors";
 import { logger } from "../../utils/logger";
 import type { BridgeExecutionContext, BridgeRequest } from "../eliza-sandbox";
@@ -22,6 +23,7 @@ const STREAM_HEADERS = {
 export interface CanonicalScopedStreamRequest {
   agentId: string;
   orgId: string;
+  agent?: AgentSandbox;
   conversationId: string;
   userId?: string;
   body: unknown;
@@ -43,9 +45,14 @@ function elapsedMs(startedAt: number): number {
   return Math.round((nowMs() - startedAt) * 10) / 10;
 }
 
-function addStreamTimingHeaders(response: Response, timings: Record<string, number>): Response {
+function addStreamTimingHeaders(
+  response: Response,
+  timings: Record<string, number>,
+): Response {
   const headers = new Headers(response.headers);
-  const entries = Object.entries(timings).filter(([, duration]) => Number.isFinite(duration));
+  const entries = Object.entries(timings).filter(([, duration]) =>
+    Number.isFinite(duration),
+  );
   if (entries.length) {
     headers.set(
       "Server-Timing",
@@ -76,7 +83,10 @@ export async function handleCanonicalScopedAgentStream(
   timings.parse = elapsedMs(parseStartedAt);
   if (!text.trim()) {
     return applyCorsHeaders(
-      Response.json({ success: false, error: "text is required" }, { status: 400 }),
+      Response.json(
+        { success: false, error: "text is required" },
+        { status: 400 },
+      ),
       CORS_METHODS,
       request.origin,
     );
@@ -101,6 +111,7 @@ export async function handleCanonicalScopedAgentStream(
       request.orgId,
       rpc,
       request.executionCtx,
+      request.agent,
     );
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {
@@ -108,9 +119,12 @@ export async function handleCanonicalScopedAgentStream(
     // error-policy:J1 boundary translation — bridgeStream rejects insufficient
     // credit before any SSE bytes exist, so callers get the canonical 402 JSON.
     if (error instanceof InsufficientCreditsError) {
-      logger.warn("[shared-runtime REST] stream send rejected: insufficient credits", {
-        agentId: request.agentId,
-      });
+      logger.warn(
+        "[shared-runtime REST] stream send rejected: insufficient credits",
+        {
+          agentId: request.agentId,
+        },
+      );
       return addStreamTimingHeaders(
         applyCorsHeaders(
           Response.json(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -46,7 +46,10 @@ type CachedAgentSandbox = Omit<AgentSandbox, AgentSandboxDateField> & {
   [Field in AgentSandboxDateField]: unknown;
 };
 
-function invalidCachedAgentTimestamp(field: AgentSandboxDateField, value: unknown): ElizaError {
+function invalidCachedAgentTimestamp(
+  field: AgentSandboxDateField,
+  value: unknown,
+): ElizaError {
   return new ElizaError("Shared-agent cache contains an invalid timestamp", {
     code: "INVALID_CACHED_AGENT_TIMESTAMP",
     context: { field, value },
@@ -54,7 +57,10 @@ function invalidCachedAgentTimestamp(field: AgentSandboxDateField, value: unknow
   });
 }
 
-function rehydrateRequiredCachedDate(value: unknown, field: AgentSandboxDateField): Date {
+function rehydrateRequiredCachedDate(
+  value: unknown,
+  field: AgentSandboxDateField,
+): Date {
   if (value instanceof Date && !Number.isNaN(value.getTime())) {
     return value;
   }
@@ -67,7 +73,10 @@ function rehydrateRequiredCachedDate(value: unknown, field: AgentSandboxDateFiel
   throw invalidCachedAgentTimestamp(field, value);
 }
 
-function rehydrateNullableCachedDate(value: unknown, field: AgentSandboxDateField): Date | null {
+function rehydrateNullableCachedDate(
+  value: unknown,
+  field: AgentSandboxDateField,
+): Date | null {
   return value === null ? null : rehydrateRequiredCachedDate(value, field);
 }
 
@@ -85,17 +94,31 @@ function rehydrateNullableCachedDate(value: unknown, field: AgentSandboxDateFiel
  * malformed values fail at this boundary because returning a row that violates
  * `AgentSandbox` would defer the fault into an unrelated route consumer.
  */
-function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
+export function rehydrateCachedAgentDates(
+  agent: CachedAgentSandbox,
+): AgentSandbox {
   return {
     ...agent,
     created_at: rehydrateRequiredCachedDate(agent.created_at, "created_at"),
     updated_at: rehydrateRequiredCachedDate(agent.updated_at, "updated_at"),
     deleted_at: rehydrateNullableCachedDate(agent.deleted_at, "deleted_at"),
     claimed_at: rehydrateNullableCachedDate(agent.claimed_at, "claimed_at"),
-    pool_ready_at: rehydrateNullableCachedDate(agent.pool_ready_at, "pool_ready_at"),
-    last_backup_at: rehydrateNullableCachedDate(agent.last_backup_at, "last_backup_at"),
-    last_heartbeat_at: rehydrateNullableCachedDate(agent.last_heartbeat_at, "last_heartbeat_at"),
-    last_billed_at: rehydrateNullableCachedDate(agent.last_billed_at, "last_billed_at"),
+    pool_ready_at: rehydrateNullableCachedDate(
+      agent.pool_ready_at,
+      "pool_ready_at",
+    ),
+    last_backup_at: rehydrateNullableCachedDate(
+      agent.last_backup_at,
+      "last_backup_at",
+    ),
+    last_heartbeat_at: rehydrateNullableCachedDate(
+      agent.last_heartbeat_at,
+      "last_heartbeat_at",
+    ),
+    last_billed_at: rehydrateNullableCachedDate(
+      agent.last_billed_at,
+      "last_billed_at",
+    ),
     shutdown_warning_sent_at: rehydrateNullableCachedDate(
       agent.shutdown_warning_sent_at,
       "shutdown_warning_sent_at",
@@ -117,7 +140,7 @@ function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
  * time-sensitive dedicated-bootstrap window, whose eligibility flips as the
  * container boots.
  */
-interface CachedSharedAgentScope {
+export interface CachedSharedAgentScope {
   orgId: string;
   agent: CachedAgentSandbox;
   /**
@@ -148,7 +171,10 @@ interface CachedSharedAgentScope {
  * full authoritative gate — the exact 401/403 taxonomy is preserved, we only
  * fast-path the HAPPY case. Session/JWT requests never reach here (no api key).
  */
-async function revalidateCachedScope(c: Context<AppEnv>, cachedOrgId: string): Promise<boolean> {
+async function revalidateCachedScope(
+  c: Context<AppEnv>,
+  cachedOrgId: string,
+): Promise<boolean> {
   const apiKey =
     c.req.header("X-API-Key") ||
     c.req.header("x-api-key") ||
@@ -160,10 +186,64 @@ async function revalidateCachedScope(c: Context<AppEnv>, cachedOrgId: string): P
   const { apiKeysService } = await import("../../services/api-keys");
   const validated = await apiKeysService.validateApiKey(apiKey);
   if (!validated || !validated.is_active) return false;
-  if (validated.expires_at && new Date(validated.expires_at) < new Date()) return false;
+  if (validated.expires_at && new Date(validated.expires_at) < new Date())
+    return false;
   // The key must still be scoped to the org the cached agent belongs to. A
   // detach/re-scope changes organization_id, so a stale cross-org read fails here.
   return validated.organization_id === cachedOrgId;
+}
+
+export async function cacheSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+  agent: AgentSandbox,
+): Promise<void> {
+  if (agent.execution_tier !== "shared" || agent.status !== "running") return;
+  await cache
+    .set(
+      CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId),
+      agent,
+      CacheTTL.sharedAgentScope.runningSandbox,
+    )
+    .catch((error) => {
+      logger.debug("[resolveSharedAgent] running sandbox cache write failed", {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
+export async function getCachedSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+): Promise<AgentSandbox | null> {
+  const cached = await cache
+    .get<CachedAgentSandbox>(
+      CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId),
+    )
+    .catch(() => null);
+  if (!cached) return null;
+  const agent = rehydrateCachedAgentDates(cached);
+  return agent.execution_tier === "shared" && agent.status === "running"
+    ? agent
+    : null;
+}
+
+export async function invalidateSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+): Promise<void> {
+  await cache
+    .del(CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId))
+    .catch((error) => {
+      logger.debug(
+        "[resolveSharedAgent] running sandbox cache invalidation failed",
+        {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    });
 }
 
 /**
@@ -180,7 +260,9 @@ async function revalidateCachedScope(c: Context<AppEnv>, cachedOrgId: string): P
  * its own subdomain REST surface instead. Returns the superset of fields the
  * leaves read; each caller takes what it needs.
  */
-export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSharedAgent> {
+export async function resolveSharedAgent(
+  c: Context<AppEnv>,
+): Promise<ResolvedSharedAgent> {
   const agentId = c.req.param("agentId");
   if (!agentId) return { error: "Missing agent id", status: 400 };
 
@@ -196,9 +278,12 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
   // (#SHADOW-ACCOUNT-DEBUG). Whichever credential the request carries wins;
   // requests carrying neither skip the cache and hit the authoritative gate.
   const apiKeyPrefix = await apiKeyScopeHashPrefix(c).catch(() => null);
-  const sessionPrefix = apiKeyPrefix ? null : await sessionScopeHashPrefix(c).catch(() => null);
+  const sessionPrefix = apiKeyPrefix
+    ? null
+    : await sessionScopeHashPrefix(c).catch(() => null);
   const isSessionScope = apiKeyPrefix == null && sessionPrefix != null;
-  const scopeKeyPrefix = apiKeyPrefix ?? (sessionPrefix ? `s:${sessionPrefix}` : null);
+  const scopeKeyPrefix =
+    apiKeyPrefix ?? (sessionPrefix ? `s:${sessionPrefix}` : null);
   const scopeCacheKey = scopeKeyPrefix
     ? CacheKeys.sharedAgentScope.resolve(scopeKeyPrefix, agentId)
     : null;
@@ -209,7 +294,11 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
   const revalidateResolvedScope = async (
     cached: CachedSharedAgentScope,
   ): Promise<ResolvedSharedAgent | null> => {
-    if (!(cached?.agent && cached.orgId && cached.agent.execution_tier === "shared")) {
+    if (!(
+      cached?.agent &&
+      cached.orgId &&
+      cached.agent.execution_tier === "shared"
+    )) {
       return null;
     }
     // SECURITY: a hit skips the expensive user/org+agent DB hydration, but it
@@ -221,7 +310,9 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
     // gate inside the 30s TTL window; we only skip the cold DB waves.
     const stillAuthorized = isSessionScope
       ? cached.stewardUserId != null &&
-        (await revalidateSessionScope(c, cached.stewardUserId).catch(() => false))
+        (await revalidateSessionScope(c, cached.stewardUserId).catch(
+          () => false,
+        ))
       : await revalidateCachedScope(c, cached.orgId).catch(() => false);
     if (!stillAuthorized) return null;
     // Restore the DATE contract lost to the cache's JSON round-trip before
@@ -255,17 +346,25 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
     const firstWrittenAtMs = cached.firstWrittenAtMs ?? now;
     // Do not refresh past the absolute cap; let the entry expire so the agent
     // row self-heals via the authoritative gate.
-    if (now - firstWrittenAtMs >= CacheTTL.sharedAgentScope.resolveMaxAgeMs) return;
+    if (now - firstWrittenAtMs >= CacheTTL.sharedAgentScope.resolveMaxAgeMs)
+      return;
     const refreshed: CachedSharedAgentScope = { ...cached, firstWrittenAtMs };
-    void cache.set(scopeCacheKey, refreshed, CacheTTL.sharedAgentScope.resolve).catch((error) => {
-      logger.debug("[resolveSharedAgent] scope cache sliding refresh failed", {
-        error: error instanceof Error ? error.message : String(error),
+    void cache
+      .set(scopeCacheKey, refreshed, CacheTTL.sharedAgentScope.resolve)
+      .catch((error) => {
+        logger.debug(
+          "[resolveSharedAgent] scope cache sliding refresh failed",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       });
-    });
   };
 
   if (scopeCacheKey) {
-    const cached = await cache.get<CachedSharedAgentScope>(scopeCacheKey).catch(() => null);
+    const cached = await cache
+      .get<CachedSharedAgentScope>(scopeCacheKey)
+      .catch(() => null);
     if (cached) {
       const resolved = await revalidateResolvedScope(cached);
       if (resolved) {
@@ -296,10 +395,10 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
         scopeCacheKey,
         CacheTTL.sharedAgentScope.resolve,
         async () => {
-          const { user, orgLookupResult: agent } = await requireUserOrApiKeyWithOrgLookup(
-            c,
-            (orgId) => agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
-          );
+          const { user, orgLookupResult: agent } =
+            await requireUserOrApiKeyWithOrgLookup(c, (orgId) =>
+              agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
+            );
           // Only a settled shared-tier agent is cacheable (never the
           // time-sensitive dedicated-bootstrap window). A non-cacheable or
           // not-found result returns null so getOrSet does NOT populate the
@@ -308,7 +407,11 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
           if (!agent || agent.execution_tier !== "shared") return null;
           const base =
             isSessionScope && typeof user.steward_id === "string"
-              ? { orgId: user.organization_id, agent, stewardUserId: user.steward_id }
+              ? {
+                  orgId: user.organization_id,
+                  agent,
+                  stewardUserId: user.steward_id,
+                }
               : { orgId: user.organization_id, agent };
           return { ...base, firstWrittenAtMs: Date.now() };
         },
@@ -325,9 +428,10 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
     }
   }
 
-  const { user, orgLookupResult: agent } = await requireUserOrApiKeyWithOrgLookup(c, (orgId) =>
-    agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
-  );
+  const { user, orgLookupResult: agent } =
+    await requireUserOrApiKeyWithOrgLookup(c, (orgId) =>
+      agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
+    );
   if (!agent) return { error: "Agent not found", status: 404 };
   if (agent.execution_tier !== "shared" && !isDedicatedBootstrapWindow(agent)) {
     return { error: "Not a shared-runtime agent", status: 404 };
@@ -347,12 +451,20 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
         : { orgId: user.organization_id, agent }),
       firstWrittenAtMs: Date.now(),
     };
-    void cache.set(scopeCacheKey, entry, CacheTTL.sharedAgentScope.resolve).catch((error) => {
-      logger.debug("[resolveSharedAgent] scope cache write failed", {
-        error: error instanceof Error ? error.message : String(error),
+    void cache
+      .set(scopeCacheKey, entry, CacheTTL.sharedAgentScope.resolve)
+      .catch((error) => {
+        logger.debug("[resolveSharedAgent] scope cache write failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
       });
-    });
+    void cacheSharedAgentRunningSandbox(agentId, user.organization_id, agent);
   }
 
-  return { agent, agentId, orgId: user.organization_id, agentName: agent.agent_name ?? "Eliza" };
+  return {
+    agent,
+    agentId,
+    orgId: user.organization_id,
+    agentName: agent.agent_name ?? "Eliza",
+  };
 }


### PR DESCRIPTION
## Summary
- collapse reservation reconciliation from a multi-statement write transaction into one Postgres CTE round trip
- preserve first-claim/idempotency semantics, legacy keyed settlement behavior, refund/overage accounting, org/cache invalidation, and balance-decrease notifications
- reuse the resolved shared-agent row/running-sandbox scope cache on the canonical stream path so bridgeStream does not issue a redundant findRunningSandbox query
- add bounded running-sandbox cache TTL plus invalidation on sandbox status updates

## Tests
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts`
- `bun test packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts --timeout 120000` currently blocked locally by existing PGlite bootstrap issue: `Cannot find module '@elizaos/core' from plugins/plugin-sql/src/index.ts`; non-DB cases pass, PGlite guard fails before DB assertions can run
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts --timeout 120000` currently blocked locally by same plugin-sql/core resolution issue; canonical stream tests pass

## Notes
- This PR is the develop-based version of #17010, opened because #17010 was stacked on #16976 and GitHub marked it conflicting against develop.
