### PR TITLE
perf(cloud): reduce billing and sandbox DB round trips

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -155,6 +155,7 @@ app.post("/", async (c) => {
   return handleCanonicalScopedAgentStream({
     agentId: r.agentId,
     orgId: r.orgId,
+    agent: r.agent,
     conversationId,
     ...("userId" in r ? { userId: r.userId } : {}),
     body: raw,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -703,6 +703,18 @@ export class AgentSandboxesRepository {
       .set({ ...data, updated_at: new Date() })
       .where(eq(agentSandboxes.id, id))
       .returning();
+    if (r && data.status !== undefined) {
+      void import("../../lib/services/shared-runtime/resolve-shared-agent")
+        .then(({ invalidateSharedAgentRunningSandbox }) =>
+          invalidateSharedAgentRunningSandbox(r.id, r.organization_id),
+        )
+        .catch((error) => {
+          logger.debug("[agent-sandboxes] running sandbox cache invalidation failed", {
+            id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    }
     return r;
   }
 

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -50,6 +50,8 @@ export const CacheKeys = {
   sharedAgentScope: {
     resolve: (keyHashPrefix: string, agentId: string) =>
       `shared-agent-scope:${keyHashPrefix}:${agentId}:v1`,
+    runningSandbox: (agentId: string, orgId: string) =>
+      `shared-agent-scope:running-sandbox:${orgId}:${agentId}:v1`,
   },
   /**
    * Inference hot-path caches (#9899). The IAC entry collapses auth + org +
@@ -277,6 +279,7 @@ export const CacheTTL = {
    */
   sharedAgentScope: {
     resolve: 30,
+    runningSandbox: 30,
     /**
      * SLIDING-TTL CAP (COLDPATH-FIX-2026-07-22): a validated scope-cache hit
      * refreshes the entry's TTL back to `resolve` so an ACTIVE conversation

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -901,6 +901,45 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
     PGLITE_TIMEOUT,
   );
 
+
+  test(
+    "concurrent settle attempts claim exactly one reconciliation row",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("9");
+      const reservationId = await insertReservation(1.0);
+
+      const [first, second] = await Promise.all([
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0.4,
+          description: "concurrent chat completion settle a",
+          metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        }),
+        creditsService.reconcile({
+          organizationId: ORG_ID,
+          reservedAmount: 1.0,
+          actualCost: 0.4,
+          description: "concurrent chat completion settle b",
+          metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+        }),
+      ]);
+
+      expect([first.adjustmentType, second.adjustmentType].sort()).toEqual(["none", "refund"]);
+      expect(await getBalance()).toBeCloseTo(9.6, 6);
+      expect(await countByType("refund")).toBe(1);
+      expect(await settlementRowsForReservation(reservationId)).toEqual([
+        {
+          amount: "0.600000",
+          type: "refund",
+          stripe_payment_intent_id: `recon:${reservationId}:refund`,
+        },
+      ]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
   test(
     "sweep ignores ambiguous pre-marker reservations",
     async () => {

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -4,7 +4,7 @@
 
 import { sql } from "drizzle-orm";
 import { type SqlExecutor, sqlRows } from "../../db/execute-helpers";
-import { dbWrite, writeTransaction } from "../../db/helpers";
+import { dbWrite } from "../../db/helpers";
 import {
   appsRepository,
   type CreditPack,
@@ -1189,30 +1189,21 @@ export class CreditsService {
     | { kind: "no_reservation_row" }
   > {
     const { organizationId, reservationTransactionId, actualCost, description, metadata } = params;
+    const normalizedActualCost = Math.max(actualCost, 0);
+    const inputMetadata = JSON.stringify(metadata ?? {});
 
-    const existingSettlementIds = async (executor: SqlExecutor): Promise<string[]> => {
-      const rows = await sqlRows<{ id: string }>(
-        executor,
-        sql`
-          SELECT id
-          FROM credit_transactions
-          WHERE metadata->>'reservation_transaction_id' = ${reservationTransactionId}
-            AND organization_id = ${organizationId}
-          ORDER BY created_at ASC
-        `,
-      );
-      return rows.map((row) => row.id);
-    };
-
-    const result = await writeTransaction(async (tx) => {
-      const reservationRows = await sqlRows<{
-        id: string;
-        amount: string | number;
-        settled_at: Date | string | null;
-      }>(
-        tx,
-        sql`
-          SELECT id, amount, settled_at
+    const rows = await sqlRows<{
+      reservation_found: boolean | string | number | null;
+      claimed: boolean | string | number | null;
+      reserved_amount: string | number | null;
+      new_balance: string | number | null;
+      settlement_ids: string[] | null;
+      adjustment_type: CreditReconciliationResult["adjustmentType"] | null;
+    }>(
+      dbWrite,
+      sql`
+        WITH reservation AS (
+          SELECT id, organization_id, amount::numeric AS amount, settled_at
           FROM credit_transactions
           WHERE id = ${reservationTransactionId}
             AND organization_id = ${organizationId}
@@ -1225,300 +1216,198 @@ export class CreditsService {
               )
             )
           LIMIT 1
-        `,
-      );
-      const reservation = reservationRows[0];
-      if (!reservation) {
-        return { kind: "no_reservation_row" as const };
-      }
-
-      const reservedAmount = Math.abs(parseNumeric(reservation.amount, "reservation_amount"));
-
-      if (reservation.settled_at !== null) {
-        return {
-          kind: "handled" as const,
-          claimed: false,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: await existingSettlementIds(tx),
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const preexistingSettlementIds = await existingSettlementIds(tx);
-      if (preexistingSettlementIds.length > 0) {
-        const markedRows = await sqlRows<{ id: string }>(
-          tx,
-          sql`
-            UPDATE credit_transactions
-            SET settled_at = NOW()
-            WHERE id = ${reservationTransactionId}
-              AND organization_id = ${organizationId}
-              AND type = 'debit'
-              AND (
-                metadata->>'type' = 'reservation'
-                OR (
-                  metadata->>'type' = 'app_chat_reservation'
-                  AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
-                )
-              )
-              AND settled_at IS NULL
-            RETURNING id
-          `,
-        );
-        return {
-          kind: "handled" as const,
-          claimed: markedRows.length > 0,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: preexistingSettlementIds,
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const claimedRows = await sqlRows<{
-        id: string;
-        amount: string | number;
-      }>(
-        tx,
-        sql`
-          UPDATE credit_transactions
+        ),
+        reservation_values AS (
+          SELECT
+            id,
+            organization_id,
+            ABS(amount)::numeric AS reserved_amount,
+            ${String(normalizedActualCost)}::numeric AS actual_cost,
+            (ABS(amount)::numeric - ${String(normalizedActualCost)}::numeric) AS difference,
+            settled_at
+          FROM reservation
+        ),
+        existing_settlements AS (
+          SELECT COALESCE(array_agg(ct.id ORDER BY ct.created_at ASC), ARRAY[]::uuid[]) AS ids
+          FROM credit_transactions ct
+          WHERE ct.metadata->>'reservation_transaction_id' = ${reservationTransactionId}
+            AND ct.organization_id = ${organizationId}
+        ),
+        claim AS (
+          UPDATE credit_transactions ct
           SET settled_at = NOW()
-          WHERE id = ${reservationTransactionId}
-            AND organization_id = ${organizationId}
-            AND type = 'debit'
+          FROM reservation_values rv
+          WHERE ct.id = rv.id
+            AND rv.settled_at IS NULL
+            AND NOT EXISTS (SELECT 1 FROM existing_settlements es WHERE cardinality(es.ids) > 0)
+            AND ct.settled_at IS NULL
+          RETURNING ct.id
+        ),
+        mark_preexisting AS (
+          UPDATE credit_transactions ct
+          SET settled_at = NOW()
+          FROM reservation_values rv
+          WHERE ct.id = rv.id
+            AND rv.settled_at IS NULL
+            AND EXISTS (SELECT 1 FROM existing_settlements es WHERE cardinality(es.ids) > 0)
+            AND ct.settled_at IS NULL
+          RETURNING ct.id
+        ),
+        mutation_plan AS (
+          SELECT
+            rv.*,
+            CASE
+              WHEN NOT EXISTS (SELECT 1 FROM claim) THEN 'none'
+              WHEN ABS(rv.difference) < ${String(EPSILON)}::numeric THEN 'none'
+              WHEN rv.difference > 0 THEN 'refund'
+              ELSE 'overage'
+            END AS phase,
+            CASE
+              WHEN NOT EXISTS (SELECT 1 FROM claim) THEN 0::numeric
+              WHEN ABS(rv.difference) < ${String(EPSILON)}::numeric THEN 0::numeric
+              ELSE ABS(rv.difference)::numeric
+            END AS amount
+          FROM reservation_values rv
+        ),
+        org AS (
+          SELECT o.id, o.credit_balance::numeric AS current_balance
+          FROM organizations o
+          JOIN mutation_plan mp ON mp.organization_id = o.id
+          WHERE mp.phase IN ('refund', 'overage')
+          FOR UPDATE
+        ),
+        org_update AS (
+          UPDATE organizations o
+          SET credit_balance = CASE
+                WHEN mp.phase = 'refund' THEN org.current_balance + mp.amount
+                WHEN mp.phase = 'overage' THEN org.current_balance - mp.amount
+                ELSE org.current_balance
+              END,
+              updated_at = NOW()
+          FROM org, mutation_plan mp
+          WHERE o.id = org.id
             AND (
-              metadata->>'type' = 'reservation'
-              OR (
-                metadata->>'type' = 'app_chat_reservation'
-                AND metadata->>'settlement_marker' = ${APP_CHAT_RESERVATION_SETTLEMENT_MARKER}
-              )
+              mp.phase = 'refund'
+              OR (mp.phase = 'overage' AND org.current_balance >= mp.amount)
             )
-            AND settled_at IS NULL
-          RETURNING id, amount
-        `,
-      );
-      const claimed = claimedRows[0];
-      if (!claimed) {
-        return {
-          kind: "handled" as const,
-          claimed: false,
-          result: {
-            reservedAmount,
-            actualCost,
-            reservationTransactionId,
-            settlementTransactionIds: await existingSettlementIds(tx),
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      const claimedReservedAmount = Math.abs(parseNumeric(claimed.amount, "reservation_amount"));
-      const normalizedActualCost = Math.max(actualCost, 0);
-      const difference = claimedReservedAmount - normalizedActualCost;
-      const baseMetadata = {
-        ...metadata,
-        reservation_transaction_id: reservationTransactionId,
-        reserved: claimedReservedAmount,
-        actual: normalizedActualCost,
-      };
-
-      if (Math.abs(difference) < EPSILON) {
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [],
-            adjustmentType: "none" as const,
-          },
-        };
-      }
-
-      if (difference > 0) {
-        const refundMetadata = JSON.stringify({
-          ...baseMetadata,
-          type: "reconciliation_refund",
-        });
-        const refundRows = await sqlRows<{
-          id: string | null;
-          new_balance: string | number | null;
-        }>(
-          tx,
-          sql`
-            WITH org AS (
-              SELECT id, credit_balance::numeric AS current_balance
-              FROM organizations
-              WHERE id = ${organizationId}
-              FOR UPDATE
-            ),
-            updated AS (
-              UPDATE organizations AS o
-              SET credit_balance = org.current_balance + ${String(difference)}::numeric,
-                  updated_at = NOW()
-              FROM org
-              WHERE o.id = org.id
-              RETURNING o.credit_balance AS new_balance
-            ),
-            inserted AS (
-              INSERT INTO credit_transactions (
-                organization_id,
-                amount,
-                type,
-                description,
-                metadata,
-                stripe_payment_intent_id,
-                created_at
-              )
-              SELECT
-                org.id,
-                ${String(difference)}::numeric,
-                'refund',
-                ${`${description} (refund)`},
-                ${refundMetadata}::jsonb,
-                ${`recon:${reservationTransactionId}:refund`},
-                NOW()
-              FROM org
-              WHERE EXISTS (SELECT 1 FROM updated)
-              ON CONFLICT (stripe_payment_intent_id) DO NOTHING
-              RETURNING id
-            )
-            SELECT
-              (SELECT id FROM inserted) AS id,
-              (SELECT new_balance FROM updated) AS new_balance
-          `,
-        );
-        const refund = refundRows[0];
-        if (!refund?.id) {
-          throw new Error("[CreditsService] Reservation refund settlement did not insert a row");
-        }
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          newBalance: parseNumeric(refund.new_balance, "new_balance"),
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [refund.id],
-            adjustmentType: "refund" as const,
-          },
-        };
-      }
-
-      const overage = -difference;
-      const overageMetadata = JSON.stringify({
-        ...baseMetadata,
-        type: "reconciliation_overage",
-      });
-      const overageRows = await sqlRows<{
-        id: string | null;
-        debited: boolean | string | number | null;
-        new_balance: string | number | null;
-      }>(
-        tx,
-        sql`
-          WITH org AS (
-            SELECT id, credit_balance::numeric AS current_balance
-            FROM organizations
-            WHERE id = ${organizationId}
-            FOR UPDATE
-          ),
-          updated AS (
-            UPDATE organizations AS o
-            SET credit_balance = org.current_balance - ${String(overage)}::numeric,
-                updated_at = NOW()
-            FROM org
-            WHERE o.id = org.id
-              AND org.current_balance >= ${String(overage)}::numeric
-            RETURNING o.credit_balance AS new_balance
-          ),
-          inserted AS (
-            INSERT INTO credit_transactions (
-              organization_id,
-              amount,
-              type,
-              description,
-              metadata,
-              stripe_payment_intent_id,
-              created_at
-            )
-            SELECT
-              org.id,
-              ${String(-overage)}::numeric,
-              'debit',
-              ${`${description} (overage)`},
-              ${overageMetadata}::jsonb,
-              ${`recon:${reservationTransactionId}:overage`},
-              NOW()
-            FROM org
-            WHERE EXISTS (SELECT 1 FROM updated)
-            ON CONFLICT (stripe_payment_intent_id) DO NOTHING
-            RETURNING id
+          RETURNING o.credit_balance AS new_balance
+        ),
+        inserted AS (
+          INSERT INTO credit_transactions (
+            organization_id,
+            amount,
+            type,
+            description,
+            metadata,
+            stripe_payment_intent_id,
+            created_at
           )
           SELECT
-            EXISTS(SELECT 1 FROM updated) AS debited,
-            (SELECT id FROM inserted) AS id,
-            (SELECT new_balance FROM updated) AS new_balance
-        `,
-      );
-      const overageRow = overageRows[0];
-      if (!isPgTrue(overageRow?.debited)) {
-        return {
-          kind: "handled" as const,
-          claimed: true,
-          result: {
-            reservedAmount: claimedReservedAmount,
-            actualCost: normalizedActualCost,
-            reservationTransactionId,
-            settlementTransactionIds: [],
-            adjustmentType: "uncollected_overage" as const,
-          },
-        };
-      }
-      if (!overageRow?.id) {
-        throw new Error("[CreditsService] Reservation overage settlement did not insert a row");
-      }
-      return {
-        kind: "handled" as const,
-        claimed: true,
-        newBalance: parseNumeric(overageRow.new_balance, "new_balance"),
-        balanceDecreaseMetadata: {
-          ...baseMetadata,
-          type: "reconciliation_overage",
-        },
-        result: {
-          reservedAmount: claimedReservedAmount,
-          actualCost: normalizedActualCost,
-          reservationTransactionId,
-          settlementTransactionIds: [overageRow.id],
-          adjustmentType: "overage" as const,
-        },
-      };
-    });
+            mp.organization_id,
+            CASE WHEN mp.phase = 'refund' THEN mp.amount ELSE -mp.amount END,
+            CASE WHEN mp.phase = 'refund' THEN 'refund' ELSE 'debit' END,
+            CASE
+              WHEN mp.phase = 'refund' THEN ${`${description} (refund)`}
+              ELSE ${`${description} (overage)`}
+            END,
+            (
+              ${inputMetadata}::jsonb ||
+              jsonb_build_object(
+                'reservation_transaction_id', ${reservationTransactionId},
+                'reserved', mp.reserved_amount,
+                'actual', mp.actual_cost,
+                'type', CASE
+                  WHEN mp.phase = 'refund' THEN 'reconciliation_refund'
+                  ELSE 'reconciliation_overage'
+                END
+              )
+            ),
+            CASE
+              WHEN mp.phase = 'refund' THEN ${`recon:${reservationTransactionId}:refund`}
+              ELSE ${`recon:${reservationTransactionId}:overage`}
+            END,
+            NOW()
+          FROM mutation_plan mp
+          WHERE mp.phase IN ('refund', 'overage')
+            AND EXISTS (SELECT 1 FROM org_update)
+          ON CONFLICT (stripe_payment_intent_id) DO NOTHING
+          RETURNING id
+        )
+        SELECT
+          EXISTS(SELECT 1 FROM reservation) AS reservation_found,
+          EXISTS(SELECT 1 FROM claim) OR EXISTS(SELECT 1 FROM mark_preexisting) AS claimed,
+          (SELECT reserved_amount FROM reservation_values) AS reserved_amount,
+          (SELECT new_balance FROM org_update) AS new_balance,
+          CASE
+            WHEN EXISTS(SELECT 1 FROM inserted) THEN (SELECT array_agg(id ORDER BY id) FROM inserted)
+            ELSE (SELECT ids FROM existing_settlements)
+          END AS settlement_ids,
+          CASE
+            WHEN NOT EXISTS(SELECT 1 FROM reservation) THEN NULL
+            WHEN NOT EXISTS(SELECT 1 FROM claim) THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mark_preexisting) THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'none') THEN 'none'
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'refund')
+              THEN CASE WHEN EXISTS(SELECT 1 FROM inserted) THEN 'refund' ELSE 'none' END
+            WHEN EXISTS(SELECT 1 FROM mutation_plan WHERE phase = 'overage')
+              THEN CASE WHEN EXISTS(SELECT 1 FROM org_update) THEN 'overage' ELSE 'uncollected_overage' END
+            ELSE 'none'
+          END AS adjustment_type
+      `,
+    );
 
-    if (result.kind !== "handled" || !result.claimed) {
-      return result;
+    const row = rows[0];
+    if (!row || !isPgTrue(row.reservation_found)) {
+      return { kind: "no_reservation_row" };
     }
 
-    await CacheInvalidation.onCreditMutation(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate credit mutation cache:", error);
-    });
-    invalidateOrganizationCache(organizationId).catch((error) => {
-      logger.error("[CreditsService] Failed to invalidate org cache:", error);
-    });
-    if (result.balanceDecreaseMetadata && result.newBalance !== undefined) {
-      this.notifyBalanceDecrease(organizationId, result.newBalance, result.balanceDecreaseMetadata);
+    const reservedAmount = parseNumeric(row.reserved_amount, "reservation_amount");
+    const adjustmentType = row.adjustment_type ?? "none";
+    const settlementTransactionIds = row.settlement_ids ?? [];
+    const result: CreditReconciliationResult = {
+      reservedAmount,
+      actualCost: normalizedActualCost,
+      reservationTransactionId,
+      settlementTransactionIds,
+      adjustmentType,
+    };
+    const handled = {
+      kind: "handled" as const,
+      claimed: isPgTrue(row.claimed),
+      ...(row.new_balance !== null && row.new_balance !== undefined
+        ? { newBalance: parseNumeric(row.new_balance, "new_balance") }
+        : {}),
+      ...(adjustmentType === "overage"
+        ? {
+            balanceDecreaseMetadata: {
+              ...metadata,
+              reservation_transaction_id: reservationTransactionId,
+              reserved: reservedAmount,
+              actual: normalizedActualCost,
+              type: "reconciliation_overage",
+            },
+          }
+        : {}),
+      result,
+    };
+
+    if (handled.claimed) {
+      await CacheInvalidation.onCreditMutation(organizationId).catch((error) => {
+        logger.error("[CreditsService] Failed to invalidate credit mutation cache:", error);
+      });
+      invalidateOrganizationCache(organizationId).catch((error) => {
+        logger.error("[CreditsService] Failed to invalidate org cache:", error);
+      });
+      if (handled.balanceDecreaseMetadata && handled.newBalance !== undefined) {
+        this.notifyBalanceDecrease(
+          organizationId,
+          handled.newBalance,
+          handled.balanceDecreaseMetadata,
+        );
+      }
     }
-    return result;
+
+    return handled;
   }
 
   async markReservationSettled(params: {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1450,6 +1450,51 @@ describe("ElizaSandboxService recoverDisconnected", () => {
   });
 });
 
+
+describe("ElizaSandboxService bridgeStream scope-cache reuse", () => {
+  test("uses the already-resolved running agent row without re-querying findRunningSandbox", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      execution_tier: "shared",
+      status: "running",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => {
+        throw new Error("findRunningSandbox should not run when the stream route passes resolvedAgent");
+      },
+    );
+    const service = new ElizaSandboxService();
+    const sharedSpy = spyOn(service as never, "bridgeSharedMessageStream" as never).mockResolvedValue(
+      new Response("event: done\ndata: {}\n\n", {
+        headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+      }) as never,
+    );
+
+    try {
+      const res = await service.bridgeStream(
+        sandbox.id,
+        sandbox.organization_id,
+        {
+          jsonrpc: "2.0",
+          id: "bridge-cache-test",
+          method: "message.send",
+          params: { text: "hello", roomId: "room-1" },
+        },
+        undefined,
+        sandbox,
+      );
+
+      expect(res?.status).toBe(200);
+      expect(findSpy).not.toHaveBeenCalled();
+      expect(sharedSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      findSpy.mockRestore();
+      sharedSpy.mockRestore();
+    }
+  });
+});
+
 describe("ElizaSandboxService heartbeat", () => {
   // Pins the behaviour the probeBridgeHealth() extraction must preserve on the
   // prod-critical heartbeat path: grace-window hysteresis and the exact DB

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -84,6 +84,7 @@ import {
   type SandboxProvider,
 } from "./sandbox-provider";
 import { isDedicatedBootstrapWindow } from "./shared-runtime/dedicated-bootstrap";
+import { getCachedSharedAgentRunningSandbox } from "./shared-runtime/resolve-shared-agent";
 import {
   type RunSharedAgentTurnResult,
   resolveSharedAgentTurnModel,
@@ -4355,8 +4356,15 @@ export class ElizaSandboxService {
     orgId: string,
     rpc: BridgeRequest,
     executionCtx?: BridgeExecutionContext,
+    resolvedAgent?: AgentSandbox,
   ): Promise<Response | null> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    const rec =
+      resolvedAgent?.id === agentId &&
+      resolvedAgent.organization_id === orgId &&
+      resolvedAgent.status === "running"
+        ? resolvedAgent
+        : (await getCachedSharedAgentRunningSandbox(agentId, orgId)) ??
+          (await agentSandboxesRepository.findRunningSandbox(agentId, orgId));
     if (!rec) {
       logger.warn("[agent-sandbox] Bridge stream to non-running sandbox", {
         agentId,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -18,6 +18,7 @@ const bridgeStream = mock(
     _orgId: string,
     _rpc: unknown,
     _executionCtx?: { waitUntil(promise: Promise<unknown>): void },
+    _resolvedAgent?: unknown,
   ): Promise<Response | null> =>
     new Response("event: done\ndata: {}\n\n", {
       headers: { "Content-Type": "text/event-stream; charset=utf-8" },
@@ -52,6 +53,17 @@ describe("handleCanonicalScopedAgentStream — executionCtx threading", () => {
     // The SAME executionCtx object must arrive as the 4th argument — the
     // shared-tier turn hands its billing tail to exactly this waitUntil.
     expect(call?.[3]).toBe(executionCtx);
+  });
+
+  test("threads the resolved agent row to bridgeStream so the stream path skips findRunningSandbox", async () => {
+    bridgeStream.mockClear();
+    const agent = { id: BASE.agentId, organization_id: BASE.orgId, status: "running" };
+
+    const res = await handleCanonicalScopedAgentStream({ ...BASE, agent: agent as never });
+
+    expect(res.status).toBe(200);
+    expect(bridgeStream).toHaveBeenCalledTimes(1);
+    expect(bridgeStream.mock.calls[0]?.[4]).toBe(agent);
   });
 
   test("no executionCtx (tests, non-Worker callers): bridgeStream receives undefined", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -5,6 +5,7 @@
  * SSE/CORS response shape used by HTTP routes and in-process voice turns.
  */
 
+import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import { InsufficientCreditsError } from "../../api/errors";
 import { logger } from "../../utils/logger";
 import type { BridgeExecutionContext, BridgeRequest } from "../eliza-sandbox";
@@ -22,6 +23,7 @@ const STREAM_HEADERS = {
 export interface CanonicalScopedStreamRequest {
   agentId: string;
   orgId: string;
+  agent?: AgentSandbox;
   conversationId: string;
   userId?: string;
   body: unknown;
@@ -101,6 +103,7 @@ export async function handleCanonicalScopedAgentStream(
       request.orgId,
       rpc,
       request.executionCtx,
+      request.agent,
     );
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -85,7 +85,7 @@ function rehydrateNullableCachedDate(value: unknown, field: AgentSandboxDateFiel
  * malformed values fail at this boundary because returning a row that violates
  * `AgentSandbox` would defer the fault into an unrelated route consumer.
  */
-function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
+export function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
   return {
     ...agent,
     created_at: rehydrateRequiredCachedDate(agent.created_at, "created_at"),
@@ -117,7 +117,7 @@ function rehydrateCachedAgentDates(agent: CachedAgentSandbox): AgentSandbox {
  * time-sensitive dedicated-bootstrap window, whose eligibility flips as the
  * container boots.
  */
-interface CachedSharedAgentScope {
+export interface CachedSharedAgentScope {
   orgId: string;
   agent: CachedAgentSandbox;
   /**
@@ -164,6 +164,50 @@ async function revalidateCachedScope(c: Context<AppEnv>, cachedOrgId: string): P
   // The key must still be scoped to the org the cached agent belongs to. A
   // detach/re-scope changes organization_id, so a stale cross-org read fails here.
   return validated.organization_id === cachedOrgId;
+}
+
+export async function cacheSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+  agent: AgentSandbox,
+): Promise<void> {
+  if (agent.execution_tier !== "shared" || agent.status !== "running") return;
+  await cache
+    .set(
+      CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId),
+      agent,
+      CacheTTL.sharedAgentScope.runningSandbox,
+    )
+    .catch((error) => {
+      logger.debug("[resolveSharedAgent] running sandbox cache write failed", {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
+export async function getCachedSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+): Promise<AgentSandbox | null> {
+  const cached = await cache
+    .get<CachedAgentSandbox>(CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId))
+    .catch(() => null);
+  if (!cached) return null;
+  const agent = rehydrateCachedAgentDates(cached);
+  return agent.execution_tier === "shared" && agent.status === "running" ? agent : null;
+}
+
+export async function invalidateSharedAgentRunningSandbox(
+  agentId: string,
+  orgId: string,
+): Promise<void> {
+  await cache.del(CacheKeys.sharedAgentScope.runningSandbox(agentId, orgId)).catch((error) => {
+    logger.debug("[resolveSharedAgent] running sandbox cache invalidation failed", {
+      agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 /**
@@ -352,6 +396,7 @@ export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSh
         error: error instanceof Error ? error.message : String(error),
       });
     });
+    void cacheSharedAgentRunningSandbox(agentId, user.organization_id, agent);
   }
 
   return { agent, agentId, orgId: user.organization_id, agentName: agent.agent_name ?? "Eliza" };


### PR DESCRIPTION
## Summary
- collapse reservation reconciliation from a multi-statement write transaction into one Postgres CTE round trip
- preserve first-claim/idempotency semantics, legacy keyed settlement behavior, refund/overage accounting, org/cache invalidation, and balance-decrease notifications
- reuse the resolved shared-agent row/running-sandbox scope cache on the canonical stream path so bridgeStream does not issue a redundant findRunningSandbox query
- add bounded running-sandbox cache TTL plus invalidation on sandbox status updates

## Tests
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts`
- `bun test packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts --timeout 120000` currently blocked locally by existing PGlite bootstrap issue: `Cannot find module '@elizaos/core' from plugins/plugin-sql/src/index.ts`; non-DB cases pass, PGlite guard fails before DB assertions can run
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts --timeout 120000` currently blocked locally by same plugin-sql/core resolution issue; canonical stream tests pass

## Notes
- Clean develop-based replacement for #17010/#17011. No workflow YAML changes.
