### PR TITLE
build(evidence): install and diagnose capture tools across platforms

### DIFF
--- a/.github/workflows/evidence-tools-platform-smoke.yml
+++ b/.github/workflows/evidence-tools-platform-smoke.yml
@@ -1,0 +1,79 @@
+name: Evidence Tools Platform Smoke
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - ".github/workflows/evidence-tools-platform-smoke.yml"
+      - "scripts/evidence-doctor.mjs"
+      - "scripts/evidence-doctor.test.mjs"
+      - "scripts/evidence-install-tools.mjs"
+      - "scripts/evidence-install-tools.test.mjs"
+      - "packages/evidence/src/ffmpeg-binaries.ts"
+      - "CONTRIBUTING.md"
+      - "package.json"
+      - "bun.lock"
+  workflow_dispatch: {}
+
+concurrency:
+  group: evidence-tools-platform-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  install-and-probe:
+    name: Real install + repeat + probe (${{ matrix.os }})
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Validate platform install plan
+        run: node scripts/evidence-install-tools.mjs --dry-run --github
+
+      - name: Record pre-install capability report
+        run: node scripts/evidence-doctor.mjs --json > evidence-tools-before.json
+
+      - name: Install repository tool packages
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Exercise real platform installer
+        run: node scripts/evidence-install-tools.mjs --skip-deps --github
+
+      - name: Prove installer idempotence
+        run: node scripts/evidence-install-tools.mjs --skip-deps --github
+
+      - name: Require baseline capture capabilities
+        run: node scripts/evidence-doctor.mjs --strict --json > evidence-tools-after.json
+
+      - name: Upload normalized capability reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: evidence-tools-${{ matrix.os }}
+          path: |
+            evidence-tools-*.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/evidence-tools-platform-smoke.yml
+++ b/.github/workflows/evidence-tools-platform-smoke.yml
@@ -62,11 +62,22 @@ jobs:
       - name: Exercise real platform installer
         run: node scripts/evidence-install-tools.mjs --skip-deps --github
 
+      - name: Record first-install capability report
+        run: node scripts/evidence-doctor.mjs --json > evidence-tools-after-first-run.json
+
+      - name: Require a fully resolved post-install plan
+        run: node scripts/evidence-install-tools.mjs --dry-run --strict --skip-deps --github
+
       - name: Prove installer idempotence
         run: node scripts/evidence-install-tools.mjs --skip-deps --github
 
       - name: Require baseline capture capabilities
         run: node scripts/evidence-doctor.mjs --strict --json > evidence-tools-after.json
+
+      - name: Prove the repeated run changed no capability
+        shell: bash
+        run: |
+          node -e 'const fs=require("node:fs");const first=JSON.parse(fs.readFileSync("evidence-tools-after-first-run.json","utf8"));const second=JSON.parse(fs.readFileSync("evidence-tools-after.json","utf8"));require("node:assert/strict").deepEqual(second,first);console.log("installer idempotence: normalized capability reports are identical");'
 
       - name: Upload normalized capability reports
         if: ${{ always() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,49 @@ Vision, VLM API keys, the claude/codex CLIs) and prints the exact install/start
 command for anything missing. Install what it flags — a missing tool is a
 fixable instruction, never a reason to ship without evidence.
 
+### Install or repair the capture toolchain
+
+From the repository root, one command installs or repairs the required
+cross-platform capture dependencies and verifies their executable behavior:
+
 ```bash
-bun run evidence:doctor            # human report of the capture toolchain
-bun run evidence:doctor -- --strict  # non-zero exit if a REQUIRED tool is missing
+bun run evidence:install-tools
+```
+
+The installer supports macOS with Homebrew, Windows with WinGet, and Linux with
+apt-get, dnf, yum, apk, pacman, or zypper. It prefers healthy system or packaged
+ffmpeg/ffprobe binaries instead of installing a redundant system copy, installs
+the repository-pinned Playwright Chromium, and runs the strict doctor before it
+returns success. Dependency bootstrap is locked and uses `--ignore-scripts`, so
+it does not run unrelated repository postinstall or artifact-sync hooks.
+
+Use `--github` to also install and execute the optional GitHub CLI; this does
+not authenticate, persist credentials, change repository permissions, or prove
+that a token can upload evidence. Use `--skip-deps` only when the locked
+workspace dependencies are already installed. `--dry-run` prints the exact
+argument-safe commands in the current platform plan without changing the host.
+
+```bash
+bun run evidence:install-tools -- --github
+bun run evidence:install-tools -- --skip-deps
+bun run evidence:install-tools -- --dry-run
+```
+
+Package downloads, Playwright browser installation, and package-manager index
+updates require network access. Linux system packages use root directly or
+require a successful `sudo -n` preflight; the installer never prompts for a
+password. Homebrew runs as the current user, while WinGet uses silent,
+non-interactive agreement flags. A missing Homebrew, WinGet, or supported Linux
+package manager is an explicit failure. Windows PATH refresh is local to the
+installer process, and no supported platform path edits shell profiles or
+developer configuration. Missing optional accelerators remain explicit
+non-blocking doctor findings; missing required OCR, media, or browser
+capabilities fail the strict doctor.
+
+```bash
+bun run evidence:doctor                   # human capability report
+bun run evidence:doctor -- --strict       # fail if a required tool is missing
+bun run evidence:doctor -- --strict --json  # normalized CI/operator report
 ```
 
 **Visual verification is layered and always available.** OCR runs the GPU/Baidu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,12 +126,22 @@ Use `--github` to also install and execute the optional GitHub CLI; this does
 not authenticate, persist credentials, change repository permissions, or prove
 that a token can upload evidence. Use `--skip-deps` only when the locked
 workspace dependencies are already installed. `--dry-run` prints the exact
-argument-safe commands in the current platform plan without changing the host.
+argument-safe commands of the one resolved plan execution also consumes —
+including the trailing strict doctor verification — without changing the host;
+lines beginning `# assumes:` note where resolution depends on the dependency
+step having run (packaged media binaries only resolve after `bun install`).
+Add `--strict` to a dry run to fail when such assumptions remain. Every step
+carries a deadline (15 minutes for package-manager operations, 2 minutes for
+probes, 10 minutes for the doctor) so a wedged package manager or download
+cannot block forever; multiply all deadlines on slow hosts with
+`--timeout-scale=<factor>` or `ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE`.
 
 ```bash
 bun run evidence:install-tools -- --github
 bun run evidence:install-tools -- --skip-deps
 bun run evidence:install-tools -- --dry-run
+bun run evidence:install-tools -- --dry-run --strict
+bun run evidence:install-tools -- --timeout-scale=3
 ```
 
 Package downloads, Playwright browser installation, and package-manager index

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "test:matrix": "node scripts/evidence-review/run-matrix.mjs --no-open",
     "test:watch-human": "bun run --cwd packages/app test:e2e:human",
     "evidence:doctor": "node scripts/evidence-doctor.mjs",
+    "evidence:install-tools": "node scripts/evidence-install-tools.mjs",
     "evidence:pr": "node scripts/pr-evidence.mjs",
     "evidence:certify": "bun packages/evidence/src/cli.ts certify",
     "evidence:review": "node scripts/evidence-review/generate.mjs --open",

--- a/packages/scripts/__tests__/evidence-tools-platform-workflow.test.ts
+++ b/packages/scripts/__tests__/evidence-tools-platform-workflow.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Static contract for the real three-platform evidence-tool installer smoke.
+ * The workflow itself exercises hosted package managers and browser launches.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string | number | boolean>;
+  "continue-on-error"?: boolean | string;
+}
+
+interface WorkflowJob {
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+  "continue-on-error"?: boolean | string;
+  strategy?: {
+    "fail-fast"?: boolean;
+    matrix?: {
+      os?: string[];
+    };
+  };
+}
+
+interface Workflow {
+  permissions?: Record<string, string>;
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    pull_request?: {
+      branches?: string[];
+      paths?: string[];
+    };
+  };
+}
+
+function loadWorkflow(): Workflow {
+  return Bun.YAML.parse(
+    readFileSync(
+      new URL(".github/workflows/evidence-tools-platform-smoke.yml", repoRoot),
+      "utf8",
+    ),
+  ) as Workflow;
+}
+
+function namedStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+describe("evidence tools platform smoke workflow", () => {
+  test("runs a real repeatable installer and strict doctor on every supported OS", () => {
+    const workflow = loadWorkflow();
+    expect(workflow.on?.pull_request?.branches).toEqual(["develop", "main"]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+
+    const job = workflow.jobs?.["install-and-probe"];
+    if (!job) throw new Error("Missing install-and-probe job");
+    expect(job.permissions).toEqual({ contents: "read" });
+    expect(
+      Object.values(workflow.jobs ?? {}).every(
+        (candidate) => candidate.permissions?.contents === "read",
+      ),
+    ).toBe(true);
+    expect(job["continue-on-error"]).toBeUndefined();
+    expect(job.strategy?.["fail-fast"]).toBe(false);
+    expect(job.strategy?.matrix?.os).toEqual([
+      "ubuntu-latest",
+      "macos-latest",
+      "windows-latest",
+    ]);
+    expect(
+      job.steps?.every((step) => step["continue-on-error"] === undefined),
+    ).toBe(true);
+
+    expect(namedStep(job, "Setup Node.js").with?.["node-version"]).toBe(
+      "24.15.0",
+    );
+    expect(namedStep(job, "Checkout").with?.["persist-credentials"]).toBe(
+      false,
+    );
+    expect(namedStep(job, "Setup Bun").with?.["bun-version"]).toBe("1.3.14");
+    expect(namedStep(job, "Validate platform install plan").run).toBe(
+      "node scripts/evidence-install-tools.mjs --dry-run --github",
+    );
+    expect(namedStep(job, "Record pre-install capability report").run).toBe(
+      "node scripts/evidence-doctor.mjs --json > evidence-tools-before.json",
+    );
+    expect(namedStep(job, "Install repository tool packages").run).toBe(
+      "bun install --frozen-lockfile --ignore-scripts",
+    );
+    const stepNames = job.steps?.map(({ name }) => name) ?? [];
+    expect(
+      stepNames.indexOf("Record pre-install capability report"),
+    ).toBeLessThan(stepNames.indexOf("Install repository tool packages"));
+
+    const installCommand =
+      "node scripts/evidence-install-tools.mjs --skip-deps --github";
+    expect(namedStep(job, "Exercise real platform installer").run).toBe(
+      installCommand,
+    );
+    expect(namedStep(job, "Prove installer idempotence").run).toBe(
+      installCommand,
+    );
+    expect(namedStep(job, "Require baseline capture capabilities").run).toBe(
+      "node scripts/evidence-doctor.mjs --strict --json > evidence-tools-after.json",
+    );
+    expect(
+      job.steps?.some(
+        (step) =>
+          step.env?.GH_TOKEN !== undefined ||
+          step.run?.includes("github.token") === true,
+      ),
+    ).toBe(false);
+
+    const upload = namedStep(job, "Upload normalized capability reports");
+    expect(upload.if).toBe(`\${{ always() }}`);
+    expect(upload.uses).toMatch(/^actions\/upload-artifact@[0-9a-f]{40}$/u);
+    expect(upload.with?.["if-no-files-found"]).toBe("error");
+    expect(upload.with?.path).toContain("evidence-tools-*.json");
+  });
+
+  test("tracks every implementation and lockfile input that can change the smoke", () => {
+    const paths = loadWorkflow().on?.pull_request?.paths;
+    for (const required of [
+      ".github/workflows/evidence-tools-platform-smoke.yml",
+      "scripts/evidence-doctor.mjs",
+      "scripts/evidence-doctor.test.mjs",
+      "scripts/evidence-install-tools.mjs",
+      "scripts/evidence-install-tools.test.mjs",
+      "packages/evidence/src/ffmpeg-binaries.ts",
+      "CONTRIBUTING.md",
+      "package.json",
+      "bun.lock",
+    ]) {
+      expect(paths).toContain(required);
+    }
+
+    const packageJson = JSON.parse(
+      readFileSync(new URL("package.json", repoRoot), "utf8"),
+    ) as { scripts?: Record<string, string> };
+    expect(packageJson.scripts?.["evidence:install-tools"]).toBe(
+      "node scripts/evidence-install-tools.mjs",
+    );
+    expect(packageJson.scripts?.["evidence:doctor"]).toBe(
+      "node scripts/evidence-doctor.mjs",
+    );
+  });
+});

--- a/packages/scripts/__tests__/evidence-tools-platform-workflow.test.ts
+++ b/packages/scripts/__tests__/evidence-tools-platform-workflow.test.ts
@@ -13,6 +13,7 @@ interface WorkflowStep {
   if?: string;
   name?: string;
   run?: string;
+  shell?: string;
   uses?: string;
   with?: Record<string, string | number | boolean>;
   "continue-on-error"?: boolean | string;
@@ -107,12 +108,50 @@ describe("evidence tools platform smoke workflow", () => {
     expect(namedStep(job, "Exercise real platform installer").run).toBe(
       installCommand,
     );
+    expect(namedStep(job, "Record first-install capability report").run).toBe(
+      "node scripts/evidence-doctor.mjs --json > evidence-tools-after-first-run.json",
+    );
+    expect(
+      namedStep(job, "Require a fully resolved post-install plan").run,
+    ).toBe(
+      "node scripts/evidence-install-tools.mjs --dry-run --strict --skip-deps --github",
+    );
     expect(namedStep(job, "Prove installer idempotence").run).toBe(
       installCommand,
     );
     expect(namedStep(job, "Require baseline capture capabilities").run).toBe(
       "node scripts/evidence-doctor.mjs --strict --json > evidence-tools-after.json",
     );
+
+    // Idempotence must be proven by comparing the normalized capability
+    // reports captured after each real installer run, not by exit code alone.
+    const idempotenceProof = namedStep(
+      job,
+      "Prove the repeated run changed no capability",
+    );
+    expect(idempotenceProof.shell).toBe("bash");
+    expect(idempotenceProof.run).toContain(
+      "evidence-tools-after-first-run.json",
+    );
+    expect(idempotenceProof.run).toContain("evidence-tools-after.json");
+    expect(idempotenceProof.run).toContain("deepEqual");
+    const orderedNames = job.steps?.map(({ name }) => name) ?? [];
+    for (const [before, after] of [
+      [
+        "Exercise real platform installer",
+        "Record first-install capability report",
+      ],
+      ["Record first-install capability report", "Prove installer idempotence"],
+      ["Prove installer idempotence", "Require baseline capture capabilities"],
+      [
+        "Require baseline capture capabilities",
+        "Prove the repeated run changed no capability",
+      ],
+    ] as const) {
+      expect(orderedNames.indexOf(before)).toBeLessThan(
+        orderedNames.indexOf(after),
+      );
+    }
     expect(
       job.steps?.some(
         (step) =>

--- a/scripts/evidence-doctor.mjs
+++ b/scripts/evidence-doctor.mjs
@@ -1,127 +1,452 @@
 #!/usr/bin/env node
 /**
- * Preflight health check for the evidence-capture toolchain. An agent runs this
- * before capturing PR evidence to learn which tools are present and — for each
- * missing one — the exact command to install or start it, so a missing binary
- * turns into a fixable instruction instead of a silent `skipped` record deep in
- * a capture run.
- *
- * Every probe reports `ok` / `missing` / `optional-missing` with a concrete
- * `fix` string; nothing here fabricates availability. Default exit is 0 (a
- * report, never a blocker); `--strict` exits non-zero when a REQUIRED tool is
- * missing so CI or a capture wrapper can gate on it. `--json` prints the same
- * findings machine-readably for the evidence harness to fold into a bundle.
- *
- * The required set is the floor every environment needs for the baseline
- * screenshot + OCR + video evidence the PR gate demands (playwright browsers,
- * ffmpeg, tesseract). The optional set unlocks richer verification (GPU/Baidu
- * OCR, Apple Vision, API- or CLI-driven VLM review) and degrades to an honest
- * skip when absent — so it is reported, never failed on.
+ * Probes the evidence-capture toolchain and emits human or normalized JSON
+ * findings. Required capabilities are shared with the installer and validated
+ * by loading packaged OCR, resolving executable media binaries, and launching
+ * the repository-pinned Playwright Chromium rather than trusting cache paths.
  */
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+import {
+  assertSupportedPlatform,
+  EVIDENCE_REQUIREMENTS,
+  resolveMediaRequirements,
+} from "./evidence-install-tools.mjs";
 
 const execFileAsync = promisify(execFile);
+const OCR_FIXTURE_TEXT = "ELIZA";
+const OCR_GLYPHS = Object.freeze({
+  E: ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+  L: ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+  I: ["11111", "00100", "00100", "00100", "00100", "00100", "11111"],
+  Z: ["11111", "00001", "00010", "00100", "01000", "10000", "11111"],
+  A: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+});
 
-/** Run `bin args…`; resolve the trimmed stdout, or null when the probe fails. */
+async function withTimeout(promise, timeoutMs, label) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function buildOcrFixtureBmp() {
+  const scale = 8;
+  const margin = 2;
+  const glyphWidth = 5;
+  const glyphHeight = 7;
+  const spacing = 2;
+  const widthUnits =
+    margin * 2 +
+    OCR_FIXTURE_TEXT.length * glyphWidth +
+    (OCR_FIXTURE_TEXT.length - 1) * spacing;
+  const heightUnits = margin * 2 + glyphHeight;
+  const width = widthUnits * scale;
+  const height = heightUnits * scale;
+  const rowStride = Math.ceil((width * 3) / 4) * 4;
+  const pixelBytes = rowStride * height;
+  const bitmap = Buffer.alloc(54 + pixelBytes);
+  bitmap.write("BM", 0, "ascii");
+  bitmap.writeUInt32LE(bitmap.length, 2);
+  bitmap.writeUInt32LE(54, 10);
+  bitmap.writeUInt32LE(40, 14);
+  bitmap.writeInt32LE(width, 18);
+  bitmap.writeInt32LE(height, 22);
+  bitmap.writeUInt16LE(1, 26);
+  bitmap.writeUInt16LE(24, 28);
+  bitmap.writeUInt32LE(pixelBytes, 34);
+  bitmap.writeInt32LE(2835, 38);
+  bitmap.writeInt32LE(2835, 42);
+  bitmap.fill(255, 54);
+
+  for (const [characterIndex, character] of [...OCR_FIXTURE_TEXT].entries()) {
+    const glyph = OCR_GLYPHS[character];
+    const originX = margin + characterIndex * (glyphWidth + spacing);
+    for (const [row, pattern] of glyph.entries()) {
+      for (const [column, pixel] of [...pattern].entries()) {
+        if (pixel !== "1") continue;
+        for (let scaleY = 0; scaleY < scale; scaleY += 1) {
+          for (let scaleX = 0; scaleX < scale; scaleX += 1) {
+            const x = (originX + column) * scale + scaleX;
+            const y = (margin + row) * scale + scaleY;
+            const bmpRow = height - y - 1;
+            const offset = 54 + bmpRow * rowStride + x * 3;
+            bitmap[offset] = 0;
+            bitmap[offset + 1] = 0;
+            bitmap[offset + 2] = 0;
+          }
+        }
+      }
+    }
+  }
+  return bitmap;
+}
+
 async function probeCommand(bin, args, timeoutMs = 10_000) {
   try {
     const { stdout, stderr } = await execFileAsync(bin, args, {
       timeout: timeoutMs,
+      windowsHide: true,
     });
     return `${stdout}${stderr}`.trim();
   } catch {
+    // error-policy:J4 an unavailable executable is an explicit probe result.
     return null;
   }
 }
 
 function firstLine(text) {
-  return (text ?? "").split("\n")[0]?.trim() ?? "";
+  return (text ?? "").split(/\r?\n/u)[0]?.trim() ?? "";
 }
 
-/** Where `scripts/gpu-vision/serve.mjs` records a ready OCR server. */
-function gpuVisionServeStatePath() {
-  const override = process.env.ELIZA_GPU_VISION_CACHE?.trim();
+function gpuVisionServeStatePath(env, homeDir) {
+  const override = env.ELIZA_GPU_VISION_CACHE?.trim();
   const root = override
     ? path.resolve(override)
-    : path.join(os.homedir(), ".cache", "eliza", "gpu-vision");
+    : path.join(homeDir, ".cache", "eliza", "gpu-vision");
   return path.join(root, "serve.json");
 }
 
-/**
- * One probe result. `required` findings that are `missing` fail `--strict`;
- * optional ones only inform. `fix` is the literal command a reader can paste.
- */
-export async function runProbes(env) {
+function platformFixes(platform) {
+  if (platform === "win32") {
+    return {
+      systemTesseract:
+        "optional system OCR: winget install --id UB-Mannheim.TesseractOCR --exact",
+      systemFfmpeg:
+        "optional system media tools: winget install --id Gyan.FFmpeg --exact",
+      github:
+        "winget install --id GitHub.cli --exact --accept-package-agreements --accept-source-agreements",
+    };
+  }
+  if (platform === "darwin") {
+    return {
+      systemTesseract: "optional system OCR: brew install tesseract",
+      systemFfmpeg: "optional system media tools: brew install ffmpeg",
+      github: "brew install gh",
+    };
+  }
+  return {
+    systemTesseract:
+      "optional system OCR: install tesseract-ocr with apt, dnf, yum, apk, pacman, or zypper",
+    systemFfmpeg:
+      "optional system media tools: install ffmpeg with apt, dnf, yum, apk, pacman, or zypper",
+    github: "install `gh` with apt, dnf, yum, apk, pacman, or zypper",
+  };
+}
+
+export async function probePackagedOcr({
+  loadTesseract = () => import(EVIDENCE_REQUIREMENTS.ocr.packageName),
+  tempRoot = os.tmpdir(),
+  timeoutMs = 60_000,
+} = {}) {
+  const directory = await mkdtemp(path.join(tempRoot, "eliza-ocr-doctor-"));
+  let worker;
+  let result;
+  try {
+    const tesseract = await loadTesseract();
+    if (typeof tesseract.createWorker !== "function") {
+      return {
+        ok: false,
+        detail: `${EVIDENCE_REQUIREMENTS.ocr.packageName} lacks createWorker`,
+      };
+    }
+    worker = await withTimeout(
+      tesseract.createWorker("eng", 1, { cachePath: directory }),
+      timeoutMs,
+      "packaged OCR worker initialization",
+    );
+    if (
+      tesseract.PSM?.SINGLE_LINE &&
+      typeof worker.setParameters === "function"
+    ) {
+      await withTimeout(
+        worker.setParameters({
+          tessedit_pageseg_mode: tesseract.PSM.SINGLE_LINE,
+        }),
+        timeoutMs,
+        "packaged OCR fixture configuration",
+      );
+    }
+    const recognition = await withTimeout(
+      worker.recognize(buildOcrFixtureBmp()),
+      timeoutMs,
+      "packaged OCR fixture recognition",
+    );
+    const transcript = String(recognition?.data?.text ?? "")
+      .toUpperCase()
+      .replaceAll(/[^A-Z0-9]/gu, "");
+    result = transcript.includes(OCR_FIXTURE_TEXT)
+      ? {
+          ok: true,
+          detail: `${EVIDENCE_REQUIREMENTS.ocr.packageName} recognized the bundled ${OCR_FIXTURE_TEXT} fixture`,
+        }
+      : {
+          ok: false,
+          detail: `${EVIDENCE_REQUIREMENTS.ocr.packageName} did not recognize the bundled fixture`,
+        };
+  } catch {
+    // error-policy:J4 package load, worker, or recognition failure is missing.
+    result = {
+      ok: false,
+      detail: `${EVIDENCE_REQUIREMENTS.ocr.packageName} could not recognize the bundled fixture`,
+    };
+  } finally {
+    try {
+      if (worker) {
+        await withTimeout(
+          worker.terminate(),
+          timeoutMs,
+          "packaged OCR worker teardown",
+        );
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+  return result;
+}
+
+export async function probeMediaPipeline(
+  resolutions,
+  { run = execFileAsync, tempRoot = os.tmpdir(), timeoutMs = 30_000 } = {},
+) {
+  if (!resolutions.ffmpeg.available || !resolutions.ffprobe.available) {
+    return {
+      ok: false,
+      detail: "ffmpeg and ffprobe must both resolve before media validation",
+    };
+  }
+  const directory = await mkdtemp(
+    path.join(tempRoot, "eliza-evidence-doctor-"),
+  );
+  const encodedPath = path.join(directory, "fixture.mp4");
+  const decodedPath = path.join(directory, "fixture.rgb");
+  try {
+    await run(
+      resolutions.ffmpeg.bin,
+      [
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=32x32:d=0.1",
+        "-frames:v",
+        "1",
+        "-c:v",
+        "mpeg4",
+        "-pix_fmt",
+        "yuv420p",
+        encodedPath,
+      ],
+      { timeout: timeoutMs, windowsHide: true },
+    );
+    const probe = await run(
+      resolutions.ffprobe.bin,
+      [
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=codec_type,width,height",
+        "-of",
+        "json",
+        encodedPath,
+      ],
+      { timeout: timeoutMs, windowsHide: true },
+    );
+    const metadata = JSON.parse(String(probe.stdout ?? ""));
+    const stream = metadata.streams?.[0];
+    if (
+      stream?.codec_type !== "video" ||
+      stream.width !== 32 ||
+      stream.height !== 32
+    ) {
+      throw new Error("ffprobe returned unexpected fixture metadata");
+    }
+    await run(
+      resolutions.ffmpeg.bin,
+      [
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        encodedPath,
+        "-frames:v",
+        "1",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        decodedPath,
+      ],
+      { timeout: timeoutMs, windowsHide: true },
+    );
+    const decoded = await stat(decodedPath);
+    if (decoded.size !== 32 * 32 * 3) {
+      throw new Error("decoded fixture has an unexpected byte length");
+    }
+    return {
+      ok: true,
+      detail: "ffmpeg encode, ffprobe metadata, and ffmpeg decode passed",
+    };
+  } catch {
+    // error-policy:J4 a failed real media round trip is unavailable.
+    return {
+      ok: false,
+      detail: "ffmpeg encode, ffprobe metadata, or ffmpeg decode failed",
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function probePlaywrightChromium() {
+  try {
+    const playwright = await import(
+      EVIDENCE_REQUIREMENTS.playwright.packageName
+    );
+    const executablePath = playwright.chromium.executablePath();
+    if (!existsSync(executablePath)) {
+      return {
+        ok: false,
+        detail: "Playwright Chromium executable is not installed",
+      };
+    }
+    const browser = await playwright.chromium.launch({
+      headless: true,
+      timeout: 30_000,
+    });
+    const version = browser.version();
+    await browser.close();
+    return {
+      ok: true,
+      detail: `Playwright Chromium ${version} launched successfully`,
+    };
+  } catch {
+    // error-policy:J4 a package, executable, or launch failure is unavailable.
+    return {
+      ok: false,
+      detail: "Playwright Chromium is not installed or could not launch",
+    };
+  }
+}
+
+export async function runProbes(
+  env,
+  {
+    platform = process.platform,
+    homeDir = os.homedir(),
+    commandProbe = probeCommand,
+    mediaResolver = resolveMediaRequirements,
+    mediaPipelineProbe = probeMediaPipeline,
+    ocrProbe = probePackagedOcr,
+    playwrightProbe = probePlaywrightChromium,
+    pathExists = existsSync,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
   const probes = [];
+  const fixes = platformFixes(platform);
 
-  // ---- Required: the baseline screenshot + OCR + video evidence floor. ----
+  const packagedOcr = await ocrProbe();
+  const systemTesseract = packagedOcr.ok
+    ? null
+    : await commandProbe(env.ELIZA_TESSERACT_BIN || "tesseract", ["--version"]);
+  probes.push({
+    id: EVIDENCE_REQUIREMENTS.ocr.id,
+    required: EVIDENCE_REQUIREMENTS.ocr.requiredByDefault,
+    ok: packagedOcr.ok || systemTesseract !== null,
+    detail: packagedOcr.ok
+      ? packagedOcr.detail
+      : systemTesseract
+        ? `${firstLine(systemTesseract)} (system fallback)`
+        : `${packagedOcr.detail}; system tesseract is also unavailable`,
+    fix: `bun run evidence:install-tools · ${fixes.systemTesseract}`,
+  });
 
-  const tesseract = await probeCommand(
-    env.ELIZA_TESSERACT_BIN || "tesseract",
+  const media = await mediaResolver();
+  const mediaPipeline = await mediaPipelineProbe(media);
+  for (const key of ["ffmpeg", "ffprobe"]) {
+    const requirement = EVIDENCE_REQUIREMENTS[key];
+    const resolution = media[key];
+    probes.push({
+      id: requirement.id,
+      required: requirement.requiredByDefault,
+      ok: resolution.available && mediaPipeline.ok,
+      detail:
+        resolution.available && mediaPipeline.ok
+          ? `${requirement.id} ${resolution.source} binary passed the encode/probe/decode fixture`
+          : resolution.available
+            ? mediaPipeline.detail
+            : `${requirement.id} has no invocable configured, system, or packaged binary`,
+      fix: `bun run evidence:install-tools · ${fixes.systemFfmpeg}`,
+    });
+  }
+
+  const playwright = await playwrightProbe();
+  probes.push({
+    id: EVIDENCE_REQUIREMENTS.playwright.id,
+    required: EVIDENCE_REQUIREMENTS.playwright.requiredByDefault,
+    ok: playwright.ok,
+    detail: playwright.detail,
+    fix: "bun run evidence:install-tools (installs the pinned Chromium build and Linux OS dependencies when passwordless sudo is available)",
+  });
+
+  const ghVersion = await commandProbe(
+    EVIDENCE_REQUIREMENTS.githubCli.systemCommand,
     ["--version"],
   );
   probes.push({
-    id: "tesseract",
-    required: true,
-    ok: tesseract !== null,
-    detail: tesseract ? firstLine(tesseract) : "tesseract not on PATH",
-    fix: "macOS: brew install tesseract · Debian/Ubuntu: sudo apt-get install -y tesseract-ocr · (the packaged tesseract.js fallback needs no system binary: ELIZA_MVP_OCR_ENGINE=packaged)",
+    id: EVIDENCE_REQUIREMENTS.githubCli.id,
+    required: EVIDENCE_REQUIREMENTS.githubCli.requiredByDefault,
+    ok: ghVersion !== null,
+    detail: ghVersion ? firstLine(ghVersion) : "GitHub CLI is not installed",
+    fix: `bun run evidence:install-tools -- --github · ${fixes.github}`,
   });
 
-  const ffmpeg = await probeCommand("ffmpeg", ["-version"]);
-  probes.push({
-    id: "ffmpeg",
-    required: true,
-    ok: ffmpeg !== null,
-    detail: ffmpeg
-      ? firstLine(ffmpeg)
-      : "ffmpeg not on PATH (ffmpeg-static ships with @elizaos/evidence for keyframe/walkthrough work)",
-    fix: "macOS: brew install ffmpeg · Debian/Ubuntu: sudo apt-get install -y ffmpeg · or rely on the bundled ffmpeg-static in packages/evidence",
-  });
-
-  const playwrightChromium = existsSyncPlaywrightBrowsers();
-  probes.push({
-    id: "playwright-browsers",
-    required: true,
-    ok: playwrightChromium,
-    detail: playwrightChromium
-      ? "Playwright browser cache present"
-      : "no Playwright browser cache found",
-    fix: "bunx playwright install chromium  (add --with-deps on Linux CI)",
-  });
-
-  // ---- Optional: richer verification; each degrades to an honest skip. ----
-
-  const gpuServe = gpuVisionServeStatePath();
+  const gpuServe = gpuVisionServeStatePath(env, homeDir);
   const gpuUrl = env.ELIZA_GPU_VISION_URL?.trim();
   probes.push({
     id: "gpu-vision-ocr",
     required: false,
-    ok: Boolean(gpuUrl) || existsSync(gpuServe),
+    ok: Boolean(gpuUrl) || pathExists(gpuServe),
     detail: gpuUrl
-      ? `ELIZA_GPU_VISION_URL=${gpuUrl}`
-      : existsSync(gpuServe)
+      ? "ELIZA_GPU_VISION_URL is configured (value hidden)"
+      : pathExists(gpuServe)
         ? `serve.json present at ${gpuServe}`
         : "GPU/Baidu Unlimited-OCR server not running (falls back to tesseract)",
     fix: "node scripts/gpu-vision/setup.mjs && node scripts/gpu-vision/serve.mjs  (GPU host; sets ELIZA_GPU_VISION_URL / serve.json)",
   });
 
   const appleVision =
-    process.platform === "darwin"
-      ? await probeCommand("swift", ["--version"])
-      : null;
+    platform === "darwin" ? await commandProbe("swift", ["--version"]) : null;
   probes.push({
     id: "apple-vision-ocr",
     required: false,
     ok: appleVision !== null,
     detail:
-      process.platform !== "darwin"
+      platform !== "darwin"
         ? "apple-vision OCR is macOS-only"
         : appleVision
           ? firstLine(appleVision)
@@ -140,46 +465,57 @@ export async function runProbes(env) {
     detail: visionApi
       ? "an API/base-url backend is configured for vision-qa"
       : "no ANTHROPIC_API_KEY / OPENAI_API_KEY / ELIZA_VISION_QA_BASE_URL set",
-    fix: "export ANTHROPIC_API_KEY=… (or OPENAI_API_KEY, or ELIZA_VISION_QA_BASE_URL for a local llama-server)",
+    fix: "configure ANTHROPIC_API_KEY, OPENAI_API_KEY, or ELIZA_VISION_QA_BASE_URL through the environment or secret store",
   });
 
-  const claudeCli = await probeCommand("claude", ["--version"]);
-  const codexCli = await probeCommand("codex", ["--version"]);
+  const claudeCli = await commandProbe("claude", ["--version"]);
+  const codexCli = await commandProbe("codex", ["--version"]);
   probes.push({
     id: "coding-agent-cli",
     required: false,
     ok: claudeCli !== null || codexCli !== null,
-    detail: [
-      claudeCli ? `claude ${firstLine(claudeCli)}` : null,
-      codexCli ? `codex ${firstLine(codexCli)}` : null,
-    ]
-      .filter(Boolean)
-      .join(" · ") || "neither claude nor codex CLI on PATH",
-    fix: "install the Claude Code CLI or the Codex CLI to let vision-qa review screenshots via an already-authed coding agent (ELIZA_VISION_QA_BACKEND=cli)",
+    detail:
+      [
+        claudeCli ? `claude ${firstLine(claudeCli)}` : null,
+        codexCli ? `codex ${firstLine(codexCli)}` : null,
+      ]
+        .filter(Boolean)
+        .join(" · ") || "neither claude nor codex CLI is on PATH",
+    fix: "install the Claude Code CLI or the Codex CLI to let vision-qa review screenshots through an already-authenticated coding agent",
   });
 
   return probes;
 }
 
-/** True when a Playwright browser cache exists in any of the usual locations. */
-function existsSyncPlaywrightBrowsers() {
-  const override = process.env.PLAYWRIGHT_BROWSERS_PATH?.trim();
-  const candidates = [
-    override,
-    path.join(os.homedir(), "Library", "Caches", "ms-playwright"),
-    path.join(os.homedir(), ".cache", "ms-playwright"),
-    path.join(
-      process.env.LOCALAPPDATA || os.homedir(),
-      "ms-playwright",
-    ),
-  ].filter(Boolean);
-  return candidates.some((dir) => existsSync(dir));
+export function summarize(probes) {
+  const requiredMissing = probes.filter((probe) => probe.required && !probe.ok);
+  const optionalMissing = probes.filter(
+    (probe) => !probe.required && !probe.ok,
+  );
+  return { requiredMissing, optionalMissing, ok: requiredMissing.length === 0 };
 }
 
-export function summarize(probes) {
-  const requiredMissing = probes.filter((p) => p.required && !p.ok);
-  const optionalMissing = probes.filter((p) => !p.required && !p.ok);
-  return { requiredMissing, optionalMissing, ok: requiredMissing.length === 0 };
+export function createDoctorReport(
+  probes,
+  {
+    platform = process.platform,
+    architecture = process.arch,
+    nodeVersion = process.version,
+  } = {},
+) {
+  const summary = summarize(probes);
+  return {
+    schemaVersion: 1,
+    platform: {
+      os: platform,
+      architecture,
+      nodeVersion,
+    },
+    ok: summary.ok,
+    requiredMissing: summary.requiredMissing.map(({ id }) => id),
+    optionalMissing: summary.optionalMissing.map(({ id }) => id),
+    probes,
+  };
 }
 
 function printHuman(probes) {
@@ -193,40 +529,61 @@ function printHuman(probes) {
   console.log("");
   if (ok) {
     console.log(
-      `Required tools present. ${optionalMissing.length} optional capability(ies) unavailable (evidence degrades to honest skips).`,
+      `Required tools present. ${optionalMissing.length} optional capability(ies) unavailable.`,
     );
   } else {
     console.log(
       `${requiredMissing.length} REQUIRED tool(s) missing: ${requiredMissing
-        .map((p) => p.id)
-        .join(", ")}. Install them before capturing evidence (see fix lines above).`,
+        .map(({ id }) => id)
+        .join(", ")}. Install them before capturing evidence.`,
     );
   }
 }
 
+export function parseDoctorArgs(args) {
+  const supported = new Set(["--help", "-h", "--json", "--strict"]);
+  for (const arg of args) {
+    if (!supported.has(arg)) {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return {
+    help: args.includes("--help") || args.includes("-h"),
+    json: args.includes("--json"),
+    strict: args.includes("--strict"),
+  };
+}
+
 async function main() {
-  const args = process.argv.slice(2);
-  if (args.includes("--help") || args.includes("-h")) {
+  const options = parseDoctorArgs(process.argv.slice(2));
+  if (options.help) {
     console.log(
       "Usage: node scripts/evidence-doctor.mjs [--json] [--strict]\n\n" +
-        "  --json    Print findings as JSON.\n" +
-        "  --strict  Exit non-zero when a REQUIRED tool is missing.\n",
+        "  --json            Print a normalized platform report as JSON.\n" +
+        "  --strict          Exit non-zero when a REQUIRED tool is missing.\n",
     );
     return;
   }
   const probes = await runProbes(process.env);
-  const { ok } = summarize(probes);
-  if (args.includes("--json")) {
-    console.log(JSON.stringify({ ok, probes }, null, 2));
+  const report = createDoctorReport(probes);
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
   } else {
     printHuman(probes);
   }
-  if (args.includes("--strict") && !ok) process.exit(1);
+  if (options.strict && !report.ok) process.exitCode = 1;
 }
 
 if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  await main();
+  try {
+    await main();
+  } catch (error) {
+    // error-policy:J1 invalid invocations become one bounded CLI failure.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`evidence-doctor: ${message}`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/evidence-doctor.mjs
+++ b/scripts/evidence-doctor.mjs
@@ -8,7 +8,7 @@
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -156,6 +156,7 @@ export async function probePackagedOcr({
   timeoutMs = 60_000,
 } = {}) {
   const directory = await mkdtemp(path.join(tempRoot, "eliza-ocr-doctor-"));
+  let workerPromise;
   let worker;
   let result;
   try {
@@ -166,8 +167,11 @@ export async function probePackagedOcr({
         detail: `${EVIDENCE_REQUIREMENTS.ocr.packageName} lacks createWorker`,
       };
     }
-    worker = await withTimeout(
+    workerPromise = Promise.resolve(
       tesseract.createWorker("eng", 1, { cachePath: directory }),
+    );
+    worker = await withTimeout(
+      workerPromise,
       timeoutMs,
       "packaged OCR worker initialization",
     );
@@ -209,17 +213,78 @@ export async function probePackagedOcr({
   } finally {
     try {
       if (worker) {
-        await withTimeout(
-          worker.terminate(),
-          timeoutMs,
-          "packaged OCR worker teardown",
-        );
+        try {
+          await withTimeout(
+            worker.terminate(),
+            timeoutMs,
+            "packaged OCR worker teardown",
+          );
+        } catch {
+          // error-policy:J6 teardown is best-effort; a hung terminate must not
+          // replace the probe result or crash the doctor.
+        }
+      } else if (workerPromise) {
+        // error-policy:J5 a createWorker call that outlived its deadline can
+        // still resolve later; its threads would keep the process alive, so
+        // terminate the late worker here — the timeout above already reported
+        // the failure, making this fire-and-forget teardown the only observer.
+        workerPromise
+          .then((lateWorker) => lateWorker?.terminate?.())
+          .catch(() => {});
       }
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
   }
   return result;
+}
+
+/**
+ * Behavioral probe for a system tesseract binary: it must recognize the
+ * generated ELIZA fixture, mirroring the evidence OCR engine's CLI shape
+ * (`tesseract <img> - --psm <n>`, see packages/evidence/src/analyzers/ocr/
+ * engines.ts). The probe uses `--psm 8` (single word) because the fixture is
+ * one word — the engine's screenshot default `--psm 6` segments the blocky
+ * glyph grid unreliably. A binary that answers --version but cannot read the
+ * fixture is not a working OCR capability and must not be reported as one.
+ */
+export async function probeSystemTesseract({
+  bin = "tesseract",
+  run = execFileAsync,
+  tempRoot = os.tmpdir(),
+  timeoutMs = 60_000,
+} = {}) {
+  const directory = await mkdtemp(
+    path.join(tempRoot, "eliza-ocr-doctor-system-"),
+  );
+  const fixturePath = path.join(directory, "fixture.bmp");
+  try {
+    await writeFile(fixturePath, buildOcrFixtureBmp());
+    const { stdout } = await run(bin, [fixturePath, "-", "--psm", "8"], {
+      timeout: timeoutMs,
+      windowsHide: true,
+    });
+    const transcript = String(stdout ?? "")
+      .toUpperCase()
+      .replaceAll(/[^A-Z0-9]/gu, "");
+    return transcript.includes(OCR_FIXTURE_TEXT)
+      ? {
+          ok: true,
+          detail: `system tesseract at ${bin} recognized the bundled ${OCR_FIXTURE_TEXT} fixture`,
+        }
+      : {
+          ok: false,
+          detail: `system tesseract at ${bin} did not recognize the bundled fixture`,
+        };
+  } catch {
+    // error-policy:J4 a missing or failing binary is an explicit probe result.
+    return {
+      ok: false,
+      detail: `system tesseract at ${bin} is unavailable or failed on the bundled fixture`,
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 }
 
 export async function probeMediaPipeline(
@@ -361,6 +426,7 @@ export async function runProbes(
     mediaResolver = resolveMediaRequirements,
     mediaPipelineProbe = probeMediaPipeline,
     ocrProbe = probePackagedOcr,
+    systemOcrProbe = probeSystemTesseract,
     playwrightProbe = probePlaywrightChromium,
     pathExists = existsSync,
   } = {},
@@ -370,18 +436,20 @@ export async function runProbes(
   const fixes = platformFixes(platform);
 
   const packagedOcr = await ocrProbe();
-  const systemTesseract = packagedOcr.ok
+  // The fallback is behavioral like the packaged probe: the system binary must
+  // recognize the same fixture, never merely answer --version.
+  const systemOcr = packagedOcr.ok
     ? null
-    : await commandProbe(env.ELIZA_TESSERACT_BIN || "tesseract", ["--version"]);
+    : await systemOcrProbe({ bin: env.ELIZA_TESSERACT_BIN || "tesseract" });
   probes.push({
     id: EVIDENCE_REQUIREMENTS.ocr.id,
     required: EVIDENCE_REQUIREMENTS.ocr.requiredByDefault,
-    ok: packagedOcr.ok || systemTesseract !== null,
+    ok: packagedOcr.ok || systemOcr?.ok === true,
     detail: packagedOcr.ok
       ? packagedOcr.detail
-      : systemTesseract
-        ? `${firstLine(systemTesseract)} (system fallback)`
-        : `${packagedOcr.detail}; system tesseract is also unavailable`,
+      : systemOcr?.ok
+        ? `${systemOcr.detail} (system fallback)`
+        : `${packagedOcr.detail}; ${systemOcr.detail}`,
     fix: `bun run evidence:install-tools · ${fixes.systemTesseract}`,
   });
 

--- a/scripts/evidence-doctor.test.mjs
+++ b/scripts/evidence-doctor.test.mjs
@@ -9,10 +9,12 @@ import { writeFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  buildOcrFixtureBmp,
   createDoctorReport,
   parseDoctorArgs,
   probeMediaPipeline,
   probePackagedOcr,
+  probeSystemTesseract,
   runProbes,
   summarize,
 } from "./evidence-doctor.mjs";
@@ -79,6 +81,11 @@ describe("evidence toolchain doctor", () => {
           ok: false,
           detail: "tesseract.js is not loadable",
         }),
+        systemOcrProbe: async () => ({
+          ok: false,
+          detail:
+            "system tesseract at tesseract is unavailable or failed on the bundled fixture",
+        }),
         playwrightProbe: async () => ({
           ok: false,
           detail: "Chromium launch failed",
@@ -97,34 +104,106 @@ describe("evidence toolchain doctor", () => {
     );
   });
 
-  it("accepts system Tesseract only when packaged OCR cannot load", async () => {
+  it("accepts system Tesseract only when it recognizes the fixture behaviorally", async () => {
     const calls = [];
+    const systemOcrProbe = async ({ bin }) => {
+      calls.push({ bin });
+      return {
+        ok: true,
+        detail: `system tesseract at ${bin} recognized the bundled ELIZA fixture`,
+      };
+    };
     const probes = await runProbes(
       { ELIZA_TESSERACT_BIN: "/tools/tesseract" },
       {
-        commandProbe: async (bin, args) => {
-          calls.push({ bin, args });
-          return bin === "/tools/tesseract"
-            ? "tesseract 5.5.0\n additional output"
-            : null;
-        },
+        commandProbe: async () => null,
         mediaResolver: healthyMedia,
         mediaPipelineProbe: healthyMediaPipeline,
         ocrProbe: async () => ({
           ok: false,
           detail: "tesseract.js is not loadable",
         }),
+        systemOcrProbe,
         playwrightProbe: healthyPlaywright,
         pathExists: () => false,
       },
     );
     const ocr = probes.find(({ id }) => id === "ocr");
     assert.equal(ocr.ok, true);
-    assert.match(ocr.detail, /tesseract 5\.5\.0 \(system fallback\)/);
-    assert.deepEqual(calls[0], {
+    assert.match(
+      ocr.detail,
+      /recognized the bundled ELIZA fixture \(system fallback\)/,
+    );
+    assert.deepEqual(calls, [{ bin: "/tools/tesseract" }]);
+  });
+
+  it("rejects a system tesseract that answers --version but fails the fixture", async () => {
+    const probes = await runProbes(
+      {},
+      {
+        commandProbe: async (bin) =>
+          bin === "tesseract" ? "tesseract 5.5.0" : null,
+        mediaResolver: healthyMedia,
+        mediaPipelineProbe: healthyMediaPipeline,
+        ocrProbe: async () => ({
+          ok: false,
+          detail: "tesseract.js could not recognize the bundled fixture",
+        }),
+        systemOcrProbe: async ({ bin }) => ({
+          ok: false,
+          detail: `system tesseract at ${bin} did not recognize the bundled fixture`,
+        }),
+        playwrightProbe: healthyPlaywright,
+        pathExists: () => false,
+      },
+    );
+    const ocr = probes.find(({ id }) => id === "ocr");
+    assert.equal(ocr.ok, false);
+    assert.match(ocr.detail, /tesseract\.js could not recognize/);
+    assert.match(ocr.detail, /system tesseract at tesseract did not recognize/);
+  });
+
+  it("probes the system binary with the evidence engine's exact invocation", async () => {
+    const calls = [];
+    const result = await probeSystemTesseract({
       bin: "/tools/tesseract",
-      args: ["--version"],
+      run: async (bin, args, options) => {
+        const { readFileSync } = await import("node:fs");
+        calls.push({
+          bin,
+          args,
+          timeout: options.timeout,
+          fixtureMatchesGenerator: readFileSync(args[0]).equals(
+            buildOcrFixtureBmp(),
+          ),
+        });
+        return { stdout: "ELIZA\n" };
+      },
     });
+    assert.equal(result.ok, true);
+    assert.match(result.detail, /recognized the bundled ELIZA fixture/);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].bin, "/tools/tesseract");
+    assert.match(calls[0].args[0], /eliza-ocr-doctor-system-.*fixture\.bmp$/);
+    assert.deepEqual(calls[0].args.slice(1), ["-", "--psm", "8"]);
+    assert.equal(calls[0].fixtureMatchesGenerator, true);
+    assert.ok(calls[0].timeout > 0);
+
+    const wrong = await probeSystemTesseract({
+      bin: "/tools/tesseract",
+      run: async () => ({ stdout: "SOMETHING ELSE" }),
+    });
+    assert.equal(wrong.ok, false);
+    assert.match(wrong.detail, /did not recognize the bundled fixture/);
+
+    const broken = await probeSystemTesseract({
+      bin: "/missing/tesseract",
+      run: async () => {
+        throw new Error("ENOENT");
+      },
+    });
+    assert.equal(broken.ok, false);
+    assert.match(broken.detail, /unavailable or failed on the bundled fixture/);
   });
 
   it("reports GitHub CLI without probing credentials or repository permissions", async () => {
@@ -262,6 +341,46 @@ describe("evidence toolchain doctor", () => {
     });
     assert.equal(result.ok, false);
     assert.match(result.detail, /did not recognize/);
+  });
+
+  it("terminates a worker whose creation outlives the probe deadline", async () => {
+    let terminated = false;
+    const result = await probePackagedOcr({
+      timeoutMs: 20,
+      loadTesseract: async () => ({
+        createWorker: () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve({
+                  terminate: async () => {
+                    terminated = true;
+                  },
+                }),
+              80,
+            );
+          }),
+      }),
+    });
+    assert.equal(result.ok, false);
+    // The late worker resolves after the probe returned; it must still be
+    // terminated so its threads cannot keep the doctor process alive.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(terminated, true);
+  });
+
+  it("keeps the probe result when worker teardown hangs past its deadline", async () => {
+    const result = await probePackagedOcr({
+      timeoutMs: 20,
+      loadTesseract: async () => ({
+        createWorker: async () => ({
+          recognize: async () => ({ data: { text: "ELIZA" } }),
+          terminate: () => new Promise(() => {}),
+        }),
+      }),
+    });
+    assert.equal(result.ok, true);
+    assert.match(result.detail, /recognized the bundled ELIZA fixture/);
   });
 
   it("requires a real ffmpeg encode, ffprobe inspection, and ffmpeg decode", async () => {

--- a/scripts/evidence-doctor.test.mjs
+++ b/scripts/evidence-doctor.test.mjs
@@ -1,29 +1,60 @@
 /**
- * Tests for the evidence-toolchain doctor. `runProbes` shells out to real
- * binaries, so these assert the shape and classification invariants (every
- * probe carries a fix, required-missing drives strict failure) rather than the
- * presence of any given tool, which varies by host.
+ * Verifies doctor classification, executable probes, redaction, normalized
+ * reporting, and strict CLI boundaries with deterministic capability fakes.
  */
 
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
 import { describe, it } from "node:test";
-import { runProbes, summarize } from "./evidence-doctor.mjs";
+import { fileURLToPath } from "node:url";
+import {
+  createDoctorReport,
+  parseDoctorArgs,
+  probeMediaPipeline,
+  probePackagedOcr,
+  runProbes,
+  summarize,
+} from "./evidence-doctor.mjs";
+import { EVIDENCE_REQUIREMENTS } from "./evidence-install-tools.mjs";
 
-describe("evidence-doctor", () => {
-  it("returns a probe for every capability with a pasteable fix", async () => {
-    const probes = await runProbes({});
-    const ids = probes.map((p) => p.id);
-    for (const id of [
-      "tesseract",
-      "ffmpeg",
-      "playwright-browsers",
-      "gpu-vision-ocr",
-      "apple-vision-ocr",
-      "vlm-vision-qa-api",
-      "coding-agent-cli",
-    ]) {
-      assert.ok(ids.includes(id), `missing probe: ${id}`);
-    }
+const healthyMedia = async () => ({
+  ffmpeg: { available: true, bin: "/tools/ffmpeg", source: "bundled" },
+  ffprobe: { available: true, bin: "/tools/ffprobe", source: "bundled" },
+});
+const healthyOcr = async () => ({
+  ok: true,
+  detail: "tesseract.js createWorker is loadable",
+});
+const healthyPlaywright = async () => ({
+  ok: true,
+  detail: "Playwright Chromium 123 launched successfully",
+});
+const healthyMediaPipeline = async () => ({
+  ok: true,
+  detail: "media fixture passed",
+});
+
+describe("evidence toolchain doctor", () => {
+  it("uses the installer catalog for every required baseline probe", async () => {
+    const probes = await runProbes(
+      {},
+      {
+        commandProbe: async () => null,
+        mediaResolver: healthyMedia,
+        mediaPipelineProbe: healthyMediaPipeline,
+        ocrProbe: healthyOcr,
+        playwrightProbe: healthyPlaywright,
+        pathExists: () => false,
+      },
+    );
+    const requiredIds = probes
+      .filter(({ required }) => required)
+      .map(({ id }) => id);
+    const catalogIds = Object.values(EVIDENCE_REQUIREMENTS)
+      .filter(({ requiredByDefault }) => requiredByDefault)
+      .map(({ id }) => id);
+    assert.deepEqual(requiredIds, catalogIds);
     for (const probe of probes) {
       assert.equal(typeof probe.ok, "boolean");
       assert.equal(typeof probe.required, "boolean");
@@ -31,24 +62,295 @@ describe("evidence-doctor", () => {
     }
   });
 
-  it("keys strict failure on required-missing only", () => {
-    const optionalOnly = summarize([
-      { id: "a", required: true, ok: true, fix: "x" },
-      { id: "b", required: false, ok: false, fix: "x" },
-    ]);
-    assert.equal(optionalOnly.ok, true);
-    assert.equal(optionalOnly.optionalMissing.length, 1);
-
-    const requiredGap = summarize([
-      { id: "a", required: true, ok: false, fix: "x" },
-    ]);
-    assert.equal(requiredGap.ok, false);
-    assert.equal(requiredGap.requiredMissing.length, 1);
+  it("requires executable ffmpeg, ffprobe, packaged OCR, and launched Chromium", async () => {
+    const probes = await runProbes(
+      {},
+      {
+        commandProbe: async () => null,
+        mediaResolver: async () => ({
+          ffmpeg: { available: false, reason: "ffmpeg binary failed" },
+          ffprobe: { available: false, reason: "ffprobe binary failed" },
+        }),
+        mediaPipelineProbe: async () => ({
+          ok: false,
+          detail: "media fixture failed",
+        }),
+        ocrProbe: async () => ({
+          ok: false,
+          detail: "tesseract.js is not loadable",
+        }),
+        playwrightProbe: async () => ({
+          ok: false,
+          detail: "Chromium launch failed",
+        }),
+        pathExists: () => true,
+      },
+    );
+    assert.deepEqual(
+      summarize(probes).requiredMissing.map(({ id }) => id),
+      ["ocr", "ffmpeg", "ffprobe", "playwright-browsers"],
+    );
+    assert.equal(
+      probes.find(({ id }) => id === "playwright-browsers").ok,
+      false,
+      "an existing cache hint must not replace a real Chromium launch",
+    );
   });
 
-  it("detects an API vision backend from env", async () => {
-    const probes = await runProbes({ ANTHROPIC_API_KEY: "sk-test" });
-    const api = probes.find((p) => p.id === "vlm-vision-qa-api");
-    assert.equal(api.ok, true);
+  it("accepts system Tesseract only when packaged OCR cannot load", async () => {
+    const calls = [];
+    const probes = await runProbes(
+      { ELIZA_TESSERACT_BIN: "/tools/tesseract" },
+      {
+        commandProbe: async (bin, args) => {
+          calls.push({ bin, args });
+          return bin === "/tools/tesseract"
+            ? "tesseract 5.5.0\n additional output"
+            : null;
+        },
+        mediaResolver: healthyMedia,
+        mediaPipelineProbe: healthyMediaPipeline,
+        ocrProbe: async () => ({
+          ok: false,
+          detail: "tesseract.js is not loadable",
+        }),
+        playwrightProbe: healthyPlaywright,
+        pathExists: () => false,
+      },
+    );
+    const ocr = probes.find(({ id }) => id === "ocr");
+    assert.equal(ocr.ok, true);
+    assert.match(ocr.detail, /tesseract 5\.5\.0 \(system fallback\)/);
+    assert.deepEqual(calls[0], {
+      bin: "/tools/tesseract",
+      args: ["--version"],
+    });
+  });
+
+  it("reports GitHub CLI without probing credentials or repository permissions", async () => {
+    const calls = [];
+    const secretUrl = "https://secret-user:secret-pass@example.test/ocr";
+    const commandProbe = async (bin, args) => {
+      calls.push({ bin, args });
+      return bin === "gh" && args[0] === "--version"
+        ? "gh version 2.99.0"
+        : null;
+    };
+    const probes = await runProbes(
+      { ELIZA_GPU_VISION_URL: secretUrl },
+      {
+        platform: "win32",
+        commandProbe,
+        mediaResolver: healthyMedia,
+        mediaPipelineProbe: healthyMediaPipeline,
+        ocrProbe: healthyOcr,
+        playwrightProbe: healthyPlaywright,
+        pathExists: () => false,
+      },
+    );
+    assert.equal(summarize(probes).ok, true);
+    const github = probes.find((probe) => probe.id === "github-cli");
+    assert.equal(github.required, false);
+    assert.equal(github.ok, true);
+    assert.deepEqual(
+      calls.filter(({ bin }) => bin === "gh"),
+      [{ bin: "gh", args: ["--version"] }],
+    );
+    const serialized = JSON.stringify(probes);
+    assert.doesNotMatch(serialized, /secret-user|secret-pass/u);
+    assert.match(
+      probes.find(({ id }) => id === "gpu-vision-ocr").detail,
+      /value hidden/,
+    );
+  });
+
+  it("emits a normalized platform report with explicit missing sets", () => {
+    const probes = [
+      {
+        id: "required",
+        required: true,
+        ok: false,
+        detail: "missing",
+        fix: "install",
+      },
+      {
+        id: "optional",
+        required: false,
+        ok: false,
+        detail: "missing",
+        fix: "configure",
+      },
+    ];
+    assert.deepEqual(
+      createDoctorReport(probes, {
+        platform: "linux",
+        architecture: "x64",
+        nodeVersion: "v24.15.0",
+      }),
+      {
+        schemaVersion: 1,
+        platform: {
+          os: "linux",
+          architecture: "x64",
+          nodeVersion: "v24.15.0",
+        },
+        ok: false,
+        requiredMissing: ["required"],
+        optionalMissing: ["optional"],
+        probes,
+      },
+    );
+  });
+
+  it("recognizes a generated bitmap through a real packaged-OCR worker contract", async () => {
+    const calls = [];
+    const result = await probePackagedOcr({
+      loadTesseract: async () => ({
+        PSM: { SINGLE_LINE: 7 },
+        createWorker: async (language, mode, options) => {
+          calls.push({
+            operation: "create",
+            language,
+            mode,
+            hasIsolatedCache: /eliza-ocr-doctor-/u.test(options.cachePath),
+          });
+          return {
+            setParameters: async (parameters) => {
+              calls.push({ operation: "configure", parameters });
+            },
+            recognize: async (fixture) => {
+              calls.push({
+                operation: "recognize",
+                signature: fixture.subarray(0, 2).toString("ascii"),
+                bytes: fixture.length,
+              });
+              return { data: { text: "ELIZA" } };
+            },
+            terminate: async () => {
+              calls.push({ operation: "terminate" });
+            },
+          };
+        },
+      }),
+    });
+    assert.equal(result.ok, true);
+    assert.match(result.detail, /recognized the bundled ELIZA fixture/);
+    assert.deepEqual(calls[0], {
+      operation: "create",
+      language: "eng",
+      mode: 1,
+      hasIsolatedCache: true,
+    });
+    assert.equal(
+      calls.find(({ operation }) => operation === "recognize").signature,
+      "BM",
+    );
+    assert.ok(
+      calls.find(({ operation }) => operation === "recognize").bytes > 1_000,
+    );
+    assert.equal(calls.at(-1).operation, "terminate");
+  });
+
+  it("rejects packaged OCR that cannot read the known fixture", async () => {
+    const result = await probePackagedOcr({
+      loadTesseract: async () => ({
+        createWorker: async () => ({
+          recognize: async () => ({ data: { text: "WRONG" } }),
+          terminate: async () => {},
+        }),
+      }),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.detail, /did not recognize/);
+  });
+
+  it("requires a real ffmpeg encode, ffprobe inspection, and ffmpeg decode", async () => {
+    const calls = [];
+    const result = await probeMediaPipeline(await healthyMedia(), {
+      run: async (bin, args) => {
+        calls.push({ bin, args });
+        if (bin === "/tools/ffprobe") {
+          return {
+            stdout: JSON.stringify({
+              streams: [{ codec_type: "video", width: 32, height: 32 }],
+            }),
+          };
+        }
+        const outputPath = args.at(-1);
+        if (args.includes("lavfi")) {
+          await writeFile(outputPath, "encoded fixture");
+        } else {
+          await writeFile(outputPath, Buffer.alloc(32 * 32 * 3));
+        }
+        return { stdout: "" };
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(calls.length, 3);
+    assert.deepEqual(
+      calls.map(({ bin }) => bin),
+      ["/tools/ffmpeg", "/tools/ffprobe", "/tools/ffmpeg"],
+    );
+    assert.ok(calls[0].args.includes("lavfi"));
+    assert.ok(calls[1].args.includes("stream=codec_type,width,height"));
+    assert.ok(calls[2].args.includes("rawvideo"));
+  });
+
+  it("lets optional absences remain non-blocking", () => {
+    const summary = summarize([
+      { id: "required", required: true, ok: true },
+      { id: "optional", required: false, ok: false },
+    ]);
+    assert.equal(summary.ok, true);
+    assert.equal(summary.requiredMissing.length, 0);
+    assert.equal(summary.optionalMissing.length, 1);
+  });
+
+  it("fails closed on unknown CLI options", () => {
+    assert.deepEqual(parseDoctorArgs(["--json", "--strict"]), {
+      help: false,
+      json: true,
+      strict: true,
+    });
+    assert.throws(
+      () => parseDoctorArgs(["--strcit"]),
+      /unknown argument: --strcit/,
+    );
+    assert.throws(
+      () => parseDoctorArgs(["unexpected-position"]),
+      /unknown argument: unexpected-position/,
+    );
+    assert.throws(
+      () => parseDoctorArgs(["--require-github"]),
+      /unknown argument: --require-github/,
+    );
+
+    const cli = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("./evidence-doctor.mjs", import.meta.url)),
+        "--strcit",
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(cli.status, 1);
+    assert.match(cli.stderr, /evidence-doctor: unknown argument: --strcit/);
+    assert.equal(cli.stdout, "");
+  });
+
+  it("rejects unsupported operating systems before probing", async () => {
+    await assert.rejects(
+      runProbes(
+        {},
+        {
+          platform: "aix",
+          mediaResolver: healthyMedia,
+          mediaPipelineProbe: healthyMediaPipeline,
+          ocrProbe: healthyOcr,
+          playwrightProbe: healthyPlaywright,
+        },
+      ),
+      /unsupported operating system/,
+    );
   });
 });

--- a/scripts/evidence-install-tools.mjs
+++ b/scripts/evidence-install-tools.mjs
@@ -1,0 +1,604 @@
+#!/usr/bin/env node
+/**
+ * Installs the baseline evidence toolchain on macOS, Linux, and Windows.
+ * The exported requirement catalog also drives the doctor, while direct
+ * argument-vector execution and process-local PATH refresh keep reruns
+ * deterministic without editing shell profiles or persisting credentials.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  resolveFfmpegBinary,
+  resolveFfprobeBinary,
+} from "../packages/evidence/src/ffmpeg-binaries.ts";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), "..");
+const SUPPORTED_PLATFORMS = new Set(["darwin", "linux", "win32"]);
+
+export const EVIDENCE_REQUIREMENTS = Object.freeze({
+  ocr: Object.freeze({
+    id: "ocr",
+    requiredByDefault: true,
+    packageName: "tesseract.js",
+  }),
+  ffmpeg: Object.freeze({
+    id: "ffmpeg",
+    requiredByDefault: true,
+    packageName: "ffmpeg-static",
+    systemCommand: "ffmpeg",
+    versionArgs: Object.freeze(["-version"]),
+  }),
+  ffprobe: Object.freeze({
+    id: "ffprobe",
+    requiredByDefault: true,
+    packageName: "ffprobe-static",
+    systemCommand: "ffprobe",
+    versionArgs: Object.freeze(["-version"]),
+  }),
+  playwright: Object.freeze({
+    id: "playwright-browsers",
+    requiredByDefault: true,
+    packageName: "playwright",
+    browserName: "chromium",
+  }),
+  githubCli: Object.freeze({
+    id: "github-cli",
+    requiredByDefault: false,
+    systemCommand: "gh",
+  }),
+});
+
+const LINUX_PACKAGE_MANAGERS = Object.freeze([
+  Object.freeze({
+    name: "apt-get",
+    updateArgs: Object.freeze(["update"]),
+    mediaArgs: Object.freeze(["install", "-y", "ffmpeg"]),
+    githubArgs: Object.freeze(["install", "-y", "gh"]),
+  }),
+  Object.freeze({
+    name: "dnf",
+    mediaArgs: Object.freeze(["install", "-y", "ffmpeg"]),
+    githubArgs: Object.freeze(["install", "-y", "gh"]),
+  }),
+  Object.freeze({
+    name: "yum",
+    mediaArgs: Object.freeze(["install", "-y", "ffmpeg"]),
+    githubArgs: Object.freeze(["install", "-y", "gh"]),
+  }),
+  Object.freeze({
+    name: "apk",
+    mediaArgs: Object.freeze(["add", "--no-cache", "ffmpeg"]),
+    githubArgs: Object.freeze(["add", "--no-cache", "github-cli"]),
+  }),
+  Object.freeze({
+    name: "pacman",
+    mediaArgs: Object.freeze(["-S", "--noconfirm", "ffmpeg"]),
+    githubArgs: Object.freeze(["-S", "--noconfirm", "github-cli"]),
+  }),
+  Object.freeze({
+    name: "zypper",
+    mediaArgs: Object.freeze(["install", "-y", "ffmpeg"]),
+    githubArgs: Object.freeze(["install", "-y", "gh"]),
+  }),
+]);
+
+export function assertSupportedPlatform(platform) {
+  if (!SUPPORTED_PLATFORMS.has(platform)) {
+    throw new Error(
+      `unsupported operating system: ${platform}; supported platforms are macOS, Linux, and Windows`,
+    );
+  }
+}
+
+function pathKeyFor(env) {
+  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "Path";
+}
+
+function mergeWindowsPath(env, additionalPaths) {
+  const pathKey = pathKeyFor(env);
+  const current = env[pathKey] ?? "";
+  const entries = [...additionalPaths, ...current.split(";")]
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const seen = new Set();
+  const unique = entries.filter((entry) => {
+    const normalized = entry.toLowerCase();
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+  return { ...env, [pathKey]: unique.join(";") };
+}
+
+/**
+ * WinGet exposes portable package shims from this per-user directory. Adding
+ * it only to child-process state makes new shims visible without modifying a
+ * user's persistent PATH.
+ */
+export function withWindowsWingetLinksPath(env) {
+  if (!env.LOCALAPPDATA) {
+    throw new Error(
+      "LOCALAPPDATA is unavailable; cannot resolve WinGet's tool links directory.",
+    );
+  }
+  const links = path.win32.join(
+    env.LOCALAPPDATA,
+    "Microsoft",
+    "WinGet",
+    "Links",
+  );
+  return mergeWindowsPath(env, [links]);
+}
+
+/**
+ * MSI-backed WinGet packages update registry PATH values, which a running
+ * Node process does not inherit. Reading and merging those values after each
+ * WinGet mutation makes verification in the same installer process reliable.
+ */
+export function refreshWindowsPath(env, { run = spawnSync } = {}) {
+  const seeded = withWindowsWingetLinksPath(env);
+  const script =
+    "[Console]::Out.Write((@([Environment]::GetEnvironmentVariable('Path','Machine'),[Environment]::GetEnvironmentVariable('Path','User')) -join [Environment]::NewLine))";
+  const result = run(
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      encoding: "utf8",
+      env: seeded,
+      windowsHide: true,
+    },
+  );
+  if (result.error) {
+    throw new Error(`could not refresh Windows PATH: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `could not refresh Windows PATH (PowerShell exited ${result.status ?? "without a status"})`,
+    );
+  }
+  const [machinePath = "", userPath = ""] = String(result.stdout ?? "").split(
+    /\r?\n/u,
+    2,
+  );
+  return mergeWindowsPath(seeded, [userPath, machinePath]);
+}
+
+function commandExists(
+  command,
+  { platform = process.platform, run = spawnSync, env = process.env } = {},
+) {
+  const probe =
+    platform === "win32"
+      ? run("where", [command], { stdio: "ignore", env })
+      : run("which", [command], { stdio: "ignore", env });
+  return probe.status === 0;
+}
+
+function nonInteractiveSudoSteps(isRoot) {
+  return isRoot
+    ? []
+    : [
+        {
+          label: "passwordless sudo preflight",
+          bin: "sudo",
+          args: ["-n", "true"],
+          failureMessage:
+            "Evidence tool installation requires passwordless sudo on this unattended runner. Install the tools manually or grant this runner noninteractive sudo, then rerun.",
+        },
+      ];
+}
+
+function linuxManager(has) {
+  return LINUX_PACKAGE_MANAGERS.find(({ name }) => has(name));
+}
+
+function linuxInstallSteps(manager, args, isRoot, label) {
+  const command = isRoot ? manager.name : "sudo";
+  const prefix = isRoot ? [] : ["-n", manager.name];
+  return [
+    ...nonInteractiveSudoSteps(isRoot),
+    ...(manager.updateArgs
+      ? [
+          {
+            label: `${label} package index`,
+            bin: command,
+            args: [...prefix, ...manager.updateArgs],
+          },
+        ]
+      : []),
+    {
+      label,
+      bin: command,
+      args: [...prefix, ...args],
+    },
+  ];
+}
+
+function mediaVerificationSteps(resolutions) {
+  const ffmpeg = EVIDENCE_REQUIREMENTS.ffmpeg;
+  const ffprobe = EVIDENCE_REQUIREMENTS.ffprobe;
+  return [
+    {
+      label: "ffmpeg verification",
+      bin: resolutions?.ffmpeg?.available
+        ? resolutions.ffmpeg.bin
+        : ffmpeg.systemCommand,
+      args: [...ffmpeg.versionArgs],
+    },
+    {
+      label: "ffprobe verification",
+      bin: resolutions?.ffprobe?.available
+        ? resolutions.ffprobe.bin
+        : ffprobe.systemCommand,
+      args: [...ffprobe.versionArgs],
+    },
+  ];
+}
+
+export function mediaInstallSteps(
+  platform,
+  {
+    has = (command) => commandExists(command, { platform }),
+    isRoot = typeof process.getuid === "function"
+      ? process.getuid() === 0
+      : false,
+    resolutions,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
+  const healthy =
+    resolutions?.ffmpeg?.available && resolutions?.ffprobe?.available;
+  if (healthy) return mediaVerificationSteps(resolutions);
+  if (
+    resolutions === undefined &&
+    has(EVIDENCE_REQUIREMENTS.ffmpeg.systemCommand) &&
+    has(EVIDENCE_REQUIREMENTS.ffprobe.systemCommand)
+  ) {
+    return mediaVerificationSteps();
+  }
+
+  if (platform === "darwin") {
+    if (!has("brew")) {
+      throw new Error(
+        "ffmpeg/ffprobe are unavailable and Homebrew is missing. Install Homebrew from https://brew.sh, then rerun.",
+      );
+    }
+    return [
+      { label: "ffmpeg and ffprobe", bin: "brew", args: ["install", "ffmpeg"] },
+      ...mediaVerificationSteps(),
+    ];
+  }
+  if (platform === "win32") {
+    if (!has("winget")) {
+      throw new Error(
+        "ffmpeg/ffprobe are unavailable and WinGet is missing. Install App Installer, then rerun.",
+      );
+    }
+    return [
+      {
+        label: "ffmpeg and ffprobe",
+        bin: "winget",
+        args: [
+          "install",
+          "--id",
+          "Gyan.FFmpeg",
+          "--exact",
+          "--accept-package-agreements",
+          "--accept-source-agreements",
+          "--silent",
+          "--disable-interactivity",
+        ],
+        refreshWindowsPath: true,
+      },
+      ...mediaVerificationSteps(),
+    ];
+  }
+
+  const manager = linuxManager(has);
+  if (!manager) {
+    throw new Error(
+      "ffmpeg/ffprobe are unavailable and no supported Linux package manager was found (apt, dnf, yum, apk, pacman, zypper). Install ffmpeg, then rerun.",
+    );
+  }
+  return [
+    ...linuxInstallSteps(
+      manager,
+      manager.mediaArgs,
+      isRoot,
+      "ffmpeg and ffprobe",
+    ),
+    ...mediaVerificationSteps(),
+  ];
+}
+
+export function githubInstallSteps(
+  platform,
+  {
+    has = (command) => commandExists(command, { platform }),
+    isRoot = typeof process.getuid === "function"
+      ? process.getuid() === 0
+      : false,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
+  const verification = {
+    label: "GitHub CLI verification",
+    bin: EVIDENCE_REQUIREMENTS.githubCli.systemCommand,
+    args: ["--version"],
+  };
+  if (has(EVIDENCE_REQUIREMENTS.githubCli.systemCommand)) {
+    return [verification];
+  }
+  if (platform === "darwin") {
+    if (!has("brew")) {
+      throw new Error(
+        "GitHub CLI is missing and Homebrew is unavailable. Install Homebrew from https://brew.sh, then rerun with --github.",
+      );
+    }
+    return [
+      { label: "GitHub CLI", bin: "brew", args: ["install", "gh"] },
+      verification,
+    ];
+  }
+  if (platform === "win32") {
+    if (!has("winget")) {
+      throw new Error(
+        "GitHub CLI is missing and WinGet is unavailable. Install App Installer, then rerun with --github.",
+      );
+    }
+    return [
+      {
+        label: "GitHub CLI",
+        bin: "winget",
+        args: [
+          "install",
+          "--id",
+          "GitHub.cli",
+          "--exact",
+          "--accept-package-agreements",
+          "--accept-source-agreements",
+          "--silent",
+          "--disable-interactivity",
+        ],
+        refreshWindowsPath: true,
+      },
+      verification,
+    ];
+  }
+
+  const manager = linuxManager(has);
+  if (!manager) {
+    throw new Error(
+      "GitHub CLI is missing and no supported Linux package manager was found (apt, dnf, yum, apk, pacman, zypper). Install `gh`, then rerun the doctor.",
+    );
+  }
+  return [
+    ...linuxInstallSteps(manager, manager.githubArgs, isRoot, "GitHub CLI"),
+    verification,
+  ];
+}
+
+export async function resolveMediaRequirements({
+  resolveFfmpeg = resolveFfmpegBinary,
+  resolveFfprobe = resolveFfprobeBinary,
+} = {}) {
+  const [ffmpeg, ffprobe] = await Promise.all([
+    resolveFfmpeg(),
+    resolveFfprobe(),
+  ]);
+  return { ffmpeg, ffprobe };
+}
+
+function workspaceDependencyStep() {
+  return {
+    label: "workspace evidence dependencies",
+    bin: "bun",
+    args: ["install", "--frozen-lockfile", "--ignore-scripts"],
+  };
+}
+
+export function buildInstallPlan({
+  platform = process.platform,
+  includeGithub = false,
+  skipDependencies = false,
+  githubOptions,
+  mediaOptions,
+} = {}) {
+  assertSupportedPlatform(platform);
+  const steps = [];
+  if (!skipDependencies) {
+    steps.push(workspaceDependencyStep());
+  }
+  steps.push(...mediaInstallSteps(platform, mediaOptions));
+  steps.push(
+    platform === "linux"
+      ? {
+          label: "Playwright Chromium and available Linux OS dependencies",
+          bin: "bash",
+          args: [
+            path.join(
+              REPO_ROOT,
+              ".github",
+              "scripts",
+              "install-playwright-browsers.sh",
+            ),
+            EVIDENCE_REQUIREMENTS.playwright.browserName,
+          ],
+        }
+      : {
+          label: "Playwright Chromium",
+          bin: "bunx",
+          args: [
+            "playwright",
+            "install",
+            EVIDENCE_REQUIREMENTS.playwright.browserName,
+          ],
+        },
+  );
+  if (includeGithub) {
+    steps.push(...githubInstallSteps(platform, githubOptions));
+  }
+  return steps;
+}
+
+export function formatCommand(step, platform = process.platform) {
+  const safeToken = /^[A-Za-z0-9_./:@%+=,-]+$/u;
+  const quote = (part) => {
+    if (safeToken.test(part)) return part;
+    return platform === "win32"
+      ? `'${part.replaceAll("'", "''")}'`
+      : `'${part.replaceAll("'", `'"'"'`)}'`;
+  };
+  return [step.bin, ...step.args].map(quote).join(" ");
+}
+
+function runStep(step, { run, env, platform }) {
+  console.log(`\n[install] ${step.label}\n  ${formatCommand(step, platform)}`);
+  const result = run(step.bin, step.args, {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+    env,
+  });
+  if (result.error) {
+    throw new Error(`${step.label} could not start: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      step.failureMessage ??
+        `${step.label} failed with exit code ${result.status ?? "unknown"}`,
+    );
+  }
+}
+
+export function executeInstallPlan(
+  steps,
+  {
+    platform = process.platform,
+    env = process.env,
+    run = spawnSync,
+    refreshPath = refreshWindowsPath,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
+  let executionEnv =
+    platform === "win32" ? withWindowsWingetLinksPath(env) : { ...env };
+  for (const step of steps) {
+    runStep(step, { run, env: executionEnv, platform });
+    if (platform === "win32" && step.refreshWindowsPath) {
+      executionEnv = refreshPath(executionEnv, { run });
+    }
+  }
+  return executionEnv;
+}
+
+function usage() {
+  console.log(`Usage: bun run evidence:install-tools -- [options]
+
+Options:
+  --github       Also install and verify GitHub CLI. Authentication and
+                 repository permissions are not changed or inferred.
+  --skip-deps    Do not run bun install; useful when dependencies are current.
+  --dry-run      Print argument-safe platform commands without running them.
+  --help, -h     Show this help.`);
+}
+
+export function parseInstallerArgs(argv) {
+  const known = new Set([
+    "--github",
+    "--skip-deps",
+    "--dry-run",
+    "--help",
+    "-h",
+  ]);
+  const unknown = argv.filter((arg) => !known.has(arg));
+  if (unknown.length > 0) {
+    throw new Error(`unknown argument(s): ${unknown.join(", ")}`);
+  }
+  return {
+    includeGithub: argv.includes("--github"),
+    skipDependencies: argv.includes("--skip-deps"),
+    dryRun: argv.includes("--dry-run"),
+    help: argv.includes("--help") || argv.includes("-h"),
+  };
+}
+
+async function main() {
+  const options = parseInstallerArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+  if (!fs.existsSync(path.join(REPO_ROOT, "package.json"))) {
+    throw new Error(`repository root not found at ${REPO_ROOT}`);
+  }
+  assertSupportedPlatform(process.platform);
+
+  if (options.dryRun) {
+    const plan = buildInstallPlan(options);
+    console.log(
+      plan.map((step) => formatCommand(step, process.platform)).join("\n"),
+    );
+    return;
+  }
+
+  let executionEnv =
+    process.platform === "win32"
+      ? withWindowsWingetLinksPath(process.env)
+      : { ...process.env };
+  Object.assign(process.env, executionEnv);
+  if (!options.skipDependencies) {
+    executionEnv = executeInstallPlan([workspaceDependencyStep()], {
+      platform: process.platform,
+      env: executionEnv,
+    });
+    Object.assign(process.env, executionEnv);
+  }
+
+  const resolutions = await resolveMediaRequirements();
+  const plan = buildInstallPlan({
+    ...options,
+    skipDependencies: true,
+    mediaOptions: { resolutions },
+  });
+  executionEnv = executeInstallPlan(plan, {
+    platform: process.platform,
+    env: executionEnv,
+  });
+
+  const doctorArgs = [
+    path.join(REPO_ROOT, "scripts", "evidence-doctor.mjs"),
+    "--strict",
+  ];
+  executeInstallPlan(
+    [
+      {
+        label: "evidence toolchain verification",
+        bin: process.execPath,
+        args: doctorArgs,
+      },
+    ],
+    { platform: process.platform, env: executionEnv },
+  );
+  if (options.includeGithub) {
+    console.log(
+      "\nGitHub CLI installation verified; authentication and repository permissions were left unchanged.",
+    );
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
+  main().catch((error) => {
+    // error-policy:J1 CLI failures are translated once into a non-zero exit.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`evidence-install-tools: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/evidence-install-tools.mjs
+++ b/scripts/evidence-install-tools.mjs
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 /**
  * Installs the baseline evidence toolchain on macOS, Linux, and Windows.
- * The exported requirement catalog also drives the doctor, while direct
+ * One side-effect-free planner (`resolveInstallPlan`) produces the step list
+ * that both `--dry-run` display and real execution consume, so the printed
+ * plan is the executed plan; when packaged media binaries can only resolve
+ * after the workspace dependency step, the plan says so explicitly and
+ * execution re-resolves through the same planner. Every step carries a
+ * deadline so no package manager, download, or probe can block forever. The
+ * exported requirement catalog also drives the doctor, while direct
  * argument-vector execution and process-local PATH refresh keep reruns
  * deterministic without editing shell profiles or persisting credentials.
  */
@@ -18,6 +24,30 @@ import {
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), "..");
 const SUPPORTED_PLATFORMS = new Set(["darwin", "linux", "win32"]);
+
+const MINUTE_MS = 60_000;
+
+/**
+ * Default per-step deadlines. Package-manager operations download and unpack;
+ * probes answer `--version`-style checks; the trailing strict doctor launches
+ * Chromium and runs OCR. Scale all of them with `--timeout-scale=<factor>` or
+ * ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE on slow hosts.
+ */
+export const STEP_TIMEOUT_DEFAULTS_MS = Object.freeze({
+  packageManager: 15 * MINUTE_MS,
+  probe: 2 * MINUTE_MS,
+  verification: 10 * MINUTE_MS,
+});
+
+/** Typed step failure so callers can distinguish timeout, start, and exit. */
+export class InstallStepError extends Error {
+  constructor(message, { step, code, cause } = {}) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "InstallStepError";
+    this.step = step?.label;
+    this.code = code;
+  }
+}
 
 export const EVIDENCE_REQUIREMENTS = Object.freeze({
   ocr: Object.freeze({
@@ -94,6 +124,22 @@ export function assertSupportedPlatform(platform) {
   }
 }
 
+/**
+ * The deadline scale multiplies every per-step deadline; a factor is easier
+ * to reason about on a slow host than editing absolute values per step.
+ */
+export function resolveStepTimeoutScale(env = process.env, flagValue) {
+  const raw = flagValue ?? env.ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE;
+  if (raw === undefined || raw === "") return 1;
+  const scale = Number(raw);
+  if (!Number.isFinite(scale) || scale <= 0) {
+    throw new Error(
+      `invalid step timeout scale ${JSON.stringify(raw)}; expected a positive number (via --timeout-scale=<factor> or ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE)`,
+    );
+  }
+  return scale;
+}
+
 function pathKeyFor(env) {
   return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "Path";
 }
@@ -138,8 +184,13 @@ export function withWindowsWingetLinksPath(env) {
  * MSI-backed WinGet packages update registry PATH values, which a running
  * Node process does not inherit. Reading and merging those values after each
  * WinGet mutation makes verification in the same installer process reliable.
+ * Registry entries merge Machine before User, matching how Windows composes
+ * the effective PATH for a new process.
  */
-export function refreshWindowsPath(env, { run = spawnSync } = {}) {
+export function refreshWindowsPath(
+  env,
+  { run = spawnSync, timeoutMs = STEP_TIMEOUT_DEFAULTS_MS.probe } = {},
+) {
   const seeded = withWindowsWingetLinksPath(env);
   const script =
     "[Console]::Out.Write((@([Environment]::GetEnvironmentVariable('Path','Machine'),[Environment]::GetEnvironmentVariable('Path','User')) -join [Environment]::NewLine))";
@@ -150,8 +201,16 @@ export function refreshWindowsPath(env, { run = spawnSync } = {}) {
       encoding: "utf8",
       env: seeded,
       windowsHide: true,
+      timeout: timeoutMs,
+      killSignal: "SIGKILL",
     },
   );
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new InstallStepError(
+      `Windows PATH refresh timed out after ${formatDeadline(timeoutMs)}`,
+      { step: { label: "Windows PATH refresh" }, code: "step-timeout" },
+    );
+  }
   if (result.error) {
     throw new Error(`could not refresh Windows PATH: ${result.error.message}`, {
       cause: result.error,
@@ -166,7 +225,7 @@ export function refreshWindowsPath(env, { run = spawnSync } = {}) {
     /\r?\n/u,
     2,
   );
-  return mergeWindowsPath(seeded, [userPath, machinePath]);
+  return mergeWindowsPath(seeded, [machinePath, userPath]);
 }
 
 function commandExists(
@@ -188,6 +247,7 @@ function nonInteractiveSudoSteps(isRoot) {
           label: "passwordless sudo preflight",
           bin: "sudo",
           args: ["-n", "true"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
           failureMessage:
             "Evidence tool installation requires passwordless sudo on this unattended runner. Install the tools manually or grant this runner noninteractive sudo, then rerun.",
         },
@@ -209,6 +269,7 @@ function linuxInstallSteps(manager, args, isRoot, label) {
             label: `${label} package index`,
             bin: command,
             args: [...prefix, ...manager.updateArgs],
+            timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
           },
         ]
       : []),
@@ -216,6 +277,7 @@ function linuxInstallSteps(manager, args, isRoot, label) {
       label,
       bin: command,
       args: [...prefix, ...args],
+      timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
     },
   ];
 }
@@ -230,6 +292,7 @@ function mediaVerificationSteps(resolutions) {
         ? resolutions.ffmpeg.bin
         : ffmpeg.systemCommand,
       args: [...ffmpeg.versionArgs],
+      timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
     },
     {
       label: "ffprobe verification",
@@ -237,10 +300,16 @@ function mediaVerificationSteps(resolutions) {
         ? resolutions.ffprobe.bin
         : ffprobe.systemCommand,
       args: [...ffprobe.versionArgs],
+      timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
     },
   ];
 }
 
+/**
+ * Media steps always plan from an explicit `resolveMediaRequirements` result;
+ * there is deliberately no system-presence shortcut here, so every caller
+ * (dry-run and execution alike) plans from the same resolution machinery.
+ */
 export function mediaInstallSteps(
   platform,
   {
@@ -252,16 +321,13 @@ export function mediaInstallSteps(
   } = {},
 ) {
   assertSupportedPlatform(platform);
-  const healthy =
-    resolutions?.ffmpeg?.available && resolutions?.ffprobe?.available;
-  if (healthy) return mediaVerificationSteps(resolutions);
-  if (
-    resolutions === undefined &&
-    has(EVIDENCE_REQUIREMENTS.ffmpeg.systemCommand) &&
-    has(EVIDENCE_REQUIREMENTS.ffprobe.systemCommand)
-  ) {
-    return mediaVerificationSteps();
+  if (!resolutions?.ffmpeg || !resolutions?.ffprobe) {
+    throw new Error(
+      "mediaInstallSteps requires ffmpeg/ffprobe resolutions from resolveMediaRequirements",
+    );
   }
+  const healthy = resolutions.ffmpeg.available && resolutions.ffprobe.available;
+  if (healthy) return mediaVerificationSteps(resolutions);
 
   if (platform === "darwin") {
     if (!has("brew")) {
@@ -270,7 +336,12 @@ export function mediaInstallSteps(
       );
     }
     return [
-      { label: "ffmpeg and ffprobe", bin: "brew", args: ["install", "ffmpeg"] },
+      {
+        label: "ffmpeg and ffprobe",
+        bin: "brew",
+        args: ["install", "ffmpeg"],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
+      },
       ...mediaVerificationSteps(),
     ];
   }
@@ -294,6 +365,7 @@ export function mediaInstallSteps(
           "--silent",
           "--disable-interactivity",
         ],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
         refreshWindowsPath: true,
       },
       ...mediaVerificationSteps(),
@@ -331,6 +403,7 @@ export function githubInstallSteps(
     label: "GitHub CLI verification",
     bin: EVIDENCE_REQUIREMENTS.githubCli.systemCommand,
     args: ["--version"],
+    timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
   };
   if (has(EVIDENCE_REQUIREMENTS.githubCli.systemCommand)) {
     return [verification];
@@ -342,7 +415,12 @@ export function githubInstallSteps(
       );
     }
     return [
-      { label: "GitHub CLI", bin: "brew", args: ["install", "gh"] },
+      {
+        label: "GitHub CLI",
+        bin: "brew",
+        args: ["install", "gh"],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
+      },
       verification,
     ];
   }
@@ -366,6 +444,7 @@ export function githubInstallSteps(
           "--silent",
           "--disable-interactivity",
         ],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
         refreshWindowsPath: true,
       },
       verification,
@@ -400,51 +479,92 @@ function workspaceDependencyStep() {
     label: "workspace evidence dependencies",
     bin: "bun",
     args: ["install", "--frozen-lockfile", "--ignore-scripts"],
+    timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
   };
 }
 
-export function buildInstallPlan({
-  platform = process.platform,
-  includeGithub = false,
-  skipDependencies = false,
-  githubOptions,
-  mediaOptions,
-} = {}) {
+function playwrightInstallStep(platform) {
+  return platform === "linux"
+    ? {
+        label: "Playwright Chromium and available Linux OS dependencies",
+        bin: "bash",
+        args: [
+          path.join(
+            REPO_ROOT,
+            ".github",
+            "scripts",
+            "install-playwright-browsers.sh",
+          ),
+          EVIDENCE_REQUIREMENTS.playwright.browserName,
+        ],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
+      }
+    : {
+        label: "Playwright Chromium",
+        bin: "bunx",
+        args: [
+          "playwright",
+          "install",
+          EVIDENCE_REQUIREMENTS.playwright.browserName,
+        ],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
+      };
+}
+
+function doctorVerificationStep() {
+  return {
+    label: "evidence toolchain verification",
+    bin: process.execPath,
+    args: [path.join(REPO_ROOT, "scripts", "evidence-doctor.mjs"), "--strict"],
+    timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.verification,
+  };
+}
+
+/**
+ * The single planner both dry-run display and real execution consume. It is
+ * side-effect-free: it resolves media through `resolveMediaRequirements` and
+ * read-only command probes, and never runs an install step. When packaged
+ * ffmpeg-static/ffprobe-static binaries cannot resolve before the workspace
+ * dependency step has run, the plan records that assumption instead of
+ * planning a premature system install; execution then re-resolves through
+ * this same planner after the dependency step.
+ */
+export async function resolveInstallPlan(
+  {
+    platform = process.platform,
+    includeGithub = false,
+    skipDependencies = false,
+    githubOptions,
+    mediaOptions,
+  } = {},
+  { resolveMedia = resolveMediaRequirements } = {},
+) {
   assertSupportedPlatform(platform);
+  const resolutions = mediaOptions?.resolutions ?? (await resolveMedia());
+  const mediaResolved = Boolean(
+    resolutions.ffmpeg?.available && resolutions.ffprobe?.available,
+  );
+  const deferredMedia = !mediaResolved && !skipDependencies;
   const steps = [];
+  const assumptions = [];
   if (!skipDependencies) {
     steps.push(workspaceDependencyStep());
   }
-  steps.push(...mediaInstallSteps(platform, mediaOptions));
-  steps.push(
-    platform === "linux"
-      ? {
-          label: "Playwright Chromium and available Linux OS dependencies",
-          bin: "bash",
-          args: [
-            path.join(
-              REPO_ROOT,
-              ".github",
-              "scripts",
-              "install-playwright-browsers.sh",
-            ),
-            EVIDENCE_REQUIREMENTS.playwright.browserName,
-          ],
-        }
-      : {
-          label: "Playwright Chromium",
-          bin: "bunx",
-          args: [
-            "playwright",
-            "install",
-            EVIDENCE_REQUIREMENTS.playwright.browserName,
-          ],
-        },
-  );
+  if (deferredMedia) {
+    assumptions.push(
+      "ffmpeg/ffprobe did not resolve from the current host state; the packaged ffmpeg-static and ffprobe-static binaries can only resolve after the workspace dependency step, so execution re-resolves this plan after that step and falls back to the system package manager only if they still cannot run",
+    );
+  } else {
+    steps.push(
+      ...mediaInstallSteps(platform, { ...mediaOptions, resolutions }),
+    );
+  }
+  steps.push(playwrightInstallStep(platform));
   if (includeGithub) {
     steps.push(...githubInstallSteps(platform, githubOptions));
   }
-  return steps;
+  steps.push(doctorVerificationStep());
+  return { steps, assumptions, resolutions, deferredMedia };
 }
 
 export function formatCommand(step, platform = process.platform) {
@@ -458,22 +578,47 @@ export function formatCommand(step, platform = process.platform) {
   return [step.bin, ...step.args].map(quote).join(" ");
 }
 
-function runStep(step, { run, env, platform }) {
-  console.log(`\n[install] ${step.label}\n  ${formatCommand(step, platform)}`);
+function formatDeadline(timeoutMs) {
+  return timeoutMs % MINUTE_MS === 0
+    ? `${timeoutMs / MINUTE_MS}m`
+    : `${Math.round(timeoutMs / 1000)}s`;
+}
+
+function runStep(step, { run, env, platform, timeoutScale }) {
+  if (!Number.isFinite(step.timeoutMs) || step.timeoutMs <= 0) {
+    throw new InstallStepError(
+      `${step.label} has no per-step deadline; every planned step must carry a positive timeoutMs`,
+      { step, code: "step-plan" },
+    );
+  }
+  const timeoutMs = Math.round(step.timeoutMs * timeoutScale);
+  console.log(
+    `\n[install] ${step.label} (deadline ${formatDeadline(timeoutMs)})\n  ${formatCommand(step, platform)}`,
+  );
   const result = run(step.bin, step.args, {
     cwd: REPO_ROOT,
     stdio: "inherit",
     env,
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
   });
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new InstallStepError(
+      `${step.label} timed out after ${formatDeadline(timeoutMs)}; rerun with --timeout-scale=<factor> or ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE to extend deadlines on slow hosts`,
+      { step, code: "step-timeout", cause: result.error },
+    );
+  }
   if (result.error) {
-    throw new Error(`${step.label} could not start: ${result.error.message}`, {
-      cause: result.error,
-    });
+    throw new InstallStepError(
+      `${step.label} could not start: ${result.error.message}`,
+      { step, code: "step-start", cause: result.error },
+    );
   }
   if (result.status !== 0) {
-    throw new Error(
+    throw new InstallStepError(
       step.failureMessage ??
         `${step.label} failed with exit code ${result.status ?? "unknown"}`,
+      { step, code: "step-exit" },
     );
   }
 }
@@ -485,15 +630,19 @@ export function executeInstallPlan(
     env = process.env,
     run = spawnSync,
     refreshPath = refreshWindowsPath,
+    timeoutScale = 1,
   } = {},
 ) {
   assertSupportedPlatform(platform);
   let executionEnv =
     platform === "win32" ? withWindowsWingetLinksPath(env) : { ...env };
   for (const step of steps) {
-    runStep(step, { run, env: executionEnv, platform });
+    runStep(step, { run, env: executionEnv, platform, timeoutScale });
     if (platform === "win32" && step.refreshWindowsPath) {
-      executionEnv = refreshPath(executionEnv, { run });
+      executionEnv = refreshPath(executionEnv, {
+        run,
+        timeoutMs: Math.round(STEP_TIMEOUT_DEFAULTS_MS.probe * timeoutScale),
+      });
     }
   }
   return executionEnv;
@@ -503,31 +652,55 @@ function usage() {
   console.log(`Usage: bun run evidence:install-tools -- [options]
 
 Options:
-  --github       Also install and verify GitHub CLI. Authentication and
-                 repository permissions are not changed or inferred.
-  --skip-deps    Do not run bun install; useful when dependencies are current.
-  --dry-run      Print argument-safe platform commands without running them.
-  --help, -h     Show this help.`);
+  --github              Also install and verify GitHub CLI. Authentication and
+                        repository permissions are not changed or inferred.
+  --skip-deps           Do not run bun install; useful when dependencies are
+                        current.
+  --dry-run             Print the resolved platform plan without running it.
+                        Lines starting with "# assumes:" note where resolution
+                        depends on the dependency step having run.
+  --strict              With --dry-run: fail when the plan carries unresolved
+                        pre-dependency assumptions.
+  --timeout-scale=<n>   Multiply every per-step deadline by <n> (also
+                        ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE) for slow hosts.
+  --help, -h            Show this help.`);
 }
 
 export function parseInstallerArgs(argv) {
-  const known = new Set([
+  const flags = new Set([
     "--github",
     "--skip-deps",
     "--dry-run",
+    "--strict",
     "--help",
     "-h",
   ]);
-  const unknown = argv.filter((arg) => !known.has(arg));
+  let timeoutScale;
+  const unknown = [];
+  for (const arg of argv) {
+    if (arg.startsWith("--timeout-scale=")) {
+      timeoutScale = arg.slice("--timeout-scale=".length);
+      continue;
+    }
+    if (!flags.has(arg)) unknown.push(arg);
+  }
   if (unknown.length > 0) {
     throw new Error(`unknown argument(s): ${unknown.join(", ")}`);
   }
-  return {
+  const options = {
     includeGithub: argv.includes("--github"),
     skipDependencies: argv.includes("--skip-deps"),
     dryRun: argv.includes("--dry-run"),
+    strict: argv.includes("--strict"),
+    timeoutScale,
     help: argv.includes("--help") || argv.includes("-h"),
   };
+  if (options.strict && !options.dryRun) {
+    throw new Error(
+      "--strict requires --dry-run; it asserts the displayed plan is fully resolved",
+    );
+  }
+  return options;
 }
 
 async function main() {
@@ -540,53 +713,60 @@ async function main() {
     throw new Error(`repository root not found at ${REPO_ROOT}`);
   }
   assertSupportedPlatform(process.platform);
+  const timeoutScale = resolveStepTimeoutScale(
+    process.env,
+    options.timeoutScale,
+  );
 
-  if (options.dryRun) {
-    const plan = buildInstallPlan(options);
-    console.log(
-      plan.map((step) => formatCommand(step, process.platform)).join("\n"),
-    );
-    return;
-  }
-
+  // Seed the WinGet links path before planning so resolution probes and every
+  // child process observe the same PATH the executed plan will use.
   let executionEnv =
     process.platform === "win32"
       ? withWindowsWingetLinksPath(process.env)
       : { ...process.env };
   Object.assign(process.env, executionEnv);
-  if (!options.skipDependencies) {
-    executionEnv = executeInstallPlan([workspaceDependencyStep()], {
-      platform: process.platform,
-      env: executionEnv,
-    });
-    Object.assign(process.env, executionEnv);
+
+  let plan = await resolveInstallPlan(options);
+
+  if (options.dryRun) {
+    console.log(
+      plan.steps
+        .map((step) => formatCommand(step, process.platform))
+        .join("\n"),
+    );
+    for (const assumption of plan.assumptions) {
+      console.log(`# assumes: ${assumption}`);
+    }
+    if (options.strict && plan.assumptions.length > 0) {
+      throw new Error(
+        `--strict dry run: the plan could not be fully resolved from the current host state:\n${plan.assumptions
+          .map((assumption) => `  - ${assumption}`)
+          .join("\n")}`,
+      );
+    }
+    return;
   }
 
-  const resolutions = await resolveMediaRequirements();
-  const plan = buildInstallPlan({
-    ...options,
-    skipDependencies: true,
-    mediaOptions: { resolutions },
-  });
-  executionEnv = executeInstallPlan(plan, {
+  if (plan.deferredMedia) {
+    // The plan's recorded assumption: packaged media binaries resolve only
+    // after the dependency step. Run that step, then re-resolve the remainder
+    // through the same planner so execution stays on the displayed contract.
+    const [dependencyStep] = plan.steps;
+    executionEnv = executeInstallPlan([dependencyStep], {
+      platform: process.platform,
+      env: executionEnv,
+      timeoutScale,
+    });
+    Object.assign(process.env, executionEnv);
+    plan = await resolveInstallPlan({ ...options, skipDependencies: true });
+  }
+
+  executeInstallPlan(plan.steps, {
     platform: process.platform,
     env: executionEnv,
+    timeoutScale,
   });
 
-  const doctorArgs = [
-    path.join(REPO_ROOT, "scripts", "evidence-doctor.mjs"),
-    "--strict",
-  ];
-  executeInstallPlan(
-    [
-      {
-        label: "evidence toolchain verification",
-        bin: process.execPath,
-        args: doctorArgs,
-      },
-    ],
-    { platform: process.platform, env: executionEnv },
-  );
   if (options.includeGithub) {
     console.log(
       "\nGitHub CLI installation verified; authentication and repository permissions were left unchanged.",

--- a/scripts/evidence-install-tools.test.mjs
+++ b/scripts/evidence-install-tools.test.mjs
@@ -10,15 +10,18 @@ import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   assertSupportedPlatform,
-  buildInstallPlan,
   EVIDENCE_REQUIREMENTS,
   executeInstallPlan,
   formatCommand,
   githubInstallSteps,
+  InstallStepError,
   mediaInstallSteps,
   parseInstallerArgs,
   refreshWindowsPath,
+  resolveInstallPlan,
   resolveMediaRequirements,
+  resolveStepTimeoutScale,
+  STEP_TIMEOUT_DEFAULTS_MS,
   withWindowsWingetLinksPath,
 } from "./evidence-install-tools.mjs";
 
@@ -46,26 +49,108 @@ describe("evidence tool installer", () => {
     assert.equal(Object.isFrozen(EVIDENCE_REQUIREMENTS.ffmpeg), true);
   });
 
-  it("installs workspace packages and the Linux Chromium dependency helper", () => {
-    const plan = buildInstallPlan({
+  it("resolves one plan for display and execution from injected media", async () => {
+    const plan = await resolveInstallPlan({
       platform: "linux",
       mediaOptions: { resolutions: packagedMedia },
     });
-    assert.deepEqual(plan[0], {
+    assert.equal(plan.deferredMedia, false);
+    assert.deepEqual(plan.assumptions, []);
+    assert.deepEqual(plan.steps[0], {
       label: "workspace evidence dependencies",
       bin: "bun",
       args: ["install", "--frozen-lockfile", "--ignore-scripts"],
+      timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
     });
     assert.deepEqual(
-      plan.slice(1, 3).map(({ bin, args }) => ({ bin, args })),
+      plan.steps.slice(1, 3).map(({ bin, args }) => ({ bin, args })),
       [
         { bin: "/packages/ffmpeg", args: ["-version"] },
         { bin: "/packages/ffprobe", args: ["-version"] },
       ],
     );
-    assert.equal(plan[3].bin, "bash");
-    assert.match(plan[3].args[0], /install-playwright-browsers\.sh$/);
-    assert.equal(plan[3].args[1], "chromium");
+    assert.equal(plan.steps[3].bin, "bash");
+    assert.match(plan.steps[3].args[0], /install-playwright-browsers\.sh$/);
+    assert.equal(plan.steps[3].args[1], "chromium");
+    const doctor = plan.steps.at(-1);
+    assert.equal(doctor.label, "evidence toolchain verification");
+    assert.match(doctor.args[0], /evidence-doctor\.mjs$/);
+    assert.deepEqual(doctor.args.slice(1), ["--strict"]);
+  });
+
+  it("resolves media through the shared resolver exactly like execution", async () => {
+    let resolverCalls = 0;
+    const plan = await resolveInstallPlan(
+      { platform: "linux", skipDependencies: true },
+      {
+        resolveMedia: async () => {
+          resolverCalls += 1;
+          return packagedMedia;
+        },
+      },
+    );
+    assert.equal(resolverCalls, 1);
+    assert.deepEqual(
+      plan.steps.slice(0, 2).map(({ bin }) => bin),
+      ["/packages/ffmpeg", "/packages/ffprobe"],
+    );
+  });
+
+  it("defers unresolved media to a post-dependency re-resolution with an explicit assumption", async () => {
+    const plan = await resolveInstallPlan(
+      { platform: "darwin" },
+      { resolveMedia: async () => unavailableMedia },
+    );
+    assert.equal(plan.deferredMedia, true);
+    assert.equal(plan.assumptions.length, 1);
+    assert.match(plan.assumptions[0], /workspace dependency step/);
+    assert.match(plan.assumptions[0], /re-resolves/);
+    // No premature system install is planned from pre-dependency state.
+    assert.ok(!plan.steps.some(({ bin }) => bin === "brew"));
+    assert.deepEqual(
+      plan.steps.map(({ label }) => label),
+      [
+        "workspace evidence dependencies",
+        "Playwright Chromium",
+        "evidence toolchain verification",
+      ],
+    );
+  });
+
+  it("never defers when dependencies are skipped: unresolved media plans a system install", async () => {
+    const plan = await resolveInstallPlan(
+      {
+        platform: "darwin",
+        skipDependencies: true,
+        mediaOptions: { has: (command) => command === "brew" },
+      },
+      { resolveMedia: async () => unavailableMedia },
+    );
+    assert.equal(plan.deferredMedia, false);
+    assert.deepEqual(plan.assumptions, []);
+    assert.ok(
+      plan.steps.some(
+        ({ bin, args }) =>
+          bin === "brew" && JSON.stringify(args) === '["install","ffmpeg"]',
+      ),
+    );
+  });
+
+  it("gives every planned step a positive deadline", async () => {
+    for (const platform of ["darwin", "linux", "win32"]) {
+      const plan = await resolveInstallPlan({
+        platform,
+        includeGithub: true,
+        githubOptions: { has: (command) => command === "gh" },
+        mediaOptions: { resolutions: packagedMedia },
+      });
+      for (const step of plan.steps) {
+        assert.ok(
+          Number.isFinite(step.timeoutMs) && step.timeoutMs > 0,
+          `${platform} step ${step.label} lacks a deadline`,
+        );
+      }
+    }
   });
 
   it("uses packaged media without planning an unrelated system install", () => {
@@ -81,17 +166,25 @@ describe("evidence tool installer", () => {
     }
   });
 
-  it("uses native Playwright installation on macOS and Windows", () => {
+  it("requires explicit media resolutions instead of presence shortcuts", () => {
+    assert.throws(
+      () => mediaInstallSteps("darwin", { has: missing }),
+      /requires ffmpeg\/ffprobe resolutions/,
+    );
+  });
+
+  it("uses native Playwright installation on macOS and Windows", async () => {
     for (const platform of ["darwin", "win32"]) {
-      const plan = buildInstallPlan({
+      const plan = await resolveInstallPlan({
         platform,
         skipDependencies: true,
         mediaOptions: { resolutions: packagedMedia },
       });
-      assert.deepEqual(plan.at(-1), {
+      assert.deepEqual(plan.steps.at(-2), {
         label: "Playwright Chromium",
         bin: "bunx",
         args: ["playwright", "install", "chromium"],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
       });
     }
   });
@@ -108,14 +201,35 @@ describe("evidence tool installer", () => {
           label: "ffmpeg and ffprobe",
           bin: "brew",
           args: ["install", "ffmpeg"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
         },
-        { label: "ffmpeg verification", bin: "ffmpeg", args: ["-version"] },
-        { label: "ffprobe verification", bin: "ffprobe", args: ["-version"] },
+        {
+          label: "ffmpeg verification",
+          bin: "ffmpeg",
+          args: ["-version"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
+        },
+        {
+          label: "ffprobe verification",
+          bin: "ffprobe",
+          args: ["-version"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
+        },
       ],
     );
     assert.deepEqual(githubInstallSteps("darwin", { has: hasBrew }), [
-      { label: "GitHub CLI", bin: "brew", args: ["install", "gh"] },
-      { label: "GitHub CLI verification", bin: "gh", args: ["--version"] },
+      {
+        label: "GitHub CLI",
+        bin: "brew",
+        args: ["install", "gh"],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
+      },
+      {
+        label: "GitHub CLI verification",
+        bin: "gh",
+        args: ["--version"],
+        timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
+      },
     ]);
   });
 
@@ -132,6 +246,7 @@ describe("evidence tool installer", () => {
     ]) {
       assert.equal(step.bin, "winget");
       assert.equal(step.refreshWindowsPath, true);
+      assert.equal(step.timeoutMs, STEP_TIMEOUT_DEFAULTS_MS.packageManager);
       assert.ok(step.args.includes(packageId));
       for (const flag of [
         "--exact",
@@ -155,6 +270,7 @@ describe("evidence tool installer", () => {
       label: "GitHub CLI verification",
       bin: "gh",
       args: ["--version"],
+      timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
     });
   });
 
@@ -222,6 +338,7 @@ describe("evidence tool installer", () => {
           label: "passwordless sudo preflight",
           bin: "sudo",
           args: ["-n", "true"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
           failureMessage:
             "Evidence tool installation requires passwordless sudo on this unattended runner. Install the tools manually or grant this runner noninteractive sudo, then rerun.",
         });
@@ -284,10 +401,52 @@ describe("evidence tool installer", () => {
     assert.match(refreshed.Path, /UserTool/);
     assert.match(refreshed.Path, /MachineTool/);
     assert.match(refreshed.Path, /WinGet\\Links/);
+    // Registry values merge in Windows' effective order: Machine before User.
+    const entries = refreshed.Path.split(";");
+    assert.ok(
+      entries.indexOf(String.raw`C:\Program Files\MachineTool`) <
+        entries.indexOf(String.raw`C:\Users\agent\UserTool`),
+    );
     assert.equal(
-      refreshed.Path.split(";").filter((entry) => /WinGet\\Links/i.test(entry))
-        .length,
+      entries.filter((entry) => /WinGet\\Links/i.test(entry)).length,
       1,
+    );
+  });
+
+  it("bounds the PowerShell PATH refresh and reports its timeout", () => {
+    const options = [];
+    refreshWindowsPath(
+      {
+        LOCALAPPDATA: String.raw`C:\Users\agent\AppData\Local`,
+        Path: String.raw`C:\Windows`,
+      },
+      {
+        run: (_bin, _args, runOptions) => {
+          options.push(runOptions);
+          return { status: 0, stdout: "" };
+        },
+      },
+    );
+    assert.equal(options[0].timeout, STEP_TIMEOUT_DEFAULTS_MS.probe);
+    assert.throws(
+      () =>
+        refreshWindowsPath(
+          {
+            LOCALAPPDATA: String.raw`C:\Users\agent\AppData\Local`,
+            Path: String.raw`C:\Windows`,
+          },
+          {
+            run: () => ({
+              error: Object.assign(new Error("timed out"), {
+                code: "ETIMEDOUT",
+              }),
+            }),
+          },
+        ),
+      (error) =>
+        error instanceof InstallStepError &&
+        error.code === "step-timeout" &&
+        /Windows PATH refresh timed out/.test(error.message),
     );
   });
 
@@ -309,12 +468,14 @@ describe("evidence tool installer", () => {
           label: "GitHub CLI",
           bin: "winget",
           args: ["install", "--id", "GitHub.cli"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
           refreshWindowsPath: true,
         },
         {
           label: "GitHub CLI verification",
           bin: "gh",
           args: ["--version"],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
         },
       ],
       {
@@ -342,7 +503,14 @@ describe("evidence tool installer", () => {
 
     const invocations = [];
     executeInstallPlan(
-      [{ label: "hostile argument", bin: "tool", args: [hostile] }],
+      [
+        {
+          label: "hostile argument",
+          bin: "tool",
+          args: [hostile],
+          timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
+        },
+      ],
       {
         platform: "linux",
         env: { PATH: "/usr/bin" },
@@ -357,14 +525,117 @@ describe("evidence tool installer", () => {
     assert.equal(invocations[0].options.shell, undefined);
   });
 
-  it("fails closed on unsupported hosts, missing managers, and unknown flags", () => {
+  it("passes scaled per-step deadlines to every spawned process", () => {
+    const invocations = [];
+    executeInstallPlan(
+      [
+        {
+          label: "bounded install",
+          bin: "tool",
+          args: ["install"],
+          timeoutMs: 600_000,
+        },
+      ],
+      {
+        platform: "linux",
+        env: { PATH: "/usr/bin" },
+        timeoutScale: 2.5,
+        run: (bin, _args, options) => {
+          invocations.push({ bin, options });
+          return { status: 0 };
+        },
+      },
+    );
+    assert.equal(invocations[0].options.timeout, 1_500_000);
+    assert.equal(invocations[0].options.killSignal, "SIGKILL");
+  });
+
+  it("rejects planned steps without a deadline instead of running unbounded", () => {
+    assert.throws(
+      () =>
+        executeInstallPlan(
+          [{ label: "unbounded step", bin: "tool", args: [] }],
+          {
+            platform: "linux",
+            run: () => ({ status: 0 }),
+          },
+        ),
+      (error) =>
+        error instanceof InstallStepError &&
+        error.code === "step-plan" &&
+        /unbounded step has no per-step deadline/.test(error.message),
+    );
+  });
+
+  it("turns a step deadline overrun into a typed named failure with operator guidance", () => {
+    assert.throws(
+      () =>
+        executeInstallPlan(
+          [
+            {
+              label: "stuck package manager",
+              bin: "tool",
+              args: ["install"],
+              timeoutMs: 60_000,
+            },
+          ],
+          {
+            platform: "linux",
+            run: () => ({
+              error: Object.assign(new Error("spawnSync tool ETIMEDOUT"), {
+                code: "ETIMEDOUT",
+              }),
+              signal: "SIGKILL",
+            }),
+          },
+        ),
+      (error) =>
+        error instanceof InstallStepError &&
+        error.code === "step-timeout" &&
+        error.step === "stuck package manager" &&
+        /timed out after 1m/.test(error.message) &&
+        /--timeout-scale=/.test(error.message) &&
+        /ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE/.test(error.message),
+    );
+  });
+
+  it("resolves the deadline scale from flag or environment and rejects nonsense", () => {
+    assert.equal(resolveStepTimeoutScale({}, undefined), 1);
+    assert.equal(resolveStepTimeoutScale({}, "3"), 3);
+    assert.equal(
+      resolveStepTimeoutScale(
+        { ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE: "0.5" },
+        undefined,
+      ),
+      0.5,
+    );
+    // An explicit flag beats the environment.
+    assert.equal(
+      resolveStepTimeoutScale(
+        { ELIZA_EVIDENCE_INSTALL_TIMEOUT_SCALE: "9" },
+        "2",
+      ),
+      2,
+    );
+    for (const bad of ["0", "-1", "banana", "Infinity"]) {
+      assert.throws(
+        () => resolveStepTimeoutScale({}, bad),
+        /invalid step timeout scale/,
+      );
+    }
+  });
+
+  it("fails closed on unsupported hosts, missing managers, and unknown flags", async () => {
     for (const platform of ["aix", "freebsd", "sunos"]) {
       assert.throws(
         () => assertSupportedPlatform(platform),
         /unsupported operating system/,
       );
-      assert.throws(
-        () => buildInstallPlan({ platform, skipDependencies: true }),
+      await assert.rejects(
+        resolveInstallPlan(
+          { platform, skipDependencies: true },
+          { resolveMedia: async () => packagedMedia },
+        ),
         /unsupported operating system/,
       );
     }
@@ -408,10 +679,27 @@ describe("evidence tool installer", () => {
       () => parseInstallerArgs(["--strcit"]),
       /unknown argument\(s\): --strcit/,
     );
-    assert.deepEqual(parseInstallerArgs(["--dry-run", "--github"]), {
-      includeGithub: true,
+    assert.throws(
+      () => parseInstallerArgs(["--strict"]),
+      /--strict requires --dry-run/,
+    );
+    assert.deepEqual(
+      parseInstallerArgs(["--dry-run", "--github", "--timeout-scale=2"]),
+      {
+        includeGithub: true,
+        skipDependencies: false,
+        dryRun: true,
+        strict: false,
+        timeoutScale: "2",
+        help: false,
+      },
+    );
+    assert.deepEqual(parseInstallerArgs(["--dry-run", "--strict"]), {
+      includeGithub: false,
       skipDependencies: false,
       dryRun: true,
+      strict: true,
+      timeoutScale: undefined,
       help: false,
     });
   });
@@ -420,24 +708,44 @@ describe("evidence tool installer", () => {
     assert.throws(
       () =>
         executeInstallPlan(
-          [{ label: "broken executable", bin: "missing", args: [] }],
+          [
+            {
+              label: "broken executable",
+              bin: "missing",
+              args: [],
+              timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.probe,
+            },
+          ],
           {
             platform: "linux",
             run: () => ({ error: new Error("spawn failed") }),
           },
         ),
-      /broken executable could not start: spawn failed/,
+      (error) =>
+        error instanceof InstallStepError &&
+        error.code === "step-start" &&
+        /broken executable could not start: spawn failed/.test(error.message),
     );
     assert.throws(
       () =>
         executeInstallPlan(
-          [{ label: "broken install", bin: "tool", args: ["install"] }],
+          [
+            {
+              label: "broken install",
+              bin: "tool",
+              args: ["install"],
+              timeoutMs: STEP_TIMEOUT_DEFAULTS_MS.packageManager,
+            },
+          ],
           {
             platform: "linux",
             run: () => ({ status: 17 }),
           },
         ),
-      /broken install failed with exit code 17/,
+      (error) =>
+        error instanceof InstallStepError &&
+        error.code === "step-exit" &&
+        /broken install failed with exit code 17/.test(error.message),
     );
 
     const sudoPlan = mediaInstallSteps("linux", {
@@ -478,12 +786,34 @@ describe("evidence tool installer", () => {
     const script = fileURLToPath(
       new URL("./evidence-install-tools.mjs", import.meta.url),
     );
+    // An unresolvable env pin forces the deferred-media path so this spawn is
+    // deterministic on any host: no media resolution, no system install plan.
+    const deferredEnv = {
+      ...process.env,
+      ELIZA_FFMPEG_BIN: "/nonexistent/evidence-doctor-test-ffmpeg",
+      ELIZA_FFPROBE_BIN: "/nonexistent/evidence-doctor-test-ffprobe",
+    };
     const dryRun = spawnSync(process.execPath, [script, "--dry-run"], {
       encoding: "utf8",
+      env: deferredEnv,
     });
     assert.equal(dryRun.status, 0, dryRun.stderr);
     assert.match(dryRun.stdout, /playwright/);
+    assert.match(dryRun.stdout, /evidence-doctor\.mjs/);
+    assert.match(dryRun.stdout, /# assumes: /);
     assert.doesNotMatch(dryRun.stdout, /\[install\]/);
+
+    const strictDryRun = spawnSync(
+      process.execPath,
+      [script, "--dry-run", "--strict"],
+      { encoding: "utf8", env: deferredEnv },
+    );
+    assert.equal(strictDryRun.status, 1);
+    assert.match(strictDryRun.stdout, /# assumes: /);
+    assert.match(
+      strictDryRun.stderr,
+      /--strict dry run: the plan could not be fully resolved/,
+    );
 
     const invalid = spawnSync(process.execPath, [script, "--strcit"], {
       encoding: "utf8",

--- a/scripts/evidence-install-tools.test.mjs
+++ b/scripts/evidence-install-tools.test.mjs
@@ -1,0 +1,498 @@
+/**
+ * Exercises every supported installer plan and boundary with deterministic
+ * process fakes; package managers and developer configuration are never
+ * mutated by this test process.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertSupportedPlatform,
+  buildInstallPlan,
+  EVIDENCE_REQUIREMENTS,
+  executeInstallPlan,
+  formatCommand,
+  githubInstallSteps,
+  mediaInstallSteps,
+  parseInstallerArgs,
+  refreshWindowsPath,
+  resolveMediaRequirements,
+  withWindowsWingetLinksPath,
+} from "./evidence-install-tools.mjs";
+
+const missing = () => false;
+const unavailableMedia = {
+  ffmpeg: { available: false, reason: "missing" },
+  ffprobe: { available: false, reason: "missing" },
+};
+const packagedMedia = {
+  ffmpeg: { available: true, bin: "/packages/ffmpeg", source: "bundled" },
+  ffprobe: { available: true, bin: "/packages/ffprobe", source: "bundled" },
+};
+
+describe("evidence tool installer", () => {
+  it("shares one immutable baseline requirement catalog", () => {
+    assert.deepEqual(
+      Object.values(EVIDENCE_REQUIREMENTS)
+        .filter(({ requiredByDefault }) => requiredByDefault)
+        .map(({ id }) => id),
+      ["ocr", "ffmpeg", "ffprobe", "playwright-browsers"],
+    );
+    assert.equal(EVIDENCE_REQUIREMENTS.githubCli.id, "github-cli");
+    assert.equal(EVIDENCE_REQUIREMENTS.githubCli.requiredByDefault, false);
+    assert.equal(Object.isFrozen(EVIDENCE_REQUIREMENTS), true);
+    assert.equal(Object.isFrozen(EVIDENCE_REQUIREMENTS.ffmpeg), true);
+  });
+
+  it("installs workspace packages and the Linux Chromium dependency helper", () => {
+    const plan = buildInstallPlan({
+      platform: "linux",
+      mediaOptions: { resolutions: packagedMedia },
+    });
+    assert.deepEqual(plan[0], {
+      label: "workspace evidence dependencies",
+      bin: "bun",
+      args: ["install", "--frozen-lockfile", "--ignore-scripts"],
+    });
+    assert.deepEqual(
+      plan.slice(1, 3).map(({ bin, args }) => ({ bin, args })),
+      [
+        { bin: "/packages/ffmpeg", args: ["-version"] },
+        { bin: "/packages/ffprobe", args: ["-version"] },
+      ],
+    );
+    assert.equal(plan[3].bin, "bash");
+    assert.match(plan[3].args[0], /install-playwright-browsers\.sh$/);
+    assert.equal(plan[3].args[1], "chromium");
+  });
+
+  it("uses packaged media without planning an unrelated system install", () => {
+    for (const platform of ["darwin", "linux", "win32"]) {
+      const plan = mediaInstallSteps(platform, {
+        has: missing,
+        resolutions: packagedMedia,
+      });
+      assert.deepEqual(
+        plan.map(({ bin }) => bin),
+        ["/packages/ffmpeg", "/packages/ffprobe"],
+      );
+    }
+  });
+
+  it("uses native Playwright installation on macOS and Windows", () => {
+    for (const platform of ["darwin", "win32"]) {
+      const plan = buildInstallPlan({
+        platform,
+        skipDependencies: true,
+        mediaOptions: { resolutions: packagedMedia },
+      });
+      assert.deepEqual(plan.at(-1), {
+        label: "Playwright Chromium",
+        bin: "bunx",
+        args: ["playwright", "install", "chromium"],
+      });
+    }
+  });
+
+  it("uses Homebrew for missing macOS media and GitHub CLI", () => {
+    const hasBrew = (command) => command === "brew";
+    assert.deepEqual(
+      mediaInstallSteps("darwin", {
+        has: hasBrew,
+        resolutions: unavailableMedia,
+      }),
+      [
+        {
+          label: "ffmpeg and ffprobe",
+          bin: "brew",
+          args: ["install", "ffmpeg"],
+        },
+        { label: "ffmpeg verification", bin: "ffmpeg", args: ["-version"] },
+        { label: "ffprobe verification", bin: "ffprobe", args: ["-version"] },
+      ],
+    );
+    assert.deepEqual(githubInstallSteps("darwin", { has: hasBrew }), [
+      { label: "GitHub CLI", bin: "brew", args: ["install", "gh"] },
+      { label: "GitHub CLI verification", bin: "gh", args: ["--version"] },
+    ]);
+  });
+
+  it("uses unattended exact WinGet packages and refresh markers", () => {
+    const hasWinget = (command) => command === "winget";
+    const media = mediaInstallSteps("win32", {
+      has: hasWinget,
+      resolutions: unavailableMedia,
+    });
+    const github = githubInstallSteps("win32", { has: hasWinget });
+    for (const [step, packageId] of [
+      [media[0], "Gyan.FFmpeg"],
+      [github[0], "GitHub.cli"],
+    ]) {
+      assert.equal(step.bin, "winget");
+      assert.equal(step.refreshWindowsPath, true);
+      assert.ok(step.args.includes(packageId));
+      for (const flag of [
+        "--exact",
+        "--accept-package-agreements",
+        "--accept-source-agreements",
+        "--silent",
+        "--disable-interactivity",
+      ]) {
+        assert.ok(step.args.includes(flag), `${packageId} lacks ${flag}`);
+      }
+      assert.ok(!step.args.some((arg) => /token|password|secret/iu.test(arg)));
+    }
+    assert.deepEqual(
+      media.slice(1).map(({ bin, args }) => ({ bin, args })),
+      [
+        { bin: "ffmpeg", args: ["-version"] },
+        { bin: "ffprobe", args: ["-version"] },
+      ],
+    );
+    assert.deepEqual(github.at(-1), {
+      label: "GitHub CLI verification",
+      bin: "gh",
+      args: ["--version"],
+    });
+  });
+
+  it("covers apt, dnf, yum, and apk as root and non-root", () => {
+    const cases = [
+      {
+        manager: "apt-get",
+        media: ["install", "-y", "ffmpeg"],
+        github: ["install", "-y", "gh"],
+        updates: true,
+      },
+      {
+        manager: "dnf",
+        media: ["install", "-y", "ffmpeg"],
+        github: ["install", "-y", "gh"],
+      },
+      {
+        manager: "yum",
+        media: ["install", "-y", "ffmpeg"],
+        github: ["install", "-y", "gh"],
+      },
+      {
+        manager: "apk",
+        media: ["add", "--no-cache", "ffmpeg"],
+        github: ["add", "--no-cache", "github-cli"],
+      },
+    ];
+    for (const testCase of cases) {
+      const hasManager = (command) => command === testCase.manager;
+      const rootMedia = mediaInstallSteps("linux", {
+        has: hasManager,
+        isRoot: true,
+        resolutions: unavailableMedia,
+      });
+      const rootGithub = githubInstallSteps("linux", {
+        has: hasManager,
+        isRoot: true,
+      });
+      assert.ok(
+        rootMedia.some(
+          ({ bin, args }) =>
+            bin === testCase.manager &&
+            JSON.stringify(args) === JSON.stringify(testCase.media),
+        ),
+      );
+      assert.ok(
+        rootGithub.some(
+          ({ bin, args }) =>
+            bin === testCase.manager &&
+            JSON.stringify(args) === JSON.stringify(testCase.github),
+        ),
+      );
+
+      const nonRootMedia = mediaInstallSteps("linux", {
+        has: hasManager,
+        isRoot: false,
+        resolutions: unavailableMedia,
+      });
+      const nonRootGithub = githubInstallSteps("linux", {
+        has: hasManager,
+        isRoot: false,
+      });
+      for (const plan of [nonRootMedia, nonRootGithub]) {
+        assert.deepEqual(plan[0], {
+          label: "passwordless sudo preflight",
+          bin: "sudo",
+          args: ["-n", "true"],
+          failureMessage:
+            "Evidence tool installation requires passwordless sudo on this unattended runner. Install the tools manually or grant this runner noninteractive sudo, then rerun.",
+        });
+        assert.ok(
+          plan
+            .filter(({ bin }) => bin === "sudo")
+            .every(({ args }) => args[0] === "-n"),
+        );
+      }
+      if (testCase.updates) {
+        assert.ok(
+          rootMedia.some(
+            ({ bin, args }) =>
+              bin === "apt-get" &&
+              JSON.stringify(args) === JSON.stringify(["update"]),
+          ),
+        );
+      }
+    }
+  });
+
+  it("keeps pacman and zypper supported by the same Linux planner", () => {
+    for (const manager of ["pacman", "zypper"]) {
+      const plan = mediaInstallSteps("linux", {
+        has: (command) => command === manager,
+        isRoot: true,
+        resolutions: unavailableMedia,
+      });
+      assert.equal(plan[0].bin, manager);
+      assert.equal(plan.at(-1).bin, "ffprobe");
+    }
+  });
+
+  it("refreshes WinGet links plus registry PATH before same-process probes", () => {
+    const initial = {
+      LOCALAPPDATA: String.raw`C:\Users\agent\AppData\Local`,
+      Path: String.raw`C:\Windows\System32`,
+    };
+    const seeded = withWindowsWingetLinksPath(initial);
+    assert.equal(
+      seeded.Path,
+      String.raw`C:\Users\agent\AppData\Local\Microsoft\WinGet\Links;C:\Windows\System32`,
+    );
+    assert.equal(initial.Path, String.raw`C:\Windows\System32`);
+    assert.equal(withWindowsWingetLinksPath(seeded).Path, seeded.Path);
+    assert.throws(
+      () => withWindowsWingetLinksPath({ Path: "C:\\Windows" }),
+      /LOCALAPPDATA is unavailable/,
+    );
+
+    const refreshed = refreshWindowsPath(seeded, {
+      run: () => ({
+        status: 0,
+        stdout:
+          String.raw`C:\Program Files\MachineTool` +
+          "\n" +
+          String.raw`C:\Users\agent\UserTool`,
+      }),
+    });
+    assert.match(refreshed.Path, /UserTool/);
+    assert.match(refreshed.Path, /MachineTool/);
+    assert.match(refreshed.Path, /WinGet\\Links/);
+    assert.equal(
+      refreshed.Path.split(";").filter((entry) => /WinGet\\Links/i.test(entry))
+        .length,
+      1,
+    );
+  });
+
+  it("uses refreshed Windows PATH for the very next verification process", () => {
+    const calls = [];
+    const run = (bin, args, options) => {
+      calls.push({ bin, args, envPath: options.env?.Path });
+      if (bin === "powershell.exe") {
+        return {
+          status: 0,
+          stdout: `${String.raw`C:\Program Files\GitHub CLI`}\n`,
+        };
+      }
+      return { status: 0 };
+    };
+    executeInstallPlan(
+      [
+        {
+          label: "GitHub CLI",
+          bin: "winget",
+          args: ["install", "--id", "GitHub.cli"],
+          refreshWindowsPath: true,
+        },
+        {
+          label: "GitHub CLI verification",
+          bin: "gh",
+          args: ["--version"],
+        },
+      ],
+      {
+        platform: "win32",
+        env: {
+          LOCALAPPDATA: String.raw`C:\Users\agent\AppData\Local`,
+          Path: String.raw`C:\Windows`,
+        },
+        run,
+      },
+    );
+    assert.match(calls.find(({ bin }) => bin === "gh").envPath, /GitHub CLI/);
+  });
+
+  it("executes argument vectors directly and quotes hostile dry-run tokens", () => {
+    const hostile = "$(touch /tmp/should-not-exist); 'quoted'";
+    assert.equal(
+      formatCommand({ bin: "tool", args: [hostile] }, "linux"),
+      `tool '$(touch /tmp/should-not-exist); '"'"'quoted'"'"''`,
+    );
+    assert.equal(
+      formatCommand({ bin: "tool", args: [hostile] }, "win32"),
+      "tool '$(touch /tmp/should-not-exist); ''quoted'''",
+    );
+
+    const invocations = [];
+    executeInstallPlan(
+      [{ label: "hostile argument", bin: "tool", args: [hostile] }],
+      {
+        platform: "linux",
+        env: { PATH: "/usr/bin" },
+        run: (bin, args, options) => {
+          invocations.push({ bin, args, options });
+          return { status: 0 };
+        },
+      },
+    );
+    assert.equal(invocations.length, 1);
+    assert.deepEqual(invocations[0].args, [hostile]);
+    assert.equal(invocations[0].options.shell, undefined);
+  });
+
+  it("fails closed on unsupported hosts, missing managers, and unknown flags", () => {
+    for (const platform of ["aix", "freebsd", "sunos"]) {
+      assert.throws(
+        () => assertSupportedPlatform(platform),
+        /unsupported operating system/,
+      );
+      assert.throws(
+        () => buildInstallPlan({ platform, skipDependencies: true }),
+        /unsupported operating system/,
+      );
+    }
+    assert.throws(
+      () =>
+        mediaInstallSteps("darwin", {
+          has: missing,
+          resolutions: unavailableMedia,
+        }),
+      /Homebrew is missing/,
+    );
+    assert.throws(
+      () =>
+        mediaInstallSteps("win32", {
+          has: missing,
+          resolutions: unavailableMedia,
+        }),
+      /WinGet is missing/,
+    );
+    assert.throws(
+      () =>
+        mediaInstallSteps("linux", {
+          has: missing,
+          resolutions: unavailableMedia,
+        }),
+      /no supported Linux package manager/,
+    );
+    assert.throws(
+      () => githubInstallSteps("darwin", { has: missing }),
+      /Homebrew is unavailable/,
+    );
+    assert.throws(
+      () => githubInstallSteps("win32", { has: missing }),
+      /WinGet is unavailable/,
+    );
+    assert.throws(
+      () => githubInstallSteps("linux", { has: missing }),
+      /no supported Linux package manager/,
+    );
+    assert.throws(
+      () => parseInstallerArgs(["--strcit"]),
+      /unknown argument\(s\): --strcit/,
+    );
+    assert.deepEqual(parseInstallerArgs(["--dry-run", "--github"]), {
+      includeGithub: true,
+      skipDependencies: false,
+      dryRun: true,
+      help: false,
+    });
+  });
+
+  it("surfaces process start, exit, sudo, and Windows PATH refresh failures", () => {
+    assert.throws(
+      () =>
+        executeInstallPlan(
+          [{ label: "broken executable", bin: "missing", args: [] }],
+          {
+            platform: "linux",
+            run: () => ({ error: new Error("spawn failed") }),
+          },
+        ),
+      /broken executable could not start: spawn failed/,
+    );
+    assert.throws(
+      () =>
+        executeInstallPlan(
+          [{ label: "broken install", bin: "tool", args: ["install"] }],
+          {
+            platform: "linux",
+            run: () => ({ status: 17 }),
+          },
+        ),
+      /broken install failed with exit code 17/,
+    );
+
+    const sudoPlan = mediaInstallSteps("linux", {
+      has: (command) => command === "apt-get",
+      isRoot: false,
+      resolutions: unavailableMedia,
+    });
+    assert.throws(
+      () =>
+        executeInstallPlan(sudoPlan, {
+          platform: "linux",
+          run: () => ({ status: 1 }),
+        }),
+      /requires passwordless sudo/,
+    );
+    assert.throws(
+      () =>
+        refreshWindowsPath(
+          {
+            LOCALAPPDATA: String.raw`C:\Users\agent\AppData\Local`,
+            Path: String.raw`C:\Windows`,
+          },
+          { run: () => ({ status: 9 }) },
+        ),
+      /PowerShell exited 9/,
+    );
+  });
+
+  it("returns existing media resolutions without fabricating availability", async () => {
+    const resolutions = await resolveMediaRequirements({
+      resolveFfmpeg: async () => packagedMedia.ffmpeg,
+      resolveFfprobe: async () => packagedMedia.ffprobe,
+    });
+    assert.deepEqual(resolutions, packagedMedia);
+  });
+
+  it("makes dry-run and invalid CLI invocations non-mutating and bounded", () => {
+    const script = fileURLToPath(
+      new URL("./evidence-install-tools.mjs", import.meta.url),
+    );
+    const dryRun = spawnSync(process.execPath, [script, "--dry-run"], {
+      encoding: "utf8",
+    });
+    assert.equal(dryRun.status, 0, dryRun.stderr);
+    assert.match(dryRun.stdout, /playwright/);
+    assert.doesNotMatch(dryRun.stdout, /\[install\]/);
+
+    const invalid = spawnSync(process.execPath, [script, "--strcit"], {
+      encoding: "utf8",
+    });
+    assert.equal(invalid.status, 1);
+    assert.equal(invalid.stdout, "");
+    assert.match(
+      invalid.stderr,
+      /evidence-install-tools: unknown argument\(s\): --strcit/,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #16990  
Parent tracker: #16926  
Related evidence foundation: #14541

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were
      run after sync.
- [x] A reviewer can confirm the change works without reading the code, from
      the tests, capability report, execution log, and three-platform smoke
      workflow below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `e7043436b5305dcfeb305e98710f194d12eaa885`;
      zero conflicts.
- [x] `bun run verify` passes post-sync (578/578 Turbo tasks plus the repository
      audits and dist-path consumer checks).

# Risks

**Medium.** The installer intentionally mutates host package/browser state when
invoked. Risk is bounded by direct executable argv (never a shell), explicit
package-manager detection, noninteractive flags, `sudo -n`, an inspectable
`--dry-run`, and post-install behavioral probes. It does not change shell
profiles, developer configuration, GitHub authentication, repository
permissions, or credentials.

# Background

## What does this PR do?

- Adds one shared requirement catalog for OCR, ffmpeg/ffprobe, Playwright
  Chromium, and the optional GitHub CLI capability.
- Makes `bun run evidence:install-tools` install or repair the required
  toolchain through Homebrew, apt/dnf/yum/apk/pacman/zypper, or WinGet.
- Replaces presence checks with real OCR recognition, media
  encode/probe/decode, and headless Chromium launch probes.
- Adds safe dry-run, strict and normalized JSON output, idempotent reruns,
  Windows process-local PATH refresh, focused contract tests, operator
  documentation, and a read-only Ubuntu/macOS/Windows smoke workflow.
- Keeps GitHub support deliberately narrow: `--github` installs/verifies the
  optional `gh` executable only. It never checks or modifies auth, tokens, API
  access, or repository permissions; upload/auth behavior remains in #16991.

## What kind of change is this?

Infrastructure/build improvement and compatibility fix.

# Documentation changes needed?

Documentation is required and has been updated in `CONTRIBUTING.md`, including
the canonical command, flags, supported package managers, privilege/network
expectations, optional capability semantics, Windows PATH behavior, and strict
doctor usage.

# Testing

## Where should a reviewer start?

Run:

```bash
bun run evidence:install-tools -- --dry-run --github
bun run evidence:install-tools -- --github
bun run evidence:doctor -- --strict
bun run evidence:doctor -- --json
```

Then inspect the `Evidence tools platform smoke` workflow: each OS records the
pre-install report, runs the installer twice, and records the final strict
normalized report.

## Detailed testing steps

- `node --test scripts/evidence-install-tools.test.mjs scripts/evidence-doctor.test.mjs`
  — 26 passed.
- `bun test packages/scripts/__tests__/evidence-tools-platform-workflow.test.ts`
  — 2 passed / 34 expectations.
- Scoped Biome check — passed.
- `actionlint .github/workflows/evidence-tools-platform-smoke.yml` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- `bun install --frozen-lockfile --ignore-scripts` — passed.
- `bun run verify` after the final rebase — 578/578 Turbo tasks and all
  repository audits passed.
- Linux, Node 24.15.0 / Bun 1.3.14: dry-run passed; actual install passed twice;
  strict doctor passed; normalized report had `ok: true` and
  `requiredMissing: []`.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: **N/A - headless build/toolchain change; no
      rendered UI surface changes.**
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: **N/A - headless build/toolchain change; no
      rendered UI surface changes.**
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: **N/A - there is no user-facing UI flow.**
<!-- evidence-row:backend-logs -->
- [x] Backend logs: **N/A - no server/backend execution path changes; real CLI
      execution output is included below and emitted by the platform workflow.**
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: **N/A - no frontend code or network state
      changes.**
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: **N/A - no agent, action, provider, prompt, or model
      behavior changes.**
<!-- evidence-row:domain-artifacts -->
- [x] [17015-platform-doctor-reports.tgz](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17015-platform-doctor-reports.tgz)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

Backend: N/A - no server/backend execution path changes.  
Frontend: N/A - no frontend code or request/state changes.

Real Linux CLI path:

```text
[install] evidence toolchain verification
Evidence toolchain doctor
  [ok  ] ocr: tesseract.js recognized the bundled ELIZA fixture
  [ok  ] ffmpeg: ffmpeg system binary passed the encode/probe/decode fixture
  [ok  ] ffprobe: ffprobe bundled binary passed the encode/probe/decode fixture
  [ok  ] playwright-browsers: Playwright Chromium 149.0.7827.55 launched successfully
  [ok  ] github-cli: gh version 2.74.0-19-gea8fc856e (2025-06-09)
Required tools present. 3 optional capability(ies) unavailable.
GitHub CLI installation verified; authentication and repository permissions were left unchanged.
```

The same actual installer completed a second time with the same required-tool
result, proving the healthy-path rerun is idempotent.

Normalized capability artifact:

```json
{
  "schemaVersion": 1,
  "platform": {
    "os": "linux",
    "architecture": "x64",
    "nodeVersion": "v24.15.0"
  },
  "ok": true,
  "requiredMissing": [],
  "optionalMissing": [
    "gpu-vision-ocr",
    "apple-vision-ocr",
    "vlm-vision-qa-api"
  ]
}
```

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered product surface changes.

### After

N/A - no rendered product surface changes.

### Walkthrough video

N/A - headless installer/doctor workflow with no UI flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

- The local host provides Linux proof only. The checked-in read-only smoke
  workflow supplies the required Ubuntu, macOS, and Windows reports and is
  expected to run on this PR; its run and artifact links will be added after it
  completes.
- Three optional capabilities are absent on the local Linux host:
  GPU/Baidu OCR, macOS Apple Vision OCR, and a configured VLM API. These are
  intentionally optional accelerators and do not make a required tool healthy.
- Passwordless sudo is unavailable locally. The installer reported that
  condition and installed Playwright Chromium without OS dependency mutation;
  the real browser launch probe still passed.
- The error-policy ratchet was retired upstream in `84bc78ea`; this PR does not
  restore or invoke the removed command.
- No secrets or credential values are present in the captured output.

