### PR TITLE
fix(ui): add my-apps baseline entry so the shell-page sweep passes on trunk

### DIFF
--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -239,6 +239,14 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
       "Browser workspace navigation/tab controls pair with the BROWSER action (plugin-browser); wallet-consent prompts are owner-in-the-loop by design and stay counted here.",
   },
   {
+    viewId: "my-apps",
+    sourceFiles: ["packages/ui/src/components/pages/MyAppsView.tsx"],
+    semanticActions: ["BROWSER"],
+    maxMutationSites: 1,
+    notes:
+      "Cloud Apps studio row navigates via navigateBrowserPath, which the BROWSER action covers; the row itself is a signed-in-gated shortcut, not a state mutation surface.",
+  },
+  {
     viewId: "relationships",
     sourceFiles: [
       "packages/ui/src/components/pages/RelationshipsView.tsx",


### PR DESCRIPTION
## What + why

Trunk is currently red on `packages/ui`: the #16951 shell-page completeness sweep fails with `packages/ui/src/components/pages/MyAppsView.tsx: 1 mutation site(s) but no baseline coverage`. MyAppsView gained a Cloud Apps studio row (`onClick={() => navigateBrowserPath(cloudStudioPath)}`, MyAppsView.tsx:73) via e0cb8deca4c, which entered develop at 05:04 — *after* #16951 merged at 04:53. Both branches were individually green; the combination fails. Found by the post-merge adversarial review of #16951.

This adds the missing `my-apps` baseline entry mapped to the registered `BROWSER` semantic action with `maxMutationSites: 1` (pinned at observed — no headroom).

## Evidence

- Ratchet suite in this branch: **13/13 passed** (`bun x vitest run src/testing/builtin-view-action-ratchet.test.ts`, 729ms) — the same suite fails at origin/develop tip with the unmapped-mutating-page finding.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-baseline-only change (one entry in builtin-view-action-ratchet.ts), no rendered UI delta`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test-baseline-only change, no rendered UI delta`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - test-baseline-only change; nothing user-exercisable to walk through`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server code touched`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no runtime code touched; the only change is a test baseline entry`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/prompt/model behavior change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the domain artifact is the ratchet suite run quoted above (13/13 passed on this branch; the same suite fails at origin/develop tip with the unmapped-mutating-page finding); no artifact exists beyond that test output`.

Closes the trunk-red finding from the #16951 post-merge review (issue #16944).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
