### PR TITLE
fix(app-control): authenticate remaining loopback actions

### DIFF
--- a/plugins/plugin-app-control/src/actions/agent-switch.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.ts
@@ -26,6 +26,7 @@ import type {
 } from "@elizaos/core";
 import { logger, resolveServerOnlyPort } from "@elizaos/core";
 import { readStringOption } from "../params.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 /** Parsed wire response of POST /api/runtime/agent-switch. */
 export interface AgentSwitchOutcome {
@@ -51,7 +52,7 @@ async function defaultSwitchAgent(
 		`http://127.0.0.1:${port}/api/runtime/agent-switch`,
 		{
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify({ profile }),
 			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 		},

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -26,6 +26,7 @@ import {
 	DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
 } from "@elizaos/shared";
 import { readStringOption } from "../params.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 export type ModelSwitchTarget = "local" | "cloud";
 
@@ -60,7 +61,7 @@ async function defaultSwitchModel(request: {
 		`http://127.0.0.1:${port}/api/runtime/model-switch`,
 		{
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify(request),
 			// Local activation waits for the model load, which can take a while on
 			// first switch — give the route more headroom than a plain API call.

--- a/plugins/plugin-app-control/src/actions/views-delete.ts
+++ b/plugins/plugin-app-control/src/actions/views-delete.ts
@@ -26,6 +26,7 @@ import { logger, resolveServerOnlyPort } from "@elizaos/core";
 import { readStringOption } from "../params.js";
 import { isProtected, resolveProtectedApps } from "../protected-apps.js";
 import type { ViewSummary } from "./views-client.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 import { scoreView } from "./views-search.js";
 
 /** Core first-party plugins that must never be deleted via the VIEWS action. */
@@ -243,7 +244,7 @@ async function unloadPlugin(
 	try {
 		const resp = await fetch(`${base}/api/plugins/uninstall`, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify({ name: pluginName }),
 			signal: AbortSignal.timeout(30_000),
 		});

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -6,7 +6,9 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAgentSwitchAction } from "./agent-switch.js";
 import { createBackgroundAction } from "./background.js";
+import { createModelSwitchAction } from "./model-switch.js";
 import { createSettingsAction } from "./settings.js";
 import { createViewsAction } from "./views.js";
 import {
@@ -145,6 +147,30 @@ async function startAuthenticatedViewsServer(
 				request.pathname === "/api/views/events/broadcast"
 			) {
 				sendJson(res, 200, { ok: true });
+				return;
+			}
+			if (
+				request.method === "POST" &&
+				request.pathname === "/api/runtime/agent-switch"
+			) {
+				sendJson(res, 200, {
+					ok: true,
+					profileId: "local",
+					profileLabel: "Local",
+				});
+				return;
+			}
+			if (
+				request.method === "POST" &&
+				request.pathname === "/api/runtime/model-switch"
+			) {
+				sendJson(res, 200, {
+					ok: true,
+					target: "cloud",
+					model: "eliza-cloud",
+					displayName: "Eliza Cloud",
+					status: "ready",
+				});
 				return;
 			}
 			sendJson(res, 404, { error: "Not found" });
@@ -295,7 +321,7 @@ describe("authenticated view loopback requests", () => {
 		).not.toContain(token);
 	});
 
-	it("authenticates every Node-side views loopback caller", async () => {
+	it("authenticates every Node-side loopback caller", async () => {
 		const token = "all-views-callers-token";
 		const server = await startAuthenticatedViewsServer(token);
 		process.env.ELIZA_PORT = String(server.port);
@@ -357,6 +383,24 @@ describe("authenticated view loopback requests", () => {
 		);
 		expect(backgroundNavigateResult.success).toBe(true);
 
+		const agentSwitchAction = createAgentSwitchAction();
+		const agentSwitchResult = await agentSwitchAction.handler(
+			runtime,
+			message("switch to local agent"),
+			undefined,
+			{ profile: "local" },
+		);
+		expect(agentSwitchResult.success).toBe(true);
+
+		const modelSwitchAction = createModelSwitchAction();
+		const modelSwitchResult = await modelSwitchAction.handler(
+			runtime,
+			message("switch model to cloud"),
+			undefined,
+			{ target: "cloud" },
+		);
+		expect(modelSwitchResult.success).toBe(true);
+
 		const settingsAction = createSettingsAction();
 		const settingsResult = await settingsAction.handler(
 			runtime,
@@ -380,6 +424,8 @@ describe("authenticated view loopback requests", () => {
 				"/api/views/events/broadcast",
 				"/api/views/search",
 				"/api/views/background/navigate",
+				"/api/runtime/agent-switch",
+				"/api/runtime/model-switch",
 			]),
 		);
 		expect(

--- a/plugins/plugin-app-control/src/actions/views-rollback.ts
+++ b/plugins/plugin-app-control/src/actions/views-rollback.ts
@@ -32,6 +32,7 @@ import type {
 import { logger, resolveServerOnlyPort } from "@elizaos/core";
 import { readStringOption } from "../params.js";
 import { isRestrictedPlatform } from "./views-platform.js";
+import { createViewsRequestHeaders } from "./views-request-auth.js";
 import {
 	deleteSnapshotRecord,
 	findSnapshotRecord,
@@ -69,7 +70,7 @@ async function reregisterPluginFromWorkdir(
 			`http://127.0.0.1:${port}/api/plugins/load-from-directory`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({ directory: workdir }),
 				signal: AbortSignal.timeout(30_000),
 			},


### PR DESCRIPTION
## Summary
- attach the same canonical/legacy API bearer header used by app-control view routes to the remaining Node-side app-control loopback POSTs
- covers agent-switch, model-switch, view uninstall, and rollback re-register paths
- extends the real TCP loopback auth integration test so these routes fail if the auth seam regresses again

## Why
PR #16979 made 401/403 settings failures friendlier, but the root class is unauthenticated Node-side loopback requests crossing a token-protected local API. #16836 fixed the /api/views subset; this closes the same seam for the remaining app-control loopback mutations instead of relying on humanized auth errors.

## Tests
- bun test plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts plugins/plugin-app-control/src/actions/agent-switch.test.ts plugins/plugin-app-control/src/actions/model-switch.test.ts *(fails in this worktree because dependencies are absent/incomplete: zod/handlebars, then markdown-it/@noble/ciphers when symlinked to another worktree node_modules)*
- bunx @biomejs/biome check plugins/plugin-app-control/src/actions/agent-switch.ts plugins/plugin-app-control/src/actions/model-switch.ts plugins/plugin-app-control/src/actions/views-delete.ts plugins/plugin-app-control/src/actions/views-rollback.ts plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts