### PR TITLE
fix(release): include simple views in npm cohort

### DIFF
--- a/packages/scripts/release-cohort.json
+++ b/packages/scripts/release-cohort.json
@@ -128,6 +128,7 @@
     "@elizaos/plugin-screenshare",
     "@elizaos/plugin-shell",
     "@elizaos/plugin-signal",
+    "@elizaos/plugin-simple-views",
     "@elizaos/plugin-slack",
     "@elizaos/plugin-sql",
     "@elizaos/plugin-streaming",


### PR DESCRIPTION
## Summary

- add `@elizaos/plugin-simple-views` to the explicit public npm release cohort
- restore runtime workspace closure for the release candidate workflow

## Release-blocker evidence

The frozen `develop` promotion preflight failed `release-workflow.test.ts` because the app now has a runtime workspace dependency on `@elizaos/plugin-simple-views`, but the explicit cohort omitted it. The closure guard expected the package and correctly blocked release preparation.

## Verification

- full eight-file release candidate suite — 57 passed, 0 failed
- `bun run verify` — 578/578 tasks; all audits; 28/28 dist consumers
- `git diff --check` — pass

## Evidence applicability

<!-- evidence-row:before-screenshots -->
- [ ] N/A - release metadata only; no rendered UI change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - release metadata only; no rendered UI change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime server behavior changed; release test output is listed above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend implementation changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, action, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain behavior changed

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI change