### PR TITLE
fix(app-control): authenticate ALL remaining loopback callers (follow-up to #17019)

### DIFF
--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -596,7 +596,7 @@ async function defaultGenerateImage(prompt: string): Promise<string> {
 		`http://127.0.0.1:${port}/api/background/generate-image`,
 		{
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: createViewsRequestHeaders(),
 			body: JSON.stringify({ prompt }),
 			signal: AbortSignal.timeout(120_000),
 		},

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -1730,9 +1730,10 @@ async function defaultRouteFetch(
 	const port = resolveServerOnlyPort(process.env);
 	const response = await fetch(`http://127.0.0.1:${port}${request.path}`, {
 		method: request.method,
-		headers: request.path.startsWith("/api/views")
-			? createViewsRequestHeaders()
-			: { "Content-Type": "application/json" },
+		// Every settings route crosses the same token-protected local API
+		// boundary (/api/config, /api/permissions, /api/wallet, /api/backups,
+		// ...), not just /api/views/*. Attach the canonical bearer everywhere.
+		headers: createViewsRequestHeaders(),
 		body: request.body === undefined ? undefined : JSON.stringify(request.body),
 		signal: AbortSignal.timeout(30_000),
 	});

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -6,6 +6,7 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAppControlClient } from "../client/api.js";
 import { createAgentSwitchAction } from "./agent-switch.js";
 import { createBackgroundAction } from "./background.js";
 import { createModelSwitchAction } from "./model-switch.js";
@@ -171,6 +172,27 @@ async function startAuthenticatedViewsServer(
 					displayName: "Eliza Cloud",
 					status: "ready",
 				});
+				return;
+			}
+			if (
+				request.method === "PUT" &&
+				request.pathname === "/api/permissions/shell"
+			) {
+				sendJson(res, 200, { ok: true, enabled: false });
+				return;
+			}
+			if (
+				request.method === "POST" &&
+				request.pathname === "/api/background/generate-image"
+			) {
+				sendJson(res, 200, { url: "/api/media/generated-test.png" });
+				return;
+			}
+			if (
+				request.method === "GET" &&
+				request.pathname === "/api/apps/installed"
+			) {
+				sendJson(res, 200, []);
 				return;
 			}
 			sendJson(res, 404, { error: "Not found" });
@@ -415,6 +437,33 @@ describe("authenticated view loopback requests", () => {
 		);
 		expect(settingsResult.success).toBe(true);
 
+		// A settings route OUTSIDE /api/views/* must carry the same bearer: the
+		// whole local API boundary is token-protected, not just the views prefix.
+		const shellPermissionResult = await settingsAction.handler(
+			runtime,
+			message("turn off shell access"),
+			undefined,
+			{
+				action: "set",
+				section: "permissions",
+				key: "shell",
+				value: "off",
+			},
+		);
+		expect(shellPermissionResult.success).toBe(true);
+
+		// The background image generator crosses the same boundary.
+		const backgroundGenerateResult = await backgroundAction.handler(
+			runtime,
+			message("generate a background of a misty mountain sunrise"),
+		);
+		expect(backgroundGenerateResult.success).toBe(true);
+
+		// The app-control loopback client (installed apps, runs, launch, stop).
+		await expect(createAppControlClient().listInstalledApps()).resolves.toEqual(
+			[],
+		);
+
 		const paths = server.requests.map((request) => request.pathname);
 		expect(paths).toEqual(
 			expect.arrayContaining([
@@ -426,6 +475,9 @@ describe("authenticated view loopback requests", () => {
 				"/api/views/background/navigate",
 				"/api/runtime/agent-switch",
 				"/api/runtime/model-switch",
+				"/api/permissions/shell",
+				"/api/background/generate-image",
+				"/api/apps/installed",
 			]),
 		);
 		expect(

--- a/plugins/plugin-app-control/src/client/api.ts
+++ b/plugins/plugin-app-control/src/client/api.ts
@@ -7,6 +7,7 @@
  */
 
 import { resolveServerOnlyPort } from "@elizaos/core";
+import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
 import type {
 	AppControlErrorPayload,
 	AppLaunchResult,
@@ -68,7 +69,7 @@ async function requestJson<T>(
 	const response = await fetch(url, {
 		...init,
 		headers: {
-			"Content-Type": "application/json",
+			...createViewsRequestHeaders(),
 			...(init.headers ?? {}),
 		},
 		signal: callerSignal

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -41,6 +41,7 @@ import {
 	resolveServerOnlyPort,
 	Service,
 } from "@elizaos/core";
+import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
 
 export const VERIFICATION_ROOM_BRIDGE_SERVICE_TYPE = "verification-room-bridge";
 
@@ -185,7 +186,7 @@ async function loadPluginFromWorkdir(
 			`http://127.0.0.1:${port}/api/plugins/load-from-directory`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({ directory: workdir }),
 				signal: AbortSignal.timeout(30_000),
 			},
@@ -245,7 +246,7 @@ async function loadAppFromWorkdir(
 			`http://127.0.0.1:${port}/api/apps/load-from-directory`,
 			{
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({ directory }),
 				signal: AbortSignal.timeout(30_000),
 			},


### PR DESCRIPTION
## What

Follow-up to #17019 (re-reviewed as part of tonight's quality re-verification). That PR covered agent-switch, model-switch, view uninstall, and rollback re-register. A full caller sweep of `plugin-app-control` for loopback `fetch`es to the token-protected local API found **four more unauthenticated callers**:

1. **`settings.ts` `defaultRouteFetch`** — only `/api/views/*` paths got the bearer. Every other settings route crossed the boundary bare: `/api/config`, `/api/permissions/*` (incl. shell on/off), `/api/wallet/config`, `/api/backups`, `/api/update/channel`, `/api/training/auto/config`. This is the biggest gap: with `ELIZA_API_TOKEN` set and loopback trust disabled (cloud containers, `ELIZA_REQUIRE_LOCAL_AUTH=1`), every non-views settings write 401s — exactly the failure class #16979's human copy narrates.
2. **`background.ts` `defaultGenerateImage`** — `/api/background/generate-image`.
3. **`client/api.ts` `AppControlClient`** — `/api/apps/installed`, `/api/apps/runs`, `/api/apps/launch`, `/api/apps/runs/:id/stop` (used by APP launch/stop actions, available-apps provider, app verification).
4. **`verification-room-bridge.ts`** — live-load POSTs to `/api/plugins/load-from-directory` and `/api/apps/load-from-directory`.

All now reuse the #16836 `createViewsRequestHeaders()` seam: canonical `ELIZA_API_TOKEN`, legacy `ELIZA_API_AUTH_TOKEN` fallback, header omitted when no token is configured (open local dev unchanged).

## Tests

- Extended `views-loopback-auth.integration.test.ts` (real TCP bearer-protected server): non-views settings route (`PUT /api/permissions/shell`), `POST /api/background/generate-image`, and the app-control client now covered in the all-callers test, plus the existing token-never-in-URL/body leak assertions over every captured request.
- Full plugin suite green locally: `bunx vitest run` → **46 files, 1527 tests passed**.
- `biome check` clean on all touched files.

## Notes

`verification-helpers.ts` screenshot capture already had its own bearer path (`resolveApiToken` + legacy fallback) and is unchanged. `views/viewManagerData.ts` is browser-side (relative URL, session auth) and out of scope.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - loopback API authentication fix; no rendered UI source or visual layout changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - loopback API authentication fix; behavior is asserted through token-protected API requests rather than pixels.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction flow changed; the affected paths are internal app-control callers to local API routes.

<!-- evidence-row:backend-logs -->
- [x] [17038-pr17038-loopback-auth-suite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17038-pr17038-loopback-auth-suite.log)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser network/session-auth path changed; browser-side `views/viewManagerData.ts` remains out of scope.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, planner, action selection, or generated response behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, wallet, scheduled task, device, or generated artifact changed; the domain artifact is the captured request set from the bearer-protected integration test.

<!-- pr17038-refresh: 2026-07-23T11:52Z -->

