### PR TITLE
fix(agent): scope wallet balance-delta baseline to wallet identity; stop new unpriced positions swallowing deltas

### DIFF
--- a/packages/agent/src/runtime/wallet-balance-delta.test.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_MIN_DELTA_USD,
   DEFAULT_THRESHOLD_PCT,
   evaluateWalletBalanceDelta,
+  pricedCoverageFlips,
   registerWalletBalanceDeltaProducer,
   resolveThresholds,
   sumWalletBalancesUsd,
@@ -26,7 +27,10 @@ import {
   WALLET_BALANCE_DELTA_GROUP_KEY,
   WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
   type WalletBalanceBaseline,
-  walletSampleFingerprint,
+  walletIdentityKey,
+  walletIdentitySwitched,
+  walletPositionPricing,
+  walletSampleLegs,
 } from "./wallet-balance-delta.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-00000000a11e";
@@ -199,17 +203,33 @@ describe("materiality math (pure)", () => {
     // 100 + 50 + 300; the errored base chain ($9000) is excluded, and the
     // unparseable token contributes nothing rather than poisoning the total.
     expect(sumWalletBalancesUsd(balances)).toBe(450);
-    // The JUP position holds units but its USD value is unknown, so it shows
-    // up as an unpriced-coverage entry; the errored base chain's positions are
+    // Identity is the sampled addresses; legs exclude the errored base chain.
+    expect(walletIdentityKey(balances)).toBe("evm:0xabc|sol:sol1");
+    expect(walletSampleLegs(balances)).toEqual(["evm:ethereum", "sol"]);
+    // The JUP position holds units but its USD value is unknown, so its
+    // coverage reads unpriced; the errored base chain's positions are
     // excluded entirely along with the leg.
-    expect(walletSampleFingerprint(balances)).toEqual([
-      "evm:ethereum",
-      "sol",
-      "unpriced:sol:token:jup",
-    ]);
+    expect(walletPositionPricing(balances)).toEqual({
+      "evm:ethereum:native": true,
+      "evm:ethereum:token:0xusdc": true,
+      "sol:native": true,
+      "sol:token:jup": false,
+    });
   });
 
-  it("price coverage is part of the fingerprint: priced↔unpriced flips change it, pure value moves do not", () => {
+  it("a wallet switch flips the identity; adding or dropping a leg family does not", () => {
+    // Same sol address, EVM leg added → composition change, not a switch.
+    expect(walletIdentitySwitched("sol:abc", "evm:0x1|sol:abc")).toBe(false);
+    // EVM leg removed, sol retained → not a switch either.
+    expect(walletIdentitySwitched("evm:0x1|sol:abc", "sol:abc")).toBe(false);
+    // A retained family's address changed → switch, on either family.
+    expect(walletIdentitySwitched("sol:abc", "sol:xyz")).toBe(true);
+    expect(walletIdentitySwitched("evm:0x1|sol:abc", "evm:0x2|sol:abc")).toBe(
+      true,
+    );
+  });
+
+  it("price coverage is tracked per position: flips on held positions register, pure value moves and new positions do not", () => {
     const priced: WalletBalancesResponse = {
       evm: {
         address: "0xabc",
@@ -248,11 +268,16 @@ describe("materiality math (pure)", () => {
       },
       solana: null,
     };
-    expect(walletSampleFingerprint(priced)).toEqual(["evm:ethereum"]);
+    const pricedCoverage = walletPositionPricing(priced);
+    // The zero-unit DUST position carries no pricing signal and is absent.
+    expect(pricedCoverage).toEqual({
+      "evm:ethereum:native": true,
+      "evm:ethereum:token:0xusdc": true,
+    });
 
     // Price outage: same units, values collapse to the upstream "0"-means-
-    // unknown encoding — the fingerprint changes, so the dispatcher
-    // re-baselines instead of reading a ~100% balance drop.
+    // unknown encoding — both held positions flip to unpriced, so the
+    // dispatcher re-baselines instead of reading a ~100% balance drop.
     const outage: WalletBalancesResponse = structuredClone(priced);
     if (!outage.evm) throw new Error("evm leg missing");
     const chain = outage.evm.chains[0];
@@ -261,20 +286,37 @@ describe("materiality math (pure)", () => {
     const usdc = chain.tokens[0];
     if (!usdc) throw new Error("usdc missing");
     usdc.valueUsd = "0";
-    expect(walletSampleFingerprint(outage)).toEqual([
-      "evm:ethereum",
-      "unpriced:evm:ethereum:native",
-      "unpriced:evm:ethereum:token:0xusdc",
-    ]);
+    expect(walletPositionPricing(outage)).toEqual({
+      "evm:ethereum:native": false,
+      "evm:ethereum:token:0xusdc": false,
+    });
+    expect(
+      pricedCoverageFlips(pricedCoverage, walletPositionPricing(outage)),
+    ).toEqual(["evm:ethereum:native", "evm:ethereum:token:0xusdc"]);
 
-    // A pure value move (units and coverage unchanged) keeps the fingerprint
-    // identical — genuine deltas still flow to the notify path.
+    // A pure value move (units and coverage unchanged) flips nothing —
+    // genuine deltas still flow to the notify path.
     const moved: WalletBalancesResponse = structuredClone(priced);
     if (!moved.evm?.chains[0]) throw new Error("chain missing");
     moved.evm.chains[0].nativeValueUsd = "40";
-    expect(walletSampleFingerprint(moved)).toEqual(
-      walletSampleFingerprint(priced),
-    );
+    expect(
+      pricedCoverageFlips(pricedCoverage, walletPositionPricing(moved)),
+    ).toEqual([]);
+
+    // A position only one sample holds (new arrival / sold out) is a real
+    // balance event, never a coverage flip.
+    expect(
+      pricedCoverageFlips(pricedCoverage, {
+        ...pricedCoverage,
+        "evm:ethereum:token:0xspam": false,
+      }),
+    ).toEqual([]);
+    expect(
+      pricedCoverageFlips(
+        { ...pricedCoverage, "evm:ethereum:token:0xgone": true },
+        pricedCoverage,
+      ),
+    ).toEqual([]);
   });
 
   it("requires BOTH the USD floor and the percent threshold", () => {
@@ -375,8 +417,9 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
       WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
     ) as WalletBalanceBaseline;
     expect(baseline1).toMatchObject({
+      walletKey: "sol:So11111111111111111111111111111111111111112",
       totalUsd: 100,
-      sampleFingerprint: ["sol"],
+      sampleLegs: ["sol"],
     });
 
     // Fire 2 (+31m): a $5 move fails the $10 floor — silent.
@@ -455,11 +498,22 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
     const fifth = await h.fire(watcher.taskId);
     expect(fifth.kind).toBe("fired");
     expect(h.notifications.list()).toHaveLength(1);
+    if (fifth.kind === "fired") {
+      // The sol address is retained, so this is a leg-composition change —
+      // NOT a wallet switch.
+      expect(fifth.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "rebaselined_leg_change",
+      });
+    }
     const rebased = h.cache.get(
       WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
     ) as WalletBalanceBaseline;
     expect(rebased.totalUsd).toBe(500);
-    expect(rebased.sampleFingerprint).toEqual(["evm:ethereum", "sol"]);
+    expect(rebased.sampleLegs).toEqual(["evm:ethereum", "sol"]);
+    expect(rebased.walletKey).toBe(
+      "evm:0xabc|sol:So11111111111111111111111111111111111111112",
+    );
 
     // Fire 6 (+later): a second material move coalesces onto the same
     // groupKey — one inbox row carrying the supersede count (§C.3).
@@ -540,11 +594,10 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
       WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
     ) as WalletBalanceBaseline;
     expect(collapsed.totalUsd).toBe(0);
-    expect(collapsed.sampleFingerprint).toEqual([
-      "sol",
-      "unpriced:sol:native",
-      "unpriced:sol:token:jup",
-    ]);
+    expect(collapsed.positionPricing).toEqual({
+      "sol:native": false,
+      "sol:token:jup": false,
+    });
 
     // Recovery: prices return at the old level — again a coverage change, so
     // no matching "Wallet balance up" flap either.
@@ -585,6 +638,276 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
       currentTotalUsd: 150,
       deltaUsd: -100,
       deltaPct: -40,
+    });
+  });
+
+  it("a NEW unpriced position (spam airdrop) never swallows a concurrent material drop in priced holdings", async () => {
+    const wallet = (args: {
+      solBalance: string;
+      solValueUsd: string;
+      tokens?: Array<{ mint: string; balance: string; valueUsd: string }>;
+    }): WalletBalancesResponse => ({
+      evm: null,
+      solana: {
+        address: "So11111111111111111111111111111111111111112",
+        solBalance: args.solBalance,
+        solValueUsd: args.solValueUsd,
+        tokens: (args.tokens ?? []).map((t) => ({
+          symbol: "SPAM",
+          name: "Spam Coin",
+          balance: t.balance,
+          decimals: 6,
+          valueUsd: t.valueUsd,
+          logoUrl: "",
+          mint: t.mint,
+        })),
+      },
+    });
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    // Baseline: 10 SOL, fully priced at $100, no tokens.
+    let sample: () => WalletBalancesResponse = () =>
+      wallet({ solBalance: "10", solValueUsd: "100" });
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => sample(),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const first = await h.fire(watcher.taskId);
+    expect(first.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+
+    // Next poll: a spam airdrop (99999 units, price unknown) appeared AND the
+    // SOL leg dropped 10 → 2 units ($100 → $20). The airdrop contributes $0
+    // to the priced total, so the totals stay apples-to-apples — the material
+    // priced-holdings drop MUST notify, never re-baseline away.
+    sample = () =>
+      wallet({
+        solBalance: "2",
+        solValueUsd: "20",
+        tokens: [{ mint: "spamcoin", balance: "99999", valueUsd: "0" }],
+      });
+    h.setNow("2026-07-23T10:31:00.000Z");
+    const second = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(second.kind).toBe("fired");
+    const inbox = h.notifications.list();
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0]?.title).toBe("Wallet balance down");
+    expect(inbox[0]?.data).toMatchObject({
+      previousTotalUsd: 100,
+      currentTotalUsd: 20,
+      deltaUsd: -80,
+      deltaPct: -80,
+    });
+
+    // The spam position is absorbed into the new baseline: if its price feed
+    // later lists it (fake liquidity pump), that priced↔unpriced flip is a
+    // coverage change on a known position — re-baseline, not a "+4000%" flap.
+    sample = () =>
+      wallet({
+        solBalance: "2",
+        solValueUsd: "20",
+        tokens: [{ mint: "spamcoin", balance: "99999", valueUsd: "820" }],
+      });
+    h.setNow("2026-07-23T11:02:00.000Z");
+    const third = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(third.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(1);
+    if (third.kind === "fired") {
+      expect(third.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "rebaselined_price_coverage_change",
+      });
+    }
+  });
+
+  it("absorbs a new position's coverage on a below-threshold tick, so a later price listing reads as a flip, not a pump notification", async () => {
+    const wallet = (
+      solValueUsd: string,
+      spamValueUsd: string | null,
+    ): WalletBalancesResponse => ({
+      evm: null,
+      solana: {
+        address: "So11111111111111111111111111111111111111112",
+        solBalance: "10",
+        solValueUsd,
+        tokens:
+          spamValueUsd === null
+            ? []
+            : [
+                {
+                  symbol: "SPAM",
+                  name: "Spam Coin",
+                  balance: "99999",
+                  decimals: 6,
+                  valueUsd: spamValueUsd,
+                  logoUrl: "",
+                  mint: "spamcoin",
+                },
+              ],
+      },
+    });
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    let sample: () => WalletBalancesResponse = () => wallet("100", null);
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => sample(),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const first = await h.fire(watcher.taskId);
+    expect(first.kind).toBe("fired");
+
+    // Spam arrives unpriced alongside an immaterial $5 drift: no notification,
+    // the anchor total stays at $100 (drift must accumulate), but the
+    // coverage map absorbs the new position.
+    sample = () => wallet("95", "0");
+    h.setNow("2026-07-23T10:31:00.000Z");
+    const second = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(second.kind).toBe("fired");
+    if (second.kind === "fired") {
+      expect(second.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "below_threshold",
+      });
+    }
+    expect(h.notifications.list()).toHaveLength(0);
+    const absorbed = h.cache.get(
+      WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
+    ) as WalletBalanceBaseline;
+    expect(absorbed.totalUsd).toBe(100);
+    expect(absorbed.positionPricing).toEqual({
+      "sol:native": true,
+      "sol:token:spamcoin": false,
+    });
+
+    // A price feed later lists the spam token at a fake-liquidity $800: that
+    // is a coverage flip on a known position — silent re-baseline, not a
+    // "wallet up 800%" notification.
+    sample = () => wallet("95", "800");
+    h.setNow("2026-07-23T11:02:00.000Z");
+    const third = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(third.kind).toBe("fired");
+    if (third.kind === "fired") {
+      expect(third.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "rebaselined_price_coverage_change",
+      });
+    }
+    expect(h.notifications.list()).toHaveLength(0);
+    expect(
+      (
+        h.cache.get(
+          WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
+        ) as WalletBalanceBaseline
+      ).totalUsd,
+    ).toBe(895);
+  });
+
+  it("a legacy pre-wallet-scoped baseline row is discarded, never compared against", async () => {
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    // Shape written by the original producer (no walletKey/positionPricing).
+    h.cache.set(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, {
+      totalUsd: 100,
+      sampleFingerprint: ["sol"],
+      observedAtIso: "2026-07-22T10:00:00.000Z",
+    });
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => solanaBalances(5000),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const outcome = await h.fire(watcher.taskId);
+    expect(outcome.kind).toBe("fired");
+    if (outcome.kind === "fired") {
+      expect(outcome.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "baseline_recorded",
+      });
+    }
+    expect(h.notifications.list()).toHaveLength(0);
+    const migrated = h.cache.get(
+      WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
+    ) as WalletBalanceBaseline;
+    expect(migrated.totalUsd).toBe(5000);
+    expect(migrated.walletKey).toBe(
+      "sol:So11111111111111111111111111111111111111112",
+    );
+  });
+
+  it("switching to a different wallet resets the baseline — never a fabricated cross-wallet delta", async () => {
+    const solanaAt = (
+      address: string,
+      usd: number,
+    ): WalletBalancesResponse => ({
+      evm: null,
+      solana: {
+        address,
+        solBalance: "1",
+        solValueUsd: String(usd),
+        tokens: [],
+      },
+    });
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    let sample: () => WalletBalancesResponse = () =>
+      solanaAt("WaLLetAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 100);
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => sample(),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const first = await h.fire(watcher.taskId);
+    expect(first.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+
+    // Owner imports a different wallet. Same leg shape, wildly different
+    // total — comparing wallet B's balance against wallet A's baseline would
+    // fabricate a "+4900%" notification. The fingerprint is wallet-scoped, so
+    // the switch resets the baseline cleanly and silently.
+    sample = () =>
+      solanaAt("WaLLetBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", 5000);
+    h.setNow("2026-07-23T10:31:00.000Z");
+    const switched = await h.fire(watcher.taskId, {
+      allowTerminalRefire: true,
+    });
+    expect(switched.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+    if (switched.kind === "fired") {
+      expect(switched.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "rebaselined_wallet_changed",
+      });
+    }
+    const rebased = h.cache.get(
+      WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
+    ) as WalletBalanceBaseline;
+    expect(rebased.totalUsd).toBe(5000);
+
+    // The reset is a clean first read for wallet B: a genuine material move
+    // on B still notifies against B's OWN baseline.
+    sample = () =>
+      solanaAt("WaLLetBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", 4000);
+    h.setNow("2026-07-23T11:02:00.000Z");
+    const move = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(move.kind).toBe("fired");
+    const inbox = h.notifications.list();
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0]?.title).toBe("Wallet balance down");
+    expect(inbox[0]?.data).toMatchObject({
+      previousTotalUsd: 5000,
+      currentTotalUsd: 4000,
+      deltaUsd: -1000,
+      deltaPct: -20,
     });
   });
 

--- a/packages/agent/src/runtime/wallet-balance-delta.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.ts
@@ -26,9 +26,18 @@
  * seeds "0" and only overwrites on a dex-price hit; wallet-dex-prices.ts
  * swallows provider failures into a partial map), so a dexscreener /
  * geckoterminal outage collapses totals to ~0 while unit balances are
- * unchanged. The sample fingerprint therefore folds in per-position price
- * coverage: a priced↔unpriced flip is a sampling change, not a balance move,
- * and re-baselines silently instead of emitting a "down ~100%" / "up" flap.
+ * unchanged. Price coverage is therefore tracked PER POSITION: a
+ * priced↔unpriced flip on a position both samples hold is a sampling change,
+ * not a balance move, and re-baselines silently instead of emitting a
+ * "down ~100%" / "up" flap. Crucially, that guard is scoped to positions the
+ * baseline knows: a NEW unpriced position (spam airdrop) contributes $0 to
+ * the total, leaves the priced holdings fully comparable, and must never
+ * swallow a concurrent material move by triggering a re-baseline.
+ *
+ * The baseline is scoped to the wallet identity (the sampled addresses).
+ * Importing a different wallet must never cross-compare the old wallet's
+ * total against the new one's — an address change resets the baseline
+ * cleanly, and the first read of the new wallet records its own baseline.
  *
  * Registered from the agent boot path (desktop/cloud only — mobile has no
  * EVM/Solana wallet surface, mirroring the /api/wallet route gate).
@@ -70,14 +79,23 @@ const RETRY_AFTER_MINUTES = 15;
 
 /** Persisted baseline: the last total we notified about (or first observed). */
 export interface WalletBalanceBaseline {
+  /** Identity of the wallet the total was sampled from (sorted address
+   * entries, e.g. `"evm:0xabc|sol:So111…"`). A mismatch means the owner
+   * switched/imported a different wallet: the baseline resets — comparing
+   * totals across wallets would fabricate a delta no wallet ever made. */
+  walletKey: string;
   totalUsd: number;
-  /** Sorted sample fingerprint: the legs the total was computed from (e.g.
-   * `"evm:ethereum"`, `"sol"`) plus one `unpriced:<position>` entry per
-   * position whose units are nonzero but whose USD value is unknown (the
-   * upstream "0"-means-unpriced encoding). A fingerprint change is a
-   * sampling-composition or price-coverage change, not a balance change; the
-   * watcher re-baselines instead of notifying. */
-  sampleFingerprint: string[];
+  /** Sorted samplable legs the total was computed from (e.g. `"evm:ethereum"`,
+   * `"sol"`). A composition change (chain errored/recovered, RPC readiness
+   * flipped, leg added/removed) makes totals incomparable → re-baseline. */
+  sampleLegs: string[];
+  /** Per-position price coverage: position id → whether its USD value was
+   * known (units > 0 positions only). Used to detect priced↔unpriced flips on
+   * positions BOTH samples hold — those collapse/restore the total without
+   * any unit moving, so they re-baseline. Positions present in only one
+   * sample are real balance events (or $0-impact unpriced arrivals) and go
+   * through the normal delta comparison. */
+  positionPricing: Record<string, boolean>;
   observedAtIso: string;
 }
 
@@ -127,51 +145,101 @@ export function sumWalletBalancesUsd(balances: WalletBalancesResponse): number {
 }
 
 /**
- * Sorted fingerprint of what the total was computed FROM: the samplable legs
- * plus one `unpriced:<position>` entry per position holding nonzero units
- * whose USD value is unknown. Upstream encodes "price unknown" as
- * `valueUsd: "0"` with no error, so without the coverage entries a price-feed
- * outage (units unchanged, values collapsed to 0) is indistinguishable from
- * the owner's balance actually going to zero — the dispatcher re-baselines on
- * any fingerprint change instead of notifying. Positions on an errored chain
- * are excluded entirely (the whole leg already is).
+ * Identity of the wallet the sample came from: sorted address entries for
+ * every present leg. EVM addresses are case-insensitive (EIP-55 is display
+ * checksumming), so they compare lowercased; Solana addresses are
+ * case-sensitive base58 and compare verbatim.
  */
-export function walletSampleFingerprint(
-  balances: WalletBalancesResponse,
-): string[] {
+export function walletIdentityKey(balances: WalletBalancesResponse): string {
   const entries: string[] = [];
-  const markUnpriced = (
-    positionId: string,
-    units: string,
-    valueUsd: string,
-  ): void => {
+  if (balances.solana) entries.push(`sol:${balances.solana.address}`);
+  if (balances.evm) {
+    entries.push(`evm:${balances.evm.address.toLowerCase()}`);
+  }
+  return entries.sort().join("|");
+}
+
+function walletKeyAddressByFamily(key: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!key) return out;
+  for (const entry of key.split("|")) {
+    const idx = entry.indexOf(":");
+    if (idx <= 0) continue;
+    out[entry.slice(0, idx)] = entry.slice(idx + 1);
+  }
+  return out;
+}
+
+/**
+ * True when the owner switched to a DIFFERENT wallet: an address for a leg
+ * family (`sol` / `evm`) present in both samples differs. Merely adding or
+ * removing a leg family keeps the retained families' identity and is a
+ * leg-composition change instead (the leg-set comparison catches it).
+ */
+export function walletIdentitySwitched(
+  previousKey: string,
+  currentKey: string,
+): boolean {
+  const previous = walletKeyAddressByFamily(previousKey);
+  const current = walletKeyAddressByFamily(currentKey);
+  for (const [family, address] of Object.entries(current)) {
+    const before = previous[family];
+    if (before !== undefined && before !== address) return true;
+  }
+  return false;
+}
+
+/**
+ * Sorted samplable legs the total was computed from. EVM chains reporting a
+ * per-chain `error` are excluded — their balances are unknown, not zero — so
+ * a leg-set change marks the totals incomparable.
+ */
+export function walletSampleLegs(balances: WalletBalancesResponse): string[] {
+  const legs: string[] = [];
+  if (balances.solana) legs.push("sol");
+  if (balances.evm) {
+    for (const chain of balances.evm.chains) {
+      if (chain.error !== null) continue;
+      legs.push(`evm:${chain.chain}`);
+    }
+  }
+  return legs.sort();
+}
+
+/**
+ * Per-position price coverage for every position holding nonzero units on a
+ * samplable leg: position id → whether its USD value is known. Upstream
+ * encodes "price unknown" as `valueUsd: "0"` with no error, so coverage —
+ * not the value itself — is what distinguishes a price-feed outage from the
+ * owner's balance actually going to zero. Positions on an errored chain are
+ * excluded entirely (the whole leg already is).
+ */
+export function walletPositionPricing(
+  balances: WalletBalancesResponse,
+): Record<string, boolean> {
+  const pricing: Record<string, boolean> = {};
+  const mark = (positionId: string, units: string, valueUsd: string): void => {
     const amount = Number.parseFloat(units);
-    if (Number.isFinite(amount) && amount > 0 && parseUsd(valueUsd) === 0) {
-      entries.push(`unpriced:${positionId}`);
+    if (Number.isFinite(amount) && amount > 0) {
+      pricing[positionId] = parseUsd(valueUsd) !== 0;
     }
   };
   if (balances.solana) {
-    entries.push("sol");
-    markUnpriced(
-      "sol:native",
-      balances.solana.solBalance,
-      balances.solana.solValueUsd,
-    );
+    mark("sol:native", balances.solana.solBalance, balances.solana.solValueUsd);
     for (const token of balances.solana.tokens) {
-      markUnpriced(`sol:token:${token.mint}`, token.balance, token.valueUsd);
+      mark(`sol:token:${token.mint}`, token.balance, token.valueUsd);
     }
   }
   if (balances.evm) {
     for (const chain of balances.evm.chains) {
       if (chain.error !== null) continue;
-      entries.push(`evm:${chain.chain}`);
-      markUnpriced(
+      mark(
         `evm:${chain.chain}:native`,
         chain.nativeBalance,
         chain.nativeValueUsd,
       );
       for (const token of chain.tokens) {
-        markUnpriced(
+        mark(
           `evm:${chain.chain}:token:${token.contractAddress.toLowerCase()}`,
           token.balance,
           token.valueUsd,
@@ -179,7 +247,27 @@ export function walletSampleFingerprint(
       }
     }
   }
-  return entries.sort();
+  return pricing;
+}
+
+/**
+ * Positions held by BOTH samples whose priced↔unpriced status flipped. Only
+ * these make the totals incomparable: a flipped position's value collapse or
+ * restoration is baked into the current total without any unit moving.
+ * Positions unique to one side (received, sold out, spam airdrop) are real
+ * balance events — or $0-impact unpriced arrivals — and never justify
+ * discarding the comparison.
+ */
+export function pricedCoverageFlips(
+  previous: Record<string, boolean>,
+  current: Record<string, boolean>,
+): string[] {
+  const flips: string[] = [];
+  for (const [positionId, priced] of Object.entries(current)) {
+    const before = previous[positionId];
+    if (before !== undefined && before !== priced) flips.push(positionId);
+  }
+  return flips.sort();
 }
 
 /**
@@ -246,13 +334,24 @@ function getNotifier(runtime: AgentRuntime): NotifierLike | null {
   return null;
 }
 
+/**
+ * Strict shape check doubles as schema migration: rows written by the
+ * pre-wallet-scoped format (no `walletKey`/`positionPricing`) fail it and are
+ * treated as no-baseline — one designed silent re-baseline on upgrade, never
+ * a comparison against a row whose wallet identity is unknown.
+ */
 function isBaseline(value: unknown): value is WalletBalanceBaseline {
   return (
     isRecord(value) &&
+    typeof value.walletKey === "string" &&
     typeof value.totalUsd === "number" &&
     Number.isFinite(value.totalUsd) &&
-    Array.isArray(value.sampleFingerprint) &&
-    value.sampleFingerprint.every((entry) => typeof entry === "string") &&
+    Array.isArray(value.sampleLegs) &&
+    value.sampleLegs.every((entry) => typeof entry === "string") &&
+    isRecord(value.positionPricing) &&
+    Object.values(value.positionPricing).every(
+      (priced) => typeof priced === "boolean",
+    ) &&
     typeof value.observedAtIso === "string"
   );
 }
@@ -328,7 +427,9 @@ export function createWalletBalanceDeltaDispatcher(
     }
 
     const totalUsd = sumWalletBalancesUsd(balances);
-    const sampleFingerprint = walletSampleFingerprint(balances);
+    const walletKey = walletIdentityKey(balances);
+    const sampleLegs = walletSampleLegs(balances);
+    const positionPricing = walletPositionPricing(balances);
     const nowIso = new Date().toISOString();
     const stored = await runtime.getCache<WalletBalanceBaseline>(
       WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
@@ -337,8 +438,10 @@ export function createWalletBalanceDeltaDispatcher(
 
     const persistBaseline = async (): Promise<void> => {
       const next: WalletBalanceBaseline = {
+        walletKey,
         totalUsd,
-        sampleFingerprint,
+        sampleLegs,
+        positionPricing,
         observedAtIso: nowIso,
       };
       await runtime.setCache(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, next);
@@ -349,33 +452,69 @@ export function createWalletBalanceDeltaDispatcher(
       return { ok: true, target: "baseline_recorded" };
     }
 
-    if (baseline.sampleFingerprint.join("|") !== sampleFingerprint.join("|")) {
-      // WHAT we can sample changed, not what the owner holds: either the leg
-      // composition moved (chain errored / recovered, RPC readiness flipped,
-      // address added/removed) or price coverage flipped (a position's USD
-      // value became unknown or recovered — the price-feed-outage flap). Both
-      // re-baseline silently; notifying would fabricate a delta the units
-      // never made.
-      const legsOf = (fp: string[]): string =>
-        fp.filter((entry) => !entry.startsWith("unpriced:")).join("|");
-      const target =
-        legsOf(baseline.sampleFingerprint) !== legsOf(sampleFingerprint)
-          ? "rebaselined_leg_change"
-          : "rebaselined_price_coverage_change";
+    if (walletIdentitySwitched(baseline.walletKey, walletKey)) {
+      // A different wallet is being sampled (imported/switched). Its balance
+      // shares nothing with the old baseline — comparing would fabricate a
+      // delta no wallet ever made. Reset cleanly: this read is the new
+      // wallet's first observation.
+      await persistBaseline();
+      logger.info(
+        {
+          src: "wallet-balance-delta",
+          agentId: runtime.agentId,
+          taskId: record.taskId,
+          previousWalletKey: baseline.walletKey,
+          currentWalletKey: walletKey,
+        },
+        "[WalletBalanceDelta] wallet identity changed — baseline reset",
+      );
+      return { ok: true, target: "rebaselined_wallet_changed" };
+    }
+
+    const rebaseline = async (
+      target: "rebaselined_leg_change" | "rebaselined_price_coverage_change",
+      changed: Record<string, unknown>,
+    ): Promise<DispatchResult> => {
+      // WHAT we can sample changed, not what the owner holds — notifying
+      // would fabricate a delta the units never made.
       await persistBaseline();
       logger.debug(
         {
           src: "wallet-balance-delta",
           agentId: runtime.agentId,
           taskId: record.taskId,
-          previousFingerprint: baseline.sampleFingerprint,
-          currentFingerprint: sampleFingerprint,
           previousTotalUsd: baseline.totalUsd,
           currentTotalUsd: totalUsd,
+          ...changed,
         },
         `[WalletBalanceDelta] sample composition changed — ${target}`,
       );
       return { ok: true, target };
+    };
+
+    if (baseline.sampleLegs.join("|") !== sampleLegs.join("|")) {
+      // Leg composition moved: chain errored/recovered, RPC readiness
+      // flipped, a leg was added/removed.
+      return rebaseline("rebaselined_leg_change", {
+        previousLegs: baseline.sampleLegs,
+        currentLegs: sampleLegs,
+      });
+    }
+
+    const coverageFlips = pricedCoverageFlips(
+      baseline.positionPricing,
+      positionPricing,
+    );
+    if (coverageFlips.length > 0) {
+      // A known position's USD value became unknown or recovered (the
+      // price-feed-outage flap): its collapse/restoration is baked into the
+      // total without any unit moving. Note this fires ONLY on positions both
+      // samples hold — a brand-new unpriced position (spam airdrop) adds $0
+      // and falls through to the normal comparison below, so it can never
+      // swallow a concurrent material move in priced holdings.
+      return rebaseline("rebaselined_price_coverage_change", {
+        coverageFlips,
+      });
     }
 
     const thresholds = resolveThresholds(record.metadata);
@@ -385,6 +524,28 @@ export function createWalletBalanceDeltaDispatcher(
       thresholds,
     });
     if (!material) {
+      // The anchor total stays put (slow drift must accumulate to material),
+      // but the coverage map absorbs positions that appeared/disappeared
+      // since the baseline: a spam token that arrives unpriced and is later
+      // listed by a price feed (fake-liquidity pump) then reads as a coverage
+      // flip on a known position — a silent re-baseline, not a "+4000%" flap.
+      const pricingChanged =
+        JSON.stringify(
+          Object.entries(baseline.positionPricing).sort(([a], [b]) =>
+            a.localeCompare(b),
+          ),
+        ) !==
+        JSON.stringify(
+          Object.entries(positionPricing).sort(([a], [b]) =>
+            a.localeCompare(b),
+          ),
+        );
+      if (pricingChanged) {
+        await runtime.setCache(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, {
+          ...baseline,
+          positionPricing,
+        } satisfies WalletBalanceBaseline);
+      }
       return { ok: true, target: "below_threshold" };
     }
 


### PR DESCRIPTION
Remediates two CONFIRMED P1 findings from the post-merge adversarial review of #16956 (wallet balance-delta producer, issue #16943), plus the review's evidence-gap note (PR tallies/logs captured on a pre-final revision).

## What + why

**Finding 1 (P1) — a new unpriced position silently swallowed concurrent material deltas.**
The producer folded price coverage into a single opaque `sampleFingerprint` list (`"unpriced:<position>"` entries). ANY new unpriced position — e.g. a spam airdrop token — changed the fingerprint, hit the re-baseline path, and permanently swallowed a concurrent material move: baseline `{SOL:10}` → next poll `{SOL:2, SPAMCOIN:99999 unpriced}` re-baselined and the $100→$20 drop never notified.
*Fix:* price coverage is now tracked **per position** (`positionPricing: Record<positionId, priced>`). Only a priced↔unpriced **flip on a position both samples hold** (the price-feed-outage flap the guard exists for) re-baselines. Positions unique to one side contribute $0 when unpriced and fall through to the normal delta comparison — no re-baseline path can swallow a delta on priced holdings. A below-threshold tick still absorbs new positions into the coverage map, so a spam token later listed by a price feed (fake-liquidity pump) reads as a coverage flip, not a "+4000%" notification.

**Finding 2 (P1) — baseline carried no wallet identity; importing a different wallet fabricated a cross-wallet delta.**
The baseline stored only `totalUsd` + fingerprint. Switching from wallet A ($100) to imported wallet B ($5000) with the same leg shape cross-compared the two and pushed a fabricated "Wallet balance up ~4900%" notification.
*Fix:* the baseline now records `walletKey` (sorted per-family address entries; EVM lowercased since EIP-55 is display checksumming, Solana verbatim). An address change on a retained family (`walletIdentitySwitched`) resets the baseline cleanly and silently (`rebaselined_wallet_changed`); the first read of the new wallet records its own baseline, and genuine moves on the new wallet still notify against that wallet's own baseline. Adding/dropping a leg family is still a leg-composition change, not a switch.

**Migration:** legacy baseline rows (pre-`walletKey` schema) fail the strict shape check and are discarded — one designed silent re-baseline on upgrade, never a comparison against a row whose wallet identity is unknown.

Regression tests for BOTH failure scenarios were verified to reproduce against the develop producer before the fix (see evidence), and the full producer suite (12 tests, real `ScheduledTaskRunnerService` + real `NotificationService`, no mocks of the thing under test) passes on the final revision.

## Reproduction on develop (pre-fix), same driver + real runner/inbox

Finding 1 — the material drop is swallowed:

```
=== fire 2 (FINDING 1): SOL 10->2 drop + NEW unpriced SPAMCOIN — must notify ===
dispatch: {"ok":true,"target":"rebaselined_price_coverage_change"}
baseline: {"totalUsd":20,"sampleFingerprint":["sol","unpriced:sol:token:spamcoin"],...}
inbox size: 0        <-- $100 -> $20 drop never notified
```

Finding 2 — the fabricated cross-wallet notification:

```
[WALLET-BALANCE-DELTA] [WalletBalanceDelta] material balance delta notified (taskId=st_mrxg2cm7_vitkvvy0, previousTotalUsd=100, currentTotalUsd=5000, deltaUsd=4900, deltaPct=4900)
=== fire 2 (FINDING 2): switch A -> B, $100 baseline vs $5000 — must reset silently ===
dispatch: {"ok":true,"messageId":"wallet-balance-delta:...","target":"delta:4900.00"}
inbox size: 1
    "title": "Wallet balance up",
    "body": "Your total balance moved up about 4900% since the last check. ..."
```

## Evidence (final revision)

| Row | Evidence |
| --- | --- |
| Real-LLM trajectories | N/A - no agent/action/provider/prompt/model behavior changes; the producer is a deterministic ScheduledTask dispatcher (pure materiality math + structured notification), no LLM in the path. |
| Backend logs | Structured `[WalletBalanceDelta]` logs from the final revision, below. |
| Frontend logs | N/A - backend-only change in `packages/agent`; no UI surface touched. |
| Screenshots (desktop + mobile) | N/A - no rendered UI change; notification widget rendering is unchanged from #16956. |
| Video walkthrough | N/A - no user-exercisable UI flow changed; end-to-end behavior is proven by the real-runner driver + inbox payloads below. |
| Per-platform capture | N/A - producer registers on the desktop/cloud boot path only; no native/mobile code touched. |
| Audio | N/A - no voice/TTS/STT involvement. |
| Domain artifacts | ScheduledTask watcher row, baseline cache rows, and notification inbox payloads from the final revision, below — reviewed by hand. |

### Backend logs (final revision, real `ScheduledTaskRunnerService` + real `NotificationService`)

<details><summary>Finding 1 fixed — spam airdrop + concurrent drop notifies</summary>

```
=== fire 1: first observation of wallet A (10 SOL, $100) — baseline ===
dispatch: {"ok":true,"target":"baseline_recorded"}
baseline: {"walletKey":"sol:WaLLetAAAA...","totalUsd":100,"sampleLegs":["sol"],"positionPricing":{"sol:native":true},"observedAtIso":"2026-07-23T11:45:09.687Z"}
inbox size: 0

[WALLET-BALANCE-DELTA] [WalletBalanceDelta] material balance delta notified (taskId=st_mrxg2jp0_703izrp1, previousTotalUsd=100, currentTotalUsd=20, deltaUsd=-80, deltaPct=-80)
=== fire 2 (FINDING 1): SOL 10->2 drop + NEW unpriced SPAMCOIN — must notify ===
dispatch: {"ok":true,"messageId":"wallet-balance-delta:st_mrxg2jp0_703izrp1:2026-07-23T10:31:00.000Z","target":"delta:-80.00"}
baseline: {"walletKey":"sol:WaLLetAAAA...","totalUsd":20,"sampleLegs":["sol"],"positionPricing":{"sol:native":true,"sol:token:spamcoin":false},...}
inbox size: 1
```

</details>

<details><summary>Finding 2 fixed — wallet switch resets silently; new wallet's own moves still notify</summary>

```
[WALLET-BALANCE-DELTA] [WalletBalanceDelta] wallet identity changed — baseline reset (taskId=st_mrxg2jp0_703izrp1, previousWalletKey=sol:WaLLetAAAA..., currentWalletKey=sol:WaLLetBBBB...)
=== fire 3 (FINDING 2): wallet switch A -> B ($20 baseline vs $5000) — must reset, never notify ===
dispatch: {"ok":true,"target":"rebaselined_wallet_changed"}
baseline: {"walletKey":"sol:WaLLetBBBB...","totalUsd":5000,"sampleLegs":["sol"],"positionPricing":{"sol:native":true},...}
inbox size: 1        <-- unchanged: only Finding 1's legit notification

[WALLET-BALANCE-DELTA] [WalletBalanceDelta] material balance delta notified (taskId=st_mrxg2jp0_703izrp1, previousTotalUsd=5000, currentTotalUsd=4000, deltaUsd=-1000, deltaPct=-20)
=== fire 4: wallet B $5000 -> $4000 (-20%) — legit notification for B ===
dispatch: {"ok":true,"messageId":"wallet-balance-delta:st_mrxg2jp0_703izrp1:2026-07-23T11:33:00.000Z","target":"delta:-1000.00"}
```

</details>

### Domain artifacts (final revision)

<details><summary>ScheduledTask watcher row (real runner)</summary>

```json
{
  "taskId": "st_mrxg2jp0_703izrp1",
  "kind": "watcher",
  "promptInstructions": "Check whether the owner's total wallet balance moved materially since the last recorded baseline and notify them when it did.",
  "trigger": { "kind": "interval", "everyMinutes": 30 },
  "priority": "low",
  "escalation": { "steps": [ { "delayMinutes": 0, "channelKey": "wallet_balance_delta" } ] },
  "respectsGlobalPause": true,
  "source": "plugin",
  "idempotencyKey": "wallet:balance-delta-watcher:v1",
  "metadata": { "walletBalanceDelta": { "minDeltaUsd": 10, "thresholdPct": 10 } },
  "executionProfile": "bg-light-30s",
  "state": { "status": "scheduled", "followupCount": 0 }
}
```

</details>

<details><summary>Notification inbox payload — Finding 1's previously-swallowed drop, now delivered</summary>

```json
{
  "id": "73bf900b-59b1-4c60-803d-83e9d3a80824",
  "title": "Wallet balance down",
  "body": "Your total balance moved down about 80.0% since the last check. Open the wallet for details.",
  "source": "wallet",
  "deepLink": "/wallet",
  "groupKey": "wallet:balance-delta",
  "data": { "previousTotalUsd": 100, "currentTotalUsd": 20, "deltaUsd": -80, "deltaPct": -80, "observedAtIso": "2026-07-23T11:45:09.688Z" }
}
```

</details>

<details><summary>Final inbox — one coalesced groupKey row (supersede count 2), no fabricated cross-wallet row</summary>

```json
{
  "id": "7d2bb6bc-1ebf-483f-9976-c5779aef0da3",
  "title": "Wallet balance down",
  "body": "Your total balance moved down about 20.0% since the last check. Open the wallet for details.",
  "groupKey": "wallet:balance-delta",
  "data": { "previousTotalUsd": 5000, "currentTotalUsd": 4000, "deltaUsd": -1000, "deltaPct": -20, "observedAtIso": "2026-07-23T11:45:09.692Z", "count": 2 }
}
```

</details>

### Test run (final revision)

```
bunx vitest run src/runtime/wallet-balance-delta.test.ts   (packages/agent)
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

New/updated tests: the two P1 regression scenarios (spam-airdrop + concurrent drop; wallet switch reset + clean first read), the below-threshold coverage-absorption path (spam later listed → flip, not pump notification), the legacy-baseline migration path, wallet-identity unit coverage, and the pre-existing outage-flap/leg-change/coalescing/no-wallet suite migrated to the new baseline schema. `tsc --noEmit` and `biome check` clean on touched files.

Remediates the post-merge review findings on #16956; original issue #16943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change in packages/agent; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change in packages/agent; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-exercisable UI flow; behavior proven by the real-runner driver + inbox payloads in the backend-logs and domain-artifacts rows

<!-- evidence-row:backend-logs -->
- [x] [17039-backend-logs-17039.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17039-backend-logs-17039.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered surface; backend-only producer change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changes; the producer is a deterministic ScheduledTask dispatcher with no LLM in the path

<!-- evidence-row:domain-artifacts -->
- [x] [17039-domain-artifacts-17039.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17039-domain-artifacts-17039.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI change to read text from

