### PR TITLE
fix(ci): admit latest deploy-eligible staging run

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -147,6 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
+      actions: read
       contents: read
     outputs:
       should_deploy: ${{ steps.admission.outputs.should_deploy }}
@@ -163,14 +164,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          current_sha=""
+          latest_eligible_run_id=""
           if [ "$EVENT_NAME" != "pull_request" ] \
             && [ "$TARGET_ENVIRONMENT" != "production" ] \
             && [ "$GITHUB_REF" != "refs/heads/main" ] \
             && [ "$FORCE" != "true" ]; then
-            current_sha="$(
-              gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/develop" \
-                --jq '.object.sha'
+            latest_eligible_run_id="$(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/cloud-cf-deploy.yml/runs?branch=develop&event=push&per_page=1" \
+                --jq '.workflow_runs[0].id'
             )"
           fi
 
@@ -179,11 +181,12 @@ jobs:
             "--environment=$TARGET_ENVIRONMENT" \
             "--ref=$GITHUB_REF" \
             "--force=$FORCE" \
-            "--run-sha=$GITHUB_SHA" \
-            "--current-develop-sha=$current_sha"
+            "--run-id=$GITHUB_RUN_ID" \
+            "--latest-eligible-run-id=$latest_eligible_run_id"
 
-          if [ "$GITHUB_SHA" != "$current_sha" ] && [ -n "$current_sha" ]; then
-            echo "Superseded staging release: run=$GITHUB_SHA current=$current_sha" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$GITHUB_RUN_ID" != "$latest_eligible_run_id" ] \
+            && [ -n "$latest_eligible_run_id" ]; then
+            echo "Superseded staging release: run=$GITHUB_RUN_ID latest=$latest_eligible_run_id" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # ---------------------------------------------------------------------------

--- a/packages/scripts/cloud/release-admission-cli.mjs
+++ b/packages/scripts/cloud/release-admission-cli.mjs
@@ -25,8 +25,8 @@ const result = decideReleaseAdmission({
   targetEnvironment: args.environment,
   ref: args.ref,
   force: args.force === "true",
-  runSha: args["run-sha"],
-  currentDevelopSha: args["current-develop-sha"],
+  runId: args["run-id"],
+  latestEligibleRunId: args["latest-eligible-run-id"],
 });
 
 // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions provides this step-output path.

--- a/packages/scripts/cloud/release-admission.mjs
+++ b/packages/scripts/cloud/release-admission.mjs
@@ -2,7 +2,7 @@
  * Decides whether a cloud release may consume build or mutation capacity.
  *
  * Production, previews, and forced rollbacks are always admitted. Automatic
- * staging releases are latest-wins: only the current develop SHA proceeds.
+ * staging releases are latest-wins among runs eligible for this workflow.
  */
 
 export function decideReleaseAdmission({
@@ -10,8 +10,8 @@ export function decideReleaseAdmission({
   targetEnvironment,
   ref,
   force,
-  runSha,
-  currentDevelopSha,
+  runId,
+  latestEligibleRunId,
 }) {
   if (
     eventName === "pull_request" ||
@@ -22,15 +22,15 @@ export function decideReleaseAdmission({
     return { shouldDeploy: true, reason: "non-supersedable-release" };
   }
 
-  if (!runSha || !currentDevelopSha) {
+  if (!runId || !latestEligibleRunId) {
     throw new Error(
-      "Automatic staging admission requires both runSha and currentDevelopSha",
+      "Automatic staging admission requires both runId and latestEligibleRunId",
     );
   }
 
-  if (runSha !== currentDevelopSha) {
-    return { shouldDeploy: false, reason: "superseded-staging-sha" };
+  if (String(runId) !== String(latestEligibleRunId)) {
+    return { shouldDeploy: false, reason: "superseded-staging-run" };
   }
 
-  return { shouldDeploy: true, reason: "current-staging-sha" };
+  return { shouldDeploy: true, reason: "latest-eligible-staging-run" };
 }

--- a/packages/scripts/cloud/release-admission.test.mjs
+++ b/packages/scripts/cloud/release-admission.test.mjs
@@ -11,24 +11,22 @@ const staging = {
   targetEnvironment: "",
   ref: "refs/heads/develop",
   force: false,
-  runSha: "current",
-  currentDevelopSha: "current",
+  runId: "200",
+  latestEligibleRunId: "200",
 };
 
 describe("decideReleaseAdmission", () => {
-  it("admits the current automatic staging SHA", () => {
+  it("admits the latest deploy-eligible staging run", () => {
     expect(decideReleaseAdmission(staging)).toEqual({
       shouldDeploy: true,
-      reason: "current-staging-sha",
+      reason: "latest-eligible-staging-run",
     });
   });
 
-  it("rejects a superseded automatic staging SHA", () => {
-    expect(
-      decideReleaseAdmission({ ...staging, runSha: "superseded" }),
-    ).toEqual({
+  it("rejects a superseded automatic staging run", () => {
+    expect(decideReleaseAdmission({ ...staging, runId: "199" })).toEqual({
       shouldDeploy: false,
-      reason: "superseded-staging-sha",
+      reason: "superseded-staging-run",
     });
   });
 
@@ -55,8 +53,8 @@ describe("decideReleaseAdmission", () => {
     expect(
       decideReleaseAdmission({
         ...input,
-        runSha: "older",
-        currentDevelopSha: "newer",
+        runId: "199",
+        latestEligibleRunId: "200",
       }),
     ).toEqual({
       shouldDeploy: true,
@@ -64,12 +62,12 @@ describe("decideReleaseAdmission", () => {
     });
   });
 
-  it("fails closed when automatic staging SHAs cannot be resolved", () => {
+  it("fails closed when automatic staging run IDs cannot be resolved", () => {
     expect(() =>
       decideReleaseAdmission({
         ...staging,
-        currentDevelopSha: "",
+        latestEligibleRunId: "",
       }),
-    ).toThrow("requires both runSha and currentDevelopSha");
+    ).toThrow("requires both runId and latestEligibleRunId");
   });
 });


### PR DESCRIPTION
# Relates to

Follow-up to #17040 found during its live post-merge deployment verification.

# Background

The initial latest-wins admission compared a run SHA with the raw `develop` head. A later commit outside Cloud CF Deploy's path filters advances the branch without creating a replacement deploy run, incorrectly rejecting the newest deploy-eligible release.

This patch compares `GITHUB_RUN_ID` with the newest `develop` push run of this workflow. Path-ineligible commits therefore do not suppress the latest valid deployment, while an actual newer Cloud CF Deploy run supersedes older runs. The admission job receives explicit `actions: read` permission.

# Risks

Low. The change narrows admission identity to the workflow's actual trigger domain. Production, PR previews, and forced rollbacks remain always-admitted.

# Testing

- `bun test packages/scripts/cloud/release-admission.test.mjs` — 6 passed, 100% policy coverage
- `bunx @biomejs/biome check packages/scripts/cloud/release-admission*.mjs`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Live #17040 post-merge run showed a deploy-eligible run followed by path-ineligible develop commits; this directly reproduced the edge condition.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] GitHub Actions run IDs are the domain artifact and admission key.

# Evidence Details

N/A for UI, audio, and LLM evidence because this changes only GitHub Actions admission policy.

## Known gaps / failures

None.