### PR TITLE
fix(ci): skip deploy source runner on automatic events

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -101,6 +101,10 @@ permissions:
 jobs:
   validate-deploy-source:
     name: Validate Canonical Deploy Source
+    # Push and pull-request refs are constrained by the trigger itself. Only a
+    # manual dispatch can select an invalid ref, so automatic releases should
+    # not wait for a hosted runner merely to execute an unconditional exit 0.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -128,7 +132,7 @@ jobs:
   authorize-staging:
     name: Authorize staging release
     needs: validate-deploy-source
-    if: ${{ github.event_name != 'pull_request' && !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     # This environment contains only deployment policy. Runtime secrets remain
@@ -143,7 +147,7 @@ jobs:
   admit-release:
     name: Admit current release
     needs: [validate-deploy-source, authorize-staging]
-    if: ${{ always() && needs.validate-deploy-source.result == 'success' && (needs.authorize-staging.result == 'success' || needs.authorize-staging.result == 'skipped') }}
+    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && (needs.authorize-staging.result == 'success' || needs.authorize-staging.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:


### PR DESCRIPTION
# Relates to

Follow-up to #17040 and #17045 from live staging cutover verification.

# Background

`validate-deploy-source` checks whether a manual dispatch selected the canonical branch. Push and pull-request refs are already constrained by workflow triggers, but they still queued a hosted runner just to exit 0. During the current hosted-runner backlog this prevented automatic releases from even reaching the independent approval gate.

This patch runs source validation only for `workflow_dispatch`. Downstream jobs explicitly accept a skipped validator for automatic events while still failing closed when a manual dispatch validator fails.

# Risks

Low. Trigger-constrained push/PR events skip a redundant check. Manual staging and production dispatches retain the existing validation.

# Testing

- `actionlint -config-file .github/actionlint.yaml .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change; no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change; no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Live run 30006132246 remained queued at the redundant validator during hosted-runner saturation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] GitHub Actions job state is the affected domain artifact.

# Evidence Details

N/A for UI, audio, frontend, and LLM evidence because this changes only workflow scheduling.

## Known gaps / failures

None.