### PR TITLE
fix: post-merge P2/evidence remediation batch (#16948 #16958 #16963 #16970 #16951)

### DIFF
--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -475,8 +475,12 @@ jobs:
             plugins/plugin-local-inference/src/services/voice/asr-timed.real.test.ts \
             plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-engine-bridge.real.test.ts \
             2>&1 | tee "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log"
-          if grep -Eq "(^| )0 pass|12 skip" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log"; then
-            echo "::error title=Fused FFI lanes skipped::the real FFI suites did not execute — staging or bun:ffi is broken"
+          # Per-cell accounting: ANY nonzero skip count means some matrix cell
+          # did not execute against the staged lib — a partial skip is as much
+          # a green-skip lie as a full-lane skip, so it fails the same way.
+          if grep -Eq "(^| )0 pass" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log" \
+            || grep -Eq "(^| )[1-9][0-9]* skip" "$VOICE_REAL_MATRIX_OUT/fused-real-bun-test.log"; then
+            echo "::error title=Fused FFI lanes skipped::one or more real FFI suite cells did not execute — staging or bun:ffi is broken"
             exit 1
           fi
 

--- a/packages/app/docs/DEVICE_LIFECYCLE_MATRIX.md
+++ b/packages/app/docs/DEVICE_LIFECYCLE_MATRIX.md
@@ -30,7 +30,10 @@ Prereqs match the rest of the Android lane (`test/android/README.md`): a
 WebView-debuggable APK installed, and for `ELIZA_ANDROID_BACKEND=local`
 (default) a working on-device agent (emulators additionally need
 root + SELinux-permissive, `ensureEmulatorPermissive`). Artifacts land in
-`.github/issue-evidence/12185-device-lifecycle/{android,ios}/`.
+`test-results/android-artifacts/12185-device-lifecycle/android/` (repo root;
+override with `ELIZA_ANDROID_ARTIFACT_DIR`) and
+`packages/app/capture-output/ios-lifecycle/` (`--out-dir`) — both gitignored;
+attach them inline on the issue/PR.
 
 ## Standard assertions (Android, after every event)
 

--- a/packages/app/docs/device-boot-startup.md
+++ b/packages/app/docs/device-boot-startup.md
@@ -203,7 +203,7 @@ bun run --cwd packages/app trace:startup --out /tmp/startup-trace.json
 
 # Full boot to a usable agent (needs a reachable backend):
 bun run --cwd packages/app trace:startup --wait-ready --runs 2 \
-  --out .github/issue-evidence/9565-startup-trace.json
+  --out test-results/evidence/9565-startup-trace.json
 ```
 
 `--runs 2` captures cold + warm. The harness
@@ -217,17 +217,17 @@ trace those paths.
 
 | Path | Capturable here | Notes |
 |---|---|---|
-| Web / PWA (remote) | ✅ harness | repeatable in CI behind a dev server; M4 Max Vite-dev baseline captured in `.github/issue-evidence/9565-startup-readiness/desktop-web-renderer-trace-m4max.json` |
+| Web / PWA (remote) | ✅ harness | repeatable in CI behind a dev server; M4 Max Vite-dev baseline captured for #9565 (summarized below) |
 | Desktop Electrobun renderer | ✅ harness (`--url`) | same renderer trace inside the WebView; use `--url` against the Electrobun renderer |
 | Android / iOS local | device-only | renderer trace identical; needs a real device/sim + the `--url` device tunnel |
 | iOS cloud | device-only | remote target; stops at `coordinator:ready` with no local boot |
 
-### Checked-in baseline: M4 Max desktop web renderer
+### Baseline: M4 Max desktop web renderer
 
-Evidence lives in
-`.github/issue-evidence/9565-startup-readiness/desktop-web-renderer-trace-m4max.json`
-with a short index at
-`.github/issue-evidence/9565-startup-readiness/README.md`.
+The raw trace JSON (`desktop-web-renderer-trace-m4max.json`) was captured for
+issue #9565; the committed `.github/issue-evidence/` bundle is retired
+(evidence now attaches inline on the issue/PR), so the numbers that matter are
+summarized in the table below.
 
 Captured on 2026-06-24 local / 2026-06-25 UTC from `bun run --cwd packages/app
 trace:startup -- --runs 2` against Vite dev on `http://localhost:2138`.

--- a/packages/app/e2e/accounts-ui/README.md
+++ b/packages/app/e2e/accounts-ui/README.md
@@ -33,8 +33,9 @@ server binds 34110 (scans up through 34139; override with
 
 Screenshots, frontend console/network logs, backend server logs, and the
 assertion transcript land in
-`.github/issue-evidence/10722-accounts-ui-e2e/`. Exit code is non-zero on any
-failed assertion or page error.
+`test-results/evidence/10722-accounts-ui-e2e/` (repo root, gitignored — attach
+the artifacts inline on the PR). Exit code is non-zero on any failed assertion
+or page error.
 
 ## Covered scenarios
 

--- a/packages/benchmarks/mobile-resource/BASELINE.md
+++ b/packages/benchmarks/mobile-resource/BASELINE.md
@@ -19,7 +19,7 @@ fabricated number (AGENTS.md §3/§7).
    files before promoting anything:
    ```bash
    node packages/benchmarks/mobile-resource/lab-artifacts.mjs \
-     --input=.github/issue-evidence/12072-lab \
+     --input=test-results/evidence/12072-lab \
      --out=packages/benchmarks/mobile-resource/results/lab \
      --fail-on-gaps
    ```

--- a/packages/benchmarks/mobile-resource/README.md
+++ b/packages/benchmarks/mobile-resource/README.md
@@ -45,7 +45,7 @@ node packages/benchmarks/mobile-resource/report.mjs
 
 # Normalize physical lab artifacts (power meter + physical iOS captures):
 node packages/benchmarks/mobile-resource/lab-artifacts.mjs \
-  --input=.github/issue-evidence/12072-lab \
+  --input=test-results/evidence/12072-lab \
   --out=packages/benchmarks/mobile-resource/results/lab \
   --fail-on-gaps
 ```

--- a/packages/benchmarks/orchestrator/README.md
+++ b/packages/benchmarks/orchestrator/README.md
@@ -704,12 +704,14 @@ latest artifact set.
 credentials that unlock benchmarks where sample/demo fallbacks are forbidden.
 
 After the latest matrix is generated and manually spot-reviewed, package the
-reviewed result set into the committed evidence location:
+reviewed result set into a local evidence bundle (gitignored; attach the
+contents inline on the issue/PR — the committed `.github/issue-evidence/`
+location is retired):
 
 ```bash
 python3 -m benchmarks.orchestrator review-package \
   --latest-dir packages/benchmarks/benchmark_results/latest \
-  --out-dir .github/issue-evidence/10199-benchmark-review \
+  --out-dir test-results/evidence/10199-benchmark-review \
   --reviewed-by <handle> \
   --reviewer-note "Opened the selected trajectories/replays and spot-reviewed model inputs, outputs, scores, and failure diagnostics."
 ```

--- a/packages/scenario-runner/docs/coding-capability-audit/MASTER_PLAN.md
+++ b/packages/scenario-runner/docs/coding-capability-audit/MASTER_PLAN.md
@@ -2,6 +2,13 @@ I'll synthesize the 12 domain audits into a master document. Let me produce the 
 
 # elizaOS Code-Writing & Agent-Orchestration Capability — Master Audit & Gap Backlog
 
+> **Evidence-location note:** this audit snapshot predates the retirement of the
+> committed `.github/issue-evidence/` directory. Wherever a work item below says
+> to land or commit artifacts under `.github/issue-evidence/…`, read that as:
+> stage locally under `test-results/evidence/…` (gitignored) and attach the
+> artifacts inline on the issue/PR per the repo-root `AGENTS.md` evidence
+> standard.
+
 **Scope:** Direct code-writing tools, sub-agent (ACP) orchestration, Smithers workflow engines, multi-account quota/switching, orchestrator/task UI, scenario-runner harness, E2E recording, dynamic reload/rollback, platform coverage, model backends, user/connector surfacing, and concurrency. Synthesized from 12 domain audits.
 
 **Verdict in one line:** The *code* is broad and largely mature (especially `plugins/plugin-agent-orchestrator`), but the *proof* is thin — almost no committed real-LLM trajectories, screenshots, video, or timelines tie the headline capabilities (live coding loop, sub-agent spawn→route, multi-account switch, 10-project concurrency) to evidence, and several flagship live harnesses are broken or stale.

--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -20,8 +20,10 @@ catalog with `SCENARIO_USE_LLM_PROXY=1` and
   broadcast ledger, including the #14910 twin-default seeding.
 - `deterministic-document-actions` covers the real core `DOCUMENT` handler and
   DocumentService DB state: list, an owner-only mutation-wall refusal for a
-  USER-granted non-owner, the owner delete (document actually gone), and the
-  not-found / missing-id rejections.
+  whitelisted connector-admin (ADMIN) non-owner — the resolved tier is pinned
+  via the real roles resolution so the fixture cannot silently degrade to
+  GUEST — the owner delete (document actually gone), and the not-found /
+  missing-id rejections.
 - `deterministic-generated-app-routes` covers a generated app loaded through the
   real AppRegistryService and app-manager routes: registry persistence,
   catalog tile data, generated hero SVG, `/api/apps/:slug/*` package routing,

--- a/packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts
@@ -15,8 +15,12 @@
  * roles.ts resolution against the strongest non-owner tier it admits,
  * nothing mocked.
  */
-import type { IAgentRuntime, UUID } from "@elizaos/core";
-import { setConnectorAdminWhitelist, stringToUuid } from "@elizaos/core";
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  checkSenderRole,
+  setConnectorAdminWhitelist,
+  stringToUuid,
+} from "@elizaos/core";
 import type {
   CapturedAction,
   ScenarioContext,
@@ -67,6 +71,30 @@ const ownerDeleteParams: JsonRecord = { action: "delete" };
 // resolves as connector-admin (ADMIN). Entity metadata survives message
 // processing (merged per source key); world-metadata role grants do not.
 const GUEST_STABLE_ID = `${SCENARIO_ID}-guest-admin`;
+
+// Pins the tier the whitelist fixture actually resolves to (#16963). If the
+// connector stamp or whitelist silently stops applying, the guest degrades to
+// GUEST and the mutation-wall refusal would still pass — for the wrong reason
+// (any non-owner is refused). This probe runs the real roles.ts resolution the
+// DOCUMENT handler uses, so a degraded fixture is a hard failure instead.
+async function expectGuestResolvesAdmin(
+  runtime: ScenarioRuntime,
+): Promise<string | undefined> {
+  const probe = {
+    entityId: stringToUuid(`scenario-account:${SCENARIO_ID}:guest`) as UUID,
+    roomId: stringToUuid(`scenario-room:${SCENARIO_ID}:guest`) as UUID,
+    agentId: runtime.agentId,
+    content: { text: "" },
+  } as Memory;
+  const check = await checkSenderRole(runtime, probe);
+  if (!check) return "guest role resolution found no world for the guest room";
+  if (check.role !== "ADMIN") {
+    return `expected the whitelisted guest to resolve as ADMIN, saw ${check.role}`;
+  }
+  return check.isOwner
+    ? "guest must never resolve as owner — the wall test would be vacuous"
+    : undefined;
+}
 
 function getDocumentService(ctx: ScenarioContext): DocumentService | null {
   const runtime = ctx.runtime as ScenarioRuntime;
@@ -223,7 +251,7 @@ export default scenario({
           telegram: { userId: GUEST_STABLE_ID },
         };
         await runtime.updateEntities([entity]);
-        return undefined;
+        return expectGuestResolvesAdmin(runtime);
       },
     },
   ],
@@ -328,6 +356,14 @@ export default scenario({
     },
   ],
   finalChecks: [
+    {
+      type: "custom",
+      // Runs before cleanup clears the whitelist, so it proves the ADMIN tier
+      // held through the refusal turn — not just at seed time (#16963).
+      name: "whitelisted guest still resolves as connector-admin (ADMIN)",
+      predicate: (ctx) =>
+        expectGuestResolvesAdmin(ctx.runtime as ScenarioRuntime),
+    },
     {
       type: "actionCalled",
       actionName: "DOCUMENT",

--- a/packages/shared/src/utils/tts-debug.loglevel.test.ts
+++ b/packages/shared/src/utils/tts-debug.loglevel.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Pins the #16958 guarantee: `ttsDebug` must emit through the real structured
+ * logger even when `LOG_LEVEL` sits above `info` (warn/error), because the
+ * operator explicitly opted in via `ELIZA_TTS_DEBUG`. The logger freezes its
+ * level at module init, so this suite pins LOG_LEVEL=error before the logger
+ * loads (vi.hoisted) and observes emission via the logger's global listener
+ * stream — no logger mocking. The listener only fires for entries that passed
+ * the level gate, so a delivered entry IS proof of emission.
+ */
+import { addLogListener, type LogEntry } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ttsDebug } from "./tts-debug";
+
+// vi.hoisted runs before the imports above evaluate, so the logger initializes
+// with the strictest common operator configuration this defect hid under.
+vi.hoisted(() => {
+  process.env.LOG_LEVEL = "error";
+});
+
+const prevFlag = process.env.ELIZA_TTS_DEBUG;
+
+describe("ttsDebug under LOG_LEVEL=error (#16958)", () => {
+  let entries: LogEntry[] = [];
+  let unsubscribe: (() => void) | null = null;
+
+  const ttsEntries = () =>
+    entries.filter((entry) => entry.msg.includes("[eliza][tts]"));
+
+  beforeEach(() => {
+    entries = [];
+    unsubscribe = addLogListener((entry) => entries.push(entry));
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = null;
+    if (prevFlag === undefined) delete process.env.ELIZA_TTS_DEBUG;
+    else process.env.ELIZA_TTS_DEBUG = prevFlag;
+  });
+
+  it("still emits when the operator explicitly set ELIZA_TTS_DEBUG=1", () => {
+    process.env.ELIZA_TTS_DEBUG = "1";
+    ttsDebug("server:cloud-tts:proxy", {
+      textChars: 11,
+      preview: "hello world",
+    });
+
+    const hits = ttsEntries();
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0]?.msg).toContain("[eliza][tts] server:cloud-tts:proxy");
+    expect(hits[0]?.msg).toContain("hello world");
+    // 50 = error: the diagnostic escalates to the active threshold so the
+    // opt-in is never silently dead; at the default LOG_LEVEL it stays info
+    // (covered by tts-debug.test.ts).
+    expect(hits[0]?.level).toBe(50);
+  });
+
+  it("emits phase-only lines too, not just detailed ones", () => {
+    process.env.ELIZA_TTS_DEBUG = "true";
+    ttsDebug("server:local-tts:request");
+
+    const hits = ttsEntries();
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0]?.msg.trim()).toBe("[eliza][tts] server:local-tts:request");
+  });
+
+  it("stays silent when the flag is unset, regardless of LOG_LEVEL", () => {
+    delete process.env.ELIZA_TTS_DEBUG;
+    ttsDebug("server:cloud-tts:proxy", { textChars: 5 });
+    expect(ttsEntries()).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/utils/tts-debug.ts
+++ b/packages/shared/src/utils/tts-debug.ts
@@ -5,12 +5,14 @@
  * Never pass secrets in `detail`. With debug on, `preview` fields may contain
  * user-visible spoken text — disable in shared logs / production.
  *
- * `ttsDebug` emits straight through the structured logger at `info` level, so
- * setting the env flag is sufficient on every server host (bare agent server,
- * app-core API, packaged desktop) — no per-host wiring exists to forget
- * (#16347). Info level is deliberate: the operator opted in explicitly, so the
- * lines must be visible at the default `LOG_LEVEL` rather than hiding behind
- * `debug`.
+ * `ttsDebug` emits straight through the structured logger, so setting the env
+ * flag is sufficient on every server host (bare agent server, app-core API,
+ * packaged desktop) — no per-host wiring exists to forget (#16347). The
+ * emission level is `info` normally, but escalates to match the logger's
+ * active threshold (`warn`/`error`/`fatal`) when `LOG_LEVEL` is stricter:
+ * the operator opted in explicitly, so the diagnostic must never be silently
+ * dead under any `LOG_LEVEL` — a below-threshold sink is the exact defect
+ * #16347 existed to kill (#16958).
  *
  * Server phases: `server:cloud-tts:*` (Eliza Cloud proxy, includes optional
  * `messageId`, `clipSegment`, `hearingFull` when the client sends
@@ -68,18 +70,35 @@ export function ttsDebugTextPreview(
   return `${singleLine.slice(0, maxChars)}…`;
 }
 
+// The logger drops entries below its LOG_LEVEL threshold, so an opted-in
+// diagnostic pinned at `info` is silently dead under LOG_LEVEL=warn/error.
+// Emit at the lowest level the active threshold still lets through: info by
+// default, escalating only as far as the configuration forces (#16958).
+function ttsEmit(): (typeof logger)["info"] {
+  const level = String(logger.level ?? "info")
+    .trim()
+    .toLowerCase();
+  if (level === "fatal" || level === "alert") return logger.fatal.bind(logger);
+  if (level === "error") return logger.error.bind(logger);
+  if (level === "warn") return logger.warn.bind(logger);
+  return logger.info.bind(logger);
+}
+
 /**
  * Emit one TTS trace line through the structured logger when
- * `ELIZA_TTS_DEBUG` is set; a no-op otherwise.
+ * `ELIZA_TTS_DEBUG` is set; a no-op otherwise. Emission is guaranteed at any
+ * `LOG_LEVEL`: the line rides at `info` normally and escalates to the active
+ * threshold when the logger is configured stricter.
  */
 export function ttsDebug(
   phase: string,
   detail?: Record<string, unknown>,
 ): void {
   if (!ttsDebugEnabled()) return;
+  const emit = ttsEmit();
   if (detail && Object.keys(detail).length > 0) {
-    logger.info(detail, `[eliza][tts] ${phase}`);
+    emit(detail, `[eliza][tts] ${phase}`);
   } else {
-    logger.info(`[eliza][tts] ${phase}`);
+    emit(`[eliza][tts] ${phase}`);
   }
 }

--- a/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
@@ -178,6 +178,60 @@ describe("builtin view action ratchet (#14369)", () => {
     },
   );
 
+  it("fails with stale-baseline when observed drops below the pinned count (#16951)", () => {
+    const automations = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "automations",
+    );
+    if (!automations) throw new Error("automations baseline entry missing");
+    // Blank one file of the multi-file aggregate: the remaining files land
+    // below the pinned total, which must surface as a stale baseline rather
+    // than silently accruing headroom for future local-only mutations.
+    const readSource = (sourcePath: string) =>
+      sourcePath === automations.sourceFiles[0]
+        ? "export const nowInert = true;"
+        : readRepoSource(sourcePath);
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [automations],
+      readSource,
+      registeredActions: REGISTERED_ACTIONS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "automations",
+        code: "stale-baseline",
+        message: expect.stringContaining("pin maxMutationSites"),
+      }),
+    ]);
+  });
+
+  it("reports only missing-source when a baseline file cannot be read", () => {
+    const automations = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "automations",
+    );
+    if (!automations) throw new Error("automations baseline entry missing");
+    // With a file unreadable the partial count is meaningless, so the
+    // stale-baseline check must stay quiet instead of piling on.
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [automations],
+      readSource: (sourcePath) =>
+        sourcePath === automations.sourceFiles[0]
+          ? null
+          : readRepoSource(sourcePath),
+      registeredActions: REGISTERED_ACTIONS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "automations",
+        code: "missing-source",
+      }),
+    ]);
+  });
+
   it("fails when a non-exempt builtin mapping references an unregistered action", () => {
     const result = validateBuiltinViewMutationCoverage({
       baseline: [

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -9,8 +9,10 @@
  *
  * Two checks compose the ratchet (#14369 shipped the first, #16944 the second):
  * the per-view coverage validator pins each baseline entry's mutation-site
- * count and verifies its semantic actions against the live registered-action
- * inventory, and the shell-page completeness sweep walks every module under
+ * count in both directions (above = unmapped local mutation, below = stale
+ * baseline that must be pinned down, #16951) and verifies its semantic actions
+ * against the live registered-action inventory, and the shell-page
+ * completeness sweep walks every module under
  * `packages/ui/src/components/pages` and fails when a mutating page is neither
  * claimed by a baseline entry nor exempt with a reason — so a brand-new
  * mutating view cannot ship un-ratcheted.
@@ -20,6 +22,12 @@ export interface BuiltinViewMutationBaselineEntry {
   viewId: string;
   sourceFiles: readonly string[];
   semanticActions: readonly string[];
+  /**
+   * Exact pinned mutation-site count across sourceFiles. The validator fails
+   * in BOTH directions: above is a new unmapped local mutation, below is a
+   * stale baseline that must be pinned down — freed headroom may never
+   * silently accrue for later local-only growth (#16951).
+   */
   maxMutationSites: number;
   exemptReason?: string;
   notes?: string;
@@ -27,7 +35,11 @@ export interface BuiltinViewMutationBaselineEntry {
 
 export interface BuiltinViewMutationFinding {
   viewId: string;
-  code: "missing-source" | "missing-semantic-action" | "new-local-mutation";
+  code:
+    | "missing-source"
+    | "missing-semantic-action"
+    | "new-local-mutation"
+    | "stale-baseline";
   message: string;
 }
 
@@ -342,9 +354,11 @@ export function validateBuiltinViewMutationCoverage(args: {
 
   for (const entry of baseline) {
     let observedMutationSites = 0;
+    let missingSource = false;
     for (const sourceFile of entry.sourceFiles) {
       const source = args.readSource(sourceFile);
       if (source == null) {
+        missingSource = true;
         findings.push({
           viewId: entry.viewId,
           code: "missing-source",
@@ -369,6 +383,20 @@ export function validateBuiltinViewMutationCoverage(args: {
         viewId: entry.viewId,
         code: "new-local-mutation",
         message: `${entry.viewId}: observed ${observedMutationSites} mutation sites exceeds baseline ${entry.maxMutationSites}; add a semantic action mapping or deliberately update the baseline`,
+      });
+    } else if (
+      observedMutationSites < entry.maxMutationSites &&
+      !missingSource
+    ) {
+      // A drop must force-pin the count down: leftover headroom would let
+      // that many future local-only mutations land unnoticed — worst on
+      // multi-file aggregates where one refactored file frees a big block
+      // (#16951). Skipped when a source is missing, since the partial count
+      // is meaningless next to the missing-source finding already emitted.
+      findings.push({
+        viewId: entry.viewId,
+        code: "stale-baseline",
+        message: `${entry.viewId}: observed ${observedMutationSites} mutation sites is below baseline ${entry.maxMutationSites}; pin maxMutationSites to ${observedMutationSites} so the freed headroom cannot absorb future local-only mutations`,
       });
     }
 

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -33,7 +33,7 @@ bun run voice:matrix
 By default the command probes the current host and writes:
 
 ```text
-.github/issue-evidence/9958-voice-matrix/
+test-results/evidence/9958-voice-matrix/
   voice-matrix.json
   voice-matrix.md
   index.html
@@ -58,7 +58,7 @@ To validate the Stage-B STT benchmark cell, point the matrix at the reviewed
 report:
 
 ```bash
-ELIZA_VOICE_STAGE_B_REPORT=.github/issue-evidence/9958-stage-b/report.json \
+ELIZA_VOICE_STAGE_B_REPORT=test-results/evidence/9958-stage-b/report.json \
   bun run voice:matrix -- --run --platform stt.stage-b.evaluation
 ```
 
@@ -66,7 +66,7 @@ To validate the real openWakeWord head wake-context cell, point the matrix at th
 reviewed report:
 
 ```bash
-ELIZA_VOICE_OPENWAKEWORD_REPORT=.github/issue-evidence/9958-openwakeword/report.json \
+ELIZA_VOICE_OPENWAKEWORD_REPORT=test-results/evidence/9958-openwakeword/report.json \
   bun run voice:matrix -- --run --platform wake.openwakeword.real-head
 ```
 
@@ -88,7 +88,7 @@ ELIZA_VOICE_OPENWAKEWORD_REPORT=.github/issue-evidence/9958-openwakeword/report.
 | `android.talkmode.native-bridge` | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` | TalkMode capture lifecycle/transcript/permission/barge-in bridge tests |
 | `android.swabble.native-bridge` | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` | Swabble wake-firing -> JS bridge event tests |
 | `wake.openwakeword.real-head` | `packages/scripts/voice-openwakeword-eval.mjs` validating a reviewed real-head report | idle wake opens the listen window, always-on wake is inert, and mid-transcription wake does not corrupt the transcript |
-| `stt.stage-b.apple-sfspeech` | `node packages/scripts/stage-b-stt-bench.mjs` (macOS) | **measured** on-device `SFSpeechRecognizer` latency/RTF/WER over on-device-synthesised speech (quiet + 10 dB noise), `.github/issue-evidence/9958-stt-stage-b-eval/` |
+| `stt.stage-b.apple-sfspeech` | `node packages/scripts/stage-b-stt-bench.mjs` (macOS) | **measured** on-device `SFSpeechRecognizer` latency/RTF/WER over on-device-synthesised speech (quiet + 10 dB noise), `test-results/evidence/9958-stt-stage-b-eval/` |
 | `stt.stage-b.evaluation` | `packages/scripts/voice-stage-b-eval.mjs` validating a paired device benchmark report | iOS `SFSpeechRecognizer`, Android `SpeechRecognizer`, and fused ASR latency/battery/accept matrix with reviewed artifacts |
 
 ## Hardware Gates

--- a/plugins/plugin-local-inference/scripts/voice-bench-shared.ts
+++ b/plugins/plugin-local-inference/scripts/voice-bench-shared.ts
@@ -69,7 +69,12 @@ export function makeBenchGates(tag: string, requireEnvName: string): BenchGates 
 	};
 }
 
-/** Load the fused lib (ABI v12) or skip. */
+/**
+ * Load the fused lib or skip. The loaded library must report exactly
+ * `ELIZA_INFERENCE_ABI_VERSION` (the canonical current contract) — the benches
+ * prove the current ABI, so the loader's graduated back-compat set is not
+ * accepted here.
+ */
 export function bootFusedFfi(gates: BenchGates): {
 	ffi: ElizaInferenceFfi;
 	libPath: string;

--- a/plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md
+++ b/plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md
@@ -126,8 +126,9 @@ exception to "skip": it **hard-fails** on any missing acoustic artifact (a clear
 
 The workbench is the single verification surface (parent decision #10), so every
 voice PR — loud-fail (#12253), latency (#12254), turn-taking (#12255), echo
-(#12256), diarization (#12257) — files a **before/after** bundle under
-`.github/issue-evidence/<issue#>-*/`, citing ceilings from the table above:
+(#12256), diarization (#12257) — attaches a **before/after** bundle inline on
+the PR (MP4/JPG/logs in `<details>`; stage locally under
+`test-results/evidence/<issue#>-*/`), citing ceilings from the table above:
 
 1. **Workbench reports (before + after)** — `voice:workbench --logic --baseline
    src/services/voice/__fixtures__/voice-workbench-logic-baseline.json` (JSON +

--- a/plugins/plugin-meetings/README.md
+++ b/plugins/plugin-meetings/README.md
@@ -161,6 +161,7 @@ bun run --cwd plugins/plugin-meetings typecheck   # tsgo --noEmit
   `createUniqueUuid(runtime, "meeting-participant:<platform>:<name>")`.
 - See the root `AGENTS.md` for repo-wide rules (ESM, logger-only, evidence).
 
+<!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->
 ## ⛔ NON-NEGOTIABLE — evidence, trajectories & real end-to-end tests
 
 > The binding, repo-wide standard is **[AGENTS.md](../../AGENTS.md)**. Read it.
@@ -191,7 +192,7 @@ bun run --cwd plugins/plugin-meetings typecheck   # tsgo --noEmit
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 
@@ -205,3 +206,4 @@ behavior, **re-capture** evidence; stale proof is worse than none.
   network log while the bot is in the call.
 - Backend `[MeetingService]` structured logs covering the whole lifecycle, and a live-LLM
   trajectory for JOIN_MEETING / LEAVE_MEETING / GET_MEETING_TRANSCRIPT action changes.
+<!-- END: evidence-and-e2e-mandate -->


### PR DESCRIPTION
# Relates to

Post-merge adversarial-review remediation batch (lane `p2-batch`): the remaining CONFIRMED P2/evidence findings against merged PRs #16948, #16958, #16963, #16970, and #16951.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branched from `origin/develop` after #17016 merged; its `my-apps` baseline entry is adopted, not duplicated).
- [x] `bun install` and `bun run verify` were run after sync (output below).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts. #17016 (my-apps baseline entry) had merged before this branch was finalized, so this branch builds on it — no duplicate entry, no conflict left for the merge queue.
- [x] `bun run verify` passes post-sync: exit 0, `Tasks: 578 successful, 578 total` (flock-serialized). After a final trivial rebase (3 unrelated develop commits), the touched-package suites and the ratchet recount were re-run green.

# Risks

Low. Five independent, finding-scoped fixes: two docs-only commits, one diagnostic-logging level fix with a regression suite, one deterministic-scenario assertion tightening, one CI-guard grep tightening plus a comment fix, one test-infra ratchet tightening. No product runtime behavior changes outside the opted-in `ELIZA_TTS_DEBUG` diagnostic path.

# Background

## What does this PR do?

One commit per confirmed finding:

1. **#16948 residuals — retire remaining live `.github/issue-evidence` instructions** (`docs(evidence)`). `plugins/plugin-meetings/README.md` gets the swept inline-PR wording plus the managed `BEGIN/END evidence-and-e2e-mandate` markers (mirroring what #16948 did for plugin-trajectory-logger); `packages/app/e2e/accounts-ui/README.md` now documents the path `run-accounts-ui-e2e.mjs` actually writes (`test-results/evidence/10722-accounts-ui-e2e/`). The repo-wide sweep also repoints the remaining live run instructions (device lifecycle matrix, startup trace, mobile-resource lab normalization, voice live matrix, voice workbench bundle, benchmark orchestrator review-package) at their real gitignored output dirs. Fixtures in `scripts/check-pr-evidence.test.mjs` and history/research docs describing the retirement are intentionally untouched — post-fix, no live instruction references the retired dir.
2. **#16958 — `ELIZA_TTS_DEBUG` silently dead under `LOG_LEVEL=warn/error`** (`fix(shared)`). The sink emitted at fixed `info`, so a stricter threshold filtered out a diagnostic the operator explicitly opted into — the exact silently-dead-diagnostic defect #16347 existed to kill. `ttsDebug` now emits at `info` normally and escalates to the logger's active threshold when configured stricter, so emission is guaranteed at any `LOG_LEVEL`. New suite (`tts-debug.loglevel.test.ts`) pins `LOG_LEVEL=error` at logger init and asserts delivery through the real listener stream — which only fires for entries that passed the level gate, so a delivered entry is proof of emission.
3. **#16963 — deterministic twin tier misstated and unpinned** (`fix(scenario-runner)`). The catalog README described the mutation-wall refusal as a USER-granted non-owner; it is a whitelisted connector-admin (ADMIN). Nothing pinned that resolution, so a silently broken whitelist stamp would degrade the guest to GUEST and the refusal would still pass for the wrong reason (any non-owner is refused). The scenario now probes the real `roles.ts` resolution (`checkSenderRole`) both in the whitelist seed and in a finalCheck that runs before cleanup clears the whitelist, failing hard on any tier other than ADMIN (and on owner, which would make the wall test vacuous).
4. **#16970 — stale ABI JSDoc + partial-skip hole in the FFI-lane guard** (`fix(ci)`). `bootFusedFfi`'s JSDoc said "(ABI v12)" while the code pins `ELIZA_INFERENCE_ABI_VERSION` (14); the comment now names the constant so it cannot drift again. The fused FFI guard in `voice-live-e2e.yml` only tripped on `0 pass` or `12 skip`, so a partial skip (some matrix cells skipped, the rest passing) satisfied the "nothing skipped" claim; it now fails on ANY nonzero skip count (per-cell accounting).
5. **#16951 P2 — builtin-view ratchet only ratcheted upward** (`fix(ui)`). When observed mutation sites dropped below `maxMutationSites`, the freed headroom silently accrued — worst on multi-file aggregates like `automations` (71), where one slimmed file could absorb dozens of future local-only mutations unnoticed. The validator now emits a `stale-baseline` finding whenever `observed < maxMutationSites` (suppressed only while a source file is unreadable, where the partial count is meaningless next to the `missing-source` finding already emitted), so every drop force-pins the count down. All 25 baseline entries verified to sit at their exact observed counts.

## What kind of change is this?

Bug fixes (CI guard, diagnostic logging, test-infra ratchet, scenario assertion) + documentation fixes.

# Documentation changes needed?

Commit 1 *is* the documentation change. `rg -n '\.github/issue-evidence'` post-fix hits only: `scripts/check-pr-evidence.test.mjs` rejection fixtures (must stay), root `CLAUDE.md`/`AGENTS.md` and docs that describe the retirement itself, and history/research records of past captures.

# Testing

## Where should a reviewer start?

- `packages/shared/src/utils/tts-debug.loglevel.test.ts` — the LOG_LEVEL=error emission pin.
- `packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts` — `expectGuestResolvesAdmin`, wired into the seed + a finalCheck.
- `packages/ui/src/testing/builtin-view-action-ratchet.ts` — the `stale-baseline` branch, plus the two new tests in its suite.
- `.github/workflows/voice-live-e2e.yml` — the tightened guard greps.

## Detailed testing steps

All automated; every touched package ran its scoped suite (transcripts in Evidence Details):

- `packages/shared`: `vitest run src/utils/tts-debug.loglevel.test.ts src/utils/tts-debug.test.ts` → 2 files, 11 tests passed.
- `packages/scenario-runner`: deterministic lane run of `deterministic-document-actions` → passed. **Negative-tested**: emptying the whitelist fails the seed with `expected the whitelisted guest to resolve as ADMIN, saw GUEST`.
- `packages/ui`: `vitest run src/testing/builtin-view-action-ratchet.test.ts` → 15 tests passed (incl. new `stale-baseline` and `missing-source`-suppression tests), re-run green after the final rebase.
- `plugins/plugin-local-inference`: `vitest run __tests__/voice-bench-shared.test.ts` → 16 tests passed.
- Workflow guard greps simulated against all four bun-test summary shapes (all-pass → passes; partial-skip → trips; full-skip → trips; explicit `0 skip` line → passes); YAML re-parsed clean.
- Root `bun run verify` (typecheck + lint): exit 0, 578/578 tasks.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI change; the packages/ui diff is test-infrastructure (builtin-view-action-ratchet.ts validator + its test), docs, CI workflow, a logging level, and a scenario assertion — nothing paints pixels`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason: no rendered UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-exercisable flow changed; all changes are CI/test/docs/diagnostic-logging`.
<!-- evidence-row:backend-logs -->
- [x] [17047-d9dbd3a4f21e-backend-logs-897c9c408047.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17047-d9dbd3a4f21e-backend-logs-897c9c408047.md)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend request/response or state change; no browser code path altered`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior changed; the scenario change adds a fixture-tier assertion to a zero-cost deterministic-proxy lane whose contract is exercised by that lane itself (pass + negative-test transcripts below); the live sibling live-document-delete is untouched`.
<!-- evidence-row:domain-artifacts -->
- [x] [17047-d9dbd3a4f21e-domain-artifacts-b73be437a805.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17047-d9dbd3a4f21e-domain-artifacts-b73be437a805.md)

# Evidence Details

## Real LLM-call trajectory

`N/A - no live-model behavior change` (see Evidence Gate row). The deterministic twin runs on the zero-cost `pr-deterministic` lane by design; its live sibling (`live-document-delete`) is unchanged.

## Backend + frontend logs

<details>
<summary>ttsDebug under LOG_LEVEL=error — real listener-stream delivery (vitest, packages/shared)</summary>

```
 Test Files  2 passed (2)
      Tests  11 passed (11)
```

`tts-debug.loglevel.test.ts` pins `LOG_LEVEL=error` via `vi.hoisted` before the logger initializes, then asserts `[eliza][tts] server:cloud-tts:proxy` (with its detail payload) arrives through `addLogListener` at level 50 (error). The listener only fires for entries that passed the level gate, so delivery IS proof of emission. A third case asserts the sink stays silent with the flag unset.
</details>

<details>
<summary>Deterministic scenario — pass run (structured runner logs)</summary>

```
 Info  [eliza-scenarios] provider: deterministic-llm-proxy
 Info  [eliza-scenarios] ▶ deterministic-document-actions
 Info  [eliza-scenarios] ✓ deterministic-document-actions passed (259ms)

| id | status | duration | failures |
| deterministic-document-actions | passed | 259ms |  |
Totals: 1 passed, 0 failed, 0 skipped of 1
```
(Re-run after the final rebase: passed, 611ms.)
</details>

<details>
<summary>Negative test — whitelist emptied, ADMIN pin trips (the finding's exact degradation)</summary>

```
 Info  [eliza-scenarios] ✗ deterministic-document-actions failed (94ms)
| deterministic-document-actions | failed | 94ms | seed whitelist the guest entity as a connector admin: expected the whitelisted guest to resolve as ADMIN, saw GUEST |
Totals: 0 passed, 1 failed, 0 skipped of 1
```
</details>

<details>
<summary>FFI skip-guard grep simulation (all four bun-test summary shapes)</summary>

```
all-pass.log: PASS                    (" 12 pass / 0 fail")
partial-skip.log: FAIL(guard trips)   (" 9 pass / 3 skip / 0 fail")  <- the hole this PR closes
full-skip.log: FAIL(guard trips)      (" 0 pass / 12 skip")
zero-skip-line.log: PASS              (" 12 pass / 0 skip / 0 fail")
```
</details>

<details>
<summary>Ratchet recount — all 25 baseline entries at exact observed counts (no headroom anywhere)</summary>

```
tasks: 0            plugins-page: 62     settings: 32       background: 0
character: 57       logs: 10             runtime: 12        database: 26
trajectories: 12    documents: 17        files: 10          memories: 21
automations: 71     triggers: 66         skills: 56         browser: 23
my-apps: 1          relationships: 29    chat: 4            launcher: 3
native-os-apps: 48  camera: 4            cloud-dashboard: 15
pendant-transcript: 7                    release-center: 13
```

Counted with the ratchet's own `MUTATION_SITE_RE` over each entry's `sourceFiles` (re-verified after the final rebase); every value equals the pinned `maxMutationSites`, so the new `stale-baseline` check passes on the current tree and will trip on the first future drop.
</details>

<details>
<summary>Package suites + root verify</summary>

```
packages/ui builtin-view-action-ratchet.test.ts:   Tests  15 passed (15)
packages/shared tts-debug suites:                  Tests  11 passed (11)
plugin-local-inference voice-bench-shared.test.ts: Tests  16 passed (16)
bun run verify (flock-serialized):                 exit 0 — Tasks: 578 successful, 578 total
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI change (test infrastructure, docs, CI workflow, logging level, scenario assertion only)`.

### Before

`N/A - see above`

### After

`N/A - see above`

### Walkthrough video

`N/A - see above`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT audio path behavior changed; the ELIZA_TTS_DEBUG fix changes only the log level a diagnostic line is emitted at (proven by the listener-stream test above)`.

## Known gaps / failures

None. Every touched package's scoped suite is green and root `bun run verify` passes. Evidence rows marked N/A above each carry a concrete reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI change to read text from; the diff touches no visual surface files (test infra, docs, CI workflow, logging level, scenario assertion only)
