### PR TITLE
fix(chat): reconcile streamed message id with persisted id to eliminate WS echo duplicates

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -58,8 +58,8 @@ vi.mock("../chat-routes.ts", async () => {
         ? { streamProtocol: requestStreamProtocol }
         : {}),
     })),
-    persistConversationMemory: vi.fn(async () => undefined),
-    persistAssistantConversationMemory: vi.fn(async () => undefined),
+    persistConversationMemory: vi.fn(async (_runtime, memory) => memory),
+    persistAssistantConversationMemory: vi.fn(async () => null),
     hasRecentVisibleAssistantMemorySince: vi.fn(async () => false),
     resolveNoResponseFallback: () => "",
   };
@@ -92,7 +92,10 @@ vi.mock("../server-helpers.ts", async () => {
   };
 });
 
-import { persistConversationMemory } from "../chat-routes.ts";
+import {
+  persistAssistantConversationMemory,
+  persistConversationMemory,
+} from "../chat-routes.ts";
 import type {
   ConversationRouteContext,
   ConversationRouteState,
@@ -469,6 +472,20 @@ describe("conversation stream SSE contract (#10712)", () => {
       agentName: "Streaming Agent",
       thought: THOUGHT,
     });
+    // The terminal `done` frame carries the persisted assistant message id
+    // (pre-minted before the deferred DB insert), and the SAME id is handed to
+    // the persistence layer — the contract the client relies on to swap its
+    // streamed temp-resp-* bubble so the proactive-message WS echo reconciles
+    // by id instead of appending a duplicate bubble.
+    const doneMessageId = payloads[doneIndex].messageId;
+    expect(typeof doneMessageId).toBe("string");
+    const persistedCall = vi
+      .mocked(persistAssistantConversationMemory)
+      .mock.calls.find((call) => call[5] === doneMessageId);
+    expect(persistedCall).toBeDefined();
+    expect(persistedCall?.[1]).toBe(ROOM_ID);
+    expect(persistedCall?.[2]).toMatchObject({ text: FINAL_TEXT });
+    expect(persistedCall?.[3]).toBe(ChannelType.DM);
     // `done` is terminal — no token frames after it.
     expect(
       payloads.slice(doneIndex + 1).some((payload) => payload.type === "token"),

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -29,6 +29,7 @@ import {
   isRateLimitError,
   logger,
   MESSAGE_SOURCE_CLIENT_CHAT,
+  type Memory,
   ModelType,
   markInference,
   nextInferenceTurnId,
@@ -2047,13 +2048,14 @@ function isDuplicateMemoryError(err: unknown): boolean {
 export async function persistConversationMemory(
   runtime: AgentRuntime,
   memory: ReturnType<typeof createMessageMemory>,
-): Promise<void> {
+): Promise<ReturnType<typeof createMessageMemory>> {
   try {
     await runtime.createMemory(memory, "messages");
   } catch (err) {
-    if (isDuplicateMemoryError(err)) return;
+    if (isDuplicateMemoryError(err)) return memory;
     throw err;
   }
+  return memory;
 }
 
 async function hasRecentAssistantMemory(
@@ -2108,6 +2110,24 @@ export async function getRecentVisibleAssistantMemoryTextSince(
   // prior turn's answer to a rapid-fire retry.
   slackMs: number = 2000,
 ): Promise<string | null> {
+  return (
+    (
+      await getRecentVisibleAssistantMemorySince(
+        runtime,
+        roomId,
+        sinceMs,
+        slackMs,
+      )
+    )?.text ?? null
+  );
+}
+
+export async function getRecentVisibleAssistantMemorySince(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  sinceMs: number,
+  slackMs: number = 2000,
+): Promise<{ id: UUID; text: string } | null> {
   try {
     const recent = await runtime.getMemories({
       roomId,
@@ -2127,11 +2147,12 @@ export async function getRecentVisibleAssistantMemoryTextSince(
       })
       .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))[0];
 
-    return (
-      (
-        persistedAssistantTurn?.content as { text?: string } | undefined
-      )?.text?.trim() ?? null
-    );
+    const text = (
+      persistedAssistantTurn?.content as { text?: string } | undefined
+    )?.text?.trim();
+    return persistedAssistantTurn?.id && text
+      ? { id: persistedAssistantTurn.id as UUID, text }
+      : null;
   } catch {
     return null;
   }
@@ -2143,7 +2164,13 @@ export async function persistAssistantConversationMemory(
   content: string | Content,
   channelType: ChannelType,
   dedupeSinceMs?: number,
-): Promise<void> {
+  // Caller-supplied memory id. The streaming route pre-mints the id and stamps
+  // it on the SSE `done` frame BEFORE this (possibly deferred) persist runs,
+  // so the client can swap its optimistic temp-resp-* bubble to the durable id
+  // and the proactive-message WS echo reconciles by id instead of appending a
+  // duplicate bubble.
+  memoryId?: UUID,
+): Promise<Memory | null> {
   const persistedContent = markSyntheticChatFailureContent(
     typeof content === "string"
       ? ({
@@ -2165,7 +2192,7 @@ export async function persistAssistantConversationMemory(
         } satisfies Content),
   );
   const trimmed = persistedContent.text.trim();
-  if (!trimmed) return;
+  if (!trimmed) return null;
 
   if (typeof dedupeSinceMs === "number") {
     const alreadyPersisted = await hasRecentAssistantMemory(
@@ -2174,13 +2201,13 @@ export async function persistAssistantConversationMemory(
       trimmed,
       dedupeSinceMs,
     );
-    if (alreadyPersisted) return;
+    if (alreadyPersisted) return null;
   }
 
-  await persistConversationMemory(
+  return await persistConversationMemory(
     runtime,
     createMessageMemory({
-      id: crypto.randomUUID() as UUID,
+      id: memoryId ?? (crypto.randomUUID() as UUID),
       entityId: runtime.agentId,
       agentId: runtime.agentId,
       roomId,

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -64,6 +64,7 @@ import {
   generateConversationTitle,
   getChatFailureReply,
   getChatMessageIdFirstSeenAt,
+  getRecentVisibleAssistantMemorySince,
   getRecentVisibleAssistantMemoryTextSince,
   hasRecentVisibleAssistantMemorySince,
   initSse,
@@ -2506,7 +2507,7 @@ export async function handleConversationRoutes(
       );
       const persistedFirstReply =
         state.runtime && firstSeenAt !== null
-          ? await getRecentVisibleAssistantMemoryTextSince(
+          ? await getRecentVisibleAssistantMemorySince(
               state.runtime,
               conv.roomId,
               firstSeenAt,
@@ -2521,8 +2522,9 @@ export async function handleConversationRoutes(
         persistedFirstReply
           ? {
               type: "done",
-              fullText: persistedFirstReply,
+              fullText: persistedFirstReply.text,
               agentName: state.agentName,
+              messageId: persistedFirstReply.id,
             }
           : {
               type: "done",
@@ -2611,7 +2613,7 @@ export async function handleConversationRoutes(
         if (!disconnectTracker.isAborted()) {
           tokenWriter.writeSnapshot(res, walletModeGuidance);
           try {
-            await persistAssistantConversationMemory(
+            const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
               walletModeGuidance,
@@ -2619,6 +2621,12 @@ export async function handleConversationRoutes(
               turnStartedAt,
             );
             conv.updatedAt = new Date().toISOString();
+            writeSseJson(res, {
+              type: "done",
+              fullText: walletModeGuidance,
+              agentName: state.agentName,
+              ...(persisted?.id ? { messageId: persisted.id } : {}),
+            });
           } catch (persistErr) {
             writeSse(res, {
               type: "error",
@@ -2626,11 +2634,6 @@ export async function handleConversationRoutes(
             });
             return true;
           }
-          writeSseJson(res, {
-            type: "done",
-            fullText: walletModeGuidance,
-            agentName: state.agentName,
-          });
         }
       } finally {
         clearInterval(heartbeatInterval);
@@ -2650,9 +2653,11 @@ export async function handleConversationRoutes(
     // the wire carries each phase transition once. Distinct consecutive phases
     // (thinking → running_action → thinking) still pass through.
     let lastStatusSignature = "thinking::";
-    // When the success path emits `done` BEFORE running persistence (latency
-    // optimization), we hand off the persistence work as a detached promise so
-    // the `finally` block can `res.end()` immediately and still observe failures.
+    // The client needs the persisted assistant id in the terminal `done` frame
+    // so it can replace its streamed `temp-resp-*` bubble in place. Create the
+    // memory before `done`, but defer only the DB insert until after the socket
+    // closes so the latency optimization stays intact and the id is still the
+    // same one the later WS proactive-message broadcast carries.
     let deferredPersistence: Promise<void> | null = null;
 
     try {
@@ -2748,13 +2753,44 @@ export async function handleConversationRoutes(
               await new Promise((resolve) => setTimeout(resolve, 60));
             }
           }
-          // Emit `done` BEFORE persistence so user-perceived end-of-turn
-          // latency excludes the ~100-500ms memory write. Persistence runs
-          // after res.end() in the `finally` block as a detached promise.
+          // Resolve the durable assistant-memory id BEFORE emitting `done` so
+          // the client can swap its optimistic temp-resp-* bubble to the
+          // persisted id, and the proactive-message WS echo then reconciles by
+          // id instead of appending a duplicate bubble. Two topologies:
+          //  - action-callback turns may have ALREADY persisted (and WS-echoed)
+          //    the reply via the client_chat send handler — reuse that memory's
+          //    id and skip the route's own persist (same suppression
+          //    shouldPersistFinalAssistantTurn provided, but id-carrying);
+          //  - otherwise pre-mint the id here and defer only the DB insert.
+          let persistedAssistantId: UUID | null = null;
+          let shouldPersistAssistantTurn = false;
+          if (result.usedActionCallbacks) {
+            const existingAssistantTurn =
+              await getRecentVisibleAssistantMemorySince(
+                runtime,
+                conv.roomId,
+                turnStartedAt,
+              );
+            if (existingAssistantTurn) {
+              persistedAssistantId = existingAssistantTurn.id;
+            } else {
+              persistedAssistantId = crypto.randomUUID() as UUID;
+              shouldPersistAssistantTurn = true;
+            }
+          } else {
+            persistedAssistantId = crypto.randomUUID() as UUID;
+            shouldPersistAssistantTurn = true;
+          }
+          // Emit `done` before the DB insert so user-perceived end-of-turn
+          // latency excludes the memory write, but include the pre-minted
+          // persisted id so the client can reconcile its streamed temp bubble.
           writeSseJson(res, {
             type: "done",
             fullText: resolvedText,
             agentName: result.agentName,
+            ...(persistedAssistantId
+              ? { messageId: persistedAssistantId }
+              : {}),
             ...(result.thought ? { thought: result.thought } : {}),
             ...(result.usage ? { usage: result.usage } : {}),
             ...(result.actionResults?.length
@@ -2783,20 +2819,14 @@ export async function handleConversationRoutes(
                 turnStartedAt,
               );
             }
-            if (
-              await shouldPersistFinalAssistantTurn(
-                runtime,
-                conv.roomId,
-                turnStartedAt,
-                result,
-              )
-            ) {
+            if (shouldPersistAssistantTurn && persistedAssistantId) {
               await persistAssistantConversationMemory(
                 runtime,
                 conv.roomId,
                 buildPersistedAssistantContent(resolvedText, result),
                 channelType,
                 turnStartedAt,
+                persistedAssistantId,
               );
             }
           })();
@@ -2838,7 +2868,7 @@ export async function handleConversationRoutes(
             "Post-generation error after text was already streamed — using streamed text",
           );
           try {
-            await persistAssistantConversationMemory(
+            const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
               streamedText,
@@ -2850,6 +2880,7 @@ export async function handleConversationRoutes(
               type: "done",
               fullText: streamedText,
               agentName: state.agentName,
+              ...(persisted?.id ? { messageId: persisted.id } : {}),
             });
           } catch (persistErr) {
             writeSse(res, {
@@ -2890,7 +2921,7 @@ export async function handleConversationRoutes(
           const providerIssueReply = getChatFailureReply(err, state.logBuffer);
           const failureKind = classifyChatFailure(err, state.logBuffer);
           try {
-            await persistAssistantConversationMemory(
+            const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
               providerIssueReply,
@@ -2901,6 +2932,7 @@ export async function handleConversationRoutes(
               type: "done",
               fullText: providerIssueReply,
               agentName: state.agentName,
+              ...(persisted?.id ? { messageId: persisted.id } : {}),
               // See non-streaming branch — renderer gates chat input on
               // failureKind === "no_provider".
               failureKind,

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -85,6 +85,7 @@ type StreamChatEvent = {
   text?: string;
   fullText?: string;
   agentName?: string;
+  messageId?: string;
   message?: string;
   thought?: string;
   noResponseReason?: string;
@@ -210,6 +211,7 @@ type StreamChatState = {
   fullText: string;
   doneText: string | null;
   doneAgentName: string | null;
+  doneMessageId: string | null;
   doneThought: string | null;
   doneNoResponseReason: "ignored" | null;
   doneUsage: ChatTokenUsage | undefined;
@@ -323,6 +325,9 @@ function applyStreamChatDoneEvent(
   if (typeof parsed.fullText === "string") state.doneText = parsed.fullText;
   if (typeof parsed.agentName === "string" && parsed.agentName.trim()) {
     state.doneAgentName = parsed.agentName;
+  }
+  if (typeof parsed.messageId === "string" && parsed.messageId.trim()) {
+    state.doneMessageId = parsed.messageId;
   }
   if (typeof parsed.thought === "string" && parsed.thought.trim()) {
     state.doneThought = parsed.thought;
@@ -1824,6 +1829,7 @@ export class ElizaClient {
     accountConnect?: AccountConnectRequest;
     localInference?: LocalInferenceChatMetadata;
     actionResults?: ChatActionResultSummary[];
+    messageId?: string;
   }> {
     // Idempotency key for the chat send. The HTTP chat path (POST
     // /api/chat[/:conversationId]/stream) lives in
@@ -1873,6 +1879,7 @@ export class ElizaClient {
       fullText: "",
       doneText: null,
       doneAgentName: null,
+      doneMessageId: null,
       doneThought: null,
       doneNoResponseReason: null,
       doneUsage: undefined,
@@ -2017,6 +2024,9 @@ export class ElizaClient {
       completed: streamState.receivedDone,
       ...(streamState.doneThought
         ? { reasoning: streamState.doneThought }
+        : {}),
+      ...(streamState.doneMessageId
+        ? { messageId: streamState.doneMessageId }
         : {}),
       ...(streamState.doneNoResponseReason
         ? { noResponseReason: streamState.doneNoResponseReason }

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -515,6 +515,13 @@ declare module "./client-base" {
       completed: boolean;
       /** Agent reasoning/thought for this turn, when the model emitted one. */
       reasoning?: string;
+      /**
+       * Persisted assistant memory id from the terminal SSE `done` frame. The
+       * client swaps its optimistic temp-resp-* bubble to this id so the
+       * proactive-message WS echo reconciles by id instead of appending a
+       * duplicate bubble.
+       */
+      messageId?: string;
       noResponseReason?: "ignored";
       usage?: ChatTokenUsage;
       /** See sendConversationMessage above. */

--- a/packages/ui/src/state/__tests__/useStreamingText.test.ts
+++ b/packages/ui/src/state/__tests__/useStreamingText.test.ts
@@ -148,6 +148,66 @@ describe("applyStreamingTextModification", () => {
     );
   });
 
+  it("complete swaps the streamed temp id to the persisted server id in place", () => {
+    const initial = [
+      userMsg("u1", "hi"),
+      assistantMsg("temp-resp-1", "hello there"),
+    ];
+    const harness = makeSetter(initial);
+
+    applyStreamingTextModification(harness.setter, {
+      messageId: "temp-resp-1",
+      mode: "complete",
+      fullText: "hello there",
+      persistedMessageId: "server-assistant-1",
+    });
+
+    expect(harness.current.map((m) => m.id)).toEqual([
+      "u1",
+      "server-assistant-1",
+    ]);
+    expect(harness.current[1].text).toBe("hello there");
+  });
+
+  it("complete id-swap drops an already-appended WS echo bubble carrying the persisted id", () => {
+    // Action-callback turns persist + broadcast mid-turn, so the
+    // proactive-message echo can land BEFORE the SSE `done` id-swap. The swap
+    // must collapse the pair to one bubble at the streamed position.
+    const initial = [
+      userMsg("u1", "hi"),
+      assistantMsg("temp-resp-1", "hello there"),
+      assistantMsg("server-assistant-1", "hello there"),
+    ];
+    const harness = makeSetter(initial);
+
+    applyStreamingTextModification(harness.setter, {
+      messageId: "temp-resp-1",
+      mode: "complete",
+      fullText: "hello there",
+      persistedMessageId: "server-assistant-1",
+    });
+
+    expect(harness.current.map((m) => m.id)).toEqual([
+      "u1",
+      "server-assistant-1",
+    ]);
+    expect(harness.current[1].text).toBe("hello there");
+  });
+
+  it("complete without persistedMessageId leaves the message id untouched", () => {
+    const initial = [assistantMsg("temp-resp-1", "partial")];
+    const harness = makeSetter(initial);
+
+    applyStreamingTextModification(harness.setter, {
+      messageId: "temp-resp-1",
+      mode: "complete",
+      fullText: "Done",
+    });
+
+    expect(harness.current[0].id).toBe("temp-resp-1");
+    expect(harness.current[0].text).toBe("Done");
+  });
+
   it("fail sets failureKind without touching text", () => {
     const initial = [assistantMsg("a1", "Streaming text")];
     const harness = makeSetter(initial);

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -667,9 +667,23 @@ export function bindReadyPhase(
       const d = depsRef.current;
       if (!d) return;
       if (cid === d.activeConversationIdRef.current)
-        d.setConversationMessages((prev: ConversationMessage[]) =>
-          prev.some((m) => m.id === msg.id) ? prev : [...prev, msg],
-        );
+        d.setConversationMessages((prev: ConversationMessage[]) => {
+          const existingIndex = prev.findIndex((m) => m.id === msg.id);
+          if (existingIndex >= 0) {
+            const existing = prev[existingIndex];
+            if (
+              existing.text === msg.text &&
+              existing.timestamp === msg.timestamp &&
+              existing.source === msg.source
+            ) {
+              return prev;
+            }
+            const next = [...prev];
+            next[existingIndex] = { ...existing, ...msg };
+            return next;
+          }
+          return [...prev, msg];
+        });
       else
         d.setUnreadConversations(
           (prev: Set<string>) => new Set([...prev, cid]),

--- a/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
@@ -79,6 +79,82 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
     window.removeEventListener(VOICE_CONTROL_EVENT, voiceHandler);
   }
 
+  it("reconciles a proactive echo with the same persisted id instead of appending", () => {
+    const deps = makeDeps();
+    deps.activeConversationIdRef.current = "conv-1";
+    let messages = [
+      { id: "temp-user-1", role: "user", text: "hi", timestamp: 1 },
+      {
+        id: "server-assistant-1",
+        role: "assistant",
+        text: "hello there",
+        timestamp: 1,
+      },
+    ];
+    deps.setConversationMessages = vi.fn((updater) => {
+      messages = typeof updater === "function" ? updater(messages) : updater;
+    });
+    const cleanup = bindReadyPhase({ current: deps });
+
+    clientMock.handlers.get("proactive-message")?.({
+      conversationId: "conv-1",
+      message: {
+        id: "server-assistant-1",
+        role: "assistant",
+        text: "hello there",
+        timestamp: 2,
+        source: "client_chat",
+      },
+    });
+
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toMatchObject({
+      id: "server-assistant-1",
+      text: "hello there",
+      timestamp: 2,
+      source: "client_chat",
+    });
+
+    teardown(cleanup);
+  });
+
+  it("appends genuinely new proactive assistant messages", () => {
+    const deps = makeDeps();
+    deps.activeConversationIdRef.current = "conv-1";
+    let messages = [
+      { id: "temp-user-1", role: "user", text: "hi", timestamp: 1 },
+      {
+        id: "temp-resp-1",
+        role: "assistant",
+        text: "hello there",
+        timestamp: 1,
+      },
+    ];
+    deps.setConversationMessages = vi.fn((updater) => {
+      messages = typeof updater === "function" ? updater(messages) : updater;
+    });
+    const cleanup = bindReadyPhase({ current: deps });
+
+    clientMock.handlers.get("proactive-message")?.({
+      conversationId: "conv-1",
+      message: {
+        id: "server-assistant-1",
+        role: "assistant",
+        text: "different answer",
+        timestamp: 2,
+        source: "client_chat",
+      },
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "temp-user-1",
+      "temp-resp-1",
+      "server-assistant-1",
+    ]);
+
+    teardown(cleanup);
+  });
+
   it("re-dispatches a START_TRANSCRIPTION voice-control agent_event to the shell", () => {
     const cleanup = bindReadyPhase({ current: makeDeps() });
 

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1733,7 +1733,8 @@ export function useChatSend(deps: UseChatSendDeps) {
           }
         } else if (
           shouldApplyFinalStreamText(streamedAssistantText, data.text) ||
-          data.reasoning
+          data.reasoning ||
+          data.messageId
         ) {
           applyStreamingModificationForConversation(convId, {
             messageId: assistantMsgId,
@@ -1744,6 +1745,7 @@ export function useChatSend(deps: UseChatSendDeps) {
               ? { accountConnect: data.accountConnect }
               : {}),
             ...(data.reasoning ? { reasoning: data.reasoning } : {}),
+            ...(data.messageId ? { persistedMessageId: data.messageId } : {}),
           });
         } else if (data.failureKind) {
           // Streaming text already matched but the server flagged a failure
@@ -1764,6 +1766,7 @@ export function useChatSend(deps: UseChatSendDeps) {
             mode: "complete",
             fullText: data.text,
             accountConnect: data.accountConnect,
+            ...(data.messageId ? { persistedMessageId: data.messageId } : {}),
           });
         }
         if (data.usage) {
@@ -2037,6 +2040,9 @@ export function useChatSend(deps: UseChatSendDeps) {
                   : {}),
                 ...(retryData.reasoning
                   ? { reasoning: retryData.reasoning }
+                  : {}),
+                ...(retryData.messageId
+                  ? { persistedMessageId: retryData.messageId }
                   : {}),
               });
             }
@@ -2621,6 +2627,7 @@ export function useChatSend(deps: UseChatSendDeps) {
               mode: "complete",
               fullText: data.text,
               ...(data.failureKind ? { failureKind: data.failureKind } : {}),
+              ...(data.messageId ? { persistedMessageId: data.messageId } : {}),
             });
           } else if (data.failureKind) {
             applyStreamingModificationForConversation(convId, {

--- a/packages/ui/src/state/useStreamingText.ts
+++ b/packages/ui/src/state/useStreamingText.ts
@@ -72,6 +72,8 @@ export type StreamingTextModification =
       accountConnect?: AccountConnectRequest;
       /** Optional agent reasoning/thought to stamp on the completed turn. */
       reasoning?: string;
+      /** Persisted server id replacing the optimistic temp-resp-* stream id. */
+      persistedMessageId?: string;
     }
   | {
       messageId: string;
@@ -119,10 +121,23 @@ function computeNextMessage(
       const sameAccountConnect = message.accountConnect === mod.accountConnect;
       const sameReasoning =
         mod.reasoning === undefined || message.reasoning === mod.reasoning;
-      if (sameText && sameFailure && sameAccountConnect && sameReasoning) {
+      const sameId =
+        mod.persistedMessageId === undefined ||
+        message.id === mod.persistedMessageId;
+      if (
+        sameText &&
+        sameFailure &&
+        sameAccountConnect &&
+        sameReasoning &&
+        sameId
+      ) {
         return null;
       }
-      const next: ConversationMessage = { ...message, text: mod.fullText };
+      const next: ConversationMessage = {
+        ...message,
+        ...(mod.persistedMessageId ? { id: mod.persistedMessageId } : {}),
+        text: mod.fullText,
+      };
       if (mod.failureKind) {
         next.failureKind = mod.failureKind;
       } else if (message.failureKind !== undefined) {
@@ -179,13 +194,36 @@ export function applyStreamingTextModification(
     }
 
     let changed = false;
-    const next = prev.map((message) => {
+    let next = prev.map((message) => {
       if (message.id !== mod.messageId) return message;
       const patched = computeNextMessage(message, mod);
       if (patched === null) return message;
       changed = true;
       return patched;
     });
+    // Id-swap dedupe: when `complete` rebinds the streamed temp bubble to the
+    // persisted server id, a proactive-message WS echo carrying that same
+    // persisted id may have ALREADY appended its own bubble (action-callback
+    // turns persist + broadcast mid-turn, before the SSE `done` arrives). Keep
+    // only the FIRST occurrence — the swapped streamed bubble at the thread
+    // position the user watched (echoes append after it) — and drop the copy.
+    if (
+      mod.mode === "complete" &&
+      mod.persistedMessageId &&
+      mod.persistedMessageId !== mod.messageId
+    ) {
+      let seen = false;
+      const deduped = next.filter((message) => {
+        if (message.id !== mod.persistedMessageId) return true;
+        if (seen) return false;
+        seen = true;
+        return true;
+      });
+      if (deduped.length !== next.length) {
+        next = deduped;
+        changed = true;
+      }
+    }
     return changed ? next : prev;
   });
 }


### PR DESCRIPTION
## Root cause

The active web chat renders the same assistant reply twice through two live transports:

1. The send path appends an optimistic `temp-resp-*` assistant bubble and `/api/conversations/:id/messages/stream` streams tokens into it.
2. The server persists the final assistant reply under a **different server UUID** and broadcasts it as a `proactive-message` WS frame (source `client_chat`) to the active conversation.
3. The proactive handler in `startup-phase-hydrate.ts` deduped **by id only**: same id → skip, otherwise append. Since the temp id and the persisted id never match, the echo appended as a second identical bubble.

Server-side persistence is NOT duplicated: the container-local transcript for the incident conversation had exactly one assistant row per user turn, and a staging-DB audit found zero adjacent duplicate persisted assistant rows. Full DB evidence in the fleet deliverable (`DOUBLE-MSG-2026-07-23.md`, sol lane; staging evidence log attached to the pr-evidence release for #17009).

## Fix: id reconciliation through the protocol (no text matching)

Replaces the rejected text-match suppression approach from #17009 (closed). Identity now flows end to end:

**Server**
- The terminal SSE `done` frame carries `messageId`, the durable persisted assistant memory id.
- The streaming success path pre-mints the id BEFORE emitting `done` and hands it to the deferred persist (`persistAssistantConversationMemory` gains an optional `memoryId`), so the done-before-persist latency optimization is untouched and the WS broadcast carries the same id.
- Action-callback turns that already persisted (and WS-echoed) mid-turn reuse that memory's id on `done` instead of minting a second one (`getRecentVisibleAssistantMemorySince` now returns `{ id, text }`).
- Wallet-guidance, streamed-then-failed, provider-failure, and idempotent-replay `done` frames all carry the persisted id too.

**Client**
- `streamChatEndpoint` surfaces `messageId` from the `done` frame.
- `useChatSend` passes it into the `complete` streaming modification as `persistedMessageId`; `useStreamingText` swaps the streamed `temp-resp-*` bubble to the persisted id **in place**, and collapses an already-appended WS echo bubble carrying that id.
- The `proactive-message` handler now reconciles by id: same id → update in place (or no-op when unchanged); different id → append. Genuinely new proactive messages still render.

## Tests

- `packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts`: `done` frame carries `messageId` and the SAME id reaches the persistence layer (6/6 green).
- `packages/ui/src/state/__tests__/useStreamingText.test.ts`: id swap in place, echo-collapse on swap, id untouched without `persistedMessageId` (17/17 green).
- `packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts`: echo with same persisted id reconciles instead of appending; distinct proactive messages still append (6/6 green).
- Also green: conversation-streaming (29), conversation/chat idempotency (20), failurekind roundtrip (10), useChatSend (74), client stream suites (23), startup-phase-hydrate suites (39).
- `tsc --noEmit` clean for all touched files in packages/agent + packages/ui; biome check clean on all touched files.

Refs #17009 (closed text-match approach). Complements the render-time backstop in #16981.

<!-- evidence-row:backend-logs -->
- [x] [17049-backend-logs.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17049-backend-logs.log)

<!-- evidence-row:frontend-logs -->
- [x] [17049-frontend-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17049-frontend-tests.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure state/protocol change; duplicate render evidenced by incident screenshot + DB audit referenced in PR body (#17009 evidence)

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure state/protocol change; behavior verified by unit tests (id swap + WS echo reconciliation)

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual surface change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/prompt change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - not a domain-specific feature

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text/UI copy change
