### PR TITLE
chore(models): finish the gemma-4-31b default-model sweep

### DIFF
--- a/.github/workflows/lifeops-bench-multi-tier.yml
+++ b/.github/workflows/lifeops-bench-multi-tier.yml
@@ -5,7 +5,7 @@
 # four-tier model registry (small / mid / large / frontier).
 #
 # Default PR cells: `--suite smoke --tiers large,frontier` (Cerebras
-# gpt-oss-120b + Anthropic Opus 4.7). Nightly runs the `core` suite over the
+# gemma-4-31b + Anthropic Opus 4.7). Nightly runs the `core` suite over the
 # same two tiers.
 #
 # All cells are skip-not-fail: missing API keys or missing local binaries

--- a/.github/workflows/lifeops-bench.yml
+++ b/.github/workflows/lifeops-bench.yml
@@ -1,7 +1,7 @@
 # LifeOps Multi-Agent Benchmark Gate
 #
 # Runs the `lifeops-bench` runner per agent (eliza, hermes, openclaw) on
-# every PR that touches the lifeops surface area. Cerebras gpt-oss-120b is
+# every PR that touches the lifeops surface area. Cerebras gemma-4-31b is
 # used by the model-backed agents.
 #
 # Local equivalent (run before pushing):

--- a/packages/agent/scripts/proactive-greeting-live-trajectory.ts
+++ b/packages/agent/scripts/proactive-greeting-live-trajectory.ts
@@ -23,7 +23,7 @@ const BASE_URL =
   process.env.CEREBRAS_BASE_URL ||
   "https://api.cerebras.ai/v1";
 const API_KEY = process.env.OPENAI_API_KEY || process.env.CEREBRAS_API_KEY;
-const MODEL = process.env.LIVE_MODEL || "gpt-oss-120b";
+const MODEL = process.env.LIVE_MODEL || "gemma-4-31b";
 
 if (!API_KEY) {
   console.error("No OPENAI_API_KEY / CEREBRAS_API_KEY set — cannot run live.");

--- a/packages/app-core/test/live-agent/settings-shell-toggle.live.e2e.test.ts
+++ b/packages/app-core/test/live-agent/settings-shell-toggle.live.e2e.test.ts
@@ -2,7 +2,7 @@
  * Live-model acceptance for the consolidated SETTINGS action (#14364, PR #14461).
  *
  * Drives the REAL message pipeline (Stage-1 classify + Stage-2 planner) against a
- * LIVE model — Cerebras gpt-oss-120b when CEREBRAS_API_KEY is set — with the
+ * LIVE model — Cerebras gemma-4-31b when CEREBRAS_API_KEY is set — with the
  * worktree `@elizaos/plugin-app-control` source (vitest aliases it to src). A
  * natural "disable shell access" / "turn off shell permissions" request must
  * SELECT the SETTINGS action and drive the permissions route
@@ -51,9 +51,9 @@ describe("SETTINGS live-model selection (#14364)", () => {
 	beforeAll(async () => {
 		if (!canRun) return;
 		writeFileSync(OUT, "");
-		// Match the acceptance bar's model: Cerebras gpt-oss-120b.
-		process.env.OPENAI_SMALL_MODEL ??= "gpt-oss-120b";
-		process.env.OPENAI_LARGE_MODEL ??= "gpt-oss-120b";
+		// Match the acceptance bar's model: Cerebras gemma-4-31b.
+		process.env.OPENAI_SMALL_MODEL ??= "gemma-4-31b";
+		process.env.OPENAI_LARGE_MODEL ??= "gemma-4-31b";
 		process.env.LOG_LEVEL = process.env.ELIZA_E2E_LOG_LEVEL ?? "error";
 		process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING = "1";
 		process.env.ELIZA_DISABLE_PROACTIVE_AGENT = "1";

--- a/packages/benchmarks/HyperliquidBench/AGENTS.md
+++ b/packages/benchmarks/HyperliquidBench/AGENTS.md
@@ -99,7 +99,7 @@ the Rust `cargo test` target and the Makefile shortcuts (`make format`, `make ch
 - Rust crates must be built before live runs:
   `cargo build --release -p hl-runner -p hl-evaluator`
 - Live network runs require `HL_PRIVATE_KEY` and `--no-demo`.
-  Default model provider is Cerebras (`gpt-oss-120b`); OpenRouter is also supported.
+  Default model provider is Cerebras (`gemma-4-31b`); OpenRouter is also supported.
 - Full background: [README.md](README.md).
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->

--- a/packages/benchmarks/HyperliquidBench/CLAUDE.md
+++ b/packages/benchmarks/HyperliquidBench/CLAUDE.md
@@ -99,7 +99,7 @@ the Rust `cargo test` target and the Makefile shortcuts (`make format`, `make ch
 - Rust crates must be built before live runs:
   `cargo build --release -p hl-runner -p hl-evaluator`
 - Live network runs require `HL_PRIVATE_KEY` and `--no-demo`.
-  Default model provider is Cerebras (`gpt-oss-120b`); OpenRouter is also supported.
+  Default model provider is Cerebras (`gemma-4-31b`); OpenRouter is also supported.
 - Full background: [README.md](README.md).
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root AGENTS.md) -->

--- a/packages/benchmarks/HyperliquidBench/README.md
+++ b/packages/benchmarks/HyperliquidBench/README.md
@@ -132,7 +132,7 @@ Artifacts match the live format but `run_meta.json` includes `"demoMode": true` 
 
 You can still exercise the LLM pipeline in demo mode. That lets you validate prompts, caching, and plan decoding without hitting the exchange.
 
-1. **Set credentials** (Cerebras is the benchmark default for gpt-oss-120b; OpenRouter remains usable if you explicitly select it):
+1. **Set credentials** (Cerebras is the benchmark default for gemma-4-31b; OpenRouter remains usable if you explicitly select it):
    ```bash
    export CEREBRAS_API_KEY=csk-...
    export BENCHMARK_MODEL_PROVIDER=cerebras

--- a/packages/benchmarks/app-eval/test_code_agent_coding.py
+++ b/packages/benchmarks/app-eval/test_code_agent_coding.py
@@ -42,7 +42,7 @@ def test_builtin_agent_command_template_points_at_helper(monkeypatch) -> None:
     template = agent_command_template(
         "elizaos",
         provider="cerebras",
-        model="gpt-oss-120b",
+        model="gemma-4-31b",
         timeout_seconds=123,
     )
 
@@ -463,7 +463,7 @@ def test_run_agent_app_eval_coding_writes_results_and_token_metrics(tmp_path: Pa
         tasks=[task],
         task_agent="elizaos",
         model_provider="cerebras",
-        model="gpt-oss-120b",
+        model="gemma-4-31b",
         command_template=(
             f"{sys.executable} {fake_agent} --workspace {{workspace}} "
             "--prompt {prompt} --task {task} --result-json {result_json}"
@@ -505,7 +505,7 @@ def test_missing_agent_result_is_not_a_success(tmp_path: Path) -> None:
         tasks=[task],
         task_agent="elizaos",
         model_provider="cerebras",
-        model="gpt-oss-120b",
+        model="gemma-4-31b",
         command_template=(
             f"{sys.executable} {fake_agent} --workspace {{workspace}} "
             "--prompt {prompt} --task {task} --result-json {result_json}"

--- a/packages/benchmarks/multitask-bench/multitask_bench/harness.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/harness.py
@@ -151,7 +151,7 @@ def _openclaw_factory(model: str | None) -> AgentFactory:
         or os.environ.get("ELIZA_PROVIDER")
         or "cerebras"
     ).strip().lower()
-    model_name = model or os.environ.get("BENCHMARK_MODEL_NAME") or "gpt-oss-120b"
+    model_name = model or os.environ.get("BENCHMARK_MODEL_NAME") or "gemma-4-31b"
     shared_client = OpenClawClient(
         provider=provider,
         model=model_name,

--- a/packages/benchmarks/openclaw-adapter/config/cerebras.openclaw.json5
+++ b/packages/benchmarks/openclaw-adapter/config/cerebras.openclaw.json5
@@ -39,7 +39,7 @@
   },
   agents: {
     defaults: {
-      model: { primary: "cerebras/gpt-oss-120b" },
+      model: { primary: "cerebras/gemma-4-31b" },
     },
   },
 }

--- a/plugins/plugin-elizacloud/package.json
+++ b/plugins/plugin-elizacloud/package.json
@@ -159,44 +159,44 @@
       },
       "ELIZAOS_CLOUD_NANO_MODEL": {
         "type": "string",
-        "description": "Nano/cheapest text model for lightweight routing and should-respond tasks (overrides NANO_MODEL). Default: gpt-oss-120b",
+        "description": "Nano/cheapest text model for lightweight routing and should-respond tasks (overrides NANO_MODEL). Default: gemma-4-31b",
         "required": false,
-        "default": "gpt-oss-120b",
+        "default": "gemma-4-31b",
         "sensitive": false
       },
       "NANO_MODEL": {
         "type": "string",
         "description": "Fallback identifier for the nano language model if ELIZAOS_CLOUD_NANO_MODEL is not set.",
         "required": false,
-        "default": "gpt-oss-120b",
+        "default": "gemma-4-31b",
         "sensitive": false
       },
       "ELIZAOS_CLOUD_SMALL_MODEL": {
         "type": "string",
-        "description": "Small/fast model for quick tasks (overrides SMALL_MODEL). Default: gpt-oss-120b",
+        "description": "Small/fast model for quick tasks (overrides SMALL_MODEL). Default: gemma-4-31b",
         "required": false,
-        "default": "gpt-oss-120b",
+        "default": "gemma-4-31b",
         "sensitive": false
       },
       "SMALL_MODEL": {
         "type": "string",
         "description": "Fallback identifier for the small language model if ELIZAOS_CLOUD_SMALL_MODEL is not set.",
         "required": false,
-        "default": "gpt-oss-120b",
+        "default": "gemma-4-31b",
         "sensitive": false
       },
       "ELIZAOS_CLOUD_MEDIUM_MODEL": {
         "type": "string",
-        "description": "Medium planning model for multi-step reasoning (overrides MEDIUM_MODEL). Default: gpt-oss-120b",
+        "description": "Medium planning model for multi-step reasoning (overrides MEDIUM_MODEL). Default: gemma-4-31b",
         "required": false,
-        "default": "gpt-oss-120b",
+        "default": "gemma-4-31b",
         "sensitive": false
       },
       "MEDIUM_MODEL": {
         "type": "string",
         "description": "Fallback identifier for the medium language model if ELIZAOS_CLOUD_MEDIUM_MODEL is not set.",
         "required": false,
-        "default": "gpt-oss-120b",
+        "default": "gemma-4-31b",
         "sensitive": false
       },
       "ELIZAOS_CLOUD_LARGE_MODEL": {


### PR DESCRIPTION
Completes the repo-wide standardization on **gemma-4-31b as the go-to default model**. `gpt-oss-120b` stays wherever it is a genuine available option; it stops posing as the default on lanes the product already standardized on gemma.

## What was already true

`DEFAULT_CEREBRAS_TEXT_MODEL = "gemma-4-31b"` (and the Eliza Cloud small/free tiers derived from it) landed in `@elizaos/shared` earlier; the lifeops tier registry, hermes-adapter, OSWorld, HyperliquidBench's cerebras path, mint/mmau cerebras entries, and the cloud model picker's recommended entry are all gemma already. This PR sweeps the stragglers found by grepping every `gpt-oss-120b` instance and classifying each.

## Flipped (was a default, now gemma-4-31b)

- **`plugins/plugin-elizacloud/package.json`** — the `pluginParameters` metadata declared `"default": "gpt-oss-120b"` for nano/small/medium (6 sites + 3 description strings) while the actual runtime resolvers (`getSmallModel`/`getNanoModel`/`getMediumModel`) default to `DEFAULT_ELIZA_CLOUD_TEXT_MODEL` = gemma-4-31b. This metadata feeds plugin discovery/config-UI "will use default" surfaces — pure drift, now aligned. (Large/mega were already declared `zai-glm-4.7`, matching `DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL`.)
- **`packages/agent/scripts/proactive-greeting-live-trajectory.ts`** — Cerebras-lane live script fallback.
- **`packages/app-core/test/live-agent/settings-shell-toggle.live.e2e.test.ts`** — Cerebras acceptance-bar model pins + comment.
- **`packages/benchmarks/multitask-bench/multitask_bench/harness.py`** — provider default is `"cerebras"` but the model fallback was `gpt-oss-120b`.
- **`packages/benchmarks/app-eval/test_code_agent_coding.py`** — three `provider="cerebras"` fixtures.
- **`packages/benchmarks/openclaw-adapter/config/cerebras.openclaw.json5`** — `model.primary` → `cerebras/gemma-4-31b` (the `models` option list, including gpt-oss, is untouched).
- **Stale comments/docs claiming gpt-oss is the Cerebras default**: `.github/workflows/lifeops-bench.yml`, `.github/workflows/lifeops-bench-multi-tier.yml` (the large tier resolves to gemma-4-31b via `model_tiers.py`), HyperliquidBench `AGENTS.md`/`CLAUDE.md`/`README.md` (its cerebras path returns gemma-4-31b).

## Deliberately kept (option, not default)

- **Model catalogs / pickers**: `model-catalog.ts` Cerebras + Eliza Cloud entries, `getModelOptions()` Groq entry, `CEREBRAS_OPENAI_MODEL_IDS`, openclaw config `models` list — gpt-oss remains selectable.
- **Groq lanes**: `provider-model-defaults.ts`, `eliza.ts` groq normalization, `provider-switch-config.ts` groq block, live-agent/live-provider groq helpers, adhdbench (provider default groq), bfcl, mind2web, voicebench docs, experience (groq/openrouter/openai chain), mmau/mint/HyperliquidBench non-cerebras entries — **no gemma-4 is served on Groq/those lanes in this repo's model registry**, so `openai/gpt-oss-120b` is the available option there, not a stale default.
- **Pricing tables** (`benchmarks/lib/pricing.py` and adapter mirrors) — they price gpt-oss runs; per the pricing doctrine, unpriced models cost `None` (never fabricated), and no public Cerebras gemma-4-31b price exists in-repo to add.
- **Quirk branches and behavior docs about gpt-oss itself** (`plugin-elizacloud/src/models/text.ts` id branch, tau/openclaw parallel-call notes, orchestrator prompt-size comment).
- **Tests exercising gpt-oss id handling** (router-variant seeds, `/model` write passthroughs, `isLikelyOpenAiTextModel` GPT-OSS exclusions, catalog role assertions, streaming tests, replay fixtures, playwright orchestrator stubs).

## Verification

- `plugins/plugin-elizacloud` vitest: **390 passed, 3 skipped** on the branch.
- `packages/benchmarks/app-eval` pytest: **identical 6-failed/11-passed before and after** the change on this host (the 6 are pre-existing sandbox-environment failures untouched by this PR; the three edited tests pass in both runs).
- `plugin-elizacloud/package.json` re-parsed as valid JSON; `git diff` is exactly 24 insertions / 24 deletions across 11 files with no code-path changes outside the listed defaults.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - defaults/metadata/docs sweep; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - defaults/metadata/docs sweep; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or audio behavior changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no server code path changed; runtime defaults were already gemma via @elizaos/shared constants

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model pipeline code changed; declared defaults aligned to the constants the runtime already resolves (gemma-lane live trajectory exists on #17041 from the same session)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain records produced by a metadata/defaults sweep

<!-- evidence-row:ocr-review -->
- [ ] N/A - no product UI screenshot evidence applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
