### PR TITLE
fix(ci): collapse staging approval and admission

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -129,25 +129,10 @@ jobs:
             exit 1
           fi
 
-  authorize-staging:
-    name: Authorize staging release
+  admit-staging:
+    name: Authorize and admit staging release
     needs: validate-deploy-source
     if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    # This environment contains only deployment policy. Runtime secrets remain
-    # in `staging`, whose jobs are reached only after this gate and admission
-    # check. Keeping approval outside every shared concurrency group prevents a
-    # reviewer wait from owning a deployment lock.
-    environment: staging-approval
-    steps:
-      - name: Record approval
-        run: echo "Staging release $GITHUB_SHA approved."
-
-  admit-release:
-    name: Admit current release
-    needs: [validate-deploy-source, authorize-staging]
-    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && (needs.authorize-staging.result == 'success' || needs.authorize-staging.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -155,6 +140,11 @@ jobs:
       contents: read
     outputs:
       should_deploy: ${{ steps.admission.outputs.should_deploy }}
+    # This environment contains only deployment policy. Runtime secrets remain
+    # in `staging`, whose jobs are reached only after this gate and admission
+    # check. Keeping approval outside every shared concurrency group prevents a
+    # reviewer wait from owning a deployment lock.
+    environment: staging-approval
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
@@ -211,8 +201,8 @@ jobs:
   # ---------------------------------------------------------------------------
   migrate-db:
     name: Run Database Migrations
-    needs: admit-release
-    if: ${{ github.event_name != 'pull_request' && needs.admit-release.outputs.should_deploy == 'true' }}
+    needs: [validate-deploy-source, admit-staging]
+    if: ${{ always() && github.event_name != 'pull_request' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') || (!((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true')) }}
     # GitHub-hosted by DEFAULT so migrations don't inherit the shared
     # self-hosted deploy fleet's heavy-checkout failure modes (mirrors
     # cloud-deploy-backend). But the hosted ubuntu-latest pool periodically


### PR DESCRIPTION
# Relates to

Final scheduling refinement for #17040, #17045, and #17046 from live cutover verification.

# Background

The secret-free approval job and latest-run admission job were sequential hosted-runner jobs. After approval, the first job only echoed a message before the second checked admission. This patch performs latest-run admission inside the approved job itself and wires migration directly to its output.

Production now goes directly from manual-source validation (or trigger-constrained push) to migration. PR previews continue through the intentionally skipped migration to the shared Pages build.

# Risks

Low. Existing policy and admission conditions are preserved while one redundant job boundary is removed.

# Testing

- `actionlint -config-file .github/actionlint.yaml .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change; no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change; no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Live run 30006222235 showed the approved echo-only job queued ahead of admission, proving the redundant boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] GitHub Actions job graph is the affected domain artifact.

# Evidence Details

N/A for UI, audio, frontend, and LLM evidence because this changes workflow scheduling only.

## Known gaps / failures

None.