### PR TITLE
perf(core): coalesce turn-scoped room + message reads on the compose hot path

### DIFF
--- a/packages/core/src/__tests__/turn-read-coalescing.test.ts
+++ b/packages/core/src/__tests__/turn-read-coalescing.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Turn-scoped single-flight DB read coalescing: one compose fan-out issues the
+ * same room lookup and room messages-scan from several providers; the runtime
+ * memo must collapse those into one adapter round-trip each, slice the shared
+ * window exactly like a direct adapter query, and self-invalidate on every
+ * write so a compose immediately after message intake can never see a stale
+ * window. Real AgentRuntime + InMemoryDatabaseAdapter (which mirrors
+ * plugin-sql's newest-first ordering) with counting delegates that still run
+ * the real adapter queries; real RECENT_MESSAGES/ATTACHMENTS/FACTS providers
+ * for the compose-level proof; no model.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { factsProvider } from "../features/advanced-capabilities/providers/facts";
+import { attachmentsProvider } from "../features/basic-capabilities/providers/attachments";
+import { recentMessagesProvider } from "../features/basic-capabilities/providers/recentMessages";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory, Room, UUID } from "../types";
+import { ChannelType } from "../types";
+
+const WORLD_ID = "33333333-3333-3333-3333-333333333330" as UUID;
+const ROOM_ID = "33333333-3333-3333-3333-333333333331" as UUID;
+const SENDER_ID = "44444444-4444-4444-4444-444444444441" as UUID;
+
+type AdapterCallCounts = {
+	getRoomsByIds: number;
+	messagesScans: number;
+};
+
+/**
+ * Count adapter reads while still executing the real query — a counting
+ * delegate, not a stub: results come from the actual in-memory store.
+ */
+function instrumentAdapter(
+	adapter: InMemoryDatabaseAdapter,
+): AdapterCallCounts {
+	const counts: AdapterCallCounts = { getRoomsByIds: 0, messagesScans: 0 };
+	const realGetRoomsByIds = adapter.getRoomsByIds.bind(adapter);
+	adapter.getRoomsByIds = async (roomIds: UUID[]) => {
+		counts.getRoomsByIds += 1;
+		return realGetRoomsByIds(roomIds);
+	};
+	const realGetMemories = adapter.getMemories.bind(adapter);
+	adapter.getMemories = async (
+		params: Parameters<InMemoryDatabaseAdapter["getMemories"]>[0],
+	) => {
+		if (params.tableName === "messages") counts.messagesScans += 1;
+		return realGetMemories(params);
+	};
+	return counts;
+}
+
+async function makeRuntime(): Promise<{
+	runtime: AgentRuntime;
+	adapter: InMemoryDatabaseAdapter;
+	counts: AdapterCallCounts;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	const runtime = new AgentRuntime({
+		character: { name: "coalescing-test" } as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	await adapter.createWorlds([
+		{
+			id: WORLD_ID,
+			agentId: runtime.agentId,
+			name: "test world",
+			metadata: { roles: {} },
+		},
+	]);
+	await adapter.createRooms([
+		{
+			id: ROOM_ID,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.DM,
+			worldId: WORLD_ID,
+		},
+	]);
+	const counts = instrumentAdapter(adapter);
+	return { runtime, adapter, counts };
+}
+
+function makeMessageRow(index: number, text?: string): Memory {
+	const suffix = index.toString(16).padStart(12, "0");
+	return {
+		id: `55555555-5555-5555-5555-${suffix}` as UUID,
+		entityId: SENDER_ID,
+		agentId: undefined as unknown as UUID,
+		roomId: ROOM_ID,
+		worldId: WORLD_ID,
+		createdAt: 1_000 + index,
+		content: { text: text ?? `message ${index}`, source: "test" },
+	} as Memory;
+}
+
+async function seedMessages(
+	adapter: InMemoryDatabaseAdapter,
+	count: number,
+): Promise<Memory[]> {
+	const rows = Array.from({ length: count }, (_, i) => makeMessageRow(i));
+	await adapter.createMemories(
+		rows.map((memory) => ({ memory, tableName: "messages" })),
+	);
+	return rows;
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("getRoom single-flight coalescing", () => {
+	it("shares one adapter query across the compose fan-out's parallel getRoom calls", async () => {
+		const { runtime, counts } = await makeRuntime();
+		// RECENT_MESSAGES / CHARACTER / PLATFORM_* / WORLD each resolve the room.
+		const rooms = await Promise.all([
+			runtime.getRoom(ROOM_ID),
+			runtime.getRoom(ROOM_ID),
+			runtime.getRoom(ROOM_ID),
+			runtime.getRoom(ROOM_ID),
+		]);
+		expect(counts.getRoomsByIds).toBe(1);
+		for (const room of rooms) expect(room?.id).toBe(ROOM_ID);
+	});
+
+	it("re-queries immediately after a room mutation (compaction-style metadata write)", async () => {
+		const { runtime, counts } = await makeRuntime();
+		const room = await runtime.getRoom(ROOM_ID);
+		expect(room).not.toBeNull();
+		await runtime.updateRoom({
+			...(room as Room),
+			metadata: { ...(room as Room).metadata, lastCompactionAt: 42 },
+		});
+		const updated = await runtime.getRoom(ROOM_ID);
+		expect(updated?.metadata?.lastCompactionAt).toBe(42);
+		expect(counts.getRoomsByIds).toBe(2);
+	});
+
+	it("does not serve a memoized null after the room is created", async () => {
+		const { runtime, counts } = await makeRuntime();
+		const missingId = "33333333-3333-3333-3333-333333333339" as UUID;
+		expect(await runtime.getRoom(missingId)).toBeNull();
+		await runtime.createRoom({
+			id: missingId,
+			source: "test",
+			type: ChannelType.DM,
+			worldId: WORLD_ID,
+		} as Room);
+		const created = await runtime.getRoom(missingId);
+		expect(created?.id).toBe(missingId);
+		expect(counts.getRoomsByIds).toBe(2);
+	});
+
+	it("re-queries after the TTL lapses (bounds cross-process staleness)", async () => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		const { runtime, counts } = await makeRuntime();
+		await runtime.getRoom(ROOM_ID);
+		await runtime.getRoom(ROOM_ID);
+		expect(counts.getRoomsByIds).toBe(1);
+		vi.setSystemTime(Date.now() + 1_001);
+		await runtime.getRoom(ROOM_ID);
+		expect(counts.getRoomsByIds).toBe(2);
+	});
+});
+
+describe("room messages-scan coalescing", () => {
+	it("serves concurrent scans at different limits from one superset fetch, sliced exactly", async () => {
+		const { runtime, adapter, counts } = await makeRuntime();
+		const rows = await seedMessages(adapter, 60);
+		// RECENT_MESSAGES (conversationLength) / FACTS (10) / ATTACHMENTS (50).
+		const [big, ten, fifty] = await Promise.all([
+			runtime.getMemories({
+				tableName: "messages",
+				roomId: ROOM_ID,
+				limit: runtime.getConversationLength(),
+				unique: false,
+			}),
+			runtime.getMemories({
+				tableName: "messages",
+				roomId: ROOM_ID,
+				limit: 10,
+				unique: false,
+			}),
+			runtime.getMemories({
+				tableName: "messages",
+				roomId: ROOM_ID,
+				count: 50,
+				unique: false,
+			}),
+		]);
+		expect(counts.messagesScans).toBe(1);
+		// Newest-first, byte-identical to a direct limit-bounded adapter query.
+		expect(big).toHaveLength(60);
+		expect(ten).toHaveLength(10);
+		expect(fifty).toHaveLength(50);
+		expect(ten[0]?.id).toBe(rows[59]?.id);
+		expect(ten[9]?.id).toBe(rows[50]?.id);
+		expect(fifty.map((m) => m.id)).toEqual(big.slice(0, 50).map((m) => m.id));
+	});
+
+	it("reproduces a start-bounded (compaction cutoff) query from the shared window", async () => {
+		const { runtime, adapter, counts } = await makeRuntime();
+		const rows = await seedMessages(adapter, 30);
+		// Prime the shared window, then ask for the post-compaction slice.
+		await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 50,
+			unique: false,
+		});
+		const cutoff = rows[20]?.createdAt as number;
+		const bounded = await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 50,
+			unique: false,
+			start: cutoff,
+		});
+		expect(counts.messagesScans).toBe(1);
+		expect(bounded).toHaveLength(10); // rows 20..29 inclusive
+		expect(bounded[0]?.id).toBe(rows[29]?.id);
+		expect(bounded[9]?.id).toBe(rows[20]?.id);
+	});
+
+	it("busts the window on createMemory so a compose right after intake sees the new message", async () => {
+		const { runtime, adapter, counts } = await makeRuntime();
+		await seedMessages(adapter, 5);
+		await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 10,
+			unique: false,
+		});
+		expect(counts.messagesScans).toBe(1);
+		// The intake sequence: persist the user message, then compose reads.
+		const incoming = makeMessageRow(99, "what did I just say?");
+		await runtime.createMemory(incoming, "messages");
+		const window = await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 10,
+			unique: false,
+		});
+		expect(counts.messagesScans).toBe(2);
+		expect(window[0]?.id).toBe(incoming.id);
+	});
+
+	it("passes filtered/ordered/scoped query shapes through to the adapter untouched", async () => {
+		const { runtime, adapter, counts } = await makeRuntime();
+		const rows = await seedMessages(adapter, 20);
+		// Prime an eligible window first — the variants below must not be
+		// served from it.
+		await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 10,
+			unique: false,
+		});
+		const ascending = await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 5,
+			unique: false,
+			orderBy: "createdAt",
+			orderDirection: "asc",
+		});
+		const keyword = await runtime.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+			limit: 5,
+			unique: false,
+			textContains: "message 3",
+		});
+		expect(counts.messagesScans).toBe(3);
+		expect(ascending[0]?.id).toBe(rows[0]?.id); // oldest-first honored
+		expect(keyword.every((m) => m.content.text?.includes("message 3"))).toBe(
+			true,
+		);
+	});
+});
+
+describe("composeState over real providers", () => {
+	it("runs RECENT_MESSAGES + ATTACHMENTS + FACTS with a single room messages-scan", async () => {
+		const { runtime, adapter, counts } = await makeRuntime();
+		await seedMessages(adapter, 12);
+		runtime.registerProvider(recentMessagesProvider);
+		runtime.registerProvider(attachmentsProvider);
+		runtime.registerProvider(factsProvider);
+		// Text references + asks to inspect an attachment, so ATTACHMENTS pays
+		// its history fetch — which must coalesce with RECENT_MESSAGES/FACTS.
+		const message = makeMessageRow(97, "what does the attached image show?");
+		await runtime.createMemory(message, "messages");
+		const countsAfterIntake = counts.messagesScans;
+		const state = await runtime.composeState(
+			message,
+			["RECENT_MESSAGES", "ATTACHMENTS", "FACTS"],
+			true,
+			true,
+		);
+		expect(counts.messagesScans - countsAfterIntake).toBe(1);
+		// Correctness gate: the just-persisted message is in the rendered window.
+		expect(state.text).toContain("what does the attached image show?");
+	});
+
+	it("skips the ATTACHMENTS history fetch entirely on a text-only turn", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seedMessages(adapter, 3);
+		let providerFetches = 0;
+		const realGetMemories = runtime.getMemories.bind(runtime);
+		runtime.getMemories = async (
+			params: Parameters<AgentRuntime["getMemories"]>[0],
+		) => {
+			providerFetches += 1;
+			return realGetMemories(params);
+		};
+		const result = await attachmentsProvider.get(
+			runtime,
+			makeMessageRow(98, "gm, how are you?"),
+			{ values: {}, data: {}, text: "" },
+		);
+		expect(providerFetches).toBe(0);
+		expect(result.text).toBe("");
+	});
+});

--- a/packages/core/src/__tests__/turn-read-coalescing.test.ts
+++ b/packages/core/src/__tests__/turn-read-coalescing.test.ts
@@ -152,6 +152,29 @@ describe("getRoom single-flight coalescing", () => {
 		expect(counts.getRoomsByIds).toBe(2);
 	});
 
+	it("invalidates the memo when ensureConnection creates the room (bypasses the upsertRooms wrapper)", async () => {
+		const { runtime, counts } = await makeRuntime();
+		const newRoomId = "33333333-3333-3333-3333-33333333333e" as UUID;
+		// A pre-create read memoizes null for the not-yet-existing room.
+		expect(await runtime.getRoom(newRoomId)).toBeNull();
+		// ensureConnection writes the room through adapter.upsertRooms directly, not
+		// this.upsertRooms — so without an explicit invalidation this read would be
+		// served the stale memoized null.
+		await runtime.ensureConnection({
+			entityId: SENDER_ID,
+			roomId: newRoomId,
+			worldId: WORLD_ID,
+			type: ChannelType.DM,
+			source: "test",
+		});
+		const before = counts.getRoomsByIds;
+		const created = await runtime.getRoom(newRoomId);
+		// The post-ensureConnection read must hit the adapter (memo invalidated) and
+		// return the created room, not the stale null.
+		expect(counts.getRoomsByIds).toBe(before + 1);
+		expect(created?.id).toBe(newRoomId);
+	});
+
 	it("re-queries after the TTL lapses (bounds cross-process staleness)", async () => {
 		vi.useFakeTimers({ toFake: ["Date"] });
 		const { runtime, counts } = await makeRuntime();

--- a/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
@@ -43,12 +43,18 @@ function attachmentMemory(createdAt = 1): Memory {
 
 function makeRuntime(
 	recentMessages: Memory[],
-	options: { hasImageDescriptionModel?: boolean } = {},
+	options: {
+		hasImageDescriptionModel?: boolean;
+		onHistoryFetch?: () => void;
+	} = {},
 ): IAgentRuntime {
 	return {
 		agentId,
 		getConversationLength: () => 20,
-		getMemories: async () => recentMessages,
+		getMemories: async () => {
+			options.onHistoryFetch?.();
+			return recentMessages;
+		},
 		getRoom: async () => null,
 		getModel: (modelType: string) =>
 			options.hasImageDescriptionModel &&
@@ -108,14 +114,23 @@ function ownerPrivateAttachmentMemory(granted = false): Memory {
 }
 
 describe("attachmentsProvider", () => {
-	it("keeps stale room attachments out of unrelated prompt text", async () => {
+	it("keeps stale room attachments out of unrelated prompt text without fetching history", async () => {
+		// The render gate is decidable from the message alone here, so the
+		// provider must not pay the conversation-history scan at all — that scan
+		// was the largest composeState provider wall on text-only turns.
+		let historyFetches = 0;
 		const result = await attachmentsProvider.get(
-			makeRuntime([attachmentMemory()]),
+			makeRuntime([attachmentMemory()], {
+				onHistoryFetch: () => {
+					historyFetches += 1;
+				},
+			}),
 			makeMessage({ text: "can you try this?" }),
 		);
 
 		expect(result.text).toBe("");
-		expect(result.data?.visibleAttachments).toHaveLength(1);
+		expect(result.data?.visibleAttachments).toHaveLength(0);
+		expect(historyFetches).toBe(0);
 	});
 
 	it("renders attachment prompt text when the current message asks about a link", async () => {
@@ -142,8 +157,13 @@ describe("attachmentsProvider", () => {
 	});
 
 	it("does not inject stale room attachments into sub-agent result turns", async () => {
+		let historyFetches = 0;
 		const result = await attachmentsProvider.get(
-			makeRuntime([attachmentMemory()]),
+			makeRuntime([attachmentMemory()], {
+				onHistoryFetch: () => {
+					historyFetches += 1;
+				},
+			}),
 			makeMessage({
 				source: "sub_agent",
 				text: "[sub-agent: app-build (opencode) — task_complete]\nResult: https://example.test/apps/demo/",
@@ -151,7 +171,8 @@ describe("attachmentsProvider", () => {
 		);
 
 		expect(result.text).toBe("");
-		expect(result.data?.visibleAttachments).toHaveLength(1);
+		expect(result.data?.visibleAttachments).toHaveLength(0);
+		expect(historyFetches).toBe(0);
 	});
 
 	it("does not advertise an ATTACHMENT read for a failure-prose description without stored text", async () => {

--- a/packages/core/src/features/basic-capabilities/providers/attachments.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.ts
@@ -68,17 +68,27 @@ function messageTextForAttachmentRelevance(message: Memory): string {
 		.join("\n");
 }
 
-function shouldRenderAttachmentPromptText(
-	message: Memory,
-	allAttachments: readonly Media[],
-): boolean {
-	if (allAttachments.length === 0) return false;
+/**
+ * The half of the render gate decidable from the current message alone —
+ * before any conversation-history fetch. When this is false the provider
+ * skips `listConversationAttachments` entirely (the room-history scan plus
+ * access-context resolution), which on a text-only turn was the single
+ * largest composeState provider wall.
+ */
+function couldRenderAttachmentPromptText(message: Memory): boolean {
 	if ((message.content.attachments ?? []).length > 0) return true;
 	if (message.content.source === MESSAGE_SOURCE_SUB_AGENT) return false;
 	const text = messageTextForAttachmentRelevance(message);
 	return (
 		ATTACHMENT_REFERENCE_RE.test(text) && ATTACHMENT_INSPECTION_RE.test(text)
 	);
+}
+
+function shouldRenderAttachmentPromptText(
+	message: Memory,
+	allAttachments: readonly Media[],
+): boolean {
+	return allAttachments.length > 0 && couldRenderAttachmentPromptText(message);
 }
 
 export const attachmentsProvider: Provider = {
@@ -96,6 +106,19 @@ export const attachmentsProvider: Provider = {
 		message: Memory,
 	): Promise<ProviderResult> => {
 		try {
+			// Gate before fetch: when the message-side half of the render gate
+			// already fails (text-only turn with no attachment reference, or a
+			// sub-agent result turn), no fetch result could change the outcome —
+			// prompt text stays empty either way, so skip the history scan. The
+			// current message carries no attachments in this branch (own
+			// attachments pass the gate), so the empty data shape is exact.
+			if (!couldRenderAttachmentPromptText(message)) {
+				return {
+					values: { attachments: "" },
+					data: { attachments: [], visibleAttachments: [], omittedCount: 0 },
+					text: "",
+				};
+			}
 			const allAttachments = await listConversationAttachments(
 				runtime,
 				message,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -89,6 +89,7 @@ import type { ResponseHandlerFieldEvaluator } from "./runtime/response-handler-f
 import { ResponseHandlerFieldRegistry } from "./runtime/response-handler-field-registry";
 import { RoomHandlerQueue } from "./runtime/room-handler-queue";
 import { ShortcutRegistry } from "./runtime/shortcut-registry";
+import { SingleFlightMemo } from "./runtime/single-flight-memo";
 import {
 	buildCanonicalSystemPrompt,
 	resolveEffectiveSystemPrompt,
@@ -988,6 +989,29 @@ export class AgentRuntime implements IAgentRuntime {
 		string,
 		InFlightProviderExecution
 	>();
+	// Turn-scoped single-flight read coalescing (see runtime/single-flight-memo).
+	// A Stage-1 compose issues getRoom 4x (RECENT_MESSAGES / CHARACTER /
+	// PLATFORM_* / WORLD) and 3 overlapping room messages-scans (RECENT_MESSAGES
+	// at conversationLength, FACTS at 10, ATTACHMENTS at ≤50); on a serializing
+	// store each duplicate is a full extra round-trip. The 1s TTL comfortably
+	// covers one compose fan-out while bounding staleness from out-of-process
+	// writers; in-process correctness comes from the mutation wrappers below
+	// invalidating the relevant key (createMemory → roomMessagesMemo,
+	// room mutators → roomReadMemo), never from the TTL.
+	private static readonly READ_MEMO_TTL_MS = 1_000;
+	private static readonly READ_MEMO_MAX_ENTRIES = 1_000;
+	// Floor for the coalesced messages window so every standard compose-time
+	// consumer (conversationLength, FACTS' 10, ATTACHMENTS' 50) is served by
+	// one superset fetch sliced per caller.
+	private static readonly ROOM_MESSAGES_MEMO_MIN_WINDOW = 50;
+	private readonly roomReadMemo = new SingleFlightMemo<Room | null>(
+		AgentRuntime.READ_MEMO_TTL_MS,
+		AgentRuntime.READ_MEMO_MAX_ENTRIES,
+	);
+	private readonly roomMessagesMemo = new SingleFlightMemo<Memory[], number>(
+		AgentRuntime.READ_MEMO_TTL_MS,
+		AgentRuntime.READ_MEMO_MAX_ENTRIES,
+	);
 	readonly fetch = fetch;
 	promptBatcher: PromptBatcher;
 	services = new Map<ServiceTypeName, Service[]>();
@@ -2383,6 +2407,8 @@ export class AgentRuntime implements IAgentRuntime {
 		this.events = {};
 		this.stateCache.clear();
 		this.providerExecutionsInFlight.clear();
+		this.roomReadMemo.invalidate();
+		this.roomMessagesMemo.invalidate();
 		this.servicePromises.clear();
 		this.servicePromiseHandlers.clear();
 		this.startingServices.clear();
@@ -2741,6 +2767,8 @@ export class AgentRuntime implements IAgentRuntime {
 					worldId: this.agentId,
 				},
 			]);
+			// The getRoom above memoized null for this id; drop it.
+			this.roomReadMemo.invalidate(this.agentId);
 		}
 		const [participantsResult] = await this.adapter.getParticipantsForRooms([
 			this.agentId,
@@ -4163,6 +4191,8 @@ export class AgentRuntime implements IAgentRuntime {
 				metadata,
 			},
 		]);
+		// The existence probe above may have memoized null/stale for this id.
+		this.roomReadMemo.invalidate(id);
 
 		this.logger.debug(
 			{ src: "agent", agentId: this.agentId, channelId: id },
@@ -9540,10 +9570,108 @@ ${section_end}`;
 		includeEmbedding?: boolean;
 		accessContext?: AccessContext;
 	}): Promise<Memory[]> {
+		const coalesced = this.coalesceRoomMessagesScan(params);
+		if (coalesced) return coalesced;
 		return this.adapter.getMemories({
 			...params,
 			limit: params.limit ?? params.count,
 			tableName: params.tableName,
+		});
+	}
+
+	/**
+	 * Single-flight coalescing for the compose-time room messages-scan. Several
+	 * providers issue the same newest-first `messages` window at different
+	 * limits within one turn (RECENT_MESSAGES at conversationLength, FACTS at
+	 * 10, ATTACHMENTS at ≤50, REPLY_CONTEXT's dedupe window); one superset
+	 * fetch serves them all, sliced per caller. Only the exact newest-first
+	 * room-scoped shape is eligible — any filter, ordering, pagination, or
+	 * access-context variation falls through to the adapter untouched, so this
+	 * can narrow no query's semantics.
+	 *
+	 * Slicing is exact, not approximate: the adapter orders newest-first
+	 * (createdAt desc, id desc), so the superset's first `limit` rows are
+	 * byte-identical to a direct `limit`-bounded query. A `start` bound (the
+	 * compaction cutoff) is a pure suffix predicate on that ordering — every
+	 * row ≥ start is newer than every row < start — so filtering the superset
+	 * then slicing reproduces the adapter's start+limit result for any
+	 * requested limit ≤ the fetched window. Requests larger than the window
+	 * bypass the memo entirely rather than risk a truncated result.
+	 *
+	 * Returns null when the query shape is not eligible.
+	 */
+	private coalesceRoomMessagesScan(params: {
+		entityId?: UUID;
+		agentId?: UUID;
+		roomId?: UUID;
+		limit?: number;
+		count?: number;
+		offset?: number;
+		unique?: boolean;
+		tableName: string;
+		start?: number;
+		end?: number;
+		worldId?: UUID;
+		metadata?: Record<string, unknown>;
+		textContains?: string;
+		orderBy?: "createdAt";
+		orderDirection?: "asc" | "desc";
+		includeEmbedding?: boolean;
+		accessContext?: AccessContext;
+	}): Promise<Memory[]> | null {
+		if (params.tableName !== "messages" || !params.roomId) return null;
+		if (
+			params.entityId !== undefined ||
+			params.agentId !== undefined ||
+			params.worldId !== undefined ||
+			params.unique ||
+			(params.offset !== undefined && params.offset !== 0) ||
+			params.end !== undefined ||
+			params.metadata !== undefined ||
+			params.textContains !== undefined ||
+			params.orderDirection === "asc" ||
+			params.includeEmbedding === false ||
+			params.accessContext !== undefined
+		) {
+			return null;
+		}
+		const requested = params.limit ?? params.count;
+		if (
+			typeof requested !== "number" ||
+			!Number.isFinite(requested) ||
+			requested <= 0
+		) {
+			return null;
+		}
+		const roomId = params.roomId;
+		const supersetLimit = Math.max(
+			requested,
+			this.getConversationLength(),
+			AgentRuntime.ROOM_MESSAGES_MEMO_MIN_WINDOW,
+		);
+		const cached = this.roomMessagesMemo.peek(roomId);
+		const window =
+			cached && cached.meta >= requested
+				? cached.promise
+				: this.roomMessagesMemo.put(
+						roomId,
+						supersetLimit,
+						this.adapter.getMemories({
+							tableName: "messages",
+							roomId,
+							limit: supersetLimit,
+							unique: false,
+						}),
+					);
+		const start = params.start;
+		return window.then((rows) => {
+			const filtered =
+				start !== undefined
+					? rows.filter((row) => (row.createdAt ?? 0) >= start)
+					: rows;
+			// Fresh array per caller (consumers sort/filter in place); the Memory
+			// objects themselves are shared read-only, like the turn state cache.
+			return filtered.slice(0, requested);
 		});
 	}
 	async getAllMemories(): Promise<Memory[]> {
@@ -9715,6 +9843,7 @@ ${section_end}`;
 		}
 
 		await this.adapter.deleteMemories(memoryIds);
+		this.roomMessagesMemo.invalidate();
 		this.logger.info(
 			{ src: "agent", agentId: this.agentId, count: memoryIds.length },
 			"Memories cleared",
@@ -9722,6 +9851,9 @@ ${section_end}`;
 	}
 	async deleteAllMemories(roomIds: UUID[], tableName: string): Promise<void> {
 		await this.adapter.deleteAllMemories(roomIds, tableName);
+		if (tableName === "messages") {
+			for (const roomId of roomIds) this.roomMessagesMemo.invalidate(roomId);
+		}
 	}
 	async countMemories(
 		roomIdOrParams:
@@ -9831,9 +9963,19 @@ ${section_end}`;
 	}
 
 	async getRoom(roomId: UUID): Promise<Room | null> {
-		const rooms = await this.adapter.getRoomsByIds([roomId]);
-		if (!rooms.length) return null;
-		return rooms[0];
+		// Coalesced: a Stage-1 compose resolves the same room several times in
+		// parallel; share one in-flight adapter query. Room mutators below
+		// invalidate the key, so a create/update/delete is visible immediately.
+		const cached = this.roomReadMemo.peek(roomId);
+		if (cached) return cached.promise;
+		return this.roomReadMemo.put(
+			roomId,
+			undefined,
+			(async () => {
+				const rooms = await this.adapter.getRoomsByIds([roomId]);
+				return rooms[0] ?? null;
+			})(),
+		);
 	}
 
 	async getRoomsByIds(roomIds: UUID[]): Promise<Room[]> {
@@ -9861,18 +10003,29 @@ ${section_end}`;
 			},
 		]);
 		if (!res.length) throw new Error("Failed to create room");
+		// Bust a possibly-memoized null from a pre-creation lookup.
+		this.roomReadMemo.invalidate(res[0]);
+		if (id) this.roomReadMemo.invalidate(id);
 		return res[0];
 	}
 
 	async createRooms(rooms: Room[]): Promise<UUID[]> {
-		return this.adapter.createRooms(rooms);
+		const ids = await this.adapter.createRooms(rooms);
+		for (const roomId of ids) this.roomReadMemo.invalidate(roomId);
+		return ids;
 	}
 	async upsertRooms(rooms: Room[]): Promise<void> {
-		return this.adapter.upsertRooms(rooms);
+		await this.adapter.upsertRooms(rooms);
+		for (const room of rooms) {
+			if (room.id) this.roomReadMemo.invalidate(room.id);
+		}
 	}
 
 	async deleteRoomsByWorldId(worldId: UUID): Promise<void> {
 		await this.adapter.deleteRoomsByWorldIds([worldId]);
+		// Room ids under the world are unknown here; drop everything.
+		this.roomReadMemo.invalidate();
+		this.roomMessagesMemo.invalidate();
 	}
 	async getRoomsForParticipant(entityId: UUID): Promise<UUID[]> {
 		return this.adapter.getRoomsForParticipants([entityId]);
@@ -10338,17 +10491,27 @@ ${section_end}`;
 	async createMemories(
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
 	): Promise<UUID[]> {
-		return this.adapter.createMemories(memories);
+		const ids = await this.adapter.createMemories(memories);
+		for (const entry of memories) {
+			if (entry.tableName === "messages" && entry.memory.roomId) {
+				this.roomMessagesMemo.invalidate(entry.memory.roomId);
+			}
+		}
+		return ids;
 	}
 
 	async updateMemories(
 		memories: Array<Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }>,
 	): Promise<void> {
-		return this.adapter.updateMemories(memories);
+		await this.adapter.updateMemories(memories);
+		// Partial updates carry no table/room; drop every cached window rather
+		// than risk serving a pre-update snapshot.
+		this.roomMessagesMemo.invalidate();
 	}
 
 	async deleteMemories(memoryIds: UUID[]): Promise<void> {
-		return this.adapter.deleteMemories(memoryIds);
+		await this.adapter.deleteMemories(memoryIds);
+		this.roomMessagesMemo.invalidate();
 	}
 
 	// ── Single-item memory wrappers ────────────────────────────────────
@@ -10409,6 +10572,13 @@ ${section_end}`;
 		const ids = await this.adapter.createMemories([
 			{ memory, tableName, unique },
 		]);
+		// The intake path persists the user message immediately before
+		// composeState reads the room window; busting the key here makes the
+		// coalesced messages-scan self-enforcing — a stale window can never
+		// drop the message currently being answered.
+		if (tableName === "messages" && memory.roomId) {
+			this.roomMessagesMemo.invalidate(memory.roomId);
+		}
 		const memoryId = ids[0];
 		await this.applyPipelineHooks(
 			"after_memory_persisted",
@@ -10421,11 +10591,13 @@ ${section_end}`;
 		memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata },
 	): Promise<boolean> {
 		await this.adapter.updateMemories([memory]);
+		this.roomMessagesMemo.invalidate();
 		return true; // Successfully updated if no error thrown
 	}
 
 	async deleteMemory(memoryId: UUID): Promise<void> {
-		return this.adapter.deleteMemories([memoryId]);
+		await this.adapter.deleteMemories([memoryId]);
+		this.roomMessagesMemo.invalidate();
 	}
 
 	// ── Participant passthroughs & wrappers ──────────────────────────────
@@ -10451,20 +10623,27 @@ ${section_end}`;
 
 	// ── Room passthroughs & wrappers ────────────────────────────────────
 	async updateRooms(rooms: Room[]): Promise<void> {
-		return this.adapter.updateRooms(rooms);
+		await this.adapter.updateRooms(rooms);
+		for (const room of rooms) {
+			if (room.id) this.roomReadMemo.invalidate(room.id);
+		}
 	}
 
 	async deleteRooms(roomIds: UUID[]): Promise<void> {
-		return this.adapter.deleteRooms(roomIds);
+		await this.adapter.deleteRooms(roomIds);
+		for (const roomId of roomIds) {
+			this.roomReadMemo.invalidate(roomId);
+			this.roomMessagesMemo.invalidate(roomId);
+		}
 	}
 
 	// Single-item room wrappers
 	async updateRoom(room: Room): Promise<void> {
-		return this.adapter.updateRooms([room]);
+		return this.updateRooms([room]);
 	}
 
 	async deleteRoom(roomId: UUID): Promise<void> {
-		return this.adapter.deleteRooms([roomId]);
+		return this.deleteRooms([roomId]);
 	}
 
 	on(event: string, callback: (data: EventPayload) => void): void {
@@ -11185,7 +11364,10 @@ ${section_end}`;
 	// ── Batch pass-throughs required by IDatabaseAdapter ────────────────
 
 	async deleteRoomsByWorldIds(worldIds: UUID[]): Promise<void> {
-		return this.adapter.deleteRoomsByWorldIds(worldIds);
+		await this.adapter.deleteRoomsByWorldIds(worldIds);
+		// Room ids under these worlds are unknown here; drop everything.
+		this.roomReadMemo.invalidate();
+		this.roomMessagesMemo.invalidate();
 	}
 
 	async getRoomsByWorlds(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4020,6 +4020,12 @@ export class AgentRuntime implements IAgentRuntime {
 			...params,
 			source: params.source ?? "default",
 		});
+		// ensureConnectionStandalone writes the room through adapter.upsertRooms directly
+		// rather than this.upsertRooms, so it bypasses the room-read memo invalidation.
+		// Invalidate here to uphold the "every room mutation is immediately visible"
+		// invariant — otherwise a concurrent compose could be served a memoized null (for
+		// a just-created room) or a <=1s-stale Room after a metadata upsert.
+		this.roomReadMemo.invalidate(params.roomId);
 		if (result.createdRoomParticipants > 0) {
 			this.logger.debug(
 				{
@@ -9630,7 +9636,11 @@ ${section_end}`;
 			params.metadata !== undefined ||
 			params.textContains !== undefined ||
 			params.orderDirection === "asc" ||
-			params.includeEmbedding === false ||
+			// The coalesced superset scan omits includeEmbedding, so it can only serve
+			// callers that don't pin the flag either way — a `true` caller would get
+			// embedding-less rows from an adapter that honors it, a `false` caller would
+			// get embeddings it asked to skip. Bypass the memo whenever it's set.
+			params.includeEmbedding !== undefined ||
 			params.accessContext !== undefined
 		) {
 			return null;

--- a/packages/core/src/runtime/single-flight-memo.ts
+++ b/packages/core/src/runtime/single-flight-memo.ts
@@ -1,0 +1,66 @@
+/**
+ * Short-TTL, in-flight-shared read memo backing the runtime's turn-scoped DB
+ * read coalescing (getRoom and the room messages-scan). A Stage-1 compose
+ * fans ~12 providers out concurrently and several of them issue the same
+ * room/messages queries; on a single-threaded store (PGlite WASM) those
+ * duplicates serialize and their latencies add up rather than overlap, so
+ * collapsing N identical reads into one round-trip directly shrinks the
+ * composeState wall. The stored value is the promise, so concurrent callers
+ * within one compose share a single in-flight query even before the TTL
+ * matters (same shipped pattern as identity-clusters.ts); a rejected fetch
+ * self-evicts so failures are retried, never cached. `meta` carries
+ * fetch-shape bookkeeping (e.g. the fetched window size) so a caller can
+ * decide whether a live entry is a superset of what it needs.
+ *
+ * Correctness leans on invalidation, not the TTL: AgentRuntime busts the
+ * relevant key inside every mutation wrapper (createMemory/updateRooms/…).
+ * The TTL only bounds staleness from writers outside this process.
+ */
+export class SingleFlightMemo<V, Meta = undefined> {
+	private readonly entries = new Map<
+		string,
+		{ at: number; meta: Meta; promise: Promise<V> }
+	>();
+
+	constructor(
+		private readonly ttlMs: number,
+		private readonly maxEntries: number,
+	) {}
+
+	/** The live (unexpired) entry for `key`, or null. Never triggers a fetch. */
+	peek(key: string): { meta: Meta; promise: Promise<V> } | null {
+		const entry = this.entries.get(key);
+		if (!entry || Date.now() - entry.at >= this.ttlMs) return null;
+		return entry;
+	}
+
+	/**
+	 * Store an in-flight fetch under `key`, replacing any existing entry. The
+	 * promise is returned unchanged so callers can `return memo.put(...)`.
+	 */
+	put(key: string, meta: Meta, promise: Promise<V>): Promise<V> {
+		promise.catch(() => {
+			// Evict only if this promise is still the resident entry — a newer
+			// fetch stored after invalidation must not be dropped by an old
+			// rejection arriving late.
+			if (this.entries.get(key)?.promise === promise) {
+				this.entries.delete(key);
+			}
+		});
+		if (this.entries.size >= this.maxEntries) {
+			const oldest = this.entries.keys().next().value;
+			if (oldest !== undefined) this.entries.delete(oldest);
+		}
+		this.entries.set(key, { at: Date.now(), meta, promise });
+		return promise;
+	}
+
+	/** Drop one key, or every entry when called without a key. */
+	invalidate(key?: string): void {
+		if (key === undefined) {
+			this.entries.clear();
+			return;
+		}
+		this.entries.delete(key);
+	}
+}


### PR DESCRIPTION
## What

Turn-scoped **single-flight DB read coalescing** on the composeState hot path — the same in-flight-shared memo pattern already shipped in #16912 (identity-cluster memo):

- **`getRoom`** was a bare `adapter.getRoomsByIds([roomId])` with no cache, fetched **~4× per compose** (RECENT_MESSAGES, entities, PLATFORM_CHAT, PLATFORM_USER each independently read the same room). Now served once per turn from a ~1s in-flight-shared memo, invalidated on every room mutation.
- **The compose-shape messages scan** (`tableName='messages'`, roomId, newest-first) is coalesced so concurrent providers requesting different limits share one superset fetch, **sliced exactly**.
- **ATTACHMENTS** now gates before fetching — skips the ~451ms room-attachments query on text-only turns.

New `packages/core/src/runtime/single-flight-memo.ts` (short-TTL, in-flight-shared promise memo, rejection self-evicting), copying `identity-clusters.ts:15-25`.

## Why

Real `InferenceTiming` on a simple DM turn (local mirror of a dedicated Eliza Cloud agent — same `@elizaos/core` runtime + model): composeState is **~250–455ms**, a 12-provider fan-out that **serializes on its slowest DB-backed providers** — ATTACHMENTS (451ms), RECENT_MESSAGES (388ms), FACTS (309ms) — with the room fetched 4× and the messages scan run more than once. On a **remote Postgres** container each duplicate round-trip also pays network RTT, so the win scales with DB latency.

**Scope (honest):** this attacks the **composeState DB slice only** (~200–400ms), not the whole ~2.5s pre-first-token turn — the bulk of that is the single `RESPONSE_HANDLER` model call, a separate (and currently parked) concern. Framing this as the DB-path lever, not the whole latency fix.

## Correctness

- **Zero prompt-content change**, no message-loop semantics touched.
- Every room/message **mutation wrapper invalidates** the memo synchronously after the adapter write, so a just-sent message / just-created room is never served stale — including `ensureConnection`, which writes via `adapter.upsertRooms` directly and is now explicitly invalidated.
- The messages-scan memo admits **only the exact newest-first room-scoped shape**; any narrowing param (entityId/agentId/worldId/unique/offset/end/metadata/textContains/asc/`includeEmbedding`/accessContext) bypasses it.
- **Contract note:** on a gate-fail (text-only) turn, `state.data.providers.ATTACHMENTS.data.attachments` is now `[]` rather than the fetched room attachments. No in-repo consumer reads that field (the ATTACHMENT read action re-fetches); flagging for any out-of-tree plugin.

## Tests

- New `turn-read-coalescing.test.ts` — **11 pass** (coalescing, mutation invalidation, the `ensureConnection`-bypass invalidation, TTL bound, exact-slice semantics against both adapter contracts).
- Adjacent compose / message / connection suites — **32 pass**.
- **Full core suite: 4,089 pass** (the 10 errors are pre-existing identically on base — a fake-runtime `reportError` gap in `message.credit-exhaustion-reply.test.ts`, not introduced here).

## Evidence

- **Real `InferenceTiming` / trajectory:** the composeState decomposition above (local mirror, `GET /api/dev/inference-timing`).
- **Harness** `perf-bench/compose-bench.ts` (real AgentRuntime + InMemoryDatabaseAdapter with a 20ms-latency serializing queue modeling single-threaded PGlite): baseline 7–8 serialized round-trips/compose collapse under the fix.
- **Live-mirror before/after cutover probe — N/A in this PR:** it requires rebuilding dists + restarting the live bot (a deploy/cutover step, not PR-CI). The local-mirror + harness numbers are the evidence here; the live wall-clock delta is a prediction pending cutover.

cc @lalalune — message-loop-adjacent core, your review. Precedent: #16912.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime perf change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime perf change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - core runtime perf change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface touched

<!-- evidence-row:backend-logs -->
- [x] [17057-backend-logs-inference-timing.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17057-backend-logs-inference-timing.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - zero prompt-content change; DB read-path optimization only, provider outputs byte-identical

<!-- evidence-row:domain-artifacts -->
- [x] [17057-domain-artifacts-test-run.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17057-domain-artifacts-test-run.txt)
