### PR TITLE
fix(core): remediate #16966 post-merge review findings (offer false-positives, LIMIT-before-filter, judge key precedence, J4 degrade)

### DIFF
--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -93,6 +93,24 @@ describe("replyClaimsCompletedSideEffect", () => {
 		).toBe(true);
 	});
 
+	it("matches bare simple-past assertions and perfective claims with a tag question", () => {
+		// "I set" with no auxiliary is still a report when the sentence is
+		// declarative — the fabrication does not need "I've" to be a claim.
+		expect(
+			replyClaimsCompletedSideEffect("I set a reminder for the 28th at 9am."),
+		).toBe(true);
+		expect(
+			replyClaimsCompletedSideEffect("I added it to your calendar for Tuesday."),
+		).toBe(true);
+		// A perfective assertion stays a claim even when a consent tag follows in
+		// the same sentence — the completed-work assertion already happened.
+		expect(
+			replyClaimsCompletedSideEffect(
+				"I've set two reminders — anything else?",
+			),
+		).toBe(true);
+	});
+
 	it("passes offers, questions, and honest denials through", () => {
 		expect(
 			replyClaimsCompletedSideEffect(
@@ -106,6 +124,66 @@ describe("replyClaimsCompletedSideEffect", () => {
 			replyClaimsCompletedSideEffect("I can set a reminder if you'd like."),
 		).toBe(false);
 		expect(replyClaimsCompletedSideEffect("The capital is Paris.")).toBe(false);
+	});
+
+	// Regression (#16966 post-merge review): consent-seeking offers phrased
+	// with a modal before "I" matched the old adjacency pattern ("Should I
+	// set…"), got rewritten to "On it.", and forced an unwanted planner run —
+	// the user asked a question and received an action instead of an answer.
+	it("passes consent-seeking offer phrasings through", () => {
+		expect(
+			replyClaimsCompletedSideEffect("Want me to set a reminder for tomorrow?"),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Should I set a reminder for tomorrow?"),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Shall I set a reminder for the 28th?"),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Do you want me to set a reminder?"),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"I can set a reminder for tomorrow morning — want me to?",
+			),
+		).toBe(false);
+	});
+
+	it("passes question phrasings and clarifying interrogatives through", () => {
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Before I set the reminder, what time works?",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"When I set reminders, mornings usually work best — should I?",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Would you like me to add it to your calendar?",
+			),
+		).toBe(false);
+	});
+
+	it("passes conditional and not-yet-done phrasings through", () => {
+		expect(
+			replyClaimsCompletedSideEffect(
+				"I could set a reminder for the 28th if you like.",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Once I've set the reminder, I'll confirm the time.",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"If I set a reminder for 9am, would that work?",
+			),
+		).toBe(false);
 	});
 
 	it("requires a schedulable subject, not just a completion verb", () => {
@@ -149,6 +227,13 @@ describe(CLAIM_EVALUATOR_NAME, () => {
 		expect(
 			await evaluator.shouldRun(
 				makeContext(simpleReplyHandler("Want me to set a reminder?")),
+			),
+		).toBe(false);
+		expect(
+			await evaluator.shouldRun(
+				makeContext(
+					simpleReplyHandler("Should I set a reminder for tomorrow?"),
+				),
 			),
 		).toBe(false);
 		// Already-planning turns are out of scope: a tool will run for real.

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -100,14 +100,14 @@ describe("replyClaimsCompletedSideEffect", () => {
 			replyClaimsCompletedSideEffect("I set a reminder for the 28th at 9am."),
 		).toBe(true);
 		expect(
-			replyClaimsCompletedSideEffect("I added it to your calendar for Tuesday."),
+			replyClaimsCompletedSideEffect(
+				"I added it to your calendar for Tuesday.",
+			),
 		).toBe(true);
 		// A perfective assertion stays a claim even when a consent tag follows in
 		// the same sentence — the completed-work assertion already happened.
 		expect(
-			replyClaimsCompletedSideEffect(
-				"I've set two reminders — anything else?",
-			),
+			replyClaimsCompletedSideEffect("I've set two reminders — anything else?"),
 		).toBe(true);
 	});
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3018,35 +3018,90 @@ function filterSelectedContextsForRole(
 	return selected;
 }
 
-// First-person completed-side-effect claims ("I've set…", "all set",
-// "reminders are set", "Done —"). Adjacency is deliberate: "I have not set"
-// and "I can set" do not match, so offers and honest denials pass through.
-// The bare "done —" branch is anchored to the start of the (trimmed) reply or
-// of a sentence, so congratulations like "Well done — that's every task
-// cleared." are not misread as completion claims.
-const COMPLETED_SIDE_EFFECT_CLAIM_PATTERN =
-	/\b(?:i(?:['’]ve| have| just)?\s+(?:set|scheduled|created|added|saved|booked|logged|arranged)\b|(?:it['’]s|it is|you['’]re|that['’]s)\s+all\s+set\b|remind(?:er)?s?\s+(?:are|is)\s+(?:set|scheduled|in\s+place)\b|(?:^|[.!?]\s+)done\s*[—–-])/i;
+// Completed-side-effect detection is split by grammatical certainty so that
+// only ASSERTIONS of finished work fire; consent-seeking offers, questions,
+// and conditionals must pass through untouched (a rewritten offer forces an
+// unwanted planner run — the user asked a question and got an action).
+//
+// Perfective first-person claims ("I've set…", "I have scheduled…", "I just
+// added…") carry an explicit completion auxiliary, so they read as reports in
+// any sentence shape — including tag questions ("I've set it — anything
+// else?"). Only a leading subordinator ("Once I've set…") turns one into a
+// plan instead of a report. Adjacency keeps denials out: "I have not set"
+// never matches.
+const PERFECTIVE_SIDE_EFFECT_CLAIM_PATTERN =
+	/\bi(?:['’]ve|\s+have|\s+just)\s+(?:(?:just|already|now)\s+)?(?:set|scheduled|created|added|saved|booked|logged|arranged)\b/gi;
+// Bare simple-past claims ("I set a reminder for 9am."). "set" is the one
+// verb here whose past tense equals its base form, so offers ("Should I
+// set…?", "Before I set…") collide with reports on the raw pattern — this
+// branch is additionally gated on the word preceding "I" and on the
+// containing sentence not being a question.
+const BARE_PAST_SIDE_EFFECT_CLAIM_PATTERN =
+	/\bi\s+(?:set|scheduled|created|added|saved|booked|logged|arranged)\b/gi;
+// State-of-the-world completion claims that need no first-person subject
+// ("that's all set", "your reminders are set", "Done —"). The bare "done —"
+// branch is anchored to the start of the (trimmed) reply or of a sentence, so
+// congratulations like "Well done — that's every task cleared." are not
+// misread as completion claims.
+const STATE_SIDE_EFFECT_CLAIM_PATTERN =
+	/\b(?:(?:it['’]s|it is|you['’]re|that['’]s)\s+all\s+set\b|remind(?:er)?s?\s+(?:are|is)\s+(?:set|scheduled|in\s+place)\b)|(?:^|[.!?]\s+)done\s*[—–-]/i;
+// A modal, interrogative auxiliary, or subordinator immediately before the
+// matched "I" makes the clause an offer/question/condition ("Should I
+// set…?", "Shall I set…?", "When I set…", "Once I've set…"), not a report of
+// finished work.
+const NON_ASSERTIVE_SIDE_EFFECT_LEAD_PATTERN =
+	/\b(?:should|shall|can|could|may|might|would|will|do|does|did|must|if|unless|once|when|whenever|while|before|after|until|whether)\s+$/i;
 // The claim must be ABOUT a schedulable/saved thing, not e.g. "I've set aside
 // some thoughts". Vocabulary mirrors the scheduled-item nouns the LifeOps
 // surfaces own.
 const SIDE_EFFECT_SUBJECT_NOUN_PATTERN =
 	/\b(?:remind(?:er)?s?|alarms?|schedul(?:e|ed|ing)|scheduled\s+(?:task|item)s?|tasks?|appointments?|calendar|routines?|habits?|goals?|todos?|to[- ]dos?|check[- ]?ins?|follow[- ]?ups?)\b/i;
 
+// True when the sentence containing the match (scanning forward from the
+// match) terminates in "?" — the shape of a consent-seeking offer or a
+// clarifying question ("I set reminders in the morning usually — should I?").
+function sideEffectClaimSentenceIsQuestion(
+	text: string,
+	fromIndex: number,
+): boolean {
+	for (let i = fromIndex; i < text.length; i += 1) {
+		const ch = text[i];
+		if (ch === "?") return true;
+		if (ch === "." || ch === "!" || ch === "\n") return false;
+	}
+	return false;
+}
+
 /**
- * True when a Stage-1 reply asserts that a scheduling/save side effect already
- * happened. On the simple path no tool has run, so any such claim is
+ * True when a Stage-1 reply ASSERTS that a scheduling/save side effect already
+ * happened. On the simple path no tool has run, so any such assertion is
  * fabricated — the "not loaded must never read as zero" doctrine applied to
  * writes: "no tool ran" must never read as "done" (#16935; observed live: a
  * bill-reminder ask answered "Done — I've set two reminders" with zero tool
- * calls, plus invented "session-only" caveats).
+ * calls, plus invented "session-only" caveats). Consent-seeking offers,
+ * questions, and conditionals ("Want me to set…?", "Should I set…?", "I could
+ * set…") are NOT claims and must return false — rewriting them to "On it."
+ * turns a question the user asked into an action they did not consent to.
  */
 export function replyClaimsCompletedSideEffect(reply: string): boolean {
 	const text = reply.trim();
 	if (!text) return false;
-	return (
-		COMPLETED_SIDE_EFFECT_CLAIM_PATTERN.test(text) &&
-		SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)
-	);
+	if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)) return false;
+	if (STATE_SIDE_EFFECT_CLAIM_PATTERN.test(text)) return true;
+	for (const match of text.matchAll(PERFECTIVE_SIDE_EFFECT_CLAIM_PATTERN)) {
+		if (
+			!NON_ASSERTIVE_SIDE_EFFECT_LEAD_PATTERN.test(text.slice(0, match.index))
+		) {
+			return true;
+		}
+	}
+	for (const match of text.matchAll(BARE_PAST_SIDE_EFFECT_CLAIM_PATTERN)) {
+		const prefix = text.slice(0, match.index);
+		if (NON_ASSERTIVE_SIDE_EFFECT_LEAD_PATTERN.test(prefix)) continue;
+		if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
+		return true;
+	}
+	return false;
 }
 
 export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvaluator[] =

--- a/packages/scenario-runner/src/cerebras-judge.test.ts
+++ b/packages/scenario-runner/src/cerebras-judge.test.ts
@@ -134,7 +134,31 @@ describe("CerebrasJudge", () => {
 
   it("throws when no apiKey is available", () => {
     delete process.env.CEREBRAS_API_KEY;
+    delete process.env.EVAL_CEREBRAS_API_KEY;
     expect(() => new CerebrasJudge()).toThrow(/CEREBRAS_API_KEY/);
+  });
+
+  // Regression (#16966 post-merge review): the constructor preferred the
+  // generic CEREBRAS_API_KEY, inverting the eval-model resolution order — on
+  // a host carrying both, the under-test provider credential silently took
+  // over judging. The judge-only EVAL_ slot must win.
+  it("prefers EVAL_CEREBRAS_API_KEY over CEREBRAS_API_KEY for the bearer token", async () => {
+    process.env.CEREBRAS_API_KEY = "generic-under-test-key";
+    process.env.EVAL_CEREBRAS_API_KEY = "judge-only-key";
+    try {
+      mockFetchOnceJson('{"score":1,"reason":"ok"}');
+      const judge = new CerebrasJudge();
+      await judge.judge("test prompt");
+      const fetchMock = globalThis.fetch as unknown as ReturnType<
+        typeof vi.fn
+      >;
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(
+        (init.headers as Record<string, string>).Authorization,
+      ).toBe("Bearer judge-only-key");
+    } finally {
+      delete process.env.EVAL_CEREBRAS_API_KEY;
+    }
   });
 
   it("parses strict JSON output, derives verdict from score", async () => {

--- a/packages/scenario-runner/src/cerebras-judge.test.ts
+++ b/packages/scenario-runner/src/cerebras-judge.test.ts
@@ -149,13 +149,11 @@ describe("CerebrasJudge", () => {
       mockFetchOnceJson('{"score":1,"reason":"ok"}');
       const judge = new CerebrasJudge();
       await judge.judge("test prompt");
-      const fetchMock = globalThis.fetch as unknown as ReturnType<
-        typeof vi.fn
-      >;
+      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
       const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(
-        (init.headers as Record<string, string>).Authorization,
-      ).toBe("Bearer judge-only-key");
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer judge-only-key",
+      );
     } finally {
       delete process.env.EVAL_CEREBRAS_API_KEY;
     }

--- a/packages/scenario-runner/src/cerebras-judge.ts
+++ b/packages/scenario-runner/src/cerebras-judge.ts
@@ -35,7 +35,7 @@ export interface CerebrasJudgeOptions {
   model?: string;
   /** OpenAI-compatible base. Default `https://api.cerebras.ai/v1`. */
   baseUrl?: string;
-  /** Bearer key. Defaults to `process.env.CEREBRAS_API_KEY`. */
+  /** Bearer key. Defaults to `EVAL_CEREBRAS_API_KEY`, then `CEREBRAS_API_KEY`. */
   apiKey?: string;
   /** Per-request abort timeout. Default 60000ms. */
   timeoutMs?: number;
@@ -228,16 +228,18 @@ export class CerebrasJudge {
       process.env.CEREBRAS_BASE_URL?.trim() ??
       "https://api.cerebras.ai/v1"
     ).replace(/\/$/, "");
-    // EVAL_CEREBRAS_API_KEY is the judge-only credential slot: the generic
-    // CEREBRAS_API_KEY doubles as a live-provider selector for the model
-    // under test (live-provider.ts), so a host that wants an independent
-    // judge WITHOUT flipping the under-test provider sets the EVAL_ variant.
-    // The lifeops enable-check (isCerebrasEvalEnabled) already accepts it;
-    // the transport must too or an EVAL_-only host throws at construction.
+    // EVAL_CEREBRAS_API_KEY is the judge-only credential slot and WINS over
+    // the generic key, matching the eval-model resolution order everywhere
+    // else (cerebras-eval-model.ts / lifeops-eval-model.ts read the
+    // role-specific EVAL_ variable first). The generic CEREBRAS_API_KEY
+    // doubles as a live-provider selector for the model under test
+    // (live-provider.ts), so a host that carries both must be able to point
+    // the judge at an independent credential/proxy without the generic key
+    // silently taking over judging.
     const apiKey =
       options.apiKey ??
-      process.env.CEREBRAS_API_KEY ??
       process.env.EVAL_CEREBRAS_API_KEY ??
+      process.env.CEREBRAS_API_KEY ??
       "";
     if (!apiKey) {
       throw new Error(

--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -317,7 +317,10 @@ async function loadLifeFromOverview(args: {
  * Owner items completed today, for the evening/recap narrative. Loaded from
  * the same service read the lifeops provider uses so the brief's "wins" and
  * the chat context can never disagree. A failed load degrades to an empty
- * list like the sibling loaders — the brief still composes.
+ * list like the sibling loaders — the brief still composes — but the failure
+ * is surfaced through `runtime.reportError` so the agent sees it in
+ * RECENT_ERRORS instead of an evening brief that silently implies a win-less
+ * day.
  */
 async function loadCompletedTodayFromService(args: {
   runtime: IAgentRuntime;
@@ -332,9 +335,14 @@ async function loadCompletedTodayFromService(args: {
       dueAt: occurrence.dueAt ?? null,
     }));
   } catch (error) {
-    logger.warn(
-      `[BRIEF] completed-today load failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    // error-policy:J4 the brief composes from independent optional sources;
+    // one broken source must not kill the whole evening brief. The degrade is
+    // designed (section omitted, narrative simply cannot claim wins) and the
+    // failure stays observable: reportError feeds RECENT_ERRORS + owner
+    // escalation rather than a log-only warn masquerading as an empty day.
+    args.runtime.reportError("Brief.loadCompletedToday", error, {
+      surface: "evening-brief-wins",
+    });
     return [];
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -3214,12 +3214,21 @@ export class LifeOpsRepository {
    * occurrences, which left recap turns blind to finished work (#16935).
    * `sinceIso` bounds on `updated_at` (completion bumps it); callers narrow to
    * the owner's local day in TypeScript where timezone math belongs.
+   *
+   * `subjectType` is pushed into SQL rather than filtered by the caller so the
+   * LIMIT can never evict matching rows: under multi-room load, agent-subject
+   * completions interleaved with the owner's would otherwise consume the
+   * window and silently drop owner wins from the evening brief.
    */
   async listCompletedOccurrenceViewsSince(
     agentId: string,
     sinceIso: string,
-    limit = 24,
+    options: { subjectType?: "owner" | "agent"; limit?: number } = {},
   ): Promise<LifeOpsOccurrenceView[]> {
+    const limit = options.limit ?? 24;
+    const subjectFilter = options.subjectType
+      ? `AND occurrence.subject_type = ${sqlQuote(options.subjectType)}`
+      : "";
     const rows = await executeRawSql(
       this.runtime,
       `SELECT occurrence.*,
@@ -3239,6 +3248,7 @@ export class LifeOpsRepository {
         WHERE occurrence.agent_id = ${sqlQuote(agentId)}
           AND occurrence.state = 'completed'
           AND occurrence.updated_at >= ${sqlQuote(sinceIso)}
+          ${subjectFilter}
         ORDER BY occurrence.updated_at DESC
         LIMIT ${sqlInteger(limit)}`,
     );

--- a/plugins/plugin-personal-assistant/src/lifeops/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service.ts
@@ -1708,15 +1708,23 @@ export class LifeOpsService extends LifeOpsServiceBase {
     };
     const todayKey = dayKey(now);
     const lookbackMs = 36 * 60 * 60 * 1000;
+    // The owner filter lives in the SQL WHERE (not here) so the row limit is
+    // applied AFTER it: with the filter in TypeScript, agent-subject
+    // completions under multi-room load consumed the LIMIT window and
+    // silently evicted owner wins from the recap (#16966 post-merge review).
+    // The scan limit is sized for the 36h window, newest-first — the local-day
+    // filter below only trims the older-than-today tail, so today's rows are
+    // never the ones cut. The final cap bounds the provider/brief block.
     const views = await this.repository.listCompletedOccurrenceViewsSince(
       this.agentId(),
       new Date(now.getTime() - lookbackMs).toISOString(),
+      { subjectType: "owner", limit: 200 },
     );
-    return views.filter(
-      (occurrence) =>
-        occurrence.subjectType === "owner" &&
-        dayKey(new Date(occurrence.updatedAt)) === todayKey,
-    );
+    return views
+      .filter(
+        (occurrence) => dayKey(new Date(occurrence.updatedAt)) === todayKey,
+      )
+      .slice(0, 24);
   }
 
   async listChannelPolicies(): Promise<LifeOpsChannelPolicy[]> {

--- a/plugins/plugin-personal-assistant/test/brief-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-action.test.ts
@@ -37,6 +37,11 @@ import {
 function makeRuntime(
   options: {
     useModel?: (modelType: string, args: { prompt: string }) => Promise<string>;
+    reportError?: (
+      scope: string,
+      error: unknown,
+      context?: Record<string, unknown>,
+    ) => void;
   } = {},
 ): IAgentRuntime {
   return {
@@ -49,6 +54,10 @@ function makeRuntime(
     },
     useModel:
       options.useModel ?? (async () => "Composed narrative from the model."),
+    // The J4 degrade in loadCompletedTodayFromService reports through the
+    // diagnostic boundary; the harness runtime must carry it so the evening
+    // composer can run without a LifeOpsService registered.
+    reportError: options.reportError ?? (() => undefined),
   } as unknown as IAgentRuntime;
 }
 
@@ -330,6 +339,36 @@ describe("BRIEF umbrella action — Daily Operations", () => {
       expect(args.prompt).toContain("Sorted receipts");
       expect(args.prompt).toContain("completedToday");
       expect(args.prompt).toContain("LEAD with those finished");
+    });
+
+    // Regression (#16966 post-merge review): the completed-today catch used
+    // to degrade with a log-only warn — a broken load silently read as a
+    // win-less day. The J4 degrade must surface through runtime.reportError
+    // so RECENT_ERRORS and owner escalation see it.
+    it("surfaces a failed completed-today load via reportError while the brief still composes", async () => {
+      const reportError = vi.fn();
+      // Default composers + a runtime with no LifeOpsService: the DEFAULT
+      // loadCompletedTodayFromService path fails for real and must degrade
+      // through its own J4 catch, not an injected stand-in.
+      const runtime = makeRuntime({ reportError });
+      const result = await callBrief(runtime, makeMessage(), {
+        subaction: "compose_evening",
+        include: { calendar: false, inbox: false, life: true, money: false },
+        format: "json",
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        briefing: { sections: Record<string, unknown> };
+      };
+      // The degrade omits the wins section entirely — a designed absence, not
+      // a fabricated empty win list rendered as a healthy day.
+      expect(data.briefing.sections).not.toHaveProperty("completedToday");
+      expect(reportError).toHaveBeenCalledTimes(1);
+      expect(reportError).toHaveBeenCalledWith(
+        "Brief.loadCompletedToday",
+        expect.anything(),
+        { surface: "evening-brief-wins" },
+      );
     });
 
     it("keeps morning briefs forward-looking (no completedToday load)", async () => {

--- a/plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts
+++ b/plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts
@@ -741,9 +741,7 @@ describe("LifeOpsRepository domain CRUD", () => {
     await repository.createDefinition(agentDefinition);
 
     const completedAt = (minutesAfterNow: number) =>
-      new Date(
-        Date.parse(NOW) + minutesAfterNow * 60_000,
-      ).toISOString();
+      new Date(Date.parse(NOW) + minutesAfterNow * 60_000).toISOString();
     const seedCompleted = async (
       base: typeof ownerBase | typeof agentBase,
       definitionId: string,
@@ -772,8 +770,18 @@ describe("LifeOpsRepository domain CRUD", () => {
 
     // Two OLDER owner wins, then six NEWER agent completions: newest-first
     // ordering puts every agent row ahead of the owner rows.
-    await seedCompleted(ownerBase, ownerDefinition.id, "owner-1", completedAt(1));
-    await seedCompleted(ownerBase, ownerDefinition.id, "owner-2", completedAt(2));
+    await seedCompleted(
+      ownerBase,
+      ownerDefinition.id,
+      "owner-1",
+      completedAt(1),
+    );
+    await seedCompleted(
+      ownerBase,
+      ownerDefinition.id,
+      "owner-2",
+      completedAt(2),
+    );
     for (let i = 0; i < 6; i += 1) {
       await seedCompleted(
         agentBase,
@@ -791,9 +799,7 @@ describe("LifeOpsRepository domain CRUD", () => {
       { limit: 4 },
     );
     expect(unfiltered).toHaveLength(4);
-    expect(
-      unfiltered.every((view) => view.subjectType === "agent"),
-    ).toBe(true);
+    expect(unfiltered.every((view) => view.subjectType === "agent")).toBe(true);
 
     // With the subject filter in SQL, the same limit returns every owner win.
     const ownerOnly = await repository.listCompletedOccurrenceViewsSince(

--- a/plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts
+++ b/plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts
@@ -696,6 +696,118 @@ describe("LifeOpsRepository domain CRUD", () => {
     ).toHaveLength(1);
   });
 
+  // Regression (#16966 post-merge review): the completed-today read applied
+  // its LIMIT before the caller's owner filter, so newer agent-subject
+  // completions under multi-room load consumed the window and silently
+  // evicted owner wins from the evening brief. The subject filter now lives
+  // in the SQL WHERE, ahead of the LIMIT.
+  it("keeps owner completions inside the limit under multi-subject load", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    const repository = new LifeOpsRepository(runtime);
+    const ownerBase = ownership(runtime.agentId);
+    const agentBase = {
+      agentId: runtime.agentId,
+      domain: "agent_ops" as const,
+      subjectType: "agent" as const,
+      subjectId: runtime.agentId,
+      visibilityScope: "agent_and_admin" as const,
+      contextPolicy: "never" as const,
+    };
+
+    const makeDefinition = (base: typeof ownerBase | typeof agentBase) =>
+      createLifeOpsTaskDefinition({
+        ...base,
+        kind: "reminder",
+        title: base.subjectType === "owner" ? "Owner win" : "Agent chore",
+        description: "multi-subject limit regression",
+        originalIntent: "seeded",
+        timezone: "UTC",
+        status: "active",
+        priority: 2,
+        cadence: { kind: "once", dueAt: LATER },
+        windowPolicy: { timezone: "UTC", windows: [] },
+        progressionRule: { kind: "none" },
+        websiteAccess: null,
+        reminderPlanId: null,
+        goalId: null,
+        source: "manual",
+        metadata: {},
+      });
+    const ownerDefinition = makeDefinition(ownerBase);
+    const agentDefinition = makeDefinition(agentBase);
+    await repository.createDefinition(ownerDefinition);
+    await repository.createDefinition(agentDefinition);
+
+    const completedAt = (minutesAfterNow: number) =>
+      new Date(
+        Date.parse(NOW) + minutesAfterNow * 60_000,
+      ).toISOString();
+    const seedCompleted = async (
+      base: typeof ownerBase | typeof agentBase,
+      definitionId: string,
+      key: string,
+      updatedAt: string,
+    ) => {
+      await repository.upsertOccurrence({
+        id: crypto.randomUUID(),
+        ...base,
+        definitionId,
+        occurrenceKey: key,
+        scheduledAt: NOW,
+        dueAt: LATER,
+        relevanceStartAt: NOW,
+        relevanceEndAt: LATER,
+        windowName: null,
+        state: "completed",
+        snoozedUntil: null,
+        completionPayload: { ok: true },
+        derivedTarget: null,
+        metadata: {},
+        createdAt: NOW,
+        updatedAt,
+      });
+    };
+
+    // Two OLDER owner wins, then six NEWER agent completions: newest-first
+    // ordering puts every agent row ahead of the owner rows.
+    await seedCompleted(ownerBase, ownerDefinition.id, "owner-1", completedAt(1));
+    await seedCompleted(ownerBase, ownerDefinition.id, "owner-2", completedAt(2));
+    for (let i = 0; i < 6; i += 1) {
+      await seedCompleted(
+        agentBase,
+        agentDefinition.id,
+        `agent-${i}`,
+        completedAt(10 + i),
+      );
+    }
+
+    // Unfiltered read at the small limit shows the eviction pressure: the
+    // window fills entirely with agent-subject rows.
+    const unfiltered = await repository.listCompletedOccurrenceViewsSince(
+      runtime.agentId,
+      NOW,
+      { limit: 4 },
+    );
+    expect(unfiltered).toHaveLength(4);
+    expect(
+      unfiltered.every((view) => view.subjectType === "agent"),
+    ).toBe(true);
+
+    // With the subject filter in SQL, the same limit returns every owner win.
+    const ownerOnly = await repository.listCompletedOccurrenceViewsSince(
+      runtime.agentId,
+      NOW,
+      { subjectType: "owner", limit: 4 },
+    );
+    expect(ownerOnly.map((view) => view.occurrenceKey).sort()).toEqual([
+      "owner-1",
+      "owner-2",
+    ]);
+    expect(ownerOnly.every((view) => view.subjectType === "owner")).toBe(true);
+  });
+
   it("round-trips connector sync, schedule, and work-thread records", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;


### PR DESCRIPTION
# Relates to

Post-merge adversarial review of #16966 (issue #16935, lane `evaluator-p1`): remediates the CONFIRMED P1 and three P2s, and follows up the live-evidence gap on the forced no-tools synthesis pass.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync (verify exit 0, flock-serialized on a shared box).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`. One conflict in `packages/core/src/services/message.ts` (develop's #16987 added sentence-start anchoring to the "done —" branch) resolved by keeping the split-by-certainty classifier AND folding in the anchor; develop's "Well done — that's every task cleared." regression test passes against the merged result.
- [x] `bun run verify` passes post-sync (exit 0).

# Risks

Low. Four finding-scoped fixes: a strictly narrower response-handler evaluator trigger (only assertions fire; every previously-caught fabrication shape is regression-locked), a SQL-side subject filter that tightens a read the evening BRIEF consumes, an env-precedence flip in the scenario-runner judge transport, and an error-policy annotation + `runtime.reportError` on an existing designed degrade. No schema changes, no new runtime surfaces.

# Background

## What does this PR do?

### P1 — `core.simple_completed_side_effect_claim` false-positived on consent-seeking offers (`packages/core/src/services/message.ts`)

The merged claim pattern made the completion auxiliary optional (`i(?:['’]ve| have| just)?\s+set…`), so the bare `I`+verb branch matched consent-seeking and conditional phrasings. Verified against the merged regex on this branch: **"Should I set a reminder for tomorrow?", "Shall I set…", "Before I set…, what time works?", "If I set…, would that work?", "When I set reminders… should I?" all matched** — each would be rewritten to "On it." and rerouted to the planner: the user asks a question and receives an action they did not consent to. Detection is now split by grammatical certainty, and only ASSERTIONS of a completed side effect fire (the zero-tools gate was already in `shouldRun`: RESPOND + `requiresTool !== true` + simple-context-only turns):

- **Perfective claims** ("I've set…", "I have scheduled…", "I just added…") keep matching in any sentence shape — including tag questions ("I've set two reminders — anything else?") — unless led by a subordinator ("Once I've set…").
- **Bare simple-past claims** ("I set a reminder for the 28th at 9am.") fire only when the word before "I" is not a modal/interrogative/subordinator AND the containing sentence does not end in "?".
- **State claims** ("that's all set", "reminders are set", "Done —") are unchanged, including develop's sentence-start anchor on "done —".
- All offer/question/conditional shapes above plus "Want me to set…?", "Do you want me to set…?", "Would you like me to add…?", "I could set… if you like", "Once I've set…, I'll confirm" pass through; "Done — I have set two reminders." and the bare-past report are still caught.

### P2 — completed-today read applied LIMIT 24 before the owner filter (`plugins/plugin-personal-assistant/src/lifeops/{repository,service}.ts`)

`listCompletedOccurrenceViewsSince` applied `LIMIT 24` in SQL while `listOwnerOccurrencesCompletedToday` filtered `subjectType === "owner"` in TypeScript. Under multi-room load, newer agent-subject completions consume the window and owner wins silently drop out of the evening BRIEF — a broken pipeline reading as a win-less day. The subject filter now lives in the SQL `WHERE` ahead of the `LIMIT` (options object `{ subjectType, limit }`), the service scans with `{ subjectType: "owner", limit: 200 }` sized for its 36h lookback (newest-first, so the local-day filter only trims the older tail), and the 24-item display cap is applied last.

### P2 — CerebrasJudge key precedence inverted (`packages/scenario-runner/src/cerebras-judge.ts`)

The constructor read `CEREBRAS_API_KEY ?? EVAL_CEREBRAS_API_KEY` — inverted vs the eval-model resolution order everywhere else (role-specific `EVAL_` first; `CEREBRAS_API_KEY` doubles as the live-provider selector for the model under test in `live-provider.ts`). On a host carrying both, the under-test credential silently took over judging. Flipped: `options.apiKey ?? EVAL_CEREBRAS_API_KEY ?? CEREBRAS_API_KEY`.

### P2 — `loadCompletedTodayFromService` catch fabricated an empty wins list (`plugins/plugin-personal-assistant/src/actions/brief.ts`)

The catch degraded with a log-only `logger.warn` and returned `[]` with no error-policy annotation — a broken load silently implied a win-less day. The degrade is kept as designed (the brief composes from independent optional sources; one broken source must not kill the whole evening brief, and the wins section is omitted rather than rendered healthy-empty), now annotated `// error-policy:J4` and surfaced through `runtime.reportError("Brief.loadCompletedToday", error, { surface: "evening-brief-wins" })` so RECENT_ERRORS and owner escalation observe the failure.

## What kind of change is this?

Bug fixes (non-breaking) + error-policy doctrine compliance + regression tests.

# Documentation changes needed?

None — rationale comments live at the fix sites per the comment doctrine.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/message.side-effect-claim.test.ts` — offer/question/conditional pass-through, bare-past + tag-question assertions, and the original fabricated-completion cases, against a real PGLite `AgentRuntime` (no runtime mocks).
- `plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts` — "keeps owner completions inside the limit under multi-subject load": seeds 2 older owner wins + 6 newer agent completions; the unfiltered read at limit 4 fills entirely with agent rows (the exact eviction the finding describes), the subject-filtered read at the same limit returns both owner wins.
- `packages/scenario-runner/src/cerebras-judge.test.ts` — with both env keys set, the Authorization header carries the `EVAL_` key.
- `plugins/plugin-personal-assistant/test/brief-action.test.ts` — a failing default completed-today load (no LifeOpsService registered — the real default loader, not an injected stand-in) composes the brief with the wins section omitted AND reports through `runtime.reportError` exactly once.

## Detailed testing steps

- `packages/core` `src/services/message.side-effect-claim.test.ts`: **11/11** (re-run post-rebase).
- `packages/core` `src/services` full suite: **529/529** (printed "errors" are the suites' own simulated failure fixtures).
- `packages/core` `src/runtime/__tests__/planner-loop.test.ts`: **110/110** (includes the #16935 tool-turn reply guarantee trio).
- `packages/scenario-runner` full suite: **279/279**; `cerebras-judge.test.ts` **26/26** (re-run post-rebase).
- `plugins/plugin-personal-assistant` `repository-domain-crud.test.ts`: **3/3** (real PGLite repository, real SQL); `brief-action.test.ts`: **16/16**.
- Root `bun run verify`: **exit 0**.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - headless evaluator/repository/judge-transport behavior; no web/desktop/mobile UI surface is touched or reachable from this diff`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason; no UI surface in the diff`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - headless scenario evidence; the observable outputs are the live-run trajectories, reports, and runner logs quoted below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: full structured runner logs for the 15 live scenario invocations (concatenated, home paths sanitized): https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17058-6effd6a3576a-runner-logs-2abc87e6e15f.log — plus the verbatim judge-transport extract: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17058-6effd6a3576a-backend-logs-41cad1d829a9.md. Tool results, judge-transport 402, and self-graded warnings are quoted in Evidence Details; the one line that could NOT be captured live — the forced-synthesis warn — is disclosed with the full attempt matrix in Known gaps.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend is exercised by this diff`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: 17 live `ELIZA_CHAT_VIA_CLI=claude`/`claude-sdk` turns on this branch, hand-read; decisive excerpts quoted below with runIds. Raw reports + run matrices + native trajectory files for every run (jsonl bundle, one line per file with sha256): https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17058-6effd6a3576a-llm-trajectory-ad893179c275.jsonl
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real PGLite rows asserted through the actual repository SQL in the multi-subject LIMIT regression (occurrence keys `owner-1`/`owner-2` returned, agent rows excluded); live-run tool results (`OWNER_TODOS_CREATE success:true`, `OWNER_REMINDERS_REVIEW success:true`) quoted below and extracted to https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17058-6effd6a3576a-domain-artifacts-a06197c5a3c6.md (underlying reports in the trajectory bundle above).
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - headless evaluator/repository/judge-transport change; no rendered UI surface to OCR`.

# Evidence Details

## Real LLM-call trajectory

Lane: `ELIZA_CHAT_VIA_CLI=claude` (plugin-cli-inference text-planner, `ELIZA_PLANNER_NATIVE_TOOLS=0`), TZ=UTC, this branch (post-fix), all runs hand-read.

**P1 fix live — consent offers ship intact after real tool work (no "On it." rewrite, no forced action):**

- `adhd-followthrough-missed-step-replan-without-guilt`, claude-opus-4-8, runId `65d2c9de-587d-4d35-9b22-6f84cd4948a0`: `OWNER_REMINDERS_REVIEW success:true`, then the reply is a consent-seeking OFFER and ships verbatim:
  > "The next move: sort yesterday's receipts today. **Want me to set a reminder** for a specific time, or are you just knocking it out now?"
- Same scenario on claude-opus-4-7 (the #16966 evidence model), runId `729acaf2-2169-4522-a9f0-d915953278bc`, judge 0.90 (self-graded, disclosed below):
  > "No big deal. Next move: block 15 minutes today to sort yesterday's receipts, then let the regular reminder pick back up tomorrow. **Want me to set that 15-minute block?**"

**Tool-turn reply guarantee follow-up (evidence gap) — decisive live excerpts:**

- **Tool-grounded confirmation ships** (claude-opus-4-8, runId `203433e1-247d-4f99-9d3e-434d44cc74be`): `OWNER_TODOS_CREATE success:true`; reply leads with the tool-grounded fact — "Your 'buy milk' todo is saved — due today, Thursday July 23, at 6:00 PM UTC." — while refusing the demanded leading invocation-literal `call:DONE{ok}`.
- **Deliberate-silence exemption respected live** (claude-opus-4-8, runId `e26d6467-b88d-458f-b86a-659002b027dc`): user demanded a literally empty reply after a dated save; trajectory: `OWNER_TODOS_CREATE success:true` → evaluator `decision:"FINISH"` → final planner iteration `{"action":"IGNORE","params":{}}` — the loop honors the explicit IGNORE (`endedWithDeliberateSilence`) and does NOT force a synthesis pass (no `[planner-loop]` warn in the log — the designed exemption, hand-verified).
- **The forced-synthesis warn itself did not fire in any of 17 live turns** — full attempt matrix and the deterministic pinning in Known gaps.

Reports, run matrices, and native trajectories for every run listed are uploaded as the llm-trajectory jsonl bundle asset linked in the Evidence Gate row (run viewers omitted — rebuildable from the matrices); excerpts above are quoted verbatim from those JSON reports and trajectory files.

## Backend + frontend logs

<details>
<summary>Judge-transport live state (why rubric scores are secondary in these runs)</summary>

```
| adhd-followthrough-end-of-day-wins-first-recap | failed | 20468ms | judge failed: cerebras error 402: {"error":{"message":"Insufficient credits. Required: $0.0070","type":"insufficient_quota",...
Warn  [scenario-runner] adhd-followthrough-missed-step-replan-without-guilt: judge scores were produced by the model under test (self-graded) — set CEREBRAS_API_KEY for an independent judge
```

The Eliza Cloud OpenAI-compat proxy credential used for independent judging in #16966 is out of credits (402 above), so runs either self-graded (runner prints the `judgeSelfGraded` warning, per #9310) or skipped judging. Decisive evidence is tool results + replies + trajectories, hand-read — not judge scores. The EVAL_-precedence fix is pinned by the transport unit test (bearer-header assertion, 26/26).
</details>

Frontend: `N/A - no frontend exercised`.

## Screenshots (before / after) + video walkthrough

`N/A - headless behavior change; no UI surface in the diff`.

### Before

`N/A - see above`

### After

`N/A - see above`

### Walkthrough video

`N/A - see above`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT path touched`.

## Known gaps / failures

**The forced no-tools synthesis warn (`[planner-loop] tool work finished without a usable reply; forced a no-tools synthesis pass`) did not fire in any live run on this branch — 17 recorded live turns across claude-opus-4-8, claude-haiku-4-5, claude-opus-4-7, and the claude-sdk backend.** The trigger requires a finished tool turn whose final message is empty/unsafe WITHOUT a deliberate STOP/IGNORE; the current subscription CLI models never enter that state:

- natural save/read/list/history turns (6 turns, 3 models): every finished tool turn carried a usable grounded reply;
- "reply with exactly `tool calls`" / markup-narration demands (3 turns): the model refused to emit markup-shaped final messages ("I can't dress this up as a system trace or name internal functions") or Stage-1 routed the turn simple;
- "no response needed" / "send an empty reply" demands (3 turns): the model either replied anyway or chose an explicit `IGNORE` terminal — which is the deliberate-silence exemption, live-verified above as correctly NOT synthesizing;
- leading/trailing invocation-literal demands `call:DONE{ok}` (3 turns, both backends): the model appended the literal after prose (kept usable by design — the heuristic is start-anchored) or refused to lead with it ("I can't lead a message with an injected control string");
- six-item batch save (1 turn): partial save + clarifying reply; recap turns (opus-4-8/haiku/opus-4-7) routed to a simple REPLY at Stage-1 (see observation below).

The firing behavior itself is pinned deterministically: `planner-loop.test.ts` "tool-turn reply guarantee (#16935)" drives the REAL `runPlannerLoop` post-pass (scripted model outputs are the only way to force a replyless finish on demand — which is precisely what the 17 recorded live attempts demonstrate): it asserts the ONE extra no-tools call happens, its grounded prose ships, deliberate IGNORE is exempt, and a synthesis failure keeps the original result — 110/110 green on this branch. The originally recorded live firing (#16966 PR body, `synthesizedUsable=false`, iteration=2) remains the only live capture of the line; on current models the net is provably (17/17) not being hit. I could not produce an honest live firing without mocking the model mid-loop, which would not be live evidence.

**Observation for maintainers (out of this lane's scope, reproducible from the attached runs):** on current develop, the `end-of-day-wins-first-recap` turn routes to a simple REPLY at Stage-1 on all three models tried (opus-4-8, haiku-4-5, opus-4-7) instead of the tasks/BRIEF path the #16966 after-runs recorded — the reply claims an empty task list despite seeded completions (runIds `d0e1092e-…`, `729acaf2-…`). Candidate window: routing-adjacent commits merged after #16966 (e.g. #16510, #16983, #17041). Worth a fresh card if it reproduces under the persona verification lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
