### PR TITLE
fix(core): close empty object schemas for Cerebras strict grammar instead of stripping them

### DIFF
--- a/packages/core/src/runtime/__tests__/schema-compat.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.test.ts
@@ -1,8 +1,11 @@
 /**
  * Unit coverage for the Cerebras schema/function-name compatibility shims
- * (`normalizeSchemaForCerebras`, `sanitizeFunctionNameForCerebras`): stripping
- * empty object schemas, recursion into nested properties and array items, and
- * identifier rewriting. Pure functions, deterministic.
+ * (`normalizeSchemaForCerebras`, `sanitizeFunctionNameForCerebras`): closing
+ * empty object schemas (explicit empty `properties` + `additionalProperties:
+ * false` — Cerebras rejects a bare `{type:"object"}` with `Object fields
+ * require at least one of: 'properties' or 'anyOf'`), recursion into nested
+ * properties and array items, and identifier rewriting. Pure functions,
+ * deterministic.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -11,7 +14,7 @@ import {
 } from "../schema-compat";
 
 describe("normalizeSchemaForCerebras", () => {
-	it("strips empty-properties + additionalProperties:false on object schemas", () => {
+	it("closes empty-properties object schemas (keeps properties:{} + additionalProperties:false)", () => {
 		const result = normalizeSchemaForCerebras({
 			type: "object",
 			properties: {},
@@ -19,17 +22,44 @@ describe("normalizeSchemaForCerebras", () => {
 			required: [],
 		}) as Record<string, unknown>;
 		expect(result.type).toBe("object");
-		expect(result.properties).toBeUndefined();
-		expect(result.additionalProperties).toBeUndefined();
+		expect(result.properties).toEqual({});
+		expect(result.additionalProperties).toBe(false);
 		expect(result.required).toBeUndefined();
 	});
 
-	it("strips properties on bare object schema", () => {
+	it("closes a bare object schema (adds properties:{} + additionalProperties:false)", () => {
+		// A bare `{type:"object"}` is request-fatal on Cerebras: the grammar
+		// compiler 400s the ENTIRE chat completion (`Object fields require at
+		// least one of: 'properties' or 'anyOf'`). Regression guard for the
+		// no-arg terminal tools (IGNORE / STOP) whose schema is exactly this
+		// shape — the earlier strip-the-keys behavior produced it.
 		const result = normalizeSchemaForCerebras({
 			type: "object",
 		}) as Record<string, unknown>;
 		expect(result.type).toBe("object");
-		expect(result.properties).toBeUndefined();
+		expect(result.properties).toEqual({});
+		expect(result.additionalProperties).toBe(false);
+	});
+
+	it("closes an open empty object (additionalProperties:true becomes false)", () => {
+		const result = normalizeSchemaForCerebras({
+			type: "object",
+			additionalProperties: true,
+		}) as Record<string, unknown>;
+		expect(result.properties).toEqual({});
+		expect(result.additionalProperties).toBe(false);
+	});
+
+	it("returns a closed empty object schema for a non-object root", () => {
+		const result = normalizeSchemaForCerebras(undefined, true) as Record<
+			string,
+			unknown
+		>;
+		expect(result).toEqual({
+			type: "object",
+			properties: {},
+			additionalProperties: false,
+		});
 	});
 
 	it("preserves populated object schemas", () => {
@@ -52,8 +82,25 @@ describe("normalizeSchemaForCerebras", () => {
 		}) as Record<string, unknown>;
 		const inner = (result.properties as Record<string, Record<string, unknown>>)
 			.inner;
-		expect(inner.properties).toBeUndefined();
-		expect(inner.additionalProperties).toBeUndefined();
+		expect(inner.properties).toEqual({});
+		expect(inner.additionalProperties).toBe(false);
+	});
+
+	it("closes a bare nested object property", () => {
+		// e.g. PAGE_DELEGATE's free-form `parameters` arg: nested
+		// `{type:"object"}` without properties is rejected by Cerebras exactly
+		// like the root shape.
+		const result = normalizeSchemaForCerebras({
+			type: "object",
+			properties: { params: { type: "object", description: "freeform" } },
+			required: ["params"],
+		}) as Record<string, unknown>;
+		const params = (
+			result.properties as Record<string, Record<string, unknown>>
+		).params;
+		expect(params.properties).toEqual({});
+		expect(params.additionalProperties).toBe(false);
+		expect(params.description).toBe("freeform");
 	});
 
 	it("recurses into array items", () => {
@@ -62,8 +109,8 @@ describe("normalizeSchemaForCerebras", () => {
 			items: { type: "object", properties: {}, additionalProperties: false },
 		}) as Record<string, unknown>;
 		const items = result.items as Record<string, unknown>;
-		expect(items.properties).toBeUndefined();
-		expect(items.additionalProperties).toBeUndefined();
+		expect(items.properties).toEqual({});
+		expect(items.additionalProperties).toBe(false);
 	});
 
 	it("preserves objects that have anyOf/oneOf even with empty properties", () => {

--- a/packages/core/src/runtime/__tests__/schema-compat.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.test.ts
@@ -1,12 +1,4 @@
-/**
- * Unit coverage for the Cerebras schema/function-name compatibility shims
- * (`normalizeSchemaForCerebras`, `sanitizeFunctionNameForCerebras`): closing
- * empty object schemas (explicit empty `properties` + `additionalProperties:
- * false` — Cerebras rejects a bare `{type:"object"}` with `Object fields
- * require at least one of: 'properties' or 'anyOf'`), recursion into nested
- * properties and array items, and identifier rewriting. Pure functions,
- * deterministic.
- */
+/** Covers Cerebras schema normalization across every JSON-schema child form. */
 import { describe, expect, it } from "vitest";
 import {
 	normalizeSchemaForCerebras,
@@ -28,11 +20,6 @@ describe("normalizeSchemaForCerebras", () => {
 	});
 
 	it("closes a bare object schema (adds properties:{} + additionalProperties:false)", () => {
-		// A bare `{type:"object"}` is request-fatal on Cerebras: the grammar
-		// compiler 400s the ENTIRE chat completion (`Object fields require at
-		// least one of: 'properties' or 'anyOf'`). Regression guard for the
-		// no-arg terminal tools (IGNORE / STOP) whose schema is exactly this
-		// shape — the earlier strip-the-keys behavior produced it.
 		const result = normalizeSchemaForCerebras({
 			type: "object",
 		}) as Record<string, unknown>;
@@ -87,9 +74,6 @@ describe("normalizeSchemaForCerebras", () => {
 	});
 
 	it("closes a bare nested object property", () => {
-		// e.g. PAGE_DELEGATE's free-form `parameters` arg: nested
-		// `{type:"object"}` without properties is rejected by Cerebras exactly
-		// like the root shape.
 		const result = normalizeSchemaForCerebras({
 			type: "object",
 			properties: { params: { type: "object", description: "freeform" } },
@@ -120,6 +104,91 @@ describe("normalizeSchemaForCerebras", () => {
 		}) as Record<string, unknown>;
 		expect(Array.isArray(result.anyOf)).toBe(true);
 		expect((result.anyOf as unknown[]).length).toBe(2);
+	});
+
+	it("walks every schema-bearing keyword", () => {
+		const bareObject = () => ({ type: "object" });
+		const result = normalizeSchemaForCerebras({
+			type: "object",
+			properties: {
+				direct: bareObject(),
+			},
+			patternProperties: { "^x-": bareObject() },
+			$defs: { hoisted: bareObject() },
+			definitions: { legacy: bareObject() },
+			dependentSchemas: { direct: bareObject() },
+			dependencies: {
+				direct: bareObject(),
+				names: ["direct"],
+			},
+			anyOf: [bareObject()],
+			oneOf: [bareObject()],
+			allOf: [bareObject()],
+			prefixItems: [bareObject()],
+			items: [bareObject(), bareObject()],
+			contains: bareObject(),
+			propertyNames: bareObject(),
+			not: bareObject(),
+			if: bareObject(),
+			// biome-ignore lint/suspicious/noThenProperty: JSON Schema reserves this key for conditional branches.
+			then: bareObject(),
+			else: bareObject(),
+			additionalProperties: bareObject(),
+			unevaluatedProperties: bareObject(),
+			unevaluatedItems: bareObject(),
+			contentSchema: bareObject(),
+			additionalItems: bareObject(),
+		}) as Record<string, unknown>;
+
+		const expectClosed = (value: unknown) => {
+			expect(value).toMatchObject({
+				type: "object",
+				properties: {},
+				additionalProperties: false,
+			});
+		};
+		expectClosed((result.properties as Record<string, unknown>).direct);
+		expectClosed((result.patternProperties as Record<string, unknown>)["^x-"]);
+		expectClosed((result.$defs as Record<string, unknown>).hoisted);
+		expectClosed((result.definitions as Record<string, unknown>).legacy);
+		expectClosed((result.dependentSchemas as Record<string, unknown>).direct);
+		expectClosed((result.dependencies as Record<string, unknown>).direct);
+		expect((result.dependencies as Record<string, unknown>).names).toEqual([
+			"direct",
+		]);
+		for (const key of ["anyOf", "oneOf", "allOf", "prefixItems"] as const) {
+			expectClosed((result[key] as unknown[])[0]);
+		}
+		for (const item of result.items as unknown[]) expectClosed(item);
+		for (const key of [
+			"contains",
+			"propertyNames",
+			"not",
+			"if",
+			"then",
+			"else",
+			"additionalProperties",
+			"unevaluatedProperties",
+			"unevaluatedItems",
+			"contentSchema",
+			"additionalItems",
+		] as const) {
+			expectClosed(result[key]);
+		}
+	});
+
+	it("closes inferred and nullable object nodes", () => {
+		expect(normalizeSchemaForCerebras({ properties: {} })).toMatchObject({
+			properties: {},
+			additionalProperties: false,
+		});
+		expect(
+			normalizeSchemaForCerebras({ type: ["object", "null"] }),
+		).toMatchObject({
+			type: ["object", "null"],
+			properties: {},
+			additionalProperties: false,
+		});
 	});
 
 	it("returns non-object scalars unchanged", () => {

--- a/packages/core/src/runtime/__tests__/schema-compat.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.test.ts
@@ -57,6 +57,7 @@ describe("normalizeSchemaForCerebras", () => {
 		}) as Record<string, unknown>;
 		expect(result.properties).toEqual({ q: { type: "string" } });
 		expect(result.required).toEqual(["q"]);
+		expect(result.additionalProperties).toBe(false);
 	});
 
 	it("recurses into nested object properties", () => {
@@ -97,13 +98,15 @@ describe("normalizeSchemaForCerebras", () => {
 		expect(items.additionalProperties).toBe(false);
 	});
 
-	it("preserves objects that have anyOf/oneOf even with empty properties", () => {
+	it("preserves anyOf object alternatives without adding an empty properties map", () => {
 		const result = normalizeSchemaForCerebras({
 			type: "object",
 			anyOf: [{ type: "string" }, { type: "number" }],
 		}) as Record<string, unknown>;
 		expect(Array.isArray(result.anyOf)).toBe(true);
 		expect((result.anyOf as unknown[]).length).toBe(2);
+		expect(result.properties).toBeUndefined();
+		expect(result.additionalProperties).toBe(false);
 	});
 
 	it("walks every schema-bearing keyword", () => {
@@ -133,7 +136,7 @@ describe("normalizeSchemaForCerebras", () => {
 			// biome-ignore lint/suspicious/noThenProperty: JSON Schema reserves this key for conditional branches.
 			then: bareObject(),
 			else: bareObject(),
-			additionalProperties: bareObject(),
+			additionalProperties: false,
 			unevaluatedProperties: bareObject(),
 			unevaluatedItems: bareObject(),
 			contentSchema: bareObject(),
@@ -167,7 +170,6 @@ describe("normalizeSchemaForCerebras", () => {
 			"if",
 			"then",
 			"else",
-			"additionalProperties",
 			"unevaluatedProperties",
 			"unevaluatedItems",
 			"contentSchema",
@@ -178,7 +180,8 @@ describe("normalizeSchemaForCerebras", () => {
 	});
 
 	it("closes inferred and nullable object nodes", () => {
-		expect(normalizeSchemaForCerebras({ properties: {} })).toMatchObject({
+		expect(normalizeSchemaForCerebras({ properties: {} })).toEqual({
+			type: "object",
 			properties: {},
 			additionalProperties: false,
 		});
@@ -189,6 +192,36 @@ describe("normalizeSchemaForCerebras", () => {
 			properties: {},
 			additionalProperties: false,
 		});
+	});
+
+	it("closes populated objects reached through tuple schemas", () => {
+		const result = normalizeSchemaForCerebras({
+			type: "array",
+			prefixItems: [
+				{
+					type: "object",
+					properties: { detail: { type: "string" } },
+					required: ["detail"],
+				},
+			],
+			items: false,
+		}) as Record<string, unknown>;
+		expect((result.prefixItems as unknown[])[0]).toEqual({
+			type: "object",
+			properties: { detail: { type: "string" } },
+			required: ["detail"],
+			additionalProperties: false,
+		});
+	});
+
+	it("preserves open-map semantics for non-strict tools", () => {
+		const schema = {
+			type: "object",
+			additionalProperties: { type: "string" },
+		};
+		expect(normalizeSchemaForCerebras(schema, true, { strict: false })).toEqual(
+			schema,
+		);
 	});
 
 	it("returns non-object scalars unchanged", () => {

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -1,10 +1,11 @@
 /**
  * Provider compatibility for JSON-schema tool grammars and function names.
  *
- * Cerebras requires an object root and an explicit properties map on every
- * object node. The normalizer walks every standard schema-bearing keyword so
- * hoisted definitions, conditionals, tuples, and map schemas cannot bypass the
- * wire contract.
+ * Cerebras requires an object root and, in strict mode, closes every object
+ * with `additionalProperties: false`. The normalizer walks every standard
+ * schema-bearing keyword so hoisted definitions, conditionals, tuples, and map
+ * schemas cannot bypass the wire contract while non-strict schemas retain
+ * their permissive semantics.
  */
 
 const FUNCTION_NAME_PATTERN = /[^a-zA-Z0-9_-]/g;
@@ -58,31 +59,66 @@ function isSchemaRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function objectSchemaNeedsProperties(node: Record<string, unknown>): boolean {
+const OBJECT_SCHEMA_KEYS = [
+	"properties",
+	"patternProperties",
+	"additionalProperties",
+	"required",
+	"dependentSchemas",
+	"dependentRequired",
+	"dependencies",
+	"propertyNames",
+	"minProperties",
+	"maxProperties",
+	"unevaluatedProperties",
+] as const;
+
+function describesObjectSchema(node: Record<string, unknown>): boolean {
 	const type = node.type;
-	const includesObject =
+	return (
 		type === "object" ||
 		(Array.isArray(type) && type.includes("object")) ||
-		"properties" in node ||
-		"patternProperties" in node ||
-		"additionalProperties" in node ||
-		"dependentSchemas" in node;
-	if (!includesObject) return false;
+		OBJECT_SCHEMA_KEYS.some((key) => key in node)
+	);
+}
+
+function enforceStrictObjectShape(node: Record<string, unknown>): void {
+	if (!describesObjectSchema(node)) return;
+	if (node.type === undefined) node.type = "object";
+
 	const properties = node.properties;
 	const hasProperties =
 		isSchemaRecord(properties) && Object.keys(properties).length > 0;
 	const hasAnyOf = Array.isArray(node.anyOf) && node.anyOf.length > 0;
-	return !hasProperties && !hasAnyOf;
+	if (!hasProperties && !hasAnyOf) {
+		node.properties = {};
+		if (Array.isArray(node.required) && node.required.length === 0) {
+			delete node.required;
+		}
+	}
+	node.additionalProperties = false;
 }
 
-function walkSchemaChildren(node: Record<string, unknown>): void {
+export interface CerebrasSchemaNormalizationOptions {
+	/**
+	 * Strict tools require closed objects at every depth. Non-strict tools still
+	 * need root compatibility and recursive cloning, but their open-map
+	 * semantics must remain intact.
+	 */
+	strict?: boolean;
+}
+
+function walkSchemaChildren(
+	node: Record<string, unknown>,
+	options: CerebrasSchemaNormalizationOptions,
+): void {
 	for (const key of SCHEMA_MAP_KEYS) {
 		const value = node[key];
 		if (!isSchemaRecord(value)) continue;
 		node[key] = Object.fromEntries(
 			Object.entries(value).map(([name, schema]) => [
 				name,
-				normalizeSchemaForCerebras(schema),
+				normalizeSchemaForCerebras(schema, false, options),
 			]),
 		);
 	}
@@ -90,20 +126,24 @@ function walkSchemaChildren(node: Record<string, unknown>): void {
 	for (const key of SCHEMA_ARRAY_KEYS) {
 		const value = node[key];
 		if (!Array.isArray(value)) continue;
-		node[key] = value.map((schema) => normalizeSchemaForCerebras(schema));
+		node[key] = value.map((schema) =>
+			normalizeSchemaForCerebras(schema, false, options),
+		);
 	}
 
 	const items = node.items;
 	if (Array.isArray(items)) {
-		node.items = items.map((schema) => normalizeSchemaForCerebras(schema));
+		node.items = items.map((schema) =>
+			normalizeSchemaForCerebras(schema, false, options),
+		);
 	} else if (items !== undefined) {
-		node.items = normalizeSchemaForCerebras(items);
+		node.items = normalizeSchemaForCerebras(items, false, options);
 	}
 
 	for (const key of SCHEMA_SINGLE_KEYS) {
 		const value = node[key];
 		if (!isSchemaRecord(value)) continue;
-		node[key] = normalizeSchemaForCerebras(value);
+		node[key] = normalizeSchemaForCerebras(value, false, options);
 	}
 
 	const dependencies = node.dependencies;
@@ -113,7 +153,7 @@ function walkSchemaChildren(node: Record<string, unknown>): void {
 				name,
 				Array.isArray(dependency)
 					? [...dependency]
-					: normalizeSchemaForCerebras(dependency),
+					: normalizeSchemaForCerebras(dependency, false, options),
 			]),
 		);
 	}
@@ -122,10 +162,15 @@ function walkSchemaChildren(node: Record<string, unknown>): void {
 export function normalizeSchemaForCerebras(
 	schema: unknown,
 	isRoot = false,
+	options: CerebrasSchemaNormalizationOptions = {},
 ): unknown {
 	if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-		// Non-object root → closed empty object schema (tool without arguments).
-		if (isRoot) return closedEmptyObjectSchema();
+		// A missing/non-object tool schema means the tool takes no arguments.
+		if (isRoot) {
+			return options.strict === false
+				? { type: "object" }
+				: closedEmptyObjectSchema();
+		}
 		return schema;
 	}
 	let node = { ...(schema as Record<string, unknown>) };
@@ -142,12 +187,8 @@ export function normalizeSchemaForCerebras(
 		};
 	}
 
-	if (objectSchemaNeedsProperties(node)) {
-		node.properties = {};
-		node.additionalProperties = false;
-		delete node.required;
-	}
+	if (options.strict !== false) enforceStrictObjectShape(node);
 
-	walkSchemaChildren(node);
+	walkSchemaChildren(node, options);
 	return node;
 }

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -1,36 +1,10 @@
 /**
- * Schema-compatibility helpers for strict-grammar inference providers.
+ * Provider compatibility for JSON-schema tool grammars and function names.
  *
- * Cerebras (and similar providers that compile JSON-schema constraints into a
- * grammar before sampling) impose constraints OpenAI does not:
- *   1. Tool-parameter root must be `type: "object"`; root `oneOf`/`anyOf`/
- *      `enum`/`not` is rejected (error: "schema must have type 'object' and
- *      not have 'oneOf'/'anyOf'/'enum'/'not' at the top level").
- *   2. Every object node must carry an explicit `properties` map (an EMPTY
- *      map is accepted): a bare `{type: "object"}` — with or without
- *      `additionalProperties` — is rejected with `Object fields require at
- *      least one of: 'properties' or 'anyOf' with a list of possible
- *      properties.` (live-bisected against api.cerebras.ai gemma-4-31b,
- *      2026-07-23).
- *   3. Under `strict: true` tools, every object node must also carry
- *      `additionalProperties: false` (`'additionalProperties' is required to
- *      be supplied and set to false.`).
- *
- * `normalizeSchemaForCerebras(schema, true)` enforces (1) by wrapping any
- * illegal-root schema under `properties.value`, and (2)+(3) by CLOSING
- * empty object schemas — `properties: {}` plus `additionalProperties: false`
- * — instead of stripping those keys. (An earlier revision deleted
- * `properties`/`required`/`additionalProperties` from empty objects, which
- * produced exactly the bare `{type:"object"}` shape rule (2) rejects: every
- * planner turn whose tool surface included a no-arg tool, e.g. the IGNORE /
- * STOP terminal sentinels, failed with a hard 400 and surfaced to the user
- * as a fabricated "something glitched" reply.)
- * Nested usage of `oneOf`/`anyOf`/`enum`/`not` is fine — only the root is
- * checked for (1).
- *
- * `sanitizeFunctionNameForCerebras` replaces invalid characters with `_`.
- * Callers should keep a `{ sanitized → original }` map and rewrite tool-call
- * names on the response.
+ * Cerebras requires an object root and an explicit properties map on every
+ * object node. The normalizer walks every standard schema-bearing keyword so
+ * hoisted definitions, conditionals, tuples, and map schemas cannot bypass the
+ * wire contract.
  */
 
 const FUNCTION_NAME_PATTERN = /[^a-zA-Z0-9_-]/g;
@@ -58,6 +32,93 @@ function closedEmptyObjectSchema(): Record<string, unknown> {
 	return { type: "object", properties: {}, additionalProperties: false };
 }
 
+const SCHEMA_ARRAY_KEYS = ["anyOf", "oneOf", "allOf", "prefixItems"] as const;
+const SCHEMA_SINGLE_KEYS = [
+	"contains",
+	"propertyNames",
+	"not",
+	"if",
+	"then",
+	"else",
+	"additionalProperties",
+	"unevaluatedProperties",
+	"unevaluatedItems",
+	"contentSchema",
+	"additionalItems",
+] as const;
+const SCHEMA_MAP_KEYS = [
+	"properties",
+	"patternProperties",
+	"$defs",
+	"definitions",
+	"dependentSchemas",
+] as const;
+
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function objectSchemaNeedsProperties(node: Record<string, unknown>): boolean {
+	const type = node.type;
+	const includesObject =
+		type === "object" ||
+		(Array.isArray(type) && type.includes("object")) ||
+		"properties" in node ||
+		"patternProperties" in node ||
+		"additionalProperties" in node ||
+		"dependentSchemas" in node;
+	if (!includesObject) return false;
+	const properties = node.properties;
+	const hasProperties =
+		isSchemaRecord(properties) && Object.keys(properties).length > 0;
+	const hasAnyOf = Array.isArray(node.anyOf) && node.anyOf.length > 0;
+	return !hasProperties && !hasAnyOf;
+}
+
+function walkSchemaChildren(node: Record<string, unknown>): void {
+	for (const key of SCHEMA_MAP_KEYS) {
+		const value = node[key];
+		if (!isSchemaRecord(value)) continue;
+		node[key] = Object.fromEntries(
+			Object.entries(value).map(([name, schema]) => [
+				name,
+				normalizeSchemaForCerebras(schema),
+			]),
+		);
+	}
+
+	for (const key of SCHEMA_ARRAY_KEYS) {
+		const value = node[key];
+		if (!Array.isArray(value)) continue;
+		node[key] = value.map((schema) => normalizeSchemaForCerebras(schema));
+	}
+
+	const items = node.items;
+	if (Array.isArray(items)) {
+		node.items = items.map((schema) => normalizeSchemaForCerebras(schema));
+	} else if (items !== undefined) {
+		node.items = normalizeSchemaForCerebras(items);
+	}
+
+	for (const key of SCHEMA_SINGLE_KEYS) {
+		const value = node[key];
+		if (!isSchemaRecord(value)) continue;
+		node[key] = normalizeSchemaForCerebras(value);
+	}
+
+	const dependencies = node.dependencies;
+	if (isSchemaRecord(dependencies)) {
+		node.dependencies = Object.fromEntries(
+			Object.entries(dependencies).map(([name, dependency]) => [
+				name,
+				Array.isArray(dependency)
+					? [...dependency]
+					: normalizeSchemaForCerebras(dependency),
+			]),
+		);
+	}
+}
+
 export function normalizeSchemaForCerebras(
 	schema: unknown,
 	isRoot = false,
@@ -81,39 +142,12 @@ export function normalizeSchemaForCerebras(
 		};
 	}
 
-	if (node.type === "object") {
-		const props = node.properties;
-		const hasProps =
-			props && typeof props === "object" && Object.keys(props).length > 0;
-		const hasAnyOf = Array.isArray(node.anyOf) && node.anyOf.length > 0;
-		const hasOneOf = Array.isArray(node.oneOf) && node.oneOf.length > 0;
-		if (!hasProps && !hasAnyOf && !hasOneOf) {
-			// Close the empty object: explicit empty `properties` plus
-			// `additionalProperties: false`. Deleting these keys (the previous
-			// behavior) yields a bare `{type:"object"}`, which Cerebras rejects
-			// with a request-fatal 400 (`Object fields require at least one of:
-			// 'properties' or 'anyOf'`), and strict-mode tools additionally
-			// require `additionalProperties: false` on every object node.
-			node.properties = {};
-			node.additionalProperties = false;
-			delete node.required;
-		} else if (hasProps) {
-			const next: Record<string, unknown> = {};
-			for (const [k, v] of Object.entries(props as Record<string, unknown>)) {
-				next[k] = normalizeSchemaForCerebras(v);
-			}
-			node.properties = next;
-		}
+	if (objectSchemaNeedsProperties(node)) {
+		node.properties = {};
+		node.additionalProperties = false;
+		delete node.required;
 	}
 
-	if (Array.isArray(node.anyOf)) {
-		node.anyOf = node.anyOf.map((v) => normalizeSchemaForCerebras(v));
-	}
-	if (Array.isArray(node.oneOf)) {
-		node.oneOf = node.oneOf.map((v) => normalizeSchemaForCerebras(v));
-	}
-	if (node.items) {
-		node.items = normalizeSchemaForCerebras(node.items);
-	}
+	walkSchemaChildren(node);
 	return node;
 }

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -2,17 +2,31 @@
  * Schema-compatibility helpers for strict-grammar inference providers.
  *
  * Cerebras (and similar providers that compile JSON-schema constraints into a
- * grammar before sampling) impose two constraints OpenAI does not:
+ * grammar before sampling) impose constraints OpenAI does not:
  *   1. Tool-parameter root must be `type: "object"`; root `oneOf`/`anyOf`/
  *      `enum`/`not` is rejected (error: "schema must have type 'object' and
  *      not have 'oneOf'/'anyOf'/'enum'/'not' at the top level").
- *   2. Empty-properties object schemas are rejected by the grammar compiler.
+ *   2. Every object node must carry an explicit `properties` map (an EMPTY
+ *      map is accepted): a bare `{type: "object"}` — with or without
+ *      `additionalProperties` — is rejected with `Object fields require at
+ *      least one of: 'properties' or 'anyOf' with a list of possible
+ *      properties.` (live-bisected against api.cerebras.ai gemma-4-31b,
+ *      2026-07-23).
+ *   3. Under `strict: true` tools, every object node must also carry
+ *      `additionalProperties: false` (`'additionalProperties' is required to
+ *      be supplied and set to false.`).
  *
  * `normalizeSchemaForCerebras(schema, true)` enforces (1) by wrapping any
- * illegal-root schema under `properties.value`, and enforces (2) by dropping
- * `properties`/`required`/`additionalProperties` when properties is empty.
+ * illegal-root schema under `properties.value`, and (2)+(3) by CLOSING
+ * empty object schemas — `properties: {}` plus `additionalProperties: false`
+ * — instead of stripping those keys. (An earlier revision deleted
+ * `properties`/`required`/`additionalProperties` from empty objects, which
+ * produced exactly the bare `{type:"object"}` shape rule (2) rejects: every
+ * planner turn whose tool surface included a no-arg tool, e.g. the IGNORE /
+ * STOP terminal sentinels, failed with a hard 400 and surfaced to the user
+ * as a fabricated "something glitched" reply.)
  * Nested usage of `oneOf`/`anyOf`/`enum`/`not` is fine — only the root is
- * checked.
+ * checked for (1).
  *
  * `sanitizeFunctionNameForCerebras` replaces invalid characters with `_`.
  * Callers should keep a `{ sanitized → original }` map and rewrite tool-call
@@ -34,13 +48,23 @@ function hasIllegalCerebrasRoot(node: Record<string, unknown>): boolean {
 	return false;
 }
 
+/**
+ * The strict-safe "object with no arguments" shape: Cerebras's validator
+ * requires an explicit (possibly empty) `properties` map on every object node
+ * and, for `strict: true` tools, `additionalProperties: false`. `required` is
+ * omitted — an empty `required` is accepted but carries no information.
+ */
+function closedEmptyObjectSchema(): Record<string, unknown> {
+	return { type: "object", properties: {}, additionalProperties: false };
+}
+
 export function normalizeSchemaForCerebras(
 	schema: unknown,
 	isRoot = false,
 ): unknown {
 	if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-		// Non-object root → empty object schema (tool without arguments).
-		if (isRoot) return { type: "object" };
+		// Non-object root → closed empty object schema (tool without arguments).
+		if (isRoot) return closedEmptyObjectSchema();
 		return schema;
 	}
 	let node = { ...(schema as Record<string, unknown>) };
@@ -64,9 +88,15 @@ export function normalizeSchemaForCerebras(
 		const hasAnyOf = Array.isArray(node.anyOf) && node.anyOf.length > 0;
 		const hasOneOf = Array.isArray(node.oneOf) && node.oneOf.length > 0;
 		if (!hasProps && !hasAnyOf && !hasOneOf) {
-			delete node.properties;
+			// Close the empty object: explicit empty `properties` plus
+			// `additionalProperties: false`. Deleting these keys (the previous
+			// behavior) yields a bare `{type:"object"}`, which Cerebras rejects
+			// with a request-fatal 400 (`Object fields require at least one of:
+			// 'properties' or 'anyOf'`), and strict-mode tools additionally
+			// require `additionalProperties: false` on every object node.
+			node.properties = {};
+			node.additionalProperties = false;
 			delete node.required;
-			delete node.additionalProperties;
 		} else if (hasProps) {
 			const next: Record<string, unknown> = {};
 			for (const [k, v] of Object.entries(props as Record<string, unknown>)) {

--- a/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
@@ -485,6 +485,29 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
                 additionalProperties: false,
               },
             },
+            {
+              name: "RECORD_TUPLE_EVIDENCE",
+              description: "Record a tuple containing structured evidence.",
+              strict: true,
+              parameters: {
+                type: "object",
+                properties: {
+                  tuple: {
+                    type: "array",
+                    prefixItems: [
+                      {
+                        type: "object",
+                        properties: { detail: { type: "string" } },
+                        required: ["detail"],
+                      },
+                    ],
+                    items: false,
+                  },
+                },
+                required: ["tuple"],
+                additionalProperties: false,
+              },
+            },
           ],
           toolChoice: { type: "tool", name: "RECORD_EVIDENCE" },
           maxTokens: 160,
@@ -513,12 +536,36 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
         strict: true,
       },
     });
+    const tupleTool = (request.tools as unknown[]).find((candidate) => {
+      if (!isRecord(candidate) || !isRecord(candidate.function)) return false;
+      return candidate.function.name === "RECORD_TUPLE_EVIDENCE";
+    });
+    expect(tupleTool).toMatchObject({
+      function: {
+        name: "RECORD_TUPLE_EVIDENCE",
+        parameters: {
+          properties: {
+            tuple: {
+              prefixItems: [
+                {
+                  type: "object",
+                  properties: { detail: { type: "string" } },
+                  required: ["detail"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          },
+        },
+        strict: true,
+      },
+    });
     expect(request.tool_choice).toEqual(expect.objectContaining({ type: "function" }));
     expect(wireCalls[0].response?.status).toBe(200);
     expect(wireCalls[0].response?.body?.utf8).toContain("tool_calls");
 
     receipts.push({
-      name: "tool-call-with-empty-terminal",
+      name: "tool-call-with-empty-terminal-and-tuple",
       status: "passed",
       wireCallIds: wireCalls.map((call) => call.id),
       result,

--- a/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
@@ -466,8 +466,15 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
           ],
           tools: [
             {
+              name: "IGNORE",
+              description: "End the turn without a user-facing response.",
+              parameters: { type: "object" },
+              strict: true,
+            },
+            {
               name: "RECORD_EVIDENCE",
               description: "Record the evidence verdict.",
+              strict: true,
               parameters: {
                 type: "object",
                 properties: {
@@ -491,11 +498,27 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
     });
     const request = requireJsonRequest(wireCalls[0]);
     expect(request.tools).toEqual(expect.any(Array));
+    const ignoreTool = (request.tools as unknown[]).find((candidate) => {
+      if (!isRecord(candidate) || !isRecord(candidate.function)) return false;
+      return candidate.function.name === "IGNORE";
+    });
+    expect(ignoreTool).toMatchObject({
+      function: {
+        name: "IGNORE",
+        parameters: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        strict: true,
+      },
+    });
     expect(request.tool_choice).toEqual(expect.objectContaining({ type: "function" }));
+    expect(wireCalls[0].response?.status).toBe(200);
     expect(wireCalls[0].response?.body?.utf8).toContain("tool_calls");
 
     receipts.push({
-      name: "tool-call",
+      name: "tool-call-with-empty-terminal",
       status: "passed",
       wireCallIds: wireCalls.map((call) => call.id),
       result,

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -667,11 +667,9 @@ function normalizeNativeToolsForCall(
     }
 
     const description = firstString(tool.description, functionTool.description);
-    // Default to a permissive object schema. The empty-properties shape
-    // (`{ type: "object", properties: {}, additionalProperties: false }`) is
-    // accepted by OpenAI but rejected by strict-grammar providers like
-    // Cerebras with `Object fields require at least one of: 'properties' or
-    // 'anyOf' with a list of possible properties`.
+    // A missing schema means the tool takes no arguments. Provider-specific
+    // normalization below turns this bare object into the explicit closed
+    // shape required by strict grammar compilers.
     const rawSchema =
       tool.parameters ?? functionTool.parameters ?? ({ type: "object" } satisfies JSONSchema7);
     const strict =

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -698,7 +698,9 @@ function normalizeNativeToolsForCall(
       // recursively so deep schemas are accepted by the grammar compiler.
       // Pass isRoot: true so the top-level invariant is enforced (must be
       // type:"object" with no root oneOf/anyOf/enum/not).
-      inputSchema = normalizeSchemaForCerebras(inputSchema, true) as JSONSchema7;
+      inputSchema = normalizeSchemaForCerebras(inputSchema, true, {
+        strict: strict !== false,
+      }) as JSONSchema7;
     }
 
     // Cerebras's grammar compiler rejects function names containing characters

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1205,9 +1205,12 @@ function sanitizeJsonSchema(
   transforms?: RecordArgTransform[]
 ): JSONSchema7 {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-    // Permissive fallback: no `properties: {}`/`additionalProperties: false`
-    // pair, which strict-grammar providers reject. See `normalizeSchemaForCerebras`
-    // in @elizaos/core for the rationale.
+    // Bare-object fallback. In Cerebras mode `normalizeSchemaForCerebras`
+    // closes this afterwards (explicit empty `properties` +
+    // `additionalProperties: false`) — Cerebras's grammar compiler rejects a
+    // bare `{type: "object"}` with a request-fatal 400. See
+    // `normalizeSchemaForCerebras` in @elizaos/core for the live-bisected
+    // provider rules.
     return { type: "object" };
   }
 


### PR DESCRIPTION
## Problem

`normalizeSchemaForCerebras` stripped `properties`, `required`, and
`additionalProperties` from empty object schemas, producing a bare
`{"type":"object"}`. Cerebras rejects that shape while compiling the complete
tool grammar, so one no-argument tool can fail an otherwise valid planner
request with HTTP 400.

The review also found a second failure mode: populated object schemas reached
through keywords such as `prefixItems` were walked but left open. Cerebras
strict mode requires `additionalProperties: false` on every object in the
schema, not only empty objects.

## Fix

- Represent strict no-argument tools as
  `{"type":"object","properties":{},"additionalProperties":false}`.
- Close every strict object schema at every supported schema-bearing depth,
  including populated tuple objects.
- Infer `type: "object"` when object-only keywords describe an implicit object.
- Preserve non-strict open-map semantics instead of replacing a schema-valued
  `additionalProperties`.
- Keep illegal non-object tool roots beneath the existing closed `value`
  wrapper and clone visited nodes rather than mutating caller-owned schemas.
- Pass each tool's strictness from `plugin-openai` into the core normalizer.

This matches Cerebras's documented strict-tool requirement that
`additionalProperties` be explicitly false for every object:
https://inference-docs.cerebras.ai/capabilities/tool-use

## Live provider validation

The live test sends three strict tools through the real plugin and Cerebras
`gpt-oss-120b`:

1. a no-argument `IGNORE` tool;
2. a forced `RECORD_EVIDENCE` tool;
3. a tuple tool containing a populated object under `prefixItems`.

The captured request proves both formerly invalid object shapes reach the wire
with `additionalProperties: false`. Cerebras returned HTTP 200 and a real
`RECORD_EVIDENCE` call with `{"verdict":"verified","count":2}`.

## Verification

- `bun run verify` — pass: 578 Turbo tasks, repository audits, and all 28
  dist-path consumers.
- `bun run --cwd packages/core test -- src/runtime/__tests__/schema-compat.test.ts`
  — 17/17 pass.
- Core full Node/browser/edge/testing build and typecheck — pass.
- `plugin-openai` build, typecheck, and Biome check — pass.
- Live Cerebras test at
  `6a3b714be978bf6e51172ec0f8a0a3bdfd2cd4a1` — pass; HTTP 200, finish reason
  `tool-calls`, release artifacts downloaded and manually reviewed, credential
  values redacted.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes; the patch is provider schema normalization only.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes; the patch is provider schema normalization only.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changes; the real provider path is captured in the wire artifact.

<!-- evidence-row:backend-logs -->
- [x] [17060-cerebras-wire-evidence.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17060-cerebras-wire-evidence.json)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser or frontend request/state path is changed.

<!-- evidence-row:llm-trajectory -->
- [x] [17060-cerebras-trajectory.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17060-cerebras-trajectory.jsonl)

<!-- evidence-row:domain-artifacts -->
- [x] [17060-cerebras-wire-evidence.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17060-cerebras-wire-evidence.json)

# Evidence Details

## Real LLM-call trajectory

The JSONL artifact records the live `ai.generateText` call, model, purpose,
finish reason, normalized tools, and restored tool input. The wire artifact
contains the credential-redacted request and response, latency, token usage,
calculated cost, exact commit SHA, and receipt tied to the same provider call.

## Backend + frontend logs

The wire artifact is the backend transport record: it includes the normalized
tool schemas sent by `plugin-openai`, redacted authorization header, provider
HTTP status/body, and parsed receipt. Frontend logs are not applicable because
no frontend code or browser state path changes.

## Screenshots and walkthrough

N/A - this change has no rendered surface.

## Known gaps / failures

The unrelated rate-limit receipt in the general Cerebras evidence harness stays
explicitly unexercised because the provider offers no deterministic 429 trigger
and this fix does not alter retry or rate-limit behavior.
