### PR TITLE
fix(workflow): reconcile orphaned schedule tasks whose workflow left the tenant

### DIFF
--- a/plugins/plugin-workflow/__tests__/integration/orphaned-schedule-reconciliation.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/orphaned-schedule-reconciliation.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Persistent scheduler/workflow regression over one shared PGlite database.
+ * It reproduces the tenant re-key orphan, its real failure notification, and
+ * a full database restart before proving startup reconciliation is isolated.
+ */
+
+import { expect, setDefaultTimeout, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentRuntime,
+  createCharacter,
+  type Plugin,
+  ServiceType,
+  stringToUuid,
+  type Task,
+  type UUID,
+} from '@elizaos/core';
+import { NotificationService } from '@elizaos/core/node';
+import { eq } from 'drizzle-orm';
+import { registerTriggerTaskWorker } from '../../../../packages/agent/src/triggers/runtime.ts';
+import { TaskService } from '../../../../packages/core/src/services/task.ts';
+import { plugin as sqlPlugin } from '../../../plugin-sql/src/index.ts';
+import { DatabaseMigrationService } from '../../../plugin-sql/src/migration-service.ts';
+import { PgliteDatabaseAdapter } from '../../../plugin-sql/src/pglite/adapter.ts';
+import { PGliteClientManager } from '../../../plugin-sql/src/pglite/manager.ts';
+import type { DrizzleDatabase } from '../../../plugin-sql/src/types.ts';
+import * as dbSchema from '../../src/db/schema.ts';
+import {
+  EMBEDDED_WORKFLOW_SERVICE_TYPE,
+  EmbeddedWorkflowService,
+  WORKFLOW_TASK_KIND,
+} from '../../src/services/embedded-workflow-service.ts';
+import { registerWorkflowDispatchService } from '../../src/services/workflow-dispatch.ts';
+import type { WorkflowDefinition } from '../../src/types/index.ts';
+
+setDefaultTimeout(120_000);
+
+const AGENT_A_ID = stringToUuid('workflow-orphan-reconciliation-agent-a');
+const AGENT_B_ID = stringToUuid('workflow-orphan-reconciliation-agent-b');
+const ORPHAN_WORKFLOW_ID = 'orphaned-tenant-a-workflow';
+const VALID_A_WORKFLOW_ID = 'valid-tenant-a-workflow';
+const VALID_B_WORKFLOW_ID = 'valid-tenant-b-workflow';
+const SCHEDULE_INTERVAL_MS = 60 * 60 * 1000;
+
+interface RuntimePair {
+  runtimeA: AgentRuntime;
+  runtimeB: AgentRuntime;
+}
+
+type PersistentTask = Task & { id: UUID };
+
+function workflowPluginForTest(includeNotifications: boolean): Plugin {
+  return {
+    name: includeNotifications
+      ? 'workflow-orphan-reconciliation-with-notifications'
+      : 'workflow-orphan-reconciliation',
+    description: 'Persistent workflow reconciliation integration services',
+    services: includeNotifications
+      ? [EmbeddedWorkflowService, NotificationService]
+      : [EmbeddedWorkflowService],
+  };
+}
+
+function createRuntime(
+  agentId: UUID,
+  adapter: PgliteDatabaseAdapter,
+  plugins: Plugin[] = []
+): AgentRuntime {
+  return Object.assign(
+    new AgentRuntime({
+      character: createCharacter({
+        id: agentId,
+        name: `WorkflowReconciliation-${agentId}`,
+        settings: { WORKFLOW_SEED_DEFAULTS: 'false' },
+      }),
+      adapter,
+      plugins,
+      logLevel: 'fatal',
+      enableAutonomy: false,
+    }),
+    { serverless: true }
+  );
+}
+
+async function createRuntimePair(
+  manager: PGliteClientManager,
+  options: { embeddedForB: boolean }
+): Promise<RuntimePair> {
+  const adapterA = new PgliteDatabaseAdapter(AGENT_A_ID, manager);
+  const adapterB = new PgliteDatabaseAdapter(AGENT_B_ID, manager);
+  await Promise.all([adapterA.init(), adapterB.init()]);
+  const runtimeA = createRuntime(AGENT_A_ID, adapterA, [workflowPluginForTest(true)]);
+  const runtimeB = createRuntime(
+    AGENT_B_ID,
+    adapterB,
+    options.embeddedForB ? [workflowPluginForTest(false)] : []
+  );
+  await runtimeA.initialize({ skipMigrations: true });
+  await runtimeB.initialize({ skipMigrations: true });
+  return { runtimeA, runtimeB };
+}
+
+async function migrateCoreTaskStore(adapter: PgliteDatabaseAdapter): Promise<void> {
+  const migrations = new DatabaseMigrationService({ databaseBackend: 'pglite' });
+  await migrations.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+}
+
+function scheduledWorkflow(id: string, name: string): WorkflowDefinition {
+  return {
+    id,
+    name,
+    nodes: [
+      {
+        id: `${id}-schedule`,
+        name: 'Schedule Trigger',
+        type: 'workflows-nodes-base.scheduleTrigger',
+        typeVersion: 1.2,
+        position: [0, 0],
+        parameters: { intervalMs: SCHEDULE_INTERVAL_MS },
+      },
+      {
+        id: `${id}-set`,
+        name: 'Set',
+        type: 'workflows-nodes-base.set',
+        typeVersion: 3.4,
+        position: [200, 0],
+        parameters: { assignments: { assignments: [] } },
+      },
+    ],
+    connections: {
+      'Schedule Trigger': { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+    },
+  };
+}
+
+async function getEmbedded(runtime: AgentRuntime): Promise<EmbeddedWorkflowService> {
+  const service = await runtime.getServiceLoadPromise(EMBEDDED_WORKFLOW_SERVICE_TYPE);
+  if (!(service instanceof EmbeddedWorkflowService)) {
+    throw new Error('Embedded workflow service did not start');
+  }
+  return service;
+}
+
+async function getTaskService(runtime: AgentRuntime): Promise<TaskService> {
+  const service = await runtime.getServiceLoadPromise(ServiceType.TASK);
+  if (!(service instanceof TaskService)) {
+    throw new Error('Task service did not start');
+  }
+  return service;
+}
+
+async function getNotificationService(runtime: AgentRuntime): Promise<NotificationService> {
+  const service = await runtime.getServiceLoadPromise(ServiceType.NOTIFICATION);
+  if (!(service instanceof NotificationService)) {
+    throw new Error('Notification service did not start');
+  }
+  return service;
+}
+
+async function workflowTasks(runtime: AgentRuntime): Promise<Task[]> {
+  return runtime.getTasks({ tags: ['workflow'] });
+}
+
+function taskForWorkflow(tasks: Task[], workflowId: string): PersistentTask {
+  const task = tasks.find((candidate) => candidate.metadata?.workflowId === workflowId);
+  if (!task?.id) {
+    throw new Error(`Persistent schedule task missing for workflow ${workflowId}`);
+  }
+  return { ...task, id: task.id };
+}
+
+async function makeTaskDue(runtime: AgentRuntime, task: Task): Promise<void> {
+  if (!task.id || !task.metadata?.trigger) {
+    throw new Error('Workflow schedule task is missing its id or trigger metadata');
+  }
+  await runtime.updateTask(task.id, {
+    metadata: {
+      ...task.metadata,
+      updatedAt: 0,
+      trigger: { ...task.metadata.trigger, nextRunAtMs: 0 },
+    },
+  });
+}
+
+async function waitForPersistedFailureNotification(runtime: AgentRuntime): Promise<void> {
+  const cacheKey = `notifications:${runtime.agentId}`;
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    const notifications = await runtime.getCache<Array<{ title?: string }>>(cacheKey);
+    if (notifications?.some((notification) => notification.title?.includes('failed'))) return;
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for the real failure notification to persist');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function stopPair(pair: RuntimePair): Promise<void> {
+  await Promise.all([pair.runtimeA.stop(), pair.runtimeB.stop()]);
+}
+
+test('restart removes only the quarantined tenant task and cannot fire or re-notify it', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'workflow-orphan-reconciliation-'));
+  const dataDir = join(tempDir, 'pglite');
+  let manager: PGliteClientManager | null = new PGliteClientManager({ dataDir });
+  let activePair: RuntimePair | null = null;
+
+  try {
+    await manager.initialize();
+    const migrationAdapter = new PgliteDatabaseAdapter(AGENT_A_ID, manager);
+    await migrationAdapter.init();
+    await migrateCoreTaskStore(migrationAdapter);
+
+    activePair = await createRuntimePair(manager, { embeddedForB: true });
+    const firstPair = activePair;
+    const workflowA = await getEmbedded(firstPair.runtimeA);
+    const workflowB = await getEmbedded(firstPair.runtimeB);
+    const notificationsA = await getNotificationService(firstPair.runtimeA);
+    const taskServiceA = await getTaskService(firstPair.runtimeA);
+    registerWorkflowDispatchService(firstPair.runtimeA);
+    registerTriggerTaskWorker(firstPair.runtimeA);
+
+    for (const definition of [
+      scheduledWorkflow(ORPHAN_WORKFLOW_ID, 'Tenant A orphan'),
+      scheduledWorkflow(VALID_A_WORKFLOW_ID, 'Tenant A valid'),
+    ]) {
+      const created = await workflowA.createWorkflow(definition);
+      await workflowA.activateWorkflow(created.id);
+    }
+    const validB = scheduledWorkflow(VALID_B_WORKFLOW_ID, 'Tenant B valid');
+    const createdB = await workflowB.createWorkflow(validB);
+    await workflowB.activateWorkflow(createdB.id);
+
+    const initialTasksA = await workflowTasks(firstPair.runtimeA);
+    const initialTasksB = await workflowTasks(firstPair.runtimeB);
+    expect(initialTasksA).toHaveLength(2);
+    expect(initialTasksB).toHaveLength(1);
+    const orphanTask = taskForWorkflow(initialTasksA, ORPHAN_WORKFLOW_ID);
+    const validBTask = taskForWorkflow(initialTasksB, VALID_B_WORKFLOW_ID);
+
+    const workflowDb = firstPair.runtimeA.db as DrizzleDatabase;
+    await workflowDb
+      .update(dbSchema.embeddedWorkflows)
+      .set({ agentId: dbSchema.LEGACY_UNSCOPED_WORKFLOW_AGENT_ID })
+      .where(eq(dbSchema.embeddedWorkflows.id, ORPHAN_WORKFLOW_ID));
+
+    await makeTaskDue(firstPair.runtimeA, orphanTask);
+    await taskServiceA.runDueTasks();
+    await waitForPersistedFailureNotification(firstPair.runtimeA);
+    const failureNotifications = notificationsA.list({ category: 'workflow' });
+    expect(failureNotifications).toHaveLength(1);
+    expect(failureNotifications[0]?.title).toContain('failed');
+
+    const firedOrphanTask = await firstPair.runtimeA.getTask(orphanTask.id);
+    if (!firedOrphanTask) {
+      throw new Error('Failed workflow schedule task disappeared before restart');
+    }
+    await makeTaskDue(firstPair.runtimeA, firedOrphanTask);
+
+    await stopPair(firstPair);
+    activePair = null;
+    await manager.close();
+    manager = null;
+
+    manager = new PGliteClientManager({ dataDir });
+    await manager.initialize();
+    activePair = await createRuntimePair(manager, { embeddedForB: false });
+    const restartedPair = activePair;
+    const restartedWorkflowA = await getEmbedded(restartedPair.runtimeA);
+    const restartedNotificationsA = await getNotificationService(restartedPair.runtimeA);
+    const restartedTaskServiceA = await getTaskService(restartedPair.runtimeA);
+    registerWorkflowDispatchService(restartedPair.runtimeA);
+    registerTriggerTaskWorker(restartedPair.runtimeA);
+
+    const restartedTasksA = await workflowTasks(restartedPair.runtimeA);
+    const restartedTasksB = await workflowTasks(restartedPair.runtimeB);
+    expect(restartedTasksA).toHaveLength(1);
+    expect(restartedTasksA[0]?.metadata?.kind).toBe(WORKFLOW_TASK_KIND);
+    expect(restartedTasksA[0]?.metadata?.workflowId).toBe(VALID_A_WORKFLOW_ID);
+    expect(restartedTasksB).toHaveLength(1);
+    expect(restartedTasksB[0]?.id).toBe(validBTask.id);
+    expect(restartedTasksB[0]?.metadata?.workflowId).toBe(VALID_B_WORKFLOW_ID);
+    expect(await restartedPair.runtimeA.getTask(orphanTask.id)).toBeNull();
+
+    const workflowRows = await (restartedPair.runtimeA.db as DrizzleDatabase)
+      .select({
+        agentId: dbSchema.embeddedWorkflows.agentId,
+        id: dbSchema.embeddedWorkflows.id,
+        active: dbSchema.embeddedWorkflows.active,
+      })
+      .from(dbSchema.embeddedWorkflows);
+    expect(workflowRows).toEqual(
+      expect.arrayContaining([
+        {
+          agentId: dbSchema.LEGACY_UNSCOPED_WORKFLOW_AGENT_ID,
+          id: ORPHAN_WORKFLOW_ID,
+          active: true,
+        },
+        { agentId: AGENT_A_ID, id: VALID_A_WORKFLOW_ID, active: true },
+        { agentId: AGENT_B_ID, id: VALID_B_WORKFLOW_ID, active: true },
+      ])
+    );
+
+    const notificationsBeforeTick = restartedNotificationsA.list({ category: 'workflow' });
+    const executionsBeforeTick = await restartedWorkflowA.listExecutions();
+    await restartedTaskServiceA.runDueTasks();
+    expect(restartedNotificationsA.list({ category: 'workflow' })).toEqual(notificationsBeforeTick);
+    expect(await restartedWorkflowA.listExecutions()).toEqual(executionsBeforeTick);
+    expect(await restartedPair.runtimeA.getTask(orphanTask.id)).toBeNull();
+    expect((await workflowTasks(restartedPair.runtimeB))[0]?.id).toBe(validBTask.id);
+  } finally {
+    try {
+      if (activePair) await stopPair(activePair);
+    } finally {
+      try {
+        if (manager) await manager.close();
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    }
+  }
+});

--- a/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
@@ -22,6 +22,10 @@ function runtime(
     db,
     getSetting: (key: string) => settings[key] ?? null,
     getService: (type: string) => services[type] ?? null,
+    getTasks: async () => [],
+    createTask: async () => '00000000-0000-4000-8000-000000000001',
+    deleteTask: async () => {},
+    reportError: () => {},
   } satisfies Partial<IAgentRuntime> & { db?: unknown };
 
   return mockRuntime as IAgentRuntime;
@@ -200,6 +204,34 @@ describe('EmbeddedWorkflowService', () => {
     await service.stop();
     await embedded.stop();
     await harness.close();
+  }, 60_000);
+
+  test('reports and fails startup when the persistent task store cannot be reconciled', async () => {
+    const harness = await persistentRuntime();
+    const reports: Array<{ scope: string; error: unknown }> = [];
+    const runtimeWithOfflineTasks = {
+      ...harness.runtime,
+      getTasks: async () => {
+        throw new Error('persistent task store unavailable');
+      },
+      reportError: (scope: string, error: unknown) => {
+        reports.push({ scope, error });
+      },
+    } as IAgentRuntime;
+
+    try {
+      await expect(EmbeddedWorkflowService.start(runtimeWithOfflineTasks)).rejects.toMatchObject({
+        code: 'WORKFLOW_SCHEDULE_RECONCILIATION_FAILED',
+        message: 'Failed to reconcile workflow schedule tasks',
+      });
+      expect(reports).toHaveLength(1);
+      expect(reports[0]).toMatchObject({
+        scope: 'EmbeddedWorkflowService.rehydrateSchedules',
+        error: { code: 'WORKFLOW_SCHEDULE_RECONCILIATION_FAILED' },
+      });
+    } finally {
+      await harness.close();
+    }
   }, 60_000);
 
   test('seeds and runs the no-LLM device health check workflow by default', async () => {
@@ -558,7 +590,16 @@ describe('EmbeddedWorkflowService', () => {
       const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-child-'));
       const client = new PGlite({ dataDir: join(dir, 'pglite') });
       const db = drizzle(client, { schema: dbSchema });
-      const runtime = { agentId: 'agent-test', db, getSetting: () => null, getService: () => null };
+      const runtime = {
+        agentId: 'agent-test',
+        db,
+        getSetting: () => null,
+        getService: () => null,
+        getTasks: async () => [],
+        createTask: async () => '00000000-0000-4000-8000-000000000001',
+        deleteTask: async () => {},
+        reportError: () => {},
+      };
       const service = await EmbeddedWorkflowService.start(runtime);
       try {
         globalThis.fetch = async (url, options) =>
@@ -714,7 +755,17 @@ describe('EmbeddedWorkflowService', () => {
       const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-code-'));
       const client = new PGlite({ dataDir: join(dir, 'pglite') });
       const db = drizzle(client, { schema: dbSchema });
-      const runtime = { agentId: 'agent-test', character: { settings: {} }, db, getSetting: () => null, getService: () => null };
+      const runtime = {
+        agentId: 'agent-test',
+        character: { settings: {} },
+        db,
+        getSetting: () => null,
+        getService: () => null,
+        getTasks: async () => [],
+        createTask: async () => '00000000-0000-4000-8000-000000000001',
+        deleteTask: async () => {},
+        reportError: () => {},
+      };
       const service = await EmbeddedWorkflowService.start(runtime);
       try {
         const created = await service.createWorkflow({
@@ -832,7 +883,17 @@ describe('EmbeddedWorkflowService', () => {
       const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-smithers-'));
       const client = new PGlite({ dataDir: join(dir, 'pglite') });
       const db = drizzle(client, { schema: dbSchema });
-      const runtime = { agentId: 'agent-test', character: { settings: {} }, db, getSetting: () => null, getService: () => null };
+      const runtime = {
+        agentId: 'agent-test',
+        character: { settings: {} },
+        db,
+        getSetting: () => null,
+        getService: () => null,
+        getTasks: async () => [],
+        createTask: async () => '00000000-0000-4000-8000-000000000001',
+        deleteTask: async () => {},
+        reportError: () => {},
+      };
       const service = await EmbeddedWorkflowService.start(runtime);
       let smithersDbPath = null;
       try {
@@ -940,7 +1001,17 @@ describe('EmbeddedWorkflowService', () => {
       const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-webhook-'));
       const client = new PGlite({ dataDir: join(dir, 'pglite') });
       const db = drizzle(client, { schema: dbSchema });
-      const runtime = { agentId: 'agent-test', character: { settings: {} }, db, getSetting: () => null, getService: () => null };
+      const runtime = {
+        agentId: 'agent-test',
+        character: { settings: {} },
+        db,
+        getSetting: () => null,
+        getService: () => null,
+        getTasks: async () => [],
+        createTask: async () => '00000000-0000-4000-8000-000000000001',
+        deleteTask: async () => {},
+        reportError: () => {},
+      };
       const service = await EmbeddedWorkflowService.start(runtime);
       try {
         const created = await service.createWorkflow({

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -2517,16 +2517,81 @@ export class EmbeddedWorkflowService extends Service {
    *  `workflow.run` / `workflow.webhook` task rows are deleted so the new
    *  `TRIGGER_DISPATCH` path is the single source of scheduled runs. */
   private async rehydrateSchedules(): Promise<void> {
-    await this.ensureSchema();
-    await this.deleteLegacyScheduleTasks();
-    const rows = await this.getDb()
-      .select()
-      .from(embeddedWorkflows)
-      .where(
-        and(eq(embeddedWorkflows.agentId, this.tenantAgentId), eq(embeddedWorkflows.active, true))
+    try {
+      await this.ensureSchema();
+      await this.deleteLegacyScheduleTasks();
+      const rows = await this.getDb()
+        .select()
+        .from(embeddedWorkflows)
+        .where(
+          and(eq(embeddedWorkflows.agentId, this.tenantAgentId), eq(embeddedWorkflows.active, true))
+        );
+      await this.deleteOrphanScheduleTasks(new Set(rows.map((row) => row.id)));
+      for (const row of rows) {
+        await this.armSchedules(row.id);
+      }
+    } catch (cause) {
+      // error-policy:J2 context-adding rethrow; startup cannot claim scheduler
+      // readiness while stale or partially re-armed workflow tasks may fire.
+      const error =
+        cause instanceof ElizaError
+          ? cause
+          : new ElizaError('Failed to reconcile workflow schedule tasks', {
+              code: 'WORKFLOW_SCHEDULE_RECONCILIATION_FAILED',
+              cause,
+              context: { agentId: this.runtime.agentId },
+              severity: 'ephemeral',
+            });
+      this.runtime.reportError('EmbeddedWorkflowService.rehydrateSchedules', error, {
+        agentId: this.runtime.agentId,
+      });
+      throw error;
+    }
+  }
+
+  /** Remove workflow-backed `TRIGGER_DISPATCH` Tasks whose workflow no longer
+   *  resolves to an ACTIVE workflow in this tenant's store.
+   *
+   *  Tasks are derived scheduling state; the workflow store is the source of
+   *  truth. Normal delete/deactivate paths clear their own tasks, but a task
+   *  can be orphaned out-of-band — most notably by the agent-scope re-key
+   *  migration, which quarantines pre-existing workflow rows under the
+   *  `__legacy_unscoped__` sentinel while the already-armed dispatch tasks
+   *  keep firing against the live tenant. Each fire then fails with
+   *  `Workflow not found: <id>` and pushes a high-priority failure
+   *  notification EVERY interval, forever. Reconciling here (before
+   *  `armSchedules` recreates the valid task set) removes the orphans at the
+   *  same boot that created them. Scoped to this agent's tasks via
+   *  `getTasks({ agentIds })`, so co-tenant agents on a shared DB are
+   *  untouched. Reconciliation is part of service readiness: an unreadable
+   *  task store must fail startup instead of leaving a known notification
+   *  loop armed. */
+  private async deleteOrphanScheduleTasks(activeWorkflowIds: ReadonlySet<string>): Promise<void> {
+    const tasks = await this.runtime.getTasks({
+      tags: [WORKFLOW_TASK_TAG],
+      agentIds: [this.runtime.agentId],
+    });
+    let removed = 0;
+    for (const task of tasks) {
+      const metadata = task.metadata as Record<string, unknown> | undefined;
+      if (metadata?.kind !== WORKFLOW_TASK_KIND) continue;
+      if (!task.id) {
+        throw new ElizaError('Workflow schedule task is missing its persistent id', {
+          code: 'WORKFLOW_SCHEDULE_TASK_ID_REQUIRED',
+          context: { agentId: this.runtime.agentId, taskName: task.name },
+          severity: 'fatal',
+        });
+      }
+      const workflowId = metadata.workflowId;
+      if (typeof workflowId === 'string' && activeWorkflowIds.has(workflowId)) continue;
+      await this.runtime.deleteTask(task.id);
+      removed += 1;
+    }
+    if (removed > 0) {
+      logger.info(
+        { src: 'plugin:workflow:embedded', agentId: this.runtime.agentId, removed },
+        `Removed ${removed} orphaned workflow schedule task(s) whose workflow is no longer active in this tenant`
       );
-    for (const row of rows) {
-      await this.armSchedules(row.id);
     }
   }
 
@@ -2784,12 +2849,6 @@ export class EmbeddedWorkflowService extends Service {
    *  by earlier service versions. Returns the count so callers (and the
    *  migration log) can verify the cleanup. */
   private async deleteLegacyScheduleTasks(): Promise<number> {
-    if (
-      typeof this.runtime.getTasks !== 'function' ||
-      typeof this.runtime.deleteTask !== 'function'
-    ) {
-      return 0;
-    }
     const tasks = await this.runtime.getTasks({
       tags: [WORKFLOW_TASK_TAG],
       agentIds: [this.runtime.agentId],
@@ -2849,7 +2908,6 @@ export class EmbeddedWorkflowService extends Service {
    *  fires within the same minute deduplicate at dispatch. */
   private async armSchedules(workflowId: string): Promise<void> {
     await this.clearSchedules(workflowId);
-    if (typeof this.runtime.createTask !== 'function') return;
     const entry = await this.getStoredWorkflow(workflowId);
     const scheduleNodes = entry.workflow.nodes.filter(
       (node) => !node.disabled && node.type === 'workflows-nodes-base.scheduleTrigger'
@@ -2888,7 +2946,6 @@ export class EmbeddedWorkflowService extends Service {
 
   /** Remove every core Task tagged for this workflow. */
   private async clearSchedules(workflowId: string): Promise<void> {
-    if (typeof this.runtime.getTasks !== 'function') return;
     const tasks = await this.runtime.getTasks({
       tags: [WORKFLOW_TASK_TAG],
       agentIds: [this.runtime.agentId],


### PR DESCRIPTION
## Problem

The agent-scope re-key migration (`eliza-workflow-agent-scope-v1`) quarantines pre-existing workflow rows under the `__legacy_unscoped__` sentinel tenant. The `TRIGGER_DISPATCH` tasks those workflows already armed remain owned by the live agent.

Those durable tasks continue firing. Tenant-scoped workflow lookup returns `Workflow not found`, and the trigger runtime persists a high-priority **Automation failed** notification on every due interval.

## Root cause

Workflow rows are authoritative; scheduler tasks are derived state. Startup rehydration only recreated tasks for active workflows. It never reconciled workflow-derived tasks that no longer resolved to an active workflow in the current tenant, and its optional runtime-method guards could silently declare startup healthy while stale tasks remained armed.

## Fix

- Reconcile every agent-scoped, workflow-kind task against the tenant's active workflow IDs before valid schedules are re-armed.
- Delete tasks for missing, inactive, or malformed workflow references. A workflow task without a persistent ID is a fatal invariant violation.
- Treat `rehydrateSchedules()` as the startup error boundary: wrap failures in `ElizaError`, report `WORKFLOW_SCHEDULE_RECONCILIATION_FAILED` through `runtime.reportError`, and fail startup.
- Remove optional capability probes around required `IAgentRuntime` task APIs. A runtime without the persistent scheduler contract is not ready.
- Keep the query agent-scoped, so another agent sharing the same database is untouched.

## Persistent integration proof

`orphaned-schedule-reconciliation.test.ts` uses the real `PgliteDatabaseAdapter`, SQL migrations, two real `AgentRuntime` tenants, the real workflow tables, real core task table, real `TaskService` + trigger worker, real workflow dispatch, and real `NotificationService`. There is no fake task array.

The test proves the failure before proving the repair:

1. Tenant A owns one valid schedule and one schedule whose workflow row is moved to `__legacy_unscoped__`; tenant B owns a valid schedule in the same physical database.
2. The orphan is made due and fired through the real scheduler. Observed backend path:
   - `Workflow execution failed for orphaned-tenant-a-workflow: Workflow not found: orphaned-tenant-a-workflow`
   - a real high-priority workflow failure notification is persisted.
3. PGlite is closed and reopened from the same data directory (process-restart boundary).
4. Startup logs `Removed 1 orphaned workflow schedule task(s) whose workflow is no longer active in this tenant`.
5. After restart:
   - tenant A's orphan task is absent;
   - tenant A's valid schedule is present;
   - tenant B's valid task retains the exact pre-restart ID;
   - the quarantined workflow row remains as the migration artifact;
   - a real scheduler tick creates no execution and does not replace/increment the persisted failure notification.

## Verification

Run on rebased head `69da42c8729a0647c32a5b56f14098657846da69` against `develop@a3b14c9433eb4d542b5a9343240ae09f339e6884`:

- Source-conditioned persistent integration test (with a temporary Bun config disabling monorepo-wide coverage reporting) — **1 pass, 0 fail, 16 assertions**.
- `bun run --cwd plugins/plugin-workflow typecheck` — pass.
- `bun run --cwd plugins/plugin-workflow build` — pass.
- scoped Biome check on all changed files — pass.

The source-conditioned workflow unit suite ran on the immediately preceding
rebased head (the branch diff was identical; the intervening base-only changes
touch app/UI/LifeOps renderer plumbing and core user-visible output filtering,
not workflow or scheduler persistence) — **22 pass, 0 fail, 89 assertions**.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend scheduler reconciliation changes no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend scheduler reconciliation changes no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no frontend or other visual user flow in this change.
<!-- evidence-row:backend-logs -->
- [x] [The real scheduler failure and startup reconciliation log lines are recorded in the persistent integration proof above](https://github.com/elizaOS/eliza/pull/17061#persistent-integration-proof).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action-planner, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Real workflow rows, task rows, notification inbox entries, and execution rows are enumerated in the persistent integration proof above](https://github.com/elizaOS/eliza/pull/17061#persistent-integration-proof).
