### PR TITLE
fix(cloud): pin a suite-local cache double in shared-runtime-chat tests

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -73,6 +73,38 @@ mock.module("./run-shared-agent-turn", () => ({
   runSharedAgentTurnStream: async () => streamTurn,
 }));
 
+// Sibling suites in the same bun process mock ../../cache/client globally with
+// partial doubles (server-wallets-provision-proof exposes only setIfNotExists;
+// resolve-shared-agent substitutes its own get/set), and bun's mock.module
+// patches the process-wide registry — so batch composition decided whether the
+// character-hydration get/set flow here saw a working cache. Pin this suite's
+// own Map-backed double instead. It cannot be built from the real module: a
+// sibling that loaded first has already replaced the registry entry, so an
+// import here returns that sibling's partial mock, not the real exports.
+const localCacheStore = new Map<string, unknown>();
+mock.module("../../cache/client", () => ({
+  NEGATIVE_CACHE_SENTINEL: { __none: true },
+  cache: {
+    isAvailable: () => true,
+    get: async (key: string) => (localCacheStore.has(key) ? localCacheStore.get(key) : null),
+    set: async (key: string, value: unknown) => {
+      localCacheStore.set(key, value);
+      return { ok: true };
+    },
+    getOrSet: async (key: string, compute: () => Promise<unknown>) => {
+      if (localCacheStore.has(key)) return localCacheStore.get(key);
+      const value = await compute();
+      localCacheStore.set(key, value);
+      return value;
+    },
+    setIfNotExists: async (key: string) => {
+      if (localCacheStore.has(key)) return false;
+      localCacheStore.set(key, "1");
+      return true;
+    },
+  },
+}));
+
 const { InsufficientCreditsError } = await import("../ai-billing");
 const { SharedRuntimeChatService } = await import("./shared-runtime-chat");
 


### PR DESCRIPTION
# Relates to

Fixes the current develop **Cloud Tests** red (`unit-tests` failing on `SharedRuntimeChatService > cold linked character returns warming while hydration stays off path`) — the same single-test signature that failed [#17054](https://github.com/elizaOS/eliza/pull/17054)'s lane twice. Unblocks #17054.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, branched from current head (`5d4540e8232`); zero conflicts.
- [x] Suites re-run (see Testing).
- [x] A reviewer can confirm the fix from the evidence below.

# Sync with develop

- [x] Branched from current `origin/develop` head; nothing to rebase.

# Risks

Minimal — one test file gains a suite-local module double; no runtime code changes.

# Background

## What does this PR do?

The cloud unit-test lane runs files in shared-process batches, and bun's `mock.module` patches the process-global registry. Two sibling suites mock `../../cache/client` with **partial** doubles: `server-wallets-provision-proof.test.ts` exposes only `setIfNotExists`; `resolve-shared-agent.test.ts` substitutes its own `get`/`set`. Whenever batch composition loads either before `shared-runtime-chat.test.ts`, the victim's character-hydration `get`/`set` flow loses its cache and the warming test fails. Today's shared-runtime churn reshuffled the batches and made the combination live: develop's latest completed Cloud Tests run fails exactly this one test, as did both runs on #17054 (whose diff adds no cloud files and whose test file has zero `mock.module` calls).

Fix: the suite pins its own Map-backed `cache/client` double alongside its five existing module mocks, making the warming contract immune to load order. (Building the double from the real module is impossible by construction — a sibling that loaded first has already replaced the registry entry — which the in-file comment records.)

Bisection evidence: reproduced red locally with the exact CI batch file list; minimized to the two-polluter combination `[sensitive-requests, server-wallets-provision-proof] + victim`; green after the change in solo, minimal-combo, full-batch, and `--isolate` runs.

## What kind of change is this?

Bug fix (test-infrastructure; non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

The single hunk in `shared-runtime-chat.test.ts` and its why-comment.

## Detailed testing steps

- Minimal red combo before fix: `bun test src/lib/services/sensitive-requests.test.ts src/lib/services/server-wallets-provision-proof.test.ts src/lib/services/shared-runtime/shared-runtime-chat.test.ts` → warming test fails; after fix → 18/18 pass.
- Exact CI batch (40 files): warming failure gone.
- `bun test --isolate src/lib/services/shared-runtime/` → 121/121 pass.
- Biome clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-infrastructure change in a `.ts` test file; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - same as before-screenshots.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the observable behavior is the CI lane turning green.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server process; the bun test outputs are attached as the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] [17062-cache-immunity-triple.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17062-cache-immunity-triple.log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

