### PR TITLE
fix(views): route localized Knowledge labels through canonical contract

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { DOCUMENTS_NAV_VOCABULARY } from "@elizaos/shared/views/shared-nav-targets";
 import { __matcherData, MATCHER_VIEW_IDS } from "@elizaos/shared/views/view-command-matcher";
 import { navIntentActionResult, resolveSharedNavIntent } from "./shared-nav-intent";
 
@@ -25,6 +26,34 @@ describe("resolveSharedNavIntent", () => {
     expect(intent?.reply).toMatch(/^Opening .+ for you\.$/);
   });
 
+  test.each([
+    ["en", "Knowledge", "open Knowledge"],
+    ["es", "Conocimiento", "abre Conocimiento"],
+    ["pt", "Conhecimento", "abra Conhecimento"],
+    ["ja", "ナレッジ", "ナレッジを開いて"],
+    ["ko", "지식", "지식을 열어"],
+    ["vi", "Tri thức", "mở Tri thức"],
+    ["zh-CN", "知识", "打开知识"],
+    ["tl", "Kaalaman", "buksan ang Kaalaman"],
+  ] as const)(
+    "%s Knowledge label %j emits the canonical documents handoff",
+    (locale, label, message) => {
+      expect(DOCUMENTS_NAV_VOCABULARY.localizedLabels[locale]).toBe(label);
+      const intent = resolveSharedNavIntent(message);
+      expect(intent).toEqual({
+        viewId: "documents",
+        label: "Knowledge",
+        reply: "Opening Knowledge for you.",
+      });
+      const result = navIntentActionResult(intent!);
+      expect(result.values).toEqual({
+        mode: "show",
+        viewId: "documents",
+        source: "agent",
+      });
+    },
+  );
+
   test("voice-change is a Settings › Voice deep-link", () => {
     for (const message of [
       "change my voice",
@@ -46,6 +75,21 @@ describe("resolveSharedNavIntent", () => {
     "I love your voice", // talking about voice, not changing it
     "can you explain how wallets work",
     "help me write an email", // help-verb, not a Help surface
+    "showcase knowledge",
+    "open knowledgebase",
+    "open knowledgeable",
+    "el conocimiento es poder",
+    "abre conocimientos avanzados",
+    "conhecimento é importante",
+    "abra conhecimentos gerais",
+    "ナレッジについて教えて",
+    "ナレッジワーカーを開いて",
+    "지식에 대해 설명해줘",
+    "지식인을 열어",
+    "tri thức rất quan trọng",
+    "知识就是力量",
+    "打开知识产权",
+    "mahalaga ang kaalaman",
     // The matcher resolves a bare "help" to its "help" id, but no Help surface
     // exists on any client, so the nav table omits it and the utterance falls
     // through to the normal LLM turn instead of navigating nowhere (#17032).

--- a/packages/shared/src/views/shared-nav-targets.ts
+++ b/packages/shared/src/views/shared-nav-targets.ts
@@ -22,6 +22,43 @@ export interface SharedNavTarget {
   label: string;
 }
 
+export const SHARED_NAV_UI_LOCALES = [
+  "en",
+  "es",
+  "pt",
+  "ja",
+  "ko",
+  "vi",
+  "zh-CN",
+  "tl",
+] as const;
+
+export type SharedNavUiLocale = (typeof SHARED_NAV_UI_LOCALES)[number];
+
+/** Labels and semantic aliases that resolve to one shared navigation target. */
+export interface SharedNavVocabulary extends SharedNavTarget {
+  localizedLabels: Readonly<Record<SharedNavUiLocale, string>>;
+  aliases: readonly string[];
+}
+
+const DOCUMENTS_LOCALIZED_LABELS = {
+  en: "Knowledge",
+  es: "Conocimiento",
+  pt: "Conhecimento",
+  ja: "ナレッジ",
+  ko: "지식",
+  vi: "Tri thức",
+  "zh-CN": "知识",
+  tl: "Kaalaman",
+} as const satisfies Readonly<Record<SharedNavUiLocale, string>>;
+
+export const DOCUMENTS_NAV_VOCABULARY = {
+  viewId: "documents",
+  label: DOCUMENTS_LOCALIZED_LABELS.en,
+  localizedLabels: DOCUMENTS_LOCALIZED_LABELS,
+  aliases: ["knowledge base", "knowledge hub"],
+} as const satisfies SharedNavVocabulary;
+
 export const SHARED_NAV_TARGETS: Readonly<Record<string, SharedNavTarget>> = {
   settings: { viewId: "settings", label: "Settings" },
   // The builtin wallet surface registers as the "inventory" tab (TAB_PATHS
@@ -36,7 +73,10 @@ export const SHARED_NAV_TARGETS: Readonly<Record<string, SharedNavTarget>> = {
   health: { viewId: "health", label: "Health" },
   todos: { viewId: "todos", label: "To-dos" },
   notes: { viewId: "notes", label: "Notes" },
-  documents: { viewId: "documents", label: "Documents" },
+  documents: {
+    viewId: DOCUMENTS_NAV_VOCABULARY.viewId,
+    label: DOCUMENTS_NAV_VOCABULARY.label,
+  },
   memories: { viewId: "memories", label: "Memories" },
   relationships: { viewId: "relationships", label: "Relationships" },
   background: { viewId: "background", label: "Background" },

--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -31,6 +31,8 @@
  * possessives/view-words to the shared lists — the regexes recompile from data.
  */
 
+import { DOCUMENTS_NAV_VOCABULARY } from "./shared-nav-targets.js";
+
 // Navigation verbs across languages (lower-cased; CJK has no case).
 const NAV_VERBS = [
   // en
@@ -563,12 +565,8 @@ const VIEW_NOUNS: Record<string, readonly string[]> = {
   documents: [
     "documents",
     "document",
-    // The registered view's user-facing label is "Knowledge" (the multimedia
-    // knowledge hub), so the label itself must be a first-class noun — users
-    // say "open knowledge" because that is the name on the tab.
-    "knowledge",
-    "knowledge base",
-    "knowledge hub",
+    ...Object.values(DOCUMENTS_NAV_VOCABULARY.localizedLabels),
+    ...DOCUMENTS_NAV_VOCABULARY.aliases,
     "files",
     "file",
     "docs",
@@ -831,13 +829,95 @@ function esc(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Sort alternation members longest-first so multiword phrases match before
-// their prefixes ("show me" before "show", "go to" before "go").
-function alt(items: readonly string[]): string {
+const LATIN_SCRIPT = /\p{Script=Latin}/u;
+const CJK_SCRIPT =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+
+function isLatinPhrase(phrase: string): boolean {
+  return LATIN_SCRIPT.test(phrase) && !CJK_SCRIPT.test(phrase);
+}
+
+function rawAlt(items: readonly string[]): string {
   return [...new Set(items)]
     .sort((a, b) => b.length - a.length)
     .map(esc)
     .join("|");
+}
+
+// Sort alternation members longest-first so multiword phrases match before
+// their prefixes. Latin-script boundaries keep labels and nav verbs from
+// matching inside unrelated words while CJK remains compatible with particles.
+function alt(items: readonly string[]): string {
+  const sorted = [...new Set(items)].sort((a, b) => b.length - a.length);
+  const latin = sorted.filter(isLatinPhrase);
+  const unbounded = sorted.filter((phrase) => !isLatinPhrase(phrase));
+  const groups = [
+    latin.length
+      ? `(?<![\\p{L}\\p{N}])(?:${rawAlt(latin)})(?![\\p{L}\\p{N}])`
+      : "",
+    unbounded.length ? `(?:${rawAlt(unbounded)})` : "",
+  ].filter(Boolean);
+  return groups.length === 1 ? groups[0] : `(?:${groups.join("|")})`;
+}
+
+const CJK_NOUN_BOUNDARIES = [
+  {
+    script: "Han",
+    endsWith: /\p{Script=Han}$/u,
+    startsWith: /^\p{Script=Han}/u,
+    particles: [],
+  },
+  {
+    script: "Hiragana",
+    endsWith: /\p{Script=Hiragana}$/u,
+    startsWith: /^\p{Script=Hiragana}/u,
+    particles: ["から", "まで", "を", "へ", "に", "の", "は", "が"],
+  },
+  {
+    script: "Katakana",
+    endsWith: /\p{Script=Katakana}$/u,
+    startsWith: /^\p{Script=Katakana}/u,
+    particles: [],
+  },
+  {
+    script: "Hangul",
+    endsWith: /\p{Script=Hangul}$/u,
+    startsWith: /^\p{Script=Hangul}/u,
+    particles: ["으로", "은", "는", "이", "가", "을", "를", "로"],
+  },
+] as const;
+
+function nounAlt(items: readonly string[]): string {
+  const remaining = new Set(items);
+  const groups: string[] = [];
+  const latin = [...remaining].filter(isLatinPhrase);
+  for (const phrase of latin) remaining.delete(phrase);
+  if (latin.length) {
+    groups.push(`(?<![\\p{L}\\p{N}])(?:${rawAlt(latin)})(?![\\p{L}\\p{N}])`);
+  }
+
+  for (const boundary of CJK_NOUN_BOUNDARIES) {
+    const phrases = [...remaining].filter((phrase) =>
+      boundary.endsWith.test(phrase),
+    );
+    for (const phrase of phrases) remaining.delete(phrase);
+    if (!phrases.length) continue;
+    const viewWords = VIEW_WORDS.filter((word) =>
+      boundary.startsWith.test(word),
+    );
+    const terminal = [
+      ...(viewWords.length ? [`(?:${rawAlt(viewWords)})`] : []),
+      `[^\\p{Script=${boundary.script}}]`,
+      "$",
+    ].join("|");
+    const particles = boundary.particles.length
+      ? `(?:${rawAlt(boundary.particles)})?`
+      : "";
+    groups.push(`(?:${rawAlt(phrases)})(?=${particles}(?:${terminal}))`);
+  }
+
+  if (remaining.size) groups.push(`(?:${rawAlt([...remaining])})`);
+  return groups.length === 1 ? groups[0] : `(?:${groups.join("|")})`;
 }
 
 const VERB_ALT = alt(NAV_VERBS);
@@ -879,7 +959,7 @@ interface CompiledView {
 // staying tight enough to avoid cross-clause false positives.
 const COMPILED: CompiledView[] = VIEW_PRIORITY.filter((v) => VIEW_NOUNS[v]).map(
   (viewId) => {
-    const N = alt(VIEW_NOUNS[viewId]);
+    const N = nounAlt(VIEW_NOUNS[viewId]);
     const pattern = [
       `(?:${VERB_ALT})[\\s\\S]{0,16}?(?:${N})`,
       `(?:${N})[\\s\\S]{0,8}?(?:${VERB_ALT})`,

--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -563,6 +563,12 @@ const VIEW_NOUNS: Record<string, readonly string[]> = {
   documents: [
     "documents",
     "document",
+    // The registered view's user-facing label is "Knowledge" (the multimedia
+    // knowledge hub), so the label itself must be a first-class noun — users
+    // say "open knowledge" because that is the name on the tab.
+    "knowledge",
+    "knowledge base",
+    "knowledge hub",
     "files",
     "file",
     "docs",

--- a/packages/ui/src/shared-nav-contract.test.ts
+++ b/packages/ui/src/shared-nav-contract.test.ts
@@ -17,7 +17,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { SHARED_NAV_TARGETS } from "@elizaos/shared/views/shared-nav-targets";
+import {
+  DOCUMENTS_NAV_VOCABULARY,
+  SHARED_NAV_TARGETS,
+  SHARED_NAV_UI_LOCALES,
+} from "@elizaos/shared/views/shared-nav-targets";
 import { describe, expect, it } from "vitest";
 import { withBuiltinShellViews } from "./hooks/useAvailableViews";
 
@@ -103,6 +107,38 @@ describe("shared-tier nav vocabulary contract", () => {
             `expected "${BUILTIN_NAV_PATHS[target.viewId]}"`,
         ).toBe(BUILTIN_NAV_PATHS[target.viewId]);
       }
+    }
+  });
+
+  it("routes the documents matcher id to the Knowledge builtin", () => {
+    expect(SHARED_NAV_TARGETS.documents).toEqual({
+      viewId: "documents",
+      label: "Knowledge",
+    });
+    expect(builtinById.get("documents")).toMatchObject({
+      id: "documents",
+      label: "Knowledge",
+      path: "/character/documents",
+    });
+  });
+
+  it("keeps the semantic vocabulary aligned with every shipped UI label", () => {
+    for (const locale of SHARED_NAV_UI_LOCALES) {
+      const catalogPath = resolve(
+        REPO_ROOT,
+        `packages/ui/src/i18n/locales/${locale}.json`,
+      );
+      const catalog: unknown = JSON.parse(readFileSync(catalogPath, "utf8"));
+      const label =
+        catalog !== null &&
+        typeof catalog === "object" &&
+        !Array.isArray(catalog)
+          ? Reflect.get(catalog, "nav.documents")
+          : undefined;
+      expect(
+        label,
+        `${locale} nav.documents drifted from the shared Knowledge routing vocabulary`,
+      ).toBe(DOCUMENTS_NAV_VOCABULARY.localizedLabels[locale]);
     }
   });
 

--- a/packages/ui/src/view-action-handoff.test.ts
+++ b/packages/ui/src/view-action-handoff.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ChatActionResultSummary } from "./api/client-types-chat";
 import {
   dispatchViewActionHandoff,
+  dispatchViewActionHandoffDirect,
   findViewActionHandoff,
   recoverMissedCurrentView,
 } from "./view-action-handoff";
@@ -72,6 +73,20 @@ describe("view action handoff", () => {
       viewLabel: "Calendar",
       viewType: "gui",
     });
+  });
+
+  it("dispatches the shared-runtime Knowledge destination without a server round-trip", () => {
+    const dispatch = vi.fn();
+    const sharedKnowledge: ChatActionResultSummary = {
+      actionName: "VIEWS",
+      success: true,
+      values: { mode: "show", viewId: "documents", source: "agent" },
+    };
+
+    expect(dispatchViewActionHandoffDirect([sharedKnowledge], dispatch)).toBe(
+      true,
+    );
+    expect(dispatch).toHaveBeenCalledWith({ viewId: "documents" });
   });
 
   it("does not duplicate history when the WebSocket already switched the route", async () => {

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -33,6 +33,11 @@ describe("matchViewCommand — explicit user examples", () => {
 		["pull up my documents", "documents"],
 		["open docs", "documents"],
 		["show my files", "documents"],
+		// the registered view's label is "Knowledge" — the on-screen name must
+		// resolve (live QA gap: "open knowledge" fell through to the planner)
+		["open knowledge", "documents"],
+		["open the knowledge base", "documents"],
+		["show my knowledge hub", "documents"],
 		["switch to focus mode", "focus"],
 		["open my goals", "goals"],
 		// coding cockpit — wins over task-coordinator's bare "coding"

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -2,6 +2,7 @@
  * Deterministic view-command matcher tests for explicit navigation phrases.
  */
 
+import { DOCUMENTS_NAV_VOCABULARY } from "@elizaos/shared/views/shared-nav-targets";
 import { describe, expect, it } from "vitest";
 import {
 	__matcherData,
@@ -33,8 +34,6 @@ describe("matchViewCommand — explicit user examples", () => {
 		["pull up my documents", "documents"],
 		["open docs", "documents"],
 		["show my files", "documents"],
-		// the registered view's label is "Knowledge" — the on-screen name must
-		// resolve (live QA gap: "open knowledge" fell through to the planner)
 		["open knowledge", "documents"],
 		["open the knowledge base", "documents"],
 		["show my knowledge hub", "documents"],
@@ -91,6 +90,27 @@ describe("matchViewCommand — multilingual", () => {
 	}
 });
 
+describe("matchViewCommand — localized Knowledge labels", () => {
+	const cases = [
+		["en", "Knowledge", "open Knowledge"],
+		["es", "Conocimiento", "abre Conocimiento"],
+		["pt", "Conhecimento", "abra Conhecimento"],
+		["ja", "ナレッジ", "ナレッジを開いて"],
+		["ko", "지식", "지식을 열어"],
+		["vi", "Tri thức", "mở Tri thức"],
+		["zh-CN", "知识", "打开知识"],
+		["tl", "Kaalaman", "buksan ang Kaalaman"],
+	] as const;
+
+	it.each(cases)(
+		"%s visible label %j routes to documents",
+		(locale, label, text) => {
+			expect(DOCUMENTS_NAV_VOCABULARY.localizedLabels[locale]).toBe(label);
+			expect(matchViewCommand(text)).toBe("documents");
+		},
+	);
+});
+
 describe("matchViewCommand — generated verb×view coverage (English)", () => {
 	const verbs = [
 		"open",
@@ -119,6 +139,21 @@ describe("matchViewCommand — precision (must NOT match)", () => {
 		"thanks, that was helpful",
 		"can you summarize this article",
 		"i love using this app",
+		"showcase knowledge",
+		"open knowledgebase",
+		"open knowledgeable",
+		"el conocimiento es poder",
+		"abre conocimientos avanzados",
+		"conhecimento é importante",
+		"abra conhecimentos gerais",
+		"ナレッジについて教えて",
+		"ナレッジワーカーを開いて",
+		"지식에 대해 설명해줘",
+		"지식인을 열어",
+		"tri thức rất quan trọng",
+		"知识就是力量",
+		"打开知识产权",
+		"mahalaga ang kaalaman",
 		"remind me to call mom", // a task, not a view command
 		"how are you doing today",
 		"",


### PR DESCRIPTION
# Relates to

Live QA regression described in this PR: commands using the visible **Knowledge** label fell out of the deterministic navigation path and could fail when the planner/provider was unavailable.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `5db27fddda7208249c65fbfeeaa00e55da9c8c2b` with zero conflicts.
- [x] `bun run install:light` and `bun run verify` were run after the final sync.
- [x] A reviewer can confirm the routing contract and its precision from the cross-layer test evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5db27fddda7208249c65fbfeeaa00e55da9c8c2b`; zero conflicts.
- [x] `bun run verify` passes post-sync, including all 578 Turbo tasks and all 28 dist-path consumer typechecks.

# Risks

**Medium.** The fix hardens the shared multilingual matcher, so an incorrect token-boundary rule could affect navigation phrases beyond Knowledge. The full `plugin-app-control` suite (46 files / 1,563 tests), generated verb×view matrix, all eight shipped locale labels, and adversarial Latin/CJK compound cases passed. The shared-runtime and client-handoff contract tests also passed.

# Background

## What does this PR do?

The original one-line fix added the English word `knowledge` to one matcher table. That addressed the observed phrase but left the underlying split-brain contract intact:

- the stable runtime/client route is internally named `documents`;
- the actual builtin route is `/character/documents`;
- the canonical English label shown to users is **Knowledge**;
- the eight shipped catalogs localize that label independently;
- the shared runtime incorrectly described the same destination as **Documents**.

This revision makes that distinction explicit and canonical. `DOCUMENTS_NAV_VOCABULARY` owns the stable `viewId: "documents"`, canonical user-facing `label: "Knowledge"`, every shipped localized label (`en`, `es`, `pt`, `ja`, `ko`, `vi`, `zh-CN`, `tl`), and the semantic aliases `knowledge base` / `knowledge hub`. Both the matcher and `SHARED_NAV_TARGETS.documents` consume that contract, so successful intents consistently emit:

```text
viewId: documents
label/reply: Knowledge / Opening Knowledge for you.
client destination: /character/documents
```

The matcher now applies Unicode-aware token boundaries. This preserves valid localized commands while rejecting substring and compound false positives such as `showcase knowledge`, `open knowledgeable`, `打开知识产权`, `ナレッジワーカーを開いて`, and `지식인을 열어`.

## What kind of change is this?

Bug fix and contract hardening; no public route or stored-data migration.

# Documentation changes needed?

No user documentation change is needed. This aligns existing labels, routes, and deterministic navigation semantics without changing the visible UI.

# Testing

## Where should a reviewer start?

1. `packages/shared/src/views/shared-nav-targets.ts` — canonical semantic vocabulary and the intentional `documents` ID / `Knowledge` label distinction.
2. `packages/shared/src/views/view-command-matcher.ts` — localized vocabulary consumption and Unicode boundary handling.
3. `packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts` — exact runtime intent and `VIEWS` action-result contract.
4. `packages/ui/src/shared-nav-contract.test.ts` and `packages/ui/src/view-action-handoff.test.ts` — real builtin/catalog alignment and direct client dispatch.

## Detailed testing steps

Run from the repository root:

```bash
bun run install:light
bun run --cwd plugins/plugin-app-control test
bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts
bun run --cwd packages/ui test -- src/shared-nav-contract.test.ts src/view-action-handoff.test.ts
bun run --cwd packages/shared typecheck
bun run --cwd plugins/plugin-app-control typecheck
bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/ui typecheck
bunx @biomejs/biome check \
  packages/shared/src/views/shared-nav-targets.ts \
  packages/shared/src/views/view-command-matcher.ts \
  plugins/plugin-app-control/src/actions/view-command-matcher.test.ts \
  packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts \
  packages/ui/src/shared-nav-contract.test.ts \
  packages/ui/src/view-action-handoff.test.ts
git diff --check origin/develop...HEAD
bun run verify
```

# Evidence Gate

This change is deterministic routing/transport code plus tests. It does not modify rendered `.tsx`, CSS, SVG, layout, copy catalogs, or any visual asset.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI source or pixels changed; the existing Knowledge view is unchanged.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI source or pixels changed; the existing Knowledge view is unchanged.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - there is no new or changed visual flow to record; this repairs the deterministic command-to-existing-route contract.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - the affected shared-runtime resolver is a pure in-process matcher with no server/logger boundary; its real source path and exact action result are exercised below.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - the client handoff is synchronous event dispatch with no new request/response; the real registry and direct-handoff contracts are exercised below.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - this is intentionally a deterministic zero-model fast path; a model call would test the fallback path instead of the code changed here.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - navigation emits a transient `VIEWS` action result and writes no DB row, memory, file, task, or other persistent artifact.

# Evidence Details

<details>
<summary>Post-rebase verification results</summary>

```text
bun run --cwd plugins/plugin-app-control test
Test Files  46 passed (46)
Tests       1563 passed (1563)

bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts
47 pass
0 fail
1516 expect() calls

packages/ui targeted contract tests
Test Files  2 passed (2)
Tests       13 passed (13)

Biome
Checked 6 files; no fixes needed.

git diff --check origin/develop...HEAD
clean

bun run verify
Turbo: 578 successful / 578 total tasks
typecheck:dist: checked 28 dist-path consumer configs
exit 0
```

</details>

## Known gaps / failures

- Screenshots/video are N/A because no rendered source or visual output changed.
- Backend/frontend logs are N/A because this path is deterministic in-process matching plus synchronous handoff, not a transport request.
- Real-LLM evidence is N/A because the repaired path deliberately avoids the planner/model.
- Domain artifacts are N/A because navigation does not persist state.
- The documented `bun run install:light` path was used instead of downloading the unrelated large artifact bundle; dependency installation, scoped checks, and the complete repository verification all passed.
