### PR TITLE
fix(ui): preserve Settings cloud login popup

### DIFF
--- a/packages/ui/src/cloud/connectors/CloudConnectorsUpsell.test.tsx
+++ b/packages/ui/src/cloud/connectors/CloudConnectorsUpsell.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+/**
+ * Covers the Cloud Connectors upsell's trusted-click login handoff. Desktop
+ * login must retain the shared popup before the asynchronous session request.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setAppValueForTests } from "../../state/app-store";
+import CloudConnectorsSettingsBody from "./CloudConnectorsUpsell";
+
+const cloudLoginWindow = vi.hoisted(() => ({
+  popup: { closed: false } as unknown as Window,
+  preOpen: vi.fn(),
+}));
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: null, agentProps: {} }),
+}));
+
+vi.mock("../../state/cloud-login-launch", () => ({
+  preOpenCloudLoginWindow: cloudLoginWindow.preOpen,
+}));
+
+vi.mock("./CloudConnectorsSection", () => ({
+  CloudConnectorsSection: () => null,
+}));
+
+function t(_key: string, opts?: { defaultValue?: string }) {
+  return opts?.defaultValue ?? _key;
+}
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+  vi.clearAllMocks();
+});
+
+describe("CloudConnectorsSettingsBody", () => {
+  it("pre-opens the shared cloud auth window before starting login", () => {
+    const handleCloudLogin = vi.fn(async () => undefined);
+    cloudLoginWindow.preOpen.mockReturnValue(cloudLoginWindow.popup);
+    __setAppValueForTests({
+      t,
+      elizaCloudConnected: false,
+      elizaCloudLoginBusy: false,
+      handleCloudLogin,
+      setActionNotice: vi.fn(),
+    } as never);
+
+    render(<CloudConnectorsSettingsBody />);
+    fireEvent.click(screen.getByRole("button", { name: "Connect Cloud" }));
+
+    expect(cloudLoginWindow.preOpen).toHaveBeenCalledTimes(1);
+    expect(handleCloudLogin).toHaveBeenCalledWith(cloudLoginWindow.popup);
+  });
+});

--- a/packages/ui/src/cloud/connectors/CloudConnectorsUpsell.tsx
+++ b/packages/ui/src/cloud/connectors/CloudConnectorsUpsell.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../components/settings/settings-layout";
 import { Button } from "../../components/ui/button";
 import { useAppSelectorShallow } from "../../state";
+import { preOpenCloudLoginWindow } from "../../state/cloud-login-launch";
 import { CloudConnectorsSection } from "./CloudConnectorsSection";
 
 const CLOUD_CONNECTOR_FEATURES = [
@@ -62,7 +63,7 @@ function CloudConnectorsUpsell(): React.JSX.Element {
   }));
 
   const handleConnect = useCallback(() => {
-    void handleCloudLogin().catch((error) => {
+    void handleCloudLogin(preOpenCloudLoginWindow()).catch((error) => {
       setActionNotice(
         error instanceof Error
           ? error.message

--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -247,7 +247,29 @@ for (const id of VISIBLE_SECTIONS) {
 }
 assert(true, "walked every visible desktop section with the rail retained");
 
-// ── 3. Hash deep-link opens a section directly ───────────────────────────────
+// ── 3. Cloud login preserves the desktop page through popup handoff ──────────
+const settingsUrlBeforeLogin = p.url();
+const popupPromise = context.waitForEvent("page");
+await p.getByRole("button", { name: "Connect Cloud" }).click();
+const authPopup = await popupPromise;
+await authPopup.waitForLoadState("domcontentloaded");
+assert(
+  p.url() === settingsUrlBeforeLogin,
+  "desktop Cloud login keeps Settings mounted instead of navigating its document",
+);
+assert(
+  (await p
+    .locator("html")
+    .getAttribute("data-eliza-settings-cloud-login-popup")) === "live",
+  "Settings passes the live pre-opened auth window into handleCloudLogin",
+);
+assert(
+  (await authPopup.evaluate(() => window.name)) === "eliza-cloud-auth",
+  "the auth handoff uses the shared named Cloud popup",
+);
+await authPopup.close();
+
+// ── 4. Hash deep-link opens a section directly ───────────────────────────────
 await p.goto(`${url}#appearance`, { waitUntil: "domcontentloaded" });
 await p.waitForSelector("#appearance");
 assert(
@@ -259,7 +281,7 @@ assert(
 await snap(p, `${String(shotIndex).padStart(2, "0")}-deeplink-appearance`);
 shotIndex += 1;
 
-// ── 4. Mobile viewport ───────────────────────────────────────────────────────
+// ── 5. Mobile viewport ───────────────────────────────────────────────────────
 const mobile = await context.newPage();
 await mobile.setViewportSize({ width: 390, height: 844 });
 await mobile.goto(url, { waitUntil: "domcontentloaded" });

--- a/packages/ui/src/components/pages/__e2e__/settings-fixture-state-stub.ts
+++ b/packages/ui/src/components/pages/__e2e__/settings-fixture-state-stub.ts
@@ -32,6 +32,13 @@ const fixtureState: Record<string, unknown> = {
   setState: () => {},
   setTab: () => {},
   setActionNotice: () => {},
+  handleCloudLogin: async (popup: Window | null = null) => {
+    document.documentElement.dataset.elizaSettingsCloudLoginPopup = Boolean(
+      popup && !popup.closed,
+    )
+      ? "live"
+      : "blocked";
+  },
 };
 
 const useApp = () => fixtureState;

--- a/packages/ui/src/components/settings/CloudOverviewSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudOverviewSection.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 /**
- * Covers the Cloud overview's account escape hatch. Mobile users can get stuck
- * on a connected Cloud session without a desktop account menu, so this section
- * must expose the same sign-out path inline with the Cloud status.
+ * Covers the Cloud overview's login launch and account escape hatch. Desktop
+ * login preserves the popup handle for the auth handoff, while connected mobile
+ * users retain the same inline sign-out path as the desktop account menu.
  */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -10,8 +10,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setAppValueForTests } from "../../state/app-store";
 import { CloudOverviewSection } from "./CloudOverviewSection";
 
+const cloudLoginWindow = vi.hoisted(() => ({
+  popup: { closed: false } as unknown as Window,
+  preOpen: vi.fn(),
+}));
+
 vi.mock("../../agent-surface", () => ({
   useAgentElement: () => ({ ref: null, agentProps: {} }),
+}));
+
+vi.mock("../../state/cloud-login-launch", () => ({
+  preOpenCloudLoginWindow: cloudLoginWindow.preOpen,
 }));
 
 function t(_key: string, opts?: { defaultValue?: string; id?: string }) {
@@ -25,7 +34,7 @@ function seedCloudOverviewState(
     elizaCloudLoginBusy: boolean;
     elizaCloudUserId: string | null;
     handleCloudDisconnect: () => Promise<void>;
-    handleCloudLogin: () => Promise<void>;
+    handleCloudLogin: (popup?: Window | null) => Promise<void>;
     handleCloudSignOut: () => Promise<void>;
   }> = {},
 ) {
@@ -49,9 +58,22 @@ afterEach(() => {
   cleanup();
   __setAppValueForTests(null);
   vi.clearAllMocks();
+  cloudLoginWindow.preOpen.mockReturnValue(cloudLoginWindow.popup);
 });
 
 describe("CloudOverviewSection", () => {
+  it("pre-opens the shared cloud auth window before starting login", () => {
+    const handleCloudLogin = vi.fn(async () => undefined);
+    cloudLoginWindow.preOpen.mockReturnValue(cloudLoginWindow.popup);
+    seedCloudOverviewState({ handleCloudLogin });
+
+    render(<CloudOverviewSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Connect Cloud" }));
+
+    expect(cloudLoginWindow.preOpen).toHaveBeenCalledTimes(1);
+    expect(handleCloudLogin).toHaveBeenCalledWith(cloudLoginWindow.popup);
+  });
+
   it("exposes a sign-out action for connected Cloud accounts", () => {
     const handleCloudDisconnect = vi.fn(async () => undefined);
     const handleCloudSignOut = vi.fn(async () => undefined);

--- a/packages/ui/src/components/settings/CloudOverviewSection.tsx
+++ b/packages/ui/src/components/settings/CloudOverviewSection.tsx
@@ -19,6 +19,7 @@ import {
 import { useCallback } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { useAppSelectorShallow } from "../../state";
+import { preOpenCloudLoginWindow } from "../../state/cloud-login-launch";
 import { Button } from "../ui/button";
 import { CloudAgentsSection } from "./CloudAgentsSection";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
@@ -78,7 +79,7 @@ export function CloudOverviewSection() {
   }));
 
   const handleConnect = useCallback(() => {
-    void handleCloudLogin().catch((error) => {
+    void handleCloudLogin(preOpenCloudLoginWindow()).catch((error) => {
       setActionNotice(
         error instanceof Error ? error.message : "Could not start Cloud login.",
         "error",

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -135,6 +135,59 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
   });
 
+  it("does not navigate the auth popup until CLI-session creation completes", async () => {
+    vi.useFakeTimers();
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: { href: "" },
+      opener: {},
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+    type DirectLoginResult = Awaited<
+      ReturnType<typeof client.cloudLoginDirect>
+    >;
+    let resolveSession: ((value: DirectLoginResult) => void) | undefined;
+    cloudLoginDirectSpy.mockReturnValue(
+      new Promise<DirectLoginResult>((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    try {
+      const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+      await act(async () => {
+        void result.current.handleCloudLogin(popup);
+        await Promise.resolve();
+      });
+
+      expect(cloudLoginDirectSpy).toHaveBeenCalledTimes(1);
+      expect(popup.location.href).toBe("");
+
+      await act(async () => {
+        resolveSession?.({
+          ok: true,
+          apiBase: "https://api.elizacloud.ai",
+          browserUrl:
+            "https://elizacloud.ai/auth/cli-login?session=sess-serialized",
+          sessionId: "sess-serialized",
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(popup.location.href).toBe(
+        "https://elizacloud.ai/auth/cli-login?session=sess-serialized",
+      );
+      expect(assignSpy).not.toHaveBeenCalled();
+
+      unmount();
+      vi.clearAllTimers();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("closes a pre-opened popup when direct cloud login startup throws", async () => {
     const popup = {
       closed: false,


### PR DESCRIPTION
## Summary

Correct the trusted-click Cloud login entry points in Settings so a hosted desktop sign-in keeps the application document alive while the authenticated CLI session is created. The Cloud Overview and disconnected Cloud Connectors handlers now open the named auth popup synchronously and pass that live window to `useCloudState.handleCloudLogin`.

Touch/mobile behavior is unchanged: `preOpenCloudLoginWindow()` returns `null` there, so the designed same-tab login path remains available.

Refs #16900. Supersedes #17008.

## Why #17008 is insufficient

#17008 adds `keepalive` to the CLI-session fetch, but the failing Settings call site entered the hosted same-tab branch *before* `cloudLoginDirect()` was called. That branch creates no CLI session at all. In the popup branch, the code already waits for the server's 201 response before navigating the popup; preserving a request after destroying the caller document would not preserve the response handler or polling state.

The concrete defect was that `CloudOverviewSection` called `handleCloudLogin()` without the pre-opened window used by the other login entry points. On hosted desktop that forced current-page `/login` navigation, matching the reported `page.evaluate: Execution context was destroyed` failure. A final call-site audit found and corrected the same omission in the disconnected `CloudConnectorsUpsell`; non-interactive boot recovery intentionally remains on the same-tab path.

## Regression coverage

- Component regressions: both Settings **Connect Cloud** controls pass the synchronously opened auth window into `handleCloudLogin`.
- State regression: a deferred real login helper proves the popup stays blank until CLI-session creation resolves, then navigates it; the current page is never assigned.
- Browser fixture regression: clicks the real Settings Cloud Overview control, requires a popup event, verifies the opener URL is unchanged, verifies the live-window marker, and verifies the named popup identity. This fails on the pre-fix call site because no popup opens.

## Verification performed

- Post-rebase focused Vitest assertions: **20/20 passed**
  - `CloudOverviewSection` + deferred `useCloudState` regressions: 19/19
  - isolated `CloudConnectorsUpsell` regression: 1/1
  - The combined host runs also passed every test they started but twice timed out starting one Vitest worker; isolating that file produced the complete passing count.
- `bun run typecheck` in `packages/ui`: **passed**
- Focused Biome check over every changed non-ignored file: **passed**
- `git diff --check origin/develop...HEAD`: **passed**
- Manual in-app Chromium fixture review:
  - pre-fix handoff marker: `blocked`
  - post-fix handoff marker: `live`
  - Settings opener URL remained mounted after the post-fix click
  - rendered Cloud Overview captures and both MP4 frames were opened and reviewed
## Remaining evidence gate

All repository gates pass on current head `15ee646265` rebased onto `origin/develop@415878c45f`: build, lint, typecheck, environment, security, evidence, Chromium fixture, Pages deployment, four-viewport aesthetic audit, and OCR audit. The PR preview is deployed at https://fix-17008-cli-session-naviga.eliza-app.pages.dev/.

This remains a draft for one substantive reason: issue #16900 requires the external F5 authenticated sign-out → sign-in canary to show the real `/api/auth/cli-session` request and poll, a session token in under 20 seconds, and a usable composer. This checkout has no Cloud test credential, the cited `projects/eliza-fleet` harness is not in an accessible repository, and the deployed app shell hangs this host's browser-control channel before interactive authentication. The F5 owner has been asked to run the exact preview or provide the harness; this PR does not claim that final live gate yet.

## Evidence matrix

- Unit/state regressions: **PASS — 20/20**
- Build/lint/typecheck/env/security: **PASS**
- Chromium Settings fixture: **PASS on current head** — Settings stays mounted, a live popup reaches `handleCloudLogin`, and the shared named popup is used ([job log](https://github.com/elizaOS/eliza/actions/runs/30019430546/job/89247953767))
- Aesthetic audit: **PASS** — all four Settings viewports are `good`, with zero console/render/overflow/quality issues
- OCR audit: **PASS** — all four Settings captures are `verified`, with no Settings regression
- Pages preview deployment: **PASS on current head** — [immutable deploy](https://325debf6.eliza-app.pages.dev) and [branch alias](https://fix-17008-cli-session-naviga.eliza-app.pages.dev/)
- Local before/after + MP4 + browser observations: **ATTACHED BELOW**
- Backend behavior change: **N/A** — no server code changed
- Live authenticated F5 flow: **PENDING external harness/authentication; required before ready/merge**
<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17064-before-current-develop-415878c45f.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17064-after-current-head-ci-15ee646265.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17064-settings-cloud-login-click-ci-15ee646265.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code changed; this draft still requires deployed authenticated network/backend proof before ready

<!-- evidence-row:frontend-logs -->
- [x] [17064-frontend-browser-observations-15ee646265.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17064-frontend-browser-observations-15ee646265.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact is created or changed by this UI handoff

<!-- evidence-row:ocr-review -->
- [x] [17064-ocr-visual-review-15ee646265.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17064-ocr-visual-review-15ee646265.txt)

