### PR TITLE
fix(core): enforce typed user-visible model output boundary

### DIFF
--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -1,11 +1,13 @@
 /**
- * Exercises the message service's structured failure-reply classifier for model
- * fallback cascades. Deterministic: the runtime only exposes a queued useModel
- * stub, so no provider, database, or live model is involved.
+ * Exercises failure-reply output classification and fallback rendering with a
+ * queued deterministic model delegate; no provider or database is involved.
  */
 import { describe, expect, it, vi } from "vitest";
 import { DefaultMessageService } from "../services/message";
+import type { Memory } from "../types/memory";
+import type { Content, UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
 
 const logger = {
 	debug: vi.fn(),
@@ -31,6 +33,38 @@ function creditError(): Error & { statusCode: number } {
 	return Object.assign(new Error("insufficient_credits"), { statusCode: 402 });
 }
 
+function makeRuntimeReturning(responses: unknown[]): IAgentRuntime {
+	const queue = [...responses];
+	return {
+		useModel: vi.fn(async () => {
+			if (queue.length === 0) throw new Error("Unexpected useModel call");
+			const next = queue.shift();
+			if (next instanceof Error) throw next;
+			return next;
+		}),
+		getModel: vi.fn(() => vi.fn()),
+		reportError: vi.fn(),
+		character: { templates: {} },
+		agentId: "00000000-0000-0000-0000-000000000001",
+		logger,
+	} as unknown as IAgentRuntime;
+}
+
+type FailureReplyService = {
+	generateFailureReplyText(
+		runtime: IAgentRuntime,
+		prompt: string,
+		stage: string,
+	): Promise<{ kind: string; value?: string }>;
+	buildStructuredFailureReply(
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		responseId: UUID,
+		stage: string,
+	): Promise<{ responseContent: Content | null }>;
+};
+
 describe("DefaultMessageService structured failure replies", () => {
 	it("preserves credit exhaustion when later fallback model slots fail generically", async () => {
 		const service = new DefaultMessageService() as unknown as {
@@ -50,5 +84,124 @@ describe("DefaultMessageService structured failure replies", () => {
 		await expect(
 			service.generateFailureReplyText(runtime, "recent messages", "test"),
 		).resolves.toEqual({ kind: "creditsExhausted" });
+	});
+
+	it("extracts the user-facing text from a structured envelope reply", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning([
+			'{"shouldRespond": true, "replyText": "sorry, that broke on my side"}',
+		]);
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({ kind: "text", value: "sorry, that broke on my side" });
+	});
+
+	it("never ships a raw JSON envelope as the failure reply", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning([
+			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"thought":"retry the open","status":"retry"}',
+			"something went sideways, mind trying that again?",
+		]);
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({
+			kind: "text",
+			value: "something went sideways, mind trying that again?",
+		});
+		expect(runtime.reportError).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a fenced action envelope hidden inside nested reply fields", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const nestedEnvelope = JSON.stringify({
+			response: JSON.stringify({
+				messageToUser:
+					'```json\n{"action":"BROWSER","parameters":{"url":"https://example.com"},"toolCallId":"call-1"}\n```',
+			}),
+		});
+		const runtime = makeRuntimeReturning([
+			nestedEnvelope,
+			"That did not work. Please try again.",
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({
+			kind: "text",
+			value: "That did not work. Please try again.",
+		});
+		expect(runtime.reportError).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects malformed control JSON and advances to the next model slot", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning([
+			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":',
+			"I hit a snag. Please try once more.",
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({
+			kind: "text",
+			value: "I hit a snag. Please try once more.",
+		});
+		expect(runtime.reportError).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not mistake genuine JSON for a control envelope", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning([
+			'{"action":"proceed","parameters":{"step":1},"status":"done"}',
+			"I could not complete that. Please try again.",
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({
+			kind: "text",
+			value: "I could not complete that. Please try again.",
+		});
+		const reportedError = (
+			runtime.reportError as unknown as { mock: { calls: unknown[][] } }
+		).mock.calls[0]?.[1] as {
+			context?: { classification?: string };
+		};
+		expect(reportedError.context?.classification).toBe("unexpected-json");
+	});
+
+	it("renders the designed default when every slot yields invalid envelopes", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const envelope = '{"action":"X","parameters":{}}';
+		const runtime = makeRuntimeReturning([
+			envelope,
+			envelope,
+			envelope,
+			envelope,
+		]);
+		const responseId = "00000000-0000-0000-0000-000000000002" as UUID;
+		const message = {
+			content: { text: "open browser" },
+			roomId: "00000000-0000-0000-0000-000000000003" as UUID,
+		} as Memory;
+		const result = await service.buildStructuredFailureReply(
+			runtime,
+			message,
+			{ values: { recentMessages: "User: open browser" } } as State,
+			responseId,
+			"test",
+		);
+
+		expect(result.responseContent?.text).toBe(
+			"Something went wrong on my end. Please try again.",
+		);
+		expect(result.responseContent?.text).not.toContain('"action"');
+		expect(runtime.reportError).toHaveBeenCalledTimes(4);
 	});
 });

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -66,6 +66,10 @@ function useModelCalls(runtime: IAgentRuntime): unknown[][] {
 	return (runtime.useModel as { mock: { calls: unknown[][] } }).mock.calls;
 }
 
+function reportErrorCalls(runtime: IAgentRuntime): unknown[][] {
+	return (runtime.reportError as { mock: { calls: unknown[][] } }).mock.calls;
+}
+
 function makeMessage(content: Partial<Memory["content"]> = {}): Memory {
 	return {
 		id: "00000000-0000-0000-0000-000000000001" as UUID,
@@ -200,6 +204,7 @@ function makeRuntime(
 		composeState: vi.fn(async () => makeState()),
 		runActionsByMode: vi.fn(async () => undefined),
 		emitEvent: vi.fn(async () => undefined),
+		reportError: vi.fn(),
 		useModel: vi.fn(async () => {
 			if (queue.length === 0) {
 				throw new Error("Unexpected useModel call");
@@ -337,6 +342,66 @@ describe("runV5MessageRuntimeStage1", () => {
 		if (result.kind === "direct_reply") {
 			expect(result.result.responseContent?.text).toBe("Hello.");
 		}
+	});
+
+	it("blocks a Stage-1 action envelope before the direct-reply route", async () => {
+		const actionEnvelope =
+			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":"retry","toolCallId":"call-1"}';
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: actionEnvelope,
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "Open example.com" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I'm not sure how to answer that.",
+			);
+			expect(result.result.responseContent?.text).not.toContain('"action"');
+		}
+		const reported = reportErrorCalls(runtime)[0]?.[1] as {
+			code?: string;
+			context?: Record<string, unknown>;
+		};
+		expect(reported.code).toBe("STAGE1_INVALID_USER_VISIBLE_OUTPUT");
+		expect(reported.context).toMatchObject({
+			stage: "response-handler",
+			classification: "action",
+			fieldPath: [],
+		});
+	});
+
+	it("preserves genuine lower-case action JSON in a Stage-1 direct reply", async () => {
+		const domainJson =
+			'{"action":"proceed","parameters":{"step":1},"status":"done"}';
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: domainJson,
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "Return the workflow record as JSON." }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(domainJson);
+		}
+		expect(runtime.reportError).not.toHaveBeenCalled();
 	});
 
 	// #16395: a per-agent maxReplyTokens setting caps Stage-1 with a real

--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import {
+	looksLikeActionEnvelopeJson,
 	looksLikeSpawnEnvelopeJson,
 	runPlannerLoop,
 	singleVerifiedUserFacingToolResultText,
@@ -546,6 +547,53 @@ describe("looksLikeSpawnEnvelopeJson — spawn-arg leak detector", () => {
 		expect(looksLikeSpawnEnvelopeJson("[1,2,3]")).toBe(false);
 		expect(looksLikeSpawnEnvelopeJson('{"task": broken')).toBe(false);
 		expect(looksLikeSpawnEnvelopeJson("")).toBe(false);
+	});
+});
+
+describe("looksLikeActionEnvelopeJson — planner fallback-envelope leak detector", () => {
+	it("flags the documented plain-JSON planner fallback envelope", () => {
+		expect(
+			looksLikeActionEnvelopeJson(
+				'{"action":"BROWSER","parameters":{"url":"https://example.com","subaction":"open"},"thought":"open the browser"}',
+			),
+		).toBe(true);
+	});
+
+	it("flags the envelope without a thought", () => {
+		expect(
+			looksLikeActionEnvelopeJson(
+				'{"action":"VIEWS","parameters":{"view":"settings"}}',
+			),
+		).toBe(true);
+	});
+
+	it("flags the envelope wrapped in a ```json fence", () => {
+		expect(
+			looksLikeActionEnvelopeJson(
+				'```json\n{"action":"WEB_SEARCH","parameters":{"query":"x"}}\n```',
+			),
+		).toBe(true);
+	});
+
+	it("does NOT flag a genuine JSON answer with foreign keys", () => {
+		expect(
+			looksLikeActionEnvelopeJson(
+				'{"action":"proceed","parameters":{"a":1},"status":"done","summary":"…"}',
+			),
+		).toBe(false);
+	});
+
+	it("does NOT flag an action string without a parameters object", () => {
+		expect(looksLikeActionEnvelopeJson('{"action":"approve"}')).toBe(false);
+		expect(
+			looksLikeActionEnvelopeJson('{"action":"approve","parameters":"yes"}'),
+		).toBe(false);
+	});
+
+	it("does NOT flag prose or unparseable text", () => {
+		expect(looksLikeActionEnvelopeJson("The action succeeded.")).toBe(false);
+		expect(looksLikeActionEnvelopeJson('{"action": broken')).toBe(false);
+		expect(looksLikeActionEnvelopeJson("")).toBe(false);
 	});
 });
 

--- a/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
@@ -61,6 +61,63 @@ describe("planner output user-visible safety", () => {
 		expect(output.toolCalls).toEqual([]);
 	});
 
+	it("preserves genuine JSON with a lowercase domain action and metadata", () => {
+		const json =
+			'{"action":"proceed","parameters":{"step":1},"status":"done","summary":"approved"}';
+		const output = parsePlannerOutput({
+			text: json,
+			toolCalls: [],
+		});
+
+		expect(output.messageToUser).toBe(json);
+		expect(output.toolCalls).toEqual([]);
+	});
+
+	it("unwraps nested reply scaffolds before projecting planner text", () => {
+		const output = parsePlannerOutput({
+			text: JSON.stringify({
+				response: JSON.stringify({
+					messageToUser: "I could not finish that. Please try again.",
+				}),
+			}),
+			toolCalls: [],
+		});
+
+		expect(output.messageToUser).toBe(
+			"I could not finish that. Please try again.",
+		);
+		expect(output.toolCalls).toEqual([]);
+	});
+
+	it("routes a fenced action envelope nested inside messageToUser without exposing it", () => {
+		const output = parsePlannerOutput(
+			JSON.stringify({
+				messageToUser:
+					'```json\n{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":"retry"}\n```',
+				toolCalls: [],
+			}),
+		);
+
+		expect(output.messageToUser).toBeUndefined();
+		expect(output.toolCalls).toEqual([
+			{
+				id: undefined,
+				name: "BROWSER",
+				params: { url: "https://example.com" },
+			},
+		]);
+	});
+
+	it("drops a malformed action envelope emitted in the native text channel", () => {
+		const output = parsePlannerOutput({
+			text: '{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":',
+			toolCalls: [],
+		});
+
+		expect(output.messageToUser).toBeUndefined();
+		expect(output.toolCalls).toEqual([]);
+	});
+
 	it("preserves a form interaction marker with a JSON body as visible message text", () => {
 		const form =
 			'[FORM]\n{"title":"Connect Discord","fields":[{"name":"token","type":"secret"}]}\n[/FORM]';

--- a/packages/core/src/runtime/__tests__/user-visible-model-output.test.ts
+++ b/packages/core/src/runtime/__tests__/user-visible-model-output.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Exercises the shared user-visible model-output boundary with adversarial
+ * envelope nesting and genuine JSON. Pure parser tests; no model or runtime.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	looksLikeActionEnvelopeJson,
+	sanitizeUserVisibleModelOutput,
+} from "../user-visible-model-output";
+
+describe("sanitizeUserVisibleModelOutput", () => {
+	it("rejects a fenced action envelope even when foreign metadata keys are present", () => {
+		const output = sanitizeUserVisibleModelOutput(
+			'```json\n{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":"retry","toolCallId":"call-1"}\n```',
+		);
+
+		expect(output).toEqual({
+			kind: "control",
+			envelope: "action",
+			malformed: false,
+			fieldPath: [],
+		});
+		expect(
+			looksLikeActionEnvelopeJson(
+				'{"action":"BROWSER","parameters":{},"status":"retry"}',
+			),
+		).toBe(true);
+	});
+
+	it("recursively rejects action envelopes hidden in nested reply fields", () => {
+		const action = JSON.stringify({
+			action: "WEB_SEARCH",
+			parameters: { query: "current weather" },
+			thought: "search first",
+			metadata: { attempt: 2 },
+		});
+		const output = sanitizeUserVisibleModelOutput(
+			JSON.stringify({
+				response: JSON.stringify({
+					messageToUser: `\`\`\`json\n${action}\n\`\`\``,
+				}),
+			}),
+		);
+
+		expect(output).toEqual({
+			kind: "control",
+			envelope: "action",
+			malformed: false,
+			fieldPath: ["response", "messageToUser"],
+		});
+
+		expect(
+			sanitizeUserVisibleModelOutput(
+				JSON.stringify({
+					response: action,
+					traceId: "trace-1",
+					foreignMetadata: true,
+				}),
+			),
+		).toEqual({
+			kind: "control",
+			envelope: "action",
+			malformed: false,
+			fieldPath: ["response"],
+		});
+	});
+
+	it("unwraps nested response scaffolds until it reaches plain user text", () => {
+		const output = sanitizeUserVisibleModelOutput(
+			JSON.stringify({
+				response: JSON.stringify({
+					replyText: "Something went wrong. Please try again.",
+				}),
+			}),
+		);
+
+		expect(output).toEqual({
+			kind: "text",
+			text: "Something went wrong. Please try again.",
+			format: "plain",
+			fieldPath: ["response", "replyText"],
+		});
+	});
+
+	it("rejects a truncated action envelope as malformed control data", () => {
+		for (const candidate of [
+			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":',
+			'{"action":"BROWSER"',
+			'{"action":"BROWSER"}',
+		]) {
+			expect(sanitizeUserVisibleModelOutput(candidate)).toEqual({
+				kind: "control",
+				envelope: "action",
+				malformed: true,
+				fieldPath: [],
+			});
+		}
+	});
+
+	it("rejects single-line fences and nested OpenAI function-call records", () => {
+		expect(
+			sanitizeUserVisibleModelOutput(
+				'```json {"action":"BROWSER","parameters":{"url":"https://example.com"}} ```',
+			),
+		).toMatchObject({
+			kind: "control",
+			envelope: "action",
+			malformed: false,
+		});
+		expect(
+			sanitizeUserVisibleModelOutput(
+				'{"function":{"name":"WEB_SEARCH","arguments":"{\\"query\\":\\"weather\\"}"},"id":"call-1"}',
+			),
+		).toMatchObject({
+			kind: "control",
+			envelope: "planner",
+			malformed: false,
+		});
+	});
+
+	it("preserves genuine JSON instead of treating any action key as control", () => {
+		const lowerCaseAction =
+			'{"action":"proceed","parameters":{"step":1},"status":"done","summary":"approved"}';
+		expect(sanitizeUserVisibleModelOutput(lowerCaseAction)).toEqual({
+			kind: "text",
+			text: lowerCaseAction,
+			format: "json",
+			fieldPath: [],
+		});
+
+		const documentedExample =
+			'{"example":{"action":"BROWSER","parameters":{"url":"https://example.com"}},"description":"planner schema example"}';
+		expect(sanitizeUserVisibleModelOutput(documentedExample)).toEqual({
+			kind: "text",
+			text: documentedExample,
+			format: "json",
+			fieldPath: [],
+		});
+	});
+
+	it("returns an explicit invalid result for a reply scaffold with no usable field", () => {
+		expect(
+			sanitizeUserVisibleModelOutput(
+				'{"shouldRespond":true,"replyText":"","contexts":["simple"]}',
+			),
+		).toEqual({
+			kind: "invalid",
+			reason: "reply-envelope-without-text",
+			fieldPath: [],
+		});
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -102,11 +102,17 @@ import type {
 	TrajectoryRecorder,
 } from "./trajectory-recorder";
 import { captureToolStageIO } from "./trajectory-recorder";
+import { sanitizeUserVisibleModelOutput } from "./user-visible-model-output";
 
 export {
 	cacheProviderOptions,
 	trajectoryStepsToMessages,
 } from "./planner-rendering";
+export {
+	looksLikeActionEnvelopeJson,
+	looksLikeEvaluatorEnvelopeJson,
+	looksLikeSpawnEnvelopeJson,
+} from "./user-visible-model-output";
 
 // Test-only re-exports for the rendering memoization unit tests.
 // Underscore-prefixed so they're impossible to mistake for production API.
@@ -1448,6 +1454,18 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
 	raw: Record<string, unknown>;
 } {
 	if (typeof raw === "string") {
+		const visibleOutput = sanitizeUserVisibleModelOutput(raw);
+		if (
+			visibleOutput.kind === "text" &&
+			visibleOutput.format === "json" &&
+			visibleOutput.fieldPath.length === 0
+		) {
+			return {
+				toolCalls: [],
+				messageToUser: visibleOutput.text,
+				raw: { text: raw },
+			};
+		}
 		return parseJsonPlannerOutput(raw);
 	}
 
@@ -1521,17 +1539,11 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
  * `decision`).
  */
 function looksLikePlannerControlJson(text: string): boolean {
-	if (looksLikeEvaluatorEnvelopeJson(text)) return true;
-	const parsed = parseJsonObject<RawPlannerOutput & { decision?: unknown }>(
-		text.trim(),
-	);
-	if (!parsed) return false;
+	const output = sanitizeUserVisibleModelOutput(text);
 	return (
-		parsed.action !== undefined ||
-		parsed.toolCalls !== undefined ||
-		parsed.messageToUser !== undefined ||
-		parsed.text !== undefined ||
-		parsed.decision !== undefined
+		output.kind === "control" ||
+		output.kind === "invalid" ||
+		output.fieldPath.length > 0
 	);
 }
 
@@ -1559,9 +1571,11 @@ function parseJsonPlannerOutput(raw: string): {
 			raw: { text: trimmed },
 		};
 	}
-	let messageToUser = sanitizePlannerMessage(
-		parsed.messageToUser ?? parsed.text,
-	);
+	const visibleOutput = sanitizeUserVisibleModelOutput(trimmed);
+	let messageToUser =
+		visibleOutput.kind === "text" && visibleOutput.fieldPath.length > 0
+			? visibleOutput.text
+			: sanitizePlannerMessage(parsed.messageToUser ?? parsed.text);
 	const toolCalls = normalizeToolCalls(parsed.toolCalls);
 	const bareActionCalls =
 		toolCalls.length === 0 ? normalizeBarePlannerAction(parsed) : [];
@@ -2717,6 +2731,14 @@ function parseEmbeddedToolCalls(text: string | undefined): PlannerToolCall[] {
 	}
 	const calls: PlannerToolCall[] = [];
 	for (const objectText of extractJsonObjects(text)) {
+		const visibleOutput = sanitizeUserVisibleModelOutput(objectText);
+		if (
+			visibleOutput.kind !== "control" ||
+			(visibleOutput.envelope !== "action" &&
+				visibleOutput.envelope !== "planner")
+		) {
+			continue;
+		}
 		let parsed: unknown;
 		try {
 			parsed = JSON.parse(objectText);
@@ -2733,6 +2755,16 @@ function parseEmbeddedToolCalls(text: string | undefined): PlannerToolCall[] {
 
 function recoverMessageFieldToolCalls(value: unknown): PlannerToolCall[] {
 	if (value == null || value === "") {
+		return [];
+	}
+	const visibleOutput = sanitizeUserVisibleModelOutput(
+		typeof value === "string" ? value : JSON.stringify(value),
+	);
+	if (
+		visibleOutput.kind !== "control" ||
+		(visibleOutput.envelope !== "action" &&
+			visibleOutput.envelope !== "planner")
+	) {
 		return [];
 	}
 	const parsed =
@@ -2801,7 +2833,10 @@ function recoverEmbeddedToolCalls(text: string): PlannerToolCall[] {
 function sanitizePlannerMessage(value: unknown): string | undefined {
 	const text = getNonEmptyString(value);
 	if (!text) return undefined;
-	return getNonEmptyString(stripJsonStructuralJunkReply(text));
+	const cleaned = getNonEmptyString(stripJsonStructuralJunkReply(text));
+	if (!cleaned) return undefined;
+	const output = sanitizeUserVisibleModelOutput(cleaned);
+	return output.kind === "text" ? getNonEmptyString(output.text) : undefined;
 }
 
 /**
@@ -4033,98 +4068,15 @@ function userSafeFinalMessage(
  */
 export const HANDLED_STEP_FALLBACK_MESSAGE = "I handled the available step.";
 
-// Canonical TASKS/spawn-arg vocabulary. A planner that hallucinates its own
-// tool-call arguments into messageToUser leaks a JSON object like
-// {"task":"…","agentType":"opencode","approvalPreset":"standard","brief":"…"}.
-// Detect it by SHAPE — the reply itself must JSON.parse to an object whose keys
-// are a subset of this vocabulary with at least two discriminators — never by
-// matching the user's words. Real prose cannot JSON.parse to this object, and a
-// genuine user-requested JSON answer carries foreign keys, so this never fires
-// on a real reply.
-const SPAWN_ARG_KEYS = new Set([
-	"task",
-	"agentType",
-	"approvalPreset",
-	"brief",
-	"workdir",
-	"model",
-	"memoryContent",
-	"agents",
-	"repo",
-	"keepAliveAfterComplete",
-	"op",
-	"action",
-]);
-const SPAWN_ARG_DISCRIMINATORS = [
-	"task",
-	"agentType",
-	"approvalPreset",
-	"brief",
-];
-
-export function looksLikeSpawnEnvelopeJson(text: string): boolean {
-	let body = text.trim();
-	const fence = body.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-	if (fence?.[1]) body = fence[1].trim();
-	if (!body.startsWith("{") || !body.endsWith("}")) return false;
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(body);
-	} catch {
-		return false;
-	}
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		return false;
-	}
-	const keys = Object.keys(parsed as Record<string, unknown>);
-	if (keys.length === 0) return false;
-	if (!keys.every((k) => SPAWN_ARG_KEYS.has(k))) return false;
-	return (
-		SPAWN_ARG_DISCRIMINATORS.filter((k) => k in (parsed as object)).length >= 2
-	);
-}
-
-/**
- * Detects a planner/evaluator CONTROL envelope returned in a user-visible
- * channel — `{"decision":"CONTINUE"|"FINISH"|"NEXT_RECOMMENDED", …}` (or
- * `route`) carrying at least one evaluator discriminator
- * (`success`/`thought`/`nextTool`/`recommendedToolCallId`). Narrow by design:
- * a bare `{"decision":"approve"}` from a real reply does not match.
- */
-export function looksLikeEvaluatorEnvelopeJson(text: string): boolean {
-	let body = text.trim();
-	const fence = body.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-	if (fence?.[1]) body = fence[1].trim();
-	if (!body.startsWith("{") || !body.endsWith("}")) return false;
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(body);
-	} catch {
-		return false;
-	}
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		return false;
-	}
-	const record = parsed as Record<string, unknown>;
-	const decision = String(record.decision ?? record.route ?? "").toUpperCase();
-	if (!["FINISH", "CONTINUE", "NEXT_RECOMMENDED"].includes(decision)) {
-		return false;
-	}
-	return (
-		typeof record.success === "boolean" ||
-		typeof record.thought === "string" ||
-		typeof record.nextTool === "object" ||
-		typeof record.recommendedToolCallId === "string"
-	);
-}
-
 function isUnsafeUserVisibleText(value: string | undefined): boolean {
 	if (!value) return false;
 	const text = value.trim();
 	if (!text) return false;
+	const output = sanitizeUserVisibleModelOutput(text);
 	if (
-		looksLikeSpawnEnvelopeJson(text) ||
-		looksLikeEvaluatorEnvelopeJson(text)
+		output.kind === "control" ||
+		output.kind === "invalid" ||
+		output.fieldPath.length > 0
 	) {
 		return true;
 	}

--- a/packages/core/src/runtime/user-visible-model-output.ts
+++ b/packages/core/src/runtime/user-visible-model-output.ts
@@ -1,0 +1,375 @@
+/**
+ * Classifies untrusted model text before it reaches a user-visible channel.
+ * The planner and failure-reply cascade share this boundary so control
+ * envelopes cannot bypass one path through different parsing rules, while
+ * ordinary JSON requested by a user remains visible.
+ */
+import { isPlainObject } from "../utils/type-guards";
+
+const MAX_REPLY_ENVELOPE_DEPTH = 8;
+const TOOL_ACTION_NAME = /^(?:functions\.)?[A-Z][A-Z0-9_.:-]*$/;
+const EVALUATOR_DECISIONS = new Set(["FINISH", "CONTINUE", "NEXT_RECOMMENDED"]);
+const SPAWN_ARG_DISCRIMINATORS = [
+	"task",
+	"agentType",
+	"approvalPreset",
+	"brief",
+] as const;
+const REPLY_FIELDS = [
+	"messageToUser",
+	"replyText",
+	"response",
+	"text",
+] as const;
+const RESPONSE_ENVELOPE_MARKERS = new Set([
+	"shouldRespond",
+	"contexts",
+	"intents",
+	"candidateActionNames",
+	"facts",
+	"relationships",
+	"thought",
+]);
+const RESPONSE_ROUTING_MARKERS = [
+	"shouldRespond",
+	"contexts",
+	"intents",
+	"candidateActionNames",
+	"facts",
+	"relationships",
+] as const;
+const RESPONSE_ENVELOPE_KEYS = new Set([
+	...REPLY_FIELDS,
+	...RESPONSE_ENVELOPE_MARKERS,
+	"id",
+	"status",
+	"metadata",
+	"usage",
+]);
+
+export type UserVisibleReplyField = (typeof REPLY_FIELDS)[number];
+export type UserVisibleControlEnvelope =
+	| "action"
+	| "planner"
+	| "evaluator"
+	| "spawn";
+
+export type UserVisibleModelOutput =
+	| {
+			kind: "empty";
+			fieldPath: readonly UserVisibleReplyField[];
+	  }
+	| {
+			kind: "text";
+			text: string;
+			format: "plain" | "json";
+			fieldPath: readonly UserVisibleReplyField[];
+	  }
+	| {
+			kind: "control";
+			envelope: UserVisibleControlEnvelope;
+			malformed: boolean;
+			fieldPath: readonly UserVisibleReplyField[];
+	  }
+	| {
+			kind: "invalid";
+			reason: "reply-envelope-without-text" | "reply-envelope-too-deep";
+			fieldPath: readonly UserVisibleReplyField[];
+	  };
+
+/**
+ * Return a typed projection of model output. Reply scaffolds are recursively
+ * unwrapped; planner, action, evaluator, and spawn records are explicit
+ * control results rather than strings a caller might accidentally display.
+ */
+export function sanitizeUserVisibleModelOutput(
+	value: string | undefined,
+): UserVisibleModelOutput {
+	return inspectValue(value, [], 0);
+}
+
+export function looksLikeActionEnvelopeJson(text: string): boolean {
+	const result = sanitizeUserVisibleModelOutput(text);
+	return result.kind === "control" && result.envelope === "action";
+}
+
+export function looksLikeEvaluatorEnvelopeJson(text: string): boolean {
+	const result = sanitizeUserVisibleModelOutput(text);
+	return result.kind === "control" && result.envelope === "evaluator";
+}
+
+export function looksLikeSpawnEnvelopeJson(text: string): boolean {
+	const result = sanitizeUserVisibleModelOutput(text);
+	return result.kind === "control" && result.envelope === "spawn";
+}
+
+function inspectValue(
+	value: unknown,
+	fieldPath: readonly UserVisibleReplyField[],
+	depth: number,
+): UserVisibleModelOutput {
+	if (depth > MAX_REPLY_ENVELOPE_DEPTH) {
+		return {
+			kind: "invalid",
+			reason: "reply-envelope-too-deep",
+			fieldPath,
+		};
+	}
+	if (typeof value === "string") {
+		return inspectString(value, fieldPath, depth);
+	}
+	if (isPlainObject(value) || Array.isArray(value)) {
+		return inspectParsedJson(value, JSON.stringify(value), fieldPath, depth);
+	}
+	return { kind: "empty", fieldPath };
+}
+
+function inspectString(
+	raw: string,
+	fieldPath: readonly UserVisibleReplyField[],
+	depth: number,
+): UserVisibleModelOutput {
+	const text = raw.trim();
+	if (!text) return { kind: "empty", fieldPath };
+
+	const fencedBody = unwrapWholeJsonFence(text);
+	const candidate = fencedBody ?? text;
+	const parsed = parseStructuredJson(candidate);
+	if (parsed !== undefined) {
+		return inspectParsedJson(parsed, text, fieldPath, depth);
+	}
+
+	const malformedEnvelope = classifyMalformedControl(candidate);
+	if (malformedEnvelope) {
+		return {
+			kind: "control",
+			envelope: malformedEnvelope,
+			malformed: true,
+			fieldPath,
+		};
+	}
+	if (looksLikeMalformedReplyEnvelope(candidate)) {
+		return {
+			kind: "invalid",
+			reason: "reply-envelope-without-text",
+			fieldPath,
+		};
+	}
+	return { kind: "text", text, format: "plain", fieldPath };
+}
+
+function inspectParsedJson(
+	parsed: unknown,
+	displayText: string,
+	fieldPath: readonly UserVisibleReplyField[],
+	depth: number,
+): UserVisibleModelOutput {
+	if (!isPlainObject(parsed)) {
+		return {
+			kind: "text",
+			text: displayText,
+			format: "json",
+			fieldPath,
+		};
+	}
+
+	const control = classifyControlRecord(parsed);
+	if (control) {
+		return {
+			kind: "control",
+			envelope: control.envelope,
+			malformed: control.malformed,
+			fieldPath,
+		};
+	}
+
+	if (!isReplyEnvelope(parsed)) {
+		for (const field of ["response", "text"] as const) {
+			if (!Object.hasOwn(parsed, field)) continue;
+			const nested = inspectValue(
+				parsed[field],
+				[...fieldPath, field],
+				depth + 1,
+			);
+			if (nested.kind === "control" || nested.kind === "invalid") {
+				return nested;
+			}
+		}
+		return {
+			kind: "text",
+			text: displayText,
+			format: "json",
+			fieldPath,
+		};
+	}
+
+	let rejected:
+		| Extract<UserVisibleModelOutput, { kind: "control" | "invalid" }>
+		| undefined;
+	for (const field of REPLY_FIELDS) {
+		if (!Object.hasOwn(parsed, field)) continue;
+		const nested = inspectValue(
+			parsed[field],
+			[...fieldPath, field],
+			depth + 1,
+		);
+		if (nested.kind === "text") return nested;
+		if (nested.kind === "control" || nested.kind === "invalid") {
+			rejected ??= nested;
+		}
+	}
+	return (
+		rejected ?? {
+			kind: "invalid",
+			reason: "reply-envelope-without-text",
+			fieldPath,
+		}
+	);
+}
+
+function parseStructuredJson(text: string): unknown | undefined {
+	if (!text.startsWith("{") && !text.startsWith("[")) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		// error-policy:J3 untrusted model output remains an explicit invalid
+		// signal; the caller never receives a fabricated parsed value.
+		return undefined;
+	}
+}
+
+function unwrapWholeJsonFence(text: string): string | undefined {
+	const match = text.match(/^```(?:json)?[ \t]*(?:\r?\n)?([\s\S]*?)```$/i);
+	return match?.[1]?.trim();
+}
+
+function classifyControlRecord(
+	record: Record<string, unknown>,
+): { envelope: UserVisibleControlEnvelope; malformed: boolean } | undefined {
+	const action = typeof record.action === "string" ? record.action.trim() : "";
+	if (TOOL_ACTION_NAME.test(action)) {
+		return {
+			envelope: "action",
+			malformed: !isPlainObject(record.parameters),
+		};
+	}
+
+	const decision = String(record.decision ?? record.route ?? "").toUpperCase();
+	if (
+		EVALUATOR_DECISIONS.has(decision) &&
+		(typeof record.success === "boolean" ||
+			typeof record.thought === "string" ||
+			isPlainObject(record.nextTool) ||
+			typeof record.recommendedToolCallId === "string")
+	) {
+		return { envelope: "evaluator", malformed: false };
+	}
+
+	if (
+		Object.hasOwn(record, "toolCalls") ||
+		(typeof record.completed === "boolean" &&
+			(typeof record.thought === "string" ||
+				REPLY_FIELDS.some((field) => Object.hasOwn(record, field))))
+	) {
+		return { envelope: "planner", malformed: false };
+	}
+
+	const nestedFunction = isPlainObject(record.function)
+		? record.function
+		: undefined;
+	const narratedToolName = [
+		record.name,
+		record.toolName,
+		record.tool,
+		record.actionName,
+		nestedFunction?.name,
+		typeof record.function === "string" ? record.function : undefined,
+		record.type,
+	].find((value): value is string => typeof value === "string");
+	const carriesTopLevelToolArguments = [
+		"input",
+		"args",
+		"arguments",
+		"params",
+		"parameters",
+	].some((key) => Object.hasOwn(record, key));
+	const carriesNestedFunctionArguments =
+		nestedFunction !== undefined &&
+		["arguments", "args", "input", "parameters"].some((key) =>
+			Object.hasOwn(nestedFunction, key),
+		);
+	if (
+		narratedToolName &&
+		TOOL_ACTION_NAME.test(narratedToolName.trim()) &&
+		(carriesTopLevelToolArguments || carriesNestedFunctionArguments)
+	) {
+		return { envelope: "planner", malformed: false };
+	}
+
+	const spawnDiscriminators = SPAWN_ARG_DISCRIMINATORS.filter((key) =>
+		Object.hasOwn(record, key),
+	);
+	if (spawnDiscriminators.length >= 2) {
+		return { envelope: "spawn", malformed: false };
+	}
+	return undefined;
+}
+
+function isReplyEnvelope(record: Record<string, unknown>): boolean {
+	if (
+		Object.hasOwn(record, "messageToUser") ||
+		Object.hasOwn(record, "replyText")
+	) {
+		return true;
+	}
+	if (RESPONSE_ROUTING_MARKERS.some((key) => Object.hasOwn(record, key))) {
+		return true;
+	}
+	const hasGenericReplyField =
+		Object.hasOwn(record, "response") || Object.hasOwn(record, "text");
+	return (
+		hasGenericReplyField &&
+		Object.keys(record).every((key) => RESPONSE_ENVELOPE_KEYS.has(key))
+	);
+}
+
+function classifyMalformedControl(
+	text: string,
+): UserVisibleControlEnvelope | undefined {
+	if (!text.startsWith("{")) return undefined;
+	const candidate = text.slice(0, 20_000);
+	const action = candidate.match(
+		/"action"\s*:\s*"((?:functions\.)?[A-Z][A-Z0-9_.:-]*)"/,
+	)?.[1];
+	if (action) return "action";
+	if (/"toolCalls"\s*:/.test(candidate)) return "planner";
+	const evaluatorDecision =
+		/"(?:decision|route)"\s*:\s*"(?:FINISH|CONTINUE|NEXT_RECOMMENDED)"/i.test(
+			candidate,
+		);
+	if (
+		evaluatorDecision &&
+		(/"success"\s*:/.test(candidate) ||
+			/"thought"\s*:/.test(candidate) ||
+			/"nextTool"\s*:/.test(candidate) ||
+			/"recommendedToolCallId"\s*:/.test(candidate))
+	) {
+		return "evaluator";
+	}
+	const spawnDiscriminators = SPAWN_ARG_DISCRIMINATORS.filter((key) =>
+		new RegExp(`"${key}"\\s*:`).test(candidate),
+	);
+	return spawnDiscriminators.length >= 2 ? "spawn" : undefined;
+}
+
+function looksLikeMalformedReplyEnvelope(text: string): boolean {
+	if (!text.startsWith("{")) return false;
+	const candidate = text.slice(0, 20_000);
+	return (
+		/"(?:messageToUser|replyText)"\s*:/.test(candidate) ||
+		(/"(?:response|text)"\s*:/.test(candidate) &&
+			[...RESPONSE_ENVELOPE_MARKERS].some((key) =>
+				new RegExp(`"${key}"\\s*:`).test(candidate),
+			))
+	);
+}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -19,6 +19,7 @@ import {
 } from "../actions/to-tool";
 import { evaluateConnectorAccountPolicies } from "../connectors/account-manager";
 import { createUniqueUuid } from "../entities";
+import { ElizaError } from "../errors";
 import {
 	formatTaskCompletionStatus,
 	type TaskCompletionAssessment,
@@ -170,6 +171,10 @@ import {
 	type TrajectoryRecorder,
 } from "../runtime/trajectory-recorder";
 import { TurnAbortedError } from "../runtime/turn-controller";
+import {
+	sanitizeUserVisibleModelOutput,
+	type UserVisibleModelOutput,
+} from "../runtime/user-visible-model-output";
 import {
 	getModelStreamChunkDeliveryDepth,
 	getStreamingContext,
@@ -4001,6 +4006,42 @@ function exposedActionMatches(
 	});
 }
 
+function userVisibleOutputClassification(
+	output: Exclude<UserVisibleModelOutput, { kind: "empty" }>,
+): string {
+	if (output.kind === "control") {
+		return `${output.malformed ? "malformed-" : ""}${output.envelope}`;
+	}
+	if (output.kind === "invalid") {
+		return output.reason;
+	}
+	return output.format === "json" ? "unexpected-json" : "unexpected-text";
+}
+
+function reportRejectedUserVisibleModelOutput(args: {
+	runtime: IAgentRuntime;
+	scope: string;
+	code: string;
+	message: string;
+	stage: string;
+	output: Exclude<UserVisibleModelOutput, { kind: "empty" }>;
+	context?: Record<string, unknown>;
+}): void {
+	args.runtime.reportError(
+		args.scope,
+		new ElizaError(args.message, {
+			code: args.code,
+			context: {
+				stage: args.stage,
+				classification: userVisibleOutputClassification(args.output),
+				fieldPath: args.output.fieldPath,
+				...args.context,
+			},
+			severity: "ephemeral",
+		}),
+	);
+}
+
 export function messageHandlerFromFieldResult(
 	result: ResponseHandlerResult,
 	fieldRun?: ResponseHandlerFieldRunResult,
@@ -6983,6 +7024,28 @@ export async function runV5MessageRuntimeStage1(args: {
 			throw new Error(
 				"v5 messageHandler returned invalid MessageHandlerResult",
 			);
+		}
+		const stageOneVisibleReply = sanitizeUserVisibleModelOutput(
+			getMessageHandlerReply(messageHandler),
+		);
+		if (stageOneVisibleReply.kind === "text") {
+			messageHandler.plan.reply = stageOneVisibleReply.text;
+		} else {
+			messageHandler.plan.reply = "";
+			if (stageOneVisibleReply.kind !== "empty") {
+				// error-policy:J3 Stage 1 is an untrusted model boundary. A
+				// control/invalid reply becomes an observable invalid signal,
+				// never a string that a direct or early-reply channel can send.
+				reportRejectedUserVisibleModelOutput({
+					runtime: args.runtime,
+					scope: "MessageService.runV5MessageRuntimeStage1",
+					code: "STAGE1_INVALID_USER_VISIBLE_OUTPUT",
+					message:
+						"Stage-1 model placed control data in the user-visible reply field",
+					stage: "response-handler",
+					output: stageOneVisibleReply,
+				});
+			}
 		}
 		const parsedResponseHandlerReply = getMessageHandlerReply(messageHandler);
 
@@ -11663,19 +11726,30 @@ export class DefaultMessageService implements IMessageService {
 				}
 
 				const cleaned = stripReasoningBlocks(response);
-				const looksStructuredReply =
-					cleaned.startsWith("{") && cleaned.includes("}");
-				const parsed = looksStructuredReply
-					? parseJSONObjectFromText(cleaned)
-					: null;
-				const replyText =
-					typeof parsed?.text === "string" && parsed.text.trim().length > 0
-						? parsed.text.trim()
-						: cleaned;
-				if (replyText) {
-					return { kind: "text", value: replyText };
+				const visible = sanitizeUserVisibleModelOutput(cleaned);
+				if (visible.kind === "text" && visible.format === "plain") {
+					return { kind: "text", value: visible.text };
 				}
+				if (visible.kind === "empty") {
+					continue;
+				}
+
+				// error-policy:J3 the fallback prompt requires plain text. A
+				// typed invalid/control result advances to the next model slot
+				// and is reported instead of masquerading as a valid reply.
+				reportRejectedUserVisibleModelOutput({
+					runtime,
+					scope: "MessageService.generateFailureReplyText",
+					code: "FAILURE_REPLY_INVALID_MODEL_OUTPUT",
+					message:
+						"Failure-reply model violated the plain-text output contract",
+					stage,
+					output: visible,
+					context: { modelType },
+				});
 			} catch (error) {
+				// error-policy:J1 this model-fallback boundary translates
+				// provider failures into the typed outcome the caller renders.
 				// If the runtime reports no LLM provider is configured at all,
 				// no further model attempts will succeed. Surface the actionable
 				// hint instead of the generic transient-failure message. See


### PR DESCRIPTION
# Relates to

- Repairs the raw model-control JSON transcript leak found in live staging QA.
- Related UI-side staging work: #17020 and #17021.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `5db27fddda7208249c65fbfeeaa00e55da9c8c2b` with zero conflicts.
- [x] Package-scoped typecheck, build, formatting, affected tests, and the complete core test suite pass after sync.
- [x] A reviewer can confirm the behavior from the attached real-model before/after reports, redacted native trajectory, and structured runtime log.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5db27fddda7208249c65fbfeeaa00e55da9c8c2b`; zero conflicts.
- [x] Post-sync affected Vitest suite, core typecheck, core build, and Biome checks pass.

# Risks

**Medium.** This changes the final projection of model-produced text in Stage 1, the planner, and the structured failure-reply cascade.

- Root action names matching elizaOS's uppercase/namespaced tool convention are reserved as control output. This is intentional: exact tool invocation records must not be displayed as prose.
- Ordinary JSON remains visible, including lower-case domain records such as `{"action":"proceed",...}` and JSON containing nested documentation examples.
- Invalid/control classifications are observable through `runtime.reportError`; they do not silently become a healthy empty result.
- Reply-envelope recursion is capped at eight levels and fails closed with a typed invalid result.

# Background

## What does this PR do?

The original patch caught one exact planner envelope and one failure-reply shape. Adversarial review found three deeper holes:

1. Foreign keys such as `status` or `toolCallId` bypassed the planner detector.
2. Fenced or malformed action records nested under `response`, `replyText`, or `messageToUser` bypassed top-level checks.
3. Most importantly, Stage 1 could place the same action record directly in `HANDLE_RESPONSE.replyText`, route it as a `simple` answer, and never enter either patched path. A real live-model run reproduced this bypass.

This repair introduces one typed user-visible model-output classifier shared by all three paths. It:

- distinguishes ordinary text/JSON from action, planner, evaluator, spawn, malformed, and invalid reply-scaffold output;
- recursively unwraps recognized reply scaffolds while preserving the field path for diagnostics;
- preserves genuine user-requested JSON instead of treating every `action` key as a tool call;
- lets planner recovery consume only canonical control shapes rather than promoting arbitrary domain JSON into tool calls;
- sanitizes Stage 1 at the earliest common boundary before direct replies, early replies, saved fallback replies, or planner context can reuse the text;
- enforces the failure prompt's plain-text-only contract and reports violations as structured `ElizaError`s.

## What kind of change is this?

Bug fix and runtime hardening; no public API removal and no database, UI, or configuration change.

# Documentation changes needed?

No. This repairs an internal runtime output contract and adds tests; public usage is unchanged.

# Testing

## Where should a reviewer start?

1. `packages/core/src/runtime/user-visible-model-output.ts`
2. The Stage-1 boundary in `packages/core/src/services/message.ts`
3. Planner integration in `packages/core/src/runtime/planner-loop.ts`
4. `user-visible-model-output.test.ts`, `message-runtime-stage1.test.ts`, and `planner-output-safety.test.ts`

## Detailed testing results

- `bun run --cwd packages/core test`: **430 files passed; 4,128 tests passed; 1 skipped**.
- Post-rebase affected Vitest run: **8 files passed; 281 tests passed**.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/core build`: passed for Node, browser, edge, testing bundle, and declarations.
- Biome on all eight changed files: passed.
- Real live-model scenario: before failed with the exact `BROWSER` object visible; after passed while preserving genuine lower-case JSON and suppressing the reserved action object.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime-only change; no UI surface or rendered pixels changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime-only change; no UI surface or rendered pixels changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed; the complete runtime flow is captured in the live scenario reports and native trajectory.

<!-- evidence-row:backend-logs -->
- [x] [Live structured backend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17065-live-backend.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, browser request, or client state changed.

<!-- evidence-row:llm-trajectory -->
- [x] [Redacted native live-model trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17065-after-native.jsonl)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the scenario intentionally performs no database, memory, scheduled-task, wallet, file-generation, or other persistent domain mutation.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshot or UI artifact exists to OCR.

# Evidence Details

## Real LLM-call trajectory

- [Before report — reproduced leak, 0 passed / 1 failed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17065-report.json)
- [After report — 1 passed / 0 failed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17065-after-report.json)
- [After redacted native JSONL](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17065-after-native.jsonl)
- [Privacy attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17065-after-native.privacy-attestation.json)

Manual review confirmed:

- Before: the visible second response was the exact reserved `{"action":"BROWSER",...,"toolCallId":"call-1"}` object.
- After: the live model still emitted that exact object inside `HANDLE_RESPONSE.replyText`; the runtime logged `STAGE1_INVALID_USER_VISIBLE_OUTPUT` and delivered `I'm not sure how to answer that.` instead.
- Both runs preserved the genuine lower-case domain JSON unchanged.

The provider is recorded as `openai` because `plugin-openai` is the adapter; the configured live endpoint was Cerebras. This was a real provider/model run, not the deterministic proxy.

## Backend + frontend logs

The attached backend log shows the real `MessageService.runV5MessageRuntimeStage1` rejection and scenario completion. Frontend logs are not applicable because this diff changes no frontend path.

## Screenshots / walkthrough / audio

N/A. No UI, audio, voice, TTS, STT, or device behavior changed.

## Known gaps / failures

- A direct `bun test` probe of one existing Vitest-only fixture could not initialize `vi.stubEnv`; the supported package runner (`bun run --cwd packages/core test`) passed that fixture and the complete core suite. This is a runner mismatch, not a product failure.
- No UI evidence exists because the diff is confined to core TypeScript runtime and deterministic tests.
