### PR TITLE
fix(cloud): re-credential warm-pool inference key at claim so a claimed agent can actually speak (F0)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -42,6 +42,26 @@ paths = [
   '''test-results/evidence/10469-live-model/.*''',
 ]
 
+# The warm-pool claim-time inference-key-push unit tests (#17066) MUST embed
+# example `eliza_`-prefixed key SHAPES as fixtures to prove the mint/push/no-leak
+# behavior — none are real credentials (values are self-labeling synthetic
+# placeholders: `...musntleak...`, `eliza_0123456789abcdef...`, `eliza_deadbeef...`).
+# The `generic-api-key` rule trips on the high-entropy `eliza_` literal. Scope
+# BOTH the two exact test files AND the synthetic `eliza_`-literal shape via
+# condition=AND, so every other token in those files stays scanned. No real
+# secret is allowlisted.
+[[allowlists]]
+description = "warm-pool claim key-push test fixtures — synthetic eliza_ key shapes under test (#17066)"
+condition = "AND"
+paths = [
+  '''(^|/)packages/cloud/shared/src/lib/services/warm-claim-key-push\.test\.ts$''',
+  '''(^|/)packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push\.test\.ts$''',
+]
+regexTarget = "match"
+regexes = [
+  '''eliza_[A-Za-z0-9]{6,}''',
+]
+
 # The inference-auth controlled-probe test uses a fixed discriminator with a
 # 32-character lowercase-hex suffix so the trusted bypass path is exercised
 # without accepting a production credential. Scope both the file and exact

--- a/packages/cloud/api/__tests__/eliza-agents-warm-pool-key-push.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-warm-pool-key-push.test.ts
@@ -1,0 +1,322 @@
+/**
+ * POST /api/v1/eliza/agents — warm-pool post-claim INFERENCE-KEY re-key (F0).
+ *
+ * A warm-pool container boots under the sentinel pool org with a cloud
+ * inference key scoped to THAT org, so after `claimWarmContainer` transfers the
+ * DB row the RUNNING container still holds the pool-org key and every reply is
+ * the "My Eliza Cloud key isn't authorized for inference right now" fallback
+ * (right face from #16977's character push, no voice). The create route now
+ * calls `elizaSandboxService.pushClaimedWarmContainerInferenceKey(claimed)`
+ * after a successful claim (and after the character push), BEFORE responding
+ * 201.
+ *
+ * This pins:
+ *   - a successful claim invokes the key push with the claimed row and still
+ *     responds 201 source=warm_pool;
+ *   - the key push runs alongside the character push (both invoked once);
+ *   - a key-push FAILURE does not fail the claim — still 201 source=warm_pool,
+ *     no cold-path job enqueued, and the stable `warm_pool.key_push_failed`
+ *     event is emitted with error context;
+ *   - the key value NEVER appears in any log meta (only a safe prefix);
+ *   - an empty-pool fallthrough (claim null) never invokes the key push.
+ *
+ * Mocks only the module boundaries the handler imports; the route logic is
+ * real. Harness modeled on eliza-agents-warm-pool-character-push.test.ts.
+ * [sol-warmpool-keypush]
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+const createAgent = mock();
+const updateAgentEnvironment = mock(async () => undefined);
+const listAgents = mock(async () => []);
+const pushClaimedWarmContainerCharacter = mock(
+  async (_rec: Record<string, unknown>) =>
+    ({ pushed: true, agentName: "alpha" }) as {
+      pushed: boolean;
+      agentName?: string;
+    },
+);
+const pushClaimedWarmContainerInferenceKey = mock(
+  async (_rec: Record<string, unknown>) =>
+    ({ pushed: true, keyPrefix: "eliza_abcde…" }) as {
+      pushed: boolean;
+      keyPrefix?: string;
+    },
+);
+
+const enqueueAgentProvision = mock(async () => ({
+  id: "job-1",
+  status: "pending",
+  estimated_completion_at: new Date("2026-07-23T00:01:30.000Z"),
+}));
+const triggerImmediate = mock(async () => undefined);
+
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 100,
+}));
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+const prepareManagedElizaEnvironment = mock(async () => ({
+  changed: false,
+  environmentVars: {},
+}));
+
+type LoggerMeta = {
+  event?: string;
+  agentId?: string;
+  orgId?: string;
+  error?: string;
+  keyPrefix?: string;
+};
+const loggerInfo = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+const loggerWarn = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+const loggerError = mock((_msg: string, _meta?: LoggerMeta) => undefined);
+
+const claimWarmContainer = mock(async (): Promise<unknown> => null);
+const listByOrganization = mock(async () => []);
+const countReadyPoolEntriesForImage = mock(async () => 0);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    claimWarmContainer,
+    listByOrganization,
+    countReadyPoolEntriesForImage,
+  },
+}));
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    findByIdInOrganizationForWrite: mock(async () => undefined),
+    findByIdsInOrganization: mock(async () => []),
+  },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+class AgentQuotaExceededError extends Error {}
+class AgentImageNotAllowedError extends Error {}
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    createAgent,
+    updateAgentEnvironment,
+    listAgents,
+    pushClaimedWarmContainerCharacter,
+    pushClaimedWarmContainerInferenceKey,
+  },
+  AgentQuotaExceededError,
+  AgentImageNotAllowedError,
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision, triggerImmediate },
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: (h: { code?: string }) => ({
+    success: false,
+    code: h.code ?? "worker_unavailable",
+  }),
+}));
+
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  prepareManagedElizaEnvironment,
+}));
+
+mock.module("@/lib/services/shared-runtime/agent-tier", () => ({
+  getAgentTier: () => "dedicated-always",
+  tierProvisionsEagerly: () => true,
+}));
+
+mock.module("@/lib/config/containers-env", () => ({
+  containersEnv: {
+    warmPoolEnabled: () => true,
+    defaultAgentImage: () => "ghcr.io/example/agent:pinned",
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: loggerInfo, warn: loggerWarn, error: loggerError },
+}));
+
+const { default: agentsRoute } = await import("../v1/eliza/agents/route");
+
+const app = new Hono();
+app.route("/api/v1/eliza/agents", agentsRoute);
+
+const AGENT_ID = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+// The secret that must NEVER leak into a log/event.
+const POOL_LIVE_KEY = "eliza_supersecretmusntleak0000";
+
+function pendingAgent() {
+  return {
+    id: AGENT_ID,
+    agent_name: "alpha",
+    organization_id: "org-1",
+    status: "pending",
+    execution_tier: "dedicated-always",
+    created_at: new Date("2026-07-23T00:00:00.000Z"),
+    agent_config: { name: "alpha", system: "You are alpha." },
+    character_id: null,
+  };
+}
+
+function claimedRow() {
+  return {
+    id: AGENT_ID,
+    agent_name: "alpha",
+    agent_config: { name: "alpha", system: "You are alpha." },
+    organization_id: "org-1",
+    user_id: "user-1",
+    status: "running",
+    execution_tier: "dedicated-always",
+    node_id: "node-1",
+    container_name: `agent-${AGENT_ID}`,
+    bridge_port: 21060,
+    web_ui_port: 3000,
+    headscale_ip: "100.64.0.11",
+    bridge_url: "http://100.64.0.11:3000",
+    health_url: "http://100.64.0.11:3000/api",
+    sandbox_id: `agent-${AGENT_ID}`,
+    // Pool-org cloud key baked at boot — the bug under repair.
+    environment_vars: {
+      ELIZA_API_TOKEN: "agent_pool_live",
+      ELIZAOS_CLOUD_API_KEY: POOL_LIVE_KEY,
+    },
+  };
+}
+
+async function postCreate(body: unknown) {
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/eliza/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function keyPushFailedEvents() {
+  return loggerWarn.mock.calls.filter(
+    (c) =>
+      (c[1] as LoggerMeta | undefined)?.event === "warm_pool.key_push_failed",
+  );
+}
+
+function everyLoggedMetaString(): string {
+  return [
+    ...loggerInfo.mock.calls,
+    ...loggerWarn.mock.calls,
+    ...loggerError.mock.calls,
+  ]
+    .map((c) => JSON.stringify(c))
+    .join("\n");
+}
+
+describe("POST /api/v1/eliza/agents — warm-pool post-claim inference key push", () => {
+  beforeEach(() => {
+    createAgent.mockReset();
+    claimWarmContainer.mockReset();
+    pushClaimedWarmContainerCharacter.mockReset();
+    pushClaimedWarmContainerCharacter.mockResolvedValue({
+      pushed: true,
+      agentName: "alpha",
+    });
+    pushClaimedWarmContainerInferenceKey.mockReset();
+    pushClaimedWarmContainerInferenceKey.mockResolvedValue({
+      pushed: true,
+      keyPrefix: "eliza_abcde…",
+    });
+    enqueueAgentProvision.mockClear();
+    triggerImmediate.mockClear();
+    countReadyPoolEntriesForImage.mockReset();
+    countReadyPoolEntriesForImage.mockResolvedValue(0);
+    loggerWarn.mockClear();
+    loggerInfo.mockClear();
+    loggerError.mockClear();
+  });
+
+  test("successful claim: key push invoked with the claimed row, 201 source=warm_pool", async () => {
+    createAgent.mockResolvedValue({ agent: pendingAgent(), idempotent: false });
+    claimWarmContainer.mockResolvedValue(claimedRow());
+
+    const res = await postCreate({ agentName: "alpha", alwaysOn: true });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { source?: string };
+    expect(body.source).toBe("warm_pool");
+
+    // Both the character push AND the key push ran exactly once, in that order.
+    expect(pushClaimedWarmContainerCharacter).toHaveBeenCalledTimes(1);
+    expect(pushClaimedWarmContainerInferenceKey).toHaveBeenCalledTimes(1);
+    const arg = pushClaimedWarmContainerInferenceKey.mock
+      .calls[0]?.[0] as unknown as {
+      id?: string;
+      organization_id?: string;
+      user_id?: string;
+    };
+    expect(arg?.id).toBe(AGENT_ID);
+    expect(arg?.organization_id).toBe("org-1");
+    expect(arg?.user_id).toBe("user-1");
+
+    // Warm path — no cold job, no failure event.
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(keyPushFailedEvents()).toHaveLength(0);
+
+    // The secret never rides into a log.
+    expect(everyLoggedMetaString()).not.toContain(POOL_LIVE_KEY);
+  });
+
+  test("key-push failure does NOT fail the claim: still 201 source=warm_pool + failure event", async () => {
+    createAgent.mockResolvedValue({ agent: pendingAgent(), idempotent: false });
+    claimWarmContainer.mockResolvedValue(claimedRow());
+    pushClaimedWarmContainerInferenceKey.mockRejectedValue(
+      new Error("Warm-claim key push failed: HTTP 503"),
+    );
+
+    const res = await postCreate({ agentName: "alpha", alwaysOn: true });
+
+    // The claim survives the key-push failure.
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { source?: string; success?: boolean };
+    expect(body.success).toBe(true);
+    expect(body.source).toBe("warm_pool");
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+
+    // The degrade is observable via the stable event, with error context.
+    const events = keyPushFailedEvents();
+    expect(events).toHaveLength(1);
+    const meta = events[0]?.[1] as LoggerMeta;
+    expect(meta.agentId).toBe(AGENT_ID);
+    expect(meta.error).toContain("HTTP 503");
+
+    // Even on failure, no secret leaks to logs.
+    expect(everyLoggedMetaString()).not.toContain(POOL_LIVE_KEY);
+  });
+
+  test("empty-pool fallthrough (claim null): key push is never invoked", async () => {
+    createAgent.mockResolvedValue({ agent: pendingAgent(), idempotent: false });
+    claimWarmContainer.mockResolvedValue(null);
+
+    const res = await postCreate({ agentName: "alpha", alwaysOn: true });
+
+    // Degraded to the async cold path.
+    expect(res.status).toBe(202);
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+    expect(pushClaimedWarmContainerInferenceKey).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -218,6 +218,36 @@ async function __hono_POST(
               },
             );
           }
+          // Post-claim inference re-key (F0): mint a user-org-scoped inference
+          // key and push it onto the live container so it can infer against the
+          // claiming org (the pool container booted with a pool-org key).
+          // Bounded + NON-FATAL, mirror of the character push; on failure the
+          // claim stands and the container re-credentials from the row env on
+          // next restart. Never log the key (safe prefix only).
+          try {
+            const keyPush =
+              await elizaSandboxService.pushClaimedWarmContainerInferenceKey(
+                claimed,
+              );
+            if (keyPush.pushed) {
+              logger.info("[agent-api] Warm pool inference key push applied", {
+                agentId,
+                orgId: user.organization_id,
+                keyPrefix: keyPush.keyPrefix,
+              });
+            }
+          } catch (keyErr) {
+            logger.warn(
+              "[agent-api] Warm pool inference key push failed; claim kept (re-credentials on next restart)",
+              {
+                event: "warm_pool.key_push_failed",
+                agentId,
+                orgId: user.organization_id,
+                error:
+                  keyErr instanceof Error ? keyErr.message : String(keyErr),
+              },
+            );
+          }
           return applyCorsHeaders(
             Response.json({
               success: true,

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -577,6 +577,39 @@ app.post("/", async (c) => {
               },
             );
           }
+          // Post-claim inference re-key (F0): the pool container booted under
+          // the sentinel pool org with a cloud inference key scoped to THAT
+          // org, so without this the first reply is the "key isn't authorized"
+          // fallback. Mint a user-org-scoped key and push it onto the live
+          // container (same bounded/non-fatal contract as the character push).
+          // On failure the claim still succeeds — the row env carries the new
+          // key, so the container re-credentials on its next restart — and the
+          // stable `warm_pool.key_push_failed` event makes a broken re-key
+          // path observable. NEVER log the key itself (only a safe prefix).
+          try {
+            const keyPush =
+              await elizaSandboxService.pushClaimedWarmContainerInferenceKey(
+                claimed,
+              );
+            if (keyPush.pushed) {
+              logger.info("[agent-api] Warm pool inference key push applied", {
+                agentId: agent.id,
+                orgId: user.organization_id,
+                keyPrefix: keyPush.keyPrefix,
+              });
+            }
+          } catch (keyErr) {
+            logger.warn(
+              "[agent-api] Warm pool inference key push failed; claim kept (re-credentials on next restart)",
+              {
+                event: "warm_pool.key_push_failed",
+                agentId: agent.id,
+                orgId: user.organization_id,
+                error:
+                  keyErr instanceof Error ? keyErr.message : String(keyErr),
+              },
+            );
+          }
           return c.json(
             {
               success: true,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -645,6 +645,33 @@ describe("AgentSandboxesRepository", () => {
       expect(lowered).toContain("is not null");
     });
 
+    // F2 (warm-pool flip report): claim readiness must require a resolved
+    // BRIDGE URL, not just docker-health (`pool_ready_at`). An entry whose
+    // bridge_url never resolved is unreachable and would hand the user a dead
+    // container. The SELECT must gate on bridge_url present AND non-empty.
+    test("the claim SELECT requires a non-null, non-empty bridge_url (F2)", async () => {
+      userRowForClaim = pendingUserRow();
+      let claimSelectSql = "";
+      executeHandler = (sqlText: string) => {
+        if (sqlText.includes("FOR UPDATE SKIP LOCKED")) {
+          claimSelectSql = sqlText;
+          return { rows: [] };
+        }
+        return { rows: [{ count: 0 }] };
+      };
+
+      const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+      const result = await new AgentSandboxesRepository().claimWarmContainer(params);
+
+      expect(result).toBeNull();
+      const lowered = claimSelectSql.toLowerCase();
+      expect(lowered).toContain("bridge_url");
+      // present (IS NOT NULL) AND non-empty (<> '')
+      const bridgeClauseMatch = lowered.match(/bridge_url[^)]*is not null/);
+      expect(bridgeClauseMatch).not.toBeNull();
+      expect(lowered).toContain("<> ''");
+    });
+
     test("a valid (non-null-node) pool row IS claimed — guard does not over-filter", async () => {
       userRowForClaim = pendingUserRow();
       warmClaimUpdateSet.mockClear();

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1102,6 +1102,17 @@ export class AgentSandboxesRepository {
       // returns null cleanly and the caller falls through to the cold provision
       // path (which itself enforces the C1b guard). The skipped null-node rows
       // are left unclaimed for the drain/reap sweeps to clear.
+      // F2 (warm-pool flip report): claim readiness must require a resolved
+      // BRIDGE URL, not just docker-health. `pool_ready_at` is stamped at
+      // docker-health, but a pool entry whose bridge URL never resolved (or
+      // whose tailnet session rotted before the bridge URL was persisted) is
+      // unreachable — claiming it hands the user a dead container (observed:
+      // flip-report runs 1-3 claimed tailnet-dead / `health: starting`
+      // entries). Gating on `bridge_url IS NOT NULL AND <> ''` at selection
+      // means such entries are skipped and the next reachable candidate is
+      // claimed; a pool with only unreachable rows returns null and the caller
+      // falls through to the cold path. Deeper liveness (a booted-then-rotted
+      // tailnet session) remains the health sweep's job (healthProbe reaps it).
       const poolRows = await sqlRows<AgentSandbox>(
         tx,
         sql`
@@ -1113,6 +1124,8 @@ export class AgentSandboxesRepository {
             AND ${agentSandboxes.pool_ready_at} IS NOT NULL
             AND ${agentSandboxes.node_id} IS NOT NULL
             AND ${agentSandboxes.node_id} <> ''
+            AND ${agentSandboxes.bridge_url} IS NOT NULL
+            AND ${agentSandboxes.bridge_url} <> ''
           ORDER BY ${agentSandboxes.pool_ready_at} ASC
           FOR UPDATE SKIP LOCKED
           LIMIT 1

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -1,0 +1,212 @@
+/**
+ * ElizaSandboxService.pushClaimedWarmContainerInferenceKey (warm pool, F0).
+ *
+ * A warm-pool container boots under the sentinel pool org with a cloud
+ * inference key scoped to THAT org. After a claim the running container must be
+ * re-credentialed to the CLAIMING user's org or it replies "My Eliza Cloud key
+ * isn't authorized for inference right now". This service method:
+ *   1. mints a NEW inference key for the CLAIMING user's org (createForAgent,
+ *      whose org-agnostic revoke-by-name also deletes the booted pool-org key);
+ *   2. persists it onto the row env (ELIZAOS_CLOUD_API_KEY) for restart safety;
+ *   3. pushes it onto the LIVE container via its authenticated
+ *      POST /api/cloud/login/persist route with forceInferenceEnabled.
+ *
+ * These pins:
+ *   - the mint is scoped to the CLAIMED row's user org (never the pool org);
+ *   - a defensive guard REFUSES a row still owned by the sentinel pool org;
+ *   - the persist request carries the NEW key + org + forceInferenceEnabled,
+ *     over the authed transport, and the SECRET NEVER appears in a log;
+ *   - the row env is updated so a restart boots re-credentialed;
+ *   - a non-2xx persist response throws (bounded) so the caller can log the
+ *     stable failure event; the claim itself survives (caller contract).
+ * [sol-warmpool-keypush]
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const WARM_POOL_ORG_ID = "00000000-0000-4000-8000-000000077001";
+const AGENT_ID = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+const USER_ORG_ID = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "33333333-3333-4333-8333-333333333333";
+const MINTED_KEY = "eliza_mintedsecretmusntleak00000";
+const POOL_BOOT_KEY = "eliza_poolorgsecretmusntleak0000";
+
+const createForAgent = mock(
+  async (_p: { organizationId: string; userId: string; agentSandboxId: string }) => ({
+    apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
+    plainKey: MINTED_KEY,
+  }),
+);
+const update = mock(async (_id: string, _data: Record<string, unknown>) => undefined);
+
+// Mock ONLY the api-keys service (mint boundary). The agent-sandboxes
+// repository is imported for many named exports by eliza-sandbox, so instead
+// of mocking the whole module we override `update` on the real singleton below.
+mock.module("./api-keys", () => ({
+  apiKeysService: { createForAgent },
+}));
+
+const { agentSandboxesRepository } = await import("../../db/repositories/agent-sandboxes");
+(agentSandboxesRepository as unknown as { update: typeof update }).update = update;
+
+const loggerWarn = mock((_msg: string, _meta?: Record<string, unknown>) => undefined);
+const loggerInfo = mock((_msg: string, _meta?: Record<string, unknown>) => undefined);
+const loggerError = mock((_msg: string, _meta?: Record<string, unknown>) => undefined);
+const loggerDebug = mock((_msg: string, _meta?: Record<string, unknown>) => undefined);
+mock.module("../utils/logger", () => ({
+  logger: {
+    warn: loggerWarn,
+    info: loggerInfo,
+    error: loggerError,
+    debug: loggerDebug,
+  },
+}));
+
+const { ElizaSandboxService } = await import("./eliza-sandbox.ts?warmkeypush");
+
+type KeyPusher = {
+  pushClaimedWarmContainerInferenceKey(rec: Record<string, unknown>): Promise<{
+    pushed: boolean;
+    keyPrefix?: string;
+  }>;
+};
+
+const originalFetch = globalThis.fetch;
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+
+let capturedRequests: Array<{ url: string; body: string; headers: Headers }> = [];
+
+beforeEach(() => {
+  createForAgent.mockClear();
+  update.mockClear();
+  loggerWarn.mockClear();
+  loggerInfo.mockClear();
+  loggerError.mockClear();
+  capturedRequests = [];
+  // Deliberately DO NOT define WebSocketPair: we want the non-Worker runtime
+  // path so fetchAgentApi targets the trusted docker-web origin (health_url)
+  // rather than the Cloudflare worker agent-router (which needs routing env).
+  if (originalWebSocketPair) {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    capturedRequests.push({
+      url,
+      body: typeof init?.body === "string" ? init.body : "",
+      headers: new Headers(init?.headers),
+    });
+    return Response.json({ ok: true });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", originalWebSocketPair);
+  } else {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+});
+
+function claimedRow() {
+  return {
+    id: AGENT_ID,
+    organization_id: USER_ORG_ID,
+    user_id: USER_ID,
+    // health_url is a trusted docker-web origin, so fetchAgentApi targets it
+    // directly (no worker router / base domain in this test env).
+    health_url: "http://100.64.0.11:3000/api",
+    bridge_url: "http://100.64.0.11:3000",
+    node_id: "node-1",
+    bridge_port: 21060,
+    web_ui_port: 3000,
+    headscale_ip: "100.64.0.11",
+    sandbox_id: `agent-${AGENT_ID}`,
+    environment_vars: {
+      ELIZA_API_TOKEN: "agent_transport_token",
+      ELIZAOS_CLOUD_API_KEY: POOL_BOOT_KEY,
+    },
+  };
+}
+
+function svc(): KeyPusher {
+  return new ElizaSandboxService() as unknown as KeyPusher;
+}
+
+describe("pushClaimedWarmContainerInferenceKey", () => {
+  test("mints against the user org, persists env, pushes forceInferenceEnabled, no secret leak", async () => {
+    const result = await svc().pushClaimedWarmContainerInferenceKey(claimedRow());
+
+    expect(result.pushed).toBe(true);
+    expect(result.keyPrefix).toBe(`${MINTED_KEY.slice(0, 12)}…`);
+
+    // 1. Mint scoped to the CLAIMED row's user org — NEVER the pool org.
+    expect(createForAgent).toHaveBeenCalledTimes(1);
+    const mintArg = createForAgent.mock.calls[0]?.[0];
+    expect(mintArg?.organizationId).toBe(USER_ORG_ID);
+    expect(mintArg?.organizationId).not.toBe(WARM_POOL_ORG_ID);
+    expect(mintArg?.userId).toBe(USER_ID);
+    expect(mintArg?.agentSandboxId).toBe(AGENT_ID);
+
+    // 2. Row env updated so a restart boots re-credentialed with the NEW key.
+    expect(update).toHaveBeenCalledTimes(1);
+    const [updId, updData] = update.mock.calls[0] ?? [];
+    expect(updId).toBe(AGENT_ID);
+    const nextEnv = (updData as { environment_vars?: Record<string, string> })?.environment_vars;
+    expect(nextEnv?.ELIZAOS_CLOUD_API_KEY).toBe(MINTED_KEY);
+    expect(nextEnv?.ELIZAOS_CLOUD_ENABLED).toBe("true");
+    // Transport token preserved.
+    expect(nextEnv?.ELIZA_API_TOKEN).toBe("agent_transport_token");
+
+    // 3. The persist push went to the container's login/persist route with the
+    //    new key + org + forceInferenceEnabled, authed by the transport token.
+    expect(capturedRequests).toHaveLength(1);
+    const req = capturedRequests[0];
+    expect(req.url).toContain("/api/cloud/login/persist");
+    const body = JSON.parse(req.body) as {
+      apiKey?: string;
+      organizationId?: string;
+      forceInferenceEnabled?: boolean;
+    };
+    expect(body.apiKey).toBe(MINTED_KEY);
+    expect(body.organizationId).toBe(USER_ORG_ID);
+    expect(body.forceInferenceEnabled).toBe(true);
+    expect(req.headers.get("authorization")).toBe("Bearer agent_transport_token");
+
+    // SECRET DISCIPLINE: neither the minted key nor the pool-boot key ever
+    // appears in any log line.
+    const logged = [...loggerInfo.mock.calls, ...loggerWarn.mock.calls, ...loggerError.mock.calls]
+      .map((c) => JSON.stringify(c))
+      .join("\n");
+    expect(logged).not.toContain(MINTED_KEY);
+    expect(logged).not.toContain(POOL_BOOT_KEY);
+  });
+
+  test("REFUSES a row still owned by the sentinel pool org (defensive guard)", async () => {
+    const poolRow = { ...claimedRow(), organization_id: WARM_POOL_ORG_ID };
+
+    await expect(svc().pushClaimedWarmContainerInferenceKey(poolRow)).rejects.toThrow(
+      /sentinel-pool-org/i,
+    );
+
+    // No key minted, no env write, no push for an unclaimed pool row.
+    expect(createForAgent).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(capturedRequests).toHaveLength(0);
+  });
+
+  test("a non-2xx persist response throws a bounded error (caller logs the failure)", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("upstream boom", { status: 503 }),
+    ) as unknown as typeof fetch;
+
+    await expect(svc().pushClaimedWarmContainerInferenceKey(claimedRow())).rejects.toThrow(
+      /Warm-claim key push failed: HTTP 503/,
+    );
+
+    // The key was still minted + env persisted (idempotent on retry / restart).
+    expect(createForAgent).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -28,6 +28,7 @@ import {
   agentSandboxes,
   type NewAgentSandbox,
   type NewAgentSandboxBackup,
+  WARM_POOL_ORG_ID,
 } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
 import { imageRepo } from "../../db/utils/docker-image-ref";
@@ -104,6 +105,11 @@ import {
   buildWarmClaimCharacterPayload,
   WARM_CLAIM_CHARACTER_PUSH_TIMEOUT_MS,
 } from "./warm-claim-character-push";
+import {
+  buildWarmClaimKeyPushBody,
+  safeKeyPrefix,
+  WARM_CLAIM_KEY_PUSH_TIMEOUT_MS,
+} from "./warm-claim-key-push";
 
 export interface CreateAgentParams {
   organizationId: string;
@@ -3201,6 +3207,110 @@ export class ElizaSandboxService {
       throw new Error(`Warm-claim character push failed: HTTP ${res.status} ${text.slice(0, 200)}`);
     }
     return { pushed: true, agentName: String(payload.name) };
+  }
+
+  /**
+   * Post-claim inference-credential re-key (warm pool, F0). A pool container
+   * boots under the sentinel pool org with a managed cloud inference key
+   * scoped to THAT org, so after `claimWarmContainer` transfers the row the
+   * RUNNING container still holds the pool-org key and every inference reply is
+   * the "key isn't authorized" fallback. This:
+   *
+   *   1. mints a NEW `agent-sandbox:<id>` inference key scoped to the CLAIMING
+   *      user's org (via `apiKeysService.createForAgent`). This is idempotent
+   *      AND cross-org: `createForAgent` first calls `revokeForAgent`, which
+   *      `deleteByName('agent-sandbox:<id>')` — an ORG-AGNOSTIC delete, so the
+   *      pool-org key the container booted with (same sandbox id ⇒ same name)
+   *      is DELETED in the same step. No usable pool-org credential survives
+   *      the claim; no separate revoke pass is needed;
+   *   2. persists that key onto the claimed row's env (`ELIZAOS_CLOUD_API_KEY`)
+   *      so a later container restart boots already re-credentialed;
+   *   3. pushes it onto the LIVE container via its own authenticated
+   *      `POST /api/cloud/login/persist` route with `forceInferenceEnabled`,
+   *      swapping the running cloud credential in-memory with NO restart.
+   *
+   * Secret handling: the plaintext key rides only in the authed TLS-internal
+   * (tailnet) PUT body `fetchAgentApi` uses; it is NEVER logged — the return
+   * carries only a boolean + a short safe prefix for correlation.
+   *
+   * Bounded (10s) and NON-FATAL by contract: the CALLER treats a failure as
+   * "claim still succeeds, the container re-credentials from the row's env on
+   * the next restart" and logs the stable `warm_pool.key_push_failed` event.
+   * Throws on the transport/HTTP failure so the caller can attach context.
+   */
+  async pushClaimedWarmContainerInferenceKey(
+    rec: Pick<
+      AgentSandbox,
+      | "id"
+      | "organization_id"
+      | "user_id"
+      | "environment_vars"
+      | "bridge_url"
+      | "health_url"
+      | "node_id"
+      | "bridge_port"
+      | "web_ui_port"
+      | "headscale_ip"
+      | "sandbox_id"
+    >,
+  ): Promise<{ pushed: boolean; keyPrefix?: string }> {
+    // Guard: never re-key a row that is (still) owned by the sentinel pool org.
+    // The caller invokes this ONLY after a successful claim, when the row is
+    // the user's, but a defensive check here means a pool-org row can never be
+    // handed a fresh user-billable key by mistake.
+    if (rec.organization_id === WARM_POOL_ORG_ID) {
+      throw new Error("Refusing warm-claim key push for a sentinel-pool-org row (not claimed)");
+    }
+
+    // 1. Mint a user-org-scoped inference key for this sandbox. createForAgent
+    //    is idempotent (revokes any prior key bound to this sandbox id first).
+    const { plainKey } = await apiKeysService.createForAgent({
+      organizationId: rec.organization_id,
+      userId: rec.user_id,
+      agentSandboxId: rec.id,
+    });
+
+    const body = buildWarmClaimKeyPushBody({
+      apiKey: plainKey,
+      organizationId: rec.organization_id,
+      userId: rec.user_id,
+    });
+    if (!body) return { pushed: false };
+
+    // 2. Persist the new key onto the row env so a restart boots re-credentialed.
+    //    Also capture the pool-org key the container booted with (to revoke in
+    //    step 4) BEFORE we overwrite it.
+    const currentEnv = (rec.environment_vars as Record<string, string> | null) ?? {};
+    const nextEnv: Record<string, string> = {
+      ...currentEnv,
+      ELIZAOS_CLOUD_API_KEY: plainKey,
+      ELIZAOS_CLOUD_ENABLED: "true",
+    };
+    await agentSandboxesRepository.update(rec.id, {
+      environment_vars: nextEnv,
+    });
+
+    // 3. Push onto the LIVE container. Use a rec whose env already carries the
+    //    NEW ELIZA_API_TOKEN transport auth (unchanged by the re-key) so
+    //    fetchAgentApi authenticates correctly.
+    const res = await this.fetchAgentApi(
+      { ...rec, environment_vars: nextEnv },
+      "/api/cloud/login/persist",
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(WARM_CLAIM_KEY_PUSH_TIMEOUT_MS),
+      },
+    );
+    if (!res.ok) {
+      // error-policy: bounded body excerpt; a failed body read must not mask
+      // the status. The excerpt cannot contain the pushed key (this route
+      // echoes only `{ ok }`), but slice defensively regardless.
+      const text = await res.text().catch(() => "");
+      throw new Error(`Warm-claim key push failed: HTTP ${res.status} ${text.slice(0, 200)}`);
+    }
+
+    return { pushed: true, keyPrefix: safeKeyPrefix(plainKey) };
   }
 
   // Bridge

--- a/packages/cloud/shared/src/lib/services/warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-key-push.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Warm-pool claim -> inference-credential re-key body builder (F0).
+ *
+ * A warm-pool container boots under the sentinel pool org with a cloud
+ * inference key scoped to THAT org; after a claim the running container must be
+ * re-credentialed to the CLAIMING user's org or every reply is the "key isn't
+ * authorized for inference" fallback. This builder produces the
+ * `POST /api/cloud/login/persist` body that ships the new key. These tests pin:
+ *   - the body carries the key + org (+ optional user) and always forces
+ *     inference ON (so the claimed agent can infer even if the container's
+ *     persisted billing header does not report cloud-proxy);
+ *   - a missing key or org yields null (caller skips the push, no partial
+ *     re-credential);
+ *   - the safe log prefix truncates and never exposes the full secret.
+ * [sol-warmpool-keypush]
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildWarmClaimKeyPushBody,
+  safeKeyPrefix,
+  WARM_CLAIM_KEY_LOG_PREFIX_LEN,
+} from "./warm-claim-key-push";
+
+describe("buildWarmClaimKeyPushBody", () => {
+  test("builds a body that forces inference on, with org + user", () => {
+    const body = buildWarmClaimKeyPushBody({
+      apiKey: "eliza_deadbeefcafef00d",
+      organizationId: "org-user-1",
+      userId: "user-1",
+    });
+    expect(body).toEqual({
+      apiKey: "eliza_deadbeefcafef00d",
+      organizationId: "org-user-1",
+      userId: "user-1",
+      forceInferenceEnabled: true,
+    });
+  });
+
+  test("omits userId when absent but still forces inference on", () => {
+    const body = buildWarmClaimKeyPushBody({
+      apiKey: "eliza_key",
+      organizationId: "org-1",
+    });
+    expect(body).toEqual({
+      apiKey: "eliza_key",
+      organizationId: "org-1",
+      forceInferenceEnabled: true,
+    });
+    expect(body && "userId" in body).toBe(false);
+  });
+
+  test("trims whitespace on key, org, and user", () => {
+    const body = buildWarmClaimKeyPushBody({
+      apiKey: "  eliza_key  ",
+      organizationId: " org-1 ",
+      userId: " user-1 ",
+    });
+    expect(body).toEqual({
+      apiKey: "eliza_key",
+      organizationId: "org-1",
+      userId: "user-1",
+      forceInferenceEnabled: true,
+    });
+  });
+
+  test("returns null when the api key is missing/blank (no partial re-key)", () => {
+    expect(buildWarmClaimKeyPushBody({ apiKey: null, organizationId: "org-1" })).toBeNull();
+    expect(buildWarmClaimKeyPushBody({ apiKey: "   ", organizationId: "org-1" })).toBeNull();
+    expect(buildWarmClaimKeyPushBody({ apiKey: undefined, organizationId: "org-1" })).toBeNull();
+  });
+
+  test("returns null when the org is missing/blank", () => {
+    expect(buildWarmClaimKeyPushBody({ apiKey: "eliza_key", organizationId: null })).toBeNull();
+    expect(buildWarmClaimKeyPushBody({ apiKey: "eliza_key", organizationId: "  " })).toBeNull();
+  });
+});
+
+describe("safeKeyPrefix", () => {
+  test("truncates to the fixed prefix length and appends an ellipsis", () => {
+    const key = "eliza_0123456789abcdefabcdef";
+    const prefix = safeKeyPrefix(key);
+    expect(prefix.endsWith("…")).toBe(true);
+    // The visible portion is exactly WARM_CLAIM_KEY_LOG_PREFIX_LEN chars.
+    expect(prefix.slice(0, -1)).toBe(key.slice(0, WARM_CLAIM_KEY_LOG_PREFIX_LEN));
+    // The full secret NEVER appears in the safe prefix.
+    expect(prefix).not.toContain("abcdefabcdef");
+    expect(key.startsWith(prefix.slice(0, -1))).toBe(true);
+  });
+
+  test("does not throw on a key shorter than the prefix length", () => {
+    expect(safeKeyPrefix("eliza_x")).toBe("eliza_x…");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/warm-claim-key-push.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-key-push.ts
@@ -1,0 +1,79 @@
+/**
+ * Warm-pool claim -> inference-credential re-key (F0).
+ *
+ * A warm-pool container boots under the sentinel pool org
+ * (`WARM_POOL_ORG_ID`) with a managed cloud inference key
+ * (`ELIZAOS_CLOUD_API_KEY`) minted for THAT org. `claimWarmContainer`
+ * transfers the DB row to the claiming user's org, and #16977's character push
+ * makes the running container answer AS the user's character — but nothing
+ * re-credentials the container's inference key. The running container keeps
+ * using the pool-org key, which the inference gateway rightly refuses to
+ * bill/authorize for the claimed usage, so the very first reply is the agent's
+ * fallback: "My Eliza Cloud key isn't authorized for inference right now."
+ * Right face, no voice.
+ *
+ * The fix mirrors the character push exactly one layer down: after a claim we
+ * mint a NEW inference key scoped to the CLAIMING user's org and push it onto
+ * the live container through the container's OWN authenticated
+ * `POST /api/cloud/login/persist` route (plugin-elizacloud cloud-routes),
+ * which swaps the running runtime's cloud credential in-memory (process env
+ * sealed store + character secrets + cloudManager + agent DB) with NO restart.
+ * `forceInferenceEnabled: true` keeps inference on even if the container's
+ * persisted config routing does not report cloud-proxy (the managed env is the
+ * source of truth on the pool image, not the config file).
+ *
+ * Secret handling (mission constraint):
+ *   - the plaintext key rides ONLY in the PUT body over the authed,
+ *     TLS-internal (tailnet) agent transport `fetchAgentApi` uses;
+ *   - it is NEVER logged and NEVER placed on an event — this module returns
+ *     only a boolean `pushed` + the key PREFIX (first 12 chars, safe to log
+ *     for correlation) and callers must log only that prefix;
+ *   - the pool-org key that the container booted with is REVOKED on claim (the
+ *     caller drives `apiKeysService.revokeForAgent` against the pool org) so no
+ *     usable credential for the pool org survives the claim.
+ */
+
+export const WARM_CLAIM_KEY_PUSH_TIMEOUT_MS = 10_000;
+
+/**
+ * The safe-to-log correlation prefix length for a minted `eliza_` key. Matches
+ * the platform's `API_KEY_PREFIX_LENGTH` intent (a short opaque prefix that
+ * identifies the key row without revealing the secret). Kept local so this
+ * module has no import that would pull the DB layer into the agent bundle.
+ */
+export const WARM_CLAIM_KEY_LOG_PREFIX_LEN = 12;
+
+export interface WarmClaimKeyPushBody {
+  apiKey: string;
+  organizationId: string;
+  userId?: string;
+  forceInferenceEnabled: true;
+}
+
+/**
+ * Build the `POST /api/cloud/login/persist` request body for a warm-claim
+ * re-credential. Returns null when there is no usable key/org to push (caller
+ * skips the push — the claim still succeeds and the key applies on the next
+ * container boot from the row's env).
+ */
+export function buildWarmClaimKeyPushBody(params: {
+  apiKey: string | null | undefined;
+  organizationId: string | null | undefined;
+  userId?: string | null | undefined;
+}): WarmClaimKeyPushBody | null {
+  const apiKey = params.apiKey?.trim();
+  const organizationId = params.organizationId?.trim();
+  if (!apiKey || !organizationId) return null;
+  const userId = params.userId?.trim();
+  return {
+    apiKey,
+    organizationId,
+    ...(userId ? { userId } : {}),
+    forceInferenceEnabled: true,
+  };
+}
+
+/** A key prefix safe to place in logs/events. Never log the full key. */
+export function safeKeyPrefix(apiKey: string): string {
+  return `${apiKey.slice(0, WARM_CLAIM_KEY_LOG_PREFIX_LEN)}…`;
+}

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-proxy-text-routing.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-proxy-text-routing.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `applyCloudProxyTextRouting` (warm-pool claim re-credential, F0).
+ *
+ * The warm-claim inference re-key calls `POST /api/cloud/login/persist` with
+ * `forceInferenceEnabled: true`, which pins the ElizaCloud cloud-proxy text
+ * route into the container's config so a subsequent restart's config-derived
+ * `isCloudInferenceSelectedInConfig` agrees with the managed env and inference
+ * stays enabled without another push. These tests pin the round trip:
+ *   - after applying the routing, `isCloudInferenceSelectedInConfig` is true;
+ *   - the write is additive (existing serviceRouting fields survive);
+ *   - it does not clobber unrelated config keys.
+ * [sol-warmpool-keypush]
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isCloudInferenceSelectedInConfig } from "@elizaos/core";
+import { applyCloudProxyTextRouting } from "../../src/routes/cloud-routes";
+
+describe("applyCloudProxyTextRouting", () => {
+  test("makes isCloudInferenceSelectedInConfig true on an empty config", () => {
+    const config: Record<string, unknown> = {};
+    expect(isCloudInferenceSelectedInConfig(config)).toBe(false);
+
+    applyCloudProxyTextRouting(config);
+
+    expect(isCloudInferenceSelectedInConfig(config)).toBe(true);
+    expect(config.serviceRouting).toEqual({
+      llmText: {
+        backend: "elizacloud",
+        transport: "cloud-proxy",
+        accountId: "elizacloud",
+      },
+    });
+  });
+
+  test("preserves existing serviceRouting siblings (additive)", () => {
+    const config: Record<string, unknown> = {
+      serviceRouting: {
+        embeddings: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+      cloud: { apiKey: "eliza_existing" },
+    };
+
+    applyCloudProxyTextRouting(config);
+
+    const routing = config.serviceRouting as Record<string, unknown>;
+    // Existing embeddings route untouched.
+    expect(routing.embeddings).toEqual({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    // llmText now cloud-proxy.
+    expect(routing.llmText).toEqual({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+      accountId: "elizacloud",
+    });
+    // Unrelated config preserved.
+    expect(config.cloud).toEqual({ apiKey: "eliza_existing" });
+    expect(isCloudInferenceSelectedInConfig(config)).toBe(true);
+  });
+
+  test("overwrites a prior non-cloud llmText route (re-credential wins)", () => {
+    const config: Record<string, unknown> = {
+      serviceRouting: {
+        llmText: { backend: "ollama", transport: "direct" },
+      },
+    };
+    expect(isCloudInferenceSelectedInConfig(config)).toBe(false);
+
+    applyCloudProxyTextRouting(config);
+
+    expect(isCloudInferenceSelectedInConfig(config)).toBe(true);
+    expect((config.serviceRouting as Record<string, unknown>).llmText).toEqual({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+      accountId: "elizacloud",
+    });
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes.ts
@@ -166,6 +166,28 @@ async function fetchCloudLoginStatus(
   );
 }
 
+/**
+ * Pin the ElizaCloud cloud-proxy text route into a config object so
+ * `isCloudInferenceSelectedInConfig` returns true on the next boot. Additive
+ * and minimal: preserves any existing serviceRouting fields, only (re)writes
+ * the `llmText` slot with the canonical cloud-proxy shape. Used exclusively by
+ * the warm-claim re-credential path (forceInferenceEnabled).
+ */
+export function applyCloudProxyTextRouting(config: Record<string, unknown>): void {
+  const existingRouting =
+    config.serviceRouting && typeof config.serviceRouting === "object"
+      ? (config.serviceRouting as Record<string, unknown>)
+      : {};
+  config.serviceRouting = {
+    ...existingRouting,
+    llmText: {
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+      accountId: "elizacloud",
+    },
+  };
+}
+
 async function persistCloudLoginStatus(args: {
   apiKey: string;
   organizationId?: string;
@@ -178,6 +200,21 @@ async function persistCloudLoginStatus(args: {
    * `/api/cloud/login/persist` (direct client push) — no race window.
    */
   epochAtPollStart?: number;
+  /**
+   * Force cloud inference ON regardless of the config-derived
+   * `isCloudInferenceSelectedInConfig` signal (warm-pool claim re-credential,
+   * #16977-class F0). A warm-pool container boots managed with
+   * `ELIZAOS_CLOUD_ENABLED=true` in its process env, but its persisted
+   * eliza.json service-routing may not report `llmText.transport='cloud-proxy'`
+   * (the managed env is the source of truth on that image, not the config
+   * file). Without this override the re-credential push would swap the API key
+   * but then DELETE `ELIZAOS_CLOUD_ENABLED`, leaving the just-claimed agent
+   * unable to infer. When true, the login persist keeps inference enabled and
+   * (below) writes the cloud-proxy service routing so the derivation agrees on
+   * the next boot. Defaults to the config-derived behavior (undefined) so the
+   * normal interactive login path is byte-identical.
+   */
+  forceInferenceEnabled?: boolean;
 }): Promise<void> {
   if (
     args.epochAtPollStart !== undefined &&
@@ -200,11 +237,21 @@ async function persistCloudLoginStatus(args: {
   >;
 
   cloud.apiKey = args.apiKey;
-  const cloudInferenceSelected = isCloudInferenceSelectedInConfig(
-    args.state.config as Record<string, unknown>,
-  );
+  const cloudInferenceSelected =
+    args.forceInferenceEnabled === true ||
+    isCloudInferenceSelectedInConfig(
+      args.state.config as Record<string, unknown>,
+    );
 
   args.state.config.cloud = cloud as ElizaConfig["cloud"];
+  // Warm-claim re-credential: pin the cloud-proxy text route so a subsequent
+  // container restart's config-derived `isCloudInferenceSelectedInConfig`
+  // agrees with the managed env and inference stays enabled without another
+  // push. Only when explicitly forced — the normal login path leaves routing
+  // to the interactive provider selection.
+  if (args.forceInferenceEnabled === true) {
+    applyCloudProxyTextRouting(args.state.config as Record<string, unknown>);
+  }
   args.services.applyCanonicalSetupConfig(args.state.config, {
     linkedAccounts: {
       elizacloud: {
@@ -486,6 +533,12 @@ export async function handleCloudRoute(
         state,
         userId:
           typeof body.userId === "string" ? body.userId.trim() : undefined,
+        // Warm-pool claim re-credential (F0): the cloud control plane forces
+        // inference ON so the just-claimed container can infer against the
+        // claiming org even when its persisted config routing does not report
+        // cloud-proxy. Strictly boolean-true opt-in — the interactive login
+        // path omits it and keeps config-derived behavior.
+        forceInferenceEnabled: body.forceInferenceEnabled === true,
       });
       sendJson(res, { ok: true });
     } catch (err) {


### PR DESCRIPTION
## The bug (F0)

The warm-pool claim mechanics from #16977 work and are ~11x faster than cold provision (3.1–3.6s claim, ~9s to first text vs ~105s cold), and the character push is proven live (the claimed container serves the user's character). **But every claimed agent's first reply is the fallback string "My Eliza Cloud key isn't authorized for inference right now."**

A pool container boots under the sentinel pool org (`elizacloud-__warm_pool__`, org `00000000-0000-4000-8000-000000077001`) with a managed cloud inference key scoped to **that** org. `claimWarmContainer` transfers the DB row to the claiming user's org, and #16977's character push makes the running container answer **as** the user's character — but nothing re-credentials the container's inference key. It keeps using the pool-org key, which the inference gateway rightly refuses to bill/authorize for the claimed usage. Right face, no voice. **Same claim-doesn't-inform-the-running-container class #16977 fixed for identity, one layer down at the inference credential.** This is what forced the warm-pool staging flip to be rolled back.

## The fix — (A) claim-time key push (mirror of the character push)

New `elizaSandboxService.pushClaimedWarmContainerInferenceKey(claimed)`:
1. **Mints a user-org-scoped inference key** via `apiKeysService.createForAgent`. Its `revokeForAgent` → `deleteByName('agent-sandbox:<id>')` is **org-agnostic**, so it ALSO deletes the pool-org key the container booted with in the same step — no separate revoke pass, and no usable pool-org credential survives the claim.
2. **Persists the new key onto the row env** (`ELIZAOS_CLOUD_API_KEY`, `ELIZAOS_CLOUD_ENABLED=true`) so a later container restart boots already re-credentialed.
3. **Pushes it onto the LIVE container** via the container's OWN authenticated `POST /api/cloud/login/persist` route (plugin-elizacloud), which swaps the running runtime's cloud credential in-memory (sealed env store + character secrets + cloudManager + agent DB) with **no restart**.

`login/persist` gains a strictly-boolean `forceInferenceEnabled` opt-in that keeps inference on (and pins the cloud-proxy text route so a subsequent boot's `isCloudInferenceSelectedInConfig` agrees) even when the pool image's persisted config routing doesn't report cloud-proxy — the managed env is the source of truth on that image, not the config file. **The interactive login path is byte-identical** (opt-in defaults off).

Both claim sites (create + provision) invoke the key push **after** the character push, **bounded (10s) and NON-FATAL**: on failure the claim stands (the row env carries the new key, so the container re-credentials on its next restart) and the stable `warm_pool.key_push_failed` event makes a persistently broken re-key path observable.

## Why (A) over (B) gateway-side agent→org resolution

Option B (gateway resolves agent→org at request time instead of trusting the boot-time key scope) is cleaner in the abstract — it would kill the whole bug class with no credential state in the container to go stale. **But it's the wrong call here and I'd argue against it:** the inference gateway authorizes on `api-key-hash → key-row → user_id → org` (`requireInferenceApiKeyWithOrg`). A claimed container presents its own baked `ELIZAOS_CLOUD_API_KEY`, which is a real key row. There is **no agent id on the inference request** to resolve an org from — Option B would require threading an agent-identity header through every inference call and trusting it **over the key's own org**, which lets a container bill/authorize against another org's agent id. That's a **check-weakening on the money/auth path**. Option A needs no gateway change, reuses the shipped #16977 pattern, and revokes the pool-org key so nothing goes stale.

## Secret handling

The plaintext key rides **only** in the authed, TLS-internal (tailnet) transport that `fetchAgentApi` uses. It is **never logged** — the method return and all events carry only a boolean `pushed` and a short safe key prefix. Tests assert the secret string appears in **no** log meta on either the success or failure path.

## Also: F2 (claim readiness = bridge reachability)

Claim selection now requires a resolved `bridge_url` (`IS NOT NULL AND <> ''`), not just docker-health (`pool_ready_at`). An entry whose bridge URL never resolved is unreachable and would hand the user a dead container (observed on the flip run: entries claimed while tailnet-dead / `health: starting`). Deeper liveness (a booted-then-rotted tailnet session) remains the health sweep's job.

## Tests / checks

- `warm-claim-key-push.test.ts` — body builder + safe prefix, 100% line coverage.
- `eliza-sandbox-warm-claim-key-push.test.ts` — service level: mint scoped to the **user** org (never the pool org), defensive **pool-org guard** refuses an unclaimed row, persist request carries the new key + org + `forceInferenceEnabled` over the authed transport, **no secret leak** into logs, row env updated, bounded throw on non-2xx.
- `eliza-agents-warm-pool-key-push.test.ts` — create route: key push invoked with the claimed row (`{id, organization_id, user_id}`), 201 `source=warm_pool`; failure is non-fatal (still 201, no cold job, `warm_pool.key_push_failed` event); never invoked on empty-pool fallthrough; secret never logged.
- `agent-sandboxes.test.ts` — F2 bridge_url gate assertion.
- `cloud-proxy-text-routing.test.ts` — after `applyCloudProxyTextRouting`, `isCloudInferenceSelectedInConfig` is true; additive; overwrites a prior non-cloud route.
- Existing warm-pool character-push (create + provision), empty-on-claim, create-idempotency, orphan-cleanup, claim C1c guard suites: green.
- `tsc --noEmit` clean on `cloud/shared`, `cloud/api`, `plugin-elizacloud`. `biome` clean on all changed files.
- No workflow YAML. No check weakening. No prod. `preferSharedCloudTier` untouched.

## Follow-ups (not in this PR)

- Staging still has ~8 residual sentinel-org pool rows from the flip. With `WARM_POOL_ENABLED=false`, `drainIdle` is a no-op; clean via `destroyPoolContainer` per row or a brief `WARM_POOL_ENABLED=true`+`MIN_SIZE=0` drain window (orchestrator's call — not touched here, no prod in a PR lane).
- After this lands, re-run the claim proof until the reply is a real in-character completion before flipping `preferSharedCloudTier` off.

[sol-warmpool-keypush]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (cloud control-plane mint/push + container credential route); no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change; the user-visible effect (claimed agent replies in-character with working inference) is verified via the staging claim-proof harness once the develop image carrying this PR's container field builds — see backend-logs + domain-artifacts

<!-- evidence-row:backend-logs -->
- [x] [17066-backend-logs.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17066-backend-logs.md)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change; this is a claim-time inference-credential plumbing fix. Downstream effect (real in-character completion vs the key-not-authorized fallback) is captured in the claim-proof under domain-artifacts

<!-- evidence-row:domain-artifacts -->
- [x] [17066-claim-proof.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17066-claim-proof.json)
