### PR TITLE
fix(ci): green up develop — update lockstep guards for merge-window drift (notes/calendar views, iOS manifest, zero-key plugin)

### DIFF
--- a/packages/agent/src/__tests__/view-user-journeys.ts
+++ b/packages/agent/src/__tests__/view-user-journeys.ts
@@ -67,6 +67,8 @@ export const PLUGIN_VIEW_LLM_MOCK_CASES: PluginViewMockCase[] = [
   { id: "feed", viewType: "gui", path: "/feed" },
   { id: "views-manager", viewType: "gui", path: "/views" },
   { id: "screenshare", viewType: "gui", path: "/screenshare" },
+  { id: "notes", viewType: "gui", path: "/notes" },
+  { id: "simple-calendar", viewType: "gui", path: "/simple-calendar" },
   { id: "task-coordinator", viewType: "gui", path: "/task-coordinator" },
   { id: "orchestrator", viewType: "gui", path: "/orchestrator" },
   { id: "cockpit", viewType: "gui", path: "/cockpit" },

--- a/packages/app/src/plugin-registrations.test.ts
+++ b/packages/app/src/plugin-registrations.test.ts
@@ -32,6 +32,7 @@ const EXPECTED_SIDE_EFFECT_PACKAGES = [
   "@elizaos/plugin-native-settings",
   "@elizaos/plugin-phone",
   "@elizaos/plugin-polymarket",
+  "@elizaos/plugin-simple-views",
   "@elizaos/plugin-trajectory-logger",
   "@elizaos/plugin-vector-browser",
   "@elizaos/plugin-wallet-ui",

--- a/packages/app/test/hmr/hmr-dependency-levels.spec.ts
+++ b/packages/app/test/hmr/hmr-dependency-levels.spec.ts
@@ -131,6 +131,14 @@ const LEVELS = [
     file: "plugins/plugin-screenshare/src/components/ScreenshareView.tsx",
   },
   {
+    name: "plugin view notes",
+    file: "plugins/plugin-simple-views/src/views/NotesView.tsx",
+  },
+  {
+    name: "plugin view simple-calendar",
+    file: "plugins/plugin-simple-views/src/views/SimpleCalendarView.tsx",
+  },
+  {
     name: "plugin view task coordinator",
     file: "plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx",
   },

--- a/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
@@ -57,10 +57,10 @@ function eliza1MobileManifest(modelId = "eliza-1-2b"): Record<string, unknown> {
   // bundle ships the 128k GGUF (run at a 64k context on mobile via load args).
   const textPath =
     modelId === "eliza-1-4b"
-      ? "text/eliza-1-4b-128k.gguf"
-      : "text/eliza-1-2b-128k.gguf";
+      ? "text/eliza-1-e4b-128k.gguf"
+      : "text/eliza-1-e2b-128k.gguf";
   const drafterPath =
-    modelId === "eliza-1-4b" ? "mtp/drafter-4b.gguf" : "mtp/drafter-2b.gguf";
+    modelId === "eliza-1-4b" ? "mtp/drafter-e4b.gguf" : "mtp/drafter-e2b.gguf";
 
   return {
     id: modelId,
@@ -264,7 +264,7 @@ async function loadKernel(options: MockOptions = {}): Promise<KernelModule> {
       // manifest, matching the shipped mobile default.
       const url = String(input);
       const modelId =
-        url.includes("eliza-1-2b") || url.includes("/2b/")
+        url.includes("eliza-1-2b") || url.includes("/e2b/")
           ? "eliza-1-2b"
           : "eliza-1-4b";
       return Response.json(eliza1MobileManifest(modelId), {
@@ -365,12 +365,12 @@ describe("iOS local-agent local inference flow", () => {
     await eventually(() => {
       const filenames = downloadModel.mock.calls.map((call) => call[1]);
       expect(filenames).toContain("eliza-1-4b.manifest.json");
-      expect(filenames).toContain("eliza-1-4b-128k.gguf");
+      expect(filenames).toContain("eliza-1-e4b-128k.gguf");
       expect(mockState.hashFile).toHaveBeenCalledWith(
         "/models/eliza-1-4b.manifest.json",
       );
       expect(mockState.hashFile).toHaveBeenCalledWith(
-        "/models/eliza-1-4b-128k.gguf",
+        "/models/eliza-1-e4b-128k.gguf",
       );
     });
   }, 30_000);

--- a/packages/ui/src/services/local-inference/active-model.test.ts
+++ b/packages/ui/src/services/local-inference/active-model.test.ts
@@ -36,17 +36,33 @@ function makeInstalledModel(
   };
 }
 
+// Published bundle contract after the Gemma-4 cutover: tier suffix →
+// architecture bundle slug used in per-tier GGUF filenames (mirrors
+// ELIZA_1_BUNDLE_SLUGS in @elizaos/shared/local-inference/catalog).
+const TIER_BUNDLE_SLUGS: Readonly<Record<string, string>> = {
+  "2b": "e2b",
+  "4b": "e4b",
+  "9b": "12b",
+  "27b": "31b",
+  "27b-256k": "31b-256k",
+};
+
+function bundleSlug(tier: string): string {
+  return TIER_BUNDLE_SLUGS[tier] ?? tier;
+}
+
 function makeTempElizaBundle(
   tier: string,
   options: { hasMtp?: boolean } = {},
 ): { bundleRoot: string; textPath: string; drafterPath: string } {
+  const slug = bundleSlug(tier);
   const bundleRoot = mkdtempSync(pathJoin(tmpdir(), "eliza-ui-mtp-"));
   mkdirSync(pathJoin(bundleRoot, "text"), { recursive: true });
-  const textPath = pathJoin(bundleRoot, "text", `eliza-1-${tier}-32k.gguf`);
+  const textPath = pathJoin(bundleRoot, "text", `eliza-1-${slug}-32k.gguf`);
   // Shape a separate-drafter MTP file. The resolver wires it only for tiers
   // whose drafter is hosted in the shared catalog (ELIZA_1_HOSTED_MTP_TIER_IDS)
   // and ignores stray on-disk drafters for every other tier.
-  const drafterPath = pathJoin(bundleRoot, "mtp", `drafter-${tier}.gguf`);
+  const drafterPath = pathJoin(bundleRoot, "mtp", `drafter-${slug}.gguf`);
   writeFileSync(textPath, "fake-text-gguf");
   if (options.hasMtp !== false) {
     mkdirSync(pathJoin(bundleRoot, "mtp"), { recursive: true });

--- a/packages/ui/src/services/local-inference/active-model.ts
+++ b/packages/ui/src/services/local-inference/active-model.ts
@@ -302,15 +302,12 @@ function mergeOverrides(
     args.maxThreads = overrides.maxThreads;
 }
 
-function stripBundlePrefix(catalogFile: string, modelId: string): string {
-  const slug = modelId.startsWith("eliza-1-")
-    ? modelId.slice("eliza-1-".length)
-    : modelId;
-  const prefix = `bundles/${slug}/`;
-  if (catalogFile.startsWith(prefix)) {
-    return catalogFile.slice(prefix.length);
-  }
-  return catalogFile;
+// Catalog component files are repo-relative `bundles/<bundle-slug>/<local>`;
+// the slug is an architecture slug (`e2b`, `12b`, …) that no longer matches
+// the tier-id suffix after the Gemma-4 cutover, so strip any single
+// `bundles/<segment>/` prefix instead of re-deriving the slug from the id.
+function stripBundlePrefix(catalogFile: string): string {
+  return catalogFile.replace(/^bundles\/[^/]+\//, "");
 }
 
 function resolveMtpDrafterPath(
@@ -325,7 +322,7 @@ function resolveMtpDrafterPath(
     catalog?.sourceModel?.components?.mtp?.file;
   if (!catalogFile) return undefined;
 
-  const localPath = stripBundlePrefix(catalogFile, installed.id);
+  const localPath = stripBundlePrefix(catalogFile);
   const candidate = pathJoin(bundleRoot, localPath);
   return existsSync(candidate) ? candidate : undefined;
 }

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/agent-routes-goal-wrapper.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/agent-routes-goal-wrapper.test.ts
@@ -3,8 +3,11 @@
  * Deterministic unit test with a stubbed runtime; no live model.
  */
 import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { handleAgentRoutes } from "../../src/api/agent-routes.ts";
 import type { RouteContext } from "../../src/api/route-utils.ts";
 
@@ -104,10 +107,27 @@ describe("agent-routes goal wrapper", () => {
   });
 
   it("POST /spawn wraps the raw task via buildGoalPrompt and stores the bare goal", async () => {
+    // The workdir must be an allowed root OUTSIDE the runtime's own checkout
+    // (#16777 refuses any checkout-nested dir, and this test process always
+    // runs from inside the repo) — route it through a configured workspace
+    // root the same way the spawn path does in production.
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "goal-wrapper-ws-"),
+    );
+    const workdir = path.join(workspaceRoot, "task");
+    await mkdir(workdir, { recursive: true });
+    const prevWorkspaceDir = process.env.ELIZA_WORKSPACE_DIR;
+    process.env.ELIZA_WORKSPACE_DIR = workspaceRoot;
+    onTestFinished(async () => {
+      if (prevWorkspaceDir === undefined)
+        delete process.env.ELIZA_WORKSPACE_DIR;
+      else process.env.ELIZA_WORKSPACE_DIR = prevWorkspaceDir;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    });
     const spawnSession = vi.fn().mockResolvedValue({
       id: "sess-1",
       agentType: "codex",
-      workdir: process.cwd(),
+      workdir,
       status: "ready",
     });
     const ctx = makeCtx({
@@ -120,7 +140,7 @@ describe("agent-routes goal wrapper", () => {
       body: {
         agentType: "codex",
         task: "Refactor the parser",
-        workdir: process.cwd(),
+        workdir,
       },
     });
     const { res, status } = fakeResponse();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -180,7 +180,9 @@ describe("classifyToolOutput", () => {
 describe("completion-evidence bundle assembly + trajectory persistence", () => {
   const prevFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
   const prevIndependent = process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY;
+  const prevStateDir = process.env.ELIZA_STATE_DIR;
   let workdir: string;
+  let stateDir: string;
 
   beforeEach(async () => {
     process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "1";
@@ -189,6 +191,11 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
     // here so these assertions exercise the evidence bundle the judge sees.
     process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY = "0";
     workdir = await mkdtemp(join(tmpdir(), "evidence-bundle-"));
+    // The trajectory artifact lives under the STATE dir (never the workspace,
+    // so evidence writes can't mask dirty-tree residuals); pin it to a temp
+    // dir so the test owns and inspects the real write location.
+    stateDir = await mkdtemp(join(tmpdir(), "evidence-state-"));
+    process.env.ELIZA_STATE_DIR = stateDir;
   });
   afterEach(() => {
     if (prevFlag === undefined) {
@@ -200,6 +207,11 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
       delete process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY;
     } else {
       process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY = prevIndependent;
+    }
+    if (prevStateDir === undefined) {
+      delete process.env.ELIZA_STATE_DIR;
+    } else {
+      process.env.ELIZA_STATE_DIR = prevStateDir;
     }
   });
 
@@ -327,10 +339,12 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
       response: "Done and tested.",
     });
 
+    // The artifact is appended under the state dir per task (never the
+    // workspace) so evidence writes cannot mask dirty-tree residuals.
     const trajectoryPath = join(
-      workdir,
-      ".eliza",
+      stateDir,
       "trajectories",
+      task.id,
       "completion-evidence.jsonl",
     );
     // The write is fire-and-forget (real mkdir + appendFile + addEvent); wait

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
@@ -134,6 +134,8 @@ function statefulAcp() {
     cancelSession: vi.fn(async () => undefined),
     getSession: vi.fn(async (sid: string) => sessions.get(sid)),
     getChangedPaths: vi.fn(() => []),
+    // Residuals gate: these one-shot sessions scaffold no owned artifacts.
+    getOrchestratorOwnedArtifacts: vi.fn(() => []),
     listSessions: vi.fn(async () => [...sessions.values()]),
     onSessionEvent: vi.fn(
       (handler: (sessionId: string, event: string, data: unknown) => void) => {
@@ -324,7 +326,13 @@ describe("TASKS:create attaches spawned sessions to the minted task thread", () 
     const acp = statefulAcp();
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const taskService = new OrchestratorTaskService(
-      { getService: () => acp, logger: console } as never,
+      {
+        getService: () => acp,
+        logger: console,
+        // The completion pipeline reads verification settings through
+        // runtime.getSetting; a bare fake without it dies mid-validation.
+        getSetting: () => undefined,
+      } as never,
       { store },
     );
     await taskService.start();
@@ -357,9 +365,15 @@ describe("TASKS:create attaches spawned sessions to the minted task thread", () 
     expect(typeof taskId).toBe("string");
     expect(taskId.length).toBeGreaterThan(0);
 
-    await vi.waitFor(async () => {
-      expect((await taskService.getTask(taskId))?.status).toBe("validating");
-    });
+    // The task_complete bridge does real work (change-set capture via git
+    // subprocesses, completion-evidence assembly) before promoting to
+    // `validating`; the default 1s waitFor bound flakes on loaded runners.
+    await vi.waitFor(
+      async () => {
+        expect((await taskService.getTask(taskId))?.status).toBe("validating");
+      },
+      { timeout: 15_000, interval: 250 },
+    );
     const detail = await taskService.getTask(taskId);
     expect(detail?.sessionCount).toBe(1);
     // The finished single-turn session is indexed for history/attribution but

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workdir-validation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workdir-validation.test.ts
@@ -48,12 +48,18 @@ describe("ensureTaskWorkdir / resolveAllowedWorkdir", () => {
     );
   });
 
-  it("accepts a dir inside the current working directory", async () => {
+  it("rejects a cwd-nested dir when cwd is the runtime's own checkout", async () => {
+    // cwd-nested dirs are generally allowed, but the runtime's OWN git
+    // checkout is never a valid sub-agent workdir (#16777): a sub-agent
+    // handed the running code's repo can fetch/checkout/reset under the live
+    // process. This test process always runs from inside the repo, so the
+    // checkout guard must win over the cwd allowance.
     const dir = path.join(process.cwd(), `.workdir-test-${process.pid}`);
     await mkdir(dir, { recursive: true });
     created.push(dir);
-    const resolved = await resolveAllowedWorkdir(dir);
-    expect(resolved.endsWith(path.basename(dir))).toBe(true);
+    await expect(resolveAllowedWorkdir(dir)).rejects.toThrow(
+      /runtime's own checkout/,
+    );
   });
 
   it("accepts a dir inside a configured workspace root (ELIZA_WORKSPACE_DIR)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -90,6 +90,10 @@ function makeFakeAcp() {
       return { stopReason: "end_turn", finalText: "ok" };
     }),
     stopSession: vi.fn(async () => undefined),
+    // The residuals gate consults the live orchestrator-owned-artifact
+    // ledger before falling back to session metadata; these sessions own
+    // no scaffolded artifacts, so the live ledger is empty.
+    getOrchestratorOwnedArtifacts: vi.fn(() => []),
   };
   return {
     service,
@@ -775,6 +779,8 @@ function makeVerifierAcp(verifierResponse: () => string) {
       stopped.push(sessionId);
     }),
     getSession: vi.fn(async () => undefined),
+    // Residuals gate: no orchestrator-scaffolded artifacts in these repos.
+    getOrchestratorOwnedArtifacts: vi.fn(() => []),
     spawnSession: vi.fn(
       async (opts: {
         approvalPreset?: string;

--- a/plugins/plugin-anthropic-proxy/package.json
+++ b/plugins/plugin-anthropic-proxy/package.json
@@ -14,6 +14,11 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./index.node.ts",
+        "import": "./index.node.ts",
+        "default": "./index.node.ts"
+      },
       "browser": {
         "types": "./dist/browser/index.d.ts",
         "import": "./dist/browser/index.browser.js",

--- a/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
+++ b/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
@@ -31,27 +31,41 @@ import type { InstalledModel } from "../src/services/types";
 
 const tmpRoots: string[] = [];
 
+// Published bundle contract after the Gemma-4 cutover: tier suffix →
+// architecture bundle slug used in every per-tier GGUF filename
+// (mirrors ELIZA_1_BUNDLE_SLUGS in @elizaos/shared/local-inference/catalog).
+const TIER_BUNDLE_SLUGS: Readonly<Record<string, string>> = {
+	"2b": "e2b",
+	"4b": "e4b",
+	"9b": "12b",
+};
+
+function bundleSlug(tier: string): string {
+	return TIER_BUNDLE_SLUGS[tier] ?? tier;
+}
+
 function makeTempBundle(args: {
 	hasMmproj: boolean;
 	hasMtp?: boolean;
 	tier: string; // e.g. "2b"
 }): { bundleRoot: string; textPath: string } {
+	const slug = bundleSlug(args.tier);
 	const root = mkdtempSync(pathJoin(tmpdir(), "eliza-ws2-mmproj-"));
 	tmpRoots.push(root);
 	mkdirSync(pathJoin(root, "text"), { recursive: true });
-	const textPath = pathJoin(root, "text", `eliza-1-${args.tier}-32k.gguf`);
+	const textPath = pathJoin(root, "text", `eliza-1-${slug}-32k.gguf`);
 	writeFileSync(textPath, "fake-text-gguf");
 	if (args.hasMmproj) {
 		mkdirSync(pathJoin(root, "vision"), { recursive: true });
 		writeFileSync(
-			pathJoin(root, "vision", `mmproj-${args.tier}.gguf`),
+			pathJoin(root, "vision", `mmproj-${slug}.gguf`),
 			"fake-mmproj-gguf",
 		);
 	}
 	if (args.hasMtp !== false) {
 		mkdirSync(pathJoin(root, "mtp"), { recursive: true });
 		writeFileSync(
-			pathJoin(root, "mtp", `drafter-${args.tier}.gguf`),
+			pathJoin(root, "mtp", `drafter-${slug}.gguf`),
 			"fake-mtp-drafter-gguf",
 		);
 	}
@@ -102,7 +116,7 @@ describe("WS2 mmproj routing", () => {
 		const resolved = await resolveLocalInferenceLoadArgs(installed);
 		expect(resolved.modelPath).toBe(bundle.textPath);
 		expect(resolved.mmprojPath).toBe(
-			pathJoin(bundle.bundleRoot, "vision", `mmproj-${tier}.gguf`),
+			pathJoin(bundle.bundleRoot, "vision", `mmproj-${bundleSlug(tier)}.gguf`),
 		);
 	});
 
@@ -159,7 +173,7 @@ describe("WS2 mmproj routing", () => {
 			const resolved = await resolveLocalInferenceLoadArgs(installed);
 			expect(resolved.modelPath).toBe(bundle.textPath);
 			expect(resolved.draftModelPath).toBe(
-				pathJoin(bundle.bundleRoot, "mtp", `drafter-${tier}.gguf`),
+				pathJoin(bundle.bundleRoot, "mtp", `drafter-${bundleSlug(tier)}.gguf`),
 			);
 			expect(resolved.draftMin).toBe(catalog?.runtime?.mtp?.draftMin);
 			expect(resolved.draftMax).toBe(catalog?.runtime?.mtp?.draftMax);
@@ -168,7 +182,7 @@ describe("WS2 mmproj routing", () => {
 
 	it("ignores an on-disk MTP drafter for tiers without a hosted Gemma drafter", async () => {
 		const tier = "9b";
-		// The active HF tree does not host `mtp/drafter-9b.gguf`, so the catalog
+		// The active HF tree does not host `mtp/drafter-12b.gguf`, so the catalog
 		// must not enable speculative decoding just because a local file with
 		// that shape exists.
 		expect(findCatalogModel(`eliza-1-${tier}`)?.runtime?.mtp).toBeUndefined();
@@ -242,7 +256,7 @@ describe("WS2 mmproj routing", () => {
 		const catalog = findCatalogModel(installed.id);
 		const path = resolveMmprojPath(installed, catalog);
 		expect(path).toBe(
-			pathJoin(bundle.bundleRoot, "vision", `mmproj-${tier}.gguf`),
+			pathJoin(bundle.bundleRoot, "vision", `mmproj-${bundleSlug(tier)}.gguf`),
 		);
 	});
 
@@ -259,7 +273,7 @@ describe("WS2 mmproj routing", () => {
 		});
 		const resolved = await resolveLocalInferenceLoadArgs(installed);
 		expect(resolved.mmprojPath).toBe(
-			pathJoin(bundle.bundleRoot, "vision", `mmproj-${tier}.gguf`),
+			pathJoin(bundle.bundleRoot, "vision", `mmproj-${bundleSlug(tier)}.gguf`),
 		);
 	});
 });

--- a/plugins/plugin-local-inference/__tests__/text-bundle.test.ts
+++ b/plugins/plugin-local-inference/__tests__/text-bundle.test.ts
@@ -50,6 +50,26 @@ const HOSTED_MTP_TIERS: ReadonlySet<string> = new Set(
 	ELIZA_1_HOSTED_MTP_TIER_IDS,
 );
 
+/**
+ * Published bundle contract after the Gemma-4 cutover: HF bundle
+ * directories use architecture slugs, not the tier-id suffix. Pinned
+ * here independently of the catalog's own slug map so a silent rename
+ * on either side fails this suite.
+ */
+const EXPECTED_TIER_BUNDLE_SLUGS: Readonly<Record<string, string>> = {
+	"eliza-1-2b": "e2b",
+	"eliza-1-4b": "e4b",
+	"eliza-1-9b": "12b",
+	"eliza-1-27b": "31b",
+	"eliza-1-27b-256k": "31b-256k",
+};
+
+function expectedBundleSlug(tierId: string): string {
+	const slug = EXPECTED_TIER_BUNDLE_SLUGS[tierId];
+	expect(slug, `${tierId} missing from EXPECTED_TIER_BUNDLE_SLUGS`).toBeTruthy();
+	return slug ?? tierId;
+}
+
 describe("per-tier text + embedding bundle resolution", () => {
 	for (const tierId of ELIZA_1_TIER_IDS) {
 		describe(tierId, () => {
@@ -78,7 +98,7 @@ describe("per-tier text + embedding bundle resolution", () => {
 				}
 				// Separate-drafter MTP is enabled only after the tier's hosted
 				// Gemma drafter GGUF is present under `mtp/drafter-<tier>.gguf`.
-				const slug = tierId.slice("eliza-1-".length);
+				const slug = expectedBundleSlug(tierId);
 				expect(model?.sourceModel?.components.mtp?.repo).toBe(
 					ELIZA_1_HF_REPO,
 				);
@@ -102,7 +122,7 @@ describe("per-tier text + embedding bundle resolution", () => {
 					// One canonical embedding file per tier — the catalog uses
 					// a single filename for every tier that ships one.
 					expect(components?.embedding?.file).toBe(
-						`bundles/${tierId.slice("eliza-1-".length)}/embedding/eliza-1-embedding.gguf`,
+						`bundles/${expectedBundleSlug(tierId)}/embedding/eliza-1-embedding.gguf`,
 					);
 				}
 			});
@@ -113,7 +133,7 @@ describe("per-tier text + embedding bundle resolution", () => {
 				if (!model || !file) return;
 				const url = buildHuggingFaceResolveUrlForPath(model, file);
 				expect(url).toContain(`/${ELIZA_1_HF_REPO}/resolve/main/`);
-				expect(url).toContain(`bundles/${tierId.slice("eliza-1-".length)}/`);
+				expect(url).toContain(`bundles/${expectedBundleSlug(tierId)}/`);
 				expect(url).toMatch(/\.gguf\?download=true$/);
 			});
 

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -579,7 +579,7 @@ export function resolveMmprojPath(
 	if (!visionComponent?.file) return undefined;
 	const bundleRoot = installed.bundleRoot;
 	if (!bundleRoot) return undefined;
-	const local = stripBundlePrefix(visionComponent.file, installed.id);
+	const local = stripBundlePrefix(visionComponent.file);
 	const candidate = pathJoin(bundleRoot, local);
 	if (!existsSync(candidate)) return undefined;
 	return candidate;
@@ -603,7 +603,7 @@ function resolveMtpDrafterPath(
 		catalog?.runtime?.mtp?.drafterFile ??
 		catalog?.sourceModel?.components?.mtp?.file;
 	if (!catalogFile) return undefined;
-	const local = stripBundlePrefix(catalogFile, installed.id);
+	const local = stripBundlePrefix(catalogFile);
 	const candidate = pathJoin(bundleRoot, local);
 	if (!existsSync(candidate)) return undefined;
 	return candidate;
@@ -620,7 +620,7 @@ function expectedMtpDrafterPath(
 		catalog?.sourceModel?.components?.mtp?.file;
 	const expected = manifestPath ?? catalogFile;
 	if (!expected) return undefined;
-	const local = stripBundlePrefix(expected, installed.id);
+	const local = stripBundlePrefix(expected);
 	return installed.bundleRoot ? pathJoin(installed.bundleRoot, local) : local;
 }
 
@@ -667,19 +667,15 @@ export class MissingMtpDrafterError extends Error {
 }
 
 /**
- * Strip the `bundles/<tier-slug>/` prefix the catalog uses for HF
- * paths so the remaining string is bundle-root-relative. When the
- * prefix isn't present, return the input unchanged.
+ * Strip the `bundles/<bundle-slug>/` prefix the catalog uses for HF
+ * paths so the remaining string is bundle-root-relative. The bundle slug
+ * is an architecture slug (`e2b`, `12b`, …) that no longer matches the
+ * tier-id suffix after the Gemma-4 cutover, so strip any single
+ * `bundles/<segment>/` prefix rather than re-deriving the slug from the
+ * model id. When the prefix isn't present, return the input unchanged.
  */
-function stripBundlePrefix(catalogFile: string, modelId: string): string {
-	const slug = modelId.startsWith("eliza-1-")
-		? modelId.slice("eliza-1-".length)
-		: modelId;
-	const prefix = `bundles/${slug}/`;
-	if (catalogFile.startsWith(prefix)) {
-		return catalogFile.slice(prefix.length);
-	}
-	return catalogFile;
+function stripBundlePrefix(catalogFile: string): string {
+	return catalogFile.replace(/^bundles\/[^/]+\//, "");
 }
 
 const DEFAULT_MOBILE_CONTEXT_CEILING = 8192;


### PR DESCRIPTION
## What

`develop` is repo-wide red: during the 2026-07-23 merge-queue window every `test.yml` run on develop was cancelled by supersession, and four independent test-vs-code drifts merged unnoticed. This PR greens develop with a single fix-forward commit. All fixes update stale lockstep guards/tests to the shipped contracts — **ZERO product-code reverts**. Two small forward product fixes are included where the drift exposed real regressions (details below).

cc @lalalune

## The four drift sources

### 1. notes / simple-calendar views (#16871)
#16871 shipped two new GUI views (`/notes`, `/simple-calendar` from `@elizaos/plugin-simple-views`) without updating three cross-package lockstep guards:
- `packages/agent/src/__tests__/view-user-journeys.ts` — added both to `PLUGIN_VIEW_LLM_MOCK_CASES` (journeys auto-derive; `plugin-view-llm-mock-coverage.test.ts` enforces lockstep with the GUI visual smoke matrix).
- `packages/app/test/hmr/hmr-dependency-levels.spec.ts` — added HMR source probes for `NotesView.tsx` and `SimpleCalendarView.tsx` (`hmr-coverage.test.ts` enforces one probe per GUI view; pre-fix it fails with `expected [ 'notes /notes', … ] to deeply equal []`).
- `packages/app/src/plugin-registrations.test.ts` — added `@elizaos/plugin-simple-views` to `EXPECTED_SIDE_EFFECT_PACKAGES` (the package self-declares `elizaos.appRegister`, so the manifest scan discovers it).

### 2. eliza-1 bundle-slug cutover (iOS/local-inference manifests)
The Gemma-4 cutover renamed per-tier GGUF filenames to architecture bundle slugs (`ELIZA_1_BUNDLE_SLUGS` in `@elizaos/shared/local-inference/catalog`: 2b→`e2b`, 4b→`e4b`, 9b→`12b`, 27b→`31b`, 27b-256k→`31b-256k`). Four test files still asserted the old tier-suffix filenames; they now mirror the shipped contract:
- `plugins/plugin-local-inference/__tests__/text-bundle.test.ts`, `__tests__/mmproj-routing.test.ts`
- `packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts`, `packages/ui/src/services/local-inference/active-model.test.ts`

**Forward fix (not a revert):** updating the tests exposed that `stripBundlePrefix` in both active-model resolvers (`plugins/plugin-local-inference/src/services/active-model.ts`, `packages/ui/src/services/local-inference/active-model.ts`) still re-derived the bundle slug from the tier id, so it never matched the real `bundles/<arch-slug>/` prefix after the rename — vision mmproj and MTP drafter resolution silently failed on real installs. It now strips any single `bundles/<segment>/` prefix.

### 3. orchestrator residuals/scaffold split (#16543) + checkout guard (#16777)
Orchestrator service changes landed without updating the unit-test fakes: the completion-residuals gate now consults `getOrchestratorOwnedArtifacts` and `getSetting`, completion-evidence JSONL moved to its state-dir location, and spawn routes reject workdirs inside the runtime checkout. Updated `plugins/plugin-agent-orchestrator/__tests__/unit/{agent-routes-goal-wrapper,completion-evidence-bundle,create-task-attaches-sessions,workdir-validation}.test.ts` and `src/__tests__/auto-goal-verify.test.ts` to the shipped contracts (taught the fakes the new methods, moved the JSONL assertion, spawn tests use a workspace root outside the checkout, pinned the checkout-rejection contract).

### 4. Zero-Key lane: anthropic-proxy scenario skip (#16989)
c68f37a9559 (#16989) removed `loadRequiredPlugin`'s relative-path special-case for `@elizaos/plugin-anthropic-proxy`, leaving a bare `import("@elizaos/plugin-anthropic-proxy")`. The scenario runner executes under `bun --conditions eliza-source`, but that package's exports map had **no `eliza-source` condition** — every target pointed at a never-built `dist/` — so the import failed, the plugin never registered, `anthropic-proxy.proxy-status` skipped, and the Zero-Key aggregator's no-unexplained-skips guard failed. Fix-forward: added the standard `eliza-source` exports condition (same shape as `plugin-app-control` / `plugin-hyperliquid`, which is why those two bare imports kept working) pointing at `./index.node.ts`.

## Verification (all run on this branch's tree)

| Area | Command | Result |
| --- | --- | --- |
| Views lockstep | `vitest run packages/agent/src/__tests__/plugin-view-llm-mock-coverage.test.ts` | 3/3 passed |
| App registrations | `vitest run packages/app/src/plugin-registrations.test.ts` | 4/4 passed |
| HMR lockstep | `vitest run packages/app/test/hmr-coverage.test.ts` | 2/2 passed (pre-fix: fails `Add HMR source probes for new GUI views`) |
| iOS/UI local-inference | `vitest run` both `packages/ui` files | 24/24 passed |
| plugin-local-inference | `vitest run` both `__tests__` files | 45/45 passed |
| Orchestrator units | `vitest run` all 5 touched files | 66 tests passed, 46/46 in `auto-goal-verify` |
| Zero-Key scenario | scenario-runner `run …/anthropic-proxy --lane pr-deterministic` | `anthropic-proxy.proxy-status | passed | 2053ms` — Totals: 1 passed, 0 failed, **0 skipped** |
| Typecheck | `bun run typecheck` in agent, app, ui, plugin-local-inference, plugin-agent-orchestrator, plugin-anthropic-proxy | clean |
| Lint | `biome check` on all 15 changed files | clean |

Note for reviewers on local repro of the orchestrator suite: `auto-goal-verify.test.ts`'s "non-git scratch dir" case requires that the OS temp dir not be inside a git work tree (true on CI runners). On a dev box where `/` happens to be a git repo, run it with `GIT_CEILING_DIRECTORIES=/tmp`.

## Evidence rows
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - CI test-guard updates, no UI change`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - CI test-guard updates, no UI change`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI flow`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: scenario-runner run shown above — `anthropic-proxy.proxy-status | passed | 2053ms`, `Totals: 1 passed, 0 failed, 0 skipped of 1` (previously: required-plugin import failed → scenario skipped → aggregator red)
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic lockstep-guard/test updates; the scenario lane runs the deterministic proxy by design`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: targeted vitest output per area — views lockstep 3/3, plugin-registrations 4/4, hmr-coverage 2/2, ui local-inference 24/24, plugin-local-inference 45/45, orchestrator 66 tests (46/46 auto-goal-verify), plus the negative control: `bun -e "import('@elizaos/plugin-anthropic-proxy')"` fails without the `eliza-source` condition and resolves `PROXY_STATUS` with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
