### PR TITLE
fix(cloud): mark drizzle-orm external in cloud-agent entrypoint esbuild

### DIFF
--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -24,7 +24,7 @@ COPY eliza/packages/app-core/deploy/cloud-agent-shared.ts ./cloud-agent-shared.t
 COPY eliza/packages/shared/src/restart-exit-code.json /shared/src/restart-exit-code.json
 RUN npx --yes esbuild@0.28.1 cloud-agent-entrypoint.ts \
       --bundle --platform=node --format=esm --target=node24 \
-      --external:@elizaos/* --external:node:* \
+      --external:@elizaos/* --external:node:* --external:drizzle-orm \
       --outfile=entrypoint.js
 
 FROM node:24-bookworm-slim

--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -11,8 +11,10 @@ ARG TAILSCALE_VERSION=1.90.8
 # Builder: precompile the standalone TS entrypoint to a single JS bundle so the
 # runtime image starts with plain `node entrypoint.js` — no `tsx` transpile on
 # the container cold-start path (issue #8812 F6). cloud-agent-shared.ts is
-# inlined; the dynamic `@elizaos/*` imports stay external and resolve from
-# /app/node_modules at runtime exactly as before.
+# inlined; every bare package import (`@elizaos/*`, `drizzle-orm`, node
+# builtins) stays external via --packages=external and resolves from
+# /app/node_modules at runtime, so adding a dependency to the entrypoint can
+# never break this precompile step.
 # ─────────────────────────────────────────────────────────────────────────────
 FROM node:24-bookworm-slim AS entrypoint-build
 WORKDIR /build
@@ -24,7 +26,7 @@ COPY eliza/packages/app-core/deploy/cloud-agent-shared.ts ./cloud-agent-shared.t
 COPY eliza/packages/shared/src/restart-exit-code.json /shared/src/restart-exit-code.json
 RUN npx --yes esbuild@0.28.1 cloud-agent-entrypoint.ts \
       --bundle --platform=node --format=esm --target=node24 \
-      --external:@elizaos/* --external:node:* --external:drizzle-orm \
+      --packages=external \
       --outfile=entrypoint.js
 
 FROM node:24-bookworm-slim


### PR DESCRIPTION
## What
Makes the esbuild step that precompiles the cloud-agent entrypoint (`packages/app-core/deploy/Dockerfile.cloud-agent`) externalize **all** bare package imports via `--packages=external` (originally: add `--external:drizzle-orm` to the externals list).

## Why
`cloud-agent-shared.ts` (inlined into the entrypoint bundle) imports `drizzle-orm`, but the externals list was only `--external:@elizaos/* --external:node:*`. So a `docker build -f Dockerfile.cloud-agent` fails at the entrypoint precompile on current develop — anyone building this image today hits it.

**Root cause, not just the symptom:** every bare package import in this bundle is *meant* to resolve at runtime from `/app/node_modules` — that is the design of the precompile step (only `cloud-agent-shared.ts` and `restart-exit-code.json` are inlined). Enumerating externals one package at a time is whack-a-mole: the next bare import would break the image build exactly like `drizzle-orm` did. `--packages=external` externalizes every bare specifier, closing the whole failure class. Verified the bundle's external surface is byte-identical to the per-package list variant (`drizzle-orm`, `node:crypto`, `node:http` static; `@elizaos/*` dynamic).

## Evidence
Found while building this Dockerfile end-to-end on a clean box: the build fails without externalizing drizzle-orm (`Could not resolve "drizzle-orm"`) and passes with it. The `--packages=external` amendment was additionally verified by replicating both Docker stages outside Docker (see rows below).

<!-- evidence-row:before-screenshots --> N/A - Dockerfile build fix, no UI
<!-- evidence-row:after-screenshots --> N/A - Dockerfile build fix, no UI
<!-- evidence-row:walkthrough-video --> N/A - Dockerfile build fix, no UI
<!-- evidence-row:frontend-logs --> N/A - no frontend
<!-- evidence-row:backend-logs --> Builder stage: the exact esbuild invocation was run against the exact `/build` + `/shared` COPY layout of the Dockerfile — `--packages=external` bundles clean (25.7kb, `restart-exit-code.json` inlined) while develop's flag set fails on `Could not resolve "drizzle-orm"`. Runtime stage: the produced `entrypoint.js` was booted under the image's runtime layout (`npm install --omit=dev @elizaos/core@alpha @elizaos/plugin-sql@alpha`, `NODE_PATH`, `NODE_ENV=production`) — `/health` answers `{"status":"initializing",...}`, plugin-sql runs its 139-statement migration through the live `drizzle-orm` import, and the optional plugins degrade as designed; full boot log in the details block below and the amended commit is https://github.com/elizaOS/eliza/commit/61a36b37372ac17b51c8cee478d86532f351cf52.
<!-- evidence-row:llm-trajectory --> N/A - build-time change, no model behavior
<!-- evidence-row:domain-artifacts --> The bundle artifact itself: external-import surface diffed between the per-package variant and `--packages=external` — identical (`drizzle-orm`, `node:crypto`, `node:http`, dynamic `@elizaos/core`/`plugin-sql`/`plugin-elizacloud`/`plugin-workflow`); commit https://github.com/elizaOS/eliza/commit/61a36b37372ac17b51c8cee478d86532f351cf52 carries the change and the original image built + smoke-checked by @NubsCarson (980MB, `node entrypoint.js` starts).

<details>
<summary>Runtime boot log of the precompiled bundle (image layout replicated: npm install @elizaos/core@alpha @elizaos/plugin-sql@alpha, NODE_PATH)</summary>

```
[cloud-agent] failed to load @elizaos/plugin-elizacloud; continuing without it { error: "Cannot find package '@elizaos/plugin-elizacloud' ..." }
[cloud-agent] failed to load @elizaos/plugin-workflow; continuing without it { error: "Cannot find package '@elizaos/plugin-workflow' ..." }
[cloud-agent] Health endpoint listening on port 39997
[cloud-agent] Bridge server listening on 127.0.0.1:39998
[cloud-agent] CRITICAL: No BRIDGE_SECRET configured — generated ephemeral secret and bound to 127.0.0.1 only
 Info       [Migration] Starting pre-1.6.5 → 1.6.5+ schema migration...
 Info       [Migration] ✓ Migration complete - pre-1.6.5 → 1.6.5+ schema migration finished
 Info       [PLUGIN:SQL] Initializing migration system
 Info       [PLUGIN:SQL] Starting migrations (environment=DEVELOPMENT, pluginCount=1, dryRun=false)
 Info       [PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=139)
 Info       [PLUGIN:SQL] Recorded migration (pluginName=@elizaos/plugin-sql, tag=0000_@elizaos/plugin-sql_mrxrobr7)

GET /health → {"status":"initializing","uptime":2.119,"runtimeReady":false,"database":"unknown",...}
```

</details>

cc @lalalune

🤖 Generated with [Claude Code](https://claude.com/claude-code)
