### PR TITLE
fix(cloud): revoke the warm-pool boot key at claim + verify the pushed key swap (#17066 hardening)

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -234,6 +234,9 @@ async function __hono_POST(
                 agentId,
                 orgId: user.organization_id,
                 keyPrefix: keyPush.keyPrefix,
+                // false = the container image predates the fingerprint echo;
+                // the push stands but the swap was not process-verified.
+                verified: keyPush.verified === true,
               });
             }
           } catch (keyErr) {

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -596,6 +596,9 @@ app.post("/", async (c) => {
                 agentId: agent.id,
                 orgId: user.organization_id,
                 keyPrefix: keyPush.keyPrefix,
+                // false = the container image predates the fingerprint echo;
+                // the push stands but the swap was not process-verified.
+                verified: keyPush.verified === true,
               });
             }
           } catch (keyErr) {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -711,6 +711,12 @@ describe("AgentSandboxesRepository", () => {
       expect(setArg.node_id).toBe("node-1");
       // Pool row deleted on claim (single record now the user's).
       expect(warmClaimDeleteWhere).toHaveBeenCalledTimes(1);
+      // The DELETED pool row's id rides out on the claimed row: the container's
+      // boot inference key is named `agent-sandbox:<pool row id>`, and the
+      // post-claim re-key can only revoke that pool-org credential if the claim
+      // carries the id out of the transaction (#17066 review — the claimed
+      // row's own id can never reach that key name).
+      expect(result?.warm_pool_row_id).toBe("pool-1");
     });
 
     test("countUnclaimedPool excludes null/empty node_id rows (ready == claimable)", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -47,6 +47,15 @@ export type {
 
 export type AgentSandboxBackupMetadata = Omit<StoredAgentSandboxBackup, "state_data">;
 
+/**
+ * A user sandbox row freshly claimed from the warm pool. `warm_pool_row_id`
+ * is the id of the pool row the claim transaction deleted — the container's
+ * boot-time inference key is named `agent-sandbox:<that id>`, so the
+ * post-claim re-key needs it to revoke the pool-org credential; it exists
+ * nowhere else once the pool row is gone (#17066 review).
+ */
+export type WarmClaimedAgentSandbox = AgentSandbox & { warm_pool_row_id: string };
+
 const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   memories: [],
   config: {},
@@ -1075,7 +1084,12 @@ export class AgentSandboxesRepository {
    * from the pool row, status flips to 'running', and the pool row is
    * deleted in the same transaction.
    *
-   * Returns the updated user row, or null when the pool is empty.
+   * Returns the updated user row — augmented with `warm_pool_row_id`, the id
+   * of the pool row deleted by this claim — or null when the pool is empty.
+   * The pool row id is otherwise lost with the deletion, but the container's
+   * BOOT credentials are named for it (`agent-sandbox:<poolRowId>` inference
+   * key), so the post-claim re-key needs it to revoke the pool-org key
+   * (#17066 review): the claimed row's own id can never reach that key name.
    */
   async claimWarmContainer(params: {
     userAgentId: string;
@@ -1085,7 +1099,7 @@ export class AgentSandboxesRepository {
     agentConfig?: Record<string, unknown>;
     characterId?: string | null;
     expectedUpdatedAt?: Date | string | null;
-  }): Promise<AgentSandbox | null> {
+  }): Promise<WarmClaimedAgentSandbox | null> {
     await ensureAgentSandboxSchema();
     return dbWrite.transaction(async (tx) => {
       // Attribution guard (audit §C1c): NEVER claim a pool row whose node_id is
@@ -1233,7 +1247,11 @@ export class AgentSandboxesRepository {
 
       await tx.delete(agentSandboxes).where(eq(agentSandboxes.id, pool.id));
 
-      return updated ?? null;
+      // Carry the deleted pool row's id out of the transaction: the container's
+      // boot-time inference key is named `agent-sandbox:<pool.id>`, and this is
+      // the last moment that id exists anywhere — the post-claim re-key uses it
+      // to revoke the pool-org credential (#17066 review).
+      return updated ? { ...updated, warm_pool_row_id: pool.id } : null;
     });
   }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -5,11 +5,15 @@
  * inference key scoped to THAT org. After a claim the running container must be
  * re-credentialed to the CLAIMING user's org or it replies "My Eliza Cloud key
  * isn't authorized for inference right now". This service method:
- *   1. mints a NEW inference key for the CLAIMING user's org (createForAgent,
- *      whose org-agnostic revoke-by-name also deletes the booted pool-org key);
+ *   1. mints a NEW inference key for the CLAIMING user's org (createForAgent
+ *      revokes only the claimed row's OWN prior key name — the pool boot key
+ *      lives under the deleted pool row's name and is untouchable here);
  *   2. persists it onto the row env (ELIZAOS_CLOUD_API_KEY) for restart safety;
  *   3. pushes it onto the LIVE container via its authenticated
- *      POST /api/cloud/login/persist route with forceInferenceEnabled.
+ *      POST /api/cloud/login/persist route with forceInferenceEnabled, and
+ *      verifies the echoed appliedKeyFingerprint when present;
+ *   4. after a successful push, revokes the pool-org BOOT key by the
+ *      warm_pool_row_id the claim carried out of its transaction.
  *
  * These pins:
  *   - the mint is scoped to the CLAIMED row's user org (never the pool org);
@@ -17,6 +21,11 @@
  *   - the persist request carries the NEW key + org + forceInferenceEnabled,
  *     over the authed transport, and the SECRET NEVER appears in a log;
  *   - the row env is updated so a restart boots re-credentialed;
+ *   - a matching fingerprint echo yields verified:true; a MISMATCH throws
+ *     (stale key shadowing the swap) and skips the pool revoke; a legacy
+ *     response without the field is pushed-but-unverified;
+ *   - the pool boot key is revoked ONLY after a successful push (never on the
+ *     failure branch), by pool row id, best-effort with a stable event;
  *   - a non-2xx persist response throws (bounded) so the caller can log the
  *     stable failure event; the claim itself survives (caller contract).
  * [sol-warmpool-keypush]
@@ -37,13 +46,14 @@ const createForAgent = mock(
     plainKey: MINTED_KEY,
   }),
 );
+const revokeForAgent = mock(async (_agentSandboxId: string) => undefined);
 const update = mock(async (_id: string, _data: Record<string, unknown>) => undefined);
 
-// Mock ONLY the api-keys service (mint boundary). The agent-sandboxes
+// Mock ONLY the api-keys service (mint + revoke boundary). The agent-sandboxes
 // repository is imported for many named exports by eliza-sandbox, so instead
 // of mocking the whole module we override `update` on the real singleton below.
 mock.module("./api-keys", () => ({
-  apiKeysService: { createForAgent },
+  apiKeysService: { createForAgent, revokeForAgent },
 }));
 
 const { agentSandboxesRepository } = await import("../../db/repositories/agent-sandboxes");
@@ -63,10 +73,15 @@ mock.module("../utils/logger", () => ({
 }));
 
 const { ElizaSandboxService } = await import("./eliza-sandbox.ts?warmkeypush");
+const { warmClaimKeyFingerprint } = await import("./warm-claim-key-push");
+
+// The fingerprint an up-to-date container echoes after applying MINTED_KEY.
+const MINTED_KEY_FINGERPRINT = await warmClaimKeyFingerprint(MINTED_KEY);
 
 type KeyPusher = {
   pushClaimedWarmContainerInferenceKey(rec: Record<string, unknown>): Promise<{
     pushed: boolean;
+    verified?: boolean;
     keyPrefix?: string;
   }>;
 };
@@ -78,6 +93,8 @@ let capturedRequests: Array<{ url: string; body: string; headers: Headers }> = [
 
 beforeEach(() => {
   createForAgent.mockClear();
+  revokeForAgent.mockReset();
+  revokeForAgent.mockResolvedValue(undefined);
   update.mockClear();
   loggerWarn.mockClear();
   loggerInfo.mockClear();
@@ -96,7 +113,12 @@ beforeEach(() => {
       body: typeof init?.body === "string" ? init.body : "",
       headers: new Headers(init?.headers),
     });
-    return Response.json({ ok: true });
+    // Default: an up-to-date container that applied the pushed key and echoes
+    // its fingerprint. Legacy/mismatch shapes are overridden per test.
+    return Response.json({
+      ok: true,
+      appliedKeyFingerprint: MINTED_KEY_FINGERPRINT,
+    });
   }) as unknown as typeof fetch;
 });
 
@@ -108,6 +130,8 @@ afterEach(() => {
     Reflect.deleteProperty(globalThis, "WebSocketPair");
   }
 });
+
+const POOL_ROW_ID = "44444444-4444-4444-8444-444444444444";
 
 function claimedRow() {
   return {
@@ -123,6 +147,9 @@ function claimedRow() {
     web_ui_port: 3000,
     headscale_ip: "100.64.0.11",
     sandbox_id: `agent-${AGENT_ID}`,
+    // Carried out of the claim tx: the id of the DELETED pool row, whose name
+    // the container's boot inference key was minted under.
+    warm_pool_row_id: POOL_ROW_ID,
     environment_vars: {
       ELIZA_API_TOKEN: "agent_transport_token",
       ELIZAOS_CLOUD_API_KEY: POOL_BOOT_KEY,
@@ -139,6 +166,8 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     const result = await svc().pushClaimedWarmContainerInferenceKey(claimedRow());
 
     expect(result.pushed).toBe(true);
+    // The container echoed the fingerprint of the minted key — process-verified.
+    expect(result.verified).toBe(true);
     expect(result.keyPrefix).toBe(`${MINTED_KEY.slice(0, 12)}…`);
 
     // 1. Mint scoped to the CLAIMED row's user org — NEVER the pool org.
@@ -174,6 +203,12 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     expect(body.forceInferenceEnabled).toBe(true);
     expect(req.headers.get("authorization")).toBe("Bearer agent_transport_token");
 
+    // 4. The pool BOOT key (named for the DELETED pool row, which the step-1
+    //    mint can never reach) is revoked after the successful push — no
+    //    sentinel-org credential survives a completed re-key (#17066 review).
+    expect(revokeForAgent).toHaveBeenCalledTimes(1);
+    expect(revokeForAgent).toHaveBeenCalledWith(POOL_ROW_ID);
+
     // SECRET DISCIPLINE: neither the minted key nor the pool-boot key ever
     // appears in any log line.
     const logged = [...loggerInfo.mock.calls, ...loggerWarn.mock.calls, ...loggerError.mock.calls]
@@ -208,5 +243,60 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     // The key was still minted + env persisted (idempotent on retry / restart).
     expect(createForAgent).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledTimes(1);
+    // The pool boot key is deliberately NOT revoked on the push-failure
+    // branch — the container may still be signing with it (e.g. the gateway
+    // relay); it dies with the next restart's re-credential instead.
+    expect(revokeForAgent).not.toHaveBeenCalled();
+  });
+
+  test("a fingerprint MISMATCH throws (stale key shadowing the swap) and skips the pool revoke", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({ ok: true, appliedKeyFingerprint: "deadbeefdeadbeef" }),
+    ) as unknown as typeof fetch;
+
+    await expect(svc().pushClaimedWarmContainerInferenceKey(claimedRow())).rejects.toThrow(
+      /fingerprint mismatch/i,
+    );
+
+    // The swap did not verifiably take: leave the pool boot key alone so the
+    // container is never stripped of the only credential it may still hold.
+    expect(revokeForAgent).not.toHaveBeenCalled();
+  });
+
+  test("a legacy container response without a fingerprint is pushed-but-unverified; revoke still runs", async () => {
+    globalThis.fetch = mock(async () => Response.json({ ok: true })) as unknown as typeof fetch;
+
+    const result = await svc().pushClaimedWarmContainerInferenceKey(claimedRow());
+
+    expect(result.pushed).toBe(true);
+    expect(result.verified).toBe(false);
+    // Transport accepted the push (HTTP 200): the boot key revoke proceeds.
+    expect(revokeForAgent).toHaveBeenCalledTimes(1);
+    expect(revokeForAgent).toHaveBeenCalledWith(POOL_ROW_ID);
+  });
+
+  test("a pool-key revoke failure is best-effort: push still reports success with the stable event", async () => {
+    revokeForAgent.mockRejectedValueOnce(new Error("db down"));
+
+    const result = await svc().pushClaimedWarmContainerInferenceKey(claimedRow());
+
+    expect(result.pushed).toBe(true);
+    expect(result.verified).toBe(true);
+    const revokeEvents = loggerWarn.mock.calls.filter(
+      (c) =>
+        (c[1] as Record<string, unknown> | undefined)?.event === "warm_pool.pool_key_revoke_failed",
+    );
+    expect(revokeEvents).toHaveLength(1);
+    expect((revokeEvents[0]?.[1] as Record<string, unknown>)?.poolRowId).toBe(POOL_ROW_ID);
+  });
+
+  test("a claimed row without warm_pool_row_id skips the revoke (nothing to revoke by)", async () => {
+    const rec = claimedRow() as Record<string, unknown>;
+    delete rec.warm_pool_row_id;
+
+    const result = await svc().pushClaimedWarmContainerInferenceKey(rec);
+
+    expect(result.pushed).toBe(true);
+    expect(revokeForAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -109,6 +109,7 @@ import {
   buildWarmClaimKeyPushBody,
   safeKeyPrefix,
   WARM_CLAIM_KEY_PUSH_TIMEOUT_MS,
+  warmClaimKeyFingerprint,
 } from "./warm-claim-key-push";
 
 export interface CreateAgentParams {
@@ -3216,22 +3217,39 @@ export class ElizaSandboxService {
    * RUNNING container still holds the pool-org key and every inference reply is
    * the "key isn't authorized" fallback. This:
    *
-   *   1. mints a NEW `agent-sandbox:<id>` inference key scoped to the CLAIMING
-   *      user's org (via `apiKeysService.createForAgent`). This is idempotent
-   *      AND cross-org: `createForAgent` first calls `revokeForAgent`, which
-   *      `deleteByName('agent-sandbox:<id>')` — an ORG-AGNOSTIC delete, so the
-   *      pool-org key the container booted with (same sandbox id ⇒ same name)
-   *      is DELETED in the same step. No usable pool-org credential survives
-   *      the claim; no separate revoke pass is needed;
-   *   2. persists that key onto the claimed row's env (`ELIZAOS_CLOUD_API_KEY`)
-   *      so a later container restart boots already re-credentialed;
+   *   1. mints a NEW `agent-sandbox:<claimedRowId>` inference key scoped to the
+   *      CLAIMING user's org (via `apiKeysService.createForAgent`, whose
+   *      revoke-by-name first clears any PRIOR key bound to the claimed row's
+   *      own id). The pool-org key the container BOOTED with is a DIFFERENT
+   *      name — `agent-sandbox:<poolRowId>`, minted when the pool entry was
+   *      provisioned under the pool row's id — so this mint alone can never
+   *      touch it (#17066 review);
+   *   2. persists the new key onto the claimed row's env
+   *      (`ELIZAOS_CLOUD_API_KEY`) so a later container restart boots already
+   *      re-credentialed;
    *   3. pushes it onto the LIVE container via its own authenticated
    *      `POST /api/cloud/login/persist` route with `forceInferenceEnabled`,
-   *      swapping the running cloud credential in-memory with NO restart.
+   *      swapping the running cloud credential in-memory with NO restart, and
+   *      VERIFIES the swap when the container echoes an
+   *      `appliedKeyFingerprint` (sha-256 prefix of the key the runtime
+   *      actually resolves post-swap): a mismatch throws — transport acceptance
+   *      alone must not report a re-credential the process didn't apply. Older
+   *      container images that don't echo a fingerprint return
+   *      `verified: false` (pushed, unverified) rather than failing the claim;
+   *   4. after a successful push, REVOKES the pool-org boot key by the pool
+   *      row id the claim carried out of its transaction
+   *      (`rec.warm_pool_row_id`), so no usable sentinel-org credential
+   *      survives a completed re-key. Revocation is best-effort teardown: the
+   *      push already succeeded, so a revoke failure is surfaced via the
+   *      stable `warm_pool.pool_key_revoke_failed` event instead of failing
+   *      the claim. On the push-FAILURE branch the pool key is deliberately
+   *      left in place (the container's relay may still be signing with it);
+   *      it dies with the container's next restart re-credential.
    *
    * Secret handling: the plaintext key rides only in the authed TLS-internal
    * (tailnet) PUT body `fetchAgentApi` uses; it is NEVER logged — the return
-   * carries only a boolean + a short safe prefix for correlation.
+   * carries only booleans + a short safe prefix, and the fingerprint exchange
+   * carries a sha-256 prefix, never key material.
    *
    * Bounded (10s) and NON-FATAL by contract: the CALLER treats a failure as
    * "claim still succeeds, the container re-credentials from the row's env on
@@ -3252,8 +3270,8 @@ export class ElizaSandboxService {
       | "web_ui_port"
       | "headscale_ip"
       | "sandbox_id"
-    >,
-  ): Promise<{ pushed: boolean; keyPrefix?: string }> {
+    > & { warm_pool_row_id?: string },
+  ): Promise<{ pushed: boolean; verified?: boolean; keyPrefix?: string }> {
     // Guard: never re-key a row that is (still) owned by the sentinel pool org.
     // The caller invokes this ONLY after a successful claim, when the row is
     // the user's, but a defensive check here means a pool-org row can never be
@@ -3263,7 +3281,9 @@ export class ElizaSandboxService {
     }
 
     // 1. Mint a user-org-scoped inference key for this sandbox. createForAgent
-    //    is idempotent (revokes any prior key bound to this sandbox id first).
+    //    is idempotent for the CLAIMED row's own key name (revokes any prior
+    //    `agent-sandbox:<rec.id>` key first); the pool BOOT key lives under the
+    //    deleted pool row's name and is revoked in step 4.
     const { plainKey } = await apiKeysService.createForAgent({
       organizationId: rec.organization_id,
       userId: rec.user_id,
@@ -3278,8 +3298,6 @@ export class ElizaSandboxService {
     if (!body) return { pushed: false };
 
     // 2. Persist the new key onto the row env so a restart boots re-credentialed.
-    //    Also capture the pool-org key the container booted with (to revoke in
-    //    step 4) BEFORE we overwrite it.
     const currentEnv = (rec.environment_vars as Record<string, string> | null) ?? {};
     const nextEnv: Record<string, string> = {
       ...currentEnv,
@@ -3305,12 +3323,63 @@ export class ElizaSandboxService {
     if (!res.ok) {
       // error-policy: bounded body excerpt; a failed body read must not mask
       // the status. The excerpt cannot contain the pushed key (this route
-      // echoes only `{ ok }`), but slice defensively regardless.
+      // echoes only `{ ok }` + a fingerprint), but slice defensively regardless.
       const text = await res.text().catch(() => "");
       throw new Error(`Warm-claim key push failed: HTTP ${res.status} ${text.slice(0, 200)}`);
     }
 
-    return { pushed: true, keyPrefix: safeKeyPrefix(plainKey) };
+    // 3b. Verify the swap when the container echoes what its runtime NOW
+    //     resolves. HTTP 200 alone attests transport acceptance; the F0 bug
+    //     class is precisely "control plane believed, process didn't", so a
+    //     fingerprint mismatch (a stale key still shadowing via a resolution
+    //     layer the persist couldn't rewrite) must fail loudly, not report
+    //     pushed. Absence of the field is an older container image — the push
+    //     stands, flagged unverified.
+    const responseBody = (await res.json().catch(() => null)) as {
+      appliedKeyFingerprint?: unknown;
+    } | null;
+    const echoedFingerprint =
+      typeof responseBody?.appliedKeyFingerprint === "string"
+        ? responseBody.appliedKeyFingerprint
+        : undefined;
+    let verified: boolean | undefined;
+    if (echoedFingerprint !== undefined) {
+      const expected = await warmClaimKeyFingerprint(plainKey);
+      if (echoedFingerprint !== expected) {
+        throw new Error(
+          "Warm-claim key push applied at transport but the container resolves a DIFFERENT cloud key (fingerprint mismatch) — a stale credential is shadowing the swap",
+        );
+      }
+      verified = true;
+    } else {
+      verified = false;
+    }
+
+    // 4. The push landed: revoke the pool-org key the container BOOTED with.
+    //    It is named for the pool row deleted by the claim
+    //    (`agent-sandbox:<warm_pool_row_id>`), so the step-1 mint could not
+    //    touch it; without this it survives as an active sentinel-org
+    //    credential bound to a row that no longer exists. Ordered AFTER the
+    //    successful push so the running container is never left signing with
+    //    a just-revoked key on the push-failure branch.
+    if (rec.warm_pool_row_id) {
+      try {
+        await apiKeysService.revokeForAgent(rec.warm_pool_row_id);
+      } catch (revokeErr) {
+        // error-policy:J6 best-effort teardown — the re-key itself succeeded;
+        // a failed revoke of the now-unused pool boot key must not fail the
+        // claim. Surfaced via a stable event so a persistently broken revoke
+        // path is observable and the stranded key can be reaped by hand.
+        logger.warn("[agent-sandbox] Warm-claim pool boot key revoke failed", {
+          event: "warm_pool.pool_key_revoke_failed",
+          agentId: rec.id,
+          poolRowId: rec.warm_pool_row_id,
+          error: revokeErr instanceof Error ? revokeErr.message : String(revokeErr),
+        });
+      }
+    }
+
+    return { pushed: true, verified, keyPrefix: safeKeyPrefix(plainKey) };
   }
 
   // Bridge

--- a/packages/cloud/shared/src/lib/services/warm-claim-key-push.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-key-push.ts
@@ -28,9 +28,15 @@
  *   - it is NEVER logged and NEVER placed on an event — this module returns
  *     only a boolean `pushed` + the key PREFIX (first 12 chars, safe to log
  *     for correlation) and callers must log only that prefix;
- *   - the pool-org key that the container booted with is REVOKED on claim (the
- *     caller drives `apiKeysService.revokeForAgent` against the pool org) so no
- *     usable credential for the pool org survives the claim.
+ *   - the container echoes back a sha-256 FINGERPRINT prefix of the key its
+ *     runtime resolves post-swap (`appliedKeyFingerprint`), never key
+ *     material — `warmClaimKeyFingerprint` is the shared derivation both
+ *     sides compare;
+ *   - the pool-org key the container BOOTED with is named for the DELETED
+ *     pool row (`agent-sandbox:<poolRowId>`), so the claim-time mint cannot
+ *     touch it; `pushClaimedWarmContainerInferenceKey` revokes it by
+ *     `warm_pool_row_id` after a successful push, so no usable sentinel-org
+ *     credential survives a completed re-key.
  */
 
 export const WARM_CLAIM_KEY_PUSH_TIMEOUT_MS = 10_000;
@@ -76,4 +82,28 @@ export function buildWarmClaimKeyPushBody(params: {
 /** A key prefix safe to place in logs/events. Never log the full key. */
 export function safeKeyPrefix(apiKey: string): string {
   return `${apiKey.slice(0, WARM_CLAIM_KEY_LOG_PREFIX_LEN)}…`;
+}
+
+/**
+ * Hex length of the sha-256 prefix the container echoes as
+ * `appliedKeyFingerprint` and the control plane compares. 16 hex chars
+ * (64 bits) is ample for an equality check between two values derived from
+ * the same secret, and reveals nothing recoverable about the key.
+ */
+export const WARM_CLAIM_KEY_FINGERPRINT_HEX_LEN = 16;
+
+/**
+ * Shared fingerprint derivation for the push-verification round trip: the
+ * container computes this over the cloud key its runtime RESOLVES after the
+ * swap, the control plane computes it over the key it MINTED, and equality
+ * proves the running process applied the pushed credential (transport 200
+ * alone cannot — the F0 lineage is "control plane believed, process didn't").
+ * Uses Web Crypto so the same function runs on Workers, Node, and Bun.
+ */
+export async function warmClaimKeyFingerprint(apiKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(apiKey));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, WARM_CLAIM_KEY_FINGERPRINT_HEX_LEN);
 }

--- a/plugins/plugin-elizacloud/__tests__/unit/applied-key-fingerprint.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/applied-key-fingerprint.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `resolveAppliedCloudKeyFingerprint` (warm-pool claim re-credential, F0).
+ *
+ * The `POST /api/cloud/login/persist` route echoes a sha-256 prefix of the
+ * cloud key the RUNNING runtime resolves after the swap, so the warm-claim
+ * control plane can verify the process applied the pushed credential instead
+ * of trusting transport acceptance (the F0 lineage is "control plane
+ * believed, process didn't"). These tests pin:
+ *   - resolution goes through `runtime.getSetting` FIRST (the inference
+ *     precedence chain) so a stale key shadowing the swap is DETECTED — the
+ *     fingerprint reflects the shadowing value, not the pushed one;
+ *   - `process.env.ELIZAOS_CLOUD_API_KEY` is the fallback when the runtime is
+ *     absent or offers no value;
+ *   - the output is a 16-hex-char sha-256 prefix and never key material;
+ *   - no key anywhere -> undefined (callers omit the field: unverified);
+ *   - a throwing getSetting degrades to the env fallback, never a crash.
+ * [sol-warmpool-keypush]
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { resolveAppliedCloudKeyFingerprint } from "../../src/routes/cloud-routes";
+
+async function sha256Prefix(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16);
+}
+
+const priorEnvKey = process.env.ELIZAOS_CLOUD_API_KEY;
+
+afterEach(() => {
+  if (priorEnvKey === undefined) delete process.env.ELIZAOS_CLOUD_API_KEY;
+  else process.env.ELIZAOS_CLOUD_API_KEY = priorEnvKey;
+});
+
+describe("resolveAppliedCloudKeyFingerprint", () => {
+  test("fingerprints the runtime-resolved key as a 16-hex sha-256 prefix", async () => {
+    const fp = await resolveAppliedCloudKeyFingerprint({
+      runtime: { getSetting: () => "eliza_resolved_key" },
+    });
+    expect(fp).toBe(await sha256Prefix("eliza_resolved_key"));
+    expect(fp).toMatch(/^[0-9a-f]{16}$/);
+    expect(fp).not.toContain("eliza_");
+  });
+
+  test("getSetting precedence wins over process.env — a shadowing stale key is detected", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_pushed_key";
+    const fp = await resolveAppliedCloudKeyFingerprint({
+      runtime: { getSetting: () => "eliza_stale_shadowing_key" },
+    });
+    // The fingerprint reflects what the runtime RESOLVES (the shadowing
+    // value), so the control plane's comparison against the pushed key fails.
+    expect(fp).toBe(await sha256Prefix("eliza_stale_shadowing_key"));
+    expect(fp).not.toBe(await sha256Prefix("eliza_pushed_key"));
+  });
+
+  test("falls back to process.env when the runtime is absent or empty-handed", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_env_key";
+    expect(await resolveAppliedCloudKeyFingerprint({ runtime: null })).toBe(
+      await sha256Prefix("eliza_env_key")
+    );
+    expect(
+      await resolveAppliedCloudKeyFingerprint({
+        runtime: { getSetting: () => undefined },
+      })
+    ).toBe(await sha256Prefix("eliza_env_key"));
+  });
+
+  test("returns undefined when no key resolves anywhere", async () => {
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    expect(await resolveAppliedCloudKeyFingerprint({ runtime: null })).toBeUndefined();
+  });
+
+  test("a throwing getSetting degrades to the env fallback", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_env_key";
+    const fp = await resolveAppliedCloudKeyFingerprint({
+      runtime: {
+        getSetting: () => {
+          throw new Error("runtime not ready");
+        },
+      },
+    });
+    expect(fp).toBe(await sha256Prefix("eliza_env_key"));
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes.ts
@@ -167,6 +167,52 @@ async function fetchCloudLoginStatus(
 }
 
 /**
+ * Sha-256 hex prefix (16 chars) of the cloud API key the RUNNING runtime
+ * resolves right now, echoed to `POST /api/cloud/login/persist` callers as
+ * `appliedKeyFingerprint`. The warm-claim re-credential control plane
+ * (`pushClaimedWarmContainerInferenceKey`) compares it against the key it
+ * minted: equality proves the process applied the pushed credential, while a
+ * transport 200 alone only proves the route ran (the F0 bug lineage is
+ * "control plane believed, process didn't"). Resolution goes through
+ * `runtime.getSetting` first — the same precedence chain inference uses, so a
+ * stale key shadowing via character secrets is DETECTED, not papered over —
+ * with `process.env` as the pre-boot fallback. Derivation mirrors
+ * `warmClaimKeyFingerprint` in cloud/shared `warm-claim-key-push.ts` (kept
+ * duplicated so the agent bundle never imports the cloud DB layer); only a
+ * digest prefix crosses the wire, never key material.
+ */
+export async function resolveAppliedCloudKeyFingerprint(state: {
+  runtime: unknown;
+}): Promise<string | undefined> {
+  const runtime = state.runtime as RuntimeCloudLike | null;
+  let resolved: unknown;
+  try {
+    resolved =
+      typeof runtime?.getSetting === "function"
+        ? runtime.getSetting("ELIZAOS_CLOUD_API_KEY")
+        : undefined;
+  } catch {
+    // error-policy:J6 best-effort — the persist itself succeeded; a probe
+    // failure downgrades the response to "unverified" (field omitted), it
+    // must not turn a completed persist into a 500.
+    resolved = undefined;
+  }
+  const key =
+    typeof resolved === "string" && resolved.trim()
+      ? resolved.trim()
+      : process.env.ELIZAOS_CLOUD_API_KEY;
+  if (!key) return undefined;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(key),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16);
+}
+
+/**
  * Pin the ElizaCloud cloud-proxy text route into a config object so
  * `isCloudInferenceSelectedInConfig` returns true on the next boot. Additive
  * and minimal: preserves any existing serviceRouting fields, only (re)writes
@@ -540,7 +586,16 @@ export async function handleCloudRoute(
         // path omits it and keeps config-derived behavior.
         forceInferenceEnabled: body.forceInferenceEnabled === true,
       });
-      sendJson(res, { ok: true });
+      // Echo what the runtime NOW resolves so the pusher can verify the swap
+      // took (fingerprint prefix only — never key material). Omitted when no
+      // key resolves; callers treat absence as pushed-but-unverified.
+      const appliedKeyFingerprint = await resolveAppliedCloudKeyFingerprint({
+        runtime: state.runtime,
+      });
+      sendJson(
+        res,
+        appliedKeyFingerprint ? { ok: true, appliedKeyFingerprint } : { ok: true },
+      );
     } catch (err) {
       // error-policy:J1 boundary translation — a persistence failure surfaces as
       // a 500 with the message; the route never reports success it did not do.


### PR DESCRIPTION
Follow-up hardening for #17066 (merged mid-review as `7cd6e85aeba`), closing both load-bearing gaps @NubsCarson's adversarial review found — one of which was a factual error in the merged PR's own security argument. Both were verified against the code before fixing.

## 1. The pool boot key was NOT revoked at claim (merged premise factually wrong)

The pool container's inference key is minted during `provision(poolRowId, WARM_POOL_ORG_ID)`, so its name is `agent-sandbox:<poolRowId>`. The claim transaction UPDATEs the **user's** row and DELETEs the pool row — so the claim-time mint (`createForAgent({agentSandboxId: claimedRow.id})`) revokes `agent-sandbox:<userAgentId>`, a **different name**, and the pool-org key survived every claim as an active credential bound to a row that no longer existed. The merged doc comments described a revoke no caller performed ("same sandbox id ⇒ same name"; "the caller drives `apiKeysService.revokeForAgent` against the pool org").

Fix:
- `claimWarmContainer` returns the claimed row augmented with `warm_pool_row_id` (typed `WarmClaimedAgentSandbox`) — the deleted pool row's id exists nowhere else once the transaction commits, and the boot key's name derives from it.
- `pushClaimedWarmContainerInferenceKey` revokes `agent-sandbox:<poolRowId>` **after a successful push** — never on the push-failure branch (the container's gateway relay may still be signing with that key) and never on a fingerprint mismatch. Best-effort teardown (`error-policy:J6`): a revoke failure emits the stable `warm_pool.pool_key_revoke_failed` event instead of failing the claim.
- The false doc comments are corrected to the real mechanics.

## 2. `pushed: true` attested transport acceptance, not an applied swap

`POST /api/cloud/login/persist` now echoes `appliedKeyFingerprint` — a 16-hex sha-256 prefix of the cloud key the runtime **resolves after the swap**, probed via `runtime.getSetting` (the same precedence chain inference uses, so a stale key shadowing via character secrets is *detected*, not papered over), with `process.env` as fallback. The pusher compares it against the key it minted:

- match → `verified: true` (process-verified swap; claim logs carry it);
- mismatch → throws (caller emits `warm_pool.key_push_failed`) and the pool-key revoke is skipped — the container is never stripped of the only credential it may still hold while the swap demonstrably didn't take;
- absent (older container image predating the echo) → `pushed: true, verified: false` — the push stands, flagged unverified, so image version skew cannot fail claims.

Only digest prefixes cross the wire, never key material; the no-secret-in-logs pins cover the fingerprint path too. On the push-failure branch nothing schedules a container restart (no restart primitive exists in the sandbox service today) — the row env carries the new key so the next restart self-heals, and the stable failure event is the operator hook; this is documented in the method contract rather than papered over.

## Verification

- cloud/shared: 39 tests across the 4 warm-pool suites (claim repo incl. new `warm_pool_row_id` pin, key-push body builder, service push incl. the 5 new revoke/verify/legacy/mismatch/no-pool-id pins, character push) — all pass post-rebase onto the merged #17066.
- cloud/api: warm-pool key-push route suite 3/3.
- plugin-elizacloud: fingerprint probe suite (5 new tests incl. getSetting-shadow detection and throwing-getSetting degrade) + cloud-proxy routing 8/8.
- `tsc --noEmit` clean on cloud/shared, cloud/api, plugin-elizacloud; Biome clean on all changed files.
- Diff is exactly the hardening delta: +392/−31 across 9 files.

Original F0 fix and its live claim-proof evidence: #17066.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cloud control-plane + container credential-route hardening; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or audio behavior; effects are credential revocation + verification, covered by the suites above

<!-- evidence-row:backend-logs -->
- [ ] N/A - control-plane unit/route suites pin the exact log/event contracts (`warm_pool.pool_key_revoke_failed`, verified flag in claim logs); the staging claim-proof re-run happens on the develop image build per #17066's follow-up plan

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain record; key rows are asserted via the mint/revoke service suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
