### PR TITLE
fix(benchmarks): capture-stop tool bridge, de-streamed forwarder, no artificial turn budgets

### DIFF
--- a/packages/benchmarks/hermes-adapter/hermes_adapter/client.py
+++ b/packages/benchmarks/hermes-adapter/hermes_adapter/client.py
@@ -88,6 +88,7 @@ _CONTROL_CONTEXT_KEYS = {
     "agent_id",
     "tools",
     "tool_choice",
+    "capture_stop",
     "benchmark_workspace_path",
 }
 
@@ -987,6 +988,10 @@ class HermesClient:
                 ctx.get("max_tokens"), fallback=self.max_tokens
             ),
             "tool_choice": _coerce_optional_str(ctx.get("tool_choice"), fallback=None),
+            # Caller-declared env-owned tool contract: the native runner stops
+            # the turn at the first captured tool batch instead of iterating
+            # on bridge acknowledgements until max_iterations_reached.
+            "capture_stop": ctx.get("capture_stop") is True,
             "request_publishable_native": nonpublishable_reason is None,
             "nonpublishable_reason": nonpublishable_reason,
         }

--- a/packages/benchmarks/hermes-adapter/hermes_adapter/env_runner.py
+++ b/packages/benchmarks/hermes-adapter/hermes_adapter/env_runner.py
@@ -293,13 +293,15 @@ def run_hermes_env(
     if env_id in {"tblite", "terminalbench_2"}:
         config_env_overrides["agent_temperature"] = 0.0
         config_env_overrides["system_prompt"] = _TERMINAL_ENV_SYSTEM_PROMPT
-        # Campaign policy: no artificial turn budget. The upstream default of
-        # 60 turns truncates hard tasks mid-repair and turns capability
-        # measurements into budget measurements; the per-task wall clock
-        # (task_timeout, also raised here) is the only terminator. Values are
-        # overridable by callers via extra_args (--env.max_agent_turns=…).
-        config_env_overrides.setdefault("max_agent_turns", 1000)
-        config_env_overrides.setdefault("task_timeout", 7200)
+        # Campaign policy: no artificial limits. The upstream defaults
+        # (max_agent_turns=60, task_timeout=1200s) truncate hard tasks
+        # mid-repair and turn capability measurements into budget
+        # measurements. Both are pydantic ints upstream, so "unlimited" is
+        # expressed as values no real rollout can reach; the task ends when
+        # the agent concludes or the surrounding orchestrator deadline (if
+        # any) fires. Caller-overridable via extra_args (--env.<key>=…).
+        config_env_overrides.setdefault("max_agent_turns", 1_000_000_000)
+        config_env_overrides.setdefault("task_timeout", 1_000_000_000)
     forwarded_args: list[str] = list(extra_args or [])
     if not _has_forwarded_arg(forwarded_args, "--env.terminal_backend"):
         forwarded_args.append(f"--env.terminal_backend={terminal_backend}")

--- a/packages/benchmarks/hermes-adapter/hermes_adapter/env_runner.py
+++ b/packages/benchmarks/hermes-adapter/hermes_adapter/env_runner.py
@@ -293,6 +293,13 @@ def run_hermes_env(
     if env_id in {"tblite", "terminalbench_2"}:
         config_env_overrides["agent_temperature"] = 0.0
         config_env_overrides["system_prompt"] = _TERMINAL_ENV_SYSTEM_PROMPT
+        # Campaign policy: no artificial turn budget. The upstream default of
+        # 60 turns truncates hard tasks mid-repair and turns capability
+        # measurements into budget measurements; the per-task wall clock
+        # (task_timeout, also raised here) is the only terminator. Values are
+        # overridable by callers via extra_args (--env.max_agent_turns=…).
+        config_env_overrides.setdefault("max_agent_turns", 1000)
+        config_env_overrides.setdefault("task_timeout", 7200)
     forwarded_args: list[str] = list(extra_args or [])
     if not _has_forwarded_arg(forwarded_args, "--env.terminal_backend"):
         forwarded_args.append(f"--env.terminal_backend={terminal_backend}")
@@ -669,12 +676,6 @@ def parse_hermes_env_result(
     )
 
 
-# Both pinned terminal envs (tblite, terminalbench_2) run HermesAgentLoop with
-# max_agent_turns=60; a rollout that spent its whole budget is a completed
-# failure measurement, not a harness cut-off.
-ENV_MAX_AGENT_TURNS = 60
-
-
 def _annotate_sample_completion(
     metrics: dict[str, Any],
     samples_path: Path,
@@ -703,13 +704,15 @@ def _annotate_sample_completion(
             continue
         last = messages[-1]
         if isinstance(last, dict) and last.get("role") == "tool" and not row.get("passed"):
-            # A trailing tool result normally means the loop was cut off before
-            # the agent could conclude. The exception: the agent spent its full
-            # turn budget — that rollout is a real, scoreable failure. Without
-            # this, hard tasks (which exhaust budgets most often) would be
-            # systematically excluded from scoring.
+            # A trailing tool result on a rollout with real agent turns is a
+            # resource-bounded failure (wall clock or turn ceiling ended the
+            # loop after the last tool execution) — a real, scoreable
+            # measurement. Harness deaths surface as row errors and are
+            # raised above; only zero-work rollouts (the agent never took a
+            # turn) stay unscoreable. The campaign runs without an artificial
+            # turn budget, so hard tasks routinely end exactly this way.
             turns = row.get("turns_used")
-            if isinstance(turns, int) and turns >= ENV_MAX_AGENT_TURNS:
+            if isinstance(turns, int) and turns > 0:
                 continue
             incomplete += 1
     if expected_samples is not None and total != expected_samples:

--- a/packages/benchmarks/hermes-adapter/hermes_adapter/env_runner.py
+++ b/packages/benchmarks/hermes-adapter/hermes_adapter/env_runner.py
@@ -669,6 +669,12 @@ def parse_hermes_env_result(
     )
 
 
+# Both pinned terminal envs (tblite, terminalbench_2) run HermesAgentLoop with
+# max_agent_turns=60; a rollout that spent its whole budget is a completed
+# failure measurement, not a harness cut-off.
+ENV_MAX_AGENT_TURNS = 60
+
+
 def _annotate_sample_completion(
     metrics: dict[str, Any],
     samples_path: Path,
@@ -697,6 +703,14 @@ def _annotate_sample_completion(
             continue
         last = messages[-1]
         if isinstance(last, dict) and last.get("role") == "tool" and not row.get("passed"):
+            # A trailing tool result normally means the loop was cut off before
+            # the agent could conclude. The exception: the agent spent its full
+            # turn budget — that rollout is a real, scoreable failure. Without
+            # this, hard tasks (which exhaust budgets most often) would be
+            # systematically excluded from scoring.
+            turns = row.get("turns_used")
+            if isinstance(turns, int) and turns >= ENV_MAX_AGENT_TURNS:
+                continue
             incomplete += 1
     if expected_samples is not None and total != expected_samples:
         raise RuntimeError(

--- a/packages/benchmarks/hermes-adapter/hermes_adapter/harness_openai_proxy.py
+++ b/packages/benchmarks/hermes-adapter/hermes_adapter/harness_openai_proxy.py
@@ -143,6 +143,17 @@ class HarnessOpenAIProxy:
             "temperature": payload.get("temperature"),
             "max_tokens": payload.get("max_tokens"),
         }
+        if self.harness in {"openclaw", "hermes"}:
+            # This proxy is a single chat-completions step: the env executes
+            # the returned tool_calls itself and replays real results on its
+            # next request. The native OpenClaw/Hermes loops must therefore
+            # stop at the first captured tool batch instead of iterating on
+            # the bridge's placeholder acknowledgements — OpenClaw bills one
+            # completion per fake round (~90 observed per tblite turn) and
+            # Hermes dies at max_iterations_reached(2/2). Eliza owns a real
+            # server-side action loop, not a capture bridge, so the key is
+            # never sent there.
+            context["capture_stop"] = True
         response = self._client.send_message(text, context=context)
         content = str(getattr(response, "text", "") or "")
         params = getattr(response, "params", {}) or {}

--- a/packages/benchmarks/hermes-adapter/hermes_adapter/native_runtime.py
+++ b/packages/benchmarks/hermes-adapter/hermes_adapter/native_runtime.py
@@ -475,13 +475,29 @@ def _agent_kwargs(
     }
 
 
+def _capture_stop_enabled(payload: Mapping[str, object]) -> bool:
+    """The turn must end at the first captured tool batch.
+
+    True for action-calling (single scored action by definition) and whenever
+    the caller declares the env-owned tool contract (``capture_stop``): the
+    benchmark env executes captured calls itself and replays real results on
+    the next turn, so letting the native loop iterate on the bridge's
+    placeholder acknowledgements burns iterations until
+    ``max_iterations_reached`` and fails an otherwise-healthy turn.
+    """
+    return (
+        payload.get("benchmark") == "action-calling"
+        or payload.get("capture_stop") is True
+    )
+
+
 def _instantiate_agent(
     agent_class: type[Any],
     payload: Mapping[str, object],
     spec: BridgeSpec,
 ) -> Any:
     holder: dict[str, Any] = {}
-    capture_stop_enabled = payload.get("benchmark") == "action-calling"
+    capture_stop_enabled = _capture_stop_enabled(payload)
 
     def _tool_complete(*_args: object, **_kwargs: object) -> None:
         # ``required`` means at least one action for the outer benchmark turn.
@@ -788,7 +804,7 @@ def run_native_turn(
     failed = result.get("failed")
     interrupted = result.get("interrupted")
     capture_stopped = (
-        payload.get("benchmark") == "action-calling"
+        _capture_stop_enabled(payload)
         and bool(captures)
         and completed is False
         and failed is False
@@ -810,7 +826,7 @@ def run_native_turn(
         module_file=module_file,
         captured_calls=len(captures),
         workspace_path=workspace_path,
-        capture_stop_enabled=payload.get("benchmark") == "action-calling",
+        capture_stop_enabled=_capture_stop_enabled(payload),
     )
     thought = result.get("last_reasoning")
     if not isinstance(thought, str) or not thought.strip():

--- a/packages/benchmarks/hermes-adapter/tests/test_env_runner.py
+++ b/packages/benchmarks/hermes-adapter/tests/test_env_runner.py
@@ -211,10 +211,11 @@ def test_env_runner_counts_incomplete_rollouts(tmp_path: Path) -> None:
     assert result.metrics["incomplete_rollouts"] == 1
 
 
-def test_env_runner_budget_exhausted_rollout_is_complete(tmp_path: Path) -> None:
-    """A rollout that spent the full 60-turn budget is a scoreable failure,
-    even when the loop necessarily ends on the last tool execution's result —
-    only an early trailing-tool cut-off marks a rollout incomplete."""
+def test_env_runner_worked_rollout_ending_on_tool_is_complete(tmp_path: Path) -> None:
+    """A rollout with real agent turns that ends on a tool result is a
+    resource-bounded failure (scoreable); only zero-work rollouts stay
+    incomplete. The campaign runs without an artificial turn budget, so hard
+    tasks routinely terminate exactly this way."""
     evals_root = tmp_path / "evals" / "tblite"
     evals_root.mkdir(parents=True)
     (evals_root / "eval-summary.json").write_text(
@@ -224,11 +225,11 @@ def test_env_runner_budget_exhausted_rollout_is_complete(tmp_path: Path) -> None
         json.dumps(
             {
                 "passed": False,
-                "turns_used": 60,
+                "turns_used": 37,
                 "messages": [
                     {"role": "user", "content": "fix it"},
                     {"role": "assistant", "tool_calls": []},
-                    {"role": "tool", "content": "ok"},
+                    {"role": "tool", "content": "wall clock ended here"},
                 ],
             }
         )
@@ -236,11 +237,11 @@ def test_env_runner_budget_exhausted_rollout_is_complete(tmp_path: Path) -> None
         + json.dumps(
             {
                 "passed": False,
-                "turns_used": 12,
+                "turns_used": 0,
                 "messages": [
                     {"role": "user", "content": "fix it"},
                     {"role": "assistant", "tool_calls": []},
-                    {"role": "tool", "content": "cut off"},
+                    {"role": "tool", "content": "died before any turn"},
                 ],
             }
         )

--- a/packages/benchmarks/hermes-adapter/tests/test_env_runner.py
+++ b/packages/benchmarks/hermes-adapter/tests/test_env_runner.py
@@ -211,6 +211,48 @@ def test_env_runner_counts_incomplete_rollouts(tmp_path: Path) -> None:
     assert result.metrics["incomplete_rollouts"] == 1
 
 
+def test_env_runner_budget_exhausted_rollout_is_complete(tmp_path: Path) -> None:
+    """A rollout that spent the full 60-turn budget is a scoreable failure,
+    even when the loop necessarily ends on the last tool execution's result —
+    only an early trailing-tool cut-off marks a rollout incomplete."""
+    evals_root = tmp_path / "evals" / "tblite"
+    evals_root.mkdir(parents=True)
+    (evals_root / "eval-summary.json").write_text(
+        json.dumps({"metrics": {"pass_rate": 0.0}})
+    )
+    (evals_root / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "passed": False,
+                "turns_used": 60,
+                "messages": [
+                    {"role": "user", "content": "fix it"},
+                    {"role": "assistant", "tool_calls": []},
+                    {"role": "tool", "content": "ok"},
+                ],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "passed": False,
+                "turns_used": 12,
+                "messages": [
+                    {"role": "user", "content": "fix it"},
+                    {"role": "assistant", "tool_calls": []},
+                    {"role": "tool", "content": "cut off"},
+                ],
+            }
+        )
+        + "\n"
+    )
+
+    result = parse_hermes_env_result(env_id="tblite", evals_root=evals_root, duration_s=0.1)
+
+    assert result.metrics["sample_rows"] == 2
+    assert result.metrics["incomplete_rollouts"] == 1
+
+
 def test_env_runner_finds_artifacts_in_subdir(tmp_path: Path) -> None:
     """atroposlib writes under a timestamped subdir — make sure rglob() finds it."""
     evals_root = tmp_path / "evals" / "tblite"

--- a/packages/benchmarks/hermes-adapter/tests/test_harness_openai_proxy.py
+++ b/packages/benchmarks/hermes-adapter/tests/test_harness_openai_proxy.py
@@ -82,8 +82,42 @@ def test_proxy_completion_forwards_messages_tools_and_returns_openai_shape() -> 
     assert context["harness_proxy"] == "openclaw"
     assert context["messages"] == payload["messages"]
     assert context["tools"] == payload["tools"]
+    # The proxy speaks single-step chat-completions: the env executes the
+    # returned tool_calls itself, so OpenClaw turns must stop after the first
+    # captured batch instead of looping on placeholder acknowledgements.
+    assert context["capture_stop"] is True
     assert response["choices"][0]["finish_reason"] == "tool_calls"
     message = response["choices"][0]["message"]
     assert message["tool_calls"][0]["function"]["name"] == "terminal"
     assert message["tool_calls"][0]["function"]["arguments"] == '{"cmd": "pytest -q"}'
     assert response["usage"]["total_tokens"] == 5
+
+
+def test_proxy_declares_env_owned_contract_for_hermes() -> None:
+    proxy = HarnessOpenAIProxy(harness="hermes", provider="cerebras", model="m")
+    proxy._client = _FakeClient()
+
+    proxy.complete(
+        {
+            "messages": [{"role": "user", "content": "fix the repo"}],
+            "tools": [{"type": "function", "function": {"name": "terminal"}}],
+        }
+    )
+
+    assert proxy._client.calls[0][1]["capture_stop"] is True
+
+
+def test_proxy_env_owned_contract_never_reaches_eliza() -> None:
+    """Eliza owns a real server-side action loop, not a capture bridge — the
+    ``capture_stop`` key must never leak into its context."""
+    proxy = HarnessOpenAIProxy(harness="eliza", provider="cerebras", model="m")
+    proxy._client = _FakeClient()
+
+    proxy.complete(
+        {
+            "messages": [{"role": "user", "content": "fix the repo"}],
+            "tools": [{"type": "function", "function": {"name": "terminal"}}],
+        }
+    )
+
+    assert "capture_stop" not in proxy._client.calls[0][1]

--- a/packages/benchmarks/hermes-adapter/tests/test_native_runtime.py
+++ b/packages/benchmarks/hermes-adapter/tests/test_native_runtime.py
@@ -472,6 +472,51 @@ def test_action_calling_stops_after_the_scored_native_action(
     )
 
 
+def test_caller_declared_capture_stop_stops_after_first_tool_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env-owned contract (``capture_stop`` payload flag, declared by the
+    harness proxy for single-step env turns) must end the native loop at the
+    first captured batch — the failure mode it guards is the tblite turn dying
+    at max_iterations_reached while looping on bridge acknowledgements."""
+    repo_path = tmp_path / "upstream"
+    repo_path.mkdir()
+    home = tmp_path / "home"
+    tools = [_tool("lookup")]
+    bridge = prepare_scoped_benchmark_plugin(
+        home,
+        tools,
+        model="claude-sonnet-test",
+        base_url="http://127.0.0.1:9411/v1",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    module, agent_class = _fake_run_agent(
+        repo_path,
+        home,
+        ["lookup"],
+        invocations=[
+            ("lookup", {"query": "orchid"}),
+            ("lookup", {"query": "unscored-follow-up"}),
+        ],
+    )
+    payload = _payload(repo_path, home, bridge, tools=tools)
+    payload["capture_stop"] = True
+
+    result = run_native_turn(payload, module_loader=lambda name: module)
+
+    assert result["actions"] == ["lookup"]
+    meta = result["params"]["_meta"]
+    assert meta["capture_stop_after_scored_action"] is True
+    assert meta["native_api_calls"] == 1
+    assert meta["native_interrupted"] is True
+    assert meta["native_turn_exit_reason"] == "interrupted_by_user"
+    assert (
+        agent_class.instances[-1].interrupt_message
+        == "benchmark_scored_action_captured"
+    )
+
+
 def test_lifecycle_turn_consumes_explicit_history_and_allows_two_tool_rounds(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/benchmarks/openclaw-adapter/AGENTS.md
+++ b/packages/benchmarks/openclaw-adapter/AGENTS.md
@@ -70,6 +70,7 @@ pytest openclaw-adapter/tests/ -v
 - Publishable runs require a loopback completion gateway. The generated config rejects remote base URLs and references the bearer token by env var rather than persisting it.
 - `OPENCLAW_DIRECT_OPENAI_COMPAT=1` and `direct_openai_compatible=True` exist only for parser/retry tests. Their telemetry sets `publishable_native=false`, so the orchestrator quarantines those results.
 - Full message history is canonicalized into the isolated turn prompt. Benchmark tools remain structured native plugin tools and only plugin-captured executions become scored tool calls.
+- The bridge never executes tools. Callers whose env executes captured calls itself (e.g. the hermes-native env proxy, one chat-completions step per turn) declare `context["capture_stop"] = True`: the embedded loop then ends after the first captured tool batch instead of iterating on placeholder acknowledgements (one billed completion per fake round). Default off — ack-loop benchmarks (orchestrator lifecycle) score reply text written after the ack.
 - Provenance records identify `openclaw.agent.embedded`, the generated config hash, native plugin bridge, model, provider, and transport on every turn.
 - No results are written by this package — results are the responsibility of the benchmark that consumes it.
 - Full background: [README.md](README.md).

--- a/packages/benchmarks/openclaw-adapter/CLAUDE.md
+++ b/packages/benchmarks/openclaw-adapter/CLAUDE.md
@@ -70,6 +70,7 @@ pytest openclaw-adapter/tests/ -v
 - Publishable runs require a loopback completion gateway. The generated config rejects remote base URLs and references the bearer token by env var rather than persisting it.
 - `OPENCLAW_DIRECT_OPENAI_COMPAT=1` and `direct_openai_compatible=True` exist only for parser/retry tests. Their telemetry sets `publishable_native=false`, so the orchestrator quarantines those results.
 - Full message history is canonicalized into the isolated turn prompt. Benchmark tools remain structured native plugin tools and only plugin-captured executions become scored tool calls.
+- The bridge never executes tools. Callers whose env executes captured calls itself (e.g. the hermes-native env proxy, one chat-completions step per turn) declare `context["capture_stop"] = True`: the embedded loop then ends after the first captured tool batch instead of iterating on placeholder acknowledgements (one billed completion per fake round). Default off — ack-loop benchmarks (orchestrator lifecycle) score reply text written after the ack.
 - Provenance records identify `openclaw.agent.embedded`, the generated config hash, native plugin bridge, model, provider, and transport on every turn.
 - No results are written by this package — results are the responsibility of the benchmark that consumes it.
 - Full background: [README.md](README.md).

--- a/packages/benchmarks/openclaw-adapter/README.md
+++ b/packages/benchmarks/openclaw-adapter/README.md
@@ -37,6 +37,16 @@ turn prompt exactly once. The synthetic lifecycle target is not dispatched;
 each call receives the shared neutral `{captured: true, effect:
 "not_executed", sequence, tool: "TASKS"}` result.
 
+Callers whose benchmark env executes captured calls itself — the hermes-native
+env proxy speaks one chat-completions step per turn and replays real tool
+results on the next request — declare `context["capture_stop"] = True`. The
+generated plugin then marks every result as terminating deferred external
+work, so the embedded loop ends after the first captured tool batch instead of
+iterating on placeholder acknowledgements (one billed completion per fake
+round) and the terminal `toolUse` turn still classifies as a delivered,
+publishable trajectory. The default (off) preserves the ack-loop contract for
+benchmarks that score reply text written after the acknowledgement.
+
 Publishable runs must use a loopback completion URL. The token appears only as
 an environment reference in generated config. Per-turn telemetry proves the
 runtime, transport, native plugin bridge, config hash, provider, and model; the

--- a/packages/benchmarks/openclaw-adapter/openclaw_adapter/client.py
+++ b/packages/benchmarks/openclaw-adapter/openclaw_adapter/client.py
@@ -108,6 +108,7 @@ _CONTROL_CONTEXT_KEYS = {
     "agent_id",
     "tools",
     "tool_choice",
+    "capture_stop",
     "benchmark_workspace_path",
 }
 
@@ -718,6 +719,15 @@ class OpenClawClient:
                 "CLAUDE_SUBSCRIPTION_GATEWAY_TOKEN", ""
             ).strip()
         state_dir = self._turn_state_dir()
+        # ``capture_stop`` is the caller-declared env-owned tool contract: the
+        # benchmark env executes captured calls itself and replays real results
+        # on the next send_message, so the embedded loop must end after the
+        # first tool batch. Without it, OpenClaw iterates on the bridge's
+        # placeholder acknowledgements — one billed completion per fake round
+        # (~90 observed per tblite turn) ending in a non-deliverable
+        # length-stop. Default off: ack-loop benchmarks (orchestrator
+        # lifecycle) score reply text the model writes after seeing the ack.
+        capture_stop = bool(ctx.get("capture_stop")) and bool(runtime_tools)
         runtime = prepare_native_runtime(
             tools=runtime_tools,
             model=self.model,
@@ -728,6 +738,7 @@ class OpenClawClient:
             thinking_level=thinking_level,
             system_prompt=native_system_prompt,
             state_dir=state_dir,
+            capture_stop=capture_stop,
         )
         self._active_native_runtime = runtime
         argv = self.build_argv(text, context)
@@ -954,7 +965,7 @@ class OpenClawClient:
                     benchmark_workspace is not None
                     and runtime.workspace_dir.resolve() != benchmark_workspace
                 ),
-                "capture_stop_after_scored_action": False,
+                "capture_stop_after_scored_action": capture_stop,
                 "native_session_evidence": session_evidence.status,
                 "native_session_sha256": session_evidence.session_sha256,
                 "native_session_terminal_stop_reason": (

--- a/packages/benchmarks/openclaw-adapter/openclaw_adapter/native_runtime.py
+++ b/packages/benchmarks/openclaw-adapter/openclaw_adapter/native_runtime.py
@@ -139,8 +139,16 @@ def prepare_native_runtime(
     thinking_level: str = "medium",
     system_prompt: str | None = None,
     state_dir: Path | None = None,
+    capture_stop: bool = False,
 ) -> NativeRuntimePaths:
-    """Materialize a key-free OpenClaw config, system prompt, and tool plugin."""
+    """Materialize a key-free OpenClaw config, system prompt, and tool plugin.
+
+    ``capture_stop`` selects the env-owned tool-execution contract: the caller
+    (a benchmark env speaking OpenAI chat-completions) executes captured tool
+    calls itself and feeds their real results back on the next turn, so the
+    embedded loop must end after the first tool batch instead of iterating on
+    the bridge's placeholder acknowledgements. See ``_write_plugin``.
+    """
 
     if not base_url.startswith("http://127.0.0.1:") and not base_url.startswith(
         "http://localhost:"
@@ -169,7 +177,7 @@ def prepare_native_runtime(
     capture_path = root / "tool-calls.jsonl"
     capture_path.write_text("", encoding="utf-8")
 
-    _write_plugin(plugin_dir, tools)
+    _write_plugin(plugin_dir, tools, capture_stop=capture_stop)
     config = _runtime_config(
         root=root,
         plugin_dir=plugin_dir,
@@ -765,7 +773,12 @@ def _runtime_config(
     }
 
 
-def _write_plugin(plugin_dir: Path, tools: tuple[BenchmarkTool, ...]) -> None:
+def _write_plugin(
+    plugin_dir: Path,
+    tools: tuple[BenchmarkTool, ...],
+    *,
+    capture_stop: bool = False,
+) -> None:
     manifest = {
         "id": PLUGIN_ID,
         "name": "elizaOS Benchmark Tool Bridge",
@@ -795,13 +808,22 @@ def _write_plugin(plugin_dir: Path, tools: tuple[BenchmarkTool, ...]) -> None:
     plugin_source = f"""/**
  * Registers the exact tool catalog supplied by one benchmark turn.
  *
- * Handlers record the selected call for the Python scorer and return a neutral
- * acknowledgement so OpenClaw's native loop, rather than this bridge, owns
- * tool selection and continuation behavior.
+ * Handlers record the selected call for the Python scorer. This bridge never
+ * executes anything: the benchmark env replays captured calls against the
+ * real environment and feeds genuine results back on the next turn. In
+ * capture-stop mode every result therefore sets `terminate` so the embedded
+ * loop ends after the first tool batch — iterating on the bridge's
+ * placeholder acknowledgements would bill one provider completion per fake
+ * round while telling the model nothing. The `async`/`status: "started"`
+ * details mark the batch as deferred external work so OpenClaw's terminal
+ * classifier treats the captured handoff as delivery rather than an empty
+ * (non-deliverable) turn. The capture file keeps the bare scorer contract
+ * either way.
  */
 import {{ appendFileSync }} from "node:fs";
 
 const tools = {json.dumps(descriptors, ensure_ascii=True)};
+const captureStop = {json.dumps(bool(capture_stop))};
 const callSequences = new Map();
 
 export default {{
@@ -846,7 +868,10 @@ export default {{
               type: "text",
               text: JSON.stringify(outcome),
             }}],
-            details: outcome,
+            details: captureStop
+              ? {{ ...outcome, async: true, status: "started" }}
+              : outcome,
+            ...(captureStop ? {{ terminate: true }} : {{}}),
           }};
         }},
       }});

--- a/packages/benchmarks/openclaw-adapter/tests/test_client.py
+++ b/packages/benchmarks/openclaw-adapter/tests/test_client.py
@@ -871,6 +871,58 @@ def test_native_turn_applies_per_turn_generation_parameters(
     assert len(meta["tool_schema_sha256"]) == 64
 
 
+def test_env_owned_tool_contract_enables_capture_stop(
+    client: OpenClawClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``capture_stop`` in context generates a terminating bridge plugin and
+    is attested in provenance; without tools the flag stays inert."""
+    monkeypatch.setenv("OPENCLAW_USE_CLI", "1")
+    plugin_sources: list[str] = []
+
+    def _fake_run(
+        argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        del argv
+        env = dict(kwargs.get("env") or {})
+        plugin_path = (
+            Path(env["OPENCLAW_STATE_DIR"]) / "benchmark-tool-bridge" / "index.mjs"
+        )
+        plugin_sources.append(
+            plugin_path.read_text(encoding="utf-8") if plugin_path.is_file() else ""
+        )
+        return _fake_completed(stdout=json.dumps({"reply": "ok"}), rc=0)
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Look up one record.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+    with patch("openclaw_adapter.client.subprocess.run", side_effect=_fake_run):
+        tooled = client.send_message(
+            "find the orchid",
+            context={"tools": [tool], "capture_stop": True},
+        )
+        toolless = client.send_message(
+            "just reply",
+            context={"capture_stop": True},
+        )
+
+    tooled_meta = tooled.params["_meta"]["openclaw_adapter"]
+    assert tooled_meta["capture_stop_after_scored_action"] is True
+    assert 'const captureStop = true;' in plugin_sources[0]
+    assert "terminate: true" in plugin_sources[0]
+    toolless_meta = toolless.params["_meta"]["openclaw_adapter"]
+    assert toolless_meta["capture_stop_after_scored_action"] is False
+
+
 def test_native_turn_loads_system_prompt_once_through_agents_md(
     client: OpenClawClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/benchmarks/openclaw-adapter/tests/test_native_openclaw_e2e.py
+++ b/packages/benchmarks/openclaw-adapter/tests/test_native_openclaw_e2e.py
@@ -1,4 +1,12 @@
-"""Exercises the installed OpenClaw loop and generated plugin against a local model stub."""
+"""Exercises the installed OpenClaw loop and generated plugin against a local model stub.
+
+The tool-bearing contract here is the capture-stop regression guard: the stub
+model demands a benchmark tool call on *every* completion, so a runtime that
+iterates on the bridge's placeholder acknowledgements would loop until the
+context/token budget dies (observed as ~90 billed completions per env turn on
+tblite). The fixed contract is exactly one provider completion per turn, a
+``toolUse``-terminated session, and a successful, publishable trajectory.
+"""
 
 from __future__ import annotations
 
@@ -108,28 +116,17 @@ def _stream_chunks(body: dict[str, Any], *, final: bool) -> list[dict[str, objec
     return chunks
 
 
-@pytest.mark.skipif(
-    not os.environ.get("OPENCLAW_E2E_BIN"),
-    reason="set OPENCLAW_E2E_BIN to run the installed OpenClaw contract",
-)
-def test_installed_openclaw_executes_generated_benchmark_tool(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    requests: list[dict[str, Any]] = []
-    telemetry_path = tmp_path / "telemetry.jsonl"
-    monkeypatch.setenv("BENCHMARK_TELEMETRY_JSONL", str(telemetry_path))
-
+def _serve_stub(
+    requests: list[dict[str, Any]],
+    *,
+    final_fn,
+) -> ThreadingHTTPServer:
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self) -> None:  # noqa: N802
             length = int(self.headers.get("content-length", "0"))
             body = json.loads(self.rfile.read(length).decode("utf-8"))
             requests.append(body)
-            messages = body.get("messages")
-            final = isinstance(messages, list) and any(
-                isinstance(message, dict) and message.get("role") == "tool"
-                for message in messages
-            )
+            final = final_fn(body)
             if body.get("stream") is True:
                 chunks = _stream_chunks(body, final=final)
                 encoded = (
@@ -151,19 +148,41 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
             return
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def _make_client(server: ThreadingHTTPServer, tmp_path: Path) -> OpenClawClient:
+    return OpenClawClient(
+        binary_path=Path(os.environ["OPENCLAW_E2E_BIN"]),
+        provider="claude-subscription",
+        model="claude-opus-4-8",
+        api_key="gateway-sentinel",
+        base_url=f"http://127.0.0.1:{server.server_port}",
+        native_state_root=tmp_path / "state",
+        thinking_level="medium",
+        timeout_s=120,
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENCLAW_E2E_BIN"),
+    reason="set OPENCLAW_E2E_BIN to run the installed OpenClaw contract",
+)
+def test_installed_openclaw_captures_tool_batch_in_one_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, Any]] = []
+    telemetry_path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setenv("BENCHMARK_TELEMETRY_JSONL", str(telemetry_path))
+
+    # The stub never yields a final text turn: every completion demands
+    # another tool call. Only a loop that stops after the first captured
+    # batch can finish this turn with a single request.
+    server = _serve_stub(requests, final_fn=lambda body: False)
     try:
-        client = OpenClawClient(
-            binary_path=Path(os.environ["OPENCLAW_E2E_BIN"]),
-            provider="claude-subscription",
-            model="claude-opus-4-8",
-            api_key="gateway-sentinel",
-            base_url=f"http://127.0.0.1:{server.server_port}",
-            native_state_root=tmp_path / "state",
-            thinking_level="medium",
-            timeout_s=120,
-        )
+        client = _make_client(server, tmp_path)
         assert client.health()["status"] == "ready"
         client.reset("probe-1", "native-openclaw-e2e")
         response = client.send_message(
@@ -179,6 +198,7 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
                 "system_hint": _SYSTEM_SENTINEL,
                 "reasoning_effort": "medium",
                 "tool_choice": "required",
+                "capture_stop": True,
                 "tools": [
                     {
                         "type": "function",
@@ -197,7 +217,7 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
         )
     finally:
         server.shutdown()
-        thread.join(timeout=5)
+        server.server_close()
 
     assert response.actions == ["record_probe"]
     assert response.params["record_probe"] == {"value": "sentinel"}
@@ -206,48 +226,51 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
     assert metadata["native_runtime_class"] == "openclaw.agent.embedded"
     assert metadata["native_runtime_api"] == "openclaw agent --local --json"
     assert metadata["tool_bridge"] == "native_plugin"
+    assert metadata["capture_stop_after_scored_action"] is True
     assert metadata["publishable_native"] is True
     assert metadata["native_system_prompt_surface"] == "workspace/AGENTS.md"
     assert metadata["native_system_prompt_in_cli_message"] is False
+    # Exactly one billed completion for the whole turn — the amplifier
+    # regression this test exists to catch.
+    assert len(requests) == 1
+    assert requests[0]["tools"][0]["function"]["name"] == "record_probe"
+    assert requests[0]["stream"] is True
+    assert requests[0]["stream_options"] == {"include_usage": True}
+    assert requests[0]["reasoning_effort"] == "medium"
+    messages = requests[0].get("messages")
+    assert isinstance(messages, list)
+    system_contents = [
+        str(message.get("content") or "")
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "system"
+    ]
+    user_contents = [
+        str(message.get("content") or "")
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "user"
+    ]
+    assert sum(content.count(_SYSTEM_SENTINEL) for content in system_contents) == 1, (
+        json.dumps(messages, ensure_ascii=True)
+    )
+    assert all(_SYSTEM_SENTINEL not in content for content in user_contents)
     expected_usage = {
-        "prompt_tokens": 28,
-        "completion_tokens": 7,
-        "total_tokens": 35,
+        "prompt_tokens": 11,
+        "completion_tokens": 4,
+        "total_tokens": 15,
         "prompt_tokens_details": {
             "cached_tokens": 0,
             "cache_write_tokens": 0,
         },
     }
     assert response.params["usage"] == expected_usage
-    assert metadata["native_session_assistant_model_call_count"] == 2
+    assert metadata["native_session_assistant_model_call_count"] == 1
+    assert metadata["native_session_terminal_stop_reason"] == "toolUse"
     assert metadata["native_usage_scope"] == "full_native_turn_aggregate"
     assert len(metadata["native_usage_sha256"]) == 64
     assert metadata["native_trajectory_evidence"] == "succeeded"
     assert len(metadata["native_trajectory_sha256"]) == 64
     assert metadata["native_runtime_identity_attested"] is True
     assert metadata["thinking_level_attested"] is True
-    assert len(requests) == 2
-    assert requests[0]["tools"][0]["function"]["name"] == "record_probe"
-    for request in requests:
-        assert request["stream"] is True
-        assert request["stream_options"] == {"include_usage": True}
-        assert request["reasoning_effort"] == "medium"
-        messages = request.get("messages")
-        assert isinstance(messages, list)
-        system_contents = [
-            str(message.get("content") or "")
-            for message in messages
-            if isinstance(message, dict) and message.get("role") == "system"
-        ]
-        user_contents = [
-            str(message.get("content") or "")
-            for message in messages
-            if isinstance(message, dict) and message.get("role") == "user"
-        ]
-        assert (
-            sum(content.count(_SYSTEM_SENTINEL) for content in system_contents) == 1
-        ), json.dumps(messages, ensure_ascii=True)
-        assert all(_SYSTEM_SENTINEL not in content for content in user_contents)
     trajectory_paths = list((tmp_path / "state").glob("**/*.trajectory.jsonl"))
     assert len(trajectory_paths) == 1
     trajectory_records = [
@@ -255,6 +278,11 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
         for line in trajectory_paths[0].read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
+    session_ended = [
+        record for record in trajectory_records if record.get("type") == "session.ended"
+    ]
+    assert len(session_ended) == 1
+    assert session_ended[0]["data"]["status"] == "success"
     model_completed = [
         record
         for record in trajectory_records
@@ -262,9 +290,9 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
     ]
     assert len(model_completed) == 1
     assert model_completed[0]["data"]["usage"] == {
-        "input": 28,
-        "output": 7,
-        "total": 35,
+        "input": 11,
+        "output": 4,
+        "total": 15,
     }
     telemetry = json.loads(telemetry_path.read_text(encoding="utf-8").splitlines()[0])
     assert telemetry["usage"] == expected_usage
@@ -273,3 +301,36 @@ def test_installed_openclaw_executes_generated_benchmark_tool(
     assert telemetry["runtime_provenance"]["native_usage_scope"] == (
         "full_native_turn_aggregate"
     )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENCLAW_E2E_BIN"),
+    reason="set OPENCLAW_E2E_BIN to run the installed OpenClaw contract",
+)
+def test_installed_openclaw_text_turn_stays_single_round(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tool-free turns (the AGENT_SMOKE shape) keep the plain text contract:
+    one completion, terminal ``stop``, and no capture-stop involvement."""
+    requests: list[dict[str, Any]] = []
+    telemetry_path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setenv("BENCHMARK_TELEMETRY_JSONL", str(telemetry_path))
+
+    server = _serve_stub(requests, final_fn=lambda body: True)
+    try:
+        client = _make_client(server, tmp_path)
+        assert client.health()["status"] == "ready"
+        client.reset("probe-2", "native-openclaw-e2e")
+        response = client.send_message("Reply with the words: probe complete")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.text == "probe complete"
+    metadata = response.params["_meta"]["openclaw_adapter"]
+    assert metadata["capture_stop_after_scored_action"] is False
+    assert metadata["publishable_native"] is True
+    assert metadata["native_session_terminal_stop_reason"] == "stop"
+    assert metadata["native_session_assistant_model_call_count"] == 1
+    assert len(requests) == 1

--- a/packages/benchmarks/openclaw-adapter/tests/test_native_runtime.py
+++ b/packages/benchmarks/openclaw-adapter/tests/test_native_runtime.py
@@ -238,6 +238,97 @@ process.stdout.write(JSON.stringify([first, second]));
     ]
 
 
+def test_capture_stop_plugin_terminates_batch_and_keeps_scorer_contract(
+    tmp_path: Path,
+) -> None:
+    """Capture-stop results must end the embedded loop (``terminate: true``)
+    and classify as deferred external work (``async``/``started`` details) so
+    the terminal turn counts as delivery, while the capture file keeps the
+    bare scorer contract with none of those runtime-facing markers."""
+    paths = prepare_native_runtime(
+        tools=normalize_benchmark_tools([_tool()]),
+        model="claude-opus-4-8",
+        base_url="http://127.0.0.1:31337",
+        timeout_s=45,
+        max_tokens=2048,
+        state_dir=tmp_path,
+        capture_stop=True,
+    )
+    plugin_path = paths.plugin_dir / "index.mjs"
+    script = f"""
+import {{ pathToFileURL }} from "node:url";
+const plugin = (await import(pathToFileURL({json.dumps(str(plugin_path))}).href)).default;
+const registrations = [];
+plugin.register({{ registerTool(tool) {{ registrations.push(tool); }} }});
+const result = await registrations[0].execute("call-1", {{ value: "sentinel" }});
+process.stdout.write(JSON.stringify(result));
+"""
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OPENCLAW_BENCHMARK_CAPTURE_PATH": str(paths.capture_path),
+        },
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["terminate"] is True
+    assert result["details"] == {
+        "captured": True,
+        "tool": "record_probe",
+        "sequence": 0,
+        "async": True,
+        "status": "started",
+    }
+    executions = read_captured_tool_executions(paths.capture_path)
+    assert [execution["result"] for execution in executions] == [
+        {"captured": True, "tool": "record_probe", "sequence": 0}
+    ]
+
+
+def test_default_plugin_keeps_neutral_acknowledgement_without_terminate(
+    tmp_path: Path,
+) -> None:
+    paths = prepare_native_runtime(
+        tools=normalize_benchmark_tools([_tool()]),
+        model="claude-opus-4-8",
+        base_url="http://127.0.0.1:31337",
+        timeout_s=45,
+        max_tokens=2048,
+        state_dir=tmp_path,
+    )
+    plugin_path = paths.plugin_dir / "index.mjs"
+    script = f"""
+import {{ pathToFileURL }} from "node:url";
+const plugin = (await import(pathToFileURL({json.dumps(str(plugin_path))}).href)).default;
+const registrations = [];
+plugin.register({{ registerTool(tool) {{ registrations.push(tool); }} }});
+const result = await registrations[0].execute("call-1", {{ value: "sentinel" }});
+process.stdout.write(JSON.stringify(result));
+"""
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OPENCLAW_BENCHMARK_CAPTURE_PATH": str(paths.capture_path),
+        },
+    )
+
+    result = json.loads(completed.stdout)
+    assert "terminate" not in result
+    assert result["details"] == {
+        "captured": True,
+        "tool": "record_probe",
+        "sequence": 0,
+    }
+
+
 def test_prepare_runtime_rejects_remote_completion_provider(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="loopback completion gateway"):
         prepare_native_runtime(

--- a/packages/benchmarks/orchestrator/provider_forwarder.py
+++ b/packages/benchmarks/orchestrator/provider_forwarder.py
@@ -8,10 +8,28 @@ nonpublishable diagnostic. This forwarder restores publishability honestly:
 it binds ``http://127.0.0.1:<port>/v1`` (satisfying openclaw's strict
 ``http://127.0.0.1:`` prefix check and hermes's loopback predicate),
 authenticates each harness lane with its own ephemeral bearer token, and
-pipes ``/v1/chat/completions``, ``/v1/embeddings``, and ``/v1/models``
-byte-for-byte to the real upstream with the real credential attached only
-inside the coordinator process. Harness legs therefore hold no real
-credential, and their traffic genuinely traverses loopback.
+relays ``/v1/chat/completions``, ``/v1/embeddings``, and ``/v1/models`` to the
+real upstream with the real credential attached only inside the coordinator
+process — byte-for-byte except for the streaming adaptation below. Harness
+legs therefore hold no real credential, and their traffic genuinely traverses
+loopback.
+
+Chat-completion streaming is de-streamed by default rather than piped raw. The
+deployed elizacloud proxy duplicates streamed tool-call arguments — it emits
+the incremental argument deltas AND re-serializes the full arguments in its
+consolidated chunk, so the spec-mandated per-index concatenation on the client
+yields invalid JSON — while its ``stream:false`` responses are correct (fixed
+by PR #16973, but production deploys through reviewer-gated ``main``). So when
+a harness sends ``"stream": true``, the forwarder rewrites the upstream request
+to ``"stream": false``, waits for the complete JSON completion, and synthesizes
+a spec-compliant OpenAI SSE stream downstream — the same "SSE is a response
+adapter over the same completed query" design the claude-subscription gateway
+uses (``packages/benchmarks/claude-subscription-gateway/src/server.ts``), and
+its chunk sequence is mirrored here: role chunk, content delta, one indexed
+tool-call delta per call with the arguments emitted exactly once, finish
+chunk, usage chunk, ``[DONE]``. This also makes forwarded runs
+transport-deterministic. ``ELIZA_FORWARDER_PASSTHROUGH_STREAMING=1`` restores
+raw streaming passthrough once the cloud fix deploys.
 
 The cohort coordinator owns the lifecycle — one forwarder per cohort, fresh
 tokens each cohort, closed in the coordinator ``finally`` where a premature
@@ -28,6 +46,7 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import os
 import secrets
 import threading
 from dataclasses import dataclass, field
@@ -42,6 +61,11 @@ from .runner import PROVIDER_BASE_URL_ENV, PROVIDER_KEY_ENV
 DEFAULT_UPSTREAM_TIMEOUT_SECONDS = 600.0
 DEFAULT_STOP_TIMEOUT_SECONDS = 30.0
 _RELAY_CHUNK_BYTES = 65536
+# Escape hatch for the de-stream default: set to 1/true/yes/on to relay
+# ``stream:true`` chat completions byte-for-byte again once the elizacloud
+# streamed-tool-call duplication fix (PR #16973) is live in production.
+PASSTHROUGH_STREAMING_ENV = "ELIZA_FORWARDER_PASSTHROUGH_STREAMING"
+_ENV_TRUTHY = frozenset({"1", "true", "yes", "on"})
 # Hop-by-hop and transport-framing headers are recomputed per hop; the
 # credential headers are replaced with the coordinator-held upstream key.
 # Accept-Encoding is pinned to identity so the relay stays a transparent byte
@@ -160,11 +184,161 @@ class _ForwarderState:
     upstream_api_key: str
     tokens_to_harness: dict[str, str]
     upstream_timeout_seconds: float
+    passthrough_streaming: bool = False
     lock: threading.Lock = field(default_factory=threading.Lock)
     lane_request_counts: dict[str, int] = field(default_factory=dict)
     unauthorized_requests: int = 0
     upstream_transport_failures: int = 0
+    upstream_invalid_completions: int = 0
+    destreamed_requests: int = 0
     aborted_connections: int = 0
+
+
+def _streaming_request_payload(body: bytes) -> dict[str, object] | None:
+    """The parsed request body iff it is a de-streamable chat completion.
+
+    Only a JSON object carrying exactly ``"stream": true`` qualifies; anything
+    else (malformed JSON, non-object payloads, absent/false/exotic ``stream``
+    values) is relayed unchanged so the upstream stays the authority on
+    accepting or rejecting it.
+    """
+
+    # error-policy:J3 the body is untrusted harness input; a parse failure is
+    # an explicit not-de-streamable verdict, never a fabricated request.
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict) or payload.get("stream") is not True:
+        return None
+    return payload
+
+
+def _synthesize_sse_frames(completion: dict[str, object]) -> list[bytes]:
+    """Adapt one complete chat completion into OpenAI SSE chunk frames.
+
+    Mirrors the claude-subscription gateway's ``sendSseCompletion`` sequence,
+    which both real downstream consumers are proven against — the hermes
+    chat-completions stream accumulator (name by assignment, arguments by
+    per-index concatenation) and OpenClaw's ``openai-completions`` transport
+    (the official openai JS SDK): per choice a role(+content) chunk, one
+    indexed tool-call delta per call with the full arguments emitted exactly
+    once (valid per spec — concatenation of one fragment is the fragment),
+    and a finish chunk; then a usage chunk when the completion carried usage,
+    then ``[DONE]``. ``id``/``model``/``created``/``system_fingerprint`` are
+    preserved from the upstream response. Raises ``ValueError`` on a payload
+    that is not a completion so the caller can fail closed instead of
+    emitting a half-valid stream.
+    """
+
+    choices = completion.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("upstream completion has no choices list")
+    base: dict[str, object] = {
+        "id": completion.get("id"),
+        "object": "chat.completion.chunk",
+        "created": completion.get("created"),
+        "model": completion.get("model"),
+    }
+    if "system_fingerprint" in completion:
+        base["system_fingerprint"] = completion["system_fingerprint"]
+    frames: list[bytes] = []
+
+    def emit(payload: dict[str, object]) -> None:
+        frames.append(
+            b"data: " + json.dumps(payload, ensure_ascii=True).encode("utf-8") + b"\n\n"
+        )
+
+    for position, choice in enumerate(choices):
+        if not isinstance(choice, dict):
+            raise ValueError("upstream completion choice is not an object")
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            raise ValueError("upstream completion choice has no message object")
+        index = choice.get("index", position)
+        initial_delta: dict[str, object] = {"role": message.get("role") or "assistant"}
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            initial_delta["content"] = content
+        # Providers that surface chain-of-thought (the cloud proxy's gemma
+        # lineup among them) put it on message.reasoning_content; hermes
+        # accumulates the streamed field of the same name, so carry it over
+        # rather than dropping it in the adaptation.
+        reasoning = message.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning:
+            initial_delta["reasoning_content"] = reasoning
+        emit(
+            {
+                **base,
+                "choices": [
+                    {
+                        "index": index,
+                        "delta": initial_delta,
+                        "finish_reason": None,
+                        "logprobs": None,
+                    }
+                ],
+                "usage": None,
+            }
+        )
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for call_position, call in enumerate(tool_calls):
+                if not isinstance(call, dict) or not isinstance(
+                    call.get("function"), dict
+                ):
+                    raise ValueError("upstream tool call has no function object")
+                function = call["function"]
+                arguments = function.get("arguments", "")
+                if not isinstance(arguments, str):
+                    # The spec requires a JSON-encoded string; normalize the
+                    # rare provider that inlines a decoded object.
+                    arguments = json.dumps(arguments, ensure_ascii=True)
+                emit(
+                    {
+                        **base,
+                        "choices": [
+                            {
+                                "index": index,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": call_position,
+                                            "id": call.get("id"),
+                                            "type": call.get("type", "function"),
+                                            "function": {
+                                                "name": function.get("name"),
+                                                "arguments": arguments,
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                                "logprobs": None,
+                            }
+                        ],
+                        "usage": None,
+                    }
+                )
+        emit(
+            {
+                **base,
+                "choices": [
+                    {
+                        "index": index,
+                        "delta": {},
+                        "finish_reason": choice.get("finish_reason"),
+                        "logprobs": None,
+                    }
+                ],
+                "usage": None,
+            }
+        )
+    usage = completion.get("usage")
+    if isinstance(usage, dict):
+        emit({**base, "choices": [], "usage": usage})
+    frames.append(b"data: [DONE]\n\n")
+    return frames
 
 
 class _ForwarderServer(ThreadingHTTPServer):
@@ -248,6 +422,14 @@ class _ForwarderHandler(BaseHTTPRequestHandler):
             )
             return
         body = self.rfile.read(int(raw_length))
+        if (
+            subpath == "/chat/completions"
+            and not self.server.state.passthrough_streaming
+        ):
+            destream_payload = _streaming_request_payload(body)
+            if destream_payload is not None:
+                self._forward_destreamed(subpath, query, destream_payload)
+                return
         self._forward("POST", subpath, query, body)
 
     def _authorized_harness(self) -> str | None:
@@ -275,13 +457,15 @@ class _ForwarderHandler(BaseHTTPRequestHandler):
             )
         return harness
 
-    def _forward(
+    def _open_upstream(
         self,
         method: str,
         subpath: str,
         query: str,
         body: bytes | None,
-    ) -> None:
+    ) -> tuple[HTTPConnection, HTTPResponse] | None:
+        """One authenticated upstream exchange, or None after a written 502."""
+
         state = self.server.state
         target = state.upstream
         upstream_path = f"{target.path_prefix}{subpath}"
@@ -297,7 +481,7 @@ class _ForwarderHandler(BaseHTTPRequestHandler):
             headers = self._outbound_headers()
             headers["Authorization"] = f"Bearer {state.upstream_api_key}"
             connection.request(method, upstream_path, body=body, headers=headers)
-            upstream_response = connection.getresponse()
+            return connection, connection.getresponse()
         except (OSError, TimeoutError) as error:
             # error-policy:J1 the forwarder is the harness-to-upstream
             # transport boundary; a transport failure surfaces as an explicit
@@ -318,11 +502,100 @@ class _ForwarderHandler(BaseHTTPRequestHandler):
                     }
                 },
             )
+            return None
+
+    def _forward(
+        self,
+        method: str,
+        subpath: str,
+        query: str,
+        body: bytes | None,
+    ) -> None:
+        exchange = self._open_upstream(method, subpath, query, body)
+        if exchange is None:
             return
+        connection, upstream_response = exchange
         try:
             self._relay_response(upstream_response)
         finally:
             connection.close()
+
+    def _forward_destreamed(
+        self,
+        subpath: str,
+        query: str,
+        payload: dict[str, object],
+    ) -> None:
+        """Complete the request upstream at ``stream:false``, answer in SSE.
+
+        ``stream_options`` is dropped alongside the rewrite because it is only
+        valid on streaming requests; the synthesized stream always ends with a
+        usage chunk when the completed response carried usage.
+        """
+
+        state = self.server.state
+        upstream_payload = dict(payload)
+        upstream_payload["stream"] = False
+        upstream_payload.pop("stream_options", None)
+        body = json.dumps(upstream_payload, ensure_ascii=True).encode("utf-8")
+        exchange = self._open_upstream("POST", subpath, query, body)
+        if exchange is None:
+            return
+        connection, upstream_response = exchange
+        try:
+            if upstream_response.status != 200:
+                # Fail closed: an upstream failure stays a failure the harness
+                # observes (both real consumers treat any non-200 as an API
+                # error before stream parsing begins) — never a fabricated
+                # completion stream.
+                self._relay_response(upstream_response)
+                return
+            raw = upstream_response.read()
+            # error-policy:J1 the forwarder is the harness-to-upstream
+            # boundary for the adapted response too: a 200 that is not a
+            # parseable chat completion becomes an explicit 502 instead of a
+            # half-valid synthesized stream.
+            try:
+                completion = json.loads(raw)
+                if not isinstance(completion, dict):
+                    raise ValueError("upstream completion is not a JSON object")
+                frames = _synthesize_sse_frames(completion)
+            except ValueError:
+                with state.lock:
+                    state.upstream_invalid_completions += 1
+                self._write_json(
+                    502,
+                    {
+                        "error": {
+                            "message": (
+                                "provider forwarder could not de-stream the "
+                                "upstream response: 200 status without a "
+                                "parseable chat completion body"
+                            ),
+                            "type": "provider_forwarder_upstream_error",
+                        }
+                    },
+                )
+                return
+            with state.lock:
+                state.destreamed_requests += 1
+            self._write_sse(frames)
+        finally:
+            connection.close()
+
+    def _write_sse(self, frames: list[bytes]) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache, no-store")
+        self.send_header("X-Accel-Buffering", "no")
+        # The synthesized stream has no Content-Length; the closed connection
+        # delimits the body exactly like the passthrough SSE branch.
+        self.close_connection = True
+        self.send_header("Connection", "close")
+        self.end_headers()
+        for frame in frames:
+            self.wfile.write(frame)
+        self.wfile.flush()
 
     def _outbound_headers(self) -> dict[str, str]:
         headers: dict[str, str] = {}
@@ -347,9 +620,10 @@ class _ForwarderHandler(BaseHTTPRequestHandler):
         else:
             # Without a known length the relay streams until upstream EOF and
             # the closed connection delimits the body for the HTTP/1.1 client.
-            # SSE (``"stream": true``) always takes this branch; each upstream
-            # read is flushed immediately so tokens reach the harness as they
-            # are produced instead of after the completion finishes.
+            # Passthrough SSE (``"stream": true`` under the escape hatch)
+            # always takes this branch; each upstream read is flushed
+            # immediately so tokens reach the harness as they are produced
+            # instead of after the completion finishes.
             self.close_connection = True
             self.send_header("Connection", "close")
         self.end_headers()
@@ -470,8 +744,13 @@ class ProviderForwarderProcess:
                 "listen_origin": self.origin,
                 "harness_lanes": sorted(self._harness_tokens),
                 "harness_request_counts": dict(state.lane_request_counts),
+                "stream_mode": (
+                    "passthrough" if state.passthrough_streaming else "de-stream"
+                ),
+                "destreamed_requests": state.destreamed_requests,
                 "unauthorized_requests": state.unauthorized_requests,
                 "upstream_transport_failures": state.upstream_transport_failures,
+                "upstream_invalid_completions": state.upstream_invalid_completions,
                 "aborted_connections": state.aborted_connections,
                 "started_at": self._started_at,
                 "closed_at": _utc_now() if closed else None,
@@ -499,12 +778,16 @@ def start_provider_forwarder(
     evidence_dir: Path,
     upstream_timeout_seconds: float = DEFAULT_UPSTREAM_TIMEOUT_SECONDS,
     stop_timeout_seconds: float = DEFAULT_STOP_TIMEOUT_SECONDS,
+    passthrough_streaming: bool | None = None,
 ) -> ProviderForwarderProcess:
     """Start a per-cohort loopback forwarder with per-harness bearer lanes.
 
     Fails closed before any worker can spend quota: a missing upstream key, a
     bind failure, or a failed self-health probe raises instead of returning a
-    half-configured boundary.
+    half-configured boundary. ``passthrough_streaming`` selects raw
+    ``stream:true`` relaying instead of the de-stream default; ``None`` defers
+    to ``ELIZA_FORWARDER_PASSTHROUGH_STREAMING`` so operators can flip the
+    escape hatch without a coordinator change.
     """
 
     normalized_provider = provider.strip().lower()
@@ -524,6 +807,11 @@ def start_provider_forwarder(
             "Provider forwarder requires a non-empty upstream API key"
         )
     upstream = _parse_upstream(upstream_base_url)
+    if passthrough_streaming is None:
+        passthrough_streaming = (
+            os.environ.get(PASSTHROUGH_STREAMING_ENV, "").strip().lower()
+            in _ENV_TRUTHY
+        )
 
     harness_tokens = {
         harness: secrets.token_urlsafe(32) for harness in normalized_harnesses
@@ -537,6 +825,7 @@ def start_provider_forwarder(
         upstream_api_key=upstream_api_key.strip(),
         tokens_to_harness={token: harness for harness, token in harness_tokens.items()},
         upstream_timeout_seconds=upstream_timeout_seconds,
+        passthrough_streaming=passthrough_streaming,
     )
     try:
         server = _ForwarderServer(("127.0.0.1", 0), state)

--- a/packages/benchmarks/orchestrator/tests/test_provider_forwarder.py
+++ b/packages/benchmarks/orchestrator/tests/test_provider_forwarder.py
@@ -1,7 +1,9 @@
 """Exercises the loopback provider forwarder against a real local HTTP
 upstream stub (standing in for the external remote cloud endpoint): auth
-lanes, JSON and SSE streaming passthrough, upstream-error passthrough, and
-fail-closed lifecycle semantics."""
+lanes, JSON relaying, the de-stream-by-default SSE adaptation (including
+immunity to the elizacloud streamed-tool-call duplication bug the stub
+reproduces), the raw-passthrough escape hatch, upstream-error passthrough,
+and fail-closed lifecycle semantics."""
 
 from __future__ import annotations
 
@@ -9,13 +11,14 @@ import json
 import socket
 import threading
 import time
-from http.client import HTTPConnection
+from http.client import HTTPConnection, HTTPResponse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
 
 from benchmarks.orchestrator.provider_forwarder import (
+    PASSTHROUGH_STREAMING_ENV,
     ForwarderLifecycleError,
     is_loopback_url,
     start_provider_forwarder,
@@ -25,6 +28,7 @@ UPSTREAM_KEY = "real-upstream-secret-key"
 CHAT_COMPLETION = {
     "id": "chatcmpl-upstream-1",
     "object": "chat.completion",
+    "created": 1750000000,
     "model": "gemma-4-31b",
     "choices": [
         {
@@ -35,6 +39,145 @@ CHAT_COMPLETION = {
     ],
     "usage": {"prompt_tokens": 12, "completion_tokens": 1, "total_tokens": 13},
 }
+TOOL_ARGUMENTS = json.dumps({"city": "Paris", "unit": "celsius"})
+TOOL_CHAT_COMPLETION = {
+    "id": "chatcmpl-upstream-tool-1",
+    "object": "chat.completion",
+    "created": 1750000123,
+    "model": "gemma-4-31b",
+    "system_fingerprint": "fp_upstream_stub",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_weather_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": TOOL_ARGUMENTS,
+                        },
+                    }
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }
+    ],
+    "usage": {"prompt_tokens": 41, "completion_tokens": 9, "total_tokens": 50},
+}
+# The deployed elizacloud proxy's streamed-tool-call duplication bug, captured
+# from raw SSE: incremental argument deltas AND a consolidated chunk that
+# re-serializes the full arguments. Spec-mandated per-index concatenation
+# yields TOOL_ARGUMENTS twice back-to-back — invalid JSON.
+BUGGY_STREAM_TOOL_CHUNKS = [
+    {
+        "id": "chatcmpl-upstream-tool-1",
+        "object": "chat.completion.chunk",
+        "created": 1750000123,
+        "model": "gemma-4-31b",
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-upstream-tool-1",
+        "object": "chat.completion.chunk",
+        "created": 1750000123,
+        "model": "gemma-4-31b",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_weather_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": ""},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-upstream-tool-1",
+        "object": "chat.completion.chunk",
+        "created": 1750000123,
+        "model": "gemma-4-31b",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": TOOL_ARGUMENTS[: len(TOOL_ARGUMENTS) // 2]},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-upstream-tool-1",
+        "object": "chat.completion.chunk",
+        "created": 1750000123,
+        "model": "gemma-4-31b",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": TOOL_ARGUMENTS[len(TOOL_ARGUMENTS) // 2 :]},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    # The bug: a consolidated chunk repeating the already-streamed arguments.
+    {
+        "id": "chatcmpl-upstream-tool-1",
+        "object": "chat.completion.chunk",
+        "created": 1750000123,
+        "model": "gemma-4-31b",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_weather_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": TOOL_ARGUMENTS,
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-upstream-tool-1",
+        "object": "chat.completion.chunk",
+        "created": 1750000123,
+        "model": "gemma-4-31b",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+    },
+]
 EMBEDDING_RESPONSE = {
     "object": "list",
     "data": [{"object": "embedding", "index": 0, "embedding": [0.25, -0.5]}],
@@ -87,7 +230,20 @@ class _UpstreamHandler(BaseHTTPRequestHandler):
                     {"error": {"message": "quota exhausted", "type": "rate_limit"}},
                 )
                 return
-            if payload.get("stream") is True:
+            has_tools = isinstance(payload, dict) and bool(payload.get("tools"))
+            if isinstance(payload, dict) and payload.get("stream") is True:
+                if has_tools:
+                    # Reproduce the deployed cloud proxy's duplication bug so
+                    # tests can prove raw passthrough corrupts arguments while
+                    # the de-streamed path never sees this response shape.
+                    self._sse(
+                        [
+                            f"data: {json.dumps(chunk)}\n\n".encode("utf-8")
+                            for chunk in BUGGY_STREAM_TOOL_CHUNKS
+                        ]
+                        + [b"data: [DONE]\n\n"]
+                    )
+                    return
                 self.close_connection = True
                 self.send_response(200)
                 self.send_header("Content-Type", "text/event-stream")
@@ -103,12 +259,30 @@ class _UpstreamHandler(BaseHTTPRequestHandler):
                 self.wfile.write(b"data: [DONE]\n\n")
                 self.wfile.flush()
                 return
-            self._json(200, CHAT_COMPLETION)
+            if self.server.invalid_json_completion:
+                body = b"upstream-returned-not-json"
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            self._json(200, TOOL_CHAT_COMPLETION if has_tools else CHAT_COMPLETION)
             return
         if self.path == "/api/v1/embeddings":
             self._json(200, EMBEDDING_RESPONSE)
             return
         self.send_error(404)
+
+    def _sse(self, frames: list[bytes]) -> None:
+        self.close_connection = True
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        for frame in frames:
+            self.wfile.write(frame)
+            self.wfile.flush()
 
 
 class _UpstreamServer(ThreadingHTTPServer):
@@ -118,6 +292,7 @@ class _UpstreamServer(ThreadingHTTPServer):
         super().__init__(("127.0.0.1", 0), _UpstreamHandler)
         self.seen: list[dict[str, object]] = []
         self.fail_status: int | None = None
+        self.invalid_json_completion = False
         self.release_stream = threading.Event()
 
 
@@ -153,6 +328,7 @@ def _request(
     token: str | None = None,
     payload: dict[str, object] | None = None,
     extra_headers: dict[str, str] | None = None,
+    raw_body: bytes | None = None,
 ) -> tuple[int, bytes, dict[str, str]]:
     parsed_port = int(base_url.rsplit(":", 1)[1].split("/", 1)[0])
     connection = HTTPConnection("127.0.0.1", parsed_port, timeout=10)
@@ -160,7 +336,7 @@ def _request(
         headers: dict[str, str] = dict(extra_headers or {})
         if token is not None:
             headers["Authorization"] = f"Bearer {token}"
-        body = None
+        body = raw_body
         if payload is not None:
             body = json.dumps(payload).encode("utf-8")
             headers["Content-Type"] = "application/json"
@@ -173,6 +349,111 @@ def _request(
         )
     finally:
         connection.close()
+
+
+def _open_stream(
+    base_url: str,
+    token: str,
+    payload: dict[str, object],
+) -> tuple[HTTPConnection, HTTPResponse]:
+    port = int(base_url.rsplit(":", 1)[1].split("/", 1)[0])
+    connection = HTTPConnection("127.0.0.1", port, timeout=10)
+    connection.request(
+        "POST",
+        "/v1/chat/completions",
+        body=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    return connection, connection.getresponse()
+
+
+def _read_sse_data(response: HTTPResponse) -> list[str]:
+    """All ``data:`` payloads of an SSE body, read to EOF."""
+
+    raw = response.read()
+    events: list[str] = []
+    for block in raw.decode("utf-8").split("\n\n"):
+        for line in block.splitlines():
+            if line.startswith("data: "):
+                events.append(line[len("data: ") :])
+    return events
+
+
+def _accumulate_openai_stream(events: list[str]) -> dict[str, object]:
+    """Reassemble a chat completion the way real SSE consumers do.
+
+    Mirrors the hermes chat-completions accumulator (which the OpenAI JS SDK
+    inside OpenClaw matches): text deltas concatenate, tool-call names are
+    assigned, and tool-call ``arguments`` fragments concatenate per index —
+    the exact contract the elizacloud duplication bug corrupts.
+    """
+
+    assert events, "stream produced no data events"
+    assert events[-1] == "[DONE]", "stream did not terminate with [DONE]"
+    content_parts: list[str] = []
+    tool_calls: dict[int, dict[str, object]] = {}
+    finish_reason = None
+    usage = None
+    for raw_event in events[:-1]:
+        chunk = json.loads(raw_event)
+        assert chunk["object"] == "chat.completion.chunk"
+        if not chunk.get("choices"):
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+            continue
+        choice = chunk["choices"][0]
+        delta = choice.get("delta") or {}
+        if delta.get("content"):
+            content_parts.append(delta["content"])
+        for tc_delta in delta.get("tool_calls") or []:
+            entry = tool_calls.setdefault(
+                tc_delta.get("index", 0),
+                {"id": "", "name": "", "arguments": ""},
+            )
+            if tc_delta.get("id"):
+                entry["id"] = tc_delta["id"]
+            function = tc_delta.get("function") or {}
+            if function.get("name"):
+                entry["name"] = function["name"]
+            if function.get("arguments"):
+                entry["arguments"] = str(entry["arguments"]) + function["arguments"]
+        if choice.get("finish_reason"):
+            finish_reason = choice["finish_reason"]
+    return {
+        "content": "".join(content_parts),
+        "tool_calls": [tool_calls[index] for index in sorted(tool_calls)],
+        "finish_reason": finish_reason,
+        "usage": usage,
+    }
+
+
+STREAMING_TOOL_REQUEST: dict[str, object] = {
+    "model": "gemma-4-31b",
+    "messages": [{"role": "user", "content": "weather in paris?"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "unit": {"type": "string"},
+                    },
+                    "required": ["city"],
+                },
+            },
+        }
+    ],
+    "tool_choice": "required",
+    "stream": True,
+    "stream_options": {"include_usage": True},
+}
 
 
 def test_is_loopback_url_matches_adapter_semantics() -> None:
@@ -263,28 +544,20 @@ def test_chat_completion_passthrough_swaps_credentials(
         forwarder.close()
 
 
-def test_streaming_chat_completion_is_piped_incrementally(
+def test_passthrough_mode_pipes_streaming_incrementally(
     upstream: _UpstreamServer, tmp_path: Path
 ) -> None:
-    forwarder = _start(upstream, tmp_path)
+    """Raw relay behavior, kept reachable through the escape hatch."""
+
+    forwarder = _start(upstream, tmp_path, passthrough_streaming=True)
     try:
         lane_token = forwarder.env_for_harness("eliza")["OPENAI_API_KEY"]
-        port = int(forwarder.base_url.rsplit(":", 1)[1].split("/", 1)[0])
-        connection = HTTPConnection("127.0.0.1", port, timeout=10)
+        connection, response = _open_stream(
+            forwarder.base_url,
+            lane_token,
+            {"model": "gemma-4-31b", "messages": [], "stream": True},
+        )
         try:
-            body = json.dumps(
-                {"model": "gemma-4-31b", "messages": [], "stream": True}
-            ).encode("utf-8")
-            connection.request(
-                "POST",
-                "/v1/chat/completions",
-                body=body,
-                headers={
-                    "Authorization": f"Bearer {lane_token}",
-                    "Content-Type": "application/json",
-                },
-            )
-            response = connection.getresponse()
             assert response.status == 200
             assert response.headers["Content-Type"] == "text/event-stream"
             # The upstream holds the stream open until release_stream is set,
@@ -306,6 +579,286 @@ def test_streaming_chat_completion_is_piped_incrementally(
             assert b"data: [DONE]" in rest
         finally:
             connection.close()
+        # The passthrough escape hatch sends stream:true upstream untouched.
+        assert upstream.seen[0]["payload"]["stream"] is True
+    finally:
+        forwarder.close()
+
+
+def test_destream_default_rewrites_upstream_and_synthesizes_compliant_sse(
+    upstream: _UpstreamServer, tmp_path: Path
+) -> None:
+    """Downstream stream:true → upstream stream:false → spec-compliant SSE."""
+
+    forwarder = _start(upstream, tmp_path)
+    try:
+        lane_token = forwarder.env_for_harness("hermes")["OPENAI_API_KEY"]
+        connection, response = _open_stream(
+            forwarder.base_url, lane_token, STREAMING_TOOL_REQUEST
+        )
+        try:
+            assert response.status == 200
+            assert response.headers["Content-Type"].startswith("text/event-stream")
+            events = _read_sse_data(response)
+        finally:
+            connection.close()
+
+        # The upstream saw exactly one non-streaming request with
+        # stream_options removed (it is invalid on stream:false requests).
+        assert len(upstream.seen) == 1
+        upstream_payload = upstream.seen[0]["payload"]
+        assert upstream_payload["stream"] is False
+        assert "stream_options" not in upstream_payload
+        assert upstream_payload["tools"] == STREAMING_TOOL_REQUEST["tools"]
+        assert upstream_payload["tool_choice"] == "required"
+
+        chunks = [json.loads(event) for event in events[:-1]]
+        assert events[-1] == "[DONE]"
+        # id/model/created/system_fingerprint survive from the upstream
+        # completed response on every chunk.
+        for chunk in chunks:
+            assert chunk["id"] == TOOL_CHAT_COMPLETION["id"]
+            assert chunk["model"] == TOOL_CHAT_COMPLETION["model"]
+            assert chunk["created"] == TOOL_CHAT_COMPLETION["created"]
+            assert (
+                chunk["system_fingerprint"]
+                == TOOL_CHAT_COMPLETION["system_fingerprint"]
+            )
+            assert chunk["object"] == "chat.completion.chunk"
+
+        # Canonical sequence mirrored from the claude-subscription gateway:
+        # role chunk, one indexed tool-call delta with the arguments emitted
+        # exactly once, finish chunk, usage chunk, [DONE].
+        role_chunk, tool_chunk, finish_chunk, usage_chunk = chunks
+        assert role_chunk["choices"][0]["delta"] == {"role": "assistant"}
+        assert role_chunk["choices"][0]["finish_reason"] is None
+
+        tool_delta = tool_chunk["choices"][0]["delta"]["tool_calls"]
+        assert tool_delta == [
+            {
+                "index": 0,
+                "id": "call_weather_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": TOOL_ARGUMENTS},
+            }
+        ]
+
+        assert finish_chunk["choices"][0]["delta"] == {}
+        assert finish_chunk["choices"][0]["finish_reason"] == "tool_calls"
+
+        assert usage_chunk["choices"] == []
+        assert usage_chunk["usage"] == TOOL_CHAT_COMPLETION["usage"]
+
+        # A real consumer's accumulation yields valid JSON arguments.
+        accumulated = _accumulate_openai_stream(events)
+        assert accumulated["finish_reason"] == "tool_calls"
+        assert accumulated["tool_calls"][0]["name"] == "get_weather"
+        assert json.loads(accumulated["tool_calls"][0]["arguments"]) == {
+            "city": "Paris",
+            "unit": "celsius",
+        }
+    finally:
+        evidence_file = forwarder.close()
+    evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+    assert evidence["stream_mode"] == "de-stream"
+    assert evidence["destreamed_requests"] == 1
+
+
+def test_destream_is_immune_to_upstream_tool_argument_duplication_bug(
+    upstream: _UpstreamServer, tmp_path: Path
+) -> None:
+    """The bug is real under raw passthrough and gone under the default.
+
+    The stub reproduces the deployed elizacloud proxy stream: incremental
+    argument deltas plus a consolidated chunk repeating the full arguments.
+    Raw passthrough hands that stream to the client, whose spec-mandated
+    concatenation produces invalid JSON; the de-stream default never lets the
+    buggy streaming path execute upstream.
+    """
+
+    passthrough = _start(upstream, tmp_path / "passthrough", passthrough_streaming=True)
+    try:
+        lane_token = passthrough.env_for_harness("openclaw")["OPENAI_API_KEY"]
+        connection, response = _open_stream(
+            passthrough.base_url, lane_token, STREAMING_TOOL_REQUEST
+        )
+        try:
+            events = _read_sse_data(response)
+        finally:
+            connection.close()
+        corrupted = _accumulate_openai_stream(events)
+        assert (
+            corrupted["tool_calls"][0]["arguments"]
+            == TOOL_ARGUMENTS + TOOL_ARGUMENTS
+        )
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(corrupted["tool_calls"][0]["arguments"])
+    finally:
+        passthrough.close()
+
+    destream = _start(upstream, tmp_path / "destream")
+    try:
+        lane_token = destream.env_for_harness("openclaw")["OPENAI_API_KEY"]
+        connection, response = _open_stream(
+            destream.base_url, lane_token, STREAMING_TOOL_REQUEST
+        )
+        try:
+            events = _read_sse_data(response)
+        finally:
+            connection.close()
+        clean = _accumulate_openai_stream(events)
+        assert json.loads(clean["tool_calls"][0]["arguments"]) == {
+            "city": "Paris",
+            "unit": "celsius",
+        }
+    finally:
+        destream.close()
+
+
+def test_destream_streams_plain_content_completions_too(
+    upstream: _UpstreamServer, tmp_path: Path
+) -> None:
+    forwarder = _start(upstream, tmp_path)
+    try:
+        lane_token = forwarder.env_for_harness("eliza")["OPENAI_API_KEY"]
+        connection, response = _open_stream(
+            forwarder.base_url,
+            lane_token,
+            {"model": "gemma-4-31b", "messages": [], "stream": True},
+        )
+        try:
+            assert response.status == 200
+            events = _read_sse_data(response)
+        finally:
+            connection.close()
+        assert upstream.seen[0]["payload"]["stream"] is False
+        accumulated = _accumulate_openai_stream(events)
+        assert accumulated["content"] == "4"
+        assert accumulated["finish_reason"] == "stop"
+        assert accumulated["usage"] == CHAT_COMPLETION["usage"]
+        assert accumulated["tool_calls"] == []
+        first_chunk = json.loads(events[0])
+        assert first_chunk["id"] == CHAT_COMPLETION["id"]
+        assert first_chunk["choices"][0]["delta"]["role"] == "assistant"
+    finally:
+        forwarder.close()
+
+
+def test_passthrough_escape_hatch_env_restores_raw_streaming(
+    upstream: _UpstreamServer,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PASSTHROUGH_STREAMING_ENV, "1")
+    forwarder = _start(upstream, tmp_path)
+    try:
+        lane_token = forwarder.env_for_harness("hermes")["OPENAI_API_KEY"]
+        upstream.release_stream.set()
+        connection, response = _open_stream(
+            forwarder.base_url,
+            lane_token,
+            {"model": "gemma-4-31b", "messages": [], "stream": True},
+        )
+        try:
+            assert response.status == 200
+            raw = response.read()
+        finally:
+            connection.close()
+        assert b"first-chunk" in raw
+        assert b"data: [DONE]" in raw
+        assert upstream.seen[0]["payload"]["stream"] is True
+    finally:
+        evidence_file = forwarder.close()
+    evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+    assert evidence["stream_mode"] == "passthrough"
+    assert evidence["destreamed_requests"] == 0
+
+
+def test_destream_relays_upstream_errors_without_fabricating_a_stream(
+    upstream: _UpstreamServer, tmp_path: Path
+) -> None:
+    upstream.fail_status = 429
+    forwarder = _start(upstream, tmp_path)
+    try:
+        lane_token = forwarder.env_for_harness("hermes")["OPENAI_API_KEY"]
+        connection, response = _open_stream(
+            forwarder.base_url, lane_token, STREAMING_TOOL_REQUEST
+        )
+        try:
+            assert response.status == 429
+            assert response.headers["Content-Type"] == "application/json"
+            body = response.read()
+        finally:
+            connection.close()
+        assert json.loads(body) == {
+            "error": {"message": "quota exhausted", "type": "rate_limit"}
+        }
+    finally:
+        forwarder.close()
+
+
+def test_destream_turns_unparseable_upstream_completion_into_502(
+    upstream: _UpstreamServer, tmp_path: Path
+) -> None:
+    upstream.invalid_json_completion = True
+    forwarder = _start(upstream, tmp_path)
+    try:
+        lane_token = forwarder.env_for_harness("eliza")["OPENAI_API_KEY"]
+        connection, response = _open_stream(
+            forwarder.base_url,
+            lane_token,
+            {"model": "gemma-4-31b", "messages": [], "stream": True},
+        )
+        try:
+            assert response.status == 502
+            body = response.read()
+        finally:
+            connection.close()
+        error = json.loads(body)["error"]
+        assert error["type"] == "provider_forwarder_upstream_error"
+    finally:
+        evidence_file = forwarder.close()
+    evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+    assert evidence["upstream_invalid_completions"] == 1
+    assert evidence["destreamed_requests"] == 0
+
+
+def test_destream_leaves_non_streaming_and_odd_bodies_untouched(
+    upstream: _UpstreamServer, tmp_path: Path
+) -> None:
+    forwarder = _start(upstream, tmp_path)
+    try:
+        lane_token = forwarder.env_for_harness("eliza")["OPENAI_API_KEY"]
+        # stream:false and stream-absent requests relay unchanged.
+        for payload in (
+            {"model": "gemma-4-31b", "messages": [], "stream": False},
+            {"model": "gemma-4-31b", "messages": []},
+        ):
+            status, body, headers = _request(
+                forwarder.base_url,
+                "POST",
+                "/v1/chat/completions",
+                token=lane_token,
+                payload=payload,
+            )
+            assert status == 200
+            assert headers["content-type"] == "application/json"
+            assert json.loads(body) == CHAT_COMPLETION
+        assert upstream.seen[0]["payload"]["stream"] is False
+        assert "stream" not in upstream.seen[1]["payload"]
+        # A non-object JSON body is not de-streamable; the upstream stays the
+        # authority on accepting or rejecting it.
+        status, body, _headers = _request(
+            forwarder.base_url,
+            "POST",
+            "/v1/chat/completions",
+            token=lane_token,
+            payload=None,
+            extra_headers={"Content-Type": "application/json"},
+            raw_body=b'["not", "a", "chat", "request"]',
+        )
+        assert status == 200
+        assert upstream.seen[2]["payload"] == ["not", "a", "chat", "request"]
     finally:
         forwarder.close()
 

--- a/packages/benchmarks/scripts/acceptance_gate.py
+++ b/packages/benchmarks/scripts/acceptance_gate.py
@@ -108,7 +108,11 @@ TIMEOUT_AGENT_SMOKE_S = 120
 # boot + pinned dataset load + docker terminal sandbox + live agent loop), so
 # the old 240s budget killed healthy runs. 900s bounds a wedged lane while
 # leaving honest headroom for slower agent loops.
-TIMEOUT_BENCHMARK_RUN_S = 900
+# The slowest observed sanity leg (openclaw on tblite broken-python) completes
+# its evaluation in ~890s of real terminal turns plus setup/teardown; 900s was
+# killing legs at the finish line. Generous headroom, not a liveness proxy —
+# the orchestrator's own deadline policy owns hang detection.
+TIMEOUT_BENCHMARK_RUN_S = 1800
 TIMEOUT_RANDOM_RUN_S = 120
 
 


### PR DESCRIPTION
## What

Follow-up to #16954 (merged) — three fixes surfaced by driving the live acceptance gate against the real cloud proxy with all three harnesses:

1. **Capture-stop tool bridge** (openclaw + hermes native lanes): the bridges captured tool calls but fed placeholder acknowledgements back to the embedded agent loop, which kept iterating — measured **87 billed completions in a single env API turn** (sessions ending `status=length` with empty terminal turns). In capture-stop mode (engaged by the harness OpenAI proxy, which owns tool execution in the env sandbox) the embedded loop terminates after the first tool batch, marked as deferred external work so the terminal classifier reads delivery. Result: openclaw tblite leg went from unfinishable-within-wallclock to **succeeding in 594s**.
2. **De-streamed provider forwarder** (default): downstream `stream:true` served from one complete `stream:false` upstream completion synthesized into spec-compliant SSE (tool-call arguments exactly once) — insulates OpenAI-stream consumers from the deployed proxy's duplicated streamed tool-call arguments until #16973 reaches production. `ELIZA_FORWARDER_PASSTHROUGH_STREAMING=1` restores passthrough. Live-probed against the real cloud: valid frames, hermes-style accumulation parses.
3. **No artificial turn budgets** (campaign policy): terminal envs ran with upstream `max_agent_turns=60`, truncating hard tasks mid-repair — a budget measurement, not a capability measurement. The adapter now overrides to 1000 turns / 7200s wall (caller-overridable); the completion classifier scores any error-free rollout with real agent turns as a resource-bounded failure and keeps only zero-work rollouts unscoreable. Plus: acceptance-gate warmup retry for the proxy's transient 503 "authorization warming" responses, and the benchmark-leg timeout raised to observed runtimes.

## Evidence

- Adapter suites: openclaw-adapter **133 passed**, hermes-adapter **159 passed** (new: capture-stop plugin contract, de-stream immunity to the duplication bug, resource-bounded completion classification).
- Forwarder suite: **20 passed** incl. live-shape duplication-bug immunity; orchestrator suite 647 passed.
- Live gate progression across iterations: 1→4 passing steps; latest full runs show eliza 229s ✓, openclaw 594s ✓ (was unfinishable), hermes real 60-turn rollout now scoreable.
- Full acceptance-gate green run: in flight, will be posted as a comment (spends live credits; the campaign this unblocks is the ultimate evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)