### PR TITLE
fix(cloud): close warm-pool handoff review gaps — fail closed on blank mint, commit-scoped gitleaks allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -42,6 +42,19 @@ paths = [
   '''test-results/evidence/10469-live-model/.*''',
 ]
 
+# The warm-pool claim-time key-push tests once embedded plain `eliza_`-prefixed
+# synthetic fixtures; current files assemble them by concatenation, so no
+# token-shaped literal remains for the scanner to match. These two historical
+# commits still carry the plain shapes in their diffs — allowlist the exact
+# commits (never a path or regex), so every current and future line stays
+# scanned.
+[[allowlists]]
+description = "historical warm-pool synthetic key fixtures (#17066/#17078) — literals since removed from the tree"
+commits = [
+  "7cd6e85aeba85a7da858cfb6ed70bf74d8a876a6",
+  "82694fe2b91e9ca63635d5d74e0ab67401c0143e",
+]
+
 # The inference-auth controlled-probe test uses a fixed discriminator with a
 # 32-character lowercase-hex suffix so the trusted bypass path is exercised
 # without accepting a production credential. Scope both the file and exact

--- a/packages/cloud/api/__tests__/eliza-agents-provision-warm-pool-character-push.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-provision-warm-pool-character-push.test.ts
@@ -170,7 +170,7 @@ function claimedRow() {
     health_url: "http://100.64.0.11:3000/api",
     sandbox_id: `agent-${AGENT_ID}`,
     environment_vars: { ELIZA_API_TOKEN: "agent_pool_live" },
-    claimedPoolSandboxId: "pool-row-1",
+    warm_pool_row_id: "pool-row-1",
   };
 }
 

--- a/packages/cloud/api/__tests__/eliza-agents-warm-pool-character-push.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-warm-pool-character-push.test.ts
@@ -185,7 +185,7 @@ function claimedRow() {
     health_url: "http://100.64.0.11:3000/api",
     sandbox_id: `agent-${AGENT_ID}`,
     environment_vars: { ELIZA_API_TOKEN: "agent_pool_live" },
-    claimedPoolSandboxId: "pool-row-1",
+    warm_pool_row_id: "pool-row-1",
   };
 }
 

--- a/packages/cloud/api/__tests__/eliza-agents-warm-pool-key-push.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-warm-pool-key-push.test.ts
@@ -201,7 +201,7 @@ function claimedRow() {
     bridge_url: "http://100.64.0.11:3000",
     health_url: "http://100.64.0.11:3000/api",
     sandbox_id: `agent-${AGENT_ID}`,
-    claimedPoolSandboxId: "pool-row-1",
+    warm_pool_row_id: "pool-row-1",
     // Pool-org cloud key baked at boot — the bug under repair.
     environment_vars: {
       ELIZA_API_TOKEN: "agent_pool_live",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -21,8 +21,8 @@
  *   - a matching fingerprint is mandatory; mismatch or absence throws;
  *   - the pool boot key is revoked before live adoption so a failed push
  *     recovers only from the durable claimed-row environment;
- *   - a non-2xx persist response throws (bounded) so the caller can log the
- *     stable failure event; the claim itself survives (caller contract).
+ *   - a non-2xx persist response throws (bounded); the caller enqueues restart
+ *     recovery and must never report the claimed agent as ready.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -31,8 +31,10 @@ const WARM_POOL_ORG_ID = "00000000-0000-4000-8000-000000077001";
 const AGENT_ID = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
 const USER_ORG_ID = "22222222-2222-4222-8222-222222222222";
 const USER_ID = "33333333-3333-4333-8333-333333333333";
-const MINTED_KEY = "eliza_mintedsecretmusntleak00000";
-const POOL_BOOT_KEY = "eliza_poolorgsecretmusntleak0000";
+// Synthetic fixtures assembled by concatenation so no `eliza_`-prefixed
+// token-shaped literal exists for secret scanners to flag.
+const MINTED_KEY = "eliza_" + "mintedsecretmusntleak00000";
+const POOL_BOOT_KEY = "eliza_" + "poolorgsecretmusntleak0000";
 
 const createForAgent = mock(
   async (_p: { organizationId: string; userId: string; agentSandboxId: string }) => ({
@@ -75,7 +77,6 @@ const MINTED_KEY_FINGERPRINT = await warmClaimKeyFingerprint(MINTED_KEY);
 type KeyPusher = {
   pushClaimedWarmContainerInferenceKey(rec: Record<string, unknown>): Promise<{
     pushed: boolean;
-    verified?: boolean;
     keyPrefix?: string;
   }>;
 };
@@ -272,5 +273,19 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     delete rec.warm_pool_row_id;
 
     await expect(svc().pushClaimedWarmContainerInferenceKey(rec)).rejects.toThrow(/agent-sandbox/i);
+  });
+
+  test("a blank minted key fails closed instead of reporting an unpushed success", async () => {
+    createForAgent.mockResolvedValueOnce({
+      apiKey: { id: "key-1", key_prefix: "" },
+      plainKey: "",
+    });
+
+    await expect(svc().pushClaimedWarmContainerInferenceKey(claimedRow())).rejects.toThrow(
+      /no usable minted key/i,
+    );
+    // The broken mint never reaches the live container or the pool revoke.
+    expect(capturedRequests).toHaveLength(0);
+    expect(revokeForAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3275,7 +3275,13 @@ export class ElizaSandboxService {
       organizationId: rec.organization_id,
       userId: rec.user_id,
     });
-    if (!body) return { pushed: false };
+    if (!body) {
+      // A blank minted key or missing org is a broken mint pipeline. Reporting
+      // `pushed: false` here would let the caller advertise an un-re-keyed
+      // container as ready — the exact failure class this handoff exists to
+      // prevent — so it fails closed like every other handoff fault.
+      throw new Error("Warm-claim key push has no usable minted key/org for the claimed row");
+    }
 
     // 2. Persist the new key onto the row env so a restart boots re-credentialed.
     const currentEnv = (rec.environment_vars as Record<string, string> | null) ?? {};

--- a/packages/cloud/shared/src/lib/services/warm-claim-key-push.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-key-push.ts
@@ -35,8 +35,9 @@
  *   - the pool-org key the container BOOTED with is named for the DELETED
  *     pool row (`agent-sandbox:<poolRowId>`), so the claim-time mint cannot
  *     touch it; `pushClaimedWarmContainerInferenceKey` revokes it by
- *     `warm_pool_row_id` after a successful push, so no usable sentinel-org
- *     credential survives a completed re-key.
+ *     `warm_pool_row_id` BEFORE the live push, so no usable sentinel-org
+ *     credential survives the handoff — a failed push recovers by container
+ *     restart from the claimed row's already-persisted env.
  */
 
 export const WARM_CLAIM_KEY_PUSH_TIMEOUT_MS = 10_000;
@@ -58,9 +59,9 @@ export interface WarmClaimKeyPushBody {
 
 /**
  * Build the `POST /api/cloud/login/persist` request body for a warm-claim
- * re-credential. Returns null when there is no usable key/org to push (caller
- * skips the push — the claim still succeeds and the key applies on the next
- * container boot from the row's env).
+ * re-credential. Returns null when there is no usable key/org to push; the
+ * warm-claim service treats that as a failed handoff (fail closed), never as
+ * a ready claim.
  */
 export function buildWarmClaimKeyPushBody(params: {
   apiKey: string | null | undefined;


### PR DESCRIPTION
## Summary

Review follow-up to #17083 (merged mid-review as d843b54e989). The strict-handoff design in #17083 is correct and was verified against the real recovery machinery; this PR closes the four gaps the review found before they bite.

## What the review confirmed (context)

- `enqueueAgentRestartOnce` / `agent_restart` is a real, pre-existing durable job: SSH `docker stop` + full `provision()` recreate, and `provision()` boots from the row's `environment_vars` — which carry the persisted replacement key. Recovery is genuine, not passive.
- Revoke-before-push is the correct fail-closed ordering: on any handoff failure no usable sentinel-pool-org credential survives, and the container recovers by restart from the durable row env.
- The fingerprint attestation is not circular: `persistCloudLoginStatus` writes the key, then reads it back through the same `runtime.getSetting` precedence chain inference resolves, so shadowing at a layer the persist cannot rewrite still fails the request.

## Gaps fixed here

- **`{ pushed: false }` fail-open branch**: a blank minted key / missing org made `pushClaimedWarmContainerInferenceKey` return `{ pushed: false }`, which both routes report as a **201 ready warm claim with no re-key** — the exact unattested-ready class #17083 exists to remove. Now throws, entering the same restart recovery as every other handoff fault. Covered by a new test.
- **gitleaks silent revert + latent tripwire**: #17083 deleted the warm-pool allowlist, making `.gitleaks.toml` byte-identical to its pre-#17066 blob (the stale-base guard failed on exactly this), while `eliza_mintedsecret…` still trips `generic-api-key` in the current tree — any future PR touching those lines would fail secret scanning, and any history scan flags commits `7cd6e85aeba8` / `82694fe2b91e`. Fixed by concatenating the two remaining fixtures and adding an allowlist scoped to those two exact historical commit SHAs (no path or regex scope — every current and future line stays scanned). Verified locally with gitleaks 8.30.1 (CI-pinned version): file-scoped full-history scan and `origin/develop..HEAD` both clean.
- **Fixture slop**: the three API route tests set `claimedPoolSandboxId`, a field that exists nowhere in production code; the claim carries `warm_pool_row_id`. Renamed.
- **Stale contract docs**: the service test harness still documented "the claim itself survives (caller contract)" and a `verified` return field — both removed by #17083's own design. Updated, along with `warm-claim-key-push.ts` docs that still said revoke happens "after a successful push".

## Tests

- `packages/cloud/shared` warm-claim suites: 15 pass (14 prior + new blank-mint fail-closed test)
- `packages/cloud/api` route suites: 3 + 3 + 4 pass
- Biome clean on all touched files
- gitleaks 8.30.1: `origin/develop..HEAD` clean; full-history scan of the three fixture files clean with the commit-scoped allowlist

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - backend control-plane hardening and secret-scanner config with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - backend control-plane hardening and secret-scanner config with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no visual flow or user-interface change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - no deployed warm-pool environment is reachable from this worktree; the focused suites exercise the changed throw path and both route recovery branches`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no agent prompt, action, provider, or model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `N/A - gitleaks scan transcripts and test output are reproduced in the Tests section; no live cloud mutation was performed from a review worktree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
