### PR TITLE
fix(app-core): lock and exercise adm-zip 0.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -353,7 +353,7 @@
         "@elizaos/vault": "workspace:*",
         "@node-rs/argon2": "^2.0.2",
         "@upstash/redis": "^1.37.0",
-        "adm-zip": "^0.5.18",
+        "adm-zip": "^0.6.0",
         "chalk": "^5.3.0",
         "commander": "^15.0.0",
         "dotenv": "^17.2.3",
@@ -10198,7 +10198,7 @@
 
     "add-stream": ["add-stream@1.0.0", "", {}, "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ=="],
 
-    "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "adze": ["adze@2.3.0", "", { "dependencies": { "@ungap/structured-clone": "1.2.0", "picocolors": "1.1.1" } }, "sha512-c5I7uXn5jZ075LbW0lhkmllq4OLQsLHbEV63MbykOQr/VPIOdTgbxGH4QoXHqakAUO3rUSEmURd5eM9GgpJB6g=="],
 
@@ -14265,6 +14265,8 @@
     "@atproto/xrpc/@atproto/lexicon": ["@atproto/lexicon@0.6.2", "", { "dependencies": { "@atproto/common-web": "^0.4.18", "@atproto/syntax": "^0.5.0", "iso-datestring-validator": "^2.2.2", "multiformats": "^9.9.0", "zod": "^3.23.8" } }, "sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw=="],
 
     "@atproto/xrpc/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@avalix/chroma/adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 

--- a/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
@@ -1044,6 +1044,45 @@ describe("Android artifact boundary selection", () => {
     ).toBe("base dex");
   });
 
+  it("parses and bounds the committed multi-module AAB without bundletool", () => {
+    const artifactBytes = fs.readFileSync(REAL_AAB_FIXTURE);
+    const entries = listAndroidArtifactEntries(REAL_AAB_FIXTURE, JAVA_HOME, {
+      artifactBytes,
+    });
+
+    expect(entries).toContain("base/manifest/AndroidManifest.xml");
+    expect(entries).toContain("base/dex/classes.dex");
+    expect(entries).toContain("initialInstall/dex/classes.dex");
+    expect(
+      readAndroidArtifactEntryBuffers(
+        REAL_AAB_FIXTURE,
+        ["base/dex/classes.dex"],
+        JAVA_HOME,
+        { artifactBytes },
+      )[0].byteLength,
+    ).toBeGreaterThan(0);
+  });
+
+  it("rejects attacker-sized declarations before payload decoding", () => {
+    const entry = "base/dex/classes.dex";
+    const archive = rewriteEntryDeclaredSize(
+      zipSync({ [entry]: Buffer.from("bounded payload") }),
+      entry,
+      0xffffffff,
+    );
+
+    expect(() =>
+      readAndroidArtifactEntryBuffers(
+        "/artifact.aab",
+        [entry],
+        JAVA_HOME,
+        { artifactBytes: archive },
+      ),
+    ).toThrow(
+      expect.objectContaining({ code: "ANDROID_ARTIFACT_ENTRY_TOO_LARGE" }),
+    );
+  });
+
   it("rejects compressed-byte declarations above the audit limit", () => {
     const archive = zipSync(
       {


### PR DESCRIPTION
## Problem

#17085 changed the direct `adm-zip` range used by the Android APK/AAB auditor
from `^0.5.18` to `^0.6.0` but did not update the root Bun lockfile. At its
merged head, a clean `bun install --frozen-lockfile --ignore-scripts` fails
with `lockfile had changes`, so the security update was not reproducibly
installable.

This dependency parses untrusted Android artifact ZIP metadata. The upgrade is
desirable, but a manifest-only bump is not a completed security fix.

## Core fix

- Lock the app-core workspace to the resolved `adm-zip@0.6.0` artifact and keep
  `@avalix/chroma` on its separately resolved `0.5.18` dependency.
- Exercise `0.6.0` against the committed 1.1 MB multi-module AAB fixture without
  relying on bundletool or a mocked archive.
- Add an adversarial `0xffffffff` uncompressed-size declaration and prove the
  audit boundary rejects it before payload decoding/allocation.

## Verification

- Before, at merge `e6aa8e68d084049f04353e05358754348c78537b`:
  `bun install --frozen-lockfile --ignore-scripts` — fails because the lockfile
  would change.
- After, at `04fdc90da21cd0012018f2244dd2cbe0cf8cf3bd`:
  `bun install --frozen-lockfile --ignore-scripts` — passes and installs the
  locked graph.
- `bun test packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs`
  — 69 pass, 6 toolchain-gated bundletool tests skipped, 0 fail, 173 assertions.
- The new real-fixture parser test reads the committed AAB and expands its real
  base DEX under the existing explicit output bounds.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changes; this is a build-time archive parser dependency.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes; this is a build-time archive parser dependency.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive product flow changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no running backend path changes; the affected boundary is the mobile build auditor.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser or frontend code changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or agent behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] [Real multi-module AAB fixture exercised by the regression test](https://github.com/elizaOS/eliza/blob/04fdc90da21cd0012018f2244dd2cbe0cf8cf3bd/packages/app-core/test/fixtures/android/install-time-permanent-modules.aab)

## Manual review

The lock diff was manually reduced to the three semantic resolution changes:
the app-core workspace range, the root `0.6.0` package integrity record, and
the nested `0.5.18` resolution still required by `@avalix/chroma`. No lockfile
reordering or unrelated dependency churn is included.
