### PR TITLE
fix(ci): restore develop merge protections removed by #17077

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -108,8 +108,8 @@ directly.
 
 The heavy post-merge develop **test lanes** in `test.yml` run on the self-hosted
 `self-hosted, hetzner-robot` pool (GitHub-hosted minutes are billing-frozen for
-this org, #13481). Pull requests use the ordinary lint, typecheck, build, and
-security workflows and remain independent of the exhaustive fleet:
+this org, #13481). Everything the pre-merge **Develop PR Gate** depends on is
+the lightweight PR surface and remains independent of the exhaustive fleet:
 
 - **Path classifiers** (`Classify changed paths`) across `test.yml`,
   `scenario-pr.yml`, `dev-smoke.yml`, `docker-ci-smoke.yml`,
@@ -117,9 +117,18 @@ security workflows and remain independent of the exhaustive fleet:
   `windows-desktop-preload-smoke.yml` run on `ubuntu-24.04`. They are git-diff +
   node scripts with no self-hosted needs; pinning them to the fleet (#8501) once
   left every downstream job queued indefinitely and gridlocked develop.
+- **`Develop PR Gate`** runs on `ubuntu-24.04` and only observes check metadata
+  from the nine lightweight component contexts. It never waits for post-merge,
+  scheduled, device, aesthetic, or exhaustive suites.
 - **`ci-ok`**, `plugin-tests-status`, and `merge-quality-gate` remain hosted
   roll-ups inside the post-merge `test.yml` orchestrator. They report branch
   health after a develop push; they are not the pre-merge required context.
+
+The aggregate contract runs directly under Node in
+`packages/scripts/develop-pr-aggregate.self-test.mjs`; the changed-file gate
+loads the same assertions through
+`packages/scripts/develop-pr-aggregate.test.mjs` so the implementation also
+appears in changed-source coverage reporting.
 
 Two SPOF guards, enforced by `packages/scripts/ci-merge-gate-contract.mjs` (run
 in the `changes` job, #13617):

--- a/.github/workflows/develop-pr-gate.yml
+++ b/.github/workflows/develop-pr-gate.yml
@@ -1,0 +1,70 @@
+# Base-trusted aggregate for the lightweight develop pull-request gate. It
+# observes GitHub check metadata only: the privileged pull_request_target job
+# never checks out or executes pull-request code, receives no secrets, and has
+# read-only permissions. The stable job stays pending until every component is
+# terminal and fails for every outcome except success.
+name: Develop PR Gate
+
+on:
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      canary:
+        description: Deterministic terminal-state canary (success is the only green outcome)
+        required: true
+        type: choice
+        options:
+          - success
+          - missing
+          - cancelled
+          - timed-out
+          - failed
+          - skipped
+          - pending-timeout
+
+concurrency:
+  group: develop-pr-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+permissions:
+  contents: read
+  checks: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Develop PR Gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      AGGREGATE_EVENT_NAME: ${{ github.event_name }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      PR_ACTION: ${{ github.event.action || '' }}
+      PR_UPDATED_AT: ${{ github.event.pull_request.updated_at || '' }}
+      POLL_TIMEOUT_SECONDS: "2400"
+      POLL_INTERVAL_SECONDS: "30"
+      CANARY_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}
+    steps:
+      - name: Check out the trusted aggregate implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Verify the aggregate state machine and workflow contract
+        run: node packages/scripts/develop-pr-aggregate.self-test.mjs
+
+      - name: Evaluate required develop checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node packages/scripts/develop-pr-aggregate.mjs

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,37 @@ permissions:
   contents: read
 
 jobs:
+  check-pr-evidence:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # Full history so the merge-base of the PR base and head resolves — the
+          # evidence diff must reflect only THIS PR's changes, not whatever landed
+          # on the base branch after the PR's branch point (#16125).
+          fetch-depth: 0
+
+      - name: Validate PR evidence rows
+        run: |
+          jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/pr-body.md"
+          PR_LABELS=$(jq -r '.pull_request.labels | map(.name) | join(",")' "$GITHUB_EVENT_PATH")
+          BASE_SHA=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+          HEAD_SHA=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
+          git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"
+          # Three-dot: diff the merge-base..head, i.e. only what THIS PR changed,
+          # not files the base branch advanced past the branch point (#16125).
+          git diff --name-only --diff-filter=ACMRT "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr-changed-files.txt"
+          git diff --name-only --diff-filter=A "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr-added-files.txt"
+          node scripts/check-pr-evidence.mjs \
+            --body-file "$RUNNER_TEMP/pr-body.md" \
+            --labels "$PR_LABELS" \
+            --changed-files-file "$RUNNER_TEMP/pr-changed-files.txt" \
+            --added-files-file "$RUNNER_TEMP/pr-added-files.txt"
+
   check-pr-title:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/stale-base-guard.yml
+++ b/.github/workflows/stale-base-guard.yml
@@ -1,0 +1,118 @@
+# Stale Base Guard
+#
+# Blocks the PR #11271 failure mode: a PR whose tree carries stale file
+# contents (an old checkout committed onto a fresh-looking base), so that
+# squash-merging it silently reverts work already merged on the target branch.
+# #11271 landed 304 files (+6,532/−21,579) titled as a small cloud-refund
+# refactor; its merge-base was 8 minutes old, so no base-age check could have
+# caught it — the reverts were inside the PR's own diff. Restoration epic:
+# #11419; this guard is the final acceptance criterion of #11376.
+#
+# What runs (packages/scripts/stale-base-guard.mjs, plumbing-only, seconds):
+#   1. Silent-revert detection — fail when the PR sets a file byte-identically
+#      back to an older blob from the target branch's history, discarding
+#      newer merged work. Re-land/heal PRs (restoring work a clobber reverted)
+#      pass; deletion-only findings are non-blocking notices unless a
+#      modification-revert corroborates the stale-tree signature.
+#   2. Staleness backstop — fail when the merge-base is > 200 first-parent
+#      commits or > 72h behind the target tip.
+#
+# Override: apply the `stale-base-ack` label for a deliberate revert — the
+# guard then passes with loud warnings instead of failing.
+#
+# The guard script + self-test are taken from the BASE branch, so a PR cannot
+# neuter the logic that gates it (bootstrap exception: while the base branch
+# predates the guard, the PR's own copy is used, with a notice). History is
+# fetched blobless (--filter=blob:none): the detector compares object ids only
+# and never reads file contents (~15 MB, a few seconds for the 1500-commit
+# window on this repo; the whole job runs well under a minute).
+name: Stale Base Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+concurrency:
+  group: stale-base-guard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: stale-base guard
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 10
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      ACK: ${{ contains(github.event.pull_request.labels.*.name, 'stale-base-ack') && '1' || '' }}
+    steps:
+      - name: Checkout target branch (guard logic comes from the base, not the PR)
+        # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          # The guard disables lazy promisor fetches while it runs. Fetch the
+          # same bounded history window up front so merge commits can resolve
+          # their parents without network fallback.
+          fetch-depth: 1500
+          filter: blob:none
+          submodules: false
+
+      # The guard steps below invoke `node` directly, but self-hosted
+      # (hetzner-robot) runners are not guaranteed to have Node on PATH, so
+      # the self-test step fails with "node: command not found". Set up Node
+      # explicitly; this workflow does not use setup-bun-workspace.
+      - name: Setup Node.js
+        # actions/setup-node@v4 (48b55a0)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Fetch PR head + bounded history (blobless)
+        run: |
+          set -euo pipefail
+          git fetch --quiet --no-tags --filter=blob:none --depth=1500 origin \
+            "$HEAD_SHA" \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Snapshot the guard from the base branch
+        run: |
+          set -euo pipefail
+          if [ -f packages/scripts/stale-base-guard.mjs ]; then
+            cp packages/scripts/stale-base-guard.mjs \
+               packages/scripts/stale-base-guard.self-test.mjs \
+               "$RUNNER_TEMP/"
+          else
+            # Bootstrap: the base branch predates the guard — only possible on
+            # the PR that first lands it (and forks of that moment). Uses the
+            # PR's own copy; lazy blob fetch is allowed for just these two reads.
+            echo "::notice::stale-base guard is not on the base branch yet — bootstrapping the script from the PR head."
+            git show "${HEAD_SHA}:packages/scripts/stale-base-guard.mjs" \
+              > "$RUNNER_TEMP/stale-base-guard.mjs"
+            git show "${HEAD_SHA}:packages/scripts/stale-base-guard.self-test.mjs" \
+              > "$RUNNER_TEMP/stale-base-guard.self-test.mjs"
+          fi
+
+      - name: Self-test the guard on fixture repos
+        run: node "$RUNNER_TEMP/stale-base-guard.self-test.mjs"
+
+      - name: Detect silent reverts + stale base
+        env:
+          # The detector is plumbing-only; hard-disable promisor blob fetches
+          # so an accidental content read fails loudly instead of hitting the
+          # network.
+          GIT_NO_LAZY_FETCH: "1"
+        run: |
+          set -euo pipefail
+          node "$RUNNER_TEMP/stale-base-guard.mjs" \
+            --base "refs/remotes/origin/${BASE_REF}" \
+            --head "$HEAD_SHA" \
+            --window 1200 \
+            --max-behind-commits 200 \
+            --max-behind-hours 72 \
+            ${ACK:+--ack} \
+            --github \
+            --summary "$GITHUB_STEP_SUMMARY"

--- a/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
+++ b/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Static contract for the base-trusted develop pull-request aggregate.
+ * It binds the stable check name to a hosted, read-only workflow and verifies
+ * that every polled context still belongs to an always-emitted owner workflow
+ * with the activity types modeled by the aggregate state machine.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  AGGREGATE_TRIGGER_ACTIONS,
+  CANARY_SCENARIOS,
+  DEFAULT_PULL_REQUEST_ACTIONS,
+  REQUIRED_CHECKS,
+} from "./develop-pr-aggregate.mjs";
+
+const DEFAULT_REPO_ROOT = resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+);
+const AGGREGATE_WORKFLOW = ".github/workflows/develop-pr-gate.yml";
+export const TRUSTED_BASE_REF_LINE =
+  "ref: $" + "{{ github.event.pull_request.base.sha || github.sha }}";
+export const OBSERVED_HEAD_LINE =
+  "HEAD_SHA: $" + "{{ github.event.pull_request.head.sha || github.sha }}";
+export const DISPATCH_CANARY_LINE =
+  "CANARY_SCENARIO: $" +
+  "{{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function assertIncludes(text, fragment, message) {
+  assert(text.includes(fragment), `${message}: missing ${fragment}`);
+}
+
+function assertEqual(actual, expected, message) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  assert(
+    actualJson === expectedJson,
+    `${message}: expected ${expectedJson}, got ${actualJson}`,
+  );
+}
+
+function unquote(value) {
+  return value.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/, "$1$2");
+}
+
+function inlineList(block, key, fallback = null) {
+  const match = block.match(
+    new RegExp(`^\\s{4}${key}:\\s*\\[([^\\]]*)\\]\\s*$`, "m"),
+  );
+  if (!match) return fallback;
+  return match[1].split(",").map(unquote).filter(Boolean);
+}
+
+function eventBlock(text, eventName, workflowPath) {
+  const lines = text.split(/\r?\n/);
+  const onIndex = lines.indexOf("on:");
+  assert(onIndex >= 0, `${workflowPath}: missing on mapping`);
+  const eventIndex = lines.findIndex(
+    (line, index) => index > onIndex && line === `  ${eventName}:`,
+  );
+  assert(eventIndex >= 0, `${workflowPath}: missing on.${eventName}`);
+  const selected = [];
+  for (let index = eventIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^\S/.test(line) || /^ {2}\S/.test(line)) break;
+    selected.push(line);
+  }
+  return selected.join("\n");
+}
+
+function count(text, pattern) {
+  return Array.from(text.matchAll(pattern)).length;
+}
+
+export function validateAggregateWorkflow(workflow) {
+  assertIncludes(workflow, "name: Develop PR Gate", "workflow name");
+  assertIncludes(
+    workflow,
+    "  pull_request_target:",
+    "base-trusted pull-request trigger",
+  );
+  assert(
+    !/^ {2}pull_request:/m.test(workflow),
+    "aggregate must not run PR-controlled workflow code via pull_request",
+  );
+  const targetBlock = eventBlock(
+    workflow,
+    "pull_request_target",
+    AGGREGATE_WORKFLOW,
+  );
+  assertEqual(
+    inlineList(targetBlock, "branches"),
+    ["develop"],
+    "aggregate target branches",
+  );
+  assertEqual(
+    inlineList(targetBlock, "types"),
+    AGGREGATE_TRIGGER_ACTIONS,
+    "aggregate activity types",
+  );
+  assert(
+    !/^\s+(paths|paths-ignore):/m.test(targetBlock),
+    "aggregate trigger must always emit; paths filters are forbidden",
+  );
+  assertIncludes(workflow, "  workflow_dispatch:", "canary dispatch trigger");
+  for (const scenario of CANARY_SCENARIOS) {
+    assertIncludes(workflow, `          - ${scenario}`, `canary ${scenario}`);
+  }
+
+  assertIncludes(workflow, "  contents: read", "contents permission");
+  assertIncludes(workflow, "  checks: read", "checks permission");
+  assertIncludes(workflow, "  actions: read", "actions permission");
+  assertIncludes(workflow, "  pull-requests: read", "pull-request permission");
+  assert(
+    !/^\s+[a-z-]+:\s*write\s*$/m.test(workflow),
+    "aggregate token permissions must remain read-only",
+  );
+  assert(
+    !workflow.includes("${{ secrets."),
+    "aggregate must not receive repository or organization secrets",
+  );
+
+  assertIncludes(workflow, "    name: Develop PR Gate", "stable job name");
+  assertIncludes(workflow, "    runs-on: ubuntu-24.04", "hosted runner");
+  assertIncludes(workflow, "    timeout-minutes: 45", "bounded timeout");
+  assertEqual(
+    count(workflow, /uses:\s*actions\/checkout@/g),
+    1,
+    "aggregate checkout count",
+  );
+  assertIncludes(workflow, TRUSTED_BASE_REF_LINE, "trusted base checkout ref");
+  assertIncludes(
+    workflow,
+    "persist-credentials: false",
+    "checkout credential isolation",
+  );
+  assert(
+    !workflow.includes("allow-unsafe-pr-checkout"),
+    "aggregate may never opt into an untrusted pull-request checkout",
+  );
+  assertIncludes(workflow, OBSERVED_HEAD_LINE, "PR head observation target");
+  assertIncludes(
+    workflow,
+    "node packages/scripts/develop-pr-aggregate.self-test.mjs",
+    "deterministic state-machine self-test",
+  );
+  assertIncludes(
+    workflow,
+    "node packages/scripts/develop-pr-aggregate.mjs",
+    "aggregate runner",
+  );
+  assertIncludes(
+    workflow,
+    DISPATCH_CANARY_LINE,
+    "dispatch-only canary boundary",
+  );
+}
+
+function validateOwnerWorkflow(text, workflowPath, expectedActions) {
+  const block = eventBlock(text, "pull_request", workflowPath);
+  const branches = inlineList(block, "branches", []);
+  assert(
+    branches.length === 0 || branches.includes("develop"),
+    `${workflowPath}: pull_request trigger does not cover develop`,
+  );
+  assert(
+    !/^\s+(paths|paths-ignore):/m.test(block),
+    `${workflowPath}: required owner may not disappear behind a path filter`,
+  );
+  assertEqual(
+    inlineList(block, "types", DEFAULT_PULL_REQUEST_ACTIONS),
+    expectedActions,
+    `${workflowPath}: modeled pull_request activity types`,
+  );
+}
+
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const read = (relativePath) =>
+    readFileSync(resolve(repoRoot, relativePath), "utf8");
+  const aggregateWorkflow = read(AGGREGATE_WORKFLOW);
+  validateAggregateWorkflow(aggregateWorkflow);
+
+  const checksByWorkflow = Map.groupBy(
+    REQUIRED_CHECKS,
+    ({ workflowPath }) => workflowPath,
+  );
+  for (const [workflowPath, checks] of checksByWorkflow) {
+    const workflow = read(workflowPath);
+    const expectedActions = checks[0].triggerActions;
+    for (const check of checks) {
+      assertEqual(
+        check.triggerActions,
+        expectedActions,
+        `${workflowPath}: contexts disagree about owner activity types`,
+      );
+      const marker =
+        check.context === "lint" ||
+        check.context === "typecheck" ||
+        check.context === "build" ||
+        check.context === "check-pr-evidence" ||
+        check.context === "check-pr-title"
+          ? `  ${check.context}:`
+          : `name: ${check.context}`;
+      assertIncludes(
+        workflow,
+        marker,
+        `${workflowPath}: owner for ${check.context}`,
+      );
+    }
+    validateOwnerWorkflow(workflow, workflowPath, expectedActions);
+  }
+
+  const contexts = REQUIRED_CHECKS.map(({ context }) => context);
+  assertEqual(
+    new Set(contexts).size,
+    contexts.length,
+    "required context names must be unique",
+  );
+  assert(
+    !contexts.includes("Develop PR Gate"),
+    "aggregate must not require its own check context",
+  );
+  return { ok: true, contexts };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const result = runContract();
+  console.log(
+    `develop-pr aggregate workflow contract passed (${result.contexts.length} contexts)`,
+  );
+}

--- a/packages/scripts/develop-pr-aggregate.mjs
+++ b/packages/scripts/develop-pr-aggregate.mjs
@@ -1,0 +1,597 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed state machine for the hosted develop pull-request aggregate.
+ * The base-trusted workflow supplies the PR head SHA, while this module binds
+ * each required check to its owning workflow and waits for one terminal result
+ * per context. Missing and non-success terminal states never become green.
+ */
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const GITHUB_ACTIONS_APP_ID = 15368;
+export const DEFAULT_PULL_REQUEST_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+];
+
+const DEVELOP_PR_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+];
+const PR_METADATA_ACTIONS = [
+  "opened",
+  "edited",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+];
+const STALE_BASE_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+];
+
+export const REQUIRED_CHECKS = Object.freeze([
+  {
+    context: "lint",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "typecheck",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "build",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "gitleaks",
+    workflowPath: ".github/workflows/gitleaks.yml",
+    triggerActions: DEFAULT_PULL_REQUEST_ACTIONS,
+  },
+  {
+    context: "check-pr-evidence",
+    workflowPath: ".github/workflows/pr.yaml",
+    triggerActions: PR_METADATA_ACTIONS,
+  },
+  {
+    context: "check-pr-title",
+    workflowPath: ".github/workflows/pr.yaml",
+    triggerActions: PR_METADATA_ACTIONS,
+  },
+  {
+    context: "stale-base guard",
+    workflowPath: ".github/workflows/stale-base-guard.yml",
+    triggerActions: STALE_BASE_ACTIONS,
+  },
+]);
+
+export const AGGREGATE_TRIGGER_ACTIONS = Object.freeze(
+  Array.from(
+    new Set(REQUIRED_CHECKS.flatMap(({ triggerActions }) => triggerActions)),
+  ),
+);
+
+export const CANARY_SCENARIOS = Object.freeze([
+  "success",
+  "missing",
+  "cancelled",
+  "timed-out",
+  "failed",
+  "skipped",
+  "pending-timeout",
+]);
+
+const SUCCESS_CONCLUSION = "success";
+const COMPLETED_STATUS = "completed";
+const API_VERSION = "2022-11-28";
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+const FRESHNESS_SKEW_MS = 10_000;
+const DEFAULT_TERMINAL_SETTLE_MS = 15_000;
+const DEFAULT_API_MAX_ATTEMPTS = 5;
+const DEFAULT_API_RETRY_BASE_MS = 1_000;
+const DEFAULT_API_RETRY_CAP_MS = 8_000;
+
+function parseTimestamp(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function latestById(runs) {
+  return runs.reduce(
+    (latest, run) =>
+      latest === null || Number(run.id) > Number(latest.id) ? run : latest,
+    null,
+  );
+}
+
+function detailForRun(run) {
+  return run.details_url || `check-run ${run.id}`;
+}
+
+function waitingResult(required, code, detail, run = null) {
+  return {
+    ...required,
+    state: "waiting",
+    code,
+    detail,
+    url: run?.details_url ?? null,
+  };
+}
+
+function failedResult(required, code, detail, run = null) {
+  return {
+    ...required,
+    state: "failed",
+    code,
+    detail,
+    url: run?.details_url ?? null,
+  };
+}
+
+/**
+ * Evaluates one API snapshot. Callers decide when the polling deadline has
+ * elapsed; before then, missing/queued/stale observations remain waiting.
+ */
+export function evaluateAggregate({
+  checkRuns,
+  headSha,
+  eventAction,
+  eventUpdatedAt,
+  nowMs,
+  deadlineReached = false,
+  terminalSettleMs = DEFAULT_TERMINAL_SETTLE_MS,
+}) {
+  const eventUpdatedMs = parseTimestamp(eventUpdatedAt);
+  const freshAfterMs =
+    eventUpdatedMs === null ? null : eventUpdatedMs - FRESHNESS_SKEW_MS;
+
+  const results = REQUIRED_CHECKS.map((required) => {
+    const candidates = checkRuns.filter(
+      (run) =>
+        run.name === required.context &&
+        Number(run.app_id) === GITHUB_ACTIONS_APP_ID &&
+        run.workflow_path === required.workflowPath &&
+        run.workflow_event === "pull_request" &&
+        run.workflow_head_sha === headSha,
+    );
+    const run = latestById(candidates);
+
+    if (run === null) {
+      const detail = `no GitHub Actions check run from ${required.workflowPath}`;
+      return deadlineReached
+        ? failedResult(required, "missing", detail)
+        : waitingResult(required, "missing", detail);
+    }
+
+    const freshRunRequired = required.triggerActions.includes(eventAction);
+    const startedMs = parseTimestamp(run.started_at);
+    if (
+      freshRunRequired &&
+      (freshAfterMs === null || startedMs === null || startedMs < freshAfterMs)
+    ) {
+      const detail = `latest owner run predates ${eventAction} event`;
+      return deadlineReached
+        ? failedResult(required, "stale-event-result", detail, run)
+        : waitingResult(required, "stale-event-result", detail, run);
+    }
+
+    if (run.status !== COMPLETED_STATUS) {
+      const detail = `${detailForRun(run)} is ${run.status || "unknown"}`;
+      return deadlineReached
+        ? failedResult(required, "pending-timeout", detail, run)
+        : waitingResult(required, "pending", detail, run);
+    }
+
+    if (run.conclusion === SUCCESS_CONCLUSION) {
+      return {
+        ...required,
+        state: "passed",
+        code: "success",
+        detail: `${detailForRun(run)} concluded success`,
+        url: run.details_url ?? null,
+      };
+    }
+
+    const completedMs = parseTimestamp(run.completed_at);
+    if (
+      !deadlineReached &&
+      completedMs !== null &&
+      nowMs - completedMs < terminalSettleMs
+    ) {
+      return waitingResult(
+        required,
+        "terminal-settling",
+        `${detailForRun(run)} concluded ${run.conclusion || "unknown"}; waiting briefly for a superseding rerun`,
+        run,
+      );
+    }
+
+    if (run.conclusion === "skipped") {
+      return failedResult(
+        required,
+        "skipped-forbidden",
+        `${detailForRun(run)} was skipped; required workflows must classify paths inside an always-emitted job`,
+        run,
+      );
+    }
+
+    return failedResult(
+      required,
+      `terminal-${run.conclusion || "unknown"}`,
+      `${detailForRun(run)} concluded ${run.conclusion || "unknown"}`,
+      run,
+    );
+  });
+
+  const failed = results.filter(({ state }) => state === "failed");
+  const waiting = results.filter(({ state }) => state === "waiting");
+  return {
+    verdict:
+      failed.length > 0
+        ? "failure"
+        : waiting.length > 0
+          ? "waiting"
+          : "success",
+    results,
+    counts: {
+      passed: results.length - failed.length - waiting.length,
+      waiting: waiting.length,
+      failed: failed.length,
+    },
+  };
+}
+
+function extractWorkflowRunId(detailsUrl) {
+  if (typeof detailsUrl !== "string") return null;
+  const match = detailsUrl.match(/\/actions\/runs\/(\d+)\/job\/\d+/);
+  return match ? Number(match[1]) : null;
+}
+
+function apiHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "elizaOS-develop-pr-aggregate",
+    "X-GitHub-Api-Version": API_VERSION,
+  };
+}
+
+function isRetryableApiStatus(status) {
+  return status === 429 || status >= 500;
+}
+
+function retryDelayMs(response, attempt, baseDelayMs, nowMs) {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    const hintedMs = Number.isFinite(seconds)
+      ? seconds * 1_000
+      : Date.parse(retryAfter) - nowMs;
+    if (Number.isFinite(hintedMs) && hintedMs > 0) {
+      return Math.min(hintedMs, DEFAULT_API_RETRY_CAP_MS);
+    }
+  }
+
+  return Math.min(baseDelayMs * 2 ** (attempt - 1), DEFAULT_API_RETRY_CAP_MS);
+}
+
+export async function requestJson(
+  url,
+  token,
+  {
+    fetchImpl = globalThis.fetch,
+    sleepImpl = sleep,
+    maxAttempts = DEFAULT_API_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_API_RETRY_BASE_MS,
+    now = Date.now,
+  } = {},
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, { headers: apiHeaders(token) });
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `GitHub API request failed for ${url} after ${maxAttempts} attempts: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+      const delayMs = Math.min(
+        baseDelayMs * 2 ** (attempt - 1),
+        DEFAULT_API_RETRY_CAP_MS,
+      );
+      console.warn(
+        `GitHub API request failed for ${url}; retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts})`,
+      );
+      await sleepImpl(delayMs);
+      continue;
+    }
+
+    if (response.ok) return response.json();
+
+    const body = await response.text();
+    const detail = `GitHub API ${response.status} for ${url}: ${body.slice(0, 500)}`;
+    if (!isRetryableApiStatus(response.status) || attempt === maxAttempts) {
+      throw new Error(detail);
+    }
+
+    const delayMs = retryDelayMs(response, attempt, baseDelayMs, now());
+    console.warn(
+      `${detail}; retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts})`,
+    );
+    await sleepImpl(delayMs);
+  }
+
+  throw new Error(`GitHub API retry loop exhausted for ${url}`);
+}
+
+export async function loadOwnedCheckRuns({
+  repository,
+  headSha,
+  token,
+  workflowRunCache = new Map(),
+}) {
+  const requiredNames = new Set(REQUIRED_CHECKS.map(({ context }) => context));
+  const rawRuns = [];
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url =
+      `https://api.github.com/repos/${repository}/commits/${headSha}/check-runs` +
+      `?filter=all&per_page=${PAGE_SIZE}&page=${page}&app_id=${GITHUB_ACTIONS_APP_ID}`;
+    const payload = await requestJson(url, token);
+    const pageRuns = Array.isArray(payload.check_runs)
+      ? payload.check_runs
+      : [];
+    rawRuns.push(...pageRuns.filter(({ name }) => requiredNames.has(name)));
+    // total_count covers every Actions check on the commit, while rawRuns is
+    // intentionally narrowed to required names. Page fullness is therefore
+    // the reliable pagination boundary for this filtered in-memory set.
+    if (pageRuns.length < PAGE_SIZE) {
+      break;
+    }
+  }
+
+  const runIds = new Set(
+    rawRuns
+      .map(({ details_url: detailsUrl }) => extractWorkflowRunId(detailsUrl))
+      .filter((runId) => runId !== null),
+  );
+  for (const runId of runIds) {
+    if (workflowRunCache.has(runId)) continue;
+    const workflowRun = await requestJson(
+      `https://api.github.com/repos/${repository}/actions/runs/${runId}`,
+      token,
+    );
+    workflowRunCache.set(runId, {
+      path: workflowRun.path,
+      event: workflowRun.event,
+      headSha: workflowRun.head_sha,
+    });
+  }
+
+  return rawRuns.map((run) => {
+    const workflowRunId = extractWorkflowRunId(run.details_url);
+    const owner =
+      workflowRunId === null ? null : workflowRunCache.get(workflowRunId);
+    return {
+      ...run,
+      app_id: run.app?.id,
+      workflow_path: owner?.path ?? null,
+      workflow_event: owner?.event ?? null,
+      workflow_head_sha: owner?.headSha ?? null,
+    };
+  });
+}
+
+function escapeCell(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+export function renderSummary(evaluation, { headSha, eventAction, attempt }) {
+  const lines = [
+    "### Develop PR Gate",
+    "",
+    `- Head SHA: \`${headSha}\``,
+    `- Pull-request action: \`${eventAction}\``,
+    `- Poll attempt: ${attempt}`,
+    `- Verdict: **${evaluation.verdict}**`,
+    `- Passed / waiting / failed: ${evaluation.counts.passed} / ${evaluation.counts.waiting} / ${evaluation.counts.failed}`,
+    "",
+    "| Required context | Owning workflow | State | Detail |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const result of evaluation.results) {
+    const detail = result.url
+      ? `[${escapeCell(result.detail)}](${result.url})`
+      : escapeCell(result.detail);
+    lines.push(
+      `| ${escapeCell(result.context)} | \`${escapeCell(result.workflowPath)}\` | ${result.state} | ${detail} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeSummary(summary) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub creates this per-job file outside Turbo's cache contract.
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (path) writeFileSync(path, summary);
+}
+
+function positiveInteger(value, name, fallback) {
+  const resolved = value === undefined || value === "" ? fallback : value;
+  if (!/^\d+$/.test(String(resolved)) || Number(resolved) <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return Number(resolved);
+}
+
+function validateProductionEnvironment(env) {
+  if (env.AGGREGATE_EVENT_NAME !== "pull_request_target") {
+    throw new Error("production aggregate requires pull_request_target");
+  }
+  if (!/^\d+$/.test(env.PR_NUMBER ?? "")) {
+    throw new Error("PR_NUMBER must be a pull request number");
+  }
+  if (!/^[0-9a-f]{40}$/.test(env.HEAD_SHA ?? "")) {
+    throw new Error("HEAD_SHA must be a full commit SHA");
+  }
+  if (!/^[^/]+\/[^/]+$/.test(env.GITHUB_REPOSITORY ?? "")) {
+    throw new Error("GITHUB_REPOSITORY must be owner/repository");
+  }
+  if (!AGGREGATE_TRIGGER_ACTIONS.includes(env.PR_ACTION)) {
+    throw new Error(`unsupported pull-request action: ${env.PR_ACTION}`);
+  }
+  if (parseTimestamp(env.PR_UPDATED_AT) === null) {
+    throw new Error("PR_UPDATED_AT must be an ISO timestamp");
+  }
+  if (!env.GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is required");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function buildCanaryCheckRuns(scenario, nowMs) {
+  if (!CANARY_SCENARIOS.includes(scenario)) {
+    throw new Error(`unsupported canary scenario: ${scenario}`);
+  }
+  const startedAt = new Date(nowMs - 60_000).toISOString();
+  const completedAt = new Date(nowMs - 30_000).toISOString();
+  const runs = REQUIRED_CHECKS.map((required, index) => ({
+    id: 10_000 + index,
+    name: required.context,
+    app_id: GITHUB_ACTIONS_APP_ID,
+    workflow_path: required.workflowPath,
+    workflow_event: "pull_request",
+    workflow_head_sha: "a".repeat(40),
+    status: COMPLETED_STATUS,
+    conclusion: SUCCESS_CONCLUSION,
+    started_at: startedAt,
+    completed_at: completedAt,
+    details_url: `https://github.example/actions/runs/1/job/${10_000 + index}`,
+  }));
+  const targetIndex = runs.findIndex(({ name }) => name === "gitleaks");
+  if (scenario === "missing") runs.splice(targetIndex, 1);
+  if (scenario === "cancelled") runs[targetIndex].conclusion = "cancelled";
+  if (scenario === "timed-out") runs[targetIndex].conclusion = "timed_out";
+  if (scenario === "failed") runs[targetIndex].conclusion = "failure";
+  if (scenario === "skipped") runs[targetIndex].conclusion = "skipped";
+  if (scenario === "pending-timeout") {
+    runs[targetIndex].status = "in_progress";
+    runs[targetIndex].conclusion = null;
+    runs[targetIndex].completed_at = null;
+  }
+  return runs;
+}
+
+async function runCanary(scenario) {
+  const nowMs = Date.now();
+  const evaluation = evaluateAggregate({
+    checkRuns: buildCanaryCheckRuns(scenario, nowMs),
+    headSha: "a".repeat(40),
+    eventAction: "synchronize",
+    eventUpdatedAt: new Date(nowMs - 90_000).toISOString(),
+    nowMs,
+    deadlineReached: true,
+    terminalSettleMs: 0,
+  });
+  const summary = renderSummary(evaluation, {
+    headSha: "synthetic-canary",
+    eventAction: scenario,
+    attempt: 1,
+  });
+  writeSummary(summary);
+  console.log(summary);
+  return evaluation.verdict === "success" ? 0 : 1;
+}
+
+async function runProduction(env) {
+  validateProductionEnvironment(env);
+  const timeoutSeconds = positiveInteger(
+    env.POLL_TIMEOUT_SECONDS,
+    "POLL_TIMEOUT_SECONDS",
+    2_400,
+  );
+  const intervalSeconds = positiveInteger(
+    env.POLL_INTERVAL_SECONDS,
+    "POLL_INTERVAL_SECONDS",
+    30,
+  );
+  const deadlineMs = Date.now() + timeoutSeconds * 1_000;
+  const workflowRunCache = new Map();
+  let attempt = 1;
+
+  while (true) {
+    const nowMs = Date.now();
+    const checkRuns = await loadOwnedCheckRuns({
+      repository: env.GITHUB_REPOSITORY,
+      headSha: env.HEAD_SHA,
+      token: env.GITHUB_TOKEN,
+      workflowRunCache,
+    });
+    const deadlineReached = nowMs >= deadlineMs;
+    const evaluation = evaluateAggregate({
+      checkRuns,
+      headSha: env.HEAD_SHA,
+      eventAction: env.PR_ACTION,
+      eventUpdatedAt: env.PR_UPDATED_AT,
+      nowMs,
+      deadlineReached,
+    });
+    const summary = renderSummary(evaluation, {
+      headSha: env.HEAD_SHA,
+      eventAction: env.PR_ACTION,
+      attempt,
+    });
+    writeSummary(summary);
+    console.log(
+      `Develop PR Gate poll ${attempt}: passed=${evaluation.counts.passed} waiting=${evaluation.counts.waiting} failed=${evaluation.counts.failed}`,
+    );
+    for (const result of evaluation.results) {
+      console.log(
+        `${result.state.toUpperCase()} ${result.context}: ${result.detail}`,
+      );
+    }
+
+    if (evaluation.verdict === "success") return 0;
+    if (evaluation.verdict === "failure") return 1;
+
+    attempt += 1;
+    await sleep(
+      Math.min(intervalSeconds * 1_000, Math.max(1, deadlineMs - nowMs)),
+    );
+  }
+}
+
+export async function main(env = process.env) {
+  const canary = env.CANARY_SCENARIO;
+  if (canary) {
+    if (env.AGGREGATE_EVENT_NAME !== "workflow_dispatch") {
+      throw new Error("canary scenarios are restricted to workflow_dispatch");
+    }
+    return runCanary(canary);
+  }
+  return runProduction(env);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.exitCode = await main();
+}

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Deterministic contract tests for the develop PR aggregate state machine and
+ * its base-trusted workflow. Synthetic check snapshots cover every terminal
+ * class without calling GitHub or waiting for real runner timeouts.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  buildCanaryCheckRuns,
+  CANARY_SCENARIOS,
+  evaluateAggregate,
+  GITHUB_ACTIONS_APP_ID,
+  REQUIRED_CHECKS,
+  renderSummary,
+  requestJson,
+} from "./develop-pr-aggregate.mjs";
+import {
+  OBSERVED_HEAD_LINE,
+  runContract,
+  TRUSTED_BASE_REF_LINE,
+  validateAggregateWorkflow,
+} from "./develop-pr-aggregate-workflow-contract.mjs";
+
+const NOW_MS = Date.parse("2026-07-14T01:00:00Z");
+const HEAD_SHA = "a".repeat(40);
+const EVENT_UPDATED_AT = new Date(NOW_MS - 90_000).toISOString();
+
+function evaluate(checkRuns, overrides = {}) {
+  return evaluateAggregate({
+    checkRuns,
+    headSha: HEAD_SHA,
+    eventAction: "synchronize",
+    eventUpdatedAt: EVENT_UPDATED_AT,
+    nowMs: NOW_MS,
+    terminalSettleMs: 0,
+    ...overrides,
+  });
+}
+
+function successRuns() {
+  return buildCanaryCheckRuns("success", NOW_MS);
+}
+
+function resultFor(evaluation, context) {
+  const result = evaluation.results.find((entry) => entry.context === context);
+  assert(result, `missing result for ${context}`);
+  return result;
+}
+
+const allGreen = evaluate(successRuns());
+assert.equal(allGreen.verdict, "success");
+assert.deepEqual(allGreen.counts, { passed: 7, waiting: 0, failed: 0 });
+
+const missingBeforeDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS));
+assert.equal(missingBeforeDeadline.verdict, "waiting");
+assert.equal(resultFor(missingBeforeDeadline, "gitleaks").code, "missing");
+const missingAtDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS), {
+  deadlineReached: true,
+});
+assert.equal(missingAtDeadline.verdict, "failure");
+assert.equal(resultFor(missingAtDeadline, "gitleaks").code, "missing");
+
+const pendingBeforeDeadline = evaluate(
+  buildCanaryCheckRuns("pending-timeout", NOW_MS),
+);
+assert.equal(pendingBeforeDeadline.verdict, "waiting");
+assert.equal(resultFor(pendingBeforeDeadline, "gitleaks").code, "pending");
+const pendingAtDeadline = evaluate(
+  buildCanaryCheckRuns("pending-timeout", NOW_MS),
+  { deadlineReached: true },
+);
+assert.equal(pendingAtDeadline.verdict, "failure");
+assert.equal(resultFor(pendingAtDeadline, "gitleaks").code, "pending-timeout");
+
+for (const [scenario, code] of [
+  ["cancelled", "terminal-cancelled"],
+  ["timed-out", "terminal-timed_out"],
+  ["failed", "terminal-failure"],
+  ["skipped", "skipped-forbidden"],
+]) {
+  const evaluation = evaluate(buildCanaryCheckRuns(scenario, NOW_MS), {
+    deadlineReached: true,
+  });
+  assert.equal(evaluation.verdict, "failure", scenario);
+  assert.equal(resultFor(evaluation, "gitleaks").code, code, scenario);
+}
+
+// Every remaining GitHub conclusion that is neither success nor skipped must
+// still fail closed through the generic terminal branch, so an unexpected or
+// future conclusion string can never be mistaken for a pass.
+for (const conclusion of [
+  "neutral",
+  "action_required",
+  "startup_failure",
+  "stale",
+]) {
+  const runs = successRuns();
+  runs.find(({ name }) => name === "gitleaks").conclusion = conclusion;
+  const evaluation = evaluate(runs, { deadlineReached: true });
+  assert.equal(evaluation.verdict, "failure", conclusion);
+  assert.equal(
+    resultFor(evaluation, "gitleaks").code,
+    `terminal-${conclusion}`,
+    conclusion,
+  );
+}
+
+const settlingRuns = buildCanaryCheckRuns("cancelled", NOW_MS);
+const cancelled = settlingRuns.find(({ name }) => name === "gitleaks");
+cancelled.completed_at = new Date(NOW_MS - 5_000).toISOString();
+const settling = evaluate(settlingRuns, { terminalSettleMs: 15_000 });
+assert.equal(settling.verdict, "waiting");
+assert.equal(resultFor(settling, "gitleaks").code, "terminal-settling");
+
+const rerunRuns = buildCanaryCheckRuns("failed", NOW_MS);
+const oldFailure = rerunRuns.find(({ name }) => name === "gitleaks");
+rerunRuns.push({
+  ...oldFailure,
+  id: Number(oldFailure.id) + 10_000,
+  conclusion: "success",
+});
+assert.equal(evaluate(rerunRuns).verdict, "success");
+
+const wrongOwnerRuns = successRuns();
+const wrongOwner = wrongOwnerRuns.find(({ name }) => name === "gitleaks");
+wrongOwner.workflow_path = ".github/workflows/untrusted.yml";
+const wrongOwnerEvaluation = evaluate(wrongOwnerRuns);
+assert.equal(wrongOwnerEvaluation.verdict, "waiting");
+assert.equal(resultFor(wrongOwnerEvaluation, "gitleaks").code, "missing");
+
+const wrongAppRuns = successRuns();
+wrongAppRuns.find(({ name }) => name === "gitleaks").app_id =
+  GITHUB_ACTIONS_APP_ID + 1;
+assert.equal(resultFor(evaluate(wrongAppRuns), "gitleaks").code, "missing");
+
+const editedRuns = successRuns();
+const editedStale = evaluate(editedRuns, {
+  eventAction: "edited",
+  eventUpdatedAt: new Date(NOW_MS - 10_000).toISOString(),
+});
+assert.equal(editedStale.verdict, "waiting");
+assert.equal(editedStale.counts.waiting, 2);
+assert.equal(resultFor(editedStale, "lint").state, "passed");
+for (const context of ["check-pr-evidence", "check-pr-title"]) {
+  const oldRun = editedRuns.find(({ name }) => name === context);
+  editedRuns.push({
+    ...oldRun,
+    id: Number(oldRun.id) + 20_000,
+    started_at: new Date(NOW_MS - 5_000).toISOString(),
+    completed_at: new Date(NOW_MS - 1_000).toISOString(),
+  });
+}
+assert.equal(
+  evaluate(editedRuns, {
+    eventAction: "edited",
+    eventUpdatedAt: new Date(NOW_MS - 10_000).toISOString(),
+  }).verdict,
+  "success",
+);
+
+const contexts = REQUIRED_CHECKS.map(({ context }) => context);
+assert.equal(new Set(contexts).size, contexts.length);
+assert(!contexts.includes("Develop PR Gate"));
+assert.deepEqual(CANARY_SCENARIOS, [
+  "success",
+  "missing",
+  "cancelled",
+  "timed-out",
+  "failed",
+  "skipped",
+  "pending-timeout",
+]);
+
+const summary = renderSummary(allGreen, {
+  headSha: HEAD_SHA,
+  eventAction: "synchronize",
+  attempt: 1,
+});
+assert.match(summary, /Verdict: \*\*success\*\*/);
+
+const apiAttempts = [];
+const retrySleeps = [];
+const retriedPayload = await requestJson(
+  "https://api.github.test/check-runs",
+  "test-token",
+  {
+    fetchImpl: async () => {
+      apiAttempts.push(Date.now());
+      if (apiAttempts.length < 3) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return Response.json({ check_runs: [] });
+    },
+    sleepImpl: async (delayMs) => retrySleeps.push(delayMs),
+    maxAttempts: 3,
+    baseDelayMs: 5,
+  },
+);
+assert.deepEqual(retriedPayload, { check_runs: [] });
+assert.equal(apiAttempts.length, 3);
+assert.deepEqual(retrySleeps, [5, 10]);
+
+let permanentAttempts = 0;
+await assert.rejects(
+  requestJson("https://api.github.test/missing", "test-token", {
+    fetchImpl: async () => {
+      permanentAttempts += 1;
+      return new Response("not found", { status: 404 });
+    },
+    sleepImpl: async () => assert.fail("404 responses must not be retried"),
+  }),
+  /GitHub API 404/,
+);
+assert.equal(permanentAttempts, 1);
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/develop-pr-gate.yml", import.meta.url),
+);
+const workflow = readFileSync(workflowPath, "utf8");
+validateAggregateWorkflow(workflow);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace("  pull_request_target:", "  pull_request:"),
+    ),
+  /pull_request_target|PR-controlled/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace("  checks: read", "  checks: write"),
+    ),
+  /checks permission|read-only/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace(
+        TRUSTED_BASE_REF_LINE,
+        OBSERVED_HEAD_LINE.replace("HEAD_SHA: ", "ref: "),
+      ),
+    ),
+  /trusted base checkout ref/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace(
+        "    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]",
+        "    types: [opened, synchronize]",
+      ),
+    ),
+  /aggregate activity types/,
+);
+
+assert.deepEqual(runContract(), { ok: true, contexts });
+console.log("develop-pr aggregate self-test passed");

--- a/packages/scripts/develop-pr-aggregate.test.mjs
+++ b/packages/scripts/develop-pr-aggregate.test.mjs
@@ -1,0 +1,10 @@
+/**
+ * Bun coverage entrypoint for the deterministic develop PR aggregate contract.
+ * The same assertions run directly under Node in the bootstrap integrity lane;
+ * this wrapper lets the changed-file gate measure the implementation they load.
+ */
+import { test } from "bun:test";
+
+test("develop PR aggregate contract and transient API retries", async () => {
+  await import("./develop-pr-aggregate.self-test.mjs");
+});


### PR DESCRIPTION
## Problem

#17077 was a runtime-latency PR, but its single commit also removed the
repository's three independent pre-merge protections:

- the base-trusted `Develop PR Gate`;
- the stale-tree/silent-revert guard;
- PR evidence validation.

It also deleted the aggregate implementation and its deterministic tests. Those
changes were called out as blocking before merge, but landed unchanged. The
result is observable immediately: PRs opened after the merge no longer receive
the stable aggregate, stale-base, or evidence contexts.

## Core fix

Restore only the CI-authority changes removed by #17077. The runtime, evaluator,
cloud credential, SQL, task-tracking, telemetry, and latency improvements from
that PR remain byte-for-byte untouched.

The eight restored files are byte-identical to the known-good parent of the
#17077 merge (`c07472dd^1`). This is intentionally a targeted policy recovery,
not a rollback of the performance work.

## Verification

- Exact file comparison against `c07472dd^1` for all eight restored paths —
  no diff.
- `node packages/scripts/develop-pr-aggregate.self-test.mjs` — pass, including
  terminal-state and transient GitHub API retry cases.
- `bun test packages/scripts/develop-pr-aggregate.test.mjs` — 1/1 pass.
- `node packages/scripts/stale-base-guard.self-test.mjs` — 9/9 pass, covering
  silent clobbers, acknowledged reverts, heals, deletions, history windows,
  commit/hour staleness, and missing merge bases.
- `node packages/scripts/ci-merge-gate-contract.mjs` — pass; classifiers retain
  hosted fallback and `ci-ok` retains quality-gate authority.
- YAML and aggregate workflow contracts are exercised by the restored
  base-trusted self-test before check evaluation.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - this restores GitHub merge-policy workflows, not an interactive product flow.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no application backend path changes.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] [Restored deterministic aggregate and stale-base contracts](https://github.com/elizaOS/eliza/commit/7de1f002fa23a95fff05be8a8c96545667f8cf6b)

## Manual review

The post-merge diff was manually partitioned before restoration. Only the
workflow/readme/aggregate files were restored; all 18 runtime and Cloud files
from #17077 were explicitly reset to current `develop` before the repair commit
was created.
