### PR TITLE
fix(test): move packages/agent vitest to the forks pool — vmForks leaks vi.mock across files

### DIFF
--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -153,7 +153,16 @@ export default defineConfig({
   test: {
     ...baseConfig.test,
     environment: "node",
-    pool: "vmForks",
+    // "forks" (not "vmForks"): the vmForks pool shares one worker process whose
+    // VM-context module interception races across test files — vi.mock factories
+    // nondeterministically leak into (or vanish from) a NEIGHBORING file's module
+    // graph when several conversation-route suites run in one invocation. Seen as
+    // conversation-failurekind-roundtrip losing its chat-routes mock (real
+    // readChatRequestPayload → "text is required") and
+    // conversation-greeting-idempotency inheriting a foreign no-op persist mock
+    // (zero greeting rows). The forks pool keeps mock registries strictly
+    // per-file, matching the root suite's pool.
+    pool: "forks",
     setupFiles: ["test/setup.ts"],
     testTimeout: 120_000,
     hookTimeout: 120_000,


### PR DESCRIPTION
## Root cause

`packages/agent/vitest.config.ts` was the only config in the repo on `pool: "vmForks"` (the root suite runs `forks`). vmForks shares one worker process; its per-file VM-context module interception races, so `vi.mock` factories nondeterministically apply to the WRONG file's module graph when several suites run in one invocation. Reproduced on pristine develop (~3 of 5 grouped runs fail), in both directions:

- `conversation-failurekind-roundtrip.test.ts` loses its own `../chat-routes.ts` mock — the REAL `readChatRequestPayload` runs and rejects the stubbed request with `"text is required"`, so no `done` frame / no JSON payload (4 tests fail).
- `conversation-greeting-idempotency.test.ts` (which mocks NOTHING) inherits a foreign no-op `persistConversationMemory` mock — zero greeting rows persist and the two requests regenerate divergent greetings (2 tests fail).

Repro:

```bash
for i in 1 2 3 4 5; do bunx vitest run --config packages/agent/vitest.config.ts \
  packages/agent/src/api/__tests__/conversation-streaming.test.ts \
  packages/agent/src/api/__tests__/conversation-idempotency.test.ts \
  packages/agent/src/api/__tests__/chat-idempotency.test.ts \
  packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts \
  packages/agent/src/api/__tests__/conversation-greeting-idempotency.test.ts | tail -2; done
```

## Fix

Switch the agent config to `pool: "forks"`, matching the root suite. The forks pool keeps mock registries strictly per-file. A rationale comment on the pool line records the failure signature so it doesn't get "optimized" back.

## Evidence

- vmForks (develop, grouped runs): run1 4 failed, run2 pass, run3 2 failed, run4 pass, run5 2 failed — victim file rotates between failurekind (mock lost) and greeting (mock inherited), matching the leak in both directions.
- forks (this branch, same group): **8/8 runs 61/61 green**.
- Full `packages/agent` lane (`bun run test`, batch runner) under forks: green — log attached in comment below.

<!-- evidence-row:backend-logs -->
- [x] [17099-vmforks-repro.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17099-vmforks-repro.log) (develop, grouped runs failing) · [17099-forks-fix-runs.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17099-forks-fix-runs.log) (8/8 green) · [17099-api-dir-forks.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17099-api-dir-forks.log) (19-file single invocation, 181/181)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-harness configuration change, no frontend surface

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/prompt change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
