### PR TITLE
fix(core): fail closed on control-record reply arrays

### DIFF
--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -153,6 +153,23 @@ describe("DefaultMessageService structured failure replies", () => {
 		expect(runtime.reportError).toHaveBeenCalledTimes(1);
 	});
 
+	it("rejects a control record inside a JSON array and advances", async () => {
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning([
+			'[{"status":"queued"},{"action":"BROWSER","parameters":{"url":"https://example.com"}}]',
+			"I could not complete that. Please try again.",
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({
+			kind: "text",
+			value: "I could not complete that. Please try again.",
+		});
+		expect(runtime.reportError).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not mistake genuine JSON for a control envelope", async () => {
 		const service =
 			new DefaultMessageService() as unknown as FailureReplyService;

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -380,6 +380,41 @@ describe("runV5MessageRuntimeStage1", () => {
 		});
 	});
 
+	it("blocks a Stage-1 array containing a control record", async () => {
+		const actionBatch =
+			'[{"status":"queued"},{"action":"BROWSER","parameters":{"url":"https://example.com"}}]';
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: actionBatch,
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "Open example.com" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I'm not sure how to answer that.",
+			);
+			expect(result.result.responseContent?.text).not.toContain("BROWSER");
+		}
+		const reported = reportErrorCalls(runtime)[0]?.[1] as {
+			code?: string;
+			context?: Record<string, unknown>;
+		};
+		expect(reported.code).toBe("STAGE1_INVALID_USER_VISIBLE_OUTPUT");
+		expect(reported.context).toMatchObject({
+			classification: "action",
+			fieldPath: [],
+		});
+	});
+
 	it("preserves genuine lower-case action JSON in a Stage-1 direct reply", async () => {
 		const domainJson =
 			'{"action":"proceed","parameters":{"step":1},"status":"done"}';

--- a/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
@@ -108,6 +108,21 @@ describe("planner output user-visible safety", () => {
 		]);
 	});
 
+	it("routes action records from a direct JSON array without exposing the batch", () => {
+		const output = parsePlannerOutput(
+			'[{"status":"queued"},{"action":"BROWSER","parameters":{"url":"https://example.com"}}]',
+		);
+
+		expect(output.messageToUser).toBeUndefined();
+		expect(output.toolCalls).toEqual([
+			{
+				id: undefined,
+				name: "BROWSER",
+				params: { url: "https://example.com" },
+			},
+		]);
+	});
+
 	it("drops a malformed action envelope emitted in the native text channel", () => {
 		const output = parsePlannerOutput({
 			text: '{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":',

--- a/packages/core/src/runtime/__tests__/user-visible-model-output.test.ts
+++ b/packages/core/src/runtime/__tests__/user-visible-model-output.test.ts
@@ -118,6 +118,27 @@ describe("sanitizeUserVisibleModelOutput", () => {
 		});
 	});
 
+	it("rejects control records in direct JSON arrays while preserving ordinary arrays", () => {
+		expect(
+			sanitizeUserVisibleModelOutput(
+				'[{"label":"first"},{"action":"BROWSER","parameters":{"url":"https://example.com"}}]',
+			),
+		).toEqual({
+			kind: "control",
+			envelope: "action",
+			malformed: false,
+			fieldPath: [],
+		});
+
+		const ordinary = '[{"label":"first"},{"action":"proceed","step":2}]';
+		expect(sanitizeUserVisibleModelOutput(ordinary)).toEqual({
+			kind: "text",
+			text: ordinary,
+			format: "json",
+			fieldPath: [],
+		});
+	});
+
 	it("preserves genuine JSON instead of treating any action key as control", () => {
 		const lowerCaseAction =
 			'{"action":"proceed","parameters":{"step":1},"status":"done","summary":"approved"}';

--- a/packages/core/src/runtime/user-visible-model-output.ts
+++ b/packages/core/src/runtime/user-visible-model-output.ts
@@ -164,6 +164,20 @@ function inspectParsedJson(
 	fieldPath: readonly UserVisibleReplyField[],
 	depth: number,
 ): UserVisibleModelOutput {
+	if (Array.isArray(parsed)) {
+		for (const entry of parsed) {
+			const nested = inspectValue(entry, fieldPath, depth + 1);
+			if (nested.kind === "control" || nested.kind === "invalid") {
+				return nested;
+			}
+		}
+		return {
+			kind: "text",
+			text: displayText,
+			format: "json",
+			fieldPath,
+		};
+	}
 	if (!isPlainObject(parsed)) {
 		return {
 			kind: "text",


### PR DESCRIPTION
# Relates to

- Closes #17101.
- Follow-up to #17065.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto `origin/develop` at `0d9cc11a795243cfcba40f14d0e4452fb31391b3`.
- [x] Net diff contains only the residual array/control-record fix and focused tests.
- [x] Affected tests, typecheck, build, Biome, and diff integrity pass on the exact pushed commit.

# What does this fix?

The typed boundary merged in #17065 correctly classifies direct control objects but returned every parsed JSON array as ordinary user-visible JSON before inspecting its entries. That left a structural bypass:

```json
[{"status":"queued"},{"action":"BROWSER","parameters":{"url":"https://example.com"}}]
```

Stage 1 or the failure-reply cascade could display that batch even though the same `BROWSER` record is rejected when emitted as a root object. The planner separately recovered array members as calls, so the three consumers no longer shared one actual contract.

This follow-up makes the canonical classifier recursively inspect direct array entries. If any entry is control or invalid, the existing typed result propagates and every consumer fails closed. Arrays containing only ordinary values remain visible, including lower-case domain records such as `{"action":"proceed"}`.

# Risk

**Low.** The behavioral change is limited to direct arrays containing a record already classified as control/invalid by the merged boundary. Ordinary arrays retain their exact original text.

# Testing

- Affected Vitest integration run: **11 files passed; 301 tests passed**, including the newly merged turn-scoped read-coalescing suite.
- Focused classifier + Stage 1 + failure-reply run: **3 files passed; 112 tests passed**.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/core build`: passed for Node, browser, edge, testing bundle, and declarations.
- Biome on all five changed files: passed.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime-only change; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime-only change; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic regression coverage exercises the exact structural bypass without an external service.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser request path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - #17065 contains the manually reviewed live-model reproduction for the underlying control-record leak; this follow-up closes a deterministic container-shape bypass in the merged parser.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain state is read or written.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshot or UI artifact exists to OCR.

# Manual review

The net diff was reviewed against the current `develop` tip. It contains only:

1. recursive inspection of direct JSON array entries at the canonical boundary;
2. preservation coverage for ordinary/lower-case domain arrays;
3. planner routing coverage for an action-record array;
4. Stage-1 direct-reply and failure-reply regression coverage.

No #17065 branch or merged commit was rewritten.
