### PR TITLE
fix(registry): remove unsafe YieldSignal listing

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
@@ -1,9 +1,0 @@
-{
-  "package": "elizaos-plugin-yieldsignal",
-  "repository": "github:Stakemate369/plugin-yieldsignal",
-  "kind": "plugin",
-  "description": "Buyer-side GET_YIELD_SIGNAL action: real-time, risk-weighted USDC/WETH lending APY on Base, paid $0.01/call via x402, EIP-712 signed and EAS-attested by the seller.",
-  "homepage": "https://yieldsignal.vercel.app",
-  "version": "0.1.0",
-  "tags": ["defi", "x402", "yield", "base", "payments"]
-}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1023,51 +1023,6 @@
       "registryKind": "plugin",
       "directory": null
     },
-    "elizaos-plugin-yieldsignal": {
-      "git": {
-        "repo": "Stakemate369/plugin-yieldsignal",
-        "v0": {
-          "branch": null
-        },
-        "v1": {
-          "branch": null
-        },
-        "v2": {
-          "branch": "main"
-        }
-      },
-      "npm": {
-        "repo": "elizaos-plugin-yieldsignal",
-        "v0": null,
-        "v1": null,
-        "v2": "0.1.0"
-      },
-      "supports": {
-        "v0": false,
-        "v1": false,
-        "v2": true
-      },
-      "description": "Buyer-side GET_YIELD_SIGNAL action: real-time, risk-weighted USDC/WETH lending APY on Base, paid $0.01/call via x402, EIP-712 signed and EAS-attested by the seller.",
-      "homepage": "https://yieldsignal.vercel.app",
-      "topics": [
-        "defi",
-        "x402",
-        "yield",
-        "base",
-        "payments"
-      ],
-      "stargazers_count": 0,
-      "language": "TypeScript",
-      "origin": "third-party",
-      "source": "community",
-      "support": "community",
-      "builtIn": false,
-      "firstParty": false,
-      "thirdParty": true,
-      "kind": "plugin",
-      "registryKind": "plugin",
-      "directory": null
-    },
     "plugin-agentscoin": {
       "git": {
         "repo": "axiosdevs/plugin-agentscoin",


### PR DESCRIPTION
Closes #17100. Follow-up to #17097.

## Root cause

The registry accepted a wallet-bearing third-party package based on metadata validation and mocked unit tests. The published package advertises a fixed $0.01 x402 payment and signed responses, but neither guarantee is enforced:

- it constructs Coinbase CdpX402Client without spend controls, so the remote 402 response chooses amount, asset, network, and payee;
- its paid action is eligible for every message without an explicit payment-intent or approval boundary;
- it does not verify the advertised EIP-712 response signature or runtime response schema;
- its external fetch has no abort deadline; and
- its tests mock the network and payment path.

The service currently asks for 10,000 atomic USDC, but that observation is not a client-side invariant. A changed or compromised service can ask the agent wallet to sign a materially different payment.

## Fix

Remove the source entry and regenerate the committed third-party registry. This is intentionally a listing removal, not an attempted patch to an independently published package.

Relisting requires enforced per-payment and cumulative caps, fixed asset/network/payee allowlists, explicit payment intent/approval semantics, signature and schema verification, bounded fetches, repository licensing, and manually reviewed real paid/adversarial E2E evidence.

## Verification

Exact base: cb0ae3576baf56bd90d22c9504d5804bc26597b2

- bun run --cwd packages/registry generate — 29 entries generated
- bun run --cwd packages/registry validate — 29 entries validated
- bun run --cwd packages/registry test — 8 files, 33 tests passed
- bun run --cwd packages/registry typecheck — passed
- git diff --check — passed
- generated diff contains only the removed package record

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime changed; registry generation and validation are build-time tooling.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime change.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI source changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI source changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or action implementation changed in this repository.

<!-- evidence-row:domain-artifacts -->
- [x] [Generated registry at exact head](https://github.com/elizaOS/eliza/blob/be20141c9c52acb0069f8a097f5775c799a77302/packages/registry/generated-registry.json) - manually reviewed diff removes exactly the unsafe package record.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or image artifact changed.



