### PR TITLE
perf(core): deliver the reply before persisting the response memory (~250-440ms off the reply path)

### DIFF
--- a/packages/core/src/services/message.deliver-then-persist.test.ts
+++ b/packages/core/src/services/message.deliver-then-persist.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Reply-delivery ordering on the simple fast path (deliver-then-save): the
+ * connector callback fires BEFORE the response-memory DB write — moving the
+ * `message:delivery:persistence` span (~250-440ms live) off time-to-reply —
+ * while the persist still completes before handleMessage resolves, a callback
+ * failure never loses the memory, a persist failure still reaches the
+ * handleMessage boundary, and an immediate follow-up read sees the stored
+ * reply. Real AgentRuntime + InMemoryDatabaseAdapter end to end; only the
+ * Stage-1 model surface is a deterministic registered handler (no live model,
+ * no network). The adapter wrapper below observes/faults the storage boundary
+ * but always delegates real writes to the real adapter.
+ */
+
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCharacter } from "../character";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { inferenceTimingRegistry } from "../inference-timing";
+import { AgentRuntime } from "../runtime";
+import type { Content, Memory } from "../types";
+import { ModelType } from "../types/model";
+import { asUUID, ChannelType, type UUID } from "../types/primitives";
+import { DefaultMessageService } from "./message";
+
+/** The Stage-1 HANDLE_RESPONSE tool-call envelope a live model emits. */
+function stage1DirectReply(replyText: string) {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "handle-response-1",
+				name: "HANDLE_RESPONSE",
+				arguments: {
+					shouldRespond: "RESPOND",
+					thought: "Direct answer.",
+					contexts: ["simple"],
+					intents: [],
+					candidateActionNames: [],
+					replyText,
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+				},
+			},
+		],
+		finishReason: "tool_calls",
+	};
+}
+
+const activeRuntimes: AgentRuntime[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		activeRuntimes.splice(0).map(async (runtime) => {
+			await runtime.stop();
+			await runtime.close();
+		}),
+	);
+});
+
+interface HarnessOptions {
+	/** Artificial latency injected on the agent-reply row write only. */
+	persistDelayMs?: number;
+	/** Fail the agent-reply row write only (incoming-message write succeeds). */
+	failReplyPersist?: boolean;
+}
+
+async function createHarness(opts: HarnessOptions = {}) {
+	const replyText = `the build finished clean, all green. probe-${v4()}`;
+	const adapter = new InMemoryDatabaseAdapter();
+	const runtime = new AgentRuntime({
+		character: createCharacter({
+			name: `DeliverThenPersist${v4().slice(0, 8)}`,
+		}),
+		adapter,
+		logLevel: "fatal",
+		enableAutonomy: false,
+	});
+	activeRuntimes.push(runtime);
+	await runtime.initialize();
+	runtime.registerModel(
+		ModelType.RESPONSE_HANDLER,
+		async () => stage1DirectReply(replyText),
+		"deterministic-test",
+	);
+
+	const roomId = asUUID(v4());
+	const entityId = asUUID(v4());
+	await runtime.ensureConnection({
+		entityId,
+		roomId,
+		worldId: asUUID(v4()),
+		userName: "tester",
+		name: "tester",
+		source: "test",
+		type: ChannelType.DM,
+	});
+
+	// Observation-only storage seam: records when the agent-reply row write
+	// COMPLETES relative to the delivery callback, and optionally injects
+	// latency or a fault for the failure-path tests. Real writes always reach
+	// the real in-memory adapter.
+	const order: string[] = [];
+	const realCreateMemories = adapter.createMemories.bind(adapter);
+	adapter.createMemories = (async (
+		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+	): Promise<UUID[]> => {
+		const isReplyWrite = memories.some(
+			({ memory, tableName }) =>
+				tableName === "messages" &&
+				memory.entityId === runtime.agentId &&
+				memory.content?.text === replyText,
+		);
+		if (isReplyWrite && opts.persistDelayMs) {
+			await new Promise((resolve) => setTimeout(resolve, opts.persistDelayMs));
+		}
+		if (isReplyWrite && opts.failReplyPersist) {
+			throw new Error("injected reply-persist failure");
+		}
+		const ids = await realCreateMemories(memories);
+		if (isReplyWrite) {
+			order.push("persist:reply");
+		}
+		return ids;
+	}) as InMemoryDatabaseAdapter["createMemories"];
+
+	const makeMessage = (): Memory => ({
+		id: asUUID(v4()),
+		entityId,
+		agentId: runtime.agentId,
+		roomId,
+		content: {
+			text: "how did the build go?",
+			source: "test",
+			channelType: ChannelType.DM,
+		},
+		createdAt: Date.now(),
+	});
+
+	const storedReplies = async (): Promise<Memory[]> => {
+		const memories = await runtime.getMemories({
+			roomId,
+			tableName: "messages",
+			count: 100,
+		});
+		return memories.filter(
+			(m) => m.entityId === runtime.agentId && m.content.text === replyText,
+		);
+	};
+
+	const service = new DefaultMessageService();
+	return {
+		runtime,
+		service,
+		roomId,
+		replyText,
+		order,
+		makeMessage,
+		storedReplies,
+	};
+}
+
+describe("simple-path deliver-then-persist ordering", () => {
+	it("fires the delivery callback before the reply persist completes, then still persists it", async () => {
+		const h = await createHarness();
+		let repliesVisibleAtDelivery = -1;
+
+		const result = await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage(),
+			async () => {
+				h.order.push("callback");
+				// Direct proof delivery precedes persistence: at delivery time the
+				// reply row is not yet readable from the real adapter.
+				repliesVisibleAtDelivery = (await h.storedReplies()).length;
+				return [];
+			},
+		);
+
+		expect(result.didRespond).toBe(true);
+		expect(result.mode).toBe("simple");
+		expect(result.responseContent?.text).toBe(h.replyText);
+		expect(repliesVisibleAtDelivery).toBe(0);
+		expect(h.order).toEqual(["callback", "persist:reply"]);
+
+		// The persist completed before handleMessage resolved: an immediate
+		// next-turn-style read sees exactly one stored reply — no drop, no
+		// double-persist.
+		const replies = await h.storedReplies();
+		expect(replies).toHaveLength(1);
+		expect(replies[0].content.text).toBe(h.replyText);
+	});
+
+	it("still persists the reply when the delivery callback throws, then rethrows that exact error", async () => {
+		const h = await createHarness();
+		const boom = new Error("connector send failed");
+
+		await expect(
+			h.service.handleMessage(h.runtime, h.makeMessage(), async () => {
+				h.order.push("callback-throw");
+				throw boom;
+			}),
+		).rejects.toBe(boom);
+
+		// The memory was persisted despite the delivery failure, and the error
+		// surfaced identity-preserved at the handleMessage boundary.
+		expect(h.order).toEqual(["callback-throw", "persist:reply"]);
+		expect(await h.storedReplies()).toHaveLength(1);
+	});
+
+	it("propagates a reply-persist failure to the handleMessage boundary after the user got the reply", async () => {
+		const h = await createHarness({ failReplyPersist: true });
+		const delivered: Content[] = [];
+
+		await expect(
+			h.service.handleMessage(h.runtime, h.makeMessage(), async (content) => {
+				delivered.push(content);
+				return [];
+			}),
+		).rejects.toThrow("injected reply-persist failure");
+
+		// Delivery happened first; the persist failure was NOT swallowed.
+		expect(delivered).toHaveLength(1);
+		expect(delivered[0].text).toBe(h.replyText);
+	});
+
+	it("keeps both failures observable when the callback AND the persist fail", async () => {
+		const h = await createHarness({ failReplyPersist: true });
+		const reported: unknown[] = [];
+		const realReportError = h.runtime.reportError.bind(h.runtime);
+		h.runtime.reportError = ((scope, error, context) => {
+			if (scope === "MessageService.simpleDeliveryCallback") {
+				reported.push(error);
+			}
+			return realReportError(scope, error, context);
+		}) as AgentRuntime["reportError"];
+		const boom = new Error("connector send failed");
+
+		// The persist failure propagates (data loss outranks delivery failure);
+		// the held delivery failure is reported, never silently superseded.
+		await expect(
+			h.service.handleMessage(h.runtime, h.makeMessage(), async () => {
+				throw boom;
+			}),
+		).rejects.toThrow("injected reply-persist failure");
+		expect(reported).toEqual([boom]);
+	});
+
+	it("records a time-to-reply that excludes the persistence span", async () => {
+		const h = await createHarness({ persistDelayMs: 150 });
+
+		await h.service.handleMessage(h.runtime, h.makeMessage(), async () => []);
+
+		const turn = inferenceTimingRegistry.recentTurns(1)[0];
+		expect(turn).toBeDefined();
+		const callbackSpan = turn.spans.find(
+			(s) => s.name === "message:delivery:callback",
+		);
+		const persistSpan = turn.spans.find(
+			(s) => s.name === "message:delivery:persistence",
+		);
+		expect(callbackSpan).toBeDefined();
+		expect(persistSpan).toBeDefined();
+		if (!callbackSpan || !persistSpan) return;
+
+		// Delivery fully completes before the persist opens, and the derived
+		// time-to-reply lands before the (artificially slow, >=150ms) persist
+		// closes — the DB write is off the reply critical path.
+		expect(persistSpan.startMs).toBeGreaterThanOrEqual(callbackSpan.endMs);
+		expect(persistSpan.durationMs).toBeGreaterThanOrEqual(140);
+		expect(turn.timeToReplyMs).not.toBeNull();
+		expect(turn.timeToReplyMs as number).toBeLessThan(persistSpan.endMs);
+	});
+});

--- a/packages/core/src/services/message.deliver-then-persist.test.ts
+++ b/packages/core/src/services/message.deliver-then-persist.test.ts
@@ -4,11 +4,13 @@
  * `message:delivery:persistence` span (~250-440ms live) off time-to-reply —
  * while the persist still completes before handleMessage resolves, a callback
  * failure never loses the memory, a persist failure still reaches the
- * handleMessage boundary, and an immediate follow-up read sees the stored
- * reply. Real AgentRuntime + InMemoryDatabaseAdapter end to end; only the
- * Stage-1 model surface is a deterministic registered handler (no live model,
- * no network). The adapter wrapper below observes/faults the storage boundary
- * but always delegates real writes to the real adapter.
+ * handleMessage boundary, and a same-room follow-up fired off the delivery
+ * (the racy case: concurrent handleMessage, NOT sequential) is barred from
+ * composing until the reply row is stored while other rooms stay unblocked.
+ * Real AgentRuntime + InMemoryDatabaseAdapter end to end; only the Stage-1
+ * model surface is a deterministic registered handler (no live model, no
+ * network). The adapter wrapper below observes/faults/holds the storage
+ * boundary but always delegates real writes to the real adapter.
  */
 
 import { v4 } from "uuid";
@@ -63,10 +65,17 @@ interface HarnessOptions {
 	persistDelayMs?: number;
 	/** Fail the agent-reply row write only (incoming-message write succeeds). */
 	failReplyPersist?: boolean;
+	/**
+	 * Hold the FIRST agent-reply row write open until `releaseReplyPersist()`
+	 * is called — a deterministic, sleep-free window for the compose-vs-persist
+	 * race tests. Later reply writes (follow-up turns) are never held.
+	 */
+	holdReplyPersist?: boolean;
 }
 
 async function createHarness(opts: HarnessOptions = {}) {
 	const replyText = `the build finished clean, all green. probe-${v4()}`;
+	const followUpReplyText = `and the tests passed too. probe-${v4()}`;
 	const adapter = new InMemoryDatabaseAdapter();
 	const runtime = new AgentRuntime({
 		character: createCharacter({
@@ -78,9 +87,23 @@ async function createHarness(opts: HarnessOptions = {}) {
 	});
 	activeRuntimes.push(runtime);
 	await runtime.initialize();
+	// Interleaving trace shared by the model handler and the storage seam.
+	const order: string[] = [];
+	// Serialized `messages` model input per Stage-1 invocation — lets tests
+	// assert what a turn's composed prompt actually contained.
+	const stage1Invocations: string[] = [];
 	runtime.registerModel(
 		ModelType.RESPONSE_HANDLER,
-		async () => stage1DirectReply(replyText),
+		async (_rt, params) => {
+			const invocation = stage1Invocations.length + 1;
+			stage1Invocations.push(
+				JSON.stringify((params as { messages?: unknown }).messages ?? null),
+			);
+			order.push(`stage1:${invocation}`);
+			return stage1DirectReply(
+				invocation === 1 ? replyText : followUpReplyText,
+			);
+		},
 		"deterministic-test",
 	);
 
@@ -98,9 +121,12 @@ async function createHarness(opts: HarnessOptions = {}) {
 
 	// Observation-only storage seam: records when the agent-reply row write
 	// COMPLETES relative to the delivery callback, and optionally injects
-	// latency or a fault for the failure-path tests. Real writes always reach
-	// the real in-memory adapter.
-	const order: string[] = [];
+	// latency, a hold-open gate, or a fault for the failure/race tests. Real
+	// writes always reach the real in-memory adapter.
+	let releaseReplyPersist: () => void = () => {};
+	const replyPersistGate = new Promise<void>((resolve) => {
+		releaseReplyPersist = resolve;
+	});
 	const realCreateMemories = adapter.createMemories.bind(adapter);
 	adapter.createMemories = (async (
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
@@ -113,6 +139,9 @@ async function createHarness(opts: HarnessOptions = {}) {
 		);
 		if (isReplyWrite && opts.persistDelayMs) {
 			await new Promise((resolve) => setTimeout(resolve, opts.persistDelayMs));
+		}
+		if (isReplyWrite && opts.holdReplyPersist) {
+			await replyPersistGate;
 		}
 		if (isReplyWrite && opts.failReplyPersist) {
 			throw new Error("injected reply-persist failure");
@@ -137,6 +166,47 @@ async function createHarness(opts: HarnessOptions = {}) {
 		createdAt: Date.now(),
 	});
 
+	const makeFollowUp = (): Memory => ({
+		id: asUUID(v4()),
+		entityId,
+		agentId: runtime.agentId,
+		roomId,
+		content: {
+			text: "nice — and did the tests pass?",
+			source: "test",
+			channelType: ChannelType.DM,
+		},
+		createdAt: Date.now(),
+	});
+
+	/** A second, unrelated room on the same runtime (cross-room isolation). */
+	const createSecondRoom = async () => {
+		const otherRoomId = asUUID(v4());
+		const otherEntityId = asUUID(v4());
+		await runtime.ensureConnection({
+			entityId: otherEntityId,
+			roomId: otherRoomId,
+			worldId: asUUID(v4()),
+			userName: "tester-b",
+			name: "tester-b",
+			source: "test",
+			type: ChannelType.DM,
+		});
+		const makeRoomBMessage = (): Memory => ({
+			id: asUUID(v4()),
+			entityId: otherEntityId,
+			agentId: runtime.agentId,
+			roomId: otherRoomId,
+			content: {
+				text: "unrelated question from another room",
+				source: "test",
+				channelType: ChannelType.DM,
+			},
+			createdAt: Date.now(),
+		});
+		return { roomId: otherRoomId, makeRoomBMessage };
+	};
+
 	const storedReplies = async (): Promise<Memory[]> => {
 		const memories = await runtime.getMemories({
 			roomId,
@@ -154,8 +224,13 @@ async function createHarness(opts: HarnessOptions = {}) {
 		service,
 		roomId,
 		replyText,
+		followUpReplyText,
 		order,
+		stage1Invocations,
 		makeMessage,
+		makeFollowUp,
+		createSecondRoom,
+		releaseReplyPersist,
 		storedReplies,
 	};
 }
@@ -181,7 +256,7 @@ describe("simple-path deliver-then-persist ordering", () => {
 		expect(result.mode).toBe("simple");
 		expect(result.responseContent?.text).toBe(h.replyText);
 		expect(repliesVisibleAtDelivery).toBe(0);
-		expect(h.order).toEqual(["callback", "persist:reply"]);
+		expect(h.order).toEqual(["stage1:1", "callback", "persist:reply"]);
 
 		// The persist completed before handleMessage resolved: an immediate
 		// next-turn-style read sees exactly one stored reply — no drop, no
@@ -204,7 +279,7 @@ describe("simple-path deliver-then-persist ordering", () => {
 
 		// The memory was persisted despite the delivery failure, and the error
 		// surfaced identity-preserved at the handleMessage boundary.
-		expect(h.order).toEqual(["callback-throw", "persist:reply"]);
+		expect(h.order).toEqual(["stage1:1", "callback-throw", "persist:reply"]);
 		expect(await h.storedReplies()).toHaveLength(1);
 	});
 
@@ -270,5 +345,89 @@ describe("simple-path deliver-then-persist ordering", () => {
 		expect(persistSpan.durationMs).toBeGreaterThanOrEqual(140);
 		expect(turn.timeToReplyMs).not.toBeNull();
 		expect(turn.timeToReplyMs as number).toBeLessThan(persistSpan.endMs);
+	});
+
+	it("bars a same-room follow-up fired from the delivery callback from composing until the reply persist completes", async () => {
+		// THE race deliver-then-persist opens up: the client reacts to the
+		// delivered reply while the reply row is still being written. The
+		// follow-up's compose must wait for the persist barrier, or its
+		// RECENT_MESSAGES omits the very reply it is answering. The persist is
+		// held open by a gate (no timing games): if the barrier did not work,
+		// the follow-up's Stage-1 would run while the gate is still closed.
+		const h = await createHarness({ holdReplyPersist: true });
+		let followUpTurn: Promise<unknown> | null = null;
+
+		const firstTurn = h.service.handleMessage(
+			h.runtime,
+			h.makeMessage(),
+			async () => {
+				h.order.push("callback");
+				// Fire-and-forget, exactly like a real client reacting to the
+				// delivered reply. A callback must never AWAIT a same-room turn
+				// to completion (documented on registerPendingReplyPersist).
+				followUpTurn = h.service.handleMessage(
+					h.runtime,
+					h.makeFollowUp(),
+					async () => [],
+				);
+				return [];
+			},
+		);
+
+		// Give the follow-up every opportunity to (incorrectly) reach Stage-1
+		// while the first reply's persist is still held open.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(h.order).toContain("callback");
+		expect(h.order).not.toContain("stage1:2");
+
+		h.releaseReplyPersist();
+		await firstTurn;
+		expect(followUpTurn).not.toBeNull();
+		await followUpTurn;
+
+		// Stage-1 for the follow-up ran only after the reply row was stored…
+		expect(h.order.indexOf("persist:reply")).toBeGreaterThan(-1);
+		expect(h.order.indexOf("stage1:2")).toBeGreaterThan(
+			h.order.indexOf("persist:reply"),
+		);
+		// …and its composed model input actually contains the delivered reply.
+		expect(h.stage1Invocations).toHaveLength(2);
+		expect(h.stage1Invocations[1]).toContain(h.replyText);
+	});
+
+	it("lets a different room proceed while another room's reply persist is still pending", async () => {
+		// The barrier is per-room: holding room A's reply persist open must not
+		// serialize room B behind it.
+		const h = await createHarness({ holdReplyPersist: true });
+		const roomB = await h.createSecondRoom();
+
+		let roomADelivered: () => void = () => {};
+		const delivered = new Promise<void>((resolve) => {
+			roomADelivered = resolve;
+		});
+		const turnA = h.service.handleMessage(
+			h.runtime,
+			h.makeMessage(),
+			async () => {
+				roomADelivered();
+				return [];
+			},
+		);
+
+		// Room A's reply is delivered and its persist is now held open.
+		await delivered;
+		const resultB = await h.service.handleMessage(
+			h.runtime,
+			roomB.makeRoomBMessage(),
+			async () => [],
+		);
+
+		// Room B ran to completion while room A's persist never finished.
+		expect(resultB.didRespond).toBe(true);
+		expect(h.order).not.toContain("persist:reply");
+
+		h.releaseReplyPersist();
+		await turnA;
+		expect(h.order).toContain("persist:reply");
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10943,10 +10943,17 @@ export class DefaultMessageService implements IMessageService {
 			if (responseContent) {
 				const deliverableResponseContent = responseContent;
 				if (mode === "simple") {
-					// Keep content hooks and DB write before delivery so the wire
-					// response and stored memory match. Do not put MESSAGE_SENT
-					// handlers or post-turn evaluators before the callback; they are
-					// side effects and must not stall user-visible streaming.
+					// Keep content hooks before delivery so the wire response carries
+					// their edits. The response-memory DB write runs AFTER the
+					// callback: it is the largest post-LLM cost on this path
+					// (~250-440ms measured via the message:delivery:persistence
+					// InferenceTiming span) and the user must not wait on it. The
+					// persist is still awaited before this turn proceeds, so
+					// everything downstream (MESSAGE_SENT, post-turn evaluators,
+					// followUp, and the next turn's RECENT_MESSAGES read) observes
+					// the stored reply. Do not put MESSAGE_SENT handlers or
+					// post-turn evaluators before the callback; they are side
+					// effects and must not stall user-visible streaming.
 					await timeInferenceSpan("message:delivery:hooks", () =>
 						runtime.applyPipelineHooks(
 							"outgoing_before_deliver",
@@ -10960,44 +10967,76 @@ export class DefaultMessageService implements IMessageService {
 							}),
 						),
 					);
-					if (responseMessages.length > 0) {
-						for (const responseMemory of responseMessages) {
-							if (
-								responseMemory.id &&
-								persistedEarlyReplyIds.has(responseMemory.id)
-							) {
-								continue;
-							}
-							responseMemory.content = deliverableResponseContent;
-							if (shouldSkipResponseMemoryPersistence(responseMemory)) {
-								runtime.logger.debug(
-									{ src: "service:message", memoryId: responseMemory.id },
-									"Skipping transient response memory persistence",
-								);
-								continue;
-							}
-							runtime.logger.debug(
-								{ src: "service:message", memoryId: responseMemory.id },
-								"Saving response to memory",
+					let deliveryFailure: { error: unknown } | null = null;
+					if (callback) {
+						try {
+							await timeInferenceSpan("message:delivery:callback", () =>
+								callback(deliverableResponseContent),
 							);
-							await timeInferenceSpan("message:delivery:persistence", () =>
-								runtime.createMemory(responseMemory, "messages"),
-							);
-
-							detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
-								this.emitMessageSent(
-									runtime,
-									responseMemory,
-									message.content.source ?? "messageHandler",
-								),
-							);
+							markInference(INFERENCE_MARKS.replyDelivered);
+						} catch (error) {
+							// error-policy:J2 ordering rethrow — delivery now precedes
+							// the response-memory persist, so a connector failure here
+							// must not skip that persist. Held and rethrown UNCHANGED
+							// (no cause-wrapping: callers classify the raw connector
+							// error) after the persist below settles.
+							deliveryFailure = { error };
 						}
 					}
-					if (callback) {
-						await timeInferenceSpan("message:delivery:callback", () =>
-							callback(deliverableResponseContent),
-						);
-						markInference(INFERENCE_MARKS.replyDelivered);
+					try {
+						if (responseMessages.length > 0) {
+							for (const responseMemory of responseMessages) {
+								if (
+									responseMemory.id &&
+									persistedEarlyReplyIds.has(responseMemory.id)
+								) {
+									continue;
+								}
+								responseMemory.content = deliverableResponseContent;
+								if (shouldSkipResponseMemoryPersistence(responseMemory)) {
+									runtime.logger.debug(
+										{ src: "service:message", memoryId: responseMemory.id },
+										"Skipping transient response memory persistence",
+									);
+									continue;
+								}
+								runtime.logger.debug(
+									{ src: "service:message", memoryId: responseMemory.id },
+									"Saving response to memory",
+								);
+								await timeInferenceSpan("message:delivery:persistence", () =>
+									runtime.createMemory(responseMemory, "messages"),
+								);
+
+								detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
+									this.emitMessageSent(
+										runtime,
+										responseMemory,
+										message.content.source ?? "messageHandler",
+									),
+								);
+							}
+						}
+					} catch (persistError) {
+						// error-policy:J2 both-failures-observable rethrow — the
+						// persist failure propagates unchanged to the handleMessage
+						// boundary exactly as before the reorder; the held delivery
+						// failure (if any) would otherwise be silently superseded,
+						// so report it here first.
+						if (deliveryFailure) {
+							runtime.reportError(
+								"MessageService.simpleDeliveryCallback",
+								deliveryFailure.error,
+								{
+									agentId: runtime.agentId,
+									roomId: message.roomId,
+								},
+							);
+						}
+						throw persistError;
+					}
+					if (deliveryFailure) {
+						throw deliveryFailure.error;
 					}
 				}
 			}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9414,6 +9414,83 @@ async function _composeContinuationDecisionState(
  */
 export class DefaultMessageService implements IMessageService {
 	/**
+	 * Rooms (keyed `${agentId}:${roomId}`) holding a reply that has been handed
+	 * to the delivery callback but whose response-memory row is not yet stored
+	 * (the simple-path deliver-then-persist window). A follow-up turn triggered
+	 * by that delivery must not compose its prompt until the reply row exists,
+	 * or RECENT_MESSAGES silently omits the reply the user is answering —
+	 * `processMessage` awaits these barriers before any composition. Barriers
+	 * always settle (resolve, never reject) whether the persist succeeds or
+	 * fails; a persist failure propagates in the owning turn, never to the
+	 * waiting turn. Same-room turns otherwise still run concurrently — turn
+	 * preemption (`turnControllers.abortTurn` fired from a later message's
+	 * Stage-1 field evaluators) depends on that, so this is deliberately a
+	 * narrow persistence barrier, not per-room handler serialization.
+	 */
+	private readonly pendingReplyPersists = new Map<string, Set<Promise<void>>>();
+
+	private pendingReplyPersistKey(runtime: IAgentRuntime, roomId: UUID): string {
+		return `${runtime.agentId}:${roomId}`;
+	}
+
+	/**
+	 * Register a delivered-reply persistence barrier. Must be called BEFORE the
+	 * delivery callback fires: the instant the reply reaches the client a
+	 * follow-up can arrive, and its compose must find this barrier already
+	 * pending. Returns the release fn; call it once the persist settles
+	 * (success or failure). Constraint for callback authors: a delivery
+	 * callback must never await a same-room `handleMessage` to completion —
+	 * that turn waits on a barrier this turn only releases after the callback
+	 * returns. Fire-and-forget from a callback is fine.
+	 */
+	private registerPendingReplyPersist(
+		runtime: IAgentRuntime,
+		roomId: UUID,
+	): () => void {
+		const key = this.pendingReplyPersistKey(runtime, roomId);
+		let release: (() => void) | undefined;
+		const barrier = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		let barriers = this.pendingReplyPersists.get(key);
+		if (!barriers) {
+			barriers = new Set();
+			this.pendingReplyPersists.set(key, barriers);
+		}
+		barriers.add(barrier);
+		return () => {
+			release?.();
+			const set = this.pendingReplyPersists.get(key);
+			if (set) {
+				set.delete(barrier);
+				if (set.size === 0) {
+					this.pendingReplyPersists.delete(key);
+				}
+			}
+		};
+	}
+
+	/**
+	 * Wait until every reply already handed to a delivery callback for this
+	 * room has finished persisting. Snapshot semantics: only barriers pending
+	 * at call time are awaited — exactly the causal set for a follow-up
+	 * reacting to a delivered reply. Rooms with no pending barrier (the
+	 * overwhelmingly common case) return without awaiting anything.
+	 */
+	private async awaitDeliveredReplyPersistence(
+		runtime: IAgentRuntime,
+		roomId: UUID,
+	): Promise<void> {
+		const barriers = this.pendingReplyPersists.get(
+			this.pendingReplyPersistKey(runtime, roomId),
+		);
+		if (!barriers || barriers.size === 0) return;
+		await timeInferenceSpan("message:compose:reply-persist-barrier", () =>
+			Promise.all([...barriers]),
+		);
+	}
+
+	/**
 	 * Main message handling entry point
 	 */
 	async handleMessage(
@@ -10098,6 +10175,13 @@ export class DefaultMessageService implements IMessageService {
 		startTime: number,
 		opts: ResolvedMessageOptions,
 	): Promise<MessageProcessingResult> {
+		// A reply already handed to a delivery callback for this room may still
+		// be persisting (deliver-then-persist fast path). Composing now would
+		// read RECENT_MESSAGES without the reply this message may be answering,
+		// so wait for those persists to settle first. Same room only, a few
+		// hundred ms worst case, and a no-op when nothing is pending.
+		await this.awaitDeliveredReplyPersistence(runtime, message.roomId);
+
 		const agentResponses = latestResponseIds.get(runtime.agentId);
 		if (!agentResponses) throw new Error("Agent responses map not found");
 
@@ -10949,11 +11033,13 @@ export class DefaultMessageService implements IMessageService {
 					// (~250-440ms measured via the message:delivery:persistence
 					// InferenceTiming span) and the user must not wait on it. The
 					// persist is still awaited before this turn proceeds, so
-					// everything downstream (MESSAGE_SENT, post-turn evaluators,
-					// followUp, and the next turn's RECENT_MESSAGES read) observes
-					// the stored reply. Do not put MESSAGE_SENT handlers or
-					// post-turn evaluators before the callback; they are side
-					// effects and must not stall user-visible streaming.
+					// everything downstream in THIS turn (MESSAGE_SENT, post-turn
+					// evaluators, followUp) observes the stored reply — and a
+					// CONCURRENT same-room turn started off this delivery waits on
+					// the pendingReplyPersists barrier before composing, so its
+					// RECENT_MESSAGES read observes it too. Do not put MESSAGE_SENT
+					// handlers or post-turn evaluators before the callback; they are
+					// side effects and must not stall user-visible streaming.
 					await timeInferenceSpan("message:delivery:hooks", () =>
 						runtime.applyPipelineHooks(
 							"outgoing_before_deliver",
@@ -10967,76 +11053,89 @@ export class DefaultMessageService implements IMessageService {
 							}),
 						),
 					);
-					let deliveryFailure: { error: unknown } | null = null;
-					if (callback) {
-						try {
-							await timeInferenceSpan("message:delivery:callback", () =>
-								callback(deliverableResponseContent),
-							);
-							markInference(INFERENCE_MARKS.replyDelivered);
-						} catch (error) {
-							// error-policy:J2 ordering rethrow — delivery now precedes
-							// the response-memory persist, so a connector failure here
-							// must not skip that persist. Held and rethrown UNCHANGED
-							// (no cause-wrapping: callers classify the raw connector
-							// error) after the persist below settles.
-							deliveryFailure = { error };
-						}
-					}
+					// Registered BEFORE the callback fires so a follow-up prompted
+					// by this delivery always finds the barrier pending; released
+					// (never rejected) in the finally once the persist settles.
+					const releaseReplyPersistBarrier = this.registerPendingReplyPersist(
+						runtime,
+						message.roomId,
+					);
 					try {
-						if (responseMessages.length > 0) {
-							for (const responseMemory of responseMessages) {
-								if (
-									responseMemory.id &&
-									persistedEarlyReplyIds.has(responseMemory.id)
-								) {
-									continue;
-								}
-								responseMemory.content = deliverableResponseContent;
-								if (shouldSkipResponseMemoryPersistence(responseMemory)) {
-									runtime.logger.debug(
-										{ src: "service:message", memoryId: responseMemory.id },
-										"Skipping transient response memory persistence",
-									);
-									continue;
-								}
-								runtime.logger.debug(
-									{ src: "service:message", memoryId: responseMemory.id },
-									"Saving response to memory",
-								);
-								await timeInferenceSpan("message:delivery:persistence", () =>
-									runtime.createMemory(responseMemory, "messages"),
-								);
-
-								detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
-									this.emitMessageSent(
-										runtime,
-										responseMemory,
-										message.content.source ?? "messageHandler",
-									),
-								);
+						// Settled-result handling instead of catch blocks: a delivery
+						// failure must not skip the persist, and callers classify the
+						// raw delivery error by identity (TURN_ABORTED / generation-
+						// timeout checks at the conversation route), so both failures
+						// are rethrown UNCHANGED after both operations settle.
+						let deliveryOutcome: PromiseSettledResult<unknown> = {
+							status: "fulfilled",
+							value: undefined,
+						};
+						if (callback) {
+							[deliveryOutcome] = await Promise.allSettled([
+								timeInferenceSpan("message:delivery:callback", () =>
+									callback(deliverableResponseContent),
+								),
+							]);
+							if (deliveryOutcome.status === "fulfilled") {
+								markInference(INFERENCE_MARKS.replyDelivered);
 							}
 						}
-					} catch (persistError) {
-						// error-policy:J2 both-failures-observable rethrow — the
-						// persist failure propagates unchanged to the handleMessage
-						// boundary exactly as before the reorder; the held delivery
-						// failure (if any) would otherwise be silently superseded,
-						// so report it here first.
-						if (deliveryFailure) {
-							runtime.reportError(
-								"MessageService.simpleDeliveryCallback",
-								deliveryFailure.error,
-								{
-									agentId: runtime.agentId,
-									roomId: message.roomId,
-								},
-							);
+						const [persistOutcome] = await Promise.allSettled([
+							(async () => {
+								for (const responseMemory of responseMessages) {
+									if (
+										responseMemory.id &&
+										persistedEarlyReplyIds.has(responseMemory.id)
+									) {
+										continue;
+									}
+									responseMemory.content = deliverableResponseContent;
+									if (shouldSkipResponseMemoryPersistence(responseMemory)) {
+										runtime.logger.debug(
+											{ src: "service:message", memoryId: responseMemory.id },
+											"Skipping transient response memory persistence",
+										);
+										continue;
+									}
+									runtime.logger.debug(
+										{ src: "service:message", memoryId: responseMemory.id },
+										"Saving response to memory",
+									);
+									await timeInferenceSpan("message:delivery:persistence", () =>
+										runtime.createMemory(responseMemory, "messages"),
+									);
+
+									detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
+										this.emitMessageSent(
+											runtime,
+											responseMemory,
+											message.content.source ?? "messageHandler",
+										),
+									);
+								}
+							})(),
+						]);
+						if (persistOutcome.status === "rejected") {
+							// The persist failure (data loss) outranks the delivery
+							// failure for propagation; the held delivery failure is
+							// reported so it is never silently superseded.
+							if (deliveryOutcome.status === "rejected") {
+								runtime.reportError(
+									"MessageService.simpleDeliveryCallback",
+									deliveryOutcome.reason,
+									{
+										agentId: runtime.agentId,
+										roomId: message.roomId,
+									},
+								);
+							}
+							throw persistOutcome.reason;
 						}
-						throw persistError;
-					}
-					if (deliveryFailure) {
-						throw deliveryFailure.error;
+						if (deliveryOutcome.status === "rejected") {
+							throw deliveryOutcome.reason;
+						}
+					} finally {
+						releaseReplyPersistBarrier();
 					}
 				}
 			}


### PR DESCRIPTION
## What
Deliver the assistant reply to the user **before** persisting the response memory. Previously the message loop `await`ed `createMemory(responseMemory)` and then called the delivery callback — so the user waited on a DB write before seeing the reply. This moves the persist off the reply critical path (delivered first, persisted after), while guaranteeing the persist still runs and its failures are observed.

## Why
Measured with real `InferenceTiming` on a live agent: the post-model `delivery` window was **~250–440ms** of awaited `createMemory` sitting *before* the user-facing callback. Same class as the merged shared-tier billing-tail defer (#16925) — take the non-user-facing work off the response path.

## Correctness (the delicate part — deliberate)
- **Persist still always runs** — deferred, not dropped; a persist failure is surfaced via `runtime.reportError`/logger, never swallowed.
- **Callback throw doesn't lose the memory** — ordering handled so a delivery error still persists.
- **Downstream ordering preserved** — anything that depends on the response memory existing (evaluators, MESSAGE_SENT emission) still awaits it; only the user-facing callback moves earlier.
- **No stale next-turn read** — the persist completes within the turn (deferred just past the callback), so an immediate follow-up's RECENT_MESSAGES sees the reply.

## Evidence — live battery on this exact code (local runtime, cloud gemma-4-31b)
12/12 normie prompts answered correctly, and the timing spans show the delivery callback firing **after** the model with the persist deferred. Simple turns 1.3–2.0s wall; web/live-info 2.7–4.4s; eliza-code write-and-run works. `message.deliver-then-persist.test.ts` added (real AgentRuntime + InMemoryDatabaseAdapter): asserts callback-before-persist, persist-still-completes, callback-throw-still-persists, and next-read-sees-reply.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime perf change, no UI
<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime perf change, no UI
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - core runtime perf change, no UI
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface
<!-- evidence-row:backend-logs -->
- [x] [17105-delivery-span-order.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17105-delivery-span-order.txt)
<!-- evidence-row:llm-trajectory -->
- [x] [17105-live-battery-12turns.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17105-live-battery-12turns.txt)
<!-- evidence-row:domain-artifacts -->
- [x] [17105-delivery-span-order.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17105-delivery-span-order.txt)

Pairs with the just-merged #17057 (compose DB coalescing). cc @lalalune

🤖 Generated with [Claude Code](https://claude.com/claude-code)

