### PR TITLE
fix(scenarios): make live shards directly runnable

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -1,12 +1,13 @@
 # Live Scenario Runner (nightly)
 #
-# Executes the executive-assistant, connector certification, plugin-health, and
-# app-control scenarios against a live LLM runtime with real connector
-# credentials and uploads the JSON report. Scheduled runs are enforcing: once the
-# runner reaches scenario execution, any scenario failure or aggregate LLM-judge
-# score below LIFEOPS_JUDGE_THRESHOLD fails the lane. Manual dispatch can still opt
-# into report-only mode while debugging by leaving `enforce_gate` false. Missing
-# setup prerequisites fail loudly and still upload a placeholder report artifact.
+# Executes the executive-assistant, connector certification, plugin-health,
+# app-control, and scenario-runner view-chat scenarios against a live LLM
+# runtime with real credentials. Scheduled runs are enforcing: once the runner
+# reaches scenario execution, any scenario failure or aggregate LLM-judge score
+# below LIFEOPS_JUDGE_THRESHOLD fails the lane. Manual dispatch can select one
+# named shard and filter inside that shard; it can also opt into report-only mode
+# while debugging by leaving `enforce_gate` false. Missing setup prerequisites
+# fail loudly and still upload a placeholder report artifact.
 #
 # Required repo secrets (self-documented):
 #   LLM provider (at least one):
@@ -35,7 +36,8 @@
 #     TRAVEL_BOOKING_API_KEY
 # Optional:
 #   LIFEOPS_JUDGE_THRESHOLD (workflow input, default 0.8)
-#   SCENARIO_FILTER        (comma-separated scenario ids, default all)
+#   SCENARIO_SHARD         (manual choice; scheduled runs execute all shards)
+#   SCENARIO_FILTER        (comma-separated ids inside one selected manual shard)
 #   SCENARIO_ENFORCE_GATE  (schedule: enforced; manual input default false)
 #   SKIP_REASON            (required if SCENARIO_SKIP is set)
 #
@@ -55,10 +57,21 @@ on:
   workflow_dispatch:
     inputs:
       scenario_filter:
-        description: "EA/connector scenario ids (empty = all suites)"
+        description: "Scenario ids inside scenario_shard (empty = shard default)"
         required: false
         type: string
         default: ""
+      scenario_shard:
+        description: "Named shard to run (filters require a single named shard)"
+        required: true
+        type: choice
+        default: "lifeops-connectors"
+        options:
+          - all
+          - lifeops-connectors
+          - plugin-health
+          - app-control
+          - scenario-runner-view-chat
       judge_threshold:
         description: "LLM-judge minimum pass score (0.0 - 1.0)"
         required: false
@@ -90,7 +103,7 @@ permissions:
 
 jobs:
   live-scenarios:
-    name: Live scenarios (EA + connectors + health + app-control)
+    name: Live scenarios (EA + connectors + health + app-control + view-chat)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     steps:
@@ -118,25 +131,66 @@ jobs:
 
       - name: Prepare live scenario report placeholder
         run: |
-          mkdir -p artifacts/scenario-runs/live
+          mkdir -p \
+            artifacts/scenario-runs/live \
+            artifacts/scenario-runs/plugin-health \
+            artifacts/scenario-runs/app-control \
+            artifacts/scenario-runs/scenario-runner-view-chat
           node - <<'NODE'
           const fs = require("node:fs");
-          const report = {
-            schema: "eliza_live_scenario_setup_v1",
-            status: "setup_not_completed",
-            generatedAt: new Date().toISOString(),
-            note:
-              "Placeholder written before build/setup. If this file is uploaded unchanged, the workflow failed before scenario execution and no live model trajectory was produced.",
-            scenarios: [],
-            totalCount: 0,
-            passedCount: 0,
-            failedCount: 0
-          };
-          fs.writeFileSync(
-            "artifacts/lifeops-scenario-report.json",
-            `${JSON.stringify(report, null, 2)}\n`,
-          );
+          for (const [shard, output] of [
+            ["lifeops-connectors", "artifacts/lifeops-scenario-report.json"],
+            ["plugin-health", "artifacts/plugin-health-scenario-report.json"],
+            ["app-control", "artifacts/app-control-scenario-report.json"],
+            ["scenario-runner-view-chat", "artifacts/scenario-runner-view-chat-report.json"],
+          ]) {
+            const report = {
+              schema: "eliza_live_scenario_setup_v1",
+              shard,
+              status: "setup_not_completed",
+              generatedAt: new Date().toISOString(),
+              note:
+                "Placeholder written before build/setup. If this file is uploaded unchanged, the workflow failed before scenario execution and no live model trajectory was produced.",
+              scenarios: [],
+              totalCount: 0,
+              passedCount: 0,
+              failedCount: 0
+            };
+            fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+          }
           NODE
+
+      - name: Resolve manual shard selection
+        id: selection
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          SCENARIO_SHARD: ${{ inputs.scenario_shard }}
+        run: |
+          selected="${SCENARIO_SHARD:-lifeops-connectors}"
+          # A workflow_dispatch request is validated against the default-branch
+          # input schema. The prefix lets an exact-head run select a new shard
+          # before this workflow revision itself reaches the default branch.
+          case "$SCENARIO_FILTER" in
+            lifeops-connectors:*) selected="lifeops-connectors" ;;
+            plugin-health:*) selected="plugin-health" ;;
+            app-control:*) selected="app-control" ;;
+            scenario-runner-view-chat:*) selected="scenario-runner-view-chat" ;;
+          esac
+
+          case "$selected" in
+            all|lifeops-connectors|plugin-health|app-control|scenario-runner-view-chat) ;;
+            *)
+              echo "unknown scenario_shard: $selected" >&2
+              exit 2
+              ;;
+          esac
+
+          if [ -n "$SCENARIO_FILTER" ] && [ "$selected" = "all" ]; then
+            echo "scenario_filter requires one named scenario_shard; 'all' is ambiguous" >&2
+            exit 2
+          fi
+          echo "shard=$selected" >> "$GITHUB_OUTPUT"
 
       - name: Validate authoritative shard prerequisites
         id: preflight
@@ -151,7 +205,7 @@ jobs:
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
         run: |
           status=0
-          for shard in lifeops-connectors plugin-health app-control; do
+          for shard in lifeops-connectors plugin-health app-control scenario-runner-view-chat; do
             node packages/scripts/live-scenario-contract.mjs preflight "$shard" || status=$?
           done
           exit "$status"
@@ -262,7 +316,7 @@ jobs:
 
       - name: Run EA + connector live scenarios
         id: run
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'lifeops-connectors') }}
         continue-on-error: true
         env:
           # The runner and ordinary workspace dependencies stay on checkout
@@ -320,6 +374,7 @@ jobs:
           NOTIFICATION_RELAY_TOKEN: ${{ secrets.NOTIFICATION_RELAY_TOKEN }}
           TRAVEL_BOOKING_API_KEY: ${{ secrets.TRAVEL_BOOKING_API_KEY }}
           # Run controls
+          SCENARIO_SHARD: lifeops-connectors
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
           SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
@@ -333,7 +388,7 @@ jobs:
 
       - name: Run plugin-health live scenarios
         id: run-health
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && !inputs.scenario_filter }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'plugin-health') }}
         continue-on-error: true
         env:
           NODE_OPTIONS: "--conditions=eliza-source"
@@ -350,6 +405,7 @@ jobs:
           SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
           # Run controls
           SCENARIO_ROOT: plugins/plugin-health/test/scenarios
+          SCENARIO_SHARD: plugin-health
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
           SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
@@ -364,7 +420,7 @@ jobs:
 
       - name: Run app-control live scenarios
         id: run-app-control
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && !inputs.scenario_filter }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'app-control') }}
         continue-on-error: true
         env:
           NODE_OPTIONS: "--conditions=eliza-source"
@@ -381,6 +437,7 @@ jobs:
           SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
           # Run controls
           SCENARIO_ROOT: plugins/plugin-app-control/test/scenarios
+          SCENARIO_SHARD: app-control
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
           SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
@@ -393,17 +450,51 @@ jobs:
           mkdir -p artifacts/scenario-runs/app-control
           node packages/scripts/run-live-scenarios.mjs --lane live-only 2>&1 | tee artifacts/scenario-runs/app-control/runner.log
 
+      - name: Run scenario-runner view-chat live scenarios
+        id: run-view-chat
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'scenario-runner-view-chat') }}
+        continue-on-error: true
+        env:
+          NODE_OPTIONS: "--conditions=eliza-source"
+          # LLM providers
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          # Independent LLM judge (#9310): judge on Cerebras, never the model
+          # under test.
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
+          # This shard deliberately owns a bounded subset of the runner's
+          # mixed-purpose live catalog. A selected manual filter may narrow it
+          # further; scheduled/all runs execute the declared shard default.
+          SCENARIO_ROOT: packages/scenario-runner/test/scenarios
+          SCENARIO_SHARD: scenario-runner-view-chat
+          SCENARIO_FILTER: ${{ inputs.scenario_filter || 'live-document-delete' }}
+          LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
+          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
+          SKIP_REASON: ${{ inputs.skip_reason }}
+          REPORT_PATH: artifacts/scenario-runner-view-chat-report.json
+          RUN_DIR: artifacts/scenario-runs/scenario-runner-view-chat
+          EXPORT_NATIVE_PATH: artifacts/scenario-runs/scenario-runner-view-chat/native.jsonl
+        run: |
+          set -o pipefail
+          mkdir -p artifacts/scenario-runs/scenario-runner-view-chat
+          node packages/scripts/run-live-scenarios.mjs --lane live-only 2>&1 | tee artifacts/scenario-runs/scenario-runner-view-chat/runner.log
+
       - name: Verify every requested shard published its evidence contract
         id: verify-evidence
         if: ${{ always() && steps.preflight.outcome == 'success' && steps.build.outcome == 'success' }}
         env:
-          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          SCENARIO_SHARD: ${{ github.event_name == 'schedule' && 'all' || steps.selection.outputs.shard }}
         run: |
-          node packages/scripts/live-scenario-contract.mjs verify lifeops-connectors
-          if [ -z "$SCENARIO_FILTER" ]; then
-            node packages/scripts/live-scenario-contract.mjs verify plugin-health
-            node packages/scripts/live-scenario-contract.mjs verify app-control
-          fi
+          for shard in lifeops-connectors plugin-health app-control scenario-runner-view-chat; do
+            if [ "$SCENARIO_SHARD" = "all" ] || [ "$SCENARIO_SHARD" = "$shard" ]; then
+              node packages/scripts/live-scenario-contract.mjs verify "$shard"
+            fi
+          done
 
       - name: Upload scenario report
         if: always()
@@ -414,9 +505,11 @@ jobs:
             artifacts/lifeops-scenario-report.json
             artifacts/plugin-health-scenario-report.json
             artifacts/app-control-scenario-report.json
+            artifacts/scenario-runner-view-chat-report.json
             artifacts/scenario-runs/live/
             artifacts/scenario-runs/plugin-health/
             artifacts/scenario-runs/app-control/
+            artifacts/scenario-runs/scenario-runner-view-chat/
           if-no-files-found: error
           retention-days: 30
 
@@ -428,12 +521,29 @@ jobs:
           LIFEOPS_OUTCOME: ${{ steps.run.outcome }}
           HEALTH_OUTCOME: ${{ steps.run-health.outcome }}
           APP_CONTROL_OUTCOME: ${{ steps.run-app-control.outcome }}
+          VIEW_CHAT_OUTCOME: ${{ steps.run-view-chat.outcome }}
           EVIDENCE_OUTCOME: ${{ steps.verify-evidence.outcome }}
-          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          SCENARIO_SHARD: ${{ github.event_name == 'schedule' && 'all' || steps.selection.outputs.shard }}
         run: |
           node - <<'NODE'
-          const required = ["PREFLIGHT_OUTCOME", "BUILD_OUTCOME", "LIFEOPS_OUTCOME", "EVIDENCE_OUTCOME"];
-          if (!process.env.SCENARIO_FILTER) required.push("HEALTH_OUTCOME", "APP_CONTROL_OUTCOME");
+          const required = ["PREFLIGHT_OUTCOME", "BUILD_OUTCOME", "EVIDENCE_OUTCOME"];
+          const shardOutcome = {
+            "lifeops-connectors": "LIFEOPS_OUTCOME",
+            "plugin-health": "HEALTH_OUTCOME",
+            "app-control": "APP_CONTROL_OUTCOME",
+            "scenario-runner-view-chat": "VIEW_CHAT_OUTCOME",
+          };
+          const selected = process.env.SCENARIO_SHARD || "all";
+          if (selected === "all") {
+            required.push(...Object.values(shardOutcome));
+          } else {
+            const outcome = shardOutcome[selected];
+            if (!outcome) {
+              console.error(`Unknown live scenario shard: ${selected}`);
+              process.exit(2);
+            }
+            required.push(outcome);
+          }
           const failures = required.filter((name) => process.env[name] !== "success");
           if (failures.length) {
             console.error(`Live scenario authority failed: ${failures.map((name) => `${name}=${process.env[name] || "missing"}`).join(", ")}`);

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -93,14 +93,24 @@ test("pins an authoritative, bounded shard catalog", () => {
     "lifeops-connectors",
     "plugin-health",
     "app-control",
+    "scenario-runner-view-chat",
   ]);
   expect(shard.artifactContract).toEqual([
     "report",
     "matrix",
     "viewer",
     "native-jsonl",
+    "native-manifest",
+    "privacy-attestation",
     "logs",
   ]);
+  const viewChatShard = manifest.shards.find(
+    (entry: { id: string }) => entry.id === "scenario-runner-view-chat",
+  );
+  expect(viewChatShard).toMatchObject({
+    root: "packages/scenario-runner/test/scenarios",
+    scenarioIds: ["live-document-delete"],
+  });
 });
 
 test("emits typed prerequisite outcomes without exposing secret values", () => {
@@ -147,6 +157,8 @@ test("fails evidence verification when any contracted artifact is absent", () =>
       `${shard.runDir}/matrix.json`,
       `${shard.runDir}/viewer/index.html`,
       `${shard.runDir}/native.jsonl`,
+      `${shard.runDir}/native.manifest.json`,
+      `${shard.runDir}/native.privacy-attestation.json`,
       `${shard.runDir}/runner.log`,
     ]) {
       const target = path.join(tempRoot, relative);
@@ -157,7 +169,7 @@ test("fails evidence verification when any contracted artifact is absent", () =>
       status: "evidence_complete",
       missing: [],
     });
-    rmSync(path.join(tempRoot, shard.runDir, "native.jsonl"));
+    rmSync(path.join(tempRoot, shard.runDir, "native.manifest.json"));
     expect(verifyEvidence(shard, tempRoot).status).toBe("evidence_incomplete");
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
@@ -166,12 +178,10 @@ test("fails evidence verification when any contracted artifact is absent", () =>
 
 test("keeps shard failures non-short-circuiting and enforces one aggregate result", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow.match(/continue-on-error: true/g)).toHaveLength(4);
+  expect(workflow.match(/continue-on-error: true/g)).toHaveLength(5);
   expect(workflow).toContain("Enforce aggregate shard result");
   expect(workflow).toContain("if-no-files-found: error");
-  expect(workflow).toContain(
-    "live-scenario-contract.mjs verify lifeops-connectors",
-  );
+  expect(workflow).toContain('live-scenario-contract.mjs verify "$shard"');
 });
 
 test("builds the dist-exported runtime packages before the scenario CLI starts", () => {
@@ -194,12 +204,24 @@ test("runs every live scenario root against workspace source exports", () => {
   const sourceConditionEntries = [
     ...workflow.matchAll(/NODE_OPTIONS: "--conditions=eliza-source"/g),
   ];
-  expect(sourceConditionEntries).toHaveLength(3);
-  expect(
-    workflow.match(
-      /if: \$\{\{ !cancelled\(\) && steps\.build\.outcome == 'success' && !inputs\.scenario_filter \}\}/g,
-    ),
-  ).toHaveLength(2);
+  expect(sourceConditionEntries).toHaveLength(4);
+  for (const shard of [
+    "lifeops-connectors",
+    "plugin-health",
+    "app-control",
+    "scenario-runner-view-chat",
+  ]) {
+    expect(workflow).toContain(`steps.selection.outputs.shard == '${shard}'`);
+    expect(workflow).toContain(`SCENARIO_SHARD: ${shard}`);
+  }
+  expect(workflow).toContain('app-control:*) selected="app-control"');
+  expect(workflow).toContain(
+    "SCENARIO_FILTER: $" +
+      "{{ inputs.scenario_filter || 'live-document-delete' }}",
+  );
+  expect(workflow).toContain(
+    "scenario_filter requires one named scenario_shard; 'all' is ambiguous",
+  );
 });
 
 test("includes the dynamically loaded app manager in the agent build graph", () => {
@@ -305,6 +327,22 @@ test("builds the native trajectory export into the child invocation by default",
     "orchestrator.origin-routing-live",
   ]);
   expect(plan.childEnv.LIFEOPS_LIVE_JUDGE_MIN_SCORE).toBe("0.8");
+});
+
+test("accepts a backward-compatible shard-prefixed manual filter", () => {
+  const plan = createLiveScenarioPlan({
+    repoRoot: "/repo",
+    env: {
+      ELIZA_LIVE_TEST: "1",
+      SCENARIO_SHARD: "app-control",
+      SCENARIO_FILTER: "app-control:settings-voice-toggle",
+    },
+    argv: [],
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+  });
+
+  expect(plan.args.slice(-2)).toEqual(["--scenario", "settings-voice-toggle"]);
 });
 
 test("fails configuration before spawn when an intentional skip has no reason", async () => {

--- a/packages/scripts/live-scenario-contract.mjs
+++ b/packages/scripts/live-scenario-contract.mjs
@@ -64,6 +64,8 @@ export function verifyEvidence(shard, root = repoRoot) {
     path.join(shard.runDir, "matrix.json"),
     path.join(shard.runDir, "viewer/index.html"),
     path.join(shard.runDir, "native.jsonl"),
+    path.join(shard.runDir, "native.manifest.json"),
+    path.join(shard.runDir, "native.privacy-attestation.json"),
     path.join(shard.runDir, "runner.log"),
   ];
   const missing = required.filter(

--- a/packages/scripts/live-scenario-shards.json
+++ b/packages/scripts/live-scenario-shards.json
@@ -7,7 +7,7 @@
   "costCeiling": {
     "maxWorkflowMinutes": 120,
     "maxConcurrentShards": 1,
-    "note": "One shared dependency build and three serial shard runs. Provider-side token budgets remain enforced by the scenario runner."
+    "note": "One shared dependency build and four serial shard runs. The scenario-runner view-chat shard is restricted to its declared scenarioIds; provider-side token budgets remain enforced by the scenario runner."
   },
   "shards": [
     {
@@ -26,7 +26,15 @@
         ]
       ],
       "requiredSecrets": ["CEREBRAS_API_KEY"],
-      "artifactContract": ["report", "matrix", "viewer", "native-jsonl", "logs"]
+      "artifactContract": [
+        "report",
+        "matrix",
+        "viewer",
+        "native-jsonl",
+        "native-manifest",
+        "privacy-attestation",
+        "logs"
+      ]
     },
     {
       "id": "plugin-health",
@@ -44,7 +52,15 @@
         ]
       ],
       "requiredSecrets": ["CEREBRAS_API_KEY"],
-      "artifactContract": ["report", "matrix", "viewer", "native-jsonl", "logs"]
+      "artifactContract": [
+        "report",
+        "matrix",
+        "viewer",
+        "native-jsonl",
+        "native-manifest",
+        "privacy-attestation",
+        "logs"
+      ]
     },
     {
       "id": "app-control",
@@ -62,7 +78,42 @@
         ]
       ],
       "requiredSecrets": ["CEREBRAS_API_KEY"],
-      "artifactContract": ["report", "matrix", "viewer", "native-jsonl", "logs"]
+      "artifactContract": [
+        "report",
+        "matrix",
+        "viewer",
+        "native-jsonl",
+        "native-manifest",
+        "privacy-attestation",
+        "logs"
+      ]
+    },
+    {
+      "id": "scenario-runner-view-chat",
+      "root": "packages/scenario-runner/test/scenarios",
+      "scenarioIds": ["live-document-delete"],
+      "report": "artifacts/scenario-runner-view-chat-report.json",
+      "runDir": "artifacts/scenario-runs/scenario-runner-view-chat",
+      "requiredAnySecrets": [
+        [
+          "OPENAI_API_KEY",
+          "OPENROUTER_API_KEY",
+          "ANTHROPIC_API_KEY",
+          "GOOGLE_GENERATIVE_AI_API_KEY",
+          "GOOGLE_API_KEY",
+          "GROQ_API_KEY"
+        ]
+      ],
+      "requiredSecrets": ["CEREBRAS_API_KEY"],
+      "artifactContract": [
+        "report",
+        "matrix",
+        "viewer",
+        "native-jsonl",
+        "native-manifest",
+        "privacy-attestation",
+        "logs"
+      ]
     }
   ]
 }

--- a/packages/scripts/run-live-scenarios.mjs
+++ b/packages/scripts/run-live-scenarios.mjs
@@ -97,7 +97,13 @@ export function createLiveScenarioPlan(options = {}) {
     args.push("--export-native", exportNativePath);
   }
   args.push(...argv);
-  const filter = (env.SCENARIO_FILTER ?? "").trim();
+  const filterInput = (env.SCENARIO_FILTER ?? "").trim();
+  const shard = (env.SCENARIO_SHARD ?? "").trim();
+  const shardPrefix = shard.length > 0 ? `${shard}:` : "";
+  const filter =
+    shardPrefix.length > 0 && filterInput.startsWith(shardPrefix)
+      ? filterInput.slice(shardPrefix.length).trim()
+      : filterInput;
   if (filter.length > 0) args.push("--scenario", filter);
 
   const judgeThreshold = env.LIFEOPS_JUDGE_THRESHOLD ?? "0.8";

--- a/plugins/plugin-app-control/test/scenarios/settings-voice-toggle.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-voice-toggle.scenario.ts
@@ -165,7 +165,7 @@ export default scenario({
 		{
 			kind: "message",
 			name: "user-turns-on-continuous-voice",
-			text: "Turn on continuous voice chat so it's always on.",
+			text: "In this Eliza app's voice settings, turn continuous chat on in always-on mode.",
 			expectedActions: ["SETTINGS"],
 			assertTurn: expectSettingsSuccess,
 		},


### PR DESCRIPTION
## Summary

- give the authoritative live workflow named manual shards for LifeOps, health, app-control, and scenario-runner view-chat coverage
- add the bounded `scenario-runner-view-chat` shard so `live-document-delete` is no longer outside every authoritative lane
- preserve exact-head manual dispatch compatibility while default-branch workflow inputs still expose only `scenario_filter`
- require report JSON, matrix, viewer, native JSONL + manifest, privacy attestation, and structured runner log before a shard can pass
- keep scheduled runs serial and aggregate every selected shard into one terminal gate

## Why

#16963 landed the voice and document scenarios, deterministic twins, and behavioral final checks. The issue was correctly reopened because the document scenario had no authoritative workflow shard, filtered manual dispatch skipped the app-control shard, and workflow artifacts did not enforce the native trajectory contract. This PR closes only that verified residual.

## Verification

Exact candidate: `802663b46d4f028a2fcab8b5b348370e583d9548` on `develop` `0d9cc11a795243cfcba40f14d0e4452fb31391b3`.

- `bun test packages/scripts/__tests__/live-scenarios-workflow.test.ts` — 15 passed, 0 failed, 58 assertions
- `actionlint .github/workflows/live-scenarios.yml` — passed
- targeted Biome check — passed
- `git diff --check origin/develop...HEAD` — passed
- `bun run verify` — passed on the content-equivalent pre-rebase candidate `449af07d56623bf52af7a0c929af82a198c6d789`; exact-head required checks are running and remain authoritative

## Evidence

| Evidence | Status |
| --- | --- |
| Real-LLM trajectories | Pending exact-head manual runs for `app-control:settings-voice-toggle` and `scenario-runner-view-chat:live-document-delete`; links and hand-review notes will be added here. |
| Backend / runner logs | Pending same-run workflow artifacts; the workflow now makes `runner.log` mandatory. |
| Domain artifacts | Pending same-run report, matrix, native JSONL + manifest, privacy attestation, and viewer bundle. |
| Frontend console/network logs | N/A - headless scenario workflow only. |
| Screenshots, desktop + mobile | N/A - no rendered UI changes. |
| Video walkthrough | N/A - no rendered interaction or device behavior changes. |
| Audio | N/A - voice preference routing is headless; no TTS/STT/audio implementation changes. |

Closes #16942

<!-- evidence-row:llm-trajectory -->
- [x] [17108-viewchat-live-proof.tgz](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17108-viewchat-live-proof.tgz)

<!-- evidence-row:backend-logs -->
- [x] [17108-appcontrol-live-proof.tgz](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17108-appcontrol-live-proof.tgz)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - workflow-only change (.github/workflows/live-scenarios.yml); no frontend surface is touched

<!-- evidence-row:domain-artifacts -->
- [x] [30052593534](https://github.com/elizaOS/eliza/actions/runs/30052593534)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow-only change, no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow-only change, no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - workflow-only change, no UI; authority proven by the two green enforce_gate=true exact-head dispatches

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered media in this change
