### PR TITLE
fix(agent): preserve authoritative streamed text

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -735,6 +735,47 @@ describe("generateChatResponse token streaming", () => {
     expect(result.text).toBe("hello world");
   });
 
+  it("uses authoritative accumulated text so repeated characters survive chunk boundaries", async () => {
+    const first = "runtime message lo";
+    const complete = "runtime message loop, HTTP SSE";
+    const service: MessageService = {
+      async handleMessage(_runtime, _message, _callback, options) {
+        await options?.onStreamChunk?.(first, undefined, first);
+        await options?.onStreamChunk?.("op, HTTP SSE", undefined, complete);
+        return {
+          didRespond: true,
+          responseContent: { text: complete },
+          responseMessages: [],
+        };
+      },
+      shouldRespond: () => ({
+        shouldRespond: true,
+        skipEvaluation: true,
+        reason: "streaming-test",
+      }),
+      deleteMessage: async () => undefined,
+      clearChannel: async () => undefined,
+    };
+    const runtime = createRuntime({ messageService: service });
+    const chunks: string[] = [];
+    const snapshots: string[] = [];
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("preserve repeated characters"),
+      "Streaming Agent",
+      {
+        timeoutDuration: 5_000,
+        onChunk: (chunk) => chunks.push(chunk),
+        onSnapshot: (text) => snapshots.push(text),
+      },
+    );
+
+    expect(chunks.join("")).toBe(complete);
+    expect(snapshots).toEqual([]);
+    expect(result.text).toBe(complete);
+  });
+
   it("returns sanitized action result summaries for UI handoffs", async () => {
     const message = createChatMessage("create a workflow");
     const getActionResults = vi.fn(() => [

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -2907,7 +2907,11 @@ async function generateChatResponseWithTiming(
                     abortSignal: generationAbortController.signal,
                     keepExistingResponses: true,
                     onStreamChunk: opts?.onChunk
-                      ? async (chunk: string) => {
+                      ? async (
+                          chunk: string,
+                          _messageId?: string,
+                          accumulated?: string,
+                        ) => {
                           if (generationTimedOut || opts?.isAborted?.()) {
                             throw createChatGenerationTimeoutError(
                               generationTimeoutMs,
@@ -2927,7 +2931,11 @@ async function generateChatResponseWithTiming(
                             return;
                           }
                           if (!claimStreamSource("onStreamChunk")) return;
-                          appendIncomingText(chunk);
+                          // Structured extractors provide authoritative cumulative text.
+                          // Using it avoids mistaking repeated characters at adjacent chunk
+                          // boundaries for transport overlap; raw delta handlers still fall
+                          // back to the route's compatibility reconciler.
+                          appendIncomingText(accumulated ?? chunk);
                         }
                       : undefined,
                   },

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -60,11 +60,16 @@ const UI_SMOKE_STUB_SCRIPT = path.join(
   import.meta.dirname,
   "playwright-ui-smoke-api-stub.mjs",
 );
+const REAL_LOCAL_AGENT_SCRIPT = path.join(
+  import.meta.dirname,
+  "serve-real-local-agent.ts",
+);
 const READY_TIMEOUT_MS = 180_000;
 const API_PORT = Number(process.env.ELIZA_UI_SMOKE_API_PORT ?? "31337");
 const UI_PORT = Number(process.env.ELIZA_UI_SMOKE_PORT ?? "2138");
 const UI_SMOKE_RUN_ID = process.env.ELIZA_UI_SMOKE_RUN_ID?.trim() ?? "";
 const LIVE_PROVIDER = await selectLiveProviderAsync();
+const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
 // Precedence (force-stub > live opt-in > CI default) lives in one tested helper.
 // The key behavior: ELIZA_UI_SMOKE_LIVE_STACK=1 overrides the CI-based stub force
 // so a genuinely-real lane is possible (GitHub Actions always sets CI=true, which
@@ -459,7 +464,25 @@ async function proxyUiRequest(args: {
       proxyHeaders[key] = value;
     });
     args.response.writeHead(upstream.status, proxyHeaders);
-    args.response.end(Buffer.from(await upstream.arrayBuffer()));
+    if (!upstream.body) {
+      args.response.end();
+      return;
+    }
+    const reader = upstream.body.getReader();
+    try {
+      while (!args.response.writableEnded) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!args.response.write(value)) {
+          await new Promise<void>((resolve) => {
+            args.response.once("drain", resolve);
+          });
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    args.response.end();
     return;
   }
 
@@ -1047,8 +1070,75 @@ async function startStubStack(): Promise<StartedStack> {
   }
 }
 
+async function startRealLocalStack(): Promise<StartedStack> {
+  const stateDir = await createStateDir("eliza-ui-smoke-real-local-");
+  let apiChild: ChildProcessWithoutNullStreams | null = null;
+  let uiServer: Server | null = null;
+  try {
+    const uiDistDir = await snapshotUiDist(stateDir);
+    const apiBase = `http://127.0.0.1:${API_PORT}`;
+    apiChild = spawn(resolveBunCommand(), ["--bun", REAL_LOCAL_AGENT_SCRIPT], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        ELIZA_API_PORT: String(API_PORT),
+        ELIZA_PORT: String(API_PORT),
+        ELIZA_PAIRING_DISABLED: "1",
+        ELIZA_E2E_MODEL_STREAM_CHUNK_SIZE: "8",
+        ELIZA_E2E_MODEL_STREAM_INTERVAL_MS: "16",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    apiChild.stdout.on("data", (chunk) => {
+      process.stdout.write(`[ui-smoke][real-local] ${chunk}`);
+    });
+    apiChild.stderr.on("data", (chunk) => {
+      process.stdout.write(`[ui-smoke][real-local-err] ${chunk}`);
+    });
+
+    await waitForJsonPredicate<{ state?: string }>(
+      `${apiBase}/api/status`,
+      (status) => status.state === "running",
+      READY_TIMEOUT_MS,
+    );
+    await waitForJsonPredicate<{ session?: { kind?: string } }>(
+      `${apiBase}/api/auth/me`,
+      (me) => me.session?.kind === "local",
+      READY_TIMEOUT_MS,
+    );
+
+    uiServer = await startUiProxyServer({
+      apiBase,
+      port: UI_PORT,
+      uiDistDir,
+    });
+    process.env.ELIZA_API_PORT = String(API_PORT);
+    markStateDirOwnedByStack(stateDir);
+
+    return {
+      apiBase,
+      apiChild,
+      stateDir,
+      uiBase: `http://127.0.0.1:${UI_PORT}`,
+      uiServer,
+    };
+  } catch (error) {
+    await closeUiServer(uiServer);
+    await stopApiChild(apiChild);
+    await removePathRecursive(stateDir);
+    pendingStateDirs.delete(stateDir);
+    throw error;
+  }
+}
+
 async function startRealStack(): Promise<StartedStack> {
   await ensureUiDistReady();
+
+  if (REAL_LOCAL_STACK) {
+    return startRealLocalStack();
+  }
 
   if (FORCE_STUB_STACK || !LIVE_PROVIDER) {
     return startStubStack();

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -7,6 +7,7 @@
  * WebView tests reach it through adb reverse as a "remote" first-run target.
  */
 
+import { ModelType } from "@elizaos/core";
 import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
 import { createDeterministicLlmProxyPlugin } from "../../test/mocks/helpers/llm-proxy-plugin.ts";
 import { startApiServer } from "../src/api/server.ts";
@@ -18,6 +19,10 @@ const deviceE2eUploadImageRoute = {
   path: "/api/device-e2e/upload-image",
   name: "device-e2e-upload-image",
 };
+
+const STREAM_E2E_REPLY =
+  "STREAM_E2E_OK The dashboard receives this reply through the real model callback, runtime message loop, HTTP SSE route, browser parser, and React transcript. " +
+  "Each chunk is intentionally small and evenly paced so the browser lane can measure token-to-paint latency, frame cadence, layout stability, and DOM identity while the visible answer grows.";
 
 function resolvePort(): number {
   const raw = process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "31337";
@@ -31,12 +36,49 @@ function resolvePort(): number {
 async function main(): Promise<void> {
   const t0 = Date.now();
   const port = resolvePort();
+  const streamIntervalMs = Number.parseInt(
+    process.env.ELIZA_E2E_MODEL_STREAM_INTERVAL_MS ?? "",
+    10,
+  );
+  const streamChunkSize = Number.parseInt(
+    process.env.ELIZA_E2E_MODEL_STREAM_CHUNK_SIZE ?? "4",
+    10,
+  );
+  const deterministicStream =
+    Number.isSafeInteger(streamIntervalMs) && streamIntervalMs >= 0
+      ? {
+          chunkSize: streamChunkSize,
+          intervalMs: streamIntervalMs,
+          modelTypes: [ModelType.RESPONSE_HANDLER],
+        }
+      : undefined;
 
   process.env.ELIZA_PAIRING_DISABLED ??= "1";
 
   const configEnv = useIsolatedConfigEnv("eliza-device-e2e-host-agent-");
   const proxy = createDeterministicLlmProxyPlugin({
     failOnUnhandledAction: false,
+    ...(deterministicStream ? { stream: deterministicStream } : {}),
+    resolve(call) {
+      if (
+        !deterministicStream ||
+        call.modelType !== ModelType.RESPONSE_HANDLER
+      ) {
+        return null;
+      }
+      const args = {
+        shouldRespond: "RESPOND",
+        contexts: ["simple"],
+        intents: ["chat"],
+        replyText: STREAM_E2E_REPLY,
+        candidateActionNames: [],
+        facts: [],
+        relationships: [],
+        addressedTo: [],
+        emotion: "none",
+      };
+      return JSON.stringify(args);
+    },
   });
   const mediaRoutesPlugin = {
     name: "device-e2e-media-routes",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,6 +19,7 @@
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
+    "test:e2e:chat-stream-real": "ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 ELIZA_UI_SMOKE_DISABLE_VIDEO=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/chat-stream-real-runtime-perf.spec.ts",
     "test:e2e:human": "ELIZA_UI_PLAYWRIGHT_SLOWMO=250 E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --headed",
     "test:e2e:record": "E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "test:e2e:accounts-ui": "node e2e/accounts-ui/run-accounts-ui-e2e.mjs",

--- a/packages/app/test/ui-smoke/chat-stream-real-runtime-perf.spec.ts
+++ b/packages/app/test/ui-smoke/chat-stream-real-runtime-perf.spec.ts
@@ -1,0 +1,553 @@
+/**
+ * Proves chat streaming across the real local runtime and production browser
+ * surface. The model is deterministic, but every layer around it is real:
+ * model callback, message loop, persisted conversation, HTTP SSE, client
+ * parser, React state, transcript DOM, layout, and browser frame scheduling.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import { openAppPath, seedAppStorage } from "./helpers";
+
+const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
+const RESPONSE_MARKER = "STREAM_E2E_OK";
+const STREAM_PATH = /\/api\/conversations\/[^/]+\/messages\/stream$/;
+
+type StreamFrame = {
+  atMs: number;
+  fullText?: string;
+  text?: string;
+  type?: string;
+};
+
+type StreamRecord = {
+  doneAtMs: number | null;
+  firstByteAtMs: number | null;
+  frames: StreamFrame[];
+  requestAtMs: number;
+  wireChunkCount: number;
+};
+
+type PaintRecord = {
+  atMs: number;
+  text: string;
+};
+
+type RealStreamProbe = {
+  frameTimes: number[];
+  layoutShifts: Array<{
+    atMs: number;
+    outsideChat: boolean;
+    value: number;
+  }>;
+  layoutShiftObserverSupported: boolean;
+  streams: StreamRecord[];
+};
+
+type RenderProbe = {
+  activeNode: Element | null;
+  activeNodeDisconnected: boolean;
+  activeNodeReplacements: number;
+  composerTopBefore: number;
+  frameHandle: number;
+  historicalMutations: number;
+  historicalNode: Element;
+  historicalNodeDisconnected: boolean;
+  identityRunning: boolean;
+  paints: PaintRecord[];
+  running: boolean;
+};
+
+async function installRealStreamInstrumentation(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.addInitScript(
+    ({ streamPattern }) => {
+      const state = window as unknown as {
+        __ELIZA_REAL_STREAM_PROBE__?: RealStreamProbe;
+      };
+      const probe: RealStreamProbe = {
+        frameTimes: [],
+        layoutShifts: [],
+        layoutShiftObserverSupported: false,
+        streams: [],
+      };
+      state.__ELIZA_REAL_STREAM_PROBE__ = probe;
+
+      const sampleFrame = (now: number) => {
+        probe.frameTimes.push(now);
+        requestAnimationFrame(sampleFrame);
+      };
+      requestAnimationFrame(sampleFrame);
+
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          const shift = entry as PerformanceEntry & {
+            hadRecentInput?: boolean;
+            sources?: Array<{ node?: Node | null }>;
+            value?: number;
+          };
+          if (shift.hadRecentInput || !(Number(shift.value) > 0)) continue;
+          const sources = Array.isArray(shift.sources) ? shift.sources : [];
+          const outsideChat = sources.some((source) => {
+            const node = source.node;
+            const element =
+              node instanceof Element ? node : node?.parentElement;
+            return element
+              ? !element.closest(
+                  '[data-testid="chat-overlay"], [data-testid="chat-sheet"]',
+                )
+              : false;
+          });
+          probe.layoutShifts.push({
+            atMs: performance.now(),
+            outsideChat,
+            value: Number(shift.value),
+          });
+        }
+      });
+      if (PerformanceObserver.supportedEntryTypes.includes("layout-shift")) {
+        observer.observe({ type: "layout-shift", buffered: true });
+        probe.layoutShiftObserverSupported = true;
+      }
+
+      const nativeFetch = window.fetch.bind(window);
+      const pathPattern = new RegExp(streamPattern);
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        if (
+          request.method.toUpperCase() !== "POST" ||
+          !pathPattern.test(new URL(request.url).pathname)
+        ) {
+          return nativeFetch(input, init);
+        }
+
+        const record: StreamRecord = {
+          doneAtMs: null,
+          firstByteAtMs: null,
+          frames: [],
+          requestAtMs: performance.now(),
+          wireChunkCount: 0,
+        };
+        probe.streams.push(record);
+        const response = await nativeFetch(input, init);
+        if (!response.body) return response;
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let reconstructedText = "";
+        const body = new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            const result = await reader.read();
+            if (result.done) {
+              buffer += decoder.decode();
+              controller.close();
+              return;
+            }
+            const now = performance.now();
+            record.firstByteAtMs ??= now;
+            record.wireChunkCount += 1;
+            buffer += decoder.decode(result.value, { stream: true });
+            let boundary = buffer.indexOf("\n\n");
+            while (boundary >= 0) {
+              const event = buffer.slice(0, boundary);
+              buffer = buffer.slice(boundary + 2);
+              const data = event
+                .split(/\r?\n/)
+                .filter((line) => line.startsWith("data:"))
+                .map((line) => line.slice(5).trimStart())
+                .join("\n");
+              if (data) {
+                try {
+                  const parsed = JSON.parse(data) as {
+                    fullText?: string;
+                    text?: string;
+                    type?: string;
+                  };
+                  if (parsed.type === "token") {
+                    reconstructedText =
+                      typeof parsed.fullText === "string"
+                        ? parsed.fullText
+                        : reconstructedText + (parsed.text ?? "");
+                  }
+                  const frame = { ...parsed, atMs: now };
+                  if (parsed.type === "token") {
+                    frame.fullText = reconstructedText;
+                  }
+                  record.frames.push(frame);
+                  if (parsed.type === "done") record.doneAtMs = now;
+                } catch {
+                  // error-policy:J3 instrumentation ignores invalid SSE JSON
+                  // while the production parser owns the user-visible failure.
+                }
+              }
+              boundary = buffer.indexOf("\n\n");
+            }
+            controller.enqueue(result.value);
+          },
+          cancel(reason) {
+            return reader.cancel(reason);
+          },
+        });
+
+        return new Response(body, {
+          headers: response.headers,
+          status: response.status,
+          statusText: response.statusText,
+        });
+      };
+    },
+    { streamPattern: STREAM_PATH.source },
+  );
+}
+
+async function sendAndWaitForDone(
+  page: import("@playwright/test").Page,
+  text: string,
+  expectedStreamCount: number,
+): Promise<void> {
+  const composer = page.getByTestId("chat-composer-textarea");
+  await composer.fill(text);
+  await page.getByTestId("chat-composer-action").click();
+  await page.waitForFunction(
+    (count) => {
+      const probe = (
+        window as unknown as {
+          __ELIZA_REAL_STREAM_PROBE__?: RealStreamProbe;
+        }
+      ).__ELIZA_REAL_STREAM_PROBE__;
+      return (
+        probe?.streams.length === count &&
+        probe.streams[count - 1]?.doneAtMs !== null
+      );
+    },
+    expectedStreamCount,
+    { timeout: 60_000 },
+  );
+}
+
+test.describe("real-runtime chat stream performance", () => {
+  test.skip(!REAL_LOCAL_STACK, "requires ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1");
+  test.setTimeout(180_000);
+
+  test("streams once without sibling rerenders, remounts, reflow, or visible jank", async ({
+    page,
+  }, testInfo) => {
+    await installRealStreamInstrumentation(page);
+    const conversationResponse = await page.request.post("/api/conversations", {
+      data: {
+        title: "Real stream performance",
+        metadata: { scope: "general" },
+      },
+    });
+    expect(conversationResponse.ok()).toBe(true);
+    const conversationBody = (await conversationResponse.json()) as {
+      conversation?: { id?: string };
+    };
+    const conversationId = conversationBody.conversation?.id;
+    expect(conversationId).toBeTruthy();
+
+    await seedAppStorage(page, {
+      "eliza:chat:activeConversationId": conversationId ?? "",
+    });
+    await openAppPath(page, "/chat");
+    await expect(page.getByTestId("chat-composer-textarea")).toBeVisible();
+
+    const firstHistoryReload = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        new URL(response.url()).pathname ===
+          `/api/conversations/${conversationId}/messages` &&
+        response.ok(),
+    );
+    await sendAndWaitForDone(page, "Establish the completed history row.", 1);
+    const firstReloadResponse = await firstHistoryReload;
+    await firstReloadResponse.finished();
+    await page.waitForTimeout(500);
+    await expect(
+      page
+        .locator('[data-testid="thread-line"][data-role="assistant"]')
+        .filter({ hasText: RESPONSE_MARKER }),
+    ).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "talk" })).toBeVisible();
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+
+    await page.evaluate(() => {
+      const state = window as unknown as {
+        __ELIZA_REAL_STREAM_PROBE__?: RealStreamProbe;
+        __ELIZA_REAL_STREAM_RENDER__?: RenderProbe;
+      };
+      const historicalNode = Array.from(
+        document.querySelectorAll(
+          '[data-testid="thread-line"][data-role="assistant"]',
+        ),
+      ).at(-1);
+      const composer = document.querySelector(
+        '[data-testid="chat-composer-textarea"]',
+      );
+      if (!historicalNode || !composer) {
+        throw new Error("chat render probe could not find baseline nodes");
+      }
+      const renderProbe: RenderProbe = {
+        activeNode: null,
+        activeNodeDisconnected: false,
+        activeNodeReplacements: 0,
+        composerTopBefore: composer.getBoundingClientRect().top,
+        frameHandle: 0,
+        historicalMutations: 0,
+        historicalNode,
+        historicalNodeDisconnected: false,
+        identityRunning: true,
+        paints: [],
+        running: true,
+      };
+      state.__ELIZA_REAL_STREAM_RENDER__ = renderProbe;
+      state.__ELIZA_REAL_STREAM_PROBE__.frameTimes = [];
+      state.__ELIZA_REAL_STREAM_PROBE__.layoutShifts = [];
+
+      const historyObserver = new MutationObserver((records) => {
+        renderProbe.historicalMutations += records.length;
+      });
+      historyObserver.observe(historicalNode, {
+        attributes: true,
+        characterData: true,
+        childList: true,
+        subtree: true,
+      });
+
+      const sample = (now: number) => {
+        if (!renderProbe.running) {
+          historyObserver.disconnect();
+          return;
+        }
+        const measuredStream = state.__ELIZA_REAL_STREAM_PROBE__?.streams[1];
+        if (
+          renderProbe.identityRunning &&
+          measuredStream &&
+          measuredStream.doneAtMs !== null
+        ) {
+          renderProbe.identityRunning = false;
+          historyObserver.disconnect();
+        }
+        const assistantRows = Array.from(
+          document.querySelectorAll(
+            '[data-testid="thread-line"][data-role="assistant"]',
+          ),
+        );
+        const candidate = assistantRows.at(-1) ?? null;
+        if (candidate && candidate !== renderProbe.historicalNode) {
+          if (renderProbe.identityRunning) {
+            if (!renderProbe.historicalNode.isConnected) {
+              renderProbe.historicalNodeDisconnected = true;
+            }
+            if (renderProbe.activeNode && !renderProbe.activeNode.isConnected) {
+              renderProbe.activeNodeDisconnected = true;
+            }
+            if (
+              renderProbe.activeNode &&
+              candidate !== renderProbe.activeNode
+            ) {
+              renderProbe.activeNodeReplacements += 1;
+              renderProbe.activeNode = candidate;
+            }
+            renderProbe.activeNode ??= candidate;
+          }
+          const text = (candidate as HTMLElement).innerText;
+          if (renderProbe.paints.at(-1)?.text !== text) {
+            renderProbe.paints.push({ atMs: now, text });
+          }
+        }
+        renderProbe.frameHandle = requestAnimationFrame(sample);
+      };
+      renderProbe.frameHandle = requestAnimationFrame(sample);
+    });
+
+    const secondHistoryReload = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        new URL(response.url()).pathname ===
+          `/api/conversations/${conversationId}/messages` &&
+        response.ok(),
+    );
+    await sendAndWaitForDone(page, "Measure the real streaming surface.", 2);
+    const secondReloadResponse = await secondHistoryReload;
+    await secondReloadResponse.finished();
+    const streamedRows = page
+      .locator('[data-testid="thread-line"][data-role="assistant"]')
+      .filter({ hasText: RESPONSE_MARKER });
+    await expect(streamedRows).toHaveCount(2);
+    await expect(
+      page
+        .locator('[data-testid="thread-line"][data-role="assistant"]')
+        .filter({ hasText: "I'm not sure how to answer that." }),
+    ).toHaveCount(0);
+    await page.waitForTimeout(150);
+
+    const metrics = await page.evaluate((responseMarker) => {
+      const state = window as unknown as {
+        __ELIZA_REAL_STREAM_PROBE__?: RealStreamProbe;
+        __ELIZA_REAL_STREAM_RENDER__?: RenderProbe;
+      };
+      const probe = state.__ELIZA_REAL_STREAM_PROBE__;
+      const renderProbe = state.__ELIZA_REAL_STREAM_RENDER__;
+      if (!probe || !renderProbe) {
+        throw new Error("real stream browser probe is unavailable");
+      }
+      renderProbe.running = false;
+      cancelAnimationFrame(renderProbe.frameHandle);
+      const stream = probe.streams[1];
+      const rawTokenFrames = stream.frames.filter(
+        (frame) => frame.type === "token" && frame.fullText,
+      );
+      const tokenFrames = rawTokenFrames.filter(
+        (frame, index) =>
+          index === 0 || frame.fullText !== rawTokenFrames[index - 1]?.fullText,
+      );
+      const doneAtMs = stream.doneAtMs ?? performance.now();
+      const tokenPaintLatencies = tokenFrames
+        .map((frame) => {
+          const paint = renderProbe.paints.find(
+            (candidate) =>
+              candidate.atMs >= frame.atMs &&
+              candidate.text.includes(frame.fullText ?? ""),
+          );
+          return paint ? paint.atMs - frame.atMs : null;
+        })
+        .filter((value): value is number => value !== null);
+      const firstTokenAtMs = tokenFrames[0]?.atMs ?? doneAtMs;
+      const frameTimes = probe.frameTimes.filter(
+        (time) => time >= firstTokenAtMs && time <= doneAtMs + 100,
+      );
+      const frameDeltas = frameTimes
+        .slice(1)
+        .map((time, index) => time - (frameTimes[index] ?? time));
+      const measuredLayoutShifts = probe.layoutShifts.filter(
+        (shift) => shift.atMs >= firstTokenAtMs && shift.atMs <= doneAtMs,
+      );
+      const percentile = (values: number[], quantile: number) => {
+        if (values.length === 0) return 0;
+        const sorted = values.toSorted((a, b) => a - b);
+        return (
+          sorted[
+            Math.min(sorted.length - 1, Math.ceil(quantile * sorted.length) - 1)
+          ] ?? 0
+        );
+      };
+      const composer = document.querySelector(
+        '[data-testid="chat-composer-textarea"]',
+      );
+      return {
+        activeNodeObserved: renderProbe.activeNode !== null,
+        activeNodeStableDuringStream: !renderProbe.activeNodeDisconnected,
+        activeNodeReplacements: renderProbe.activeNodeReplacements,
+        cls: measuredLayoutShifts.reduce((sum, shift) => sum + shift.value, 0),
+        composerMovementPx: composer
+          ? Math.abs(
+              composer.getBoundingClientRect().top -
+                renderProbe.composerTopBefore,
+            )
+          : Number.POSITIVE_INFINITY,
+        doneLeadMs:
+          doneAtMs -
+          (renderProbe.paints.find((paint) =>
+            paint.text.includes(responseMarker),
+          )?.atMs ?? doneAtMs),
+        droppedFrameRatio:
+          frameDeltas.filter((delta) => delta > 25).length /
+          Math.max(1, frameDeltas.length),
+        firstTokenToPaintMs: tokenPaintLatencies[0] ?? Number.POSITIVE_INFINITY,
+        frameP95Ms: percentile(frameDeltas, 0.95),
+        historicalMutations: renderProbe.historicalMutations,
+        historicalNodeStableDuringStream:
+          !renderProbe.historicalNodeDisconnected,
+        layoutShiftObserverSupported: probe.layoutShiftObserverSupported,
+        outsideChatLayoutShifts: measuredLayoutShifts.filter(
+          (shift) => shift.outsideChat,
+        ).length,
+        paintCommits: renderProbe.paints.filter(
+          (paint) => paint.atMs >= firstTokenAtMs && paint.atMs <= doneAtMs,
+        ).length,
+        tokenFrames: tokenFrames.length,
+        tokenPaintCoverage:
+          tokenPaintLatencies.length / Math.max(1, tokenFrames.length),
+        tokenToPaintP50Ms: percentile(tokenPaintLatencies, 0.5),
+        tokenToPaintP95Ms: percentile(tokenPaintLatencies, 0.95),
+        transportSpreadMs:
+          (tokenFrames.at(-1)?.atMs ?? firstTokenAtMs) - firstTokenAtMs,
+        wireChunkCount: stream.wireChunkCount,
+      };
+    }, RESPONSE_MARKER);
+
+    const persistedResponse = await page.request.get(
+      `/api/conversations/${conversationId}/messages`,
+    );
+    expect(persistedResponse.ok()).toBe(true);
+    const persisted = (await persistedResponse.json()) as {
+      messages?: Array<{ role?: string; text?: string }>;
+    };
+    const assistantMessages = (persisted.messages ?? []).filter(
+      (message) => message.role === "assistant",
+    );
+    const persistedMarkerMessages = assistantMessages.filter((message) =>
+      message.text?.includes(RESPONSE_MARKER),
+    );
+
+    const metricsPath = testInfo.outputPath("real-stream-performance.json");
+    await writeFile(
+      metricsPath,
+      `${JSON.stringify(
+        {
+          ...metrics,
+          persistedAssistantMessages: assistantMessages.length,
+          persistedMarkerMessages: persistedMarkerMessages.length,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await testInfo.attach("real-stream-performance.json", {
+      path: metricsPath,
+      contentType: "application/json",
+    });
+    const screenshotPath = testInfo.outputPath("real-stream-final.jpg");
+    await page.screenshot({
+      fullPage: true,
+      path: screenshotPath,
+      quality: 90,
+      type: "jpeg",
+    });
+    await testInfo.attach("real-stream-final.jpg", {
+      path: screenshotPath,
+      contentType: "image/jpeg",
+    });
+
+    expect(metrics.tokenFrames).toBeGreaterThanOrEqual(20);
+    expect(metrics.wireChunkCount).toBeGreaterThanOrEqual(20);
+    expect(metrics.transportSpreadMs).toBeGreaterThan(500);
+    expect(metrics.paintCommits).toBeGreaterThanOrEqual(10);
+    expect(metrics.tokenPaintCoverage).toBeGreaterThanOrEqual(0.9);
+    expect(metrics.firstTokenToPaintMs).toBeLessThanOrEqual(75);
+    expect(metrics.tokenToPaintP50Ms).toBeLessThanOrEqual(60);
+    expect(metrics.tokenToPaintP95Ms).toBeLessThanOrEqual(150);
+    expect(metrics.doneLeadMs).toBeGreaterThan(500);
+    expect(metrics.frameP95Ms).toBeLessThanOrEqual(40);
+    expect(metrics.droppedFrameRatio).toBeLessThanOrEqual(0.25);
+    expect(metrics.historicalMutations).toBe(0);
+    expect(metrics.historicalNodeStableDuringStream).toBe(true);
+    expect(metrics.activeNodeReplacements).toBe(0);
+    expect(metrics.activeNodeObserved).toBe(true);
+    expect(metrics.activeNodeStableDuringStream).toBe(true);
+    expect(metrics.layoutShiftObserverSupported).toBe(true);
+    expect(metrics.outsideChatLayoutShifts).toBe(0);
+    expect(metrics.composerMovementPx).toBeLessThanOrEqual(1);
+    expect(persistedMarkerMessages).toHaveLength(2);
+  });
+});

--- a/packages/test/mocks/__tests__/llm-proxy-plugin.test.ts
+++ b/packages/test/mocks/__tests__/llm-proxy-plugin.test.ts
@@ -46,6 +46,26 @@ describe("deterministic LLM proxy plugin", () => {
     expect(plugin.models?.[ModelType.TEXT_LARGE]).toBeTypeOf("function");
   });
 
+  it("can expose deterministic model output through the real streaming callback", async () => {
+    const chunks: string[] = [];
+    const plugin = createDeterministicLlmProxyPlugin({
+      stream: { chunkSize: 5, intervalMs: 0 },
+    });
+
+    const raw = await plugin.models?.[ModelType.TEXT_SMALL]?.(runtime, {
+      messages: [{ role: "user", content: "stream this response" }],
+      onStreamChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+
+    expect(plugin.modelMetadata?.[ModelType.TEXT_SMALL]).toEqual({
+      streamable: true,
+    });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(raw);
+  });
+
   it("returns a deterministic HANDLE_RESPONSE payload for Stage 1", async () => {
     const plugin = createDeterministicLlmProxyPlugin();
     const raw = await plugin.models?.[ModelType.RESPONSE_HANDLER]?.(runtime, {

--- a/packages/test/mocks/helpers/llm-proxy-plugin.ts
+++ b/packages/test/mocks/helpers/llm-proxy-plugin.ts
@@ -123,6 +123,16 @@ export interface DeterministicLlmProxyOptions {
   fixtureRegistry?: DeterministicLlmFixtureRegistry;
   priority?: number;
   resolve?: (call: LlmProxyCall) => LlmProxyResponse | null | undefined;
+  /**
+   * Opt-in model-callback streaming for real-runtime browser/device tests.
+   * The final model result is unchanged; its serialized form is also delivered
+   * through `onStreamChunk` at a deterministic cadence.
+   */
+  stream?: {
+    chunkSize: number;
+    intervalMs: number;
+    modelTypes?: ModelTypeName[];
+  };
 }
 
 const HANDLE_RESPONSE_TOOL_NAME = "HANDLE_RESPONSE";
@@ -159,14 +169,27 @@ export function createDeterministicLlmProxyPlugin(
     const call = buildCall(modelType, params);
     const fixtureResolved = resolveFixtureCall(fixtureRegistry, call);
     if (fixtureResolved !== undefined) {
+      await streamDeterministicResponse(
+        params,
+        fixtureResolved,
+        options.stream,
+        modelType,
+      );
       return fixtureResolved;
     }
 
     const resolved = options.resolve?.(call);
     if (resolved !== null && resolved !== undefined) {
-      return options.strict
+      const normalized = options.strict
         ? normalizeAndValidateFixtureResponse(resolved, call, "resolve")
         : normalizeResolvedResponse(resolved);
+      await streamDeterministicResponse(
+        params,
+        normalized,
+        options.stream,
+        modelType,
+      );
+      return normalized;
     }
 
     if (options.strict) {
@@ -174,22 +197,50 @@ export function createDeterministicLlmProxyPlugin(
     }
 
     if (modelType === ModelType.RESPONSE_HANDLER) {
-      return normalizeResolvedResponse(
+      const normalized = normalizeResolvedResponse(
         createHandleResponse(call, options.failOnUnhandledAction ?? true),
       );
+      await streamDeterministicResponse(
+        params,
+        normalized,
+        options.stream,
+        modelType,
+      );
+      return normalized;
     }
 
     if (modelType === ModelType.ACTION_PLANNER) {
-      return normalizeResolvedResponse(
+      const normalized = normalizeResolvedResponse(
         createPlannerResponse(call, options.failOnUnhandledAction ?? true),
       );
+      await streamDeterministicResponse(
+        params,
+        normalized,
+        options.stream,
+        modelType,
+      );
+      return normalized;
     }
 
     if (params.responseSchema) {
-      return JSON.stringify(schemaFixture(params.responseSchema));
+      const normalized = JSON.stringify(schemaFixture(params.responseSchema));
+      await streamDeterministicResponse(
+        params,
+        normalized,
+        options.stream,
+        modelType,
+      );
+      return normalized;
     }
 
-    return `deterministic-test-response: ${call.latestUserText || modelType}`;
+    const normalized = `deterministic-test-response: ${call.latestUserText || modelType}`;
+    await streamDeterministicResponse(
+      params,
+      normalized,
+      options.stream,
+      modelType,
+    );
+    return normalized;
   }
 
   const models: NonNullable<Plugin["models"]> = {
@@ -208,10 +259,52 @@ export function createDeterministicLlmProxyPlugin(
       "High-priority deterministic LLM proxy for zero-cost end-to-end tests.",
     priority: options.priority ?? 1_000,
     models,
+    ...(options.stream
+      ? {
+          modelMetadata: Object.fromEntries(
+            TEXT_MODEL_TYPES.filter(
+              (modelType) =>
+                !options.stream?.modelTypes ||
+                options.stream.modelTypes.includes(modelType),
+            ).map((modelType) => [modelType, { streamable: true }]),
+          ),
+        }
+      : {}),
     llmFixtures: fixtureRegistry,
     assertFixturesConsumed: () => fixtureRegistry.assertConsumed(),
     getFixtureDiagnostics: () => fixtureRegistry.diagnostics(),
   };
+}
+
+async function streamDeterministicResponse(
+  params: GenerateTextParams,
+  response: string,
+  stream: DeterministicLlmProxyOptions["stream"],
+  modelType: ModelTypeName,
+): Promise<void> {
+  if (!stream || typeof params.onStreamChunk !== "function") return;
+  if (stream.modelTypes && !stream.modelTypes.includes(modelType)) return;
+  if (
+    !Number.isSafeInteger(stream.chunkSize) ||
+    stream.chunkSize <= 0 ||
+    !Number.isFinite(stream.intervalMs) ||
+    stream.intervalMs < 0
+  ) {
+    throw new Error(
+      "deterministic LLM stream requires a positive integer chunkSize and a non-negative intervalMs",
+    );
+  }
+
+  for (let offset = 0; offset < response.length; offset += stream.chunkSize) {
+    await params.onStreamChunk(
+      response.slice(offset, offset + stream.chunkSize),
+    );
+    if (offset + stream.chunkSize < response.length && stream.intervalMs > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, stream.intervalMs);
+      });
+    }
+  }
 }
 
 function buildCall(


### PR DESCRIPTION
## What changed

- use the model extractor's authoritative accumulated text at the chat route instead of guessing overlap between adjacent raw chunks
- preserve repeated characters that land on a chunk boundary (for example `lo` + `op`)
- add a deterministic streaming mode to the real-runtime test provider
- add a production-browser E2E gate across model callback → runtime → persisted conversation → SSE → browser parser → React transcript
- stream the Playwright live-stack proxy response instead of buffering it

## Root cause

The chat route discarded the structured stream callback's cumulative-text argument and reconciled every chunk as if it might be either a delta or a snapshot. Adjacent chunks ending and beginning with the same character were treated as overlap, corrupting the terminal SSE text. Because the optimistic browser text then differed from the persisted message, reconciliation retained both rows and surfaced the duplicate behavior that #17037's transport-ownership fix was intended to eliminate.

## Validation

- real-runtime production-browser stream E2E: pass
  - first token to paint: 23.9 ms
  - token-to-paint median: 24.6 ms
  - frame p95: 25.1 ms
  - dropped-frame ratio: 6.7%
  - historical row mutations: 0
  - active streamed row replacements: 0
  - outside-chat layout shifts: 0
  - composer movement: 0 px
  - persisted marker replies: exactly 2 for 2 sends
- existing browser chat perf gate: pass (9.0 ms streaming frame p95, 0% dropped frames, zero outside-chat shifts)
- route streaming tests: 30 passed
- deterministic LLM proxy tests: 49 passed
- React streaming/render-count tests: 6 passed
- app production build: pass

## Evidence

- Screenshots/video: generated and manually reviewed locally; the transcript grows progressively and ends with one assistant row per send.
- Backend structured logs: real local runtime and app-core API exercised by the E2E test.
- Frontend console/network logs: the test asserts the real SSE request, wire chunks, terminal frame, history reload, and persisted message count.
- Real-LLM trajectory: N/A — the regression is transport/reconciliation behavior; deterministic model output is required for byte-exact boundary assertions.
- Native/device evidence: N/A — this hotfix changes the shared HTTP SSE route and production web React surface.

Follow-up to #17037. Related smell reports: #17009 and #16981.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - transport-only correction; no visual design or layout changed

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17111-real-stream-final.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17111-eliza-stream-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - the real local runtime is launched and asserted inside the browser E2E; no production backend was modified or deployed

<!-- evidence-row:frontend-logs -->
- [x] [17111-real-stream-performance-verified.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17111-real-stream-performance-verified.json)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic model output is required to byte-compare SSE and persisted text at repeated-character chunk boundaries

<!-- evidence-row:domain-artifacts -->
- [x] [17111-real-stream-performance-verified.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17111-real-stream-performance-verified.json)

