### PR TITLE
fix(scripts): exclude .claude from the dist-path consumer walk

### DIFF
--- a/packages/scripts/typecheck-dist-path-consumers.mjs
+++ b/packages/scripts/typecheck-dist-path-consumers.mjs
@@ -19,6 +19,10 @@ const repoRoot = path.resolve(
 );
 const distPathsConfig = path.join(repoRoot, "tsconfig.dist-paths.json");
 const ignoredDirs = new Set([
+  // .claude holds agent tooling state, including .claude/worktrees — complete
+  // sibling checkouts that appear and vanish mid-run (workflow subagents).
+  // Walking them both typechecks foreign checkouts and races their deletion.
+  ".claude",
   ".git",
   ".next",
   ".turbo",


### PR DESCRIPTION
## Problem

`bun run verify` dies intermittently in `typecheck:dist` whenever Claude Code workflow subagents are active:

```
Error: ENOENT: no such file or directory
  path: '…/.claude/worktrees/agent-a5a075de5fb0ae6c3/packages/agent/tsconfig.build.json'
error: script "typecheck:dist" exited with code 1
```

`typecheck-dist-path-consumers.mjs` already root-excludes the sibling-checkout containers (`.worktrees`, `.audit-worktrees`, `.codex-*-worktrees`) but not `.claude`, whose `worktrees/` subdir holds the same class of complete sibling checkouts — including ephemeral workflow-subagent worktrees that appear and vanish mid-run. The walker both typechecks foreign checkouts and races their deletion.

## Fix

Add `.claude` to `ignoredDirs` (any depth — nested checkouts carry their own `.claude` state dirs too; none ever holds a first-party tsconfig consumer). Repro + fix proof: `node packages/scripts/typecheck-dist-path-consumers.mjs` failed with the ENOENT above on a tree with active subagent worktrees; with this change the same `generate-dist-paths-config --check` → `prepare-dist-path-declarations` → `typecheck-dist-path-consumers` chain exits 0.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - CI-hygiene script change; no UI surface.

<!-- evidence-row:after-screenshots -->
N/A - CI-hygiene script change; no UI surface.

<!-- evidence-row:walkthrough-video -->
N/A - CI-hygiene script change; no user-facing flow to record.

<!-- evidence-row:backend-logs -->
N/A - dev-tooling script, not a runtime path; the ENOENT failure log and green re-run are quoted in the PR description above.

<!-- evidence-row:frontend-logs -->
N/A - no frontend involvement.

<!-- evidence-row:llm-trajectory -->
N/A - no agent/model/prompt behavior touched.

<!-- evidence-row:domain-artifacts -->
N/A - no domain data produced; the artifact is the green verify chain quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
