### PR TITLE
fix(agent): make conversation readiness proofs invalidation-safe

### DIFF
--- a/packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
+++ b/packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
@@ -9,8 +9,8 @@ import {
   handleCharacterRoutes,
 } from "../character-routes.ts";
 import {
+  assertConversationConnectionRuntime,
   captureConversationConnectionDescriptor,
-  hasReadyConversationConnection,
   scheduleConversationConnectionEnsure,
 } from "../conversation-connection-readiness.ts";
 
@@ -43,7 +43,9 @@ describe("character connection topology invalidation", () => {
     } as unknown as AgentRuntime;
     const oldDescriptor = captureDescriptor(runtime, "Old Name");
     await scheduleConversationConnectionEnsure(oldDescriptor, async () => {});
-    expect(hasReadyConversationConnection(oldDescriptor)).toBe(true);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, oldDescriptor),
+    ).not.toThrow();
 
     const json = vi.fn();
     const handled = await handleCharacterRoutes({
@@ -69,9 +71,20 @@ describe("character connection topology invalidation", () => {
       expect.anything(),
       expect.objectContaining({ ok: true, agentName: "New Name" }),
     );
-    expect(hasReadyConversationConnection(oldDescriptor)).toBe(false);
-    expect(
-      hasReadyConversationConnection(captureDescriptor(runtime, "New Name")),
-    ).toBe(false);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, oldDescriptor),
+    ).toThrow(
+      expect.objectContaining({
+        code: "CONVERSATION_CONNECTION_INVALIDATED",
+      }),
+    );
+    const renamedDescriptor = captureDescriptor(runtime, "New Name");
+    await scheduleConversationConnectionEnsure(
+      renamedDescriptor,
+      async () => {},
+    );
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, renamedDescriptor),
+    ).not.toThrow();
   });
 });

--- a/packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
+++ b/packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Verifies character renames invalidate connection proofs before persisting the
+ * new topology, so old-name completions cannot become ready afterward.
+ */
+import { type AgentRuntime, stringToUuid, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CharacterRouteContext,
+  handleCharacterRoutes,
+} from "../character-routes.ts";
+import {
+  captureConversationConnectionDescriptor,
+  hasReadyConversationConnection,
+  scheduleConversationConnectionEnsure,
+} from "../conversation-connection-readiness.ts";
+
+function captureDescriptor(runtime: AgentRuntime, agentName: string) {
+  return captureConversationConnectionDescriptor({
+    runtime,
+    conversationId: "rename-conversation",
+    roomId: stringToUuid("rename-room") as UUID,
+    agentName,
+    worldId: stringToUuid(`${agentName}-web-chat-world`) as UUID,
+    messageServerId: stringToUuid(`${agentName}-web-server`) as UUID,
+    channelId: "web-conv-rename-conversation",
+    ownerId: stringToUuid("rename-owner") as UUID,
+    callerEntityId: stringToUuid("rename-caller") as UUID,
+    callerRole: "USER",
+    callerUserName: "rename-caller",
+  });
+}
+
+describe("character connection topology invalidation", () => {
+  it("invalidates the old-name proof through the PUT character route", async () => {
+    const runtime = {
+      agentId: stringToUuid("rename-agent") as UUID,
+      character: {
+        name: "Old Name",
+        settings: {},
+      },
+      updateAgent: vi.fn(async () => undefined),
+      createMemory: vi.fn(async () => undefined),
+    } as unknown as AgentRuntime;
+    const oldDescriptor = captureDescriptor(runtime, "Old Name");
+    await scheduleConversationConnectionEnsure(oldDescriptor, async () => {});
+    expect(hasReadyConversationConnection(oldDescriptor)).toBe(true);
+
+    const json = vi.fn();
+    const handled = await handleCharacterRoutes({
+      req: { url: "/api/character" },
+      res: {},
+      method: "PUT",
+      pathname: "/api/character",
+      state: {
+        runtime,
+        agentName: "Old Name",
+      },
+      readJsonBody: vi.fn(async () => ({ name: "New Name" })),
+      json,
+      error: vi.fn(),
+      pickRandomNames: vi.fn(() => ["Unused"]),
+      validateCharacter: vi.fn(() => ({ success: true })),
+    } as unknown as CharacterRouteContext);
+
+    expect(handled).toBe(true);
+    expect(runtime.character.name).toBe("New Name");
+    expect(runtime.updateAgent).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: true, agentName: "New Name" }),
+    );
+    expect(hasReadyConversationConnection(oldDescriptor)).toBe(false);
+    expect(
+      hasReadyConversationConnection(captureDescriptor(runtime, "New Name")),
+    ).toBe(false);
+  });
+});

--- a/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Exercises the connection-proof coordinator under overlapping refresh,
+ * deletion, failure, topology, and runtime replacement races.
+ */
+import { type AgentRuntime, stringToUuid, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertConversationConnectionRuntime,
+  captureConversationConnectionDescriptor,
+  hasReadyConversationConnection,
+  invalidateConversationConnectionTopology,
+  prepareConversationConnectionRoom,
+  scheduleConversationConnectionEnsure,
+  serializeConversationConnectionRoomDeletion,
+} from "../conversation-connection-readiness.ts";
+
+function createRuntime(name = "Readiness Agent"): AgentRuntime {
+  return {
+    agentId: stringToUuid(`readiness-runtime-${name}`),
+    character: { name },
+  } as unknown as AgentRuntime;
+}
+
+function captureDescriptor(
+  runtime: AgentRuntime,
+  input: {
+    conversationId?: string;
+    roomSeed?: string;
+    agentName?: string;
+    callerSeed?: string;
+    callerRole?: "OWNER" | "USER" | "GUEST";
+    ownerSeed?: string;
+  } = {},
+) {
+  const agentName = input.agentName ?? runtime.character.name ?? "Eliza";
+  const conversationId = input.conversationId ?? "conversation-1";
+  return captureConversationConnectionDescriptor({
+    runtime,
+    conversationId,
+    roomId: stringToUuid(input.roomSeed ?? "readiness-room") as UUID,
+    agentName,
+    worldId: stringToUuid(`${agentName}-world`) as UUID,
+    messageServerId: stringToUuid(`${agentName}-server`) as UUID,
+    channelId: `web-conv-${conversationId}`,
+    ownerId: stringToUuid(input.ownerSeed ?? "readiness-owner") as UUID,
+    callerEntityId: stringToUuid(
+      input.callerSeed ?? "readiness-caller",
+    ) as UUID,
+    callerRole: input.callerRole ?? "USER",
+    callerUserName: input.callerSeed ?? "readiness-caller",
+  });
+}
+
+function deferred() {
+  let resolve: (() => void) | undefined;
+  let reject: ((reason: unknown) => void) | undefined;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {
+    promise,
+    resolve: () => resolve?.(),
+    reject: (reason: unknown) => reject?.(reason),
+  };
+}
+
+describe("conversation connection readiness", () => {
+  it("coalesces identical in-flight refreshes", async () => {
+    const runtime = createRuntime();
+    const descriptor = captureDescriptor(runtime);
+    const gate = deferred();
+    const ensure = vi.fn(async () => gate.promise);
+
+    const first = scheduleConversationConnectionEnsure(descriptor, ensure);
+    const second = scheduleConversationConnectionEnsure(descriptor, ensure);
+
+    expect(second).toBe(first);
+    await vi.waitFor(() => expect(ensure).toHaveBeenCalledTimes(1));
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+    expect(hasReadyConversationConnection(descriptor)).toBe(true);
+  });
+
+  it("serializes overlapping role reconciliation for the shared world", async () => {
+    const runtime = createRuntime();
+    const firstDescriptor = captureDescriptor(runtime, {
+      callerSeed: "readiness-user",
+      callerRole: "USER",
+    });
+    const secondDescriptor = captureDescriptor(runtime, {
+      callerSeed: "readiness-guest",
+      callerRole: "GUEST",
+    });
+    const firstGate = deferred();
+    const starts: string[] = [];
+    let active = 0;
+    let maximumActive = 0;
+
+    const first = scheduleConversationConnectionEnsure(
+      firstDescriptor,
+      async () => {
+        starts.push("user");
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await firstGate.promise;
+        active -= 1;
+      },
+    );
+    const second = scheduleConversationConnectionEnsure(
+      secondDescriptor,
+      async () => {
+        starts.push("guest");
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        active -= 1;
+      },
+    );
+
+    await vi.waitFor(() => expect(starts).toEqual(["user"]));
+    expect(active).toBe(1);
+    firstGate.resolve();
+    await Promise.all([first, second]);
+
+    expect(starts).toEqual(["user", "guest"]);
+    expect(maximumActive).toBe(1);
+    expect(hasReadyConversationConnection(firstDescriptor)).toBe(true);
+    expect(hasReadyConversationConnection(secondDescriptor)).toBe(true);
+  });
+
+  it("does not let an older role proof revive after the same caller is reconciled", async () => {
+    const runtime = createRuntime();
+    const userDescriptor = captureDescriptor(runtime, {
+      callerRole: "USER",
+    });
+    await scheduleConversationConnectionEnsure(userDescriptor, async () => {});
+    expect(hasReadyConversationConnection(userDescriptor)).toBe(true);
+
+    const guestDescriptor = captureDescriptor(runtime, {
+      callerRole: "GUEST",
+    });
+    expect(hasReadyConversationConnection(guestDescriptor)).toBe(false);
+    await scheduleConversationConnectionEnsure(guestDescriptor, async () => {});
+
+    expect(hasReadyConversationConnection(userDescriptor)).toBe(false);
+    expect(hasReadyConversationConnection(guestDescriptor)).toBe(true);
+    expect(
+      hasReadyConversationConnection(
+        captureDescriptor(runtime, { callerRole: "USER" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("invalidates the shared topology immediately when its owner changes", async () => {
+    const runtime = createRuntime();
+    const firstOwner = captureDescriptor(runtime, {
+      ownerSeed: "readiness-owner-one",
+    });
+    await scheduleConversationConnectionEnsure(firstOwner, async () => {});
+    expect(hasReadyConversationConnection(firstOwner)).toBe(true);
+
+    const secondOwner = captureDescriptor(runtime, {
+      ownerSeed: "readiness-owner-two",
+    });
+    expect(hasReadyConversationConnection(firstOwner)).toBe(false);
+    expect(hasReadyConversationConnection(secondOwner)).toBe(false);
+  });
+
+  it("invalidates every proof after a refresh fails", async () => {
+    const runtime = createRuntime();
+    const descriptor = captureDescriptor(runtime);
+
+    await scheduleConversationConnectionEnsure(descriptor, async () => {});
+    expect(hasReadyConversationConnection(descriptor)).toBe(true);
+
+    await expect(
+      scheduleConversationConnectionEnsure(descriptor, async () => {
+        throw new Error("world role write failed");
+      }),
+    ).rejects.toMatchObject({
+      code: "CONVERSATION_CONNECTION_REFRESH_FAILED",
+    });
+
+    const nextDescriptor = captureDescriptor(runtime);
+    expect(hasReadyConversationConnection(descriptor)).toBe(false);
+    expect(hasReadyConversationConnection(nextDescriptor)).toBe(false);
+  });
+
+  it("keeps a late refresh from reviving a deleted room generation", async () => {
+    const runtime = createRuntime();
+    const descriptor = captureDescriptor(runtime);
+    await scheduleConversationConnectionEnsure(descriptor, async () => {});
+
+    const refreshStarted = deferred();
+    const refreshGate = deferred();
+    const lateRefresh = scheduleConversationConnectionEnsure(
+      descriptor,
+      async () => {
+        refreshStarted.resolve();
+        await refreshGate.promise;
+      },
+    );
+    await refreshStarted.promise;
+
+    const deleteRoom = vi.fn(async () => {});
+    const deletion = serializeConversationConnectionRoomDeletion(
+      runtime,
+      descriptor.roomId,
+      deleteRoom,
+    );
+    expect(hasReadyConversationConnection(descriptor)).toBe(false);
+
+    refreshGate.resolve();
+    await expect(lateRefresh).rejects.toMatchObject({
+      code: "CONVERSATION_CONNECTION_INVALIDATED",
+    });
+    await deletion;
+    expect(deleteRoom).toHaveBeenCalledTimes(1);
+
+    const blockedDescriptor = captureDescriptor(runtime);
+    await expect(
+      scheduleConversationConnectionEnsure(blockedDescriptor, async () => {}),
+    ).rejects.toMatchObject({
+      code: "CONVERSATION_CONNECTION_ROOM_BLOCKED",
+    });
+
+    prepareConversationConnectionRoom(runtime, descriptor.roomId);
+    const recreatedDescriptor = captureDescriptor(runtime);
+    await scheduleConversationConnectionEnsure(
+      recreatedDescriptor,
+      async () => {},
+    );
+    expect(hasReadyConversationConnection(recreatedDescriptor)).toBe(true);
+  });
+
+  it("rejects old-name completion after an in-place topology change", async () => {
+    const runtime = createRuntime("Old Name");
+    const oldDescriptor = captureDescriptor(runtime);
+    await scheduleConversationConnectionEnsure(oldDescriptor, async () => {});
+
+    const refreshStarted = deferred();
+    const refreshGate = deferred();
+    const oldRefresh = scheduleConversationConnectionEnsure(
+      oldDescriptor,
+      async () => {
+        refreshStarted.resolve();
+        await refreshGate.promise;
+      },
+    );
+    await refreshStarted.promise;
+
+    invalidateConversationConnectionTopology(runtime);
+    runtime.character.name = "New Name";
+    const newDescriptor = captureDescriptor(runtime, {
+      agentName: "New Name",
+    });
+    const newEnsure = vi.fn(async () => {});
+    const newRefresh = scheduleConversationConnectionEnsure(
+      newDescriptor,
+      newEnsure,
+    );
+
+    refreshGate.resolve();
+    await expect(oldRefresh).rejects.toMatchObject({
+      code: "CONVERSATION_CONNECTION_INVALIDATED",
+    });
+    await newRefresh;
+
+    expect(newEnsure).toHaveBeenCalledTimes(1);
+    expect(hasReadyConversationConnection(oldDescriptor)).toBe(false);
+    expect(hasReadyConversationConnection(newDescriptor)).toBe(true);
+  });
+
+  it("rejects a turn when the route state replaces its exact runtime", () => {
+    const originalRuntime = createRuntime("Original Runtime");
+    const replacementRuntime = createRuntime("Replacement Runtime");
+    const descriptor = captureDescriptor(originalRuntime);
+
+    expect(() =>
+      assertConversationConnectionRuntime(replacementRuntime, descriptor),
+    ).toThrow(
+      expect.objectContaining({ code: "CONVERSATION_RUNTIME_CHANGED" }),
+    );
+  });
+});

--- a/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
@@ -1,15 +1,13 @@
 /**
- * Exercises the connection-proof coordinator under overlapping refresh,
- * deletion, failure, topology, and runtime replacement races.
+ * Exercises serialized connection reconciliation and descriptor invalidation
+ * under overlap, deletion, failure, topology replacement, and bounded tracking.
  */
 import { type AgentRuntime, stringToUuid, type UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   assertConversationConnectionRuntime,
   captureConversationConnectionDescriptor,
-  hasReadyConversationConnection,
   invalidateConversationConnectionTopology,
-  prepareConversationConnectionRoom,
   scheduleConversationConnectionEnsure,
   serializeConversationConnectionRoomDeletion,
 } from "../conversation-connection-readiness.ts";
@@ -66,7 +64,7 @@ function deferred() {
 }
 
 describe("conversation connection readiness", () => {
-  it("coalesces identical in-flight refreshes", async () => {
+  it("coalesces only identical in-flight reconciliation", async () => {
     const runtime = createRuntime();
     const descriptor = captureDescriptor(runtime);
     const gate = deferred();
@@ -81,10 +79,12 @@ describe("conversation connection readiness", () => {
     await Promise.all([first, second]);
 
     expect(ensure).toHaveBeenCalledTimes(1);
-    expect(hasReadyConversationConnection(descriptor)).toBe(true);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, descriptor),
+    ).not.toThrow();
   });
 
-  it("serializes overlapping role reconciliation for the shared world", async () => {
+  it("serializes every caller reconciliation for the shared world", async () => {
     const runtime = createRuntime();
     const firstDescriptor = captureDescriptor(runtime, {
       callerSeed: "readiness-user",
@@ -120,60 +120,62 @@ describe("conversation connection readiness", () => {
     );
 
     await vi.waitFor(() => expect(starts).toEqual(["user"]));
-    expect(active).toBe(1);
     firstGate.resolve();
     await Promise.all([first, second]);
 
     expect(starts).toEqual(["user", "guest"]);
     expect(maximumActive).toBe(1);
-    expect(hasReadyConversationConnection(firstDescriptor)).toBe(true);
-    expect(hasReadyConversationConnection(secondDescriptor)).toBe(true);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, firstDescriptor),
+    ).not.toThrow();
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, secondDescriptor),
+    ).not.toThrow();
   });
 
-  it("does not let an older role proof revive after the same caller is reconciled", async () => {
+  it("does not cache success across sequential turns", async () => {
     const runtime = createRuntime();
-    const userDescriptor = captureDescriptor(runtime, {
-      callerRole: "USER",
-    });
-    await scheduleConversationConnectionEnsure(userDescriptor, async () => {});
-    expect(hasReadyConversationConnection(userDescriptor)).toBe(true);
+    const descriptor = captureDescriptor(runtime);
+    const firstEnsure = vi.fn(async () => {});
+    const secondEnsure = vi.fn(async () => {});
 
-    const guestDescriptor = captureDescriptor(runtime, {
-      callerRole: "GUEST",
-    });
-    expect(hasReadyConversationConnection(guestDescriptor)).toBe(false);
-    await scheduleConversationConnectionEnsure(guestDescriptor, async () => {});
+    await scheduleConversationConnectionEnsure(descriptor, firstEnsure);
+    await scheduleConversationConnectionEnsure(
+      captureDescriptor(runtime),
+      secondEnsure,
+    );
 
-    expect(hasReadyConversationConnection(userDescriptor)).toBe(false);
-    expect(hasReadyConversationConnection(guestDescriptor)).toBe(true);
-    expect(
-      hasReadyConversationConnection(
-        captureDescriptor(runtime, { callerRole: "USER" }),
-      ),
-    ).toBe(false);
+    expect(firstEnsure).toHaveBeenCalledTimes(1);
+    expect(secondEnsure).toHaveBeenCalledTimes(1);
   });
 
-  it("invalidates the shared topology immediately when its owner changes", async () => {
+  it("invalidates an ensured descriptor immediately when its owner changes", async () => {
     const runtime = createRuntime();
     const firstOwner = captureDescriptor(runtime, {
       ownerSeed: "readiness-owner-one",
     });
     await scheduleConversationConnectionEnsure(firstOwner, async () => {});
-    expect(hasReadyConversationConnection(firstOwner)).toBe(true);
 
     const secondOwner = captureDescriptor(runtime, {
       ownerSeed: "readiness-owner-two",
     });
-    expect(hasReadyConversationConnection(firstOwner)).toBe(false);
-    expect(hasReadyConversationConnection(secondOwner)).toBe(false);
+
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, firstOwner),
+    ).toThrow(
+      expect.objectContaining({
+        code: "CONVERSATION_CONNECTION_INVALIDATED",
+      }),
+    );
+    await scheduleConversationConnectionEnsure(secondOwner, async () => {});
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, secondOwner),
+    ).not.toThrow();
   });
 
-  it("invalidates every proof after a refresh fails", async () => {
+  it("invalidates the descriptor after failure and allows a fresh retry", async () => {
     const runtime = createRuntime();
     const descriptor = captureDescriptor(runtime);
-
-    await scheduleConversationConnectionEnsure(descriptor, async () => {});
-    expect(hasReadyConversationConnection(descriptor)).toBe(true);
 
     await expect(
       scheduleConversationConnectionEnsure(descriptor, async () => {
@@ -182,21 +184,85 @@ describe("conversation connection readiness", () => {
     ).rejects.toMatchObject({
       code: "CONVERSATION_CONNECTION_REFRESH_FAILED",
     });
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, descriptor),
+    ).toThrow(
+      expect.objectContaining({
+        code: "CONVERSATION_CONNECTION_INVALIDATED",
+      }),
+    );
 
-    const nextDescriptor = captureDescriptor(runtime);
-    expect(hasReadyConversationConnection(descriptor)).toBe(false);
-    expect(hasReadyConversationConnection(nextDescriptor)).toBe(false);
+    const retryDescriptor = captureDescriptor(runtime);
+    const retry = vi.fn(async () => {});
+    await scheduleConversationConnectionEnsure(retryDescriptor, retry);
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, retryDescriptor),
+    ).not.toThrow();
   });
 
-  it("keeps a late refresh from reviving a deleted room generation", async () => {
+  it("times out callers while quarantining the unsettled raw mutation", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = createRuntime();
+      const descriptor = captureDescriptor(runtime);
+      const ensureStarted = deferred();
+      const ensureGate = deferred();
+      const ensure = vi.fn(async () => {
+        ensureStarted.resolve();
+        await ensureGate.promise;
+      });
+
+      const first = scheduleConversationConnectionEnsure(descriptor, ensure);
+      const firstRejection = expect(first).rejects.toMatchObject({
+        code: "CONVERSATION_CONNECTION_TIMEOUT",
+      });
+      await ensureStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await firstRejection;
+
+      const quarantinedDescriptor = captureDescriptor(runtime);
+      const blockedEnsure = vi.fn(async () => {});
+      await expect(
+        scheduleConversationConnectionEnsure(
+          quarantinedDescriptor,
+          blockedEnsure,
+        ),
+      ).rejects.toMatchObject({
+        code: "CONVERSATION_CONNECTION_TIMEOUT",
+      });
+      expect(blockedEnsure).not.toHaveBeenCalled();
+
+      ensureGate.resolve();
+      for (let index = 0; index < 5; index += 1) {
+        await Promise.resolve();
+      }
+
+      const recoveredDescriptor = captureDescriptor(runtime);
+      const recoveredEnsure = vi.fn(async () => {});
+      await scheduleConversationConnectionEnsure(
+        recoveredDescriptor,
+        recoveredEnsure,
+      );
+      expect(recoveredEnsure).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("invalidates ensured and in-flight descriptors across room deletion", async () => {
     const runtime = createRuntime();
-    const descriptor = captureDescriptor(runtime);
-    await scheduleConversationConnectionEnsure(descriptor, async () => {});
+    const ensuredDescriptor = captureDescriptor(runtime);
+    await scheduleConversationConnectionEnsure(
+      ensuredDescriptor,
+      async () => {},
+    );
 
     const refreshStarted = deferred();
     const refreshGate = deferred();
     const lateRefresh = scheduleConversationConnectionEnsure(
-      descriptor,
+      ensuredDescriptor,
       async () => {
         refreshStarted.resolve();
         await refreshGate.promise;
@@ -207,70 +273,89 @@ describe("conversation connection readiness", () => {
     const deleteRoom = vi.fn(async () => {});
     const deletion = serializeConversationConnectionRoomDeletion(
       runtime,
-      descriptor.roomId,
+      ensuredDescriptor.roomId,
       deleteRoom,
     );
-    expect(hasReadyConversationConnection(descriptor)).toBe(false);
+    const duringDeletionDescriptor = captureDescriptor(runtime);
+
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, ensuredDescriptor),
+    ).toThrow();
+    await expect(
+      scheduleConversationConnectionEnsure(
+        duringDeletionDescriptor,
+        async () => {},
+      ),
+    ).rejects.toMatchObject({
+      code: "CONVERSATION_CONNECTION_ROOM_BLOCKED",
+    });
 
     refreshGate.resolve();
     await expect(lateRefresh).rejects.toMatchObject({
       code: "CONVERSATION_CONNECTION_INVALIDATED",
     });
     await deletion;
+
     expect(deleteRoom).toHaveBeenCalledTimes(1);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, ensuredDescriptor),
+    ).toThrow();
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, duringDeletionDescriptor),
+    ).toThrow();
 
-    const blockedDescriptor = captureDescriptor(runtime);
-    await expect(
-      scheduleConversationConnectionEnsure(blockedDescriptor, async () => {}),
-    ).rejects.toMatchObject({
-      code: "CONVERSATION_CONNECTION_ROOM_BLOCKED",
-    });
-
-    prepareConversationConnectionRoom(runtime, descriptor.roomId);
     const recreatedDescriptor = captureDescriptor(runtime);
     await scheduleConversationConnectionEnsure(
       recreatedDescriptor,
       async () => {},
     );
-    expect(hasReadyConversationConnection(recreatedDescriptor)).toBe(true);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, recreatedDescriptor),
+    ).not.toThrow();
   });
 
-  it("rejects old-name completion after an in-place topology change", async () => {
+  it("rejects an ensured descriptor after an in-place rename", async () => {
     const runtime = createRuntime("Old Name");
     const oldDescriptor = captureDescriptor(runtime);
     await scheduleConversationConnectionEnsure(oldDescriptor, async () => {});
-
-    const refreshStarted = deferred();
-    const refreshGate = deferred();
-    const oldRefresh = scheduleConversationConnectionEnsure(
-      oldDescriptor,
-      async () => {
-        refreshStarted.resolve();
-        await refreshGate.promise;
-      },
-    );
-    await refreshStarted.promise;
 
     invalidateConversationConnectionTopology(runtime);
     runtime.character.name = "New Name";
     const newDescriptor = captureDescriptor(runtime, {
       agentName: "New Name",
     });
-    const newEnsure = vi.fn(async () => {});
-    const newRefresh = scheduleConversationConnectionEnsure(
-      newDescriptor,
-      newEnsure,
+
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, oldDescriptor),
+    ).toThrow(
+      expect.objectContaining({
+        code: "CONVERSATION_CONNECTION_INVALIDATED",
+      }),
     );
+    await scheduleConversationConnectionEnsure(newDescriptor, async () => {});
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, newDescriptor),
+    ).not.toThrow();
+  });
 
-    refreshGate.resolve();
-    await expect(oldRefresh).rejects.toMatchObject({
-      code: "CONVERSATION_CONNECTION_INVALIDATED",
-    });
-    await newRefresh;
+  it("eviction invalidates old room tokens instead of reviving them", () => {
+    const runtime = createRuntime();
+    const oldest = captureDescriptor(runtime, { roomSeed: "room-0" });
 
-    expect(newEnsure).toHaveBeenCalledTimes(1);
-    expect(hasReadyConversationConnection(oldDescriptor)).toBe(false);
-    expect(hasReadyConversationConnection(newDescriptor)).toBe(true);
+    for (let index = 1; index <= 2_048; index += 1) {
+      captureDescriptor(runtime, { roomSeed: `room-${index}` });
+    }
+
+    expect(() => assertConversationConnectionRuntime(runtime, oldest)).toThrow(
+      expect.objectContaining({
+        code: "CONVERSATION_CONNECTION_INVALIDATED",
+      }),
+    );
+    const recaptured = captureDescriptor(runtime, { roomSeed: "room-0" });
+    expect(recaptured.roomGeneration).not.toBe(oldest.roomGeneration);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, recaptured),
+    ).not.toThrow();
   });
 
   it("rejects a turn when the route state replaces its exact runtime", () => {

--- a/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
@@ -154,14 +154,27 @@ function createState(
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
+  const worlds = new Map<
+    UUID,
+    { id: UUID; agentId: UUID; metadata: Record<string, unknown> }
+  >();
   const runtime = {
     agentId: AGENT_ID,
     character: { name: "Test Agent" },
     logger,
     getMemories: vi.fn(async () => memories),
-    ensureConnection: vi.fn(async () => undefined),
+    ensureConnection: vi.fn(async (input: { worldId?: UUID }) => {
+      if (!input.worldId) throw new Error("worldId is required");
+      if (!worlds.has(input.worldId)) {
+        worlds.set(input.worldId, {
+          id: input.worldId,
+          agentId: AGENT_ID,
+          metadata: {},
+        });
+      }
+    }),
     updateWorld: vi.fn(async () => undefined),
-    getWorld: vi.fn(async () => null),
+    getWorld: vi.fn(async (worldId: UUID) => worlds.get(worldId) ?? null),
     getRoom: vi.fn(async () => null),
     adapter: {},
   };

--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -128,6 +128,10 @@ function createHarness(): TestHarness {
     },
   );
   const storedMemories: Memory[] = [];
+  const worlds = new Map<
+    UUID,
+    { id: UUID; agentId: UUID; metadata: Record<string, unknown> }
+  >();
   const createMemory = vi.fn(async (memory: Memory) => {
     storedMemories.push(memory);
     return memory.id ?? stringToUuid("created-memory");
@@ -159,9 +163,18 @@ function createHarness(): TestHarness {
     createMemory,
     createLogs: vi.fn(async () => undefined),
     getMemories: vi.fn(async () => storedMemories),
-    ensureConnection: vi.fn(async () => undefined),
+    ensureConnection: vi.fn(async (input: { worldId?: UUID }) => {
+      if (!input.worldId) throw new Error("worldId is required");
+      if (!worlds.has(input.worldId)) {
+        worlds.set(input.worldId, {
+          id: input.worldId,
+          agentId: AGENT_ID,
+          metadata: {},
+        });
+      }
+    }),
     updateWorld: vi.fn(async () => undefined),
-    getWorld: vi.fn(async () => null),
+    getWorld: vi.fn(async (worldId: UUID) => worlds.get(worldId) ?? null),
     getRoom: vi.fn(async () => null),
     reportError: vi.fn(),
     adapter: {} as never,

--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -39,6 +39,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // single fixture drives both the legacy and delta-v2 framings through the real
 // route handler.
 let requestStreamProtocol: "delta-v2" | undefined;
+let requestClientMessageId: string | undefined;
 
 vi.mock("../chat-routes.ts", async () => {
   const actual =
@@ -56,6 +57,9 @@ vi.mock("../chat-routes.ts", async () => {
       metadata: undefined,
       ...(requestStreamProtocol
         ? { streamProtocol: requestStreamProtocol }
+        : {}),
+      ...(requestClientMessageId
+        ? { clientMessageId: requestClientMessageId }
         : {}),
     })),
     persistConversationMemory: vi.fn(async (_runtime, memory) => memory),
@@ -96,6 +100,7 @@ import {
   persistAssistantConversationMemory,
   persistConversationMemory,
 } from "../chat-routes.ts";
+import { serializeConversationConnectionRoomDeletion } from "../conversation-connection-readiness.ts";
 import type {
   ConversationRouteContext,
   ConversationRouteState,
@@ -473,10 +478,35 @@ function createDeferred() {
   };
 }
 
+function createGatedMessageService(
+  started: ReturnType<typeof createDeferred>,
+  gate: ReturnType<typeof createDeferred>,
+): NonNullable<AgentRuntime["messageService"]> {
+  return {
+    async handleMessage() {
+      started.resolve();
+      await gate.promise;
+      return {
+        didRespond: true,
+        responseContent: { text: FINAL_TEXT, thought: THOUGHT },
+        responseMessages: [],
+      };
+    },
+    shouldRespond: () => ({
+      shouldRespond: true,
+      skipEvaluation: true,
+      reason: "stream-contract-gated-test",
+    }),
+    deleteMessage: async () => undefined,
+    clearChannel: async () => undefined,
+  };
+}
+
 describe("conversation stream SSE contract (#10712)", () => {
   afterEach(() => {
     vi.clearAllMocks();
     requestStreamProtocol = undefined;
+    requestClientMessageId = undefined;
   });
 
   it("emits thinking→streaming status, ordered cumulative token frames, then a terminal done frame with thought", async () => {
@@ -568,72 +598,62 @@ describe("conversation stream SSE contract (#10712)", () => {
     expect(streamingStatusIndex).toBeLessThan(firstTokenIndex);
   });
 
-  it("refreshes a previously proven connection alongside generation without racing user persistence", async () => {
-    const first = createCtx();
-    await handleConversationRoutes(first.ctx);
-
-    const runtime = first.state.runtime;
+  it("awaits connection reconciliation before persistence and generation", async () => {
+    const fixture = createCtx();
+    const runtime = fixture.state.runtime;
     if (!runtime) throw new Error("runtime fixture missing");
-    let finishRefresh: (() => void) | undefined;
-    const refresh = new Promise<void>((resolve) => {
-      finishRefresh = resolve;
-    });
+    const refresh = createDeferred();
+    const reconcile = vi
+      .mocked(runtime.ensureConnection)
+      .getMockImplementation();
+    if (!reconcile) throw new Error("connection fixture missing");
     vi.mocked(runtime.ensureConnection).mockImplementationOnce(
-      async () => refresh,
+      async (input) => {
+        await refresh.promise;
+        await reconcile(input);
+      },
     );
     vi.mocked(persistConversationMemory).mockClear();
-    first.useModel.mockClear();
-
-    const socket = createMockSocket();
-    const req = createReq(socket);
-    const { res, record } = createMockRes();
-    const secondCtx = {
-      ...first.ctx,
-      req,
-      res,
-      state: first.state,
-    };
-    const turn = handleConversationRoutes(secondCtx);
+    fixture.useModel.mockClear();
+    const turn = handleConversationRoutes(fixture.ctx);
 
     await vi.waitFor(() => {
-      expect(first.useModel).toHaveBeenCalledTimes(1);
+      expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
     });
-    expect(persistConversationMemory).toHaveBeenCalledTimes(1);
-    expect(record.ended).toBe(false);
+    expect(persistConversationMemory).not.toHaveBeenCalled();
+    expect(fixture.useModel).not.toHaveBeenCalled();
+    expect(fixture.record.ended).toBe(false);
 
-    finishRefresh?.();
+    refresh.resolve();
     await turn;
-    expect(record.ended).toBe(true);
+    expect(persistConversationMemory).toHaveBeenCalledTimes(1);
+    expect(fixture.useModel).toHaveBeenCalledTimes(1);
+    expect(fixture.record.ended).toBe(true);
   });
 
-  it("fails closed when a warm refresh rejects after visible tokens stream", async () => {
+  it("releases an undelivered connection failure for retry with the same id", async () => {
+    requestClientMessageId = "connection-retry-id";
     const first = createCtx();
-    await handleConversationRoutes(first.ctx);
-
     const runtime = first.state.runtime;
     if (!runtime) throw new Error("runtime fixture missing");
     const failedRefresh = createDeferred();
     vi.mocked(runtime.ensureConnection).mockImplementationOnce(
       async () => failedRefresh.promise,
     );
-    first.useModel.mockClear();
+    vi.mocked(persistConversationMemory).mockClear();
     vi.mocked(persistAssistantConversationMemory).mockClear();
 
-    const second = createFollowupCtx(first.ctx, first.state);
-    const secondTurn = handleConversationRoutes(second.ctx);
+    const firstTurn = handleConversationRoutes(first.ctx);
     await vi.waitFor(() => {
-      expect(first.useModel).toHaveBeenCalledTimes(1);
-      expect(
-        parseSsePayloads(second.record.writes).some(
-          (payload) => payload.type === "token",
-        ),
-      ).toBe(true);
+      expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
     });
+    expect(first.useModel).not.toHaveBeenCalled();
+    expect(persistConversationMemory).not.toHaveBeenCalled();
 
     failedRefresh.reject(new Error("role reconciliation failed"));
-    await secondTurn;
+    await firstTurn;
 
-    const failedPayloads = parseSsePayloads(second.record.writes);
+    const failedPayloads = parseSsePayloads(first.record.writes);
     expect(failedPayloads).toContainEqual(
       expect.objectContaining({
         type: "error",
@@ -645,90 +665,85 @@ describe("conversation stream SSE contract (#10712)", () => {
     );
     expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
 
-    const coldRetryGate = createDeferred();
     vi.mocked(runtime.ensureConnection).mockClear();
-    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
-      async () => coldRetryGate.promise,
-    );
     first.useModel.mockClear();
-    const third = createFollowupCtx(first.ctx, first.state);
-    const thirdTurn = handleConversationRoutes(third.ctx);
+    const retry = createFollowupCtx(first.ctx, first.state);
+    await handleConversationRoutes(retry.ctx);
 
-    await vi.waitFor(() => {
-      expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
-    });
-    expect(first.useModel).not.toHaveBeenCalled();
-    expect(third.record.ended).toBe(false);
-
-    coldRetryGate.resolve();
-    await thirdTurn;
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
     expect(first.useModel).toHaveBeenCalledTimes(1);
-    expect(third.record.ended).toBe(true);
+    expect(
+      parseSsePayloads(retry.record.writes).some(
+        (payload) => payload.type === "done",
+      ),
+    ).toBe(true);
   });
 
-  it("joins a warm refresh when generation fails and gives the prerequisite failure priority", async () => {
-    const first = createCtx();
-    await handleConversationRoutes(first.ctx);
-
-    const runtime = first.state.runtime;
-    if (!runtime?.messageService) throw new Error("runtime fixture missing");
-    const failedRefresh = createDeferred();
+  it("fails closed when the room is deleted after ensure and allows retry", async () => {
+    requestClientMessageId = "delete-during-generation-id";
     const generationStarted = createDeferred();
-    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
-      async () => failedRefresh.promise,
+    const generationGate = createDeferred();
+    const first = createCtx(
+      createGatedMessageService(generationStarted, generationGate),
     );
-    runtime.messageService = {
-      ...runtime.messageService,
-      handleMessage: vi.fn(async () => {
-        generationStarted.resolve();
-        throw new Error("generation failed first");
-      }),
-    };
+    const runtime = first.state.runtime;
+    if (!runtime) throw new Error("runtime fixture missing");
     vi.mocked(persistAssistantConversationMemory).mockClear();
 
-    const second = createFollowupCtx(first.ctx, first.state);
-    const turn = handleConversationRoutes(second.ctx);
+    const turn = handleConversationRoutes(first.ctx);
     await generationStarted.promise;
 
-    expect(second.record.ended).toBe(false);
-    failedRefresh.reject(new Error("refresh failed second"));
+    await serializeConversationConnectionRoomDeletion(
+      runtime,
+      ROOM_ID,
+      async () => {},
+    );
+    generationGate.resolve();
     await turn;
 
-    const payloads = parseSsePayloads(second.record.writes);
+    const payloads = parseSsePayloads(first.record.writes);
     expect(payloads).toContainEqual(
       expect.objectContaining({
         type: "error",
-        message: expect.stringContaining("refresh failed second"),
+        message: expect.stringContaining("invalidated"),
       }),
     );
     expect(payloads.some((payload) => payload.type === "done")).toBe(false);
     expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
+
+    runtime.messageService = createModelBackedMessageService();
+    first.useModel.mockClear();
+    const retry = createFollowupCtx(first.ctx, first.state);
+    await handleConversationRoutes(retry.ctx);
+
+    expect(first.useModel).toHaveBeenCalledTimes(1);
+    expect(
+      parseSsePayloads(retry.record.writes).some(
+        (payload) => payload.type === "done",
+      ),
+    ).toBe(true);
   });
 
   it("fails the terminal frame if route state swaps runtimes mid-turn", async () => {
-    const first = createCtx();
-    await handleConversationRoutes(first.ctx);
-
+    const generationStarted = createDeferred();
+    const generationGate = createDeferred();
+    const first = createCtx(
+      createGatedMessageService(generationStarted, generationGate),
+    );
     const runtime = first.state.runtime;
     if (!runtime) throw new Error("runtime fixture missing");
-    const refreshGate = createDeferred();
-    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
-      async () => refreshGate.promise,
-    );
-    first.useModel.mockClear();
     vi.mocked(persistAssistantConversationMemory).mockClear();
 
-    const second = createFollowupCtx(first.ctx, first.state);
-    const turn = handleConversationRoutes(second.ctx);
-    await vi.waitFor(() => expect(first.useModel).toHaveBeenCalledTimes(1));
+    const turn = handleConversationRoutes(first.ctx);
+    await generationStarted.promise;
 
     const replacement = createState().state.runtime;
     if (!replacement) throw new Error("replacement fixture missing");
     first.state.runtime = replacement;
-    refreshGate.resolve();
+    generationGate.resolve();
     await turn;
 
-    const payloads = parseSsePayloads(second.record.writes);
+    const payloads = parseSsePayloads(first.record.writes);
     expect(payloads).toContainEqual(
       expect.objectContaining({
         type: "error",

--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -346,6 +346,15 @@ function createState(
     updatedAt: new Date().toISOString(),
   };
   const useModel = createStreamingUseModelFixture();
+  const worlds = new Map<
+    UUID,
+    {
+      id: UUID;
+      agentId: UUID;
+      messageServerId?: UUID;
+      metadata: Record<string, unknown>;
+    }
+  >();
   const runtime = {
     agentId: AGENT_ID,
     character: {
@@ -359,9 +368,21 @@ function createState(
     emitEvent: vi.fn(async () => undefined),
     useModel: useModel as unknown as AgentRuntime["useModel"],
     messageService: messageServiceOverride ?? createModelBackedMessageService(),
-    ensureConnection: vi.fn(async () => undefined),
+    ensureConnection: vi.fn(
+      async (input: { worldId?: UUID; messageServerId?: UUID }) => {
+        if (!input.worldId) throw new Error("worldId is required");
+        if (!worlds.has(input.worldId)) {
+          worlds.set(input.worldId, {
+            id: input.worldId,
+            agentId: AGENT_ID,
+            messageServerId: input.messageServerId,
+            metadata: {},
+          });
+        }
+      },
+    ),
     updateWorld: vi.fn(async () => undefined),
-    getWorld: vi.fn(async () => null),
+    getWorld: vi.fn(async (worldId: UUID) => worlds.get(worldId) ?? null),
     getRoom: vi.fn(async () => null),
     getService: vi.fn(() => null),
     getServicesByType: vi.fn(() => []),
@@ -416,6 +437,40 @@ function createCtx(
     }),
   } as unknown as ConversationRouteContext;
   return { ctx, record, state, useModel };
+}
+
+function createFollowupCtx(
+  baseCtx: ConversationRouteContext,
+  state: ConversationRouteState,
+): {
+  ctx: ConversationRouteContext;
+  record: MockResponseRecord;
+} {
+  const req = createReq(createMockSocket());
+  const { res, record } = createMockRes();
+  return {
+    ctx: {
+      ...baseCtx,
+      req,
+      res,
+      state,
+    },
+    record,
+  };
+}
+
+function createDeferred() {
+  let resolve: (() => void) | undefined;
+  let reject: ((reason: unknown) => void) | undefined;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {
+    promise,
+    resolve: () => resolve?.(),
+    reject: (reason: unknown) => reject?.(reason),
+  };
 }
 
 describe("conversation stream SSE contract (#10712)", () => {
@@ -549,6 +604,139 @@ describe("conversation stream SSE contract (#10712)", () => {
     finishRefresh?.();
     await turn;
     expect(record.ended).toBe(true);
+  });
+
+  it("fails closed when a warm refresh rejects after visible tokens stream", async () => {
+    const first = createCtx();
+    await handleConversationRoutes(first.ctx);
+
+    const runtime = first.state.runtime;
+    if (!runtime) throw new Error("runtime fixture missing");
+    const failedRefresh = createDeferred();
+    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
+      async () => failedRefresh.promise,
+    );
+    first.useModel.mockClear();
+    vi.mocked(persistAssistantConversationMemory).mockClear();
+
+    const second = createFollowupCtx(first.ctx, first.state);
+    const secondTurn = handleConversationRoutes(second.ctx);
+    await vi.waitFor(() => {
+      expect(first.useModel).toHaveBeenCalledTimes(1);
+      expect(
+        parseSsePayloads(second.record.writes).some(
+          (payload) => payload.type === "token",
+        ),
+      ).toBe(true);
+    });
+
+    failedRefresh.reject(new Error("role reconciliation failed"));
+    await secondTurn;
+
+    const failedPayloads = parseSsePayloads(second.record.writes);
+    expect(failedPayloads).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("role reconciliation failed"),
+      }),
+    );
+    expect(failedPayloads.some((payload) => payload.type === "done")).toBe(
+      false,
+    );
+    expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
+
+    const coldRetryGate = createDeferred();
+    vi.mocked(runtime.ensureConnection).mockClear();
+    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
+      async () => coldRetryGate.promise,
+    );
+    first.useModel.mockClear();
+    const third = createFollowupCtx(first.ctx, first.state);
+    const thirdTurn = handleConversationRoutes(third.ctx);
+
+    await vi.waitFor(() => {
+      expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
+    });
+    expect(first.useModel).not.toHaveBeenCalled();
+    expect(third.record.ended).toBe(false);
+
+    coldRetryGate.resolve();
+    await thirdTurn;
+    expect(first.useModel).toHaveBeenCalledTimes(1);
+    expect(third.record.ended).toBe(true);
+  });
+
+  it("joins a warm refresh when generation fails and gives the prerequisite failure priority", async () => {
+    const first = createCtx();
+    await handleConversationRoutes(first.ctx);
+
+    const runtime = first.state.runtime;
+    if (!runtime?.messageService) throw new Error("runtime fixture missing");
+    const failedRefresh = createDeferred();
+    const generationStarted = createDeferred();
+    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
+      async () => failedRefresh.promise,
+    );
+    runtime.messageService = {
+      ...runtime.messageService,
+      handleMessage: vi.fn(async () => {
+        generationStarted.resolve();
+        throw new Error("generation failed first");
+      }),
+    };
+    vi.mocked(persistAssistantConversationMemory).mockClear();
+
+    const second = createFollowupCtx(first.ctx, first.state);
+    const turn = handleConversationRoutes(second.ctx);
+    await generationStarted.promise;
+
+    expect(second.record.ended).toBe(false);
+    failedRefresh.reject(new Error("refresh failed second"));
+    await turn;
+
+    const payloads = parseSsePayloads(second.record.writes);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("refresh failed second"),
+      }),
+    );
+    expect(payloads.some((payload) => payload.type === "done")).toBe(false);
+    expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
+  });
+
+  it("fails the terminal frame if route state swaps runtimes mid-turn", async () => {
+    const first = createCtx();
+    await handleConversationRoutes(first.ctx);
+
+    const runtime = first.state.runtime;
+    if (!runtime) throw new Error("runtime fixture missing");
+    const refreshGate = createDeferred();
+    vi.mocked(runtime.ensureConnection).mockImplementationOnce(
+      async () => refreshGate.promise,
+    );
+    first.useModel.mockClear();
+    vi.mocked(persistAssistantConversationMemory).mockClear();
+
+    const second = createFollowupCtx(first.ctx, first.state);
+    const turn = handleConversationRoutes(second.ctx);
+    await vi.waitFor(() => expect(first.useModel).toHaveBeenCalledTimes(1));
+
+    const replacement = createState().state.runtime;
+    if (!replacement) throw new Error("replacement fixture missing");
+    first.state.runtime = replacement;
+    refreshGate.resolve();
+    await turn;
+
+    const payloads = parseSsePayloads(second.record.writes);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("runtime changed"),
+      }),
+    );
+    expect(payloads.some((payload) => payload.type === "done")).toBe(false);
+    expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
   });
 
   it("carries a direct VIEWS shortcut result on the terminal done frame", async () => {

--- a/packages/agent/src/api/character-routes.ts
+++ b/packages/agent/src/api/character-routes.ts
@@ -18,6 +18,7 @@ import {
   type RuntimeCharacterLike,
   recordCharacterHistory,
 } from "../services/character-history.ts";
+import { invalidateConversationConnectionTopology } from "./conversation-connection-readiness.ts";
 
 interface CharacterGenerateContext {
   name?: string;
@@ -421,13 +422,16 @@ export async function handleCharacterRoutes(
       return true;
     }
 
-    if (state.runtime) {
-      const character = state.runtime.character;
+    const runtime = state.runtime;
+    if (runtime) {
+      const character = runtime.character;
       const previousCharacter = buildCharacterHistorySnapshot(
         character as RuntimeCharacterLike,
       );
       const previousCharacterName =
         typeof character.name === "string" ? character.name : undefined;
+      const nextStoredCharacterName =
+        body.name != null ? String(body.name) : previousCharacterName;
       const nextCharacterName =
         typeof body.name === "string" && body.name.trim()
           ? body.name.trim()
@@ -435,6 +439,12 @@ export async function handleCharacterRoutes(
             ? character.name.trim()
             : state.agentName;
 
+      if (
+        nextStoredCharacterName !== undefined &&
+        nextStoredCharacterName !== previousCharacterName
+      ) {
+        invalidateConversationConnectionTopology(runtime);
+      }
       if (body.name != null) character.name = String(body.name);
       if (body.username != null) character.username = String(body.username);
       if (body.bio != null) {
@@ -478,15 +488,15 @@ export async function handleCharacterRoutes(
       const charData = buildCharacterHistorySnapshot(
         character as RuntimeCharacterLike,
       );
-      await state.runtime.updateAgent(state.runtime.agentId, {
+      await runtime.updateAgent(runtime.agentId, {
         name: character.name,
         metadata: {
-          ...(state.runtime.character as { metadata?: Record<string, unknown> })
+          ...(runtime.character as { metadata?: Record<string, unknown> })
             .metadata,
           character: charData,
         },
       });
-      await recordCharacterHistory(state.runtime, {
+      await recordCharacterHistory(runtime, {
         previousCharacter,
         nextCharacter: character as RuntimeCharacterLike,
         source: "manual",

--- a/packages/agent/src/api/conversation-connection-readiness.ts
+++ b/packages/agent/src/api/conversation-connection-readiness.ts
@@ -1,0 +1,502 @@
+/**
+ * Coordinates web-conversation connection proofs for one running agent.
+ *
+ * A proof is tied to an immutable runtime/topology/caller descriptor. All
+ * mutations are serialized because every web conversation shares one world,
+ * while generation may overlap a refresh only after that exact descriptor has
+ * completed once. Generation counters keep late completions from reviving
+ * proofs invalidated by failure, deletion, or an in-place topology change.
+ */
+import { type AgentRuntime, ElizaError, type UUID } from "@elizaos/core";
+import type { BoundaryWorldRole } from "./boundary-role-resolver.ts";
+
+const MAX_READY_CONNECTION_PROOFS = 2_048;
+const MAX_BLOCKED_CONVERSATION_ROOMS = 5_000;
+
+const CONNECTION_ERROR_CODES = new Set([
+  "CONVERSATION_CONNECTION_INVALIDATED",
+  "CONVERSATION_CONNECTION_REFRESH_FAILED",
+  "CONVERSATION_CONNECTION_ROOM_BLOCKED",
+  "CONVERSATION_RUNTIME_CHANGED",
+]);
+
+export interface ConversationConnectionDescriptor {
+  readonly runtime: AgentRuntime;
+  readonly runtimeAgentId: UUID;
+  readonly conversationId: string;
+  readonly roomId: UUID;
+  readonly worldId: UUID;
+  readonly messageServerId: UUID;
+  readonly channelId: string;
+  readonly agentName: string;
+  readonly ownerId: UUID;
+  readonly callerEntityId: UUID;
+  readonly callerRole: BoundaryWorldRole;
+  readonly callerUserName: string;
+  readonly topologyIdentity: string;
+  readonly proofIdentity: string;
+  readonly topologyGeneration: number;
+  readonly roomGeneration: number;
+}
+
+interface ReadyConnectionProof {
+  readonly roomId: UUID;
+  readonly ownerId: UUID;
+  readonly callerEntityId: UUID;
+  readonly callerRole: BoundaryWorldRole;
+  readonly callerUserName: string;
+  readonly topologyGeneration: number;
+  readonly roomGeneration: number;
+}
+
+interface InFlightConnectionEnsure {
+  readonly descriptor: ConversationConnectionDescriptor;
+  readonly promise: Promise<void>;
+}
+
+interface ConversationConnectionRegistry {
+  topologyIdentity: string | null;
+  topologyGeneration: number;
+  readonly roomGenerations: Map<UUID, number>;
+  readonly readyProofs: Map<string, ReadyConnectionProof>;
+  readonly inFlightEnsures: Map<string, InFlightConnectionEnsure>;
+  readonly blockedRooms: Set<UUID>;
+  mutationTail: Promise<void>;
+}
+
+const registries = new WeakMap<AgentRuntime, ConversationConnectionRegistry>();
+
+function getRegistry(runtime: AgentRuntime): ConversationConnectionRegistry {
+  let registry = registries.get(runtime);
+  if (!registry) {
+    registry = {
+      topologyIdentity: null,
+      topologyGeneration: 0,
+      roomGenerations: new Map(),
+      readyProofs: new Map(),
+      inFlightEnsures: new Map(),
+      blockedRooms: new Set(),
+      mutationTail: Promise.resolve(),
+    };
+    registries.set(runtime, registry);
+  }
+  return registry;
+}
+
+function connectionTopologyIdentity(input: {
+  runtimeAgentId: UUID;
+  agentName: string;
+  worldId: UUID;
+  messageServerId: UUID;
+  ownerId: UUID;
+}): string {
+  return JSON.stringify([
+    input.runtimeAgentId,
+    input.agentName,
+    input.worldId,
+    input.messageServerId,
+    input.ownerId,
+  ]);
+}
+
+function connectionProofIdentity(input: {
+  topologyIdentity: string;
+  conversationId: string;
+  roomId: UUID;
+  channelId: string;
+  ownerId: UUID;
+  callerEntityId: UUID;
+  callerRole: BoundaryWorldRole;
+  callerUserName: string;
+}): string {
+  return JSON.stringify([
+    input.topologyIdentity,
+    input.conversationId,
+    input.roomId,
+    input.channelId,
+    input.ownerId,
+    input.callerEntityId,
+    input.callerRole,
+    input.callerUserName,
+  ]);
+}
+
+function invalidateTopology(
+  registry: ConversationConnectionRegistry,
+  nextTopologyIdentity: string | null,
+): void {
+  registry.topologyGeneration += 1;
+  registry.topologyIdentity = nextTopologyIdentity;
+  registry.readyProofs.clear();
+}
+
+function deleteRoomProofs(
+  registry: ConversationConnectionRegistry,
+  roomId: UUID,
+): void {
+  for (const [identity, proof] of registry.readyProofs) {
+    if (proof.roomId === roomId) {
+      registry.readyProofs.delete(identity);
+    }
+  }
+}
+
+function incrementRoomGeneration(
+  registry: ConversationConnectionRegistry,
+  roomId: UUID,
+): number {
+  const nextGeneration = (registry.roomGenerations.get(roomId) ?? 0) + 1;
+  registry.roomGenerations.set(roomId, nextGeneration);
+  deleteRoomProofs(registry, roomId);
+  return nextGeneration;
+}
+
+function pruneReadyProofs(registry: ConversationConnectionRegistry): void {
+  while (registry.readyProofs.size > MAX_READY_CONNECTION_PROOFS) {
+    const oldestIdentity = registry.readyProofs.keys().next().value;
+    if (typeof oldestIdentity !== "string") return;
+    registry.readyProofs.delete(oldestIdentity);
+  }
+}
+
+function deleteConflictingCallerProofs(
+  registry: ConversationConnectionRegistry,
+  descriptor: ConversationConnectionDescriptor,
+): void {
+  for (const [identity, proof] of registry.readyProofs) {
+    if (
+      proof.ownerId !== descriptor.ownerId ||
+      (proof.callerEntityId === descriptor.callerEntityId &&
+        (proof.callerRole !== descriptor.callerRole ||
+          proof.callerUserName !== descriptor.callerUserName))
+    ) {
+      registry.readyProofs.delete(identity);
+    }
+  }
+}
+
+function pruneBlockedRooms(registry: ConversationConnectionRegistry): void {
+  const candidateCount = registry.blockedRooms.size;
+  let inspected = 0;
+  while (
+    registry.blockedRooms.size > MAX_BLOCKED_CONVERSATION_ROOMS &&
+    inspected < candidateCount
+  ) {
+    const oldestRoomId = registry.blockedRooms.values().next().value;
+    if (typeof oldestRoomId !== "string") return;
+    inspected += 1;
+    const hasInFlightEnsure = Array.from(
+      registry.inFlightEnsures.values(),
+    ).some((entry) => entry.descriptor.roomId === oldestRoomId);
+    if (hasInFlightEnsure) {
+      registry.blockedRooms.delete(oldestRoomId);
+      registry.blockedRooms.add(oldestRoomId);
+      continue;
+    }
+    registry.blockedRooms.delete(oldestRoomId);
+    registry.roomGenerations.delete(oldestRoomId);
+  }
+}
+
+function descriptorGenerationsAreCurrent(
+  registry: ConversationConnectionRegistry,
+  descriptor: ConversationConnectionDescriptor,
+): boolean {
+  return (
+    registry.topologyIdentity === descriptor.topologyIdentity &&
+    registry.topologyGeneration === descriptor.topologyGeneration &&
+    (registry.roomGenerations.get(descriptor.roomId) ?? 0) ===
+      descriptor.roomGeneration
+  );
+}
+
+function descriptorIsCurrent(
+  registry: ConversationConnectionRegistry,
+  descriptor: ConversationConnectionDescriptor,
+): boolean {
+  return (
+    descriptorGenerationsAreCurrent(registry, descriptor) &&
+    !registry.blockedRooms.has(descriptor.roomId)
+  );
+}
+
+function invalidatedConnectionError(
+  descriptor: ConversationConnectionDescriptor,
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError("Conversation connection proof was invalidated", {
+    code: "CONVERSATION_CONNECTION_INVALIDATED",
+    ...(cause !== undefined ? { cause } : {}),
+    context: {
+      agentId: descriptor.runtimeAgentId,
+      conversationId: descriptor.conversationId,
+      roomId: descriptor.roomId,
+      worldId: descriptor.worldId,
+    },
+    severity: "ephemeral",
+  });
+}
+
+function assertDescriptorCurrent(
+  registry: ConversationConnectionRegistry,
+  descriptor: ConversationConnectionDescriptor,
+): void {
+  if (!descriptorGenerationsAreCurrent(registry, descriptor)) {
+    throw invalidatedConnectionError(descriptor);
+  }
+  if (registry.blockedRooms.has(descriptor.roomId)) {
+    throw new ElizaError("Conversation room is being deleted", {
+      code: "CONVERSATION_CONNECTION_ROOM_BLOCKED",
+      context: {
+        agentId: descriptor.runtimeAgentId,
+        conversationId: descriptor.conversationId,
+        roomId: descriptor.roomId,
+      },
+      severity: "ephemeral",
+    });
+  }
+}
+
+function enqueueConnectionMutation(
+  registry: ConversationConnectionRegistry,
+  mutation: () => Promise<void>,
+): Promise<void> {
+  const run = registry.mutationTail.then(mutation, mutation);
+  registry.mutationTail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * Captures every mutable input that determines the connection writes. The
+ * returned descriptor remains valid only for the generations recorded here.
+ */
+export function captureConversationConnectionDescriptor(input: {
+  runtime: AgentRuntime;
+  conversationId: string;
+  roomId: UUID;
+  agentName: string;
+  worldId: UUID;
+  messageServerId: UUID;
+  channelId: string;
+  ownerId: UUID;
+  callerEntityId: UUID;
+  callerRole: BoundaryWorldRole;
+  callerUserName: string;
+}): ConversationConnectionDescriptor {
+  const registry = getRegistry(input.runtime);
+  const topologyIdentity = connectionTopologyIdentity({
+    runtimeAgentId: input.runtime.agentId,
+    agentName: input.agentName,
+    worldId: input.worldId,
+    messageServerId: input.messageServerId,
+    ownerId: input.ownerId,
+  });
+  if (registry.topologyIdentity === null) {
+    registry.topologyIdentity = topologyIdentity;
+  } else if (registry.topologyIdentity !== topologyIdentity) {
+    invalidateTopology(registry, topologyIdentity);
+  }
+
+  const proofIdentity = connectionProofIdentity({
+    topologyIdentity,
+    conversationId: input.conversationId,
+    roomId: input.roomId,
+    channelId: input.channelId,
+    ownerId: input.ownerId,
+    callerEntityId: input.callerEntityId,
+    callerRole: input.callerRole,
+    callerUserName: input.callerUserName,
+  });
+
+  return Object.freeze({
+    runtime: input.runtime,
+    runtimeAgentId: input.runtime.agentId,
+    conversationId: input.conversationId,
+    roomId: input.roomId,
+    worldId: input.worldId,
+    messageServerId: input.messageServerId,
+    channelId: input.channelId,
+    agentName: input.agentName,
+    ownerId: input.ownerId,
+    callerEntityId: input.callerEntityId,
+    callerRole: input.callerRole,
+    callerUserName: input.callerUserName,
+    topologyIdentity,
+    proofIdentity,
+    topologyGeneration: registry.topologyGeneration,
+    roomGeneration: registry.roomGenerations.get(input.roomId) ?? 0,
+  });
+}
+
+/** Returns true only for the exact current descriptor and refreshes its LRU. */
+export function hasReadyConversationConnection(
+  descriptor: ConversationConnectionDescriptor,
+): boolean {
+  const registry = getRegistry(descriptor.runtime);
+  if (!descriptorIsCurrent(registry, descriptor)) return false;
+  const proof = registry.readyProofs.get(descriptor.proofIdentity);
+  if (
+    !proof ||
+    proof.topologyGeneration !== descriptor.topologyGeneration ||
+    proof.roomGeneration !== descriptor.roomGeneration
+  ) {
+    return false;
+  }
+  registry.readyProofs.delete(descriptor.proofIdentity);
+  registry.readyProofs.set(descriptor.proofIdentity, proof);
+  return true;
+}
+
+/**
+ * Coalesces identical work and serializes all web-world mutations for the
+ * runtime. A failed mutation clears every proof for that topology because the
+ * shared world may have been only partially reconciled.
+ */
+export function scheduleConversationConnectionEnsure(
+  descriptor: ConversationConnectionDescriptor,
+  ensure: () => Promise<void>,
+): Promise<void> {
+  const registry = getRegistry(descriptor.runtime);
+  try {
+    assertDescriptorCurrent(registry, descriptor);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+
+  const existing = registry.inFlightEnsures.get(descriptor.proofIdentity);
+  if (
+    existing &&
+    existing.descriptor.topologyGeneration === descriptor.topologyGeneration &&
+    existing.descriptor.roomGeneration === descriptor.roomGeneration
+  ) {
+    return existing.promise;
+  }
+
+  const run = enqueueConnectionMutation(registry, async () => {
+    assertDescriptorCurrent(registry, descriptor);
+    try {
+      await ensure();
+      assertDescriptorCurrent(registry, descriptor);
+      deleteConflictingCallerProofs(registry, descriptor);
+      registry.readyProofs.delete(descriptor.proofIdentity);
+      registry.readyProofs.set(descriptor.proofIdentity, {
+        roomId: descriptor.roomId,
+        ownerId: descriptor.ownerId,
+        callerEntityId: descriptor.callerEntityId,
+        callerRole: descriptor.callerRole,
+        callerUserName: descriptor.callerUserName,
+        topologyGeneration: descriptor.topologyGeneration,
+        roomGeneration: descriptor.roomGeneration,
+      });
+      pruneReadyProofs(registry);
+    } catch (error) {
+      if (isConversationConnectionError(error)) {
+        throw error;
+      }
+      if (!descriptorIsCurrent(registry, descriptor)) {
+        throw invalidatedConnectionError(descriptor, error);
+      }
+      invalidateTopology(registry, registry.topologyIdentity);
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new ElizaError(
+        `Conversation connection refresh failed: ${reason}`,
+        {
+          code: "CONVERSATION_CONNECTION_REFRESH_FAILED",
+          cause: error,
+          context: {
+            agentId: descriptor.runtimeAgentId,
+            conversationId: descriptor.conversationId,
+            roomId: descriptor.roomId,
+            worldId: descriptor.worldId,
+          },
+          severity: "ephemeral",
+        },
+      );
+    }
+  });
+
+  let tracked: Promise<void>;
+  tracked = run.finally(() => {
+    if (
+      registry.inFlightEnsures.get(descriptor.proofIdentity)?.promise ===
+      tracked
+    ) {
+      registry.inFlightEnsures.delete(descriptor.proofIdentity);
+    }
+  });
+  registry.inFlightEnsures.set(descriptor.proofIdentity, {
+    descriptor,
+    promise: tracked,
+  });
+  // error-policy:J5 stream routes join this guarded rejection before emitting
+  // their terminal frame; serial route callers await the returned promise.
+  tracked.catch(() => {});
+  return tracked;
+}
+
+/** Invalidates every proof and in-flight generation for an in-place rename. */
+export function invalidateConversationConnectionTopology(
+  runtime: AgentRuntime,
+): void {
+  invalidateTopology(getRegistry(runtime), null);
+}
+
+/**
+ * Unblocks an explicitly recreated room and gives it a new generation. Normal
+ * stream requests cannot clear a deletion block.
+ */
+export function prepareConversationConnectionRoom(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): void {
+  const registry = getRegistry(runtime);
+  registry.blockedRooms.delete(roomId);
+  incrementRoomGeneration(registry, roomId);
+}
+
+/**
+ * Invalidates immediately, then performs deletion after all earlier connection
+ * mutations. A late ensure therefore fails its generation check before the
+ * serialized delete removes the room.
+ */
+export async function serializeConversationConnectionRoomDeletion(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  deleteRoom: () => Promise<void>,
+): Promise<void> {
+  const registry = getRegistry(runtime);
+  incrementRoomGeneration(registry, roomId);
+  registry.blockedRooms.delete(roomId);
+  registry.blockedRooms.add(roomId);
+  pruneBlockedRooms(registry);
+  await enqueueConnectionMutation(registry, deleteRoom);
+}
+
+/** Rejects a turn whose runtime was replaced while its work was in flight. */
+export function assertConversationConnectionRuntime(
+  currentRuntime: AgentRuntime | null,
+  descriptor: ConversationConnectionDescriptor,
+): void {
+  if (currentRuntime !== descriptor.runtime) {
+    throw new ElizaError("Conversation runtime changed during the turn", {
+      code: "CONVERSATION_RUNTIME_CHANGED",
+      context: {
+        expectedAgentId: descriptor.runtimeAgentId,
+        conversationId: descriptor.conversationId,
+        roomId: descriptor.roomId,
+        currentAgentId: currentRuntime?.agentId,
+      },
+      severity: "ephemeral",
+    });
+  }
+}
+
+/** Narrows errors that must terminate the stream without a success fallback. */
+export function isConversationConnectionError(
+  error: unknown,
+): error is ElizaError {
+  return error instanceof ElizaError && CONNECTION_ERROR_CODES.has(error.code);
+}

--- a/packages/agent/src/api/conversation-connection-readiness.ts
+++ b/packages/agent/src/api/conversation-connection-readiness.ts
@@ -1,22 +1,25 @@
 /**
- * Coordinates web-conversation connection proofs for one running agent.
+ * Serializes web-conversation topology reconciliation for a running agent.
  *
- * A proof is tied to an immutable runtime/topology/caller descriptor. All
- * mutations are serialized because every web conversation shares one world,
- * while generation may overlap a refresh only after that exact descriptor has
- * completed once. Generation counters keep late completions from reviving
- * proofs invalidated by failure, deletion, or an in-place topology change.
+ * Descriptors capture the exact runtime, topology, room generation, and caller
+ * used by a turn. Connection work is single-flight per descriptor and serialized
+ * per runtime because every web conversation mutates one shared world. Room
+ * generation tokens are globally unique and safely evictable: eviction makes an
+ * old descriptor invalid instead of letting a default generation revive it.
  */
 import { type AgentRuntime, ElizaError, type UUID } from "@elizaos/core";
 import type { BoundaryWorldRole } from "./boundary-role-resolver.ts";
 
-const MAX_READY_CONNECTION_PROOFS = 2_048;
-const MAX_BLOCKED_CONVERSATION_ROOMS = 5_000;
+const MAX_TRACKED_CONVERSATION_ROOMS = 2_048;
+const MAX_PENDING_CONNECTION_MUTATIONS = 256;
+const CONNECTION_MUTATION_TIMEOUT_MS = 15_000;
 
 const CONNECTION_ERROR_CODES = new Set([
   "CONVERSATION_CONNECTION_INVALIDATED",
+  "CONVERSATION_CONNECTION_QUEUE_SATURATED",
   "CONVERSATION_CONNECTION_REFRESH_FAILED",
   "CONVERSATION_CONNECTION_ROOM_BLOCKED",
+  "CONVERSATION_CONNECTION_TIMEOUT",
   "CONVERSATION_RUNTIME_CHANGED",
 ]);
 
@@ -39,16 +42,6 @@ export interface ConversationConnectionDescriptor {
   readonly roomGeneration: number;
 }
 
-interface ReadyConnectionProof {
-  readonly roomId: UUID;
-  readonly ownerId: UUID;
-  readonly callerEntityId: UUID;
-  readonly callerRole: BoundaryWorldRole;
-  readonly callerUserName: string;
-  readonly topologyGeneration: number;
-  readonly roomGeneration: number;
-}
-
 interface InFlightConnectionEnsure {
   readonly descriptor: ConversationConnectionDescriptor;
   readonly promise: Promise<void>;
@@ -57,10 +50,12 @@ interface InFlightConnectionEnsure {
 interface ConversationConnectionRegistry {
   topologyIdentity: string | null;
   topologyGeneration: number;
+  nextRoomGeneration: number;
   readonly roomGenerations: Map<UUID, number>;
-  readonly readyProofs: Map<string, ReadyConnectionProof>;
   readonly inFlightEnsures: Map<string, InFlightConnectionEnsure>;
   readonly blockedRooms: Set<UUID>;
+  readonly stalledMutations: Set<Promise<void>>;
+  pendingMutationCount: number;
   mutationTail: Promise<void>;
 }
 
@@ -72,10 +67,12 @@ function getRegistry(runtime: AgentRuntime): ConversationConnectionRegistry {
     registry = {
       topologyIdentity: null,
       topologyGeneration: 0,
+      nextRoomGeneration: 0,
       roomGenerations: new Map(),
-      readyProofs: new Map(),
       inFlightEnsures: new Map(),
       blockedRooms: new Set(),
+      stalledMutations: new Set(),
+      pendingMutationCount: 0,
       mutationTail: Promise.resolve(),
     };
     registries.set(runtime, registry);
@@ -127,75 +124,67 @@ function invalidateTopology(
 ): void {
   registry.topologyGeneration += 1;
   registry.topologyIdentity = nextTopologyIdentity;
-  registry.readyProofs.clear();
 }
 
-function deleteRoomProofs(
+function roomHasInFlightEnsure(
   registry: ConversationConnectionRegistry,
   roomId: UUID,
-): void {
-  for (const [identity, proof] of registry.readyProofs) {
-    if (proof.roomId === roomId) {
-      registry.readyProofs.delete(identity);
+): boolean {
+  return Array.from(registry.inFlightEnsures.values()).some(
+    (entry) => entry.descriptor.roomId === roomId,
+  );
+}
+
+function pruneRoomGenerations(registry: ConversationConnectionRegistry): void {
+  const candidateCount = registry.roomGenerations.size;
+  let inspected = 0;
+  while (
+    registry.roomGenerations.size > MAX_TRACKED_CONVERSATION_ROOMS &&
+    inspected < candidateCount
+  ) {
+    const oldestRoomId = registry.roomGenerations.keys().next().value;
+    if (typeof oldestRoomId !== "string") return;
+    inspected += 1;
+    if (
+      registry.blockedRooms.has(oldestRoomId) ||
+      roomHasInFlightEnsure(registry, oldestRoomId)
+    ) {
+      const generation = registry.roomGenerations.get(oldestRoomId);
+      registry.roomGenerations.delete(oldestRoomId);
+      if (generation !== undefined) {
+        registry.roomGenerations.set(oldestRoomId, generation);
+      }
+      continue;
     }
+    // Missing is an invalid generation. A later capture allocates a globally
+    // unique token, so eviction can never make an old descriptor current.
+    registry.roomGenerations.delete(oldestRoomId);
   }
 }
 
-function incrementRoomGeneration(
+function allocateRoomGeneration(
   registry: ConversationConnectionRegistry,
   roomId: UUID,
 ): number {
-  const nextGeneration = (registry.roomGenerations.get(roomId) ?? 0) + 1;
-  registry.roomGenerations.set(roomId, nextGeneration);
-  deleteRoomProofs(registry, roomId);
-  return nextGeneration;
+  registry.nextRoomGeneration += 1;
+  const generation = registry.nextRoomGeneration;
+  registry.roomGenerations.delete(roomId);
+  registry.roomGenerations.set(roomId, generation);
+  pruneRoomGenerations(registry);
+  return generation;
 }
 
-function pruneReadyProofs(registry: ConversationConnectionRegistry): void {
-  while (registry.readyProofs.size > MAX_READY_CONNECTION_PROOFS) {
-    const oldestIdentity = registry.readyProofs.keys().next().value;
-    if (typeof oldestIdentity !== "string") return;
-    registry.readyProofs.delete(oldestIdentity);
-  }
-}
-
-function deleteConflictingCallerProofs(
+function currentRoomGeneration(
   registry: ConversationConnectionRegistry,
-  descriptor: ConversationConnectionDescriptor,
-): void {
-  for (const [identity, proof] of registry.readyProofs) {
-    if (
-      proof.ownerId !== descriptor.ownerId ||
-      (proof.callerEntityId === descriptor.callerEntityId &&
-        (proof.callerRole !== descriptor.callerRole ||
-          proof.callerUserName !== descriptor.callerUserName))
-    ) {
-      registry.readyProofs.delete(identity);
-    }
+  roomId: UUID,
+): number {
+  const generation = registry.roomGenerations.get(roomId);
+  if (generation !== undefined) {
+    registry.roomGenerations.delete(roomId);
+    registry.roomGenerations.set(roomId, generation);
+    return generation;
   }
-}
-
-function pruneBlockedRooms(registry: ConversationConnectionRegistry): void {
-  const candidateCount = registry.blockedRooms.size;
-  let inspected = 0;
-  while (
-    registry.blockedRooms.size > MAX_BLOCKED_CONVERSATION_ROOMS &&
-    inspected < candidateCount
-  ) {
-    const oldestRoomId = registry.blockedRooms.values().next().value;
-    if (typeof oldestRoomId !== "string") return;
-    inspected += 1;
-    const hasInFlightEnsure = Array.from(
-      registry.inFlightEnsures.values(),
-    ).some((entry) => entry.descriptor.roomId === oldestRoomId);
-    if (hasInFlightEnsure) {
-      registry.blockedRooms.delete(oldestRoomId);
-      registry.blockedRooms.add(oldestRoomId);
-      continue;
-    }
-    registry.blockedRooms.delete(oldestRoomId);
-    registry.roomGenerations.delete(oldestRoomId);
-  }
+  return allocateRoomGeneration(registry, roomId);
 }
 
 function descriptorGenerationsAreCurrent(
@@ -205,7 +194,7 @@ function descriptorGenerationsAreCurrent(
   return (
     registry.topologyIdentity === descriptor.topologyIdentity &&
     registry.topologyGeneration === descriptor.topologyGeneration &&
-    (registry.roomGenerations.get(descriptor.roomId) ?? 0) ===
+    registry.roomGenerations.get(descriptor.roomId) ===
       descriptor.roomGeneration
   );
 }
@@ -224,7 +213,7 @@ function invalidatedConnectionError(
   descriptor: ConversationConnectionDescriptor,
   cause?: unknown,
 ): ElizaError {
-  return new ElizaError("Conversation connection proof was invalidated", {
+  return new ElizaError("Conversation connection descriptor was invalidated", {
     code: "CONVERSATION_CONNECTION_INVALIDATED",
     ...(cause !== undefined ? { cause } : {}),
     context: {
@@ -257,16 +246,108 @@ function assertDescriptorCurrent(
   }
 }
 
+interface ConnectionMutationContext {
+  readonly agentId: UUID;
+  readonly roomId: UUID;
+  readonly conversationId?: string;
+  readonly worldId?: UUID;
+}
+
+interface EnqueuedConnectionMutation {
+  /** The exclusive lock remains attached to this promise until I/O settles. */
+  readonly raw: Promise<void>;
+  /** The request-facing observer rejects at the bounded deadline. */
+  readonly result: Promise<void>;
+}
+
+function mutationUnavailableError(
+  context: ConnectionMutationContext,
+  code:
+    | "CONVERSATION_CONNECTION_QUEUE_SATURATED"
+    | "CONVERSATION_CONNECTION_TIMEOUT",
+  message: string,
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    context: { ...context },
+    severity: "ephemeral",
+  });
+}
+
 function enqueueConnectionMutation(
   registry: ConversationConnectionRegistry,
+  context: ConnectionMutationContext,
   mutation: () => Promise<void>,
-): Promise<void> {
-  const run = registry.mutationTail.then(mutation, mutation);
+  onTimeout: () => void,
+): EnqueuedConnectionMutation {
+  if (registry.stalledMutations.size > 0) {
+    throw mutationUnavailableError(
+      context,
+      "CONVERSATION_CONNECTION_TIMEOUT",
+      "Conversation connection reconciliation is quarantined behind an unsettled write",
+    );
+  }
+  if (registry.pendingMutationCount >= MAX_PENDING_CONNECTION_MUTATIONS) {
+    throw mutationUnavailableError(
+      context,
+      "CONVERSATION_CONNECTION_QUEUE_SATURATED",
+      "Conversation connection reconciliation queue is saturated",
+    );
+  }
+
+  const timeoutError = mutationUnavailableError(
+    context,
+    "CONVERSATION_CONNECTION_TIMEOUT",
+    "Conversation connection reconciliation exceeded its deadline",
+  );
+  let cancelledBeforeStart = false;
+  const execute = async (): Promise<void> => {
+    if (cancelledBeforeStart) throw timeoutError;
+    await mutation();
+  };
+
+  registry.pendingMutationCount += 1;
+  const run = registry.mutationTail.then(execute, execute);
   registry.mutationTail = run.then(
     () => undefined,
     () => undefined,
   );
-  return run;
+
+  let observerSettled = false;
+  const result = new Promise<void>((resolve, reject) => {
+    const deadline = setTimeout(() => {
+      if (observerSettled) return;
+      observerSettled = true;
+      cancelledBeforeStart = true;
+      onTimeout();
+      // The request may fail now, but the raw write keeps exclusive ownership
+      // of mutationTail. New mutations fail fast until that I/O truly settles.
+      registry.stalledMutations.add(run);
+      reject(timeoutError);
+    }, CONNECTION_MUTATION_TIMEOUT_MS);
+
+    run.then(
+      () => {
+        clearTimeout(deadline);
+        if (observerSettled) return;
+        observerSettled = true;
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(deadline);
+        if (observerSettled) return;
+        observerSettled = true;
+        reject(error);
+      },
+    );
+  });
+
+  const releaseMutation = (): void => {
+    registry.pendingMutationCount -= 1;
+    registry.stalledMutations.delete(run);
+  };
+  run.then(releaseMutation, releaseMutation);
+  return { raw: run, result };
 }
 
 /**
@@ -327,33 +408,13 @@ export function captureConversationConnectionDescriptor(input: {
     topologyIdentity,
     proofIdentity,
     topologyGeneration: registry.topologyGeneration,
-    roomGeneration: registry.roomGenerations.get(input.roomId) ?? 0,
+    roomGeneration: currentRoomGeneration(registry, input.roomId),
   });
 }
 
-/** Returns true only for the exact current descriptor and refreshes its LRU. */
-export function hasReadyConversationConnection(
-  descriptor: ConversationConnectionDescriptor,
-): boolean {
-  const registry = getRegistry(descriptor.runtime);
-  if (!descriptorIsCurrent(registry, descriptor)) return false;
-  const proof = registry.readyProofs.get(descriptor.proofIdentity);
-  if (
-    !proof ||
-    proof.topologyGeneration !== descriptor.topologyGeneration ||
-    proof.roomGeneration !== descriptor.roomGeneration
-  ) {
-    return false;
-  }
-  registry.readyProofs.delete(descriptor.proofIdentity);
-  registry.readyProofs.set(descriptor.proofIdentity, proof);
-  return true;
-}
-
 /**
- * Coalesces identical work and serializes all web-world mutations for the
- * runtime. A failed mutation clears every proof for that topology because the
- * shared world may have been only partially reconciled.
+ * Coalesces identical work and serializes shared-world mutations. Callers await
+ * this prerequisite before generation; it is not a success cache.
  */
 export function scheduleConversationConnectionEnsure(
   descriptor: ConversationConnectionDescriptor,
@@ -375,48 +436,53 @@ export function scheduleConversationConnectionEnsure(
     return existing.promise;
   }
 
-  const run = enqueueConnectionMutation(registry, async () => {
-    assertDescriptorCurrent(registry, descriptor);
-    try {
-      await ensure();
-      assertDescriptorCurrent(registry, descriptor);
-      deleteConflictingCallerProofs(registry, descriptor);
-      registry.readyProofs.delete(descriptor.proofIdentity);
-      registry.readyProofs.set(descriptor.proofIdentity, {
+  let run: Promise<void>;
+  try {
+    run = enqueueConnectionMutation(
+      registry,
+      {
+        agentId: descriptor.runtimeAgentId,
+        conversationId: descriptor.conversationId,
         roomId: descriptor.roomId,
-        ownerId: descriptor.ownerId,
-        callerEntityId: descriptor.callerEntityId,
-        callerRole: descriptor.callerRole,
-        callerUserName: descriptor.callerUserName,
-        topologyGeneration: descriptor.topologyGeneration,
-        roomGeneration: descriptor.roomGeneration,
-      });
-      pruneReadyProofs(registry);
-    } catch (error) {
-      if (isConversationConnectionError(error)) {
-        throw error;
-      }
-      if (!descriptorIsCurrent(registry, descriptor)) {
-        throw invalidatedConnectionError(descriptor, error);
-      }
-      invalidateTopology(registry, registry.topologyIdentity);
-      const reason = error instanceof Error ? error.message : String(error);
-      throw new ElizaError(
-        `Conversation connection refresh failed: ${reason}`,
-        {
-          code: "CONVERSATION_CONNECTION_REFRESH_FAILED",
-          cause: error,
-          context: {
-            agentId: descriptor.runtimeAgentId,
-            conversationId: descriptor.conversationId,
-            roomId: descriptor.roomId,
-            worldId: descriptor.worldId,
-          },
-          severity: "ephemeral",
-        },
-      );
-    }
-  });
+        worldId: descriptor.worldId,
+      },
+      async () => {
+        assertDescriptorCurrent(registry, descriptor);
+        try {
+          await ensure();
+          assertDescriptorCurrent(registry, descriptor);
+        } catch (error) {
+          if (isConversationConnectionError(error)) {
+            throw error;
+          }
+          if (!descriptorIsCurrent(registry, descriptor)) {
+            throw invalidatedConnectionError(descriptor, error);
+          }
+          invalidateTopology(registry, registry.topologyIdentity);
+          const reason = error instanceof Error ? error.message : String(error);
+          throw new ElizaError(
+            `Conversation connection reconciliation failed: ${reason}`,
+            {
+              code: "CONVERSATION_CONNECTION_REFRESH_FAILED",
+              cause: error,
+              context: {
+                agentId: descriptor.runtimeAgentId,
+                conversationId: descriptor.conversationId,
+                roomId: descriptor.roomId,
+                worldId: descriptor.worldId,
+              },
+              severity: "ephemeral",
+            },
+          );
+        }
+      },
+      () => {
+        invalidateTopology(registry, registry.topologyIdentity);
+      },
+    ).result;
+  } catch (error) {
+    return Promise.reject(error);
+  }
 
   let tracked: Promise<void>;
   tracked = run.finally(() => {
@@ -426,41 +492,40 @@ export function scheduleConversationConnectionEnsure(
     ) {
       registry.inFlightEnsures.delete(descriptor.proofIdentity);
     }
+    pruneRoomGenerations(registry);
   });
   registry.inFlightEnsures.set(descriptor.proofIdentity, {
     descriptor,
     promise: tracked,
   });
-  // error-policy:J5 stream routes join this guarded rejection before emitting
-  // their terminal frame; serial route callers await the returned promise.
+  // error-policy:J5 route callers await the returned promise; this observer
+  // prevents a rejection from becoming unhandled before a queued caller joins.
   tracked.catch(() => {});
   return tracked;
 }
 
-/** Invalidates every proof and in-flight generation for an in-place rename. */
+/** Invalidates every descriptor and in-flight ensure for an in-place rename. */
 export function invalidateConversationConnectionTopology(
   runtime: AgentRuntime,
 ): void {
   invalidateTopology(getRegistry(runtime), null);
 }
 
-/**
- * Unblocks an explicitly recreated room and gives it a new generation. Normal
- * stream requests cannot clear a deletion block.
- */
+/** Gives an explicitly created or recreated room a fresh generation token. */
 export function prepareConversationConnectionRoom(
   runtime: AgentRuntime,
   roomId: UUID,
 ): void {
   const registry = getRegistry(runtime);
   registry.blockedRooms.delete(roomId);
-  incrementRoomGeneration(registry, roomId);
+  allocateRoomGeneration(registry, roomId);
 }
 
 /**
- * Invalidates immediately, then performs deletion after all earlier connection
- * mutations. A late ensure therefore fails its generation check before the
- * serialized delete removes the room.
+ * Invalidates immediately, drains earlier reconciliation, and blocks new work
+ * until deletion completes. Retiring the generation makes every descriptor
+ * captured before or during deletion permanently stale without retaining a
+ * historical tombstone in memory.
  */
 export async function serializeConversationConnectionRoomDeletion(
   runtime: AgentRuntime,
@@ -468,14 +533,34 @@ export async function serializeConversationConnectionRoomDeletion(
   deleteRoom: () => Promise<void>,
 ): Promise<void> {
   const registry = getRegistry(runtime);
-  incrementRoomGeneration(registry, roomId);
-  registry.blockedRooms.delete(roomId);
+  allocateRoomGeneration(registry, roomId);
   registry.blockedRooms.add(roomId);
-  pruneBlockedRooms(registry);
-  await enqueueConnectionMutation(registry, deleteRoom);
+  let queued: EnqueuedConnectionMutation;
+  try {
+    queued = enqueueConnectionMutation(
+      registry,
+      { agentId: runtime.agentId, roomId },
+      deleteRoom,
+      () => undefined,
+    );
+  } catch (error) {
+    registry.blockedRooms.delete(roomId);
+    registry.roomGenerations.delete(roomId);
+    throw error;
+  }
+
+  const releaseRoom = (): void => {
+    registry.blockedRooms.delete(roomId);
+    registry.roomGenerations.delete(roomId);
+  };
+  queued.raw.then(releaseRoom, releaseRoom);
+  await queued.result;
 }
 
-/** Rejects a turn whose runtime was replaced while its work was in flight. */
+/**
+ * Rejects a turn when its runtime, topology, or room generation changed after
+ * capture, including deletion and in-place character rename.
+ */
 export function assertConversationConnectionRuntime(
   currentRuntime: AgentRuntime | null,
   descriptor: ConversationConnectionDescriptor,
@@ -492,9 +577,10 @@ export function assertConversationConnectionRuntime(
       severity: "ephemeral",
     });
   }
+  assertDescriptorCurrent(getRegistry(descriptor.runtime), descriptor);
 }
 
-/** Narrows errors that must terminate the stream without a success fallback. */
+/** Narrows errors that must terminate the request without a success fallback. */
 export function isConversationConnectionError(
   error: unknown,
 ): error is ElizaError {

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -26,6 +26,7 @@ import {
   ChannelType,
   type Content,
   createMessageMemory,
+  ElizaError,
   logger,
   MESSAGE_SOURCE_AGENT_GREETING,
   MESSAGE_SOURCE_CLIENT_CHAT,
@@ -83,6 +84,16 @@ import {
   writeSseJson,
 } from "./chat-routes.ts";
 import { resolveClientChatAdminEntityId } from "./client-chat-admin.ts";
+import {
+  assertConversationConnectionRuntime,
+  type ConversationConnectionDescriptor,
+  captureConversationConnectionDescriptor,
+  hasReadyConversationConnection,
+  isConversationConnectionError,
+  prepareConversationConnectionRoom,
+  scheduleConversationConnectionEnsure,
+  serializeConversationConnectionRoomDeletion,
+} from "./conversation-connection-readiness.ts";
 import {
   buildConversationRoomMetadata,
   sanitizeConversationMetadata,
@@ -549,18 +560,56 @@ function isTurnAbortError(err: unknown): boolean {
   );
 }
 
+type PromiseOutcome<T> =
+  | { readonly status: "fulfilled"; readonly value: T }
+  | { readonly status: "rejected"; readonly reason: unknown };
+
+function observePromise<T>(promise: Promise<T>): Promise<PromiseOutcome<T>> {
+  return promise.then<PromiseOutcome<T>, PromiseOutcome<T>>(
+    (value) => ({ status: "fulfilled", value }),
+    (reason: unknown) => ({ status: "rejected", reason }),
+  );
+}
+
+function unwrapPromiseOutcome<T>(outcome: PromiseOutcome<T>): T {
+  if (outcome.status === "rejected") {
+    throw outcome.reason;
+  }
+  return outcome.value;
+}
+
+function ensureAdminEntityIdForRuntime(
+  state: ConversationRouteState,
+  runtime: AgentRuntime | null,
+): UUID {
+  const resolutionState = {
+    runtime,
+    adminEntityId: state.adminEntityId,
+    chatUserId: state.chatUserId,
+    config: state.config,
+    agentName: state.agentName,
+  };
+  const ownerId = resolveClientChatAdminEntityId(resolutionState);
+  if (state.runtime === runtime) {
+    state.adminEntityId = ownerId;
+    state.chatUserId = ownerId;
+  }
+  return ownerId;
+}
+
 function ensureAdminEntityId(state: ConversationRouteState): UUID {
-  return resolveConversationAdminEntityId(state);
+  return ensureAdminEntityIdForRuntime(state, state.runtime);
 }
 
 function resolveConversationCaller(
   req: http.IncomingMessage,
   state: ConversationRouteState,
+  runtime: AgentRuntime | null = state.runtime,
 ): { entityId: UUID; role: WaifuChatWorldRole; userName: string } {
   const access = resolveWaifuChatAccess(req);
   if (!access) {
     return {
-      entityId: ensureAdminEntityId(state),
+      entityId: ensureAdminEntityIdForRuntime(state, runtime),
       role: "OWNER",
       userName: resolveAppUserName(state.config),
     };
@@ -636,7 +685,21 @@ async function ensureWorldOwnershipAndRoles(
   callerRole: WaifuChatWorldRole,
 ): Promise<void> {
   const world = await runtime.getWorld(worldId);
-  if (!world) return;
+  if (!world) {
+    throw new ElizaError(
+      "Conversation world is missing after connection initialization",
+      {
+        code: "CONVERSATION_WORLD_MISSING",
+        context: {
+          agentId: runtime.agentId,
+          worldId,
+          ownerId,
+          callerId,
+        },
+        severity: "fatal",
+      },
+    );
+  }
   let needsUpdate = false;
   if (!world.metadata) {
     world.metadata = {};
@@ -715,24 +778,30 @@ async function deleteConversationRoomData(
   runtime: AgentRuntime,
   roomId: UUID,
 ): Promise<void> {
-  const runtimeWithDelete = runtime as AgentRuntime & {
-    deleteRoom?: (id: UUID) => Promise<unknown>;
-    adapter?: {
-      db?: {
+  await serializeConversationConnectionRoomDeletion(
+    runtime,
+    roomId,
+    async () => {
+      const runtimeWithDelete = runtime as AgentRuntime & {
         deleteRoom?: (id: UUID) => Promise<unknown>;
+        adapter?: {
+          db?: {
+            deleteRoom?: (id: UUID) => Promise<unknown>;
+          };
+        };
       };
-    };
-  };
 
-  if (typeof runtimeWithDelete.deleteRoom === "function") {
-    await runtimeWithDelete.deleteRoom(roomId);
-    return;
-  }
+      if (typeof runtimeWithDelete.deleteRoom === "function") {
+        await runtimeWithDelete.deleteRoom(roomId);
+        return;
+      }
 
-  const dbDeleteRoom = runtimeWithDelete.adapter.db.deleteRoom;
-  if (typeof dbDeleteRoom === "function") {
-    await dbDeleteRoom.call(runtimeWithDelete.adapter.db, roomId);
-  }
+      const dbDeleteRoom = runtimeWithDelete.adapter.db.deleteRoom;
+      if (typeof dbDeleteRoom === "function") {
+        await dbDeleteRoom.call(runtimeWithDelete.adapter.db, roomId);
+      }
+    },
+  );
 }
 
 async function deleteConversationMemories(
@@ -798,77 +867,78 @@ async function deleteConversationMemories(
   return deletedCount;
 }
 
-async function ensureConversationRoom(
+function captureConversationConnection(
   state: ConversationRouteState,
+  runtime: AgentRuntime,
   conv: ConversationMeta,
   caller: {
     entityId: UUID;
     role: WaifuChatWorldRole;
     userName: string;
   },
-): Promise<void> {
-  if (!state.runtime) return;
-  const runtime = state.runtime;
+): ConversationConnectionDescriptor {
   const agentName = runtime.character.name ?? "Eliza";
-  const ownerId = ensureAdminEntityId(state);
+  const ownerId = ensureAdminEntityIdForRuntime(state, runtime);
   const worldId = stringToUuid(`${agentName}-web-chat-world`);
   const messageServerId = stringToUuid(`${agentName}-web-server`) as UUID;
-  await runtime.ensureConnection({
-    entityId: caller.entityId,
+  return captureConversationConnectionDescriptor({
+    runtime,
+    conversationId: conv.id,
     roomId: conv.roomId,
+    agentName,
     worldId,
-    userName: caller.userName,
-    source: MESSAGE_SOURCE_CLIENT_CHAT,
-    channelId: `web-conv-${conv.id}`,
-    type: ChannelType.DM,
     messageServerId,
-    metadata: { ownership: { ownerId }, waifuRole: caller.role },
+    channelId: `web-conv-${conv.id}`,
+    ownerId,
+    callerEntityId: caller.entityId,
+    callerRole: caller.role,
+    callerUserName: caller.userName,
+  });
+}
+
+async function establishConversationConnection(
+  descriptor: ConversationConnectionDescriptor,
+): Promise<void> {
+  await descriptor.runtime.ensureConnection({
+    entityId: descriptor.callerEntityId,
+    roomId: descriptor.roomId,
+    worldId: descriptor.worldId,
+    userName: descriptor.callerUserName,
+    source: MESSAGE_SOURCE_CLIENT_CHAT,
+    channelId: descriptor.channelId,
+    type: ChannelType.DM,
+    messageServerId: descriptor.messageServerId,
+    metadata: {
+      ownership: { ownerId: descriptor.ownerId },
+      waifuRole: descriptor.callerRole,
+    },
   });
   await ensureWorldOwnershipAndRoles(
-    runtime,
-    worldId as UUID,
-    ownerId,
-    caller.entityId,
-    caller.role,
+    descriptor.runtime,
+    descriptor.worldId,
+    descriptor.ownerId,
+    descriptor.callerEntityId,
+    descriptor.callerRole,
   );
-  let readyConnections = conversationConnectionReadiness.get(runtime);
-  if (!readyConnections) {
-    readyConnections = new Set<string>();
-    conversationConnectionReadiness.set(runtime, readyConnections);
-  }
-  readyConnections.add(conversationConnectionKey(state, conv, caller));
 }
 
-const conversationConnectionReadiness = new WeakMap<
-  AgentRuntime,
-  Set<string>
->();
-
-function conversationConnectionKey(
-  state: ConversationRouteState,
-  conv: ConversationMeta,
-  caller: { entityId: UUID; role: WaifuChatWorldRole; userName: string },
-): string {
-  return [
-    conv.roomId,
-    caller.entityId,
-    caller.role,
-    caller.userName,
-    ensureAdminEntityId(state),
-  ].join(":");
-}
-
-function hasReadyConversationConnection(
+async function ensureConversationRoom(
   state: ConversationRouteState,
   runtime: AgentRuntime,
   conv: ConversationMeta,
   caller: { entityId: UUID; role: WaifuChatWorldRole; userName: string },
-): boolean {
-  return (
-    conversationConnectionReadiness
-      .get(runtime)
-      ?.has(conversationConnectionKey(state, conv, caller)) === true
+): Promise<ConversationConnectionDescriptor> {
+  const descriptor = captureConversationConnection(
+    state,
+    runtime,
+    conv,
+    caller,
   );
+  await scheduleConversationConnectionEnsure(descriptor, () =>
+    establishConversationConnection(descriptor),
+  );
+  assertConversationConnectionRuntime(state.runtime, descriptor);
+  return descriptor;
 }
 
 async function syncConversationRoomState(
@@ -1860,12 +1930,15 @@ export async function handleConversationRoutes(
     // Soft cap: evict the oldest conversation when the map exceeds 500
     evictOldestConversation(state.conversations, 500);
 
-    if (state.runtime) {
+    const runtime = state.runtime;
+    if (runtime) {
       try {
+        prepareConversationConnectionRoom(runtime, conv.roomId);
         await ensureConversationRoom(
           state,
+          runtime,
           conv,
-          resolveConversationCaller(req, state),
+          resolveConversationCaller(req, state, runtime),
         );
         await syncConversationRoomState(state, conv);
         if (body.includeGreeting === true) {
@@ -2282,6 +2355,7 @@ export async function handleConversationRoutes(
     await waitForConversationRestore(state);
 
     let conv = state.conversations.get(convId);
+    let createdConversation = false;
     if (!conv) {
       const now = new Date().toISOString();
       conv = {
@@ -2296,11 +2370,15 @@ export async function handleConversationRoutes(
       };
       state.conversations.set(convId, conv);
       evictOldestConversation(state.conversations, 500);
+      createdConversation = true;
     }
 
-    const caller = resolveConversationCaller(req, state);
+    if (createdConversation) {
+      prepareConversationConnectionRoom(runtime, conv.roomId);
+    }
+    const caller = resolveConversationCaller(req, state, runtime);
     try {
-      await ensureConversationRoom(state, conv, caller);
+      await ensureConversationRoom(state, runtime, conv, caller);
     } catch (err) {
       error(
         res,
@@ -2613,7 +2691,7 @@ export async function handleConversationRoutes(
       return failStream("Agent is not running");
     }
 
-    const caller = resolveConversationCaller(req, state);
+    const caller = resolveConversationCaller(req, state, runtime);
     const userId = caller.entityId;
     const turnStartedAt = Date.now();
 
@@ -2628,14 +2706,26 @@ export async function handleConversationRoutes(
       metadata: chatMetadata,
     });
 
-    let connectionRefresh: Promise<void> = Promise.resolve();
-    if (hasReadyConversationConnection(state, runtime, conv, caller)) {
-      connectionRefresh = ensureConversationRoom(state, conv, caller);
-      // error-policy:J5 the rejection is observed before the terminal frame.
-      connectionRefresh.catch(() => {});
-    } else {
+    const connectionDescriptor = captureConversationConnection(
+      state,
+      runtime,
+      conv,
+      caller,
+    );
+    const connectionWasReady =
+      hasReadyConversationConnection(connectionDescriptor);
+    const connectionRefreshOutcome = observePromise(
+      scheduleConversationConnectionEnsure(connectionDescriptor, () =>
+        establishConversationConnection(connectionDescriptor),
+      ),
+    );
+    if (!connectionWasReady) {
       try {
-        await ensureConversationRoom(state, conv, caller);
+        unwrapPromiseOutcome(await connectionRefreshOutcome);
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
       } catch (err) {
         return failStream(
           `Failed to initialize conversation room: ${getErrorMessage(err)}`,
@@ -2643,8 +2733,20 @@ export async function handleConversationRoutes(
       }
     }
     try {
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
       await persistConversationMemory(runtime, messageToStore);
     } catch (err) {
+      try {
+        unwrapPromiseOutcome(await connectionRefreshOutcome);
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
+      } catch (connectionErr) {
+        return failStream(
+          `Failed to refresh conversation room: ${getErrorMessage(connectionErr)}`,
+        );
+      }
       return failStream(
         `Failed to store user message: ${getErrorMessage(err)}`,
       );
@@ -2654,8 +2756,12 @@ export async function handleConversationRoutes(
     if (walletModeGuidance) {
       const endActiveChatTurn = beginActiveChatTurn(state);
       try {
+        unwrapPromiseOutcome(await connectionRefreshOutcome);
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
         if (!disconnectTracker.isAborted()) {
-          await connectionRefresh;
           tokenWriter.writeSnapshot(res, walletModeGuidance);
           try {
             const persisted = await persistAssistantConversationMemory(
@@ -2664,6 +2770,10 @@ export async function handleConversationRoutes(
               walletModeGuidance,
               channelType,
               turnStartedAt,
+            );
+            assertConversationConnectionRuntime(
+              state.runtime,
+              connectionDescriptor,
             );
             conv.updatedAt = new Date().toISOString();
             writeSseJson(res, {
@@ -2679,6 +2789,15 @@ export async function handleConversationRoutes(
             });
             return true;
           }
+        }
+      } catch (err) {
+        if (!disconnectTracker.isAborted()) {
+          writeSse(res, {
+            type: "error",
+            message: isConversationConnectionError(err)
+              ? `Failed to refresh conversation room: ${getErrorMessage(err)}`
+              : getErrorMessage(err),
+          });
         }
       } finally {
         clearInterval(heartbeatInterval);
@@ -2706,83 +2825,85 @@ export async function handleConversationRoutes(
     let deferredPersistence: Promise<void> | null = null;
 
     try {
-      const result = await generateChatResponse(
-        runtime,
-        userMessage,
-        state.agentName,
-        {
-          isAborted: () => disconnectTracker.isAborted(),
-          abortSignal: disconnectTracker.signal,
-          onStatus: (status) => {
-            if (
-              disconnectTracker.isAborted() ||
-              disconnectTracker.checkConnectionClosed()
-            ) {
-              return;
-            }
-            // Array.join renders absent optional fields as empty segments, so
-            // the dedup key is stable without nullish-coalescing each field.
-            const signature = [
-              status.kind,
-              status.actionName,
-              status.toolName,
-            ].join(":");
-            if (signature === lastStatusSignature) {
-              return;
-            }
-            lastStatusSignature = signature;
-            writeChatStatusSse(res, status);
-          },
-          onToolEvent: (event) => {
-            if (
-              disconnectTracker.isAborted() ||
-              disconnectTracker.checkConnectionClosed()
-            ) {
-              return;
-            }
-            writeChatToolSse(res, event);
-          },
-          onChunk: (chunk) => {
-            if (!chunk) return;
-            if (
-              disconnectTracker.isAborted() ||
-              disconnectTracker.checkConnectionClosed()
-            ) {
-              return;
-            }
-            streamedText += chunk;
-            tokenWriter.writeChunk(res, chunk, streamedText);
-          },
-          onSnapshot: (text) => {
-            if (!text) return;
-            if (
-              !streamedText ||
-              disconnectTracker.isAborted() ||
-              disconnectTracker.checkConnectionClosed()
-            ) {
-              return;
-            }
-            // Structured field extractors can briefly normalize whitespace or
-            // closing punctuation while the same visible field is still
-            // streaming. Do not shrink the user-visible token stream for
-            // prefix-equivalent snapshots; later longer snapshots/deltas still
-            // advance normally.
-            if (
-              text.length < streamedText.length &&
-              streamedText.startsWith(text)
-            ) {
-              return;
-            }
-            streamedText = text;
-            tokenWriter.writeSnapshot(res, streamedText);
-          },
-          resolveNoResponseText: () =>
-            resolveNoResponseFallback(state.logBuffer, runtime),
-          preferredLanguage,
-        },
-      );
+      const [generationOutcome, refreshOutcome] = await Promise.all([
+        observePromise(
+          generateChatResponse(runtime, userMessage, state.agentName, {
+            isAborted: () => disconnectTracker.isAborted(),
+            abortSignal: disconnectTracker.signal,
+            onStatus: (status) => {
+              if (
+                disconnectTracker.isAborted() ||
+                disconnectTracker.checkConnectionClosed()
+              ) {
+                return;
+              }
+              // Array.join renders absent optional fields as empty segments, so
+              // the dedup key is stable without nullish-coalescing each field.
+              const signature = [
+                status.kind,
+                status.actionName,
+                status.toolName,
+              ].join(":");
+              if (signature === lastStatusSignature) {
+                return;
+              }
+              lastStatusSignature = signature;
+              writeChatStatusSse(res, status);
+            },
+            onToolEvent: (event) => {
+              if (
+                disconnectTracker.isAborted() ||
+                disconnectTracker.checkConnectionClosed()
+              ) {
+                return;
+              }
+              writeChatToolSse(res, event);
+            },
+            onChunk: (chunk) => {
+              if (!chunk) return;
+              if (
+                disconnectTracker.isAborted() ||
+                disconnectTracker.checkConnectionClosed()
+              ) {
+                return;
+              }
+              streamedText += chunk;
+              tokenWriter.writeChunk(res, chunk, streamedText);
+            },
+            onSnapshot: (text) => {
+              if (!text) return;
+              if (
+                !streamedText ||
+                disconnectTracker.isAborted() ||
+                disconnectTracker.checkConnectionClosed()
+              ) {
+                return;
+              }
+              // Structured field extractors can briefly normalize whitespace or
+              // closing punctuation while the same visible field is still
+              // streaming. Do not shrink the user-visible token stream for
+              // prefix-equivalent snapshots; later longer snapshots/deltas still
+              // advance normally.
+              if (
+                text.length < streamedText.length &&
+                streamedText.startsWith(text)
+              ) {
+                return;
+              }
+              streamedText = text;
+              tokenWriter.writeSnapshot(res, streamedText);
+            },
+            resolveNoResponseText: () =>
+              resolveNoResponseFallback(state.logBuffer, runtime),
+            preferredLanguage,
+          }),
+        ),
+        connectionRefreshOutcome,
+      ]);
 
-      await connectionRefresh;
+      unwrapPromiseOutcome(refreshOutcome);
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
+      const result = unwrapPromiseOutcome(generationOutcome);
 
       if (!disconnectTracker.isAborted()) {
         conv.updatedAt = new Date().toISOString();
@@ -2831,6 +2952,10 @@ export async function handleConversationRoutes(
           // Emit `done` before the DB insert so user-perceived end-of-turn
           // latency excludes the memory write, but include the pre-minted
           // persisted id so the client can reconcile its streamed temp bubble.
+          assertConversationConnectionRuntime(
+            state.runtime,
+            connectionDescriptor,
+          );
           writeSseJson(res, {
             type: "done",
             fullText: resolvedText,
@@ -2878,6 +3003,10 @@ export async function handleConversationRoutes(
             }
           })();
         } else {
+          assertConversationConnectionRuntime(
+            state.runtime,
+            connectionDescriptor,
+          );
           writeSseJson(res, {
             type: "done",
             fullText: "",
@@ -2891,7 +3020,34 @@ export async function handleConversationRoutes(
         }
       }
     } catch (err) {
-      if (isTurnAbortError(err)) {
+      let terminalError = err;
+      try {
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
+      } catch (runtimeError) {
+        terminalError = runtimeError;
+      }
+
+      if (isConversationConnectionError(terminalError)) {
+        logger.warn(
+          {
+            err: getErrorMessage(terminalError),
+            conversationId: conv.id,
+            roomId: conv.roomId,
+          },
+          "[ConversationStream] connection prerequisite failed",
+        );
+        if (disconnectTracker.isAborted()) {
+          releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+        } else {
+          writeSse(res, {
+            type: "error",
+            message: `Failed to refresh conversation room: ${getErrorMessage(terminalError)}`,
+          });
+        }
+      } else if (isTurnAbortError(terminalError)) {
         logger.info(
           { conversationId: conv.id, roomId: conv.roomId },
           "[ConversationStream] generation aborted",
@@ -2909,7 +3065,7 @@ export async function handleConversationRoutes(
         if (streamedText) {
           logger.warn(
             {
-              err: getErrorMessage(err),
+              err: getErrorMessage(terminalError),
               streamedTextLength: streamedText.length,
             },
             "Post-generation error after text was already streamed — using streamed text",
@@ -2921,6 +3077,10 @@ export async function handleConversationRoutes(
               streamedText,
               channelType,
               turnStartedAt,
+            );
+            assertConversationConnectionRuntime(
+              state.runtime,
+              connectionDescriptor,
             );
             conv.updatedAt = new Date().toISOString();
             writeSseJson(res, {
@@ -2938,8 +3098,11 @@ export async function handleConversationRoutes(
         } else {
           logger.warn(
             {
-              err: getErrorMessage(err),
-              stack: err instanceof Error ? err.stack : undefined,
+              err: getErrorMessage(terminalError),
+              stack:
+                terminalError instanceof Error
+                  ? terminalError.stack
+                  : undefined,
             },
             "Chat generation failed with no streamed text",
           );
@@ -2952,12 +3115,24 @@ export async function handleConversationRoutes(
           if (alreadyPersistedVisibleAssistantTurn) {
             logger.warn(
               {
-                err: getErrorMessage(err),
+                err: getErrorMessage(terminalError),
                 conversationId: conv.id,
                 roomId: conv.roomId,
               },
               "Chat generation failed after an assistant reply was already persisted — suppressing synthetic fallback",
             );
+            try {
+              assertConversationConnectionRuntime(
+                state.runtime,
+                connectionDescriptor,
+              );
+            } catch (connectionErr) {
+              writeSse(res, {
+                type: "error",
+                message: getErrorMessage(connectionErr),
+              });
+              return true;
+            }
             writeSseJson(res, {
               type: "done",
               fullText: "",
@@ -2965,14 +3140,24 @@ export async function handleConversationRoutes(
             });
             return true;
           }
-          const providerIssueReply = getChatFailureReply(err, state.logBuffer);
-          const failureKind = classifyChatFailure(err, state.logBuffer);
+          const providerIssueReply = getChatFailureReply(
+            terminalError,
+            state.logBuffer,
+          );
+          const failureKind = classifyChatFailure(
+            terminalError,
+            state.logBuffer,
+          );
           try {
             const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
               providerIssueReply,
               channelType,
+            );
+            assertConversationConnectionRuntime(
+              state.runtime,
+              connectionDescriptor,
             );
             conv.updatedAt = new Date().toISOString();
             writeSse(res, {
@@ -3090,12 +3275,12 @@ export async function handleConversationRoutes(
       error(res, "Agent is not running", 503);
       return true;
     }
-    const caller = resolveConversationCaller(req, state);
+    const caller = resolveConversationCaller(req, state, runtime);
     const userId = caller.entityId;
     const turnStartedAt = Date.now();
 
     try {
-      await ensureConversationRoom(state, conv, caller);
+      await ensureConversationRoom(state, runtime, conv, caller);
     } catch (err) {
       error(
         res,
@@ -3276,8 +3461,9 @@ export async function handleConversationRoutes(
     try {
       await ensureConversationRoom(
         state,
+        runtime,
         conv,
-        resolveConversationCaller(req, state),
+        resolveConversationCaller(req, state, runtime),
       );
     } catch (err) {
       error(

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -88,7 +88,6 @@ import {
   assertConversationConnectionRuntime,
   type ConversationConnectionDescriptor,
   captureConversationConnectionDescriptor,
-  hasReadyConversationConnection,
   isConversationConnectionError,
   prepareConversationConnectionRoom,
   scheduleConversationConnectionEnsure,
@@ -558,24 +557,6 @@ function isTurnAbortError(err: unknown): boolean {
     err.name === "TurnAbortedError" ||
     err.message.startsWith("Turn aborted:")
   );
-}
-
-type PromiseOutcome<T> =
-  | { readonly status: "fulfilled"; readonly value: T }
-  | { readonly status: "rejected"; readonly reason: unknown };
-
-function observePromise<T>(promise: Promise<T>): Promise<PromiseOutcome<T>> {
-  return promise.then<PromiseOutcome<T>, PromiseOutcome<T>>(
-    (value) => ({ status: "fulfilled", value }),
-    (reason: unknown) => ({ status: "rejected", reason }),
-  );
-}
-
-function unwrapPromiseOutcome<T>(outcome: PromiseOutcome<T>): T {
-  if (outcome.status === "rejected") {
-    throw outcome.reason;
-  }
-  return outcome.value;
 }
 
 function ensureAdminEntityIdForRuntime(
@@ -2712,39 +2693,26 @@ export async function handleConversationRoutes(
       conv,
       caller,
     );
-    const connectionWasReady =
-      hasReadyConversationConnection(connectionDescriptor);
-    const connectionRefreshOutcome = observePromise(
-      scheduleConversationConnectionEnsure(connectionDescriptor, () =>
+    try {
+      await scheduleConversationConnectionEnsure(connectionDescriptor, () =>
         establishConversationConnection(connectionDescriptor),
-      ),
-    );
-    if (!connectionWasReady) {
-      try {
-        unwrapPromiseOutcome(await connectionRefreshOutcome);
-        assertConversationConnectionRuntime(
-          state.runtime,
-          connectionDescriptor,
-        );
-      } catch (err) {
-        return failStream(
-          `Failed to initialize conversation room: ${getErrorMessage(err)}`,
-        );
-      }
+      );
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
+    } catch (err) {
+      releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+      return failStream(
+        `Failed to initialize conversation room: ${getErrorMessage(err)}`,
+      );
     }
     try {
       assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
       await persistConversationMemory(runtime, messageToStore);
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
     } catch (err) {
-      try {
-        unwrapPromiseOutcome(await connectionRefreshOutcome);
-        assertConversationConnectionRuntime(
-          state.runtime,
-          connectionDescriptor,
-        );
-      } catch (connectionErr) {
+      if (isConversationConnectionError(err)) {
+        releaseChatMessageId(conv.roomId, clientMessageId ?? null);
         return failStream(
-          `Failed to refresh conversation room: ${getErrorMessage(connectionErr)}`,
+          `Failed to refresh conversation room: ${getErrorMessage(err)}`,
         );
       }
       return failStream(
@@ -2756,7 +2724,6 @@ export async function handleConversationRoutes(
     if (walletModeGuidance) {
       const endActiveChatTurn = beginActiveChatTurn(state);
       try {
-        unwrapPromiseOutcome(await connectionRefreshOutcome);
         assertConversationConnectionRuntime(
           state.runtime,
           connectionDescriptor,
@@ -2764,6 +2731,10 @@ export async function handleConversationRoutes(
         if (!disconnectTracker.isAborted()) {
           tokenWriter.writeSnapshot(res, walletModeGuidance);
           try {
+            assertConversationConnectionRuntime(
+              state.runtime,
+              connectionDescriptor,
+            );
             const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
@@ -2783,6 +2754,9 @@ export async function handleConversationRoutes(
               ...(persisted?.id ? { messageId: persisted.id } : {}),
             });
           } catch (persistErr) {
+            if (isConversationConnectionError(persistErr)) {
+              releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+            }
             writeSse(res, {
               type: "error",
               message: getErrorMessage(persistErr),
@@ -2791,6 +2765,9 @@ export async function handleConversationRoutes(
           }
         }
       } catch (err) {
+        if (isConversationConnectionError(err)) {
+          releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+        }
         if (!disconnectTracker.isAborted()) {
           writeSse(res, {
             type: "error",
@@ -2825,85 +2802,82 @@ export async function handleConversationRoutes(
     let deferredPersistence: Promise<void> | null = null;
 
     try {
-      const [generationOutcome, refreshOutcome] = await Promise.all([
-        observePromise(
-          generateChatResponse(runtime, userMessage, state.agentName, {
-            isAborted: () => disconnectTracker.isAborted(),
-            abortSignal: disconnectTracker.signal,
-            onStatus: (status) => {
-              if (
-                disconnectTracker.isAborted() ||
-                disconnectTracker.checkConnectionClosed()
-              ) {
-                return;
-              }
-              // Array.join renders absent optional fields as empty segments, so
-              // the dedup key is stable without nullish-coalescing each field.
-              const signature = [
-                status.kind,
-                status.actionName,
-                status.toolName,
-              ].join(":");
-              if (signature === lastStatusSignature) {
-                return;
-              }
-              lastStatusSignature = signature;
-              writeChatStatusSse(res, status);
-            },
-            onToolEvent: (event) => {
-              if (
-                disconnectTracker.isAborted() ||
-                disconnectTracker.checkConnectionClosed()
-              ) {
-                return;
-              }
-              writeChatToolSse(res, event);
-            },
-            onChunk: (chunk) => {
-              if (!chunk) return;
-              if (
-                disconnectTracker.isAborted() ||
-                disconnectTracker.checkConnectionClosed()
-              ) {
-                return;
-              }
-              streamedText += chunk;
-              tokenWriter.writeChunk(res, chunk, streamedText);
-            },
-            onSnapshot: (text) => {
-              if (!text) return;
-              if (
-                !streamedText ||
-                disconnectTracker.isAborted() ||
-                disconnectTracker.checkConnectionClosed()
-              ) {
-                return;
-              }
-              // Structured field extractors can briefly normalize whitespace or
-              // closing punctuation while the same visible field is still
-              // streaming. Do not shrink the user-visible token stream for
-              // prefix-equivalent snapshots; later longer snapshots/deltas still
-              // advance normally.
-              if (
-                text.length < streamedText.length &&
-                streamedText.startsWith(text)
-              ) {
-                return;
-              }
-              streamedText = text;
-              tokenWriter.writeSnapshot(res, streamedText);
-            },
-            resolveNoResponseText: () =>
-              resolveNoResponseFallback(state.logBuffer, runtime),
-            preferredLanguage,
-          }),
-        ),
-        connectionRefreshOutcome,
-      ]);
-
-      unwrapPromiseOutcome(refreshOutcome);
+      const result = await generateChatResponse(
+        runtime,
+        userMessage,
+        state.agentName,
+        {
+          isAborted: () => disconnectTracker.isAborted(),
+          abortSignal: disconnectTracker.signal,
+          onStatus: (status) => {
+            if (
+              disconnectTracker.isAborted() ||
+              disconnectTracker.checkConnectionClosed()
+            ) {
+              return;
+            }
+            // Array.join renders absent optional fields as empty segments, so
+            // the dedup key is stable without nullish-coalescing each field.
+            const signature = [
+              status.kind,
+              status.actionName,
+              status.toolName,
+            ].join(":");
+            if (signature === lastStatusSignature) {
+              return;
+            }
+            lastStatusSignature = signature;
+            writeChatStatusSse(res, status);
+          },
+          onToolEvent: (event) => {
+            if (
+              disconnectTracker.isAborted() ||
+              disconnectTracker.checkConnectionClosed()
+            ) {
+              return;
+            }
+            writeChatToolSse(res, event);
+          },
+          onChunk: (chunk) => {
+            if (!chunk) return;
+            if (
+              disconnectTracker.isAborted() ||
+              disconnectTracker.checkConnectionClosed()
+            ) {
+              return;
+            }
+            streamedText += chunk;
+            tokenWriter.writeChunk(res, chunk, streamedText);
+          },
+          onSnapshot: (text) => {
+            if (!text) return;
+            if (
+              !streamedText ||
+              disconnectTracker.isAborted() ||
+              disconnectTracker.checkConnectionClosed()
+            ) {
+              return;
+            }
+            // Structured field extractors can briefly normalize whitespace or
+            // closing punctuation while the same visible field is still
+            // streaming. Do not shrink the user-visible token stream for
+            // prefix-equivalent snapshots; later longer snapshots/deltas still
+            // advance normally.
+            if (
+              text.length < streamedText.length &&
+              streamedText.startsWith(text)
+            ) {
+              return;
+            }
+            streamedText = text;
+            tokenWriter.writeSnapshot(res, streamedText);
+          },
+          resolveNoResponseText: () =>
+            resolveNoResponseFallback(state.logBuffer, runtime),
+          preferredLanguage,
+        },
+      );
       assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
-      const result = unwrapPromiseOutcome(generationOutcome);
 
       if (!disconnectTracker.isAborted()) {
         conv.updatedAt = new Date().toISOString();
@@ -2984,6 +2958,10 @@ export async function handleConversationRoutes(
           });
           deferredPersistence = (async () => {
             if (result.actionCallbackHistory?.length) {
+              assertConversationConnectionRuntime(
+                state.runtime,
+                connectionDescriptor,
+              );
               await persistRecentAssistantActionCallbackHistory(
                 runtime,
                 conv.roomId,
@@ -2992,6 +2970,10 @@ export async function handleConversationRoutes(
               );
             }
             if (shouldPersistAssistantTurn && persistedAssistantId) {
+              assertConversationConnectionRuntime(
+                state.runtime,
+                connectionDescriptor,
+              );
               await persistAssistantConversationMemory(
                 runtime,
                 conv.roomId,
@@ -3039,9 +3021,8 @@ export async function handleConversationRoutes(
           },
           "[ConversationStream] connection prerequisite failed",
         );
-        if (disconnectTracker.isAborted()) {
-          releaseChatMessageId(conv.roomId, clientMessageId ?? null);
-        } else {
+        releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+        if (!disconnectTracker.isAborted()) {
           writeSse(res, {
             type: "error",
             message: `Failed to refresh conversation room: ${getErrorMessage(terminalError)}`,
@@ -3071,6 +3052,10 @@ export async function handleConversationRoutes(
             "Post-generation error after text was already streamed — using streamed text",
           );
           try {
+            assertConversationConnectionRuntime(
+              state.runtime,
+              connectionDescriptor,
+            );
             const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
@@ -3090,6 +3075,9 @@ export async function handleConversationRoutes(
               ...(persisted?.id ? { messageId: persisted.id } : {}),
             });
           } catch (persistErr) {
+            if (isConversationConnectionError(persistErr)) {
+              releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+            }
             writeSse(res, {
               type: "error",
               message: getErrorMessage(persistErr),
@@ -3127,6 +3115,7 @@ export async function handleConversationRoutes(
                 connectionDescriptor,
               );
             } catch (connectionErr) {
+              releaseChatMessageId(conv.roomId, clientMessageId ?? null);
               writeSse(res, {
                 type: "error",
                 message: getErrorMessage(connectionErr),
@@ -3149,6 +3138,10 @@ export async function handleConversationRoutes(
             state.logBuffer,
           );
           try {
+            assertConversationConnectionRuntime(
+              state.runtime,
+              connectionDescriptor,
+            );
             const persisted = await persistAssistantConversationMemory(
               runtime,
               conv.roomId,
@@ -3170,6 +3163,9 @@ export async function handleConversationRoutes(
               failureKind,
             });
           } catch (persistErr) {
+            if (isConversationConnectionError(persistErr)) {
+              releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+            }
             writeSse(res, {
               type: "error",
               message: getErrorMessage(persistErr),
@@ -3279,9 +3275,16 @@ export async function handleConversationRoutes(
     const userId = caller.entityId;
     const turnStartedAt = Date.now();
 
+    let connectionDescriptor: ConversationConnectionDescriptor;
     try {
-      await ensureConversationRoom(state, runtime, conv, caller);
+      connectionDescriptor = await ensureConversationRoom(
+        state,
+        runtime,
+        conv,
+        caller,
+      );
     } catch (err) {
+      releaseChatMessageId(conv.roomId, clientMessageId ?? null);
       error(
         res,
         `Failed to initialize conversation room: ${getErrorMessage(err)}`,
@@ -3302,8 +3305,13 @@ export async function handleConversationRoutes(
     });
 
     try {
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
       await persistConversationMemory(runtime, messageToStore);
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
     } catch (err) {
+      if (isConversationConnectionError(err)) {
+        releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+      }
       error(res, `Failed to store user message: ${getErrorMessage(err)}`, 500);
       return true;
     }
@@ -3312,6 +3320,10 @@ export async function handleConversationRoutes(
     if (walletModeGuidance) {
       const endActiveChatTurn = beginActiveChatTurn(state);
       try {
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
         await persistAssistantConversationMemory(
           runtime,
           conv.roomId,
@@ -3319,12 +3331,19 @@ export async function handleConversationRoutes(
           channelType,
           turnStartedAt,
         );
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
         conv.updatedAt = new Date().toISOString();
         json(res, {
           text: walletModeGuidance,
           agentName: state.agentName,
         });
       } catch (persistErr) {
+        if (isConversationConnectionError(persistErr)) {
+          releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+        }
         error(res, getErrorMessage(persistErr), 500);
       } finally {
         endActiveChatTurn();
@@ -3344,6 +3363,7 @@ export async function handleConversationRoutes(
           preferredLanguage,
         },
       );
+      assertConversationConnectionRuntime(state.runtime, connectionDescriptor);
 
       conv.updatedAt = new Date().toISOString();
       if (result.noResponseReason !== "ignored") {
@@ -3353,6 +3373,10 @@ export async function handleConversationRoutes(
           runtime,
         );
         if (result.actionCallbackHistory?.length) {
+          assertConversationConnectionRuntime(
+            state.runtime,
+            connectionDescriptor,
+          );
           await persistRecentAssistantActionCallbackHistory(
             runtime,
             conv.roomId,
@@ -3368,6 +3392,10 @@ export async function handleConversationRoutes(
             result,
           )
         ) {
+          assertConversationConnectionRuntime(
+            state.runtime,
+            connectionDescriptor,
+          );
           await persistAssistantConversationMemory(
             runtime,
             conv.roomId,
@@ -3376,6 +3404,10 @@ export async function handleConversationRoutes(
             turnStartedAt,
           );
         }
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
         json(res, {
           text: resolvedText,
           agentName: result.agentName,
@@ -3394,6 +3426,10 @@ export async function handleConversationRoutes(
             : {}),
         });
       } else {
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
         json(res, {
           text: "",
           agentName: result.agentName,
@@ -3407,14 +3443,31 @@ export async function handleConversationRoutes(
       logger.warn(
         `[conversations] POST /messages failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (isConversationConnectionError(err)) {
+        releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+        error(
+          res,
+          `Failed to refresh conversation room: ${getErrorMessage(err)}`,
+          500,
+        );
+        return true;
+      }
       const providerIssueReply = getChatFailureReply(err, state.logBuffer);
       const failureKind = classifyChatFailure(err, state.logBuffer);
       try {
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
+        );
         await persistAssistantConversationMemory(
           runtime,
           conv.roomId,
           providerIssueReply,
           channelType,
+        );
+        assertConversationConnectionRuntime(
+          state.runtime,
+          connectionDescriptor,
         );
         conv.updatedAt = new Date().toISOString();
         json(res, {
@@ -3427,6 +3480,9 @@ export async function handleConversationRoutes(
           failureKind,
         });
       } catch (persistErr) {
+        if (isConversationConnectionError(persistErr)) {
+          releaseChatMessageId(conv.roomId, clientMessageId ?? null);
+        }
         error(res, getErrorMessage(persistErr), 500);
       }
     } finally {
@@ -3681,6 +3737,14 @@ export async function handleConversationRoutes(
       try {
         await deleteConversationRoomData(state.runtime, conv.roomId);
       } catch (err) {
+        if (isConversationConnectionError(err)) {
+          error(
+            res,
+            `Failed to serialize conversation deletion: ${getErrorMessage(err)}`,
+            503,
+          );
+          return true;
+        }
         logger.debug(
           `[conversations] Failed to delete room data for ${convId}: ${err instanceof Error ? err.message : String(err)}`,
         );

--- a/packages/core/src/connection.test.ts
+++ b/packages/core/src/connection.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Exercises connection reconciliation against the production in-memory adapter,
+ * including durable shared-world role metadata across sequential callers.
+ */
+import { describe, expect, it } from "vitest";
+import { ensureConnection } from "./connection";
+import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import { recordOwnerGrant, recordRoleGrant } from "./roles";
+import { stringToUuid } from "./utils";
+
+describe("ensureConnection", () => {
+	it("preserves existing role grants when another caller reconciles", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("connection-role-agent");
+		const ownerId = stringToUuid("connection-role-owner");
+		const firstCallerId = stringToUuid("connection-role-first-caller");
+		const secondCallerId = stringToUuid("connection-role-second-caller");
+		const worldId = stringToUuid("connection-role-world");
+		const messageServerId = stringToUuid("connection-role-server");
+
+		const reconcile = async (callerId: typeof firstCallerId) => {
+			await ensureConnection(adapter, {
+				agentId,
+				entityId: callerId,
+				roomId: stringToUuid(`connection-role-room-${callerId}`),
+				worldId,
+				messageServerId,
+				source: "client_chat",
+				channelId: `connection-role-channel-${callerId}`,
+				metadata: {
+					ownership: { ownerId },
+					waifuRole: "USER",
+				},
+			});
+
+			const [world] = await adapter.getWorldsByIds([worldId]);
+			if (!world?.metadata) throw new Error("reconciled world is missing");
+			recordOwnerGrant(world.metadata, ownerId);
+			recordRoleGrant(world.metadata, callerId, "USER", "connector_admin");
+			await adapter.updateWorlds([world]);
+		};
+
+		await reconcile(firstCallerId);
+		await reconcile(secondCallerId);
+
+		const [world] = await adapter.getWorldsByIds([worldId]);
+		expect(world?.metadata?.roles).toMatchObject({
+			[ownerId]: "OWNER",
+			[firstCallerId]: "USER",
+			[secondCallerId]: "USER",
+		});
+		expect(world?.metadata?.roleSources).toMatchObject({
+			[ownerId]: "owner",
+			[firstCallerId]: "connector_admin",
+			[secondCallerId]: "connector_admin",
+		});
+	});
+});

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -109,7 +109,10 @@ export async function ensureConnections(
 					: `World for room ${c.roomId}`,
 			agentId,
 			messageServerId: c.messageServerId,
-			metadata: c.metadata,
+			metadata: {
+				...(worldMap.get(worldId)?.metadata ?? {}),
+				...(c.metadata ?? {}),
+			},
 		};
 		worldMap.set(worldId, world);
 
@@ -164,10 +167,27 @@ export async function ensureConnections(
 	}
 	if (entities.length) await adapter.upsertEntities(entities);
 
-	const worlds = [...worldMap.values()].map((w) => ({
-		...w,
-		agentId,
-	}));
+	const worldIds = [...worldMap.keys()] as UUID[];
+	const existingWorlds =
+		worldIds.length > 0 ? await adapter.getWorldsByIds(worldIds) : [];
+	const existingWorldsById = new Map(
+		existingWorlds.map((world) => [world.id, world]),
+	);
+	const worlds = [...worldMap.values()].map((world) => {
+		const existing = existingWorldsById.get(world.id);
+		return {
+			...existing,
+			...world,
+			agentId,
+			// Connection establishment contributes metadata; it does not own the
+			// full world document. Replacing this object erases durable role grants
+			// every time another participant connects to the shared world.
+			metadata: {
+				...(existing?.metadata ?? {}),
+				...(world.metadata ?? {}),
+			},
+		};
+	});
 	if (worlds.length) await adapter.upsertWorlds(worlds);
 
 	const rooms = [...roomMap.values()].map((r) => ({


### PR DESCRIPTION
Fixes #17106.

## Summary

This is the correctness repair for the connection-readiness cache introduced by #17074.

- preserves existing world metadata when another caller connects, so one caller cannot erase another caller's role grant;
- removes the successful-readiness cache and reconciles every turn before persistence or generation;
- serializes shared-world mutations while coalescing only identical in-flight work;
- fences every descriptor by exact runtime, topology, room generation, caller identity, and deletion state;
- makes room generations globally unique and safely evictable, so a stale descriptor cannot revive after deletion;
- applies a 15-second request-facing deadline without releasing the raw mutation lock: hung adapter I/O remains quarantined and later writes fail fast until it actually settles;
- awaits readiness before REST/SSE generation, rejects stale terminal success, and releases the client message id on every undelivered connection failure.

## Root cause

The old registry treated a completed ensure as permanent proof. The underlying world, room, runtime, caller role, or character name could change while the cache continued to say "ready." Concurrent callers also updated one shared world with read/replace writes, so a later connection could erase the first caller's role metadata. Moving refresh off the critical path let generation and callbacks run before that prerequisite was known to be valid.

The replacement treats connection reconciliation as a required turn prerequisite. It preserves raw mutation exclusivity even when the HTTP caller times out; it does not use a lock-releasing `Promise.race`.

## Validation on exact head

- 42 focused tests across the real in-memory adapter, readiness races, rename/delete/runtime replacement, idempotency, failure-kind, and full SSE contract;
- hung-I/O test proves timeout at 15 seconds, no second write starts, quarantine remains exclusive, and recovery occurs only after raw I/O settles;
- `packages/core` typecheck passed;
- Biome passed on all seven changed files;
- `git diff --check` passed.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered component or visual style changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered component or visual style changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending - the real-runtime streaming performance walkthrough will run against merged `develop`, as requested for the demo lane.
<!-- evidence-row:backend-logs -->
- [x] Focused route and lifecycle suite: 6 files, 42 tests, including real adapter state and emitted SSE frames.
<!-- evidence-row:frontend-logs -->
- [ ] Pending - browser console/network capture will be collected with the post-merge real-runtime stream test.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this prerequisite executes before model generation and does not change prompts, actions, providers, or model selection.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the output is transient connection topology and structured HTTP/SSE failure state.
<!-- evidence-row:ocr-review -->
- [x] N/A - there are no new screenshots or changed pixels to OCR.

