### PR TITLE
fix(local-inference): declare AOSP runtime dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4199,6 +4199,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-aosp-local-inference": "workspace:*",
         "@elizaos/plugin-capacitor-bridge": "workspace:*",
         "@elizaos/plugin-computeruse": "workspace:*",
         "@elizaos/shared": "workspace:*",

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -134,6 +134,7 @@
 	},
 	"dependencies": {
 		"@elizaos/core": "workspace:*",
+		"@elizaos/plugin-aosp-local-inference": "workspace:*",
 		"@elizaos/plugin-capacitor-bridge": "workspace:*",
 		"@elizaos/plugin-computeruse": "workspace:*",
 		"@elizaos/shared": "workspace:*",


### PR DESCRIPTION
# Relates to

Closes #17121.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin develop && git rebase origin/develop`).
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the
      before/after module-resolution proof below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `500074a2e51682f6f874706fcb0f272a748a9c79`;
      zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. This changes only the workspace dependency graph: it declares an existing
runtime import that `plugin-local-inference` already executes. No runtime logic,
native implementation, UI, API, or persisted data changes. The added edge means
installers now place the AOSP package in the importing package's own resolution
scope instead of relying on an incidental root-level workspace link.

# Background

## What does this PR do?

`plugins/plugin-local-inference/src/local-inference-routes.ts` dynamically imports
`@elizaos/plugin-aosp-local-inference`, but the importing package did not declare
that module. A dirty/root workspace happened to make typecheck pass because an
unrelated root-level symlink leaked the package into resolution. A fresh
worktree did not create the required package-local link, and removing the leaked
root link exposed the real `TS2307`.

This adds the runtime dependency to `plugin-local-inference/package.json` and the
matching importer edge to `bun.lock`. It does not add a fallback, alias, or
TypeScript path workaround; the package graph now represents the runtime graph.

## What kind of change is this?

Bug fix (non-breaking dependency-manifest correction).

# Documentation changes needed?

No. This repairs package metadata for an existing internal runtime import; it
does not change a documented API or user workflow.

# Testing

## Where should a reviewer start?

Review the two-line diff, then compare the negative control and clean-install
proof below. The decisive condition is that typecheck passes while the
root-level AOSP link is absent.

## Detailed testing steps

1. In a fresh worktree before this fix, install dependencies and temporarily
   move `node_modules/@elizaos/plugin-aosp-local-inference` out of resolution.
2. Run `bun run --cwd plugins/plugin-local-inference typecheck`.
3. Observe the pre-fix failure:

   ```text
   src/local-inference-routes.ts(125,3): error TS2307: Cannot find module '@elizaos/plugin-aosp-local-inference'
   ```

4. On this branch, run `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile`
   in a detached worktree with no pre-existing `node_modules`.
5. Confirm the installer creates:

   ```text
   plugins/plugin-local-inference/node_modules/@elizaos/plugin-aosp-local-inference
     -> ../../../plugin-aosp-local-inference
   ```

6. Hide the root-level AOSP link for the complete command and run:

   ```bash
   bun run --cwd plugins/plugin-local-inference typecheck
   bun run --cwd packages/app typecheck
   ```

7. Both commands pass, and the harness asserts that the root link remains absent
   until both commands finish.

Additional post-sync validation:

- `bun install --frozen-lockfile` — pass (fresh detached worktree, 8,587 packages)
- `bun run typecheck` — pass (343/343 Turbo tasks)
- `bun run verify` — pass
- `bunx @biomejs/biome check plugins/plugin-local-inference/package.json` — pass
- `git diff --check origin/develop...HEAD` — pass

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - package metadata only; no desktop or mobile UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - package metadata only; no desktop or mobile UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user flow or rendered behavior change to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server request path or backend behavior changes; package-manager
      and compiler output above are the applicable execution evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state transition, console behavior, or network
      behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, planner, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact is produced; the applicable
      package-local workspace-link output is reproduced inline in **Testing**.

# Evidence Details

## Real LLM-call trajectory

N/A - dependency metadata only; no model call path changes.

## Backend + frontend logs

N/A - no backend or frontend runtime path changes. The relevant real execution
output is the package-manager link plus compiler results in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surfaces change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, audio, or inference implementation changes.

## Known gaps / failures

None. Visual, runtime-log, live-model, audio, native-device, and persisted-domain
evidence are explicitly N/A because the complete diff is two package dependency
declarations. The failure and repair are directly demonstrated at the package
resolution boundary.
