### PR TITLE
fix(app-control): ratchet My Apps mutations and add stop

### DIFF
--- a/packages/agent/src/api/builtin-app-mutation-live-route.test.ts
+++ b/packages/agent/src/api/builtin-app-mutation-live-route.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Proves My Apps semantic twins against a real AgentRuntime and TCP API host:
+ * APP stop moves a real AppManager run out of inventory, and VIEWS show
+ * resolves the hidden Cloud Apps shell page from the server view registry.
+ * No action, route, runtime, or service is mocked.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  type Action,
+  type ActionResult,
+  AgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import {
+  appControlPlugin,
+  createAppControlClient,
+} from "@elizaos/plugin-app-control";
+import { afterEach, describe, expect, it } from "vitest";
+import { startApiServer } from "./server.ts";
+
+const TEST_APP = "ratchet-proof";
+const TEST_PLUGIN = "@test/ratchet-proof";
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+
+const originalEnv = new Map<string, string | undefined>();
+const touchedEnv = [
+  "ELIZA_API_AUTH_TOKEN",
+  "ELIZA_API_BIND_HOST",
+  "ELIZA_API_PORT",
+  "ELIZA_API_TOKEN",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_PORT",
+  "ELIZA_STATE_DIR",
+] as const;
+
+function snapshotEnvironment(): void {
+  originalEnv.clear();
+  for (const key of touchedEnv) originalEnv.set(key, process.env[key]);
+}
+
+function restoreEnvironment(): void {
+  for (const key of touchedEnv) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  originalEnv.clear();
+}
+
+function requireAction(runtime: AgentRuntime, name: string): Action {
+  const action = runtime.actions.find((candidate) => candidate.name === name);
+  if (!action) throw new Error(`Expected runtime action ${name}`);
+  return action;
+}
+
+async function invokeAppStop(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<ActionResult> {
+  const message = {
+    id: randomUUID(),
+    agentId: runtime.agentId,
+    entityId: runtime.agentId,
+    roomId,
+    content: { text: "stop the ratchet proof app" },
+  } as Memory;
+  const result = await requireAction(runtime, "APP").handler(
+    runtime,
+    message,
+    undefined,
+    { parameters: { action: "stop", app: TEST_APP } },
+    undefined,
+  );
+  if (!result) throw new Error("APP returned no action result");
+  return result;
+}
+
+async function invokeCloudAppsShow(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<ActionResult> {
+  const message = {
+    id: randomUUID(),
+    agentId: runtime.agentId,
+    entityId: runtime.agentId,
+    roomId,
+    content: { text: "Open the requested deployment studio." },
+  } as Memory;
+  const result = await requireAction(runtime, "VIEWS").handler(
+    runtime,
+    message,
+    undefined,
+    { parameters: { action: "show", view: "cloud-apps" } },
+    undefined,
+  );
+  if (!result) throw new Error("VIEWS returned no action result");
+  return result;
+}
+
+async function seedInstalledApp(root: string): Promise<void> {
+  const stateDir = path.join(root, "state");
+  const cacheDir = path.join(stateDir, "cache");
+  await mkdir(cacheDir, { recursive: true });
+
+  const configPath = path.join(stateDir, "eliza.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      logging: { level: "error" },
+      plugins: {
+        installs: {
+          [TEST_PLUGIN]: {
+            source: "npm",
+            spec: `${TEST_PLUGIN}@1.0.0`,
+            version: "1.0.0",
+            installedAt: "2026-07-23T00:00:00.000Z",
+          },
+        },
+      },
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(cacheDir, "registry.json"),
+    JSON.stringify({
+      fetchedAt: Date.now(),
+      plugins: [
+        [
+          TEST_APP,
+          {
+            name: TEST_APP,
+            gitRepo: "test/ratchet-proof",
+            gitUrl: "https://example.test/ratchet-proof.git",
+            directory: null,
+            description: "Real APP stop route fixture.",
+            homepage: "https://example.test/ratchet-proof",
+            topics: ["app", "test"],
+            stars: 0,
+            language: "TypeScript",
+            npm: {
+              package: TEST_PLUGIN,
+              v0Version: null,
+              v1Version: null,
+              v2Version: "1.0.0",
+            },
+            git: {
+              v0Branch: null,
+              v1Branch: null,
+              v2Branch: "main",
+            },
+            supports: { v0: false, v1: false, v2: true },
+            kind: "app",
+            appMeta: {
+              displayName: "Ratchet Proof",
+              category: "tool",
+              launchType: "connect",
+              launchUrl: "https://example.test/ratchet-proof",
+              icon: null,
+              heroImage: null,
+              capabilities: [],
+              minPlayers: null,
+              maxPlayers: null,
+            },
+          },
+        ],
+      ],
+    }),
+    "utf8",
+  );
+
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+  process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+  process.env.ELIZA_API_TOKEN = "ratchet-live-route-token";
+  delete process.env.ELIZA_API_AUTH_TOKEN;
+}
+
+afterEach(restoreEnvironment);
+
+describe("My Apps semantic route parity (#16944)", () => {
+  it("stops a real app run and resolves Cloud Apps through VIEWS.show", async () => {
+    snapshotEnvironment();
+    const root = await mkdtemp(path.join(tmpdir(), "eliza-app-stop-ratchet-"));
+    let runtime: AgentRuntime | null = null;
+    let api: ApiServer | null = null;
+    try {
+      await seedInstalledApp(root);
+      runtime = new AgentRuntime({
+        logLevel: "fatal",
+        plugins: [appControlPlugin],
+      });
+      await runtime.initialize({
+        allowNoDatabase: true,
+        skipMigrations: true,
+      });
+      await runtime.getServiceLoadPromise("app-registry");
+      await runtime.getServiceLoadPromise("app-worker-host");
+
+      api = await startApiServer({
+        port: 0,
+        runtime,
+        skipDeferredStartupWork: true,
+      });
+      process.env.ELIZA_PORT = String(api.port);
+      process.env.ELIZA_API_PORT = String(api.port);
+
+      const client = createAppControlClient();
+      const shown = await invokeCloudAppsShow(runtime, randomUUID() as UUID);
+      expect(shown).toEqual(
+        expect.objectContaining({
+          success: true,
+          values: expect.objectContaining({
+            mode: "show",
+            viewId: "cloud-apps",
+            label: "Cloud Apps",
+          }),
+          data: expect.objectContaining({
+            view: expect.objectContaining({
+              id: "cloud-apps",
+              path: "/cloud-apps",
+              visibleInManager: false,
+            }),
+          }),
+        }),
+      );
+      const currentViewResponse = await fetch(
+        `http://127.0.0.1:${api.port}/api/views/current`,
+        {
+          headers: {
+            Authorization: "Bearer ratchet-live-route-token",
+          },
+        },
+      );
+      expect(currentViewResponse.ok).toBe(true);
+      await expect(currentViewResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          currentView: expect.objectContaining({
+            viewId: "cloud-apps",
+            viewPath: "/cloud-apps",
+          }),
+        }),
+      );
+
+      const launched = await client.launchApp(TEST_APP);
+      expect(launched.run).toEqual(
+        expect.objectContaining({
+          appName: TEST_APP,
+          status: "running",
+        }),
+      );
+      await expect(client.listAppRuns()).resolves.toEqual([
+        expect.objectContaining({
+          appName: TEST_APP,
+          status: "running",
+        }),
+      ]);
+
+      const stopped = await invokeAppStop(runtime, randomUUID() as UUID);
+      expect(stopped).toEqual(
+        expect.objectContaining({
+          success: true,
+          values: expect.objectContaining({
+            mode: "stop",
+            appName: TEST_APP,
+            stopScope: "viewer-session",
+          }),
+        }),
+      );
+      await expect(client.listAppRuns()).resolves.toEqual([]);
+
+      const alreadyStopped = await invokeAppStop(runtime, randomUUID() as UUID);
+      expect(alreadyStopped).toEqual(
+        expect.objectContaining({
+          success: false,
+          values: expect.objectContaining({
+            mode: "stop",
+            appName: TEST_APP,
+            stopScope: "nothing-stopped",
+          }),
+        }),
+      );
+      await expect(client.listAppRuns()).resolves.toEqual([]);
+    } finally {
+      if (api) await api.close();
+      if (runtime) {
+        await runtime.stop({ fast: true });
+        await runtime.close();
+      }
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -181,6 +181,22 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     visibleInManager: true,
   },
   {
+    id: "cloud-apps",
+    viewKind: "release",
+    label: "Cloud Apps",
+    description: "Manage, deploy, and monetize apps published on Eliza Cloud",
+    icon: "Grid3x3",
+    heroImagePath: "assets/view-heroes/plugins-page.png",
+    path: "/cloud-apps",
+    order: 58,
+    tags: ["cloud", "apps", "applications", "deploy", "monetize"],
+    // The renderer registers the native studio in-process under this same id
+    // and path. Keeping it in the server registry makes VIEWS/show resolve the
+    // My Apps navigation row instead of claiming an action that cannot open it.
+    visibleInManager: false,
+    platforms: ["web", "desktop", "ios", "android"],
+  },
+  {
     id: "plugins-page",
     viewKind: "system",
     label: "Plugins",

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -63,6 +63,12 @@
       "@elizaos/plugin-app-manager": [
         "../../plugins/plugin-app-manager/src/index.ts"
       ],
+      "@elizaos/plugin-app-control": [
+        "../../plugins/plugin-app-control/src/index.ts"
+      ],
+      "@elizaos/plugin-app-control/*": [
+        "../../plugins/plugin-app-control/src/*"
+      ],
       "@elizaos/plugin-registry": [
         "../../plugins/plugin-registry/src/index.ts"
       ],

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -104,6 +104,34 @@ export default defineConfig({
           "node_modules/.bun/node_modules/react-dom/client.js",
         ),
       },
+      // These packages are exercised through source-level route tests. Put
+      // their exact aliases before the base package aliases so subpaths cannot
+      // be rewritten as an invalid suffix on an index.ts replacement.
+      {
+        find: /^@elizaos\/plugin-app-control$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-app-control/src/index.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-app-control\/(.+)$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-app-control/src/$1",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-app-manager$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-app-manager/src/index.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-wallet\/(.+)$/,
+        replacement: path.join(monorepoRoot, "plugins/plugin-wallet/src/$1.ts"),
+      },
       ...baseAliases,
       {
         find: /^@elizaos\/vault$/,
@@ -129,23 +157,6 @@ export default defineConfig({
           "typescript",
           "src",
           "index.ts",
-        ),
-      },
-      // Source-alias plugin-app-control so view-id drift tests see the current
-      // exports (MATCHER_VIEW_IDS / CONTEXT_VIEWS / INTENT_VIEW_IDS) instead of a
-      // stale dist build.
-      {
-        find: /^@elizaos\/plugin-app-control$/,
-        replacement: path.join(
-          monorepoRoot,
-          "plugins/plugin-app-control/src/index.ts",
-        ),
-      },
-      {
-        find: /^@elizaos\/plugin-app-control\/(.+)$/,
-        replacement: path.join(
-          monorepoRoot,
-          "plugins/plugin-app-control/src/$1",
         ),
       },
     ],

--- a/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
@@ -48,6 +48,7 @@ const REGISTERED_ACTIONS = new Set([
   ...collectRegisteredActionInventory(repoRoot).map((entry) => entry.name),
   ...canonicalSpecActionNames(),
 ]);
+const REGISTERED_VIEWS = new Set(["cloud-apps"]);
 
 function readRepoSource(sourcePath: string): string {
   return readFileSync(path.join(repoRoot, sourcePath), "utf8");
@@ -83,6 +84,7 @@ describe("builtin view action ratchet (#14369)", () => {
     const result = validateBuiltinViewMutationCoverage({
       readSource: readRepoSource,
       registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
     });
 
     expect(result.findings).toEqual([]);
@@ -113,6 +115,11 @@ describe("builtin view action ratchet (#14369)", () => {
           semanticActions: ["SCHEDULED_TASKS", "TRIGGER"],
         }),
         expect.objectContaining({
+          viewId: "my-apps",
+          observedMutationSites: 27,
+          semanticActions: ["APP", "VIEWS"],
+        }),
+        expect.objectContaining({
           viewId: "logs",
           exempt: true,
         }),
@@ -135,6 +142,7 @@ describe("builtin view action ratchet (#14369)", () => {
       baseline: [tasks],
       readSource: () => sourceWithNewButton,
       registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
     });
 
     expect(result.ok).toBe(false);
@@ -169,6 +177,7 @@ describe("builtin view action ratchet (#14369)", () => {
         baseline: [entry],
         readSource,
         registeredActions: REGISTERED_ACTIONS,
+        registeredViews: REGISTERED_VIEWS,
       });
 
       expect(result.ok).toBe(false);
@@ -195,6 +204,7 @@ describe("builtin view action ratchet (#14369)", () => {
       baseline: [automations],
       readSource,
       registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
     });
 
     expect(result.ok).toBe(false);
@@ -221,6 +231,7 @@ describe("builtin view action ratchet (#14369)", () => {
           ? null
           : readRepoSource(sourcePath),
       registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
     });
 
     expect(result.ok).toBe(false);
@@ -244,6 +255,7 @@ describe("builtin view action ratchet (#14369)", () => {
       ],
       readSource: () => "<button onClick={save}>Save</button>",
       registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
     });
 
     expect(result.ok).toBe(false);
@@ -251,6 +263,245 @@ describe("builtin view action ratchet (#14369)", () => {
       expect.objectContaining({
         viewId: "synthetic",
         code: "missing-semantic-action",
+      }),
+    ]);
+  });
+
+  it("inventories every direct and mounted My Apps mutation with explicit authority", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps?.mutationAffordances) {
+      throw new Error("my-apps mutation inventory missing");
+    }
+
+    const claimedByFile = new Map<string, number>();
+    for (const affordance of myApps.mutationAffordances) {
+      claimedByFile.set(
+        affordance.sourceFile,
+        (claimedByFile.get(affordance.sourceFile) ?? 0) + 1,
+      );
+    }
+
+    expect(Object.fromEntries(claimedByFile)).toEqual({
+      "packages/ui/src/components/pages/MyAppsView.tsx": 1,
+      "packages/ui/src/components/settings/AppsManagementSection.tsx": 26,
+    });
+    expect(
+      myApps.mutationAuthorities?.map((authority) => ({
+        action: authority.semanticAction,
+        operations: [...authority.actionOperations],
+      })),
+    ).toEqual([
+      {
+        action: "APP",
+        operations: [
+          "create",
+          "launch",
+          "list",
+          "load_from_directory",
+          "relaunch",
+          "stop",
+        ],
+      },
+      { action: "VIEWS", operations: ["show"] },
+    ]);
+    expect(myApps.mountedSourceFiles).toEqual([
+      expect.objectContaining({
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        mountedBy: "packages/ui/src/components/pages/MyAppsView.tsx",
+      }),
+    ]);
+    expect(
+      myApps.mutationAffordances.find(
+        (affordance) => affordance.id === "cloud-apps.open",
+      )?.viewTarget,
+    ).toEqual({
+      id: "cloud-apps",
+      sourceSignature:
+        '.find((page) => page.id === "cloud-apps")?.path ?? null',
+    });
+  });
+
+  it("fails when the VIEWS.show target is absent from the server view registry", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps) throw new Error("my-apps baseline entry missing");
+    const withoutCloudApps = new Set(
+      [...REGISTERED_VIEWS].filter((viewId) => viewId !== "cloud-apps"),
+    );
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [myApps],
+      readSource: readRepoSource,
+      registeredActions: REGISTERED_ACTIONS,
+      registeredViews: withoutCloudApps,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "my-apps",
+        code: "mutation-view-target-drift",
+        message: expect.stringContaining("registered server view inventory"),
+      }),
+    ]);
+  });
+
+  it("fails when the Cloud Apps control stops selecting its declared view target", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps) throw new Error("my-apps baseline entry missing");
+    const page = "packages/ui/src/components/pages/MyAppsView.tsx";
+    const source = readRepoSource(page).replace(
+      '.find((page) => page.id === "cloud-apps")?.path ?? null',
+      '.find((page) => page.id === "cloud-deployments")?.path ?? null',
+    );
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [myApps],
+      readSource: (sourcePath) =>
+        sourcePath === page ? source : readRepoSource(sourcePath),
+      registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "my-apps",
+        code: "mutation-view-target-drift",
+      }),
+    ]);
+  });
+
+  it("fails when the mounted app-management child gains an uninventoried mutation", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps) throw new Error("my-apps baseline entry missing");
+    const child =
+      "packages/ui/src/components/settings/AppsManagementSection.tsx";
+    const injected = `${readRepoSource(child)}
+      export function InjectedAppMutation() {
+        return <button onClick={() => window.localStorage.setItem("x", "1")}>Local only</button>;
+      }
+    `;
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [myApps],
+      readSource: (sourcePath) =>
+        sourcePath === child ? injected : readRepoSource(sourcePath),
+      registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          viewId: "my-apps",
+          code: "new-local-mutation",
+        }),
+        expect.objectContaining({
+          viewId: "my-apps",
+          code: "mutation-inventory-count",
+          message: expect.stringContaining("add or remove named operations"),
+        }),
+      ]),
+    );
+  });
+
+  it("fails when a named My Apps operation drifts away from its source", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps) throw new Error("my-apps baseline entry missing");
+    const page = "packages/ui/src/components/pages/MyAppsView.tsx";
+    const source = readRepoSource(page).replace(
+      "onClick={() => navigateBrowserPath(cloudStudioPath)}",
+      "onClick={() => navigateBrowserPath(String(cloudStudioPath))}",
+    );
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [myApps],
+      readSource: (sourcePath) =>
+        sourcePath === page ? source : readRepoSource(sourcePath),
+      registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "my-apps",
+        code: "mutation-signature-drift",
+        message: expect.stringContaining("cloud-apps.open"),
+      }),
+    ]);
+  });
+
+  it("fails closed when a named My Apps affordance lacks operation authority", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps?.mutationAffordances) {
+      throw new Error("my-apps mutation inventory missing");
+    }
+    const [first, ...rest] = myApps.mutationAffordances;
+    if (!first) throw new Error("my-apps mutation inventory is empty");
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [
+        {
+          ...myApps,
+          mutationAffordances: [{ ...first, actionOperations: [] }, ...rest],
+        },
+      ],
+      readSource: readRepoSource,
+      registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          viewId: "my-apps",
+          code: "mutation-action-drift",
+          message: expect.stringContaining("has no declared authority"),
+        }),
+      ]),
+    );
+  });
+
+  it("fails when the mounted My Apps child is no longer mounted", () => {
+    const myApps = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "my-apps",
+    );
+    if (!myApps) throw new Error("my-apps baseline entry missing");
+    const page = "packages/ui/src/components/pages/MyAppsView.tsx";
+    const source = readRepoSource(page).replace(
+      "<AppsManagementSection />",
+      "<div />",
+    );
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [myApps],
+      readSource: (sourcePath) =>
+        sourcePath === page ? source : readRepoSource(sourcePath),
+      registeredActions: REGISTERED_ACTIONS,
+      registeredViews: REGISTERED_VIEWS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "my-apps",
+        code: "mutation-mount-drift",
       }),
     ]);
   });

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -23,6 +23,20 @@ export interface BuiltinViewMutationBaselineEntry {
   sourceFiles: readonly string[];
   semanticActions: readonly string[];
   /**
+   * Named affordance inventory for views whose controls are mounted through
+   * child components. Each stable source signature contains exactly one
+   * mutation expression, so count-preserving handler swaps still fail.
+   */
+  mutationAffordances?: readonly BuiltinViewMutationAffordance[];
+  /**
+   * Operations that the mapped actions actually authorize for this view.
+   * Affordances fail closed when they name an action or operation outside this
+   * table.
+   */
+  mutationAuthorities?: readonly BuiltinViewMutationAuthority[];
+  /** Verified parent-child mounts that make source-file coverage transitive. */
+  mountedSourceFiles?: readonly BuiltinViewMountedSource[];
+  /**
    * Exact pinned mutation-site count across sourceFiles. The validator fails
    * in BOTH directions: above is a new unmapped local mutation, below is a
    * stale baseline that must be pinned down — freed headroom may never
@@ -33,13 +47,48 @@ export interface BuiltinViewMutationBaselineEntry {
   notes?: string;
 }
 
+export interface BuiltinViewMutationAffordance {
+  id: string;
+  sourceFile: string;
+  /** Stable, unique source text containing exactly one mutation expression. */
+  sourceSignature: string;
+  semanticAction: string;
+  actionOperations: readonly string[];
+  /**
+   * Registered view resolved by a VIEWS/show affordance. The source signature
+   * binds the declared id to the control's actual target selection.
+   */
+  viewTarget?: {
+    id: string;
+    sourceSignature: string;
+  };
+}
+
+export interface BuiltinViewMutationAuthority {
+  semanticAction: string;
+  actionOperations: readonly string[];
+}
+
+export interface BuiltinViewMountedSource {
+  sourceFile: string;
+  mountedBy: string;
+  importSignature: string;
+  renderSignature: string;
+}
+
 export interface BuiltinViewMutationFinding {
   viewId: string;
   code:
     | "missing-source"
     | "missing-semantic-action"
     | "new-local-mutation"
-    | "stale-baseline";
+    | "stale-baseline"
+    | "mutation-inventory-count"
+    | "mutation-inventory-source"
+    | "mutation-signature-drift"
+    | "mutation-action-drift"
+    | "mutation-mount-drift"
+    | "mutation-view-target-drift";
   message: string;
 }
 
@@ -252,11 +301,280 @@ export const BUILTIN_VIEW_MUTATION_BASELINE = [
   },
   {
     viewId: "my-apps",
-    sourceFiles: ["packages/ui/src/components/pages/MyAppsView.tsx"],
-    semanticActions: ["BROWSER"],
-    maxMutationSites: 1,
+    sourceFiles: [
+      "packages/ui/src/components/pages/MyAppsView.tsx",
+      "packages/ui/src/components/settings/AppsManagementSection.tsx",
+    ],
+    semanticActions: ["APP", "VIEWS"],
+    mutationAuthorities: [
+      {
+        semanticAction: "APP",
+        actionOperations: [
+          "create",
+          "launch",
+          "list",
+          "load_from_directory",
+          "relaunch",
+          "stop",
+        ],
+      },
+      {
+        semanticAction: "VIEWS",
+        actionOperations: ["show"],
+      },
+    ],
+    mountedSourceFiles: [
+      {
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        mountedBy: "packages/ui/src/components/pages/MyAppsView.tsx",
+        importSignature:
+          'import { AppsManagementSection } from "../settings/AppsManagementSection";',
+        renderSignature: "<AppsManagementSection />",
+      },
+    ],
+    mutationAffordances: [
+      {
+        id: "cloud-apps.open",
+        sourceFile: "packages/ui/src/components/pages/MyAppsView.tsx",
+        sourceSignature: "onClick={() => navigateBrowserPath(cloudStudioPath)}",
+        semanticAction: "VIEWS",
+        actionOperations: ["show"],
+        viewTarget: {
+          id: "cloud-apps",
+          sourceSignature:
+            '.find((page) => page.id === "cloud-apps")?.path ?? null',
+        },
+      },
+      {
+        id: "app-row.agent-bridge",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "useAgentElement<HTMLButtonElement>({\n    id: agentId,",
+        semanticAction: "APP",
+        actionOperations: ["launch", "relaunch", "create", "stop"],
+      },
+      {
+        id: "app-row.pointer-bridge",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onClick={onClick}",
+        semanticAction: "APP",
+        actionOperations: ["launch", "relaunch", "create", "stop"],
+      },
+      {
+        id: "create.disclosure.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-create-toggle",',
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "load.disclosure.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-load-toggle",',
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "relaunch.verify.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-verify-on-relaunch",',
+        semanticAction: "APP",
+        actionOperations: ["relaunch"],
+      },
+      {
+        id: "create.intent.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLTextAreaElement>({\n      id: "apps-create-intent",',
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "create.submit.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-create-submit",',
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "create.cancel.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-create-cancel",',
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "load.directory.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLInputElement>({\n      id: "apps-load-directory",',
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "load.submit.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-load-submit",',
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "load.cancel.agent",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'useAgentElement<HTMLButtonElement>({\n      id: "apps-load-cancel",',
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "create.disclosure.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "onClick={() => {\n              setShowCreate((v) => !v);",
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "load.disclosure.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "onClick={() => {\n              setShowLoad((v) => !v);",
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "relaunch.verify.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          'onCheckedChange={(checked: boolean | "indeterminate") =>\n                  setVerifyOnRelaunch(!!checked)',
+        semanticAction: "APP",
+        actionOperations: ["relaunch"],
+      },
+      {
+        id: "create.submit.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onSubmit={handleCreateSubmit}",
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "create.intent.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onChange={(e) => setCreateIntent(e.target.value)}",
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "create.edit-target.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "onValueChange={(value) =>\n                  setCreateEditTarget(",
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "create.cancel.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "onClick={() => {\n                    setShowCreate(false);",
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "load.submit.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onSubmit={handleLoadSubmit}",
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "load.directory.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "onChange={(e: React.ChangeEvent<HTMLInputElement>) =>\n                  setLoadDirectory(e.target.value)",
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "load.cancel.pointer",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature:
+          "onClick={() => {\n                    setShowLoad(false);",
+        semanticAction: "APP",
+        actionOperations: ["load_from_directory"],
+      },
+      {
+        id: "inventory.retry",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onClick={() => void refresh()}",
+        semanticAction: "APP",
+        actionOperations: ["list"],
+      },
+      {
+        id: "app.launch",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onClick={() => void handleLaunch(app)}",
+        semanticAction: "APP",
+        actionOperations: ["launch"],
+      },
+      {
+        id: "app.relaunch",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onClick={() => void handleRelaunch(app)}",
+        semanticAction: "APP",
+        actionOperations: ["relaunch"],
+      },
+      {
+        id: "app.edit",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onClick={() => void handleEdit(app)}",
+        semanticAction: "APP",
+        actionOperations: ["create"],
+      },
+      {
+        id: "app.stop",
+        sourceFile:
+          "packages/ui/src/components/settings/AppsManagementSection.tsx",
+        sourceSignature: "onClick={() => void handleStop(app)}",
+        semanticAction: "APP",
+        actionOperations: ["stop"],
+      },
+    ],
+    maxMutationSites: 27,
     notes:
-      "Cloud Apps studio row navigates via navigateBrowserPath, which the BROWSER action covers; the row itself is a signed-in-gated shortcut, not a state mutation surface.",
+      "The standalone page mounts AppsManagementSection, so its complete app-control surface is inventoried here instead of disappearing behind a child component. APP owns app lifecycle; VIEWS owns the signed-in Cloud Apps shell navigation.",
   },
   {
     viewId: "relationships",
@@ -347,15 +665,32 @@ export function countBuiltinViewMutationSites(source: string): number {
   return source.match(MUTATION_SITE_RE)?.length ?? 0;
 }
 
+function countExactOccurrences(source: string, signature: string): number {
+  if (signature.length === 0) return 0;
+  let count = 0;
+  let offset = 0;
+  while (offset <= source.length - signature.length) {
+    const index = source.indexOf(signature, offset);
+    if (index < 0) break;
+    count += 1;
+    offset = index + signature.length;
+  }
+  return count;
+}
+
 export function validateBuiltinViewMutationCoverage(args: {
   baseline?: readonly BuiltinViewMutationBaselineEntry[];
   readSource: (path: string) => string | null | undefined;
   registeredActions: ReadonlySet<string>;
+  registeredViews: ReadonlySet<string>;
 }): BuiltinViewMutationValidationResult {
   const baseline: readonly BuiltinViewMutationBaselineEntry[] =
     args.baseline ?? BUILTIN_VIEW_MUTATION_BASELINE;
   const registeredActions = new Set(
     [...args.registeredActions].map((action) => action.toUpperCase()),
+  );
+  const registeredViews = new Set(
+    [...args.registeredViews].map((viewId) => viewId.toLowerCase()),
   );
   const findings: BuiltinViewMutationFinding[] = [];
   const coverage: BuiltinViewMutationCoverage[] = [];
@@ -363,6 +698,8 @@ export function validateBuiltinViewMutationCoverage(args: {
   for (const entry of baseline) {
     let observedMutationSites = 0;
     let missingSource = false;
+    const sourceByFile = new Map<string, string>();
+    const observedByFile = new Map<string, number>();
     for (const sourceFile of entry.sourceFiles) {
       const source = args.readSource(sourceFile);
       if (source == null) {
@@ -374,7 +711,10 @@ export function validateBuiltinViewMutationCoverage(args: {
         });
         continue;
       }
-      observedMutationSites += countBuiltinViewMutationSites(source);
+      const sourceMutationSites = countBuiltinViewMutationSites(source);
+      sourceByFile.set(sourceFile, source);
+      observedByFile.set(sourceFile, sourceMutationSites);
+      observedMutationSites += sourceMutationSites;
     }
 
     const exempt = Boolean(entry.exemptReason);
@@ -423,6 +763,200 @@ export function validateBuiltinViewMutationCoverage(args: {
         code: "missing-semantic-action",
         message: `${entry.viewId}: mutating builtin view is not exempt and declares no semantic action mapping`,
       });
+    }
+
+    for (const mount of entry.mountedSourceFiles ?? []) {
+      if (
+        !entry.sourceFiles.includes(mount.sourceFile) ||
+        !entry.sourceFiles.includes(mount.mountedBy) ||
+        mount.sourceFile === mount.mountedBy
+      ) {
+        findings.push({
+          viewId: entry.viewId,
+          code: "mutation-mount-drift",
+          message: `${entry.viewId}: mounted source ${mount.sourceFile} must name a distinct parent and both files must be claimed by sourceFiles`,
+        });
+        continue;
+      }
+      const parentSource = sourceByFile.get(mount.mountedBy);
+      if (
+        parentSource !== undefined &&
+        (countExactOccurrences(parentSource, mount.importSignature) !== 1 ||
+          countExactOccurrences(parentSource, mount.renderSignature) !== 1)
+      ) {
+        findings.push({
+          viewId: entry.viewId,
+          code: "mutation-mount-drift",
+          message: `${entry.viewId}: ${mount.sourceFile} is no longer imported and rendered exactly once by ${mount.mountedBy}`,
+        });
+      }
+    }
+
+    const mutationAffordances = entry.mutationAffordances;
+    if (mutationAffordances) {
+      const claimedByFile = new Map<string, number>();
+      const affordanceIds = new Set<string>();
+      const affordanceActions = new Set<string>();
+      const usedAuthorities = new Set<string>();
+      const declaredActions = new Set(
+        entry.semanticActions.map((action) => action.toUpperCase()),
+      );
+      const authorityByAction = new Map<string, Set<string>>();
+
+      for (const authority of entry.mutationAuthorities ?? []) {
+        const action = authority.semanticAction.toUpperCase();
+        if (
+          authorityByAction.has(action) ||
+          !declaredActions.has(action) ||
+          authority.actionOperations.length === 0 ||
+          authority.actionOperations.some(
+            (operation) => operation.trim().length === 0,
+          )
+        ) {
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-action-drift",
+            message: `${entry.viewId}: invalid or duplicate mutation authority for ${authority.semanticAction}`,
+          });
+          continue;
+        }
+        authorityByAction.set(
+          action,
+          new Set(
+            authority.actionOperations.map((operation) => operation.trim()),
+          ),
+        );
+      }
+
+      for (const affordance of mutationAffordances) {
+        if (affordanceIds.has(affordance.id)) {
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-inventory-source",
+            message: `${entry.viewId}: duplicate mutation affordance id ${affordance.id}`,
+          });
+        }
+        affordanceIds.add(affordance.id);
+        const action = affordance.semanticAction.toUpperCase();
+        affordanceActions.add(action);
+
+        if (
+          !entry.sourceFiles.includes(affordance.sourceFile) ||
+          countBuiltinViewMutationSites(affordance.sourceSignature) !== 1
+        ) {
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-inventory-source",
+            message: `${entry.viewId}: mutation affordance ${affordance.id} must belong to sourceFiles and its signature must contain exactly one mutation expression`,
+          });
+          continue;
+        }
+        claimedByFile.set(
+          affordance.sourceFile,
+          (claimedByFile.get(affordance.sourceFile) ?? 0) + 1,
+        );
+
+        const source = sourceByFile.get(affordance.sourceFile);
+        if (source !== undefined) {
+          const occurrences = countExactOccurrences(
+            source,
+            affordance.sourceSignature,
+          );
+          if (occurrences !== 1) {
+            findings.push({
+              viewId: entry.viewId,
+              code: "mutation-signature-drift",
+              message: `${entry.viewId}: mutation affordance ${affordance.id} expected its source signature exactly once in ${affordance.sourceFile}, observed ${occurrences}`,
+            });
+          }
+        }
+
+        const authority = authorityByAction.get(action);
+        if (
+          !declaredActions.has(action) ||
+          !authority ||
+          affordance.actionOperations.length === 0
+        ) {
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-action-drift",
+            message: `${entry.viewId}: mutation affordance ${affordance.id} has no declared authority for ${affordance.semanticAction}`,
+          });
+          continue;
+        }
+        for (const operation of affordance.actionOperations) {
+          const normalizedOperation = operation.trim();
+          if (
+            normalizedOperation.length === 0 ||
+            !authority.has(normalizedOperation)
+          ) {
+            findings.push({
+              viewId: entry.viewId,
+              code: "mutation-action-drift",
+              message: `${entry.viewId}: mutation affordance ${affordance.id} maps to unauthorized ${affordance.semanticAction}.${operation}`,
+            });
+            continue;
+          }
+          usedAuthorities.add(`${action}\u0000${normalizedOperation}`);
+        }
+
+        const isViewShow =
+          action === "VIEWS" &&
+          affordance.actionOperations.some(
+            (operation) => operation.trim().toLowerCase() === "show",
+          );
+        const target = affordance.viewTarget;
+        if (
+          (isViewShow && !target) ||
+          (target &&
+            (action !== "VIEWS" ||
+              !isViewShow ||
+              target.id.trim().length === 0 ||
+              countExactOccurrences(source ?? "", target.sourceSignature) !==
+                1 ||
+              !registeredViews.has(target.id.trim().toLowerCase())))
+        ) {
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-view-target-drift",
+            message: `${entry.viewId}: mutation affordance ${affordance.id} must bind VIEWS.show to one view id present in the registered server view inventory`,
+          });
+        }
+      }
+
+      for (const sourceFile of entry.sourceFiles) {
+        const observed = observedByFile.get(sourceFile);
+        if (observed == null) continue;
+        const claimed = claimedByFile.get(sourceFile) ?? 0;
+        if (claimed !== observed) {
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-inventory-count",
+            message: `${entry.viewId}: mutation inventory claims ${claimed} of ${observed} site(s) in ${sourceFile}; add or remove named operations instead of changing only maxMutationSites`,
+          });
+        }
+      }
+
+      const actionsWithoutAffordances = [...declaredActions].filter(
+        (action) => !affordanceActions.has(action),
+      );
+      if (actionsWithoutAffordances.length > 0) {
+        findings.push({
+          viewId: entry.viewId,
+          code: "mutation-action-drift",
+          message: `${entry.viewId}: semanticActions ${actionsWithoutAffordances.join(", ")} have no named mutation affordance`,
+        });
+      }
+      for (const [action, operations] of authorityByAction) {
+        for (const operation of operations) {
+          if (usedAuthorities.has(`${action}\u0000${operation}`)) continue;
+          findings.push({
+            viewId: entry.viewId,
+            code: "mutation-action-drift",
+            message: `${entry.viewId}: mutation authority ${action}.${operation} has no named affordance`,
+          });
+        }
+      }
     }
   }
 

--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -12,7 +12,7 @@ This plugin registers four actions, one natural-language shortcut set, two evalu
 
 | Name | File | Description |
 |---|---|---|
-| `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
+| `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `stop`, `load_from_directory`, `list`, `create`. `stop` uses the canonical name-based `/api/apps/stop` route without uninstalling or relaunching. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
 | `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `icon`, `rollback`, `delete`/`remove`. Create/edit/icon/rollback/delete are owner-gated; read modes are open. `rollback` resets a created/edited view-or-plugin workdir to the pre-edit git snapshot taken before the coding agent ran (#8915) and re-registers it via `load-from-directory`. |
 | `BACKGROUND` | `src/actions/background.ts` | Change the unified app background from chat. Ops: `set` (color name/hex, a named **programmable GLSL shader** preset — `aurora`/`lava`/`plasma`/`waves`/`nebula` — plus relative uniform tweaks like *slower*/*brighter*/*bigger* (#10694), an uploaded image attachment, or a generated image from a prompt), `undo`, `redo`, `reset`. The action names a preset id + uniform patch only; the GLSL source lives in `@elizaos/ui` (`backgrounds/shader-presets.ts`) where `useBackgroundApplyChannel` resolves id→source, validates it, and `ProgrammableShaderBackground` renders it via three.js with a compile-validate + frame-watchdog + context-loss-recovery + reduced-motion + color-field fallback. Broadcasts a `background:apply` view event via `POST /api/views/events/broadcast`; the renderer applies it to the shared `BackgroundConfig` store. Drives the SAME background as the `/background` view — there is no separate homescreen-scene surface. |
 | `SETTINGS` | `src/actions/settings.ts` | Describe, list, and change built-in settings; mutations use the same semantic routes as the UI. Successful list/set results own canonical reply text and declare a single-operation turn complete once the plan queue is drained, avoiding a redundant evaluator model call on native function-calling backends without suppressing multi-tool evaluation. Owner-gated. |
@@ -69,6 +69,7 @@ src/
     app.ts                        APP action dispatcher; imports sub-handlers below
     app-launch.ts                 launch sub-handler
     app-relaunch.ts               relaunch sub-handler (stop + launch, optional verify)
+    app-stop.ts                   stop sub-handler (canonical name/run route, no relaunch)
     app-list.ts                   list sub-handler
     app-load-from-directory.ts    load_from_directory sub-handler
     app-create.ts                 create sub-handler (multi-turn scaffold + coding agent)
@@ -173,6 +174,7 @@ Follow the same pattern in `src/actions/views.ts` and create a `src/actions/view
 ## Conventions / gotchas
 
 - **Loopback HTTP only.** The client (`src/client/api.ts`) and all action helpers call the Eliza dashboard over `http://127.0.0.1:<port>`. Port is auto-detected; never hardcode it.
+- **APP stop shares the UI route.** Name-based `APP action=stop` calls `/api/apps/stop`, the same canonical AppManager path as `AppsManagementSection`; a successful stop and `nothing-stopped` are distinct typed results.
 - **APP action requires owner role.** `hasOwnerAccess` from `@elizaos/core` gates all `APP` writes. `VIEWS` read modes are open; write modes (`create`, `edit`, `delete`) are owner-gated.
 - **Multi-turn flows.** `APP create` and `VIEWS create` use `hasPendingIntent` / `hasPendingViewsCreateIntent` to detect follow-up choice replies (`new`, `edit-N`, `cancel`). Both check a pending-task record in the runtime before routing to the create sub-handler.
 - **Create flows work outside a checkout and preflight their dependencies.** `src/actions/scaffold-env.ts` resolves the min-plugin / min-project templates from the repo root first and then from the installed `elizaos` package (declared as a dependency so packaged builds ship the templates), lands new plugins in `<stateDir>/plugins` when the repo root has no plugins/ dir, and `preflightCodingDispatch` checks the orchestrator action + a coding CLI on PATH BEFORE scaffolding so a missing prerequisite answers with setup guidance instead of a dead-end error (or a half-created workdir). Keep new scaffold paths on these helpers; do not reintroduce repo-root-only resolution.

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -12,7 +12,7 @@ This plugin registers four actions, one natural-language shortcut set, two evalu
 
 | Name | File | Description |
 |---|---|---|
-| `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
+| `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `stop`, `load_from_directory`, `list`, `create`. `stop` uses the canonical name-based `/api/apps/stop` route without uninstalling or relaunching. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
 | `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `icon`, `rollback`, `delete`/`remove`. Create/edit/icon/rollback/delete are owner-gated; read modes are open. `rollback` resets a created/edited view-or-plugin workdir to the pre-edit git snapshot taken before the coding agent ran (#8915) and re-registers it via `load-from-directory`. |
 | `BACKGROUND` | `src/actions/background.ts` | Change the unified app background from chat. Ops: `set` (color name/hex, a named **programmable GLSL shader** preset — `aurora`/`lava`/`plasma`/`waves`/`nebula` — plus relative uniform tweaks like *slower*/*brighter*/*bigger* (#10694), an uploaded image attachment, or a generated image from a prompt), `undo`, `redo`, `reset`. The action names a preset id + uniform patch only; the GLSL source lives in `@elizaos/ui` (`backgrounds/shader-presets.ts`) where `useBackgroundApplyChannel` resolves id→source, validates it, and `ProgrammableShaderBackground` renders it via three.js with a compile-validate + frame-watchdog + context-loss-recovery + reduced-motion + color-field fallback. Broadcasts a `background:apply` view event via `POST /api/views/events/broadcast`; the renderer applies it to the shared `BackgroundConfig` store. Drives the SAME background as the `/background` view — there is no separate homescreen-scene surface. |
 | `SETTINGS` | `src/actions/settings.ts` | Describe, list, and change built-in settings; mutations use the same semantic routes as the UI. Successful list/set results own canonical reply text and declare a single-operation turn complete once the plan queue is drained, avoiding a redundant evaluator model call on native function-calling backends without suppressing multi-tool evaluation. Owner-gated. |
@@ -69,6 +69,7 @@ src/
     app.ts                        APP action dispatcher; imports sub-handlers below
     app-launch.ts                 launch sub-handler
     app-relaunch.ts               relaunch sub-handler (stop + launch, optional verify)
+    app-stop.ts                   stop sub-handler (canonical name/run route, no relaunch)
     app-list.ts                   list sub-handler
     app-load-from-directory.ts    load_from_directory sub-handler
     app-create.ts                 create sub-handler (multi-turn scaffold + coding agent)
@@ -173,6 +174,7 @@ Follow the same pattern in `src/actions/views.ts` and create a `src/actions/view
 ## Conventions / gotchas
 
 - **Loopback HTTP only.** The client (`src/client/api.ts`) and all action helpers call the Eliza dashboard over `http://127.0.0.1:<port>`. Port is auto-detected; never hardcode it.
+- **APP stop shares the UI route.** Name-based `APP action=stop` calls `/api/apps/stop`, the same canonical AppManager path as `AppsManagementSection`; a successful stop and `nothing-stopped` are distinct typed results.
 - **APP action requires owner role.** `hasOwnerAccess` from `@elizaos/core` gates all `APP` writes. `VIEWS` read modes are open; write modes (`create`, `edit`, `delete`) are owner-gated.
 - **Multi-turn flows.** `APP create` and `VIEWS create` use `hasPendingIntent` / `hasPendingViewsCreateIntent` to detect follow-up choice replies (`new`, `edit-N`, `cancel`). Both check a pending-task record in the runtime before routing to the create sub-handler.
 - **Create flows work outside a checkout and preflight their dependencies.** `src/actions/scaffold-env.ts` resolves the min-plugin / min-project templates from the repo root first and then from the installed `elizaos` package (declared as a dependency so packaged builds ship the templates), lands new plugins in `<stateDir>/plugins` when the repo root has no plugins/ dir, and `preflightCodingDispatch` checks the orchestrator action + a coding CLI on PATH BEFORE scaffolding so a missing prerequisite answers with setup guidance instead of a dead-end error (or a half-created workdir). Keep new scaffold paths on these helpers; do not reintroduce repo-root-only resolution.

--- a/plugins/plugin-app-control/README.md
+++ b/plugins/plugin-app-control/README.md
@@ -9,6 +9,7 @@ Loading this plugin gives an Eliza agent three new actions:
 **APP** — Unified app lifecycle control. The agent can:
 - Launch a registered app by name (`"launch shopify"`)
 - Relaunch (stop then start) a running app, optionally running verification after (`"relaunch shopify and verify"`)
+- Stop a running app without uninstalling or relaunching it (`"stop the shopify app"`)
 - List installed and currently-running apps (`"what apps are open?"`)
 - Load apps from a local directory into the registry (`"load apps from /my/dev/apps"`)
 - Scaffold a new Eliza app through a multi-turn flow that asks new/edit/cancel, scaffolds from the min-app template, and dispatches a coding agent with AppVerificationService validation (`"build me a note-taking app"`)

--- a/plugins/plugin-app-control/src/actions/app-stop.ts
+++ b/plugins/plugin-app-control/src/actions/app-stop.ts
@@ -1,0 +1,82 @@
+/**
+ * Stops a registered app through the same name-based route used by the app
+ * management UI. Name resolution stays in the action so ambiguous planner
+ * targets never reach the state-changing HTTP boundary.
+ */
+
+import type { ActionResult, HandlerCallback, Memory } from "@elizaos/core";
+import type { AppControlClient } from "../client/api.js";
+import { extractCloseTarget } from "../params.js";
+import { formatAppCandidates, resolveInstalledApp } from "../resolve.js";
+
+export interface RunStopInput {
+	client: AppControlClient;
+	message: Memory;
+	options?: Record<string, unknown>;
+	callback?: HandlerCallback;
+}
+
+export async function runStop({
+	client,
+	message,
+	options,
+	callback,
+}: RunStopInput): Promise<ActionResult> {
+	const { runId, appName: target } = extractCloseTarget(message, options);
+
+	if (runId) {
+		const result = await client.stopAppRun(runId);
+		await callback?.({ text: result.message });
+		return {
+			success: result.success,
+			text: result.message,
+			values: {
+				mode: "stop",
+				appName: result.appName,
+				runId: result.runId,
+				stopScope: result.stopScope,
+			},
+			data: { stop: result },
+		};
+	}
+
+	if (!target) {
+		const text =
+			'I need an app name or runId to stop. Try: "stop the feed app".';
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	const installed = await client.listInstalledApps();
+	const resolution = resolveInstalledApp(target, installed);
+
+	if (resolution.kind === "ambiguous") {
+		const candidates = resolution.candidates ?? [];
+		const text = `"${target}" matches multiple apps:\n${formatAppCandidates(
+			candidates,
+		)}\nPlease specify which one.`;
+		await callback?.({ text });
+		return { success: false, text, data: { candidates } };
+	}
+
+	if (resolution.kind === "none") {
+		const text = `No installed app matches "${target}". Try \`mode=list\` to see what's available.`;
+		await callback?.({ text });
+		return { success: false, text, data: { target } };
+	}
+
+	const appName = resolution.match?.name ?? target;
+	const result = await client.stopApp(appName);
+	await callback?.({ text: result.message });
+	return {
+		success: result.success,
+		text: result.message,
+		values: {
+			mode: "stop",
+			appName: result.appName,
+			runId: result.runId,
+			stopScope: result.stopScope,
+		},
+		data: { stop: result },
+	};
+}

--- a/plugins/plugin-app-control/src/actions/app.test.ts
+++ b/plugins/plugin-app-control/src/actions/app.test.ts
@@ -1,12 +1,120 @@
 /**
- * Role-policy tests for the APP action owner-only gate.
+ * APP contract coverage keeps its owner gate, planner schema, deterministic
+ * stop routing, and typed stop result aligned with the dashboard lifecycle
+ * route.
  */
 
-import { describe, expect, it } from "vitest";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { AppControlClient } from "../client/api.js";
 import { createAppAction } from "./app.js";
 
 describe("APP action role policy", () => {
 	it("advertises the same owner-only gate enforced by validate and handler", () => {
 		expect(createAppAction().roleGate).toEqual({ minRole: "OWNER" });
+	});
+
+	it("denies stop before any app-control request when the caller is not the owner", async () => {
+		const client: AppControlClient = {
+			listInstalledApps: vi.fn(),
+			listAppRuns: vi.fn(),
+			launchApp: vi.fn(),
+			stopApp: vi.fn(),
+			stopAppRun: vi.fn(),
+		};
+		const action = createAppAction({
+			client,
+			hasOwnerAccess: async () => false,
+		});
+		const result = await action.handler(
+			{ agentId: "agent-1" } as IAgentRuntime,
+			{
+				entityId: "viewer-1",
+				content: { text: "stop the chess app" },
+			} as Memory,
+			undefined,
+			{ parameters: { action: "stop", app: "chess" } },
+			undefined,
+		);
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: false,
+				text: expect.stringContaining("only the owner"),
+			}),
+		);
+		expect(client.listInstalledApps).not.toHaveBeenCalled();
+		expect(client.stopApp).not.toHaveBeenCalled();
+	});
+});
+
+describe("APP stop mode", () => {
+	it("advertises stop as a typed planner operation", () => {
+		const actionParameter = createAppAction().parameters?.find(
+			(parameter) => parameter.name === "action",
+		);
+		expect(actionParameter?.schema).toEqual(
+			expect.objectContaining({
+				enum: expect.arrayContaining(["launch", "relaunch", "stop"]),
+			}),
+		);
+	});
+
+	it("routes a standalone stop request without relaunching the app", async () => {
+		const stopApp = vi.fn(async () => ({
+			success: true,
+			appName: "chess",
+			runId: null,
+			stoppedAt: "2026-07-23T00:00:00.000Z",
+			pluginUninstalled: false,
+			needsRestart: false,
+			stopScope: "viewer-session" as const,
+			message: "Chess stopped.",
+		}));
+		const client: AppControlClient = {
+			listInstalledApps: async () => [
+				{
+					name: "chess",
+					displayName: "Chess",
+					pluginName: "@test/chess",
+					version: "1.0.0",
+					installedAt: "2026-07-23T00:00:00.000Z",
+				},
+			],
+			listAppRuns: async () => [],
+			launchApp: vi.fn(),
+			stopApp,
+			stopAppRun: vi.fn(),
+		};
+		const action = createAppAction({
+			client,
+			hasOwnerAccess: async () => true,
+		});
+		const runtime = { agentId: "agent-1" } as IAgentRuntime;
+		const message = {
+			entityId: "owner-1",
+			content: { text: "stop the chess app" },
+		} as Memory;
+
+		const result = await action.handler(
+			runtime,
+			message,
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		expect(stopApp).toHaveBeenCalledWith("chess");
+		expect(client.launchApp).not.toHaveBeenCalled();
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: true,
+				values: expect.objectContaining({
+					mode: "stop",
+					appName: "chess",
+					stopScope: "viewer-session",
+				}),
+			}),
+		);
 	});
 });

--- a/plugins/plugin-app-control/src/actions/app.ts
+++ b/plugins/plugin-app-control/src/actions/app.ts
@@ -1,15 +1,13 @@
 /**
- * @module plugin-app-control/actions/app
- *
- * Unified APP action with actions (`launch`, `relaunch`,
- * `load_from_directory`, `list`, `create`).
+ * Dispatches the unified APP action across launch, relaunch, stop,
+ * load-from-directory, list, and create operations.
  *
  * Validate gates on owner role + structured context + a lookup against
  * any pending APP_CREATE intent task in the same room (so the multi-turn
  * choice reply still resolves).
  *
- * Handler is pure dispatch — sub-handlers live in app-launch / app-relaunch
- * / app-list / app-load-from-directory / app-create.
+ * Sub-handlers own each operation so this module remains the planner contract
+ * and authorization boundary.
  */
 
 import path from "node:path";
@@ -32,10 +30,12 @@ import { runLaunch } from "./app-launch.js";
 import { runList } from "./app-list.js";
 import { runLoadFromDirectory } from "./app-load-from-directory.js";
 import { runRelaunch } from "./app-relaunch.js";
+import { runStop } from "./app-stop.js";
 
 export type AppMode =
 	| "launch"
 	| "relaunch"
+	| "stop"
 	| "load_from_directory"
 	| "list"
 	| "create";
@@ -43,6 +43,7 @@ export type AppMode =
 const MODES: readonly AppMode[] = [
 	"launch",
 	"relaunch",
+	"stop",
 	"load_from_directory",
 	"list",
 	"create",
@@ -104,14 +105,8 @@ function inferMode(
 	if (RELAUNCH_VERBS.test(trimmed) && APP_NOUN.test(trimmed)) return "relaunch";
 
 	if (STOP_VERBS.test(trimmed) && APP_NOUN.test(trimmed)) {
-		// Stop folds into relaunch only when paired with a launch verb;
-		// otherwise it's not an APP-action concern (no close mode).
 		if (LAUNCH_VERBS.test(trimmed)) return "relaunch";
-		// Fall through — stand-alone "close X app" still routes to relaunch
-		// with verify off, treating it as a stop+relaunch is wrong; we
-		// instead route to list so the user can see candidates without
-		// silently restarting.
-		return "list";
+		return "stop";
 	}
 
 	if (LAUNCH_VERBS.test(trimmed) && APP_NOUN.test(trimmed)) return "launch";
@@ -174,6 +169,8 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 			"RUN_APP",
 			"RESTART_APP",
 			"RELAUNCH_APP",
+			"STOP_APP",
+			"CLOSE_APP",
 			"CREATE_APP",
 			"BUILD_APP",
 			"NEW_APP",
@@ -187,21 +184,22 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 			"running",
 			"launch",
 			"relaunch",
+			"stop",
 			"scaffold",
 		],
 		description:
-			"Unified control of apps installed on this device. action=launch starts a registered app; action=relaunch stops then launches (optionally with verify); action=list shows installed + running apps; action=load_from_directory registers apps from an absolute folder; action=create runs the multi-turn create-or-edit flow that searches existing apps, asks new/edit/cancel, scaffolds from the min-app template, and dispatches a coding agent with AppVerificationService validator.",
+			"Unified control of apps installed on this device. action=launch starts a registered app; action=relaunch stops then launches (optionally with verify); action=stop stops a running app without uninstalling it; action=list shows installed + running apps; action=load_from_directory registers apps from an absolute folder; action=create runs the multi-turn create-or-edit flow that searches existing apps, asks new/edit/cancel, scaffolds from the min-app template, and dispatches a coding agent with AppVerificationService validator.",
 		descriptionCompressed:
-			"apps launch|relaunch|list|load_folder|create; create scaffolds, coding-agent, verify",
+			"apps launch|relaunch|stop|list|load_folder|create; create scaffolds, coding-agent, verify",
 		routingHint:
-			"Installed applications themselves -> APP. 'Show me the apps', 'what apps are installed/running', launching or restarting a registered app, registering apps from a folder, or building a new app is APP (action=list|launch|relaunch|load_from_directory|create) — answer installed-app-list requests with APP action=list, never with a UI view list. VIEWS covers UI views/panels and the apps *page*; APP covers the applications. The user's own Eliza Cloud apps ('my cloud apps', hosted apps/sites created or deployed on Eliza Cloud) are LIST_CLOUD_APPS, NOT this action.",
+			"Installed applications themselves -> APP. 'Show me the apps', 'list my apps', 'what apps are installed/running', launching, stopping, or restarting a registered app, registering apps from a folder, or building a new app is APP (action=list|launch|stop|relaunch|load_from_directory|create) — answer installed-app-list requests with APP action=list, never with a UI view list. VIEWS covers UI views/panels and the apps *page*; APP covers the applications. The user's own Eliza Cloud apps ('my cloud apps', hosted apps/sites created or deployed on Eliza Cloud) are LIST_CLOUD_APPS, NOT this action.",
 		suppressPostActionContinuation: true,
 
 		parameters: [
 			{
 				name: "action",
 				description:
-					"Operation: launch | relaunch | load_from_directory | list | create.",
+					"Operation: launch | relaunch | stop | load_from_directory | list | create.",
 				required: true,
 				schema: {
 					type: "string",
@@ -220,7 +218,7 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 			{
 				name: "app",
 				description:
-					"App name, slug, or display name (launch / relaunch / create-edit).",
+					"App name, slug, or display name (launch / relaunch / stop / create-edit).",
 				required: false,
 				schema: { type: "string" },
 			},
@@ -233,7 +231,7 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 			{
 				name: "runId",
 				description:
-					"Specific run id to stop before relaunching (relaunch mode).",
+					"Specific run id to stop (stop mode) or stop before relaunching (relaunch mode).",
 				required: false,
 				schema: { type: "string" },
 			},
@@ -374,6 +372,13 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 						options: actionOptions,
 						callback,
 					});
+				case "stop":
+					return runStop({
+						client,
+						message,
+						options: actionOptions,
+						callback,
+					});
 				case "list":
 					return runList({ client });
 				case "load_from_directory":
@@ -397,6 +402,19 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 		},
 
 		examples: [
+			[
+				{
+					name: "{{user1}}",
+					content: { text: "stop the shopify app" },
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: "Shopify stopped.",
+						action: "APP",
+					},
+				},
+			],
 			[
 				{
 					name: "{{user1}}",

--- a/plugins/plugin-app-control/src/client/api.test.ts
+++ b/plugins/plugin-app-control/src/client/api.test.ts
@@ -1,6 +1,6 @@
 /**
- * Verifies that app-control HTTP operations use workload-specific deadlines
- * and preserve caller cancellation at the loopback boundary.
+ * Verifies app-control deadlines, caller cancellation, and the typed no-op
+ * result used by APP stop at the loopback boundary.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppControlClient } from "./api.js";
@@ -25,6 +25,18 @@ function responseFor(url: string): Response {
 			run: null,
 		});
 	}
+	if (url.endsWith("/api/apps/stop")) {
+		return jsonResponse({
+			success: false,
+			appName: "chess",
+			runId: null,
+			stoppedAt: "2026-07-22T00:00:00.000Z",
+			pluginUninstalled: false,
+			needsRestart: false,
+			stopScope: "nothing-stopped",
+			message: "No active app run found.",
+		});
+	}
 	if (url.endsWith("/api/apps/runs/run-1/stop")) {
 		return jsonResponse({
 			success: true,
@@ -35,6 +47,18 @@ function responseFor(url: string): Response {
 			needsRestart: false,
 			stopScope: "viewer-session",
 			message: "Stopped",
+		});
+	}
+	if (url.endsWith("/api/apps/runs/missing/stop")) {
+		return jsonResponse({
+			success: false,
+			appName: "",
+			runId: "missing",
+			stoppedAt: "2026-07-22T00:00:00.000Z",
+			pluginUninstalled: false,
+			needsRestart: false,
+			stopScope: "nothing-stopped",
+			message: 'App run "missing" was not found.',
 		});
 	}
 	throw new Error(`Unexpected test URL: ${url}`);
@@ -62,10 +86,82 @@ describe("app-control client deadlines", () => {
 
 		await client.listInstalledApps();
 		await client.listAppRuns();
+		await client.stopApp("chess");
 		await client.stopAppRun("run-1");
 		await client.launchApp("chess");
 
-		expect(deadlines).toEqual([2_000, 2_000, 10_000, 120_000]);
+		expect(deadlines).toEqual([2_000, 2_000, 10_000, 10_000, 120_000]);
+	});
+
+	it("preserves a typed nothing-stopped result from the name-based UI route", async () => {
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+			new AbortController().signal,
+		);
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				requests.push({ url: String(input), init });
+				return responseFor(String(input));
+			}),
+		);
+
+		await expect(createAppControlClient().stopApp("chess")).resolves.toEqual(
+			expect.objectContaining({
+				success: false,
+				appName: "chess",
+				stopScope: "nothing-stopped",
+			}),
+		);
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.url).toMatch(/\/api\/apps\/stop$/);
+		expect(requests[0]?.init?.body).toBe(JSON.stringify({ name: "chess" }));
+	});
+
+	it("preserves a typed nothing-stopped result for an explicit run id", async () => {
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+			new AbortController().signal,
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request) =>
+				responseFor(String(input)),
+			),
+		);
+
+		await expect(
+			createAppControlClient().stopAppRun("missing"),
+		).resolves.toEqual(
+			expect.objectContaining({
+				success: false,
+				runId: "missing",
+				stopScope: "nothing-stopped",
+			}),
+		);
+	});
+
+	it("rejects a malformed stop result instead of fabricating success", async () => {
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+			new AbortController().signal,
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				jsonResponse({
+					appName: "chess",
+					runId: null,
+					stoppedAt: "2026-07-22T00:00:00.000Z",
+					pluginUninstalled: false,
+					needsRestart: false,
+					stopScope: "nothing-stopped",
+					message: "No active app run found.",
+				}),
+			),
+		);
+
+		await expect(createAppControlClient().stopApp("chess")).rejects.toThrow(
+			"Malformed stop result: missing required fields",
+		);
 	});
 
 	it("propagates caller cancellation through the combined request signal", async () => {

--- a/plugins/plugin-app-control/src/client/api.ts
+++ b/plugins/plugin-app-control/src/client/api.ts
@@ -24,6 +24,7 @@ export interface AppControlClient {
 	listInstalledApps(signal?: AbortSignal): Promise<InstalledAppInfo[]>;
 	listAppRuns(signal?: AbortSignal): Promise<AppRunSummary[]>;
 	launchApp(name: string, signal?: AbortSignal): Promise<AppLaunchResult>;
+	stopApp(name: string, signal?: AbortSignal): Promise<AppStopResult>;
 	stopAppRun(runId: string, signal?: AbortSignal): Promise<AppStopResult>;
 }
 
@@ -62,6 +63,7 @@ async function requestJson<T>(
 	parse: (body: unknown) => T,
 	errorContext: string,
 	deadlineMs: number,
+	acceptExplicitFailure = false,
 ): Promise<T> {
 	const url = `${getApiBase()}${path}`;
 	const deadlineSignal = AbortSignal.timeout(deadlineMs);
@@ -94,10 +96,10 @@ async function requestJson<T>(
 		throw new Error(extractErrorMessage(response.status, body, errorContext));
 	}
 
-	// The server sometimes returns { success: false } with a 200 status (e.g.
-	// app not found). Surface those as explicit errors instead of trying to
-	// parse them into a typed result.
+	// A small number of mutation routes use HTTP 200 for a typed no-op result.
+	// Only callers with a parser for that explicit failure shape may opt in.
 	if (
+		!acceptExplicitFailure &&
 		body &&
 		typeof body === "object" &&
 		(body as AppControlErrorPayload).success === false
@@ -218,12 +220,20 @@ function parseStopResult(body: unknown): AppStopResult {
 	const stoppedAt = entry.stoppedAt;
 	const stopScope = entry.stopScope;
 	const message = entry.message;
+	const success = entry.success;
+	const pluginUninstalled = entry.pluginUninstalled;
+	const needsRestart = entry.needsRestart;
+	const runId = entry.runId;
 	if (
 		typeof appName !== "string" ||
 		typeof stoppedAt !== "string" ||
-		typeof message !== "string"
+		typeof message !== "string" ||
+		typeof success !== "boolean" ||
+		typeof pluginUninstalled !== "boolean" ||
+		typeof needsRestart !== "boolean" ||
+		(runId !== null && typeof runId !== "string")
 	) {
-		throw new Error("Malformed stop result: missing required string fields");
+		throw new Error("Malformed stop result: missing required fields");
 	}
 	if (
 		stopScope !== "plugin-uninstalled" &&
@@ -232,14 +242,13 @@ function parseStopResult(body: unknown): AppStopResult {
 	) {
 		throw new Error(`Malformed stop result: unexpected stopScope ${stopScope}`);
 	}
-	const runId = entry.runId;
 	return {
-		success: entry.success !== false,
+		success,
 		appName,
-		runId: typeof runId === "string" ? runId : null,
+		runId,
 		stoppedAt,
-		pluginUninstalled: Boolean(entry.pluginUninstalled),
-		needsRestart: Boolean(entry.needsRestart),
+		pluginUninstalled,
+		needsRestart,
 		stopScope,
 		message,
 	};
@@ -281,6 +290,21 @@ export function createAppControlClient(): AppControlClient {
 			);
 		},
 
+		async stopApp(name: string, signal?: AbortSignal) {
+			return requestJson(
+				"/api/apps/stop",
+				{
+					method: "POST",
+					body: JSON.stringify({ name }),
+					signal,
+				},
+				parseStopResult,
+				`Failed to stop app ${name}`,
+				LOOPBACK_STOP_DEADLINE_MS,
+				true,
+			);
+		},
+
 		async stopAppRun(runId: string, signal?: AbortSignal) {
 			return requestJson(
 				`/api/apps/runs/${encodeURIComponent(runId)}/stop`,
@@ -288,6 +312,7 @@ export function createAppControlClient(): AppControlClient {
 				parseStopResult,
 				`Failed to stop app run ${runId}`,
 				LOOPBACK_STOP_DEADLINE_MS,
+				true,
 			);
 		},
 	};

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -1,10 +1,9 @@
 /**
- * @module plugin-app-control
- * @description elizaOS plugin that lets the Eliza agent launch, close, list,
- * relaunch, load-from-directory, and create Eliza apps.
+ * Registers the app lifecycle, shell-view, settings, and background controls
+ * exposed to Eliza agents.
  *
  * Surface:
- * - One unified `APP` action (sub-modes: launch / relaunch / list /
+ * - One unified `APP` action (sub-modes: launch / relaunch / stop / list /
  *   load_from_directory / create).
  * - `available_apps` provider — installed + running apps for the planner.
  * - `AppRegistryService` — persists load_from_directory registrations and

--- a/plugins/plugin-app-control/test/scenarios/app-stop.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-stop.scenario.ts
@@ -1,0 +1,246 @@
+/**
+ * Live-model APP stop coverage backed by a real TCP API host and AppManager
+ * run. The seed launches a synthetic installed app through the production
+ * route; the model must select APP stop and leave the run inventory empty.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { startApiServer } from "@elizaos/agent/api/server";
+import { AgentRuntime } from "@elizaos/core";
+import {
+	createAppControlClient,
+	type AppRunSummary,
+} from "@elizaos/plugin-app-control";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const TEST_APP = "ratchet-proof";
+const TEST_PLUGIN = "@test/ratchet-proof";
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+
+let apiServer: ApiServer | null = null;
+let fixtureRoot: string | null = null;
+const previousEnv = new Map<string, string | undefined>();
+const touchedEnv = [
+	"ELIZA_API_AUTH_TOKEN",
+	"ELIZA_API_BIND_HOST",
+	"ELIZA_API_PORT",
+	"ELIZA_API_TOKEN",
+	"ELIZA_CONFIG_PATH",
+	"ELIZA_PERSIST_CONFIG_PATH",
+	"ELIZA_PORT",
+	"ELIZA_STATE_DIR",
+] as const;
+
+function restoreEnvironment(): void {
+	for (const key of touchedEnv) {
+		const previous = previousEnv.get(key);
+		if (previous === undefined) delete process.env[key];
+		else process.env[key] = previous;
+	}
+	previousEnv.clear();
+}
+
+async function startRunningApp(runtime: AgentRuntime): Promise<void> {
+	if (apiServer || fixtureRoot) {
+		throw new Error("app-stop scenario fixture is already running");
+	}
+	for (const key of touchedEnv) previousEnv.set(key, process.env[key]);
+
+	fixtureRoot = await mkdtemp(path.join(tmpdir(), "eliza-app-stop-scenario-"));
+	const stateDir = path.join(fixtureRoot, "state");
+	const cacheDir = path.join(stateDir, "cache");
+	const configPath = path.join(stateDir, "eliza.json");
+	await mkdir(cacheDir, { recursive: true });
+	await writeFile(
+		configPath,
+		JSON.stringify({
+			logging: { level: "error" },
+			plugins: {
+				installs: {
+					[TEST_PLUGIN]: {
+						source: "npm",
+						spec: `${TEST_PLUGIN}@1.0.0`,
+						version: "1.0.0",
+						installedAt: "2026-07-23T00:00:00.000Z",
+					},
+				},
+			},
+		}),
+		"utf8",
+	);
+	await writeFile(
+		path.join(cacheDir, "registry.json"),
+		JSON.stringify({
+			fetchedAt: Date.now(),
+			plugins: [
+				[
+					TEST_APP,
+					{
+						name: TEST_APP,
+						gitRepo: "test/ratchet-proof",
+						gitUrl: "https://example.test/ratchet-proof.git",
+						directory: null,
+						description: "Live APP stop trajectory fixture.",
+						homepage: "https://example.test/ratchet-proof",
+						topics: ["app", "test"],
+						stars: 0,
+						language: "TypeScript",
+						npm: {
+							package: TEST_PLUGIN,
+							v0Version: null,
+							v1Version: null,
+							v2Version: "1.0.0",
+						},
+						git: {
+							v0Branch: null,
+							v1Branch: null,
+							v2Branch: "main",
+						},
+						supports: { v0: false, v1: false, v2: true },
+						kind: "app",
+						appMeta: {
+							displayName: "Ratchet Proof",
+							category: "tool",
+							launchType: "connect",
+							launchUrl: "https://example.test/ratchet-proof",
+							icon: null,
+							heroImage: null,
+							capabilities: [],
+							minPlayers: null,
+							maxPlayers: null,
+						},
+					},
+				],
+			],
+		}),
+		"utf8",
+	);
+
+	process.env.ELIZA_STATE_DIR = stateDir;
+	process.env.ELIZA_CONFIG_PATH = configPath;
+	process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+	process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+	process.env.ELIZA_API_TOKEN = "app-stop-live-scenario-token";
+	delete process.env.ELIZA_API_AUTH_TOKEN;
+	apiServer = await startApiServer({
+		port: 0,
+		runtime,
+		skipDeferredStartupWork: true,
+	});
+	process.env.ELIZA_PORT = String(apiServer.port);
+	process.env.ELIZA_API_PORT = String(apiServer.port);
+
+	const launch = await createAppControlClient().launchApp(TEST_APP);
+	if (!launch.run || launch.run.status !== "running") {
+		throw new Error(
+			`Expected a running ${TEST_APP} fixture, received ${launch.run?.status ?? "no run"}`,
+		);
+	}
+}
+
+async function assertRunStopped(): Promise<void> {
+	const runs: AppRunSummary[] = await createAppControlClient().listAppRuns();
+	if (runs.some((run) => run.appName === TEST_APP)) {
+		throw new Error(`${TEST_APP} remained in the real AppManager run inventory`);
+	}
+}
+
+async function assertStoppedAndDisposeFixture(): Promise<void> {
+	const activeServer = apiServer;
+	const activeRoot = fixtureRoot;
+	try {
+		await assertRunStopped();
+	} finally {
+		apiServer = null;
+		fixtureRoot = null;
+		if (activeServer) await activeServer.close();
+		if (activeRoot) await rm(activeRoot, { recursive: true, force: true });
+		restoreEnvironment();
+	}
+}
+
+export default scenario({
+	lane: "live-only",
+	id: "app-stop",
+	title: "APP action stops a running app without relaunching",
+	domain: "app-control",
+	tags: ["app-control", "app", "stop", "live-route"],
+	isolation: "per-scenario",
+	requires: {
+		plugins: ["@elizaos/plugin-app-control"],
+	},
+	seed: [
+		{
+			type: "custom",
+			name: "launch a real AppManager run through the TCP API",
+			apply: async (ctx) => {
+				if (!(ctx.runtime instanceof AgentRuntime)) {
+					return "scenario runtime is not an AgentRuntime";
+				}
+				await startRunningApp(ctx.runtime);
+			},
+		},
+	],
+	cleanup: [
+		{
+			type: "custom",
+			name: "assert the run stopped, then dispose the API host and state",
+			apply: assertStoppedAndDisposeFixture,
+		},
+	],
+	rooms: [
+		{
+			id: "main",
+			source: "telegram",
+			title: "App Control Stop",
+		},
+	],
+	turns: [
+		{
+			kind: "message",
+			name: "user-stops-running-app",
+			text: "Stop the Ratchet Proof app. Do not relaunch it.",
+			assertTurn: (turn) => {
+				const call = turn.actionsCalled.find(
+					(action) => action.actionName === "APP",
+				);
+				if (!call?.result?.success) {
+					return `APP stop did not succeed: ${call?.error?.message ?? call?.result?.text ?? "action not called"}`;
+				}
+				if (call.result.values?.mode !== "stop") {
+					return `APP selected mode ${String(call.result.values?.mode)} instead of stop`;
+				}
+				const stop = call.result.data?.stop;
+				if (
+					!stop ||
+					typeof stop !== "object" ||
+					Array.isArray(stop) ||
+					!("stopScope" in stop) ||
+					stop.stopScope !== "viewer-session"
+				) {
+					return "APP stop omitted the typed viewer-session result";
+				}
+			},
+		},
+	],
+	finalChecks: [
+		{
+			type: "selectedAction",
+			actionName: "APP",
+		},
+		{
+			type: "selectedActionArguments",
+			actionName: "APP",
+			includesAll: [/stop/i, /ratchet-proof|Ratchet Proof/i],
+		},
+		{
+			type: "actionCalled",
+			actionName: "APP",
+			status: "success",
+			minCount: 1,
+		},
+	],
+});


### PR DESCRIPTION
# Relates to

Closes #16944.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@88df752407d346a0491a5fa9902bc555be5a8997` with zero conflicts.
- [x] `bun install` was run after sync. Exact-head `bun run verify` is pending host availability and is tracked under **Known gaps / failures**.
- [x] A reviewer can confirm the semantic path from the evidence and exact-head runs below.

# Sync with develop

- [x] Rebased onto `origin/develop@88df752407d346a0491a5fa9902bc555be5a8997`; zero conflicts.
- [ ] Exact-head `bun run verify` pending; see **Known gaps / failures**.

# Risks

Low-to-medium. The change adds an intentionally hidden `cloud-apps` entry to the server view registry so `VIEWS.show` can resolve the renderer's existing shell page, and adds `APP stop` to the owner-gated app-control action. The real TCP regression covers list/show/navigation, launch/stop/no-op state, and typed route results.

# Background

## What does this PR do?

- Expands the My Apps ratchet from its page-local handler to the complete 27-site mounted `AppsManagementSection` inventory.
- Names every My Apps affordance and pins it to an authorized `APP` operation.
- Binds the Cloud Apps row to `VIEWS.show` + `cloud-apps`, verifies the source actually selects that target, and requires the target to exist in the supplied registered-view inventory.
- Registers `cloud-apps` in the server registry consumed by `GET /api/views`, while keeping it hidden from the view manager.
- Adds owner-gated `APP action=stop`, typed loopback results, a real AgentRuntime/TCP/AppManager regression, and a live-model scenario.

## What kind of change is this?

Bug fix and regression-test hardening.

# Documentation changes needed?

The plugin README and package guides describe `APP stop` and the shared UI route. No user-facing documentation change is required.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/testing/builtin-view-action-ratchet.test.ts`
2. `packages/agent/src/api/builtin-app-mutation-live-route.test.ts`
3. `plugins/plugin-app-control/test/scenarios/app-stop.scenario.ts`

## Detailed testing steps

Exact head: `3075fe09578254114db676c0bafa6020bc1b4a21`.

- `bun run --cwd packages/ui test src/testing/builtin-view-action-ratchet.test.ts` — 1 file, 22 tests passed.
- `bun x vitest run --config vitest.config.ts src/actions/app.test.ts src/client/api.test.ts` in `plugins/plugin-app-control` — 2 files, 9 tests passed.
- `bun x vitest run --config vitest.config.ts src/api/builtin-app-mutation-live-route.test.ts src/api/views-routes.hero.test.ts src/api/views-routes.hero-coverage.test.ts` in `packages/agent` — 3 files, 7 tests passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd plugins/plugin-app-control typecheck` — passed.
- Exact-head Tests workflow: https://github.com/elizaOS/eliza/actions/runs/30045649338
- Exact-head Live Scenarios workflow: https://github.com/elizaOS/eliza/actions/runs/30045651672

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test/action/server-registry change only; no rendered UI source or pixel delta.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test/action/server-registry change only; no rendered UI source or pixel delta.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no rendered UI behavior or visual state changed.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [exact-head Tests workflow](https://github.com/elizaOS/eliza/actions/runs/30045649338) runs the real AgentRuntime/TCP/AppManager route regression and full client lane.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend runtime code changed; the navigation contract is exercised at the real loopback view API boundary.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [exact-head credentialed Live Scenarios workflow](https://github.com/elizaOS/eliza/actions/runs/30045651672) includes the `app-stop` scenario and uploads report/run/native-jsonl artifacts.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [exact-head Tests workflow](https://github.com/elizaOS/eliza/actions/runs/30045649338) observes the real AppManager run inventory transition running → stopped → typed nothing-stopped; [Live Scenarios](https://github.com/elizaOS/eliza/actions/runs/30045651672) records the same live-model action result.

# Evidence Details

## Real LLM-call trajectory

The credentialed exact-head workflow above is running. Before review, its `app-stop` report, raw action arguments/result, model output, AppManager inventory cleanup, and native JSONL will be downloaded and manually read; the findings will be added here.

## Backend + frontend logs

The exact-head AgentRuntime regression proves:

1. `VIEWS action=show view=cloud-apps` resolves a `visibleInManager: false` server view and changes `/api/views/current` to `/cloud-apps`.
2. A real AppManager run is launched through the TCP API.
3. `APP action=stop` removes it without relaunching.
4. A second stop returns the typed `nothing-stopped` result and the inventory remains empty.

Frontend logs are N/A because no frontend runtime source changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI source or visual behavior changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- Exact-head full `packages/ui` suite and `bun run verify` are queued locally until the shared verification host is clear.
- The exact-head Tests and Live Scenarios workflows are currently running; this PR remains draft until their artifacts are inspected and results are recorded.
- Standalone `bun run --cwd packages/agent typecheck` currently fails on unchanged optional-plugin dist declarations (`plugin-streaming`, `plugin-vision`, `plugin-background-runner`, `plugin-native-filesystem`, and capacitor bridge subpaths). The changed agent sources compile and pass through the real integration tests; root verification will exercise the repository's intended build/typecheck order.
