### PR TITLE
ci: publish exact demo agent image

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -4,7 +4,7 @@ name: Build Agent Image
 # cloud sandbox provisioner. Three trigger surfaces:
 #   - push to develop/main → :develop / :stable + :latest, plus :sha-<short>
 #   - GitHub release created → release tag (e.g. v2.0.0-alpha.176)
-#   - workflow_dispatch → manual reruns
+#   - workflow_dispatch → manual canonical reruns or digest-preserving demo promotion
 # The previous release-only workflow (image.yaml) duplicated this entire
 # pre-build sequence; it's been deleted in favor of this consolidated build.
 
@@ -27,10 +27,20 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+    inputs:
+      publication_target:
+        description: Immutable GHCR destination for this manual build
+        required: true
+        default: canonical
+        type: choice
+        options:
+          - canonical
+          - demo
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DEMO_IMAGE_REPOSITORY: ghcr.io/elizaos/eliza-demo
 
 # Default to least privilege. Override per-job where needed.
 # cancel superseded in-flight runs for the same PR to free hosted-runner
@@ -211,18 +221,51 @@ jobs:
             env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760
             env.BUILDKIT_STEP_LOG_MAX_SPEED=10485760
 
-      # github.repository preserves the org's casing (elizaOS/eliza), but Docker
-      # tags must be all-lowercase. metadata-action lowercases for the push tags,
-      # but the raw :ci-boot-verify tag below needs an explicit lowercased image
-      # name or `docker build`/`docker push` fails with "repository name must be
-      # lowercase".
-      - id: image
-        run: echo "name=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+      # The demo repository is an operator-only canary boundary, not a
+      # caller-supplied registry escape hatch. Keep the mapping in shell as a
+      # second fail-closed check behind workflow_dispatch's choice input, and
+      # force every non-manual event to the canonical repository.
+      - name: Resolve publication repository
+        id: image
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.publication_target || 'canonical' }}
+        run: |
+          set -euo pipefail
+          canonical_repository="$(
+            printf '%s/%s' "$REGISTRY" "$IMAGE_NAME" |
+              tr '[:upper:]' '[:lower:]'
+          )"
+          case "$REQUESTED_TARGET" in
+            canonical)
+              destination_repository="$canonical_repository"
+              ;;
+            demo)
+              if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+                echo "::error::The demo image repository is available only to workflow_dispatch." >&2
+                exit 1
+              fi
+              destination_repository="$DEMO_IMAGE_REPOSITORY"
+              ;;
+            *)
+              echo "::error::Unsupported publication target." >&2
+              exit 1
+              ;;
+          esac
+          # The image is always built, booted, and first published through the
+          # canonical repository. Demo publication is a digest-preserving
+          # server-side promotion below, so it cannot drift from those bytes.
+          echo "name=$canonical_repository" >> "$GITHUB_OUTPUT"
+          echo "metadata_name=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "destination_name=$destination_repository" >> "$GITHUB_OUTPUT"
+          echo "publication_target=$REQUESTED_TARGET" >> "$GITHUB_OUTPUT"
 
       - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.image.outputs.metadata_name }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           # develop push  → :develop + :sha-<short>
           # main push     → :stable + :latest + :sha-<short>
           # release       → the git tag verbatim (e.g. v2.0.0-alpha.176)
@@ -304,27 +347,78 @@ jobs:
       # `docker push` it, so the published bytes are byte-for-byte the image
       # that just booted cleanly. No rebuild means no chance of shipping a
       # different image than the one that was verified.
-      - id: push
+      - name: Push exact verified image
+        id: push
         env:
           LOCAL_IMAGE: ${{ steps.image.outputs.name }}:ci-boot-verify
+          PUBLISH_REPOSITORY: ${{ steps.image.outputs.name }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           set -euo pipefail
+          verified_image_id="$(docker image inspect --format '{{ .Id }}' "$LOCAL_IMAGE")"
+          if [[ ! "$verified_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::The boot-verified local image has no valid image ID." >&2
+            exit 1
+          fi
           first_tag=""
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
+            case "$tag" in
+              "$PUBLISH_REPOSITORY":*) ;;
+              *)
+                echo "::error::Refusing to push a tag outside the selected publication repository." >&2
+                exit 1
+                ;;
+            esac
             [ -z "$first_tag" ] && first_tag="$tag"
             echo "Tagging $LOCAL_IMAGE as $tag and pushing"
             docker tag "$LOCAL_IMAGE" "$tag"
+            tagged_image_id="$(docker image inspect --format '{{ .Id }}' "$tag")"
+            if [ "$tagged_image_id" != "$verified_image_id" ]; then
+              echo "::error::The publication tag does not identify the boot-verified local image." >&2
+              exit 1
+            fi
             docker push "$tag"
           done <<< "$TAGS"
-          # Resolve the published digest from a pushed tag (its RepoDigests is
-          # populated by the push above) for the attestation step.
+          if [ -z "$first_tag" ]; then
+            echo "::error::No image tags were produced for publication." >&2
+            exit 1
+          fi
+          # Resolve only a digest bound to the canonical publication source. A local
+          # image can carry RepoDigests from multiple repositories, so taking
+          # the first entry could attest the wrong subject.
           digest=""
-          if [ -n "$first_tag" ]; then
-            digest="$(docker inspect --format '{{ index .RepoDigests 0 }}' "$first_tag" 2>/dev/null | sed 's/.*@//' || true)"
+          while IFS= read -r repo_digest; do
+            case "$repo_digest" in
+              "$PUBLISH_REPOSITORY"@sha256:*)
+                digest="${repo_digest#*@}"
+                break
+                ;;
+            esac
+          done < <(docker inspect --format '{{ range .RepoDigests }}{{ println . }}{{ end }}' "$first_tag")
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Published image has no digest for the canonical repository." >&2
+            exit 1
+          fi
+          immutable_tag=""
+          while IFS= read -r tag; do
+            case "$tag" in
+              "$PUBLISH_REPOSITORY":sha-*)
+                if [ -n "$immutable_tag" ]; then
+                  echo "::error::More than one immutable SHA tag was produced." >&2
+                  exit 1
+                fi
+                immutable_tag="$tag"
+                ;;
+            esac
+          done <<< "$TAGS"
+          if [ -z "$immutable_tag" ]; then
+            echo "::error::No immutable SHA tag was produced for publication." >&2
+            exit 1
           fi
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "image_id=$verified_image_id" >> "$GITHUB_OUTPUT"
+          echo "immutable_tag=$immutable_tag" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact attestation
         if: ${{ steps.push.outputs.digest != '' }}
@@ -334,7 +428,59 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Setup digest-preserving image promotion
+        if: ${{ steps.image.outputs.publication_target == 'demo' }}
+        uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0
+        with:
+          version: v0.20.6
+
+      - name: Promote exact canonical digest to demo
+        if: ${{ steps.image.outputs.publication_target == 'demo' }}
+        id: promote-demo
+        env:
+          DESTINATION_REPOSITORY: ${{ steps.image.outputs.destination_name }}
+          SOURCE_DIGEST: ${{ steps.push.outputs.digest }}
+          SOURCE_IMMUTABLE_TAG: ${{ steps.push.outputs.immutable_tag }}
+          SOURCE_REPOSITORY: ${{ steps.image.outputs.name }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_REPOSITORY" != "ghcr.io/elizaos/eliza" ]; then
+            echo "::error::Demo promotion requires the canonical elizaOS source repository." >&2
+            exit 1
+          fi
+          if [ "$DESTINATION_REPOSITORY" != "ghcr.io/elizaos/eliza-demo" ]; then
+            echo "::error::Demo promotion destination is outside the closed allowlist." >&2
+            exit 1
+          fi
+          case "$SOURCE_IMMUTABLE_TAG" in
+            "$SOURCE_REPOSITORY":sha-*) tag_name="${SOURCE_IMMUTABLE_TAG#*:}" ;;
+            *)
+              echo "::error::Demo promotion requires the canonical immutable SHA tag." >&2
+              exit 1
+              ;;
+          esac
+          destination_tag="${DESTINATION_REPOSITORY}:${tag_name}"
+          crane copy \
+            "$SOURCE_REPOSITORY@$SOURCE_DIGEST" \
+            "$destination_tag"
+          destination_digest="$(crane digest "$destination_tag")"
+          if [ "$destination_digest" != "$SOURCE_DIGEST" ]; then
+            echo "::error::Demo promotion changed the canonical manifest digest." >&2
+            exit 1
+          fi
+          echo "digest=$destination_digest" >> "$GITHUB_OUTPUT"
+          echo "name=$DESTINATION_REPOSITORY" >> "$GITHUB_OUTPUT"
+
+      - name: Generate demo artifact attestation
+        if: ${{ steps.image.outputs.publication_target == 'demo' }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+        with:
+          subject-name: ${{ steps.promote-demo.outputs.name }}
+          subject-digest: ${{ steps.promote-demo.outputs.digest }}
+          push-to-registry: true
+
       - name: Make Docker image public
+        if: ${{ steps.image.outputs.publication_target == 'canonical' }}
         # Idempotent — patching to public when already public is a no-op.
         # Previously lived in image.yaml; folded in here on consolidation.
         run: |
@@ -344,3 +490,39 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/user/packages/container/${{ env.IMAGE_NAME }}/visibility \
             -d '{"visibility":"public"}'
+
+      - name: Verify demo image is anonymously pullable
+        if: ${{ steps.image.outputs.publication_target == 'demo' }}
+        env:
+          EXPECTED_DIGEST: ${{ steps.promote-demo.outputs.digest }}
+          EXPECTED_IMAGE_ID: ${{ steps.push.outputs.image_id }}
+        run: |
+          set -euo pipefail
+          manifest_file="$(mktemp)"
+          headers_file="$(mktemp)"
+          trap 'rm -f "$manifest_file" "$headers_file"' EXIT
+          token="$(
+            curl --fail-with-body --silent --show-error \
+              'https://ghcr.io/token?scope=repository%3Aelizaos%2Feliza-demo%3Apull' |
+              jq -er '.token'
+          )"
+          curl --fail-with-body --silent --show-error \
+            --dump-header "$headers_file" \
+            --output "$manifest_file" \
+            -H 'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
+            -H "Authorization: Bearer $token" \
+            "https://ghcr.io/v2/elizaos/eliza-demo/manifests/$EXPECTED_DIGEST"
+          remote_digest="$(
+            tr -d '\r' < "$headers_file" |
+              awk 'tolower($1) == "docker-content-digest:" { print $2 }' |
+              tail -n 1
+          )"
+          remote_image_id="$(jq -er '.config.digest' "$manifest_file")"
+          if [ "$remote_digest" != "$EXPECTED_DIGEST" ]; then
+            echo "::error::Anonymous GHCR read returned a different manifest digest." >&2
+            exit 1
+          fi
+          if [ "$remote_image_id" != "$EXPECTED_IMAGE_ID" ]; then
+            echo "::error::Published demo manifest does not reference the boot-verified image config." >&2
+            exit 1
+          fi

--- a/packages/scripts/__tests__/build-agent-image-workflow.test.ts
+++ b/packages/scripts/__tests__/build-agent-image-workflow.test.ts
@@ -1,6 +1,18 @@
-// Exercises tests build agent image workflow.test automation behavior with deterministic script fixtures.
+/**
+ * Static and executable contracts for managed-agent image publication.
+ */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const workflowText = readFileSync(
   new URL("../../../.github/workflows/build-agent-image.yml", import.meta.url),
@@ -9,6 +21,10 @@ const workflowText = readFileSync(
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function githubExpression(value: string): string {
+  return ["$", "{{ ", value, " }}"].join("");
 }
 
 function extractStepRunBlock(stepName: string): string {
@@ -47,7 +63,323 @@ function extractTurboFilters(runBlock: string): string[] {
     .sort();
 }
 
+function runPublicationResolver(
+  eventName: string,
+  requestedTarget: string,
+): {
+  exitCode: number;
+  output: Map<string, string>;
+  stderr: string;
+} {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "eliza-image-publication-"),
+  );
+  const githubOutput = join(temporaryDirectory, "github-output");
+  const result = Bun.spawnSync(
+    ["bash", "-c", extractStepRunBlock("Resolve publication repository")],
+    {
+      env: {
+        ...process.env,
+        DEMO_IMAGE_REPOSITORY: "ghcr.io/elizaos/eliza-demo",
+        EVENT_NAME: eventName,
+        GITHUB_OUTPUT: githubOutput,
+        IMAGE_NAME: "elizaOS/eliza",
+        REGISTRY: "ghcr.io",
+        REQUESTED_TARGET: requestedTarget,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const output = new Map<string, string>();
+  if (existsSync(githubOutput)) {
+    for (const line of readFileSync(githubOutput, "utf8").trim().split("\n")) {
+      const separator = line.indexOf("=");
+      if (separator > 0) {
+        output.set(line.slice(0, separator), line.slice(separator + 1));
+      }
+    }
+  }
+  rmSync(temporaryDirectory, { recursive: true, force: true });
+
+  return {
+    exitCode: result.exitCode,
+    output,
+    stderr: result.stderr.toString(),
+  };
+}
+
+function runDemoPromotion(overrides: Partial<Record<string, string>> = {}): {
+  craneLog: string;
+  exitCode: number;
+  output: string;
+  stderr: string;
+} {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "eliza-image-promotion-"),
+  );
+  const binaryDirectory = join(temporaryDirectory, "bin");
+  const cranePath = join(binaryDirectory, "crane");
+  const craneLog = join(temporaryDirectory, "crane.log");
+  const githubOutput = join(temporaryDirectory, "github-output");
+  mkdirSync(binaryDirectory);
+  writeFileSync(
+    cranePath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "copy" ]; then
+  printf '%s\\n' "$2" "$3" > "$CRANE_LOG"
+  exit 0
+fi
+if [ "$1" = "digest" ]; then
+  printf '%s\\n' "$MOCK_CRANE_DIGEST"
+  exit 0
+fi
+exit 91
+`,
+  );
+  chmodSync(cranePath, 0o755);
+  const sourceDigest = `sha256:${"a".repeat(64)}`;
+  const result = Bun.spawnSync(
+    [
+      "bash",
+      "-c",
+      extractStepRunBlock("Promote exact canonical digest to demo"),
+    ],
+    {
+      env: {
+        ...process.env,
+        CRANE_LOG: craneLog,
+        DESTINATION_REPOSITORY: "ghcr.io/elizaos/eliza-demo",
+        GITHUB_OUTPUT: githubOutput,
+        MOCK_CRANE_DIGEST: sourceDigest,
+        PATH: `${binaryDirectory}:${process.env.PATH}`,
+        SOURCE_DIGEST: sourceDigest,
+        SOURCE_IMMUTABLE_TAG: "ghcr.io/elizaos/eliza:sha-abcdef0",
+        SOURCE_REPOSITORY: "ghcr.io/elizaos/eliza",
+        ...overrides,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const response = {
+    craneLog: existsSync(craneLog) ? readFileSync(craneLog, "utf8") : "",
+    exitCode: result.exitCode,
+    output: existsSync(githubOutput) ? readFileSync(githubOutput, "utf8") : "",
+    stderr: result.stderr.toString(),
+  };
+  rmSync(temporaryDirectory, { recursive: true, force: true });
+  return response;
+}
+
 describe("build-agent-image workflow", () => {
+  test("exposes only canonical and demo as closed manual publication targets", () => {
+    expect(workflowText).toContain(`  workflow_dispatch:
+    inputs:
+      publication_target:
+        description: Immutable GHCR destination for this manual build
+        required: true
+        default: canonical
+        type: choice
+        options:
+          - canonical
+          - demo`);
+    expect(workflowText).not.toMatch(
+      /publication_target:[\s\S]*?type:\s*(?:string|environment)/,
+    );
+    expect(workflowText).toContain("REGISTRY: ghcr.io");
+    expect(workflowText).toContain(
+      `IMAGE_NAME: ${githubExpression("github.repository")}`,
+    );
+    expect(workflowText).toContain(
+      "DEMO_IMAGE_REPOSITORY: ghcr.io/elizaos/eliza-demo",
+    );
+    expect(workflowText.match(/inputs\.publication_target/g)).toHaveLength(1);
+  });
+
+  test("keeps push and release publication on the canonical repository", () => {
+    for (const eventName of ["push", "release"]) {
+      const result = runPublicationResolver(eventName, "canonical");
+      expect(result.exitCode).toBe(0);
+      expect(result.output.get("name")).toBe("ghcr.io/elizaos/eliza");
+      expect(result.output.get("metadata_name")).toBe("ghcr.io/elizaOS/eliza");
+      expect(result.output.get("destination_name")).toBe(
+        "ghcr.io/elizaos/eliza",
+      );
+      expect(result.output.get("publication_target")).toBe("canonical");
+    }
+
+    expect(workflowText).toContain(
+      `type=raw,value=develop,enable=${githubExpression("github.ref == 'refs/heads/develop'")}`,
+    );
+    expect(workflowText).toContain(
+      `type=raw,value=stable,enable=${githubExpression("github.ref == 'refs/heads/main'")}`,
+    );
+    expect(workflowText).toContain(
+      `type=raw,value=latest,enable=${githubExpression("github.ref == 'refs/heads/main'")}`,
+    );
+    expect(workflowText).toContain("type=ref,event=tag");
+    expect(workflowText).toContain("type=sha,prefix=sha-,format=short");
+  });
+
+  test("allows the exact demo repository only on manual dispatch", () => {
+    const manual = runPublicationResolver("workflow_dispatch", "demo");
+    expect(manual.exitCode).toBe(0);
+    expect(manual.output.get("name")).toBe("ghcr.io/elizaos/eliza");
+    expect(manual.output.get("metadata_name")).toBe("ghcr.io/elizaOS/eliza");
+    expect(manual.output.get("destination_name")).toBe(
+      "ghcr.io/elizaos/eliza-demo",
+    );
+    expect(manual.output.get("publication_target")).toBe("demo");
+
+    for (const eventName of ["push", "release"]) {
+      const rejected = runPublicationResolver(eventName, "demo");
+      expect(rejected.exitCode).not.toBe(0);
+      expect(rejected.output.size).toBe(0);
+      expect(rejected.stderr).toContain("available only to workflow_dispatch");
+    }
+  });
+
+  test("rejects arbitrary or shell-shaped publication targets without evaluation", () => {
+    const sentinel = join(
+      tmpdir(),
+      `eliza-image-publication-sentinel-${process.pid}`,
+    );
+    rmSync(sentinel, { force: true });
+    const malicious = runPublicationResolver(
+      "workflow_dispatch",
+      `demo$(touch ${sentinel})`,
+    );
+
+    expect(malicious.exitCode).not.toBe(0);
+    expect(malicious.output.size).toBe(0);
+    expect(malicious.stderr).toContain("Unsupported publication target");
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  test("promotes the canonical verified digest into the selected demo repository", () => {
+    expect(workflowText).toContain(
+      `images: ${githubExpression("steps.image.outputs.metadata_name")}`,
+    );
+    expect(workflowText).toContain(
+      `tags: ${githubExpression("steps.image.outputs.name")}:ci-boot-verify`,
+    );
+    expect(workflowText).toContain(
+      `type=registry,ref=${githubExpression("steps.image.outputs.name")}:buildcache`,
+    );
+    expect(workflowText).toContain(
+      `org.opencontainers.image.source=${githubExpression("github.server_url")}/${githubExpression("github.repository")}`,
+    );
+
+    const pushBlock = extractStepRunBlock("Push exact verified image");
+    expect(pushBlock).toContain('"$PUBLISH_REPOSITORY":*)');
+    expect(pushBlock).toContain('"$PUBLISH_REPOSITORY"@sha256:*)');
+    expect(pushBlock).not.toContain("index .RepoDigests 0");
+    expect(pushBlock).toContain(
+      "Published image has no digest for the canonical repository",
+    );
+    expect(pushBlock).toContain(
+      'tagged_image_id="$(docker image inspect --format',
+    );
+    expect(pushBlock).toContain(
+      'if [ "$tagged_image_id" != "$verified_image_id" ]',
+    );
+    expect(pushBlock).toContain('"$PUBLISH_REPOSITORY":sha-*)');
+
+    expect(workflowText).toContain(
+      `subject-name: ${githubExpression("steps.image.outputs.name")}`,
+    );
+    expect(workflowText).toContain(
+      "uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0",
+    );
+    expect(workflowText).toContain("version: v0.20.6");
+
+    const promotionBlock = extractStepRunBlock(
+      "Promote exact canonical digest to demo",
+    );
+    expect(promotionBlock).toContain(
+      '[ "$SOURCE_REPOSITORY" != "ghcr.io/elizaos/eliza" ]',
+    );
+    expect(promotionBlock).toContain(
+      '[ "$DESTINATION_REPOSITORY" != "ghcr.io/elizaos/eliza-demo" ]',
+    );
+    expect(promotionBlock).toContain('"$SOURCE_REPOSITORY@$SOURCE_DIGEST"');
+    expect(promotionBlock).toContain('crane digest "$destination_tag"');
+    expect(promotionBlock).toContain(
+      'if [ "$destination_digest" != "$SOURCE_DIGEST" ]',
+    );
+
+    expect(workflowText).toContain(
+      `subject-name: ${githubExpression("steps.promote-demo.outputs.name")}`,
+    );
+    expect(workflowText).toContain(
+      `subject-digest: ${githubExpression("steps.promote-demo.outputs.digest")}`,
+    );
+
+    const publicProbe = extractStepRunBlock(
+      "Verify demo image is anonymously pullable",
+    );
+    expect(publicProbe).toContain(
+      "https://ghcr.io/token?scope=repository%3Aelizaos%2Feliza-demo%3Apull",
+    );
+    expect(publicProbe).toContain(
+      "https://ghcr.io/v2/elizaos/eliza-demo/manifests/$EXPECTED_DIGEST",
+    );
+    expect(publicProbe).toContain(
+      'if [ "$remote_digest" != "$EXPECTED_DIGEST" ]',
+    );
+    expect(publicProbe).toContain(
+      'if [ "$remote_image_id" != "$EXPECTED_IMAGE_ID" ]',
+    );
+
+    expect(workflowText).toContain(
+      `if: ${githubExpression("steps.image.outputs.publication_target == 'canonical'")}`,
+    );
+    expect(workflowText).toContain(
+      `https://api.github.com/user/packages/container/${githubExpression("env.IMAGE_NAME")}/visibility`,
+    );
+    expect(workflowText).not.toContain(
+      "api.github.com/orgs/elizaOS/packages/container/eliza-demo/visibility",
+    );
+    expect(workflowText).not.toContain(
+      `images: ${githubExpression("env.REGISTRY")}/${githubExpression("env.IMAGE_NAME")}`,
+    );
+  });
+
+  test("copies only an immutable canonical digest and rejects promotion drift", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    const successful = runDemoPromotion();
+    expect(successful.exitCode).toBe(0);
+    expect(successful.craneLog).toBe(
+      `ghcr.io/elizaos/eliza@${digest}\nghcr.io/elizaos/eliza-demo:sha-abcdef0\n`,
+    );
+    expect(successful.output).toContain(`digest=${digest}`);
+    expect(successful.output).toContain("name=ghcr.io/elizaos/eliza-demo");
+
+    const arbitraryDestination = runDemoPromotion({
+      DESTINATION_REPOSITORY: "ghcr.io/elizaos/not-demo",
+    });
+    expect(arbitraryDestination.exitCode).not.toBe(0);
+    expect(arbitraryDestination.craneLog).toBe("");
+    expect(arbitraryDestination.stderr).toContain("closed allowlist");
+
+    const mutableSource = runDemoPromotion({
+      SOURCE_IMMUTABLE_TAG: "ghcr.io/elizaos/eliza:develop",
+    });
+    expect(mutableSource.exitCode).not.toBe(0);
+    expect(mutableSource.craneLog).toBe("");
+    expect(mutableSource.stderr).toContain("immutable SHA tag");
+
+    const changedDigest = runDemoPromotion({
+      MOCK_CRANE_DIGEST: `sha256:${"b".repeat(64)}`,
+    });
+    expect(changedDigest.exitCode).not.toBe(0);
+    expect(changedDigest.stderr).toContain(
+      "changed the canonical manifest digest",
+    );
+  });
+
   test("uses Turbo filters for Docker workspace artifact builds", () => {
     const runBlock = extractStepRunBlock("Build Docker workspace artifacts");
 


### PR DESCRIPTION
## Problem

The exact-agent canary API correctly accepts only immutable `ghcr.io/elizaos/eliza-demo@sha256:…` targets, but the canonical agent-image workflow can publish only `ghcr.io/elizaos/eliza`. That leaves no sanctioned, attested path for the demo canary image.

## Fix

Add a closed `workflow_dispatch` choice for `canonical` or `demo`. Demo runs still build, boot-verify, and publish the canonical image first; pinned Crane then promotes that exact canonical digest into `eliza-demo`. The workflow fails closed unless source and destination manifest digests match, creates destination-bound provenance, and anonymously reads the demo manifest by digest while asserting its config ID is the boot-verified local image ID. Push/release behavior remains canonical.

Part of #16905.

## Verification

- Exact patch-id: `9dcb847d2fda6ce483499d0b3aa137f6b6d0ee79`
- Workflow-contract tests: 8/8, 88 assertions
- actionlint + shellcheck: zero findings
- YAML parse, Biome, and `git diff --check`: pass
- Two independent security/release reviews: no P0/P1
- Exact candidate build: https://github.com/elizaOS/eliza/actions/runs/30045771226

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - GitHub Actions publication workflow only; no rendered UI.

<!-- evidence-row:after-screenshots -->
N/A - GitHub Actions publication workflow only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing interaction; the exact workflow run above is the executable walkthrough.

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/actions/runs/30045771226 - exact build, boot verification, digest promotion, attestation, and anonymous-pull logs.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or runtime involved.

<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, provider, or agent decision behavior changed.

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/actions/runs/30045771226 - produces the immutable canonical and demo digest plus destination-bound attestation; run is intentionally fail-closed until all checks pass.
