### PR TITLE
test(gateway): add CLI lifecycle coverage salvaged from #16811

### DIFF
--- a/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
+++ b/packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts
@@ -10,6 +10,8 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   inspectBrokerReadiness,
+  MinimumFreeSpaceGuard,
+  parseGatewayCliArguments,
   runGatewayCli,
   writeAuditJsonl,
 } from "../src/cli.js";
@@ -51,6 +53,105 @@ function withoutApiBillingEnvironment(): NodeJS.ProcessEnv {
 }
 
 describe("gateway CLI", () => {
+  it("parses the complete lifecycle contract and derives private artifact defaults", () => {
+    expect(
+      parseGatewayCliArguments([
+        "--",
+        "--ready-file",
+        "/tmp/gateway.ready",
+        "--audit-file",
+        "/tmp/gateway.audit",
+        "--content-contract-file",
+        "/tmp/gateway.contract",
+        "--benchmark-namespace",
+        "cohort-a",
+        "--storage-root",
+        "/tmp",
+        "--minimum-free-bytes",
+        "4096",
+      ]),
+    ).toEqual({
+      readyFile: "/tmp/gateway.ready",
+      auditFile: "/tmp/gateway.audit",
+      contentContractFile: "/tmp/gateway.contract",
+      replayFile: "/tmp/gateway.audit.responses.jsonl",
+      hmacKeyFile: "/tmp/gateway.audit.responses.jsonl.hmac-key",
+      benchmarkNamespace: "cohort-a",
+      storageRoot: "/tmp",
+      minimumFreeBytes: 4096,
+    });
+  });
+
+  it.each([
+    [[], "invalid_arguments"],
+    [["--ready-file"], "invalid_arguments"],
+    [
+      ["--ready-file", "relative", "--audit-file", "/tmp/audit"],
+      "invalid_arguments",
+    ],
+    [
+      ["--ready-file", "/tmp/same", "--audit-file", "/tmp/same"],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--replay-file",
+        "/tmp/ready",
+      ],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--content-contract-file",
+        "/tmp/audit",
+      ],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--minimum-free-bytes",
+        "-1",
+      ],
+      "invalid_arguments",
+    ],
+    [
+      [
+        "--ready-file",
+        "/tmp/ready",
+        "--audit-file",
+        "/tmp/audit",
+        "--wat",
+        "x",
+      ],
+      "invalid_arguments",
+    ],
+  ])("rejects invalid lifecycle arguments %#", (argv, code) => {
+    expect(() => parseGatewayCliArguments(argv)).toThrow(
+      expect.objectContaining({ code }),
+    );
+  });
+
+  it("checks configured storage reserves without I/O when the threshold is zero", async () => {
+    await expect(
+      new MinimumFreeSpaceGuard("/missing", 0).assertReady(),
+    ).resolves.toBeUndefined();
+    await expect(
+      new MinimumFreeSpaceGuard("/tmp", Number.MAX_SAFE_INTEGER).assertReady(),
+    ).rejects.toThrow("storage reserve is below its required threshold");
+  });
+
   it("projects allowlisted redacted audit fields to private JSONL", async () => {
     const directory = await mkdtemp(join(tmpdir(), "claude-gateway-audit-"));
     const auditFile = join(directory, "cohort.jsonl");


### PR DESCRIPTION
# Relates to

Salvage from closed PR #16811 (branch `fix/develop-ci-regressions`). That PR was closed in favor of landing its clusters piecemeal (see #16810); the only branch-unique content still missing from `develop` was the gateway CLI lifecycle unit coverage added in commit `721056f3b46`. This PR ports exactly that coverage onto current `develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Scoped verification was run after sync (package `test`, `typecheck`, and
      Biome `lint:check` for `packages/benchmarks/claude-subscription-gateway`
      — the only package touched); results are pasted below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Branched directly from the latest `origin/develop` (`a2adea091dc`); zero conflicts.
- [x] Package-scoped `test` + `typecheck` + `lint:check` pass post-sync (output below).

# Risks

Low. Test-only change: one file, `packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts`, +101 lines, no production code touched. The tests are pure unit tests (no network, no model I/O, no child processes).

# Background

## What does this PR do?

Adds direct unit coverage for the gateway CLI lifecycle argument contract in `@elizaos/claude-subscription-gateway`:

- **Happy path**: `parseGatewayCliArguments` parses the complete flag set (`--ready-file`, `--audit-file`, `--content-contract-file`, `--benchmark-namespace`, `--storage-root`, `--minimum-free-bytes`) and derives the private replay/HMAC-key artifact defaults (`<audit>.responses.jsonl`, `<replay>.hmac-key`).
- **Invalid-argument matrix** (8 cases): empty argv, flag without value, relative path, ready/audit collision, replay/ready collision, content-contract/audit collision, negative `--minimum-free-bytes`, unknown flag — each rejected with a typed `invalid_arguments` `GatewayCliError`.
- **Storage-reserve boundary**: `MinimumFreeSpaceGuard` performs no I/O when the threshold is zero (proved with a nonexistent root) and rejects when the configured reserve exceeds available space.

These paths were previously exercised only indirectly through the spawned-child lifecycle tests, which cannot distinguish which validation rejected the process.

Provenance: authored on `fix/develop-ci-regressions` (#16811, commit `721056f3b46`), ported by hand onto current `develop` rather than cherry-picked. The 2-line `src/cli.ts` `FileHandle` typing that accompanied it on that branch is already present on `develop` in equivalent form (`import type { FileHandle } from "node:fs/promises"`), so no source change ships here.

## What kind of change is this?

Improvements (test coverage only; no functional change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/benchmarks/claude-subscription-gateway/tests/cli.test.ts` — the three new blocks at the top of the `gateway CLI` describe: `parses the complete lifecycle contract…`, `rejects invalid lifecycle arguments` (`it.each`, 8 cases), and `checks configured storage reserves without I/O when the threshold is zero`.

## Detailed testing steps

```bash
cd packages/benchmarks/claude-subscription-gateway
bun run test        # 9 files, 68 tests, all pass (was 58 on develop)
bun run typecheck   # clean
bun run lint:check  # clean
```

None: Automated tests are acceptable — this change is itself test coverage.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend test-only change; no UI surface affected.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend test-only change; no UI surface affected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend test-only change; no user flow to walk through.
<!-- evidence-row:backend-logs -->
- [x] [17134-gateway-cli-test-run.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17134-gateway-cli-test-run.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - backend test-only change; no frontend request/response involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior change; pure unit tests with no model I/O.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; the tests are pure in-process assertions.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; the new tests never touch a model.

## Backend + frontend logs

Frontend: N/A - no frontend involved.

Backend (test run against current `develop`):

<details>
<summary>bun run test — 9 files, 68 tests, all pass (14 in cli.test.ts, incl. the 10 new cases)</summary>

```
$ vitest run

 RUN  v4.1.5 packages/benchmarks/claude-subscription-gateway

 Test Files  9 passed (9)
      Tests  68 passed (68)

 ✓ tests/cli.test.ts > gateway CLI > parses the complete lifecycle contract and derives private artifact defaults
 ✓ tests/cli.test.ts > gateway CLI > rejects invalid lifecycle arguments 0..7 (8 cases)
 ✓ tests/cli.test.ts > gateway CLI > checks configured storage reserves without I/O when the threshold is zero
 ✓ tests/cli.test.ts > gateway CLI > projects allowlisted redacted audit fields to private JSONL
 ✓ tests/cli.test.ts > gateway CLI > publishes readiness privately, stays alive, and flushes audit after SIGTERM even when readiness was consumed
 ✓ tests/cli.test.ts > gateway CLI > rejects ambient API billing credentials before server startup or readiness
 ✓ tests/cli.test.ts > gateway CLI > reports linked account-pool readiness from broker health

$ tsc --noEmit        # clean
$ bunx @biomejs/biome check .   # Checked 25 files. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

N/A - backend test-only change; no UI surface.

### After

N/A - backend test-only change; no UI surface.

### Walkthrough video

N/A - backend test-only change; no user flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface touched.

## Known gaps / failures

None. Full package suite, typecheck, and Biome check pass against current `develop`. Repo-wide `bun run verify` was not run for this one-package test-only diff; the touched package's own `typecheck` + `lint:check` + `test` lanes (which are what CI runs for it) are green.

