### PR TITLE
fix(agent): compare residual holdings on a wallet price-coverage flip instead of re-baselining the whole total

### DIFF
--- a/packages/agent/src/runtime/wallet-balance-delta.test.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.test.ts
@@ -786,8 +786,11 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
     });
 
     // A price feed later lists the spam token at a fake-liquidity $800: that
-    // is a coverage flip on a known position — silent re-baseline, not a
-    // "wallet up 800%" notification.
+    // is a coverage flip on a known position — silent re-baseline of the
+    // flipped contribution only, not a "wallet up 800%" notification. The
+    // residual anchor is preserved: SOL's immaterial $5 drift is NOT
+    // re-anchored away, so the new baseline is anchor $100 + spam $800 =
+    // $900, not the raw $895 sample.
     sample = () => wallet("95", "800");
     h.setNow("2026-07-23T11:02:00.000Z");
     const third = await h.fire(watcher.taskId, { allowTerminalRefire: true });
@@ -805,7 +808,159 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
           WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
         ) as WalletBalanceBaseline
       ).totalUsd,
-    ).toBe(895);
+    ).toBe(900);
+  });
+
+  it("an attacker-timed price listing on a spam token cannot rebaseline away a concurrent material crash in priced holdings", async () => {
+    const wallet = (args: {
+      solValueUsd: string;
+      spamValueUsd: string;
+    }): WalletBalancesResponse => ({
+      evm: null,
+      solana: {
+        address: "So11111111111111111111111111111111111111112",
+        solBalance: "10",
+        solValueUsd: args.solValueUsd,
+        tokens: [
+          {
+            symbol: "SPAM",
+            name: "Spam Coin",
+            balance: "99999",
+            decimals: 6,
+            valueUsd: args.spamValueUsd,
+            logoUrl: "",
+            mint: "spamcoin",
+          },
+        ],
+      },
+    });
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    // Baseline: 10 SOL priced at $100 plus an already-held unpriced spam
+    // airdrop (contributes $0).
+    let sample: () => WalletBalancesResponse = () =>
+      wallet({ solValueUsd: "100", spamValueUsd: "0" });
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => sample(),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const first = await h.fire(watcher.taskId);
+    expect(first.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+
+    // Attacker-timed coverage flip: the spam token gets a dexscreener listing
+    // (fake liquidity, $500) on the SAME tick SOL crashes $100 → $20. The
+    // flip makes only the spam position incomparable — the residual priced
+    // holdings moved materially and MUST notify; a whole-total re-baseline
+    // here would let anyone with a spam token mute real crashes at will.
+    sample = () => wallet({ solValueUsd: "20", spamValueUsd: "500" });
+    h.setNow("2026-07-23T10:31:00.000Z");
+    const second = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(second.kind).toBe("fired");
+    const inbox = h.notifications.list();
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0]?.title).toBe("Wallet balance down");
+    // The comparison excludes the flipped spam position from BOTH sides:
+    // $100 residual baseline vs $20 residual current.
+    expect(inbox[0]?.data).toMatchObject({
+      previousTotalUsd: 100,
+      currentTotalUsd: 20,
+      deltaUsd: -80,
+      deltaPct: -80,
+    });
+  });
+
+  it("a flapping coverage bit on one dust position cannot permanently mute the watcher, and the flap surfaces via reportError", async () => {
+    const wallet = (args: {
+      solValueUsd: string;
+      dustValueUsd: string;
+    }): WalletBalancesResponse => ({
+      evm: null,
+      solana: {
+        address: "So11111111111111111111111111111111111111112",
+        solBalance: "10",
+        solValueUsd: args.solValueUsd,
+        tokens: [
+          {
+            symbol: "DUST",
+            name: "Dust Coin",
+            balance: "5",
+            decimals: 6,
+            valueUsd: args.dustValueUsd,
+            logoUrl: "",
+            mint: "dusty",
+          },
+        ],
+      },
+    });
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    const coverageFlapReports = () =>
+      h.reported.filter(
+        (r) =>
+          (r as { scope?: string }).scope === "WalletBalanceDelta.coverageFlap",
+      );
+    // Baseline: SOL $100 plus a dust token priced at $1.
+    let sample: () => WalletBalancesResponse = () =>
+      wallet({ solValueUsd: "100", dustValueUsd: "1" });
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => sample(),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const first = await h.fire(watcher.taskId);
+    expect(first.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+
+    // The dust token's price feed flaps priced↔unpriced on EVERY tick while
+    // SOL drifts down $3/tick. Each flap tick may re-baseline only the dust
+    // position's own contribution — the SOL drift must keep accumulating
+    // toward the thresholds instead of being re-anchored away every 30 min.
+    sample = () => wallet({ solValueUsd: "97", dustValueUsd: "0" });
+    h.setNow("2026-07-23T10:31:00.000Z");
+    const flap1 = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(flap1.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+    expect(coverageFlapReports()).toHaveLength(0);
+
+    sample = () => wallet({ solValueUsd: "94", dustValueUsd: "1" });
+    h.setNow("2026-07-23T11:02:00.000Z");
+    const flap2 = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(flap2.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+    expect(coverageFlapReports()).toHaveLength(0);
+
+    // Third silent coverage re-baseline inside the flap window: the repeated
+    // flap is a systemic price-feed problem and must surface observably
+    // (runtime.reportError → RECENT_ERRORS), not sit at debug forever.
+    sample = () => wallet({ solValueUsd: "91", dustValueUsd: "0" });
+    h.setNow("2026-07-23T11:33:00.000Z");
+    const flap3 = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(flap3.kind).toBe("fired");
+    expect(h.notifications.list()).toHaveLength(0);
+    expect(coverageFlapReports().length).toBeGreaterThan(0);
+
+    // The accumulated SOL drift ($100 → $85) is now material against the
+    // preserved anchor even though THIS tick also flips the dust bit — the
+    // watcher is not muted by the flap.
+    sample = () => wallet({ solValueUsd: "85", dustValueUsd: "1" });
+    h.setNow("2026-07-23T12:04:00.000Z");
+    const fifth = await h.fire(watcher.taskId, { allowTerminalRefire: true });
+    expect(fifth.kind).toBe("fired");
+    const inbox = h.notifications.list();
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0]?.title).toBe("Wallet balance down");
+    expect(inbox[0]?.data).toMatchObject({
+      previousTotalUsd: 100,
+      currentTotalUsd: 85,
+      deltaUsd: -15,
+      deltaPct: -15,
+    });
   });
 
   it("a legacy pre-wallet-scoped baseline row is discarded, never compared against", async () => {
@@ -840,6 +995,44 @@ describe("balance-delta watcher — real runner + real notification inbox", () =
     expect(migrated.walletKey).toBe(
       "sol:So11111111111111111111111111111111111111112",
     );
+  });
+
+  it("a coverage-bits-only baseline row (#17039 shape) is discarded, never compared against", async () => {
+    const h = await makeHarness("2026-07-23T10:00:00.000Z");
+    // Shape written before per-position values existed: coverage booleans
+    // only. Without positionValuesUsd the residual math cannot excise a
+    // flipped position, so the row must be treated as no-baseline (one
+    // designed silent re-baseline on upgrade), never compared against.
+    h.cache.set(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, {
+      walletKey: "sol:So11111111111111111111111111111111111111112",
+      totalUsd: 100,
+      sampleLegs: ["sol"],
+      positionPricing: { "sol:native": true },
+      observedAtIso: "2026-07-22T10:00:00.000Z",
+    });
+    await registerWalletBalanceDeltaProducer(h.runtime, {
+      source: async () => solanaBalances(5000),
+    });
+    const runner = h.runnerService.getRunner({ agentId: AGENT_ID });
+    const watcher = (await runner.list()).find(
+      (t) => t.idempotencyKey === WALLET_BALANCE_DELTA_TASK_IDEMPOTENCY_KEY,
+    );
+    if (!watcher) throw new Error("watcher not scheduled");
+    const outcome = await h.fire(watcher.taskId);
+    expect(outcome.kind).toBe("fired");
+    if (outcome.kind === "fired") {
+      expect(outcome.task.metadata?.lastDispatchResult).toMatchObject({
+        ok: true,
+        target: "baseline_recorded",
+      });
+    }
+    expect(h.notifications.list()).toHaveLength(0);
+    const migrated = h.cache.get(
+      WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
+    ) as WalletBalanceBaseline;
+    expect(migrated.totalUsd).toBe(5000);
+    expect(migrated.positionValuesUsd).toEqual({ "sol:native": 5000 });
+    expect(migrated.coverageFlapCount).toBe(0);
   });
 
   it("switching to a different wallet resets the baseline — never a fabricated cross-wallet delta", async () => {

--- a/packages/agent/src/runtime/wallet-balance-delta.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.ts
@@ -27,12 +27,21 @@
  * swallows provider failures into a partial map), so a dexscreener /
  * geckoterminal outage collapses totals to ~0 while unit balances are
  * unchanged. Price coverage is therefore tracked PER POSITION: a
- * priced↔unpriced flip on a position both samples hold is a sampling change,
- * not a balance move, and re-baselines silently instead of emitting a
- * "down ~100%" / "up" flap. Crucially, that guard is scoped to positions the
- * baseline knows: a NEW unpriced position (spam airdrop) contributes $0 to
- * the total, leaves the priced holdings fully comparable, and must never
- * swallow a concurrent material move by triggering a re-baseline.
+ * priced↔unpriced flip on a position both samples hold is a sampling change
+ * on THAT position only, not a balance move. The baseline records each
+ * position's USD value alongside its coverage bit so a flip excises just the
+ * flipped positions from both totals and compares the residual — re-anchoring
+ * the whole total on any flip would hand anyone who can time a price listing
+ * on a spam token (fake-liquidity dexscreener pump) a mute button for a
+ * concurrent real crash, and would let one flapping dust position re-anchor
+ * the drift accumulator every tick. When the residual holdings did not move
+ * materially, only the flipped contribution is re-baselined, and a run of
+ * consecutive flip re-baselines is escalated via `runtime.reportError` as a
+ * systemic price-feed problem instead of flapping silently at debug forever.
+ * The guard stays scoped to positions the baseline knows: a NEW unpriced
+ * position (spam airdrop) contributes $0 to the total, leaves the priced
+ * holdings fully comparable, and must never swallow a concurrent material
+ * move by triggering a re-baseline.
  *
  * The baseline is scoped to the wallet identity (the sampled addresses).
  * Importing a different wallet must never cross-compare the old wallet's
@@ -77,6 +86,13 @@ export const DEFAULT_THRESHOLD_PCT = 10;
 
 const RETRY_AFTER_MINUTES = 15;
 
+/** Consecutive silent coverage-flip re-baselines tolerated before the flap is
+ * escalated via `runtime.reportError` as a systemic price-feed problem. One
+ * flip is a routine outage/listing event and two covers the matching
+ * recovery; a third consecutive flip means a feed is oscillating and the
+ * watcher is spending every tick re-anchoring instead of watching. */
+const COVERAGE_FLAP_REPORT_THRESHOLD = 3;
+
 /** Persisted baseline: the last total we notified about (or first observed). */
 export interface WalletBalanceBaseline {
   /** Identity of the wallet the total was sampled from (sorted address
@@ -92,10 +108,22 @@ export interface WalletBalanceBaseline {
   /** Per-position price coverage: position id → whether its USD value was
    * known (units > 0 positions only). Used to detect priced↔unpriced flips on
    * positions BOTH samples hold — those collapse/restore the total without
-   * any unit moving, so they re-baseline. Positions present in only one
-   * sample are real balance events (or $0-impact unpriced arrivals) and go
-   * through the normal delta comparison. */
+   * any unit moving. Positions present in only one sample are real balance
+   * events (or $0-impact unpriced arrivals) and go through the normal delta
+   * comparison. */
   positionPricing: Record<string, boolean>;
+  /** Per-position USD value at the time this row was written — same key set
+   * as {@link positionPricing} (the validator enforces the congruence). On a
+   * coverage flip these let the comparison excise ONLY the flipped positions
+   * from both totals: the residual, consistently-priced holdings stay
+   * comparable, so a flip can never re-baseline away a concurrent material
+   * move elsewhere in the wallet. */
+  positionValuesUsd: Record<string, number>;
+  /** Consecutive coverage-flip re-baselines since the last fully comparable
+   * tick. At {@link COVERAGE_FLAP_REPORT_THRESHOLD} the flap escalates via
+   * `runtime.reportError` — a feed oscillating priced↔unpriced every tick is
+   * a systemic sampling problem, not routine composition drift. */
+  coverageFlapCount: number;
   observedAtIso: string;
 }
 
@@ -206,22 +234,22 @@ export function walletSampleLegs(balances: WalletBalancesResponse): string[] {
   return legs.sort();
 }
 
-/**
- * Per-position price coverage for every position holding nonzero units on a
- * samplable leg: position id → whether its USD value is known. Upstream
- * encodes "price unknown" as `valueUsd: "0"` with no error, so coverage —
- * not the value itself — is what distinguishes a price-feed outage from the
- * owner's balance actually going to zero. Positions on an errored chain are
- * excluded entirely (the whole leg already is).
- */
-export function walletPositionPricing(
+/** Coverage bit + USD value for one held position, captured in one pass so
+ * the two per-position maps in the baseline can never disagree. */
+interface PositionSnapshot {
+  priced: boolean;
+  valueUsd: number;
+}
+
+function walletPositionSnapshots(
   balances: WalletBalancesResponse,
-): Record<string, boolean> {
-  const pricing: Record<string, boolean> = {};
+): Record<string, PositionSnapshot> {
+  const positions: Record<string, PositionSnapshot> = {};
   const mark = (positionId: string, units: string, valueUsd: string): void => {
     const amount = Number.parseFloat(units);
     if (Number.isFinite(amount) && amount > 0) {
-      pricing[positionId] = parseUsd(valueUsd) !== 0;
+      const value = parseUsd(valueUsd);
+      positions[positionId] = { priced: value !== 0, valueUsd: value };
     }
   };
   if (balances.solana) {
@@ -247,7 +275,43 @@ export function walletPositionPricing(
       }
     }
   }
-  return pricing;
+  return positions;
+}
+
+/**
+ * Per-position price coverage for every position holding nonzero units on a
+ * samplable leg: position id → whether its USD value is known. Upstream
+ * encodes "price unknown" as `valueUsd: "0"` with no error, so coverage —
+ * not the value itself — is what distinguishes a price-feed outage from the
+ * owner's balance actually going to zero. Positions on an errored chain are
+ * excluded entirely (the whole leg already is).
+ */
+export function walletPositionPricing(
+  balances: WalletBalancesResponse,
+): Record<string, boolean> {
+  return Object.fromEntries(
+    Object.entries(walletPositionSnapshots(balances)).map(([id, snapshot]) => [
+      id,
+      snapshot.priced,
+    ]),
+  );
+}
+
+/**
+ * Per-position USD value for the same position set as
+ * {@link walletPositionPricing} (an unpriced position reads $0 — its real
+ * contribution to the sampled total). Persisted in the baseline so a
+ * coverage flip can subtract exactly the flipped positions from both totals.
+ */
+export function walletPositionValues(
+  balances: WalletBalancesResponse,
+): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(walletPositionSnapshots(balances)).map(([id, snapshot]) => [
+      id,
+      snapshot.valueUsd,
+    ]),
+  );
 }
 
 /**
@@ -334,11 +398,24 @@ function getNotifier(runtime: AgentRuntime): NotifierLike | null {
   return null;
 }
 
+function sameKeySet(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length && aKeys.every((key) => key in b)
+  );
+}
+
 /**
- * Strict shape check doubles as schema migration: rows written by the
- * pre-wallet-scoped format (no `walletKey`/`positionPricing`) fail it and are
- * treated as no-baseline — one designed silent re-baseline on upgrade, never
- * a comparison against a row whose wallet identity is unknown.
+ * Strict shape check doubles as schema migration: rows written by earlier
+ * formats — pre-wallet-scoped (no `walletKey`/`positionPricing`, #16943) and
+ * coverage-bits-only (no `positionValuesUsd`/`coverageFlapCount`, #17039) —
+ * fail it and are treated as no-baseline: one designed silent re-baseline on
+ * upgrade, never a comparison against a row missing the fields the residual
+ * math needs. The pricing/value key-set congruence check makes the flipped
+ * lookups in the dispatcher total.
  */
 function isBaseline(value: unknown): value is WalletBalanceBaseline {
   return (
@@ -352,6 +429,14 @@ function isBaseline(value: unknown): value is WalletBalanceBaseline {
     Object.values(value.positionPricing).every(
       (priced) => typeof priced === "boolean",
     ) &&
+    isRecord(value.positionValuesUsd) &&
+    Object.values(value.positionValuesUsd).every(
+      (usd) => typeof usd === "number" && Number.isFinite(usd),
+    ) &&
+    sameKeySet(value.positionPricing, value.positionValuesUsd) &&
+    typeof value.coverageFlapCount === "number" &&
+    Number.isInteger(value.coverageFlapCount) &&
+    value.coverageFlapCount >= 0 &&
     typeof value.observedAtIso === "string"
   );
 }
@@ -430,6 +515,7 @@ export function createWalletBalanceDeltaDispatcher(
     const walletKey = walletIdentityKey(balances);
     const sampleLegs = walletSampleLegs(balances);
     const positionPricing = walletPositionPricing(balances);
+    const positionValuesUsd = walletPositionValues(balances);
     const nowIso = new Date().toISOString();
     const stored = await runtime.getCache<WalletBalanceBaseline>(
       WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY,
@@ -442,6 +528,8 @@ export function createWalletBalanceDeltaDispatcher(
         totalUsd,
         sampleLegs,
         positionPricing,
+        positionValuesUsd,
+        coverageFlapCount: 0,
         observedAtIso: nowIso,
       };
       await runtime.setCache(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, next);
@@ -471,12 +559,11 @@ export function createWalletBalanceDeltaDispatcher(
       return { ok: true, target: "rebaselined_wallet_changed" };
     }
 
-    const rebaseline = async (
-      target: "rebaselined_leg_change" | "rebaselined_price_coverage_change",
-      changed: Record<string, unknown>,
-    ): Promise<DispatchResult> => {
-      // WHAT we can sample changed, not what the owner holds — notifying
-      // would fabricate a delta the units never made.
+    if (baseline.sampleLegs.join("|") !== sampleLegs.join("|")) {
+      // Leg composition moved: chain errored/recovered, RPC readiness
+      // flipped, a leg was added/removed. WHAT we can sample changed, not
+      // what the owner holds — notifying would fabricate a delta the units
+      // never made.
       await persistBaseline();
       logger.debug(
         {
@@ -485,50 +572,110 @@ export function createWalletBalanceDeltaDispatcher(
           taskId: record.taskId,
           previousTotalUsd: baseline.totalUsd,
           currentTotalUsd: totalUsd,
-          ...changed,
+          previousLegs: baseline.sampleLegs,
+          currentLegs: sampleLegs,
         },
-        `[WalletBalanceDelta] sample composition changed — ${target}`,
+        "[WalletBalanceDelta] sample composition changed — rebaselined_leg_change",
       );
-      return { ok: true, target };
-    };
-
-    if (baseline.sampleLegs.join("|") !== sampleLegs.join("|")) {
-      // Leg composition moved: chain errored/recovered, RPC readiness
-      // flipped, a leg was added/removed.
-      return rebaseline("rebaselined_leg_change", {
-        previousLegs: baseline.sampleLegs,
-        currentLegs: sampleLegs,
-      });
+      return { ok: true, target: "rebaselined_leg_change" };
     }
 
+    // A known position's USD value became unknown or recovered (the
+    // price-feed-outage flap): its collapse/restoration is baked into the
+    // total without any unit moving. Only the FLIPPED positions are
+    // incomparable, so excise exactly those from both totals and compare the
+    // residual — a whole-total re-baseline here would let an attacker-timed
+    // price listing on a spam token mute a concurrent real crash, and would
+    // let one flapping dust position re-anchor the drift accumulator every
+    // tick. Flips fire ONLY on positions both samples hold — a brand-new
+    // unpriced position (spam airdrop) adds $0 and stays in the comparison.
     const coverageFlips = pricedCoverageFlips(
       baseline.positionPricing,
       positionPricing,
     );
-    if (coverageFlips.length > 0) {
-      // A known position's USD value became unknown or recovered (the
-      // price-feed-outage flap): its collapse/restoration is baked into the
-      // total without any unit moving. Note this fires ONLY on positions both
-      // samples hold — a brand-new unpriced position (spam airdrop) adds $0
-      // and falls through to the normal comparison below, so it can never
-      // swallow a concurrent material move in priced holdings.
-      return rebaseline("rebaselined_price_coverage_change", {
-        coverageFlips,
-      });
-    }
+    const flippedValueSum = (values: Record<string, number>): number => {
+      let sum = 0;
+      for (const positionId of coverageFlips) {
+        const value = values[positionId];
+        if (value === undefined) {
+          // isBaseline enforces pricing/value key congruence and the current
+          // maps come from one snapshot pass — a miss is a programming error,
+          // and the runner's dispatch boundary translates the throw.
+          throw new Error(
+            `[WalletBalanceDelta] no USD value recorded for flipped position ${positionId}`,
+          );
+        }
+        sum += value;
+      }
+      return sum;
+    };
+    const baselineCompareUsd =
+      baseline.totalUsd - flippedValueSum(baseline.positionValuesUsd);
+    const currentCompareUsd = totalUsd - flippedValueSum(positionValuesUsd);
 
     const thresholds = resolveThresholds(record.metadata);
     const { material, deltaUsd, deltaPct } = evaluateWalletBalanceDelta({
-      baselineUsd: baseline.totalUsd,
-      currentUsd: totalUsd,
+      baselineUsd: baselineCompareUsd,
+      currentUsd: currentCompareUsd,
       thresholds,
     });
+
+    if (!material && coverageFlips.length > 0) {
+      // The residual holdings did not move materially: this tick is only a
+      // coverage flip. Re-baseline the flipped contribution alone — the
+      // residual anchor carries over so slow drift on consistently-priced
+      // positions keeps accumulating toward the thresholds.
+      const coverageFlapCount = baseline.coverageFlapCount + 1;
+      const next: WalletBalanceBaseline = {
+        walletKey,
+        totalUsd: baselineCompareUsd + flippedValueSum(positionValuesUsd),
+        sampleLegs,
+        positionPricing,
+        positionValuesUsd,
+        coverageFlapCount,
+        observedAtIso: nowIso,
+      };
+      await runtime.setCache(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, next);
+      if (coverageFlapCount >= COVERAGE_FLAP_REPORT_THRESHOLD) {
+        // A feed oscillating priced↔unpriced tick after tick is a systemic
+        // sampling problem the owner/agent must see (RECENT_ERRORS), not a
+        // silent debug-level re-anchor loop.
+        runtime.reportError(
+          "WalletBalanceDelta.coverageFlap",
+          new Error(
+            `price coverage flapped ${coverageFlapCount} consecutive ticks on: ${coverageFlips.join(", ")}`,
+          ),
+          {
+            taskId: record.taskId,
+            coverageFlips,
+            coverageFlapCount,
+          },
+        );
+      } else {
+        logger.debug(
+          {
+            src: "wallet-balance-delta",
+            agentId: runtime.agentId,
+            taskId: record.taskId,
+            previousTotalUsd: baseline.totalUsd,
+            currentTotalUsd: totalUsd,
+            coverageFlips,
+            coverageFlapCount,
+          },
+          "[WalletBalanceDelta] price coverage changed — rebaselined_price_coverage_change",
+        );
+      }
+      return { ok: true, target: "rebaselined_price_coverage_change" };
+    }
+
     if (!material) {
       // The anchor total stays put (slow drift must accumulate to material),
-      // but the coverage map absorbs positions that appeared/disappeared
-      // since the baseline: a spam token that arrives unpriced and is later
-      // listed by a price feed (fake-liquidity pump) then reads as a coverage
-      // flip on a known position — a silent re-baseline, not a "+4000%" flap.
+      // but the coverage/value maps absorb positions that appeared or
+      // disappeared since the baseline: a spam token that arrives unpriced
+      // and is later listed by a price feed (fake-liquidity pump) then reads
+      // as a coverage flip on a known position — a silent partial
+      // re-baseline, not a "+4000%" flap. A fully comparable tick also ends
+      // any flap window.
       const pricingChanged =
         JSON.stringify(
           Object.entries(baseline.positionPricing).sort(([a], [b]) =>
@@ -540,10 +687,12 @@ export function createWalletBalanceDeltaDispatcher(
             a.localeCompare(b),
           ),
         );
-      if (pricingChanged) {
+      if (pricingChanged || baseline.coverageFlapCount > 0) {
         await runtime.setCache(WALLET_BALANCE_DELTA_BASELINE_CACHE_KEY, {
           ...baseline,
           positionPricing,
+          positionValuesUsd,
+          coverageFlapCount: 0,
         } satisfies WalletBalanceBaseline);
       }
       return { ok: true, target: "below_threshold" };
@@ -571,7 +720,7 @@ export function createWalletBalanceDeltaDispatcher(
         // Percent-only body: lock-screen-safe on shared devices; dollar
         // figures live in `data` for in-app consumers.
         body:
-          baseline.totalUsd > 0
+          baselineCompareUsd > 0
             ? `Your total balance moved ${direction} about ${pctLabel} since the last check. Open the wallet for details.`
             : `Your wallet just received funds. Open the wallet for details.`,
         category: "general",
@@ -579,9 +728,12 @@ export function createWalletBalanceDeltaDispatcher(
         source: "wallet",
         deepLink: "/wallet",
         groupKey: WALLET_BALANCE_DELTA_GROUP_KEY,
+        // On a flip tick these are the RESIDUAL totals (flipped positions
+        // excised from both sides) — the numbers the materiality decision was
+        // actually made on, so deltaUsd/deltaPct stay internally consistent.
         data: {
-          previousTotalUsd: baseline.totalUsd,
-          currentTotalUsd: totalUsd,
+          previousTotalUsd: baselineCompareUsd,
+          currentTotalUsd: currentCompareUsd,
           deltaUsd,
           deltaPct,
           observedAtIso: nowIso,
@@ -612,8 +764,9 @@ export function createWalletBalanceDeltaDispatcher(
         src: "wallet-balance-delta",
         agentId: runtime.agentId,
         taskId: record.taskId,
-        previousTotalUsd: baseline.totalUsd,
-        currentTotalUsd: totalUsd,
+        previousTotalUsd: baselineCompareUsd,
+        currentTotalUsd: currentCompareUsd,
+        coverageFlips,
         deltaUsd,
         deltaPct,
       },


### PR DESCRIPTION
# Relates to

Follow-up hardening of the merged wallet balance-delta watcher fix #17039 (producer introduced in #16943). Confirmed P1 from the post-merge adversarial review of #17039: the coverage-flip guard re-baselines the ENTIRE total on any priced↔unpriced flip of a both-held position, with no materiality bound, because the baseline stores only coverage booleans.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`88df752407d`); zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low–medium. Scope is one file (`packages/agent/src/runtime/wallet-balance-delta.ts`) plus its test suite. The baseline cache row gains two required fields (`positionValuesUsd`, `coverageFlapCount`); rows written by the older shapes (#16943 and #17039) fail the strict validator and are discarded — one designed silent re-baseline on upgrade, exactly the migration rule #17039 established. Notification `data.previousTotalUsd`/`currentTotalUsd` on a flip tick now carry the residual totals the materiality decision was made on (internally consistent with `deltaUsd`/`deltaPct`).

# Background

## What does this PR do?

Fixes two confirmed failure modes in the merged #17039 coverage-flip re-baseline path:

- **Failure A (attacker-timed mute).** A dexscreener price listing appearing on a spam token (fake liquidity) on the SAME tick as a real crash in priced holdings read as a coverage flip and re-baselined the whole total — the crash notification was swallowed, falsifying the #17039 PR-body invariant that a spam airdrop can never mute a concurrent material move.
- **Failure B (permanent mute via flap).** A coverage bit flapping priced↔unpriced on one dust position re-baselined the whole total EVERY tick, so slow material drift on the honestly-priced holdings never accumulated — the watcher was permanently muted, with no signal above debug.

The fix records per-position USD values in the baseline alongside the coverage bits (same key set, validator-enforced congruence). On a flip, the comparison excises ONLY the flipped positions from both totals:

- a material move in the residual (consistently-priced) holdings still notifies;
- an immaterial residual re-baselines just the flipped contribution, so the anchor keeps accumulating drift;
- three consecutive silent flip re-baselines escalate via `runtime.reportError("WalletBalanceDelta.coverageFlap", …)` → `RECENT_ERRORS`, so a flapping feed is a visible systemic problem instead of a silent debug loop.

## What kind of change is this?

Bug fix (non-breaking; cache-row schema migrates by designed discard).

# Documentation changes needed?

My changes do not require a change to the project documentation. The module header prose documents the new residual-comparison and flap-escalation invariants.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/wallet-balance-delta.test.ts` — the two new regression tests (drafted to fail on pre-fix develop, red log attached below):

- "an attacker-timed price listing on a spam token cannot rebaseline away a concurrent material crash in priced holdings"
- "a flapping coverage bit on one dust position cannot permanently mute the watcher, and the flap surfaces via reportError"

plus "a coverage-bits-only baseline row (#17039 shape) is discarded, never compared against" for the schema migration. All 15 tests run the REAL `ScheduledTaskRunnerService` + REAL `NotificationService` (only the network balance source is injected), same harness as the existing 12-test suite.

## Detailed testing steps

```bash
cd packages/agent
../../node_modules/.bin/vitest run src/runtime/wallet-balance-delta.test.ts
```

Red-first proof: on pre-fix develop (`288907e4aed`) the two new tests fail exactly at the muted-notification and missing-reportError assertions — [red run (2 failed / 12 passed)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17137-red-run.log). With the fix: [green run (15/15 passed)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17137-green-run.log). `tsc --noEmit` and `biome check` clean for the package; root `bun run verify` run post-sync — [verify log (578/578 tasks, exit 0)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17137-verify.log).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend-only change to a headless scheduled-task producer in packages/agent; no UI surface is touched or reachable from this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend-only change to a headless scheduled-task producer in packages/agent; no UI surface is touched or reachable from this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-driveable flow; the watcher fires on a 30-minute scheduler tick. The complete real-service flow (runner fire → dispatcher → notification inbox / reportError) is captured in the backend logs and domain artifacts below.`
<!-- evidence-row:backend-logs -->
- [x] [17137-backend-structured.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17137-backend-structured.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code path participates; the producer emits into NotificationService server-side.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - deterministic structural watcher on the contributed dispatch channel; promptInstructions is never rendered or routed on (per module contract), and no model/prompt/action behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] [17137-domain-artifacts-raw.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17137-domain-artifacts-raw.log)

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic structural watcher; no model call exists on this code path (the dispatch channel is deterministic and never renders promptInstructions).`

## Backend + frontend logs

Backend structured logs from driving the REAL runner + dispatcher + NotificationService through both confirmed failure scenarios (uploaded on the evidence row; decisive lines):

```
[INFO] [WalletBalanceDelta] material balance delta notified (previousTotalUsd=100, currentTotalUsd=20, coverageFlips=["sol:token:spamcoin"], deltaUsd=-80, deltaPct=-80)
[DEBUG] [WalletBalanceDelta] price coverage changed — rebaselined_price_coverage_change (previousTotalUsd=101, currentTotalUsd=97, coverageFlips=["sol:token:dusty"], coverageFlapCount=1)
[DEBUG] [WalletBalanceDelta] price coverage changed — rebaselined_price_coverage_change (previousTotalUsd=100, currentTotalUsd=95, coverageFlips=["sol:token:dusty"], coverageFlapCount=2)
REPORT_ERROR scope=WalletBalanceDelta.coverageFlap error=Error: price coverage flapped 3 consecutive ticks on: sol:token:dusty
[INFO] [WalletBalanceDelta] material balance delta notified (previousTotalUsd=100, currentTotalUsd=85, coverageFlips=["sol:token:dusty"], deltaUsd=-15, deltaPct=-15)
```

Scenario A: the spam token's $500 listing lands on the same tick SOL crashes $100→$20 — the crash still notifies (−80%), where pre-fix code silently re-baselined. Scenario B: the dust flap re-baselines only the dust contribution each tick (anchor stays $100 while SOL drifts), escalates at flap 3, and the accumulated $100→$85 drift notifies on tick 5.

Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

`N/A - backend-only scheduled-task producer; no rendered surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT involvement.`

## Known gaps / failures

- UI/video/frontend/trajectory rows are N/A for the reasons stated inline (headless backend watcher; deterministic dispatch, no model call).
- `bun run audit:error-policy-ratchet` (named in root CLAUDE.md) does not exist as a script on current develop; the change adds no catch handlers — the one new throw is fail-fast and the flap path escalates via `runtime.reportError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


