### PR TITLE
registry: re-list elizaos-plugin-yieldsignal @0.2.0 (security review addressed)

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
@@ -1,0 +1,9 @@
+{
+  "package": "elizaos-plugin-yieldsignal",
+  "repository": "github:Stakemate369/plugin-yieldsignal",
+  "kind": "plugin",
+  "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification and schema validation.",
+  "homepage": "https://yieldsignal.vercel.app",
+  "version": "0.2.0",
+  "tags": ["defi", "x402", "yield", "base", "payments"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1023,6 +1023,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-yieldsignal": {
+      "git": {
+        "repo": "Stakemate369/plugin-yieldsignal",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-yieldsignal",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification and schema validation.",
+      "homepage": "https://yieldsignal.vercel.app",
+      "topics": [
+        "defi",
+        "x402",
+        "yield",
+        "base",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-agentscoin": {
       "git": {
         "repo": "axiosdevs/plugin-agentscoin",


### PR DESCRIPTION
## Re-list `elizaos-plugin-yieldsignal` after addressing the 0.1.0 security review

Thanks for the detailed post-merge security review of 0.1.0 — every point was fair and correct. The plugin holds a spending wallet, so that scrutiny is exactly right. This re-lists the plugin at **`0.2.0`**, which addresses each finding at the code level. Point-by-point:

**1. No client-side spend limit → fixed.** `CdpX402Client` is now constructed with hard `SpendControls` (`src/security.ts#buildSpendControls`):
- `maxAmountPerPayment`: **$0.10** USDC atomic (well above the advertised $0.01/$0.05, but a server demanding $5 is rejected before signing)
- `maxCumulativeSpend`: **$2.00** over a rolling **24h** window
- `allowedNetworks`: `["eip155:8453"]` (Base only), `allowedAssets`: `[USDC]`, `allowedPayees`: `[0x5611…472a]`

A tampered or swapped 402 challenge can no longer redirect the wallet to a different amount, asset, network, or payee.

**2. Action valid for all messages → fixed.** `validate` now gates on explicit yield intent (`hasYieldIntent`) instead of returning `true` unconditionally. The wallet is never touched on unrelated messages.

**3. Advertised EIP-712 authenticity not implemented → fixed.** Responses are now verified client-side (`verifyYieldSignalSignature`): `viem.verifyTypedData` over the `X-Signal-*` headers, the embedded `contentHash` checked against `keccak256(rawBody)`, and the signer pinned to the advertised payee. An unsigned or tampered response is **rejected**, not returned.

**4. No bounded I/O → fixed.** The paid fetch runs under an `AbortController` with a default 15s timeout.

**5. Tests only mock the path / no LICENSE → addressed.** Added `LICENSE` (MIT) and 13 adversarial unit tests (`src/security.test.ts`) that use real `viem` signatures to cover: signer-mismatch rejection, tampered-body (contentHash) rejection, bad-signature rejection, malformed-payload rejection, schema rejection of malformed/wrong-asset bodies, the spend-policy values, and the intent gate. Response validation is now a real runtime schema check, not a cast.

Also declared `@x402/core`, `@x402/evm` and `viem` as explicit dependencies (the client genuinely needs them at runtime).

**On real end-to-end payment evidence:** the service is live with real 402 challenges, and the receiving address (`0x5611…472a`) has prior real settlements on Base mainnet. I'm happy to provide a real paid-call transcript (including adversarial/over-priced 402 responses being rejected by the spend controls) for manual review — just say the word and I'll attach it.

- npm: https://www.npmjs.com/package/elizaos-plugin-yieldsignal (`0.2.0`)
- repo: https://github.com/Stakemate369/plugin-yieldsignal
- diff since review: hardening commit `1161ff2`

Only `packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json` and the regenerated `generated-registry.json` are changed. Follow-up to #17097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
