### PR TITLE
feat(ui): make orange clouds the default background on all surfaces

### DIFF
--- a/packages/ui/src/state/background-catalog.test.ts
+++ b/packages/ui/src/state/background-catalog.test.ts
@@ -84,19 +84,24 @@ describe("background catalog (#13538)", () => {
     }
   });
 
-  it("the boot default is the Canopy jungle wallpaper over the black base", () => {
-    // The app boots to the Canopy photo wallpaper (misty jungle river valley).
-    // The base color stays black so the host-chrome FOUC/manifest baseline is
-    // unchanged and the black→image settle is invisible at boot.
+  it("the boot default is the Ember Night sunset-clouds wallpaper over the black base", () => {
+    // The app boots to the Ember Night photo wallpaper (warm orange sunset in
+    // the clouds) on EVERY surface. The base color stays black so the
+    // host-chrome FOUC/manifest baseline is unchanged and the black→image
+    // settle is invisible at boot.
     expect(DEFAULT_BACKGROUND_CONFIG.mode).toBe("image");
     expect(DEFAULT_BACKGROUND_CONFIG.color).toBe("#000000");
-    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe("/wallpapers/canopy.webp");
-    // The Ember Night gallery tile still resolves to the served sunset asset.
+    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe("/bg-sunset.webp");
+    // The boot default and the catalog's declared default id agree: the Ember
+    // Night gallery tile resolves to the same served sunset asset the app
+    // opens on, so the divergence between the boot config and the catalog
+    // default is closed.
     const def = BACKGROUND_CATALOG.find(
       (e) => e.id === DEFAULT_BACKGROUND_CATALOG_ID,
     );
     expect(def?.kind).toBe("image");
     expect(def?.source).toBe("/bg-sunset.webp");
+    expect(def?.source).toBe(DEFAULT_BACKGROUND_CONFIG.imageUrl);
   });
 
   it("resolveCatalogEntry matches by id, label, and fuzzy name", () => {

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_BACKGROUND_CONFIG,
 } from "./ui-preferences";
 
-// The boot default is the Canopy jungle wallpaper, returned for
+// The boot default is the Ember Night sunset-clouds wallpaper, returned for
 // empty/absent/unusable-record input.
 const DEFAULT = DEFAULT_BACKGROUND_CONFIG;
 // A present-but-malformed config still collapses to the plain shader field (a
@@ -153,17 +153,17 @@ describe("background config persistence", () => {
   });
 });
 
-describe("boot-default migration (black shader → Canopy, one-shot)", () => {
-  it("rewrites a persisted old-default black shader to the Canopy default once", () => {
-    // The previous boot default was eagerly persisted on first boot, so an
-    // install that never chose a background stores exactly this shape.
+describe("boot-default migration (prior defaults → Ember Night sunset, one-shot)", () => {
+  it("rewrites a persisted old-default black shader to the sunset default once", () => {
+    // The v1 boot default was eagerly persisted on first boot, so an install
+    // that never chose a background stores exactly this shape.
     localStorage.setItem(
       "eliza:ui-background",
       JSON.stringify({ mode: "shader", color: DEFAULT_BACKGROUND_COLOR }),
     );
     expect(loadBackgroundConfig()).toEqual(DEFAULT);
-    // The migration is one-shot: a deliberate return to the black shader
-    // afterwards sticks on every future load.
+    // One-shot: a deliberate return to the black shader afterwards sticks on
+    // every future load.
     saveBackgroundConfig({ mode: "shader", color: DEFAULT_BACKGROUND_COLOR });
     expect(loadBackgroundConfig()).toEqual({
       mode: "shader",
@@ -171,7 +171,33 @@ describe("boot-default migration (black shader → Canopy, one-shot)", () => {
     });
   });
 
-  it("never touches an explicit non-default background", () => {
+  it("rewrites a persisted old-default Canopy (green) wallpaper to the sunset default once", () => {
+    // The v2 boot default (Canopy green) was likewise eagerly persisted for
+    // installs that never chose, so "never chose" reads as exactly this shape.
+    localStorage.setItem(
+      "eliza:ui-background",
+      JSON.stringify({
+        mode: "image",
+        color: DEFAULT_BACKGROUND_COLOR,
+        imageUrl: "/wallpapers/canopy.webp",
+      }),
+    );
+    expect(loadBackgroundConfig()).toEqual(DEFAULT);
+    expect(DEFAULT.imageUrl).toBe("/bg-sunset.webp");
+    // One-shot: a deliberate re-pick of Canopy afterwards sticks forever.
+    saveBackgroundConfig({
+      mode: "image",
+      color: DEFAULT_BACKGROUND_COLOR,
+      imageUrl: "/wallpapers/canopy.webp",
+    });
+    expect(loadBackgroundConfig()).toEqual({
+      mode: "image",
+      color: DEFAULT_BACKGROUND_COLOR,
+      imageUrl: "/wallpapers/canopy.webp",
+    });
+  });
+
+  it("never touches an explicit non-default background (deliberate picks are respected)", () => {
     localStorage.setItem(
       "eliza:ui-background",
       JSON.stringify({ mode: "shader", color: "#059669" }),
@@ -179,6 +205,22 @@ describe("boot-default migration (black shader → Canopy, one-shot)", () => {
     expect(loadBackgroundConfig()).toEqual({
       mode: "shader",
       color: "#059669",
+    });
+  });
+
+  it("never touches an explicit non-default wallpaper (e.g. Reef)", () => {
+    localStorage.setItem(
+      "eliza:ui-background",
+      JSON.stringify({
+        mode: "image",
+        color: DEFAULT_BACKGROUND_COLOR,
+        imageUrl: "/wallpapers/reef.webp",
+      }),
+    );
+    expect(loadBackgroundConfig()).toEqual({
+      mode: "image",
+      color: DEFAULT_BACKGROUND_COLOR,
+      imageUrl: "/wallpapers/reef.webp",
     });
   });
 

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -227,14 +227,39 @@ export function normalizeBackgroundConfig(value: unknown): BackgroundConfig {
   return { mode: "shader", color };
 }
 
-// One-shot boot-default migration flag. The boot default changed from the
-// black ember shader to the Canopy wallpaper, but the previous default was
-// eagerly persisted on first boot — "never chose a background" is stored as
-// exactly {mode:"shader", color:#000000} and is indistinguishable from a
-// deliberate pick of the plain black field. The migration rewrites that one
-// shape to the new default a single time; the flag guarantees a user who
-// deliberately returns to the black shader AFTERWARDS keeps it forever.
-const UI_BACKGROUND_DEFAULT_MIGRATION_KEY = "eliza:ui-background-default-v2";
+// One-shot boot-default migration flag. The boot default has moved twice:
+//   v2: black ember shader → Canopy (green) wallpaper.
+//   v3: Canopy (green) → Ember Night sunset-clouds (orange) wallpaper — the
+//       orange sunset every fresh surface now opens on.
+// The previous default was eagerly persisted on first boot, so "never chose a
+// background" is stored as exactly the-previous-default shape and is
+// indistinguishable from a deliberate pick of that same background. Each
+// migration rewrites ONLY the specific previous-default shape(s) to the new
+// default, exactly once, then stamps its flag — so a user who deliberately
+// re-selects an old default AFTER the migration keeps it forever. Every other
+// (non-default) saved wallpaper is left untouched: deliberate preferences are
+// never stomped.
+const UI_BACKGROUND_DEFAULT_MIGRATION_KEY = "eliza:ui-background-default-v3";
+
+// The prior boot defaults this migration is allowed to rewrite to the current
+// default. A persisted config matching one of these shapes AND not yet migrated
+// is treated as "never chose" and flipped to {@link DEFAULT_BACKGROUND_CONFIG}.
+// Any other saved config is a deliberate pick and is preserved as-is.
+function isPriorBootDefaultConfig(config: BackgroundConfig): boolean {
+  // v1 default: the plain black ember shader field.
+  if (config.mode === "shader" && config.color === DEFAULT_BACKGROUND_COLOR) {
+    return true;
+  }
+  // v2 default: the Canopy (green) photo wallpaper over the black base.
+  if (
+    config.mode === "image" &&
+    config.color === DEFAULT_BACKGROUND_COLOR &&
+    config.imageUrl === "/wallpapers/canopy.webp"
+  ) {
+    return true;
+  }
+  return false;
+}
 
 export function loadBackgroundConfig(): BackgroundConfig {
   return tryLocalStorage(
@@ -245,16 +270,12 @@ export function loadBackgroundConfig(): BackgroundConfig {
       );
       if (!migrated) {
         // Stamp on the first load either way: a fresh install starts on the
-        // new default, so any later shader-black pick is deliberate.
+        // new default, so any later pick of an old default is deliberate.
         shellLocalStorage.setItem(UI_BACKGROUND_DEFAULT_MIGRATION_KEY, "1");
       }
       if (!raw) return { ...DEFAULT_BACKGROUND_CONFIG };
       const config = normalizeBackgroundConfig(JSON.parse(raw));
-      if (
-        !migrated &&
-        config.mode === "shader" &&
-        config.color === DEFAULT_BACKGROUND_COLOR
-      ) {
+      if (!migrated && isPriorBootDefaultConfig(config)) {
         return { ...DEFAULT_BACKGROUND_CONFIG };
       }
       return config;

--- a/packages/ui/src/state/ui-preferences.ts
+++ b/packages/ui/src/state/ui-preferences.ts
@@ -85,8 +85,8 @@ export const DEFAULT_BACKGROUND_GLOW = "#ff6a1f";
 /**
  * The shader-mode config for the black ember field: the fallback when an
  * image background is cleared or fails to load, and the base the color
- * swatches and the glsl fallback resolve to. (The boot default is the Canopy
- * wallpaper — see {@link DEFAULT_BACKGROUND_CONFIG}.)
+ * swatches and the glsl fallback resolve to. (The boot default is the Ember
+ * Night sunset-clouds wallpaper — see {@link DEFAULT_BACKGROUND_CONFIG}.)
  */
 export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "shader",
@@ -96,8 +96,9 @@ export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
 /**
  * The curated "Ember Night" wallpaper: a warm sunset in the clouds, served as
  * a same-origin static asset from `packages/app/public`. It renders the
- * `ember-night` gallery tile (no longer the boot default — the app boots to
- * the Canopy wallpaper). A served, code-free, same-origin image the apply
+ * `ember-night` gallery tile AND is the boot default (see
+ * {@link DEFAULT_BACKGROUND_CONFIG}) — the orange sunset-clouds field every
+ * fresh surface opens on. A served, code-free, same-origin image the apply
  * channel already trusts (same class as the gradient data URLs and the
  * `/api/media/<hash>` uploads) — it carries no GLSL source or preset id, so the
  * confinement invariants (#11088 / #13523) hold. The bytes live in `public/`
@@ -134,20 +135,26 @@ const PHOTO_WALLPAPER_IDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The boot default background: the "Canopy" photo wallpaper — a misty jungle
- * river valley in deep, layered greens — over the black base color. The base
- * stays {@link DEFAULT_BACKGROUND_COLOR} so every piece of host chrome that
- * tracks it (launch FOUC guard, PWA theme-color, manifest, native splashes)
- * keeps its black baseline, and canopy's near-black darkest tones make the
- * black→image settle invisible at boot. If the image is cleared or fails to
- * load the shell falls back to the shader ember field
- * ({@link DEFAULT_SHADER_BACKGROUND_CONFIG}); every other curated scene stays
- * a user-selectable gallery option.
+ * The boot default background: the "Ember Night" sunset-clouds wallpaper — a
+ * warm orange sunset breaking through layered clouds ({@link
+ * SUNSET_WALLPAPER_URL}) — over the black base color. This is the single boot
+ * default for EVERY surface (desktop web, installed PWA, native shell) and
+ * every fresh session; it matches {@link SHARED_DEFAULT_BACKGROUND_CATALOG_ID}
+ * (`ember-night`) so the boot config and the catalog's declared default agree,
+ * and the default tile in the gallery is the same wallpaper the app opens on.
+ * The base stays {@link DEFAULT_BACKGROUND_COLOR} so every piece of host chrome
+ * that tracks it (launch FOUC guard, PWA theme-color, manifest, native
+ * splashes) keeps its black baseline and the black→image settle stays quiet at
+ * boot. If the image is cleared or fails to load the shell falls back to the
+ * shader ember field ({@link DEFAULT_SHADER_BACKGROUND_CONFIG}); every other
+ * curated scene (including Canopy) stays a user-selectable gallery option and
+ * any preference a user has already saved is respected — only the DEFAULT for
+ * fresh/never-chosen surfaces flips to the orange sunset clouds.
  */
 export const DEFAULT_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "image",
   color: DEFAULT_BACKGROUND_COLOR,
-  imageUrl: photoWallpaperUrl("canopy"),
+  imageUrl: SUNSET_WALLPAPER_URL,
 };
 
 /* ── Background catalog (curated + metadata) ──────────────────────────── */

--- a/packages/ui/src/state/useDisplayPreferences.background.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.background.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("useDisplayPreferences — background history + undo", () => {
-  it("starts on the boot default (Canopy wallpaper) with nothing to undo", () => {
+  it("starts on the boot default (Ember Night sunset wallpaper) with nothing to undo", () => {
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.state.backgroundConfig).toEqual(
       DEFAULT_BACKGROUND_CONFIG,


### PR DESCRIPTION
## What

Make the **orange sunset-in-the-clouds** wallpaper the default background on **every surface** (desktop web, installed PWA, native shell) and every fresh session, replacing the green Canopy default.

## Root cause of the phone/desktop divergence

There is **no** platform- or display-mode-specific default branch in the code. The divergence came from a mismatch between two "default" declarations:

| Source | Value | Renders |
| --- | --- | --- |
| `DEFAULT_BACKGROUND_CONFIG` (`packages/ui/src/state/ui-preferences.ts`) — the actual boot default | `/wallpapers/canopy.webp` | **green** (misty jungle river valley, avg RGB ≈ `(3,16,15)`) |
| `DEFAULT_BACKGROUND_CATALOG_ID` (`@elizaos/shared`) — the catalog's declared default | `ember-night` → `/bg-sunset.webp` | **orange** (warm sunset clouds, avg RGB ≈ `(149,67,53)`) |

Shadow's installed phone PWA still carried the **older ember-night/sunset default** in its `localStorage` (from before the boot default was switched to Canopy). Every fresh desktop web session and newly-provisioned surface booted to the current `DEFAULT_BACKGROUND_CONFIG` → the green Canopy. So the *same* app showed orange on the phone and green everywhere else — purely a persisted-vs-current-default skew, not a per-viewport theme.

## Fix

1. **Point `DEFAULT_BACKGROUND_CONFIG` at the sunset (orange clouds) wallpaper** (`/bg-sunset.webp`), matching `SHARED_DEFAULT_BACKGROUND_CATALOG_ID` (`ember-night`). The boot config and the catalog's declared default now agree on every surface, closing the divergence at the source.
2. **Bump the one-shot boot-default migration to `v3`.** Installs that never made a deliberate pick — persisted as *exactly* a prior default shape (plain black shader **or** the Canopy green wallpaper) — self-heal once to the orange sunset default. Any other saved wallpaper is a deliberate choice and is preserved untouched; a later deliberate re-pick of black/Canopy sticks forever.

Users keep the full gallery picker; **only the DEFAULT for fresh/never-chosen surfaces changes.** Existing deliberate preferences are respected, not stomped.

The `#000000` base color is unchanged, so the launch FOUC guard, PWA `theme-color`, manifest colors, and native splashes keep their black baseline and the black→image settle stays quiet at boot.

## Before / After

| | Before | After |
| --- | --- | --- |
| Fresh desktop web | Canopy (green) | **Ember Night sunset (orange clouds)** |
| Fresh / reset PWA | Canopy (green) | **Ember Night sunset (orange clouds)** |
| Native shell first run | Canopy (green) | **Ember Night sunset (orange clouds)** |
| Phone PWA (old persisted default) | Sunset (orange) | Sunset (orange) — now matches everyone |
| User who picked e.g. Reef/Slate/custom | preserved | preserved (unchanged) |

Pixel evidence (40×40 average of the shipped assets):
- `packages/app/public/bg-sunset.webp` → `(149,67,53)` = warm orange ✅ (the "orange clouds")
- `packages/app/public/wallpapers/canopy.webp` → `(3,16,15)` = green ✅ (the old default)

## Tests

- `background-catalog.test.ts`: boot default now asserts `imageUrl === "/bg-sunset.webp"` and that the boot config equals the catalog default entry's source (divergence guard). ✅ passing.
- `persistence.background.test.ts`: migration suite extended — black-shader → sunset, **Canopy → sunset**, and two respect-deliberate-picks cases (shader `#059669`, wallpaper Reef).
- `useDisplayPreferences.background.test.tsx`: boot-default description updated.

## Files

- `packages/ui/src/state/ui-preferences.ts`
- `packages/ui/src/state/persistence.ts`
- `packages/ui/src/state/background-catalog.test.ts`
- `packages/ui/src/state/persistence.background.test.ts`
- `packages/ui/src/state/useDisplayPreferences.background.test.tsx`

[sol-orange-clouds]
