### PR TITLE
fix(ci): pin admin-agent-image-canary Bun to canonical 1.3.14

### DIFF
--- a/.github/workflows/admin-agent-image-canary.yml
+++ b/.github/workflows/admin-agent-image-canary.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: 1.4.0
+          bun-version: "1.3.14" # pinned: repo packageManager is bun@1.4.0, an unpublished version (GH+npm 404) that makes bare setup-bun fail here; match .github/ci-bun-version.json (#15071)
 
       - name: Validate live-client and workflow contracts
         run: bun test packages/scripts/cloud/admin/agent-image-canary-live.test.ts


### PR DESCRIPTION
# Relates to

Develop post-merge CI failure on run [30053103972](https://github.com/elizaOS/eliza/actions/runs/30053103972) (commit a8aa655): `Classify changed paths`, `Plugin Tests`, `Zero-Key Deterministic E2E`, and `ci-ok` all red.

# Risks

Low. One-line CI workflow pin change; no runtime code touched.

# Background

## What does this PR do?

Pins `bun-version` in `.github/workflows/admin-agent-image-canary.yml` to the canonical `1.3.14` (`.github/ci-bun-version.json`), matching every other concrete pin in the repo.

The canary workflow (added in fc72acf107c) pinned Bun `1.4.0`, which violates the ci-bun-version contract enforced in the `Classify changed paths` job. That single failure cascaded: the plugin/zero-key matrices were skipped downstream, their check jobs report skipped-as-failure on push events, and `ci-ok` went red. Bun `1.4.0` is also unpublished (GH+npm 404), so bare `setup-bun` with that pin cannot resolve at runtime anyway — `1.3.14` is what the canary lane would need to actually run.

## What kind of change is this?

Bug fix (CI-only).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`node packages/scripts/ci-bun-version-contract.mjs` on this branch:

```
ci bun version contract passed (canonical 1.3.14; 35 concrete pin(s) in lockstep; 9 gate lane(s) pinned)
```

## Detailed testing steps

None: the contract script plus the `Classify changed paths` job on this PR exercise the change directly.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow pin change only; no UI surface affected. Before state: red run https://github.com/elizaOS/eliza/actions/runs/30053103972
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow pin change only; no UI surface affected. After state: this PR's green `Classify changed paths` job.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; CI configuration change.
<!-- evidence-row:backend-logs -->
- [x] Contract check output (the failing gate) now passes locally against this branch tree: `ci bun version contract passed (canonical 1.3.14; 35 concrete pin(s) in lockstep; 9 gate lane(s) pinned)`. Failing before-log: https://github.com/elizaOS/eliza/actions/runs/30053103972/job/89359179245
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involvement.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts; the artifact is the CI workflow file itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
