### PR TITLE
fix(ci): backport canonical Bun pin for image canary

### DIFF
--- a/.github/workflows/admin-agent-image-canary.yml
+++ b/.github/workflows/admin-agent-image-canary.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: 1.4.0
+          bun-version: "1.3.14" # pinned: repo packageManager is bun@1.4.0, an unpublished version (GH+npm 404) that makes bare setup-bun fail here; match .github/ci-bun-version.json (#15071)
 
       - name: Validate live-client and workflow contracts
         run: bun test packages/scripts/cloud/admin/agent-image-canary-live.test.ts

--- a/packages/scripts/cloud/admin/agent-image-canary-live.test.ts
+++ b/packages/scripts/cloud/admin/agent-image-canary-live.test.ts
@@ -1534,7 +1534,7 @@ describe("admin agent image canary workflow", () => {
     expect(source).toContain(
       "Recovery requires one lowercase prior request UUID.",
     );
-    expect(source).toContain("bun-version: 1.4.0");
+    expect(source).toContain('bun-version: "1.3.14"');
     expect(source).toContain("agent-image-canary-live.test.ts");
     expect(source).toContain("agent-image-canary-live.ts");
   });


### PR DESCRIPTION
# Relates to

Backport of merged develop PR #17147 plus its exact contract expectation. Failed production canary run: https://github.com/elizaOS/eliza/actions/runs/30057105612

# Risks

Low. Two semantic lines in workflow/test only; no runtime, control-plane, image, or device code changes.

# Background

The production canary stopped before mutation because `oven-sh/setup-bun` requested unpublished `bun-v1.4.0` and received HTTP 404. This pins the workflow to the repository canonical CI Bun `1.3.14` and updates the focused test assertion. Every trust, identity, mutation, evidence, and rollback gate remains byte-identical.

# Testing

- `node packages/scripts/ci-bun-version-contract.mjs` — PASS (35 pins, 9 gate lanes)
- `bun test packages/scripts/cloud/admin/agent-image-canary-live.test.ts` — 37/37 PASS, 211 assertions
- Biome on changed TypeScript — PASS
- YAML parse — PASS
- `git diff --check` — PASS
- Independent review of exact diff SHA256 `10fc662198cc07df240993b1f208d2fd4f5d8c344f8ecfe41e242624640c1719` — PASS, no P0/P1

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow-only change. Before proof is run 30057105612 Setup Bun HTTP 404; no canary mutation executed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface. After proof is the green canonical-version contract and 37 focused workflow/live-client tests.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] [Failed canary run 30057105612](https://github.com/elizaOS/eliza/actions/runs/30057105612) records `bun-v1.4.0` HTTP 404 and skipped mutation; local gates prove canonical `1.3.14`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involvement.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - workflow/test-only repair; immutable image and production agent were untouched.
