### PR TITLE
fix(cloud): preserve replacement cleanup CAS precision

### DIFF
--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -655,6 +655,160 @@ describe("admin agent image rollout on primary PGlite", () => {
     });
   });
 
+  test("replacement enrichment and cleanup preserve a PostgreSQL microsecond fence", async () => {
+    const seeded = await seedAgents(1);
+    const agentId = seeded.targets[0]!.agentId;
+    await dbWrite.insert(dockerNodes).values({
+      node_id: "node-new",
+      hostname: "node-new.internal",
+      status: "healthy",
+      enabled: true,
+      capacity: 8,
+      allocated_count: 2,
+    });
+    const provider = new DockerSandboxProvider();
+    const cleanup = spyOn(provider, "stopOnSpecificNodeForReplacement").mockResolvedValue(
+      undefined,
+    );
+    const service = new ElizaSandboxService(
+      provider as unknown as SandboxProvider,
+    ) as unknown as ElizaSandboxService & ReplacementStageService;
+    const expected = {
+      status: "running" as const,
+      environmentRevision: 0,
+      sandboxId: "sandbox-1",
+      nodeId: "node-1",
+      containerName: "agent-1",
+    };
+    const intent = replacementHandle({
+      agentId,
+      nodeId: "node-new",
+      containerName: "agent-new",
+      previousVpnNodeId: "vpn-old",
+    });
+    const created = replacementHandle({
+      agentId,
+      nodeId: "node-new",
+      containerName: "agent-new",
+      containerId: "sha256:container-new",
+      previousVpnNodeId: "vpn-old",
+    });
+    const registered = replacementHandle({
+      agentId,
+      nodeId: "node-new",
+      containerName: "agent-new",
+      containerId: "sha256:container-new",
+      vpnNodeId: "vpn-new",
+      previousVpnNodeId: "vpn-old",
+    });
+
+    await service.persistReplacementCleanupStage(
+      agentId,
+      seeded.organizationId,
+      intent,
+      expected,
+      "intent",
+    );
+    await dbWrite.execute(sql`
+      UPDATE ${agentSandboxes}
+      SET replacement_cleanup_created_at =
+        TIMESTAMPTZ '2026-07-23 12:01:00.123456+00'
+      WHERE id = ${agentId}
+    `);
+    const precision = await dbWrite.execute<{ fractional: string }>(sql`
+      SELECT to_char(replacement_cleanup_created_at, 'US') AS fractional
+      FROM ${agentSandboxes}
+      WHERE id = ${agentId}
+    `);
+    expect(precision.rows[0]?.fractional).toBe("123456");
+
+    await service.persistReplacementCleanupStage(
+      agentId,
+      seeded.organizationId,
+      created,
+      expected,
+      "created",
+    );
+    const afterCreated = await agentSandboxesRepository.findByIdAndOrg(
+      agentId,
+      seeded.organizationId,
+    );
+    expect(afterCreated).toMatchObject({
+      replacement_cleanup_container_id: "sha256:container-new",
+      replacement_cleanup_vpn_node_id: null,
+      replacement_cleanup_allocation_counted: true,
+    });
+    const createdAt = afterCreated?.replacement_cleanup_created_at;
+    expect(createdAt).toBeInstanceOf(Date);
+    const createdPrecision = await dbWrite.execute<{ fractional: string }>(sql`
+      SELECT to_char(replacement_cleanup_created_at, 'US') AS fractional
+      FROM ${agentSandboxes}
+      WHERE id = ${agentId}
+    `);
+    expect(createdPrecision.rows[0]?.fractional).toBe("123456");
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-new")))[0]
+        ?.allocated_count,
+    ).toBe(3);
+
+    await service.persistReplacementCleanupStage(
+      agentId,
+      seeded.organizationId,
+      created,
+      expected,
+      "created",
+    );
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_container_id: "sha256:container-new",
+      replacement_cleanup_vpn_node_id: null,
+      replacement_cleanup_created_at: createdAt,
+    });
+    await service.persistReplacementCleanupStage(
+      agentId,
+      seeded.organizationId,
+      registered,
+      expected,
+      "vpn",
+    );
+    await service.persistReplacementCleanupStage(
+      agentId,
+      seeded.organizationId,
+      registered,
+      expected,
+      "vpn",
+    );
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_container_id: "sha256:container-new",
+      replacement_cleanup_vpn_node_id: "vpn-new",
+      replacement_cleanup_created_at: createdAt,
+      replacement_cleanup_allocation_counted: true,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-new")))[0]
+        ?.allocated_count,
+    ).toBe(3);
+
+    await service.convergeReplacementCleanupFence(agentId, seeded.organizationId);
+    await service.convergeReplacementCleanupFence(agentId, seeded.organizationId);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: null,
+      replacement_cleanup_attempt_id: null,
+      replacement_cleanup_container_id: null,
+      replacement_cleanup_allocation_counted: null,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-new")))[0]
+        ?.allocated_count,
+    ).toBe(2);
+  });
+
   test("replacement cleanup proves absence outside the transaction and fences a changed locator", async () => {
     const seeded = await seedAgents(1);
     const agentId = seeded.targets[0]!.agentId;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -7782,7 +7782,7 @@ export class ElizaSandboxService {
             replacement_cleanup_preserved_vpn_node_id = NULL,
             replacement_cleanup_vpn_registration_started_at = NULL,
             replacement_cleanup_allocation_counted = TRUE,
-            replacement_cleanup_created_at = NOW(),
+            replacement_cleanup_created_at = date_trunc('milliseconds', NOW()),
             error_message = NULL,
             last_heartbeat_at = NOW(),
             updated_at = NOW()
@@ -7800,7 +7800,7 @@ export class ElizaSandboxService {
             AND replacement_cleanup_preserved_vpn_node_id IS NOT DISTINCT FROM ${cleanupLocator.previousVpnNodeId}
             AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${cleanupLocator.vpnRegistrationStartedAt}
             AND replacement_cleanup_allocation_counted = ${cleanupLocator.allocationCounted}
-            AND replacement_cleanup_created_at = ${cleanupLocator.createdAt}
+            AND ${this.replacementCleanupCreatedAtMatches(cleanupLocator.createdAt)}
             AND deletion_attempt_id IS NULL
             AND (
               claimed_at IS NULL
@@ -8291,7 +8291,7 @@ export class ElizaSandboxService {
             replacement_cleanup_preserved_vpn_node_id = NULL,
             replacement_cleanup_vpn_registration_started_at = NULL,
             replacement_cleanup_allocation_counted = TRUE,
-            replacement_cleanup_created_at = NOW(),
+            replacement_cleanup_created_at = date_trunc('milliseconds', NOW()),
             last_heartbeat_at = NOW(),
             updated_at = NOW()
           WHERE id = ${agentId}
@@ -8308,7 +8308,7 @@ export class ElizaSandboxService {
             AND replacement_cleanup_preserved_vpn_node_id IS NOT DISTINCT FROM ${cleanupLocator.previousVpnNodeId}
             AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${cleanupLocator.vpnRegistrationStartedAt}
             AND replacement_cleanup_allocation_counted = ${cleanupLocator.allocationCounted}
-            AND replacement_cleanup_created_at = ${cleanupLocator.createdAt}
+            AND ${this.replacementCleanupCreatedAtMatches(cleanupLocator.createdAt)}
             AND deletion_attempt_id IS NULL
             AND (
               claimed_at IS NULL
@@ -8578,6 +8578,18 @@ export class ElizaSandboxService {
     return parsed;
   }
 
+  /**
+   * PostgreSQL retains microseconds that JavaScript Date cannot round-trip.
+   * The durable placement fields fence identity; this one-millisecond window
+   * preserves the timestamp generation check without making valid CAS writes
+   * miss solely because the database carried sub-millisecond precision.
+   */
+  private replacementCleanupCreatedAtMatches(createdAt: Date) {
+    const nextMillisecond = new Date(createdAt.getTime() + 1);
+    return sql`${agentSandboxes.replacement_cleanup_created_at} >= ${createdAt}
+      AND ${agentSandboxes.replacement_cleanup_created_at} < ${nextMillisecond}`;
+  }
+
   private replacementLocatorFromHandle(
     handle: SandboxHandle,
   ): Omit<ReplacementCleanupLocator, "createdAt"> {
@@ -8767,7 +8779,7 @@ export class ElizaSandboxService {
             AND replacement_cleanup_preserved_vpn_node_id IS NOT DISTINCT FROM ${existing.previousVpnNodeId}
             AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${existing.vpnRegistrationStartedAt}
             AND replacement_cleanup_allocation_counted = ${existing.allocationCounted}
-            AND replacement_cleanup_created_at = ${existing.createdAt}
+            AND ${this.replacementCleanupCreatedAtMatches(existing.createdAt)}
           RETURNING id
         `);
         if (enriched.rows.length !== 1) {
@@ -8816,7 +8828,7 @@ export class ElizaSandboxService {
           replacement_cleanup_preserved_vpn_node_id = ${incoming.previousVpnNodeId},
           replacement_cleanup_vpn_registration_started_at = ${incoming.vpnRegistrationStartedAt},
           replacement_cleanup_allocation_counted = ${incoming.allocationCounted},
-          replacement_cleanup_created_at = NOW(),
+          replacement_cleanup_created_at = date_trunc('milliseconds', NOW()),
           updated_at = NOW()
         WHERE id = ${agentId}
           AND organization_id = ${orgId}
@@ -8873,7 +8885,7 @@ export class ElizaSandboxService {
           AND replacement_cleanup_preserved_vpn_node_id IS NOT DISTINCT FROM ${existing.previousVpnNodeId}
           AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${existing.vpnRegistrationStartedAt}
           AND replacement_cleanup_allocation_counted = ${existing.allocationCounted}
-          AND replacement_cleanup_created_at = ${existing.createdAt}
+          AND ${this.replacementCleanupCreatedAtMatches(existing.createdAt)}
         RETURNING id
       `);
       if (persisted.rows.length !== 1) {
@@ -9070,7 +9082,7 @@ export class ElizaSandboxService {
           AND replacement_cleanup_preserved_vpn_node_id IS NOT DISTINCT FROM ${locator.previousVpnNodeId}
           AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${locator.vpnRegistrationStartedAt}
           AND replacement_cleanup_allocation_counted = ${locator.allocationCounted}
-          AND replacement_cleanup_created_at = ${locator.createdAt}
+          AND ${this.replacementCleanupCreatedAtMatches(locator.createdAt)}
         RETURNING id
       `);
       if (cleared.rows.length !== 1) {


### PR DESCRIPTION
## Problem

The exact-agent image canary durably fenced its replacement before Docker/VPN work, but PostgreSQL retained microseconds in `replacement_cleanup_created_at` while the Node/Drizzle read path round-tripped that value through a millisecond-only JavaScript `Date`. Five subsequent lifecycle CAS predicates compared the truncated value with exact timestamp equality. The first created-stage enrichment therefore matched zero rows, and the reconciler could not clear the same fence.

The old serving agent remained unchanged; cutover never occurred.

## Fix

- Persist new replacement cleanup timestamps at millisecond precision.
- Compare legacy cleanup timestamps through one half-open millisecond equivalence window while retaining every durable attempt, placement, VPN, allocation, serving-generation, and lifecycle fence.
- Cover a real PostgreSQL-style `123456` microsecond timestamp through intent, Docker-created enrichment, VPN enrichment, idempotent retries, remote cleanup, and exact-once capacity release in PGlite.

Closes #17149.

## Verification

- Base: `2629c8008c1452f534b6e05068738084c860880a`
- Head: `8f7539ade2bd329690e141cd248f8eb457076b36`
- Tree: `93f01bac890056392bc56c2eccc20e3ed01d7070`
- Stable patch-id: `d79944400b34e32c64bb709a16a8d94a3fb63093`
- Binary diff SHA-256: `aa240de55303a43b0d32d14dee9c7ddad59b6bf5b5af444b555852466ae87fee`
- Real PGlite rollout lifecycle: 45/45 tests, 369 assertions
- Replacement cleanup suite: 18/18 tests, 69 assertions
- Provisioning-worker image rollout: 3/3 tests, 35 assertions
- Cloud shared typecheck: pass
- Package lint + exact-file Biome + `git diff --check`: pass
- Two independent read-only reviews bound to the exact head/diff: no P0/P1

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - backend lifecycle/CAS repair; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
N/A - backend lifecycle/CAS repair; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing interaction; the real PGlite lifecycle test is the executable walkthrough.

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/actions/runs/30060505483 - sanitized production diagnosis showing `Unresolved replacement cleanup enrichment CAS failed`. Focused test logs will be attached by CI for this exact head.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or browser runtime involved.

<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, provider, or agent decision behavior changed.

<!-- evidence-row:domain-artifacts -->
Real PGlite row proof preserves `123456` microseconds, persists exact Docker/VPN identities, retains capacity `3` across enrichment retries, clears every durable cleanup field after remote absence proof, and releases capacity exactly once back to `2`.
