### PR TITLE
fix(cloud): prevent provisioning worker heap abort

### DIFF
--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -7,10 +7,17 @@ const workflow = readFileSync(
   join(root, ".github/workflows/deploy-eliza-provisioning-worker.yml"),
   "utf8",
 );
+const provisioningService = readFileSync(
+  join(root, "packages/scripts/cloud/admin/eliza-provisioning-worker.service"),
+  "utf8",
+);
 const services = [
-  "packages/scripts/cloud/admin/eliza-provisioning-worker.service",
-  "packages/scripts/cloud/admin/eliza-agent-router.service",
-].map((path) => readFileSync(join(root, path), "utf8"));
+  provisioningService,
+  readFileSync(
+    join(root, "packages/scripts/cloud/admin/eliza-agent-router.service"),
+    "utf8",
+  ),
+];
 
 describe("provisioning worker deployment contract", () => {
   it("resolves one immutable SHA and deploys exactly that snapshot", () => {
@@ -60,5 +67,35 @@ describe("provisioning worker deployment contract", () => {
         "ExecStartPre=/opt/eliza/packages/scripts/cloud/admin/ensure-generated-keywords.sh",
       );
     }
+  });
+
+  it("keeps replacement workload memory inside the control-plane service fence", () => {
+    const oldSpaceMatches = [
+      ...provisioningService.matchAll(
+        /^Environment=NODE_OPTIONS=--max-old-space-size=(\d+)$/gm,
+      ),
+    ];
+    const memoryHighMatches = [
+      ...provisioningService.matchAll(/^MemoryHigh=(\d+)M$/gm),
+    ];
+    const memoryMaxMatches = [
+      ...provisioningService.matchAll(/^MemoryMax=(\d+)M$/gm),
+    ];
+
+    expect(oldSpaceMatches).toHaveLength(1);
+    expect(memoryHighMatches).toHaveLength(1);
+    expect(memoryMaxMatches).toHaveLength(1);
+
+    const oldSpaceMiB = Number(oldSpaceMatches[0]?.[1]);
+    const memoryHighMiB = Number(memoryHighMatches[0]?.[1]);
+    const memoryMaxMiB = Number(memoryMaxMatches[0]?.[1]);
+
+    expect(oldSpaceMiB).toBe(1536);
+    expect(memoryHighMiB).toBe(1792);
+    expect(memoryMaxMiB).toBe(2048);
+    expect(oldSpaceMiB).toBeLessThan(memoryHighMiB);
+    expect(memoryHighMiB).toBeLessThan(memoryMaxMiB);
+    expect(memoryHighMiB - oldSpaceMiB).toBeGreaterThanOrEqual(256);
+    expect(memoryMaxMiB - oldSpaceMiB).toBeGreaterThanOrEqual(512);
   });
 });

--- a/packages/scripts/cloud/admin/eliza-provisioning-worker.service
+++ b/packages/scripts/cloud/admin/eliza-provisioning-worker.service
@@ -13,15 +13,17 @@ EnvironmentFile=/opt/eliza/cloud/.env.local
 # ssh2 + dockerode are Node-only, so the daemon runs under tsx (not bun).
 # Use the installed workspace binary directly; `npx tsx` adds npm/esbuild
 # startup overhead and has hit Node worker heap limits on the deploy host.
-Environment=NODE_OPTIONS=--max-old-space-size=1024
+Environment=NODE_OPTIONS=--max-old-space-size=1536
 ExecStartPre=/opt/eliza/packages/scripts/cloud/admin/ensure-generated-keywords.sh
 ExecStart=/opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
 
 Restart=always
 RestartSec=5
 
-MemoryMax=1536M
-MemoryHigh=1024M
+# Blue/green replacement loads the provider and runtime health graph in one
+# process. Keep measured old-space demand below a hard per-service host fence.
+MemoryHigh=1792M
+MemoryMax=2048M
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
# Relates to

Closes #17154.

- [x] This PR targets `develop` and is rebased onto exact `origin/develop` `e22a951bd8f122937921a948399daa1babff9e78` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] The focused contract test and independent review below let a reviewer confirm the bounded service change without reading the implementation.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low and isolated to the provisioning-worker systemd unit. The worker may use up to 2 GiB instead of 1.5 GiB on the documented 8 GiB cpx32 control-plane host. The apps worker, router, agent images, Cloud API, database, rollback/CAS behavior, and devices are unchanged.

# Background

## What does this PR do?

Raises only the provisioning worker's V8 old-space limit from 1024 MiB to 1536 MiB and its systemd soft/hard fences to 1792/2048 MiB. The prior exact image-canary attempt aborted at about 1.15 GiB old-space with V8 exit 134 under the 1024 MiB cap. The new ladder preserves 256 MiB between old-space and soft pressure and 512 MiB between old-space and the hard cgroup limit.

The deployment contract now asserts exactly one of each directive, their exact values, and the ordering/headroom invariants.

## What kind of change is this?

Bug fix (non-breaking control-plane reliability repair).

# Documentation changes needed?

N/A - the values and rationale live with the systemd unit and its executable deployment contract; no user-facing or operator workflow changes.

# Testing

## Where should a reviewer start?

- `packages/scripts/cloud/admin/eliza-provisioning-worker.service`
- `packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts`

## Detailed testing steps

```text
bun install --frozen-lockfile                                  PASS
bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
  5 pass, 0 fail, 30 assertions                               PASS
biome check packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
                                                               PASS
git diff --check                                               PASS
bun run verify                                                 PASS
```

Independent review bound to binary diff SHA-256 `dd715d3486422b15b3eb747f2c36fb36f3a554f1762dfd4f226f6a8e43356cd0`: **PASS, no P0/P1**. Exact commit `b1470fe8cd09bdb3a872f31c44aa3a73660ad356`, tree `9747bdff9d85252002d947a6d7c65b981b9ee98b`, stable patch-id `302cf848808b5dd822662427b86fae1049e377fa`.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - this systemd-only control-plane change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this systemd-only control-plane change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-operable visual flow in this two-file service-unit change.
<!-- evidence-row:backend-logs -->
- [x] The exact failed canary journal was inspected: V8 old-space reached approximately 1154 MiB and terminated with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` / exit 134. Post-deploy evidence will verify effective limits, host headroom, stable restart count, and a distinct bounded canary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source, request, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The executable contract binds the exact service artifact to `1536 / 1792 / 2048 MiB` with strict count, ordering, and headroom assertions.

# Evidence Details

## Real LLM-call trajectory

N/A - this changes only the provisioning-worker process memory fence.

## Backend + frontend logs

Before: the exact actor-bound canary job failed before cutover after the provisioning worker exited 134; the encrypted journal showed a V8 heap-limit abort at approximately 1.15 GiB old-space. The old agent remained serving and rollback-safe.

After: deployment will be accepted only after the effective systemd properties, host memory headroom, `NRestarts`, and a new immutable-image canary are checked.

Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - systemd-only backend service configuration.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

None in source validation. Production verification necessarily follows merge because the reviewed unit must first enter the protected exact-main deployment path; that proof is fail-closed and does not relax the canary, rollback, CAS, or environment approval controls.

# Deploy Notes

Deploy the provisioning worker from the exact promoted main commit. Before dispatching a new request UUID, verify effective `NODE_OPTIONS`, `MemoryHigh`, `MemoryMax`, host `MemAvailable`, stable `NRestarts`, no pending replacement cleanup, and no in-flight lifecycle job. Do not recover or rerun the failed job, globally pin an image, write database state manually, or restart an agent ad hoc.
