### PR TITLE
fix(cloud): harden replacement cleanup recovery

### DIFF
--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -231,6 +231,10 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
   // local plaintext endpoint, so bypass the remote-TLS enforcement.
   const tls = hyperdriveUrl ? { url: hyperdriveUrl, ssl: undefined } : enforceTlsForRemote(url);
   const options: PoolConfig = { connectionString: tls.url };
+  // A remote Node daemon must fail a saturated pool checkout instead of
+  // waiting forever behind a leaked transaction while outer job timers merely
+  // abandon their awaiters.
+  options.connectionTimeoutMillis = 30_000;
   if (tls.ssl) options.ssl = tls.ssl;
   // Identify our connections in pg_stat_activity. Railway sets
   // RAILWAY_SERVICE_NAME per service, so on a shared Postgres a connection leak

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -9,7 +9,10 @@ import {
   selectPrunableBackupIds,
 } from "../../lib/services/agent-backup-diff";
 import { AGENT_MANAGED_DISCORD_KEY } from "../../lib/services/eliza-agent-config";
-import { elizaProvisionAdvisoryLockSql } from "../../lib/services/eliza-provision-lock";
+import {
+  configureElizaLifecycleTransaction,
+  elizaProvisionAdvisoryLockSql,
+} from "../../lib/services/eliza-provision-lock";
 import { mergeWarmClaimEnvironmentVars } from "../../lib/services/warm-claim-character-push";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import { getObjectText, offloadJsonField } from "../../lib/storage/object-store";
@@ -1293,6 +1296,7 @@ export class AgentSandboxesRepository {
   }): Promise<WarmClaimedAgentSandbox | null> {
     await ensureAgentSandboxSchema();
     return dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
       await tx.execute(elizaProvisionAdvisoryLockSql(params.organizationId, params.userAgentId));
       // Attribution guard (audit §C1c): NEVER claim a pool row whose node_id is
       // null/empty. createPoolContainer provisions via the same provision() path

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -6,6 +6,7 @@ import {
   isAdminCanaryImageJobData,
   isPendingAdminCanaryCutoverAudit,
 } from "../../lib/services/admin-canary-image";
+import { configureElizaLifecycleTransaction } from "../../lib/services/eliza-provision-lock";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import {
   hydrateJsonField,
@@ -617,6 +618,7 @@ export class JobsRepository {
     }
 
     return await dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtextextended('eliza:image-change-capacity:v1', 0))`,
       );

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -74,6 +74,16 @@ type ReplacementStageService = {
   ): Promise<void>;
 };
 
+type ReplacementCleanupService = {
+  retirePersistedReplacementCleanup(
+    agentId: string,
+    orgId: string,
+    expectation?: undefined,
+    onConvergedInTx?: undefined,
+    source?: "lifecycle" | "background-reconcile" | "admin-converge",
+  ): Promise<"missing" | "clean" | "deferred" | "retired">;
+};
+
 function replacementHandle(params: {
   agentId: string;
   nodeId: string;
@@ -874,6 +884,290 @@ describe("admin agent image rollout on primary PGlite", () => {
     });
     expect(
       (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-new")))[0]
+        ?.allocated_count,
+    ).toBe(2);
+  });
+
+  test("replacement cleanup sweep waits for lifecycle completion and candidate grace", async () => {
+    const seeded = await seedAgents(1);
+    const agentId = seeded.targets[0]!.agentId;
+    await dbWrite.insert(dockerNodes).values({
+      node_id: "node-candidate",
+      hostname: "node-candidate.internal",
+      status: "healthy",
+      enabled: true,
+      capacity: 8,
+      allocated_count: 3,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "agent-old",
+        replacement_cleanup_node_id: "node-candidate",
+        replacement_cleanup_container_name: "agent-old",
+        replacement_cleanup_attempt_id: null,
+        replacement_cleanup_container_id: null,
+        replacement_cleanup_vpn_node_id: "vpn-old",
+        replacement_cleanup_vpn_node_name: null,
+        replacement_cleanup_preserved_vpn_node_id: null,
+        replacement_cleanup_vpn_registration_started_at: null,
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date(),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+    const [job] = await dbWrite
+      .insert(jobs)
+      .values({
+        type: JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+        status: "pending",
+        organization_id: seeded.organizationId,
+        user_id: seeded.actorUserId,
+        agent_id: agentId,
+        data: {},
+      })
+      .returning();
+
+    const provider = new DockerSandboxProvider();
+    const cleanup = spyOn(provider, "stopOnSpecificNodeForReplacement").mockResolvedValue(
+      undefined,
+    );
+    const service = new ElizaSandboxService(provider as unknown as SandboxProvider);
+
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 0,
+      retired: 0,
+      failed: 0,
+    });
+    await dbWrite.update(jobs).set({ status: "in_progress" }).where(eq(jobs.id, job!.id));
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 0,
+      retired: 0,
+      failed: 0,
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: "agent-old",
+      replacement_cleanup_vpn_node_id: "vpn-old",
+      replacement_cleanup_allocation_counted: true,
+    });
+
+    await dbWrite.update(jobs).set({ status: "completed" }).where(eq(jobs.id, job!.id));
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 1,
+      retired: 1,
+      failed: 0,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: null,
+      replacement_cleanup_vpn_node_id: null,
+      replacement_cleanup_allocation_counted: null,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-candidate")))[0]
+        ?.allocated_count,
+    ).toBe(2);
+
+    await dbWrite
+      .update(dockerNodes)
+      .set({ allocated_count: 3 })
+      .where(eq(dockerNodes.node_id, "node-candidate"));
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "agent-candidate",
+        replacement_cleanup_node_id: "node-candidate",
+        replacement_cleanup_container_name: "agent-candidate",
+        replacement_cleanup_attempt_id: REPLACEMENT_ATTEMPT_ID,
+        replacement_cleanup_container_id: "sha256:container-candidate",
+        replacement_cleanup_vpn_node_id: "vpn-candidate",
+        replacement_cleanup_vpn_node_name: "agent-candidate-vpn",
+        replacement_cleanup_preserved_vpn_node_id: "vpn-live",
+        replacement_cleanup_vpn_registration_started_at: new Date(REPLACEMENT_STARTED_AT),
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date(),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 0,
+      retired: 0,
+      failed: 0,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: "agent-candidate",
+      replacement_cleanup_attempt_id: REPLACEMENT_ATTEMPT_ID,
+      replacement_cleanup_allocation_counted: true,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-candidate")))[0]
+        ?.allocated_count,
+    ).toBe(3);
+
+    await dbWrite.execute(sql`
+      UPDATE ${agentSandboxes}
+      SET replacement_cleanup_created_at = NOW() - INTERVAL '31 minutes'
+      WHERE id = ${agentId}
+    `);
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 1,
+      retired: 1,
+      failed: 0,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(2);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: null,
+      replacement_cleanup_attempt_id: null,
+      replacement_cleanup_allocation_counted: null,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-candidate")))[0]
+        ?.allocated_count,
+    ).toBe(2);
+
+    await dbWrite
+      .update(dockerNodes)
+      .set({ allocated_count: 3 })
+      .where(eq(dockerNodes.node_id, "node-candidate"));
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "agent-failed",
+        replacement_cleanup_node_id: "node-candidate",
+        replacement_cleanup_container_name: "agent-failed",
+        replacement_cleanup_attempt_id: REPLACEMENT_ATTEMPT_ID,
+        replacement_cleanup_container_id: "sha256:container-failed",
+        replacement_cleanup_vpn_node_id: "vpn-failed",
+        replacement_cleanup_vpn_node_name: "agent-failed-vpn",
+        replacement_cleanup_preserved_vpn_node_id: "vpn-live",
+        replacement_cleanup_vpn_registration_started_at: new Date(REPLACEMENT_STARTED_AT),
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date(),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+    await dbWrite.execute(sql`
+      UPDATE ${agentSandboxes}
+      SET replacement_cleanup_created_at = NOW() - INTERVAL '31 minutes'
+      WHERE id = ${agentId}
+    `);
+    cleanup.mockRejectedValueOnce(new Error("remote cleanup unavailable"));
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 1,
+      retired: 0,
+      failed: 1,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(3);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: "agent-failed",
+      replacement_cleanup_attempt_id: REPLACEMENT_ATTEMPT_ID,
+      replacement_cleanup_allocation_counted: true,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-candidate")))[0]
+        ?.allocated_count,
+    ).toBe(3);
+  });
+
+  test("replacement cleanup rechecks lifecycle jobs after candidate selection", async () => {
+    const seeded = await seedAgents(1);
+    const agentId = seeded.targets[0]!.agentId;
+    await dbWrite.insert(dockerNodes).values({
+      node_id: "node-race",
+      hostname: "node-race.internal",
+      status: "healthy",
+      enabled: true,
+      capacity: 8,
+      allocated_count: 3,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "agent-race-old",
+        replacement_cleanup_node_id: "node-race",
+        replacement_cleanup_container_name: "agent-race-old",
+        replacement_cleanup_attempt_id: null,
+        replacement_cleanup_container_id: null,
+        replacement_cleanup_vpn_node_id: "vpn-race-old",
+        replacement_cleanup_vpn_node_name: null,
+        replacement_cleanup_preserved_vpn_node_id: null,
+        replacement_cleanup_vpn_registration_started_at: null,
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date(),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+
+    const provider = new DockerSandboxProvider();
+    const cleanup = spyOn(provider, "stopOnSpecificNodeForReplacement").mockResolvedValue(
+      undefined,
+    );
+    const service = new ElizaSandboxService(provider as unknown as SandboxProvider);
+    const cleanupService = service as unknown as ReplacementCleanupService;
+    const retire = cleanupService.retirePersistedReplacementCleanup.bind(service);
+    let insertedJobId: string | null = null;
+    spyOn(cleanupService, "retirePersistedReplacementCleanup").mockImplementation(
+      async (...args) => {
+        if (!insertedJobId) {
+          const [job] = await dbWrite
+            .insert(jobs)
+            .values({
+              type: JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+              status: "pending",
+              organization_id: seeded.organizationId,
+              user_id: seeded.actorUserId,
+              agent_id: agentId,
+              data: {},
+            })
+            .returning({ id: jobs.id });
+          insertedJobId = job!.id;
+        }
+        return retire(...args);
+      },
+    );
+
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 1,
+      retired: 0,
+      failed: 0,
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: "agent-race-old",
+      replacement_cleanup_vpn_node_id: "vpn-race-old",
+      replacement_cleanup_allocation_counted: true,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-race")))[0]
+        ?.allocated_count,
+    ).toBe(3);
+
+    await dbWrite.update(jobs).set({ status: "completed" }).where(eq(jobs.id, insertedJobId!));
+    expect(await service.reconcileReplacementCleanupFences()).toEqual({
+      total: 1,
+      retired: 1,
+      failed: 0,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: null,
+      replacement_cleanup_vpn_node_id: null,
+      replacement_cleanup_allocation_counted: null,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.node_id, "node-race")))[0]
         ?.allocated_count,
     ).toBe(2);
   });

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
@@ -57,6 +57,8 @@ function makeTx(txIndex: number) {
       const { sql: text, params } = new PgDialect().sqlToQuery(query);
       if (text.includes("pg_advisory_xact_lock")) {
         events.push({ tx: txIndex, kind: "lock", detail: String(params[1] ?? "") });
+      } else if (text.includes("set_config")) {
+        events.push({ tx: txIndex, kind: "deadline", detail: params.join(",") });
       } else {
         events.push({ tx: txIndex, kind: "execute" });
       }
@@ -212,6 +214,7 @@ describe("tier-upgrade single-flight span (#15943)", () => {
 
     const phase1 = events.filter((event) => event.tx === 1);
     expect(phase1.map((event) => event.kind)).toEqual([
+      "deadline",
       "lock",
       "lock",
       "select-live-target",
@@ -220,8 +223,9 @@ describe("tier-upgrade single-flight span (#15943)", () => {
     // Global lock order: the ORG-WIDE agent-create lock is acquired FIRST
     // (quota atomicity against createAgent and other-source upgrades,
     // #16042 review), then the per-source tier-upgrade lock.
-    expect(phase1[0]?.detail).toBe("agent-create");
-    expect(phase1[1]?.detail).toBe(`tier-upgrade:${SRC}`);
+    expect(phase1[0]?.detail).toBe("10000ms,30000ms");
+    expect(phase1[1]?.detail).toBe("agent-create");
+    expect(phase1[2]?.detail).toBe(`tier-upgrade:${SRC}`);
 
     // The load-bearing assertion: target insert AND provision-job insert are
     // statements of the SAME transaction that took the org + tier-upgrade
@@ -230,21 +234,29 @@ describe("tier-upgrade single-flight span (#15943)", () => {
     // locks and the head of the list changes.
     const phase3 = events.filter((event) => event.tx === 2);
     expect(phase3.map((event) => event.kind)).toEqual([
+      "deadline",
       "lock",
       "lock",
       "select-live-target",
       "select-quota-count",
       "insert-target",
+      "deadline",
       "lock",
       "select-sandbox-for-enqueue",
       "select-active-job",
+      "select-active-job",
       "insert-provision-job",
     ]);
-    expect(phase3[0]?.detail).toBe("agent-create");
-    expect(phase3[1]?.detail).toBe(`tier-upgrade:${SRC}`);
+    expect(phase3[0]?.detail).toBe("10000ms,30000ms");
+    expect(phase3[1]?.detail).toBe("agent-create");
+    expect(phase3[2]?.detail).toBe(`tier-upgrade:${SRC}`);
     // The nested provision lock is keyed on the freshly minted target id
     // (org → tier-upgrade → provision; never any other order).
-    expect(phase3[5]?.detail).toBe(result.agent.id);
+    expect(phase3.filter((event) => event.kind === "lock").map((event) => event.detail)).toEqual([
+      "agent-create",
+      `tier-upgrade:${SRC}`,
+      result.agent.id,
+    ]);
 
     // Happy path: the prepared credentials were adopted, not revoked.
     expect(prepCalls).toBe(1);
@@ -268,7 +280,12 @@ describe("tier-upgrade single-flight span (#15943)", () => {
     expect(txCounter).toBe(1);
     expect(prepCalls).toBe(0);
     expect(revokeForAgent).not.toHaveBeenCalled();
-    expect(events.map((event) => event.kind)).toEqual(["lock", "lock", "select-live-target"]);
+    expect(events.map((event) => event.kind)).toEqual([
+      "deadline",
+      "lock",
+      "lock",
+      "select-live-target",
+    ]);
   });
 
   test("losing the race inside the boundary revokes the candidate credentials and adopts the winner's target", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -53,6 +53,7 @@ import { encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
 import { apiKeysService } from "./api-keys";
 import { AGENT_UPGRADED_FROM_KEY } from "./eliza-agent-config";
 import {
+  configureElizaLifecycleTransaction,
   elizaAgentCreateAdvisoryLockSql,
   elizaAgentTierUpgradeAdvisoryLockSql,
 } from "./eliza-provision-lock";
@@ -273,6 +274,7 @@ export async function createTierUpgradeTargetWithProvision(
   // Anything durable a previous winner committed is visible here, so retries
   // and post-commit racers return without preparing any state of their own.
   const preexisting = await dbWrite.transaction(async (tx) => {
+    await configureElizaLifecycleTransaction(tx);
     // Org lock FIRST (global order: org → tier-upgrade → provision): the
     // quota count is only atomic if every quota-consuming creation path —
     // createAgent, coding containers, upgrades of OTHER source agents —
@@ -322,6 +324,7 @@ export async function createTierUpgradeTargetWithProvision(
     // under the org + per-source locks. A rollback discards target and job
     // together.
     result = await dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
       // Same global lock order as phase 1: org → tier-upgrade (→ the nested
       // enqueue's provision lock). The org lock is what makes the quota
       // count→insert atomic against createAgent and other-source upgrades.

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
@@ -23,7 +23,7 @@ export async function countAllocatedWorkloadsOnNodeWithDatabase(
   database: WorkloadCountDatabase,
   nodeId: string,
 ): Promise<number> {
-  const [[containerRow], [agentRow]] = await Promise.all([
+  const [[containerRow], [agentRow], [replacementRow]] = await Promise.all([
     database
       .select({ count: sql<number>`count(*)::int` })
       .from(containers)
@@ -45,7 +45,16 @@ export async function countAllocatedWorkloadsOnNodeWithDatabase(
           )})`,
         ),
       ),
+    database
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.replacement_cleanup_node_id, nodeId),
+          eq(agentSandboxes.replacement_cleanup_allocation_counted, true),
+        ),
+      ),
   ]);
 
-  return containerRow.count + agentRow.count;
+  return containerRow.count + agentRow.count + replacementRow.count;
 }

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -70,7 +70,15 @@ describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () =
 
   test("sums container + agent counts (one row each here) into total live slots", async () => {
     const total = await countAllocatedWorkloadsOnNode("node-under-test");
-    expect(where).toHaveBeenCalledTimes(2);
-    expect(total).toBe(2);
+    expect(where).toHaveBeenCalledTimes(3);
+    expect(total).toBe(3);
+  });
+
+  test("counts a durable replacement reservation as its own live slot", async () => {
+    await countAllocatedWorkloadsOnNode("replacement-node");
+
+    const rendered = capturedWheres.map(renderParams);
+    expect(rendered.filter((params) => params.includes("replacement-node"))).toHaveLength(3);
+    expect(rendered.some((params) => params.includes("true"))).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
@@ -77,6 +77,47 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
     expect(orphans).toEqual([]);
   });
 
+  test("keeps both primary and replacement placements owned by one sandbox row", () => {
+    const rows: LiveContainerRef[] = [
+      { key: "same", status: "running", nodeId: "node-old", updatedAtMs: 1 },
+      {
+        key: "same",
+        status: "replacement_cleanup_owned",
+        nodeId: "node-new",
+        updatedAtMs: 1,
+      },
+    ];
+    const config = { ...AGENT_DIFF, nodeAware: true, nodeMoveGraceMs: 1 };
+
+    expect(
+      computeOrphanContainersToReap(
+        [{ ...container("agent-same", "old"), createdAtMs: 1 }],
+        rows,
+        config,
+        "node-old",
+        10,
+      ),
+    ).toEqual([]);
+    expect(
+      computeOrphanContainersToReap(
+        [{ ...container("agent-same", "new"), createdAtMs: 1 }],
+        rows,
+        config,
+        "node-new",
+        10,
+      ),
+    ).toEqual([]);
+    expect(
+      computeOrphanContainersToReap(
+        [{ ...container("agent-same", "ghost"), createdAtMs: 1 }],
+        rows,
+        config,
+        "node-third",
+        10,
+      ),
+    ).toEqual([{ name: "agent-same", id: "ghost", key: "same", reason: "wrong_node" }]);
+  });
+
   test("does NOT reap a row in deletion_pending (delete job owns teardown)", () => {
     const orphans = compute(
       [container("agent-deleting", "c4")],

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -91,12 +91,10 @@ export function agentIdFromContainerName(name: string): string | null {
 }
 
 /**
- * Load (key, status, nodeId, updatedAtMs) for the agent_sandboxes rows matching
- * the given agent ids, including terminal-state rows. The reconciler needs the
- * status to tell a missing row (`no_db_row`) from a terminal one
- * (`terminal_db_row`), and the node + timestamp to detect a stale twin left on
- * an old node by a re-provision (`wrong_node`, #15228). `agent_sandboxes.id` is
- * a PRIMARY KEY, so each key maps to at most one row.
+ * Load every owned placement for the agent_sandboxes rows matching the given
+ * ids. A replacement fence owns a second real container until its exact remote
+ * retirement and capacity release complete, so both primary and replacement
+ * nodes must protect that key from the orphan reaper.
  */
 async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<LiveContainerRef[]> {
   if (agentIds.length === 0) return [];
@@ -106,15 +104,32 @@ async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<Li
       status: agentSandboxes.status,
       nodeId: agentSandboxes.node_id,
       updatedAt: agentSandboxes.updated_at,
+      replacementNodeId: agentSandboxes.replacement_cleanup_node_id,
+      replacementCreatedAt: agentSandboxes.replacement_cleanup_created_at,
     })
     .from(agentSandboxes)
     .where(inArray(agentSandboxes.id, agentIds as string[]));
-  return rows.map((r) => ({
-    key: r.key,
-    status: r.status,
-    nodeId: r.nodeId ?? undefined,
-    updatedAtMs: r.updatedAt ? new Date(r.updatedAt).getTime() : undefined,
-  }));
+  return rows.flatMap((row) => {
+    const placements: LiveContainerRef[] = [
+      {
+        key: row.key,
+        status: row.status,
+        nodeId: row.nodeId ?? undefined,
+        updatedAtMs: row.updatedAt ? new Date(row.updatedAt).getTime() : undefined,
+      },
+    ];
+    if (row.replacementNodeId) {
+      placements.push({
+        key: row.key,
+        status: "replacement_cleanup_owned",
+        nodeId: row.replacementNodeId,
+        updatedAtMs: row.replacementCreatedAt
+          ? new Date(row.replacementCreatedAt).getTime()
+          : undefined,
+      });
+    }
+    return placements;
+  });
 }
 
 /**
@@ -152,7 +167,7 @@ export function reconcileOrphanContainersOnNodes(): Promise<OrphanReconcileResul
  * recreate them elsewhere — so they do NOT count as retained.
  */
 export async function countRetainedWorkloadsOnNode(nodeId: string): Promise<number> {
-  const [containerCount, agentCount] = await Promise.all([
+  const [containerCount, agentCount, replacementCount] = await Promise.all([
     countRows(
       dbRead
         .select({ count: sql<number>`count(*)::int` })
@@ -176,7 +191,13 @@ export async function countRetainedWorkloadsOnNode(nodeId: string): Promise<numb
           ),
         ),
     ),
+    countRows(
+      dbRead
+        .select({ count: sql<number>`count(*)::int` })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.replacement_cleanup_node_id, nodeId)),
+    ),
   ]);
 
-  return containerCount + agentCount;
+  return containerCount + agentCount + replacementCount;
 }

--- a/packages/cloud/shared/src/lib/services/eliza-provision-lock.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-provision-lock.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Exercises the lifecycle advisory-lock deadline against two real PostgreSQL sessions.
+ * PGlite and statement mocks cannot reproduce cross-session lock contention.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { Client } from "pg";
+import type { DbTransaction } from "../../db/client";
+import {
+  configureElizaLifecycleTransaction,
+  elizaProvisionAdvisoryLockSql,
+} from "./eliza-provision-lock";
+import {
+  acquireEphemeralPostgres,
+  type EphemeralPostgres,
+} from "./tenant-db/__tests__/ephemeral-postgres";
+
+const SKIP_REASON =
+  "[Eliza lifecycle lock deadline] SKIPPED — no real PostgreSQL available. " +
+  "Set APPS_TENANT_DB_EPHEMERAL=1 with Docker, or provide APPS_TENANT_DB_TEST_DSN.";
+
+const postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
+if (!postgres) {
+  console.warn(SKIP_REASON);
+}
+
+afterAll(async () => {
+  await postgres?.stop();
+});
+
+const realPostgres = postgres ? describe : describe.skip;
+
+function transactionExecutor(client: Client): Pick<DbTransaction, "execute"> {
+  const dialect = new PgDialect();
+  return {
+    execute: async (query: SQL) => {
+      const rendered = dialect.sqlToQuery(query);
+      const result = await client.query(rendered.sql, rendered.params);
+      return { rows: result.rows } as never;
+    },
+  };
+}
+
+realPostgres("Eliza lifecycle transaction deadlines", () => {
+  test("a contending advisory lock times out transaction-locally and the session remains reusable", async () => {
+    if (!postgres) throw new Error("real PostgreSQL was not acquired");
+    const holder = new Client({ connectionString: postgres.dsn });
+    const contender = new Client({ connectionString: postgres.dsn });
+    await Promise.all([holder.connect(), contender.connect()]);
+
+    try {
+      const baselineLockTimeout = await contender.query<{ lock_timeout: string }>(
+        "SHOW lock_timeout",
+      );
+      const baselineStatementTimeout = await contender.query<{ statement_timeout: string }>(
+        "SHOW statement_timeout",
+      );
+      await holder.query("BEGIN");
+      await contender.query("BEGIN");
+      const lock = elizaProvisionAdvisoryLockSql("deadline-org", "deadline-agent");
+      await transactionExecutor(holder).execute(lock);
+      await configureElizaLifecycleTransaction(transactionExecutor(contender));
+
+      const lockTimeout = await contender.query<{ lock_timeout: string }>("SHOW lock_timeout");
+      const statementTimeout = await contender.query<{ statement_timeout: string }>(
+        "SHOW statement_timeout",
+      );
+      expect(lockTimeout.rows[0]?.lock_timeout).toBe("10s");
+      expect(statementTimeout.rows[0]?.statement_timeout).toBe("30s");
+
+      const startedAt = Date.now();
+      await expect(transactionExecutor(contender).execute(lock)).rejects.toMatchObject({
+        code: "55P03",
+      });
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeGreaterThanOrEqual(9_000);
+      expect(elapsedMs).toBeLessThan(20_000);
+
+      await contender.query("ROLLBACK");
+      expect(
+        (await contender.query<{ lock_timeout: string }>("SHOW lock_timeout")).rows[0]
+          ?.lock_timeout,
+      ).toBe(baselineLockTimeout.rows[0]?.lock_timeout);
+      expect(
+        (await contender.query<{ statement_timeout: string }>("SHOW statement_timeout")).rows[0]
+          ?.statement_timeout,
+      ).toBe(baselineStatementTimeout.rows[0]?.statement_timeout);
+
+      await holder.query("ROLLBACK");
+      await contender.query("BEGIN");
+      await configureElizaLifecycleTransaction(transactionExecutor(contender));
+      await expect(transactionExecutor(contender).execute(lock)).resolves.toMatchObject({
+        rows: expect.any(Array),
+      });
+      await contender.query("ROLLBACK");
+    } finally {
+      await Promise.allSettled([holder.query("ROLLBACK"), contender.query("ROLLBACK")]);
+      await Promise.allSettled([holder.end(), contender.end()]);
+    }
+  }, 30_000);
+});

--- a/packages/cloud/shared/src/lib/services/eliza-provision-lock.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-provision-lock.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Pins the SQL contract for bounded Eliza lifecycle transactions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { DbTransaction } from "../../db/client";
+import { configureElizaLifecycleTransaction } from "./eliza-provision-lock";
+
+describe("configureElizaLifecycleTransaction", () => {
+  test("sets transaction-local lock and statement deadlines before advisory work", async () => {
+    const statements: SQL[] = [];
+    const tx = {
+      execute: async (query: SQL) => {
+        statements.push(query);
+        return { rows: [] } as never;
+      },
+    } as Pick<DbTransaction, "execute">;
+
+    await configureElizaLifecycleTransaction(tx);
+
+    expect(statements).toHaveLength(1);
+    const rendered = new PgDialect().sqlToQuery(statements[0]!);
+    expect(rendered.sql).toContain("set_config('lock_timeout'");
+    expect(rendered.sql).toContain("set_config('statement_timeout'");
+    expect(rendered.sql).toContain("TRUE");
+    expect(rendered.params).toEqual(["10000ms", "30000ms"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-provision-lock.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-provision-lock.ts
@@ -1,5 +1,27 @@
-// Coordinates cloud service eliza provision lock behavior behind route handlers.
+/**
+ * Coordinates bounded cloud agent lifecycle locks behind route handlers.
+ */
+
 import { sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
+
+export const ELIZA_LIFECYCLE_LOCK_TIMEOUT_MS = 10_000;
+export const ELIZA_LIFECYCLE_STATEMENT_TIMEOUT_MS = 30_000;
+
+/**
+ * Bounds every transaction that acquires an Eliza lifecycle advisory lock.
+ * PostgreSQL advisory waits otherwise outlive JavaScript promise timeouts and
+ * can retain a pooled connection after its caller has already abandoned work.
+ */
+export async function configureElizaLifecycleTransaction(
+  tx: Pick<DbTransaction, "execute">,
+): Promise<void> {
+  await tx.execute(sql`
+    SELECT
+      set_config('lock_timeout', ${`${ELIZA_LIFECYCLE_LOCK_TIMEOUT_MS}ms`}, TRUE),
+      set_config('statement_timeout', ${`${ELIZA_LIFECYCLE_STATEMENT_TIMEOUT_MS}ms`}, TRUE)
+  `);
+}
 
 /**
  * Per-agent lifecycle advisory lock shared by enqueue/delete/shutdown paths.

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -25,6 +25,7 @@ let existingRows: AgentSandbox[] = [];
 let insertedRows: NewAgentSandbox[] = [];
 let capturedSelectWhere: SQL | undefined;
 let executeCalls: number = 0;
+let deadlineParams: string[][] = [];
 // The capped (#11023) path's `select({count}).from().where()` is AWAITED at
 // `.where()` (no orderBy/for/limit), so the chain is thenable and resolves to
 // these count rows. The reuse guard instead ends in `.limit()` (returns
@@ -38,8 +39,12 @@ let lockKeys: string[] = [];
 const txExecute = mock(async (sql: SQL) => {
   executeCalls += 1;
   try {
-    const { params } = new PgDialect().sqlToQuery(sql);
-    if (params.length > 1) lockKeys.push(String(params[1] ?? ""));
+    const { sql: text, params } = new PgDialect().sqlToQuery(sql);
+    if (text.includes("pg_advisory_xact_lock")) {
+      lockKeys.push(String(params[1] ?? ""));
+    } else if (text.includes("set_config")) {
+      deadlineParams.push(params.map(String));
+    }
   } catch {
     // non-advisory-lock execute (none today) — ignore for ordering capture
   }
@@ -172,6 +177,7 @@ function resetTx(): void {
   insertedRows = [];
   capturedSelectWhere = undefined;
   executeCalls = 0;
+  deadlineParams = [];
   countRows = [{ count: 0 }];
   lockKeys = [];
   txExecute.mockClear();
@@ -201,7 +207,8 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
     });
     expect(first.idempotent).toBe(false);
     expect(insertedRows.length).toBe(1);
-    expect(executeCalls).toBe(1); // advisory lock taken
+    expect(executeCalls).toBe(2); // transaction deadline, then advisory lock
+    expect(deadlineParams).toEqual([["10000ms", "30000ms"]]);
 
     // 2nd call: the just-created row is now the org's non-terminal agent.
     existingRows = [{ ...baseRow(), id: first.agent.id, organization_id: ORG_A }];
@@ -313,7 +320,8 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
     // The count + insert ran inside the transaction that first took the org
     // advisory lock — so the check and the write are atomic (no TOCTOU).
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(executeCalls).toBe(1);
+    expect(executeCalls).toBe(2);
+    expect(deadlineParams).toEqual([["10000ms", "30000ms"]]);
     // The count scoped to this org AND to the quota-counted statuses. The
     // filter uses inArray → the status values are query PARAMS, not inline
     // literals; and the quota count is intentionally BROADER than the reuse
@@ -346,7 +354,8 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
     ).rejects.toBeInstanceOf(AgentQuotaExceededError);
 
     // The lock was taken (so the count was authoritative) but NO row was inserted.
-    expect(executeCalls).toBe(1);
+    expect(executeCalls).toBe(2);
+    expect(deadlineParams).toEqual([["10000ms", "30000ms"]]);
     expect(insertedRows.length).toBe(0);
   });
 
@@ -402,6 +411,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
     // serialize creates with DIFFERENT images against one org's quota, and the
     // strict org→image order keeps this path deadlock-free vs createAgent.
     expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v1"]);
+    expect(deadlineParams).toEqual([["10000ms", "30000ms"]]);
     // The quota count scoped to the org + quota-counted statuses ran under the
     // lock. inArray parameterizes the status values (params, not inline SQL),
     // and the count is intentionally BROADER than the reuse guard.
@@ -433,6 +443,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
     expect(insertedRows.length).toBe(0);
     // Both locks were still taken (ordering preserved) before the refusal.
     expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v6"]);
+    expect(deadlineParams).toEqual([["10000ms", "30000ms"]]);
   });
 
   test("a same-image retry at the cap still returns the existing row (idempotent) — never 429", async () => {
@@ -471,6 +482,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
     // Coding containers ALWAYS run in the transaction (per-image idempotency),
     // so both locks are taken even uncapped — but no count gates the insert.
     expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v9"]);
+    expect(deadlineParams).toEqual([["10000ms", "30000ms"]]);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -78,6 +78,7 @@ import {
   withReusedElizaCharacterOwnership,
 } from "./eliza-agent-config";
 import {
+  configureElizaLifecycleTransaction,
   elizaAgentCreateAdvisoryLockSql,
   elizaCodingContainerImageAdvisoryLockSql,
   elizaProvisionAdvisoryLockSql,
@@ -88,7 +89,7 @@ import {
   prepareManagedElizaSharedEnvironment,
 } from "./managed-eliza-config";
 import { prepareManagedElizaEnvironment } from "./managed-eliza-env";
-import { JOB_TYPES } from "./provisioning-job-types";
+import { EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES, JOB_TYPES } from "./provisioning-job-types";
 import { mergeRuntimeAgentSecretsFromEnv } from "./runtime-agent-secrets";
 import { resolveSandboxContainerLaunchConfig } from "./sandbox-container-launch-config";
 import {
@@ -518,6 +519,10 @@ const SNAPSHOT_MAX_EXPANDED_BYTES = (() => {
 })();
 const SNAPSHOT_RESTORE_TIMEOUT_MS = 120_000;
 const UPGRADE_RUNTIME_HEALTH_GATE_TIMEOUT_MS = 30_000;
+// A timed-out lifecycle awaiter does not cancel its underlying work. Keep a
+// pre-cutover replacement out of the crash-recovery sweep long enough for the
+// 15-minute cold-boot job ceiling and any bounded leaf cleanup to settle.
+const PRE_CUTOVER_REPLACEMENT_SWEEP_GRACE_MINUTES = 30;
 // Hard cap on the container+VPN teardown during agent delete. The underlying
 // docker rm (60s) and headscale deletion (15s) are each internally bounded, but
 // an EARLY hang (SSH connect / provider init) was not — and a single stuck node
@@ -1332,6 +1337,7 @@ export class ElizaSandboxService {
       // uses and refuse past the cap.
       const cap = params.maxNonTerminalAgents;
       return dbWrite.transaction(async (tx) => {
+        await configureElizaLifecycleTransaction(tx);
         await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
         await assertOrgAgentQuota(tx, params.organizationId, cap);
 
@@ -1349,6 +1355,7 @@ export class ElizaSandboxService {
     // double-call / provision flap can't strand the org with N agents (each =
     // a container + per-tenant DB + ingress).
     return dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
       await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
 
       const [existing] = await tx
@@ -1410,6 +1417,7 @@ export class ElizaSandboxService {
     });
 
     return dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
       // Acquire the per-ORG agent-create lock BEFORE the per-image lock. The
       // image lock alone (keyed on the exact docker_image) does NOT serialize
       // two concurrent creates for DIFFERENT images against one org, so the
@@ -8992,7 +9000,14 @@ export class ElizaSandboxService {
     orgId: string,
     expectation?: AdminCanaryCleanupExpectation,
     onConvergedInTx?: (tx: DbTransaction) => Promise<void>,
-  ): Promise<"missing" | "clean" | "retired"> {
+    source: "lifecycle" | "background-reconcile" | "admin-converge" = "lifecycle",
+  ): Promise<"missing" | "clean" | "deferred" | "retired"> {
+    const startedAt = Date.now();
+    logger.info("[agent-sandbox] Replacement cleanup started", {
+      agentId,
+      organizationId: orgId,
+      source,
+    });
     const snapshot = await dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, orgId);
       const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
@@ -9000,6 +9015,19 @@ export class ElizaSandboxService {
       const locator = this.getReplacementCleanupLocator(current);
       if (expectation) {
         this.assertAdminCanaryCleanupExpectation(current, locator, expectation);
+      }
+      if (
+        source === "background-reconcile" &&
+        (await this.hasActiveExclusiveLifecycleJobTx(tx, agentId, orgId))
+      ) {
+        return { state: "deferred" as const };
+      }
+      if (
+        source === "background-reconcile" &&
+        locator?.replacementAttemptId !== null &&
+        !(await this.isReplacementCleanupSweepEligibleTx(tx, agentId, orgId))
+      ) {
+        return { state: "deferred" as const };
       }
       if (locator) return { state: "pending" as const, locator };
       if (onConvergedInTx) await onConvergedInTx(tx);
@@ -9014,6 +9042,15 @@ export class ElizaSandboxService {
     const stopOnSpecificNodeForReplacement =
       provider.stopOnSpecificNodeForReplacement.bind(provider);
     const { locator } = snapshot;
+    logger.info("[agent-sandbox] Replacement cleanup remote retirement started", {
+      agentId,
+      organizationId: orgId,
+      source,
+      nodeId: locator.nodeId,
+      containerName: locator.containerName,
+      preCutover: locator.replacementAttemptId !== null,
+      elapsedMs: Date.now() - startedAt,
+    });
 
     await stopOnSpecificNodeForReplacement(
       locator.nodeId,
@@ -9028,8 +9065,14 @@ export class ElizaSandboxService {
         allocationCounted: locator.allocationCounted,
       },
     );
+    logger.info("[agent-sandbox] Replacement cleanup remote absence proven", {
+      agentId,
+      organizationId: orgId,
+      source,
+      elapsedMs: Date.now() - startedAt,
+    });
 
-    return dbWrite.transaction(async (tx) => {
+    const outcome = await dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, orgId);
       const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
       if (!current) {
@@ -9096,6 +9139,13 @@ export class ElizaSandboxService {
       if (onConvergedInTx) await onConvergedInTx(tx);
       return "retired" as const;
     });
+    logger.info("[agent-sandbox] Replacement cleanup fence retired", {
+      agentId,
+      organizationId: orgId,
+      source,
+      elapsedMs: Date.now() - startedAt,
+    });
+    return outcome;
   }
 
   /**
@@ -9112,6 +9162,19 @@ export class ElizaSandboxService {
       SELECT id, organization_id
       FROM ${agentSandboxes}
       WHERE replacement_cleanup_sandbox_id IS NOT NULL
+        AND (
+          replacement_cleanup_attempt_id IS NULL
+          OR replacement_cleanup_created_at <=
+            NOW() - (${PRE_CUTOVER_REPLACEMENT_SWEEP_GRACE_MINUTES} * INTERVAL '1 minute')
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM ${jobs}
+          WHERE ${jobs.organization_id} = ${agentSandboxes.organization_id}
+            AND ${jobs.agent_id} = ${agentSandboxes.id}::text
+            AND ${jobs.status} IN ('pending', 'in_progress')
+            AND ${inArray(jobs.type, EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES)}
+        )
       ORDER BY replacement_cleanup_created_at ASC
       LIMIT ${limit}
     `);
@@ -9120,7 +9183,13 @@ export class ElizaSandboxService {
     for (const row of pending.rows) {
       try {
         if (
-          (await this.retirePersistedReplacementCleanup(row.id, row.organization_id)) === "retired"
+          (await this.retirePersistedReplacementCleanup(
+            row.id,
+            row.organization_id,
+            undefined,
+            undefined,
+            "background-reconcile",
+          )) === "retired"
         ) {
           retired += 1;
         }
@@ -9154,6 +9223,7 @@ export class ElizaSandboxService {
       orgId,
       expectation,
       onConvergedInTx,
+      "admin-converge",
     );
     if (outcome === "missing") {
       throw expectation
@@ -9165,7 +9235,44 @@ export class ElizaSandboxService {
   }
 
   private async lockLifecycle(tx: LifecycleTx, agentId: string, orgId: string): Promise<void> {
+    await configureElizaLifecycleTransaction(tx);
     await tx.execute(elizaProvisionAdvisoryLockSql(orgId, agentId));
+  }
+
+  private async isReplacementCleanupSweepEligibleTx(
+    tx: LifecycleTx,
+    agentId: string,
+    orgId: string,
+  ): Promise<boolean> {
+    const result = await tx.execute<{ eligible: boolean }>(sql`
+      SELECT (
+        replacement_cleanup_attempt_id IS NULL
+        OR replacement_cleanup_created_at <=
+          NOW() - (${PRE_CUTOVER_REPLACEMENT_SWEEP_GRACE_MINUTES} * INTERVAL '1 minute')
+      ) AS eligible
+      FROM ${agentSandboxes}
+      WHERE id = ${agentId}
+        AND organization_id = ${orgId}
+      LIMIT 1
+    `);
+    return result.rows[0]?.eligible === true;
+  }
+
+  private async hasActiveExclusiveLifecycleJobTx(
+    tx: LifecycleTx,
+    agentId: string,
+    orgId: string,
+  ): Promise<boolean> {
+    const result = await tx.execute<{ id: string }>(sql`
+      SELECT id
+      FROM ${jobs}
+      WHERE ${jobs.organization_id} = ${orgId}
+        AND ${jobs.agent_id} = ${agentId}
+        AND ${jobs.status} IN ('pending', 'in_progress')
+        AND ${inArray(jobs.type, EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES)}
+      LIMIT 1
+    `);
+    return result.rows.length > 0;
   }
 
   private async getAgentForLifecycleMutation(

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -194,10 +194,10 @@ export const DEFAULT_NODE_MOVE_GRACE_MS = 5 * 60_000;
  * (never reaped) if ANY of its rows is non-terminal. This is order-independent,
  * so it does not matter that the `WHERE key IN (...)` query has no ORDER BY.
  *
- * For agents the key is `agent_sandboxes.id`, a PRIMARY KEY, so each key maps to
- * AT MOST ONE row — the per-key list is a singleton and `every(terminal)`
- * reduces to the single-row terminal check, i.e. identical reaping decisions to
- * the previous last-write-wins map. (Proof of behavior-preservation.)
+ * For agents the storage key is `agent_sandboxes.id`, a PRIMARY KEY. Its loader
+ * may nevertheless emit two live placement refs while a replacement fence owns
+ * both the serving and replacement containers; either placement protects the
+ * key on its exact node until fenced retirement completes.
  *
  * Containers whose name does not match the managed pattern are ignored
  * entirely — they belong to something else on the node.

--- a/packages/cloud/shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-job-types.ts
@@ -96,6 +96,25 @@ export const JOB_TYPES = {
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];
 
+/**
+ * Agent lifecycle operations that exclusively own placement and replacement
+ * resources while pending or running. Cleanup and enqueue paths share this
+ * list so a background reconciler cannot retire a blue candidate still owned
+ * by an active operation.
+ */
+export const EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES: readonly ProvisioningJobType[] = [
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_DELETE,
+  JOB_TYPES.AGENT_SUSPEND,
+  JOB_TYPES.AGENT_RESUME,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_DOWNGRADE,
+  JOB_TYPES.AGENT_SLEEP,
+  JOB_TYPES.AGENT_WAKE,
+  JOB_TYPES.AGENT_UPGRADE,
+  JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+];
+
 // ── Lanes (which daemon claims which jobs) ──────────────────────────────────
 // The one `jobs` table + ProvisioningJobService codepath is shared, but the
 // rows split into two INDEPENDENT lanes that can be claimed by SEPARATE daemons:

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-agent-downgrade.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-agent-downgrade.test.ts
@@ -55,6 +55,12 @@ function makeDowngradeJob(): Job {
 
 function withClaimedDowngradeJob() {
   const job = makeDowngradeJob();
+  const conflictSpy = spyOn(
+    provisioningJobService as unknown as {
+      assertNoConflictingLifecycleExecution(job: Job): Promise<void>;
+    },
+    "assertNoConflictingLifecycleExecution",
+  ).mockResolvedValue(undefined);
   const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockImplementation(
     async (filters: { type: ProvisioningJobType }) =>
       filters.type === JOB_TYPES.AGENT_DOWNGRADE ? [job] : [],
@@ -67,6 +73,7 @@ function withClaimedDowngradeJob() {
     updateStatusSpy,
     incrementSpy,
     restore() {
+      conflictSpy.mockRestore();
       claimSpy.mockRestore();
       recoverSpy.mockRestore();
       updateStatusSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -425,6 +425,23 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     expect(up.created).toBe(true);
     expect((up.job.data as { toDigest?: string }).toDigest).toBe("sha256:new");
 
+    await expect(
+      provisioningJobService.enqueueAgentDowngradeOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+        dockerImage: "eliza/agent",
+        fromDigest: "sha256:new",
+      }),
+    ).rejects.toMatchObject({
+      code: "session_not_ready",
+      message: expect.stringContaining("conflicting agent_upgrade job"),
+    });
+    await dbWrite
+      .update(jobs)
+      .set({ status: "completed", completed_at: new Date() })
+      .where(eq(jobs.id, up.job.id));
+
     const down = await provisioningJobService.enqueueAgentDowngradeOnce({
       agentId,
       organizationId: orgId,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -56,6 +56,7 @@ import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-
 import { readContainerProvisionJobData } from "./container-jobs-data";
 import { dispatchContainerStopJob } from "./container-stop-job-service";
 import {
+  configureElizaLifecycleTransaction,
   elizaAdminCanaryRolloutAdvisoryLockSql,
   elizaProvisionAdvisoryLockSql,
 } from "./eliza-provision-lock";
@@ -64,7 +65,11 @@ import {
   elizaSandboxService,
   SNAPSHOT_ENDPOINT_UNSUPPORTED,
 } from "./eliza-sandbox";
-import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
+import {
+  EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES,
+  JOB_TYPES,
+  type ProvisioningJobType,
+} from "./provisioning-job-types";
 import {
   isWaifuWebhookTargetUrl,
   resolveWaifuWebhookTarget,
@@ -1011,11 +1016,6 @@ const SHARED_IMAGE_CHANGE_JOB_TYPES: ProvisioningJobType[] = [
   JOB_TYPES.AGENT_UPGRADE,
   JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
 ];
-const EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES: ProvisioningJobType[] = [
-  ...ADMIN_CANARY_CONFLICTING_JOB_TYPES,
-  ...SHARED_IMAGE_CHANGE_JOB_TYPES,
-];
-
 export class ProvisioningJobService {
   /**
    * Common path for the seven `enqueueAgent*Once` methods. Acquires the
@@ -1065,6 +1065,7 @@ export class ProvisioningJobService {
       estimated_completion_at: new Date(Date.now() + opts.estimatedDurationMs),
     };
 
+    await configureElizaLifecycleTransaction(tx);
     await tx.execute(elizaProvisionAdvisoryLockSql(opts.organizationId, opts.agentId));
 
     const [sandbox] = await tx
@@ -1137,9 +1138,11 @@ export class ProvisioningJobService {
     opts.validateSandbox?.(sandbox);
 
     const configuredConflicts = opts.mutuallyExclusiveJobTypes ?? [];
-    const symmetricConflicts = EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(opts.jobType)
-      ? EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES
-      : [];
+    const symmetricConflicts =
+      opts.jobType !== JOB_TYPES.AGENT_DELETE &&
+      EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(opts.jobType)
+        ? EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES
+        : [];
     const conflictingTypes = [...new Set([...configuredConflicts, ...symmetricConflicts])].filter(
       (jobType) => jobType !== opts.jobType,
     );
@@ -1959,6 +1962,7 @@ export class ProvisioningJobService {
     }
 
     return await dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
       await tx.execute(elizaAdminCanaryRolloutAdvisoryLockSql());
 
       const replay = await tx
@@ -2981,41 +2985,47 @@ export class ProvisioningJobService {
     }
   }
 
-  private async executeJob(job: Job): Promise<void> {
+  private async assertNoConflictingLifecycleExecution(job: Job): Promise<void> {
     if (
-      EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(job.type as ProvisioningJobType) &&
-      job.agent_id
+      !EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(job.type as ProvisioningJobType) ||
+      !job.agent_id
     ) {
-      await dbWrite.transaction(async (tx) => {
-        await tx.execute(elizaProvisionAdvisoryLockSql(job.organization_id, job.agent_id!));
-        const [conflict] = await tx
-          .select({ id: jobs.id, type: jobs.type, status: jobs.status })
-          .from(jobs)
-          .where(
-            and(
-              eq(jobs.organization_id, job.organization_id),
-              eq(jobs.agent_id, job.agent_id!),
-              inArray(jobs.type, EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES),
-              ne(jobs.id, job.id),
-              sql`${jobs.status} IN ('pending', 'in_progress')`,
-            ),
-          )
-          .orderBy(desc(jobs.created_at))
-          .limit(1);
-        if (conflict) {
-          throw new ApiError(
-            409,
-            "session_not_ready",
-            `Agent ${job.agent_id} has conflicting ${conflict.type} job ${conflict.id}`,
-            {
-              conflictingJobId: conflict.id,
-              conflictingJobType: conflict.type,
-              conflictingJobStatus: conflict.status,
-            },
-          );
-        }
-      });
+      return;
     }
+    await dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
+      await tx.execute(elizaProvisionAdvisoryLockSql(job.organization_id, job.agent_id!));
+      const [conflict] = await tx
+        .select({ id: jobs.id, type: jobs.type, status: jobs.status })
+        .from(jobs)
+        .where(
+          and(
+            eq(jobs.organization_id, job.organization_id),
+            eq(jobs.agent_id, job.agent_id!),
+            inArray(jobs.type, EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES),
+            ne(jobs.id, job.id),
+            sql`${jobs.status} IN ('pending', 'in_progress')`,
+          ),
+        )
+        .orderBy(desc(jobs.created_at))
+        .limit(1);
+      if (conflict) {
+        throw new ApiError(
+          409,
+          "session_not_ready",
+          `Agent ${job.agent_id} has conflicting ${conflict.type} job ${conflict.id}`,
+          {
+            conflictingJobId: conflict.id,
+            conflictingJobType: conflict.type,
+            conflictingJobStatus: conflict.status,
+          },
+        );
+      }
+    });
+  }
+
+  private async executeJob(job: Job): Promise<void> {
+    await this.assertNoConflictingLifecycleExecution(job);
     switch (job.type) {
       case JOB_TYPES.AGENT_PROVISION:
         await this.executeAgentProvision(job);


### PR DESCRIPTION
Closes #17158. Exact semantic backport of merged develop PR #17159 for the protected production API/provisioning worker.

## Outcome

This prevents the replacement-cleanup reconciler from deleting a pre-cutover blue agent while its lifecycle job still owns that replacement, and prevents PostgreSQL pool/advisory-lock waits from outliving the provisioning job that invoked them.

The serving generation remains fail-closed: cleanup keeps the durable locator and node allocation until exact remote absence and a lifecycle-locked CAS are both proven.

## Exact replay

- Main base: `262d5dc51f60c943e38be63d0f44ec80dcbb6b4d`
- Main backport: `4f32398a37c5ee8c913e417e54821c5386c24294`
- Tree: `4761058c18dbd346c1a82a066c27a7f51daad936`
- Merged develop source: `54852f650c8d4b49d993b58f103041339dce4b9f`
- Stable patch-id on both commits: `e162b38b8e88966f52691f7f93960507b68b2c98`
- Cherry-pick was conflict-free; worktree is clean.

## Production changes

- Exclude pending/in-progress lifecycle jobs in the outer replacement-cleanup sweep and recheck them under the per-agent lifecycle and row locks.
- Use a database-time 30-minute grace for pre-cutover candidates only.
- Retain replacement capacity/orphan ownership until exact cleanup convergence.
- Apply transaction-local 10-second lock and 30-second statement deadlines to every Eliza lifecycle/admin advisory-lock transaction.
- Bound PostgreSQL pool checkout at 30 seconds.
- Preserve authoritative delete-wins behavior and all durable identity/CAS fences.
- Add sanitized cleanup source/stage/elapsed logging.

## Verification on the exact main replay

- Admin rollout PGlite lifecycle: 47/47, including the outer-select→inner-lock race.
- Replacement capacity/workload ownership: 20/20.
- Lifecycle/helper/create/tier locks: 19/19.
- Repositories/orphan recovery: 46/46.
- Scheduled lifecycle sentinel: 18/18.
- Downgrade conflict contract: 2/2.
- `packages/cloud/shared` typecheck: PASS.
- Biome and `git diff --check`: PASS.
- The identical develop object also passed a real two-session PostgreSQL test: SQLSTATE `55P03` at 10 seconds, transaction-local timeout restoration, and successful reuse after holder release.
- Independent review on the exact semantic patch: terminal PASS / GO, no P0/P1.

## Risk and rollback

No image allowlist widening, fleet pin, manual database write, or ad-hoc agent restart. Any ambiguous or failed cleanup keeps the durable fence and capacity allocation. The existing serving generation remains unchanged until the one-agent canary proves cutover and cleanup.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend control-plane only; no rendered UI changed.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend control-plane only; LP3 proof follows the healthy canary.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no visual user flow changed.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `The sanitized failing canary packet and exact local PostgreSQL/PGlite results are recorded in #17159; protected rollout logs will bind the deployed main SHA.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend source changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model/prompt/action/provider behavior changed; final acceptance includes a real Cerebras reply.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `Real PGlite lifecycle/fence/allocation rows and a real PostgreSQL two-session lock were asserted; the production canary job and post-restart Simple Views state are the deployment gate.`

## Deploy notes

Deploy the exact merged main API and provisioning worker, then run exactly one bounded canary for agent `747a415a-e1ac-4c32-a147-9ab8c5a69d99` to:

`ghcr.io/elizaos/eliza-demo@sha256:934d6f4c85b4f405e6ff284af1cde27b2b852a12b42eb516885b9d9ec2a5d061`

Do not recover the failed job, globally pin, manually write database state, or restart the agent outside the reconciler-owned workflow.
