### PR TITLE
fix(auth): complete late native session recovery

### DIFF
--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -58,8 +58,16 @@ export function resolveCloudPairExchangeUrl(cloudApiBase?: string): string {
     .replace(/\/+$/, "")
     .replace(/\/api\/v1\/?$/, "");
   const url = new URL(`${base}/api/auth/pair`);
-  if (url.hostname === "www.elizacloud.ai") {
-    url.hostname = "elizacloud.ai";
+  const apiHost = new Map([
+    ["elizacloud.ai", "api.elizacloud.ai"],
+    ["www.elizacloud.ai", "api.elizacloud.ai"],
+    ["app.elizacloud.ai", "api.elizacloud.ai"],
+    ["dev.elizacloud.ai", "api.elizacloud.ai"],
+    ["staging.elizacloud.ai", "api-staging.elizacloud.ai"],
+    ["app-staging.elizacloud.ai", "api-staging.elizacloud.ai"],
+  ]).get(url.hostname.toLowerCase());
+  if (apiHost) {
+    url.hostname = apiHost;
   }
   return url.toString();
 }

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -80,14 +80,20 @@ describe("CloudPairRelay", () => {
 
   it("resolves the Cloud pair exchange endpoint from site and API bases", () => {
     expect(resolveCloudPairExchangeUrl("https://elizacloud.ai")).toBe(
-      "https://elizacloud.ai/api/auth/pair",
+      "https://api.elizacloud.ai/api/auth/pair",
     );
     expect(
       resolveCloudPairExchangeUrl("https://api.elizacloud.ai/api/v1"),
     ).toBe("https://api.elizacloud.ai/api/auth/pair");
     expect(resolveCloudPairExchangeUrl("https://www.elizacloud.ai")).toBe(
-      "https://elizacloud.ai/api/auth/pair",
+      "https://api.elizacloud.ai/api/auth/pair",
     );
+    expect(resolveNativeCloudPairExchangeUrl("https://elizacloud.ai")).toBe(
+      "https://api.elizacloud.ai/api/auth/pair/native",
+    );
+    expect(
+      resolveNativeCloudPairExchangeUrl("https://staging.elizacloud.ai"),
+    ).toBe("https://api-staging.elizacloud.ai/api/auth/pair/native");
     expect(
       resolveNativeCloudPairExchangeUrl("https://api.elizacloud.ai/api/v1"),
     ).toBe("https://api.elizacloud.ai/api/auth/pair/native");

--- a/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
@@ -9,7 +9,7 @@
  * agent with a valid cloud session must transition to "recovering" (transparent
  * re-pair) instead of "idle" (password-wall dead-end).
  */
-import { render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock the environment reads the hook makes so we can drive the decision.
@@ -89,6 +89,7 @@ function cloudServer(agentId: string) {
 }
 
 afterEach(() => {
+  cleanup();
   delete (globalThis as { Capacitor?: unknown }).Capacitor;
   vi.clearAllMocks();
   // Restore the default "no cookie" behavior after clearAllMocks wipes it.
@@ -286,6 +287,44 @@ describe("useAgentSessionRecovery", () => {
       expect(statuses[statuses.length - 1]).toBe("cloud-reauth-required");
     });
     expect(mockRunRecovery).not.toHaveBeenCalled();
+  });
+
+  it("re-pairs when native SIWE supplies the Cloud token after the initial recovery attempt", async () => {
+    (globalThis as { Capacitor?: unknown }).Capacitor = {
+      isNativePlatform: () => true,
+    };
+    let cloudToken: string | null = null;
+    mockCloudToken.mockImplementation(() => cloudToken);
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery.mockReturnValue(new Promise(() => {}));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(status) => statuses.push(status)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses.at(-1)).toBe("cloud-reauth-required");
+    });
+    expect(mockRunRecovery).not.toHaveBeenCalled();
+
+    cloudToken = "steward.jwt.from-native-siwe";
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    });
+
+    await waitFor(() => {
+      expect(mockRunRecovery).toHaveBeenCalledTimes(1);
+    });
+    expect(statuses).toContain("recovering");
+    expect(mockRunRecovery.mock.calls[0][0]).toMatchObject({
+      agentId: "agent-1",
+      cloudToken: "steward.jwt.from-native-siwe",
+    });
   });
 
   it("REGRESSION: returning PWA with no app-origin token but a live Eliza Cloud cookie silently re-pairs instead of dead-ending", async () => {

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -18,6 +18,7 @@
  * owner-password wall.
  */
 
+import { logger } from "@elizaos/logger";
 import { useEffect, useRef, useState } from "react";
 import { getCloudAuthToken } from "../api/client-cloud";
 import { getBootConfig } from "../config/boot-config";
@@ -87,9 +88,32 @@ export function useAgentSessionRecovery(
   // A loading refetch briefly leaves the unauthenticated state, so only a
   // confirmed session (or remount) may rearm recovery for a later genuine 401.
   const attemptedRef = useRef(false);
+  const awaitingCloudTokenRef = useRef(false);
   const attemptedFallbackRef = useRef<ManagedCloudAgentRecoveryStatus>(
     "cloud-retry-required",
   );
+  const [cloudTokenSnapshot, setCloudTokenSnapshot] = useState(() =>
+    getCloudAuthToken(),
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const rearmAfterCloudReauth = () => {
+      const cloudToken = getCloudAuthToken();
+      setCloudTokenSnapshot(cloudToken);
+      if (!awaitingCloudTokenRef.current || !cloudToken?.trim()) {
+        return;
+      }
+      awaitingCloudTokenRef.current = false;
+      attemptedRef.current = false;
+    };
+
+    window.addEventListener("steward-token-sync", rearmAfterCloudReauth);
+    return () => {
+      window.removeEventListener("steward-token-sync", rearmAfterCloudReauth);
+    };
+  }, []);
 
   useEffect(() => {
     const consumeRedirectInProcess = shouldConsumePairRedirectInProcess();
@@ -103,10 +127,13 @@ export function useAgentSessionRecovery(
       managedStatus: ManagedCloudAgentRecoveryStatus = "cloud-retry-required",
     ) => {
       attemptedFallbackRef.current = managedStatus;
+      awaitingCloudTokenRef.current =
+        isManagedNative && managedStatus === "cloud-reauth-required";
       setStatus(fallbackStatus(managedStatus));
     };
 
     if (!active) {
+      awaitingCloudTokenRef.current = false;
       if (isAuthenticated) {
         attemptedRef.current = false;
         attemptedFallbackRef.current = "cloud-retry-required";
@@ -144,6 +171,7 @@ export function useAgentSessionRecovery(
       decision: ReturnType<typeof resolveAgentSessionRecovery>,
       cloudToken: string,
     ) => {
+      awaitingCloudTokenRef.current = false;
       if (decision.action !== "re-pair") {
         showFallback(
           cloudToken.trim() ? "cloud-manage-required" : "cloud-reauth-required",
@@ -172,6 +200,14 @@ export function useAgentSessionRecovery(
           // the bearer in-process and triggers `onRecovered`. Failures retain
           // enough classification for reauth versus non-destructive retry.
           if (!result.ok) {
+            logger.warn(
+              {
+                agentId: decision.agentId,
+                reason: result.reason,
+                message: result.message,
+              },
+              "[AgentSessionRecovery] managed-agent re-pair failed",
+            );
             showFallback(
               result.reason === "unauthorized"
                 ? "cloud-reauth-required"
@@ -179,16 +215,36 @@ export function useAgentSessionRecovery(
                   ? "cloud-manage-required"
                   : "cloud-retry-required",
             );
+          } else {
+            logger.info(
+              {
+                agentId: decision.agentId,
+                mode: result.mode,
+              },
+              "[AgentSessionRecovery] managed-agent re-pair succeeded",
+            );
           }
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           // error-policy:J4 an unclassified repair failure keeps the existing
           // Cloud token and degrades to a non-destructive retry surface.
-          if (!cancelled) showFallback("cloud-retry-required");
+          if (!cancelled) {
+            logger.warn(
+              {
+                agentId: decision.agentId,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Unknown recovery failure",
+              },
+              "[AgentSessionRecovery] managed-agent re-pair threw",
+            );
+            showFallback("cloud-retry-required");
+          }
         });
     };
 
-    const initialInput = resolveInput(getCloudAuthToken());
+    const initialInput = resolveInput(cloudTokenSnapshot);
     const initialDecision = resolveAgentSessionRecovery(initialInput);
     const initialCloudToken = initialInput.cloudToken?.trim();
 
@@ -227,6 +283,16 @@ export function useAgentSessionRecovery(
         if (!token) {
           // No cookie / refresh failed / timed out: the notice is honest now.
           showFallback("cloud-reauth-required");
+          // Native SIWE can finish in the narrow window between the cookie
+          // refresh resolving and the fallback being armed. Its sync event has
+          // already fired, so re-check the canonical token once instead of
+          // waiting forever for a second event.
+          const lateCloudToken = getCloudAuthToken();
+          if (awaitingCloudTokenRef.current && lateCloudToken?.trim()) {
+            awaitingCloudTokenRef.current = false;
+            attemptedRef.current = false;
+            setCloudTokenSnapshot(lateCloudToken);
+          }
           return;
         }
         const decision = resolveAgentSessionRecovery(
@@ -244,7 +310,14 @@ export function useAgentSessionRecovery(
       cancelled = true;
     };
     // setStatus and attemptedRef are stable; all third-party inputs are listed.
-  }, [active, reason, navigate, onRecovered, isAuthenticated]);
+  }, [
+    active,
+    reason,
+    navigate,
+    onRecovered,
+    isAuthenticated,
+    cloudTokenSnapshot,
+  ]);
 
   return status;
 }

--- a/packages/ui/src/state/cloud-siwe-login.test.ts
+++ b/packages/ui/src/state/cloud-siwe-login.test.ts
@@ -219,12 +219,15 @@ describe("e2e wallet + SIWE login", () => {
     window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
     await installE2eWalletIfRequested();
     const { verified } = mockFetch();
+    const tokenSync = vi.fn();
+    window.addEventListener("steward-token-sync", tokenSync, { once: true });
 
     const apiKey = await siweLoginWithInjectedWallet("https://api.test/");
     expect(apiKey).toBe("eliza_test_api_key");
     expect(window.localStorage.getItem("steward_session_token")).toBe(
       "eliza_test_api_key",
     );
+    expect(tokenSync).toHaveBeenCalledTimes(1);
 
     // The signed message embeds the server's nonce/domain and the signature
     // genuinely recovers to the wallet address — exactly what the cloud API's

--- a/packages/ui/src/state/cloud-siwe-login.ts
+++ b/packages/ui/src/state/cloud-siwe-login.ts
@@ -251,6 +251,7 @@ export async function siweLoginWithInjectedWallet(
   }
 
   writeStoredStewardToken(verified.apiKey);
+  window.dispatchEvent(new CustomEvent("steward-token-sync"));
   logger.info(
     `[CloudSiweLogin] SIWE login verified for ${address.slice(0, 6)}…${address.slice(-4)}`,
   );

--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -202,6 +202,72 @@ describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
     expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_TIMEOUT" });
   });
 
+  it.each([401, 429] as const)(
+    "advances a rejected adopted bearer (%s) to the auth gate instead of warming forever",
+    async (status) => {
+      persistenceMock.loadPersistedActiveServer.mockReturnValue({
+        id: "cloud:agent-123",
+        kind: "cloud",
+        label: "Eliza Cloud",
+      });
+      clientMock.hasToken.mockReturnValue(true);
+      clientMock.listConversations.mockRejectedValue({
+        status,
+        message: "Unauthorized",
+      });
+
+      const dispatch = vi.fn();
+      const deps = createDeps();
+
+      await runStartingRuntime(
+        deps,
+        dispatch,
+        1,
+        { current: 1 },
+        { current: false },
+        { current: null },
+        "cloud-managed",
+      );
+
+      expect(clientMock.listConversations).toHaveBeenCalledTimes(1);
+      expect(deps.setConnected).toHaveBeenCalledWith(false);
+      expect(deps.setFirstRunLoading).toHaveBeenCalledWith(false);
+      expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+      expect(deps.setStartupError).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps a tokenless native 401 in warmup while credential injection is pending", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+    clientMock.hasToken.mockReturnValue(false);
+
+    const cancelled = { current: false };
+    clientMock.listConversations.mockImplementation(async () => {
+      cancelled.current = true;
+      throw { status: 401, message: "Unauthorized" };
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      cancelled,
+      { current: null },
+      "cloud-managed",
+    );
+
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+
   // ── CONVERSATIONS-500 HARDENING (persistent 5xx must not spin forever) ──
 
   it("persistent /api/conversations 500 + /api/status canRespond → advances to chat despite the broken list endpoint", async () => {

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -183,12 +183,14 @@ function isCloudManagedActiveServer(): boolean {
  *     deadline. It must be classified distinctly so the warmup can (a) confirm
  *     readiness off /api/status instead, and (b) surface an actionable error
  *     rather than an infinite spinner if the whole surface stays broken.
- * The 401/429 auth cases are already resolved during the polling-backend phase
- * before starting-runtime, so a rejection here does not need auth disambiguation.
+ * A bearer can become stale after polling-backend has already advanced, so a
+ * 401/429 with an adopted token must reach the auth gate instead of looking
+ * like an indefinitely warming container.
  */
 type PassthroughProbe =
   | { kind: "serving" }
   | { kind: "warming" }
+  | { kind: "auth-required"; status: 401 | 429 }
   | { kind: "errored"; status: number };
 
 async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
@@ -197,6 +199,9 @@ async function probeCloudProxyPassthrough(): Promise<PassthroughProbe> {
     return { kind: "serving" };
   } catch (err) {
     const status = asApiLikeError(err)?.status;
+    if ((status === 401 || status === 429) && client.hasToken()) {
+      return { kind: "auth-required", status };
+    }
     // A 5xx means the runtime answered but the list read errored — the agent is
     // likely UP (that is exactly the shared-agent conversations 500 class). Any
     // other failure (404 "Agent not found", network/timeout, no status) is
@@ -645,6 +650,17 @@ async function runCloudManagedWarmup(
     if (probe.kind === "serving") {
       // The passthrough answers → the warmed runtime is genuinely serving.
       await advanceReady("conversations passthrough serving");
+      return;
+    }
+
+    if (probe.kind === "auth-required") {
+      // The passthrough is reachable and rejected the bearer. Advancing mounts
+      // the normal auth gate, where managed Cloud recovery can exchange a
+      // fresh agent credential; treating this as warmup would hide that gate
+      // behind the startup screen until the absolute timeout.
+      deps.setConnected(false);
+      deps.setFirstRunLoading(false);
+      dispatch({ type: "AGENT_RUNNING" });
       return;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #17109 / #16855 after running the merged change through a real cold native boot.

- advance stale adopted 401/429 bearers from managed Cloud warmup to the auth gate instead of spinning until startup timeout
- rearm managed-agent recovery when native SIWE supplies the Steward token after the first tokenless recovery attempt
- emit the established `steward-token-sync` contract after SIWE persists its verified session
- normalize Eliza Cloud web hosts to the API host for `/api/auth/pair[/native]`
- add credential-safe recovery outcome diagnostics

## Why #17109 was incomplete

The merged PR's tests started at the already-mounted auth gate with a Cloud token available. A real native cold boot has two additional races:

1. the stale agent bearer can be rejected during managed startup before the auth gate mounts;
2. genuine SIWE can complete after the hook's initial tokenless attempt.

The live run then exposed a third integration gap: the native exchange was resolved against `elizacloud.ai`, while `/api/auth/pair/native` is served by `api.elizacloud.ai`.

## Verification

- `bun install` after rebasing onto current `origin/develop`
- `bun run verify`
  - 578/578 Turbo tasks passed
  - repository audits passed
  - 28/28 dist-path consumers passed
- focused recovery/auth suite: 5 files / 76 tests passed before the final host-only patch
- final Cloud pairing file: 13/13 tests passed, including apex and staging host normalization
- `bun run --cwd packages/ui typecheck`
- exact-commit-predecessor iOS simulator build succeeded with renderer build `8c29b564ff97`, stamped from the branch commit
- real native cold boot proved:
  - harness wallet installed
  - genuine SIWE verified
  - late recovery attempt fired
  - pre-normalization exchange failed at the web apex with typed `reason=error, message=Not found`

## Visual audit

`bun run --cwd packages/app audit:app` was attempted twice. No page verdict was produced: the audit's Playwright web server failed to become ready and hit its 20-minute outer timeout while its cold renderer build wrapper remained stuck. This is an audit infrastructure failure, not a computed `needs-work`/`broken` page result. The direct production renderer and iOS builds both completed successfully.

## Evidence applicability

- Real LLM trajectories: N/A — no model/action/provider/prompt behavior changed.
- Backend logs: N/A — client recovery orchestration and endpoint selection only.
- Frontend/native logs: captured locally; they show genuine SIWE followed by the recovery attempt and the pre-fix apex 404 classification.
- Screenshots/video: N/A for visual behavior — this changes an existing auth recovery transition and endpoint routing, not layout or styling. The app visual audit was attempted as documented above.

Closes #16855

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17161-pr17109-before.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17161-pr17109-after.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17161-pr17109-reproduction.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code changed; the existing Cloud route is selected by the client resolver

<!-- evidence-row:frontend-logs -->
- [x] [17161-pr17109-native-recovery.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17161-pr17109-native-recovery.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - auth orchestration produces no durable domain artifact beyond the verified session credential

<!-- evidence-row:ocr-review -->
- [x] [17161-pr17109-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17161-pr17109-ocr-review.txt)
