### PR TITLE
fix(ci): green the develop test lanes broken by the 2026-07-23 merges

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -342,6 +342,10 @@ export * from "./services/setup-cli";
 export * from "./services/setup-rpc";
 // Export setup services
 export * from "./services/setup-state";
+// TaskService is exported so hosts and tests can `instanceof`-check the
+// runtime-registered instance; a relative src import would create a second
+// class identity against the built package and always fail that check.
+export { TaskService } from "./services/task";
 export {
 	getTaskSchedulerAdapter,
 	markTaskSchedulerDirty,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -4020,11 +4020,20 @@ function shouldRecoverSilentFailedFinish(args: {
 	return latestFailedToolStep(args.trajectory) !== undefined;
 }
 
+/**
+ * Generic last-resort reply for a turn that ends on a failed tool with no
+ * user-safe tool-owned text. Exported so the message service can recognize it
+ * and drop it as redundant when the failed tool's own callback already told
+ * the user what happened.
+ */
+export const FAILED_TOOL_FALLBACK_MESSAGE =
+	"I tried to complete that, but the available runtime step failed before it produced a usable result.";
+
 function failedToolFallbackMessage(
 	trajectory: PlannerTrajectory,
 ): string | undefined {
 	if (!latestFailedToolStep(trajectory)) return undefined;
-	return "I tried to complete that, but the available runtime step failed before it produced a usable result.";
+	return FAILED_TOOL_FALLBACK_MESSAGE;
 }
 
 function exposedToolNameSet(
@@ -4259,7 +4268,7 @@ function groundedFailedToolMessage(step: PlannerStep): string {
 			: result?.userFacingText;
 	const candidate = sanitizePlannerMessage(toolOwnedText);
 	if (candidate && !isUnsafeUserVisibleText(candidate)) return candidate;
-	return "I tried to complete that, but the available runtime step failed before it produced a usable result.";
+	return FAILED_TOOL_FALLBACK_MESSAGE;
 }
 
 function terminalToolCallFinish(

--- a/packages/core/src/services/message.transcript-visibility.test.ts
+++ b/packages/core/src/services/message.transcript-visibility.test.ts
@@ -311,7 +311,11 @@ describe("DefaultMessageService transcript visibility integration", () => {
 		expect(persisted).toHaveLength(1);
 		expect(persisted[0]?.content.text).toBe(visibleSummary);
 		expect(persisted[0]?.content.transcriptVisibility).toBeUndefined();
-		expect(harness.persistedAtCallback).toEqual([true]);
+		// Core delivers the visible reply before persisting the response memory
+		// (#17105 took the write off the reply path); durability-before-terminal
+		// is the conversation route's contract, not the callback's. The summary
+		// is persisted by the time handleMessage resolves (asserted above).
+		expect(harness.persistedAtCallback).toEqual([false]);
 		expect(harness.callbacks).toHaveLength(1);
 		expect(harness.callbacks[0]?.text).toBe(visibleSummary);
 		expect(harness.sent).toHaveLength(1);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -128,6 +128,7 @@ import {
 import {
 	actionResultToPlannerToolResult,
 	cacheProviderOptions,
+	FAILED_TOOL_FALLBACK_MESSAGE,
 	type PlannerLoopParams,
 	type PlannerLoopResult,
 	type PlannerRuntime,
@@ -1660,6 +1661,31 @@ export function transcriptionModeActive(
  */
 export function normalizeVisibleTextForDuplicateCheck(text: string): string {
 	return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/**
+ * True when a text already delivered through an action callback covers the
+ * (normalized) planned reply — either verbatim or as a strict superset ending
+ * at a non-word boundary, so a short prefix never swallows an unrelated longer
+ * line ("created" must not match "created issue …"). Shared by the planner
+ * echo suppression and the reply-egress claim gate so both agree on what
+ * "the user already saw this" means.
+ */
+function deliveredTextsCoverReply(
+	deliveredVisibleTexts: ReadonlySet<string>,
+	normalizedReply: string,
+): boolean {
+	if (normalizedReply.length === 0) return false;
+	for (const delivered of deliveredVisibleTexts) {
+		if (
+			delivered === normalizedReply ||
+			(delivered.startsWith(normalizedReply) &&
+				/[^a-z0-9]/i.test(delivered.charAt(normalizedReply.length)))
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /** Zerollama/OpenAI-style async media endpoints should be delivered as attachments, not echoed as chat copy. */
@@ -8123,7 +8149,20 @@ export async function runV5MessageRuntimeStage1(args: {
 			actionResults: egressActionResults,
 			actions: args.runtime.actions,
 		});
-		if (plannedReplyEgressDecision.verdict === "reject") {
+		// A reply an action callback already delivered this turn (verbatim or as
+		// a strict superset) is a planner echo: the suppression below drops it, so
+		// it never egresses. Bouncing it here instead would follow the visible,
+		// action-owned confirmation with a contradicting "couldn't verify" bubble.
+		const plannedReplyAlreadyDelivered = deliveredTextsCoverReply(
+			deliveredVisibleTexts,
+			normalizeVisibleTextForDuplicateCheck(
+				String(plannerResult.finalMessage ?? ""),
+			),
+		);
+		if (
+			plannedReplyEgressDecision.verdict === "reject" &&
+			!plannedReplyAlreadyDelivered
+		) {
 			args.runtime.logger?.warn?.(
 				{
 					src: "service:message",
@@ -8218,18 +8257,31 @@ export async function runV5MessageRuntimeStage1(args: {
 		// longer line ("created" must not match "created issue …").
 		const normalizedPlannedReply =
 			normalizeVisibleTextForDuplicateCheck(effectiveReplyText);
-		const plannedTextRepeatsActionReply =
-			normalizedPlannedReply.length > 0 &&
-			[...deliveredVisibleTexts].some(
-				(delivered) =>
-					delivered === normalizedPlannedReply ||
-					(delivered.startsWith(normalizedPlannedReply) &&
-						/[^a-z0-9]/i.test(delivered.charAt(normalizedPlannedReply.length))),
-			);
+		const plannedTextRepeatsActionReply = deliveredTextsCoverReply(
+			deliveredVisibleTexts,
+			normalizedPlannedReply,
+		);
+		// The planner's generic failed-tool fallback exists so a failed turn is
+		// never silent. When the failed action's own callback already delivered
+		// its user-facing explanation (a confirmation preview, a "cloud-only"
+		// boundary notice), appending "I tried … but it failed" contradicts what
+		// the user just read — drop the fallback and let the tool's words stand.
+		const plannedTextIsRedundantFailureFallback =
+			effectiveReplyText === FAILED_TOOL_FALLBACK_MESSAGE &&
+			actionResults.some((result) => {
+				if (result.success !== false) return false;
+				return [result.userFacingText, result.text].some((ownedText) => {
+					const normalized = normalizeVisibleTextForDuplicateCheck(
+						String(ownedText ?? ""),
+					);
+					return normalized.length > 0 && deliveredVisibleTexts.has(normalized);
+				});
+			});
 		const shouldSendPlannedText =
 			Boolean(effectiveReplyText) &&
 			!plannedTextRepeatsEarlyReply &&
-			!plannedTextRepeatsActionReply;
+			!plannedTextRepeatsActionReply &&
+			!plannedTextIsRedundantFailureFallback;
 		// Voice-gate provenance (#14873): only the Stage-1 ack has unambiguous
 		// model provenance here (`messageHandler.plan.reply` is the Stage-1
 		// model's own field). The planner's `finalMessage` is deliberately NOT

--- a/packages/core/src/services/message.ttft-prefetch.test.ts
+++ b/packages/core/src/services/message.ttft-prefetch.test.ts
@@ -250,9 +250,13 @@ describe("post-turn evaluation detachment", () => {
 		});
 		const service = new DefaultMessageService();
 
+		// The message must carry a post-turn semantic signal ("remember" matches
+		// POST_TURN_SEMANTIC_SIGNAL) — a plain smalltalk reply now skips
+		// runPostTurnEvaluators entirely, and this test is about the evaluator
+		// running detached, not about the skip gate.
 		const connectorWait = service.handleMessage(
 			runtime,
-			userMessage("reply before reflection finishes"),
+			userMessage("remember to reply before reflection finishes"),
 		);
 		await expect(connectorWait).resolves.toBeDefined();
 		await evaluatorStarted;

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -554,6 +554,11 @@ export async function createScenarioRuntime(
       // rewrite (services/message) would spend an unfixtured TEXT_SMALL call and
       // restyle that text, so keep it off in the deterministic harness.
       ACTION_CALLBACK_VOICE_REWRITE: "false",
+      // LifeOps inbox priority scoring is a background TEXT_SMALL batch; under
+      // the strict proxy it has no fixtures, and its reported failure leaks
+      // into the RECENT_ERRORS provider text that strict turn fixtures key on
+      // (deterministic-pr-smoke went red exactly this way).
+      LIFEOPS_INBOX_PRIORITY_SCORING: "false",
     },
   });
 

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -601,12 +601,12 @@ export default scenario({
       text: "Open the settings view",
       actionName: "VIEWS",
       options: { action: "show", view: "settings", viewType: "gui" },
-      responseIncludesAny: ["Navigated to Settings"],
+      responseIncludesAny: ["Opened Settings"],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "VIEWS",
           parameters: { action: "show", view: "settings", viewType: "gui" },
-          responseText: "Navigated to Settings (gui).",
+          responseText: "Opened Settings.",
           resultFields: {
             "values.mode": "show",
             "values.viewId": "settings",
@@ -621,7 +621,7 @@ export default scenario({
       text: "Open the remote ledger view",
       actionName: "VIEWS",
       options: { action: "open", view: "remote-ledger", viewType: "gui" },
-      responseIncludesAny: ["Navigated to Remote Ledger"],
+      responseIncludesAny: ["Opened Remote Ledger"],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "VIEWS",
@@ -630,7 +630,7 @@ export default scenario({
             view: "remote-ledger",
             viewType: "gui",
           },
-          responseText: "Navigated to Remote Ledger (gui).",
+          responseText: "Opened Remote Ledger.",
           resultFields: {
             "values.mode": "show",
             "values.viewId": "remote-ledger",

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -441,7 +441,7 @@ export default scenario({
               view: "settings",
               viewType: "gui",
             },
-            "Navigated to Settings (gui).",
+            "Opened Settings.",
           ),
           handleResponseFixture("Search views for finance", "VIEWS"),
           plannerFixture(
@@ -644,7 +644,7 @@ export default scenario({
       kind: "message",
       name: "natural language opens a view",
       text: "Open the settings view",
-      responseIncludesAny: ["Navigated to Settings"],
+      responseIncludesAny: ["Opened Settings"],
       assertTurn: (execution) =>
         expectRoutedAction(execution, {
           actionName: "VIEWS",

--- a/packages/scenario-runner/test/scenarios/deterministic-lifeops-multiday-journey.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-lifeops-multiday-journey.scenario.ts
@@ -92,9 +92,13 @@ const getText =
 const completeText = "Run SCHEDULED_TASKS to complete the pharmacy reminder";
 const historyText = "Run SCHEDULED_TASKS to read the pharmacy reminder history";
 
+// Owner-chat reminder creates delegate to the OWNER_REMINDERS definition
+// flow (routing contract in scheduled-task.ts); "custom" keeps the raw
+// scheduler surface whose recurrence/snooze/refire mechanics this journey
+// deterministically exercises.
 const createParameters = {
   action: "create",
-  kind: "reminder",
+  kind: "custom",
   promptInstructions: "call the pharmacy about the prescription refill",
   trigger: { kind: "cron", expression: "0 9 * * *", tz: "UTC" },
   priority: "medium",

--- a/packages/scenario-runner/test/scenarios/deterministic-lifeops-scheduled-tasks.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-lifeops-scheduled-tasks.scenario.ts
@@ -31,9 +31,12 @@ const completeText =
 const historyText =
   "Run SCHEDULED_TASKS to read the deterministic water reminder history";
 
+// Owner-chat reminder creates delegate to the OWNER_REMINDERS definition
+// flow (routing contract in scheduled-task.ts); "custom" keeps the raw
+// scheduler admin surface this scenario deterministically exercises.
 const createParameters = {
   action: "create",
-  kind: "reminder",
+  kind: "custom",
   promptInstructions: "drink a glass of water",
   trigger: { kind: "manual" },
   priority: "medium",
@@ -46,7 +49,7 @@ const createParameters = {
 
 const listParameters = {
   action: "list",
-  kind: "reminder",
+  kind: "custom",
   status: "scheduled",
   ownerVisibleOnly: true,
 };
@@ -259,8 +262,8 @@ function expectCreatedTurn(
   if (typeof task.taskId !== "string" || task.taskId.length === 0) {
     return `expected task.taskId string, saw ${stableStringify(task.taskId)}`;
   }
-  if (task.kind !== "reminder") {
-    return `expected task.kind=reminder, saw ${String(task.kind)}`;
+  if (task.kind !== "custom") {
+    return `expected task.kind=custom, saw ${String(task.kind)}`;
   }
   if (task.promptInstructions !== createParameters.promptInstructions) {
     return `expected task.promptInstructions=${createParameters.promptInstructions}, saw ${String(task.promptInstructions)}`;

--- a/packages/scenario-runner/test/scenarios/deterministic-pr-smoke.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-pr-smoke.scenario.ts
@@ -142,6 +142,12 @@ export default scenario({
         resetAppControlHttpLoopback();
         const runtime = ctx.runtime as RuntimeWithScenarioLlmFixtures;
         runtime.scenarioLlmFixtures?.register(
+          // The simple-reply path answers straight from the stage-1 router
+          // response (`replyText`); no follow-up TEXT_SMALL call fires. The
+          // router fixture is therefore the required one, and the direct
+          // TEXT_SMALL fixture stays registered only as an optional guard so
+          // a regression that reintroduces the second call still resolves
+          // deterministically instead of failing strict-mode.
           {
             name: "pr-smoke-deterministic-direct-reply",
             match: {
@@ -149,7 +155,8 @@ export default scenario({
               input: "hello deterministic proxy",
             },
             response: "deterministic-test-response: hello deterministic proxy",
-            times: 1,
+            required: false,
+            times: { min: 0, max: 1 },
           },
           {
             name: "pr-smoke-deterministic-router-reply",
@@ -170,8 +177,7 @@ export default scenario({
               addressedTo: [],
               emotion: "none",
             },
-            required: false,
-            times: { min: 0, max: 1 },
+            times: 1,
           },
         );
         registerAppControlHttpHandler((request) => {
@@ -180,7 +186,12 @@ export default scenario({
             return jsonResponse({ views });
           }
           if (request.pathname.endsWith("/interact")) {
+            // The interact route contract carries an authoritative `success`
+            // boolean (parseViewInteractionResponse rejects bodies without
+            // one); the receipt summary filters `success` out, so the visible
+            // "(returned ok, capability, value)" text is unchanged.
             return jsonResponse({
+              success: true,
               ok: true,
               capability: "fill-input",
               value: "Remote Ledger Updated",
@@ -363,6 +374,7 @@ export default scenario({
             pathname: "/api/views/remote-ledger/interact",
             response: {
               body: {
+                success: true,
                 ok: true,
                 capability: "fill-input",
                 value: "Remote Ledger Updated",

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
@@ -42,7 +42,7 @@ type CoveredView = {
 
 // The curated domain views covered by CURATED_MULTILINGUAL (calendar, wallet,
 // inbox, settings), with the label + path the loopback registry serves. The
-// VIEWS show handler echoes `label` back ("Navigated to <label> (gui).") and
+// VIEWS show handler echoes `label` back ("Opened <label>.") and
 // surfaces `data.view.path`, so these must match what the registry returns.
 const COVERED_VIEWS: CoveredView[] = [
   { id: "calendar", label: "Calendar", path: "/apps/calendar" },
@@ -84,7 +84,7 @@ function expectShowTurn(
   execution: ScenarioTurnExecution,
   view: CoveredView,
 ): string | undefined {
-  const expectedText = `Navigated to ${view.label} (gui).`;
+  const expectedText = `Opened ${view.label}.`;
   if (execution.responseText !== expectedText) {
     return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
   }
@@ -186,7 +186,7 @@ export default scenario({
       text: entry.phrase,
       actionName: "VIEWS",
       options: { action: "show", viewType: "gui" },
-      responseIncludesAny: [`Navigated to ${view.label}`],
+      responseIncludesAny: [`Opened ${view.label}`],
       assertTurn: (execution: ScenarioTurnExecution) =>
         expectShowTurn(execution, view),
     };

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
@@ -32,11 +32,14 @@ import {
 type BuiltinView = {
   id: string;
   label: string;
+  navigationLabel?: string;
   path: string;
 };
 
 const BUILTIN_VIEWS: BuiltinView[] = [
-  { id: "chat", label: "Chat", path: "/chat" },
+  // Chat surfaces on Home (the overlay is the chat surface), so the show
+  // receipt names Home while the resolved view stays `chat`.
+  { id: "chat", label: "Chat", navigationLabel: "Home", path: "/chat" },
   { id: "character", label: "Character", path: "/character" },
   { id: "automations", label: "Automations", path: "/automations" },
   { id: "plugins-page", label: "Plugins", path: "/apps/plugins" },
@@ -70,7 +73,7 @@ function expectShowTurn(
   execution: ScenarioTurnExecution,
   view: BuiltinView,
 ): string | undefined {
-  const expectedText = `Navigated to ${view.label} (gui).`;
+  const expectedText = `Opened ${view.navigationLabel ?? view.label}.`;
   if (execution.responseText !== expectedText) {
     return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
   }
@@ -97,8 +100,9 @@ function expectShowTurn(
   if (values.viewId !== view.id) {
     return `expected result.values.viewId=${view.id}, saw ${String(values.viewId)}`;
   }
-  if (values.label !== view.label) {
-    return `expected result.values.label=${view.label}, saw ${String(values.label)}`;
+  const expectedLabel = view.navigationLabel ?? view.label;
+  if (values.label !== expectedLabel) {
+    return `expected result.values.label=${expectedLabel}, saw ${String(values.label)}`;
   }
   const data = toRecord(action.result?.data);
   const resolvedView = toRecord(data.view);
@@ -155,7 +159,7 @@ export default scenario({
     text: `Open the ${view.label} view`,
     actionName: "VIEWS",
     options: { action: "show", view: view.id, viewType: "gui" },
-    responseIncludesAny: [`Navigated to ${view.label}`],
+    responseIncludesAny: [`Opened ${view.navigationLabel ?? view.label}`],
     assertTurn: (execution: ScenarioTurnExecution) =>
       expectShowTurn(execution, view),
   })),

--- a/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
@@ -45,6 +45,9 @@ type VoiceView = {
   // View id the rigid matcher resolves `noun` to (matchViewCommand).
   id: string;
   label: string;
+  // SHARED_NAV_TARGETS canonical label the show receipt echoes when it
+  // differs from the registry label (e.g. todos -> "To-dos").
+  navigationLabel?: string;
   path: string;
 };
 
@@ -58,11 +61,18 @@ const VOICE_VIEWS: VoiceView[] = [
   },
   { noun: "wallet", id: "wallet", label: "Wallet", path: "/apps/wallet" },
   { noun: "inbox", id: "inbox", label: "Inbox", path: "/apps/inbox" },
-  { noun: "todos", id: "todos", label: "Todos", path: "/apps/todos" },
+  {
+    noun: "todos",
+    id: "todos",
+    label: "Todos",
+    navigationLabel: "To-dos",
+    path: "/apps/todos",
+  },
   {
     noun: "documents",
     id: "documents",
     label: "Documents",
+    navigationLabel: "Knowledge",
     path: "/apps/documents",
   },
   // Voice "contacts" → the relationships view (matcher noun synonym).
@@ -98,7 +108,7 @@ function expectVoiceTurn(
   execution: ScenarioTurnExecution,
   view: VoiceView,
 ): string | undefined {
-  const expectedText = `Navigated to ${view.label} (gui).`;
+  const expectedText = `Opened ${view.navigationLabel ?? view.label}.`;
   if (execution.responseText !== expectedText) {
     return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
   }
@@ -129,8 +139,9 @@ function expectVoiceTurn(
   if (values.viewId !== view.id) {
     return `expected result.values.viewId=${view.id}, saw ${String(values.viewId)}`;
   }
-  if (values.label !== view.label) {
-    return `expected result.values.label=${view.label}, saw ${String(values.label)}`;
+  const expectedLabel = view.navigationLabel ?? view.label;
+  if (values.label !== expectedLabel) {
+    return `expected result.values.label=${expectedLabel}, saw ${String(values.label)}`;
   }
   const data = toRecord(action.result?.data);
   const resolvedView = toRecord(data.view);
@@ -191,7 +202,7 @@ export default scenario({
     text: view.noun,
     actionName: "VIEWS",
     options: { action: "show", viewType: "gui" },
-    responseIncludesAny: [`Navigated to ${view.label}`],
+    responseIncludesAny: [`Opened ${view.navigationLabel ?? view.label}`],
     assertTurn: (execution: ScenarioTurnExecution) =>
       expectVoiceTurn(execution, view),
   })),

--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -98,6 +98,7 @@ vi.mock("./hooks/useAvailableViews", () => ({
 
 vi.mock("./hooks/useAuthStatus", () => ({
   isAuthenticatedNow: () => false,
+  useIsAuthenticated: () => false,
   subscribeAuthStatus: () => () => undefined,
   useAuthStatus: () => ({
     state: { phase: appState.authPhase },

--- a/plugins/plugin-github/src/actions/issue-op.ts
+++ b/plugins/plugin-github/src/actions/issue-op.ts
@@ -420,12 +420,13 @@ export const issueOpAction: Action = {
       describeSelection(selection),
       options,
     );
+    const prompt = `${preview} Reply yes to confirm or no to cancel.`;
     const decision = await requireConfirmation({
       runtime,
       message,
       actionName: "GITHUB_ISSUE_OP",
       pendingKey: `${op}:${repo}`,
-      prompt: `${preview} Reply yes to confirm or no to cancel.`,
+      prompt,
       callback,
     });
     if (decision.status === "pending") {
@@ -433,6 +434,11 @@ export const issueOpAction: Action = {
         success: false,
         requiresConfirmation: true,
         preview,
+        // Mirror the delivered prompt and the pending-interaction markers so
+        // the planner terminal path grounds on the tool-owned text instead of
+        // appending its generic failed-tool fallback after the visible prompt.
+        text: prompt,
+        data: { requiresConfirmation: true, preview, awaitingUserInput: true },
       };
     }
     if (decision.status === "cancelled") {

--- a/plugins/plugin-github/src/types.ts
+++ b/plugins/plugin-github/src/types.ts
@@ -176,7 +176,21 @@ export type GitHubPrOp = "list" | "review";
 export type GitHubActionResult<T = unknown> =
   | { success: true; data: T; text?: string }
   | { success: false; error: string }
-  | { success: false; requiresConfirmation: true; preview: string };
+  | {
+      success: false;
+      requiresConfirmation: true;
+      preview: string;
+      /** The delivered confirmation prompt. The planner's terminal path only
+       * trusts tool-owned text on the result, and only spots the pending
+       * interaction through `data` markers — without both it appends its
+       * generic failed-tool fallback after the visible prompt. */
+      text: string;
+      data: {
+        requiresConfirmation: true;
+        preview: string;
+        awaitingUserInput: true;
+      };
+    };
 
 export interface RateLimitError {
   kind: "rate-limit";

--- a/plugins/plugin-openai/__tests__/cerebras-tool-strictness.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-tool-strictness.shape.test.ts
@@ -71,10 +71,12 @@ describe("Cerebras native tool strictness", () => {
     ]);
 
     expectUniformStrictness(tools, false);
+    // Canonical closed shape from core's closedEmptyObjectSchema: `required`
+    // is deliberately omitted — an empty `required` is accepted by the
+    // grammar compiler but carries no information.
     expect(tools.zero_arg_tool?.inputSchema.jsonSchema).toEqual({
       type: "object",
       properties: {},
-      required: [],
       additionalProperties: false,
     });
   });

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -657,6 +657,26 @@ function normalizeNativeToolsForCall(
 
   const toolSet: Record<string, unknown> = {};
 
+  // Cerebras's grammar compiler treats strictness as request-wide, not
+  // per-tool: one non-strict (or unflagged) tool downgrades every tool in the
+  // call, so the wire flag must be emitted uniformly — and always explicitly,
+  // since an omitted flag is not the same as false to the compiler. Schema
+  // handling below still follows each tool's declared flag (a declared
+  // non-strict schema passes through raw; everything else is sanitized).
+  const cerebrasRequestStrict =
+    options.cerebrasMode === true &&
+    tools.every((rawTool) => {
+      const tool = asRecord(rawTool);
+      const functionTool = asRecord(tool.function);
+      const declared =
+        typeof tool.strict === "boolean"
+          ? tool.strict
+          : typeof functionTool.strict === "boolean"
+            ? functionTool.strict
+            : undefined;
+      return declared === true;
+    });
+
   for (const rawTool of tools) {
     const tool = asRecord(rawTool);
     const functionTool = asRecord(tool.function);
@@ -717,7 +737,11 @@ function normalizeNativeToolsForCall(
     toolSet[registeredName] = {
       ...(description ? { description } : {}),
       inputSchema: jsonSchema(inputSchema as JSONSchema7),
-      ...(strict === undefined ? {} : { strict }),
+      ...(options.cerebrasMode
+        ? { strict: cerebrasRequestStrict }
+        : strict === undefined
+          ? {}
+          : { strict }),
     };
   }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service.ts
@@ -2636,6 +2636,20 @@ export class LifeOpsService extends LifeOpsServiceBase {
       getXDms: (...args) => this.getXDms(...args),
     },
     loadPriorityScoringSettings: async () => {
+      // Deterministic harnesses opt out the same way they disable the
+      // character-voice rewrite (ACTION_CALLBACK_VOICE_REWRITE): scoring spends
+      // background TEXT_SMALL calls that a strict scenario LLM proxy has no
+      // fixtures for, and the resulting reported errors contaminate the
+      // RECENT_ERRORS provider text that strict turn fixtures key on.
+      const scoringOverride = this.runtime.getSetting(
+        "LIFEOPS_INBOX_PRIORITY_SCORING",
+      );
+      if (
+        typeof scoringOverride === "string" &&
+        scoringOverride.trim().toLowerCase() === "false"
+      ) {
+        return { enabled: false, model: null };
+      }
       try {
         const state = await loadLifeOpsAppState(this.runtime);
         return {

--- a/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
@@ -28,6 +28,16 @@ function ownerMessage(agentId: UUID, text: string): Memory {
   } as Memory;
 }
 
+// Owner-chat reminder creates delegate to the OWNER_REMINDERS definition flow
+// (routing contract in scheduled-task.ts); only autonomy-sourced messages keep
+// the raw scheduler surface this file exercises. Creates therefore arrive as
+// autonomy messages, the way background automations schedule their own work.
+function autonomyMessage(agentId: UUID, text: string): Memory {
+  const message = ownerMessage(agentId, text);
+  message.content.source = "autonomy";
+  return message;
+}
+
 describe("SCHEDULED_TASK action", () => {
   let runtimeResult: RealTestRuntimeResult | null = null;
 
@@ -44,7 +54,7 @@ describe("SCHEDULED_TASK action", () => {
 
     const created = await scheduledTaskAction.handler?.(
       runtime,
-      ownerMessage(runtime.agentId, "schedule a reminder"),
+      autonomyMessage(runtime.agentId, "schedule a reminder"),
       undefined,
       {
         parameters: {
@@ -135,7 +145,7 @@ describe("SCHEDULED_TASK action", () => {
 
     const result = await scheduledTaskAction.handler?.(
       runtime,
-      ownerMessage(runtime.agentId, "schedule a gated reminder"),
+      autonomyMessage(runtime.agentId, "schedule a gated reminder"),
       undefined,
       {
         parameters: {
@@ -173,7 +183,10 @@ describe("SCHEDULED_TASK action", () => {
     );
     const tasks = (listed?.data as { tasks?: ScheduledTask[] } | undefined)
       ?.tasks;
-    expect(tasks).toHaveLength(0);
+    if (!tasks) throw new Error("list did not return scheduled tasks");
+    // First-run defaults seed check-in/watcher/recap/output tasks on a fresh
+    // runtime; the rejected create must not have written its reminder row.
+    expect(tasks.filter((task) => task.kind === "reminder")).toHaveLength(0);
   });
 
   it("get returns NOT_FOUND for an unknown taskId", async () => {
@@ -205,7 +218,7 @@ describe("SCHEDULED_TASK action", () => {
     for (const instructions of ["sort the receipts", "reply to Jordan"]) {
       const created = await scheduledTaskAction.handler?.(
         runtime,
-        ownerMessage(runtime.agentId, `remind me to ${instructions}`),
+        autonomyMessage(runtime.agentId, `remind me to ${instructions}`),
         undefined,
         {
           parameters: {

--- a/plugins/plugin-workflow/__tests__/integration/orphaned-schedule-reconciliation.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/orphaned-schedule-reconciliation.test.ts
@@ -17,10 +17,12 @@ import {
   type Task,
   type UUID,
 } from '@elizaos/core';
-import { NotificationService } from '@elizaos/core/node';
+// TaskService must come from the same package entry the runtime loads —
+// a relative src import creates a second class identity and the
+// `instanceof TaskService` readiness check always fails against it.
+import { NotificationService, TaskService } from '@elizaos/core/node';
 import { eq } from 'drizzle-orm';
 import { registerTriggerTaskWorker } from '../../../../packages/agent/src/triggers/runtime.ts';
-import { TaskService } from '../../../../packages/core/src/services/task.ts';
 import { plugin as sqlPlugin } from '../../../plugin-sql/src/index.ts';
 import { DatabaseMigrationService } from '../../../plugin-sql/src/migration-service.ts';
 import { PgliteDatabaseAdapter } from '../../../plugin-sql/src/pglite/adapter.ts';

--- a/plugins/plugin-workflow/__tests__/integration/workflow-crash-recovery.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/workflow-crash-recovery.test.ts
@@ -45,6 +45,10 @@ test('startup resumes a killed execution without duplicating its persisted side 
     db,
     getSetting: (key: string) => (key === 'WORKFLOW_SEED_DEFAULTS' ? 'false' : undefined),
     getService: () => null,
+    getTasks: async () => [],
+    createTask: async () => '00000000-0000-4000-8000-000000000001',
+    deleteTask: async () => {},
+    reportError: () => {},
   } as never;
   const server = createServer();
   let sideEffectCalls = 0;

--- a/plugins/plugin-workflow/__tests__/unit/respond-to-event.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/respond-to-event.test.ts
@@ -43,7 +43,16 @@ interface RuntimeMockOptions {
 
 type RespondToEventRuntime = Pick<
   IAgentRuntime,
-  'agentId' | 'db' | 'getSetting' | 'getService' | 'createMemory' | 'logger'
+  | 'agentId'
+  | 'db'
+  | 'getSetting'
+  | 'getService'
+  | 'createMemory'
+  | 'logger'
+  | 'getTasks'
+  | 'createTask'
+  | 'deleteTask'
+  | 'reportError'
 >;
 
 function buildRuntime(options: RuntimeMockOptions = {}): {
@@ -63,6 +72,10 @@ function buildRuntime(options: RuntimeMockOptions = {}): {
     db: options.db,
     getSetting: () => null,
     getService: (type: string) => services[type] ?? services[type.toLowerCase()] ?? null,
+    getTasks: async () => [],
+    createTask: async () => '00000000-0000-4000-8000-000000000001' as UUID,
+    deleteTask: async () => {},
+    reportError: () => {},
     createMemory: mock(async (memory: CapturedMemory, _table: string) => {
       capturedMemories.push(memory);
       return memory;


### PR DESCRIPTION
# Relates to

Develop post-merge CI reds on [run 30054386125](https://github.com/elizaOS/eliza/actions/runs/30054386125) (and the identical pre-canary failures on [run 30047861919](https://github.com/elizaOS/eliza/actions/runs/30047861919)): Server Tests, Client Tests, Integration Lane (personal-assistant), Plugin Tests (2/4), Zero-Key scenario runner → Zero-Key Deterministic E2E → ci-ok. These are the failures that were masked while `Classify changed paths` was red (fixed by #17147) and re-surfaced once it went green.

# Risks

Medium-low. One product-behavior change in core (planner-reply egress ordering, see below); everything else is test/scenario/harness alignment with behavior changes that already shipped to develop.

# Background

## What does this PR do?

Each 07-23 develop merge that changed product behavior left tests asserting the old behavior. This PR aligns them, and fixes one real product-ordering bug found in the process:

- **core / Server Tests** — `planner-happy-path` "voice-rewritten echo suppression": the #17126 reply-egress claim gate ran *before* the action-echo suppression, so a reply an action callback had already delivered got replaced with a contradicting "I couldn't verify…" bounce instead of being suppressed. The egress gate now exempts a reply that matches a delivered action-callback text (verbatim or strict superset — same rule as the suppression, shared via one helper). `message.ttft-prefetch` detachment test: #17105 gates post-turn evaluators on a semantic signal; the test's smalltalk reply no longer reached the evaluator and hung to timeout — the test message now carries a semantic signal ("remember …").
- **agent / Server Tests** — `persistence-after-done`: the #17119 conversation-connection readiness fence checks the world exists after `ensureConnection`; the fixture's `getWorld` returned `null`, so every test short-circuited at readiness (`CONVERSATION_WORLD_MISSING`) before the streaming path under test. The fixture now returns a minimal world.
- **ui / Client Tests** — `App.chat-overlay-first-run`: `useAgentSessionRecovery` now calls `useIsAuthenticated` from `./hooks/useAuthStatus`; the test's module mock predates that export. Added it.
- **personal-assistant / Integration Lane** — `scheduled-task-action.integration`: #17116 delegates owner-chat `create kind:"reminder"` to the OWNER_REMINDERS flow; only autonomy-sourced creates keep the raw scheduler surface this file exercises. Creates are now autonomy-sourced, and the "wrote no row" assert is seeded-defaults-aware (first-run seeds check-in/watcher/recap/output tasks).
- **plugin-workflow / Plugin Tests (2/4)** — #17061 removed the runtime-capability guards (fail-fast reconciliation) but only updated one of three test files' runtime doubles; `respond-to-event` and `workflow-crash-recovery` doubles now provide `getTasks`/`createTask`/`deleteTask`/`reportError`. Its own acceptance test (`orphaned-schedule-reconciliation`) failed on a class-identity bug: it imported `TaskService` by relative src path while the runtime instantiates the built copy, so `instanceof` always failed — `TaskService` is now exported from `@elizaos/core/node` and the test imports it from there.
- **scenario-runner / Zero-Key** — three deterministic scenarios: (1) the LifeOps inbox priority-scoring background batch fires unfixtured TEXT_SMALL calls under the strict proxy and its reported failure contaminates the RECENT_ERRORS provider text that strict fixtures key on — the deterministic harness now disables it via `LIFEOPS_INBOX_PRIORITY_SCORING=false` (mirroring `ACTION_CALLBACK_VOICE_REWRITE=false`), honored in the PA composition seam; (2) the two lifeops scenarios created `kind:"reminder"` raw scheduler tasks from chat, which #17116 now delegates — they use `kind:"custom"` to keep exercising the raw admin surface; (3) `deterministic-pr-smoke`: the simple-reply path answers from the stage-1 router `replyText` with no follow-up TEXT_SMALL call, so the required direct-reply fixture could never be consumed — required-ness flipped to the router fixture; and the view-interact loopback stub now carries the authoritative `success` boolean that `parseViewInteractionResponse` requires since the interaction-receipt hardening (the receipt summary filters `success`, so the asserted visible text is unchanged).

The 07-23 late-evening merges (receipt singularization, terminal-path rework, Cerebras strictness test) added further reds, fixed here too:

- **core / Server Tests** — the new `message.transcript-visibility` evaluator-summary test asserted persist-before-callback; #17105 deliberately delivers before persisting (durability-before-terminal is the conversation route's contract) — expectation aligned. **Product fix:** a turn ending on a failed tool whose own callback already delivered its user-facing explanation (a confirmation preview, an "only available in the cloud runtime" boundary notice) also emitted the planner's generic "I tried to complete that, but …" fallback — a contradictory second bubble glued onto the visible receipt. The fallback (now the exported `FAILED_TOOL_FALLBACK_MESSAGE`) is suppressed when a failed action result's text was already delivered this turn; turns with no visible failure text keep it, so failed turns are never silent.
- **plugin-openai / Plugin Tests (3/4)** — the new `cerebras-tool-strictness.shape` test landed red: it asserts Cerebras's request-wide strictness contract (one non-strict or unflagged tool downgrades the whole array, flag always explicit) which the normalizer never implemented — implemented in `normalizeNativeToolsForCall`; the zero-arg schema expectation is aligned with core's documented `closedEmptyObjectSchema` shape (`required` deliberately omitted).
- **scenario-runner / Zero-Key** — the navigation-receipt copy change ("Navigated to X (gui)." → "Opened X.", chat → "Home", todos → "To-dos" per `SHARED_NAV_TARGETS`) swept through `deterministic-view-switching`, `-multilingual`, `-view-voice`, `-app-control-actions`, and `-app-control-nl-routing` expectations.

## What kind of change is this?

Bug fixes (CI-green restoration; two product fixes in core, one in plugin-openai).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The failing lanes on run 30054386125, then the same test files in this PR's CI run.

## Detailed testing steps

None: the previously failing CI lanes exercise every change.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test/CI fixes; no UI surface changed. Before state: red lanes on https://github.com/elizaOS/eliza/actions/runs/30054386125
<!-- evidence-row:after-screenshots -->
- [x] N/A - test/CI fixes; no UI surface changed. After state: this PR's CI lanes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] Local runs against a clean develop worktree: core `planner-happy-path` + `message.side-effect-claim` 44/44 passed; core `message.ttft-prefetch` 22 passed; agent `persistence-after-done` 5/5 passed; ui `App.chat-overlay-first-run` 4/4 passed; plugin-workflow `orphaned-schedule-reconciliation` 1/1 passed (16 asserts) and `workflow-crash-recovery` passed solo. Failing-lane logs: https://github.com/elizaOS/eliza/actions/runs/30054386125
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime change (test mock only).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic zero-key scenario changes only; the pr-deterministic lane in this PR's CI is the trajectory evidence (strict LLM proxy, no live model involved).
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts; deliverable is green CI lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
