### PR TITLE
fix(ci): align tests and harnesses with the lanes unmasked by #17163

### DIFF
--- a/packages/agent/test/api/chat-augmentation-route.test.ts
+++ b/packages/agent/test/api/chat-augmentation-route.test.ts
@@ -173,6 +173,10 @@ function createRuntime(
     getRoom: vi.fn(async () => null),
     getService: vi.fn(() => null),
     getServiceLoadPromise: vi.fn(async () => undefined),
+    // The route's J7 diagnostic paths (inference-timing persistence, recovery
+    // failures) call runtime.reportError; a fixture without it turns those
+    // catches into unhandled TypeErrors that abort the flow under test.
+    reportError: vi.fn(),
     getServicesByType: vi.fn(() => []),
     emitEvent: vi.fn(async () => undefined),
     drainChatPreHandlers: vi.fn(async () => null),
@@ -313,16 +317,19 @@ describe("document-query-recovery is skipped on a plain turn through the message
     expect(textLargeRecoveryCalls(useModel)).toHaveLength(0);
   });
 
-  it("DOES fire exactly one TEXT_LARGE recovery call when the corpus returns a sub-threshold candidate (negative control)", async () => {
-    // Proves the zero-call assertions above are not vacuous: when documents
-    // exist but the top candidate falls below the relevance threshold, the
-    // recovery TEXT_LARGE round-trip is the intended behaviour and the spy
-    // filter detects it through the same route path.
+  it("keeps the sub-threshold path LLM-free: the lexical cross-scope retry replaced query recovery (negative control)", async () => {
+    // This is the case that used to fire the recovery TEXT_LARGE round-trip:
+    // documents exist but the top candidate falls below the relevance
+    // threshold. #16916 removed that model call — the augmentation now retries
+    // lexically across scopes instead. Pinning zero TEXT_LARGE calls HERE
+    // keeps the zero-call assertions above non-vacuous: this turn provably
+    // exercises the below-threshold branch (the corpus is searched more than
+    // once), and even it may not spend a model round-trip.
     const agentId = stringToUuid("recovery-fires-agent") as UUID;
     const documents = {
       // First search (raw user prompt) returns a sub-threshold candidate;
-      // documents clearly exist, so recovery is warranted. Recovered-query
-      // searches return nothing, so the turn still falls through to a reply.
+      // the lexical/cross-scope retries return nothing, so the turn still
+      // falls through to a reply.
       searchDocuments: vi
         .fn()
         .mockResolvedValueOnce([
@@ -334,9 +341,7 @@ describe("document-query-recovery is skipped on a plain turn through the message
         ])
         .mockResolvedValue([]),
     };
-    // Recovery model returns a parseable queries JSON so the recovered-query
-    // searches run; none clear the threshold, so the message passes through.
-    const useModel = vi.fn(async () => JSON.stringify({ queries: ["x"] }));
+    const useModel = vi.fn(async () => "");
     const runtime = createRuntime(agentId, {
       messageService: createMessageService("ok"),
       getService: vi.fn((name: string) =>
@@ -355,10 +360,9 @@ describe("document-query-recovery is skipped on a plain turn through the message
     const handled = await invoke();
     expect(handled).toBe(true);
     expect(record.status).toBe(200);
-    expect(textLargeRecoveryCalls(useModel)).toHaveLength(1);
-    expect(textLargeRecoveryCalls(useModel)[0][1]).toMatchObject({
-      responseFormat: { type: "json_object" },
-    });
+    // The below-threshold branch ran a retry search, not a model call.
+    expect(documents.searchDocuments.mock.calls.length).toBeGreaterThan(1);
+    expect(textLargeRecoveryCalls(useModel)).toHaveLength(0);
   });
 
   it("does not call useModel at all from augmentation when the documents service is absent", async () => {

--- a/packages/ui/src/components/chat/render-parity.contract.test.tsx
+++ b/packages/ui/src/components/chat/render-parity.contract.test.tsx
@@ -209,24 +209,6 @@ const CORPUS: Array<{ name: string; message: ConversationMessage }> = [
     ),
   },
   {
-    name: "reasoning block (single text segment)",
-    message: assistant("You're free after 3pm.", {
-      reasoning: "I checked the calendar and the afternoon is open.",
-    }),
-  },
-  {
-    name: "reasoning block (multi-segment)",
-    message: assistant("The answer is:\n```txt\n42\n```", {
-      reasoning: "I considered several options and settled on 42.",
-    }),
-  },
-  {
-    name: "reasoning + code",
-    message: assistant("Use this:\n```py\nprint(42)\n```", {
-      reasoning: "Python is the simplest demonstration here.",
-    }),
-  },
-  {
     name: "secret request",
     message: assistant("I need a key to continue.", {
       secretRequest: SECRET_REQUEST,
@@ -283,15 +265,16 @@ describe("chat render parity (ThreadLine vs MessageContent) — #9954", () => {
       const fp = fingerprint(view.container);
       if (fp.hasChoiceWidget) seen.add("choice");
       if (fp.hasCodeBlock) seen.add("code");
-      if (fp.hasReasoning) seen.add("reasoning");
       if (fp.hasSecretRequest) seen.add("secret");
       if (fp.hasNoProviderGate) seen.add("no-provider");
       cleanup();
     }
     // If the corpus stopped covering an affordance the parity check would pass
-    // trivially — assert all five rich structures actually appear.
+    // trivially — assert all four rich structures actually appear. (Reasoning
+    // is a PINNED divergence below, not a parity affordance: the overlay never
+    // renders it.)
     expect([...seen].sort()).toEqual(
-      ["choice", "code", "no-provider", "reasoning", "secret"].sort(),
+      ["choice", "code", "no-provider", "secret"].sort(),
     );
   });
 });
@@ -329,11 +312,13 @@ describe("chat render parity — PINNED divergences (intended/tracked) — #9954
     expect(overlayPrint.hasInlineCode).toBe(false);
   });
 
-  // (2) Secret request with a rich body + reasoning. MessageContent early-returns
-  //     ONLY the SensitiveRequestBlock — body code/widgets and reasoning are
-  //     suppressed. ThreadLine co-renders the body (so a fenced block still shows
-  //     a code block), the secret block, AND reasoning. Both emit exactly one
-  //     sensitive-request (agreement); the surrounding body is what diverges.
+  // (2) Secret request with a rich body. MessageContent early-returns ONLY the
+  //     SensitiveRequestBlock — body code/widgets are suppressed. ThreadLine
+  //     co-renders the body (so a fenced block still shows a code block) AND
+  //     the secret block. Both emit exactly one sensitive-request (agreement);
+  //     the surrounding body is what diverges. Reasoning appears on neither
+  //     surface here — ChatView suppresses the whole body, and the overlay
+  //     never renders reasoning at all (pin 3).
   it("PIN: a secret request suppresses the body in ChatView, co-renders it in the overlay", () => {
     const { viewPrint, overlayPrint } = renderBoth(
       assistant("Paste the token:\n```ts\nconst t = 1;\n```", {
@@ -349,7 +334,35 @@ describe("chat render parity — PINNED divergences (intended/tracked) — #9954
     expect(overlayPrint).toMatchObject({
       hasSecretRequest: true,
       hasCodeBlock: true,
-      hasReasoning: true,
+      hasReasoning: false,
+    });
+  });
+
+  // (3) Model reasoning. ChatView renders the collapsed ThinkingBlock
+  //     disclosure; the overlay's message body deliberately keeps reasoning
+  //     out of transcript chrome (renderOverlayMessageBody: "tool traces and
+  //     model reasoning remain available to diagnostics but never become
+  //     transcript chrome"). The rest of the body keeps full parity.
+  it("PIN: model reasoning renders a ThinkingBlock in ChatView, never in the overlay", () => {
+    const { viewPrint, overlayPrint } = renderBoth(
+      assistant("You're free after 3pm.", {
+        reasoning: "I checked the calendar and the afternoon is open.",
+      }),
+    );
+    expect(viewPrint.hasReasoning).toBe(true);
+    expect(overlayPrint.hasReasoning).toBe(false);
+  });
+
+  it("PIN: reasoning alongside code diverges only on the ThinkingBlock — the code block keeps parity", () => {
+    const { viewPrint, overlayPrint } = renderBoth(
+      assistant("Use this:\n```py\nprint(42)\n```", {
+        reasoning: "Python is the simplest demonstration here.",
+      }),
+    );
+    expect(viewPrint).toMatchObject({ hasReasoning: true, hasCodeBlock: true });
+    expect(overlayPrint).toMatchObject({
+      hasReasoning: false,
+      hasCodeBlock: true,
     });
   });
 });

--- a/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
@@ -266,7 +266,11 @@ describe("ChatOverlay first-run gating", () => {
     expect(composer.contains(decorativeHandle)).toBe(true);
     expect(decorativeHandle.getAttribute("aria-hidden")).toBe("true");
     expect(decorativeHandle.tagName).toBe("SPAN");
-    expect(composer.className.split(" ")).toContain("py-2");
+    // The composer keeps its normal equal-inset padding during first-run —
+    // the responsive clamp token from the composer row, not a taller pt-5.
+    expect(composer.className.split(" ")).toContain(
+      "py-[clamp(0.125rem,0.75dvh,0.375rem)]",
+    );
     expect(composer.className.split(" ")).not.toContain("pt-5");
     expect(sheet.getAttribute("data-variant")).toBe("open");
     expect(sheet.getAttribute("data-detent")).toBe("full");

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/multi-project-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/multi-project-scenario.ts
@@ -135,6 +135,13 @@ export class MultiProjectAcp {
     return [];
   }
 
+  // Auto goal verification reads the orchestrator-owned artifact ledger;
+  // without this the optional-chained call throws and completions park in
+  // `validating` (mirrors the main orchestrator-scenario-harness stub).
+  getOrchestratorOwnedArtifacts(_sessionId: string): [] {
+    return [];
+  }
+
   async stopSession(id: string): Promise<void> {
     const s = this.sessions.get(id);
     if (s) s.status = "stopped";

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-grilling-harness.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-grilling-harness.ts
@@ -48,6 +48,10 @@ export function makeScriptedAcp() {
     },
     stopSession: async () => undefined,
     getChangedPaths: () => [],
+    // Auto goal verification reads the orchestrator-owned artifact ledger;
+    // without this the optional-chained call throws and the residual gate
+    // never runs (completions park in `validating`).
+    getOrchestratorOwnedArtifacts: (_sessionId: string): [] => [],
     getSession: async () => undefined,
     updateSessionMetadata: async () => undefined,
   };

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-scenario-harness.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-scenario-harness.ts
@@ -15,6 +15,7 @@ import {
 } from "@elizaos/core";
 import { AcpService } from "../../../src/services/acp-service.js";
 import { augmentTaskWithDeployGuidance } from "../../../src/services/app-deploy-guidance.js";
+import type { OrchestratorOwnedArtifact } from "../../../src/services/orchestrator-artifact-ownership.js";
 import { OrchestratorTaskService } from "../../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../../src/services/orchestrator-task-store.js";
 import type { OrchestratorTaskDocument } from "../../../src/services/orchestrator-task-types.js";
@@ -206,6 +207,15 @@ class ScenarioAcpService {
   }
 
   getChangedPaths(_sessionId: string): string[] {
+    return [];
+  }
+
+  // Auto goal verification reads the orchestrator-owned artifact ledger
+  // (residualsOrchestratorOwnedArtifacts); without this the optional-chained
+  // call throws and every changeset-backed completion parks in `validating`.
+  getOrchestratorOwnedArtifacts(
+    _sessionId: string,
+  ): OrchestratorOwnedArtifact[] {
     return [];
   }
 


### PR DESCRIPTION
# Relates to

Follow-up to #17163: the lanes it fixed unmasked the next layer of failures on the develop post-merge run [30141434704](https://github.com/elizaOS/eliza/actions/runs/30141434704) — Zero-Key scenario runner (orchestrator lane, previously never reached), Client Tests (late-07-24 UI merges), and Server Tests (one stale agent route test).

# Risks

Low. Test/harness alignment only — no product code changed.

# Background

## What does this PR do?

- **Zero-Key scenario runner** — with the deterministic lane green (40/40 in run 30141434704), the job progressed to the orchestrator lane for the first time in days: 7/13 scenarios failed with `acp?.getOrchestratorOwnedArtifacts is not a function` — auto goal verification reads the orchestrator-owned artifact ledger, and the three scenario-harness ACP stubs (orchestrator-scenario-harness, MultiProjectAcp, makeScriptedAcp) predate that method, so every changeset-backed completion parked in `validating`. All three stubs now provide it; the lane runs 13/13 locally.
- **Client Tests** — the first-run mock fix from #17163 holds (App.chat-overlay-first-run passes in CI); the remaining failures came from the chat-interaction-polish merges: (1) the overlay's message body now deliberately keeps model reasoning out of transcript chrome, so the render-parity contract moves reasoning from the parity corpus to the PINNED-divergences section (ChatView renders the ThinkingBlock, the overlay never does), with the coverage guard updated; (2) the composer row's `py-2` became the equal-inset clamp token — the first-run handle test asserts the new literal.
- **Server Tests** — `chat-augmentation-route.test.ts`'s negative control asserted the TEXT_LARGE query-recovery round-trip that #16916 removed (replaced by the lexical cross-scope retry). The test now pins the new contract: the sub-threshold branch retries the corpus search without any model call. The fixture also grows `runtime.reportError`, which the reworked chat-routes J7 diagnostics call.

## What kind of change is this?

Bug fixes (test/harness alignment; CI-green restoration).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The three failing lanes on run 30141434704, then the same jobs on this PR's post-merge run.

## Detailed testing steps

None: the previously failing CI lanes exercise every change.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test/harness fixes; no UI runtime change. Before state: red lanes on https://github.com/elizaOS/eliza/actions/runs/30141434704
<!-- evidence-row:after-screenshots -->
- [x] N/A - test/harness fixes; no UI runtime change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] Local verification on a clean develop worktree: orchestrator scenario lane 13/13 passed; render-parity contract 12/12 passed; ChatOverlay.firstrun 19/19 passed; chat-augmentation-route 3/3 passed. Failing before-logs: https://github.com/elizaOS/eliza/actions/runs/30141434704
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-only change (no frontend runtime code touched).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic zero-key scenarios only; the orchestrator lane in this PR's CI is the trajectory evidence (strict LLM proxy, no live model).
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts; deliverable is green CI lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
