### PR TITLE
fix(registry): bump @wealthville/plugin-wealthville to 0.2.1

### DIFF
--- a/packages/registry/entries/third-party/wealthville__plugin-wealthville.json
+++ b/packages/registry/entries/third-party/wealthville__plugin-wealthville.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "Wealthville liquidity-pool scores, ENTER/HOLD/EXIT verdicts, and public miss-inclusive track record for DeFi agents (Solana + EVM).",
   "homepage": "https://wealthville.net/developers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "directory": "elizaos-plugin",
   "tags": ["solana", "defi", "liquidity-pools", "scoring", "wealthville"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -571,7 +571,7 @@
         "repo": "@wealthville/plugin-wealthville",
         "v0": null,
         "v1": null,
-        "v2": "0.2.0"
+        "v2": "0.2.1"
       },
       "supports": {
         "v0": false,


### PR DESCRIPTION
Small follow-up to #16374.

That entry pins `"version": "0.2.0"`, which is a version behind what's on npm — and the gap matters here rather than being cosmetic. `0.2.0` has no `agentConfig`, so anything resolving the plugin from the registry-listed version can't see its configuration surface:

```
$ npm view @wealthville/plugin-wealthville@0.2.0 agentConfig
(empty)

$ npm view @wealthville/plugin-wealthville@0.2.1 agentConfig
{ pluginType: 'elizaos:plugin:1.0.0', pluginParameters: { WEALTHVILLE_API_KEY: {...}, WEALTHVILLE_API_URL: {...} } }
```

`0.2.1` is published and is the first version carrying `pluginType` + `pluginParameters` (both parameters optional — the API works anonymously).

Changed the `version` field in the entry and regenerated the wire registry per the package README; the generated diff is the single `npm.v2` value.

```
$ node packages/registry/src/validate-cli.ts
[registry] 30 third-party entries validated

$ node packages/registry/src/generate.ts
Generated .../generated-registry.json (30 third-party entries)
```

No other entries touched.