### PR TITLE
fix(discord): register outbound DM recipients before send

### DIFF
--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -5,7 +5,11 @@
  * connector registration, account lookup, command registration, and message
  * mutations execute production code without opening a gateway connection.
  */
-import { ChannelType as CoreChannelType } from "@elizaos/core";
+import {
+	ChannelType as CoreChannelType,
+	type Memory,
+	type UUID,
+} from "@elizaos/core";
 import { Collection, ChannelType as DiscordChannelType } from "discord.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -40,6 +44,7 @@ type MutableDiscordService = DiscordService & {
 function makeRuntime() {
 	const rooms = new Map<string, unknown>();
 	const worlds = new Map<string, unknown>();
+	const memories = new Map<string, Memory>();
 	return {
 		agentId: AGENT_ID,
 		character: { name: "Eliza", settings: {} },
@@ -62,6 +67,16 @@ function makeRuntime() {
 		}),
 		getRoom: vi.fn(async (roomId) => rooms.get(String(roomId)) ?? null),
 		getWorld: vi.fn(async (worldId) => worlds.get(String(worldId)) ?? null),
+		getMemoryById: vi.fn(
+			async (memoryId: UUID) => memories.get(String(memoryId)) ?? null,
+		),
+		createMemory: vi.fn(async (memory: Memory) => {
+			if (!memory.id) {
+				throw new Error("Discord message memory must have a stable id");
+			}
+			memories.set(String(memory.id), memory);
+			return memory.id;
+		}),
 		getEntityById: vi.fn(async () => null),
 		getRelationships: vi.fn(async () => []),
 		emitEvent: vi.fn(),
@@ -156,13 +171,30 @@ function makeDiscordGraph() {
 		type: DiscordChannelType.GuildVoice,
 		isVoiceBased: () => true,
 	};
+	const dmChannel = {
+		id: "888888888888888888",
+		name: "sender",
+		type: DiscordChannelType.DM,
+		isTextBased: () => true,
+		isVoiceBased: () => false,
+		isThread: () => false,
+		send: vi.fn(async (payload: { content?: string }) =>
+			makeMessage({
+				id: "555555555555555555",
+				content: payload.content,
+				author: { id: "999999999999999999", username: "bot" },
+			}),
+		),
+	};
 	const cachedUser = {
 		id: "222222222222222222",
 		username: "sender",
+		displayName: "Sender",
 		globalName: "Sender",
 		tag: "sender#0001",
 		bot: false,
-		createDM: vi.fn(),
+		dmChannel,
+		createDM: vi.fn(async () => dmChannel),
 	};
 	const member = {
 		id: cachedUser.id,
@@ -229,10 +261,12 @@ function makeDiscordGraph() {
 			cache: new Collection([
 				[textChannel.id, textChannel],
 				[voiceChannel.id, voiceChannel],
+				[dmChannel.id, dmChannel],
 			]),
 			fetch: vi.fn(async (channelId: string) => {
 				if (channelId === textChannel.id) return textChannel;
 				if (channelId === voiceChannel.id) return voiceChannel;
+				if (channelId === dmChannel.id) return dmChannel;
 				return null;
 			}),
 		},
@@ -246,7 +280,16 @@ function makeDiscordGraph() {
 		},
 		destroy: vi.fn().mockResolvedValue(undefined),
 	};
-	return { botMember, cachedUser, client, guild, member, message, textChannel };
+	return {
+		botMember,
+		cachedUser,
+		client,
+		dmChannel,
+		guild,
+		member,
+		message,
+		textChannel,
+	};
 }
 
 function makeState(
@@ -364,6 +407,111 @@ describe("DiscordService.getAccountLabel", () => {
 });
 
 describe("DiscordService account-scoped primitives", () => {
+	it("registers a resolved outbound DM recipient before delivering the message", async () => {
+		const { graph, runtime, service } = makeService();
+		const recipientEntityId = service.resolveDiscordEntityId(
+			graph.cachedUser.id,
+		);
+
+		const persisted = await service.handleSendMessage(
+			runtime as never,
+			{
+				source: "discord",
+				accountId: "work",
+				entityId: graph.cachedUser.id as UUID,
+			},
+			{ text: "remember this outbound DM" },
+		);
+
+		expect(runtime.ensureConnection).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				entityId: recipientEntityId,
+				userId: graph.cachedUser.id,
+				userName: graph.cachedUser.username,
+				name: graph.cachedUser.displayName,
+				channelId: graph.dmChannel.id,
+				type: CoreChannelType.DM,
+				metadata: { accountId: "work" },
+			}),
+		);
+		expect(runtime.ensureConnection).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				entityId: AGENT_ID,
+				channelId: graph.dmChannel.id,
+				type: CoreChannelType.DM,
+				metadata: { accountId: "work" },
+			}),
+		);
+		expect(runtime.ensureConnection.mock.invocationCallOrder[0]).toBeLessThan(
+			graph.dmChannel.send.mock.invocationCallOrder[0],
+		);
+		expect(graph.dmChannel.send).toHaveBeenCalledWith(
+			expect.objectContaining({ content: "remember this outbound DM" }),
+		);
+		expect(persisted).toMatchObject({
+			entityId: AGENT_ID,
+			content: { text: "remember this outbound DM" },
+			metadata: { accountId: "work" },
+		});
+	});
+
+	it("preserves a canonical runtime entity when resolving its Discord identity", async () => {
+		const { graph, runtime, service } = makeService();
+		const recipientEntityId = "00000000-0000-0000-0000-000000000099" as UUID;
+		service.resolveDiscordTargetUserId = vi.fn(async () => graph.cachedUser.id);
+
+		await service.handleSendMessage(
+			runtime as never,
+			{
+				source: "discord",
+				accountId: "work",
+				entityId: recipientEntityId,
+			},
+			{ text: "preserve the linked runtime identity" },
+		);
+
+		expect(runtime.ensureConnection).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				entityId: recipientEntityId,
+				userId: graph.cachedUser.id,
+			}),
+		);
+	});
+
+	it("fails before DM delivery and leaves the same request retryable", async () => {
+		const { graph, runtime, service } = makeService();
+		const target = {
+			source: "discord",
+			accountId: "work",
+			entityId: graph.cachedUser.id as UUID,
+		};
+		const content = {
+			text: "must not escape before participation is durable",
+		};
+		runtime.ensureConnection.mockRejectedValueOnce(
+			new Error("recipient persistence unavailable"),
+		);
+
+		await expect(
+			service.handleSendMessage(runtime as never, target, content),
+		).rejects.toThrow("recipient persistence unavailable");
+
+		expect(graph.dmChannel.send).not.toHaveBeenCalled();
+		expect(runtime.createMemory).not.toHaveBeenCalled();
+
+		await expect(
+			service.handleSendMessage(runtime as never, target, content),
+		).resolves.toMatchObject({
+			entityId: AGENT_ID,
+			content: { text: content.text },
+		});
+		expect(graph.dmChannel.send).toHaveBeenCalledTimes(1);
+		expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+	});
+
 	it("registers account connectors and scopes wrapper calls to the selected account", async () => {
 		const { runtime, service } = makeService();
 		DiscordService.registerSendHandlers(runtime as never, service);

--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -512,6 +512,79 @@ describe("DiscordService account-scoped primitives", () => {
 		expect(runtime.createMemory).toHaveBeenCalledTimes(1);
 	});
 
+	it("allows a concurrent request to deliver when the first participant write fails", async () => {
+		const { graph, runtime, service } = makeService();
+		const target = {
+			source: "discord",
+			accountId: "work",
+			entityId: graph.cachedUser.id as UUID,
+		};
+		const content = { text: "deliver exactly once after durable membership" };
+		let rejectFirstWrite: ((error: Error) => void) | undefined;
+		let markFirstWriteStarted: (() => void) | undefined;
+		const firstWriteStarted = new Promise<void>((resolve) => {
+			markFirstWriteStarted = resolve;
+		});
+		const firstWrite = new Promise<void>((_resolve, reject) => {
+			rejectFirstWrite = reject;
+		});
+		runtime.ensureConnection
+			.mockImplementationOnce(async () => {
+				markFirstWriteStarted?.();
+				return firstWrite;
+			})
+			.mockResolvedValue(undefined);
+
+		const firstAttempt = service.handleSendMessage(
+			runtime as never,
+			target,
+			content,
+		);
+		await firstWriteStarted;
+		expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
+
+		const secondAttempt = service.handleSendMessage(
+			runtime as never,
+			target,
+			content,
+		);
+		await expect(secondAttempt).resolves.toMatchObject({
+			entityId: AGENT_ID,
+			content: { text: content.text },
+		});
+
+		rejectFirstWrite?.(new Error("first participant write failed"));
+		await expect(firstAttempt).rejects.toThrow(
+			"first participant write failed",
+		);
+		expect(graph.dmChannel.send).toHaveBeenCalledTimes(1);
+		expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not register a DM recipient for a guild-channel send", async () => {
+		const { graph, runtime, service } = makeService();
+
+		await service.handleSendMessage(
+			runtime as never,
+			{
+				source: "discord",
+				accountId: "work",
+				channelId: graph.textChannel.id,
+			},
+			{ text: "guild delivery" },
+		);
+
+		expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
+		expect(runtime.ensureConnection).toHaveBeenCalledWith(
+			expect.objectContaining({
+				entityId: AGENT_ID,
+				channelId: graph.textChannel.id,
+				type: CoreChannelType.GROUP,
+			}),
+		);
+		expect(graph.textChannel.send).toHaveBeenCalledTimes(1);
+	});
+
 	it("registers account connectors and scopes wrapper calls to the selected account", async () => {
 		const { runtime, service } = makeService();
 		DiscordService.registerSendHandlers(runtime as never, service);

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -1712,6 +1712,14 @@ export class DiscordService extends Service implements IDiscordService {
 
 		let targetChannel: Channel | undefined | null = null;
 		let resolvedChannelId: string | null = null;
+		let dmRecipient:
+			| {
+					entityId: UUID;
+					discordUserId: string;
+					userName?: string;
+					name?: string;
+			  }
+			| undefined;
 
 		try {
 			if (target.channelId) {
@@ -1745,6 +1753,19 @@ export class DiscordService extends Service implements IDiscordService {
 				const user = await client.users.fetch(discordUserId);
 				if (user) {
 					targetChannel = user.dmChannel ?? (await user.createDM());
+					// Connector user listings carry Discord snowflakes in entityId,
+					// while identity-linked targets already carry their canonical UUID.
+					const recipientEntityId = normalizeDiscordTargetUserId(
+						target.entityId,
+					)
+						? this.resolveDiscordEntityId(discordUserId)
+						: (target.entityId as UUID);
+					dmRecipient = {
+						entityId: recipientEntityId,
+						discordUserId,
+						userName: user.username,
+						name: user.displayName || user.username,
+					};
 				}
 			} else {
 				throw new Error(
@@ -1807,6 +1828,15 @@ export class DiscordService extends Service implements IDiscordService {
 					const channelType = await this.getChannelType(
 						targetChannel as Channel,
 					);
+					const targetChannelGuild =
+						"guild" in targetChannel ? targetChannel.guild : null;
+					const serverId = targetChannelGuild?.id
+						? targetChannelGuild.id
+						: targetChannel.id;
+					const worldId = createUniqueUuid(runtime, serverId) as UUID;
+					const worldName = targetChannelGuild?.name
+						? targetChannelGuild.name
+						: undefined;
 
 					const textContent = normalizeDiscordMessageText(content.text);
 					const outboundReplyToMessageId =
@@ -1842,6 +1872,27 @@ export class DiscordService extends Service implements IDiscordService {
 							return;
 						}
 						outboundReservation = outboundDedupe.reservation;
+						if (dmRecipient) {
+							// Participant registration precedes the external send so a
+							// successful Discord delivery can always be discovered through
+							// the recipient's runtime rooms.
+							await this.runtime.ensureConnection({
+								entityId: dmRecipient.entityId,
+								roomId,
+								userName: dmRecipient.userName,
+								userId: dmRecipient.discordUserId as UUID,
+								name: dmRecipient.name,
+								source: "discord",
+								channelId: targetChannel.id,
+								messageServerId: stringToUuid(serverId),
+								type: channelType,
+								worldId,
+								worldName,
+								metadata: {
+									accountId,
+								},
+							});
+						}
 						if (textContent) {
 							const chunks = splitMessage(textContent, MAX_MESSAGE_LENGTH);
 							if (chunks.length > 1) {
@@ -1906,16 +1957,6 @@ export class DiscordService extends Service implements IDiscordService {
 						outboundReservation = undefined;
 						runtime.logger.warn("No text content or attachments provided");
 					}
-
-					const targetChannelGuild =
-						"guild" in targetChannel ? targetChannel.guild : null;
-					const serverId = targetChannelGuild?.id
-						? targetChannelGuild.id
-						: targetChannel.id;
-					const worldId = createUniqueUuid(runtime, serverId) as UUID;
-					const worldName = targetChannelGuild?.name
-						? targetChannelGuild.name
-						: undefined;
 
 					const clientUser = client.user;
 					await this.runtime.ensureConnection({

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -1842,6 +1842,51 @@ export class DiscordService extends Service implements IDiscordService {
 					const outboundReplyToMessageId =
 						discordReplyReferenceFromContent(content);
 					if (textContent || files.length > 0) {
+						const clientUser = client.user;
+						if (dmRecipient) {
+							// Durable room membership must exist before delivery
+							// reservation or the external send. A failed write leaves a
+							// concurrent identical request free to deliver, while a
+							// successful write remains useful if Discord later rejects the
+							// message.
+							await this.runtime.ensureConnection({
+								entityId: dmRecipient.entityId,
+								roomId,
+								userName: dmRecipient.userName,
+								userId: dmRecipient.discordUserId as UUID,
+								name: dmRecipient.name,
+								source: "discord",
+								channelId: targetChannel.id,
+								messageServerId: stringToUuid(serverId),
+								type: channelType,
+								worldId,
+								worldName,
+								metadata: {
+									accountId,
+								},
+							});
+						}
+						await this.runtime.ensureConnection({
+							entityId: runtime.agentId,
+							roomId,
+							roomName:
+								"name" in targetChannel &&
+								typeof targetChannel.name === "string"
+									? targetChannel.name
+									: clientUser.displayName || clientUser.username || undefined,
+							userName: clientUser.username ? clientUser.username : undefined,
+							name: clientUser.displayName || clientUser.username || undefined,
+							source: "discord",
+							channelId: targetChannel.id,
+							messageServerId: stringToUuid(serverId),
+							type: channelType,
+							worldId,
+							worldName,
+							metadata: {
+								accountId,
+							},
+						});
+
 						const outboundDedupe = beginDiscordOutboundDelivery({
 							accountId,
 							channelId: targetChannel.id,
@@ -1872,27 +1917,6 @@ export class DiscordService extends Service implements IDiscordService {
 							return;
 						}
 						outboundReservation = outboundDedupe.reservation;
-						if (dmRecipient) {
-							// Participant registration precedes the external send so a
-							// successful Discord delivery can always be discovered through
-							// the recipient's runtime rooms.
-							await this.runtime.ensureConnection({
-								entityId: dmRecipient.entityId,
-								roomId,
-								userName: dmRecipient.userName,
-								userId: dmRecipient.discordUserId as UUID,
-								name: dmRecipient.name,
-								source: "discord",
-								channelId: targetChannel.id,
-								messageServerId: stringToUuid(serverId),
-								type: channelType,
-								worldId,
-								worldName,
-								metadata: {
-									accountId,
-								},
-							});
-						}
 						if (textContent) {
 							const chunks = splitMessage(textContent, MAX_MESSAGE_LENGTH);
 							if (chunks.length > 1) {
@@ -1957,27 +1981,6 @@ export class DiscordService extends Service implements IDiscordService {
 						outboundReservation = undefined;
 						runtime.logger.warn("No text content or attachments provided");
 					}
-
-					const clientUser = client.user;
-					await this.runtime.ensureConnection({
-						entityId: runtime.agentId,
-						roomId,
-						roomName:
-							"name" in targetChannel && typeof targetChannel.name === "string"
-								? targetChannel.name
-								: clientUser.displayName || clientUser.username || undefined,
-						userName: clientUser.username ? clientUser.username : undefined,
-						name: clientUser.displayName || clientUser.username || undefined,
-						source: "discord",
-						channelId: targetChannel.id,
-						messageServerId: stringToUuid(serverId),
-						type: channelType,
-						worldId,
-						worldName,
-						metadata: {
-							accountId,
-						},
-					});
 
 					let lastPersistedMemory: Memory | undefined;
 					for (const sentMsg of sentMessages) {


### PR DESCRIPTION
## Summary

Reconstructs the narrow, still-missing outbound Discord DM participant fix from #16624 on current `develop`.

Entity-targeted DMs now register the recipient in the exact runtime DM room before the external send. Raw Discord snowflakes resolve through the canonical entity mapper; canonical UUID targets remain canonical. A failed registration sends and persists nothing, releases the dedupe reservation, and allows an identical retry.

Relates to #16623. Supersedes only the Discord participant portion of #16624; it intentionally excludes `read_with_contact`, argument aliases, and relevant-conversations performance changes.

## Risk

Medium: connector send boundary. The change is limited to entity-targeted DMs and fails closed before external delivery.

## Verification

- Focused service boundary: 10/10
- Full `plugin-discord`: 475/475
- Package typecheck: pass
- Package build: pass
- Biome on both changed files: pass
- `git diff --check`: pass
- Independent review bound to `c192b193f0b9092fa96be7e4c478c826110f3944`: PASS, no P0/P1

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - connector/runtime behavior; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - connector/runtime behavior; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual surface changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no sandbox Discord credential is available in this environment; the PR remains draft and cannot merge until this row is replaced by the real send → participant → recall log.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no sandbox Discord credential is available in this environment; the PR remains draft and cannot merge until this row is replaced by the live message and participant-room memory artifact.

## Current limitation

No Discord sandbox token/account is configured on this Mac or in its dedicated Keychain service, so live connector evidence has not been fabricated. The deterministic real-service-boundary tests are green; merge readiness waits on the live round trip.