### PR TITLE
feat(core): add canonical small/large model-pair resolver

### DIFF
--- a/packages/core/src/__tests__/canonical-model-barrels.test.ts
+++ b/packages/core/src/__tests__/canonical-model-barrels.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies browser and edge consumers receive the real family-gated resolver
+ * through the public core entrypoints.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as browserCore from "../index.browser";
+import * as edgeCore from "../index.edge";
+import {
+	CANONICAL_MODEL_ENV_KEYS,
+	readCanonicalModel,
+} from "../utils/canonical-model";
+
+describe.each([
+	["browser", browserCore],
+	["edge", edgeCore],
+] as const)("@elizaos/core %s entrypoint", (_name, entrypoint) => {
+	it("exports the canonical model-pair contract", () => {
+		expect(entrypoint.CANONICAL_MODEL_ENV_KEYS).toBe(CANONICAL_MODEL_ENV_KEYS);
+		expect(entrypoint.readCanonicalModel).toBe(readCanonicalModel);
+		expect(entrypoint.canonicalModelIsQualified).toBeTypeOf("function");
+	});
+
+	it("retains family gating through the public entrypoint", () => {
+		const options = {
+			env: { ELIZA_MODEL_LARGE: "anthropic/claude-opus" },
+		};
+		expect(
+			entrypoint.readCanonicalModel(null, "large", "anthropic", options),
+		).toBe("claude-opus");
+		expect(
+			entrypoint.readCanonicalModel(null, "large", "openai", options),
+		).toBeUndefined();
+	});
+});

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -183,6 +183,7 @@ export {
 export { Semaphore } from "./utils/batch-queue/semaphore.js";
 export * from "./utils/boolean";
 export * from "./utils/buffer";
+export * from "./utils/canonical-model";
 export type {
 	ConfirmationDecision,
 	ConfirmationStatus,

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -98,6 +98,7 @@ export {
 } from "./utils";
 export { Semaphore } from "./utils/batch-queue/semaphore.js";
 export * from "./utils/buffer";
+export * from "./utils/canonical-model";
 export * from "./utils/channel-utils";
 export * from "./utils/description-compressed-lint";
 export * from "./utils/environment";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -420,6 +420,7 @@ export {
 export { Semaphore } from "./utils/batch-queue/semaphore.js";
 export * from "./utils/boolean";
 export * from "./utils/buffer";
+export * from "./utils/canonical-model";
 // Export channel utilities (room/world helpers)
 export * from "./utils/channel-utils";
 export type {

--- a/packages/core/src/utils/canonical-model.test.ts
+++ b/packages/core/src/utils/canonical-model.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Exercises model-pair precedence and family gating with deterministic
+ * per-agent settings and environment records; no provider or model is mocked.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	CANONICAL_MODEL_ENV_KEYS,
+	type CanonicalModelFamily,
+	canonicalModelIsQualified,
+	readCanonicalModel,
+} from "./canonical-model";
+
+const EMPTY_ENV = {};
+
+function reader(
+	values: Record<string, string | number | boolean | null | undefined>,
+) {
+	return {
+		getSetting: (key: string) => values[key] ?? null,
+	};
+}
+
+function options(small?: string, large?: string): { env: NodeJS.ProcessEnv } {
+	return {
+		env: {
+			ELIZA_MODEL_SMALL: small,
+			ELIZA_MODEL_LARGE: large,
+		},
+	};
+}
+
+describe("canonical model pair contract", () => {
+	it("binds each tier to one stable environment key", () => {
+		expect(CANONICAL_MODEL_ENV_KEYS).toEqual({
+			small: "ELIZA_MODEL_SMALL",
+			large: "ELIZA_MODEL_LARGE",
+		});
+	});
+
+	it("returns undefined when a tier is absent or blank", () => {
+		expect(
+			readCanonicalModel(null, "small", "openai", { env: EMPTY_ENV }),
+		).toBeUndefined();
+		expect(
+			readCanonicalModel(null, "small", "openai", options(" \t ")),
+		).toBeUndefined();
+	});
+
+	it("keeps the small and large tiers independent", () => {
+		const env = options("small-model", "large-model");
+		expect(readCanonicalModel(null, "small", "openai", env)).toBe(
+			"small-model",
+		);
+		expect(readCanonicalModel(null, "large", "openai", env)).toBe(
+			"large-model",
+		);
+	});
+
+	it("prefers a per-agent setting over the deployment environment", () => {
+		const runtime = reader({ ELIZA_MODEL_SMALL: "agent-model" });
+		expect(
+			readCanonicalModel(
+				runtime,
+				"small",
+				"openai",
+				options("deployment-model"),
+			),
+		).toBe("agent-model");
+	});
+
+	it("treats a blank per-agent string as unset and reads the environment", () => {
+		const runtime = reader({ ELIZA_MODEL_SMALL: "  " });
+		expect(
+			readCanonicalModel(
+				runtime,
+				"small",
+				"openai",
+				options("deployment-model"),
+			),
+		).toBe("deployment-model");
+	});
+
+	it.each([false, true, 0, 42])(
+		"rejects the explicit non-string runtime value %j without leaking the environment fallback",
+		(runtimeValue) => {
+			const runtime = reader({ ELIZA_MODEL_SMALL: runtimeValue });
+			expect(
+				readCanonicalModel(
+					runtime,
+					"small",
+					"openai",
+					options("deployment-model"),
+				),
+			).toBeUndefined();
+		},
+	);
+
+	it("shares an unqualified model across every supported family", () => {
+		const families: CanonicalModelFamily[] = [
+			"openai",
+			"anthropic",
+			"ollama",
+			"google",
+			"elizacloud",
+			"cerebras",
+			"groq",
+			"claude",
+			"codex",
+		];
+		for (const family of families) {
+			expect(
+				readCanonicalModel(null, "small", family, options("shared-model")),
+			).toBe("shared-model");
+		}
+	});
+
+	it.each([
+		["anthropic/claude-opus", "anthropic", "claude-opus"],
+		["claude/claude-opus", "anthropic", "claude-opus"],
+		["anthropic/claude-opus", "claude", "claude-opus"],
+		["openai/gpt-5", "openai", "gpt-5"],
+		["gpt/gpt-5", "codex", "gpt-5"],
+		["google-genai/gemini-pro", "google", "gemini-pro"],
+		["gemini/gemini-flash", "google", "gemini-flash"],
+		["eliza-cloud/fast", "elizacloud", "fast"],
+		["cloud/large", "elizacloud", "large"],
+	] as const)("accepts %s for the %s family", (value, family, expected) => {
+		expect(
+			readCanonicalModel(null, "large", family, options(undefined, value)),
+		).toBe(expected);
+	});
+
+	it("matches qualifier tokens case-insensitively and preserves model casing", () => {
+		expect(
+			readCanonicalModel(
+				null,
+				"large",
+				"anthropic",
+				options(undefined, "  AnThRoPiC / Claude-Opus-4-8  "),
+			),
+		).toBe("Claude-Opus-4-8");
+	});
+
+	it("rejects a qualified value for every nonmatching family", () => {
+		const env = options(undefined, "anthropic/claude-opus");
+		for (const family of [
+			"openai",
+			"google",
+			"groq",
+			"cerebras",
+			"codex",
+		] as const) {
+			expect(readCanonicalModel(null, "large", family, env)).toBeUndefined();
+		}
+	});
+
+	it("rejects a qualified value when the caller cannot prove its family", () => {
+		expect(
+			readCanonicalModel(
+				null,
+				"large",
+				undefined,
+				options(undefined, "anthropic/claude-opus"),
+			),
+		).toBeUndefined();
+	});
+
+	it.each(["anthrpic", "toString", "__proto__"])(
+		"fails closed for unsupported caller family %s at the JavaScript boundary",
+		(unsupportedFamily) => {
+			const unsupported = unsupportedFamily as CanonicalModelFamily;
+			expect(
+				readCanonicalModel(
+					null,
+					"large",
+					unsupported,
+					options(undefined, "anthropic/claude-opus"),
+				),
+			).toBeUndefined();
+			expect(
+				readCanonicalModel(
+					null,
+					"large",
+					unsupported,
+					options(undefined, "shared-model"),
+				),
+			).toBeUndefined();
+		},
+	);
+
+	it("preserves unknown-prefix slash ids as native model ids", () => {
+		const nativeId = "meta-llama/llama-4-maverick";
+		expect(readCanonicalModel(null, "small", "groq", options(nativeId))).toBe(
+			nativeId,
+		);
+		expect(
+			readCanonicalModel(null, "small", undefined, options(nativeId)),
+		).toBe(nativeId);
+	});
+
+	it("supports family-pinning a slash-bearing native id", () => {
+		const pinned = options("groq/openai/gpt-oss-120b");
+		expect(readCanonicalModel(null, "small", "groq", pinned)).toBe(
+			"openai/gpt-oss-120b",
+		);
+		expect(
+			readCanonicalModel(null, "small", "cerebras", pinned),
+		).toBeUndefined();
+	});
+
+	it("treats a colliding known prefix as a qualifier", () => {
+		const env = options("openai/gpt-oss-120b");
+		expect(readCanonicalModel(null, "small", "openai", env)).toBe(
+			"gpt-oss-120b",
+		);
+		expect(readCanonicalModel(null, "small", "groq", env)).toBeUndefined();
+	});
+
+	it.each([
+		"anthropic/",
+		"anthropic/ ",
+		"anthropic//claude-opus",
+		"/model",
+		"model\u0000name",
+		"model\nname",
+	])("rejects malformed model value %j", (value) => {
+		expect(
+			readCanonicalModel(null, "large", "anthropic", options(undefined, value)),
+		).toBeUndefined();
+	});
+
+	it("does not fall through to env after a malformed per-agent value", () => {
+		const runtime = reader({ ELIZA_MODEL_LARGE: "anthropic/" });
+		expect(
+			readCanonicalModel(
+				runtime,
+				"large",
+				"anthropic",
+				options(undefined, "anthropic/env-model"),
+			),
+		).toBeUndefined();
+	});
+});
+
+describe("canonicalModelIsQualified", () => {
+	it("recognizes valid family qualifications but not native slash ids", () => {
+		expect(
+			canonicalModelIsQualified(
+				null,
+				"large",
+				options(undefined, "anthropic/claude-opus"),
+			),
+		).toBe(true);
+		expect(
+			canonicalModelIsQualified(
+				null,
+				"large",
+				options(undefined, "meta-llama/llama-4"),
+			),
+		).toBe(false);
+	});
+
+	it("returns false for missing, malformed, or mistyped runtime values", () => {
+		expect(canonicalModelIsQualified(null, "large", { env: EMPTY_ENV })).toBe(
+			false,
+		);
+		expect(
+			canonicalModelIsQualified(
+				null,
+				"large",
+				options(undefined, "anthropic/"),
+			),
+		).toBe(false);
+		expect(
+			canonicalModelIsQualified(
+				reader({ ELIZA_MODEL_LARGE: true }),
+				"large",
+				options(undefined, "anthropic/env-model"),
+			),
+		).toBe(false);
+	});
+
+	it("uses env after a blank runtime value", () => {
+		expect(
+			canonicalModelIsQualified(
+				reader({ ELIZA_MODEL_LARGE: " " }),
+				"large",
+				options(undefined, "anthropic/env-model"),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/core/src/utils/canonical-model.ts
+++ b/packages/core/src/utils/canonical-model.ts
@@ -1,0 +1,155 @@
+/**
+ * Resolves the deployment-wide small/large model pair while preventing a
+ * provider-qualified model id from crossing model families.
+ *
+ * Per-agent settings outrank environment defaults. Blank runtime values are
+ * unset, while malformed or mistyped runtime values fail closed so an
+ * explicit per-agent value cannot silently expose a host-level fallback.
+ * Provider adapters own the surrounding precedence against their specific
+ * escape hatches, bare aliases, and defaults.
+ */
+
+import { type ReadEnvOptions, readEnv } from "./read-env.js";
+import type { SettingReader } from "./resolve-setting.js";
+
+export const CANONICAL_MODEL_ENV_KEYS = {
+	small: "ELIZA_MODEL_SMALL",
+	large: "ELIZA_MODEL_LARGE",
+} as const;
+
+export type CanonicalModelTier = keyof typeof CANONICAL_MODEL_ENV_KEYS;
+
+const FAMILY_ALIASES = {
+	openai: ["openai", "gpt"],
+	anthropic: ["anthropic", "claude"],
+	ollama: ["ollama"],
+	google: ["google", "google-genai", "gemini"],
+	elizacloud: ["elizacloud", "eliza-cloud", "cloud"],
+	cerebras: ["cerebras"],
+	groq: ["groq"],
+	claude: ["claude", "anthropic"],
+	codex: ["codex", "openai", "gpt"],
+} as const satisfies Record<string, readonly string[]>;
+
+export type CanonicalModelFamily = keyof typeof FAMILY_ALIASES;
+
+export type CanonicalModelReadOptions = Pick<ReadEnvOptions, "env">;
+
+const KNOWN_FAMILY_TOKENS: ReadonlySet<string> = new Set(
+	Object.values(FAMILY_ALIASES).flat(),
+);
+
+type ConfiguredCanonicalModel =
+	| { state: "missing" }
+	| { state: "invalid" }
+	| { state: "value"; value: string };
+
+type ParsedCanonicalModel =
+	| { kind: "unqualified"; model: string }
+	| { kind: "qualified"; familyToken: string; model: string };
+
+function isCanonicalModelFamily(value: string): value is CanonicalModelFamily {
+	return Object.hasOwn(FAMILY_ALIASES, value);
+}
+
+function readConfiguredCanonicalModel(
+	runtime: SettingReader | null | undefined,
+	tier: CanonicalModelTier,
+	options: CanonicalModelReadOptions,
+): ConfiguredCanonicalModel {
+	const key = CANONICAL_MODEL_ENV_KEYS[tier];
+	const runtimeValue = runtime?.getSetting(key);
+	if (runtimeValue !== undefined && runtimeValue !== null) {
+		if (typeof runtimeValue !== "string") {
+			return { state: "invalid" };
+		}
+		const normalizedRuntimeValue = runtimeValue.trim();
+		if (normalizedRuntimeValue) {
+			return { state: "value", value: normalizedRuntimeValue };
+		}
+	}
+
+	const envValue = readEnv(key, { env: options.env });
+	return envValue ? { state: "value", value: envValue } : { state: "missing" };
+}
+
+function parseCanonicalModel(value: string): ParsedCanonicalModel | undefined {
+	for (const character of value) {
+		const codePoint = character.codePointAt(0);
+		if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+			return undefined;
+		}
+	}
+
+	const slash = value.indexOf("/");
+	if (slash < 0) {
+		return { kind: "unqualified", model: value };
+	}
+	if (slash === 0) {
+		return undefined;
+	}
+
+	const familyToken = value.slice(0, slash).trim().toLowerCase();
+	if (!KNOWN_FAMILY_TOKENS.has(familyToken)) {
+		return { kind: "unqualified", model: value };
+	}
+
+	const model = value.slice(slash + 1).trim();
+	if (!model || model.startsWith("/")) {
+		return undefined;
+	}
+	return { kind: "qualified", familyToken, model };
+}
+
+/**
+ * Reports whether the selected pair value carries a recognized family
+ * qualifier. Native slash-bearing ids whose first segment is not a recognized
+ * family remain unqualified.
+ */
+export function canonicalModelIsQualified(
+	runtime: SettingReader | null | undefined,
+	tier: CanonicalModelTier,
+	options: CanonicalModelReadOptions = {},
+): boolean {
+	const configured = readConfiguredCanonicalModel(runtime, tier, options);
+	if (configured.state !== "value") {
+		return false;
+	}
+	return parseCanonicalModel(configured.value)?.kind === "qualified";
+}
+
+/**
+ * Reads one canonical model tier and applies its family gate.
+ *
+ * Qualified values return only to their matching provider or transport
+ * family. Omitting `family` accepts only unqualified values, which is useful
+ * for host code that cannot prove which provider will consume the result.
+ */
+export function readCanonicalModel(
+	runtime: SettingReader | null | undefined,
+	tier: CanonicalModelTier,
+	family?: CanonicalModelFamily,
+	options: CanonicalModelReadOptions = {},
+): string | undefined {
+	const configured = readConfiguredCanonicalModel(runtime, tier, options);
+	if (configured.state !== "value") {
+		return undefined;
+	}
+
+	const parsed = parseCanonicalModel(configured.value);
+	if (!parsed) {
+		return undefined;
+	}
+	if (family !== undefined && !isCanonicalModelFamily(family)) {
+		return undefined;
+	}
+	if (parsed.kind === "unqualified") {
+		return parsed.model;
+	}
+	if (!family) {
+		return undefined;
+	}
+
+	const aliases: readonly string[] = FAMILY_ALIASES[family];
+	return aliases.includes(parsed.familyToken) ? parsed.model : undefined;
+}


### PR DESCRIPTION
Closes #17170. Extracted from the still-valid core portion of #16591.

## Summary

Adds the typed, browser-safe core resolver for canonical small/large model slots and exports it consistently from Node, browser, and edge entrypoints.

This is deliberately only the foundation. It does not wire providers, CLI inference, host seeding/display, or Cloud configuration.

## Contract

- Runtime setting outranks injected environment.
- Blank runtime values defer to environment.
- Explicit malformed/mistyped runtime values fail closed.
- Known family qualifications are accepted only for the matching family.
- Native slash IDs and family-pinned slash IDs remain intact.
- Empty, control-character, double-known-prefix, and unknown-caller-family inputs are rejected.

## Verification

- Focused resolver/barrel tests: 42/42
- Resolver coverage: 100% statements, branches, functions, and lines
- Full core: 4,254 pass / 1 intentional skip
- Core typecheck: pass
- Node/browser/edge/testing build + declaration output: pass
- Actual built-entry import smoke across Node/browser/edge: pass
- Biome on all six changed files: pass
- `git diff --check`: pass
- Independent review bound to `b6a93c3b35a8e279fc5bfd967938f535b5a85005`: PASS, no P0/P1

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - typed core configuration foundation; no UI or existing visual behavior changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - typed core configuration foundation; no UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - this foundation has no runtime consumer yet; executable proof is the built-entry smoke and full core test matrix above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend consumer or behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no provider or model invocation path is wired by this PR.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no provider, deployment, database, or device artifact is produced by this foundation.

## Follow-up units

1. Provider adapters with provider-specific precedence/family tests.
2. CLI Claude/Codex tier mapping with live session proof.
3. Host seeding/display and Cloud allowlists/defaults after adapters.