### PR TITLE
fix(cloud): recover stale managed canaries safely

### DIFF
--- a/.github/workflows/managed-dedicated-canary.yml
+++ b/.github/workflows/managed-dedicated-canary.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: "17 8 * * *"
   workflow_dispatch:
+    inputs:
+      stale_canary_suffix:
+        description: "Exact prior workflow suffix (r<run-id>a<attempt>) to verify and delete before creating the fresh canary"
+        required: false
+        type: string
+        default: ""
   # A maintainer-applied label lets the workflow prove a new harness before it
   # reaches the default branch; the staging environment still owns secret and
   # approval policy.
@@ -34,6 +40,7 @@ jobs:
     env:
       CLOUD_DEDICATED_CANARY_BASE_URL: https://api-staging.elizacloud.ai
       CLOUD_DEDICATED_CANARY_EVIDENCE_PATH: reports/managed-dedicated-canary.json
+      CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX: ${{ inputs.stale_canary_suffix || '' }}
       # Keep this identical to App Live's accepted repository-secret contract.
       ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
     steps:
@@ -73,6 +80,24 @@ jobs:
               "Managed dedicated canary is pinned to the exact staging origin without userinfo, path, query, or fragment",
             );
           }
+          NODE
+
+      - name: Bind stale-recovery intent
+        id: recovery_intent
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs";
+          const raw =
+            process.env.CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX ?? "";
+          const requested = raw !== "";
+          if (requested && !/^r[1-9]\d{7,19}a[1-9]\d{0,3}$/.test(raw)) {
+            throw new Error("Stale-canary recovery input is invalid");
+          }
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `requested=${requested ? "true" : "false"}\n`,
+          );
           NODE
 
       - name: Checkout exact run commit
@@ -150,6 +175,7 @@ jobs:
         env:
           LIVE_PROCESS_STATUS: ${{ steps.live.outputs.status }}
           PRIVACY_VALIDATED: ${{ steps.privacy.outputs.validated }}
+          EXPECTED_RECOVERY_REQUESTED: ${{ steps.recovery_intent.outputs.requested }}
           # Canonical staging rejects feature-ref deploys. A labeled PR therefore
           # proves the exact harness at its checked-out head against the deployed
           # base it proposes to extend; post-merge runs prove their own SHA.
@@ -173,6 +199,11 @@ jobs:
               import { validateManagedDedicatedCanaryEvidence } from "./packages/scripts/cloud/admin/managed-dedicated-canary.ts";
               const evidence = JSON.parse(readFileSync(process.env.CLOUD_DEDICATED_CANARY_EVIDENCE_PATH, "utf8"));
               const errors = validateManagedDedicatedCanaryEvidence(evidence);
+              const expectedRecoveryRequested =
+                process.env.EXPECTED_RECOVERY_REQUESTED === "true";
+              if (evidence.recovery?.requested !== expectedRecoveryRequested) {
+                errors.push("workflow_recovery_intent_mismatch");
+              }
               if (errors.length > 0) {
                 console.error("::error::Canary evidence rejected: " + errors.join(","));
                 process.exit(1);
@@ -210,6 +241,10 @@ jobs:
             console.log("- paths: `" + evidence.path.successfulPaths + "/2`");
             console.log("- bridge transport: `" + evidence.path.bridgeTransport + "`");
             console.log("- chat requests: `" + evidence.capacity.chatRequests + "/" + evidence.capacity.maxChatRequests + "`");
+            console.log("- recovery requested: `" + evidence.recovery.requested + "`");
+            console.log("- recovery match: `" + evidence.recovery.match + "`");
+            console.log("- recovery performed: `" + evidence.recovery.performed + "`");
+            console.log("- recovery confirmed: `" + evidence.recovery.confirmed + "`");
             console.log("- cleanup: `" + evidence.cleanup.status + "`");
             console.log("");
             console.log("| phase | ms |");

--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies that agent DELETE requests preserve synchronous shared cleanup while
+ * routing dedicated and failed shared teardown through the delete-wins queue.
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
@@ -121,15 +125,21 @@ function sharedAgent(overrides: Record<string, unknown> = {}) {
   };
 }
 
-async function deleteRequest() {
+async function deleteRequest(body?: Record<string, unknown> | string) {
   return app.fetch(
     new Request("https://api.example.test/api/v1/eliza/agents/agent-1", {
       method: "DELETE",
+      ...(body !== undefined
+        ? {
+            headers: { "content-type": "application/json" },
+            body: typeof body === "string" ? body : JSON.stringify(body),
+          }
+        : {}),
     }),
   );
 }
 
-describe("DELETE /api/v1/eliza/agents/:agentId shared-runtime fallback", () => {
+describe("DELETE /api/v1/eliza/agents/:agentId", () => {
   beforeEach(() => {
     requireUserOrApiKeyWithOrg.mockClear();
     getAgent.mockReset();
@@ -173,6 +183,91 @@ describe("DELETE /api/v1/eliza/agents/:agentId shared-runtime fallback", () => {
       expect.stringContaining("falling back to async delete job"),
       expect.objectContaining({ agentId: "agent-1", orgId: "org-1" }),
     );
+  });
+
+  test("preserves the normal provisioning conflict without an identity precondition", async () => {
+    getAgent.mockResolvedValueOnce(
+      sharedAgent({
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+      }),
+    );
+
+    const response = await deleteRequest();
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Agent provisioning is in progress",
+    });
+    expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();
+  });
+
+  test("treats a whitespace-only body as the legacy no-body delete", async () => {
+    getAgent.mockResolvedValueOnce(
+      sharedAgent({
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+      }),
+    );
+
+    const response = await deleteRequest(" \n\t ");
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Agent provisioning is in progress",
+    });
+    expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();
+  });
+
+  test("lets the delete-wins queue retire an exact conditionally matched provisioning agent", async () => {
+    getAgent.mockResolvedValueOnce(
+      sharedAgent({
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+      }),
+    );
+
+    const response = await deleteRequest({
+      expectedAgentName: "Canary Agent",
+      expectedCreatedAt: "2026-07-07T08:00:00.000Z",
+      expectedExecutionTier: "dedicated-always",
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      created: true,
+      data: {
+        jobId: "delete-job-1",
+        agentId: "agent-1",
+        status: "pending",
+      },
+    });
+    expect(deleteAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentDeleteOnce).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      expectedIdentity: {
+        agentName: "Canary Agent",
+        createdAt: "2026-07-07T08:00:00.000Z",
+        executionTier: "dedicated-always",
+      },
+    });
+    expect(triggerImmediate).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects an invalid conditional delete before queueing", async () => {
+    const response = await deleteRequest({
+      expectedAgentName: "Canary Agent",
+      expectedCreatedAt: "not-a-timestamp",
+      expectedExecutionTier: "dedicated-always",
+    });
+
+    expect(response.status).toBe(400);
+    expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();
   });
 
   test("still returns terminal sync errors without queueing a doomed delete", async () => {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -46,6 +46,19 @@ const editAgentSchema = z
     message: "Provide agentName and/or agentConfig",
   });
 
+const conditionalDeleteSchema = z
+  .object({
+    expectedAgentName: z.string().min(1).max(100),
+    expectedCreatedAt: z.string().datetime({ offset: true }),
+    expectedExecutionTier: z.enum([
+      "shared",
+      "dedicated-lazy",
+      "dedicated-always",
+      "custom",
+    ]),
+  })
+  .strict();
+
 type Agent = NonNullable<
   Awaited<ReturnType<typeof elizaSandboxService.getAgent>>
 >;
@@ -372,6 +385,44 @@ app.delete("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
+    let expectedIdentity:
+      | {
+          agentName: string;
+          createdAt: string;
+          executionTier:
+            | "shared"
+            | "dedicated-lazy"
+            | "dedicated-always"
+            | "custom";
+        }
+      | undefined;
+    if (c.req.raw.body !== null) {
+      const rawBody = await c.req.text();
+      if (rawBody.trim() !== "") {
+        let body: unknown;
+        try {
+          body = JSON.parse(rawBody);
+        } catch {
+          // error-policy:J3 malformed JSON is an invalid conditional request
+          return c.json(
+            { success: false, error: "Invalid conditional delete request" },
+            400,
+          );
+        }
+        const parsed = conditionalDeleteSchema.safeParse(body);
+        if (!parsed.success) {
+          return c.json(
+            { success: false, error: "Invalid conditional delete request" },
+            400,
+          );
+        }
+        expectedIdentity = {
+          agentName: parsed.data.expectedAgentName,
+          createdAt: parsed.data.expectedCreatedAt,
+          executionTier: parsed.data.expectedExecutionTier,
+        };
+      }
+    }
 
     const existing = await elizaSandboxService.getAgent(
       agentId,
@@ -381,14 +432,14 @@ app.delete("/", async (c) => {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
-    if (existing.status === "provisioning") {
+    if (existing.status === "provisioning" && !expectedIdentity) {
       return c.json(
         { success: false, error: "Agent provisioning is in progress" },
         409,
       );
     }
 
-    if (existing.execution_tier === "shared") {
+    if (existing.execution_tier === "shared" && !expectedIdentity) {
       const result = await elizaSandboxService.deleteAgent(
         agentId,
         user.organization_id,
@@ -447,6 +498,7 @@ app.delete("/", async (c) => {
       agentId,
       organizationId: user.organization_id,
       userId: user.id,
+      expectedIdentity,
     });
 
     // Best-effort wake of the worker so the user does not wait for the

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -1,7 +1,7 @@
 /**
  * Enqueue-side delete-lifecycle hardening for ProvisioningJobService:
- *   - enqueueAgentDeleteOnce.beforeInsert cancels the agent's OTHER pending /
- *     in_progress lifecycle jobs (delete wins; never self-cancels the delete).
+ *   - enqueueAgentDeleteOnce.beforeInsert cancels only quiescent pending jobs
+ *     and never self-cancels the delete.
  *   - enqueueScheduledBackups only enqueues reachable (bridge_url IS NOT NULL)
  *     running, non-pool agents — idle agents never get an auto snapshot job.
  *   - reEnqueueFailedDeletions re-arms old `deletion_failed` rows by enqueuing a
@@ -34,7 +34,7 @@ const realOutboundUrlExports = { ...realOutboundUrl };
 
 // ---- captured query state ----
 let capturedSelectWhere: SQL | undefined;
-let capturedUpdateWhere: SQL | undefined;
+let capturedCancellationWhere: SQL | undefined;
 let selectRows: unknown[] = [];
 let cancelledReturning: Array<{ id: string }> = [];
 
@@ -64,11 +64,20 @@ const txSelect = mock(() => {
   } as Record<string, unknown>;
   return chain;
 });
-const txUpdateWhere = mock((clause: SQL) => {
-  capturedUpdateWhere = clause;
-  return { returning: mock(async () => cancelledReturning) };
-});
-const txUpdateSet = mock(() => ({ where: txUpdateWhere }));
+const txUpdateSet = mock((values: { status?: string }) => ({
+  where: mock((clause: SQL) => {
+    if (values.status === "cancelled") {
+      capturedCancellationWhere = clause;
+    }
+    const rows =
+      values.status === "deletion_pending"
+        ? [{ id: "agent" }]
+        : values.status === "cancelled"
+          ? cancelledReturning
+          : [];
+    return { returning: mock(async () => rows) };
+  }),
+}));
 const txUpdate = mock(() => ({ set: txUpdateSet }));
 const txInsertValues = mock(() => ({
   returning: mock(async () => [{ id: "job-1", type: "agent_delete", status: "pending", data: {} }]),
@@ -125,7 +134,7 @@ mock.module("../../db/repositories/jobs", () => ({
 
 afterEach(() => {
   capturedSelectWhere = undefined;
-  capturedUpdateWhere = undefined;
+  capturedCancellationWhere = undefined;
   selectRows = [];
   cancelledReturning = [];
   txSelectCall = 0;
@@ -138,7 +147,7 @@ afterAll(() => {
 });
 
 describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", () => {
-  test("marks the agent's non-delete pending/in_progress jobs cancelled", async () => {
+  test("marks only the agent's quiescent non-delete pending jobs cancelled", async () => {
     cancelledReturning = [{ id: "j-restart" }, { id: "j-snapshot" }];
     const orgId = "22222222-2222-4222-8222-222222222222";
     const agentId = "agent";
@@ -159,18 +168,19 @@ describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", (
     expect(cancelSet).toBeDefined();
 
     // The cancel WHERE is scoped to this org AND this agent, excludes
-    // agent_delete (delete never self-cancels), and only touches
-    // pending/in_progress rows (terminal jobs are never reopened). Asserting the
-    // scoping prevents a future edit from cancelling sibling agents' or other
-    // orgs' jobs.
-    if (!capturedUpdateWhere) throw new Error("cancel WHERE clause was not captured");
-    const sql = new PgDialect().sqlToQuery(capturedUpdateWhere);
-    // Status filter: only pending/in_progress, never a terminal status.
-    expect(sql.sql).toContain("pending");
-    expect(sql.sql).toContain("in_progress");
-    expect(sql.sql).not.toContain("completed");
-    expect(sql.sql).not.toContain("cancelled");
-    expect(sql.sql).not.toContain("failed");
+    // agent_delete (delete never self-cancels), and only touches pending rows
+    // whose execution is provably quiescent. Asserting the scoping prevents a
+    // future edit from cancelling sibling agents' or other orgs' jobs.
+    if (!capturedCancellationWhere) {
+      throw new Error("cancel WHERE clause was not captured");
+    }
+    const sql = new PgDialect().sqlToQuery(capturedCancellationWhere);
+    expect(sql.sql).toContain("started_at");
+    expect(sql.params).toContain("pending");
+    expect(sql.params).not.toContain("in_progress");
+    expect(sql.params).not.toContain("completed");
+    expect(sql.params).not.toContain("cancelled");
+    expect(sql.params).not.toContain("failed");
     // Type filter: excludes agent_delete (the != operator + the bound value).
     expect(sql.sql).toMatch(/<>|!=|not/i);
     expect(sql.params).toContain("agent_delete");

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
@@ -523,6 +523,355 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     expect(suspendRows[0]?.status).toBe("cancelled");
     const deleteRows = await jobsOfType(agentId, JOB_TYPES.AGENT_DELETE);
     expect(deleteRows[0]?.status).toBe("pending");
+  });
+
+  test("conditional delete atomically owns the exact stale provisioning identity", async () => {
+    const { orgId, userId } = await seedOwner();
+    const createdAt = new Date("2026-07-13T08:17:00.000Z");
+    const agentName = "managed-dedicated-canary-r30081355987a1";
+    const [sandbox] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: orgId,
+        user_id: userId,
+        agent_name: agentName,
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+        created_at: createdAt,
+        updated_at: createdAt,
+      })
+      .returning();
+    await dbWrite.execute(sql`
+      UPDATE ${agentSandboxes}
+      SET created_at = ${"2026-07-13T08:17:00.000123Z"}::timestamptz
+      WHERE id = ${sandbox.id}
+    `);
+    const provision = await provisioningJobService.enqueueAgentProvisionOnce({
+      agentId: sandbox.id,
+      organizationId: orgId,
+      userId,
+      agentName,
+    });
+    await dbWrite
+      .update(jobs)
+      .set({
+        status: "failed",
+        started_at: createdAt,
+        updated_at: createdAt,
+      })
+      .where(eq(jobs.id, provision.job.id));
+
+    const deletion = await provisioningJobService.enqueueAgentDeleteOnce({
+      agentId: sandbox.id,
+      organizationId: orgId,
+      userId,
+      expectedIdentity: {
+        agentName,
+        createdAt: createdAt.toISOString(),
+        executionTier: "dedicated-always",
+      },
+    });
+
+    expect(deletion.created).toBe(true);
+    const [updated] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(updated?.status).toBe("deletion_pending");
+    const [provisionRow] = await jobsOfType(sandbox.id, JOB_TYPES.AGENT_PROVISION);
+    expect(provisionRow?.id).toBe(provision.job.id);
+    expect(provisionRow?.status).toBe("failed");
+    expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(1);
+  });
+
+  test("conditional delete cancels a retry-pending job only after its quiescence window", async () => {
+    const { orgId, userId } = await seedOwner();
+    const createdAt = new Date(Date.now() - 20 * 60 * 1000);
+    const agentName = "managed-dedicated-canary-r30081355987a1";
+    const [sandbox] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: orgId,
+        user_id: userId,
+        agent_name: agentName,
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+        created_at: createdAt,
+        updated_at: createdAt,
+      })
+      .returning();
+    const provision = await provisioningJobService.enqueueAgentProvisionOnce({
+      agentId: sandbox.id,
+      organizationId: orgId,
+      userId,
+      agentName,
+    });
+    await dbWrite
+      .update(jobs)
+      .set({
+        status: "pending",
+        started_at: createdAt,
+        updated_at: createdAt,
+      })
+      .where(eq(jobs.id, provision.job.id));
+
+    const deletion = await provisioningJobService.enqueueAgentDeleteOnce({
+      agentId: sandbox.id,
+      organizationId: orgId,
+      userId,
+      expectedIdentity: {
+        agentName,
+        createdAt: createdAt.toISOString(),
+        executionTier: "dedicated-always",
+      },
+    });
+
+    expect(deletion.created).toBe(true);
+    const [provisionRow] = await jobsOfType(sandbox.id, JOB_TYPES.AGENT_PROVISION);
+    expect(provisionRow?.status).toBe("cancelled");
+    expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(1);
+  });
+
+  for (const activeStatus of ["pending", "in_progress", "failed", "cancelled"] as const) {
+    test(`conditional delete refuses a non-quiescent ${activeStatus} lifecycle job`, async () => {
+      const { orgId, userId } = await seedOwner();
+      const createdAt = new Date();
+      const agentName = "managed-dedicated-canary-r30081355987a1";
+      const [sandbox] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: agentName,
+          status: "provisioning",
+          execution_tier: "dedicated-always",
+          created_at: createdAt,
+          updated_at: createdAt,
+        })
+        .returning();
+      const provision = await provisioningJobService.enqueueAgentProvisionOnce({
+        agentId: sandbox.id,
+        organizationId: orgId,
+        userId,
+        agentName,
+      });
+      await dbWrite
+        .update(jobs)
+        .set({
+          status: activeStatus,
+          started_at: createdAt,
+          updated_at: createdAt,
+        })
+        .where(eq(jobs.id, provision.job.id));
+
+      await expect(
+        provisioningJobService.enqueueAgentDeleteOnce({
+          agentId: sandbox.id,
+          organizationId: orgId,
+          userId,
+          expectedIdentity: {
+            agentName,
+            createdAt: createdAt.toISOString(),
+            executionTier: "dedicated-always",
+          },
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: "session_not_ready",
+      });
+
+      const [unchanged] = await dbWrite
+        .select()
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, sandbox.id));
+      expect(unchanged?.status).toBe("provisioning");
+      const [provisionRow] = await jobsOfType(sandbox.id, JOB_TYPES.AGENT_PROVISION);
+      expect(provisionRow?.status).toBe(activeStatus);
+      expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(0);
+    });
+  }
+
+  test("conditional delete rolls back when the identity changed", async () => {
+    const { orgId, userId } = await seedOwner();
+    const createdAt = new Date("2026-07-13T08:17:00.000Z");
+    const [sandbox] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: orgId,
+        user_id: userId,
+        agent_name: "repurposed-agent",
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+        created_at: createdAt,
+        updated_at: createdAt,
+      })
+      .returning();
+
+    await expect(
+      provisioningJobService.enqueueAgentDeleteOnce({
+        agentId: sandbox.id,
+        organizationId: orgId,
+        userId,
+        expectedIdentity: {
+          agentName: "repurposed-agent",
+          createdAt: "2026-07-13T08:17:00.001Z",
+          executionTier: "dedicated-always",
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+    });
+
+    const [unchanged] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(unchanged?.status).toBe("provisioning");
+    expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(0);
+  });
+
+  for (const mismatch of ["name", "tier"] as const) {
+    test(`conditional delete rolls back on an exact ${mismatch} mismatch`, async () => {
+      const { orgId, userId } = await seedOwner();
+      const createdAt = new Date("2026-07-13T08:17:00.000Z");
+      const agentName = "managed-dedicated-canary-r30081355987a1";
+      const [sandbox] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: agentName,
+          status: "provisioning",
+          execution_tier: "dedicated-always",
+          created_at: createdAt,
+          updated_at: createdAt,
+        })
+        .returning();
+
+      await expect(
+        provisioningJobService.enqueueAgentDeleteOnce({
+          agentId: sandbox.id,
+          organizationId: orgId,
+          userId,
+          expectedIdentity: {
+            agentName: mismatch === "name" ? `${agentName}-different` : agentName,
+            createdAt: createdAt.toISOString(),
+            executionTier: mismatch === "tier" ? "dedicated-lazy" : "dedicated-always",
+          },
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: "session_not_ready",
+      });
+
+      const [unchanged] = await dbWrite
+        .select()
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, sandbox.id));
+      expect(unchanged?.status).toBe("provisioning");
+      expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(0);
+    });
+  }
+
+  for (const credentialState of ["pending", "attested"] as const) {
+    test(`conditional delete preserves a ${credentialState} warm-claim handoff`, async () => {
+      const { orgId, userId } = await seedOwner();
+      const createdAt = new Date("2026-07-13T08:17:00.000Z");
+      const agentName = "managed-dedicated-canary-r30081355987a1";
+      const [sandbox] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: agentName,
+          status: "provisioning",
+          execution_tier: "dedicated-always",
+          claimed_at: createdAt,
+          warm_claim_credential_state: credentialState,
+          created_at: createdAt,
+          updated_at: createdAt,
+        })
+        .returning();
+      const provision = await provisioningJobService.enqueueAgentProvisionOnce({
+        agentId: sandbox.id,
+        organizationId: orgId,
+        userId,
+        agentName,
+      });
+
+      await expect(
+        provisioningJobService.enqueueAgentDeleteOnce({
+          agentId: sandbox.id,
+          organizationId: orgId,
+          userId,
+          expectedIdentity: {
+            agentName,
+            createdAt: createdAt.toISOString(),
+            executionTier: "dedicated-always",
+          },
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: "session_not_ready",
+      });
+
+      const [unchanged] = await dbWrite
+        .select()
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, sandbox.id));
+      expect(unchanged?.status).toBe("provisioning");
+      const [provisionRow] = await jobsOfType(sandbox.id, JOB_TYPES.AGENT_PROVISION);
+      expect(provisionRow?.id).toBe(provision.job.id);
+      expect(provisionRow?.status).toBe("pending");
+      expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(0);
+    });
+  }
+
+  test("conditional delete preserves the replacement-cleanup conflict", async () => {
+    const { orgId, userId } = await seedOwner();
+    const createdAt = new Date("2026-07-13T08:17:00.000Z");
+    const agentName = "managed-dedicated-canary-r30081355987a1";
+    const [sandbox] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: orgId,
+        user_id: userId,
+        agent_name: agentName,
+        status: "provisioning",
+        execution_tier: "dedicated-always",
+        created_at: createdAt,
+        updated_at: createdAt,
+        replacement_cleanup_sandbox_id: "replacement-sandbox",
+        replacement_cleanup_node_id: "replacement-node",
+        replacement_cleanup_container_name: "replacement-container",
+        replacement_cleanup_attempt_id: "77777777-7777-4777-8777-777777777777",
+        replacement_cleanup_allocation_counted: false,
+        replacement_cleanup_created_at: createdAt,
+      })
+      .returning();
+
+    await expect(
+      provisioningJobService.enqueueAgentDeleteOnce({
+        agentId: sandbox.id,
+        organizationId: orgId,
+        userId,
+        expectedIdentity: {
+          agentName,
+          createdAt: createdAt.toISOString(),
+          executionTier: "dedicated-always",
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+    });
+    const [unchanged] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(unchanged?.status).toBe("provisioning");
+    expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(0);
   });
 
   test("enqueue against a missing agent throws Agent not found", async () => {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -14,7 +14,19 @@
  */
 
 import { ElizaError } from "@elizaos/core";
-import { and, desc, eq, inArray, isNotNull, ne, type SQL, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  notInArray,
+  or,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
@@ -26,6 +38,7 @@ import {
   prepareJobInsertData,
 } from "../../db/repositories/jobs";
 import {
+  type AgentExecutionTier,
   agentSandboxes,
   UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
 } from "../../db/schemas/agent-sandboxes";
@@ -713,6 +726,9 @@ export interface EnqueueAgentSnapshotResult {
 
 interface LifecycleSandboxRow {
   id: string;
+  agent_name: string | null;
+  created_at: Date;
+  execution_tier: AgentExecutionTier;
   status: string;
   updated_at: Date | null;
   claimed_at: Date | null;
@@ -730,6 +746,7 @@ interface LifecycleSandboxRow {
   image_digest: string | null;
   previous_docker_image: string | null;
   previous_image_digest: string | null;
+  replacement_cleanup_sandbox_id: string | null;
   deletion_attempt_id: string | null;
   deletion_started_at: Date | null;
 }
@@ -858,6 +875,13 @@ export const PER_JOB_TIMEOUT_MS = parsePositiveIntEnv(
  */
 const DEFAULT_STALE_JOB_THRESHOLD_MS = 5 * 60 * 1000;
 const COLD_BOOT_STALE_JOB_THRESHOLD_MS = 15 * 60 * 1000;
+/**
+ * Conditional deletion waits this long after a claimed lifecycle job leaves
+ * an active state. The outer job timeout is a promise race and cannot abort
+ * its underlying bounded SSH/HTTP work, so a recent `failed`, `cancelled`, or
+ * retry-pending row is not proof that execution is quiescent.
+ */
+const DELETE_DETACHED_EXECUTION_QUIESCENCE_MS = COLD_BOOT_STALE_JOB_THRESHOLD_MS;
 const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
   JOB_TYPES.AGENT_PROVISION,
   JOB_TYPES.AGENT_RESUME,
@@ -1071,6 +1095,9 @@ export class ProvisioningJobService {
     const [sandbox] = await tx
       .select({
         id: agentSandboxes.id,
+        agent_name: agentSandboxes.agent_name,
+        created_at: agentSandboxes.created_at,
+        execution_tier: agentSandboxes.execution_tier,
         status: agentSandboxes.status,
         updated_at: agentSandboxes.updated_at,
         claimed_at: agentSandboxes.claimed_at,
@@ -1335,7 +1362,17 @@ export class ProvisioningJobService {
     organizationId: string;
     userId: string;
     webhookUrl?: string;
+    expectedIdentity?: {
+      agentName: string;
+      createdAt: Date | string;
+      executionTier: AgentExecutionTier;
+    };
   }): Promise<EnqueueAgentDeleteResult> {
+    const expectedIdentity = params.expectedIdentity;
+    const expectedCreatedAt = expectedIdentity ? new Date(expectedIdentity.createdAt) : null;
+    if (expectedCreatedAt && !Number.isFinite(expectedCreatedAt.getTime())) {
+      throw new ApiError(400, "validation_error", "Expected agent creation timestamp is invalid");
+    }
     return this.enqueueLifecycleJob<AgentDeleteJobData>({
       jobType: JOB_TYPES.AGENT_DELETE,
       jobData: {
@@ -1353,6 +1390,21 @@ export class ProvisioningJobService {
       // sub-second. 30s matches docker-sandbox-provider.stop() timeout.
       estimatedDurationMs: 30_000,
       logName: "agent_delete",
+      validateSandbox: expectedIdentity
+        ? (sandbox) => {
+            if (
+              sandbox.agent_name !== expectedIdentity.agentName ||
+              sandbox.created_at.getTime() !== expectedCreatedAt?.getTime() ||
+              sandbox.execution_tier !== expectedIdentity.executionTier
+            ) {
+              throw new ApiError(
+                409,
+                "session_not_ready",
+                "Agent identity changed before deletion",
+              );
+            }
+          }
+        : undefined,
       // Flip status so the UI shows "deleting" and concurrent mutations
       // bail. Actual row removal happens in executeAgentDelete once SSH
       // stop() succeeds.
@@ -1362,8 +1414,80 @@ export class ProvisioningJobService {
           (sandbox.warm_claim_credential_state === "pending" ||
             sandbox.warm_claim_credential_state === "attested")
         ) {
-          throw new Error("Warm-claim credential handoff is still in progress");
+          throw new ApiError(
+            409,
+            "session_not_ready",
+            "Warm-claim credential handoff is still in progress",
+          );
         }
+        const quiescentBefore = new Date(Date.now() - DELETE_DETACHED_EXECUTION_QUIESCENCE_MS);
+
+        // Pending work that was never claimed is safe to cancel. A retry row
+        // keeps started_at from its prior claim, so it is cancelled only after
+        // the detached-work window proves the old execution has drained.
+        const cancelled = await tx
+          .update(jobs)
+          .set({ status: "cancelled", updated_at: new Date() })
+          .where(
+            and(
+              eq(jobs.organization_id, params.organizationId),
+              eq(jobs.agent_id, params.agentId),
+              ne(jobs.type, JOB_TYPES.AGENT_DELETE),
+              eq(jobs.status, "pending"),
+              or(isNull(jobs.started_at), sql`${jobs.updated_at} < ${quiescentBefore}`),
+            ),
+          )
+          .returning({ id: jobs.id });
+
+        // Never overwrite an active execution claim. Recent terminal rows for
+        // exclusive lifecycle work also remain fenced because withTimeout()
+        // releases only the awaiter; the underlying bounded operation may
+        // still be writing placement, key, or container state.
+        const [conflict] = await tx
+          .select({
+            id: jobs.id,
+            type: jobs.type,
+            status: jobs.status,
+          })
+          .from(jobs)
+          .where(
+            and(
+              eq(jobs.organization_id, params.organizationId),
+              eq(jobs.agent_id, params.agentId),
+              ne(jobs.type, JOB_TYPES.AGENT_DELETE),
+              or(
+                eq(jobs.status, "in_progress"),
+                and(eq(jobs.status, "pending"), isNotNull(jobs.started_at)),
+                and(
+                  inArray(jobs.type, [...EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES]),
+                  sql`${jobs.status} IN ('failed', 'cancelled')`,
+                  isNotNull(jobs.started_at),
+                  sql`${jobs.updated_at} >= ${quiescentBefore}`,
+                  cancelled.length > 0
+                    ? notInArray(
+                        jobs.id,
+                        cancelled.map((job) => job.id),
+                      )
+                    : undefined,
+                ),
+              ),
+            ),
+          )
+          .orderBy(desc(jobs.updated_at))
+          .limit(1);
+        if (conflict) {
+          throw new ApiError(
+            409,
+            "session_not_ready",
+            `Agent ${params.agentId} has non-quiescent ${conflict.type} job ${conflict.id}`,
+            {
+              conflictingJobId: conflict.id,
+              conflictingJobType: conflict.type,
+              conflictingJobStatus: conflict.status,
+            },
+          );
+        }
+
         // A genuine user-initiated delete (the row is not already in a deletion
         // state) starts the deletion-failure counter fresh — error_count may
         // carry a stale provisioning-error value, and a new delete should get a
@@ -1382,7 +1506,20 @@ export class ProvisioningJobService {
           isRecoveryReEnqueue && sandbox.deletion_attempt_id
             ? sandbox.deletion_attempt_id
             : crypto.randomUUID();
-        await tx
+        const identityPredicates =
+          expectedIdentity && expectedCreatedAt
+            ? [
+                eq(agentSandboxes.agent_name, expectedIdentity.agentName),
+                sql`${agentSandboxes.created_at} >= ${expectedCreatedAt}
+                AND ${agentSandboxes.created_at} < ${new Date(expectedCreatedAt.getTime() + 1)}`,
+                eq(agentSandboxes.execution_tier, expectedIdentity.executionTier),
+                isNull(agentSandboxes.deleted_at),
+                isNull(agentSandboxes.replacement_cleanup_sandbox_id),
+                sql`COALESCE(${agentSandboxes.warm_claim_credential_state}, '')
+                NOT IN ('pending', 'attested')`,
+              ]
+            : [];
+        const owned = await tx
           .update(agentSandboxes)
           .set({
             status: "deletion_pending" as const,
@@ -1394,34 +1531,27 @@ export class ProvisioningJobService {
             ...(isRecoveryReEnqueue ? {} : { error_count: 0 }),
             updated_at: new Date(),
           })
-          .where(eq(agentSandboxes.id, params.agentId));
-
-        // Cancel any OTHER lifecycle jobs still queued for this agent. Delete
-        // wins: a pending restart/wake/resume/etc. that runs after the row is
-        // flipped to deletion_pending (or deleted) would either re-provision a
-        // container we are tearing down or fail noisily. Marking them
-        // `cancelled` (a terminal status claimPendingJobs/recoverStaleJobs
-        // never touch) drops them cleanly and keeps them auditable. The
-        // agent_delete row itself is inserted right after this and is excluded
-        // by type, so it is never self-cancelled.
-        const cancelled = await tx
-          .update(jobs)
-          .set({ status: "cancelled", updated_at: new Date() })
           .where(
             and(
-              eq(jobs.organization_id, params.organizationId),
-              eq(jobs.agent_id, params.agentId),
-              ne(jobs.type, JOB_TYPES.AGENT_DELETE),
-              sql`${jobs.status} IN ('pending', 'in_progress')`,
+              eq(agentSandboxes.id, params.agentId),
+              eq(agentSandboxes.organization_id, params.organizationId),
+              ...identityPredicates,
             ),
           )
-          .returning({ id: jobs.id });
+          .returning({ id: agentSandboxes.id });
+        if (owned.length !== 1) {
+          throw new ApiError(409, "session_not_ready", "Agent identity changed before deletion");
+        }
+
         if (cancelled.length > 0) {
-          logger.info("[provisioning-jobs] Cancelled pending jobs superseded by agent_delete", {
-            agentId: params.agentId,
-            orgId: params.organizationId,
-            cancelledCount: cancelled.length,
-          });
+          logger.info(
+            "[provisioning-jobs] Cancelled quiescent pending jobs superseded by agent_delete",
+            {
+              agentId: params.agentId,
+              orgId: params.organizationId,
+              cancelledCount: cancelled.length,
+            },
+          );
         }
       },
     });

--- a/packages/scripts/__tests__/managed-dedicated-canary-workflow.test.ts
+++ b/packages/scripts/__tests__/managed-dedicated-canary-workflow.test.ts
@@ -65,6 +65,15 @@ describe("managed dedicated staging canary workflow (#16194)", () => {
   test("is maintainer-triggered or scheduled, staging-only, serialized, and never uses Hetzner credentials", () => {
     expect(workflow.on?.schedule).toBeDefined();
     expect(workflow.on?.workflow_dispatch).toBeDefined();
+    expect(workflow.on?.workflow_dispatch).toMatchObject({
+      inputs: {
+        stale_canary_suffix: {
+          required: false,
+          type: "string",
+          default: "",
+        },
+      },
+    });
     expect(workflow.on?.pull_request).toEqual({ types: ["labeled"] });
     expect(workflow.on?.push).toBeUndefined();
     expect(job?.if).toContain("run-managed-dedicated-canary");
@@ -72,6 +81,9 @@ describe("managed dedicated staging canary workflow (#16194)", () => {
     expect(job?.["timeout-minutes"]).toBe(45);
     expect(job?.env?.CLOUD_DEDICATED_CANARY_BASE_URL).toBe(
       "https://api-staging.elizacloud.ai",
+    );
+    expect(job?.env?.CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX).toBe(
+      "$" + "{{ inputs.stale_canary_suffix || '' }}",
     );
     expect(workflow.concurrency).toEqual({
       group: "managed-dedicated-staging-canary",
@@ -146,6 +158,20 @@ describe("managed dedicated staging canary workflow (#16194)", () => {
     expect(step("Run bounded managed dedicated canary").run).toContain(
       "managed-dedicated-canary.ts",
     );
+  });
+
+  test("binds workflow recovery intent to the independently validated artifact", () => {
+    const intent = step("Bind stale-recovery intent");
+    expect(intent.id).toBe("recovery_intent");
+    expect(intent.run).toContain("requested=${requested");
+    expect(intent.run).not.toContain("console.log(raw)");
+    const enforce = step("Enforce live proof, deployed SHA, and cleanup");
+    expect(enforce.env?.EXPECTED_RECOVERY_REQUESTED).toBe(
+      "$" + "{{ steps.recovery_intent.outputs.requested }}",
+    );
+    expect(enforce.run).toContain("workflow_recovery_intent_mismatch");
+    expect(enforce.run).toContain("evidence.recovery.performed");
+    expect(enforce.run).toContain("evidence.recovery.confirmed");
   });
 
   test("makes missing evidence, zero paths, cleanup failure, and stale deploy ancestry red", () => {
@@ -243,6 +269,7 @@ describe("managed dedicated staging canary workflow (#16194)", () => {
     for (const name of [
       "Require real Cloud credential",
       "Require exact staging target",
+      "Bind stale-recovery intent",
       "Validate canary and failure contracts",
       "Run bounded managed dedicated canary",
       "Validate privacy-safe evidence artifact",

--- a/packages/scripts/cloud/admin/MANAGED_DEDICATED_CANARY.md
+++ b/packages/scripts/cloud/admin/MANAGED_DEDICATED_CANARY.md
@@ -21,6 +21,18 @@ disposable identity row to leak or clean separately.
   Provision/readiness and cleanup use shared absolute deadlines; the workflow
   caps control-plane calls at 30 seconds and has a 45-minute hard cap that
   leaves room for `finally` cleanup.
+- A maintainer may recover one investigated leftover by dispatching with its
+  exact deterministic suffix (`r<run-id>a<attempt>`). Recovery requires exactly
+  one prefix match, verifies ID, full name, creation timestamp, and
+  `dedicated-always` tier with a fresh GET, then sends those immutable identity
+  fields through the normal authenticated DELETE/job path. The lifecycle
+  transaction rechecks them under the per-agent lock and atomically refuses
+  replacement-cleanup, active warm-claim, and non-quiescent lifecycle-work
+  fences. A final 404 is required before the fresh canary can be created.
+  Invalid, absent, mismatched, shared-tier, active, or multiple identities fail
+  closed without deleting anything. The privacy-safe artifact records only
+  requested/match/accepted-or-ambiguous/confirmed state; it never records the
+  suffix, name, IDs, timestamps, or job IDs.
 - Create sends top-level `alwaysOn: true`, `forceCreate: true`, and
   `autoProvision: true`. The returned and final tier must both be
   `dedicated-always`.
@@ -31,8 +43,10 @@ disposable identity row to leak or clean separately.
   Each path has at most two attempts (four top-level chat requests total). Canned,
   fallback, degraded, echo, wrong-transport, missing-token, and incomplete SSE
   responses are red.
-- `finally` re-reads and matches both the in-memory ID and unique name before
-  deleting. An asynchronous delete job is polled and a final `404` is required.
+- `finally` waits for the known provision job to complete, then re-reads and
+  matches the in-memory ID, unique name, tier, and creation timestamp before
+  deleting. It never deletes over an active or recently detached lifecycle
+  execution. An asynchronous delete job is polled and a final `404` is required.
   Cleanup failure overrides any earlier pass.
 - If the create POST may have committed before its response was lost, the
   canary retries exact-name discovery within both a wall-clock and attempt cap.

--- a/packages/scripts/cloud/admin/managed-dedicated-canary.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Exercises the staging canary's fail-closed identity, capacity, live-path,
+ * privacy, and exact-cleanup contracts through a deterministic HTTP fixture.
+ */
 import { describe, expect, test } from "bun:test";
 import type { ManagedDedicatedCanaryEvidence } from "./managed-dedicated-canary";
 import {
@@ -10,7 +14,10 @@ import {
 const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const PROVISION_JOB_ID = "22222222-2222-4222-8222-222222222222";
 const DELETE_JOB_ID = "33333333-3333-4333-8333-333333333333";
+const STALE_AGENT_ID = "44444444-4444-4444-8444-444444444444";
+const STALE_DELETE_JOB_ID = "55555555-5555-4555-8555-555555555555";
 const SUFFIX = "12345678901234567890";
+const STALE_SUFFIX = "r30081355987a1";
 const SECRET = "cloud_test_secret_never_emit";
 const DEPLOYED_COMMIT = "a".repeat(40);
 const START_MS = Date.parse("2026-07-13T02:30:00.000Z");
@@ -18,6 +25,12 @@ const START_MS = Date.parse("2026-07-13T02:30:00.000Z");
 interface FixtureOptions {
   healthCommit?: string | null;
   existingCanary?: boolean;
+  existingCanaryCount?: number;
+  existingCanarySuffix?: string;
+  staleCleanupFails?: boolean;
+  staleDeleteThrows?: boolean;
+  staleIdentityMismatch?: boolean;
+  staleTier?: string;
   createdTier?: string;
   readyTier?: string;
   mesh?: boolean;
@@ -26,6 +39,8 @@ interface FixtureOptions {
   bridgeReply?: "real" | "canned";
   cleanupFails?: boolean;
   postCommitsThenThrows?: boolean;
+  provisionNeverCompletes?: boolean;
+  provisionCompletesAfterPolls?: number;
   recoveryListFailures?: number;
   recoveryNeverFinds?: boolean;
   bridgeStatusError?: unknown;
@@ -48,7 +63,12 @@ function createFixture(options: FixtureOptions = {}) {
   let nowMs = START_MS;
   let created = false;
   let deleted = false;
+  let staleDeleted = false;
   let createBody: Record<string, unknown> | null = null;
+  let staleDeleteBody: Record<string, unknown> | null = null;
+  let freshDeleteBody: Record<string, unknown> | null = null;
+  let provisionPolls = 0;
+  let provisionCompleted = false;
   let recoveryListFailures = options.recoveryListFailures ?? 0;
   const calls: Array<{ method: string; pathname: string }> = [];
 
@@ -75,21 +95,30 @@ function createFixture(options: FixtureOptions = {}) {
       }
       return response({
         success: true,
-        data: options.existingCanary
-          ? [
-              {
-                id: "existing-id",
-                agentName: "managed-dedicated-canary-existing",
-              },
-            ]
-          : created && !options.recoveryNeverFinds
-            ? [
+        data:
+          !staleDeleted &&
+          (options.existingCanaryCount ?? (options.existingCanary ? 1 : 0)) > 0
+            ? Array.from(
                 {
-                  id: AGENT_ID,
-                  agentName: String(createBody?.agentName ?? "missing"),
+                  length:
+                    options.existingCanaryCount ??
+                    (options.existingCanary ? 1 : 0),
                 },
-              ]
-            : [],
+                (_, index) => ({
+                  id: index === 0 ? STALE_AGENT_ID : `stale-agent-${index + 1}`,
+                  agentName: `managed-dedicated-canary-${
+                    options.existingCanarySuffix ?? "existing"
+                  }`,
+                }),
+              )
+            : created && !options.recoveryNeverFinds
+              ? [
+                  {
+                    id: AGENT_ID,
+                    agentName: String(createBody?.agentName ?? "missing"),
+                  },
+                ]
+              : [],
       });
     }
 
@@ -117,6 +146,18 @@ function createFixture(options: FixtureOptions = {}) {
     }
 
     if (url.pathname === `/api/v1/jobs/${PROVISION_JOB_ID}`) {
+      provisionPolls += 1;
+      if (
+        options.provisionNeverCompletes ||
+        (options.provisionCompletesAfterPolls !== undefined &&
+          provisionPolls < options.provisionCompletesAfterPolls)
+      ) {
+        return response({
+          success: true,
+          data: { status: "in_progress" },
+        });
+      }
+      provisionCompleted = true;
       return response({
         success: true,
         data: { status: "completed", result: { status: "running" } },
@@ -126,6 +167,58 @@ function createFixture(options: FixtureOptions = {}) {
     if (url.pathname === `/api/v1/jobs/${DELETE_JOB_ID}`) {
       deleted = true;
       return response({ success: true, data: { status: "completed" } });
+    }
+
+    if (url.pathname === `/api/v1/jobs/${STALE_DELETE_JOB_ID}`) {
+      staleDeleted = true;
+      return response({ success: true, data: { status: "completed" } });
+    }
+
+    if (
+      url.pathname === `/api/v1/eliza/agents/${STALE_AGENT_ID}` &&
+      method === "GET"
+    ) {
+      if (staleDeleted) {
+        return response({ success: false, error: "not found" }, 404);
+      }
+      return response({
+        success: true,
+        data: {
+          id: options.staleIdentityMismatch ? AGENT_ID : STALE_AGENT_ID,
+          agentName: `managed-dedicated-canary-${
+            options.existingCanarySuffix ?? "existing"
+          }`,
+          executionTier: options.staleTier ?? "dedicated-always",
+          createdAt: "2026-07-13T08:17:00.000Z",
+          status: "error",
+        },
+      });
+    }
+
+    if (
+      url.pathname === `/api/v1/eliza/agents/${STALE_AGENT_ID}` &&
+      method === "DELETE"
+    ) {
+      staleDeleteBody = JSON.parse(String(init?.body)) as Record<
+        string,
+        unknown
+      >;
+      if (options.staleDeleteThrows) {
+        throw new Error("simulated transport ambiguity");
+      }
+      if (options.staleCleanupFails) {
+        return response(
+          { success: false, error: "provisioning is in progress" },
+          409,
+        );
+      }
+      return response(
+        {
+          success: true,
+          data: { jobId: STALE_DELETE_JOB_ID, status: "pending" },
+        },
+        202,
+      );
     }
 
     if (
@@ -139,10 +232,11 @@ function createFixture(options: FixtureOptions = {}) {
         data: {
           id: AGENT_ID,
           agentName,
-          status: "running",
+          status: provisionCompleted ? "running" : "provisioning",
           databaseStatus: "ready",
           executionTier:
             options.readyTier ?? options.createdTier ?? "dedicated-always",
+          createdAt: "2026-07-13T02:30:00.000Z",
           lastHeartbeatAt:
             options.heartbeatAt === undefined
               ? new Date(nowMs - 5_000).toISOString()
@@ -161,6 +255,10 @@ function createFixture(options: FixtureOptions = {}) {
       url.pathname === `/api/v1/eliza/agents/${AGENT_ID}` &&
       method === "DELETE"
     ) {
+      freshDeleteBody = JSON.parse(String(init?.body)) as Record<
+        string,
+        unknown
+      >;
       if (options.cleanupFails) {
         return response({ success: false, error: "delete failed" }, 500);
       }
@@ -245,13 +343,22 @@ function createFixture(options: FixtureOptions = {}) {
     get createBody() {
       return createBody;
     },
+    get staleDeleteBody() {
+      return staleDeleteBody;
+    },
+    get freshDeleteBody() {
+      return freshDeleteBody;
+    },
     get created() {
       return created;
     },
   };
 }
 
-async function runFixture(options: FixtureOptions = {}) {
+async function runFixture(
+  options: FixtureOptions = {},
+  canaryOptions: { staleCanarySuffix?: string } = {},
+) {
   const fixture = createFixture(options);
   const evidence = await runManagedDedicatedCanary({
     apiKey: SECRET,
@@ -264,6 +371,7 @@ async function runFixture(options: FixtureOptions = {}) {
     cleanupTimeoutMs: 30,
     createRecoveryTimeoutMs: 30,
     createRecoveryPollIntervalMs: 10,
+    ...canaryOptions,
   });
   return { fixture, evidence };
 }
@@ -291,6 +399,12 @@ describe("managed dedicated canary", () => {
       maxChatRequests: 4,
       chatRequests: 2,
     });
+    expect(evidence.recovery).toEqual({
+      requested: false,
+      match: "none",
+      performed: "not-attempted",
+      confirmed: false,
+    });
     expect(evidence.cleanup.status).toBe("passed");
     expect(evidence.cleanup.possibleOrphan).toBe(false);
     expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
@@ -299,6 +413,11 @@ describe("managed dedicated canary", () => {
       alwaysOn: true,
       forceCreate: true,
       autoProvision: true,
+    });
+    expect(fixture.freshDeleteBody).toEqual({
+      expectedAgentName: `managed-dedicated-canary-${SUFFIX}`,
+      expectedCreatedAt: "2026-07-13T02:30:00.000Z",
+      expectedExecutionTier: "dedicated-always",
     });
     expect(
       fixture.calls.filter(
@@ -369,6 +488,25 @@ describe("managed dedicated canary", () => {
     expect(fixture.calls).toHaveLength(0);
   });
 
+  test("an invalid stale-canary suffix fails before any network access", async () => {
+    const fixture = createFixture();
+    const evidence = await runManagedDedicatedCanary({
+      apiKey: SECRET,
+      suffix: SUFFIX,
+      staleCanarySuffix: "managed-dedicated-canary-delete-anything",
+      fetch: fixture.fetch,
+      now: fixture.now,
+      sleep: fixture.sleep,
+    });
+
+    expect(evidence.failure).toEqual({
+      phase: "config",
+      code: "invalid_stale_canary_suffix",
+    });
+    expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
+    expect(fixture.calls).toHaveLength(0);
+  });
+
   test("refuses production even when a valid credential is present", async () => {
     const fixture = createFixture();
     const evidence = await runManagedDedicatedCanary({
@@ -432,6 +570,172 @@ describe("managed dedicated canary", () => {
     expect(fixture.created).toBe(false);
   });
 
+  test("an explicit exact suffix deletes one verified stale canary before the fresh proof", async () => {
+    const { fixture, evidence } = await runFixture(
+      {
+        existingCanary: true,
+        existingCanarySuffix: STALE_SUFFIX,
+      },
+      { staleCanarySuffix: STALE_SUFFIX },
+    );
+
+    expect(evidence.verdict).toBe("pass");
+    expect(evidence.failure).toBeNull();
+    expect(evidence.capacity.createdAgents).toBe(1);
+    expect(evidence.recovery).toEqual({
+      requested: true,
+      match: "one",
+      performed: "accepted",
+      confirmed: true,
+    });
+    expect(evidence.cleanup).toEqual({
+      status: "passed",
+      possibleOrphan: false,
+    });
+    expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
+    expect(validateManagedDedicatedCanaryEvidence(evidence)).toEqual([]);
+    expect(fixture.staleDeleteBody).toEqual({
+      expectedAgentName: `managed-dedicated-canary-${STALE_SUFFIX}`,
+      expectedCreatedAt: "2026-07-13T08:17:00.000Z",
+      expectedExecutionTier: "dedicated-always",
+    });
+    expect(fixture.calls.filter((call) => call.method === "DELETE")).toEqual([
+      {
+        method: "DELETE",
+        pathname: `/api/v1/eliza/agents/${STALE_AGENT_ID}`,
+      },
+      {
+        method: "DELETE",
+        pathname: `/api/v1/eliza/agents/${AGENT_ID}`,
+      },
+    ]);
+  });
+
+  test("an explicit recovery suffix fails when its stale canary is absent", async () => {
+    const { fixture, evidence } = await runFixture(
+      {},
+      { staleCanarySuffix: STALE_SUFFIX },
+    );
+
+    expect(evidence.failure).toEqual({
+      phase: "capacity_guard",
+      code: "expected_stale_canary_missing",
+    });
+    expect(evidence.recovery).toEqual({
+      requested: true,
+      match: "none",
+      performed: "not-attempted",
+      confirmed: false,
+    });
+    expect(fixture.created).toBe(false);
+  });
+
+  test("stale recovery refuses a different valid canary identity without deleting", async () => {
+    const { fixture, evidence } = await runFixture(
+      {
+        existingCanary: true,
+        existingCanarySuffix: STALE_SUFFIX,
+      },
+      { staleCanarySuffix: "r30081355988a1" },
+    );
+
+    expect(evidence.failure).toEqual({
+      phase: "capacity_guard",
+      code: "identity_mismatch",
+    });
+    expect(fixture.created).toBe(false);
+    expect(
+      fixture.calls.filter((call) => call.method === "DELETE"),
+    ).toHaveLength(0);
+  });
+
+  test("stale recovery refuses a non-dedicated target without deleting", async () => {
+    const { fixture, evidence } = await runFixture(
+      {
+        existingCanary: true,
+        existingCanarySuffix: STALE_SUFFIX,
+        staleTier: "shared",
+      },
+      { staleCanarySuffix: STALE_SUFFIX },
+    );
+
+    expect(evidence.failure).toEqual({
+      phase: "capacity_guard",
+      code: "identity_mismatch",
+    });
+    expect(fixture.created).toBe(false);
+    expect(
+      fixture.calls.filter((call) => call.method === "DELETE"),
+    ).toHaveLength(0);
+  });
+
+  test("stale recovery fails closed when more than one canary exists", async () => {
+    const { fixture, evidence } = await runFixture(
+      {
+        existingCanaryCount: 2,
+        existingCanarySuffix: STALE_SUFFIX,
+      },
+      { staleCanarySuffix: STALE_SUFFIX },
+    );
+
+    expect(evidence.failure).toEqual({
+      phase: "capacity_guard",
+      code: "existing_canary_present",
+    });
+    expect(fixture.created).toBe(false);
+    expect(
+      fixture.calls.filter((call) => call.method === "DELETE"),
+    ).toHaveLength(0);
+  });
+
+  test("stale recovery reports a normal API conflict and never creates a second canary", async () => {
+    const { fixture, evidence } = await runFixture(
+      {
+        existingCanary: true,
+        existingCanarySuffix: STALE_SUFFIX,
+        staleCleanupFails: true,
+      },
+      { staleCanarySuffix: STALE_SUFFIX },
+    );
+
+    expect(evidence.failure).toEqual({
+      phase: "capacity_guard",
+      code: "unexpected_http_409",
+    });
+    expect(fixture.created).toBe(false);
+    expect(
+      fixture.calls.filter(
+        (call) =>
+          call.method === "DELETE" &&
+          call.pathname === `/api/v1/eliza/agents/${STALE_AGENT_ID}`,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("stale recovery records an ambiguous delete transport and never creates a second canary", async () => {
+    const { fixture, evidence } = await runFixture(
+      {
+        existingCanary: true,
+        existingCanarySuffix: STALE_SUFFIX,
+        staleDeleteThrows: true,
+      },
+      { staleCanarySuffix: STALE_SUFFIX },
+    );
+
+    expect(evidence.failure).toEqual({
+      phase: "capacity_guard",
+      code: "request_failed",
+    });
+    expect(evidence.recovery).toEqual({
+      requested: true,
+      match: "one",
+      performed: "ambiguous",
+      confirmed: false,
+    });
+    expect(fixture.created).toBe(false);
+    expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
+  });
+
   test("a shared-tier response is red and the exact fresh row is still deleted", async () => {
     const { evidence } = await runFixture({
       createdTier: "shared",
@@ -450,12 +754,21 @@ describe("managed dedicated canary", () => {
 
   test("red evidence classifies an unknown upstream tier without retaining it", async () => {
     const unsafeTier = "private-tier-secret-value";
-    const { evidence } = await runFixture({ createdTier: unsafeTier });
+    const { evidence, fixture } = await runFixture({
+      createdTier: unsafeTier,
+    });
     expect(evidence.failure).toEqual({
-      phase: "create",
-      code: "wrong_execution_tier",
+      phase: "cleanup",
+      code: "identity_mismatch",
     });
     expect(evidence.path.observedTier).toBe("other");
+    expect(evidence.cleanup).toEqual({
+      status: "failed",
+      possibleOrphan: true,
+    });
+    expect(
+      fixture.calls.filter((call) => call.method === "DELETE"),
+    ).toHaveLength(0);
     expect(JSON.stringify(evidence)).not.toContain(unsafeTier);
     expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
   });
@@ -518,6 +831,58 @@ describe("managed dedicated canary", () => {
     });
     expect(
       fixture.calls.filter((call) => call.method === "DELETE"),
+    ).toHaveLength(1);
+  });
+
+  test("cleanup refuses to delete while the known provision job is still running", async () => {
+    const { fixture, evidence } = await runFixture({
+      provisionNeverCompletes: true,
+    });
+
+    expect(evidence.failure).toEqual({
+      phase: "cleanup_job",
+      code: "job_timeout",
+    });
+    expect(evidence.cleanup).toEqual({
+      status: "failed",
+      possibleOrphan: true,
+    });
+    expect(
+      fixture.calls.filter(
+        (call) =>
+          call.method === "DELETE" &&
+          call.pathname === `/api/v1/eliza/agents/${AGENT_ID}`,
+      ),
+    ).toHaveLength(0);
+    expect(fixture.freshDeleteBody).toBeNull();
+  });
+
+  test("cleanup waits for the known provision job to quiesce before deleting", async () => {
+    const { fixture, evidence } = await runFixture({
+      provisionCompletesAfterPolls: 4,
+    });
+
+    expect(evidence.failure).toEqual({
+      phase: "provision",
+      code: "job_timeout",
+    });
+    expect(evidence.cleanup).toEqual({
+      status: "passed",
+      possibleOrphan: false,
+    });
+    expect(
+      fixture.calls.filter(
+        (call) =>
+          call.method === "GET" &&
+          call.pathname === `/api/v1/jobs/${PROVISION_JOB_ID}`,
+      ),
+    ).toHaveLength(4);
+    expect(
+      fixture.calls.filter(
+        (call) =>
+          call.method === "DELETE" &&
+          call.pathname === `/api/v1/eliza/agents/${AGENT_ID}`,
+      ),
     ).toHaveLength(1);
   });
 
@@ -753,6 +1118,36 @@ describe("managed dedicated canary", () => {
     expect(errors).toContain("unsafe_timing_value");
   });
 
+  test("strict artifact validation rejects contradictory recovery claims", async () => {
+    const { evidence } = await runFixture();
+    const mutationWithoutRequest = structuredClone(evidence);
+    mutationWithoutRequest.recovery = {
+      requested: false,
+      match: "none",
+      performed: "accepted",
+      confirmed: true,
+    };
+    const confirmationWithoutAcceptance = structuredClone(evidence);
+    confirmationWithoutAcceptance.recovery = {
+      requested: true,
+      match: "one",
+      performed: "ambiguous",
+      confirmed: true,
+    };
+
+    expect(
+      validateManagedDedicatedCanaryArtifact(mutationWithoutRequest),
+    ).toEqual(
+      expect.arrayContaining([
+        "unsafe_recovery_performed_without_exact_request",
+        "unsafe_recovery_nonmatch_mutation",
+      ]),
+    );
+    expect(
+      validateManagedDedicatedCanaryArtifact(confirmationWithoutAcceptance),
+    ).toContain("unsafe_recovery_confirmation_without_acceptance");
+  });
+
   test("cleanup failure overrides a successful path and stays red", async () => {
     const { evidence } = await runFixture({
       cleanupFails: true,
@@ -776,7 +1171,7 @@ describe("managed dedicated canary", () => {
     );
     expect(
       validateManagedDedicatedCanaryEvidence({
-        schemaVersion: 1,
+        schemaVersion: 2,
         verdict: "pass",
         deployedCommit: DEPLOYED_COMMIT,
         path: {
@@ -795,6 +1190,12 @@ describe("managed dedicated canary", () => {
           createdAgents: 1,
           maxChatRequests: 4,
           chatRequests: 0,
+        },
+        recovery: {
+          requested: false,
+          match: "none",
+          performed: "not-attempted",
+          confirmed: false,
         },
         cleanup: { status: "passed" },
         failure: null,

--- a/packages/scripts/cloud/admin/managed-dedicated-canary.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary.ts
@@ -16,6 +16,11 @@ import { SMOKE_AGENT_PLUGINS } from "./smoke-agent-plugins";
 
 type JsonObject = Record<string, unknown>;
 type Fetch = typeof globalThis.fetch;
+type AgentExecutionTier =
+  | "shared"
+  | "dedicated-lazy"
+  | "dedicated-always"
+  | "custom";
 type PrivacySafeObservedTier =
   | "shared"
   | "dedicated-lazy"
@@ -30,8 +35,8 @@ const HEARTBEAT_MAX_AGE_MS = 120_000;
 const HEARTBEAT_FUTURE_SKEW_MS = 30_000;
 const CONTROL_REQUEST_TIMEOUT_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 130_000;
-const READY_TIMEOUT_MS = 12 * 60_000;
-const CLEANUP_TIMEOUT_MS = 4 * 60_000;
+const READY_TIMEOUT_MS = 16 * 60_000;
+const CLEANUP_TIMEOUT_MS = 6 * 60_000;
 const MAX_ARTIFACT_TIMING_MS = 45 * 60_000;
 const POLL_INTERVAL_MS = 5_000;
 const CREATE_RECOVERY_TIMEOUT_MS = 30_000;
@@ -86,6 +91,7 @@ const PRIVACY_SAFE_FAILURE_PHASES = new Set([
 ]);
 const PRIVACY_SAFE_FAILURE_CODES = new Set([
   "invalid_run_suffix",
+  "invalid_stale_canary_suffix",
   "error_event",
   "unexpected_error",
   "request_failed",
@@ -119,11 +125,13 @@ const PRIVACY_SAFE_FAILURE_CODES = new Set([
   "non_staging_target_refused",
   "missing_deploy_commit",
   "existing_canary_present",
+  "expected_stale_canary_missing",
+  "stale_canary_disappeared",
   "missing_agent_id",
 ]);
 
 export interface ManagedDedicatedCanaryEvidence {
-  schemaVersion: 1;
+  schemaVersion: 2;
   verdict: "pass" | "fail";
   deployedCommit: string | null;
   path: {
@@ -142,6 +150,12 @@ export interface ManagedDedicatedCanaryEvidence {
     createdAgents: number;
     maxChatRequests: number;
     chatRequests: number;
+  };
+  recovery: {
+    requested: boolean;
+    match: "not-checked" | "none" | "one" | "multiple";
+    performed: "not-attempted" | "accepted" | "ambiguous";
+    confirmed: boolean;
   };
   timingsMs: Partial<Record<TimingPhase, number>>;
   cleanup: {
@@ -167,6 +181,7 @@ export interface ManagedDedicatedCanaryOptions {
   pollIntervalMs?: number;
   createRecoveryTimeoutMs?: number;
   createRecoveryPollIntervalMs?: number;
+  staleCanarySuffix?: string;
 }
 
 class CanaryFailure extends Error {
@@ -195,6 +210,20 @@ function dataRecord(body: JsonObject): JsonObject | null {
 function stringField(record: JsonObject | null, key: string): string | null {
   const value = record?.[key];
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isAgentExecutionTier(
+  value: string | null,
+): value is AgentExecutionTier {
+  switch (value) {
+    case "shared":
+    case "dedicated-lazy":
+    case "dedicated-always":
+    case "custom":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function privacySafeObservedTier(
@@ -228,6 +257,14 @@ function sanitizeSuffix(value: string): string {
     throw new CanaryFailure("config", "invalid_run_suffix");
   }
   return normalized;
+}
+
+function validateStaleCanarySuffix(value: string | undefined): string | null {
+  if (value === undefined || value === "") return null;
+  if (!/^r[1-9]\d{7,19}a[1-9]\d{0,3}$/.test(value)) {
+    throw new CanaryFailure("config", "invalid_stale_canary_suffix");
+  }
+  return value;
 }
 
 function isStagingBaseUrl(value: string): boolean {
@@ -332,7 +369,7 @@ function sseText(event: string, data: JsonObject | null): string {
 
 function freshEvidence(): ManagedDedicatedCanaryEvidence {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     verdict: "fail",
     deployedCommit: null,
     path: {
@@ -351,6 +388,12 @@ function freshEvidence(): ManagedDedicatedCanaryEvidence {
       createdAgents: 0,
       maxChatRequests: MAX_CHAT_ATTEMPTS_PER_PATH * 2,
       chatRequests: 0,
+    },
+    recovery: {
+      requested: false,
+      match: "not-checked",
+      performed: "not-attempted",
+      confirmed: false,
     },
     timingsMs: {},
     cleanup: { status: "not-required", possibleOrphan: false },
@@ -420,6 +463,7 @@ export function validateManagedDedicatedCanaryArtifact(
       "deployedCommit",
       "path",
       "capacity",
+      "recovery",
       "timingsMs",
       "cleanup",
       "failure",
@@ -428,7 +472,7 @@ export function validateManagedDedicatedCanaryArtifact(
   );
   if (!evidence) return errors;
 
-  if (evidence.schemaVersion !== 1) errors.push("unsafe_schema_version");
+  if (evidence.schemaVersion !== 2) errors.push("unsafe_schema_version");
   if (evidence.verdict !== "pass" && evidence.verdict !== "fail") {
     errors.push("unsafe_verdict");
   }
@@ -511,6 +555,51 @@ export function validateManagedDedicatedCanaryArtifact(
       )
     ) {
       errors.push("unsafe_chat_requests");
+    }
+  }
+
+  const recovery = exactEvidenceRecord(
+    evidence.recovery,
+    "recovery",
+    ["requested", "match", "performed", "confirmed"],
+    errors,
+  );
+  if (recovery) {
+    if (typeof recovery.requested !== "boolean") {
+      errors.push("unsafe_recovery_requested");
+    }
+    if (
+      recovery.match !== "not-checked" &&
+      recovery.match !== "none" &&
+      recovery.match !== "one" &&
+      recovery.match !== "multiple"
+    ) {
+      errors.push("unsafe_recovery_match");
+    }
+    if (
+      recovery.performed !== "not-attempted" &&
+      recovery.performed !== "accepted" &&
+      recovery.performed !== "ambiguous"
+    ) {
+      errors.push("unsafe_recovery_performed");
+    }
+    if (typeof recovery.confirmed !== "boolean") {
+      errors.push("unsafe_recovery_confirmed");
+    }
+    if (
+      recovery.performed !== "not-attempted" &&
+      (recovery.requested !== true || recovery.match !== "one")
+    ) {
+      errors.push("unsafe_recovery_performed_without_exact_request");
+    }
+    if (recovery.confirmed === true && recovery.performed !== "accepted") {
+      errors.push("unsafe_recovery_confirmation_without_acceptance");
+    }
+    if (
+      recovery.match !== "one" &&
+      (recovery.performed !== "not-attempted" || recovery.confirmed !== false)
+    ) {
+      errors.push("unsafe_recovery_nonmatch_mutation");
     }
   }
 
@@ -613,7 +702,7 @@ export function validateManagedDedicatedCanaryEvidence(
   if (!isRecord(value)) return ["evidence_not_an_object"];
   const evidence = value as unknown as ManagedDedicatedCanaryEvidence;
   const errors: string[] = [];
-  if (evidence.schemaVersion !== 1) errors.push("wrong_schema_version");
+  if (evidence.schemaVersion !== 2) errors.push("wrong_schema_version");
   if (evidence.verdict !== "pass") errors.push("verdict_not_pass");
   if (!/^[a-f0-9]{40}$/.test(evidence.deployedCommit ?? "")) {
     errors.push("missing_deployed_commit");
@@ -644,6 +733,22 @@ export function validateManagedDedicatedCanaryEvidence(
     evidence.capacity?.createdAgents !== 1
   ) {
     errors.push("created_agent_count_invalid");
+  }
+  if (evidence.recovery?.requested === true) {
+    if (
+      evidence.recovery.match !== "one" ||
+      evidence.recovery.performed !== "accepted" ||
+      evidence.recovery.confirmed !== true
+    ) {
+      errors.push("stale_recovery_not_proven");
+    }
+  } else if (
+    evidence.recovery?.requested !== false ||
+    evidence.recovery?.match !== "none" ||
+    evidence.recovery?.performed !== "not-attempted" ||
+    evidence.recovery?.confirmed !== false
+  ) {
+    errors.push("unexpected_stale_recovery");
   }
   if (
     evidence.capacity?.maxChatRequests !== MAX_CHAT_ATTEMPTS_PER_PATH * 2 ||
@@ -751,9 +856,13 @@ export async function runManagedDedicatedCanary(
   const rawSuffix =
     options.suffix ??
     `${Date.now().toString(36)}${randomBytes(6).toString("hex")}`;
+  const rawStaleCanarySuffix = options.staleCanarySuffix;
   let suffix = "";
   let expectedName = "";
+  let staleCanarySuffix: string | null = null;
   let agentId: string | null = null;
+  let provisionJobId: string | null = null;
+  let provisionJobCompleted = false;
   let possibleOrphan = false;
 
   async function request(
@@ -805,6 +914,106 @@ export async function runManagedDedicatedCanary(
       throw new CanaryFailure(phase, "invalid_agent_list");
     }
     return body.data;
+  }
+
+  async function deleteVerifiedStaleCanary(
+    staleAgent: JsonObject,
+  ): Promise<void> {
+    // Workflow serialization rules out a live sibling canary. The explicit
+    // run-derived suffix still binds recovery to the investigated row so a
+    // prefix collision can never authorize an arbitrary agent deletion.
+    if (!staleCanarySuffix) {
+      throw new CanaryFailure("capacity_guard", "existing_canary_present");
+    }
+    const staleAgentId = stringField(staleAgent, "id");
+    const staleAgentName = stringField(staleAgent, "agentName");
+    const expectedStaleName = `${CANARY_NAME_PREFIX}${staleCanarySuffix}`;
+    if (!staleAgentId) {
+      throw new CanaryFailure("capacity_guard", "missing_agent_id");
+    }
+    if (staleAgentName !== expectedStaleName) {
+      throw new CanaryFailure("capacity_guard", "identity_mismatch");
+    }
+
+    const cleanupDeadline = now() + cleanupTimeoutMs;
+    const current = await request(
+      "capacity_guard",
+      `/api/v1/eliza/agents/${encodeURIComponent(staleAgentId)}`,
+      {},
+      [200, 404],
+    );
+    if (current.status === 404) {
+      throw new CanaryFailure("capacity_guard", "stale_canary_disappeared");
+    }
+    const currentData = dataRecord(current.body);
+    const staleCreatedAt = stringField(currentData, "createdAt");
+    if (
+      !currentData ||
+      stringField(currentData, "id") !== staleAgentId ||
+      stringField(currentData, "agentName") !== expectedStaleName ||
+      stringField(currentData, "executionTier") !== EXPECTED_TIER ||
+      !staleCreatedAt
+    ) {
+      throw new CanaryFailure("capacity_guard", "identity_mismatch");
+    }
+
+    let deletion: { status: number; body: JsonObject };
+    try {
+      deletion = await request(
+        "capacity_guard",
+        `/api/v1/eliza/agents/${encodeURIComponent(staleAgentId)}`,
+        {
+          method: "DELETE",
+          body: JSON.stringify({
+            expectedAgentName: expectedStaleName,
+            expectedCreatedAt: staleCreatedAt,
+            expectedExecutionTier: EXPECTED_TIER,
+          }),
+        },
+        [200, 202, 404],
+      );
+    } catch (error) {
+      if (asFailure(error).code === "request_failed") {
+        evidence.recovery.performed = "ambiguous";
+      }
+      throw error;
+    }
+    if (deletion.status === 404) {
+      throw new CanaryFailure("capacity_guard", "stale_canary_disappeared");
+    }
+    evidence.recovery.performed = "accepted";
+    if (deletion.status === 202) {
+      const jobId = stringField(dataRecord(deletion.body), "jobId");
+      if (!jobId) {
+        throw new CanaryFailure("capacity_guard", "missing_delete_job");
+      }
+      await pollJob(
+        jobId,
+        "capacity_guard",
+        Math.max(1, cleanupDeadline - now()),
+      );
+    }
+    while (now() < cleanupDeadline) {
+      const confirmation = await request(
+        "capacity_guard",
+        `/api/v1/eliza/agents/${encodeURIComponent(staleAgentId)}`,
+        {},
+        [200, 404],
+      );
+      if (confirmation.status === 404) return;
+      const confirmationData = dataRecord(confirmation.body);
+      if (
+        !confirmationData ||
+        stringField(confirmationData, "id") !== staleAgentId ||
+        stringField(confirmationData, "agentName") !== expectedStaleName ||
+        stringField(confirmationData, "executionTier") !== EXPECTED_TIER ||
+        stringField(confirmationData, "createdAt") !== staleCreatedAt
+      ) {
+        throw new CanaryFailure("capacity_guard", "identity_mismatch");
+      }
+      await sleep(pollIntervalMs);
+    }
+    throw new CanaryFailure("capacity_guard", "delete_not_confirmed");
   }
 
   async function recoverCreatedAgent(): Promise<boolean> {
@@ -1094,31 +1303,46 @@ export async function runManagedDedicatedCanary(
         return;
       }
       const cleanupDeadline = now() + cleanupTimeoutMs;
-      while (now() < cleanupDeadline) {
-        const current = await getAgent("cleanup_verify", [200, 404]);
-        if (current.status === 404) {
-          agentId = null;
-          evidence.cleanup.status = "passed";
-          evidence.cleanup.possibleOrphan = false;
-          return;
-        }
-        if (!current.data) {
-          throw new CanaryFailure("cleanup", "missing_agent_data");
-        }
-        if (
-          stringField(current.data, "id") !== agentId ||
-          stringField(current.data, "agentName") !== expectedName
-        ) {
-          throw new CanaryFailure("cleanup", "identity_mismatch");
-        }
-        if (stringField(current.data, "status") !== "provisioning") break;
-        await sleep(pollIntervalMs);
+      if (provisionJobId && !provisionJobCompleted) {
+        await pollJob(
+          provisionJobId,
+          "cleanup_job",
+          Math.max(1, cleanupDeadline - now()),
+        );
+        provisionJobCompleted = true;
+      }
+      const current = await getAgent("cleanup_verify", [200, 404]);
+      if (current.status === 404) {
+        agentId = null;
+        evidence.cleanup.status = "passed";
+        evidence.cleanup.possibleOrphan = false;
+        return;
+      }
+      if (!current.data) {
+        throw new CanaryFailure("cleanup", "missing_agent_data");
+      }
+      const cleanupCreatedAt = stringField(current.data, "createdAt");
+      const cleanupExecutionTier = stringField(current.data, "executionTier");
+      if (
+        stringField(current.data, "id") !== agentId ||
+        stringField(current.data, "agentName") !== expectedName ||
+        !isAgentExecutionTier(cleanupExecutionTier) ||
+        !cleanupCreatedAt
+      ) {
+        throw new CanaryFailure("cleanup", "identity_mismatch");
       }
 
       const result = await request(
         "cleanup_delete",
         `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`,
-        { method: "DELETE" },
+        {
+          method: "DELETE",
+          body: JSON.stringify({
+            expectedAgentName: expectedName,
+            expectedCreatedAt: cleanupCreatedAt,
+            expectedExecutionTier: cleanupExecutionTier,
+          }),
+        },
         [200, 202, 404],
       );
       if (result.status === 202) {
@@ -1138,6 +1362,15 @@ export async function runManagedDedicatedCanary(
           evidence.cleanup.possibleOrphan = false;
           return;
         }
+        if (
+          !check.data ||
+          stringField(check.data, "id") !== agentId ||
+          stringField(check.data, "agentName") !== expectedName ||
+          stringField(check.data, "executionTier") !== cleanupExecutionTier ||
+          stringField(check.data, "createdAt") !== cleanupCreatedAt
+        ) {
+          throw new CanaryFailure("cleanup", "identity_mismatch");
+        }
         await sleep(pollIntervalMs);
       }
       throw new CanaryFailure("cleanup", "delete_not_confirmed");
@@ -1148,6 +1381,8 @@ export async function runManagedDedicatedCanary(
 
   try {
     suffix = sanitizeSuffix(rawSuffix);
+    staleCanarySuffix = validateStaleCanarySuffix(rawStaleCanarySuffix);
+    evidence.recovery.requested = staleCanarySuffix !== null;
     expectedName = `${CANARY_NAME_PREFIX}${suffix}`;
     if (!apiKey) {
       throw new CanaryFailure("config", "missing_cloud_credential");
@@ -1167,15 +1402,39 @@ export async function runManagedDedicatedCanary(
 
     await inTimedPhase(evidence, "capacityGuard", now, async () => {
       const before = await listAgents("capacity_guard");
+      const existingCanaries = before.filter((agent) =>
+        (stringField(agent, "agentName") ?? "").startsWith(CANARY_NAME_PREFIX),
+      );
+      if (existingCanaries.length === 0) {
+        evidence.recovery.match = "none";
+        if (staleCanarySuffix) {
+          throw new CanaryFailure(
+            "capacity_guard",
+            "expected_stale_canary_missing",
+          );
+        }
+        return;
+      }
+      if (existingCanaries.length > 1) {
+        evidence.recovery.match = "multiple";
+        throw new CanaryFailure("capacity_guard", "existing_canary_present");
+      }
+      evidence.recovery.match = "one";
+      if (!staleCanarySuffix) {
+        throw new CanaryFailure("capacity_guard", "existing_canary_present");
+      }
+      await deleteVerifiedStaleCanary(existingCanaries[0]);
+      const after = await listAgents("capacity_guard");
       if (
-        before.some((agent) =>
+        after.some((agent) =>
           (stringField(agent, "agentName") ?? "").startsWith(
             CANARY_NAME_PREFIX,
           ),
         )
       ) {
-        throw new CanaryFailure("capacity_guard", "existing_canary_present");
+        throw new CanaryFailure("capacity_guard", "delete_not_confirmed");
       }
+      evidence.recovery.confirmed = true;
     });
 
     const createDone = timedPhase(evidence, "create", now);
@@ -1217,14 +1476,15 @@ export async function runManagedDedicatedCanary(
       if (observedTier !== EXPECTED_TIER) {
         throw new CanaryFailure("create", "wrong_execution_tier");
       }
-      const jobId = stringField(data, "jobId");
+      provisionJobId = stringField(data, "jobId");
       readinessDeadline = now() + readyTimeoutMs;
-      if (jobId) {
+      if (provisionJobId) {
         await pollJob(
-          jobId,
+          provisionJobId,
           "provision",
           Math.max(1, readinessDeadline - now()),
         );
+        provisionJobCompleted = true;
       }
     } catch (error) {
       if (!agentId && createFailureMayHaveCommitted(error)) {
@@ -1281,6 +1541,9 @@ async function main(): Promise<void> {
       githubRunId && githubRunAttempt
         ? `r${githubRunId}a${githubRunAttempt}`
         : undefined,
+    staleCanarySuffix: workflowEnv(
+      "CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX",
+    ),
   });
   await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, {
     mode: 0o600,


### PR DESCRIPTION
## Summary

- add an authenticated, organization-scoped conditional Eliza-agent DELETE contract that owns an exact name, creation timestamp, and execution tier under the existing lifecycle advisory lock
- fail closed around replacement cleanup, warm claims, in-progress work, retry ownership, and recent detached lifecycle execution; only quiescent stale work may be cancelled before the exact CAS
- recover the one explicitly supplied stale managed-canary suffix through normal GET/DELETE/job APIs, then require final 404 proof before provisioning a fresh canary
- bind recovery intent into workflow dispatch evidence and keep the evidence schema privacy-safe

## Why

The staging managed-dedicated canary is blocked by one old exact canary row from run 30081355987. Generic deletion, direct database edits, and prefix-wide cleanup are unsafe. This change provides a bounded exact-identity recovery path without weakening deployment or environment protections.

Refs #17158

## Proof

- bun run test:cloud — all 11 batches passed, 0 failures
- bun run verify:cloud — 85/85 tasks passed
- bun run verify — 578/578 lint/typecheck tasks plus all repository audits and 28 dist-path consumer checks passed
- bun run build:cloud — passed
- bun run build:core — 71/71 tasks passed
- focused canary/workflow tests — 48 passed, 0 failed
- API DELETE route tests — 6 passed, 0 failed
- focused Cloud shared real-PGlite lifecycle tests — 37 passed, 0 failed
- production Worker dry-run — passed
- git diff --check — clean
- independent blocker review — APPROVED, no remaining P0/P1

## Safety invariants

- no direct database mutation or ad-hoc host/container cleanup
- no broad prefix delete
- no token or suffix disclosure in artifacts
- no second provision while a known provision job is still nonterminal
- no environment-policy change or self-approval bypass
- normal no-body/whitespace DELETE behavior remains backward compatible

## UI evidence

N/A — no UI or renderer path changed.

## Post-merge rollout

1. Deploy the exact merge SHA to staging API and provisioning worker.
2. Dispatch one sanctioned staging canary with stale suffix r30081355987a1.
3. Require recovery confirmation, fresh canary proof, cleanup confirmation, and terminal green.
4. Only then selectively backport the exact proven change to production and repeat the protected canary before physical LP3 Notes/Calendar validation.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend and control-plane only; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend and control-plane only; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [30187410103](https://github.com/elizaOS/eliza/actions/runs/30187410103)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the exact staging canary artifact is intentionally produced only after the merged SHA is deployed
