### PR TITLE
chore(registry): register Ruby High community plugin

### DIFF
--- a/packages/registry/entries/third-party/rati-osf__plugin-ruby-high.json
+++ b/packages/registry/entries/third-party/rati-osf__plugin-ruby-high.json
@@ -1,0 +1,9 @@
+{
+  "package": "@rati-osf/plugin-ruby-high",
+  "repository": "github:cenetex/plugin-ruby-high",
+  "kind": "app",
+  "description": "Send an elizaOS agent to Ruby High to enroll, attend classes, answer questions, and learn alongside humans and agents.",
+  "homepage": "https://ruby-high.ai",
+  "version": "0.1.1",
+  "tags": ["ruby-high", "education", "agents", "game"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -227,6 +227,50 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@rati-osf/plugin-ruby-high": {
+      "git": {
+        "repo": "cenetex/plugin-ruby-high",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@rati-osf/plugin-ruby-high",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Send an elizaOS agent to Ruby High to enroll, attend classes, answer questions, and learn alongside humans and agents.",
+      "homepage": "https://ruby-high.ai",
+      "topics": [
+        "ruby-high",
+        "education",
+        "agents",
+        "game"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "app",
+      "registryKind": "app",
+      "directory": null
+    },
     "@seekdaseek/plugin-agentfeed": {
       "git": {
         "repo": "seekdaseek/plugin-agentfeed",


### PR DESCRIPTION
# Relates to

- https://github.com/cenetex/app-ruby-high/issues/162

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] The package-scoped validation, test, typecheck, and generation commands
      pass after sync. The sparse-checkout install limitation is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Package-scoped checks pass post-sync. The exact unrelated full-workspace
      install blocker is documented in **Known gaps / failures** below.

# Risks

Low. This adds one third-party metadata entry and its generator-produced wire
registry record. It does not change runtime code or first-party registry data.

# Background

## What does this PR do?

Registers [`@rati-osf/plugin-ruby-high@0.1.1`](https://www.npmjs.com/package/@rati-osf/plugin-ruby-high)
as a community elizaOS plugin. Ruby High lets an Eliza agent enroll, attend
classes, answer questions, track progress, and learn alongside human and agent
students.

The source entry follows the current in-repo registry schema. The committed
wire-format change was produced by `bun run --cwd packages/registry generate`.

## What kind of change is this?

Improvement: adds a third-party plugin to the community registry.

# Documentation changes needed?

No documentation change is needed. The entry follows the existing third-party
submission guide and schema.

# Testing

## Where should a reviewer start?

`packages/registry/entries/third-party/rati-osf__plugin-ruby-high.json`

## Detailed testing steps

From the repository root:

```bash
bun run --cwd packages/registry validate
bun run --cwd packages/registry generate
bun run --cwd packages/registry test
bun run --cwd packages/registry typecheck
git diff --exit-code
```

Observed post-sync results:

- 31 third-party entries validated.
- 8 test files passed, 33 tests passed.
- Typecheck passed.
- Regeneration produced no diff from the committed wire registry.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - metadata-only JSON change with no affected UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - metadata-only JSON change with no affected UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changes in this repository.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend or runtime code path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, model, or evaluator code changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the published npm package is linked above; the source
      entry and regenerated `generated-registry.json` are the registry artifacts
      in this PR.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR changes registry metadata only and does not alter agent behavior.

## Backend + frontend logs

N/A - this PR changes registry metadata only and runs no backend or frontend
code path.

## Screenshots (before / after) + video walkthrough

N/A - this PR has no rendered UI diff.

## Audio / voice walkthrough

N/A - this PR does not affect voice, transcript, TTS, STT, or audio behavior.

## Known gaps / failures

`bun install --frozen-lockfile --ignore-scripts --filter @elizaos/registry`
cannot run in a sparse checkout because Bun requires every unrelated workspace
declared by the monorepo root to be present. To keep validation scoped and avoid
an unnecessary full-monorepo checkout, the exact locked registry dependencies
were installed in a separate temporary directory. The registry's real package
test suite (8 files / 33 tests), typecheck, validator, and generator all passed
against the checked-out source.

The released `@elizaos/cli@1.7.2` publish test still targets the archived
`elizaos-plugins/registry` repository and returns GitHub 404. This PR uses the
current documented in-repo registry process under `packages/registry`, whose
validator and generator pass.
