### PR TITLE
fix(cloud): bound the v1 snapshot retain budget by what restore can consume (#17172 §1)

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -21,7 +21,12 @@ function tokenMatches(expected: string, provided: string): boolean {
 }
 
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
-const MAX_BACKUP_BODY_BYTES = 128 * 1024 * 1024; // 128 MB
+/**
+ * Restore's request-body cap IS the v1 restorable ceiling: anything retained
+ * above it can never be restored here (#17172). Shared with the retain side so
+ * the two cannot drift.
+ */
+const MAX_BACKUP_BODY_BYTES = MAX_RESTORABLE_AGENT_BACKUP_BYTES;
 
 import path from "node:path";
 import {
@@ -47,7 +52,10 @@ import type {
   FavoriteAppsStore,
 } from "@elizaos/plugin-app-manager";
 import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
-import { readAliasedEnv } from "@elizaos/shared";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  readAliasedEnv,
+} from "@elizaos/shared";
 import {
   getStylePresets,
   normalizeCharacterLanguage,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -52,10 +52,8 @@ import type {
   FavoriteAppsStore,
 } from "@elizaos/plugin-app-manager";
 import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
-import {
-  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
-  readAliasedEnv,
-} from "@elizaos/shared";
+import { readAliasedEnv } from "@elizaos/shared";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
 import {
   getStylePresets,
   normalizeCharacterLanguage,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -5,7 +5,10 @@
  */
 import { randomUUID } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
-import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  SnapshotPayloadTooLargeError,
+} from "@elizaos/shared/agent-backup-limits";
 import {
   and,
   asc,
@@ -2132,9 +2135,10 @@ export class AgentSandboxesRepository {
       chainBytes +=
         cursor.size_bytes ?? Buffer.byteLength(JSON.stringify(cursor.state_data), "utf8");
       if (chainBytes > MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES) {
-        throw new Error(
-          `Backup chain for ${backupId} exceeds ${MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES} bytes`,
-        );
+        // Typed so the restore sites can tell "too large to apply" from "gone":
+        // the chain is intact and decryptable, so this must fail the provision
+        // closed rather than degrade to an empty boot, and it must never prune.
+        throw new SnapshotPayloadTooLargeError(chainBytes, MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES);
       }
       chain.push(await hydrateAgentSandboxBackup(cursor));
       if (cursor.backup_kind === "full") break;

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -5,6 +5,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared";
 import {
   and,
   asc,
@@ -118,7 +119,7 @@ const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   workspaceFiles: {},
 };
 const MAX_RECONSTRUCTED_BACKUP_CHAIN_DEPTH = 100;
-const MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES = 128 * 1024 * 1024;
+const MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES = MAX_RESTORABLE_AGENT_BACKUP_BYTES;
 
 /**
  * Correlates a sandbox row with the queue operations that legitimately own its

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -5,7 +5,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
-import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
 import {
   and,
   asc,
@@ -119,6 +119,10 @@ const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   workspaceFiles: {},
 };
 const MAX_RECONSTRUCTED_BACKUP_CHAIN_DEPTH = 100;
+/**
+ * A reconstructed chain has to fit the same v1 restorable ceiling as any other
+ * backup wire payload — it is what gets handed to restore (#17172).
+ */
 const MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES = MAX_RESTORABLE_AGENT_BACKUP_BYTES;
 
 /**

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
@@ -14,6 +14,7 @@ import {
   planIncrementalBackup,
   reconstructFromChain,
   resolveBackupChain,
+  resolveBackupChainBytes,
   selectPrunableBackupIds,
 } from "./agent-backup-diff";
 
@@ -286,5 +287,42 @@ describe("backup chains", () => {
 
   test("selectPrunableBackupIds returns nothing when under the keep count", () => {
     expect(selectPrunableBackupIds(nodes, 10)).toEqual([]);
+  });
+});
+
+describe("resolveBackupChainBytes (#17172 retained-implies-restorable)", () => {
+  const sized = (
+    id: string,
+    kind: "full" | "incremental",
+    parent: string | null,
+    sizeBytes: number | null,
+  ) => ({ id, backupKind: kind, parentBackupId: parent, createdAtMs: 0, sizeBytes });
+
+  test("sums the stored inputs of the chain, not the reconstructed output", () => {
+    // Reconstruction budgets base-full + every delta; this must match it.
+    const nodes = [
+      sized("a", "full", null, 100),
+      sized("b", "incremental", "a", 20),
+      sized("c", "incremental", "b", 5),
+    ];
+    expect(resolveBackupChainBytes(nodes, "c")).toBe(125);
+    expect(resolveBackupChainBytes(nodes, "b")).toBe(120);
+    expect(resolveBackupChainBytes(nodes, "a")).toBe(100);
+  });
+
+  test("returns null when any ancestor has an unrecorded size, so callers fail closed", () => {
+    // An unprovable total must not be silently treated as small: the caller
+    // stores a full backup instead of extending a chain it cannot bound.
+    const nodes = [sized("a", "full", null, null), sized("b", "incremental", "a", 20)];
+    expect(resolveBackupChainBytes(nodes, "b")).toBeNull();
+  });
+
+  test("ignores rows outside the target's chain", () => {
+    const nodes = [
+      sized("a", "full", null, 100),
+      sized("b", "incremental", "a", 20),
+      sized("other", "full", null, 999_999),
+    ];
+    expect(resolveBackupChainBytes(nodes, "b")).toBe(120);
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.ts
@@ -290,6 +290,37 @@ export function incrementalChainDepth(nodes: BackupChainNode[], targetId: string
   return resolveBackupChain(nodes, targetId).length - 1;
 }
 
+/** A chain node plus its stored PLAINTEXT wire size; `null` when unrecorded. */
+export interface BackupChainSizedNode extends BackupChainNode {
+  sizeBytes: number | null;
+}
+
+/**
+ * Sum the stored PLAINTEXT wire bytes of the chain that reconstructs
+ * `targetId` — precisely the quantity reconstruction budgets (the base full
+ * plus every delta, NOT the reconstructed output).
+ *
+ * Returns `null` when any row in the chain has an unrecorded `size_bytes`: the
+ * total cannot be proven to fit, and a caller deciding whether to extend the
+ * chain must fail closed rather than guess. `size_bytes` is measured before
+ * encryption/base64/offload at every write site, so this stays in the same
+ * plaintext unit as the reconstruction budget — no base64 inflation factor
+ * belongs here.
+ */
+export function resolveBackupChainBytes(
+  nodes: BackupChainSizedNode[],
+  targetId: string,
+): number | null {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  let total = 0;
+  for (const id of resolveBackupChain(nodes, targetId)) {
+    const size = byId.get(id)?.sizeBytes ?? null;
+    if (size === null) return null;
+    total += size;
+  }
+  return total;
+}
+
 /**
  * Choose which backups to delete while keeping the newest `keep` restore points
  * AND every ancestor any retained backup still needs. The kept set is

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -25,6 +25,10 @@ process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { KmsError, StewardKmsAdapter } from "@elizaos/security/kms";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  SnapshotPayloadTooLargeError,
+} from "@elizaos/shared/agent-backup-limits";
 import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
 import { resetKmsClientForTests } from "../../db/crypto/kms-client";
@@ -1184,5 +1188,42 @@ describe("r2-offloaded backups (real S3 client against a local object-store stub
     for (const key of unrelatedKeys) {
       expect(getCounts.get(key)).toBeUndefined();
     }
+  });
+  test("a chain over the restorable budget is refused with the typed error", async () => {
+    const sandboxId = await seedSandbox();
+    // The chain sum reads `size_bytes` when present, so the budget is breached
+    // by two declared sizes rather than by materialising 128 MiB of payload.
+    const half = Math.ceil(MAX_RESTORABLE_AGENT_BACKUP_BYTES / 2) + 1;
+    const parent = await agentSandboxesRepository.createBackup({
+      sandbox_record_id: sandboxId,
+      snapshot_type: "auto",
+      state_data: sampleState("chain-parent"),
+      size_bytes: half,
+      backup_kind: "full",
+      content_hash: computeStateHash(sampleState("chain-parent")),
+    });
+    const child = await agentSandboxesRepository.createBackup({
+      sandbox_record_id: sandboxId,
+      snapshot_type: "auto",
+      state_data: sampleState("chain-child"),
+      size_bytes: half,
+      backup_kind: "incremental",
+      parent_backup_id: parent.id,
+      content_hash: computeStateHash(sampleState("chain-child")),
+    });
+
+    // Typed, not a plain Error: the restore sites branch on this class to fail
+    // the provision closed instead of degrading to an empty boot, and a plain
+    // Error would take the untyped rethrow path with no consent guidance.
+    await expect(agentSandboxesRepository.getReconstructedBackupState(child.id)).rejects.toThrow(
+      SnapshotPayloadTooLargeError,
+    );
+
+    // The chain must survive the refusal — it is intact, only too large.
+    const rows = await dbWrite
+      .select({ id: agentSandboxBackups.id })
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.sandbox_record_id, sandboxId));
+    expect(rows).toHaveLength(2);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -796,6 +796,23 @@ describe("ElizaSandboxService state restore auth", () => {
     expect(fetchCalls).toBe(0);
   });
 
+  test("the oversized-push refusal is unrecoverable but NOT permanently lost (#17172)", async () => {
+    // Classification is the whole point of typing this error: provisioning
+    // must stop retrying (the same bytes breach the same limit every time),
+    // while the stored backup chain stays intact and must never be pruned.
+    const {
+      SnapshotPayloadTooLargeError,
+      isUnrecoverableSnapshotError,
+      isPermanentlyLostSnapshot,
+    } = await import("./eliza-sandbox.ts?actual");
+    const err = new SnapshotPayloadTooLargeError(200, 100);
+
+    expect(isUnrecoverableSnapshotError(err)).toBe(true);
+    expect(isPermanentlyLostSnapshot(err)).toBe(false);
+    expect(err.payloadBytes).toBe(200);
+    expect(err.limitBytes).toBe(100);
+  });
+
   test("pushes a restore payload that fits the v1 restorable limit (#17172)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     let fetchCalls = 0;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -760,6 +760,67 @@ describe("ElizaSandboxService state restore auth", () => {
     });
   });
 
+  test("refuses a restore payload over the v1 restorable limit BEFORE the fetch (#17172)", async () => {
+    // `/api/restore` caps its request body at the same canonical limit, so an
+    // oversized push is a guaranteed far-end rejection. This runs on the
+    // blue/green rollback path, where a failed request is a failed ROLLBACK —
+    // so the refusal has to happen locally, before anything is sent.
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const { MAX_RESTORABLE_AGENT_BACKUP_BYTES } = await import(
+      "@elizaos/shared/agent-backup-limits"
+    );
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls += 1;
+      return Response.json({ ok: true });
+    });
+
+    // One oversized value is enough to push the serialized body past the cap;
+    // build it from a repeated char so the payload is big but cheap to make.
+    const oversized = "x".repeat(MAX_RESTORABLE_AGENT_BACKUP_BYTES + 1024);
+    const push = (
+      new ElizaSandboxService() as unknown as {
+        pushState: (
+          bridgeUrl: string,
+          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          options: { trusted: true; authRec: Pick<AgentSandbox, "id" | "environment_vars"> },
+        ) => Promise<void>;
+      }
+    ).pushState(
+      "https://runtime.example",
+      { memories: [], config: { blob: oversized }, workspaceFiles: {} },
+      { trusted: true, authRec: customSandbox() },
+    );
+
+    await expect(push).rejects.toThrow(/exceeds the v1 restorable limit/);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("pushes a restore payload that fits the v1 restorable limit (#17172)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls += 1;
+      return Response.json({ ok: true });
+    });
+
+    await (
+      new ElizaSandboxService() as unknown as {
+        pushState: (
+          bridgeUrl: string,
+          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          options: { trusted: true; authRec: Pick<AgentSandbox, "id" | "environment_vars"> },
+        ) => Promise<void>;
+      }
+    ).pushState(
+      "https://runtime.example",
+      { memories: [], config: { small: "payload" }, workspaceFiles: {} },
+      { trusted: true, authRec: customSandbox() },
+    );
+
+    expect(fetchCalls).toBe(1);
+  });
+
   test("keeps legacy bridge URL restores unauthenticated when no sandbox record is supplied", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const requests: Array<{ headers: Record<string, string> }> = [];

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1389,8 +1389,11 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
       findById: agentSandboxesRepository.findById,
       trySetProvisioning: agentSandboxesRepository.trySetProvisioning,
       getBackupById: agentSandboxesRepository.getBackupById,
+      getLatestBackup: agentSandboxesRepository.getLatestBackup,
       getReconstructedBackupState: agentSandboxesRepository.getReconstructedBackupState,
     };
+    // Ordinary provisions (no override) read the LATEST backup, not an id.
+    agentSandboxesRepository.getLatestBackup = mock(async () => backup);
     agentSandboxesRepository.findByIdAndOrg = mock(async () => rec);
     agentSandboxesRepository.findById = mock(async () => rec);
     agentSandboxesRepository.trySetProvisioning = mock(async () => ({
@@ -1426,6 +1429,7 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
         agentSandboxesRepository.findById = originals.findById;
         agentSandboxesRepository.trySetProvisioning = originals.trySetProvisioning;
         agentSandboxesRepository.getBackupById = originals.getBackupById;
+        agentSandboxesRepository.getLatestBackup = originals.getLatestBackup;
         agentSandboxesRepository.getReconstructedBackupState =
           originals.getReconstructedBackupState;
         createForAgentSpy.mockRestore();
@@ -1504,6 +1508,172 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
       h.restore();
     }
   });
+
+  test("an oversized restore FAILS an ORDINARY provision closed — no silent fresh boot (#17180 §1)", async () => {
+    // The chain is intact, only too large. Booting empty would silently drop
+    // every byte of it, so the refusal must look exactly like the explicit
+    // from-backup failure: status error, container torn down, chain unpruned.
+    const { SnapshotPayloadTooLargeError } = await import("./eliza-sandbox.ts?actual");
+    const h = await armFromBackupProvision({
+      reconstructError: new SnapshotPayloadTooLargeError(200 * 1024 * 1024, 128 * 1024 * 1024),
+    });
+    try {
+      const result = await h.svc.provision(h.rec.id, h.rec.organization_id);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("expected provision failure");
+      expect(result.error).toContain("forceFreshBoot");
+      expect(h.updateSpy).toHaveBeenCalledWith(
+        h.rec.id,
+        expect.objectContaining({ status: "error" }),
+      );
+      expect(h.provider.stop).toHaveBeenCalled();
+      expect(h.pruneSpy).not.toHaveBeenCalled();
+    } finally {
+      h.restore();
+    }
+  });
+
+  test("an oversized restore PUSH also fails an ordinary provision closed (#17180 §1)", async () => {
+    const { SnapshotPayloadTooLargeError } = await import("./eliza-sandbox.ts?actual");
+    const h = await armFromBackupProvision({});
+    // The push-side refusal fires from the serialized body size inside
+    // pushState; injecting at the method boundary avoids materializing 128 MiB
+    // in the test while exercising the provision branch that catches it.
+    const pushSpy = spyOn(
+      h.svc as unknown as { pushState: () => Promise<void> },
+      "pushState",
+    ).mockRejectedValue(new SnapshotPayloadTooLargeError(200 * 1024 * 1024, 128 * 1024 * 1024));
+    try {
+      const result = await h.svc.provision(h.rec.id, h.rec.organization_id);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("expected provision failure");
+      expect(result.error).toContain("forceFreshBoot");
+      expect(h.updateSpy).toHaveBeenCalledWith(
+        h.rec.id,
+        expect.objectContaining({ status: "error" }),
+      );
+      expect(h.pruneSpy).not.toHaveBeenCalled();
+    } finally {
+      pushSpy.mockRestore();
+      h.restore();
+    }
+  });
+});
+
+describe("ElizaSandboxService shutdown fails closed without a current capture (#17180 §2)", () => {
+  test("a failing pre-stop capture refuses the shutdown and leaves the agent running", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider: SandboxProvider = {
+      create: mock(async () => {
+        throw new Error("must not create");
+      }),
+      stop: mock(async () => {}),
+      stopForReplacement: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+    const svc = new ElizaSandboxService(provider);
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    const fetchSnap = spyOn(
+      svc as unknown as { fetchSnapshotState: () => Promise<never> },
+      "fetchSnapshotState",
+    ).mockRejectedValue(new Error("snapshot endpoint timed out"));
+    try {
+      const result = await svc.shutdown(rec.id, rec.organization_id);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Refusing to stop without a current backup");
+      expect(result.error).toContain("snapshot endpoint timed out");
+      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      getForWrite.mockRestore();
+      fetchSnap.mockRestore();
+    }
+  });
+});
+
+describe("ElizaSandboxService sleep refuses an unproven fallback backup (#17180 §3)", () => {
+  test("capture failed and the latest stored backup cannot be verified — sleep aborts", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider: SandboxProvider = {
+      create: mock(async () => {
+        throw new Error("must not create");
+      }),
+      stop: mock(async () => {}),
+      stopForReplacement: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+    globalThis.fetch = mock(async () => {
+      throw new Error("snapshot unavailable");
+    });
+    const find = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(rec);
+    // Unstamped row whose payload really fails decrypt: a GENUINE envelope
+    // encrypted under different AAD coordinates, so the verifier's decrypt
+    // (bound to this row's id) raises a real AeadError and the REAL gate
+    // classifies it decrypt-failed. (A non-envelope object would pass through
+    // decrypt as legacy plaintext; a malformed key id would be an infra throw.)
+    resetKmsClientForTests();
+    const foreignEnvelope = await encryptField(
+      KMS_TEST_ORG,
+      '{"memories":[],"config":{},"workspaceFiles":{}}',
+      KMS_TEST_COORDS,
+    );
+    const storedBackup = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue(
+      {
+        id: "stale-unproven",
+        sandbox_record_id: rec.id,
+        snapshot_type: "pre-shutdown",
+        state_data: {
+          kind: "encrypted-agent-backup-state",
+          algorithm: "kms-aes-256-gcm",
+          ...foreignEnvelope,
+        },
+        state_data_storage: "inline",
+        state_data_key: null,
+        backup_kind: "full",
+        parent_backup_id: null,
+        content_hash: null,
+        size_bytes: 2,
+        verification_status: null,
+        verified_at: null,
+        verification_error: null,
+        created_at: new Date("2026-01-01T00:00:00.000Z"),
+      } as never,
+    );
+    const stamp = spyOn(agentSandboxesRepository, "stampBackupVerification").mockResolvedValue(
+      undefined as never,
+    );
+    const listMeta = spyOn(agentSandboxesRepository, "listBackupMetadata").mockResolvedValue(
+      [] as never,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update");
+    try {
+      const result = await new ElizaSandboxService(provider).executeSleep(
+        rec.id,
+        rec.organization_id,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.containerRemoved).toBe(false);
+      expect(result.error).toContain("Refusing to deactivate on an unproven backup");
+      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      find.mockRestore();
+      storedBackup.mockRestore();
+      stamp.mockRestore();
+      listMeta.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
 });
 
 describe("ElizaSandboxService sleep", () => {
@@ -1528,6 +1698,11 @@ describe("ElizaSandboxService sleep", () => {
     const latestBackupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
       undefined,
     );
+    // The gate consults the un-hydrated read; nothing durable exists.
+    const storedBackupSpy = spyOn(
+      agentSandboxesRepository,
+      "getLatestStoredBackup",
+    ).mockResolvedValue(undefined);
     const createBackupSpy = spyOn(agentSandboxesRepository, "createBackup");
     const updateSpy = spyOn(agentSandboxesRepository, "update");
 
@@ -1549,6 +1724,7 @@ describe("ElizaSandboxService sleep", () => {
     } finally {
       findSpy.mockRestore();
       latestBackupSpy.mockRestore();
+      storedBackupSpy.mockRestore();
       createBackupSpy.mockRestore();
       updateSpy.mockRestore();
     }
@@ -3239,6 +3415,18 @@ describe("replacement lifecycle teardown is absence-proof", () => {
     const backup = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue({
       id: "durable-backup",
     } as never);
+    // Fresh verified stamp: the sleep fallback gate accepts this row without
+    // a live decrypt, keeping these tests focused on the later stages.
+    const storedBackup = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue(
+      {
+        id: "durable-backup",
+        sandbox_record_id: rec.id,
+        snapshot_type: "pre-shutdown",
+        verification_status: "verified",
+        verified_at: new Date(),
+        created_at: new Date(),
+      } as never,
+    );
     const tx = armSleepTransaction(svc, rec);
     try {
       const result = await svc.executeSleep(AGENT, ORG);
@@ -3254,6 +3442,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       upgradeTransactionImpl = null;
       find.mockRestore();
       backup.mockRestore();
+      storedBackup.mockRestore();
       tx.lockLifecycle.mockRestore();
       tx.getForMutation.mockRestore();
       tx.activeReplacement.mockRestore();
@@ -3283,6 +3472,18 @@ describe("replacement lifecycle teardown is absence-proof", () => {
     const backup = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue({
       id: "durable-backup",
     } as never);
+    // Fresh verified stamp: the sleep fallback gate accepts this row without
+    // a live decrypt, keeping these tests focused on the later stages.
+    const storedBackup = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue(
+      {
+        id: "durable-backup",
+        sandbox_record_id: rec.id,
+        snapshot_type: "pre-shutdown",
+        verification_status: "verified",
+        verified_at: new Date(),
+        created_at: new Date(),
+      } as never,
+    );
     const tx = armSleepTransaction(svc, replacement);
 
     try {
@@ -3298,6 +3499,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       upgradeTransactionImpl = null;
       find.mockRestore();
       backup.mockRestore();
+      storedBackup.mockRestore();
       tx.lockLifecycle.mockRestore();
       tx.getForMutation.mockRestore();
       tx.activeReplacement.mockRestore();
@@ -3320,6 +3522,18 @@ describe("replacement lifecycle teardown is absence-proof", () => {
     const backup = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue({
       id: "durable-backup",
     } as never);
+    // Fresh verified stamp: the sleep fallback gate accepts this row without
+    // a live decrypt, keeping these tests focused on the later stages.
+    const storedBackup = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue(
+      {
+        id: "durable-backup",
+        sandbox_record_id: rec.id,
+        snapshot_type: "pre-shutdown",
+        verification_status: "verified",
+        verified_at: new Date(),
+        created_at: new Date(),
+      } as never,
+    );
     const prune = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(undefined);
     const tx = armSleepTransaction(svc, rec);
 
@@ -3338,6 +3552,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       upgradeTransactionImpl = null;
       find.mockRestore();
       backup.mockRestore();
+      storedBackup.mockRestore();
       prune.mockRestore();
       tx.lockLifecycle.mockRestore();
       tx.getForMutation.mockRestore();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -796,18 +796,19 @@ describe("ElizaSandboxService state restore auth", () => {
     expect(fetchCalls).toBe(0);
   });
 
-  test("the oversized-push refusal is unrecoverable but NOT permanently lost (#17172)", async () => {
-    // Classification is the whole point of typing this error: provisioning
-    // must stop retrying (the same bytes breach the same limit every time),
-    // while the stored backup chain stays intact and must never be pruned.
-    const {
-      SnapshotPayloadTooLargeError,
-      isUnrecoverableSnapshotError,
-      isPermanentlyLostSnapshot,
-    } = await import("./eliza-sandbox.ts?actual");
+  test("the oversized refusal is neither unrecoverable nor permanently lost (#17172)", async () => {
+    // Both classifiers must say no. "Unrecoverable" authorises the fresh-boot
+    // degrade, and an oversized chain is intact and decryptable — degrading it
+    // would discard recoverable state because of a limit we chose. "Permanently
+    // lost" additionally authorises pruning, which would destroy that chain.
+    // The refusal gets its own terminal branch at each restore site instead.
+    const { isUnrecoverableSnapshotError, isPermanentlyLostSnapshot } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const { SnapshotPayloadTooLargeError } = await import("@elizaos/shared/agent-backup-limits");
     const err = new SnapshotPayloadTooLargeError(200, 100);
 
-    expect(isUnrecoverableSnapshotError(err)).toBe(true);
+    expect(isUnrecoverableSnapshotError(err)).toBe(false);
     expect(isPermanentlyLostSnapshot(err)).toBe(false);
     expect(err.payloadBytes).toBe(200);
     expect(err.limitBytes).toBe(100);
@@ -1513,7 +1514,7 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
     // The chain is intact, only too large. Booting empty would silently drop
     // every byte of it, so the refusal must look exactly like the explicit
     // from-backup failure: status error, container torn down, chain unpruned.
-    const { SnapshotPayloadTooLargeError } = await import("./eliza-sandbox.ts?actual");
+    const { SnapshotPayloadTooLargeError } = await import("@elizaos/shared/agent-backup-limits");
     const h = await armFromBackupProvision({
       reconstructError: new SnapshotPayloadTooLargeError(200 * 1024 * 1024, 128 * 1024 * 1024),
     });
@@ -1535,7 +1536,7 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
   });
 
   test("an oversized restore PUSH also fails an ordinary provision closed (#17180 §1)", async () => {
-    const { SnapshotPayloadTooLargeError } = await import("./eliza-sandbox.ts?actual");
+    const { SnapshotPayloadTooLargeError } = await import("@elizaos/shared/agent-backup-limits");
     const h = await armFromBackupProvision({});
     // The push-side refusal fires from the serialized body size inside
     // pushState; injecting at the method boundary avoids materializing 128 MiB

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -59,6 +59,7 @@ import {
   estimateDeltaBytes,
   incrementalChainDepth,
   planIncrementalBackup,
+  resolveBackupChainBytes,
 } from "./agent-backup-diff";
 import { decryptAgentEnvVars, encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
 import {
@@ -6011,20 +6012,46 @@ export class ElizaSandboxService {
             backupKind: b.backup_kind,
             parentBackupId: b.parent_backup_id,
             createdAtMs: b.created_at.getTime(),
+            // Kept so the projected chain sum below needs no extra query.
+            sizeBytes: b.size_bytes ?? null,
           }));
           const chainDepth = incrementalChainDepth(nodes, latest.id);
           const plan = planIncrementalBackup({ base: baseState, next: stateData, chainDepth });
           if (plan.kind === "incremental") {
-            return {
-              sandbox_record_id: sandboxRecordId,
-              snapshot_type: type,
-              // The state_data jsonb holds a BackupDelta for incremental rows.
-              state_data: plan.delta,
-              size_bytes: estimateDeltaBytes(plan.delta),
-              backup_kind: "incremental",
-              parent_backup_id: latest.id,
-              content_hash: contentHash,
-            };
+            // retained-implies-restorable (#17172): reconstruction budgets the
+            // SUM of the chain's stored inputs, so appending a delta that
+            // pushes that sum past the ceiling would make this row canonical
+            // AND unreconstructable in the same write — the invariant this PR
+            // exists to hold. A full backup is always reconstructable, so it is
+            // the correct fail-closed outcome, both when the projection
+            // breaches and when it cannot be computed (an ancestor with an
+            // unrecorded size_bytes).
+            const deltaBytes = estimateDeltaBytes(plan.delta);
+            const existingChainBytes = resolveBackupChainBytes(nodes, latest.id);
+            if (
+              existingChainBytes !== null &&
+              existingChainBytes + deltaBytes <= MAX_RESTORABLE_AGENT_BACKUP_BYTES
+            ) {
+              return {
+                sandbox_record_id: sandboxRecordId,
+                snapshot_type: type,
+                // The state_data jsonb holds a BackupDelta for incremental rows.
+                state_data: plan.delta,
+                size_bytes: deltaBytes,
+                backup_kind: "incremental",
+                parent_backup_id: latest.id,
+                content_hash: contentHash,
+              };
+            }
+            logger.info(
+              "[agent-sandbox] Storing a full backup: an incremental would exceed the restorable chain budget",
+              {
+                sandboxRecordId,
+                existingChainBytes,
+                deltaBytes,
+                limitBytes: MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+              },
+            );
           }
         }
       } catch (error) {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -878,6 +878,28 @@ const UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
 // so they must degrade-but-PRESERVE the chain: never prune a snapshot a
 // token-corrected resume could still restore (#15274).
 const PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES = new Set([404, 410]);
+
+/**
+ * A reconstructed restore payload larger than what `/api/restore` accepts, so
+ * the push is refused locally instead of being sent to be rejected (#17172).
+ *
+ * Typed because the classification matters in both directions: retrying is
+ * pointless (the same bytes exceed the same limit every time), so this must
+ * read as UNRECOVERABLE — but the stored backup chain is intact and still
+ * decryptable, so it must NOT read as permanently lost and must never prune the
+ * chain.
+ */
+export class SnapshotPayloadTooLargeError extends Error {
+  readonly name = "SnapshotPayloadTooLargeError";
+  constructor(
+    readonly payloadBytes: number,
+    readonly limitBytes: number,
+  ) {
+    super(
+      `State restore refused: reconstructed payload of ${payloadBytes} bytes exceeds the v1 restorable limit of ${limitBytes} bytes`,
+    );
+  }
+}
 // Anchored on the exact `fetchSnapshotState` / `pushState` throw shapes so only
 // this file's snapshot HTTP throw sites classify — an unrelated error that
 // merely embeds one of these strings does not.
@@ -923,6 +945,10 @@ const SNAPSHOT_HTTP_ERROR_SHAPE =
 export function isUnrecoverableSnapshotError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
+  // A local size refusal is deterministic: the same reconstructed bytes breach
+  // the same limit on every attempt, so retrying only burns the provision.
+  // Deliberately absent from `isPermanentlyLostSnapshot` — the chain is intact.
+  if (error.name === "SnapshotPayloadTooLargeError") return true;
   const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
   return match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
@@ -9701,9 +9727,7 @@ export class ElizaSandboxService {
     const body = JSON.stringify(state);
     const bodyBytes = Buffer.byteLength(body, "utf8");
     if (bodyBytes > MAX_RESTORABLE_AGENT_BACKUP_BYTES) {
-      throw new Error(
-        `State restore refused: reconstructed payload of ${bodyBytes} bytes exceeds the v1 restorable limit of ${MAX_RESTORABLE_AGENT_BACKUP_BYTES} bytes`,
-      );
+      throw new SnapshotPayloadTooLargeError(bodyBytes, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
     }
     const requestInit: RequestInit = {
       method: "POST",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2584,6 +2584,15 @@ export class ElizaSandboxService {
             // failure here fails the provision (retryable by the wake job)
             // instead of booting empty (#15603 B6).
             if (restoreOverride?.kind === "from-backup") throw error;
+            if (error instanceof SnapshotPayloadTooLargeError) {
+              // Size refusal fails CLOSED even on an ordinary provision: the
+              // chain is intact, only too large — booting empty would silently
+              // drop every byte of it. The one consent path is wake's
+              // forceFreshBoot.
+              throw new Error(
+                `Restore refused: ${error.message}. Booting empty would discard this agent's state; wake with forceFreshBoot to explicitly accept the data loss.`,
+              );
+            }
             if (!isUnrecoverableSnapshotError(error)) throw error;
             await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
             backup = undefined;
@@ -2617,6 +2626,12 @@ export class ElizaSandboxService {
               // restore point that cannot be pushed fails the provision rather
               // than degrading (#15603 B6).
               throw error;
+            } else if (error instanceof SnapshotPayloadTooLargeError) {
+              // Same fail-closed rule as the fetch branch: an oversized state
+              // is refused, never silently traded for an empty boot.
+              throw new Error(
+                `Restore refused: ${error.message}. Booting empty would discard this agent's state; wake with forceFreshBoot to explicitly accept the data loss.`,
+              );
             } else if (isUnrecoverableSnapshotError(error)) {
               await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
             } else {
@@ -6850,6 +6865,7 @@ export class ElizaSandboxService {
 
   async shutdown(agentId: string, orgId: string): Promise<{ success: boolean; error?: string }> {
     let snapshotAgentId: string | null = null;
+    let captureUnsupported = false;
     let preShutdownSnapshot: {
       stateData: AgentBackupStateData;
       sizeBytes: number;
@@ -6858,13 +6874,32 @@ export class ElizaSandboxService {
 
     const snapshotSource = await this.getAgentForWrite(agentId, orgId);
     if (snapshotSource?.status === "running" && snapshotSource.bridge_url) {
-      preShutdownSnapshot = await this.fetchSnapshotState(snapshotSource).catch((error) => {
-        logger.warn("[agent-sandbox] Pre-shutdown backup fetch failed", {
-          agentId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return null;
-      });
+      try {
+        preShutdownSnapshot = await this.fetchSnapshotState(snapshotSource);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message === SNAPSHOT_ENDPOINT_UNSUPPORTED) {
+          // The deployed image cannot snapshot by construction; requiring a
+          // capture it can never produce would make this agent unstoppable.
+          captureUnsupported = true;
+          logger.warn(
+            "[agent-sandbox] Shutdown proceeding without capture: image has no snapshot endpoint",
+            { agentId },
+          );
+        } else {
+          // Fail CLOSED: stopping the container without a current capture
+          // silently discards everything since the last backup. A shutdown
+          // that cannot prove a capture leaves the agent running and says so.
+          logger.error("[agent-sandbox] Shutdown refused: pre-stop capture failed", {
+            agentId,
+            error: message,
+          });
+          return {
+            success: false,
+            error: `Refusing to stop without a current backup: ${message}`,
+          };
+        }
+      }
     }
 
     const result = await dbWrite.transaction(async (tx) => {
@@ -6909,11 +6944,19 @@ export class ElizaSandboxService {
         } as const;
       }
 
-      if (
-        preShutdownSnapshot &&
-        rec.status === "running" &&
-        rec.bridge_url === preShutdownSnapshot.bridgeUrl
-      ) {
+      if (rec.status === "running" && rec.bridge_url && !captureUnsupported) {
+        // The capture must be OF THIS generation. A capture taken against a
+        // different bridge_url (the row moved between the unlocked fetch and
+        // this locked read) is some other container's state; persisting it
+        // would masquerade as current, and stopping without persisting would
+        // silently discard the delta. Both refuse.
+        if (!preShutdownSnapshot || rec.bridge_url !== preShutdownSnapshot.bridgeUrl) {
+          return {
+            success: false,
+            error:
+              "Refusing to stop: the agent's lifecycle generation moved after the pre-stop capture; retry the shutdown.",
+          } as const;
+        }
         await this.persistSnapshotWithinTransaction(
           tx,
           rec.id,
@@ -7158,10 +7201,36 @@ export class ElizaSandboxService {
       }
     }
     if (!backupId) {
-      const existing = await agentSandboxesRepository.getLatestBackup(rec.id);
-      if (existing) {
-        backupId = existing.id;
-      } else {
+      // The fallback destroys newer compute state in favor of whatever this
+      // resolves to, so "a backup row exists" is not enough: it must be PROVEN
+      // restorable (fresh verified stamp, or a live decrypt+chain+hash
+      // verification right now) before the container is stopped. The wake gate
+      // already implements exactly that proof, alternative scan included.
+      const gate = await runWakeRestoreIntegrityGate({
+        sandboxRecordId: rec.id,
+        agentName: rec.agent_name,
+      });
+      if (!gate.ok) {
+        logger.error("[agent-sandbox] Sleep aborted: no restorable backup proven", {
+          agentId,
+          sandboxRecordId: rec.id,
+          failure: gate.failure.kind,
+        });
+        return {
+          success: false,
+          containerRemoved: false,
+          error: `Refusing to deactivate on an unproven backup; agent was left running. ${formatWakeRestoreIntegrityError(gate.failure)}`,
+        };
+      }
+      if (gate.backupId) {
+        backupId = gate.backupId;
+      } else if (gate.verification === "disabled") {
+        // Kill switch: with the gate off, keep the pre-gate behavior of
+        // accepting the latest backup rather than inventing a third mode.
+        const existing = await agentSandboxesRepository.getLatestBackup(rec.id);
+        if (existing) backupId = existing.id;
+      }
+      if (!backupId) {
         logger.error("[agent-sandbox] Sleep aborted: no durable backup available", {
           agentId,
           sandboxRecordId: rec.id,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6,6 +6,7 @@
 import crypto from "node:crypto";
 import { isIP } from "node:net";
 import { ElizaError } from "@elizaos/core";
+import { resolveRetainableAgentBackupBytes } from "@elizaos/shared";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { type Database, dbWrite } from "../../db/helpers";
@@ -505,11 +506,15 @@ const SNAPSHOT_FETCH_TIMEOUT_MS = 120_000;
  * doubled it). The raw budget is enforced WHILE streaming — bytes past it are
  * never retained — and the expanded file budgets are validated before the
  * payload is persisted. Env-overridable for staging soak.
+ *
+ * The raw budget is the RETAIN side of the v1 wire contract, so it is bounded
+ * by what restore accepts: the override may lower it, never raise it past
+ * `MAX_RESTORABLE_AGENT_BACKUP_BYTES` (#17172). Retaining more than that
+ * yields a snapshot that authorizes a cutover and can never be restored.
  */
-const SNAPSHOT_MAX_RAW_BYTES = (() => {
-  const raw = Number.parseInt(process.env.ELIZA_SNAPSHOT_MAX_RAW_BYTES ?? "", 10);
-  return Number.isFinite(raw) && raw > 0 ? raw : 256 * 1024 * 1024;
-})();
+const SNAPSHOT_MAX_RAW_BYTES = resolveRetainableAgentBackupBytes(
+  process.env.ELIZA_SNAPSHOT_MAX_RAW_BYTES,
+);
 const SNAPSHOT_MAX_FILES = (() => {
   const raw = Number.parseInt(process.env.ELIZA_SNAPSHOT_MAX_FILES ?? "", 10);
   return Number.isFinite(raw) && raw > 0 ? raw : 5_000;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -9,6 +9,7 @@ import { ElizaError } from "@elizaos/core";
 import {
   MAX_RESTORABLE_AGENT_BACKUP_BYTES,
   resolveRetainableAgentBackupBytes,
+  SnapshotPayloadTooLargeError,
 } from "@elizaos/shared/agent-backup-limits";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
@@ -880,27 +881,6 @@ const UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
 // token-corrected resume could still restore (#15274).
 const PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES = new Set([404, 410]);
 
-/**
- * A reconstructed restore payload larger than what `/api/restore` accepts, so
- * the push is refused locally instead of being sent to be rejected (#17172).
- *
- * Typed because the classification matters in both directions: retrying is
- * pointless (the same bytes exceed the same limit every time), so this must
- * read as UNRECOVERABLE — but the stored backup chain is intact and still
- * decryptable, so it must NOT read as permanently lost and must never prune the
- * chain.
- */
-export class SnapshotPayloadTooLargeError extends Error {
-  readonly name = "SnapshotPayloadTooLargeError";
-  constructor(
-    readonly payloadBytes: number,
-    readonly limitBytes: number,
-  ) {
-    super(
-      `State restore refused: reconstructed payload of ${payloadBytes} bytes exceeds the v1 restorable limit of ${limitBytes} bytes`,
-    );
-  }
-}
 // Anchored on the exact `fetchSnapshotState` / `pushState` throw shapes so only
 // this file's snapshot HTTP throw sites classify — an unrelated error that
 // merely embeds one of these strings does not.
@@ -946,10 +926,12 @@ const SNAPSHOT_HTTP_ERROR_SHAPE =
 export function isUnrecoverableSnapshotError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
-  // A local size refusal is deterministic: the same reconstructed bytes breach
-  // the same limit on every attempt, so retrying only burns the provision.
-  // Deliberately absent from `isPermanentlyLostSnapshot` — the chain is intact.
-  if (error.name === "SnapshotPayloadTooLargeError") return true;
+  // A size refusal is deliberately NOT unrecoverable-for-this-provision. It is
+  // deterministic, so retrying is pointless — but the chain is intact and
+  // restorable in principle, and the only reason it cannot be applied is a
+  // limit WE chose. Degrading it to a fresh boot would discard recoverable
+  // state; it gets its own terminal branch at each restore site instead, and
+  // the one way past it is wake's explicit `forceFreshBoot` consent.
   const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
   return match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
@@ -2583,7 +2565,10 @@ export class ElizaSandboxService {
             // fresh boot — the caller opted into THAT restore point, so a
             // failure here fails the provision (retryable by the wake job)
             // instead of booting empty (#15603 B6).
-            if (restoreOverride?.kind === "from-backup") throw error;
+            // Ordered before the from-backup rethrow: the gated wake ALWAYS
+            // passes `from-backup`, so checking that first would swallow the
+            // consent sentence on the one path where the consent mechanism
+            // exists.
             if (error instanceof SnapshotPayloadTooLargeError) {
               // Size refusal fails CLOSED even on an ordinary provision: the
               // chain is intact, only too large — booting empty would silently
@@ -2593,6 +2578,7 @@ export class ElizaSandboxService {
                 `Restore refused: ${error.message}. Booting empty would discard this agent's state; wake with forceFreshBoot to explicitly accept the data loss.`,
               );
             }
+            if (restoreOverride?.kind === "from-backup") throw error;
             if (!isUnrecoverableSnapshotError(error)) throw error;
             await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
             backup = undefined;
@@ -2621,17 +2607,18 @@ export class ElizaSandboxService {
                   backupId: backup?.id,
                 },
               );
+            } else if (error instanceof SnapshotPayloadTooLargeError) {
+              // Ordered before the from-backup rethrow for the same reason as
+              // the fetch branch: a gated wake would otherwise never see the
+              // consent sentence.
+              throw new Error(
+                `Restore refused: ${error.message}. Booting empty would discard this agent's state; wake with forceFreshBoot to explicitly accept the data loss.`,
+              );
             } else if (restoreOverride?.kind === "from-backup") {
               // Same no-silent-fresh-boot rule as the fetch above: an explicit
               // restore point that cannot be pushed fails the provision rather
               // than degrading (#15603 B6).
               throw error;
-            } else if (error instanceof SnapshotPayloadTooLargeError) {
-              // Same fail-closed rule as the fetch branch: an oversized state
-              // is refused, never silently traded for an empty boot.
-              throw new Error(
-                `Restore refused: ${error.message}. Booting empty would discard this agent's state; wake with forceFreshBoot to explicitly accept the data loss.`,
-              );
             } else if (isUnrecoverableSnapshotError(error)) {
               await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
             } else {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6,7 +6,10 @@
 import crypto from "node:crypto";
 import { isIP } from "node:net";
 import { ElizaError } from "@elizaos/core";
-import { resolveRetainableAgentBackupBytes } from "@elizaos/shared";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  resolveRetainableAgentBackupBytes,
+} from "@elizaos/shared/agent-backup-limits";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { type Database, dbWrite } from "../../db/helpers";
@@ -9689,9 +9692,22 @@ export class ElizaSandboxService {
       authRec?: Pick<AgentSandbox, "id" | "environment_vars">;
     },
   ) {
+    // Measure the assembled payload ONCE, before it leaves the worker (#17172).
+    // `/api/restore` caps its request body at the same canonical limit, so an
+    // oversized push is a guaranteed far-end rejection — and this runs on the
+    // blue/green ROLLBACK path, where discovering that after the request is a
+    // failed rollback rather than a clean refusal. Stringifying into a local
+    // also avoids building the payload twice.
+    const body = JSON.stringify(state);
+    const bodyBytes = Buffer.byteLength(body, "utf8");
+    if (bodyBytes > MAX_RESTORABLE_AGENT_BACKUP_BYTES) {
+      throw new Error(
+        `State restore refused: reconstructed payload of ${bodyBytes} bytes exceeds the v1 restorable limit of ${MAX_RESTORABLE_AGENT_BACKUP_BYTES} bytes`,
+      );
+    }
     const requestInit: RequestInit = {
       method: "POST",
-      body: JSON.stringify(state),
+      body,
       signal: AbortSignal.timeout(SNAPSHOT_RESTORE_TIMEOUT_MS),
     };
     const res =

--- a/packages/shared/src/agent-backup-limits.test.ts
+++ b/packages/shared/src/agent-backup-limits.test.ts
@@ -49,12 +49,38 @@ describe("agent-backup limits", () => {
     );
   });
 
-  it("falls back to the canonical ceiling on malformed or non-positive overrides", () => {
-    for (const raw of ["", "   ", "not-a-number", "0", "-1", "NaN"]) {
+  it("treats an absent or blank override as unset and defaults", () => {
+    // Blank is indistinguishable from unset in a systemd EnvironmentFile, so it
+    // stays a default rather than a hard failure.
+    for (const raw of [undefined, "", "   "]) {
       expect(resolveRetainableAgentBackupBytes(raw)).toBe(
         MAX_RESTORABLE_AGENT_BACKUP_BYTES,
       );
     }
+  });
+
+  it("fails fast on a configured-but-invalid override instead of defaulting", () => {
+    // An operator who set the variable meant to change the budget. Silently
+    // running on the canonical limit would hide the misconfiguration behind
+    // behavior that looks deliberate.
+    for (const raw of ["not-a-number", "0", "-1", "NaN", "1e9", " 12 34 "]) {
+      expect(() => resolveRetainableAgentBackupBytes(raw)).toThrow(
+        /Invalid snapshot retain budget/,
+      );
+    }
+  });
+
+  it("rejects a malformed numeric PREFIX rather than silently misreading it", () => {
+    // `Number.parseInt` reads all three of these as 128 — the silent misread
+    // this parser exists to prevent (an operator writing a unit suffix would
+    // get a 128-BYTE budget without a word).
+    for (const raw of ["128MiB", "128abc", "128_000", "0x80"]) {
+      expect(() => resolveRetainableAgentBackupBytes(raw)).toThrow(
+        /Invalid snapshot retain budget/,
+      );
+    }
+    // Surrounding whitespace is only formatting, so it is trimmed, not rejected.
+    expect(resolveRetainableAgentBackupBytes("  1048576  ")).toBe(1048576);
   });
 
   it("accepts the exact limit and clamps limit+1 (boundary)", () => {

--- a/packages/shared/src/agent-backup-limits.test.ts
+++ b/packages/shared/src/agent-backup-limits.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pins the v1 agent-backup size contract: the retain budget can never exceed
+ * what restore accepts.
+ *
+ * The production canary in #17172 retained a snapshot Cloud allowed (256 MiB)
+ * but restore could not consume (128 MiB cap), producing a backup that
+ * authorized a cutover and was impossible to restore. These tests hold the
+ * clamp that makes that state unreachable — including through the operator env
+ * override, which previously could re-open the gap by configuration alone.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  resolveRetainableAgentBackupBytes,
+} from "./agent-backup-limits.js";
+
+const MIB = 1024 * 1024;
+
+describe("agent-backup limits", () => {
+  it("pins the canonical restorable ceiling at 128 MiB", () => {
+    // The smallest consumer on the restore path (the agent's /api/restore body
+    // cap) is what makes a backup restorable at all; the canonical limit must
+    // equal it, not the larger retain-side budget that caused #17172.
+    expect(MAX_RESTORABLE_AGENT_BACKUP_BYTES).toBe(128 * MIB);
+  });
+
+  it("defaults to the canonical ceiling when no override is set", () => {
+    expect(resolveRetainableAgentBackupBytes(undefined)).toBe(
+      MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    );
+  });
+
+  it("honors an override that LOWERS the retain budget", () => {
+    // Lowering is the override's real purpose (staging soak, constrained
+    // worker) and stays safe: a smaller retained payload is still restorable.
+    expect(resolveRetainableAgentBackupBytes(String(32 * MIB))).toBe(32 * MIB);
+  });
+
+  it("clamps an override that would RAISE the retain budget past restore", () => {
+    // The #17172 regression in one line: configuration must not be able to
+    // retain more than restore accepts.
+    expect(resolveRetainableAgentBackupBytes(String(512 * MIB))).toBe(
+      MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    );
+    // The exact pre-fix value that produced the unrestorable canary snapshot.
+    expect(resolveRetainableAgentBackupBytes(String(256 * MIB))).toBe(
+      MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    );
+  });
+
+  it("falls back to the canonical ceiling on malformed or non-positive overrides", () => {
+    for (const raw of ["", "   ", "not-a-number", "0", "-1", "NaN"]) {
+      expect(resolveRetainableAgentBackupBytes(raw)).toBe(
+        MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+      );
+    }
+  });
+
+  it("accepts the exact limit and clamps limit+1 (boundary)", () => {
+    expect(
+      resolveRetainableAgentBackupBytes(
+        String(MAX_RESTORABLE_AGENT_BACKUP_BYTES),
+      ),
+    ).toBe(MAX_RESTORABLE_AGENT_BACKUP_BYTES);
+    expect(
+      resolveRetainableAgentBackupBytes(
+        String(MAX_RESTORABLE_AGENT_BACKUP_BYTES + 1),
+      ),
+    ).toBe(MAX_RESTORABLE_AGENT_BACKUP_BYTES);
+  });
+
+  it("never resolves a retain budget above the restorable ceiling, for any input", () => {
+    // The anti-drift invariant itself: whatever an operator sets, the retain
+    // side stays within what restore can consume.
+    const inputs = [
+      undefined,
+      "1",
+      "1048576",
+      String(128 * MIB),
+      String(1024 * MIB),
+      "999999999999",
+    ];
+    for (const raw of inputs) {
+      expect(resolveRetainableAgentBackupBytes(raw)).toBeLessThanOrEqual(
+        MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+      );
+    }
+  });
+});

--- a/packages/shared/src/agent-backup-limits.ts
+++ b/packages/shared/src/agent-backup-limits.ts
@@ -61,3 +61,29 @@ export function resolveRetainableAgentBackupBytes(
   }
   return Math.min(parsed, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
 }
+
+/**
+ * A restore payload larger than what the restore path accepts, refused locally
+ * instead of being sent to be rejected (#17172).
+ *
+ * It lives beside the limits themselves because BOTH sides that enforce them
+ * throw it — the service before pushing state, and backup-chain reconstruction
+ * while walking the chain — and a service-owned class would make the repository
+ * import its own consumer.
+ *
+ * Typed because the classification matters in both directions: retrying is
+ * pointless (the same bytes exceed the same limit every time), but the stored
+ * chain is intact and still decryptable, so this must never read as permanently
+ * lost and must never prune the chain.
+ */
+export class SnapshotPayloadTooLargeError extends Error {
+  readonly name = "SnapshotPayloadTooLargeError";
+  constructor(
+    readonly payloadBytes: number,
+    readonly limitBytes: number,
+  ) {
+    super(
+      `State restore refused: reconstructed payload of ${payloadBytes} bytes exceeds the v1 restorable limit of ${limitBytes} bytes`,
+    );
+  }
+}

--- a/packages/shared/src/agent-backup-limits.ts
+++ b/packages/shared/src/agent-backup-limits.ts
@@ -1,0 +1,45 @@
+/**
+ * Agent-backup size limits shared by everything that RETAINS or CONSUMES a v1
+ * agent snapshot.
+ *
+ * A v1 snapshot is one JSON document on the wire. Retaining one that is larger
+ * than what restore accepts produces a backup that authorizes a cutover and can
+ * never be restored — the exact production-canary failure in #17172: Cloud
+ * retained up to 256 MiB while `/api/restore`
+ * (`packages/agent/src/api/server.ts`) and backup-chain reconstruction
+ * (`packages/cloud/shared/src/db/repositories/agent-sandboxes.ts`) both cap at
+ * 128 MiB, so a 128-256 MiB snapshot was a silent dead end.
+ *
+ * Every side imports THIS module so the numbers cannot drift apart again.
+ */
+
+/**
+ * Canonical maximum RESTORABLE v1 wire size. A retained v1 backup above this is
+ * unrestorable by construction, so it must never be retained in the first
+ * place. Raising this alone is meaningless: it is bounded by what the smallest
+ * consumer on the restore path accepts (`/api/restore`'s request-body cap and
+ * the backup-chain reconstruction cap), so all of them move together or not at
+ * all.
+ */
+export const MAX_RESTORABLE_AGENT_BACKUP_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Resolve the snapshot RETAIN budget from an operator override, clamped so it
+ * can never exceed {@link MAX_RESTORABLE_AGENT_BACKUP_BYTES}.
+ *
+ * The override exists to LOWER the budget (staging soak, a memory-constrained
+ * worker). Allowing it to raise the budget past what restore accepts would
+ * silently re-open the retain-vs-restore divergence through configuration
+ * alone, which is why the clamp lives here next to the limit rather than at the
+ * call site.
+ *
+ * A missing, non-numeric, or non-positive value yields the canonical limit.
+ */
+export function resolveRetainableAgentBackupBytes(
+  rawOverride: string | undefined,
+): number {
+  const parsed = Number.parseInt(rawOverride ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+  return Math.min(parsed, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
+}

--- a/packages/shared/src/agent-backup-limits.ts
+++ b/packages/shared/src/agent-backup-limits.ts
@@ -11,6 +11,7 @@
  * 128 MiB, so a 128-256 MiB snapshot was a silent dead end.
  *
  * Every side imports THIS module so the numbers cannot drift apart again.
+ * The producer-side capture budget (#17214) derives from the same constant.
  */
 
 /**

--- a/packages/shared/src/agent-backup-limits.ts
+++ b/packages/shared/src/agent-backup-limits.ts
@@ -33,13 +33,30 @@ export const MAX_RESTORABLE_AGENT_BACKUP_BYTES = 128 * 1024 * 1024;
  * alone, which is why the clamp lives here next to the limit rather than at the
  * call site.
  *
- * A missing, non-numeric, or non-positive value yields the canonical limit.
+ * Only an ABSENT override defaults. A present-but-invalid value throws rather
+ * than silently falling back: an operator who set the variable meant to change
+ * the budget, so quietly running on the canonical limit would hide a
+ * misconfiguration behind behavior that looks deliberate. `Number.parseInt` is
+ * deliberately not used — it accepts malformed numeric prefixes (`"128MiB"` and
+ * `"128abc"` both yield 128), which is exactly the silent-misread this guards.
  */
 export function resolveRetainableAgentBackupBytes(
   rawOverride: string | undefined,
 ): number {
-  const parsed = Number.parseInt(rawOverride ?? "", 10);
-  if (!Number.isFinite(parsed) || parsed <= 0)
-    return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+  if (rawOverride === undefined) return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+  const trimmed = rawOverride.trim();
+  if (trimmed === "") return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(
+      `Invalid snapshot retain budget ${JSON.stringify(rawOverride)}: expected a positive integer count of bytes`,
+    );
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `Invalid snapshot retain budget ${JSON.stringify(rawOverride)}: expected a positive integer count of bytes`,
+    );
+  }
   return Math.min(parsed, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,11 @@
  * Public surface: barrel exports for the shared workspace contract.
  */
 
+// Agent-backup size limits — the single source of truth for the maximum
+// RESTORABLE v1 snapshot wire size, imported by every side that retains or
+// consumes a snapshot so a backup can never be retained above what restore
+// accepts (#17172).
+export * from "./agent-backup-limits.js";
 export * from "./api/agent-api-types.js";
 export * from "./api/command-transport-types.js";
 export * from "./api/http-helpers.js";


### PR DESCRIPTION
# Relates to

Implements the immediate v1 safety alignment from **#17172 §1** and the fail-closed lifecycle consequences discovered while reviewing it. In addition to sharing the 128 MiB retain/restore ceiling, this head prevents oversized incremental chains, rejects oversized restore pushes locally, refuses ordinary provision when intact state cannot fit, refuses shutdown after a failed current-generation capture, and refuses sleep on an unverified fallback backup. The legacy standby bridge, additive v2 backup protocol, and rollout architecture in §2–4 remain out of scope.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] Targeted verification recorded under **Testing** (changed-package tests + typecheck).

# Risks

This intentionally changes lifecycle behavior in the safe direction: shutdown and sleep can now refuse to deactivate compute when a current or verified-restorable backup cannot be proven, and ordinary provision refuses to boot empty from an intact oversized chain. Operators may see an explicit failure where the old code silently discarded recoverable state. The retain ceiling only decreases (256 MiB -> 128 MiB), no heap/body limit is raised, small v1 backups remain valid, and explicit `forceFreshBoot` is the sole data-loss consent path.

# Background

## What does this PR do?

The production canary failed because Cloud **retained** a snapshot larger than anything on the restore path can **consume**:

| Side | Constant | Before | After |
|---|---|---|---|
| retain | `SNAPSHOT_MAX_RAW_BYTES` (`eliza-sandbox.ts`) | **256 MiB** | canonical (128 MiB), env-clamped |
| restore | `MAX_BACKUP_BODY_BYTES` (`packages/agent/src/api/server.ts`) | 128 MiB | canonical |
| reconstruct | `MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES` (`agent-sandboxes.ts`) | 128 MiB | canonical |

A 128–256 MiB snapshot was therefore retained, authorized a cutover, and could never be restored.

- New `packages/shared/src/agent-backup-limits.ts` holds **`MAX_RESTORABLE_AGENT_BACKUP_BYTES` (128 MiB)** — the one canonical v1 restorable wire size. `@elizaos/shared` is already a dependency of **both** `packages/agent` and `packages/cloud/shared`, so retain, restore and reconstruction import one source of truth with no import cycle. This mirrors the existing `chat-upload-limits.ts` precedent (a leaf limits module both sides import so they cannot drift).
- `resolveRetainableAgentBackupBytes()` resolves the `ELIZA_SNAPSHOT_MAX_RAW_BYTES` operator override **clamped to the canonical limit**. The override keeps its real purpose (lowering the budget for a staging soak or a constrained worker) but can no longer re-open the divergence by configuration alone — which it could before.
- The breach still fails exactly where it already did: **while streaming, before retention** (`readBodyWithinBudget`), so a too-large snapshot is never persisted and never authorizes a cutover.

## Deliberately NOT changed: the verifier's decrypt budget

`DEFAULT_MAX_DECRYPT_BYTES` (256 MiB, `agent-backup-verifier.ts`) is left alone on purpose. It is a **per-cycle aggregate** budget spanning a batch of backups, not a per-backup wire size — a different axis. Lowering it to 128 MiB would be a *regression*: one max-size backup would consume an entire cycle, so the sweep would verify a single backup per cycle. At 256 MiB a max-size (128 MiB) backup always fits with room to spare, and `chargeBudget` already distinguishes `payload-exceeds-cycle-budget` (permanent, stop sampling) from `cycle-budget-exhausted` (transient, defer) — so the "can never verify" case is already handled correctly.

## What kind of change is this?

Bug fix (correctness: removes a retainable-but-unrestorable backup state).

# Documentation changes needed?

My changes do not require a change to the project documentation; the new module documents the contract at its definition.

# Testing

## Where should a reviewer start?

`packages/shared/src/agent-backup-limits.test.ts` — it pins the whole contract: the canonical ceiling is 128 MiB; an override that **lowers** is honored; an override that **raises** (including the exact pre-fix 256 MiB that produced the unrestorable canary snapshot) is clamped; malformed/non-positive fall back; exact-limit passes and limit+1 clamps; and a final invariant case asserting no input can ever resolve a retain budget above the restorable ceiling — the guard that fails if someone raises one side without the other.

## Detailed testing steps

Independent current-head verification: shared limit contract 9/9; backup diff/chain 33/33; complete sandbox lifecycle 172/172 with 1,328 assertions; real PGLite/KMS/object-store verifier 33/33 with 215 assertions; focused changed lifecycle cases 6/6; focused typed chain-budget refusal 1/1; shared, agent, and cloud-shared typechecks clean. Machine-readable reports and the manually reviewed structured failure logs are linked in the evidence rows and review comment.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backup size-limit correctness in .ts; no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backup size-limit correctness in .ts; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; the contract is pinned by the changed test lane.`
<!-- evidence-row:backend-logs -->
- [x] [17180#issuecomment-5150459343](https://github.com/elizaOS/eliza/pull/17180#issuecomment-5150459343)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; backup size limits only.`
<!-- evidence-row:domain-artifacts -->
- [x] [17180-pr17180-verifier-junit.xml](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17180-pr17180-verifier-junit.xml)

# Evidence Details

The load-bearing new property is the **clamp**, not the constant: before this PR an operator could set `ELIZA_SNAPSHOT_MAX_RAW_BYTES=268435456` and silently recreate the exact canary failure. The test asserts that specific value now resolves to the canonical 128 MiB, plus a general invariant over a range of inputs so the property holds for anything an operator types.

## Known gaps / failures

The v1 path is now fail-closed and retained backups are bounded by what restore can consume, but agents whose state genuinely exceeds 128 MiB are not made backupable by this PR. The legacy standby bridge, additive v2 chunked backup protocol, and rollout work from #17172 §2–4 remain necessary for those agents. Verification covers the real PGLite schema, KMS encryption/decryption, stored rows, object-storage boundaries, chain reconstruction, and service lifecycle logic; it does not claim a deployed >128 MiB production-canary run.

[stan-cloud]

