### PR TITLE
fix(cloud): diagnose stale canary deletes safely

### DIFF
--- a/.github/workflows/managed-dedicated-canary.yml
+++ b/.github/workflows/managed-dedicated-canary.yml
@@ -268,7 +268,6 @@ jobs:
     environment: staging
     timeout-minutes: 10
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
       CANARY_DIAGNOSTIC_SUFFIX: ${{ inputs.diagnose_stale_canary_suffix }}
       CANARY_RECOVERY_SUFFIX: ${{ inputs.stale_canary_suffix }}
       CANARY_DIAGNOSTIC_RAW_PATH: reports/managed-dedicated-canary-diagnostic.raw.json
@@ -290,6 +289,9 @@ jobs:
 
       - name: Query exact stale canary read-only
         shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PGOPTIONS: -c default_transaction_read_only=on -c statement_timeout=20000
         run: |
           set -euo pipefail
           if [[ ! "$CANARY_DIAGNOSTIC_SUFFIX" =~ ^r[1-9][0-9]{7,19}a[1-9][0-9]{0,3}$ ]]; then
@@ -334,29 +336,33 @@ jobs:
           ),
           newest_jobs AS (
             SELECT
-              jobs.status,
-              jobs.error,
-              CASE
-                WHEN jobs.result IS NULL THEN NULL
-                ELSE json_build_object(
-                  'containerStopped', jobs.result -> 'containerStopped',
-                  'rowDeleted', jobs.result -> 'rowDeleted',
-                  'error', jobs.result -> 'error'
-                )
-              END AS result,
-              jobs.attempts,
-              jobs.max_attempts AS "maxAttempts",
-              jobs.result_storage AS "resultStorage",
-              jobs.error_storage AS "errorStorage",
-              jobs.scheduled_for AS "scheduledFor",
-              jobs.started_at AS "startedAt",
-              jobs.completed_at AS "completedAt",
-              jobs.created_at AS "createdAt",
-              jobs.updated_at AS "updatedAt"
+              jobs.id AS sort_id,
+              jobs.created_at AS sort_created_at,
+              json_build_object(
+                'status', jobs.status,
+                'error', jobs.error,
+                'result', CASE
+                  WHEN jobs.result IS NULL THEN NULL
+                  ELSE json_build_object(
+                    'containerStopped', jobs.result -> 'containerStopped',
+                    'rowDeleted', jobs.result -> 'rowDeleted',
+                    'error', jobs.result -> 'error'
+                  )
+                END,
+                'attempts', jobs.attempts,
+                'maxAttempts', jobs.max_attempts,
+                'resultStorage', jobs.result_storage,
+                'errorStorage', jobs.error_storage,
+                'scheduledFor', jobs.scheduled_for,
+                'startedAt', jobs.started_at,
+                'completedAt', jobs.completed_at,
+                'createdAt', jobs.created_at,
+                'updatedAt', jobs.updated_at
+              ) AS diagnostic
             FROM jobs
             INNER JOIN target ON target.id::text = jobs.agent_id
             WHERE jobs.type = 'agent_delete'
-            ORDER BY jobs.created_at DESC
+            ORDER BY jobs.created_at DESC, jobs.id DESC
             LIMIT 3
           )
           SELECT json_build_object(
@@ -380,7 +386,10 @@ jobs:
             ),
             'jobs', COALESCE(
               (
-                SELECT json_agg(newest_jobs ORDER BY newest_jobs."createdAt" DESC)
+                SELECT json_agg(
+                  newest_jobs.diagnostic
+                  ORDER BY newest_jobs.sort_created_at DESC, newest_jobs.sort_id DESC
+                )
                 FROM newest_jobs
               ),
               '[]'::json

--- a/.github/workflows/managed-dedicated-canary.yml
+++ b/.github/workflows/managed-dedicated-canary.yml
@@ -398,6 +398,10 @@ jobs:
           COMMIT;
           SQL
 
+      - name: Classify privacy-safe diagnostic
+        shell: bash
+        run: |
+          set -euo pipefail
           bun run packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts \
             "$CANARY_DIAGNOSTIC_SUFFIX" \
             "$CANARY_DIAGNOSTIC_RAW_PATH" \
@@ -427,9 +431,9 @@ jobs:
             console.log("- exact target count: `" + evidence.targetCount + "`");
             console.log("- sandbox status: `" + evidence.sandbox.status + "`");
             console.log("- sandbox error class: `" + evidence.sandbox.errorCode + "`");
-            console.log("- deletion owned: `" + evidence.sandbox.deletionOwned + "`");
             console.log("- latest job status: `" + latestJob.status + "`");
             console.log("- latest job error class: `" + latestJob.errorCode + "`");
+            console.log("- latest persisted result class: `" + latestJob.resultErrorCode + "`");
             console.log("- attempts: `" + latestJob.attempts + "/" + latestJob.maxAttempts + "`");
             console.log("- container stopped: `" + latestJob.containerStopped + "`");
             console.log("- row deleted: `" + latestJob.rowDeleted + "`");

--- a/.github/workflows/managed-dedicated-canary.yml
+++ b/.github/workflows/managed-dedicated-canary.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: string
         default: ""
+      diagnose_stale_canary_suffix:
+        description: "Read-only staging diagnosis for one exact stale canary suffix; performs no canary or lifecycle mutation"
+        required: false
+        type: string
+        default: ""
   # A maintainer-applied label lets the workflow prove a new harness before it
   # reaches the default branch; the staging environment still owns secret and
   # approval policy.
@@ -31,7 +36,7 @@ permissions:
 jobs:
   canary:
     name: Provision + bridge + SSE + cleanup
-    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'run-managed-dedicated-canary' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.label.name == 'run-managed-dedicated-canary') && inputs.diagnose_stale_canary_suffix == '' }}
     runs-on: ubuntu-24.04
     environment: staging
     # The script's absolute worst-case request budgets stay below this cap and
@@ -255,3 +260,168 @@ jobs:
           ' >> "$GITHUB_STEP_SUMMARY"
 
           echo "Managed dedicated canary passed with exact cleanup."
+
+  diagnose:
+    name: Read-only stale canary diagnosis
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.diagnose_stale_canary_suffix != '' }}
+    runs-on: ubuntu-24.04
+    environment: staging
+    timeout-minutes: 10
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      CANARY_DIAGNOSTIC_SUFFIX: ${{ inputs.diagnose_stale_canary_suffix }}
+      CANARY_RECOVERY_SUFFIX: ${{ inputs.stale_canary_suffix }}
+      CANARY_DIAGNOSTIC_RAW_PATH: reports/managed-dedicated-canary-diagnostic.raw.json
+      CANARY_DIAGNOSTIC_EVIDENCE_PATH: reports/managed-dedicated-canary-diagnostic.json
+    steps:
+      - name: Checkout exact diagnostic source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: canary
+
+      - name: Validate diagnostic contracts
+        run: bun test packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+
+      - name: Query exact stale canary read-only
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANARY_DIAGNOSTIC_SUFFIX" =~ ^r[1-9][0-9]{7,19}a[1-9][0-9]{0,3}$ ]]; then
+            echo "::error::Diagnostic suffix is invalid."
+            exit 1
+          fi
+          if [[ -n "$CANARY_RECOVERY_SUFFIX" ]]; then
+            echo "::error::Diagnostic and mutation recovery inputs are mutually exclusive."
+            exit 1
+          fi
+          if [[ -z "${DATABASE_URL:-}" ]]; then
+            echo "::error::Staging DATABASE_URL is unavailable."
+            exit 1
+          fi
+
+          mkdir -p reports
+          umask 077
+          psql "$DATABASE_URL" \
+            --no-psqlrc \
+            --no-align \
+            --tuples-only \
+            --quiet \
+            --set ON_ERROR_STOP=1 \
+            --set suffix="$CANARY_DIAGNOSTIC_SUFFIX" \
+            > "$CANARY_DIAGNOSTIC_RAW_PATH" <<'SQL'
+          BEGIN READ ONLY;
+          SET LOCAL statement_timeout = '20s';
+          WITH target AS (
+            SELECT
+              id,
+              status,
+              error_message,
+              error_count,
+              deletion_attempt_id IS NOT NULL AS deletion_owned,
+              deletion_started_at,
+              updated_at,
+              sandbox_id IS NOT NULL AS sandbox_id_present,
+              node_id IS NOT NULL AS node_id_present,
+              container_name IS NOT NULL AS container_name_present
+            FROM agent_sandboxes
+            WHERE agent_name = 'managed-dedicated-canary-' || :'suffix'
+          ),
+          newest_jobs AS (
+            SELECT
+              jobs.status,
+              jobs.error,
+              CASE
+                WHEN jobs.result IS NULL THEN NULL
+                ELSE json_build_object(
+                  'containerStopped', jobs.result -> 'containerStopped',
+                  'rowDeleted', jobs.result -> 'rowDeleted',
+                  'error', jobs.result -> 'error'
+                )
+              END AS result,
+              jobs.attempts,
+              jobs.max_attempts AS "maxAttempts",
+              jobs.result_storage AS "resultStorage",
+              jobs.error_storage AS "errorStorage",
+              jobs.scheduled_for AS "scheduledFor",
+              jobs.started_at AS "startedAt",
+              jobs.completed_at AS "completedAt",
+              jobs.created_at AS "createdAt",
+              jobs.updated_at AS "updatedAt"
+            FROM jobs
+            INNER JOIN target ON target.id::text = jobs.agent_id
+            WHERE jobs.type = 'agent_delete'
+            ORDER BY jobs.created_at DESC
+            LIMIT 3
+          )
+          SELECT json_build_object(
+            'targetCount', (SELECT count(*) FROM target),
+            'agent', (
+              SELECT json_build_object(
+                'status', status,
+                'errorMessage', error_message,
+                'errorCount', error_count,
+                'deletionOwned', deletion_owned,
+                'deletionStartedAt', deletion_started_at,
+                'updatedAt', updated_at,
+                'locator', json_build_object(
+                  'sandboxIdPresent', sandbox_id_present,
+                  'nodeIdPresent', node_id_present,
+                  'containerNamePresent', container_name_present
+                )
+              )
+              FROM target
+              LIMIT 1
+            ),
+            'jobs', COALESCE(
+              (
+                SELECT json_agg(newest_jobs ORDER BY newest_jobs."createdAt" DESC)
+                FROM newest_jobs
+              ),
+              '[]'::json
+            )
+          );
+          COMMIT;
+          SQL
+
+          bun run packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts \
+            "$CANARY_DIAGNOSTIC_SUFFIX" \
+            "$CANARY_DIAGNOSTIC_RAW_PATH" \
+            "$CANARY_DIAGNOSTIC_EVIDENCE_PATH"
+          rm -f "$CANARY_DIAGNOSTIC_RAW_PATH"
+
+      - name: Upload privacy-safe diagnostic
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: managed-dedicated-canary-diagnostic-${{ github.run_id }}-${{ github.run_attempt }}
+          path: reports/managed-dedicated-canary-diagnostic.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summarize classified result
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun -e '
+            import { readFileSync } from "node:fs";
+            const evidence = JSON.parse(
+              readFileSync(process.env.CANARY_DIAGNOSTIC_EVIDENCE_PATH, "utf8"),
+            );
+            const latestJob = evidence.jobs[0];
+            console.log("### Managed dedicated staging canary diagnostic");
+            console.log("");
+            console.log("- exact target count: `" + evidence.targetCount + "`");
+            console.log("- sandbox status: `" + evidence.sandbox.status + "`");
+            console.log("- sandbox error class: `" + evidence.sandbox.errorCode + "`");
+            console.log("- deletion owned: `" + evidence.sandbox.deletionOwned + "`");
+            console.log("- latest job status: `" + latestJob.status + "`");
+            console.log("- latest job error class: `" + latestJob.errorCode + "`");
+            console.log("- attempts: `" + latestJob.attempts + "/" + latestJob.maxAttempts + "`");
+            console.log("- container stopped: `" + latestJob.containerStopped + "`");
+            console.log("- row deleted: `" + latestJob.rowDeleted + "`");
+          ' >> "$GITHUB_STEP_SUMMARY"

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -75,12 +75,6 @@ describe("managed dedicated canary diagnostic", () => {
         status: "deletion_failed",
         errorCode: "sandbox_stop_failed",
         errorCount: 1,
-        deletionOwned: true,
-        locator: {
-          sandboxIdPresent: true,
-          nodeIdPresent: true,
-          containerNamePresent: true,
-        },
         deletionStartedAt: "2026-07-26T23:08:09.000Z",
         updatedAt: "2026-07-26T23:11:30.000Z",
       },
@@ -92,6 +86,7 @@ describe("managed dedicated canary diagnostic", () => {
           containerStopped: false,
           rowDeleted: false,
           errorCode: "sandbox_stop_failed",
+          resultErrorCode: "sandbox_stop_failed",
           scheduledFor: "2026-07-26T23:10:30.000Z",
           startedAt: "2026-07-26T23:10:31.000Z",
           completedAt: "2026-07-26T23:11:30.000Z",
@@ -200,7 +195,7 @@ describe("managed dedicated canary diagnostic", () => {
     ).toThrow(message);
   });
 
-  test("rejects disagreement between stored error sources", () => {
+  test("preserves distinct terminal and prior-attempt result classifications", () => {
     const input = failedDeleteInput();
     const [job] = input.jobs as Record<string, unknown>[];
     job.result = {
@@ -208,9 +203,86 @@ describe("managed dedicated canary diagnostic", () => {
       rowDeleted: false,
       error: "credential revoke failed",
     };
+    const evidence = sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX);
+    expect(evidence.jobs[0]).toMatchObject({
+      errorCode: "sandbox_stop_failed",
+      resultErrorCode: "credential_revoke_failed",
+    });
+  });
+
+  test("classifies row-delete failures without publishing the SQL text", () => {
+    const input = failedDeleteInput();
+    const agent = input.agent as Record<string, unknown>;
+    const [job] = input.jobs as Record<string, unknown>[];
+    const error =
+      'Failed query: DELETE FROM "agent_sandboxes" WHERE "agent_sandboxes"."id" = $1';
+    agent.errorMessage = `Deletion permanently failed after 3 attempts: ${error}`;
+    job.error = error;
+    job.result = {
+      containerStopped: true,
+      rowDeleted: false,
+      error: "Failed to delete sandbox",
+    };
+
+    const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+      JSON.stringify(input),
+      SUFFIX,
+    );
+    const evidence = JSON.parse(canonical);
+    expect(evidence.sandbox.errorCode).toBe("row_delete_failed");
+    expect(evidence.jobs[0]).toMatchObject({
+      errorCode: "row_delete_failed",
+      resultErrorCode: "sandbox_stop_failed",
+    });
+    expect(canonical).not.toContain("DELETE FROM");
+    expect(canonical).not.toContain("agent_sandboxes");
+  });
+
+  test("uses terminal updatedAt when failed jobs have no completedAt", () => {
+    const input = failedDeleteInput();
+    const [job] = input.jobs as Record<string, unknown>[];
+    job.completedAt = null;
+
+    expect(
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX).jobs[0]
+        ?.durationMs,
+    ).toBe(59_000);
+  });
+
+  test.each([
+    [
+      "attempts above maxAttempts",
+      (job: Record<string, unknown>) => {
+        job.attempts = 4;
+      },
+      "attempts exceed",
+    ],
+    [
+      "row deletion without a stopped container",
+      (job: Record<string, unknown>) => {
+        job.result = {
+          containerStopped: false,
+          rowDeleted: true,
+          error: null,
+        };
+        job.error = null;
+        job.status = "completed";
+      },
+      "deleted a row without",
+    ],
+    [
+      "failed status without attempts",
+      (job: Record<string, unknown>) => {
+        job.attempts = 0;
+      },
+      "invalid failed",
+    ],
+  ])("rejects semantic contradiction: %s", (_name, mutate, message) => {
+    const input = failedDeleteInput();
+    mutate((input.jobs as Record<string, unknown>[])[0]);
     expect(() =>
       sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
-    ).toThrow("error sources disagree");
+    ).toThrow(message);
   });
 
   test("requires newest-first job ordering", () => {
@@ -246,6 +318,9 @@ describe("managed dedicated canary diagnostic", () => {
     expect(workflow).toContain("inputs.diagnose_stale_canary_suffix == ''");
     expect(workflow).toContain(
       "bun run packages/scripts/cloud/admin/managed-dedicated-canary.ts",
+    );
+    expect(workflow).toMatch(
+      /managed-dedicated-canary-diagnostic\.ts \\\n\s+"\$CANARY_DIAGNOSTIC_SUFFIX" \\\n\s+"\$CANARY_DIAGNOSTIC_RAW_PATH" \\\n\s+"\$CANARY_DIAGNOSTIC_EVIDENCE_PATH"/,
     );
 
     const sql = workflow.match(/<<'SQL'\n([\s\S]*?)\n\s+SQL/)?.[1];

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Proves the staging canary diagnostic remains read-only, exact-targeted, and
+ * incapable of publishing identifiers or unclassified operator error text.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  canonicalizeManagedDedicatedCanaryDiagnostic,
+  sanitizeManagedDedicatedCanaryDiagnostic,
+  writeManagedDedicatedCanaryDiagnostic,
+} from "./managed-dedicated-canary-diagnostic";
+
+const SUFFIX = "r30081355987a1";
+
+function failedDeleteInput(): Record<string, unknown> {
+  return {
+    targetCount: 1,
+    agent: {
+      status: "deletion_failed",
+      errorMessage:
+        "Deletion permanently failed after 3 attempts: Failed to delete sandbox",
+      errorCount: 1,
+      deletionOwned: true,
+      deletionStartedAt: "2026-07-26T23:08:09.000Z",
+      updatedAt: "2026-07-26T23:11:30.000Z",
+      locator: {
+        sandboxIdPresent: true,
+        nodeIdPresent: true,
+        containerNamePresent: true,
+      },
+    },
+    jobs: [
+      {
+        status: "failed",
+        error: "Failed to delete sandbox",
+        result: {
+          containerStopped: false,
+          rowDeleted: false,
+          error: "Failed to delete sandbox",
+        },
+        attempts: 3,
+        maxAttempts: 3,
+        resultStorage: "inline",
+        errorStorage: "inline",
+        scheduledFor: "2026-07-26T23:10:30.000Z",
+        startedAt: "2026-07-26T23:10:31.000Z",
+        completedAt: "2026-07-26T23:11:30.000Z",
+        createdAt: "2026-07-26T23:08:09.000Z",
+        updatedAt: "2026-07-26T23:11:30.000Z",
+      },
+    ],
+  };
+}
+
+describe("managed dedicated canary diagnostic", () => {
+  test("emits only the classified lifecycle facts needed for retry decisions", () => {
+    const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
+      failedDeleteInput(),
+      SUFFIX,
+    );
+
+    expect(evidence).toEqual({
+      schemaVersion: 1,
+      targetCount: 1,
+      sandbox: {
+        status: "deletion_failed",
+        errorCode: "sandbox_stop_failed",
+        errorCount: 1,
+        deletionOwned: true,
+        locator: {
+          sandboxIdPresent: true,
+          nodeIdPresent: true,
+          containerNamePresent: true,
+        },
+        deletionStartedAt: "2026-07-26T23:08:09.000Z",
+        updatedAt: "2026-07-26T23:11:30.000Z",
+      },
+      jobs: [
+        {
+          status: "failed",
+          attempts: 3,
+          maxAttempts: 3,
+          containerStopped: false,
+          rowDeleted: false,
+          errorCode: "sandbox_stop_failed",
+          scheduledFor: "2026-07-26T23:10:30.000Z",
+          startedAt: "2026-07-26T23:10:31.000Z",
+          completedAt: "2026-07-26T23:11:30.000Z",
+          createdAt: "2026-07-26T23:08:09.000Z",
+          updatedAt: "2026-07-26T23:11:30.000Z",
+          durationMs: 59_000,
+          queueDurationMs: 142_000,
+        },
+      ],
+    });
+
+    const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+      JSON.stringify(failedDeleteInput()),
+      SUFFIX,
+    );
+    expect(canonical).not.toContain(SUFFIX);
+    expect(canonical).not.toContain("Failed to delete sandbox");
+    expect(canonical).not.toContain("managed-dedicated-canary-");
+  });
+
+  test("writes the canonical artifact with owner-only permissions", () => {
+    const directory = mkdtempSync(join(tmpdir(), "managed-canary-diagnostic-"));
+    const rawPath = join(directory, "raw.json");
+    const evidencePath = join(directory, "evidence.json");
+    writeFileSync(rawPath, JSON.stringify(failedDeleteInput()), {
+      mode: 0o600,
+    });
+    chmodSync(rawPath, 0o600);
+
+    writeManagedDedicatedCanaryDiagnostic(rawPath, evidencePath, SUFFIX);
+
+    expect(statSync(evidencePath).mode & 0o777).toBe(0o600);
+    expect(
+      JSON.parse(readFileSync(evidencePath, "utf8")).jobs[0].errorCode,
+    ).toBe("sandbox_stop_failed");
+  });
+
+  test.each([
+    ["invalid suffix", failedDeleteInput(), "r1a1", "suffix"],
+    [
+      "zero targets",
+      { ...failedDeleteInput(), targetCount: 0, agent: null, jobs: [] },
+      SUFFIX,
+      "exactly one",
+    ],
+    [
+      "unexpected root key",
+      {
+        ...failedDeleteInput(),
+        agentId: "55f332f8-da54-4c53-952c-a38f5f01287b",
+      },
+      SUFFIX,
+      "unexpected shape",
+    ],
+    [
+      "non-inline payload",
+      {
+        ...failedDeleteInput(),
+        jobs: [
+          {
+            ...(failedDeleteInput().jobs as Record<string, unknown>[])[0],
+            errorStorage: "r2",
+          },
+        ],
+      },
+      SUFFIX,
+      "non-inline",
+    ],
+    [
+      "unclassified operator text",
+      {
+        ...failedDeleteInput(),
+        jobs: [
+          {
+            ...(failedDeleteInput().jobs as Record<string, unknown>[])[0],
+            error: "remote execution returned an unexpected opaque failure",
+            result: null,
+          },
+        ],
+      },
+      SUFFIX,
+      "privacy-safe classifier",
+    ],
+    [
+      "raw result identifier",
+      {
+        ...failedDeleteInput(),
+        jobs: [
+          {
+            ...(failedDeleteInput().jobs as Record<string, unknown>[])[0],
+            result: {
+              containerStopped: false,
+              rowDeleted: false,
+              error: "Failed to delete sandbox",
+              cloudAgentId: "55f332f8-da54-4c53-952c-a38f5f01287b",
+            },
+          },
+        ],
+      },
+      SUFFIX,
+      "unexpected shape",
+    ],
+  ])("fails closed for %s", (_name, input, suffix, message) => {
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, suffix),
+    ).toThrow(message);
+  });
+
+  test("rejects disagreement between stored error sources", () => {
+    const input = failedDeleteInput();
+    const [job] = input.jobs as Record<string, unknown>[];
+    job.result = {
+      containerStopped: false,
+      rowDeleted: false,
+      error: "credential revoke failed",
+    };
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow("error sources disagree");
+  });
+
+  test("requires newest-first job ordering", () => {
+    const input = failedDeleteInput();
+    const [newest] = input.jobs as Record<string, unknown>[];
+    input.jobs = [
+      newest,
+      {
+        ...newest,
+        createdAt: "2026-07-26T23:09:09.000Z",
+        startedAt: "2026-07-26T23:09:10.000Z",
+        completedAt: "2026-07-26T23:09:11.000Z",
+      },
+    ];
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow("newest-first");
+  });
+
+  test("keeps diagnostic SQL read-only and the normal canary path intact", () => {
+    const workflow = readFileSync(
+      join(
+        import.meta.dir,
+        "../../../../.github/workflows/managed-dedicated-canary.yml",
+      ),
+      "utf8",
+    );
+    expect(workflow).toContain("BEGIN READ ONLY;");
+    expect(workflow).toContain("SET LOCAL statement_timeout = '20s';");
+    expect(workflow).toContain(
+      "WHERE agent_name = 'managed-dedicated-canary-' || :'suffix'",
+    );
+    expect(workflow).toContain("inputs.diagnose_stale_canary_suffix == ''");
+    expect(workflow).toContain(
+      "bun run packages/scripts/cloud/admin/managed-dedicated-canary.ts",
+    );
+
+    const sql = workflow.match(/<<'SQL'\n([\s\S]*?)\n\s+SQL/)?.[1];
+    expect(sql).toBeTruthy();
+    expect(sql).not.toMatch(
+      /\b(?:INSERT|UPDATE|DELETE|ALTER|DROP|TRUNCATE|CREATE)\b/i,
+    );
+  });
+});

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -39,6 +39,7 @@ type ErrorCode =
   | "agent_not_found"
   | "lifecycle_conflict"
   | "credential_revoke_failed"
+  | "row_delete_failed"
   | "database_failed"
   | "timeout";
 
@@ -49,12 +50,6 @@ export interface ManagedDedicatedCanaryDiagnostic {
     status: string;
     errorCode: ErrorCode;
     errorCount: number;
-    deletionOwned: boolean;
-    locator: {
-      sandboxIdPresent: boolean;
-      nodeIdPresent: boolean;
-      containerNamePresent: boolean;
-    };
     deletionStartedAt: string | null;
     updatedAt: string;
   };
@@ -65,6 +60,7 @@ export interface ManagedDedicatedCanaryDiagnostic {
     containerStopped: boolean | null;
     rowDeleted: boolean | null;
     errorCode: ErrorCode;
+    resultErrorCode: ErrorCode;
     scheduledFor: string;
     startedAt: string | null;
     completedAt: string | null;
@@ -152,6 +148,14 @@ function classifyError(value: unknown, label: string): ErrorCode {
     return classifyError(permanentDelete[1], `${label} cause`);
   if (value === "Failed to delete sandbox") return "sandbox_stop_failed";
   if (value === "Agent not found") return "agent_not_found";
+  if (/failed query:[\s\S]*delete from\s+"?agent_sandboxes"?/i.test(value)) {
+    return "row_delete_failed";
+  }
+  if (
+    /failed query:[\s\S]*(?:delete from|update)\s+"?api_keys"?/i.test(value)
+  ) {
+    return "credential_revoke_failed";
+  }
   if (
     /(?:lifecycle|identity changed|ownership changed|non-quiescent|organization id mismatch)/i.test(
       value,
@@ -161,7 +165,9 @@ function classifyError(value: unknown, label: string): ErrorCode {
   }
   if (/(?:revoke|credential)/i.test(value)) return "credential_revoke_failed";
   if (
-    /(?:database|postgres|sql|transaction|deadlock|connection)/i.test(value)
+    /(?:failed query|database|postgres|sql|transaction|deadlock|connection)/i.test(
+      value,
+    )
   ) {
     return "database_failed";
   }
@@ -214,6 +220,18 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     ["sandboxIdPresent", "nodeIdPresent", "containerNamePresent"],
     "agent.locator",
   );
+  const deletionOwned = boolean(agent.deletionOwned, "agent.deletionOwned");
+  const deletionStartedAt = timestamp(
+    agent.deletionStartedAt,
+    "agent.deletionStartedAt",
+    true,
+  );
+  if (deletionOwned !== (deletionStartedAt !== null)) {
+    throw new Error("agent deletion ownership and timestamp disagree");
+  }
+  boolean(locator.sandboxIdPresent, "locator.sandboxIdPresent");
+  boolean(locator.nodeIdPresent, "locator.nodeIdPresent");
+  boolean(locator.containerNamePresent, "locator.containerNamePresent");
 
   if (
     !Array.isArray(root.jobs) ||
@@ -275,14 +293,6 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
         `jobs[${index}].result.error`,
       );
     }
-    if (
-      jobErrorCode !== "none" &&
-      resultErrorCode !== "none" &&
-      jobErrorCode !== resultErrorCode
-    ) {
-      throw new Error(`jobs[${index}] error sources disagree`);
-    }
-
     const scheduledFor = timestamp(
       job.scheduledFor,
       `jobs[${index}].scheduledFor`,
@@ -306,57 +316,89 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
       `jobs[${index}].updatedAt`,
     ) as string;
     const createdAtMs = Date.parse(createdAt);
-    if (createdAtMs >= previousCreatedAt) {
+    if (createdAtMs > previousCreatedAt) {
       throw new Error("jobs are not strictly newest-first");
     }
     previousCreatedAt = createdAtMs;
 
+    const attempts = integer(job.attempts, `jobs[${index}].attempts`, 0, 100);
+    const maxAttempts = integer(
+      job.maxAttempts,
+      `jobs[${index}].maxAttempts`,
+      1,
+      100,
+    );
+    if (attempts > maxAttempts) {
+      throw new Error(`jobs[${index}] attempts exceed maxAttempts`);
+    }
+    if (rowDeleted === true && containerStopped !== true) {
+      throw new Error(
+        `jobs[${index}] deleted a row without a stopped container`,
+      );
+    }
+    if (
+      job.status === "completed" &&
+      (jobErrorCode !== "none" ||
+        resultErrorCode !== "none" ||
+        containerStopped !== true ||
+        rowDeleted !== true)
+    ) {
+      throw new Error(`jobs[${index}] has an invalid completed result`);
+    }
+    if (
+      job.status === "failed" &&
+      (attempts === 0 || jobErrorCode === "none")
+    ) {
+      throw new Error(`jobs[${index}] has an invalid failed result`);
+    }
+    const terminalAt =
+      completedAt ??
+      (job.status === "completed" ||
+      job.status === "failed" ||
+      job.status === "cancelled"
+        ? updatedAt
+        : null);
+    elapsedMs(createdAt, updatedAt);
+
     return {
       status: job.status,
-      attempts: integer(job.attempts, `jobs[${index}].attempts`, 0, 100),
-      maxAttempts: integer(
-        job.maxAttempts,
-        `jobs[${index}].maxAttempts`,
-        1,
-        100,
-      ),
+      attempts,
+      maxAttempts,
       containerStopped,
       rowDeleted,
-      errorCode: jobErrorCode === "none" ? resultErrorCode : jobErrorCode,
+      errorCode: jobErrorCode,
+      resultErrorCode,
       scheduledFor,
       startedAt,
       completedAt,
       createdAt,
       updatedAt,
-      durationMs: elapsedMs(startedAt, completedAt),
+      durationMs: elapsedMs(startedAt, terminalAt),
       queueDurationMs: elapsedMs(createdAt, startedAt),
     };
   });
+
+  const sandboxErrorCode = classifyError(
+    agent.errorMessage,
+    "agent.errorMessage",
+  );
+  if (
+    agent.status === "deletion_failed" &&
+    (sandboxErrorCode === "none" ||
+      jobs[0]?.status !== "failed" ||
+      jobs[0].errorCode !== sandboxErrorCode)
+  ) {
+    throw new Error("sandbox and latest failed deletion job disagree");
+  }
 
   return {
     schemaVersion: 1,
     targetCount: 1,
     sandbox: {
       status: agent.status,
-      errorCode: classifyError(agent.errorMessage, "agent.errorMessage"),
+      errorCode: sandboxErrorCode,
       errorCount: integer(agent.errorCount, "agent.errorCount", 0, 1_000),
-      deletionOwned: boolean(agent.deletionOwned, "agent.deletionOwned"),
-      locator: {
-        sandboxIdPresent: boolean(
-          locator.sandboxIdPresent,
-          "locator.sandboxIdPresent",
-        ),
-        nodeIdPresent: boolean(locator.nodeIdPresent, "locator.nodeIdPresent"),
-        containerNamePresent: boolean(
-          locator.containerNamePresent,
-          "locator.containerNamePresent",
-        ),
-      },
-      deletionStartedAt: timestamp(
-        agent.deletionStartedAt,
-        "agent.deletionStartedAt",
-        true,
-      ),
+      deletionStartedAt,
       updatedAt: timestamp(agent.updatedAt, "agent.updatedAt") as string,
     },
     jobs,

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -1,0 +1,407 @@
+/**
+ * Converts one staging-only, read-only canary database snapshot into a strict
+ * privacy-safe operator artifact. The raw snapshot never leaves its workflow
+ * runner; only allowlisted lifecycle facts and classified failures are emitted.
+ */
+
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+
+type JsonRecord = Record<string, unknown>;
+
+const SUFFIX_PATTERN = /^r[1-9][0-9]{7,19}a[1-9][0-9]{0,3}$/;
+const UUID_PATTERN =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i;
+const FORBIDDEN_OUTPUT_PATTERN =
+  /(?:https?:\/\/|(?:\d{1,3}\.){3}\d{1,3}|\b(?:token|secret|password|api[_-]?key)\b|managed-dedicated-canary-|sha256:)/i;
+
+const SANDBOX_STATUSES = new Set([
+  "pending",
+  "provisioning",
+  "running",
+  "stopped",
+  "sleeping",
+  "disconnected",
+  "error",
+  "deletion_pending",
+  "deletion_failed",
+]);
+const JOB_STATUSES = new Set([
+  "pending",
+  "in_progress",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+type ErrorCode =
+  | "none"
+  | "sandbox_stop_failed"
+  | "agent_not_found"
+  | "lifecycle_conflict"
+  | "credential_revoke_failed"
+  | "database_failed"
+  | "timeout";
+
+export interface ManagedDedicatedCanaryDiagnostic {
+  schemaVersion: 1;
+  targetCount: 1;
+  sandbox: {
+    status: string;
+    errorCode: ErrorCode;
+    errorCount: number;
+    deletionOwned: boolean;
+    locator: {
+      sandboxIdPresent: boolean;
+      nodeIdPresent: boolean;
+      containerNamePresent: boolean;
+    };
+    deletionStartedAt: string | null;
+    updatedAt: string;
+  };
+  jobs: Array<{
+    status: string;
+    attempts: number;
+    maxAttempts: number;
+    containerStopped: boolean | null;
+    rowDeleted: boolean | null;
+    errorCode: ErrorCode;
+    scheduledFor: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+    durationMs: number | null;
+    queueDurationMs: number | null;
+  }>;
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonRecord;
+}
+
+function exactKeys(
+  value: JsonRecord,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    throw new Error(`${label} has an unexpected shape`);
+  }
+}
+
+function integer(
+  value: unknown,
+  label: string,
+  minimum = 0,
+  maximum = Number.MAX_SAFE_INTEGER,
+) {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < minimum ||
+    (value as number) > maximum
+  ) {
+    throw new Error(
+      `${label} must be an integer between ${minimum} and ${maximum}`,
+    );
+  }
+  return value as number;
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function nullableBoolean(value: unknown, label: string): boolean | null {
+  if (value === null) return null;
+  return boolean(value, label);
+}
+
+function timestamp(
+  value: unknown,
+  label: string,
+  nullable = false,
+): string | null {
+  if (nullable && value === null) return null;
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    throw new Error(
+      `${label} must be an ISO timestamp${nullable ? " or null" : ""}`,
+    );
+  }
+  return new Date(value).toISOString();
+}
+
+function classifyError(value: unknown, label: string): ErrorCode {
+  if (value === null) return "none";
+  if (typeof value !== "string" || value.length === 0 || value.length > 2_000) {
+    throw new Error(`${label} must be a bounded string or null`);
+  }
+  const permanentDelete =
+    /^Deletion permanently failed after [1-9][0-9]* attempts: (.+)$/.exec(
+      value,
+    );
+  if (permanentDelete)
+    return classifyError(permanentDelete[1], `${label} cause`);
+  if (value === "Failed to delete sandbox") return "sandbox_stop_failed";
+  if (value === "Agent not found") return "agent_not_found";
+  if (
+    /(?:lifecycle|identity changed|ownership changed|non-quiescent|organization id mismatch)/i.test(
+      value,
+    )
+  ) {
+    return "lifecycle_conflict";
+  }
+  if (/(?:revoke|credential)/i.test(value)) return "credential_revoke_failed";
+  if (
+    /(?:database|postgres|sql|transaction|deadlock|connection)/i.test(value)
+  ) {
+    return "database_failed";
+  }
+  if (/(?:timed out|timeout)/i.test(value)) return "timeout";
+  throw new Error(`${label} is not covered by the privacy-safe classifier`);
+}
+
+function elapsedMs(start: string | null, end: string | null): number | null {
+  if (!start || !end) return null;
+  const elapsed = Date.parse(end) - Date.parse(start);
+  if (!Number.isSafeInteger(elapsed) || elapsed < 0) {
+    throw new Error("diagnostic timestamps are out of order");
+  }
+  return elapsed;
+}
+
+export function sanitizeManagedDedicatedCanaryDiagnostic(
+  raw: unknown,
+  suffix: string,
+): ManagedDedicatedCanaryDiagnostic {
+  if (!SUFFIX_PATTERN.test(suffix))
+    throw new Error("diagnostic suffix is invalid");
+
+  const root = record(raw, "diagnostic input");
+  exactKeys(root, ["targetCount", "agent", "jobs"], "diagnostic input");
+  if (integer(root.targetCount, "targetCount", 0, 2) !== 1) {
+    throw new Error("diagnostic input must resolve exactly one target");
+  }
+
+  const agent = record(root.agent, "agent");
+  exactKeys(
+    agent,
+    [
+      "status",
+      "errorMessage",
+      "errorCount",
+      "deletionOwned",
+      "deletionStartedAt",
+      "updatedAt",
+      "locator",
+    ],
+    "agent",
+  );
+  if (typeof agent.status !== "string" || !SANDBOX_STATUSES.has(agent.status)) {
+    throw new Error("agent.status is invalid");
+  }
+  const locator = record(agent.locator, "agent.locator");
+  exactKeys(
+    locator,
+    ["sandboxIdPresent", "nodeIdPresent", "containerNamePresent"],
+    "agent.locator",
+  );
+
+  if (
+    !Array.isArray(root.jobs) ||
+    root.jobs.length < 1 ||
+    root.jobs.length > 5
+  ) {
+    throw new Error("jobs must contain one to five newest-first records");
+  }
+
+  let previousCreatedAt = Number.POSITIVE_INFINITY;
+  const jobs = root.jobs.map((value, index) => {
+    const job = record(value, `jobs[${index}]`);
+    exactKeys(
+      job,
+      [
+        "status",
+        "error",
+        "result",
+        "attempts",
+        "maxAttempts",
+        "resultStorage",
+        "errorStorage",
+        "scheduledFor",
+        "startedAt",
+        "completedAt",
+        "createdAt",
+        "updatedAt",
+      ],
+      `jobs[${index}]`,
+    );
+    if (typeof job.status !== "string" || !JOB_STATUSES.has(job.status)) {
+      throw new Error(`jobs[${index}].status is invalid`);
+    }
+    if (job.resultStorage !== "inline" || job.errorStorage !== "inline") {
+      throw new Error(`jobs[${index}] has non-inline diagnostic payloads`);
+    }
+
+    const jobErrorCode = classifyError(job.error, `jobs[${index}].error`);
+    let containerStopped: boolean | null = null;
+    let rowDeleted: boolean | null = null;
+    let resultErrorCode: ErrorCode = "none";
+    if (job.result !== null) {
+      const result = record(job.result, `jobs[${index}].result`);
+      exactKeys(
+        result,
+        ["containerStopped", "rowDeleted", "error"],
+        `jobs[${index}].result`,
+      );
+      containerStopped = nullableBoolean(
+        result.containerStopped,
+        `jobs[${index}].result.containerStopped`,
+      );
+      rowDeleted = nullableBoolean(
+        result.rowDeleted,
+        `jobs[${index}].result.rowDeleted`,
+      );
+      resultErrorCode = classifyError(
+        result.error,
+        `jobs[${index}].result.error`,
+      );
+    }
+    if (
+      jobErrorCode !== "none" &&
+      resultErrorCode !== "none" &&
+      jobErrorCode !== resultErrorCode
+    ) {
+      throw new Error(`jobs[${index}] error sources disagree`);
+    }
+
+    const scheduledFor = timestamp(
+      job.scheduledFor,
+      `jobs[${index}].scheduledFor`,
+    ) as string;
+    const startedAt = timestamp(
+      job.startedAt,
+      `jobs[${index}].startedAt`,
+      true,
+    );
+    const completedAt = timestamp(
+      job.completedAt,
+      `jobs[${index}].completedAt`,
+      true,
+    );
+    const createdAt = timestamp(
+      job.createdAt,
+      `jobs[${index}].createdAt`,
+    ) as string;
+    const updatedAt = timestamp(
+      job.updatedAt,
+      `jobs[${index}].updatedAt`,
+    ) as string;
+    const createdAtMs = Date.parse(createdAt);
+    if (createdAtMs >= previousCreatedAt) {
+      throw new Error("jobs are not strictly newest-first");
+    }
+    previousCreatedAt = createdAtMs;
+
+    return {
+      status: job.status,
+      attempts: integer(job.attempts, `jobs[${index}].attempts`, 0, 100),
+      maxAttempts: integer(
+        job.maxAttempts,
+        `jobs[${index}].maxAttempts`,
+        1,
+        100,
+      ),
+      containerStopped,
+      rowDeleted,
+      errorCode: jobErrorCode === "none" ? resultErrorCode : jobErrorCode,
+      scheduledFor,
+      startedAt,
+      completedAt,
+      createdAt,
+      updatedAt,
+      durationMs: elapsedMs(startedAt, completedAt),
+      queueDurationMs: elapsedMs(createdAt, startedAt),
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    targetCount: 1,
+    sandbox: {
+      status: agent.status,
+      errorCode: classifyError(agent.errorMessage, "agent.errorMessage"),
+      errorCount: integer(agent.errorCount, "agent.errorCount", 0, 1_000),
+      deletionOwned: boolean(agent.deletionOwned, "agent.deletionOwned"),
+      locator: {
+        sandboxIdPresent: boolean(
+          locator.sandboxIdPresent,
+          "locator.sandboxIdPresent",
+        ),
+        nodeIdPresent: boolean(locator.nodeIdPresent, "locator.nodeIdPresent"),
+        containerNamePresent: boolean(
+          locator.containerNamePresent,
+          "locator.containerNamePresent",
+        ),
+      },
+      deletionStartedAt: timestamp(
+        agent.deletionStartedAt,
+        "agent.deletionStartedAt",
+        true,
+      ),
+      updatedAt: timestamp(agent.updatedAt, "agent.updatedAt") as string,
+    },
+    jobs,
+  };
+}
+
+export function canonicalizeManagedDedicatedCanaryDiagnostic(
+  rawText: string,
+  suffix: string,
+): string {
+  const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
+    JSON.parse(rawText),
+    suffix,
+  );
+  const canonical = `${JSON.stringify(evidence, null, 2)}\n`;
+  if (
+    UUID_PATTERN.test(canonical) ||
+    FORBIDDEN_OUTPUT_PATTERN.test(canonical)
+  ) {
+    throw new Error(
+      "privacy-safe diagnostic contains a forbidden identifier or secret shape",
+    );
+  }
+  return canonical;
+}
+
+export function writeManagedDedicatedCanaryDiagnostic(
+  rawPath: string,
+  evidencePath: string,
+  suffix: string,
+): void {
+  const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+    readFileSync(rawPath, "utf8"),
+    suffix,
+  );
+  writeFileSync(evidencePath, canonical, { mode: 0o600 });
+  chmodSync(evidencePath, 0o600);
+}
+
+if (import.meta.main) {
+  const [suffix, rawPath, evidencePath] = process.argv.slice(2);
+  if (!suffix || !rawPath || !evidencePath) {
+    throw new Error(
+      "canary diagnostic requires suffix, raw path, and evidence path",
+    );
+  }
+  writeManagedDedicatedCanaryDiagnostic(rawPath, evidencePath, suffix);
+}


### PR DESCRIPTION
## Summary

- add a workflow-dispatch-only, staging-only read-only diagnostic for one exact managed-canary suffix
- query exactly one sandbox plus its three newest `agent_delete` jobs inside `BEGIN READ ONLY`, with `default_transaction_read_only=on`, a 20-second statement cap, and a step-scoped database credential
- convert the private raw row into a mode-0600 strict allowlist containing only statuses, counts, booleans, classified failure codes, and timestamps/durations
- reject unknown shapes/text, non-inline payloads, contradictory lifecycle state, zero/multiple targets, and any output containing identifier/URL/IP/secret patterns
- leave the normal schedule, labeled-PR, and manual canary path unchanged unless the explicit diagnostic input is selected

## Why

The exact post-merge staging recovery canary for #17173 (run 30224564063, deployed commit `e00283274bd6490f6fedc02fd56f9de92dbe29fd`) found one stale dedicated canary and received `202` for its identity-bound delete, but the async `agent_delete` exhausted three attempts after 200.9 seconds. The public artifact correctly collapses private job details to `job_failed`; a blind retry is unsafe until operators know whether the failure happened before or after provider-side slot release.

Closes #17184

## Proof

- focused diagnostic tests — 16 passed, 0 failed
- executable privacy/shape tests — unknown raw errors, identifiers, non-inline payloads, mismatched retry results, row-delete classification, terminal duration, semantic contradictions, exact CLI wiring
- `actionlint .github/workflows/managed-dedicated-canary.yml` — passed
- Biome exact two TypeScript files — passed
- `git diff --check` — clean
- independent workflow/security review — no P0 or code-path P1; merge-first dispatch required by the existing develop-only staging environment rule
- error-policy ratchet — N/A: the exact base does not contain the named audit script; the new production file adds no catch or console usage

## Safety invariants

- no POST, DELETE, UPDATE, INSERT, DDL, host SSH, provider call, or canary creation
- no environment-policy change; dispatch occurs only after merge from exact `develop`
- database credential exists only in the SQL step and is absent from tests, transformer, upload, and summary
- both client default and explicit SQL transaction are read-only
- raw database JSON stays mode-0600 on the ephemeral runner and is deleted before upload
- no IDs, names, suffixes, org/user data, database strings, hosts, URLs, IPs, digests, credentials, or raw errors enter the artifact/summary
- production is untouched

## Post-merge proof

1. Dispatch exact suffix `r30081355987a1` from merged `develop`.
2. Require exactly one target and a privacy-safe terminal job classification.
3. Decide source repair versus sanctioned retry from that packet; do not rerun deletion blindly.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend diagnostic tooling only; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend diagnostic tooling only; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [failed staging recovery run 30224564063](https://github.com/elizaOS/eliza/actions/runs/30224564063); privacy-safe diagnostic artifact will be linked immediately after merge-first dispatch

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the privacy-safe read-only diagnostic artifact is intentionally produced from the merged develop workflow only
