### PR TITLE
fix(cloud): adapt staging database URL for psql

### DIFF
--- a/.github/workflows/managed-dedicated-canary.yml
+++ b/.github/workflows/managed-dedicated-canary.yml
@@ -309,7 +309,11 @@ jobs:
 
           mkdir -p reports
           umask 077
-          psql "$DATABASE_URL" \
+          PSQL_DATABASE_URL="$(
+            bun packages/scripts/cloud/admin/libpq-connection-url.ts
+          )"
+          echo "::add-mask::$PSQL_DATABASE_URL"
+          psql "$PSQL_DATABASE_URL" \
             --no-psqlrc \
             --no-align \
             --tuples-only \

--- a/packages/scripts/cloud/admin/libpq-connection-url.ts
+++ b/packages/scripts/cloud/admin/libpq-connection-url.ts
@@ -16,7 +16,20 @@ export function toLibpqConnectionUrl(value: string): string {
     throw new Error("database URL must use PostgreSQL");
   }
 
-  url.searchParams.delete("uselibpqcompat");
+  const compatibilityHints = [...url.searchParams].filter(
+    ([key]) => key.toLowerCase() === "uselibpqcompat",
+  );
+  if (
+    compatibilityHints.length > 1 ||
+    compatibilityHints.some(
+      ([key, hint]) => key !== "uselibpqcompat" || hint !== "true",
+    )
+  ) {
+    throw new Error("database URL has an invalid libpq compatibility hint");
+  }
+  if (compatibilityHints.length === 1) {
+    url.searchParams.delete("uselibpqcompat");
+  }
   return url.toString();
 }
 

--- a/packages/scripts/cloud/admin/libpq-connection-url.ts
+++ b/packages/scripts/cloud/admin/libpq-connection-url.ts
@@ -1,0 +1,25 @@
+/**
+ * Adapts a PostgreSQL URI for libpq clients without changing its connection
+ * identity or security options. Provider-specific client hints are removed
+ * only when libpq rejects them before establishing a connection.
+ */
+
+const LIBPQ_PROTOCOLS = new Set(["postgres:", "postgresql:"]);
+
+export function toLibpqConnectionUrl(value: string): string {
+  if (!value) {
+    throw new Error("database URL is required");
+  }
+
+  const url = new URL(value);
+  if (!LIBPQ_PROTOCOLS.has(url.protocol)) {
+    throw new Error("database URL must use PostgreSQL");
+  }
+
+  url.searchParams.delete("uselibpqcompat");
+  return url.toString();
+}
+
+if (import.meta.main) {
+  process.stdout.write(toLibpqConnectionUrl(process.env.DATABASE_URL ?? ""));
+}

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -18,8 +18,34 @@ import {
   sanitizeManagedDedicatedCanaryDiagnostic,
   writeManagedDedicatedCanaryDiagnostic,
 } from "./managed-dedicated-canary-diagnostic";
+import { toLibpqConnectionUrl } from "./libpq-connection-url";
 
 const SUFFIX = "r30081355987a1";
+
+describe("libpq connection URL", () => {
+  test("removes only the provider client compatibility hint", () => {
+    expect(
+      toLibpqConnectionUrl(
+        "postgresql://operator:p%40ss@db.example.test:5432/eliza?sslmode=require&uselibpqcompat=true&channel_binding=require",
+      ),
+    ).toBe(
+      "postgresql://operator:p%40ss@db.example.test:5432/eliza?sslmode=require&channel_binding=require",
+    );
+  });
+
+  test("preserves a URL that already contains only libpq options", () => {
+    const value =
+      "postgres://operator:secret@db.example.test/eliza?sslmode=verify-full";
+    expect(toLibpqConnectionUrl(value)).toBe(value);
+  });
+
+  test.each(["", "https://db.example.test/eliza"])(
+    "rejects a non-PostgreSQL connection URL",
+    (value) => {
+      expect(() => toLibpqConnectionUrl(value)).toThrow();
+    },
+  );
+});
 
 function failedDeleteInput(): Record<string, unknown> {
   return {
@@ -312,6 +338,12 @@ describe("managed dedicated canary diagnostic", () => {
     );
     expect(workflow).toContain("BEGIN READ ONLY;");
     expect(workflow).toContain("SET LOCAL statement_timeout = '20s';");
+    expect(workflow).toContain(
+      "bun packages/scripts/cloud/admin/libpq-connection-url.ts",
+    );
+    expect(workflow).toContain('echo "::add-mask::$PSQL_DATABASE_URL"');
+    expect(workflow).toContain('psql "$PSQL_DATABASE_URL"');
+    expect(workflow).not.toContain('psql "$DATABASE_URL"');
     expect(workflow).toContain(
       "WHERE agent_name = 'managed-dedicated-canary-' || :'suffix'",
     );

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -45,6 +45,19 @@ describe("libpq connection URL", () => {
       expect(() => toLibpqConnectionUrl(value)).toThrow();
     },
   );
+
+  test.each([
+    "?uselibpqcompat=false",
+    "?uselibpqcompat=",
+    "?uselibpqcompat=true&uselibpqcompat=true",
+    "?UseLibpqCompat=true",
+  ])("rejects an ambiguous compatibility hint: %s", (query) => {
+    expect(() =>
+      toLibpqConnectionUrl(
+        `postgresql://operator:secret@db.example.test/eliza${query}`,
+      ),
+    ).toThrow("invalid libpq compatibility hint");
+  });
 });
 
 function failedDeleteInput(): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- adapt the staging database URI for the `psql` diagnostic by removing only one exact provider hint, `uselibpqcompat=true`
- preserve PostgreSQL identity, credentials, SSL mode, channel binding, and every other query option
- fail closed for false, empty, duplicate, or case-variant compatibility hints
- mask the derived libpq URI before use while retaining both `default_transaction_read_only=on` and `BEGIN READ ONLY`
- leave the normal canary path unchanged

## Why

The first post-merge read-only diagnostic run [30225747138](https://github.com/elizaOS/eliza/actions/runs/30225747138) stopped before connecting because the staging URI contains `uselibpqcompat`, which Bun clients understand but libpq rejects as an unknown URI parameter. No SQL, canary, retry, or Cloud mutation occurred.

Refs #17184

## Proof

- focused diagnostic tests: 24 passed, 0 failed
- URI contract tests cover exact true-hint removal, preservation of libpq options, and fail-closed false/empty/duplicate/case-variant/protocol behavior
- `actionlint .github/workflows/managed-dedicated-canary.yml`: passed
- Biome exact touched TypeScript files: passed
- `git diff --check`: clean
- exact head: `e79ad8379fc08b6094f909c61807fda701aae544`
- independent exact-head review: PASS, no P0 or P1

## Safety invariants

- no database query or external mutation occurs in this patch
- the derived URI is masked before `psql` receives it and is never written to an artifact
- only one exact true compatibility hint is removed; SSL and connection security parameters remain byte-semantically present
- ambiguous compatibility hints abort before connection
- the SQL remains an explicit read-only transaction with a client-level read-only default and statement timeout
- production and the failed staging canary remain untouched

## Post-merge proof

Dispatch the diagnostic-only input from exact merged `develop`, download the allowlisted mode-0600 artifact, and classify the stale delete before considering any retry.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend workflow compatibility fix only; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend workflow compatibility fix only; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [read-only diagnostic failure 30225747138](https://github.com/elizaOS/eliza/actions/runs/30225747138) proves the exact pre-connection libpq incompatibility

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain mutation; the post-merge run will emit only the privacy-safe diagnostic artifact