### PR TITLE
fix(cloud): classify canary delete lifecycle blockers

### DIFF
--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -249,6 +249,40 @@ describe("managed dedicated canary diagnostic", () => {
     });
   });
 
+  test.each([
+    [
+      "Agent replacement cleanup is still pending",
+      "replacement_cleanup_pending",
+    ],
+    ["Agent provisioning is in progress", "provisioning_in_progress"],
+  ])(
+    "classifies the canonical delete lifecycle boundary: %s",
+    (message, expectedCode) => {
+      const input = failedDeleteInput();
+      const agent = input.agent as Record<string, unknown>;
+      const [job] = input.jobs as Record<string, unknown>[];
+      agent.errorMessage = `Deletion permanently failed after 3 attempts: ${message}`;
+      job.error = message;
+      job.result = {
+        containerStopped: false,
+        rowDeleted: false,
+        error: message,
+      };
+
+      const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+        JSON.stringify(input),
+        SUFFIX,
+      );
+      const evidence = JSON.parse(canonical);
+      expect(evidence.sandbox.errorCode).toBe(expectedCode);
+      expect(evidence.jobs[0]).toMatchObject({
+        errorCode: expectedCode,
+        resultErrorCode: expectedCode,
+      });
+      expect(canonical).not.toContain(message);
+    },
+  );
+
   test("classifies row-delete failures without publishing the SQL text", () => {
     const input = failedDeleteInput();
     const agent = input.agent as Record<string, unknown>;

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -37,6 +37,8 @@ type ErrorCode =
   | "none"
   | "sandbox_stop_failed"
   | "agent_not_found"
+  | "replacement_cleanup_pending"
+  | "provisioning_in_progress"
   | "lifecycle_conflict"
   | "credential_revoke_failed"
   | "row_delete_failed"
@@ -148,6 +150,12 @@ function classifyError(value: unknown, label: string): ErrorCode {
     return classifyError(permanentDelete[1], `${label} cause`);
   if (value === "Failed to delete sandbox") return "sandbox_stop_failed";
   if (value === "Agent not found") return "agent_not_found";
+  if (value === "Agent replacement cleanup is still pending") {
+    return "replacement_cleanup_pending";
+  }
+  if (value === "Agent provisioning is in progress") {
+    return "provisioning_in_progress";
+  }
   if (/failed query:[\s\S]*delete from\s+"?agent_sandboxes"?/i.test(value)) {
     return "row_delete_failed";
   }


### PR DESCRIPTION
## Summary

- add privacy-safe distinct classifications for the two canonical delete precondition failures not covered by the initial diagnostic
- classify `replacement_cleanup_pending` separately from `provisioning_in_progress`
- preserve fail-closed behavior for every other unknown operator error
- prove the raw canonical messages never enter the uploaded artifact

## Why

Read-only diagnostic run [30225974420](https://github.com/elizaOS/eliza/actions/runs/30225974420) successfully connected and completed its explicit read-only SQL transaction, then stopped before upload because the newest delete job contained one uncovered canonical lifecycle-boundary message. Static exhaustiveness of `deleteAgent` shows the only uncovered returned messages are the two added here. No canary, delete, retry, or Cloud mutation occurred.

Refs #17184

## Proof

- focused diagnostic tests: 26 passed, 0 failed
- both exact lifecycle messages classify through job error, persisted result error, and wrapped sandbox error
- canonical artifact assertions prove neither raw message is published
- Biome exact two files: passed
- `git diff --check`: clean
- exact head: `fbe88bd28eedaa5a04bd5f0d9cbb0424d2ca90e5`
- independent exact-head exhaustiveness/privacy review: PASS, no P0 or P1

## Safety invariants

- no SQL, workflow, provider, canary, or mutation behavior changes
- only canonical service-owned exact messages gain allowlisted codes
- arbitrary or unexpected error text still fails closed before upload
- output remains identifier-free and mode-0600
- production and staging state remain untouched

## Post-merge proof

Dispatch the read-only diagnostic from exact merged `develop`; require a single privacy-safe lifecycle classification before choosing any source fix or retry.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend classifier only; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend classifier only; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [classifier stop run 30225974420](https://github.com/elizaOS/eliza/actions/runs/30225974420) proves SQL passed and unknown text remained private

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain mutation; next merged run will emit only allowlisted classification codes