### PR TITLE
fix(cloud): classify exclusive canary job conflicts

### DIFF
--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -283,6 +283,70 @@ describe("managed dedicated canary diagnostic", () => {
     },
   );
 
+  test.each([
+    "agent_provision",
+    "agent_delete",
+    "agent_suspend",
+    "agent_resume",
+    "agent_restart",
+    "agent_downgrade",
+    "agent_sleep",
+    "agent_wake",
+    "agent_upgrade",
+    "agent_admin_canary_image",
+  ])(
+    "classifies the exclusive-job conflict without publishing identifiers: %s",
+    (jobType) => {
+      const input = failedDeleteInput();
+      const agent = input.agent as Record<string, unknown>;
+      const [job] = input.jobs as Record<string, unknown>[];
+      const error =
+        `Agent 55f332f8-da54-4c53-952c-a38f5f01287b has conflicting ${jobType} ` +
+        "job 398b3cae-4aa0-4f63-8736-ac3c7ca9ab96";
+      agent.errorMessage = `Deletion permanently failed after 3 attempts: ${error}`;
+      job.error = error;
+      job.result = null;
+
+      const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+        JSON.stringify(input),
+        SUFFIX,
+      );
+      const evidence = JSON.parse(canonical);
+      expect(evidence.sandbox.errorCode).toBe("lifecycle_conflict");
+      expect(evidence.jobs[0]).toMatchObject({
+        errorCode: "lifecycle_conflict",
+        resultErrorCode: "none",
+        containerStopped: null,
+        rowDeleted: null,
+      });
+      expect(canonical).not.toContain("55f332f8");
+      expect(canonical).not.toContain("398b3cae");
+      expect(canonical).not.toContain("has conflicting");
+    },
+  );
+
+  test.each([
+    "Agent 55f332f8-da54-4c53-952c-a38f5f01287b has conflicting agent_message job 398b3cae-4aa0-4f63-8736-ac3c7ca9ab96",
+    "Agent 55f332f8-da54-4c53-952c-a38f5f01287b has conflicting agent_logs job 398b3cae-4aa0-4f63-8736-ac3c7ca9ab96",
+    "Agent 55f332f8-da54-4c53-952c-a38f5f01287b has conflicting container_delete job 398b3cae-4aa0-4f63-8736-ac3c7ca9ab96",
+    "Agent not-a-uuid has conflicting agent_delete job 398b3cae-4aa0-4f63-8736-ac3c7ca9ab96",
+    "Agent 55f332f8-da54-4c53-952c-a38f5f01287b has conflicting agent_delete job 398b3cae-4aa0-4f63-8736-ac3c7ca9ab96 trailing",
+  ])("rejects a noncanonical lifecycle-conflict message", (error) => {
+    const input = failedDeleteInput();
+    const agent = input.agent as Record<string, unknown>;
+    const [job] = input.jobs as Record<string, unknown>[];
+    agent.errorMessage = `Deletion permanently failed after 3 attempts: ${error}`;
+    job.error = error;
+    job.result = null;
+
+    expect(() =>
+      canonicalizeManagedDedicatedCanaryDiagnostic(
+        JSON.stringify(input),
+        SUFFIX,
+      ),
+    ).toThrow("privacy-safe classifier");
+  });
+
   test("classifies row-delete failures without publishing the SQL text", () => {
     const input = failedDeleteInput();
     const agent = input.agent as Record<string, unknown>;

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -9,8 +9,15 @@ import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 type JsonRecord = Record<string, unknown>;
 
 const SUFFIX_PATTERN = /^r[1-9][0-9]{7,19}a[1-9][0-9]{0,3}$/;
-const UUID_PATTERN =
-  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i;
+const UUID_PATTERN_SOURCE =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+const UUID_PATTERN = new RegExp(`\\b${UUID_PATTERN_SOURCE}\\b`, "i");
+const EXCLUSIVE_LIFECYCLE_JOB_TYPE_PATTERN =
+  "agent_(?:provision|delete|suspend|resume|restart|downgrade|sleep|wake|upgrade|admin_canary_image)";
+const LIFECYCLE_JOB_CONFLICT_PATTERN = new RegExp(
+  `^Agent ${UUID_PATTERN_SOURCE} has conflicting ${EXCLUSIVE_LIFECYCLE_JOB_TYPE_PATTERN} job ${UUID_PATTERN_SOURCE}$`,
+  "i",
+);
 const FORBIDDEN_OUTPUT_PATTERN =
   /(?:https?:\/\/|(?:\d{1,3}\.){3}\d{1,3}|\b(?:token|secret|password|api[_-]?key)\b|managed-dedicated-canary-|sha256:)/i;
 
@@ -155,6 +162,9 @@ function classifyError(value: unknown, label: string): ErrorCode {
   }
   if (value === "Agent provisioning is in progress") {
     return "provisioning_in_progress";
+  }
+  if (LIFECYCLE_JOB_CONFLICT_PATTERN.test(value)) {
+    return "lifecycle_conflict";
   }
   if (/failed query:[\s\S]*delete from\s+"?agent_sandboxes"?/i.test(value)) {
     return "row_delete_failed";


### PR DESCRIPTION
## Summary

- classify the worker’s exact dynamic exclusive-lifecycle conflict message as the existing privacy-safe `lifecycle_conflict` code
- require anchored canonical UUIDs at both identifier positions and an explicit allowlist of all ten exclusive agent lifecycle job types
- discard both identifiers and the raw message from the canonical artifact
- keep nonexclusive job types, malformed identifiers, suffix text, and every other unknown message fail-closed

## Why

Read-only diagnostic run [30226104014](https://github.com/elizaOS/eliza/actions/runs/30226104014) again completed SQL and stopped at `jobs[0].error`. The remaining normal pre-dispatch path is `assertNoConflictingLifecycleExecution`, which emits a dynamic message containing the agent and conflicting job IDs before `executeAgentDelete` runs. This patch recognizes only that exact service-owned envelope. No provider stop, retry, delete, or Cloud mutation occurred.

Refs #17184

## Proof

- focused diagnostic tests: 41 passed, 0 failed
- all ten exclusive lifecycle types accepted
- nonexclusive agent, container, malformed UUID, and trailing-text variants rejected
- canonical artifact proves both UUIDs and raw conflict text are absent
- Biome exact two files: passed
- `git diff --check`: clean
- exact head: `561f67947e616196b48dc1657a9f86b9d6961596`
- independent exact-head review: PASS, no P0 or P1

## Safety invariants

- classifier-only change; no workflow, SQL, provider, canary, or mutation behavior changes
- dynamic IDs never enter output
- only the exact exclusive-lifecycle envelope maps to a preexisting code
- invariant failures and unknown/dynamic text continue to fail closed
- production and staging state remain untouched

## Post-merge proof

Dispatch the read-only diagnostic from exact merged `develop`; require the privacy-safe artifact before choosing any source fix or retry.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend classifier only; no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend classifier only; no UI pixels changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [fail-closed run 30226104014](https://github.com/elizaOS/eliza/actions/runs/30226104014) proves SQL passed and dynamic identifiers remained private

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain mutation; next merged run will emit only allowlisted classification codes