### PR TITLE
fix(cloud): profile unclassified canary delete errors

### DIFF
--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -13,12 +13,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { toLibpqConnectionUrl } from "./libpq-connection-url";
 import {
   canonicalizeManagedDedicatedCanaryDiagnostic,
   sanitizeManagedDedicatedCanaryDiagnostic,
   writeManagedDedicatedCanaryDiagnostic,
 } from "./managed-dedicated-canary-diagnostic";
-import { toLibpqConnectionUrl } from "./libpq-connection-url";
 
 const SUFFIX = "r30081355987a1";
 
@@ -355,7 +355,8 @@ describe("managed dedicated canary diagnostic", () => {
       "opaque https://u:p@example.test/a?q=secret#frag 192.0.2.44 user@example.test " +
       "Bearer eyJhbGciOiJIUzI1NiJ9.abc.sig ghp_1234567890 AWS_SECRET_ACCESS_KEY " +
       "api_key=password -----BEGIN PRIVATE KEY----- sha256:deadbeef " +
-      '{"x":"::error::${{secrets.X}}"}\r\n\t\u0000\u001b[31m\u202e\u200b\u0301\u0430\ud800';
+      '{"x":"::error::$' +
+      '{{secrets.X}}"}\r\n\t\u0000\u001b[31m\u202e\u200b\u0301\u0430\ud800';
     const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
       JSON.stringify(unclassifiedLatestJobInput(error)),
       SUFFIX,
@@ -802,25 +803,22 @@ describe("managed dedicated canary diagnostic", () => {
       "2026-07-26T23:10:31.000Z",
       "2026-07-26T23:11:31.000Z",
     ],
-  ])(
-    "rejects terminal recovery with %s",
-    (_name, startedAt, completedAt) => {
-      const input = failedDeleteInput();
-      const agent = input.agent as Record<string, unknown>;
-      const [job] = input.jobs as Record<string, unknown>[];
-      agent.status = "deletion_pending";
-      agent.errorMessage = null;
-      agent.errorCount = 0;
-      job.error = "Job timed out 3 times - max attempts reached";
-      job.result = null;
-      job.startedAt = startedAt;
-      job.completedAt = completedAt;
+  ])("rejects terminal recovery with %s", (_name, startedAt, completedAt) => {
+    const input = failedDeleteInput();
+    const agent = input.agent as Record<string, unknown>;
+    const [job] = input.jobs as Record<string, unknown>[];
+    agent.status = "deletion_pending";
+    agent.errorMessage = null;
+    agent.errorCount = 0;
+    job.error = "Job timed out 3 times - max attempts reached";
+    job.result = null;
+    job.startedAt = startedAt;
+    job.completedAt = completedAt;
 
-      expect(() =>
-        sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
-      ).toThrow("recovery timestamps disagree");
-    },
-  );
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow("recovery timestamps disagree");
+  });
 
   test.each([
     [
@@ -857,10 +855,7 @@ describe("managed dedicated canary diagnostic", () => {
       "worker_restart_recovered",
       "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
     ],
-    [
-      "timeout_recovered",
-      "Job timed out - recovered for retry (attempt 1/3)",
-    ],
+    ["timeout_recovered", "Job timed out - recovered for retry (attempt 1/3)"],
   ])(
     "keeps %s separate from terminal errors for pending and running jobs",
     (expectedCode, message) => {
@@ -1024,35 +1019,32 @@ describe("managed dedicated canary diagnostic", () => {
       "2026-07-26T23:11:30.000Z",
       "recovery status is invalid",
     ],
-  ])(
-    "rejects %s",
-    (_name, status, startedAt, completedAt, expectedError) => {
-      const input = failedDeleteInput();
-      const agent = input.agent as Record<string, unknown>;
-      const [job] = input.jobs as Record<string, unknown>[];
-      agent.status = "deletion_pending";
-      agent.errorMessage = null;
-      agent.errorCount = 0;
-      job.status = status;
-      job.error =
-        "Job interrupted by worker restart - recovered for retry (attempt 1/3)";
-      job.result =
-        status === "completed"
-          ? {
-              containerStopped: true,
-              rowDeleted: true,
-              error: null,
-            }
-          : null;
-      job.attempts = 1;
-      job.startedAt = startedAt;
-      job.completedAt = completedAt;
+  ])("rejects %s", (_name, status, startedAt, completedAt, expectedError) => {
+    const input = failedDeleteInput();
+    const agent = input.agent as Record<string, unknown>;
+    const [job] = input.jobs as Record<string, unknown>[];
+    agent.status = "deletion_pending";
+    agent.errorMessage = null;
+    agent.errorCount = 0;
+    job.status = status;
+    job.error =
+      "Job interrupted by worker restart - recovered for retry (attempt 1/3)";
+    job.result =
+      status === "completed"
+        ? {
+            containerStopped: true,
+            rowDeleted: true,
+            error: null,
+          }
+        : null;
+    job.attempts = 1;
+    job.startedAt = startedAt;
+    job.completedAt = completedAt;
 
-      expect(() =>
-        sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
-      ).toThrow(expectedError);
-    },
-  );
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow(expectedError);
+  });
 
   test.each([
     "Job interrupted by worker restart - recovered for retry (attempt 0/3)",
@@ -1101,8 +1093,7 @@ describe("managed dedicated canary diagnostic", () => {
       const input = failedDeleteInput();
       const agent = input.agent as Record<string, unknown>;
       const [job] = input.jobs as Record<string, unknown>[];
-      const malformed =
-        "Job timed out - recovered  for retry (attempt 1/3)";
+      const malformed = "Job timed out - recovered  for retry (attempt 1/3)";
       if (boundary === "agent") {
         agent.errorMessage = `Deletion permanently failed after 3 attempts: ${malformed}`;
       } else {

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -100,6 +100,19 @@ function failedDeleteInput(): Record<string, unknown> {
   };
 }
 
+function unclassifiedLatestJobInput(error: unknown): Record<string, unknown> {
+  const input = failedDeleteInput();
+  const agent = input.agent as Record<string, unknown>;
+  const [job] = input.jobs as Record<string, unknown>[];
+  agent.status = "deletion_pending";
+  agent.errorMessage = null;
+  agent.errorCount = 0;
+  job.error = error;
+  job.result = null;
+  job.completedAt = null;
+  return input;
+}
+
 describe("managed dedicated canary diagnostic", () => {
   test("emits only the classified lifecycle facts needed for retry decisions", () => {
     const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
@@ -108,7 +121,7 @@ describe("managed dedicated canary diagnostic", () => {
     );
 
     expect(evidence).toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
       targetCount: 1,
       sandbox: {
         status: "deletion_failed",
@@ -125,6 +138,7 @@ describe("managed dedicated canary diagnostic", () => {
           containerStopped: false,
           rowDeleted: false,
           errorCode: "sandbox_stop_failed",
+          unclassifiedProfile: null,
           recoveryCode: "none",
           resultErrorCode: "sandbox_stop_failed",
           scheduledFor: "2026-07-26T23:10:30.000Z",
@@ -196,21 +210,6 @@ describe("managed dedicated canary diagnostic", () => {
       "non-inline",
     ],
     [
-      "unclassified operator text",
-      {
-        ...failedDeleteInput(),
-        jobs: [
-          {
-            ...(failedDeleteInput().jobs as Record<string, unknown>[])[0],
-            error: "remote execution returned an unexpected opaque failure",
-            result: null,
-          },
-        ],
-      },
-      SUFFIX,
-      "privacy-safe classifier",
-    ],
-    [
       "raw result identifier",
       {
         ...failedDeleteInput(),
@@ -233,6 +232,336 @@ describe("managed dedicated canary diagnostic", () => {
     expect(() =>
       sanitizeManagedDedicatedCanaryDiagnostic(input, suffix),
     ).toThrow(message);
+  });
+
+  test.each([
+    [1, "1_64"],
+    [64, "1_64"],
+    [65, "65_128"],
+    [128, "65_128"],
+    [129, "129_256"],
+    [256, "129_256"],
+    [257, "257_512"],
+    [512, "257_512"],
+    [513, "513_2000"],
+    [2_000, "513_2000"],
+  ])(
+    "profiles an unclassified latest job in the fixed %s-code-unit bucket",
+    (length, expectedBucket) => {
+      const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
+        unclassifiedLatestJobInput("x".repeat(length)),
+        SUFFIX,
+      );
+
+      expect(evidence).toMatchObject({
+        schemaVersion: 3,
+        sandbox: {
+          errorCode: "none",
+        },
+        jobs: [
+          {
+            errorCode: "unclassified",
+            unclassifiedProfile: {
+              lengthBucket: expectedBucket,
+              writerHints: {
+                jobRunnerLike: false,
+                deleteLifecycleLike: false,
+                persistenceLike: false,
+                containerRuntimeLike: false,
+                transportLike: false,
+              },
+            },
+          },
+        ],
+      });
+    },
+  );
+
+  test.each([
+    ["empty", ""],
+    ["over-limit", "x".repeat(2_001)],
+    ["non-string", 17],
+  ])("rejects an invalid unclassified %s value", (_name, error) => {
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(
+        unclassifiedLatestJobInput(error),
+        SUFFIX,
+      ),
+    ).toThrow("bounded string");
+  });
+
+  test.each([
+    ["32 surrogate pairs", "😀".repeat(32), "1_64"],
+    ["33 surrogate pairs", "😀".repeat(33), "65_128"],
+    ["unpaired surrogate", "\ud800", "1_64"],
+  ])("uses JavaScript UTF-16 units for %s", (_name, error, lengthBucket) => {
+    const profile = sanitizeManagedDedicatedCanaryDiagnostic(
+      unclassifiedLatestJobInput(error),
+      SUFFIX,
+    ).jobs[0]?.unclassifiedProfile;
+    expect(profile?.lengthBucket).toBe(lengthBucket);
+  });
+
+  test.each([
+    ["job agent_delete returned an opaque failure", "jobRunnerLike"],
+    ["Agent deletion intent was not persisted", "deleteLifecycleLike"],
+    ["PGlite driver returned an opaque failure", "persistenceLike"],
+    ["SSH executor returned an opaque failure", "containerRuntimeLike"],
+    ["getaddrinfo returned an opaque failure", "transportLike"],
+  ])("emits one anchored %s hint", (error, expectedHint) => {
+    const hints = sanitizeManagedDedicatedCanaryDiagnostic(
+      unclassifiedLatestJobInput(error),
+      SUFFIX,
+    ).jobs[0]?.unclassifiedProfile?.writerHints;
+    expect(hints).toEqual({
+      jobRunnerLike: expectedHint === "jobRunnerLike",
+      deleteLifecycleLike: expectedHint === "deleteLifecycleLike",
+      persistenceLike: expectedHint === "persistenceLike",
+      containerRuntimeLike: expectedHint === "containerRuntimeLike",
+      transportLike: expectedHint === "transportLike",
+    });
+  });
+
+  test("uses fixed precedence when one value carries every family marker", () => {
+    const error =
+      "job agent_delete Agent deletion intent PGlite SSH getaddrinfo";
+    const hints = sanitizeManagedDedicatedCanaryDiagnostic(
+      unclassifiedLatestJobInput(error),
+      SUFFIX,
+    ).jobs[0]?.unclassifiedProfile?.writerHints;
+    expect(hints).toEqual({
+      jobRunnerLike: true,
+      deleteLifecycleLike: false,
+      persistenceLike: false,
+      containerRuntimeLike: false,
+      transportLike: false,
+    });
+  });
+
+  test("equal-length same-family secrets produce byte-identical profiles", () => {
+    const left = sanitizeManagedDedicatedCanaryDiagnostic(
+      unclassifiedLatestJobInput("job agent_delete secret-AAAA"),
+      SUFFIX,
+    ).jobs[0]?.unclassifiedProfile;
+    const right = sanitizeManagedDedicatedCanaryDiagnostic(
+      unclassifiedLatestJobInput("job agent_delete secret-BBBB"),
+      SUFFIX,
+    ).jobs[0]?.unclassifiedProfile;
+    expect(JSON.stringify(left)).toBe(JSON.stringify(right));
+  });
+
+  test("canonical output never includes malicious unclassified input", () => {
+    const error =
+      "opaque https://u:p@example.test/a?q=secret#frag 192.0.2.44 user@example.test " +
+      "Bearer eyJhbGciOiJIUzI1NiJ9.abc.sig ghp_1234567890 AWS_SECRET_ACCESS_KEY " +
+      "api_key=password -----BEGIN PRIVATE KEY----- sha256:deadbeef " +
+      '{"x":"::error::${{secrets.X}}"}\r\n\t\u0000\u001b[31m\u202e\u200b\u0301\u0430\ud800';
+    const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+      JSON.stringify(unclassifiedLatestJobInput(error)),
+      SUFFIX,
+    );
+    const evidence = JSON.parse(canonical);
+    expect(evidence.jobs[0]).toMatchObject({
+      errorCode: "unclassified",
+      unclassifiedProfile: {
+        writerHints: {
+          jobRunnerLike: false,
+          deleteLifecycleLike: false,
+          persistenceLike: false,
+          containerRuntimeLike: false,
+          transportLike: false,
+        },
+      },
+    });
+    for (const forbidden of [
+      "example.test",
+      "192.0.2.44",
+      "Bearer",
+      "ghp_",
+      "AWS_",
+      "api_key",
+      "PRIVATE KEY",
+      "sha256",
+      "deadbeef",
+      "::error::",
+      "secrets.X",
+      "opaque",
+    ]) {
+      expect(canonical).not.toContain(forbidden);
+    }
+  });
+
+  test.each([
+    [
+      "completed status",
+      (job: Record<string, unknown>) => {
+        job.status = "completed";
+        job.result = {
+          containerStopped: true,
+          rowDeleted: true,
+          error: null,
+        };
+      },
+    ],
+    [
+      "cancelled status",
+      (job: Record<string, unknown>) => {
+        job.status = "cancelled";
+      },
+    ],
+    [
+      "missing claim timestamp",
+      (job: Record<string, unknown>) => {
+        job.startedAt = null;
+      },
+    ],
+    [
+      "terminal timestamp",
+      (job: Record<string, unknown>) => {
+        job.completedAt = "2026-07-26T23:11:30.000Z";
+      },
+    ],
+    [
+      "zero attempts",
+      (job: Record<string, unknown>) => {
+        job.attempts = 0;
+      },
+    ],
+    [
+      "failed below max attempts",
+      (job: Record<string, unknown>) => {
+        job.attempts = 2;
+      },
+    ],
+    [
+      "pending at max attempts",
+      (job: Record<string, unknown>) => {
+        job.status = "pending";
+      },
+    ],
+  ])("rejects an unclassified job with %s", (_name, mutate) => {
+    const input = unclassifiedLatestJobInput("opaque failure");
+    mutate((input.jobs as Record<string, unknown>[])[0]);
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow("unclassified lifecycle is inconsistent");
+  });
+
+  test.each(["pending", "in_progress"])(
+    "accepts a claimed nonterminal unclassified %s job below max attempts",
+    (status) => {
+      const input = unclassifiedLatestJobInput("opaque failure");
+      const [job] = input.jobs as Record<string, unknown>[];
+      job.status = status;
+      job.attempts = 1;
+      expect(
+        sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX).jobs[0],
+      ).toMatchObject({
+        status,
+        attempts: 1,
+        maxAttempts: 3,
+        errorCode: "unclassified",
+      });
+    },
+  );
+
+  test.each([
+    "Failed to delete sandbox",
+    "Agent replacement cleanup is still pending",
+    "Agent provisioning is in progress",
+    "Agent deletion ownership changed",
+  ])("accepts an exact partial result for unclassified text: %s", (error) => {
+    const input = unclassifiedLatestJobInput("opaque failure");
+    const [job] = input.jobs as Record<string, unknown>[];
+    job.result = {
+      containerStopped: false,
+      rowDeleted: false,
+      error,
+    };
+    expect(
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX).jobs[0],
+    ).toMatchObject({
+      errorCode: "unclassified",
+      containerStopped: false,
+      rowDeleted: false,
+    });
+  });
+
+  test.each([
+    [
+      "successful-looking",
+      { containerStopped: true, rowDeleted: true, error: null },
+    ],
+    [
+      "null flags",
+      {
+        containerStopped: null,
+        rowDeleted: null,
+        error: "Failed to delete sandbox",
+      },
+    ],
+    [
+      "unknown result",
+      {
+        containerStopped: false,
+        rowDeleted: false,
+        error: "opaque result",
+      },
+    ],
+  ])("rejects an unclassified job with %s result", (_name, result) => {
+    const input = unclassifiedLatestJobInput("opaque failure");
+    (input.jobs as Record<string, unknown>[])[0].result = result;
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow();
+  });
+
+  test("keeps older unknown job errors fail-closed", () => {
+    const input = failedDeleteInput();
+    const [latest] = input.jobs as Record<string, unknown>[];
+    input.jobs = [
+      latest,
+      {
+        ...latest,
+        error: "opaque older failure",
+        result: null,
+        completedAt: null,
+        createdAt: "2026-07-26T23:07:09.000Z",
+      },
+    ];
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow("privacy-safe classifier");
+  });
+
+  test("emits at most one profile when older jobs are classified", () => {
+    const input = unclassifiedLatestJobInput("opaque latest failure");
+    const [latest] = input.jobs as Record<string, unknown>[];
+    input.jobs = [
+      latest,
+      {
+        ...latest,
+        error: "Failed to delete sandbox",
+        result: {
+          containerStopped: false,
+          rowDeleted: false,
+          error: "Failed to delete sandbox",
+        },
+        createdAt: "2026-07-26T23:07:09.000Z",
+      },
+    ];
+    const evidence = sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX);
+    expect(evidence.jobs[0]?.unclassifiedProfile).not.toBeNull();
+    expect(evidence.jobs[1]?.unclassifiedProfile).toBeNull();
+  });
+
+  test("keeps an unknown sandbox error fail-closed", () => {
+    const input = failedDeleteInput();
+    (input.agent as Record<string, unknown>).errorMessage =
+      "opaque sandbox failure";
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+    ).toThrow("privacy-safe classifier");
   });
 
   test("preserves distinct terminal and prior-attempt result classifications", () => {

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -61,10 +61,7 @@ type ErrorCode =
   | "database_failed"
   | "timeout";
 
-type RecoveryCode =
-  | "none"
-  | "worker_restart_recovered"
-  | "timeout_recovered";
+type RecoveryCode = "none" | "worker_restart_recovered" | "timeout_recovered";
 
 interface RecoveryClassification {
   code: Exclude<RecoveryCode, "none">;
@@ -77,12 +74,7 @@ interface TerminalFailureClassification {
   attempts: number;
 }
 
-type ErrorLengthBucket =
-  | "1_64"
-  | "65_128"
-  | "129_256"
-  | "257_512"
-  | "513_2000";
+type ErrorLengthBucket = "1_64" | "65_128" | "129_256" | "257_512" | "513_2000";
 
 interface UnclassifiedErrorProfile {
   lengthBucket: ErrorLengthBucket;
@@ -102,10 +94,7 @@ interface JobErrorClassification {
 
 const RECOVERY_PARTIAL_RESULT_ERRORS = new Map<string, ErrorCode>([
   ["Failed to delete sandbox", "sandbox_stop_failed"],
-  [
-    "Agent replacement cleanup is still pending",
-    "replacement_cleanup_pending",
-  ],
+  ["Agent replacement cleanup is still pending", "replacement_cleanup_pending"],
   ["Agent provisioning is in progress", "provisioning_in_progress"],
   ["Agent deletion ownership changed", "lifecycle_conflict"],
 ]);
@@ -372,8 +361,7 @@ function classifyJobError(
   label: string,
   allowUnclassified: boolean,
 ): JobErrorClassification {
-  if (value === null)
-    return { code: "none", unclassifiedProfile: null };
+  if (value === null) return { code: "none", unclassifiedProfile: null };
   if (typeof value !== "string" || value.length === 0 || value.length > 2_000) {
     throw new Error(`${label} must be a bounded string or null`);
   }
@@ -381,9 +369,7 @@ function classifyJobError(
   return {
     code,
     unclassifiedProfile:
-      code === "unclassified"
-        ? buildUnclassifiedErrorProfile(value)
-        : null,
+      code === "unclassified" ? buildUnclassifiedErrorProfile(value) : null,
   };
 }
 
@@ -524,17 +510,11 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     }
 
     const terminalFailure =
-      typeof job.error === "string"
-        ? classifyTerminalFailure(job.error)
-        : null;
+      typeof job.error === "string" ? classifyTerminalFailure(job.error) : null;
     const recovery = classifyRecovery(job.error, `jobs[${index}].error`);
     const jobError = recovery
       ? { code: "none" as const, unclassifiedProfile: null }
-      : classifyJobError(
-          job.error,
-          `jobs[${index}].error`,
-          index === 0,
-        );
+      : classifyJobError(job.error, `jobs[${index}].error`, index === 0);
     const jobErrorCode = jobError.code;
     let containerStopped: boolean | null = null;
     let rowDeleted: boolean | null = null;
@@ -615,11 +595,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     ) {
       throw new Error(`jobs[${index}] recovery counters disagree`);
     }
-    if (
-      recovery &&
-      job.status !== "pending" &&
-      job.status !== "in_progress"
-    ) {
+    if (recovery && job.status !== "pending" && job.status !== "in_progress") {
       throw new Error(`jobs[${index}] recovery status is invalid`);
     }
     if (
@@ -637,7 +613,9 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
         RECOVERY_PARTIAL_RESULT_ERRORS.get(resultErrorValue) !==
           resultErrorCode)
     ) {
-      throw new Error(`jobs[${index}] recovery result is not a partial failure`);
+      throw new Error(
+        `jobs[${index}] recovery result is not a partial failure`,
+      );
     }
     if (
       jobErrorCode === "unclassified" &&

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -21,6 +21,8 @@ const LIFECYCLE_JOB_CONFLICT_PATTERN = new RegExp(
 const FORBIDDEN_OUTPUT_PATTERN =
   /(?:https?:\/\/|(?:\d{1,3}\.){3}\d{1,3}|\b(?:token|secret|password|api[_-]?key)\b|managed-dedicated-canary-|sha256:)/i;
 const TIMEOUT_ERROR_PATTERN = /(?:timed out|timeout)/i;
+const PERMANENT_DELETE_PATTERN =
+  /^Deletion permanently failed after [1-9][0-9]* attempts: (.+)$/;
 const WORKER_RESTART_TERMINAL_PATTERN =
   /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - max attempts reached$/;
 const TIMEOUT_TERMINAL_PATTERN =
@@ -47,6 +49,7 @@ const JOB_STATUSES = new Set([
 
 type ErrorCode =
   | "none"
+  | "unclassified"
   | "sandbox_stop_failed"
   | "agent_not_found"
   | "replacement_cleanup_pending"
@@ -74,6 +77,29 @@ interface TerminalFailureClassification {
   attempts: number;
 }
 
+type ErrorLengthBucket =
+  | "1_64"
+  | "65_128"
+  | "129_256"
+  | "257_512"
+  | "513_2000";
+
+interface UnclassifiedErrorProfile {
+  lengthBucket: ErrorLengthBucket;
+  writerHints: {
+    jobRunnerLike: boolean;
+    deleteLifecycleLike: boolean;
+    persistenceLike: boolean;
+    containerRuntimeLike: boolean;
+    transportLike: boolean;
+  };
+}
+
+interface JobErrorClassification {
+  code: ErrorCode;
+  unclassifiedProfile: UnclassifiedErrorProfile | null;
+}
+
 const RECOVERY_PARTIAL_RESULT_ERRORS = new Map<string, ErrorCode>([
   ["Failed to delete sandbox", "sandbox_stop_failed"],
   [
@@ -85,7 +111,7 @@ const RECOVERY_PARTIAL_RESULT_ERRORS = new Map<string, ErrorCode>([
 ]);
 
 export interface ManagedDedicatedCanaryDiagnostic {
-  schemaVersion: 2;
+  schemaVersion: 3;
   targetCount: 1;
   sandbox: {
     status: string;
@@ -103,6 +129,7 @@ export interface ManagedDedicatedCanaryDiagnostic {
     errorCode: ErrorCode;
     recoveryCode: RecoveryCode;
     resultErrorCode: ErrorCode;
+    unclassifiedProfile: UnclassifiedErrorProfile | null;
     scheduledFor: string;
     startedAt: string | null;
     completedAt: string | null;
@@ -203,6 +230,66 @@ function classifyTerminalFailure(
   return null;
 }
 
+function buildUnclassifiedErrorProfile(
+  value: string,
+): UnclassifiedErrorProfile {
+  const lengthBucket: ErrorLengthBucket =
+    value.length <= 64
+      ? "1_64"
+      : value.length <= 128
+        ? "65_128"
+        : value.length <= 256
+          ? "129_256"
+          : value.length <= 512
+            ? "257_512"
+            : "513_2000";
+  const writerHints = {
+    jobRunnerLike: false,
+    deleteLifecycleLike: false,
+    persistenceLike: false,
+    containerRuntimeLike: false,
+    transportLike: false,
+  };
+  // Exact prefixes and first-match precedence keep this diagnostic useful
+  // without turning arbitrary operator text into a fingerprinting channel.
+  if (
+    /^job agent_delete\b/.test(value) ||
+    /^Invalid agent delete job data for job /.test(value) ||
+    /^Organization ID mismatch: job\.data\.organizationId /.test(value) ||
+    /^Job not found: /.test(value)
+  ) {
+    writerHints.jobRunnerLike = true;
+  } else if (
+    /^(?:Agent deletion intent was not persisted|Deletion |Failed to delete\b|Unknown agent_delete failure$)/.test(
+      value,
+    )
+  ) {
+    writerHints.deleteLifecycleLike = true;
+  } else if (
+    /^(?:Failed query:|Database |PGlite |Postgres |PostgresError:|PostgreSQL |SQL |Transaction |Deadlock )/.test(
+      value,
+    )
+  ) {
+    writerHints.persistenceLike = true;
+  } else if (
+    /^(?:Docker |SSH |Headscale |Sandbox provider |Container runtime )/.test(
+      value,
+    )
+  ) {
+    writerHints.containerRuntimeLike = true;
+  } else if (
+    /^(?:fetch |Fetch |connect |Connect |connection |Connection |getaddrinfo |socket |Socket |ECONNRESET\b|ECONNREFUSED\b|ENETDOWN\b|ENETUNREACH\b|EHOSTUNREACH\b|ETIMEDOUT\b)/.test(
+      value,
+    )
+  ) {
+    writerHints.transportLike = true;
+  }
+  return {
+    lengthBucket,
+    writerHints,
+  };
+}
+
 function timestamp(
   value: unknown,
   label: string,
@@ -217,17 +304,22 @@ function timestamp(
   return new Date(value).toISOString();
 }
 
-function classifyError(value: unknown, label: string): ErrorCode {
+function classifyError(
+  value: unknown,
+  label: string,
+  allowUnclassified = false,
+): ErrorCode {
   if (value === null) return "none";
   if (typeof value !== "string" || value.length === 0 || value.length > 2_000) {
     throw new Error(`${label} must be a bounded string or null`);
   }
-  const permanentDelete =
-    /^Deletion permanently failed after [1-9][0-9]* attempts: (.+)$/.exec(
-      value,
-    );
+  const permanentDelete = PERMANENT_DELETE_PATTERN.exec(value);
   if (permanentDelete)
-    return classifyError(permanentDelete[1], `${label} cause`);
+    return classifyError(
+      permanentDelete[1],
+      `${label} cause`,
+      allowUnclassified,
+    );
   const terminalFailure = classifyTerminalFailure(value);
   if (terminalFailure) return terminalFailure.code;
   if (
@@ -271,7 +363,28 @@ function classifyError(value: unknown, label: string): ErrorCode {
     return "database_failed";
   }
   if (TIMEOUT_ERROR_PATTERN.test(value)) return "timeout";
+  if (allowUnclassified) return "unclassified";
   throw new Error(`${label} is not covered by the privacy-safe classifier`);
+}
+
+function classifyJobError(
+  value: unknown,
+  label: string,
+  allowUnclassified: boolean,
+): JobErrorClassification {
+  if (value === null)
+    return { code: "none", unclassifiedProfile: null };
+  if (typeof value !== "string" || value.length === 0 || value.length > 2_000) {
+    throw new Error(`${label} must be a bounded string or null`);
+  }
+  const code = classifyError(value, label, allowUnclassified);
+  return {
+    code,
+    unclassifiedProfile:
+      code === "unclassified"
+        ? buildUnclassifiedErrorProfile(value)
+        : null,
+  };
 }
 
 function classifyRecovery(
@@ -415,9 +528,14 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
         ? classifyTerminalFailure(job.error)
         : null;
     const recovery = classifyRecovery(job.error, `jobs[${index}].error`);
-    const jobErrorCode = recovery
-      ? "none"
-      : classifyError(job.error, `jobs[${index}].error`);
+    const jobError = recovery
+      ? { code: "none" as const, unclassifiedProfile: null }
+      : classifyJobError(
+          job.error,
+          `jobs[${index}].error`,
+          index === 0,
+        );
+    const jobErrorCode = jobError.code;
     let containerStopped: boolean | null = null;
     let rowDeleted: boolean | null = null;
     let resultErrorCode: ErrorCode = "none";
@@ -521,6 +639,32 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     ) {
       throw new Error(`jobs[${index}] recovery result is not a partial failure`);
     }
+    if (
+      jobErrorCode === "unclassified" &&
+      (job.status === "completed" ||
+        job.status === "cancelled" ||
+        startedAt === null ||
+        completedAt !== null ||
+        attempts === 0 ||
+        (job.status === "failed"
+          ? attempts !== maxAttempts
+          : attempts >= maxAttempts))
+    ) {
+      throw new Error(`jobs[${index}] unclassified lifecycle is inconsistent`);
+    }
+    if (
+      jobErrorCode === "unclassified" &&
+      job.result !== null &&
+      (containerStopped !== false ||
+        rowDeleted !== false ||
+        typeof resultErrorValue !== "string" ||
+        RECOVERY_PARTIAL_RESULT_ERRORS.get(resultErrorValue) !==
+          resultErrorCode)
+    ) {
+      throw new Error(
+        `jobs[${index}] unclassified result is not a partial failure`,
+      );
+    }
     if (rowDeleted === true && containerStopped !== true) {
       throw new Error(
         `jobs[${index}] deleted a row without a stopped container`,
@@ -557,6 +701,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
       containerStopped,
       rowDeleted,
       errorCode: jobErrorCode,
+      unclassifiedProfile: jobError.unclassifiedProfile,
       recoveryCode: recovery?.code ?? "none",
       resultErrorCode,
       scheduledFor,
@@ -583,7 +728,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
   }
 
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     targetCount: 1,
     sandbox: {
       status: agent.status,


### PR DESCRIPTION
# Relates to

Closes #17191. Supports the bounded diagnosis for #17184.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Based on exact `origin/develop` `7904e2abcdf22337e05d4b454c7ef6623136b59c`; zero conflicts and 0 commits behind at push time.
- [x] `bun run verify` passes post-sync: 578/578 Turbo tasks plus repository audits.

# Risks

Low. This changes only the read-only admin diagnostic classifier and its tests. It does not alter SQL, the diagnostic workflow, Cloud state, delete/retry behavior, deployment, or devices. The principal risk is accidental disclosure of an unclassified error; the implementation therefore emits only a fixed-schema length bucket and one-hot-or-none source-owned writer hints, while retaining all existing forbidden-output scans and fail-closed boundaries.

# Background

## What does this PR do?

The staging canary diagnostic correctly stopped when the newest delete job contained an error not covered by its privacy-safe classifier. This PR adds a deliberately coarse `unclassified` profile for that one field only:

- known classifiers still run first;
- only `jobs[0].error` may use the fallback;
- no raw text, normalized text, hash, substring, identifier, or secret is emitted;
- output contains only a bounded length bucket and one-hot-or-none fixed writer hints;
- malformed recovery, sandbox errors, `result.error`, and older job errors still fail closed;
- impossible job/status/result combinations still fail closed.

The workflow and SQL query are byte-identical to the base.

## What kind of change is this?

Bug fix (non-breaking diagnostic observability fix).

# Documentation changes needed?

No project documentation change is required. The fixed output contract and privacy invariants are documented and exhaustively tested in the diagnostic module.

# Testing

## Where should a reviewer start?

- `packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts`
- `packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts`

## Detailed testing steps

1. Run:
   `bun test packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts`
2. Verify 153 tests / 245 assertions pass.
3. Run:
   `bunx --bun biome@2.5.5 check packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts`
4. Run `actionlint`, `git diff --check`, and `bun run verify`.
5. Inspect the adversarial fixtures: malicious raw bytes must not occur anywhere in serialized output, while known, malformed, non-latest, sandbox, and result-error cases preserve their prior behavior.

Additional exact-object review:

- Two independent reviewers returned PASS/no P0 or P1 on exact head `616543d6b935e6644fac71620c39155962b6ee0e`, tree `458f42aa74c9d0987b7690af863812648cd2506d`.
- Combined diff SHA-256: `93ff6c1a1c26711c9c5e93e58159127d3aa9f93b16ce0c0950320f06dde5a87a`.
- Stable patch ID: `46912a945ebb53ee4ae305dd6d5d071b9af89da8`.

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - read-only CLI/admin diagnostic; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - read-only CLI/admin diagnostic; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow.
<!-- evidence-row:backend-logs -->
- [x] [Read-only workflow run 30228347794](https://github.com/elizaOS/eliza/actions/runs/30228347794) exercised the real staging query and stopped at the exact privacy boundary: `jobs[0].error is not covered by the privacy-safe classifier`. It uploaded no artifact and performed no delete, retry, or staging mutation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the pre-fix real run intentionally produced no artifact because the classifier failed closed. After merge, one bounded read-only diagnostic run will validate the new fixed-schema artifact; it will not retry deletion.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

Backend: run `30228347794` proved the real query path and exact fail-closed boundary. Raw database/error content was not printed, extracted, or uploaded.

Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - non-UI diagnostic-only change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- No live post-change staging artifact is attached before merge because the workflow must execute trusted code from the target branch after review/merge. The bounded follow-up is exactly one read-only diagnostic dispatch.
- That follow-up will stop again if the unknown value is outside the newly reviewed `jobs[0].error` boundary.
- No delete retry, global image pin, manual database write, deployment, or device action is part of this PR.
