### PR TITLE
fix(cloud): sanitize bounded canary job history

### DIFF
--- a/.github/workflows/managed-dedicated-canary.yml
+++ b/.github/workflows/managed-dedicated-canary.yml
@@ -294,6 +294,13 @@ jobs:
           PGOPTIONS: -c default_transaction_read_only=on -c statement_timeout=20000
         run: |
           set -euo pipefail
+          raw_ready=false
+          cleanup_incomplete_raw() {
+            if [[ "$raw_ready" != true ]]; then
+              rm -f -- "$CANARY_DIAGNOSTIC_RAW_PATH"
+            fi
+          }
+          trap cleanup_incomplete_raw EXIT
           if [[ ! "$CANARY_DIAGNOSTIC_SUFFIX" =~ ^r[1-9][0-9]{7,19}a[1-9][0-9]{0,3}$ ]]; then
             echo "::error::Diagnostic suffix is invalid."
             exit 1
@@ -401,16 +408,17 @@ jobs:
           );
           COMMIT;
           SQL
+          raw_ready=true
 
       - name: Classify privacy-safe diagnostic
         shell: bash
         run: |
           set -euo pipefail
+          trap 'rm -f -- "$CANARY_DIAGNOSTIC_RAW_PATH"' EXIT
           bun run packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts \
             "$CANARY_DIAGNOSTIC_SUFFIX" \
             "$CANARY_DIAGNOSTIC_RAW_PATH" \
             "$CANARY_DIAGNOSTIC_EVIDENCE_PATH"
-          rm -f "$CANARY_DIAGNOSTIC_RAW_PATH"
 
       - name: Upload privacy-safe diagnostic
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -113,6 +113,28 @@ function unclassifiedLatestJobInput(error: unknown): Record<string, unknown> {
   return input;
 }
 
+function boundedHistoryInput(errors: unknown[]): Record<string, unknown> {
+  if (errors.length === 0) {
+    return { ...failedDeleteInput(), jobs: [] };
+  }
+  const input = unclassifiedLatestJobInput(errors[0]);
+  const [template] = input.jobs as Record<string, unknown>[];
+  input.jobs = errors.map((error, index) => {
+    const offset = index * 60_000;
+    const shift = (value: string) =>
+      new Date(Date.parse(value) - offset).toISOString();
+    return {
+      ...template,
+      error,
+      scheduledFor: shift(template.scheduledFor as string),
+      startedAt: shift(template.startedAt as string),
+      createdAt: shift(template.createdAt as string),
+      updatedAt: shift(template.updatedAt as string),
+    };
+  });
+  return input;
+}
+
 describe("managed dedicated canary diagnostic", () => {
   test("emits only the classified lifecycle facts needed for retry decisions", () => {
     const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
@@ -392,6 +414,73 @@ describe("managed dedicated canary diagnostic", () => {
     }
   });
 
+  test("never publishes malicious input from any bounded history position", () => {
+    const malicious = [
+      "opaque https://u:p@example.test/a?q=secret#frag 192.0.2.44 ",
+      "55f332f8-da54-4c53-952c-a38f5f01287b Bearer eyJ.abc.sig ",
+      `${SUFFIX} sha256:deadbeef api_key=password ::error::`,
+      "$" + "{{secrets.X}}\r\n\t\u0000\u001b[31m\u202e\u200b\u0301\u0430\ud800",
+    ].join("");
+    const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
+      JSON.stringify(boundedHistoryInput([malicious, malicious, malicious])),
+      SUFFIX,
+    );
+    const evidence = JSON.parse(canonical);
+
+    expect(evidence.jobs).toHaveLength(3);
+    expect(
+      evidence.jobs.every(
+        (job: Record<string, unknown>) =>
+          job.errorCode === "unclassified" && job.unclassifiedProfile !== null,
+      ),
+    ).toBe(true);
+    for (const forbidden of [
+      "example.test",
+      "192.0.2.44",
+      "55f332f8",
+      "Bearer",
+      SUFFIX,
+      "sha256",
+      "deadbeef",
+      "api_key",
+      "::error::",
+      "secrets.X",
+      "opaque",
+    ]) {
+      expect(canonical).not.toContain(forbidden);
+    }
+  });
+
+  test.each([0, 1, 2])(
+    "keeps equal-shape secrets indistinguishable at history index %i",
+    (index) => {
+      const leftErrors = ["opaque neutral", "opaque neutral", "opaque neutral"];
+      const rightErrors = [...leftErrors];
+      leftErrors[index] = "job agent_delete secret-AAAA";
+      rightErrors[index] = "job agent_delete secret-BBBB";
+      const left = sanitizeManagedDedicatedCanaryDiagnostic(
+        boundedHistoryInput(leftErrors),
+        SUFFIX,
+      ).jobs[index]?.unclassifiedProfile;
+      const right = sanitizeManagedDedicatedCanaryDiagnostic(
+        boundedHistoryInput(rightErrors),
+        SUFFIX,
+      ).jobs[index]?.unclassifiedProfile;
+
+      expect(JSON.stringify(left)).toBe(JSON.stringify(right));
+    },
+  );
+
+  test("uses fixed UTF-16 buckets at nonzero history positions", () => {
+    const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
+      boundedHistoryInput(["x".repeat(64), "x".repeat(65), "😀".repeat(257)]),
+      SUFFIX,
+    );
+    expect(
+      evidence.jobs.map((job) => job.unclassifiedProfile?.lengthBucket ?? null),
+    ).toEqual(["1_64", "65_128", "513_2000"]);
+  });
+
   test.each([
     [
       "completed status",
@@ -517,43 +606,111 @@ describe("managed dedicated canary diagnostic", () => {
     ).toThrow();
   });
 
-  test("keeps older unknown job errors fail-closed", () => {
-    const input = failedDeleteInput();
-    const [latest] = input.jobs as Record<string, unknown>[];
-    input.jobs = [
-      latest,
-      {
-        ...latest,
-        error: "opaque older failure",
-        result: null,
-        completedAt: null,
-        createdAt: "2026-07-26T23:07:09.000Z",
-      },
-    ];
-    expect(() =>
-      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
-    ).toThrow("privacy-safe classifier");
+  test.each([0, 1, 2])(
+    "keeps an unknown result error fail-closed at history index %i",
+    (index) => {
+      const input = boundedHistoryInput([
+        "opaque failure",
+        "opaque failure",
+        "opaque failure",
+      ]);
+      (input.jobs as Record<string, unknown>[])[index].result = {
+        containerStopped: false,
+        rowDeleted: false,
+        error: "opaque result",
+      };
+      expect(() =>
+        sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+      ).toThrow("privacy-safe classifier");
+    },
+  );
+
+  test.each([1, 2])(
+    "rejects malformed recovery provenance at history index %i",
+    (index) => {
+      const errors = [
+        "opaque latest failure",
+        "opaque historical failure",
+        "opaque oldest failure",
+      ];
+      errors[index] = "Job timed out - recovered  for retry (attempt 1/3)";
+      const input = boundedHistoryInput(errors);
+      const job = (input.jobs as Record<string, unknown>[])[index];
+      job.status = "pending";
+      job.attempts = 1;
+
+      expect(() =>
+        sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
+      ).toThrow("malformed recovery provenance");
+    },
+  );
+
+  test.each([
+    [["opaque 0", "Failed to delete sandbox", "Failed to delete sandbox"], [0]],
+    [["Failed to delete sandbox", "opaque 1", "Failed to delete sandbox"], [1]],
+    [["Failed to delete sandbox", "Failed to delete sandbox", "opaque 2"], [2]],
+    [
+      ["opaque 0", "opaque 1", "Failed to delete sandbox"],
+      [0, 1],
+    ],
+    [
+      ["opaque 0", "Failed to delete sandbox", "opaque 2"],
+      [0, 2],
+    ],
+    [
+      ["Failed to delete sandbox", "opaque 1", "opaque 2"],
+      [1, 2],
+    ],
+    [
+      ["opaque 0", "opaque 1", "opaque 2"],
+      [0, 1, 2],
+    ],
+  ])(
+    "profiles only the unknown errors in a bounded history: %j",
+    (errors, expectedIndexes) => {
+      const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
+        boundedHistoryInput(errors),
+        SUFFIX,
+      );
+      expect(evidence.jobs).toHaveLength(3);
+      for (const [index, job] of evidence.jobs.entries()) {
+        const isUnclassified = expectedIndexes.includes(index);
+        expect(job.errorCode).toBe(
+          isUnclassified ? "unclassified" : "sandbox_stop_failed",
+        );
+        expect(job.unclassifiedProfile === null).toBe(!isUnclassified);
+      }
+    },
+  );
+
+  test("keeps all known historical errors classified without profiles", () => {
+    const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
+      boundedHistoryInput([
+        "Failed to delete sandbox",
+        "Agent provisioning is in progress",
+        "database connection failed",
+      ]),
+      SUFFIX,
+    );
+    expect(
+      evidence.jobs.map(({ errorCode, unclassifiedProfile }) => ({
+        errorCode,
+        unclassifiedProfile,
+      })),
+    ).toEqual([
+      { errorCode: "sandbox_stop_failed", unclassifiedProfile: null },
+      { errorCode: "provisioning_in_progress", unclassifiedProfile: null },
+      { errorCode: "database_failed", unclassifiedProfile: null },
+    ]);
   });
 
-  test("emits at most one profile when older jobs are classified", () => {
-    const input = unclassifiedLatestJobInput("opaque latest failure");
-    const [latest] = input.jobs as Record<string, unknown>[];
-    input.jobs = [
-      latest,
-      {
-        ...latest,
-        error: "Failed to delete sandbox",
-        result: {
-          containerStopped: false,
-          rowDeleted: false,
-          error: "Failed to delete sandbox",
-        },
-        createdAt: "2026-07-26T23:07:09.000Z",
-      },
-    ];
-    const evidence = sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX);
-    expect(evidence.jobs[0]?.unclassifiedProfile).not.toBeNull();
-    expect(evidence.jobs[1]?.unclassifiedProfile).toBeNull();
+  test.each([0, 4])("rejects a %i-job history", (count) => {
+    expect(() =>
+      sanitizeManagedDedicatedCanaryDiagnostic(
+        boundedHistoryInput(Array.from({ length: count }, () => "opaque")),
+        SUFFIX,
+      ),
+    ).toThrow("one to three");
   });
 
   test("keeps an unknown sandbox error fail-closed", () => {
@@ -1386,6 +1543,38 @@ describe("managed dedicated canary diagnostic", () => {
     expect(workflow).toContain(
       "WHERE agent_name = 'managed-dedicated-canary-' || :'suffix'",
     );
+    expect(workflow).toContain("ORDER BY jobs.created_at DESC, jobs.id DESC");
+    expect(workflow).toContain("LIMIT 3");
+    expect(workflow).toContain("trap cleanup_incomplete_raw EXIT");
+    expect(workflow).toContain(
+      "trap 'rm -f -- \"$CANARY_DIAGNOSTIC_RAW_PATH\"' EXIT",
+    );
+    const queryCleanupFunction = workflow.indexOf("cleanup_incomplete_raw() {");
+    const queryCleanupTrap = workflow.indexOf(
+      "trap cleanup_incomplete_raw EXIT",
+    );
+    const queryExecution = workflow.indexOf('psql "$PSQL_DATABASE_URL"');
+    const queryCompletion = workflow.indexOf("raw_ready=true");
+    const classifyStep = workflow.indexOf(
+      "- name: Classify privacy-safe diagnostic",
+    );
+    const classifyCleanupTrap = workflow.indexOf(
+      "trap 'rm -f -- \"$CANARY_DIAGNOSTIC_RAW_PATH\"' EXIT",
+    );
+    const classifierExecution = workflow.indexOf(
+      "bun run packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts",
+    );
+    const uploadStep = workflow.indexOf(
+      "- name: Upload privacy-safe diagnostic",
+    );
+    expect(queryCleanupFunction).toBeGreaterThanOrEqual(0);
+    expect(queryCleanupFunction).toBeLessThan(queryCleanupTrap);
+    expect(queryCleanupTrap).toBeLessThan(queryExecution);
+    expect(queryExecution).toBeLessThan(queryCompletion);
+    expect(queryCompletion).toBeLessThan(classifyStep);
+    expect(classifyStep).toBeLessThan(classifyCleanupTrap);
+    expect(classifyCleanupTrap).toBeLessThan(classifierExecution);
+    expect(classifierExecution).toBeLessThan(uploadStep);
     expect(workflow).toContain("inputs.diagnose_stale_canary_suffix == ''");
     expect(workflow).toContain(
       "bun run packages/scripts/cloud/admin/managed-dedicated-canary.ts",

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -359,13 +359,12 @@ function classifyError(
 function classifyJobError(
   value: unknown,
   label: string,
-  allowUnclassified: boolean,
 ): JobErrorClassification {
   if (value === null) return { code: "none", unclassifiedProfile: null };
   if (typeof value !== "string" || value.length === 0 || value.length > 2_000) {
     throw new Error(`${label} must be a bounded string or null`);
   }
-  const code = classifyError(value, label, allowUnclassified);
+  const code = classifyError(value, label, true);
   return {
     code,
     unclassifiedProfile:
@@ -476,9 +475,9 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
   if (
     !Array.isArray(root.jobs) ||
     root.jobs.length < 1 ||
-    root.jobs.length > 5
+    root.jobs.length > 3
   ) {
-    throw new Error("jobs must contain one to five newest-first records");
+    throw new Error("jobs must contain one to three newest-first records");
   }
 
   let previousCreatedAt = Number.POSITIVE_INFINITY;
@@ -514,7 +513,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     const recovery = classifyRecovery(job.error, `jobs[${index}].error`);
     const jobError = recovery
       ? { code: "none" as const, unclassifiedProfile: null }
-      : classifyJobError(job.error, `jobs[${index}].error`, index === 0);
+      : classifyJobError(job.error, `jobs[${index}].error`);
     const jobErrorCode = jobError.code;
     let containerStopped: boolean | null = null;
     let rowDeleted: boolean | null = null;


### PR DESCRIPTION
# Relates to

Fixes #17197. Supports the bounded diagnosis for #17184 without changing delete behavior.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop`.
- [x] `bun run install:light` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the evidence below.

# Sync with develop

- [x] Based on exact `origin/develop` `e194c8a0f77cc24be735417571c61402610cbd56`; zero conflicts and zero commits behind at freeze time.
- [x] `bun run verify` passes on the exact final object: 578/578 Turbo tasks plus all repository follow-on audits.

# Risks

Low and bounded. This changes only the read-only admin diagnostic sanitizer, its workflow cleanup, and tests. It does not alter production delete/retry behavior, widen the SQL target, change permissions, deploy code, or touch devices.

The disclosure surface is deliberately finite: at most three newest-first job-error profiles, each selected from five fixed length buckets and six mutually exclusive writer-hint states. The total maximum channel is approximately 14.72 bits. Known and recovery classifiers run first; sandbox errors, `result.error`, malformed recovery, impossible lifecycle states, and out-of-contract envelopes still fail closed.

# Background

## What does this PR do?

The first post-#17196 read-only run correctly stopped because the historical `jobs[1].error` was outside the one-field fallback. The SQL already returns exactly the newest three delete jobs because that history is required to distinguish an unresolved orphan from its recovery attempts.

This PR:

- aligns the parser with that exact one-to-three-job contract;
- permits the same fixed-schema coarse profile for `jobs[0..2].error`;
- retains every stricter classifier and semantic invariant;
- proves raw values, identifiers, URLs, IPs, digests, credentials, workflow commands, control bytes, and malicious Unicode cannot reach canonical output;
- cleans partial raw query output on query failure and always removes raw input after classifier success or failure;
- binds cleanup/query/classification/upload statement ordering in tests.

No raw, normalized, hashed, or substring-derived error material is emitted.

## What kind of change is this?

Bug fix for read-only operational diagnostics.

# Documentation changes needed?

No project documentation change is required. The fixed schema, bounded-history rationale, privacy budget, and failure boundaries are encoded in the sanitizer and adversarial contract tests.

# Testing

## Where should a reviewer start?

- `packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts`
- `packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts`
- `.github/workflows/managed-dedicated-canary.yml`

## Detailed testing steps

1. Run `bun test packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts`.
2. Confirm 171/171 tests and 328 assertions pass, with 100% function coverage and 95.04% sanitizer line coverage.
3. Run pinned Biome 2.5.5 on the two TypeScript files.
4. Run `actionlint .github/workflows/managed-dedicated-canary.yml`.
5. Run `git diff --check` and `bun run verify`.

Exact-object proof:

- Commit: `d0b7ccd7e1c73859d547418e64753f81673c3bd2`
- Tree: `57a44ac1c04470feed97b5df6c07ac21b17d2bef`
- Parent: `e194c8a0f77cc24be735417571c61402610cbd56`
- Binary diff SHA-256: `e98599013e98bb0c656e2b4907262dc1c2e9a938a2867e759b6d86d695611279`
- Stable patch ID: `88531adbfc9b52e963e022011b41f502660d8512`
- Two independent exact-object reviews: PASS, no P0/P1/P2.

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - read-only CLI/admin diagnostic; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - read-only CLI/admin diagnostic; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow.
<!-- evidence-row:backend-logs -->
- [x] [Read-only workflow run 30229973668](https://github.com/elizaOS/eliza/actions/runs/30229973668) exercised the exact newest-three-job query, skipped the mutation job, and stopped before upload at the historical-job privacy boundary. It produced no artifact and made no staging/delete/retry mutation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the real pre-fix run intentionally produced no artifact because the classifier failed closed. After merge, exactly one read-only dispatch will validate the bounded schema-v3 artifact or stop at a newly identified strict boundary.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

Backend: run `30229973668` proved the real read-only SQL path, newest-three history requirement, skipped mutation job, and exact fail-closed boundary. Raw database/error content was not printed, extracted, or uploaded.

Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - non-UI diagnostic-only change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- A live post-change artifact cannot be produced from trusted `develop` code before merge. The bounded follow-up is exactly one read-only workflow dispatch after merge.
- That follow-up will stop at any new strict boundary; it will not automatically redispatch.
- No delete retry, manual database write, global image pin, deployment, staging mutation, or device action is part of this PR.
