### PR TITLE
fix(benchmarks): comma-split run --benchmarks so the scheduled orchestrator lane parses its ID list

### DIFF
--- a/.github/workflows/benchmark-orchestrator-scheduled.yml
+++ b/.github/workflows/benchmark-orchestrator-scheduled.yml
@@ -124,7 +124,9 @@ jobs:
           MODEL: ${{ inputs.model || 'gemma-4-31b' }}
           PYTHONUNBUFFERED: "1"
         run: |
-          set -e
+          # pipefail so an orchestrator crash fails THIS step instead of being
+          # masked by tee and surfacing later as a confusing publishability error.
+          set -eo pipefail
           PYTHONPATH=packages python -m benchmarks.orchestrator run \
             --benchmarks "$BENCHMARKS" \
             --provider "$PROVIDER" \

--- a/packages/benchmarks/orchestrator/cli.py
+++ b/packages/benchmarks/orchestrator/cli.py
@@ -91,7 +91,17 @@ def _build_request(args: argparse.Namespace, adapters: dict[str, Any]) -> RunReq
     if args.all:
         benchmarks = tuple(sorted(adapters.keys()))
     elif args.benchmarks:
-        benchmarks = tuple(args.benchmarks)
+        # Each nargs item may itself be comma-separated (same contract as
+        # --harnesses/--adapters), e.g. --benchmarks "bfcl,mint" tau_bench.
+        split = [
+            part.strip()
+            for item in args.benchmarks
+            for part in str(item).split(",")
+            if part.strip()
+        ]
+        if not split:
+            raise SystemExit("--benchmarks must be a non-empty list of benchmark IDs")
+        benchmarks = tuple(dict.fromkeys(split))
     else:
         benchmarks = tuple(sorted(adapters.keys()))
 
@@ -1244,7 +1254,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--benchmarks",
         nargs="+",
         default=None,
-        help="Benchmark IDs to run (default: all)",
+        help="Benchmark IDs to run (space- or comma-separated; default: all)",
     )
     p_run.add_argument("--agent", default="eliza", help="Agent label for this run")
     p_run.add_argument(

--- a/packages/benchmarks/orchestrator/tests/test_cli_benchmark_selection.py
+++ b/packages/benchmarks/orchestrator/tests/test_cli_benchmark_selection.py
@@ -1,0 +1,43 @@
+"""Covers benchmark selection forms used by operators and scheduled runs."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.orchestrator import cli
+
+ADAPTERS = {"bfcl": object(), "mint": object(), "tau_bench": object()}
+
+
+def _run_args(argv: list[str]):
+    return cli.build_parser().parse_args(["run", *argv])
+
+
+def test_comma_joined_single_token_splits() -> None:
+    args = _run_args(["--benchmarks", "bfcl,mint,tau_bench"])
+    request = cli._build_request(args, ADAPTERS)
+    assert request.benchmarks == ("bfcl", "mint", "tau_bench")
+
+
+def test_space_separated_tokens_still_work() -> None:
+    args = _run_args(["--benchmarks", "bfcl", "mint"])
+    request = cli._build_request(args, ADAPTERS)
+    assert request.benchmarks == ("bfcl", "mint")
+
+
+def test_mixed_tokens_split_dedupe_and_strip() -> None:
+    args = _run_args(["--benchmarks", "bfcl, mint", "tau_bench,bfcl"])
+    request = cli._build_request(args, ADAPTERS)
+    assert request.benchmarks == ("bfcl", "mint", "tau_bench")
+
+
+def test_all_flag_ignores_benchmarks_selection() -> None:
+    args = _run_args(["--all", "--benchmarks", "mint"])
+    request = cli._build_request(args, ADAPTERS)
+    assert request.benchmarks == ("bfcl", "mint", "tau_bench")
+
+
+def test_empty_selection_rejected() -> None:
+    args = _run_args(["--benchmarks", ",", " "])
+    with pytest.raises(SystemExit):
+        cli._build_request(args, ADAPTERS)


### PR DESCRIPTION
## What

`Benchmark orchestrator (scheduled)` has failed every Monday since Jul 6 (runs #2–#5). The workflow passes its benchmark list as one comma-joined string:

```yaml
BENCHMARKS: bfcl,action-calling,agentbench,tau_bench,mint,context_bench
...
--benchmarks "$BENCHMARKS"
```

but the `run` subcommand's `--benchmarks` is `nargs="+"` with no comma handling, so the entire string reaches `run_benchmarks` as a **single** benchmark ID:

<details><summary>Traceback from run 30245846419 (Jul 27)</summary>

```
File ".../packages/benchmarks/orchestrator/runner.py", line 3008, in run_benchmarks
  raise ValueError(f"Unknown benchmark IDs: {', '.join(sorted(missing))}")
ValueError: Unknown benchmark IDs: bfcl,action-calling,agentbench,tau_bench,mint,context_bench
```
(one fused token — note no `', '` separators)

</details>

The lane has never actually run green: the Jun 29 "success" (run #1) was a vacuous skip on the missing `GROQ_API_KEY` secret. #11196 (Jul 2) switched the gate to `CEREBRAS_API_KEY`, which *is* configured, so the lane started really executing on Jul 6 — and crashed instantly every week since. The crash itself was attributed to the wrong step because `python ... | tee` under plain `set -e` masks python's exit code; the failure only surfaced later as a confusing `missing_latest_dir` publishability error.

## Fix

- `_build_request` now splits each `--benchmarks` nargs token on commas (strip + dedupe, `SystemExit` on an empty result) — the same contract `--harnesses` and `--adapters` already honor, and what `review-all --benchmarks`'s help ("space- or comma-separated") already promises. This is the single choke point, so both `run` and `review-all` are fixed.
- `run --benchmarks` help text now documents "space- or comma-separated".
- The workflow's run step uses `set -eo pipefail` so an orchestrator crash fails its own step instead of being masked by `tee`.

## Evidence

**Repro through the real code path** (no key needed; `discover_adapters` → `run_benchmarks`):

```
$ PYTHONPATH=. python3 -m benchmarks.orchestrator run --benchmarks "fake-a,fake-b" --provider cerebras --model gemma-4-31b
# before: ValueError: Unknown benchmark IDs: fake-a,fake-b      (1 fused ID)
# after:  ValueError: Unknown benchmark IDs: fake-a, fake-b     (2 IDs, correctly split)
```

**All six scheduled IDs resolve as registered adapters** after the split:

```
$ PYTHONPATH=. python3 -m benchmarks.orchestrator list-benchmarks | grep -E "bfcl|action-calling|agentbench|tau_bench|mint|context_bench"
- action-calling   dir=action-calling     ...
- agentbench       dir=agentbench         ...
- bfcl             dir=bfcl               ...
- context_bench    dir=context-bench      ...
- mint             dir=mint               ...
- tau_bench        dir=tau-bench          ...
```

**Tests** — new `orchestrator/tests/test_cli_benchmark_selection.py` (comma-joined, space-separated, mixed w/ dedupe+strip, `--all` precedence, empty rejection) plus the existing cli-importing suites:

```
$ PYTHONPATH=. python3 -m pytest benchmarks/orchestrator/tests/test_cli_benchmark_selection.py benchmarks/orchestrator/tests/test_latest_{comparability,readiness,publishability}.py benchmarks/orchestrator/tests/test_review_package.py -q
63 passed in 0.28s
```

- Real-model trajectory: **N/A** — the crash happens during argv parsing, before any model call; the parse fix is fully exercised by the real-code-path repro above. The next scheduled Monday run (or a `workflow_dispatch`) is the live real-model proof of the lane end-to-end.
- Screenshots/video/frontend logs: **N/A** — CLI/CI-only change, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI and scheduled-workflow parser change; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI and scheduled-workflow parser change; no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction or rendered UI

<!-- evidence-row:backend-logs -->
- [x] [17203-pr17203-parser-tests.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17203-pr17203-parser-tests.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - failure and fix are confined to argv parsing before model invocation

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - parser/workflow control-flow fix produces no persistent domain artifact
