### PR TITLE
fix(registry): bump Wealthville plugin to 0.2.1

### DIFF
--- a/packages/registry/entries/third-party/wealthville__plugin-wealthville.json
+++ b/packages/registry/entries/third-party/wealthville__plugin-wealthville.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "Wealthville liquidity-pool scores, ENTER/HOLD/EXIT verdicts, and public miss-inclusive track record for DeFi agents (Solana + EVM).",
   "homepage": "https://wealthville.net/developers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "directory": "elizaos-plugin",
   "tags": ["solana", "defi", "liquidity-pools", "scoring", "wealthville"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -571,7 +571,7 @@
         "repo": "@wealthville/plugin-wealthville",
         "v0": null,
         "v1": null,
-        "v2": "0.2.0"
+        "v2": "0.2.1"
       },
       "supports": {
         "v0": false,


### PR DESCRIPTION
## What

Recreates the safe two-line portion of #17166 directly on current `develop`, without that PRs diverged `main` history. Updates the source registry entry and generated wire registry for `@wealthville/plugin-wealthville` from `0.2.0` to `0.2.1`.

The published npm package was independently rebuilt from public upstream source commit `135504cf1d780bbb86595f61886022fcbe75b586`; JavaScript and declaration hashes matched the published `0.2.1` package. The release adds `agentConfig` metadata for the existing API URL/key configuration and does not add a new runtime authorization path.

## Validation

- `bun run --cwd packages/registry validate` — 30 entries validated
- `bun run --cwd packages/registry generate` — generated registry reproduced
- `bun run --cwd packages/registry test` — 33 passed
- `bun run --cwd packages/registry typecheck` — passed

<!-- evidence-row:before-screenshots -->
- [ ] N/A - registry metadata only; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - registry metadata only; no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or rendered UI path

<!-- evidence-row:backend-logs -->
- [ ] N/A - declarative registry data only; validation output is summarized above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or evaluator behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - registry metadata is the changed declarative source itself; no runtime domain artifact is produced