### PR TITLE
fix(ci): skip oversized Bun cache in bounded jobs

### DIFF
--- a/.github/workflows/feed-env-audit.yml
+++ b/.github/workflows/feed-env-audit.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454)
           install-command: bun install
+          # This cache can exceed a fresh install even on an exact key and
+          # consume the bounded job before the audit itself starts.
+          cache-bun-install: "false"
 
       - name: Env audit check
         run: bun run --cwd packages/feed env:audit:check

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile
+          # Fork lint is intentionally bounded; restoring the broad fallback
+          # can cost more than installing the exact lockfile dependency set.
+          cache-bun-install: "false"
 
       - name: Run anti-larp test gate self-test
         run: bun run audit:focused-tests:self-test


### PR DESCRIPTION
## What

Disables the Bun install cache in the two bounded jobs where restoring or saving the 1.609 GB cache costs more than a fresh dependency install:

- Env Audit (`10m` job), which timed out restoring an oversized exact-key Bun 1.3.14 cache before the audit ran
- Quality (Fork) lint (`15m` job), which restored a cross-version fallback cache, completed every assertion, then exceeded the job budget during cache cleanup

Bun setup, dependency installation, postinstall, generated data, symlink repair, and the separate Turbo cache are unchanged. Type Check and Build already use this opt-out for the same measured reason.

Exact head: `70f51ea4fef213e2c9b01b089818adfbd87f1761` (based directly on current `develop`).

## Evidence

- [Original Env Audit timeout in exact-key cache setup](https://github.com/elizaOS/eliza/actions/runs/30316732961/job/90149666332)
- [Original Quality lint completed assertions then timed out in post-cache cleanup](https://github.com/elizaOS/eliza/actions/runs/30316732971/job/90149663435)
- [Exact-head Env Audit](https://github.com/elizaOS/eliza/actions/runs/30320582334/job/90155427645)
- [Exact-head manual Quality (Fork) dispatch](https://github.com/elizaOS/eliza/actions/runs/30320627824): lint passed in 2m50s with the cache opt-out
- `actionlint .github/workflows/feed-env-audit.yml .github/workflows/quality-fork.yml` passes
- `git diff --check` passes

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI workflow behavior only; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI workflow behavior only; no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or rendered UI path

<!-- evidence-row:backend-logs -->
- [x] [Exact-head workflow logs](https://github.com/elizaOS/eliza/actions/runs/30320627824)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - workflow orchestration change produces no runtime domain artifact