### PR TITLE
fix(scheduling): deterministic local-time resolution across DST

### DIFF
--- a/plugins/plugin-scheduling/src/anchors/anchor-registry.test.ts
+++ b/plugins/plugin-scheduling/src/anchors/anchor-registry.test.ts
@@ -19,8 +19,8 @@ import {
 /**
  * Built-in LifeOps anchors resolve owner-window times into concrete fire
  * instants in the owner's timezone — the basis for `relative_to_anchor`
- * scheduling. The math must land on the correct UTC instant and degrade to
- * null on missing/invalid windows.
+ * scheduling. The math must land on the correct UTC instant, degrade to null
+ * only when a window is absent, and reject malformed supplied times.
  */
 
 const ctx = (
@@ -74,11 +74,17 @@ describe("built-in anchors", () => {
     });
   });
 
-  it("returns null on a missing window or malformed time", () => {
+  it("returns null for a missing window and a typed error for malformed time", () => {
     expect(anchor("morning.start").resolve(ctx({}))).toBeNull();
-    expect(
+    expect(() =>
       anchor("night.start").resolve(ctx({ eveningWindow: { start: "25:61" } })),
-    ).toBeNull();
+    ).toThrow(
+      expect.objectContaining({
+        code: "invalid_local_time",
+        reason: "malformed_hhmm",
+        localTime: "25:61",
+      }),
+    );
   });
 
   it("treats meeting.ended as event-driven (always null here)", () => {

--- a/plugins/plugin-scheduling/src/anchors/anchor-registry.ts
+++ b/plugins/plugin-scheduling/src/anchors/anchor-registry.ts
@@ -18,6 +18,7 @@
 
 import type { IAgentRuntime } from "@elizaos/core";
 import type { AnchorRegistry } from "../scheduled-task/consolidation-policy.js";
+import { resolveLocalHHMMToIso } from "../scheduled-task/local-time.js";
 import type {
   AnchorContext,
   AnchorContribution,
@@ -49,64 +50,10 @@ function nullableTimeAnchor(args: {
       const tz = context.ownerFacts.timezone ?? "UTC";
       const window = context.ownerFacts[windowKey];
       const value = edge === "start" ? window?.start : window?.end;
-      if (!value) return null;
-      return resolveLocalHHMM(context.nowIso, value, tz);
+      const atIso = resolveLocalHHMMToIso(new Date(context.nowIso), value, tz);
+      return atIso === null ? null : { atIso };
     },
   };
-}
-
-function resolveLocalHHMM(
-  nowIso: string,
-  hhmm: string,
-  tz: string,
-): { atIso: string } | null {
-  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(hhmm);
-  if (!match) return null;
-  const hour = Number.parseInt(match[1] ?? "0", 10);
-  const minute = Number.parseInt(match[2] ?? "0", 10);
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone: tz,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  const parts = formatter.formatToParts(new Date(nowIso));
-  const y = Number.parseInt(
-    parts.find((p) => p.type === "year")?.value ?? "1970",
-    10,
-  );
-  const mo = Number.parseInt(
-    parts.find((p) => p.type === "month")?.value ?? "01",
-    10,
-  );
-  const d = Number.parseInt(
-    parts.find((p) => p.type === "day")?.value ?? "01",
-    10,
-  );
-  const localDate = new Date(Date.UTC(y, mo - 1, d, hour, minute, 0));
-  const offsetFormatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz,
-    timeZoneName: "longOffset",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  const tzParts = offsetFormatter.formatToParts(localDate);
-  const offsetStr =
-    tzParts.find((p) => p.type === "timeZoneName")?.value ?? "GMT";
-  const offsetMatch = /GMT([+-]\d{1,2})(?::?(\d{2}))?/.exec(offsetStr);
-  let offsetMinutes = 0;
-  if (offsetMatch) {
-    const sign = offsetMatch[1]?.startsWith("-") ? -1 : 1;
-    const oh = Math.abs(Number.parseInt(offsetMatch[1] ?? "0", 10));
-    const om = Number.parseInt(offsetMatch[2] ?? "0", 10);
-    offsetMinutes = sign * (oh * 60 + om);
-  }
-  const atMs = localDate.getTime() - offsetMinutes * 60_000;
-  return { atIso: new Date(atMs).toISOString() };
 }
 
 const morningStartAnchor: AnchorContribution = nullableTimeAnchor({
@@ -137,7 +84,8 @@ const lunchStartAnchor: AnchorContribution = {
   },
   resolve(context) {
     const tz = context.ownerFacts.timezone ?? "UTC";
-    return resolveLocalHHMM(context.nowIso, "12:00", tz);
+    const atIso = resolveLocalHHMMToIso(new Date(context.nowIso), "12:00", tz);
+    return atIso === null ? null : { atIso };
   },
 };
 

--- a/plugins/plugin-scheduling/src/scheduled-task/consolidation-policy.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/consolidation-policy.ts
@@ -13,6 +13,7 @@
  * combined card; `sequential` staggers; `parallel` fires all at once.
  */
 
+import { resolveLocalHHMMToIso } from "./local-time.js";
 import type {
   AnchorConsolidationPolicy,
   AnchorContext,
@@ -70,69 +71,12 @@ export function createAnchorRegistry(): AnchorRegistry {
 
 function todayIsoWithLocalHHMM(
   nowIso: string,
-  hhmm: string,
+  hhmm: string | undefined,
   tz: string,
 ): { atIso: string } | null {
-  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(hhmm);
-  if (!match) return null;
-  const hour = Number.parseInt(match[1] ?? "0", 10);
-  const minute = Number.parseInt(match[2] ?? "0", 10);
-  // Start from the local-date string for the given tz, then construct an
-  // ISO that represents that local hour/minute.
-  try {
-    const formatter = new Intl.DateTimeFormat("en-CA", {
-      timeZone: tz,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-    const parts = formatter.formatToParts(new Date(nowIso));
-    const y = Number.parseInt(
-      parts.find((p) => p.type === "year")?.value ?? "1970",
-      10,
-    );
-    const mo = Number.parseInt(
-      parts.find((p) => p.type === "month")?.value ?? "01",
-      10,
-    );
-    const d = Number.parseInt(
-      parts.find((p) => p.type === "day")?.value ?? "01",
-      10,
-    );
-    // Build a UTC iso then offset by the tz offset from this date.
-    // Simplest correct approach: ask Intl for the offset minutes for this
-    // local datetime by formatting an offset.
-    const localDate = new Date(Date.UTC(y, mo - 1, d, hour, minute, 0));
-    // Compute the offset by formatting localDate in the tz and reading
-    // longOffset; fall back to UTC if not supported.
-    const offsetFormatter = new Intl.DateTimeFormat("en-US", {
-      timeZone: tz,
-      timeZoneName: "longOffset",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    const tzParts = offsetFormatter.formatToParts(localDate);
-    const offsetStr =
-      tzParts.find((p) => p.type === "timeZoneName")?.value ?? "GMT";
-    const offsetMatch = /GMT([+-]\d{1,2})(?::?(\d{2}))?/.exec(offsetStr);
-    let offsetMinutes = 0;
-    if (offsetMatch) {
-      const sign = offsetMatch[1]?.startsWith("-") ? -1 : 1;
-      const oh = Math.abs(Number.parseInt(offsetMatch[1] ?? "0", 10));
-      const om = Number.parseInt(offsetMatch[2] ?? "0", 10);
-      offsetMinutes = sign * (oh * 60 + om);
-    }
-    const atMs = localDate.getTime() - offsetMinutes * 60_000;
-    return { atIso: new Date(atMs).toISOString() };
-  } catch {
-    return null;
-  }
+  const atIso = resolveLocalHHMMToIso(new Date(nowIso), hhmm, tz);
+  return atIso === null ? null : { atIso };
 }
-
 const fallbackWakeConfirmedAnchor: AnchorContribution = {
   anchorKey: "wake.confirmed",
   describe: {
@@ -142,7 +86,6 @@ const fallbackWakeConfirmedAnchor: AnchorContribution = {
   resolve(context) {
     const tz = context.ownerFacts.timezone ?? "UTC";
     const start = context.ownerFacts.morningWindow?.start;
-    if (!start) return null;
     return todayIsoWithLocalHHMM(context.nowIso, start, tz);
   },
 };

--- a/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts
@@ -10,16 +10,22 @@
  *    (01:00:00Z). Fall-back: 2026-10-25 03:00 CEST -> 02:00 CET (01:00:00Z).
  *  - Australia/Lord_Howe fall-back: 2026-04-05 02:00 LHDT -> 01:30 LHST
  *    (15:00:00Z Apr 4). The repeated local span is 30 minutes, not an hour.
+ *    Spring-forward is 2026-10-04 02:00 LHST -> 02:30 LHDT
+ *    (15:30:00Z Oct 3), so the skipped span is also 30 minutes.
  *
- * Where behavior at a nonexistent/ambiguous local time is a judgment call the
- * tests PIN the current behavior with an explicit comment instead of
- * asserting an ideal; anything producing NaN/invalid dates would be a bug
- * (none found — asserted throughout via `Number.isFinite(Date.parse(...))`).
+ * Wall-clock anchors follow Temporal-compatible disambiguation: repeated times
+ * choose the earlier instant and skipped times move forward by the transition
+ * gap. Cron preserves its separately documented skip/dedupe semantics.
  */
 
 import { describe, expect, it } from "vitest";
 
+import {
+  createAnchorRegistry,
+  registerAppLifeOpsAnchors,
+} from "../anchors/anchor-registry.js";
 import { isScheduledTaskDue, markWindowFireIfNeeded } from "./due.js";
+import { InvalidLocalTimeError, resolveLocalHHMMToIso } from "./local-time.js";
 import { computeNextFireAt } from "./next-fire-at.js";
 import type {
   OwnerFactsView,
@@ -31,6 +37,8 @@ const MINUTE_MS = 60_000;
 const NY = "America/New_York";
 const BERLIN = "Europe/Berlin";
 const LORD_HOWE = "Australia/Lord_Howe";
+const SANTIAGO = "America/Santiago";
+const APIA = "Pacific/Apia";
 
 function makeTask(args: {
   trigger: ScheduledTaskTrigger;
@@ -103,11 +111,7 @@ describe("local HH:MM resolution at DST boundaries (relative_to_anchor)", () => 
     );
   }
 
-  it("NY spring-forward: nonexistent 02:30 maps FORWARD to 03:30 EDT (pinned)", async () => {
-    // 02:30 local does not exist on 2026-03-08. Current behavior: the
-    // offset is sampled at the wall-clock-as-UTC instant (still EST), so the
-    // result lands one hour after the requested wall time. Judgment call —
-    // pinned, not asserted as ideal. It is a valid instant, never NaN.
+  it("NY spring-forward: nonexistent 02:30 moves forward to 03:30 EDT", async () => {
     const iso = await resolveMorningStart(
       "2026-03-08T15:00:00.000Z",
       "02:30",
@@ -118,7 +122,7 @@ describe("local HH:MM resolution at DST boundaries (relative_to_anchor)", () => 
     expect(Number.isFinite(Date.parse(iso ?? ""))).toBe(true);
   });
 
-  it("NY fall-back: ambiguous 01:30 resolves to the FIRST (EDT) occurrence (pinned)", async () => {
+  it("NY fall-back: ambiguous 01:30 resolves to the first EDT occurrence", async () => {
     const iso = await resolveMorningStart(
       "2026-11-01T15:00:00.000Z",
       "01:30",
@@ -129,27 +133,44 @@ describe("local HH:MM resolution at DST boundaries (relative_to_anchor)", () => 
     expect(localHourMinute(iso ?? "", NY)).toBe("01:30");
   });
 
-  it("Berlin spring-forward: nonexistent 02:30 maps BACKWARD to 01:30 CET (pinned)", async () => {
-    // Asymmetric with NY: Berlin's wall-clock-as-UTC instant falls on the
-    // CEST side of the transition, so the result lands one hour BEFORE the
-    // requested wall time. Pinned current behavior; still a valid instant.
+  it("Berlin spring-forward: nonexistent 02:30 moves forward to 03:30 CEST", async () => {
     const iso = await resolveMorningStart(
       "2026-03-29T12:00:00.000Z",
       "02:30",
       BERLIN,
     );
-    expect(iso).toBe("2026-03-29T00:30:00.000Z");
-    expect(localHourMinute(iso ?? "", BERLIN)).toBe("01:30");
+    expect(iso).toBe("2026-03-29T01:30:00.000Z");
+    expect(localHourMinute(iso ?? "", BERLIN)).toBe("03:30");
   });
 
-  it("Berlin fall-back: ambiguous 02:30 resolves to the SECOND (CET) occurrence (pinned)", async () => {
+  it("Berlin fall-back: ambiguous 02:30 resolves to the first CEST occurrence", async () => {
     const iso = await resolveMorningStart(
       "2026-10-25T12:00:00.000Z",
       "02:30",
       BERLIN,
     );
-    expect(iso).toBe("2026-10-25T01:30:00.000Z");
+    expect(iso).toBe("2026-10-25T00:30:00.000Z");
     expect(localHourMinute(iso ?? "", BERLIN)).toBe("02:30");
+  });
+
+  it("Lord Howe spring-forward moves a skipped 02:15 by the 30-minute gap", async () => {
+    const iso = await resolveMorningStart(
+      "2026-10-04T06:00:00.000Z",
+      "02:15",
+      LORD_HOWE,
+    );
+    expect(iso).toBe("2026-10-03T15:45:00.000Z");
+    expect(localHourMinute(iso ?? "", LORD_HOWE)).toBe("02:45");
+  });
+
+  it("Lord Howe fall-back resolves repeated 01:45 to the first LHDT occurrence", async () => {
+    const iso = await resolveMorningStart(
+      "2026-04-05T06:00:00.000Z",
+      "01:45",
+      LORD_HOWE,
+    );
+    expect(iso).toBe("2026-04-04T14:45:00.000Z");
+    expect(localHourMinute(iso ?? "", LORD_HOWE)).toBe("01:45");
   });
 
   it("due evaluation agrees with the resolved instant on the NY spring-forward day", async () => {
@@ -175,6 +196,217 @@ describe("local HH:MM resolution at DST boundaries (relative_to_anchor)", () => 
     });
     expect(at.due).toBe(true);
     expect(at.occurrenceAtIso).toBe("2026-03-08T07:30:00.000Z");
+  });
+
+  it("distinguishes an absent time from a malformed supplied time", () => {
+    expect(
+      resolveLocalHHMMToIso(
+        new Date("2026-05-11T12:00:00.000Z"),
+        undefined,
+        "UTC",
+      ),
+    ).toBeNull();
+
+    for (const malformed of ["", "7:30", "24:00", "12:60", "noon"]) {
+      try {
+        resolveLocalHHMMToIso(
+          new Date("2026-05-11T12:00:00.000Z"),
+          malformed,
+          "UTC",
+        );
+        throw new Error(`expected ${JSON.stringify(malformed)} to fail`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidLocalTimeError);
+        expect(error).toMatchObject({
+          code: "invalid_local_time",
+          reason: "malformed_hhmm",
+          localTime: malformed,
+        });
+      }
+    }
+  });
+
+  it("returns a typed error for an invalid timezone", () => {
+    expect(() =>
+      resolveLocalHHMMToIso(
+        new Date("2026-05-11T12:00:00.000Z"),
+        "09:00",
+        "Mars/Olympus",
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: "invalid_local_time",
+        reason: "invalid_time_zone",
+        timeZone: "Mars/Olympus",
+      }),
+    );
+  });
+
+  it("does not silently replace a malformed bedtime with the default", async () => {
+    const task = makeTask({
+      trigger: {
+        kind: "relative_to_anchor",
+        anchorKey: "bedtime.target",
+        offsetMinutes: 0,
+      },
+    });
+    const context = {
+      now: new Date("2026-05-11T12:00:00.000Z"),
+      ownerFacts: { timezone: "UTC", eveningWindow: { end: "25:00" } },
+      anchors: null,
+    } satisfies Parameters<typeof computeNextFireAt>[1];
+
+    await expect(computeNextFireAt(task, context)).rejects.toMatchObject({
+      code: "invalid_local_time",
+      reason: "malformed_hhmm",
+      localTime: "25:00",
+    });
+    await expect(
+      isScheduledTaskDue(task, {
+        now: context.now,
+        ownerFacts: context.ownerFacts,
+      }),
+    ).rejects.toBeInstanceOf(InvalidLocalTimeError);
+  });
+
+  it("makes due evaluation and indexing reject the same malformed window", async () => {
+    const task = makeTask({
+      trigger: { kind: "during_window", windowKey: "morning" },
+    });
+    const ownerFacts: OwnerFactsView = {
+      timezone: "UTC",
+      morningWindow: { start: "not-a-time", end: "11:00" },
+    };
+
+    await expect(
+      computeNextFireAt(task, {
+        now: new Date("2026-05-11T12:00:00.000Z"),
+        ownerFacts,
+        anchors: null,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_local_time",
+      reason: "malformed_hhmm",
+      localTime: "not-a-time",
+    });
+    await expect(
+      isScheduledTaskDue(task, {
+        now: new Date("2026-05-11T12:00:00.000Z"),
+        ownerFacts,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_local_time",
+      reason: "malformed_hhmm",
+      localTime: "not-a-time",
+    });
+  });
+
+  it("still applies the bedtime default only when the owner fact is absent", async () => {
+    const iso = await computeNextFireAt(
+      makeTask({
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "bedtime.target",
+          offsetMinutes: 0,
+        },
+      }),
+      {
+        now: new Date("2026-05-11T12:00:00.000Z"),
+        ownerFacts: { timezone: "UTC" },
+        anchors: null,
+      },
+    );
+    expect(iso).toBe("2026-05-11T22:30:00.000Z");
+  });
+
+  it("uses the canonical resolver through the production anchor registry", async () => {
+    const anchors = createAnchorRegistry();
+    registerAppLifeOpsAnchors(anchors);
+    const iso = await computeNextFireAt(
+      makeTask({
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "morning.start",
+          offsetMinutes: 0,
+        },
+      }),
+      {
+        now: new Date("2026-09-06T12:00:00.000Z"),
+        ownerFacts: {
+          timezone: SANTIAGO,
+          morningWindow: { start: "00:00" },
+        },
+        anchors,
+      },
+    );
+    expect(iso).toBe("2026-09-06T04:00:00.000Z");
+    expect(localHourMinute(iso ?? "", SANTIAGO)).toBe("01:00");
+  });
+
+  it("does not let the production anchor registry swallow malformed local time", async () => {
+    const anchors = createAnchorRegistry();
+    registerAppLifeOpsAnchors(anchors);
+    await expect(
+      computeNextFireAt(
+        makeTask({
+          trigger: {
+            kind: "relative_to_anchor",
+            anchorKey: "morning.start",
+            offsetMinutes: 0,
+          },
+        }),
+        {
+          now: new Date("2026-05-11T12:00:00.000Z"),
+          ownerFacts: {
+            timezone: "UTC",
+            morningWindow: { start: "bad-time" },
+          },
+          anchors,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_local_time",
+      reason: "malformed_hhmm",
+      localTime: "bad-time",
+    });
+  });
+
+  it("Santiago 2026-09-06: compatible resolution advances skipped midnight to 01:00", () => {
+    const iso = resolveLocalHHMMToIso(
+      new Date("2026-09-05T16:00:00.000Z"),
+      "00:00",
+      SANTIAGO,
+      1,
+    );
+    expect(iso).toBe("2026-09-06T04:00:00.000Z");
+    expect(localDate(iso ?? "", SANTIAGO)).toBe("2026-09-06");
+    expect(localHourMinute(iso ?? "", SANTIAGO)).toBe("01:00");
+  });
+
+  it("indexes across Santiago's midnight transition without inventing 00:00", async () => {
+    const next = await computeNextFireAt(
+      makeTask({ trigger: { kind: "during_window", windowKey: "night" } }),
+      {
+        // 2026-09-05 23:30 CLT. The next local-day boundary is 01:00 CLST.
+        now: new Date("2026-09-06T03:30:00.000Z"),
+        ownerFacts: { timezone: SANTIAGO },
+        anchors: null,
+      },
+    );
+    expect(next).toBe("2026-09-06T04:00:00.000Z");
+    expect(localHourMinute(next ?? "", SANTIAGO)).toBe("01:00");
+  });
+
+  it("Apia's skipped 2011-12-30 resolves to the same wall time after the date jump", () => {
+    const iso = resolveLocalHHMMToIso(
+      new Date("2011-12-29T22:00:00.000Z"),
+      "06:00",
+      APIA,
+      1,
+    );
+    expect(iso).toBe("2011-12-30T16:00:00.000Z");
+    expect(localDate(iso ?? "", APIA)).toBe("2011-12-31");
+    expect(localHourMinute(iso ?? "", APIA)).toBe("06:00");
   });
 });
 
@@ -454,12 +686,7 @@ describe("during_window on DST transition days", () => {
     ]);
   });
 
-  it("PINNED: the next-fire-at index is one hour late for the window on the NY spring-forward day", async () => {
-    // `nextWindowStartIso` samples the tz offset at the wall-clock-as-UTC
-    // instant (still EST at 06:00Z), yielding 11:00Z = 07:00 EDT, while the
-    // authoritative due evaluation opens the window at 10:00Z = 06:00 EDT.
-    // The index is documented as approximate ("next candidate fire time");
-    // the tick still fires inside the 06:00-11:00 window, one hour late.
+  it("indexes the exact local window start across NY DST transitions", async () => {
     const facts: OwnerFactsView = {
       timezone: NY,
       morningWindow: { start: "06:00", end: "11:00" },
@@ -472,10 +699,9 @@ describe("during_window on DST transition days", () => {
         anchors: null,
       },
     );
-    expect(next).toBe("2026-03-08T11:00:00.000Z");
-    expect(localHourMinute(next ?? "", NY)).toBe("07:00");
+    expect(next).toBe("2026-03-08T10:00:00.000Z");
+    expect(localHourMinute(next ?? "", NY)).toBe("06:00");
 
-    // On the fall-back day the same computation is exact (06:00 EST).
     const fallBack = await computeNextFireAt(
       makeTask({ trigger: { kind: "during_window", windowKey: "morning" } }),
       {
@@ -486,5 +712,22 @@ describe("during_window on DST transition days", () => {
     );
     expect(fallBack).toBe("2026-11-01T11:00:00.000Z");
     expect(localHourMinute(fallBack ?? "", NY)).toBe("06:00");
+  });
+
+  it("projects tomorrow by local date instead of adding 24 hours across DST", async () => {
+    const facts: OwnerFactsView = {
+      timezone: NY,
+      morningWindow: { start: "06:00", end: "11:00" },
+    };
+    const next = await computeNextFireAt(
+      makeTask({ trigger: { kind: "during_window", windowKey: "morning" } }),
+      {
+        now: new Date("2026-03-07T20:00:00.000Z"),
+        ownerFacts: facts,
+        anchors: null,
+      },
+    );
+    expect(next).toBe("2026-03-08T10:00:00.000Z");
+    expect(localHourMinute(next ?? "", NY)).toBe("06:00");
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/due-property.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due-property.test.ts
@@ -13,9 +13,10 @@
  *      (occurrences are strictly monotonic across a fire chain);
  *  (d) interval tasks with non-positive / non-finite `everyMinutes` never
  *      fire and never index;
- *  (e) due evaluation and next-fire-at never throw for any structurally
- *      valid task, including malformed-ish metadata, garbage ISO strings,
- *      and extreme numeric trigger fields.
+ *  (e) due evaluation and next-fire-at return typed results for structurally
+ *      valid task data, or `InvalidLocalTimeError` for malformed owner-local
+ *      times; malformed metadata and extreme numeric fields never leak an
+ *      untyped exception.
  *
  * Property (e) originally caught two real crashes (RangeError: Invalid Date):
  * `relative_to_anchor` with an `offsetMinutes` whose ms product leaves the
@@ -31,6 +32,7 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 import { isScheduledTaskDue, markWindowFireIfNeeded } from "./due.js";
+import { InvalidLocalTimeError } from "./local-time.js";
 import { computeNextFireAt } from "./next-fire-at.js";
 import type {
   OwnerFactsView,
@@ -772,7 +774,7 @@ describe("due/next-fire-at fuzz: never throws on hostile-but-type-shaped tasks",
     expect(performance.now() - started).toBeLessThan(2000);
   });
 
-  it("isScheduledTaskDue and computeNextFireAt return typed results, never throw", async () => {
+  it("returns typed results or a typed invalid-local-time error", async () => {
     await fc.assert(
       fc.asyncProperty(
         arbHostileTask,
@@ -782,23 +784,34 @@ describe("due/next-fire-at fuzz: never throws on hostile-but-type-shaped tasks",
           const task = makeTask(shape);
           const now = new Date(msAt(nowMin));
 
-          const decision = await isScheduledTaskDue(task, { now, ownerFacts });
-          expect(typeof decision.due).toBe("boolean");
-          expect(typeof decision.reason).toBe("string");
-          if (decision.due) {
-            expect(
-              Number.isFinite(Date.parse(decision.occurrenceAtIso ?? "")),
-            ).toBe(true);
+          try {
+            const decision = await isScheduledTaskDue(task, {
+              now,
+              ownerFacts,
+            });
+            expect(typeof decision.due).toBe("boolean");
+            expect(typeof decision.reason).toBe("string");
+            if (decision.due) {
+              expect(
+                Number.isFinite(Date.parse(decision.occurrenceAtIso ?? "")),
+              ).toBe(true);
+            }
+          } catch (error) {
+            expect(error).toBeInstanceOf(InvalidLocalTimeError);
           }
 
-          const next = await computeNextFireAt(task, {
-            now,
-            ownerFacts,
-            anchors: null,
-          });
-          expect(next === null || typeof next === "string").toBe(true);
-          if (next !== null) {
-            expect(Number.isFinite(Date.parse(next))).toBe(true);
+          try {
+            const next = await computeNextFireAt(task, {
+              now,
+              ownerFacts,
+              anchors: null,
+            });
+            expect(next === null || typeof next === "string").toBe(true);
+            if (next !== null) {
+              expect(Number.isFinite(Date.parse(next))).toBe(true);
+            }
+          } catch (error) {
+            expect(error).toBeInstanceOf(InvalidLocalTimeError);
           }
         },
       ),

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -12,6 +12,7 @@
 import { computeNextCronRunAtMs, stringToUuid } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
+import { parseLocalHHMM, resolveLocalHHMMToIso } from "./local-time.js";
 import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
@@ -104,54 +105,6 @@ function localDateKey(date: Date, timeZone: string): string {
   return `${parts.year.toString().padStart(4, "0")}-${parts.month
     .toString()
     .padStart(2, "0")}-${parts.day.toString().padStart(2, "0")}`;
-}
-
-function minutesFromHHMM(value: string | undefined): number | null {
-  if (!value) return null;
-  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value);
-  if (!match) return null;
-  return Number(match[1]) * 60 + Number(match[2]);
-}
-
-function localHHMMToIso(
-  now: Date,
-  hhmm: string | undefined,
-  timeZone: string,
-): string | null {
-  const minutes = minutesFromHHMM(hhmm);
-  if (minutes === null) return null;
-  const parts = localParts(now, timeZone);
-  const hour = Math.floor(minutes / 60);
-  const minute = minutes % 60;
-  const localAsUtc = Date.UTC(
-    parts.year,
-    parts.month - 1,
-    parts.day,
-    hour,
-    minute,
-  );
-  const offsetFormatter = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    timeZoneName: "longOffset",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  const offsetParts = offsetFormatter.formatToParts(new Date(localAsUtc));
-  const offsetValue =
-    offsetParts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
-  const offsetMatch = /GMT([+-]\d{1,2})(?::?(\d{2}))?/.exec(offsetValue);
-  let offsetMinutes = 0;
-  if (offsetMatch) {
-    const sign = offsetMatch[1]?.startsWith("-") ? -1 : 1;
-    const hours = Math.abs(Number.parseInt(offsetMatch[1] ?? "0", 10));
-    const minutesPart = Number.parseInt(offsetMatch[2] ?? "0", 10);
-    offsetMinutes = sign * (hours * 60 + minutesPart);
-  }
-  return new Date(localAsUtc - offsetMinutes * MINUTE_MS).toISOString();
 }
 
 function metadataCreatedAtMs(task: ScheduledTask): number | null {
@@ -300,7 +253,7 @@ async function resolveAnchorIso(
     trigger.anchorKey === "wake.observed" ||
     trigger.anchorKey === "morning.start"
   ) {
-    return localHHMMToIso(
+    return resolveLocalHHMMToIso(
       context.now,
       ownerFacts.morningWindow?.start,
       timeZone,
@@ -308,19 +261,22 @@ async function resolveAnchorIso(
   }
   if (trigger.anchorKey === "bedtime.target") {
     return (
-      localHHMMToIso(context.now, ownerFacts.eveningWindow?.end, timeZone) ??
-      localHHMMToIso(context.now, "22:30", timeZone)
+      resolveLocalHHMMToIso(
+        context.now,
+        ownerFacts.eveningWindow?.end,
+        timeZone,
+      ) ?? resolveLocalHHMMToIso(context.now, "22:30", timeZone)
     );
   }
   if (trigger.anchorKey === "night.start") {
-    return localHHMMToIso(
+    return resolveLocalHHMMToIso(
       context.now,
       ownerFacts.eveningWindow?.start,
       timeZone,
     );
   }
   if (trigger.anchorKey === "lunch.start") {
-    return localHHMMToIso(context.now, "12:00", timeZone);
+    return resolveLocalHHMMToIso(context.now, "12:00", timeZone);
   }
   return null;
 }
@@ -361,11 +317,11 @@ function windowBoundsMinutes(
   ownerFacts: OwnerFactsView,
 ): Array<{ name: string; start: number; end: number }> {
   const morningStart =
-    minutesFromHHMM(ownerFacts.morningWindow?.start) ?? 6 * 60;
-  const morningEnd = minutesFromHHMM(ownerFacts.morningWindow?.end) ?? 11 * 60;
+    parseLocalHHMM(ownerFacts.morningWindow?.start) ?? 6 * 60;
+  const morningEnd = parseLocalHHMM(ownerFacts.morningWindow?.end) ?? 11 * 60;
   const eveningStart =
-    minutesFromHHMM(ownerFacts.eveningWindow?.start) ?? 18 * 60;
-  const eveningEnd = minutesFromHHMM(ownerFacts.eveningWindow?.end) ?? 22 * 60;
+    parseLocalHHMM(ownerFacts.eveningWindow?.start) ?? 18 * 60;
+  const eveningEnd = parseLocalHHMM(ownerFacts.eveningWindow?.end) ?? 22 * 60;
   const afternoonStart = morningEnd;
   const afternoonEnd = eveningStart;
   const windows: Record<

--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
@@ -1,0 +1,205 @@
+/**
+ * Resolves a local HH:MM on an owner's calendar date to one deterministic UTC
+ * instant. Ambiguous fall-back times choose the earlier occurrence; skipped
+ * spring-forward times move forward by the size of the timezone gap, matching
+ * Temporal's compatible disambiguation and common calendar behavior.
+ */
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const OFFSET_SAMPLE_HOURS = [-48, -36, -24, -12, 0, 12, 24, 36, 48];
+
+export type InvalidLocalTimeReason =
+  | "malformed_hhmm"
+  | "invalid_time_zone"
+  | "unresolvable_local_time";
+
+/**
+ * A supplied local time is invalid or cannot be resolved in its timezone.
+ * Absence is represented separately by `null`; callers must not turn malformed
+ * owner facts into an absent value and silently apply a default.
+ */
+export class InvalidLocalTimeError extends Error {
+  readonly code = "invalid_local_time";
+
+  constructor(
+    readonly reason: InvalidLocalTimeReason,
+    readonly localTime: string | undefined,
+    readonly timeZone?: string,
+  ) {
+    const detail =
+      reason === "malformed_hhmm"
+        ? `invalid local time ${JSON.stringify(localTime)}; expected HH:MM`
+        : reason === "invalid_time_zone"
+          ? `invalid timezone ${JSON.stringify(timeZone)}`
+          : `local time ${JSON.stringify(localTime)} cannot be resolved in ${JSON.stringify(timeZone)}`;
+    super(detail);
+    this.name = "InvalidLocalTimeError";
+  }
+}
+
+interface LocalMinuteParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+const partsFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const offsetFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function partsFormatter(timeZone: string): Intl.DateTimeFormat {
+  const existing = partsFormatterCache.get(timeZone);
+  if (existing) return existing;
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  partsFormatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+function offsetFormatter(timeZone: string): Intl.DateTimeFormat {
+  const existing = offsetFormatterCache.get(timeZone);
+  if (existing) return existing;
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "longOffset",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  offsetFormatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+function localParts(date: Date, timeZone: string): LocalMinuteParts {
+  const parts = partsFormatter(timeZone).formatToParts(date);
+  const read = (type: Intl.DateTimeFormatPartTypes): number => {
+    const value = parts.find((part) => part.type === type)?.value;
+    if (!value) throw new Error(`missing timezone date part: ${type}`);
+    return Number(value);
+  };
+  return {
+    year: read("year"),
+    month: read("month"),
+    day: read("day"),
+    hour: read("hour") % 24,
+    minute: read("minute"),
+  };
+}
+
+function offsetMinutes(date: Date, timeZone: string): number {
+  const token =
+    offsetFormatter(timeZone)
+      .formatToParts(date)
+      .find((part) => part.type === "timeZoneName")
+      ?.value.trim() ?? "GMT";
+  if (token === "GMT" || token === "UTC") return 0;
+  const match = /^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/.exec(token);
+  if (!match) {
+    throw new Error(`unsupported timezone offset token: ${token}`);
+  }
+  const sign = match[1] === "+" ? 1 : -1;
+  return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+}
+
+function sameLocalMinute(
+  candidate: Date,
+  target: LocalMinuteParts,
+  timeZone: string,
+): boolean {
+  const actual = localParts(candidate, timeZone);
+  return (
+    actual.year === target.year &&
+    actual.month === target.month &&
+    actual.day === target.day &&
+    actual.hour === target.hour &&
+    actual.minute === target.minute
+  );
+}
+
+function addLocalDays(
+  date: Pick<LocalMinuteParts, "year" | "month" | "day">,
+  dayOffset: number,
+): Pick<LocalMinuteParts, "year" | "month" | "day"> {
+  const shifted = new Date(
+    Date.UTC(date.year, date.month - 1, date.day + dayOffset, 12),
+  );
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+  };
+}
+
+export function parseLocalHHMM(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value);
+  if (!match) {
+    throw new InvalidLocalTimeError("malformed_hhmm", value);
+  }
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+export function resolveLocalHHMMToIso(
+  now: Date,
+  hhmm: string | undefined,
+  timeZone: string,
+  dayOffset = 0,
+): string | null {
+  const minuteOfDay = parseLocalHHMM(hhmm);
+  if (minuteOfDay === null) return null;
+  try {
+    const current = localParts(now, timeZone);
+    const date = addLocalDays(current, dayOffset);
+    const target: LocalMinuteParts = {
+      ...date,
+      hour: Math.floor(minuteOfDay / 60),
+      minute: minuteOfDay % 60,
+    };
+    const wallClockAsUtc = Date.UTC(
+      target.year,
+      target.month - 1,
+      target.day,
+      target.hour,
+      target.minute,
+    );
+    const offsets = new Set(
+      OFFSET_SAMPLE_HOURS.map((hours) =>
+        offsetMinutes(new Date(wallClockAsUtc + hours * HOUR_MS), timeZone),
+      ),
+    );
+    const exactCandidates = [...offsets]
+      .map((offset) => new Date(wallClockAsUtc - offset * MINUTE_MS))
+      .filter((candidate) => sameLocalMinute(candidate, target, timeZone))
+      .sort((left, right) => left.getTime() - right.getTime());
+    if (exactCandidates.length > 0) {
+      return exactCandidates[0].toISOString();
+    }
+
+    const offsetBefore = offsetMinutes(
+      new Date(wallClockAsUtc - 48 * HOUR_MS),
+      timeZone,
+    );
+    const offsetAfter = offsetMinutes(
+      new Date(wallClockAsUtc + 48 * HOUR_MS),
+      timeZone,
+    );
+    if (offsetAfter > offsetBefore) {
+      return new Date(wallClockAsUtc - offsetBefore * MINUTE_MS).toISOString();
+    }
+  } catch (error) {
+    // error-policy:J2 convert Intl's implementation-specific RangeError into
+    // a stable error type that callers can handle without parsing text.
+    if (error instanceof InvalidLocalTimeError) throw error;
+    throw new InvalidLocalTimeError("invalid_time_zone", hhmm, timeZone);
+  }
+  throw new InvalidLocalTimeError("unresolvable_local_time", hhmm, timeZone);
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
@@ -18,6 +18,7 @@
 import { computeNextCronRunAtMs } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
+import { resolveLocalHHMMToIso } from "./local-time.js";
 import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
@@ -49,79 +50,6 @@ function isRepresentableMs(ms: number): boolean {
   return Number.isFinite(ms) && Math.abs(ms) <= MAX_DATE_MS;
 }
 
-function minutesFromHHMM(value: string | undefined): number | null {
-  if (!value) return null;
-  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value);
-  if (!match) return null;
-  return Number(match[1]) * 60 + Number(match[2]);
-}
-
-function localParts(
-  date: Date,
-  timeZone: string,
-): { year: number; month: number; day: number; hour: number; minute: number } {
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  const parts = formatter.formatToParts(date);
-  const read = (type: string): number =>
-    Number(parts.find((part) => part.type === type)?.value ?? 0);
-  return {
-    year: read("year"),
-    month: read("month"),
-    day: read("day"),
-    hour: read("hour") % 24,
-    minute: read("minute"),
-  };
-}
-
-function localHHMMToIso(
-  now: Date,
-  hhmm: string | undefined,
-  timeZone: string,
-): string | null {
-  const minutes = minutesFromHHMM(hhmm);
-  if (minutes === null) return null;
-  const parts = localParts(now, timeZone);
-  const hour = Math.floor(minutes / 60);
-  const minute = minutes % 60;
-  const localAsUtc = Date.UTC(
-    parts.year,
-    parts.month - 1,
-    parts.day,
-    hour,
-    minute,
-  );
-  const offsetFormatter = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    timeZoneName: "longOffset",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  const offsetParts = offsetFormatter.formatToParts(new Date(localAsUtc));
-  const offsetValue =
-    offsetParts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
-  const offsetMatch = /GMT([+-]\d{1,2})(?::?(\d{2}))?/.exec(offsetValue);
-  let offsetMinutes = 0;
-  if (offsetMatch) {
-    const sign = offsetMatch[1]?.startsWith("-") ? -1 : 1;
-    const hours = Math.abs(Number.parseInt(offsetMatch[1] ?? "0", 10));
-    const minutesPart = Number.parseInt(offsetMatch[2] ?? "0", 10);
-    offsetMinutes = sign * (hours * 60 + minutesPart);
-  }
-  return new Date(localAsUtc - offsetMinutes * MINUTE_MS).toISOString();
-}
-
 function nextWindowStartIso(
   windowKey: string,
   context: ComputeNextFireAtContext,
@@ -131,52 +59,45 @@ function nextWindowStartIso(
   const morningStart = facts.morningWindow?.start;
   const eveningStart = facts.eveningWindow?.start;
   const eveningEnd = facts.eveningWindow?.end;
-  let candidates: string[] = [];
+  let candidateTimes: Array<string | undefined>;
   switch (windowKey) {
     case "morning":
-      candidates = [localHHMMToIso(context.now, morningStart, timeZone) ?? ""];
+      candidateTimes = [morningStart];
       break;
     case "afternoon":
-      candidates = [
-        localHHMMToIso(context.now, facts.morningWindow?.end, timeZone) ?? "",
-      ];
+      candidateTimes = [facts.morningWindow?.end];
       break;
     case "evening":
-      candidates = [localHHMMToIso(context.now, eveningStart, timeZone) ?? ""];
+      candidateTimes = [eveningStart];
       break;
     case "night":
-      candidates = [
-        localHHMMToIso(context.now, eveningEnd, timeZone) ?? "",
-        localHHMMToIso(context.now, "00:00", timeZone) ?? "",
-      ];
+      candidateTimes = [eveningEnd, "00:00"];
       break;
     case "morning_or_night":
-      candidates = [
-        localHHMMToIso(context.now, morningStart, timeZone) ?? "",
-        localHHMMToIso(context.now, eveningEnd, timeZone) ?? "",
-      ];
+      candidateTimes = [morningStart, eveningEnd];
       break;
     case "morning_or_evening":
-      candidates = [
-        localHHMMToIso(context.now, morningStart, timeZone) ?? "",
-        localHHMMToIso(context.now, eveningStart, timeZone) ?? "",
-      ];
+      candidateTimes = [morningStart, eveningStart];
       break;
     default:
       return null;
   }
   const nowMs = context.now.getTime();
-  const upcoming = candidates
+  const today = candidateTimes
+    .map((hhmm) => resolveLocalHHMMToIso(context.now, hhmm, timeZone, 0))
     .map((iso) => parseIsoMs(iso))
-    .filter((ms): ms is number => ms !== null);
-  if (upcoming.length === 0) return null;
-  const future = upcoming.find((ms) => ms >= nowMs);
+    .filter((ms): ms is number => ms !== null)
+    .sort((left, right) => left - right);
+  const future = today.find((ms) => ms >= nowMs);
   if (future !== undefined) return new Date(future).toISOString();
-  // All today's window-starts are in the past; bump to same local-HHMM
-  // tomorrow. The runner re-computes after each fire, so we only need a
-  // coarse "tomorrow morning" candidate here.
-  const earliest = Math.min(...upcoming);
-  return new Date(earliest + 24 * 60 * MINUTE_MS).toISOString();
+
+  const tomorrow = candidateTimes
+    .map((hhmm) => resolveLocalHHMMToIso(context.now, hhmm, timeZone, 1))
+    .map((iso) => parseIsoMs(iso))
+    .filter((ms): ms is number => ms !== null)
+    .sort((left, right) => left - right);
+  const earliest = tomorrow[0];
+  return earliest === undefined ? null : new Date(earliest).toISOString();
 }
 
 async function nextAnchorIso(
@@ -214,23 +135,26 @@ async function nextAnchorIso(
     trigger.anchorKey === "wake.observed" ||
     trigger.anchorKey === "morning.start"
   ) {
-    baseIso = localHHMMToIso(
+    baseIso = resolveLocalHHMMToIso(
       context.now,
       ownerFacts.morningWindow?.start,
       timeZone,
     );
   } else if (trigger.anchorKey === "bedtime.target") {
     baseIso =
-      localHHMMToIso(context.now, ownerFacts.eveningWindow?.end, timeZone) ??
-      localHHMMToIso(context.now, "22:30", timeZone);
+      resolveLocalHHMMToIso(
+        context.now,
+        ownerFacts.eveningWindow?.end,
+        timeZone,
+      ) ?? resolveLocalHHMMToIso(context.now, "22:30", timeZone);
   } else if (trigger.anchorKey === "night.start") {
-    baseIso = localHHMMToIso(
+    baseIso = resolveLocalHHMMToIso(
       context.now,
       ownerFacts.eveningWindow?.start,
       timeZone,
     );
   } else if (trigger.anchorKey === "lunch.start") {
-    baseIso = localHHMMToIso(context.now, "12:00", timeZone);
+    baseIso = resolveLocalHHMMToIso(context.now, "12:00", timeZone);
   }
   if (!baseIso) return null;
   const atMs = Date.parse(baseIso) + trigger.offsetMinutes * MINUTE_MS;


### PR DESCRIPTION
## What this is

A narrow extraction of the deterministic owner-local time resolver from @lalalune's draft #17206, rebased onto current `develop` (`27d21400c9a`).

After Shaw's blocking reviews, this PR is now **DST resolver work only**. It contains no calendar availability/source-health API, no `DispatchReceipt`, and no reservation metadata helper.

## What lands

- One canonical `HH:MM` → UTC resolver shared by due evaluation, next-fire indexing, and the production/fallback anchor registries.
- Temporal-compatible DST behavior:
  - ambiguous fall-back times choose the earlier occurrence;
  - skipped local times advance by the timezone gap;
  - non-hour transitions are supported;
  - a whole skipped local date advances by the date-line gap.
- `InvalidLocalTimeError` distinguishes malformed supplied values from genuinely absent owner facts.
  - Missing values may still use an intentional default.
  - Malformed values never become `null`, never silently select a default, and produce the same typed failure in due and index paths.

## Boundary coverage

- America/New_York spring/fall transitions
- Europe/Berlin spring/fall transitions
- Australia/Lord_Howe 30-minute transitions
- **America/Santiago 2026-09-06**, where local midnight does not exist and `00:00` resolves compatibly to `01:00`
- **Pacific/Apia 2011-12-30**, where the entire local date was skipped
- The registered production anchor path, not only the `anchors: null` fallback path

## Explicitly removed / deferred

The earlier availability/source-health evaluator, `DispatchReceipt` additions, and reservation helper have been removed completely.

Availability can return only with authoritative per-grant acquisition, pagination/coverage proof, canonical sync/tombstone identity, and sanitized public failures. Receipt types can return only with enforcement in runner policy, persistence, and real connector paths.

## Authorship and overlap

The resolver originated in Shaw's #17206 extraction and Shaw remains `Co-authored-by` on the commit. The initial PR described all extracted production blobs as byte-identical; that is no longer claimed because this revision adds the typed-error hardening and production-anchor consolidation requested in review.

The former #17176 overlap was the removed availability surface. **No #17176 availability acceptance bullet remains implemented here, and this PR does not claim #17176.** No receipt scope from #17177 remains either.

Refs: #17206, #17176, #17177

## Verification

- `plugin-scheduling`: **23 test files passed, 305 tests passed**
- `dst-boundaries.test.ts`: **31/31 passed**
- `tsc --noEmit -p tsconfig.json`: passed
- Biome check over all 8 changed files: passed
- Final diff: **8 scheduling-only files**, `569 additions / 331 deletions`

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; scheduling library code only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface or visual change.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; deterministic scheduling primitives only.`
<!-- evidence-row:backend-logs -->
- [x] [17209-scheduling-vitest.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17209-scheduling-vitest.log) — 303 tests passed at head 87634a57395; tsc and Biome passed.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model, prompt, action, or provider path.`
<!-- evidence-row:domain-artifacts -->
- [x] Pinned timezone assertions cover folds, gaps, skipped midnight, and a skipped date: https://github.com/elizaOS/eliza/blob/87634a573952f21c3a4bb3ac949e11276e30bcd7/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts

[sol-lifeops-extract]

