### PR TITLE
fix(personal-assistant): gate private context by audience

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -5934,42 +5934,50 @@ export class AgentRuntime implements IAgentRuntime {
 							attemptMeta,
 						);
 					}
-					streamedText += safeChunk;
+					let deliverableChunk = safeChunk;
 					// Per-token hook dispatch: skip the whole ceremony (trajectory
 					// lookup, context-object build, awaited invoke) when nothing is
 					// registered for the phase — the common zero-hook stream would
-					// otherwise pay it for every token. The length check reads the
-					// cached per-phase list, so a hook registered mid-stream is still
-					// picked up on the next chunk.
+					// otherwise pay it for every token. Mutating hooks may blank or
+					// rewrite the chunk; read the same context back before any client,
+					// structured extractor, or TTS path can observe it.
 					if (this.hooksForPhase("model_stream_chunk").length > 0) {
 						const trajStream = getTrajectoryContext();
+						const hookContext = modelStreamChunkPipelineHookContext({
+							source: "use_model",
+							chunk: safeChunk,
+							messageId: msgId,
+							roomId:
+								(trajStream?.roomId as UUID | undefined) ??
+								this.currentRoomId ??
+								this.agentId,
+							runId: this.getCurrentRunId(),
+							...(trajStream?.messageId
+								? { responseId: trajStream.messageId as UUID }
+								: {}),
+							accumulated: `${streamedText}${safeChunk}`,
+						});
 						await this.invokePipelineHooks(
 							"model_stream_chunk",
-							modelStreamChunkPipelineHookContext({
-								source: "use_model",
-								chunk: safeChunk,
-								messageId: msgId,
-								roomId:
-									(trajStream?.roomId as UUID | undefined) ??
-									this.currentRoomId ??
-									this.agentId,
-								runId: this.getCurrentRunId(),
-								...(trajStream?.messageId
-									? { responseId: trajStream.messageId as UUID }
-									: {}),
-								accumulated: streamedText,
-							}),
+							hookContext,
 							"Model stream chunk (useModel)",
 							false,
 						);
+						deliverableChunk = hookContext.chunk;
 					}
+					if (deliverableChunk.length === 0) return;
+					streamedText += deliverableChunk;
 					await runInsideModelStreamChunkDelivery(async () => {
+						const deliverableVisibleChunk =
+							deliverableChunk === safeChunk ? visibleChunk : deliverableChunk;
 						if (structuredExtractor) {
-							structuredExtractor.push(visibleChunk);
+							structuredExtractor.push(deliverableVisibleChunk);
 							return;
 						}
-						if (paramsChunk) await paramsChunk(visibleChunk, msgId, undefined);
-						if (ctxChunk) await ctxChunk(visibleChunk, msgId, undefined);
+						if (paramsChunk)
+							await paramsChunk(deliverableVisibleChunk, msgId, undefined);
+						if (ctxChunk)
+							await ctxChunk(deliverableVisibleChunk, msgId, undefined);
 					});
 				};
 				// When a guard is active, route every chunk through the scanner: it

--- a/packages/core/src/runtime/__tests__/model-stream-chunk-hooks.test.ts
+++ b/packages/core/src/runtime/__tests__/model-stream-chunk-hooks.test.ts
@@ -93,6 +93,30 @@ describe("AgentRuntime.useModel model_stream_chunk hooks", () => {
 		]);
 	});
 
+	it("honors mutating delivery hooks before any downstream stream callback", async () => {
+		const runtime = makeRuntime();
+		registerStreamingModel(runtime);
+		const received: string[] = [];
+		runtime.registerPipelineHook({
+			id: "deny-stream-delivery",
+			phase: "model_stream_chunk",
+			mutatesPrimary: true,
+			handler: (_rt, ctx) => {
+				if (ctx.phase === "model_stream_chunk") {
+					ctx.chunk = "";
+					ctx.accumulated = "";
+				}
+			},
+		});
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream it",
+			onStreamChunk: (chunk: string) => received.push(chunk),
+		});
+
+		expect(received).toEqual([]);
+	});
+
 	it("picks up a hook registered mid-stream on the next chunk (cache invalidation)", async () => {
 		const runtime = makeRuntime();
 		registerStreamingModel(runtime);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9415,12 +9415,25 @@ export function stripReplyWhenActionOwnsTurn(
 	return filtered.length > 0 ? filtered : ["REPLY"];
 }
 
+/**
+ * Content objects that already passed the `outgoing_before_deliver` pipeline
+ * phase at a dedicated seam (simple reply, early voice reply, terminal
+ * payload). `wrapSingleTurnVisibleCallback.deliver` re-dispatches the phase for
+ * anything NOT in this set so actions-mode callbacks — the one visible seam
+ * without its own dispatch — still pass delivery-time policy hooks (e.g.
+ * private-audience revalidation) exactly once.
+ */
+const outgoingHooksApplied = new WeakSet<Content>();
+
 export function wrapSingleTurnVisibleCallback(
 	runtime: Pick<IAgentRuntime, "agentId" | "logger"> &
-		Partial<Pick<IAgentRuntime, "character" | "useModel">> & {
+		Partial<
+			Pick<IAgentRuntime, "character" | "useModel" | "applyPipelineHooks">
+		> & {
 			getService?: IAgentRuntime["getService"];
 		},
-	message: Pick<Memory, "id" | "roomId" | "entityId">,
+	message: Pick<Memory, "id" | "roomId" | "entityId"> &
+		Partial<Pick<Memory, "content" | "metadata" | "agentId" | "createdAt">>,
 	callback?: HandlerCallback,
 	recordDeliveredVisibleText?: (text: string) => void,
 ): HandlerCallback | undefined {
@@ -9429,6 +9442,27 @@ export function wrapSingleTurnVisibleCallback(
 	const deliver = async (response: Content, actionName?: string) => {
 		if (response.transcriptVisibility === "internal") {
 			return [];
+		}
+		// Action callbacks reach the wire only through this wrap; every other
+		// visible seam dispatches outgoing_before_deliver itself and marks the
+		// content, so this fires exactly once per delivered payload. Hooks
+		// mutate `response` in place (mutatesPrimary), so the sanitization and
+		// callback below observe the post-hook content.
+		if (
+			!outgoingHooksApplied.has(response) &&
+			typeof runtime.applyPipelineHooks === "function"
+		) {
+			outgoingHooksApplied.add(response);
+			await runtime.applyPipelineHooks(
+				"outgoing_before_deliver",
+				outgoingPipelineHookContext(response, {
+					source: "action",
+					roomId: message.roomId,
+					...("content" in message ? { message: message as Memory } : {}),
+					...(actionName ? { actionName } : {}),
+					...(response.responseId ? { responseId: response.responseId } : {}),
+				}),
+			);
 		}
 		// Shared post-model, pre-channel sanitization (#15888): every visible
 		// delivery — action callbacks, early replies, simple replies, terminal
@@ -10092,32 +10126,49 @@ export class DefaultMessageService implements IMessageService {
 				const wrappedOnStreamChunk: StreamChunkCallback | undefined =
 					userOnStreamChunk
 						? async (chunk, messageId, accumulated) => {
-								let streamText: string;
-								// If we have accumulated text, also sync streamTextFallback so the
-								// fallback path has accurate state if the stream source later changes.
-								if (accumulated !== undefined) {
-									streamTextFallback = accumulated;
-									streamText = accumulated;
-								} else {
-									streamTextFallback += chunk;
-									streamText = streamTextFallback;
-								}
-
+								// Mutating hooks may blank or rewrite the chunk; read the same
+								// context back so the fallback buffer, first-sentence TTS, and
+								// the user callback below all observe the post-hook stream —
+								// never the raw tokens a hook denied.
+								let deliverableChunk = chunk;
+								let deliverableAccumulated = accumulated;
 								// Skip when this callback is invoked from `useModel`'s stream loop:
 								// `source: "use_model"` already ran for the same raw chunk (Node ALS).
 								if (getModelStreamChunkDeliveryDepth() === 0) {
+									const hookContext = modelStreamChunkPipelineHookContext({
+										source: "message_service",
+										chunk,
+										messageId,
+										roomId: message.roomId,
+										runId: runtime.getCurrentRunId(),
+										responseId,
+										accumulated,
+									});
 									await runtime.applyPipelineHooks(
 										"model_stream_chunk",
-										modelStreamChunkPipelineHookContext({
-											source: "message_service",
-											chunk,
-											messageId,
-											roomId: message.roomId,
-											runId: runtime.getCurrentRunId(),
-											responseId,
-											accumulated,
-										}),
+										hookContext,
 									);
+									deliverableChunk = hookContext.chunk;
+									if (accumulated !== undefined) {
+										deliverableAccumulated =
+											hookContext.accumulated ?? accumulated;
+									}
+								}
+								// A hook that blanked a non-empty chunk denied delivery:
+								// nothing downstream may observe this token.
+								if (chunk.length > 0 && deliverableChunk.length === 0) {
+									return;
+								}
+
+								let streamText: string;
+								// If we have accumulated text, also sync streamTextFallback so the
+								// fallback path has accurate state if the stream source later changes.
+								if (deliverableAccumulated !== undefined) {
+									streamTextFallback = deliverableAccumulated;
+									streamText = deliverableAccumulated;
+								} else {
+									streamTextFallback += deliverableChunk;
+									streamText = streamTextFallback;
 								}
 
 								// First-sentence cloud-TTS path. The local-inference voice loop
@@ -10132,7 +10183,7 @@ export class DefaultMessageService implements IMessageService {
 								// structured output that would garble hasFirstSentence() and TTS.
 								if (
 									!firstSentenceSent &&
-									accumulated !== undefined &&
+									deliverableAccumulated !== undefined &&
 									hasFirstSentence(streamText)
 								) {
 									const { first } = extractFirstSentence(streamText);
@@ -10219,7 +10270,11 @@ export class DefaultMessageService implements IMessageService {
 									}
 								}
 
-								await userOnStreamChunk(chunk, messageId, accumulated);
+								await userOnStreamChunk(
+									deliverableChunk,
+									messageId,
+									deliverableAccumulated,
+								);
 							}
 						: undefined;
 
@@ -10996,6 +11051,7 @@ export class DefaultMessageService implements IMessageService {
 						// genuine agent voice — so gated transports must not re-voice it.
 						agentVoiced: true,
 					};
+					outgoingHooksApplied.add(earlyContent);
 					await runtime.applyPipelineHooks(
 						"outgoing_before_deliver",
 						outgoingPipelineHookContext(earlyContent, {
@@ -11461,6 +11517,7 @@ export class DefaultMessageService implements IMessageService {
 					// RECENT_MESSAGES read observes it too. Do not put MESSAGE_SENT
 					// handlers or post-turn evaluators before the callback; they are
 					// side effects and must not stall user-visible streaming.
+					outgoingHooksApplied.add(deliverableResponseContent);
 					await timeInferenceSpan("message:delivery:hooks", () =>
 						runtime.applyPipelineHooks(
 							"outgoing_before_deliver",
@@ -11620,6 +11677,7 @@ export class DefaultMessageService implements IMessageService {
 				inReplyTo: createUniqueUuid(runtime, message.id),
 			};
 
+			outgoingHooksApplied.add(terminalContent);
 			await timeInferenceSpan("message:delivery:hooks", () =>
 				runtime.applyPipelineHooks(
 					"outgoing_before_deliver",

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -37,7 +37,11 @@ import {
   createCalendarActionRunner,
 } from "@elizaos/plugin-calendar";
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
-import { hasLifeOpsAccess, INTERNAL_URL } from "../lifeops/access.js";
+import { INTERNAL_URL } from "../lifeops/access.js";
+import {
+  assertLifeOpsAudienceAtDelivery,
+  authorizeLifeOpsPrivateContext,
+} from "../lifeops/audience-policy.js";
 import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
 import {
   formatCalendarEventDateTime,
@@ -817,7 +821,12 @@ export const calendarAction: Action & {
     runtime: IAgentRuntime,
     message: Memory,
   ): Promise<boolean> => {
-    return hasLifeOpsAccess(runtime, message);
+    const gate = await authorizeLifeOpsPrivateContext({
+      runtime,
+      message,
+      sources: [{ kind: "calendar", id: "calendar.action" }],
+    });
+    return gate.canLoadPrivateContext;
   },
   handler: async (
     runtime: IAgentRuntime,
@@ -826,11 +835,32 @@ export const calendarAction: Action & {
     options,
     callback,
   ): Promise<ActionResult> => {
-    if (!(await hasLifeOpsAccess(runtime, message))) {
-      const text = "Calendar actions are restricted to the owner.";
-      await callback?.({ text });
-      return { text, success: false, data: { error: "PERMISSION_DENIED" } };
+    const audienceGate = await authorizeLifeOpsPrivateContext({
+      runtime,
+      message,
+      sources: [{ kind: "calendar", id: "calendar.action" }],
+    });
+    if (!audienceGate.canLoadPrivateContext) {
+      const text = "Calendar actions require an owner-only private chat.";
+      return {
+        text,
+        success: false,
+        data: {
+          error: "AUDIENCE_DENIED",
+          lifeOpsAudienceReceipts: audienceGate.receipts,
+        },
+      };
     }
+    const deliveryCheckedCallback: HandlerCallback | undefined = callback
+      ? async (content, actionName) => {
+          await assertLifeOpsAudienceAtDelivery(
+            runtime,
+            message,
+            audienceGate.envelope,
+          );
+          return callback(content, actionName);
+        }
+      : undefined;
     const resolved = await resolveActionArgs<
       OwnerCalendarSubaction,
       OwnerCalendarParameters
@@ -846,7 +876,7 @@ export const calendarAction: Action & {
       const text =
         resolved.clarification ||
         "Tell me whether you want to view your calendar, create an event, check availability, propose times, or adjust scheduling preferences.";
-      await callback?.({ text });
+      await deliveryCheckedCallback?.({ text });
       return {
         text,
         success: false,
@@ -861,7 +891,7 @@ export const calendarAction: Action & {
     if (!subaction) {
       const text =
         "Tell me whether you want to view your calendar, create an event, check availability, propose times, or adjust scheduling preferences.";
-      await callback?.({ text });
+      await deliveryCheckedCallback?.({ text });
       return {
         text,
         success: false,
@@ -872,7 +902,14 @@ export const calendarAction: Action & {
       ...(options ?? {}),
       parameters: resolved.params as HandlerOptions["parameters"],
     };
-    return route(subaction, runtime, message, state, mergedOptions, callback);
+    return route(
+      subaction,
+      runtime,
+      message,
+      state,
+      mergedOptions,
+      deliveryCheckedCallback,
+    );
   },
   parameters: [
     {

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
@@ -179,6 +179,29 @@ describe("shared LifeOps audience boundary (production provider/action paths)", 
     },
   );
 
+  it.each([ChannelType.DM, ChannelType.API, ChannelType.VOICE_DM])(
+    "keeps a group room denied when its message carries the private stamp %s",
+    async (messageType) => {
+      const roomId = await room(ChannelType.GROUP, [
+        runtime.agentId,
+        ownerId,
+        otherId,
+      ]);
+      const gate = await authorizeLifeOpsPrivateContext({
+        runtime,
+        message: message(roomId, messageType),
+        sources: PRIVATE_SOURCES,
+      });
+      expect(gate.canLoadPrivateContext).toBe(false);
+      expect(gate.envelope).toBeNull();
+      expect(gate.receipts[0]).toMatchObject({
+        roomAudienceClass: "group",
+        decision: "exclude",
+        reason: "excluded_group_destination",
+      });
+    },
+  );
+
   it("binds provenance to the persisted agent id, ignoring mutable display/message persona", async () => {
     const roomId = await room(ChannelType.DM, [runtime.agentId, ownerId]);
     const request = message(roomId, ChannelType.API);
@@ -357,7 +380,9 @@ describe("shared LifeOps audience boundary (production provider/action paths)", 
       },
     });
     expect(gate.canLoadPrivateContext).toBe(false);
-    expect(gate.receipts[0].reason).toBe("excluded_non_owner_requester");
+    // A broken role lookup is distinguishable from a genuine non-owner so the
+    // receipt trail cannot read a failed pipeline as an authorization verdict.
+    expect(gate.receipts[0].reason).toBe("excluded_owner_lookup_failed");
     expect(reportError).toHaveBeenCalledWith(
       "LifeOpsAudience.metadata",
       expect.any(Error),

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
@@ -1,0 +1,664 @@
+/**
+ * Integration coverage for the LifeOps audience egress gate.
+ *
+ * A real PGlite-backed AgentRuntime owns room, participant, and role metadata;
+ * the only seam is a canary-bearing loader used after the exported provider
+ * gate, proving denied destinations are filtered before private context can be
+ * read or composed for a model prompt.
+ */
+import {
+  AgentRuntime,
+  ChannelType,
+  type Character,
+  createMessageMemory,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { DatabaseMigrationService } from "../../../plugin-sql/src/migration-service.js";
+import { PgliteDatabaseAdapter } from "../../../plugin-sql/src/pglite/adapter.js";
+import { PGliteClientManager } from "../../../plugin-sql/src/pglite/manager.js";
+import * as schema from "../../../plugin-sql/src/schema/index.js";
+import type { DrizzleDatabase } from "../../../plugin-sql/src/types.js";
+import {
+  lifeOpsProvider,
+  resolveLifeOpsProviderAudienceGate,
+} from "../providers/lifeops.js";
+import {
+  evaluateLifeOpsAudiencePolicy,
+  type LifeOpsAudienceGateResult,
+  type LifeOpsAudienceReason,
+  type LifeOpsAudienceSource,
+} from "./audience-policy.js";
+import { LifeOpsService } from "./service.js";
+
+const OWNER_CANARY = "OWNER_SECRET_CORPUS_ALPINE_7421";
+const LEAK_CORPUS = {
+  gmail: "GMAIL_CANARY_INBOX_QUARTZ_8123",
+  calendar: "CALENDAR_CANARY_EVENT_ONYX_4772",
+  privateMemory: "PRIVATE_MEMORY_CANARY_VAULT_1936",
+} as const;
+const AGENT_PERSONA = "persona-alpha";
+const OTHER_PERSONA = "persona-beta";
+
+const PRIVATE_SOURCE: LifeOpsAudienceSource = {
+  kind: "private_memory",
+  id: "private-canary",
+  classification: "persona_scoped",
+  persona: AGENT_PERSONA,
+};
+
+const PUBLIC_SOURCE: LifeOpsAudienceSource = {
+  kind: "public_memory",
+  id: "public-release-note",
+  classification: "public",
+  persona: null,
+};
+
+const CROSS_PERSONA_CALENDAR_SOURCE: LifeOpsAudienceSource = {
+  kind: "calendar",
+  id: "calendar-beta",
+  classification: "persona_scoped",
+  persona: OTHER_PERSONA,
+};
+
+const CROSS_PERSONA_GMAIL_SOURCE: LifeOpsAudienceSource = {
+  kind: "gmail",
+  id: "gmail-beta",
+  classification: "persona_scoped",
+  persona: OTHER_PERSONA,
+};
+
+async function loadAfterGate(
+  gate: LifeOpsAudienceGateResult,
+  loader: () => Promise<string>,
+): Promise<string> {
+  return gate.canLoadPrivateContext ? loader() : "";
+}
+
+function uuid(): UUID {
+  return crypto.randomUUID() as UUID;
+}
+
+function message(args: {
+  entityId: UUID;
+  roomId: UUID;
+  channelType: ChannelType;
+  requestingPersona?: string;
+  persona?: string;
+}): Memory {
+  return createMessageMemory({
+    id: uuid(),
+    entityId: args.entityId,
+    roomId: args.roomId,
+    content: {
+      text: "read my LifeOps context",
+      source: "test",
+      channelType: args.channelType,
+      ...(args.requestingPersona
+        ? { requestingPersona: args.requestingPersona }
+        : {}),
+      ...(args.persona ? { persona: args.persona } : {}),
+    },
+  });
+}
+
+describe("LifeOps audience policy (real runtime + PGlite)", () => {
+  let manager: PGliteClientManager;
+  let adapter: PgliteDatabaseAdapter;
+  let runtime: AgentRuntime;
+  let ownerId: UUID;
+  let otherId: UUID;
+  let outsiderId: UUID;
+  let worldId: UUID;
+
+  beforeAll(async () => {
+    ownerId = uuid();
+    otherId = uuid();
+    outsiderId = uuid();
+    const agentId = uuid();
+    manager = new PGliteClientManager({});
+    await manager.initialize();
+    adapter = new PgliteDatabaseAdapter(agentId, manager);
+    await adapter.init();
+    const migrationService = new DatabaseMigrationService();
+    await migrationService.initializeWithDatabase(
+      adapter.getDatabase() as DrizzleDatabase,
+    );
+    migrationService.discoverAndRegisterPluginSchemas([
+      { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
+    ]);
+    await migrationService.runAllPluginMigrations();
+    await adapter.createAgent({
+      id: agentId,
+      name: AGENT_PERSONA,
+      bio: ["Test audience-policy agent"],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    runtime = new AgentRuntime({
+      agentId,
+      character: {
+        id: agentId,
+        name: AGENT_PERSONA,
+      } as Character,
+      adapter,
+    });
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId, false);
+    worldId = uuid();
+    await runtime.ensureWorldExists({
+      id: worldId,
+      name: "audience-policy-world",
+      agentId: runtime.agentId,
+    } as Parameters<typeof runtime.ensureWorldExists>[0]);
+    for (const entityId of [
+      runtime.agentId as UUID,
+      ownerId,
+      otherId,
+      outsiderId,
+    ]) {
+      await runtime.createEntity({
+        id: entityId,
+        names: [entityId],
+        agentId: runtime.agentId,
+      });
+    }
+  }, 180_000);
+
+  afterAll(async () => {
+    await adapter?.close();
+    await manager?.close();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function ensureRoom(args: {
+    type: ChannelType;
+    participants: UUID[];
+  }): Promise<UUID> {
+    const roomId = uuid();
+    await runtime.createRoom({
+      id: roomId,
+      name: `room-${roomId}`,
+      source: "test",
+      type: args.type,
+      channelId: roomId,
+      worldId,
+    });
+    for (const participant of args.participants) {
+      await runtime.ensureParticipantInRoom(participant, roomId);
+    }
+    return roomId;
+  }
+
+  async function expectReason(args: {
+    roomId: UUID;
+    requester: UUID;
+    messageType: ChannelType;
+    source?: LifeOpsAudienceSource;
+    reason: LifeOpsAudienceReason;
+    decision?: "include" | "exclude";
+    requestingPersona?: string;
+  }) {
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime,
+      message: message({
+        entityId: args.requester,
+        roomId: args.roomId,
+        channelType: args.messageType,
+        requestingPersona: args.requestingPersona ?? AGENT_PERSONA,
+      }),
+      sources: [args.source ?? PRIVATE_SOURCE],
+      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+    });
+    expect(gate.receipts).toHaveLength(1);
+    expect(gate.receipts[0]).toMatchObject({
+      decision: args.decision ?? "exclude",
+      reason: args.reason,
+      requestEntityId: args.requester,
+      destinationRoomId: args.roomId,
+    });
+    expect(gate.receipts[0].participantEntityIds).toEqual(
+      [...gate.receipts[0].participantEntityIds].sort(),
+    );
+    return gate;
+  }
+
+  function wrapRuntime(
+    overrides: Partial<
+      Pick<AgentRuntime, "getRoom" | "getParticipantsForRoom">
+    >,
+  ): AgentRuntime {
+    const wrapped = Object.create(runtime) as AgentRuntime;
+    Object.assign(wrapped, overrides);
+    return wrapped;
+  }
+
+  it("allows owner DM private context and returns an inclusion receipt", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    const gate = await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      reason: "included_private_dm",
+      decision: "include",
+    });
+    let reads = 0;
+    const text = await loadAfterGate(gate, async () => {
+      reads += 1;
+      return OWNER_CANARY;
+    });
+    expect(reads).toBe(1);
+    expect(text).toBe(OWNER_CANARY);
+  });
+
+  it("allows public memory in an owner DM with an explicit public-DM receipt", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      source: PUBLIC_SOURCE,
+      reason: "included_public_dm",
+      decision: "include",
+    });
+  });
+
+  it("denies owner private context in groups before loader or provider reads", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.GROUP,
+      participants: [runtime.agentId as UUID, ownerId, otherId],
+    });
+    const gate = await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.GROUP,
+      reason: "excluded_group_destination",
+    });
+    let reads = 0;
+    const text = await loadAfterGate(gate, async () => {
+      reads += 1;
+      return Object.values(LEAK_CORPUS).join("\n");
+    });
+    expect(reads).toBe(0);
+    for (const canary of Object.values(LEAK_CORPUS)) {
+      expect(text).not.toContain(canary);
+    }
+
+    const overviewSpy = vi
+      .spyOn(LifeOpsService.prototype, "getOverview")
+      .mockRejectedValue(new Error(LEAK_CORPUS.privateMemory));
+    const calendarSpy = vi
+      .spyOn(LifeOpsService.prototype, "getNextCalendarEventContext")
+      .mockRejectedValue(new Error(LEAK_CORPUS.calendar));
+    const gmailSpy = vi
+      .spyOn(LifeOpsService.prototype, "getGmailTriage")
+      .mockRejectedValue(new Error(LEAK_CORPUS.gmail));
+
+    const providerResult = await lifeOpsProvider.get(
+      runtime,
+      message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.GROUP,
+        requestingPersona: AGENT_PERSONA,
+      }),
+      { values: {}, data: {}, text: "" },
+    );
+    expect(overviewSpy).not.toHaveBeenCalled();
+    expect(calendarSpy).not.toHaveBeenCalled();
+    expect(gmailSpy).not.toHaveBeenCalled();
+    const serializedProviderResult = JSON.stringify(providerResult);
+    for (const canary of Object.values(LEAK_CORPUS)) {
+      expect(providerResult.text).not.toContain(canary);
+      expect(serializedProviderResult).not.toContain(canary);
+    }
+    expect(providerResult.text).not.toContain("Owner profile:");
+    expect(providerResult.text).not.toContain("Inbox:");
+    expect(providerResult.text).not.toContain("Next event:");
+    expect(providerResult.data?.lifeOpsAudienceReceipts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          decision: "exclude",
+          reason: "excluded_group_destination",
+        }),
+      ]),
+    );
+  });
+
+  it("denies missing room metadata", async () => {
+    await expectReason({
+      roomId: uuid(),
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      reason: "excluded_missing_room",
+    });
+  });
+
+  it("distinguishes room metadata lookup failures without leaking exception payloads", async () => {
+    const roomId = uuid();
+    const failureCanary = "ROOM_LOOKUP_FAILURE_PAYLOAD_EMERALD_6331";
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime: wrapRuntime({
+        getRoom: async () => {
+          throw new Error(failureCanary);
+        },
+      }),
+      message: message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.DM,
+      }),
+      sources: [PRIVATE_SOURCE],
+      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+    });
+    expect(gate.receipts[0]).toMatchObject({
+      decision: "exclude",
+      reason: "excluded_metadata_lookup_failed",
+      destinationRoomType: null,
+      participantEntityIds: [],
+    });
+    expect(JSON.stringify(gate)).not.toContain(failureCanary);
+  });
+
+  it("denies missing or empty participant metadata", async () => {
+    const roomId = await ensureRoom({ type: ChannelType.DM, participants: [] });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      reason: "excluded_missing_participants",
+    });
+  });
+
+  it("distinguishes participant metadata lookup failures without leaking exception payloads", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    const failureCanary = "PARTICIPANT_LOOKUP_FAILURE_PAYLOAD_TOPAZ_9214";
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime: wrapRuntime({
+        getParticipantsForRoom: async () => {
+          throw new Error(failureCanary);
+        },
+      }),
+      message: message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.DM,
+      }),
+      sources: [PRIVATE_SOURCE],
+      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+    });
+    expect(gate.receipts[0]).toMatchObject({
+      decision: "exclude",
+      reason: "excluded_metadata_lookup_failed",
+      destinationRoomType: ChannelType.DM,
+      participantEntityIds: [],
+    });
+    expect(JSON.stringify(gate)).not.toContain(failureCanary);
+  });
+
+  it("denies null-ish participant responses", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime: wrapRuntime({
+        getParticipantsForRoom: async () => null as unknown as UUID[],
+      }),
+      message: message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.DM,
+      }),
+      sources: [PRIVATE_SOURCE],
+      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+    });
+    expect(gate.receipts[0]).toMatchObject({
+      decision: "exclude",
+      reason: "excluded_missing_participants",
+    });
+  });
+
+  it("denies stale private participant sets", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId, otherId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      reason: "excluded_unexpected_participants",
+    });
+  });
+
+  it("denies private destinations when the agent is not an authoritative participant", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [ownerId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      reason: "excluded_agent_not_participant",
+    });
+  });
+
+  it("denies cross-persona sources without hardcoded names", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.DM,
+      source: { ...PRIVATE_SOURCE, persona: OTHER_PERSONA },
+      requestingPersona: AGENT_PERSONA,
+      reason: "excluded_cross_persona",
+    });
+  });
+
+  it("does not let message content spoof the authoritative requesting persona", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime,
+      message: message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.DM,
+        requestingPersona: OTHER_PERSONA,
+        persona: OTHER_PERSONA,
+      }),
+      sources: [{ ...PRIVATE_SOURCE, persona: OTHER_PERSONA }],
+      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+    });
+    expect(gate.receipts[0]).toMatchObject({
+      decision: "exclude",
+      reason: "excluded_cross_persona",
+      requestingPersona: AGENT_PERSONA,
+    });
+    expect(gate.canLoadPrivateContext).toBe(false);
+  });
+
+  it("allows explicitly public memory in an authoritative group", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.GROUP,
+      participants: [runtime.agentId as UUID, ownerId, otherId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.GROUP,
+      source: PUBLIC_SOURCE,
+      reason: "included_public_group",
+      decision: "include",
+    });
+    const gate = await resolveLifeOpsProviderAudienceGate(
+      runtime,
+      message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.GROUP,
+        requestingPersona: AGENT_PERSONA,
+      }),
+      [PUBLIC_SOURCE],
+    );
+    expect(gate.canLoadPrivateContext).toBe(false);
+  });
+
+  it("denies explicitly public group memory when the agent is not an authoritative participant", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.GROUP,
+      participants: [ownerId, otherId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.GROUP,
+      source: PUBLIC_SOURCE,
+      reason: "excluded_agent_not_participant",
+    });
+  });
+
+  it("keeps bundled private context closed when any requested private source is denied", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime,
+      message: message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.DM,
+        requestingPersona: AGENT_PERSONA,
+      }),
+      sources: [
+        PRIVATE_SOURCE,
+        CROSS_PERSONA_CALENDAR_SOURCE,
+        CROSS_PERSONA_GMAIL_SOURCE,
+      ],
+      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+    });
+    expect(gate.canLoadPrivateContext).toBe(false);
+    expect(gate.receipts.map((receipt) => receipt.reason)).toEqual([
+      "included_private_dm",
+      "excluded_cross_persona",
+      "excluded_cross_persona",
+    ]);
+    let reads = 0;
+    const text = await loadAfterGate(gate, async () => {
+      reads += 1;
+      return Object.values(LEAK_CORPUS).join("\n");
+    });
+    expect(reads).toBe(0);
+    for (const canary of Object.values(LEAK_CORPUS)) {
+      expect(text).not.toContain(canary);
+    }
+  });
+
+  it("denies when the requester is not a room participant", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.GROUP,
+      participants: [runtime.agentId as UUID, otherId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.GROUP,
+      reason: "excluded_requester_not_participant",
+    });
+  });
+
+  it("denies channel-type mismatch between message and stored room", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.GROUP,
+      reason: "excluded_channel_type_mismatch",
+    });
+  });
+
+  it("does not let SELF or API message types relax mismatched stored room metadata", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, ownerId],
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.SELF,
+      reason: "excluded_channel_type_mismatch",
+    });
+    await expectReason({
+      roomId,
+      requester: ownerId,
+      messageType: ChannelType.API,
+      reason: "excluded_channel_type_mismatch",
+    });
+  });
+
+  it("denies non-owner requesters with receipts", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.DM,
+      participants: [runtime.agentId as UUID, otherId],
+    });
+    await expectReason({
+      roomId,
+      requester: otherId,
+      messageType: ChannelType.DM,
+      reason: "excluded_non_owner_requester",
+    });
+  });
+
+  it("uses the same exported gate as the live provider", async () => {
+    const roomId = await ensureRoom({
+      type: ChannelType.GROUP,
+      participants: [runtime.agentId as UUID, ownerId, otherId],
+    });
+    const gate = await resolveLifeOpsProviderAudienceGate(
+      runtime,
+      message({
+        entityId: ownerId,
+        roomId,
+        channelType: ChannelType.GROUP,
+        requestingPersona: AGENT_PERSONA,
+      }),
+    );
+    expect(gate.canLoadPrivateContext).toBe(false);
+    expect(gate.receipts.map((receipt) => receipt.reason)).toEqual([
+      "excluded_group_destination",
+      "excluded_group_destination",
+      "excluded_group_destination",
+    ]);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
@@ -14,6 +14,7 @@ import {
   outgoingPipelineHookContext,
   type State,
   type UUID,
+  wrapSingleTurnVisibleCallback,
 } from "@elizaos/core";
 import {
   afterAll,
@@ -301,6 +302,42 @@ describe("shared LifeOps audience boundary (production provider/action paths)", 
     };
     await runtime.applyPipelineHooks("model_stream_chunk", streamContext);
     expect(streamContext.chunk).toBe("");
+  });
+
+  it("revalidates actions-mode callbacks at the shared visible-callback wrap", async () => {
+    // Actions-mode deliveries never hit the simple/terminal outgoing seams;
+    // they funnel through wrapSingleTurnVisibleCallback, which must dispatch
+    // outgoing_before_deliver so unwrapped action callbacks (not just the
+    // hand-wrapped calendar action) are revalidated at delivery time.
+    const roomId = await room(ChannelType.DM, [runtime.agentId, ownerId]);
+    const request = message(roomId, ChannelType.API);
+    const gate = await authorizeLifeOpsPrivateContext({
+      runtime,
+      message: request,
+      sources: PRIVATE_SOURCES,
+    });
+    expect(gate.canLoadPrivateContext).toBe(true);
+
+    // Concurrent membership mutation after authorization, before delivery.
+    await runtime.ensureParticipantInRoom(otherId, roomId);
+
+    runtime.setSetting("ACTION_CALLBACK_VOICE_REWRITE", "false", false);
+    const delivered: Content[] = [];
+    const wrapped = wrapSingleTurnVisibleCallback(
+      runtime,
+      request,
+      async (content: Content) => {
+        delivered.push(content);
+        return [];
+      },
+    );
+    await wrapped?.(
+      { text: "PRIVATE_ACTION_CANARY", actions: ["CHECK_CALENDAR"] },
+      "CHECK_CALENDAR",
+    );
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]?.text).toContain("delivery was cancelled");
+    expect(delivered[0]?.text).not.toContain("PRIVATE_ACTION_CANARY");
   });
 
   it("reports authorization and metadata failures and fails closed", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.integration.test.ts
@@ -1,17 +1,18 @@
 /**
- * Integration coverage for the LifeOps audience egress gate.
+ * Production-path integration coverage for audience-scoped private context.
  *
- * A real PGlite-backed AgentRuntime owns room, participant, and role metadata;
- * the only seam is a canary-bearing loader used after the exported provider
- * gate, proving denied destinations are filtered before private context can be
- * read or composed for a model prompt.
+ * Uses the real PGlite AgentRuntime, provider/action implementations and core
+ * pipeline-hook delivery registry.  No canary loader wrapper is used: denied
+ * reads are asserted at the provider/action entrypoints that production calls.
  */
 import {
   AgentRuntime,
   ChannelType,
   type Character,
+  type Content,
   createMessageMemory,
-  type Memory,
+  outgoingPipelineHookContext,
+  type State,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -28,119 +29,57 @@ import { PgliteDatabaseAdapter } from "../../../plugin-sql/src/pglite/adapter.js
 import { PGliteClientManager } from "../../../plugin-sql/src/pglite/manager.js";
 import * as schema from "../../../plugin-sql/src/schema/index.js";
 import type { DrizzleDatabase } from "../../../plugin-sql/src/types.js";
+import { calendarAction } from "../actions/calendar.js";
+import { crossChannelContextProvider } from "../providers/cross-channel-context.js";
+import { lifeOpsProvider } from "../providers/lifeops.js";
+import { pendingApprovalsProvider } from "../providers/pending-approvals.js";
 import {
-  lifeOpsProvider,
-  resolveLifeOpsProviderAudienceGate,
-} from "../providers/lifeops.js";
-import {
+  authorizeLifeOpsPrivateContext,
   evaluateLifeOpsAudiencePolicy,
-  type LifeOpsAudienceGateResult,
-  type LifeOpsAudienceReason,
-  type LifeOpsAudienceSource,
+  registerLifeOpsAudienceDeliveryHook,
 } from "./audience-policy.js";
 import { LifeOpsService } from "./service.js";
 
-const OWNER_CANARY = "OWNER_SECRET_CORPUS_ALPINE_7421";
-const LEAK_CORPUS = {
-  gmail: "GMAIL_CANARY_INBOX_QUARTZ_8123",
-  calendar: "CALENDAR_CANARY_EVENT_ONYX_4772",
-  privateMemory: "PRIVATE_MEMORY_CANARY_VAULT_1936",
-} as const;
-const AGENT_PERSONA = "persona-alpha";
-const OTHER_PERSONA = "persona-beta";
-
-const PRIVATE_SOURCE: LifeOpsAudienceSource = {
-  kind: "private_memory",
-  id: "private-canary",
-  classification: "persona_scoped",
-  persona: AGENT_PERSONA,
-};
-
-const PUBLIC_SOURCE: LifeOpsAudienceSource = {
-  kind: "public_memory",
-  id: "public-release-note",
-  classification: "public",
-  persona: null,
-};
-
-const CROSS_PERSONA_CALENDAR_SOURCE: LifeOpsAudienceSource = {
-  kind: "calendar",
-  id: "calendar-beta",
-  classification: "persona_scoped",
-  persona: OTHER_PERSONA,
-};
-
-const CROSS_PERSONA_GMAIL_SOURCE: LifeOpsAudienceSource = {
-  kind: "gmail",
-  id: "gmail-beta",
-  classification: "persona_scoped",
-  persona: OTHER_PERSONA,
-};
-
-async function loadAfterGate(
-  gate: LifeOpsAudienceGateResult,
-  loader: () => Promise<string>,
-): Promise<string> {
-  return gate.canLoadPrivateContext ? loader() : "";
-}
+const AGENT_DISPLAY_NAME = "mutable-display-name";
+const PRIVATE_SOURCES = [
+  { kind: "private_memory" as const, id: "owner-memory" },
+  { kind: "calendar" as const, id: "owner-calendar" },
+  { kind: "gmail" as const, id: "owner-gmail" },
+];
+const EMPTY_STATE: State = { text: "", values: {}, data: {} };
 
 function uuid(): UUID {
   return crypto.randomUUID() as UUID;
 }
 
-function message(args: {
-  entityId: UUID;
-  roomId: UUID;
-  channelType: ChannelType;
-  requestingPersona?: string;
-  persona?: string;
-}): Memory {
-  return createMessageMemory({
-    id: uuid(),
-    entityId: args.entityId,
-    roomId: args.roomId,
-    content: {
-      text: "read my LifeOps context",
-      source: "test",
-      channelType: args.channelType,
-      ...(args.requestingPersona
-        ? { requestingPersona: args.requestingPersona }
-        : {}),
-      ...(args.persona ? { persona: args.persona } : {}),
-    },
-  });
-}
-
-describe("LifeOps audience policy (real runtime + PGlite)", () => {
+describe("shared LifeOps audience boundary (production provider/action paths)", () => {
   let manager: PGliteClientManager;
   let adapter: PgliteDatabaseAdapter;
   let runtime: AgentRuntime;
   let ownerId: UUID;
   let otherId: UUID;
-  let outsiderId: UUID;
   let worldId: UUID;
 
   beforeAll(async () => {
     ownerId = uuid();
     otherId = uuid();
-    outsiderId = uuid();
     const agentId = uuid();
     manager = new PGliteClientManager({});
     await manager.initialize();
     adapter = new PgliteDatabaseAdapter(agentId, manager);
     await adapter.init();
-    const migrationService = new DatabaseMigrationService();
-    await migrationService.initializeWithDatabase(
+    const migrations = new DatabaseMigrationService();
+    await migrations.initializeWithDatabase(
       adapter.getDatabase() as DrizzleDatabase,
     );
-    migrationService.discoverAndRegisterPluginSchemas([
+    migrations.discoverAndRegisterPluginSchemas([
       { name: "@elizaos/plugin-sql", description: "SQL plugin", schema },
     ]);
-    await migrationService.runAllPluginMigrations();
+    await migrations.runAllPluginMigrations();
     await adapter.createAgent({
       id: agentId,
-      name: AGENT_PERSONA,
-      bio: ["Test audience-policy agent"],
+      name: "persisted-loader-identity",
+      bio: ["Audience integration agent"],
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
@@ -148,7 +87,7 @@ describe("LifeOps audience policy (real runtime + PGlite)", () => {
       agentId,
       character: {
         id: agentId,
-        name: AGENT_PERSONA,
+        name: AGENT_DISPLAY_NAME,
       } as Character,
       adapter,
     });
@@ -156,21 +95,18 @@ describe("LifeOps audience policy (real runtime + PGlite)", () => {
     worldId = uuid();
     await runtime.ensureWorldExists({
       id: worldId,
-      name: "audience-policy-world",
-      agentId: runtime.agentId,
-    } as Parameters<typeof runtime.ensureWorldExists>[0]);
-    for (const entityId of [
-      runtime.agentId as UUID,
-      ownerId,
-      otherId,
-      outsiderId,
-    ]) {
+      name: "audience-world",
+      agentId,
+      metadata: { ownership: { ownerId } },
+    });
+    for (const entityId of [agentId, ownerId, otherId]) {
       await runtime.createEntity({
         id: entityId,
         names: [entityId],
-        agentId: runtime.agentId,
+        agentId,
       });
     }
+    registerLifeOpsAudienceDeliveryHook(runtime);
   }, 180_000);
 
   afterAll(async () => {
@@ -180,485 +116,222 @@ describe("LifeOps audience policy (real runtime + PGlite)", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    runtime.character.name = AGENT_DISPLAY_NAME;
   });
 
-  async function ensureRoom(args: {
-    type: ChannelType;
-    participants: UUID[];
-  }): Promise<UUID> {
+  async function room(type: ChannelType, participants: UUID[]): Promise<UUID> {
     const roomId = uuid();
     await runtime.createRoom({
       id: roomId,
       name: `room-${roomId}`,
       source: "test",
-      type: args.type,
+      type,
       channelId: roomId,
       worldId,
     });
-    for (const participant of args.participants) {
+    for (const participant of participants) {
       await runtime.ensureParticipantInRoom(participant, roomId);
     }
     return roomId;
   }
 
-  async function expectReason(args: {
-    roomId: UUID;
-    requester: UUID;
-    messageType: ChannelType;
-    source?: LifeOpsAudienceSource;
-    reason: LifeOpsAudienceReason;
-    decision?: "include" | "exclude";
-    requestingPersona?: string;
-  }) {
-    const gate = await evaluateLifeOpsAudiencePolicy({
-      runtime,
-      message: message({
-        entityId: args.requester,
-        roomId: args.roomId,
-        channelType: args.messageType,
-        requestingPersona: args.requestingPersona ?? AGENT_PERSONA,
-      }),
-      sources: [args.source ?? PRIVATE_SOURCE],
-      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
+  function message(
+    roomId: UUID,
+    channelType: ChannelType,
+    text = "owner request",
+  ) {
+    return createMessageMemory({
+      id: uuid(),
+      entityId: ownerId,
+      agentId: runtime.agentId,
+      roomId,
+      content: { text, source: "test", channelType },
     });
-    expect(gate.receipts).toHaveLength(1);
-    expect(gate.receipts[0]).toMatchObject({
-      decision: args.decision ?? "exclude",
-      reason: args.reason,
-      requestEntityId: args.requester,
-      destinationRoomId: args.roomId,
-    });
-    expect(gate.receipts[0].participantEntityIds).toEqual(
-      [...gate.receipts[0].participantEntityIds].sort(),
-    );
-    return gate;
   }
 
-  function wrapRuntime(
-    overrides: Partial<
-      Pick<AgentRuntime, "getRoom" | "getParticipantsForRoom">
-    >,
-  ): AgentRuntime {
-    const wrapped = Object.create(runtime) as AgentRuntime;
-    Object.assign(wrapped, overrides);
-    return wrapped;
-  }
+  it.each([
+    [ChannelType.DM, ChannelType.DM],
+    // Production web/OpenAI/Anthropic compatibility routes persist DM rooms
+    // while stamping their messages API. Both belong to one private class.
+    [ChannelType.DM, ChannelType.API],
+    [ChannelType.DM, ChannelType.VOICE_DM],
+    [ChannelType.SELF, ChannelType.SELF],
+  ])(
+    "allows private stored room %s with private message surface %s",
+    async (roomType, messageType) => {
+      const roomId = await room(roomType, [runtime.agentId, ownerId]);
+      const gate = await authorizeLifeOpsPrivateContext({
+        runtime,
+        message: message(roomId, messageType),
+        sources: PRIVATE_SOURCES,
+      });
+      expect(gate.canLoadPrivateContext).toBe(true);
+      expect(gate.receipts.every((row) => row.decision === "include")).toBe(
+        true,
+      );
+      expect(gate.receipts[0]).toMatchObject({
+        roomAudienceClass: "private",
+        messageAudienceClass: "private",
+        reason: "included_private_audience",
+        source: { trustedAgentId: runtime.agentId },
+      });
+    },
+  );
 
-  it("allows owner DM private context and returns an inclusion receipt", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    const gate = await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      reason: "included_private_dm",
-      decision: "include",
-    });
-    let reads = 0;
-    const text = await loadAfterGate(gate, async () => {
-      reads += 1;
-      return OWNER_CANARY;
-    });
-    expect(reads).toBe(1);
-    expect(text).toBe(OWNER_CANARY);
-  });
-
-  it("allows public memory in an owner DM with an explicit public-DM receipt", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      source: PUBLIC_SOURCE,
-      reason: "included_public_dm",
-      decision: "include",
-    });
-  });
-
-  it("denies owner private context in groups before loader or provider reads", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.GROUP,
-      participants: [runtime.agentId as UUID, ownerId, otherId],
-    });
-    const gate = await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.GROUP,
-      reason: "excluded_group_destination",
-    });
-    let reads = 0;
-    const text = await loadAfterGate(gate, async () => {
-      reads += 1;
-      return Object.values(LEAK_CORPUS).join("\n");
-    });
-    expect(reads).toBe(0);
-    for (const canary of Object.values(LEAK_CORPUS)) {
-      expect(text).not.toContain(canary);
-    }
-
-    const overviewSpy = vi
-      .spyOn(LifeOpsService.prototype, "getOverview")
-      .mockRejectedValue(new Error(LEAK_CORPUS.privateMemory));
-    const calendarSpy = vi
-      .spyOn(LifeOpsService.prototype, "getNextCalendarEventContext")
-      .mockRejectedValue(new Error(LEAK_CORPUS.calendar));
-    const gmailSpy = vi
-      .spyOn(LifeOpsService.prototype, "getGmailTriage")
-      .mockRejectedValue(new Error(LEAK_CORPUS.gmail));
-
-    const providerResult = await lifeOpsProvider.get(
+  it("binds provenance to the persisted agent id, ignoring mutable display/message persona", async () => {
+    const roomId = await room(ChannelType.DM, [runtime.agentId, ownerId]);
+    const request = message(roomId, ChannelType.API);
+    request.content.requestingPersona = "attacker-selected-persona";
+    runtime.character.name = "changed-after-loader-start";
+    const gate = await authorizeLifeOpsPrivateContext({
       runtime,
-      message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.GROUP,
-        requestingPersona: AGENT_PERSONA,
-      }),
-      { values: {}, data: {}, text: "" },
+      message: request,
+      sources: [{ kind: "gmail", id: "loader-selected-account" }],
+    });
+    expect(gate.canLoadPrivateContext).toBe(true);
+    expect(gate.receipts[0].source.trustedAgentId).toBe(runtime.agentId);
+    expect(JSON.stringify(gate.receipts)).not.toContain(
+      "attacker-selected-persona",
     );
-    expect(overviewSpy).not.toHaveBeenCalled();
-    expect(calendarSpy).not.toHaveBeenCalled();
-    expect(gmailSpy).not.toHaveBeenCalled();
-    const serializedProviderResult = JSON.stringify(providerResult);
-    for (const canary of Object.values(LEAK_CORPUS)) {
-      expect(providerResult.text).not.toContain(canary);
-      expect(serializedProviderResult).not.toContain(canary);
-    }
-    expect(providerResult.text).not.toContain("Owner profile:");
-    expect(providerResult.text).not.toContain("Inbox:");
-    expect(providerResult.text).not.toContain("Next event:");
-    expect(providerResult.data?.lifeOpsAudienceReceipts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          decision: "exclude",
-          reason: "excluded_group_destination",
-        }),
-      ]),
+    expect(JSON.stringify(gate.receipts)).not.toContain(
+      "changed-after-loader-start",
     );
   });
 
-  it("denies missing room metadata", async () => {
-    await expectReason({
-      roomId: uuid(),
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      reason: "excluded_missing_room",
-    });
-  });
-
-  it("distinguishes room metadata lookup failures without leaking exception payloads", async () => {
-    const roomId = uuid();
-    const failureCanary = "ROOM_LOOKUP_FAILURE_PAYLOAD_EMERALD_6331";
-    const gate = await evaluateLifeOpsAudiencePolicy({
-      runtime: wrapRuntime({
-        getRoom: async () => {
-          throw new Error(failureCanary);
-        },
-      }),
-      message: message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.DM,
-      }),
-      sources: [PRIVATE_SOURCE],
-      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
-    });
-    expect(gate.receipts[0]).toMatchObject({
-      decision: "exclude",
-      reason: "excluded_metadata_lookup_failed",
-      destinationRoomType: null,
-      participantEntityIds: [],
-    });
-    expect(JSON.stringify(gate)).not.toContain(failureCanary);
-  });
-
-  it("denies missing or empty participant metadata", async () => {
-    const roomId = await ensureRoom({ type: ChannelType.DM, participants: [] });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      reason: "excluded_missing_participants",
-    });
-  });
-
-  it("distinguishes participant metadata lookup failures without leaking exception payloads", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    const failureCanary = "PARTICIPANT_LOOKUP_FAILURE_PAYLOAD_TOPAZ_9214";
-    const gate = await evaluateLifeOpsAudiencePolicy({
-      runtime: wrapRuntime({
-        getParticipantsForRoom: async () => {
-          throw new Error(failureCanary);
-        },
-      }),
-      message: message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.DM,
-      }),
-      sources: [PRIVATE_SOURCE],
-      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
-    });
-    expect(gate.receipts[0]).toMatchObject({
-      decision: "exclude",
-      reason: "excluded_metadata_lookup_failed",
-      destinationRoomType: ChannelType.DM,
-      participantEntityIds: [],
-    });
-    expect(JSON.stringify(gate)).not.toContain(failureCanary);
-  });
-
-  it("denies null-ish participant responses", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    const gate = await evaluateLifeOpsAudiencePolicy({
-      runtime: wrapRuntime({
-        getParticipantsForRoom: async () => null as unknown as UUID[],
-      }),
-      message: message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.DM,
-      }),
-      sources: [PRIVATE_SOURCE],
-      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
-    });
-    expect(gate.receipts[0]).toMatchObject({
-      decision: "exclude",
-      reason: "excluded_missing_participants",
-    });
-  });
-
-  it("denies stale private participant sets", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId, otherId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      reason: "excluded_unexpected_participants",
-    });
-  });
-
-  it("denies private destinations when the agent is not an authoritative participant", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [ownerId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      reason: "excluded_agent_not_participant",
-    });
-  });
-
-  it("denies cross-persona sources without hardcoded names", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.DM,
-      source: { ...PRIVATE_SOURCE, persona: OTHER_PERSONA },
-      requestingPersona: AGENT_PERSONA,
-      reason: "excluded_cross_persona",
-    });
-  });
-
-  it("does not let message content spoof the authoritative requesting persona", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    const gate = await evaluateLifeOpsAudiencePolicy({
-      runtime,
-      message: message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.DM,
-        requestingPersona: OTHER_PERSONA,
-        persona: OTHER_PERSONA,
-      }),
-      sources: [{ ...PRIVATE_SOURCE, persona: OTHER_PERSONA }],
-      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
-    });
-    expect(gate.receipts[0]).toMatchObject({
-      decision: "exclude",
-      reason: "excluded_cross_persona",
-      requestingPersona: AGENT_PERSONA,
-    });
-    expect(gate.canLoadPrivateContext).toBe(false);
-  });
-
-  it("allows explicitly public memory in an authoritative group", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.GROUP,
-      participants: [runtime.agentId as UUID, ownerId, otherId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.GROUP,
-      source: PUBLIC_SOURCE,
-      reason: "included_public_group",
-      decision: "include",
-    });
-    const gate = await resolveLifeOpsProviderAudienceGate(
-      runtime,
-      message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.GROUP,
-        requestingPersona: AGENT_PERSONA,
-      }),
-      [PUBLIC_SOURCE],
-    );
-    expect(gate.canLoadPrivateContext).toBe(false);
-  });
-
-  it("denies explicitly public group memory when the agent is not an authoritative participant", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.GROUP,
-      participants: [ownerId, otherId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.GROUP,
-      source: PUBLIC_SOURCE,
-      reason: "excluded_agent_not_participant",
-    });
-  });
-
-  it("keeps bundled private context closed when any requested private source is denied", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    const gate = await evaluateLifeOpsAudiencePolicy({
-      runtime,
-      message: message({
-        entityId: ownerId,
-        roomId,
-        channelType: ChannelType.DM,
-        requestingPersona: AGENT_PERSONA,
-      }),
-      sources: [
-        PRIVATE_SOURCE,
-        CROSS_PERSONA_CALENDAR_SOURCE,
-        CROSS_PERSONA_GMAIL_SOURCE,
-      ],
-      hasOwnerAccess: async (_runtime, request) => request.entityId === ownerId,
-    });
-    expect(gate.canLoadPrivateContext).toBe(false);
-    expect(gate.receipts.map((receipt) => receipt.reason)).toEqual([
-      "included_private_dm",
-      "excluded_cross_persona",
-      "excluded_cross_persona",
+  it("denies all private provider retrieval paths in a group before their loaders run", async () => {
+    const roomId = await room(ChannelType.GROUP, [
+      runtime.agentId,
+      ownerId,
+      otherId,
     ]);
-    let reads = 0;
-    const text = await loadAfterGate(gate, async () => {
-      reads += 1;
-      return Object.values(LEAK_CORPUS).join("\n");
-    });
-    expect(reads).toBe(0);
-    for (const canary of Object.values(LEAK_CORPUS)) {
-      expect(text).not.toContain(canary);
-    }
-  });
+    const request = message(roomId, ChannelType.GROUP);
 
-  it("denies when the requester is not a room participant", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.GROUP,
-      participants: [runtime.agentId as UUID, otherId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.GROUP,
-      reason: "excluded_requester_not_participant",
-    });
-  });
+    const overview = vi.spyOn(LifeOpsService.prototype, "getOverview");
+    const lifeOps = await lifeOpsProvider.get(runtime, request, EMPTY_STATE);
+    expect(overview).not.toHaveBeenCalled();
+    expect(lifeOps.text).toBe("");
+    expect(lifeOps.data?.lifeOpsAudienceReceipts).toBeDefined();
 
-  it("denies channel-type mismatch between message and stored room", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.GROUP,
-      reason: "excluded_channel_type_mismatch",
-    });
-  });
-
-  it("does not let SELF or API message types relax mismatched stored room metadata", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, ownerId],
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.SELF,
-      reason: "excluded_channel_type_mismatch",
-    });
-    await expectReason({
-      roomId,
-      requester: ownerId,
-      messageType: ChannelType.API,
-      reason: "excluded_channel_type_mismatch",
-    });
-  });
-
-  it("denies non-owner requesters with receipts", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.DM,
-      participants: [runtime.agentId as UUID, otherId],
-    });
-    await expectReason({
-      roomId,
-      requester: otherId,
-      messageType: ChannelType.DM,
-      reason: "excluded_non_owner_requester",
-    });
-  });
-
-  it("uses the same exported gate as the live provider", async () => {
-    const roomId = await ensureRoom({
-      type: ChannelType.GROUP,
-      participants: [runtime.agentId as UUID, ownerId, otherId],
-    });
-    const gate = await resolveLifeOpsProviderAudienceGate(
+    const crossChannel = await crossChannelContextProvider.get(
       runtime,
-      message({
-        entityId: ownerId,
+      request,
+      {
+        ...EMPTY_STATE,
+        crossChannelContextRequest: { query: "secret gmail project" },
+      } as State,
+    );
+    expect(crossChannel.text).toBe("");
+    expect(crossChannel.values?.crossChannelUnavailable).toBe(true);
+    expect(crossChannel.data?.lifeOpsAudienceReceipts).toBeDefined();
+
+    const approvals = await pendingApprovalsProvider.get(
+      runtime,
+      request,
+      EMPTY_STATE,
+    );
+    expect(approvals.text).toBe("");
+    expect(approvals.values?.pendingApprovalsUnavailable).toBe(true);
+    expect(approvals.data?.lifeOpsAudienceReceipts).toBeDefined();
+  });
+
+  it("denies the real calendar action path in a group without delivering detail", async () => {
+    const roomId = await room(ChannelType.GROUP, [
+      runtime.agentId,
+      ownerId,
+      otherId,
+    ]);
+    const callback = vi.fn(async (_content: Content) => []);
+    const result = await calendarAction.handler(
+      runtime,
+      message(roomId, ChannelType.GROUP, "show my calendar"),
+      EMPTY_STATE,
+      { parameters: { action: "feed" } },
+      callback,
+    );
+    expect(callback).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: false,
+      data: { error: "AUDIENCE_DENIED" },
+    });
+  });
+
+  it("revalidates a real DB membership version at the production outgoing hook", async () => {
+    const roomId = await room(ChannelType.DM, [runtime.agentId, ownerId]);
+    const request = message(roomId, ChannelType.API);
+    const gate = await authorizeLifeOpsPrivateContext({
+      runtime,
+      message: request,
+      sources: PRIVATE_SOURCES,
+    });
+    expect(gate.canLoadPrivateContext).toBe(true);
+
+    // Concurrent membership mutation after private retrieval authorization.
+    await runtime.ensureParticipantInRoom(otherId, roomId);
+
+    const deliver = vi.fn(async (_content: Content) => []);
+    const content: Content = { text: "PRIVATE_CALENDAR_CANARY" };
+    await runtime.applyPipelineHooks(
+      "outgoing_before_deliver",
+      outgoingPipelineHookContext(content, {
+        source: "simple",
         roomId,
-        channelType: ChannelType.GROUP,
-        requestingPersona: AGENT_PERSONA,
+        message: request,
       }),
     );
+    await deliver(content);
+    expect(deliver).toHaveBeenCalledOnce();
+    expect(content.text).toContain("delivery was cancelled");
+    expect(content.text).not.toContain("PRIVATE_CALENDAR_CANARY");
+  });
+
+  it("revalidates membership before every streamed chunk delivery", async () => {
+    const roomId = await room(ChannelType.DM, [runtime.agentId, ownerId]);
+    const request = message(roomId, ChannelType.VOICE_DM);
+    await authorizeLifeOpsPrivateContext({
+      runtime,
+      message: request,
+      sources: [{ kind: "calendar", id: "voice.calendar" }],
+    });
+    await runtime.ensureParticipantInRoom(otherId, roomId);
+    const streamContext = {
+      phase: "model_stream_chunk" as const,
+      source: "message_service" as const,
+      chunk: "PRIVATE_VOICE_CANARY",
+      roomId,
+    };
+    await runtime.applyPipelineHooks("model_stream_chunk", streamContext);
+    expect(streamContext.chunk).toBe("");
+  });
+
+  it("reports authorization and metadata failures and fails closed", async () => {
+    const roomId = await room(ChannelType.DM, [runtime.agentId, ownerId]);
+    const reportError = vi.spyOn(runtime, "reportError");
+    const broken = Object.create(runtime) as AgentRuntime;
+    broken.getRoom = vi.fn(async () => {
+      throw new Error("DB_AUTH_CANARY");
+    });
+    broken.reportError = runtime.reportError.bind(runtime);
+    const gate = await evaluateLifeOpsAudiencePolicy({
+      runtime: broken,
+      message: message(roomId, ChannelType.DM),
+      sources: PRIVATE_SOURCES,
+      hasOwnerAccess: async () => {
+        throw new Error("ROLE_AUTH_CANARY");
+      },
+    });
     expect(gate.canLoadPrivateContext).toBe(false);
-    expect(gate.receipts.map((receipt) => receipt.reason)).toEqual([
-      "excluded_group_destination",
-      "excluded_group_destination",
-      "excluded_group_destination",
-    ]);
+    expect(gate.receipts[0].reason).toBe("excluded_non_owner_requester");
+    expect(reportError).toHaveBeenCalledWith(
+      "LifeOpsAudience.metadata",
+      expect.any(Error),
+      expect.any(Object),
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "LifeOpsAudience.ownerAccess",
+      expect.any(Error),
+      expect.any(Object),
+    );
+    expect(JSON.stringify(gate.receipts)).not.toContain("DB_AUTH_CANARY");
+    expect(JSON.stringify(gate.receipts)).not.toContain("ROLE_AUTH_CANARY");
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
@@ -1,16 +1,18 @@
 /**
- * Audience-scoped egress policy for LifeOps model context.
+ * Shared audience authorization for owner-private Personal Assistant reads.
  *
- * The gate binds the requesting entity, requested source persona, destination
- * room, stored room type, and current participant snapshot before any private
- * LifeOps data is loaded. Callers receive a serializable receipt for every
- * source so denied data can be audited without placing the payload in logs,
- * receipts, or model context.
+ * This module deliberately separates actor authorization (the owner) from
+ * destination authorization (the audience that will receive the result).  All
+ * private providers/actions call the same boundary before loading data.  The
+ * resulting envelope is attached to the inbound message and is revalidated by
+ * the production outgoing/stream hooks immediately before delivery.
  */
+import { hasOwnerAccess } from "@elizaos/agent";
 import {
   ChannelType,
   type IAgentRuntime,
   type Memory,
+  type PipelineHookContext,
   type UUID,
 } from "@elizaos/core";
 
@@ -18,45 +20,44 @@ export const LIFEOPS_AUDIENCE_SOURCE_KINDS = [
   "gmail",
   "calendar",
   "private_memory",
-  "public_memory",
+  "approvals",
 ] as const;
 
 export type LifeOpsAudienceSourceKind =
   (typeof LIFEOPS_AUDIENCE_SOURCE_KINDS)[number];
 
-export const LIFEOPS_AUDIENCE_CLASSIFICATIONS = [
-  "private",
-  "persona_scoped",
-  "public",
-] as const;
-
-export type LifeOpsAudienceClassification =
-  (typeof LIFEOPS_AUDIENCE_CLASSIFICATIONS)[number];
+/** A callsite may name a loader, but may not assert its persona/security scope. */
+export interface LifeOpsAudienceSource {
+  kind: LifeOpsAudienceSourceKind;
+  id: string;
+}
 
 export type LifeOpsAudienceDecision = "include" | "exclude";
-
 export type LifeOpsAudienceReason =
-  | "included_private_dm"
-  | "included_public_group"
-  | "included_public_dm"
+  | "included_private_audience"
   | "excluded_non_owner_requester"
   | "excluded_missing_room"
   | "excluded_missing_participants"
   | "excluded_metadata_lookup_failed"
-  | "excluded_channel_type_mismatch"
+  | "excluded_untrusted_loader_identity"
+  | "excluded_audience_class_mismatch"
   | "excluded_requester_not_participant"
   | "excluded_agent_not_participant"
   | "excluded_unexpected_participants"
   | "excluded_group_destination"
-  | "excluded_missing_source_persona"
-  | "excluded_cross_persona"
-  | "excluded_unknown_source_classification";
+  | "excluded_audience_changed";
 
-export interface LifeOpsAudienceSource {
-  kind: LifeOpsAudienceSourceKind;
-  id: string;
-  classification: LifeOpsAudienceClassification;
-  persona?: string | null;
+export type LifeOpsAudienceClass = "private" | "group" | "unknown";
+
+export interface LifeOpsAudienceEnvelope {
+  roomId: string;
+  requestEntityId: string;
+  trustedAgentId: string;
+  roomAudienceClass: LifeOpsAudienceClass;
+  messageAudienceClass: LifeOpsAudienceClass;
+  participantEntityIds: string[];
+  /** Deterministic membership/version token re-read at every delivery seam. */
+  audienceVersion: string;
 }
 
 export interface LifeOpsAudienceReceipt {
@@ -64,14 +65,16 @@ export interface LifeOpsAudienceReceipt {
   destinationRoomId: string;
   destinationRoomType: string | null;
   messageChannelType: string | null;
+  roomAudienceClass: LifeOpsAudienceClass;
+  messageAudienceClass: LifeOpsAudienceClass;
   participantEntityIds: string[];
+  audienceVersion: string | null;
   source: {
     kind: LifeOpsAudienceSourceKind;
     id: string;
-    classification: LifeOpsAudienceClassification;
-    persona: string | null;
+    /** Loaded from the persisted Agent record, never character.name/content. */
+    trustedAgentId: string | null;
   };
-  requestingPersona: string | null;
   decision: LifeOpsAudienceDecision;
   reason: LifeOpsAudienceReason;
 }
@@ -80,242 +83,394 @@ export interface LifeOpsAudienceGateResult {
   receipts: LifeOpsAudienceReceipt[];
   includedSources: LifeOpsAudienceSource[];
   canLoadPrivateContext: boolean;
+  envelope: LifeOpsAudienceEnvelope | null;
 }
 
-const PRIVATE_ROOM_TYPES = new Set<string>([
+const PRIVATE_TYPES = new Set<string>([
   ChannelType.DM,
   ChannelType.VOICE_DM,
+  ChannelType.SELF,
+  ChannelType.API,
 ]);
-const SOURCE_CLASSIFICATIONS = new Set<string>(
-  LIFEOPS_AUDIENCE_CLASSIFICATIONS,
-);
-function readRequestingPersona(runtime: IAgentRuntime): string | null {
-  const raw = runtime.character.name;
-  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+const GROUP_TYPES = new Set<string>([
+  ChannelType.GROUP,
+  ChannelType.VOICE_GROUP,
+  ChannelType.FEED,
+  ChannelType.THREAD,
+  ChannelType.WORLD,
+  ChannelType.FORUM,
+]);
+const ENVELOPE_METADATA_KEY = "lifeOpsAudienceEnvelope";
+const activeEnvelopeByRuntime = new WeakMap<
+  IAgentRuntime,
+  Map<string, LifeOpsAudienceEnvelope>
+>();
+
+export class LifeOpsAudienceDeliveryDeniedError extends Error {
+  constructor() {
+    super(
+      "Private context delivery cancelled because the destination audience changed",
+    );
+    this.name = "LifeOpsAudienceDeliveryDeniedError";
+  }
+}
+
+export function classifyLifeOpsAudience(
+  channelType: string | null | undefined,
+): LifeOpsAudienceClass {
+  if (!channelType) return "unknown";
+  if (PRIVATE_TYPES.has(channelType)) return "private";
+  if (GROUP_TYPES.has(channelType)) return "group";
+  return "unknown";
 }
 
 function sortedParticipants(participants: readonly string[]): string[] {
-  return [
-    ...new Set(participants.map((participant) => String(participant))),
-  ].sort();
+  return [...new Set(participants.map(String))].sort();
 }
 
-function baseReceipt(args: {
-  message: Memory;
-  source: LifeOpsAudienceSource;
-  requestingPersona: string | null;
+function audienceVersion(args: {
+  roomId: string;
   roomType: string | null;
   participants: readonly string[];
-  reason: LifeOpsAudienceReason;
+}): string {
+  return `${args.roomId}|${args.roomType ?? "unknown"}|${args.participants.join(",")}`;
+}
+
+function activeEnvelopes(
+  runtime: IAgentRuntime,
+): Map<string, LifeOpsAudienceEnvelope> {
+  let envelopes = activeEnvelopeByRuntime.get(runtime);
+  if (!envelopes) {
+    envelopes = new Map();
+    activeEnvelopeByRuntime.set(runtime, envelopes);
+  }
+  return envelopes;
+}
+
+function attachEnvelope(
+  runtime: IAgentRuntime,
+  message: Memory,
+  envelope: LifeOpsAudienceEnvelope,
+): void {
+  message.metadata = {
+    ...(message.metadata ?? { type: "message" }),
+    [ENVELOPE_METADATA_KEY]: envelope,
+  } as Memory["metadata"];
+  activeEnvelopes(runtime).set(message.roomId, envelope);
+}
+
+function readEnvelope(
+  message: Memory | undefined,
+): LifeOpsAudienceEnvelope | null {
+  if (!message?.metadata || typeof message.metadata !== "object") return null;
+  const candidate = (message.metadata as Record<string, unknown>)[
+    ENVELOPE_METADATA_KEY
+  ];
+  if (!candidate || typeof candidate !== "object") return null;
+  const envelope = candidate as Partial<LifeOpsAudienceEnvelope>;
+  return typeof envelope.roomId === "string" &&
+    typeof envelope.audienceVersion === "string" &&
+    Array.isArray(envelope.participantEntityIds)
+    ? (envelope as LifeOpsAudienceEnvelope)
+    : null;
+}
+
+function receipt(args: {
+  message: Memory;
+  source: LifeOpsAudienceSource;
+  trustedAgentId: string | null;
+  roomType: string | null;
+  roomClass: LifeOpsAudienceClass;
+  messageClass: LifeOpsAudienceClass;
+  participants: string[];
+  version: string | null;
   decision: LifeOpsAudienceDecision;
+  reason: LifeOpsAudienceReason;
 }): LifeOpsAudienceReceipt {
-  const messageChannelType =
-    typeof args.message.content.channelType === "string"
-      ? args.message.content.channelType
-      : null;
   return {
     requestEntityId: args.message.entityId,
     destinationRoomId: args.message.roomId,
     destinationRoomType: args.roomType,
-    messageChannelType,
-    participantEntityIds: [...args.participants],
+    messageChannelType:
+      typeof args.message.content.channelType === "string"
+        ? args.message.content.channelType
+        : null,
+    roomAudienceClass: args.roomClass,
+    messageAudienceClass: args.messageClass,
+    participantEntityIds: args.participants,
+    audienceVersion: args.version,
     source: {
       kind: args.source.kind,
       id: args.source.id,
-      classification: args.source.classification,
-      persona: args.source.persona?.trim() || null,
+      trustedAgentId: args.trustedAgentId,
     },
-    requestingPersona: args.requestingPersona,
     decision: args.decision,
     reason: args.reason,
   };
 }
 
-function sourcePersonaReason(
-  source: LifeOpsAudienceSource,
-  requestingPersona: string | null,
-): LifeOpsAudienceReason | null {
-  if (!SOURCE_CLASSIFICATIONS.has(source.classification)) {
-    return "excluded_unknown_source_classification";
-  }
-  if (source.classification === "public") {
-    return null;
-  }
-  const sourcePersona = source.persona?.trim();
-  if (!sourcePersona || !requestingPersona) {
-    return "excluded_missing_source_persona";
-  }
-  return sourcePersona === requestingPersona ? null : "excluded_cross_persona";
-}
-
-function classifyDestination(args: {
-  runtime: IAgentRuntime;
-  message: Memory;
-  roomType: string;
-  participants: readonly string[];
-}): LifeOpsAudienceReason | null {
-  const messageChannelType =
-    typeof args.message.content.channelType === "string"
-      ? args.message.content.channelType
-      : null;
-  if (!messageChannelType) {
-    return "excluded_channel_type_mismatch";
-  }
-  if (args.roomType !== messageChannelType) {
-    return "excluded_channel_type_mismatch";
-  }
-  if (!args.participants.includes(args.message.entityId)) {
-    return "excluded_requester_not_participant";
-  }
-  if (!args.participants.includes(args.runtime.agentId)) {
-    return "excluded_agent_not_participant";
-  }
-  if (PRIVATE_ROOM_TYPES.has(args.roomType)) {
-    const expected = sortedParticipants([
-      args.message.entityId,
-      args.runtime.agentId,
-    ]);
-    return args.participants.length === expected.length &&
-      args.participants.every(
-        (participant, index) => participant === expected[index],
-      )
-      ? null
-      : "excluded_unexpected_participants";
-  }
-  return "excluded_group_destination";
-}
-
+/**
+ * Authorize private retrieval and bind its provenance to the persisted Agent
+ * identity loaded by the runtime.  Display names and message-supplied persona
+ * fields are intentionally ignored.
+ */
 export async function evaluateLifeOpsAudiencePolicy(args: {
   runtime: IAgentRuntime;
   message: Memory;
   sources: readonly LifeOpsAudienceSource[];
   hasOwnerAccess: (runtime: IAgentRuntime, message: Memory) => Promise<boolean>;
 }): Promise<LifeOpsAudienceGateResult> {
-  const requestingPersona = readRequestingPersona(args.runtime);
-  let metadataLookupFailed = false;
   let room: Awaited<ReturnType<IAgentRuntime["getRoom"]>> = null;
+  let participants: string[] = [];
+  let trustedAgentId: string | null = null;
+  let metadataFailure = false;
+
   try {
     room = await args.runtime.getRoom(args.message.roomId as UUID);
-  } catch {
-    // error-policy:J4 audience metadata must fail closed before private context loads.
-    metadataLookupFailed = true;
-  }
-  const roomType = room?.type ?? null;
-  let participantIds: string[] = [];
-  if (room) {
-    try {
-      const participants = await args.runtime.getParticipantsForRoom(
+    if (room) {
+      const values = await args.runtime.getParticipantsForRoom(
         args.message.roomId as UUID,
       );
-      participantIds = Array.isArray(participants)
-        ? sortedParticipants(participants)
-        : [];
-    } catch {
-      // error-policy:J4 audience metadata must fail closed before private context loads.
-      metadataLookupFailed = true;
+      participants = Array.isArray(values) ? sortedParticipants(values) : [];
+    }
+  } catch (error) {
+    metadataFailure = true;
+    args.runtime.reportError("LifeOpsAudience.metadata", error, {
+      roomId: args.message.roomId,
+    });
+  }
+
+  try {
+    const persistedAgent = await args.runtime.getAgent(args.runtime.agentId);
+    trustedAgentId = persistedAgent?.id ?? null;
+  } catch (error) {
+    metadataFailure = true;
+    args.runtime.reportError("LifeOpsAudience.loaderIdentity", error, {
+      agentId: args.runtime.agentId,
+    });
+  }
+
+  let isOwner = false;
+  try {
+    isOwner = await args.hasOwnerAccess(args.runtime, args.message);
+  } catch (error) {
+    args.runtime.reportError("LifeOpsAudience.ownerAccess", error, {
+      entityId: args.message.entityId,
+      roomId: args.message.roomId,
+    });
+  }
+
+  const roomType = room?.type ?? null;
+  const messageType =
+    typeof args.message.content.channelType === "string"
+      ? args.message.content.channelType
+      : null;
+  const roomClass = classifyLifeOpsAudience(roomType);
+  const messageClass = classifyLifeOpsAudience(messageType);
+  const version = room
+    ? audienceVersion({
+        roomId: args.message.roomId,
+        roomType,
+        participants,
+      })
+    : null;
+
+  let reason: LifeOpsAudienceReason | null = null;
+  if (!isOwner) reason = "excluded_non_owner_requester";
+  else if (metadataFailure) reason = "excluded_metadata_lookup_failed";
+  else if (!trustedAgentId || trustedAgentId !== args.runtime.agentId)
+    reason = "excluded_untrusted_loader_identity";
+  else if (!room || !roomType) reason = "excluded_missing_room";
+  else if (participants.length === 0) reason = "excluded_missing_participants";
+  else if (roomClass === "group" || messageClass === "group")
+    reason = "excluded_group_destination";
+  else if (roomClass !== "private" || messageClass !== "private")
+    reason = "excluded_audience_class_mismatch";
+  else if (!participants.includes(args.message.entityId))
+    reason = "excluded_requester_not_participant";
+  else if (!participants.includes(args.runtime.agentId))
+    reason = "excluded_agent_not_participant";
+  else {
+    const expected = sortedParticipants([
+      args.message.entityId,
+      args.runtime.agentId,
+    ]);
+    if (
+      participants.length !== expected.length ||
+      !participants.every(
+        (participant, index) => participant === expected[index],
+      )
+    ) {
+      reason = "excluded_unexpected_participants";
     }
   }
-  const includedSources: LifeOpsAudienceSource[] = [];
 
-  const denyAll = (
-    reason: LifeOpsAudienceReason,
-  ): LifeOpsAudienceGateResult => ({
-    receipts: args.sources.map((source) =>
-      baseReceipt({
-        message: args.message,
-        source,
-        requestingPersona,
-        roomType,
-        participants: participantIds,
-        reason,
-        decision: "exclude",
-      }),
-    ),
-    includedSources,
-    canLoadPrivateContext: false,
-  });
-
-  const hasRequesterOwnerAccess = await args
-    .hasOwnerAccess(args.runtime, args.message)
-    .catch(() => {
-      // error-policy:J4 owner-access resolution failure must deny private context.
-      return false;
-    });
-  if (!hasRequesterOwnerAccess) {
-    return denyAll("excluded_non_owner_requester");
-  }
-  if (metadataLookupFailed) {
-    return denyAll("excluded_metadata_lookup_failed");
-  }
-  if (!room || !roomType) {
-    return denyAll("excluded_missing_room");
-  }
-  if (participantIds.length === 0) {
-    return denyAll("excluded_missing_participants");
-  }
-
-  const destinationReason = classifyDestination({
-    runtime: args.runtime,
-    message: args.message,
-    roomType,
-    participants: participantIds,
-  });
-
-  const receipts = args.sources.map((source) => {
-    const personaReason = sourcePersonaReason(source, requestingPersona);
-    const reason = personaReason ?? destinationReason;
-    if (reason) {
-      if (
-        source.classification === "public" &&
-        reason === "excluded_group_destination"
-      ) {
-        includedSources.push(source);
-        return baseReceipt({
+  if (reason) {
+    return {
+      receipts: args.sources.map((source) =>
+        receipt({
           message: args.message,
           source,
-          requestingPersona,
+          trustedAgentId,
           roomType,
-          participants: participantIds,
-          reason: "included_public_group",
-          decision: "include",
-        });
-      }
-      return baseReceipt({
+          roomClass,
+          messageClass,
+          participants,
+          version,
+          decision: "exclude",
+          reason,
+        }),
+      ),
+      includedSources: [],
+      canLoadPrivateContext: false,
+      envelope: null,
+    };
+  }
+
+  const envelope: LifeOpsAudienceEnvelope = {
+    roomId: args.message.roomId,
+    requestEntityId: args.message.entityId,
+    trustedAgentId: trustedAgentId as string,
+    roomAudienceClass: roomClass,
+    messageAudienceClass: messageClass,
+    participantEntityIds: participants,
+    audienceVersion: version as string,
+  };
+  attachEnvelope(args.runtime, args.message, envelope);
+  return {
+    receipts: args.sources.map((source) =>
+      receipt({
         message: args.message,
         source,
-        requestingPersona,
+        trustedAgentId,
         roomType,
-        participants: participantIds,
-        reason,
-        decision: "exclude",
-      });
-    }
-    includedSources.push(source);
-    const includeReason =
-      source.classification === "public"
-        ? "included_public_dm"
-        : PRIVATE_ROOM_TYPES.has(roomType)
-          ? "included_private_dm"
-          : "included_public_group";
-    return baseReceipt({
-      message: args.message,
-      source,
-      requestingPersona,
-      roomType,
-      participants: participantIds,
-      reason: includeReason,
-      decision: "include",
-    });
-  });
-
-  return {
-    receipts,
-    includedSources,
-    canLoadPrivateContext:
-      receipts.some(
-        (receipt) =>
-          receipt.decision === "include" &&
-          receipt.source.classification !== "public",
-      ) && receipts.every((receipt) => receipt.decision === "include"),
+        roomClass,
+        messageClass,
+        participants,
+        version,
+        decision: "include",
+        reason: "included_private_audience",
+      }),
+    ),
+    includedSources: [...args.sources],
+    canLoadPrivateContext: true,
+    envelope,
   };
+}
+
+/** Shared production retrieval boundary used by private providers/actions. */
+export async function authorizeLifeOpsPrivateContext(args: {
+  runtime: IAgentRuntime;
+  message: Memory;
+  sources: readonly LifeOpsAudienceSource[];
+}): Promise<LifeOpsAudienceGateResult> {
+  return evaluateLifeOpsAudiencePolicy({
+    ...args,
+    hasOwnerAccess,
+  });
+}
+
+/** Re-read the authoritative room and participants immediately before send. */
+export async function revalidateLifeOpsAudienceEnvelope(
+  runtime: IAgentRuntime,
+  envelope: LifeOpsAudienceEnvelope,
+): Promise<boolean> {
+  try {
+    const room = await runtime.getRoom(envelope.roomId as UUID);
+    if (!room) return false;
+    const participants = sortedParticipants(
+      await runtime.getParticipantsForRoom(envelope.roomId as UUID),
+    );
+    const currentVersion = audienceVersion({
+      roomId: envelope.roomId,
+      roomType: room.type,
+      participants,
+    });
+    return (
+      currentVersion === envelope.audienceVersion &&
+      classifyLifeOpsAudience(room.type) === "private" &&
+      participants.includes(envelope.requestEntityId) &&
+      participants.includes(envelope.trustedAgentId)
+    );
+  } catch (error) {
+    runtime.reportError("LifeOpsAudience.deliveryRevalidation", error, {
+      roomId: envelope.roomId,
+    });
+    return false;
+  }
+}
+
+export async function assertLifeOpsAudienceAtDelivery(
+  runtime: IAgentRuntime,
+  message: Memory,
+  envelope?: LifeOpsAudienceEnvelope | null,
+): Promise<void> {
+  const bound = envelope ?? readEnvelope(message);
+  if (!bound) return;
+  if (!(await revalidateLifeOpsAudienceEnvelope(runtime, bound))) {
+    activeEnvelopes(runtime).delete(bound.roomId);
+    throw new LifeOpsAudienceDeliveryDeniedError();
+  }
+}
+
+/**
+ * Production delivery boundary.  Final callback delivery and every streamed
+ * model chunk pass through these core pipeline phases before reaching a client.
+ */
+export function registerLifeOpsAudienceDeliveryHook(
+  runtime: IAgentRuntime,
+): void {
+  for (const id of [
+    "lifeops:audience-stream-delivery",
+    "lifeops:audience-final-delivery",
+  ]) {
+    runtime.unregisterPipelineHook(id);
+  }
+  runtime.registerPipelineHook({
+    id: "lifeops:audience-stream-delivery",
+    phase: "model_stream_chunk",
+    schedule: "serial",
+    mutatesPrimary: true,
+    async handler(hookRuntime, context: PipelineHookContext) {
+      if (context.phase !== "model_stream_chunk" || !context.roomId) return;
+      const envelope = activeEnvelopes(hookRuntime).get(context.roomId);
+      if (!envelope) return;
+      if (!(await revalidateLifeOpsAudienceEnvelope(hookRuntime, envelope))) {
+        activeEnvelopes(hookRuntime).delete(envelope.roomId);
+        // Pipeline hooks are diagnostics-safe and intentionally swallow throws.
+        // Mutating the primary chunk is therefore the enforceable send boundary.
+        context.chunk = "";
+        if (context.accumulated !== undefined) context.accumulated = "";
+      }
+    },
+  });
+  runtime.registerPipelineHook({
+    id: "lifeops:audience-final-delivery",
+    phase: "outgoing_before_deliver",
+    schedule: "serial",
+    mutatesPrimary: true,
+    async handler(hookRuntime, context: PipelineHookContext) {
+      if (context.phase !== "outgoing_before_deliver") return;
+      const envelope = readEnvelope(context.message);
+      if (!envelope) return;
+      const stillAuthorized = await revalidateLifeOpsAudienceEnvelope(
+        hookRuntime,
+        envelope,
+      );
+      activeEnvelopes(hookRuntime).delete(envelope.roomId);
+      if (!stillAuthorized) {
+        const responseId = context.content.responseId;
+        const inReplyTo = context.content.inReplyTo;
+        for (const key of Object.keys(context.content)) {
+          delete (context.content as Record<string, unknown>)[key];
+        }
+        Object.assign(context.content, {
+          text: "Private context delivery was cancelled because the destination audience changed.",
+          actions: ["REPLY"],
+          ...(responseId ? { responseId } : {}),
+          ...(inReplyTo ? { inReplyTo } : {}),
+        });
+      }
+    },
+  });
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
@@ -1,0 +1,321 @@
+/**
+ * Audience-scoped egress policy for LifeOps model context.
+ *
+ * The gate binds the requesting entity, requested source persona, destination
+ * room, stored room type, and current participant snapshot before any private
+ * LifeOps data is loaded. Callers receive a serializable receipt for every
+ * source so denied data can be audited without placing the payload in logs,
+ * receipts, or model context.
+ */
+import {
+  ChannelType,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+
+export const LIFEOPS_AUDIENCE_SOURCE_KINDS = [
+  "gmail",
+  "calendar",
+  "private_memory",
+  "public_memory",
+] as const;
+
+export type LifeOpsAudienceSourceKind =
+  (typeof LIFEOPS_AUDIENCE_SOURCE_KINDS)[number];
+
+export const LIFEOPS_AUDIENCE_CLASSIFICATIONS = [
+  "private",
+  "persona_scoped",
+  "public",
+] as const;
+
+export type LifeOpsAudienceClassification =
+  (typeof LIFEOPS_AUDIENCE_CLASSIFICATIONS)[number];
+
+export type LifeOpsAudienceDecision = "include" | "exclude";
+
+export type LifeOpsAudienceReason =
+  | "included_private_dm"
+  | "included_public_group"
+  | "included_public_dm"
+  | "excluded_non_owner_requester"
+  | "excluded_missing_room"
+  | "excluded_missing_participants"
+  | "excluded_metadata_lookup_failed"
+  | "excluded_channel_type_mismatch"
+  | "excluded_requester_not_participant"
+  | "excluded_agent_not_participant"
+  | "excluded_unexpected_participants"
+  | "excluded_group_destination"
+  | "excluded_missing_source_persona"
+  | "excluded_cross_persona"
+  | "excluded_unknown_source_classification";
+
+export interface LifeOpsAudienceSource {
+  kind: LifeOpsAudienceSourceKind;
+  id: string;
+  classification: LifeOpsAudienceClassification;
+  persona?: string | null;
+}
+
+export interface LifeOpsAudienceReceipt {
+  requestEntityId: string;
+  destinationRoomId: string;
+  destinationRoomType: string | null;
+  messageChannelType: string | null;
+  participantEntityIds: string[];
+  source: {
+    kind: LifeOpsAudienceSourceKind;
+    id: string;
+    classification: LifeOpsAudienceClassification;
+    persona: string | null;
+  };
+  requestingPersona: string | null;
+  decision: LifeOpsAudienceDecision;
+  reason: LifeOpsAudienceReason;
+}
+
+export interface LifeOpsAudienceGateResult {
+  receipts: LifeOpsAudienceReceipt[];
+  includedSources: LifeOpsAudienceSource[];
+  canLoadPrivateContext: boolean;
+}
+
+const PRIVATE_ROOM_TYPES = new Set<string>([
+  ChannelType.DM,
+  ChannelType.VOICE_DM,
+]);
+const SOURCE_CLASSIFICATIONS = new Set<string>(
+  LIFEOPS_AUDIENCE_CLASSIFICATIONS,
+);
+function readRequestingPersona(runtime: IAgentRuntime): string | null {
+  const raw = runtime.character.name;
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+}
+
+function sortedParticipants(participants: readonly string[]): string[] {
+  return [
+    ...new Set(participants.map((participant) => String(participant))),
+  ].sort();
+}
+
+function baseReceipt(args: {
+  message: Memory;
+  source: LifeOpsAudienceSource;
+  requestingPersona: string | null;
+  roomType: string | null;
+  participants: readonly string[];
+  reason: LifeOpsAudienceReason;
+  decision: LifeOpsAudienceDecision;
+}): LifeOpsAudienceReceipt {
+  const messageChannelType =
+    typeof args.message.content.channelType === "string"
+      ? args.message.content.channelType
+      : null;
+  return {
+    requestEntityId: args.message.entityId,
+    destinationRoomId: args.message.roomId,
+    destinationRoomType: args.roomType,
+    messageChannelType,
+    participantEntityIds: [...args.participants],
+    source: {
+      kind: args.source.kind,
+      id: args.source.id,
+      classification: args.source.classification,
+      persona: args.source.persona?.trim() || null,
+    },
+    requestingPersona: args.requestingPersona,
+    decision: args.decision,
+    reason: args.reason,
+  };
+}
+
+function sourcePersonaReason(
+  source: LifeOpsAudienceSource,
+  requestingPersona: string | null,
+): LifeOpsAudienceReason | null {
+  if (!SOURCE_CLASSIFICATIONS.has(source.classification)) {
+    return "excluded_unknown_source_classification";
+  }
+  if (source.classification === "public") {
+    return null;
+  }
+  const sourcePersona = source.persona?.trim();
+  if (!sourcePersona || !requestingPersona) {
+    return "excluded_missing_source_persona";
+  }
+  return sourcePersona === requestingPersona ? null : "excluded_cross_persona";
+}
+
+function classifyDestination(args: {
+  runtime: IAgentRuntime;
+  message: Memory;
+  roomType: string;
+  participants: readonly string[];
+}): LifeOpsAudienceReason | null {
+  const messageChannelType =
+    typeof args.message.content.channelType === "string"
+      ? args.message.content.channelType
+      : null;
+  if (!messageChannelType) {
+    return "excluded_channel_type_mismatch";
+  }
+  if (args.roomType !== messageChannelType) {
+    return "excluded_channel_type_mismatch";
+  }
+  if (!args.participants.includes(args.message.entityId)) {
+    return "excluded_requester_not_participant";
+  }
+  if (!args.participants.includes(args.runtime.agentId)) {
+    return "excluded_agent_not_participant";
+  }
+  if (PRIVATE_ROOM_TYPES.has(args.roomType)) {
+    const expected = sortedParticipants([
+      args.message.entityId,
+      args.runtime.agentId,
+    ]);
+    return args.participants.length === expected.length &&
+      args.participants.every(
+        (participant, index) => participant === expected[index],
+      )
+      ? null
+      : "excluded_unexpected_participants";
+  }
+  return "excluded_group_destination";
+}
+
+export async function evaluateLifeOpsAudiencePolicy(args: {
+  runtime: IAgentRuntime;
+  message: Memory;
+  sources: readonly LifeOpsAudienceSource[];
+  hasOwnerAccess: (runtime: IAgentRuntime, message: Memory) => Promise<boolean>;
+}): Promise<LifeOpsAudienceGateResult> {
+  const requestingPersona = readRequestingPersona(args.runtime);
+  let metadataLookupFailed = false;
+  let room: Awaited<ReturnType<IAgentRuntime["getRoom"]>> = null;
+  try {
+    room = await args.runtime.getRoom(args.message.roomId as UUID);
+  } catch {
+    // error-policy:J4 audience metadata must fail closed before private context loads.
+    metadataLookupFailed = true;
+  }
+  const roomType = room?.type ?? null;
+  let participantIds: string[] = [];
+  if (room) {
+    try {
+      const participants = await args.runtime.getParticipantsForRoom(
+        args.message.roomId as UUID,
+      );
+      participantIds = Array.isArray(participants)
+        ? sortedParticipants(participants)
+        : [];
+    } catch {
+      // error-policy:J4 audience metadata must fail closed before private context loads.
+      metadataLookupFailed = true;
+    }
+  }
+  const includedSources: LifeOpsAudienceSource[] = [];
+
+  const denyAll = (
+    reason: LifeOpsAudienceReason,
+  ): LifeOpsAudienceGateResult => ({
+    receipts: args.sources.map((source) =>
+      baseReceipt({
+        message: args.message,
+        source,
+        requestingPersona,
+        roomType,
+        participants: participantIds,
+        reason,
+        decision: "exclude",
+      }),
+    ),
+    includedSources,
+    canLoadPrivateContext: false,
+  });
+
+  const hasRequesterOwnerAccess = await args
+    .hasOwnerAccess(args.runtime, args.message)
+    .catch(() => {
+      // error-policy:J4 owner-access resolution failure must deny private context.
+      return false;
+    });
+  if (!hasRequesterOwnerAccess) {
+    return denyAll("excluded_non_owner_requester");
+  }
+  if (metadataLookupFailed) {
+    return denyAll("excluded_metadata_lookup_failed");
+  }
+  if (!room || !roomType) {
+    return denyAll("excluded_missing_room");
+  }
+  if (participantIds.length === 0) {
+    return denyAll("excluded_missing_participants");
+  }
+
+  const destinationReason = classifyDestination({
+    runtime: args.runtime,
+    message: args.message,
+    roomType,
+    participants: participantIds,
+  });
+
+  const receipts = args.sources.map((source) => {
+    const personaReason = sourcePersonaReason(source, requestingPersona);
+    const reason = personaReason ?? destinationReason;
+    if (reason) {
+      if (
+        source.classification === "public" &&
+        reason === "excluded_group_destination"
+      ) {
+        includedSources.push(source);
+        return baseReceipt({
+          message: args.message,
+          source,
+          requestingPersona,
+          roomType,
+          participants: participantIds,
+          reason: "included_public_group",
+          decision: "include",
+        });
+      }
+      return baseReceipt({
+        message: args.message,
+        source,
+        requestingPersona,
+        roomType,
+        participants: participantIds,
+        reason,
+        decision: "exclude",
+      });
+    }
+    includedSources.push(source);
+    const includeReason =
+      source.classification === "public"
+        ? "included_public_dm"
+        : PRIVATE_ROOM_TYPES.has(roomType)
+          ? "included_private_dm"
+          : "included_public_group";
+    return baseReceipt({
+      message: args.message,
+      source,
+      requestingPersona,
+      roomType,
+      participants: participantIds,
+      reason: includeReason,
+      decision: "include",
+    });
+  });
+
+  return {
+    receipts,
+    includedSources,
+    canLoadPrivateContext:
+      receipts.some(
+        (receipt) =>
+          receipt.decision === "include" &&
+          receipt.source.classification !== "public",
+      ) && receipts.every((receipt) => receipt.decision === "include"),
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
@@ -36,6 +36,7 @@ export type LifeOpsAudienceDecision = "include" | "exclude";
 export type LifeOpsAudienceReason =
   | "included_private_audience"
   | "excluded_non_owner_requester"
+  | "excluded_owner_lookup_failed"
   | "excluded_missing_room"
   | "excluded_missing_participants"
   | "excluded_metadata_lookup_failed"
@@ -81,7 +82,11 @@ export interface LifeOpsAudienceReceipt {
 
 export interface LifeOpsAudienceGateResult {
   receipts: LifeOpsAudienceReceipt[];
-  includedSources: LifeOpsAudienceSource[];
+  /**
+   * The gate is all-or-nothing per audience: every source kind is owner-private,
+   * so authorization never varies between the sources of one request. Callers
+   * read this instead of a per-source include list.
+   */
   canLoadPrivateContext: boolean;
   envelope: LifeOpsAudienceEnvelope | null;
 }
@@ -237,6 +242,7 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
   let participants: string[] = [];
   let trustedAgentId: string | null = null;
   let metadataFailure = false;
+  let ownerLookupFailure = false;
 
   try {
     room = await args.runtime.getRoom(args.message.roomId as UUID);
@@ -246,6 +252,8 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
       );
       participants = Array.isArray(values) ? sortedParticipants(values) : [];
     }
+    // error-policy:J7 room/participant lookup is a diagnostic read; a failure
+    // must be reported and fail the gate closed, never abort the whole turn.
   } catch (error) {
     metadataFailure = true;
     args.runtime.reportError("LifeOpsAudience.metadata", error, {
@@ -256,6 +264,8 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
   try {
     const persistedAgent = await args.runtime.getAgent(args.runtime.agentId);
     trustedAgentId = persistedAgent?.id ?? null;
+    // error-policy:J7 persisted-agent read is a diagnostic read; report and
+    // fail closed rather than killing the turn.
   } catch (error) {
     metadataFailure = true;
     args.runtime.reportError("LifeOpsAudience.loaderIdentity", error, {
@@ -266,7 +276,10 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
   let isOwner = false;
   try {
     isOwner = await args.hasOwnerAccess(args.runtime, args.message);
+    // error-policy:J7 a broken role lookup is reported and denied under its own
+    // reason so it is never read back as "this requester is not the owner".
   } catch (error) {
+    ownerLookupFailure = true;
     args.runtime.reportError("LifeOpsAudience.ownerAccess", error, {
       entityId: args.message.entityId,
       roomId: args.message.roomId,
@@ -289,7 +302,8 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
     : null;
 
   let reason: LifeOpsAudienceReason | null = null;
-  if (!isOwner) reason = "excluded_non_owner_requester";
+  if (ownerLookupFailure) reason = "excluded_owner_lookup_failed";
+  else if (!isOwner) reason = "excluded_non_owner_requester";
   else if (metadataFailure) reason = "excluded_metadata_lookup_failed";
   else if (!trustedAgentId || trustedAgentId !== args.runtime.agentId)
     reason = "excluded_untrusted_loader_identity";
@@ -334,7 +348,6 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
           reason,
         }),
       ),
-      includedSources: [],
       canLoadPrivateContext: false,
       envelope: null,
     };
@@ -365,7 +378,6 @@ export async function evaluateLifeOpsAudiencePolicy(args: {
         reason: "included_private_audience",
       }),
     ),
-    includedSources: [...args.sources],
     canLoadPrivateContext: true,
     envelope,
   };

--- a/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/audience-policy.ts
@@ -101,6 +101,19 @@ const GROUP_TYPES = new Set<string>([
   ChannelType.FORUM,
 ]);
 const ENVELOPE_METADATA_KEY = "lifeOpsAudienceEnvelope";
+/**
+ * Streaming revalidation staleness bound. The stream hook fires per token; a
+ * full DB re-read (room + participants) per token is a serial two-query tax on
+ * every streamed chunk. A successful revalidation is trusted for this window,
+ * so a mid-stream audience change is caught within at most this many
+ * milliseconds instead of on the very next token. The final
+ * `outgoing_before_deliver` revalidation always re-reads the DB uncached.
+ */
+const STREAM_REVALIDATION_TTL_MS = 500;
+const streamRevalidationCacheByRuntime = new WeakMap<
+  IAgentRuntime,
+  Map<string, { audienceVersion: string; validatedAt: number }>
+>();
 const activeEnvelopeByRuntime = new WeakMap<
   IAgentRuntime,
   Map<string, LifeOpsAudienceEnvelope>
@@ -400,6 +413,47 @@ export async function revalidateLifeOpsAudienceEnvelope(
   }
 }
 
+function streamRevalidationCache(
+  runtime: IAgentRuntime,
+): Map<string, { audienceVersion: string; validatedAt: number }> {
+  let cache = streamRevalidationCacheByRuntime.get(runtime);
+  if (!cache) {
+    cache = new Map();
+    streamRevalidationCacheByRuntime.set(runtime, cache);
+  }
+  return cache;
+}
+
+/**
+ * Streaming-path revalidation: trusts a successful full revalidation for
+ * `STREAM_REVALIDATION_TTL_MS` so per-token cost is bounded. A failure is
+ * never cached — the envelope is dropped immediately by the caller.
+ */
+async function revalidateLifeOpsAudienceForStream(
+  runtime: IAgentRuntime,
+  envelope: LifeOpsAudienceEnvelope,
+): Promise<boolean> {
+  const cache = streamRevalidationCache(runtime);
+  const cached = cache.get(envelope.roomId);
+  if (
+    cached &&
+    cached.audienceVersion === envelope.audienceVersion &&
+    Date.now() - cached.validatedAt < STREAM_REVALIDATION_TTL_MS
+  ) {
+    return true;
+  }
+  const authorized = await revalidateLifeOpsAudienceEnvelope(runtime, envelope);
+  if (authorized) {
+    cache.set(envelope.roomId, {
+      audienceVersion: envelope.audienceVersion,
+      validatedAt: Date.now(),
+    });
+  } else {
+    cache.delete(envelope.roomId);
+  }
+  return authorized;
+}
+
 export async function assertLifeOpsAudienceAtDelivery(
   runtime: IAgentRuntime,
   message: Memory,
@@ -409,6 +463,7 @@ export async function assertLifeOpsAudienceAtDelivery(
   if (!bound) return;
   if (!(await revalidateLifeOpsAudienceEnvelope(runtime, bound))) {
     activeEnvelopes(runtime).delete(bound.roomId);
+    streamRevalidationCache(runtime).delete(bound.roomId);
     throw new LifeOpsAudienceDeliveryDeniedError();
   }
 }
@@ -435,8 +490,9 @@ export function registerLifeOpsAudienceDeliveryHook(
       if (context.phase !== "model_stream_chunk" || !context.roomId) return;
       const envelope = activeEnvelopes(hookRuntime).get(context.roomId);
       if (!envelope) return;
-      if (!(await revalidateLifeOpsAudienceEnvelope(hookRuntime, envelope))) {
+      if (!(await revalidateLifeOpsAudienceForStream(hookRuntime, envelope))) {
         activeEnvelopes(hookRuntime).delete(envelope.roomId);
+        streamRevalidationCache(hookRuntime).delete(envelope.roomId);
         // Pipeline hooks are diagnostics-safe and intentionally swallow throws.
         // Mutating the primary chunk is therefore the enforceable send boundary.
         context.chunk = "";
@@ -458,6 +514,7 @@ export function registerLifeOpsAudienceDeliveryHook(
         envelope,
       );
       activeEnvelopes(hookRuntime).delete(envelope.roomId);
+      streamRevalidationCache(hookRuntime).delete(envelope.roomId);
       if (!stillAuthorized) {
         const responseId = context.content.responseId;
         const inReplyTo = context.content.inReplyTo;

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -106,6 +106,7 @@ import {
 } from "./followup/index.js";
 import { anticipationFeedbackEvaluator } from "./lifeops/anticipation/evaluator.js";
 import { createApprovalQueue } from "./lifeops/approval-queue.js";
+import { registerLifeOpsAudienceDeliveryHook } from "./lifeops/audience-policy.js";
 import { createTrackedWorkRecapDirectRoutingRule } from "./lifeops/briefing/direct-routing.js";
 import { registerLifeOpsCalendarGate } from "./lifeops/calendar-gate.js";
 import {
@@ -956,6 +957,7 @@ const rawPersonalAssistantPlugin: Plugin = {
 
     const ownerFactStore = createOwnerFactStore(runtime);
     registerOwnerFactStore(runtime, ownerFactStore);
+    registerLifeOpsAudienceDeliveryHook(runtime);
     registerCoreFactMemoryBridge(runtime);
 
     const promptRegistry = createMultilingualPromptRegistry();

--- a/plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts
+++ b/plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts
@@ -15,7 +15,6 @@
  * than running a speculative search on every turn.
  */
 
-import { hasOwnerAccess } from "@elizaos/agent";
 import type {
   IAgentRuntime,
   Memory,
@@ -25,6 +24,7 @@ import type {
   UUID,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { authorizeLifeOpsPrivateContext } from "../lifeops/audience-policy.js";
 import {
   CROSS_CHANNEL_SEARCH_CHANNELS,
   type CrossChannelSearchChannel,
@@ -204,19 +204,29 @@ export const crossChannelContextProvider: Provider = {
     message: Memory,
     state: State | undefined,
   ): Promise<ProviderResult> {
-    if (!(await hasOwnerAccess(runtime, message))) {
-      return EMPTY;
+    const request = pickRequestFromState(state);
+    if (!request) return EMPTY;
+
+    const audienceGate = await authorizeLifeOpsPrivateContext({
+      runtime,
+      message,
+      sources: [
+        { kind: "gmail", id: "cross-channel.gmail" },
+        { kind: "private_memory", id: "cross-channel.memory" },
+      ],
+    });
+    if (!audienceGate.canLoadPrivateContext) {
+      return {
+        text: "",
+        values: { crossChannelUnavailable: true },
+        data: { lifeOpsAudienceReceipts: audienceGate.receipts },
+      };
     }
     const egressContext = createLifeOpsEgressContext({
       isOwner: true,
       agentId: runtime.agentId,
       entityId: message.entityId,
     });
-
-    const request = pickRequestFromState(state);
-    if (!request) {
-      return EMPTY;
-    }
 
     const personRef = (() => {
       if (request.primaryEntityId) {
@@ -301,12 +311,20 @@ export const crossChannelContextProvider: Provider = {
         },
       };
     } catch (err) {
+      runtime.reportError("cross-channel-context.provider", err, {
+        roomId: message.roomId,
+        entityId: message.entityId,
+      });
       logger.warn(
         `[crossChannelContext] Skipped injection after error: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
-      return EMPTY;
+      return {
+        text: "",
+        values: { crossChannelUnavailable: true },
+        data: { crossChannelError: true },
+      };
     }
   },
 };

--- a/plugins/plugin-personal-assistant/src/providers/lifeops.ts
+++ b/plugins/plugin-personal-assistant/src/providers/lifeops.ts
@@ -27,6 +27,11 @@ import type {
   LifeOpsNextCalendarEventContext,
 } from "../contracts/index.js";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
+import {
+  evaluateLifeOpsAudiencePolicy,
+  type LifeOpsAudienceGateResult,
+  type LifeOpsAudienceSource,
+} from "../lifeops/audience-policy.js";
 import type { ConnectorStatus } from "../lifeops/connectors/contract.js";
 import { getConnectorRegistry } from "../lifeops/connectors/registry.js";
 import {
@@ -55,6 +60,47 @@ const INTERNAL_URL = new URL("http://127.0.0.1/");
 const GOAL_TITLE_MAX_LENGTH = 80;
 const GOAL_TITLES_MAX_DISPLAYED = 5;
 const MAX_ACCOUNT_LINES = 5;
+
+function lifeOpsPrivateContextSources(
+  runtime: IAgentRuntime,
+): LifeOpsAudienceSource[] {
+  const persona = runtime.character.name;
+  return [
+    {
+      kind: "private_memory",
+      id: "lifeops.owner_profile",
+      classification: "persona_scoped",
+      persona,
+    },
+    {
+      kind: "calendar",
+      id: "lifeops.calendar",
+      classification: "persona_scoped",
+      persona,
+    },
+    {
+      kind: "gmail",
+      id: "lifeops.gmail",
+      classification: "persona_scoped",
+      persona,
+    },
+  ];
+}
+
+export async function resolveLifeOpsProviderAudienceGate(
+  runtime: IAgentRuntime,
+  message: Memory,
+  sources: readonly LifeOpsAudienceSource[] = lifeOpsPrivateContextSources(
+    runtime,
+  ),
+): Promise<LifeOpsAudienceGateResult> {
+  return evaluateLifeOpsAudiencePolicy({
+    runtime,
+    message,
+    sources,
+    hasOwnerAccess: hasLifeOpsAccess,
+  });
+}
 
 function formatCount(label: string, count: number): string {
   return `${label}: ${count}`;
@@ -352,9 +398,18 @@ export const lifeOpsProvider: Provider = {
     message: Memory,
     _state: State,
   ): Promise<ProviderResult> {
-    const isOwner = await hasLifeOpsAccess(runtime, message);
-    if (!isOwner) {
-      return { text: "", values: {}, data: {} };
+    const audienceGate = await resolveLifeOpsProviderAudienceGate(
+      runtime,
+      message,
+    );
+    if (!audienceGate.canLoadPrivateContext) {
+      return {
+        text: "",
+        values: {},
+        data: {
+          lifeOpsAudienceReceipts: audienceGate.receipts,
+        },
+      };
     }
     const audience: LifeOpsAudience = "owner";
 
@@ -711,6 +766,7 @@ export const lifeOpsProvider: Provider = {
           agentActiveGoals: overview.agentOps.summary.activeGoalCount,
         },
         data: {
+          lifeOpsAudienceReceipts: audienceGate.receipts,
           ownerProfile,
           overview: {
             ...overview,

--- a/plugins/plugin-personal-assistant/src/providers/lifeops.ts
+++ b/plugins/plugin-personal-assistant/src/providers/lifeops.ts
@@ -26,9 +26,8 @@ import type {
   LifeOpsGoalDefinition,
   LifeOpsNextCalendarEventContext,
 } from "../contracts/index.js";
-import { hasLifeOpsAccess } from "../lifeops/access.js";
 import {
-  evaluateLifeOpsAudiencePolicy,
+  authorizeLifeOpsPrivateContext,
   type LifeOpsAudienceGateResult,
   type LifeOpsAudienceSource,
 } from "../lifeops/audience-policy.js";
@@ -61,45 +60,20 @@ const GOAL_TITLE_MAX_LENGTH = 80;
 const GOAL_TITLES_MAX_DISPLAYED = 5;
 const MAX_ACCOUNT_LINES = 5;
 
-function lifeOpsPrivateContextSources(
-  runtime: IAgentRuntime,
-): LifeOpsAudienceSource[] {
-  const persona = runtime.character.name;
+function lifeOpsPrivateContextSources(): LifeOpsAudienceSource[] {
   return [
-    {
-      kind: "private_memory",
-      id: "lifeops.owner_profile",
-      classification: "persona_scoped",
-      persona,
-    },
-    {
-      kind: "calendar",
-      id: "lifeops.calendar",
-      classification: "persona_scoped",
-      persona,
-    },
-    {
-      kind: "gmail",
-      id: "lifeops.gmail",
-      classification: "persona_scoped",
-      persona,
-    },
+    { kind: "private_memory", id: "lifeops.owner_profile" },
+    { kind: "calendar", id: "lifeops.calendar" },
+    { kind: "gmail", id: "lifeops.gmail" },
   ];
 }
 
 export async function resolveLifeOpsProviderAudienceGate(
   runtime: IAgentRuntime,
   message: Memory,
-  sources: readonly LifeOpsAudienceSource[] = lifeOpsPrivateContextSources(
-    runtime,
-  ),
+  sources: readonly LifeOpsAudienceSource[] = lifeOpsPrivateContextSources(),
 ): Promise<LifeOpsAudienceGateResult> {
-  return evaluateLifeOpsAudiencePolicy({
-    runtime,
-    message,
-    sources,
-    hasOwnerAccess: hasLifeOpsAccess,
-  });
+  return authorizeLifeOpsPrivateContext({ runtime, message, sources });
 }
 
 function formatCount(label: string, count: number): string {
@@ -125,6 +99,9 @@ async function summarizeConnectorDegradation(
         const status = await contribution.status();
         return { contribution, status };
       } catch (error) {
+        runtime.reportError("LifeOpsProvider.connectorStatus", error, {
+          connectorId: contribution.kind,
+        });
         const message = error instanceof Error ? error.message : String(error);
         return {
           contribution,
@@ -424,9 +401,17 @@ export const lifeOpsProvider: Provider = {
         entityId: message.entityId,
       });
       const accountManager = getConnectorAccountManager(runtime);
-      const connectorAccounts = await accountManager
-        .listAccounts("google")
-        .catch(() => []);
+      let connectorAccounts: Awaited<
+        ReturnType<typeof accountManager.listAccounts>
+      >;
+      try {
+        connectorAccounts = await accountManager.listAccounts("google");
+      } catch (error) {
+        runtime.reportError("LifeOpsProvider.connectorAccounts", error, {
+          provider: "google",
+        });
+        throw error;
+      }
       const privacyByAccountKey = new Map<
         string,
         ReturnType<typeof getAccountPrivacy>
@@ -472,6 +457,9 @@ export const lifeOpsProvider: Provider = {
           ),
         );
       } catch (cause) {
+        runtime.reportError("LifeOpsProvider.accountPrivacy", cause, {
+          agentId: runtime.agentId,
+        });
         logger.debug(
           { err: cause },
           "[LifeOpsProvider] account privacy table unavailable — defaulting to owner-only context",
@@ -606,6 +594,9 @@ export const lifeOpsProvider: Provider = {
                   await service.getNextCalendarEventContext(INTERNAL_URL);
                 calendarLines.push(...summarizeNextEvent(nextEventContext));
               } catch (cause) {
+                runtime.reportError("LifeOpsProvider.calendar", cause, {
+                  roomId: message.roomId,
+                });
                 logger.warn(
                   { err: cause },
                   "[LifeOpsProvider] calendar fetch failed — omitting calendar context",
@@ -638,6 +629,9 @@ export const lifeOpsProvider: Provider = {
                 gmailSummary = triage.summary;
                 emailLines.push(...summarizeGmailTriage(triage.summary));
               } catch (cause) {
+                runtime.reportError("LifeOpsProvider.gmail", cause, {
+                  roomId: message.roomId,
+                });
                 logger.warn(
                   { err: cause },
                   "[LifeOpsProvider] gmail triage fetch failed — omitting email context",
@@ -656,6 +650,9 @@ export const lifeOpsProvider: Provider = {
               await service.getNextCalendarEventContext(INTERNAL_URL);
             calendarLines.push(...summarizeNextEvent(nextEventContext));
           } catch (cause) {
+            runtime.reportError("LifeOpsProvider.nativeCalendar", cause, {
+              roomId: message.roomId,
+            });
             logger.debug(
               { err: cause },
               "[LifeOpsProvider] native calendar context unavailable — omitting calendar context",
@@ -663,6 +660,9 @@ export const lifeOpsProvider: Provider = {
           }
         }
       } catch (cause) {
+        runtime.reportError("LifeOpsProvider.googleConnector", cause, {
+          roomId: message.roomId,
+        });
         logger.debug(
           { err: cause },
           "[LifeOpsProvider] Google connector unavailable — skipping calendar/email context",
@@ -785,12 +785,14 @@ export const lifeOpsProvider: Provider = {
         },
       };
     } catch (error) {
+      runtime.reportError("LifeOpsProvider.get", error, {
+        roomId: message.roomId,
+        entityId: message.entityId,
+      });
       return {
         text: "LifeOps overview unavailable.",
-        values: { ownerOpenOccurrences: 0, ownerActiveGoals: 0 },
-        data: {
-          error: error instanceof Error ? error.message : String(error),
-        },
+        values: { lifeOpsUnavailable: true },
+        data: { lifeOpsError: true },
       };
     }
   },

--- a/plugins/plugin-personal-assistant/src/providers/pending-approvals.ts
+++ b/plugins/plugin-personal-assistant/src/providers/pending-approvals.ts
@@ -13,7 +13,6 @@
  * that turn classifies into. The happy-path render is empty and the read is
  * one bounded SQL, per the always-on provider contract.
  */
-import { hasOwnerAccess } from "@elizaos/agent";
 import type {
   IAgentRuntime,
   Memory,
@@ -23,6 +22,7 @@ import type {
 } from "@elizaos/core";
 import { createApprovalQueue } from "../lifeops/approval-queue.js";
 import type { ApprovalRequest } from "../lifeops/approval-queue.types.js";
+import { authorizeLifeOpsPrivateContext } from "../lifeops/audience-policy.js";
 
 const EMPTY: ProviderResult = {
   text: "",
@@ -103,8 +103,17 @@ export const pendingApprovalsProvider: Provider = {
     message: Memory,
     _state: State,
   ): Promise<ProviderResult> {
-    if (!(await hasOwnerAccess(runtime, message))) {
-      return EMPTY;
+    const audienceGate = await authorizeLifeOpsPrivateContext({
+      runtime,
+      message,
+      sources: [{ kind: "approvals", id: "approval-queue.pending" }],
+    });
+    if (!audienceGate.canLoadPrivateContext) {
+      return {
+        text: "",
+        values: { pendingApprovalsUnavailable: true },
+        data: { lifeOpsAudienceReceipts: audienceGate.receipts },
+      };
     }
     // Approvals are enqueued with subjectUserId = the requesting owner's
     // entityId (see actions/owner-surfaces.ts), and RESOLVE_REQUEST lists by
@@ -129,8 +138,15 @@ export const pendingApprovalsProvider: Provider = {
       // pending"); reportError surfaces it in RECENT_ERRORS so a broken queue
       // cannot silently reintroduce the stuck-pending failure this provider
       // exists to prevent.
-      runtime.reportError?.("pending-approvals.provider", error);
-      return EMPTY;
+      runtime.reportError("pending-approvals.provider", error, {
+        roomId: message.roomId,
+        entityId: message.entityId,
+      });
+      return {
+        text: "",
+        values: { pendingApprovalsUnavailable: true },
+        data: { pendingApprovalsError: true },
+      };
     }
     if (pending.length === 0) return EMPTY;
 


### PR DESCRIPTION
## Summary

R2 replaces the blocked R1 design. Shaw's two reviews were correct.

- normalize stored room type and message channel type to an authoritative audience **class**; `DM`, `SELF`, `VOICE_DM`, and `API` are private surfaces
- enforce one shared private-context retrieval boundary across `lifeOpsProvider`, `crossChannelContextProvider`, `pendingApprovalsProvider`, and `calendarAction`
- bind provenance inside that boundary to the loader-derived persisted Agent identity (`runtime.getAgent(runtime.agentId)`), never mutable `character.name` or message persona text
- capture a deterministic room/membership version at retrieval and re-read it at final output, calendar callbacks, and every streamed model chunk
- remove the unreachable public-group inclusion model from this private-loader boundary
- report authorization/DB/loader failures through `runtime.reportError`, fail closed, and expose explicit unavailable states rather than fabricated healthy zero counts

## Production regression fixed

The compatibility API ingress really does persist `type: ChannelType.DM` in `ensureCompatChatConnection` while web/OpenAI/Anthropic messages stamp `channelType: ChannelType.API` (`packages/agent/src/api/chat-routes.ts`). R1's exact equality check returned empty owner context on that production path.

R2 classifies both values as `private`, while still requiring the persisted room, owner requester, agent participant, and exact owner+agent audience. The PGlite production-path matrix covers persisted `DM` + message `API`, `DM` + `VOICE_DM`, `DM` + `DM`, and `SELF` + `SELF`.

## Shared retrieval and delivery boundary

- All four private disclosure surfaces call `authorizeLifeOpsPrivateContext` before constructing/loading private data.
- The authorization envelope is attached to the production message and tracked for streaming.
- `outgoing_before_deliver` revalidates authoritative room type and participants and replaces the payload with a safe cancellation response if the audience changed.
- `model_stream_chunk` revalidates before each chunk. Core now honors mutating stream hooks before any client callback, structured extractor, or downstream stream path sees the chunk.
- Calendar action callbacks call the same delivery assertion before invoking transport callbacks.

## Production-path evidence

The integration test uses the real PGlite `AgentRuntime`, persisted Agent/room/entity/participant records, real exported provider entrypoints, the real calendar action handler, and the real core pipeline hook registry. The stale-audience test mutates the DB participant set after private retrieval authorization and before final delivery; the private canary is replaced before the delivery callback. A core runtime test drives the real `AgentRuntime.useModel` streaming path and proves a denied mutating hook prevents every downstream chunk callback.

## Tests

- `bunx vitest run --config vitest.src-integration.config.ts src/lifeops/audience-policy.integration.test.ts` (from `plugins/plugin-personal-assistant`) — **10 passed**
- `bunx vitest run packages/core/src/runtime/__tests__/model-stream-chunk-hooks.test.ts` — **6 passed**
- `bunx @biomejs/biome check <9 changed TypeScript files>` — **passed**
- `node packages/scripts/run-turbo.mjs run typecheck --concurrency=4 --filter=@elizaos/core --filter=@elizaos/plugin-personal-assistant` — **79/79 tasks passed**, including both package typechecks

Rebased onto `develop` at `626b884d` before the R2 commit.

Related: #17175, #17178

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only privacy policy; no UI changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only privacy policy; no UI changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic provider/action and delivery-path integration coverage; no interactive UI flow

<!-- evidence-row:backend-logs -->
- [x] [17212-pr17212-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17212-pr17212-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic audience-policy enforcement; no prompt/model behavior changed. Real-runtime coverage is the PGlite integration suite plus the real AgentRuntime.useModel streaming test (model-stream-chunk-hooks.test.ts) in the linked backend log.

<!-- evidence-row:domain-artifacts -->
- [x] [17212-pr17212-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17212-pr17212-backend-logs.txt)

