### PR TITLE
feat(discord): P4 group-room coordination — speaker lease, latest-human-edge-wins, bot-loop budget

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -337,3 +337,18 @@ description = "eliza-1 smoke SFT corpus (synthetic training rows, not credential
 paths = [
   '''(^|/)packages/training/data/final-eliza1-smoke/.*\.jsonl$''',
 ]
+
+# plugin-discord/group-coordination.ts: DISCORD_SPEAKER_LEASE_TABLE's value is
+# the literal Postgres table name "discord_coordination_reply_slots" — which is
+# coincidentally the exact shape the `discord-client-secret` rule looks for (the
+# word "discord" followed by a 32-char lowercase/underscore token). The same
+# identifier appears verbatim in the plugin migration and in its CREATE TABLE
+# statements, so it is a schema name, not a credential. Match the full
+# assignment rather than allowlisting the path, so every other token in that
+# file — including a genuine DISCORD_CLIENT_SECRET — remains scanned.
+[[allowlists]]
+description = "Discord coordination table-name constant (schema identifier, not a credential)"
+regexTarget = "match"
+regexes = [
+  '''DISCORD_SPEAKER_LEASE_TABLE\s*=\s*"discord_coordination_reply_slots"''',
+]

--- a/bun.lock
+++ b/bun.lock
@@ -3565,6 +3565,7 @@
         "@sapphire/snowflake": "3.5.5",
         "discord-api-types": "^0.38.0",
         "discord.js": "^14.26.4",
+        "drizzle-orm": "^0.45.1",
         "fast-deep-equal": "3.1.3",
         "fast-levenshtein": "^3.0.0",
         "fluent-ffmpeg": "^2.1.3",

--- a/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
@@ -61,7 +61,7 @@ function makeService() {
 		handleReactionAdd: vi.fn(),
 		handleReactionRemove: vi.fn(),
 		isChannelAllowed: vi.fn(() => true),
-		messageManager: { handleMessage: vi.fn() },
+		messageManager: { handleMessage: vi.fn(), noteHumanEdge: vi.fn() },
 		resolveDiscordEntityId: vi.fn(),
 		runtime: {
 			agentId: "agent",
@@ -88,8 +88,11 @@ function makeMessage(
 	return {
 		id,
 		content: "hello",
+		createdTimestamp: 1_700_000_000_000,
 		author: { id: "user-1", bot: false, username: "alice" },
 		channel: { id: channelId, type: channelType },
+		guild:
+			channelType === DiscordChannelType.GuildText ? { id: "guild-1" } : null,
 	};
 }
 
@@ -145,6 +148,34 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 
 		expect(debouncerState.channelEnqueue).toHaveBeenCalledTimes(1);
 		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
+		// Production gateway path: every guild human message advances the durable
+		// edge before dispatch/debounce, including messages this agent may not
+		// ultimately answer.
+		expect(service.messageManager.noteHumanEdge).toHaveBeenCalledWith(
+			"channel-1",
+			"msg-channel-1",
+			1_700_000_000_000,
+		);
+	});
+
+	it("never advances the human edge for a bot-authored guild message", async () => {
+		const service = makeService();
+		service.discordSettings.shouldIgnoreBotMessages = false;
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+		const botMessage = makeMessage(
+			DiscordChannelType.GuildText,
+			"channel-bot",
+		) as ReturnType<typeof makeMessage> & {
+			author: { id: string; bot: boolean; username: string };
+		};
+		botMessage.author = { id: "other-bot", bot: true, username: "bot" };
+
+		service.client.emit("messageCreate", botMessage);
+		await tick();
+
+		expect(service.messageManager.noteHumanEdge).not.toHaveBeenCalled();
+		expect(debouncerState.channelEnqueue).toHaveBeenCalledTimes(1);
 	});
 
 	it("serializes rapid DMs in the same channel: the second awaits the first, neither dropped", async () => {

--- a/plugins/plugin-discord/__tests__/group-coordination.test.ts
+++ b/plugins/plugin-discord/__tests__/group-coordination.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Unit tests for the PURE parts of the P4 group-room coordination primitive:
+ * config parsing, contender-token derivation, deterministic nonce, snowflake
+ * ordering, trust-roster parsing, scope validation, and the edge-currency
+ * decision function.
+ *
+ * The stateful protocol (claim races, expiry/reclaim, lane budgets, sweeper
+ * recovery, fenced delivery) is covered ONLY against a real plugin-sql adapter
+ * in `test/group-coordination-pglite.test.ts` and
+ * `test/messages-group-coordination-pglite.test.ts`. It deliberately has no
+ * in-process fake store: the previous shared-Map version of these tests passed
+ * while `runtime.db` was absent, which proved a fallback code path rather than
+ * the durable protocol the feature ships.
+ */
+import { stringToUuid, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	compareDiscordSnowflake,
+	createDiscordContenderToken,
+	deterministicCoordinationNonce,
+	deterministicDiscordNonce,
+	emitCoordinationReceipt,
+	evaluateEdgeCurrency,
+	getGroupCoordinationConfig,
+	parseTrustRoster,
+	requireCoordinationScope,
+	speakerLeaseId,
+} from "../group-coordination.ts";
+
+const CHANNEL = "111000000000000001";
+const AGENT_A = stringToUuid("agent-a") as UUID;
+const AGENT_B = stringToUuid("agent-b") as UUID;
+const SERVER_ID = stringToUuid("coord-server") as UUID;
+
+describe("speakerLeaseId", () => {
+	it("is agent-independent, generation-scoped, and lane-scoped", () => {
+		expect(speakerLeaseId(CHANNEL, "m1", 0)).toBe(
+			speakerLeaseId(CHANNEL, "m1", 0),
+		);
+		expect(speakerLeaseId(CHANNEL, "m1", 0)).not.toBe(
+			speakerLeaseId(CHANNEL, "m1", 1),
+		);
+		expect(speakerLeaseId(CHANNEL, "m1", 0)).not.toBe(
+			speakerLeaseId(CHANNEL, "m2", 0),
+		);
+		// Human and bot reply lanes must never collide on one row id.
+		expect(speakerLeaseId(CHANNEL, "m1", 0, "human")).not.toBe(
+			speakerLeaseId(CHANNEL, "m1", 0, "bot"),
+		);
+	});
+});
+
+describe("createDiscordContenderToken", () => {
+	it("distinguishes two managers that share one agentId", () => {
+		const left = createDiscordContenderToken({
+			accountId: "default",
+			agentId: AGENT_A,
+			runtimeInstanceId: "instance-1",
+		});
+		const right = createDiscordContenderToken({
+			accountId: "default",
+			agentId: AGENT_A,
+			runtimeInstanceId: "instance-2",
+		});
+		expect(left).not.toBe(right);
+	});
+
+	it("distinguishes two accounts on one runtime instance", () => {
+		const left = createDiscordContenderToken({
+			accountId: "acct-a",
+			agentId: AGENT_A,
+			runtimeInstanceId: "instance-1",
+		});
+		const right = createDiscordContenderToken({
+			accountId: "acct-b",
+			agentId: AGENT_A,
+			runtimeInstanceId: "instance-1",
+		});
+		expect(left).not.toBe(right);
+	});
+
+	it("is stable for the same identity triple", () => {
+		const args = {
+			accountId: "default",
+			agentId: AGENT_B,
+			runtimeInstanceId: "instance-9",
+		};
+		expect(createDiscordContenderToken(args)).toBe(
+			createDiscordContenderToken(args),
+		);
+	});
+});
+
+describe("deterministicDiscordNonce", () => {
+	it("is stable per (account, channel, author, edge, chunk)", () => {
+		const args = {
+			accountId: "default",
+			channelId: CHANNEL,
+			authorId: "555",
+			edgeMessageId: "m1",
+			contentKey: "0",
+		};
+		expect(deterministicDiscordNonce(args)).toBe(
+			deterministicDiscordNonce(args),
+		);
+	});
+
+	it("differs per chunk so multi-chunk replies are not collapsed by Discord", () => {
+		const base = {
+			accountId: "default",
+			channelId: CHANNEL,
+			authorId: "555",
+			edgeMessageId: "m1",
+		};
+		expect(deterministicDiscordNonce({ ...base, contentKey: "0" })).not.toBe(
+			deterministicDiscordNonce({ ...base, contentKey: "1" }),
+		);
+	});
+
+	it("fits Discord's nonce length limit (<= 25 chars)", () => {
+		const nonce = deterministicDiscordNonce({
+			accountId: "default",
+			channelId: CHANNEL,
+			authorId: "555",
+			edgeMessageId: "m1",
+		});
+		expect(nonce.length).toBeLessThanOrEqual(25);
+	});
+});
+
+describe("deterministicCoordinationNonce", () => {
+	it("is independent of contender/runtime identity for crash recovery", () => {
+		const sharedLease = {
+			serverId: SERVER_ID,
+			trustGroupId: "group-1",
+			channelId: CHANNEL,
+			edgeEpoch: "edge-1",
+			lane: "human" as const,
+			generation: 0,
+		};
+		const firstWorker = deterministicCoordinationNonce(sharedLease, "0");
+		const recoveredWorker = deterministicCoordinationNonce(
+			{ ...sharedLease },
+			"0",
+		);
+		expect(firstWorker).toBe(recoveredWorker);
+		expect(firstWorker).toHaveLength(24);
+	});
+
+	it("distinguishes budget slots and chunks", () => {
+		const lease = {
+			serverId: SERVER_ID,
+			trustGroupId: "group-1",
+			channelId: CHANNEL,
+			edgeEpoch: "edge-1",
+			lane: "bot" as const,
+			generation: 0,
+		};
+		expect(deterministicCoordinationNonce(lease, "0")).not.toBe(
+			deterministicCoordinationNonce({ ...lease, generation: 1 }, "0"),
+		);
+		expect(deterministicCoordinationNonce(lease, "0")).not.toBe(
+			deterministicCoordinationNonce(lease, "1"),
+		);
+	});
+});
+
+describe("compareDiscordSnowflake", () => {
+	it("orders snowflakes as integers, not lexically", () => {
+		// Lexical comparison gets this backwards: "9..." > "10..." as a string.
+		expect(
+			compareDiscordSnowflake("10000000000000000", "9999999999999999"),
+		).toBe(1);
+		expect(
+			compareDiscordSnowflake("9999999999999999", "10000000000000000"),
+		).toBe(-1);
+		expect(compareDiscordSnowflake("123", "123")).toBe(0);
+	});
+
+	it("exceeds Number.MAX_SAFE_INTEGER without precision loss", () => {
+		// These two differ only in the last digit and are both > 2^53.
+		const a = "1400000000000000001";
+		const b = "1400000000000000002";
+		expect(Number(a) === Number(b)).toBe(true); // float would tie
+		expect(compareDiscordSnowflake(a, b)).toBe(-1); // BigInt does not
+	});
+});
+
+describe("parseTrustRoster", () => {
+	it("parses, trims, lowercases, and drops blanks", () => {
+		const roster = parseTrustRoster(` ${AGENT_A.toUpperCase()} , ,${AGENT_B} `);
+		expect(roster.has(AGENT_A.toLowerCase())).toBe(true);
+		expect(roster.has(AGENT_B.toLowerCase())).toBe(true);
+		expect(roster.size).toBe(2);
+	});
+
+	it("treats missing/empty config as an empty roster (fails closed upstream)", () => {
+		expect(parseTrustRoster(undefined).size).toBe(0);
+		expect(parseTrustRoster("").size).toBe(0);
+		expect(parseTrustRoster("  ,  ").size).toBe(0);
+	});
+});
+
+describe("requireCoordinationScope", () => {
+	function store(settings: Record<string, string>, agentId: UUID = AGENT_A) {
+		return { agentId, getSetting: (key: string) => settings[key] };
+	}
+
+	const complete = {
+		DISCORD_GROUP_COORDINATION_ENABLED: "true",
+		DISCORD_GROUP_COORDINATION_SERVER_ID: SERVER_ID,
+		DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID: "group-1",
+		DISCORD_COORDINATION_TRUST_MEMBERS: `${AGENT_A},${AGENT_B}`,
+		ELIZA_RUNTIME_INSTANCE_ID: "instance-1",
+	};
+
+	it("builds a scope when fully configured", () => {
+		const scope = requireCoordinationScope(store(complete), "default");
+		expect(scope.serverId).toBe(SERVER_ID);
+		expect(scope.trustGroupId).toBe("group-1");
+		expect(scope.runtimeInstanceId).toBe("instance-1");
+		expect(scope.contenderToken).toContain(AGENT_A);
+	});
+
+	it("refuses when the feature is off", () => {
+		expect(() =>
+			requireCoordinationScope(
+				store({ ...complete, DISCORD_GROUP_COORDINATION_ENABLED: "false" }),
+				"default",
+			),
+		).toThrow(/not enabled/);
+	});
+
+	it("refuses without a server/trust-group id", () => {
+		const { DISCORD_GROUP_COORDINATION_SERVER_ID: _drop, ...rest } = complete;
+		expect(() => requireCoordinationScope(store(rest), "default")).toThrow(
+			/SERVER_ID/,
+		);
+	});
+
+	it("refuses without an explicit operator trust roster", () => {
+		const { DISCORD_COORDINATION_TRUST_MEMBERS: _drop, ...rest } = complete;
+		expect(() => requireCoordinationScope(store(rest), "default")).toThrow(
+			/TRUST_MEMBERS/,
+		);
+	});
+
+	it("refuses an agent that is not on the roster (trust is not self-minted)", () => {
+		const intruder = stringToUuid("agent-intruder") as UUID;
+		expect(() =>
+			requireCoordinationScope(store(complete, intruder), "default"),
+		).toThrow(/not listed in DISCORD_COORDINATION_TRUST_MEMBERS/);
+	});
+});
+
+describe("evaluateEdgeCurrency", () => {
+	// The persisted-edge lookup is covered on the PGlite path; here the decision
+	// function is exercised against an explicit latest-edge reading.
+	const scope = {
+		accountId: "default",
+		serverId: SERVER_ID,
+		trustGroupId: "group-1",
+		contenderToken: "token",
+		runtimeInstanceId: "instance-1",
+	};
+
+	function ownerWithEdge(edgeMessageId: string) {
+		return {
+			agentId: AGENT_A,
+			db: {
+				execute: async () => ({
+					rows: [
+						{
+							edge_message_id: edgeMessageId,
+							edge_epoch: edgeMessageId,
+							updated_at: new Date(),
+						},
+					],
+				}),
+			},
+		};
+	}
+
+	it("is current when the edge is this message", async () => {
+		const decision = await evaluateEdgeCurrency({
+			owner: ownerWithEdge("m5"),
+			channelId: CHANNEL,
+			edgeMessageId: "m5",
+			scope,
+		});
+		expect(decision.current).toBe(true);
+	});
+
+	it("is stale when a newer human message set the edge", async () => {
+		const decision = await evaluateEdgeCurrency({
+			owner: ownerWithEdge("m9"),
+			channelId: CHANNEL,
+			edgeMessageId: "m5",
+			scope,
+		});
+		expect(decision.current).toBe(false);
+		expect(decision.latestEdgeMessageId).toBe("m9");
+	});
+
+	it("stays current when the coalesced batch contains the latest edge", async () => {
+		const decision = await evaluateEdgeCurrency({
+			owner: ownerWithEdge("m9"),
+			channelId: CHANNEL,
+			edgeMessageId: "m5",
+			coalescedMessageIds: ["m5", "m9"],
+			scope,
+		});
+		expect(decision.current).toBe(true);
+	});
+
+	it("never drops explicitly addressed work even when superseded", async () => {
+		const decision = await evaluateEdgeCurrency({
+			owner: ownerWithEdge("m9"),
+			channelId: CHANNEL,
+			edgeMessageId: "m5",
+			explicitlyAddressed: true,
+			scope,
+		});
+		expect(decision.current).toBe(true);
+	});
+});
+
+describe("coordination audit failures", () => {
+	it("reports receipt storage failure through the J7 audit scope", async () => {
+		const reportError = vi.fn();
+		const writeFailure = new Error("audit database unavailable");
+		const ok = await emitCoordinationReceipt(
+			{
+				agentId: AGENT_A,
+				reportError,
+				db: { execute: vi.fn(async () => Promise.reject(writeFailure)) },
+			},
+			{
+				kind: "lease-claim",
+				channelId: CHANNEL,
+				edgeMessageId: "m1",
+				roomId: stringToUuid("audit-room") as UUID,
+				entityId: stringToUuid("audit-entity") as UUID,
+				outcome: "won",
+				scope: {
+					accountId: "default",
+					serverId: SERVER_ID,
+					trustGroupId: "group-1",
+					contenderToken: "token-a",
+					runtimeInstanceId: "instance-1",
+				},
+			},
+		);
+
+		expect(ok).toBe(false);
+		expect(reportError).toHaveBeenCalledWith(
+			"discord:coordination.audit",
+			writeFailure,
+			expect.objectContaining({
+				kind: "lease-claim",
+				channelId: CHANNEL,
+				edgeMessageId: "m1",
+			}),
+		);
+	});
+});
+
+describe("getGroupCoordinationConfig", () => {
+	it("defaults off with sane lease/budget values", () => {
+		const config = getGroupCoordinationConfig(() => undefined);
+		expect(config.enabled).toBe(false);
+		expect(config.leaseMs).toBeGreaterThan(120_000);
+		expect(config.botReplyBudget).toBe(1);
+	});
+
+	it("parses explicit settings", () => {
+		const settings: Record<string, string> = {
+			DISCORD_GROUP_COORDINATION_ENABLED: "true",
+			DISCORD_SPEAKER_LEASE_MS: "30000",
+			DISCORD_BOT_REPLY_BUDGET: "2",
+		};
+		const config = getGroupCoordinationConfig((key) => settings[key]);
+		expect(config).toEqual({
+			enabled: true,
+			leaseMs: 30_000,
+			botReplyBudget: 2,
+			heartbeatMs: 30_000,
+			sweepMs: 60_000,
+			serverId: undefined,
+			trustGroupId: undefined,
+		});
+	});
+
+	it("sweeper interval is configurable and can be disabled with 0", () => {
+		const onSettings: Record<string, string> = {
+			DISCORD_COORDINATION_SWEEP_MS: "15000",
+		};
+		expect(getGroupCoordinationConfig((key) => onSettings[key]).sweepMs).toBe(
+			15_000,
+		);
+		const offSettings: Record<string, string> = {
+			DISCORD_COORDINATION_SWEEP_MS: "0",
+		};
+		expect(getGroupCoordinationConfig((key) => offSettings[key]).sweepMs).toBe(
+			0,
+		);
+	});
+});

--- a/plugins/plugin-discord/coordination-schema.ts
+++ b/plugins/plugin-discord/coordination-schema.ts
@@ -1,0 +1,161 @@
+/**
+ * Durable Discord group-room coordination tables. These tables intentionally
+ * live in `public` with explicit `server_id` columns so plugin-sql's production
+ * Row Level Security pass applies the same tenant policy used by core message
+ * server tables.
+ */
+import { sql } from "drizzle-orm";
+import {
+	boolean,
+	index,
+	integer,
+	pgTable,
+	primaryKey,
+	text,
+	timestamp,
+	unique,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+
+export const discordCoordinationTrustMembersTable = pgTable(
+	"discord_coordination_trust_members",
+	{
+		serverId: uuid("server_id").notNull(),
+		accountId: text("account_id").notNull(),
+		trustGroupId: text("trust_group_id").notNull(),
+		runtimeInstanceId: text("runtime_instance_id").notNull(),
+		agentId: uuid("agent_id").notNull(),
+		allowed: boolean("allowed").default(true).notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.default(sql`now()`)
+			.notNull(),
+	},
+	(table) => [
+		primaryKey({
+			columns: [
+				table.serverId,
+				table.accountId,
+				table.trustGroupId,
+				table.agentId,
+			],
+		}),
+		index("discord_coord_trust_server_idx").on(table.serverId),
+	],
+);
+
+export const discordCoordinationHumanEdgesTable = pgTable(
+	"discord_coordination_human_edges",
+	{
+		serverId: uuid("server_id").notNull(),
+		trustGroupId: text("trust_group_id").notNull(),
+		channelId: text("channel_id").notNull(),
+		edgeMessageId: text("edge_message_id").notNull(),
+		edgeEpoch: text("edge_epoch").notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.default(sql`now()`)
+			.notNull(),
+	},
+	(table) => [
+		primaryKey({
+			columns: [table.serverId, table.trustGroupId, table.channelId],
+		}),
+		unique("discord_coord_human_edge_epoch_unique").on(
+			table.serverId,
+			table.trustGroupId,
+			table.channelId,
+			table.edgeEpoch,
+		),
+	],
+);
+
+export const discordCoordinationReplySlotsTable = pgTable(
+	"discord_coordination_reply_slots",
+	{
+		serverId: uuid("server_id").notNull(),
+		trustGroupId: text("trust_group_id").notNull(),
+		accountId: text("account_id").notNull(),
+		channelId: text("channel_id").notNull(),
+		edgeEpoch: text("edge_epoch").notNull(),
+		// Reply lanes are budgeted independently: answering the human who set the
+		// edge must not consume the bot-to-bot reply budget for that same edge (and
+		// vice versa). Without this column both lanes contend for slot_index 0 and
+		// the first human answer exhausts the bot budget for the whole edge.
+		lane: text("lane").default("human").notNull(),
+		slotIndex: integer("slot_index").notNull(),
+		contenderToken: text("contender_token").notNull(),
+		inboundMessageId: text("inbound_message_id").notNull(),
+		nonce: text("nonce").notNull(),
+		state: text("state").default("claimed").notNull(),
+		claimedAt: timestamp("claimed_at", { withTimezone: true })
+			.default(sql`now()`)
+			.notNull(),
+		heartbeatAt: timestamp("heartbeat_at", { withTimezone: true })
+			.default(sql`now()`)
+			.notNull(),
+		expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+		deliveredMessageId: text("delivered_message_id"),
+		// Bounds crash-sweeper re-dispatch: a poison inbound that kills every
+		// holder is retired after MAX_SWEEP_RECOVERY_ATTEMPTS instead of looping.
+		recoveryAttempts: integer("recovery_attempts").default(0).notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.default(sql`now()`)
+			.notNull(),
+	},
+	(table) => [
+		primaryKey({
+			columns: [
+				table.serverId,
+				table.trustGroupId,
+				table.channelId,
+				table.edgeEpoch,
+				table.lane,
+				table.slotIndex,
+			],
+		}),
+		// One inbound bot message may spend at most one budget slot. Without this
+		// partial unique index, two contenders can win slot 0 and slot 1 for the
+		// SAME bot message when budget > 1 and both send.
+		uniqueIndex("discord_coord_reply_slots_bot_inbound_uq")
+			.on(
+				table.serverId,
+				table.trustGroupId,
+				table.channelId,
+				table.edgeEpoch,
+				table.lane,
+				table.inboundMessageId,
+			)
+			.where(sql`${table.lane} = 'bot'`),
+		index("discord_coord_reply_slots_nonce_idx").on(table.nonce),
+		index("discord_coord_reply_slots_expiry_idx").on(table.expiresAt),
+	],
+);
+
+export const discordCoordinationReceiptsTable = pgTable(
+	"discord_coordination_receipts",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		serverId: uuid("server_id").notNull(),
+		accountId: text("account_id").notNull(),
+		trustGroupId: text("trust_group_id").notNull(),
+		channelId: text("channel_id").notNull(),
+		edgeMessageId: text("edge_message_id").notNull(),
+		edgeEpoch: text("edge_epoch"),
+		kind: text("kind").notNull(),
+		outcome: text("outcome"),
+		contenderToken: text("contender_token"),
+		holderToken: text("holder_token"),
+		detail: text("detail"),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.default(sql`now()`)
+			.notNull(),
+	},
+	(table) => [
+		index("discord_coord_receipts_server_idx").on(table.serverId),
+		index("discord_coord_receipts_channel_idx").on(
+			table.serverId,
+			table.accountId,
+			table.channelId,
+		),
+	],
+);

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -344,6 +344,23 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				message.channel.id,
 				message.id,
 			);
+			// P4 group coordination: only human (non-bot) messages advance the
+			// conversation edge; bot messages never do, which is one half of the
+			// bot-to-bot loop breaker (see group-coordination.ts). This writes the
+			// DURABLE edge row (not an in-process map) so every human message the
+			// gateway sees supersedes in-flight generations across all contenders,
+			// including messages that never trigger a dispatch on this agent.
+			if (
+				!message.author.bot &&
+				message.guild &&
+				typeof service.messageManager.noteHumanEdge === "function"
+			) {
+				await service.messageManager.noteHumanEdge(
+					message.channel.id,
+					message.id,
+					message.createdTimestamp ?? Date.now(),
+				);
+			}
 		}
 
 		// Persisted mute gate. Consults the same participant/world mute state

--- a/plugins/plugin-discord/group-coordination.ts
+++ b/plugins/plugin-discord/group-coordination.ts
@@ -1,0 +1,1115 @@
+/**
+ * Durable group-room coordination for Discord replies. The coordinator keeps
+ * the human edge, speaker slots, lease heartbeat, delivery receipts, and trust
+ * membership in shared SQL rows scoped by `server_id`, so independent runtimes
+ * and processes contend on one database surface instead of agent-local memory.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { type IAgentRuntime, stringToUuid, type UUID } from "@elizaos/core";
+import { sql } from "drizzle-orm";
+
+export const DISCORD_SPEAKER_LEASE_TABLE = "discord_coordination_reply_slots";
+export const DISCORD_COORDINATION_RECEIPT_TABLE =
+	"discord_coordination_receipts";
+export const MAX_LEASE_GENERATIONS = 64;
+export const DEFAULT_SPEAKER_LEASE_MS = 180_000;
+export const DEFAULT_BOT_REPLY_BUDGET = 1;
+export const DISCORD_COORDINATION_AUDIT_SCOPE = "discord:coordination.audit";
+
+const DEFAULT_HEARTBEAT_MS = 30_000;
+
+export const DEFAULT_COORDINATION_SWEEP_MS = 60_000;
+
+export interface GroupCoordinationConfig {
+	enabled: boolean;
+	leaseMs: number;
+	botReplyBudget: number;
+	heartbeatMs: number;
+	sweepMs: number;
+	serverId?: UUID;
+	trustGroupId?: string;
+}
+
+function parseBoolean(value: unknown, fallback: boolean): boolean {
+	if (value === undefined || value === null) return fallback;
+	return String(value).trim().toLowerCase() === "true";
+}
+
+function parsePositiveInteger(value: unknown, fallback: number): number {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInteger(value: unknown, fallback: number): number {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function normalizeOptionalUuid(value: unknown): UUID | undefined {
+	const text = typeof value === "string" ? value.trim() : "";
+	if (!text) return undefined;
+	return text as UUID;
+}
+
+export function getGroupCoordinationConfig(
+	getSetting: (key: string) => unknown,
+): GroupCoordinationConfig {
+	return {
+		enabled: parseBoolean(
+			getSetting("DISCORD_GROUP_COORDINATION_ENABLED"),
+			false,
+		),
+		leaseMs: parsePositiveInteger(
+			getSetting("DISCORD_SPEAKER_LEASE_MS"),
+			DEFAULT_SPEAKER_LEASE_MS,
+		),
+		botReplyBudget: parseNonNegativeInteger(
+			getSetting("DISCORD_BOT_REPLY_BUDGET"),
+			DEFAULT_BOT_REPLY_BUDGET,
+		),
+		heartbeatMs: parsePositiveInteger(
+			getSetting("DISCORD_COORDINATION_HEARTBEAT_MS"),
+			DEFAULT_HEARTBEAT_MS,
+		),
+		sweepMs: parseNonNegativeInteger(
+			getSetting("DISCORD_COORDINATION_SWEEP_MS"),
+			DEFAULT_COORDINATION_SWEEP_MS,
+		),
+		serverId: normalizeOptionalUuid(
+			getSetting("DISCORD_GROUP_COORDINATION_SERVER_ID") ??
+				getSetting("ELIZA_SERVER_ID"),
+		),
+		trustGroupId:
+			typeof getSetting("DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID") ===
+				"string" &&
+			String(getSetting("DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID")).trim()
+				? String(getSetting("DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID")).trim()
+				: undefined,
+	};
+}
+
+export type SpeakerLeaseStore = Pick<IAgentRuntime, "agentId"> &
+	Partial<Pick<IAgentRuntime, "reportError">> & {
+		db?: object;
+		adapter?: { db?: object };
+	};
+
+export interface SpeakerLease {
+	id: UUID;
+	channelId: string;
+	edgeMessageId: string;
+	lane: CoordinationLane;
+	generation: number;
+	holderAgentId: UUID;
+	contenderToken: string;
+	accountId: string;
+	serverId?: UUID;
+	trustGroupId?: string;
+	edgeEpoch?: string;
+	claimedAt: number;
+	expiresAt: number;
+	entityId: UUID;
+	roomId: UUID;
+	worldId?: UUID;
+	nonce?: string;
+}
+
+export type SpeakerLeaseClaimOutcome = "won" | "renewed" | "reclaimed" | "lost";
+
+export interface SpeakerLeaseClaimResult {
+	outcome: SpeakerLeaseClaimOutcome;
+	lease: SpeakerLease;
+}
+
+export function speakerLeaseId(
+	channelId: string,
+	edgeMessageId: string,
+	generation: number,
+	lane: CoordinationLane = "human",
+): UUID {
+	return stringToUuid(
+		`discord-speaker-lease:${channelId}:${edgeMessageId}:${lane}:g${generation}`,
+	);
+}
+
+export function createDiscordContenderToken(options: {
+	accountId?: string;
+	agentId: UUID;
+	runtimeInstanceId?: string;
+}): string {
+	const accountId = options.accountId ?? "default";
+	const runtimeInstanceId = options.runtimeInstanceId ?? randomUUID();
+	return `discord:${accountId}:${options.agentId}:${runtimeInstanceId}`;
+}
+
+export function deterministicDiscordNonce(options: {
+	accountId?: string;
+	channelId: string;
+	authorId: string;
+	edgeMessageId: string;
+	contentKey?: string;
+}): string {
+	return createHash("sha256")
+		.update(
+			[
+				"eliza-discord",
+				options.accountId ?? "default",
+				options.channelId,
+				options.authorId,
+				options.edgeMessageId,
+				options.contentKey ?? "",
+			].join(":"),
+		)
+		.digest("hex")
+		.slice(0, 24);
+}
+
+/**
+ * Provider nonce for a coordinated send. It deliberately excludes agent and
+ * runtime-instance identity: recovery by another worker managing the SAME
+ * Discord account must reproduce the original nonce. Slot generation
+ * distinguishes budgeted bot replies under one human edge.
+ */
+export function deterministicCoordinationNonce(
+	lease: Pick<
+		SpeakerLease,
+		| "serverId"
+		| "trustGroupId"
+		| "channelId"
+		| "edgeEpoch"
+		| "lane"
+		| "generation"
+	>,
+	contentKey: string,
+): string {
+	return createHash("sha256")
+		.update(
+			[
+				"eliza-discord-coordination",
+				lease.serverId ?? "",
+				lease.trustGroupId ?? "",
+				lease.channelId,
+				lease.edgeEpoch ?? "",
+				lease.lane,
+				String(lease.generation),
+				contentKey,
+			].join(":"),
+		)
+		.digest("hex")
+		.slice(0, 24);
+}
+
+type SqlExecutor = {
+	execute(query: unknown): Promise<{ rows?: unknown[] } | unknown>;
+};
+
+function getSqlExecutor(store: SpeakerLeaseStore): SqlExecutor | undefined {
+	const direct = store.db;
+	if (direct && typeof (direct as SqlExecutor).execute === "function") {
+		return direct as SqlExecutor;
+	}
+	const adapterDb = store.adapter?.db;
+	if (adapterDb && typeof (adapterDb as SqlExecutor).execute === "function") {
+		return adapterDb as SqlExecutor;
+	}
+	return undefined;
+}
+
+function dateFromMs(ms: number): Date {
+	return new Date(ms);
+}
+
+function msFromDb(value: unknown): number {
+	if (value instanceof Date) return value.getTime();
+	if (typeof value === "string" || typeof value === "number") {
+		const parsed = new Date(value).getTime();
+		return Number.isFinite(parsed) ? parsed : Date.now();
+	}
+	return Date.now();
+}
+
+export function compareDiscordSnowflake(a: string, b: string): number {
+	if (/^\d+$/.test(a) && /^\d+$/.test(b)) {
+		const left = BigInt(a);
+		const right = BigInt(b);
+		return left === right ? 0 : left > right ? 1 : -1;
+	}
+	return a.localeCompare(b);
+}
+
+function rowRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function rowsOf(result: unknown): Record<string, unknown>[] {
+	const rows = rowRecord(result).rows;
+	return Array.isArray(rows) ? rows.map(rowRecord) : [];
+}
+
+async function ensureCoordinationTables(db: SqlExecutor): Promise<void> {
+	// The plugin schema/migration owns these tables so plugin-sql can apply its
+	// production server_id RLS policy. Runtime DDL would create an unprotected
+	// table after the RLS pass, so enabled deployments fail closed instead.
+	await db.execute(
+		sql`SELECT 1 FROM discord_coordination_trust_members LIMIT 0`,
+	);
+	await db.execute(sql`SELECT 1 FROM discord_coordination_human_edges LIMIT 0`);
+	await db.execute(sql`SELECT 1 FROM discord_coordination_reply_slots LIMIT 0`);
+	await db.execute(sql`SELECT 1 FROM discord_coordination_receipts LIMIT 0`);
+}
+
+export interface CoordinationScope {
+	accountId: string;
+	serverId: UUID;
+	trustGroupId: string;
+	contenderToken: string;
+	runtimeInstanceId: string;
+}
+
+/**
+ * Reply lanes are budgeted separately. Answering the human who set the edge is
+ * the `human` lane (always exactly one slot); answering another bot that
+ * addressed us is the `bot` lane (bounded by DISCORD_BOT_REPLY_BUDGET). Sharing
+ * one lane would let the human answer exhaust the bot budget for that edge.
+ */
+export type CoordinationLane = "human" | "bot";
+
+/**
+ * Operator-declared trust roster for a coordination group:
+ * `DISCORD_COORDINATION_TRUST_MEMBERS` is a comma-separated list of agent ids
+ * allowed to contend in the group. Membership rows are DERIVED from it, never
+ * self-minted — an agent that merely knows the server/trust-group ids cannot
+ * register itself and then pass its own trust check.
+ */
+export function parseTrustRoster(value: unknown): Set<string> {
+	return new Set(
+		String(value ?? "")
+			.split(",")
+			.map((entry) => entry.trim().toLowerCase())
+			.filter((entry) => entry.length > 0),
+	);
+}
+
+export function requireCoordinationScope(
+	store: Pick<IAgentRuntime, "agentId" | "getSetting">,
+	accountId: string,
+): CoordinationScope {
+	const config = getGroupCoordinationConfig((key) => store.getSetting(key));
+	if (!config.enabled) {
+		throw new Error("Discord group coordination is not enabled");
+	}
+	if (!config.serverId || !config.trustGroupId) {
+		throw new Error(
+			"DISCORD_GROUP_COORDINATION_ENABLED requires DISCORD_GROUP_COORDINATION_SERVER_ID/ELIZA_SERVER_ID and DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID",
+		);
+	}
+	const roster = parseTrustRoster(
+		store.getSetting("DISCORD_COORDINATION_TRUST_MEMBERS"),
+	);
+	if (roster.size === 0) {
+		throw new Error(
+			"DISCORD_GROUP_COORDINATION_ENABLED requires DISCORD_COORDINATION_TRUST_MEMBERS (explicit agent-id roster for the trust group)",
+		);
+	}
+	if (!roster.has(String(store.agentId).toLowerCase())) {
+		throw new Error(
+			`Agent ${store.agentId} is not listed in DISCORD_COORDINATION_TRUST_MEMBERS for group ${config.trustGroupId}`,
+		);
+	}
+	const runtimeInstanceId =
+		String(store.getSetting("ELIZA_RUNTIME_INSTANCE_ID") ?? "").trim() ||
+		randomUUID();
+	return {
+		accountId,
+		serverId: config.serverId,
+		trustGroupId: config.trustGroupId,
+		runtimeInstanceId,
+		contenderToken: createDiscordContenderToken({
+			accountId,
+			agentId: store.agentId,
+			runtimeInstanceId,
+		}),
+	};
+}
+
+export async function registerCoordinationTrustMember(
+	store: SpeakerLeaseStore & Partial<Pick<IAgentRuntime, "getSetting">>,
+	scope: CoordinationScope,
+): Promise<void> {
+	const db = getSqlExecutor(store);
+	if (!db) {
+		throw new Error(
+			"Discord group coordination requires plugin-sql runtime.db",
+		);
+	}
+	// Trust is operator-declared, not self-asserted: an agent may only publish a
+	// membership row for itself if the operator listed it in the roster. Without
+	// this, self-registration would make assertTrusted vacuous.
+	if (typeof store.getSetting === "function") {
+		const roster = parseTrustRoster(
+			store.getSetting("DISCORD_COORDINATION_TRUST_MEMBERS"),
+		);
+		if (!roster.has(String(store.agentId).toLowerCase())) {
+			throw new Error(
+				`Agent ${store.agentId} is not listed in DISCORD_COORDINATION_TRUST_MEMBERS for group ${scope.trustGroupId}`,
+			);
+		}
+	}
+	await ensureCoordinationTables(db);
+	await db.execute(sql`
+		INSERT INTO discord_coordination_trust_members
+			(server_id, account_id, trust_group_id, runtime_instance_id, agent_id, allowed, updated_at)
+		VALUES (${scope.serverId}, ${scope.accountId}, ${scope.trustGroupId}, ${scope.runtimeInstanceId}, ${store.agentId}, TRUE, NOW())
+		ON CONFLICT (server_id, account_id, trust_group_id, agent_id)
+		DO UPDATE SET runtime_instance_id = EXCLUDED.runtime_instance_id, allowed = TRUE, updated_at = NOW()
+	`);
+}
+
+async function assertTrusted(
+	store: SpeakerLeaseStore,
+	scope: CoordinationScope,
+): Promise<void> {
+	const db = getSqlExecutor(store);
+	if (!db) {
+		throw new Error(
+			"Discord group coordination requires plugin-sql runtime.db",
+		);
+	}
+	await ensureCoordinationTables(db);
+	const result = await db.execute(sql`
+		SELECT allowed FROM discord_coordination_trust_members
+		WHERE server_id = ${scope.serverId}
+			AND account_id = ${scope.accountId}
+			AND trust_group_id = ${scope.trustGroupId}
+			AND agent_id = ${store.agentId}
+	`);
+	if (rowsOf(result)[0]?.allowed !== true) {
+		throw new Error(
+			`Discord coordination contender is not trusted for group ${scope.trustGroupId}`,
+		);
+	}
+}
+
+export async function recordDiscordHumanEdge(
+	owner: SpeakerLeaseStore | object | undefined,
+	channelId: string | undefined,
+	messageId: string | undefined,
+	_at: number = Date.now(),
+	scope?: CoordinationScope,
+): Promise<void> {
+	if (!owner || !channelId || !messageId || !scope) return;
+	const db = getSqlExecutor(owner as SpeakerLeaseStore);
+	if (!db) return;
+	await ensureCoordinationTables(db);
+	await assertTrusted(owner as SpeakerLeaseStore, scope);
+	await db.execute(sql`
+		INSERT INTO discord_coordination_human_edges
+			(server_id, trust_group_id, channel_id, edge_message_id, edge_epoch, updated_at)
+		VALUES (${scope.serverId}, ${scope.trustGroupId}, ${channelId}, ${messageId}, ${messageId}, NOW())
+		ON CONFLICT (server_id, trust_group_id, channel_id)
+		DO UPDATE SET
+			edge_message_id = CASE
+				WHEN EXCLUDED.edge_message_id::numeric > discord_coordination_human_edges.edge_message_id::numeric
+				THEN EXCLUDED.edge_message_id
+				ELSE discord_coordination_human_edges.edge_message_id
+			END,
+			edge_epoch = CASE
+				WHEN EXCLUDED.edge_message_id::numeric > discord_coordination_human_edges.edge_message_id::numeric
+				THEN EXCLUDED.edge_epoch
+				ELSE discord_coordination_human_edges.edge_epoch
+			END,
+			updated_at = NOW()
+	`);
+}
+
+export async function getDiscordHumanEdge(
+	owner: SpeakerLeaseStore | object | undefined,
+	channelId: string | undefined,
+	scope?: CoordinationScope,
+): Promise<{ messageId: string; at: number; edgeEpoch: string } | undefined> {
+	if (!owner || !channelId || !scope) return undefined;
+	const db = getSqlExecutor(owner as SpeakerLeaseStore);
+	if (!db) return undefined;
+	await ensureCoordinationTables(db);
+	const result = await db.execute(sql`
+		SELECT edge_message_id, edge_epoch, updated_at
+		FROM discord_coordination_human_edges
+		WHERE server_id = ${scope.serverId}
+			AND trust_group_id = ${scope.trustGroupId}
+			AND channel_id = ${channelId}
+	`);
+	const row = rowsOf(result)[0];
+	if (!row) return undefined;
+	return {
+		messageId: String(row.edge_message_id),
+		edgeEpoch: String(row.edge_epoch),
+		at: msFromDb(row.updated_at),
+	};
+}
+
+export interface EdgeCurrencyDecision {
+	current: boolean;
+	latestEdgeMessageId?: string;
+	edgeEpoch?: string;
+}
+
+export async function evaluateEdgeCurrency(options: {
+	owner: SpeakerLeaseStore | object | undefined;
+	channelId: string | undefined;
+	edgeMessageId: string;
+	coalescedMessageIds?: string[];
+	explicitlyAddressed?: boolean;
+	scope?: CoordinationScope;
+}): Promise<EdgeCurrencyDecision> {
+	const latest = await getDiscordHumanEdge(
+		options.owner,
+		options.channelId,
+		options.scope,
+	);
+	if (!latest) return { current: true, edgeEpoch: options.edgeMessageId };
+	if (latest.messageId === options.edgeMessageId) {
+		return {
+			current: true,
+			latestEdgeMessageId: latest.messageId,
+			edgeEpoch: latest.edgeEpoch,
+		};
+	}
+	if (options.coalescedMessageIds?.includes(latest.messageId)) {
+		return {
+			current: true,
+			latestEdgeMessageId: latest.messageId,
+			edgeEpoch: latest.edgeEpoch,
+		};
+	}
+	if (options.explicitlyAddressed) {
+		return {
+			current: true,
+			latestEdgeMessageId: latest.messageId,
+			edgeEpoch: latest.edgeEpoch,
+		};
+	}
+	return {
+		current: false,
+		latestEdgeMessageId: latest.messageId,
+		edgeEpoch: latest.edgeEpoch,
+	};
+}
+
+export interface SpeakerLeaseClaimParams {
+	channelId: string;
+	edgeMessageId: string;
+	roomId: UUID;
+	entityId: UUID;
+	worldId?: UUID;
+	leaseMs: number;
+	now?: number;
+	accountId?: string;
+	scope?: CoordinationScope;
+	contenderToken?: string;
+	nonce?: string;
+	slotCount?: number;
+	lane?: CoordinationLane;
+}
+
+function decodeSlot(
+	row: Record<string, unknown>,
+	params: SpeakerLeaseClaimParams,
+	scope: CoordinationScope,
+): SpeakerLease {
+	const slotIndex =
+		typeof row.slot_index === "number"
+			? row.slot_index
+			: Number.parseInt(String(row.slot_index ?? "0"), 10);
+	const holderToken = String(row.contender_token ?? scope.contenderToken);
+	const lane = (
+		String(row.lane ?? params.lane ?? "human") === "bot" ? "bot" : "human"
+	) as CoordinationLane;
+	return {
+		id: speakerLeaseId(params.channelId, params.edgeMessageId, slotIndex, lane),
+		channelId: params.channelId,
+		edgeMessageId: params.edgeMessageId,
+		lane,
+		generation: slotIndex,
+		holderAgentId: storeAgentIdFromToken(holderToken, scope),
+		contenderToken: holderToken,
+		accountId: scope.accountId,
+		serverId: scope.serverId,
+		trustGroupId: scope.trustGroupId,
+		edgeEpoch: String(row.edge_epoch ?? params.edgeMessageId),
+		claimedAt: msFromDb(row.claimed_at),
+		expiresAt: msFromDb(row.expires_at),
+		entityId: params.entityId,
+		roomId: params.roomId,
+		worldId: params.worldId,
+		nonce: String(row.nonce ?? params.nonce ?? ""),
+	};
+}
+
+function storeAgentIdFromToken(token: string, scope: CoordinationScope): UUID {
+	const parts = token.split(":");
+	return (parts[2] || scope.contenderToken.split(":")[2] || "") as UUID;
+}
+
+export async function claimSpeakerLease(
+	store: SpeakerLeaseStore,
+	params: SpeakerLeaseClaimParams,
+): Promise<SpeakerLeaseClaimResult> {
+	if (!params.scope) {
+		throw new Error(
+			"Discord group coordination requires a durable CoordinationScope",
+		);
+	}
+	const db = getSqlExecutor(store);
+	if (!db) {
+		throw new Error(
+			"Discord group coordination requires plugin-sql runtime.db",
+		);
+	}
+	const scope = params.scope;
+	const now = params.now ?? Date.now();
+	const expiresAt = dateFromMs(now + params.leaseMs);
+	const nonce =
+		params.nonce ??
+		deterministicDiscordNonce({
+			accountId: scope.accountId,
+			channelId: params.channelId,
+			authorId: String(params.entityId),
+			edgeMessageId: params.edgeMessageId,
+		});
+	await ensureCoordinationTables(db);
+	await assertTrusted(store, scope);
+	const lane: CoordinationLane = params.lane ?? "human";
+	const edge =
+		(await getDiscordHumanEdge(store, params.channelId, scope)) ??
+		({
+			messageId: params.edgeMessageId,
+			edgeEpoch: params.edgeMessageId,
+			at: now,
+		} as const);
+	const slotCount = Math.max(1, params.slotCount ?? 1);
+	for (
+		let slotIndex = 0;
+		slotIndex < Math.min(slotCount, MAX_LEASE_GENERATIONS);
+		slotIndex += 1
+	) {
+		// First claim is a strict first-writer-wins insert. Every contender uses
+		// the same agent-independent primary-key row, and ON CONFLICT DO NOTHING
+		// makes the winner atomic without allowing a concurrent writer to mutate
+		// the settled holder.
+		const inserted = rowsOf(
+			await db.execute(sql`
+				INSERT INTO discord_coordination_reply_slots
+					(server_id, trust_group_id, account_id, channel_id, edge_epoch, lane, slot_index, contender_token, inbound_message_id, nonce, state, claimed_at, heartbeat_at, expires_at, updated_at)
+				VALUES (${scope.serverId}, ${scope.trustGroupId}, ${scope.accountId}, ${params.channelId}, ${edge.edgeEpoch}, ${lane}, ${slotIndex}, ${scope.contenderToken}, ${params.edgeMessageId}, ${nonce}, 'claimed', NOW(), NOW(), ${expiresAt}, NOW())
+				ON CONFLICT DO NOTHING
+				RETURNING *
+			`),
+		)[0];
+		if (inserted) {
+			return { outcome: "won", lease: decodeSlot(inserted, params, scope) };
+		}
+
+		const settled = rowsOf(
+			await db.execute(sql`
+				SELECT * FROM discord_coordination_reply_slots
+				WHERE server_id = ${scope.serverId}
+					AND trust_group_id = ${scope.trustGroupId}
+					AND channel_id = ${params.channelId}
+					AND edge_epoch = ${edge.edgeEpoch}
+					AND lane = ${lane}
+					AND slot_index = ${slotIndex}
+			`),
+		)[0];
+		if (!settled) continue;
+
+		// A slot that reached a terminal outcome is never reclaimable by expiry:
+		// the reply either went out (`delivered`) or the budget was spent. Treating
+		// it as free would let an expired-but-answered edge be answered twice.
+		const state = String(settled.state ?? "claimed");
+		if (
+			state === "delivered" ||
+			state === "consumed" ||
+			state === "abandoned" ||
+			typeof settled.delivered_message_id === "string"
+		) {
+			continue;
+		}
+		if (msFromDb(settled.expires_at) > now && state === "claimed") {
+			const liveLease = decodeSlot(settled, params, scope);
+			if (liveLease.contenderToken === scope.contenderToken) {
+				return { outcome: "renewed", lease: liveLease };
+			}
+			continue;
+		}
+
+		// Expiry/release reclaim is a separate compare-and-set. This preserves the
+		// strict DO NOTHING initial race while still allowing one successor to
+		// recover a dead holder. The settled token/state predicates prevent a stale
+		// observation from overwriting a newer holder.
+		const reclaimed = rowsOf(
+			await db.execute(sql`
+				UPDATE discord_coordination_reply_slots
+				SET account_id = ${scope.accountId},
+					contender_token = ${scope.contenderToken},
+					inbound_message_id = ${params.edgeMessageId},
+					nonce = ${nonce},
+					state = 'claimed',
+					claimed_at = NOW(),
+					heartbeat_at = NOW(),
+					expires_at = ${expiresAt},
+					updated_at = NOW()
+				WHERE server_id = ${scope.serverId}
+					AND trust_group_id = ${scope.trustGroupId}
+					AND channel_id = ${params.channelId}
+					AND edge_epoch = ${edge.edgeEpoch}
+					AND lane = ${lane}
+					AND slot_index = ${slotIndex}
+					-- Recovery is Discord-account-affine. Other accounts may contend
+					-- initially, but cannot replay a winner's send with different
+					-- provider credentials/idempotency scope after a crash.
+					AND account_id = ${scope.accountId}
+					AND contender_token = ${String(settled.contender_token)}
+					AND state = ${state}
+					AND delivered_message_id IS NULL
+					AND state NOT IN ('delivered', 'consumed', 'abandoned')
+					AND (expires_at <= NOW() OR state IN ('released', 'expired'))
+				RETURNING *
+			`),
+		)[0];
+		if (reclaimed) {
+			return {
+				outcome: "reclaimed",
+				lease: decodeSlot(reclaimed, params, scope),
+			};
+		}
+	}
+	const existing = await db.execute(sql`
+		SELECT * FROM discord_coordination_reply_slots
+		WHERE server_id = ${scope.serverId}
+			AND trust_group_id = ${scope.trustGroupId}
+			AND channel_id = ${params.channelId}
+			AND edge_epoch = ${edge.edgeEpoch}
+			AND lane = ${lane}
+		ORDER BY slot_index ASC
+		LIMIT 1
+	`);
+	const row = rowsOf(existing)[0];
+	if (row) {
+		return { outcome: "lost", lease: decodeSlot(row, params, scope) };
+	}
+	return {
+		outcome: "lost",
+		lease: {
+			id: speakerLeaseId(params.channelId, params.edgeMessageId, 0, lane),
+			channelId: params.channelId,
+			edgeMessageId: params.edgeMessageId,
+			lane,
+			generation: 0,
+			holderAgentId: store.agentId,
+			contenderToken: scope.contenderToken,
+			accountId: scope.accountId,
+			serverId: scope.serverId,
+			trustGroupId: scope.trustGroupId,
+			edgeEpoch: edge.edgeEpoch,
+			claimedAt: now,
+			expiresAt: now,
+			entityId: params.entityId,
+			roomId: params.roomId,
+			worldId: params.worldId,
+			nonce,
+		},
+	};
+}
+
+export interface SpeakerLeaseVerifyResult {
+	held: boolean;
+	reason?: "expired" | "superseded" | "not-holder" | "missing";
+	deliveredMessageId?: string;
+}
+
+export async function verifySpeakerLease(
+	store: SpeakerLeaseStore,
+	lease: SpeakerLease,
+	now: number = Date.now(),
+): Promise<SpeakerLeaseVerifyResult> {
+	if (!lease.serverId || !lease.edgeEpoch) {
+		return { held: false, reason: "missing" };
+	}
+	const db = getSqlExecutor(store);
+	if (!db)
+		throw new Error(
+			"Discord group coordination requires plugin-sql runtime.db",
+		);
+	const result = await db.execute(sql`
+		SELECT * FROM discord_coordination_reply_slots
+		WHERE server_id = ${lease.serverId}
+			AND trust_group_id = ${lease.trustGroupId}
+			AND channel_id = ${lease.channelId}
+			AND edge_epoch = ${lease.edgeEpoch}
+			AND lane = ${lease.lane ?? "human"}
+			AND slot_index = ${lease.generation}
+	`);
+	const row = rowsOf(result)[0];
+	if (!row) return { held: false, reason: "missing" };
+	if (String(row.contender_token) !== lease.contenderToken) {
+		return { held: false, reason: "not-holder" };
+	}
+	if (msFromDb(row.expires_at) <= now)
+		return { held: false, reason: "expired" };
+	return {
+		held: true,
+		deliveredMessageId:
+			typeof row.delivered_message_id === "string"
+				? row.delivered_message_id
+				: undefined,
+	};
+}
+
+export async function renewSpeakerLease(
+	store: SpeakerLeaseStore,
+	lease: SpeakerLease,
+	leaseMs: number,
+): Promise<boolean> {
+	// A lease without tenant scope is not a lease: the fence must fail closed.
+	if (!lease.serverId || !lease.edgeEpoch) return false;
+	const db = getSqlExecutor(store);
+	if (!db) return false;
+	const result = await db.execute(sql`
+		UPDATE discord_coordination_reply_slots
+		SET heartbeat_at = NOW(), expires_at = ${dateFromMs(Date.now() + leaseMs)}, updated_at = NOW()
+		WHERE server_id = ${lease.serverId}
+			AND trust_group_id = ${lease.trustGroupId}
+			AND channel_id = ${lease.channelId}
+			AND edge_epoch = ${lease.edgeEpoch}
+			AND lane = ${lease.lane ?? "human"}
+			AND slot_index = ${lease.generation}
+			AND contender_token = ${lease.contenderToken}
+			AND state = 'claimed'
+			AND expires_at > NOW()
+		RETURNING *
+	`);
+	return rowsOf(result).length > 0;
+}
+
+/**
+ * Release a claimed slot that will never produce a reply (aborted before the
+ * third-party send: superseded edge, model failure, empty response). Without this
+ * the slot sits `claimed` until it expires, the sweeper then re-dispatches an
+ * edge that was deliberately abandoned, and for the bot lane the budget stays
+ * spent for the rest of the edge. Only the holder can release, and a slot that
+ * already delivered is never released.
+ */
+export async function releaseSpeakerLease(
+	store: SpeakerLeaseStore,
+	lease: SpeakerLease,
+	reason: string,
+): Promise<void> {
+	if (!lease.serverId || !lease.edgeEpoch) return;
+	const db = getSqlExecutor(store);
+	if (!db) return;
+	await db.execute(sql`
+		UPDATE discord_coordination_reply_slots
+		SET state = 'released',
+			expires_at = NOW(),
+			heartbeat_at = NOW(),
+			updated_at = NOW()
+		WHERE server_id = ${lease.serverId}
+			AND trust_group_id = ${lease.trustGroupId}
+			AND channel_id = ${lease.channelId}
+			AND edge_epoch = ${lease.edgeEpoch}
+			AND lane = ${lease.lane ?? "human"}
+			AND slot_index = ${lease.generation}
+			AND contender_token = ${lease.contenderToken}
+			AND delivered_message_id IS NULL
+			AND state = 'claimed'
+	`);
+	void reason;
+}
+
+export async function reconcileDiscordDelivery(
+	store: SpeakerLeaseStore,
+	lease: SpeakerLease,
+	deliveredMessageId: string,
+): Promise<void> {
+	if (!lease.serverId || !lease.edgeEpoch) return;
+	const db = getSqlExecutor(store);
+	if (!db) return;
+	await db.execute(sql`
+		UPDATE discord_coordination_reply_slots
+		SET state = 'delivered',
+			delivered_message_id = ${deliveredMessageId},
+			heartbeat_at = NOW(),
+			updated_at = NOW()
+		WHERE server_id = ${lease.serverId}
+			AND trust_group_id = ${lease.trustGroupId}
+			AND channel_id = ${lease.channelId}
+			AND edge_epoch = ${lease.edgeEpoch}
+			AND lane = ${lease.lane ?? "human"}
+			AND slot_index = ${lease.generation}
+			AND contender_token = ${lease.contenderToken}
+	`);
+}
+
+export async function shouldSuppressBotReply(options: {
+	owner: SpeakerLeaseStore | object | undefined;
+	channelId: string | undefined;
+	explicitlyAddressed: boolean;
+	budget: number;
+	scope?: CoordinationScope;
+}): Promise<{
+	suppress: boolean;
+	reason?: "not-addressed" | "budget-exhausted";
+}> {
+	if (!options.explicitlyAddressed) {
+		return { suppress: true, reason: "not-addressed" };
+	}
+	if (!options.owner || !options.channelId || !options.scope) {
+		return { suppress: false };
+	}
+	const db = getSqlExecutor(options.owner as SpeakerLeaseStore);
+	if (!db) return { suppress: false };
+	const edge = await getDiscordHumanEdge(
+		options.owner,
+		options.channelId,
+		options.scope,
+	);
+	// The budget is defined relative to a human-edge epoch. Before the first
+	// human edge there is no budget to spend, so an addressed bot message must be
+	// suppressed rather than manufacturing a bot-authored epoch (which would let
+	// each new bot message reset its own budget and loop forever).
+	if (!edge) return { suppress: true, reason: "budget-exhausted" };
+	// Bot-lane rows only: the human-lane slot for this edge is the answer to the
+	// human and must not count against the bot-to-bot loop budget. `released`
+	// rows are abandoned attempts and are likewise not spend.
+	const result = await db.execute(sql`
+		SELECT COUNT(*) AS count
+		FROM discord_coordination_reply_slots
+		WHERE server_id = ${options.scope.serverId}
+			AND trust_group_id = ${options.scope.trustGroupId}
+			AND channel_id = ${options.channelId}
+			AND edge_epoch = ${edge.edgeEpoch}
+			AND lane = 'bot'
+			AND state IN ('claimed', 'consumed', 'delivered')
+	`);
+	const used = Number(rowsOf(result)[0]?.count ?? 0);
+	if (used >= options.budget) {
+		return { suppress: true, reason: "budget-exhausted" };
+	}
+	return { suppress: false };
+}
+
+/**
+ * A reply slot recovered by the crash sweeper: the holder's lease expired in
+ * state `claimed` with no delivered message, meaning the winner crashed (or
+ * lost its process) between claim and delivery and the human edge is
+ * unanswered. The sweeper marks the row `expired` (atomically, first sweeper
+ * wins) and returns it so the caller can re-dispatch the inbound message
+ * through the normal handle path, where the ordinary claim/fence machinery
+ * decides who answers.
+ */
+export interface SweptCoordinationSlot {
+	channelId: string;
+	edgeEpoch: string;
+	lane: CoordinationLane;
+	slotIndex: number;
+	inboundMessageId: string;
+	holderToken: string;
+	recoveryAttempts: number;
+}
+
+/**
+ * Bound on sweeper re-dispatch per slot. A message that reproducibly kills its
+ * holder (poison inbound) would otherwise be recovered, crash the next holder,
+ * expire, and be recovered again forever. After this many recoveries the slot
+ * is terminally `abandoned` and reported, never re-dispatched.
+ */
+export const MAX_SWEEP_RECOVERY_ATTEMPTS = 3;
+
+export async function sweepExpiredCoordinationSlots(
+	store: SpeakerLeaseStore,
+	scope: CoordinationScope,
+	now: number = Date.now(),
+	/**
+	 * Channels this sweeper can actually re-dispatch into. Recovery is only
+	 * meaningful for a channel whose Discord client this process holds: sweeping
+	 * an unreachable channel terminally expires the slot (spending a recovery
+	 * attempt) while the re-dispatch silently fails, leaving the human edge
+	 * permanently unanswered. Undefined = no restriction (single-account
+	 * deployments and protocol-level tests).
+	 */
+	reachableChannelIds?: readonly string[],
+): Promise<SweptCoordinationSlot[]> {
+	const db = getSqlExecutor(store);
+	if (!db) return [];
+	if (reachableChannelIds && reachableChannelIds.length === 0) return [];
+	const channelFilter = reachableChannelIds
+		? sql`AND channel_id IN (${sql.join(
+				reachableChannelIds.map((id) => sql`${id}`),
+				sql`, `,
+			)})`
+		: sql``;
+	await ensureCoordinationTables(db);
+	await assertTrusted(store, scope);
+	// Slots past the recovery bound are retired instead of recovered, so a poison
+	// inbound cannot be re-dispatched indefinitely.
+	await db.execute(sql`
+		UPDATE discord_coordination_reply_slots
+		SET state = 'abandoned', updated_at = NOW()
+		WHERE server_id = ${scope.serverId}
+			AND trust_group_id = ${scope.trustGroupId}
+			AND account_id = ${scope.accountId}
+			AND state = 'claimed'
+			AND expires_at <= ${dateFromMs(now)}
+			AND delivered_message_id IS NULL
+			AND recovery_attempts >= ${MAX_SWEEP_RECOVERY_ATTEMPTS}
+			${channelFilter}
+	`);
+	const result = await db.execute(sql`
+		UPDATE discord_coordination_reply_slots
+		SET state = 'expired',
+			recovery_attempts = recovery_attempts + 1,
+			updated_at = NOW()
+		WHERE server_id = ${scope.serverId}
+			AND trust_group_id = ${scope.trustGroupId}
+			AND account_id = ${scope.accountId}
+			AND state = 'claimed'
+			AND expires_at <= ${dateFromMs(now)}
+			AND delivered_message_id IS NULL
+			AND recovery_attempts < ${MAX_SWEEP_RECOVERY_ATTEMPTS}
+			${channelFilter}
+		RETURNING channel_id, edge_epoch, lane, slot_index, inbound_message_id, contender_token, recovery_attempts
+	`);
+	return rowsOf(result).map((row) => ({
+		channelId: String(row.channel_id),
+		edgeEpoch: String(row.edge_epoch),
+		lane: (String(row.lane ?? "human") === "bot"
+			? "bot"
+			: "human") as CoordinationLane,
+		slotIndex:
+			typeof row.slot_index === "number"
+				? row.slot_index
+				: Number.parseInt(String(row.slot_index ?? "0"), 10),
+		inboundMessageId: String(row.inbound_message_id),
+		holderToken: String(row.contender_token),
+		recoveryAttempts: Number(row.recovery_attempts ?? 1),
+	}));
+}
+
+/**
+ * Re-arm a swept slot when redispatch did not claim it. The update is a guarded
+ * compare-and-set: if redispatch succeeded (state/token changed), this is a
+ * no-op. Otherwise the next sweep retries after `retryMs`, bounded by the
+ * already-incremented recovery counter.
+ */
+export async function rearmSweptCoordinationSlot(
+	store: SpeakerLeaseStore,
+	scope: CoordinationScope,
+	slot: SweptCoordinationSlot,
+	retryMs: number,
+): Promise<boolean> {
+	const db = getSqlExecutor(store);
+	if (!db) return false;
+	const result = await db.execute(sql`
+		UPDATE discord_coordination_reply_slots
+		SET state = 'claimed',
+			heartbeat_at = NOW(),
+			expires_at = ${dateFromMs(Date.now() + Math.max(1_000, retryMs))},
+			updated_at = NOW()
+		WHERE server_id = ${scope.serverId}
+			AND trust_group_id = ${scope.trustGroupId}
+			AND account_id = ${scope.accountId}
+			AND channel_id = ${slot.channelId}
+			AND edge_epoch = ${slot.edgeEpoch}
+			AND lane = ${slot.lane}
+			AND slot_index = ${slot.slotIndex}
+			AND contender_token = ${slot.holderToken}
+			AND state = 'expired'
+			AND delivered_message_id IS NULL
+		RETURNING slot_index
+	`);
+	return rowsOf(result).length > 0;
+}
+
+export type CoordinationReceiptKind =
+	| "lease-claim"
+	| "stale-edge-abort"
+	| "lost-lease-abort"
+	| "bot-loop-suppress"
+	| "delivery-reconciled"
+	| "sweeper-recovery"
+	| "coordination-error";
+
+export interface CoordinationReceiptParams {
+	kind: CoordinationReceiptKind;
+	channelId: string;
+	edgeMessageId: string;
+	roomId: UUID;
+	entityId: UUID;
+	worldId?: UUID;
+	outcome?: string;
+	generation?: number;
+	holderAgentId?: UUID;
+	holderToken?: string;
+	edgeEpoch?: string;
+	detail?: Record<string, unknown>;
+	scope?: CoordinationScope;
+}
+
+export type CoordinationReceiptStore = Pick<IAgentRuntime, "agentId"> &
+	Partial<Pick<IAgentRuntime, "reportError">> & {
+		db?: object;
+		adapter?: { db?: object };
+	};
+
+export async function emitCoordinationReceipt(
+	store: CoordinationReceiptStore,
+	params: CoordinationReceiptParams,
+): Promise<boolean> {
+	try {
+		if (params.scope) {
+			const db = getSqlExecutor(store as SpeakerLeaseStore);
+			if (!db) {
+				throw new Error(
+					"Discord coordination audit requires plugin-sql runtime.db",
+				);
+			}
+			await ensureCoordinationTables(db);
+			await db.execute(sql`
+				INSERT INTO discord_coordination_receipts
+					(id, server_id, account_id, trust_group_id, channel_id, edge_message_id, edge_epoch, kind, outcome, contender_token, holder_token, detail, created_at)
+				VALUES (
+					${randomUUID()},
+					${params.scope.serverId},
+					${params.scope.accountId},
+					${params.scope.trustGroupId},
+					${params.channelId},
+					${params.edgeMessageId},
+					${params.edgeEpoch ?? null},
+					${params.kind},
+					${params.outcome ?? null},
+					${params.scope.contenderToken},
+					${params.holderToken ?? null},
+					${params.detail ? JSON.stringify(params.detail) : null},
+					NOW()
+				)
+			`);
+			return true;
+		}
+		// No scope means the caller is not on the durable path; audit rows only
+		// exist in the coordination schema, so report instead of silently writing
+		// an untenanted memory row nobody reads.
+		throw new Error(
+			"Discord coordination audit requires a durable CoordinationScope",
+		);
+	} catch (error) {
+		store.reportError?.(DISCORD_COORDINATION_AUDIT_SCOPE, error, {
+			kind: params.kind,
+			channelId: params.channelId,
+			edgeMessageId: params.edgeMessageId,
+			outcome: params.outcome,
+		});
+		return false;
+	}
+}

--- a/plugins/plugin-discord/index.ts
+++ b/plugins/plugin-discord/index.ts
@@ -15,6 +15,7 @@ import {
 import { printBanner } from "./banner";
 import { createDiscordConnectorAccountProvider } from "./connector-account-provider";
 import { DISCORD_SERVICE_NAME } from "./constants";
+import * as discordCoordinationSchema from "./coordination-schema";
 import { discordDataRoutes } from "./data-routes";
 import { registerDiscordTargetSource } from "./discord-target-source";
 import { DiscordOwnerPairingServiceImpl } from "./owner-pairing-service";
@@ -46,6 +47,7 @@ const discordPlugin: Plugin = {
 	routes: [...discordSetupRoutes, ...discordDataRoutes],
 	actions: [],
 	providers: [],
+	schema: discordCoordinationSchema,
 	tests: [new DiscordTestSuite()],
 	autoEnable: {
 		connectorKeys: ["discord"],

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -3,7 +3,7 @@
  * and dispatches replies to Discord (content, attachments, chunking, pairing
  * gate) and maps interaction URLs into the outgoing payload.
  */
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
 	attestDeliveryAudienceFromCanonicalRoom,
 	type ChannelType,
@@ -47,6 +47,29 @@ import type { ICompatRuntime } from "./compat";
 import { checkDiscordDmAccess } from "./dm-access";
 import { createDraftStreamController } from "./draft-stream";
 import { getDiscordSettings } from "./environment";
+import {
+	type CoordinationScope,
+	claimSpeakerLease,
+	createDiscordContenderToken,
+	DISCORD_COORDINATION_AUDIT_SCOPE,
+	deterministicCoordinationNonce,
+	deterministicDiscordNonce,
+	emitCoordinationReceipt,
+	evaluateEdgeCurrency,
+	type GroupCoordinationConfig,
+	getGroupCoordinationConfig,
+	rearmSweptCoordinationSlot,
+	reconcileDiscordDelivery,
+	recordDiscordHumanEdge,
+	registerCoordinationTrustMember,
+	releaseSpeakerLease,
+	renewSpeakerLease,
+	requireCoordinationScope,
+	type SpeakerLease,
+	shouldSuppressBotReply,
+	sweepExpiredCoordinationSlots,
+	verifySpeakerLease,
+} from "./group-coordination";
 import { buildDiscordWorldMetadata } from "./identity";
 import { formatInboundEnvelope } from "./inbound-envelope";
 import { buildDiscordReplyPayload } from "./interactions";
@@ -318,6 +341,17 @@ function stringField(
 ): string | undefined {
 	const value = record?.[field];
 	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function hasSqlExecutor(runtime: ICompatRuntime): boolean {
+	const candidate = runtime as ICompatRuntime & {
+		db?: { execute?: unknown };
+		adapter?: { db?: { execute?: unknown } };
+	};
+	return (
+		typeof candidate.db?.execute === "function" ||
+		typeof candidate.adapter?.db?.execute === "function"
+	);
 }
 
 export function hasActiveTaskAgentWorkForMessage(
@@ -807,6 +841,11 @@ export class MessageManager {
 	private envelopeEnabled: boolean;
 	private draftStreamingEnabled: boolean;
 	private stalenessConfig: DiscordStalenessConfig;
+	private groupCoordinationConfig: GroupCoordinationConfig;
+	private readonly runtimeInstanceId: string;
+	private readonly contenderToken: string;
+	private coordinationSweeperHandle?: ReturnType<typeof setInterval>;
+	private coordinationSweepInFlight = false;
 	private recentlyProcessedMessageIds = new Map<string, number>();
 	private static readonly PROCESSED_MESSAGE_TTL_MS = 2 * 60 * 1000;
 	/**
@@ -861,6 +900,225 @@ export class MessageManager {
 		this.stalenessConfig = getDiscordStalenessConfig((key) =>
 			this.runtime.getSetting(key),
 		);
+		this.groupCoordinationConfig = getGroupCoordinationConfig((key) =>
+			this.runtime.getSetting(key),
+		);
+		// Draft streaming creates/edits Discord messages before the final callback.
+		// Keep it off until that path is protected by the same outbound fence.
+		if (this.groupCoordinationConfig.enabled) {
+			this.draftStreamingEnabled = false;
+		}
+		this.runtimeInstanceId =
+			String(
+				this.runtime.getSetting("ELIZA_RUNTIME_INSTANCE_ID") ?? "",
+			).trim() || randomUUID();
+		this.contenderToken = createDiscordContenderToken({
+			accountId: this.accountId,
+			agentId: this.runtime.agentId,
+			runtimeInstanceId: this.runtimeInstanceId,
+		});
+		this.startCoordinationSweeper();
+	}
+
+	/**
+	 * Crash-recovery sweeper (production trigger for expired claims). A winner
+	 * that crashed between claim and delivery leaves a `claimed` slot with no
+	 * `delivered_message_id`; nothing else in the protocol revisits that edge
+	 * unless the identical message is redelivered. This interval atomically
+	 * expires such slots (first sweeper wins the UPDATE) and re-dispatches the
+	 * original inbound Discord message through the NORMAL handleMessage path,
+	 * where the durable turn record resumes the reply (bounded by its attempt
+	 * counter) and the ordinary claim/fence machinery decides who answers.
+	 */
+	private startCoordinationSweeper(): void {
+		const config = this.groupCoordinationConfig;
+		if (!config.enabled || config.sweepMs <= 0) return;
+		if (!hasSqlExecutor(this.runtime)) return;
+		let scope: CoordinationScope;
+		try {
+			scope = requireCoordinationScope(
+				{
+					agentId: this.runtime.agentId,
+					getSetting: (key) =>
+						key === "ELIZA_RUNTIME_INSTANCE_ID"
+							? this.runtimeInstanceId
+							: this.runtime.getSetting(key),
+				},
+				this.accountId,
+			);
+		} catch {
+			// Incomplete coordination config surfaces loudly on the message path;
+			// the sweeper simply has nothing durable to sweep.
+			return;
+		}
+		scope.contenderToken = this.contenderToken;
+		this.coordinationSweeperHandle = setInterval(() => {
+			void this.runCoordinationSweep(scope);
+		}, config.sweepMs);
+		this.coordinationSweeperHandle.unref?.();
+	}
+
+	private async runCoordinationSweep(scope: CoordinationScope): Promise<void> {
+		if (this.coordinationSweepInFlight) return;
+		this.coordinationSweepInFlight = true;
+		try {
+			// Only sweep channels this client can actually re-dispatch into.
+			// Terminally expiring a slot for an unreachable channel spends a recovery
+			// attempt while the re-dispatch silently fails, which loses the edge.
+			const swept = await sweepExpiredCoordinationSlots(
+				this.runtime,
+				scope,
+				Date.now(),
+				[...this.client.channels.cache.keys()],
+			);
+			for (const slot of swept) {
+				const roomId = createUniqueUuid(this.runtime, slot.channelId);
+				await emitCoordinationReceipt(this.runtime, {
+					kind: "sweeper-recovery",
+					channelId: slot.channelId,
+					edgeMessageId: slot.inboundMessageId,
+					roomId,
+					entityId: this.runtime.agentId,
+					outcome: "expired-claim-recovered",
+					generation: slot.slotIndex,
+					holderToken: slot.holderToken,
+					edgeEpoch: slot.edgeEpoch,
+					detail: {
+						lane: slot.lane,
+						recoveryAttempts: slot.recoveryAttempts,
+					},
+					scope,
+				});
+				try {
+					await this.redispatchSweptMessage(
+						slot.channelId,
+						slot.inboundMessageId,
+					);
+				} finally {
+					// Sweeping changes `claimed` -> `expired` before Discord fetch. If
+					// fetch/dispatch fails (or dispatch declines before claiming), re-arm
+					// the exact old row so a later sweep retries. If dispatch DID claim
+					// it, the guarded state/token CAS is a no-op.
+					await rearmSweptCoordinationSlot(
+						this.runtime,
+						scope,
+						slot,
+						this.groupCoordinationConfig.sweepMs,
+					);
+				}
+			}
+		} catch (error) {
+			this.runtime.reportError?.("discord:coordination.sweeper", error, {
+				accountId: this.accountId,
+			});
+		} finally {
+			this.coordinationSweepInFlight = false;
+		}
+	}
+
+	private async redispatchSweptMessage(
+		channelId: string,
+		inboundMessageId: string,
+	): Promise<void> {
+		try {
+			const channel = await this.client.channels.fetch(channelId);
+			if (!channel || !("messages" in channel)) return;
+			const inbound = await (channel as TextChannel).messages.fetch(
+				inboundMessageId,
+			);
+			if (!inbound) return;
+			// Clear this manager's in-process dedupe entry before re-dispatching.
+			// The sweep interval (60s default) is SHORTER than the processed-id TTL
+			// (120s), so on the crash path that matters most — the holder process
+			// still alive but its generation dead — handleMessage would drop the
+			// recovery as a "duplicate" and the edge would never be answered.
+			// Cross-process safety does not rest on this guard: the durable slot
+			// claim + outbound fence decide who may actually send.
+			this.releaseMessageProcessing(inboundMessageId);
+			await this.handleMessage(inbound);
+		} catch (error) {
+			this.runtime.reportError?.("discord:coordination.sweeper", error, {
+				channelId,
+				inboundMessageId,
+				phase: "redispatch",
+			});
+		}
+	}
+
+	/**
+	 * Resolve this manager's durable coordination scope, or undefined when the
+	 * feature is off / not backed by plugin-sql. Never throws: callers on the
+	 * gateway path must not break message intake on a misconfiguration, which the
+	 * dispatch path already reports loudly.
+	 */
+	private tryCoordinationScope(): CoordinationScope | undefined {
+		if (!this.groupCoordinationConfig.enabled) return undefined;
+		if (!hasSqlExecutor(this.runtime)) return undefined;
+		try {
+			const scope = requireCoordinationScope(
+				{
+					agentId: this.runtime.agentId,
+					getSetting: (key) =>
+						key === "ELIZA_RUNTIME_INSTANCE_ID"
+							? this.runtimeInstanceId
+							: this.runtime.getSetting(key),
+				},
+				this.accountId,
+			);
+			scope.contenderToken = this.contenderToken;
+			return scope;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Advance the durable human edge from the GATEWAY listener (messageCreate),
+	 * i.e. for every human message the connector observes — not only the ones
+	 * this agent goes on to dispatch.
+	 *
+	 * This is the production path for "latest human edge wins". Previously the
+	 * gateway hook wrote only to the in-process WeakMap, so on a mention-gated
+	 * deployment a human message that did not trigger a dispatch never advanced
+	 * the persisted edge, and an in-flight generation answering an older message
+	 * was never recognised as stale. The durable table is the shared surface all
+	 * contenders read, so the gateway must write THERE.
+	 */
+	public async noteHumanEdge(
+		channelId: string | undefined,
+		messageId: string | undefined,
+		createdTimestamp: number,
+	): Promise<void> {
+		if (!this.groupCoordinationConfig.enabled || !channelId || !messageId) {
+			return;
+		}
+		const scope = this.tryCoordinationScope();
+		if (!scope) return;
+		try {
+			await registerCoordinationTrustMember(this.runtime, scope);
+			await recordDiscordHumanEdge(
+				this.runtime,
+				channelId,
+				messageId,
+				createdTimestamp,
+				scope,
+			);
+		} catch (error) {
+			this.runtime.reportError?.(DISCORD_COORDINATION_AUDIT_SCOPE, error, {
+				channelId,
+				messageId,
+				phase: "gateway-edge",
+				accountId: this.accountId,
+			});
+		}
+	}
+
+	/** Stop background coordination work. Idempotent. */
+	public destroy(): void {
+		if (this.coordinationSweeperHandle) {
+			clearInterval(this.coordinationSweeperHandle);
+			this.coordinationSweeperHandle = undefined;
+		}
 	}
 
 	/**
@@ -1497,6 +1755,220 @@ export class MessageManager {
 				);
 			}
 
+			// ── P4 group coordination gate (multi-human + multi-agent rooms) ──
+			//
+			// Opt-in via DISCORD_GROUP_COORDINATION_ENABLED. Three structural
+			// guarantees before this agent may commit a model turn in a group room:
+			//   1. Bot-to-bot loop prevention: a bot-authored message only earns a
+			//      reply when it explicitly addresses this bot AND the per-channel
+			//      consecutive bot-reply budget (reset by each human message) is
+			//      not exhausted. Suppressed messages are still ingested.
+			//   2. One active speaker per human edge: a durable speaker lease keyed
+			//      (channelId, edgeMessageId) — agent-independent row id — must be
+			//      won. Losing the race is a silent ingest, with a receipt.
+			//   3. Latest-human-edge-wins at claim time: a turn whose edge has been
+			//      superseded by a newer human message aborts here, unless the
+			//      message explicitly addressed this bot (explicitly addressed work
+			//      is never dropped) or the coalesced batch contains the new edge.
+			// A second edge/lease verification runs again in the response callback
+			// immediately before the third-party send (see below).
+			let speakerLease: SpeakerLease | undefined;
+			let coordinationScope: CoordinationScope | undefined;
+			const coordination = this.groupCoordinationConfig;
+			const coalescedEdgeIds = (message as DiscordMessageWithCoalescedMetadata)
+				.__discordCoalescedMessageIds;
+			if (coordination.enabled && !isDM && message.id) {
+				const coordinationDbAvailable = hasSqlExecutor(this.runtime);
+				if (coordinationDbAvailable) {
+					coordinationScope = requireCoordinationScope(
+						{
+							agentId: this.runtime.agentId,
+							getSetting: (key) => {
+								if (key === "ELIZA_RUNTIME_INSTANCE_ID") {
+									return this.runtimeInstanceId;
+								}
+								return this.runtime.getSetting(key);
+							},
+						},
+						this.accountId,
+					);
+					coordinationScope.contenderToken = this.contenderToken;
+					await registerCoordinationTrustMember(
+						this.runtime,
+						coordinationScope,
+					);
+				} else {
+					// Fail closed, with no test escape hatch. A NODE_ENV bypass here let
+					// the suites exercise the in-process WeakMap fallback while claiming
+					// to cover the durable protocol; the coordination tests now boot a
+					// real plugin-sql runtime instead.
+					throw new Error(
+						"DISCORD_GROUP_COORDINATION_ENABLED requires plugin-sql runtime.db",
+					);
+				}
+				// Direct dispatch paths (and tests) may bypass the gateway listener
+				// that records edges; recording here is idempotent (monotonic guard).
+				if (!message.author?.bot) {
+					await recordDiscordHumanEdge(
+						this.runtime,
+						message.channel.id,
+						message.id,
+						message.createdTimestamp ?? Date.now(),
+						coordinationScope,
+					);
+				} else {
+					const suppression = await shouldSuppressBotReply({
+						owner: this.runtime,
+						channelId: message.channel.id,
+						explicitlyAddressed: isBotDirectlyAddressed,
+						budget: coordination.botReplyBudget,
+						scope: coordinationScope,
+					});
+					if (suppression.suppress) {
+						const inboundPersistence = await this.persistInboundMemory(
+							newMessage,
+							message.id,
+						);
+						inboundMemoryCommitted = inboundPersistence !== "missing-id";
+						turnRecord = await this.closeTurnAsIngestOnly(turnRecord);
+						await emitCoordinationReceipt(this.runtime, {
+							kind: "bot-loop-suppress",
+							channelId: message.channel.id,
+							edgeMessageId: message.id,
+							roomId,
+							entityId: newMessage.entityId,
+							worldId,
+							outcome: suppression.reason,
+							scope: coordinationScope,
+						});
+						this.runtime.logger.debug(
+							{
+								src: "plugin:discord",
+								agentId: this.runtime.agentId,
+								channelId: message.channel.id,
+								messageId: message.id,
+								reason: suppression.reason,
+							},
+							"Group coordination: suppressing reply to bot message",
+						);
+						return;
+					}
+				}
+
+				const claim = await claimSpeakerLease(this.runtime, {
+					channelId: message.channel.id,
+					edgeMessageId: message.id,
+					roomId,
+					entityId: newMessage.entityId,
+					worldId,
+					leaseMs: coordination.leaseMs,
+					// Human replies and bot-to-bot replies are separate lanes with
+					// separate budgets; sharing a lane made the human answer spend the
+					// bot budget for the same edge.
+					lane: message.author?.bot ? "bot" : "human",
+					slotCount: message.author?.bot ? coordination.botReplyBudget : 1,
+					accountId: this.accountId,
+					scope: coordinationScope,
+					contenderToken: this.contenderToken,
+					nonce: deterministicDiscordNonce({
+						accountId: this.accountId,
+						channelId: message.channel.id,
+						authorId: message.author.id,
+						edgeMessageId: message.id,
+					}),
+				});
+				await emitCoordinationReceipt(this.runtime, {
+					kind: "lease-claim",
+					channelId: message.channel.id,
+					edgeMessageId: message.id,
+					roomId,
+					entityId: newMessage.entityId,
+					worldId,
+					outcome: claim.outcome,
+					generation: claim.lease.generation,
+					holderAgentId: claim.lease.holderAgentId,
+					holderToken: claim.lease.contenderToken,
+					edgeEpoch: claim.lease.edgeEpoch,
+					scope: coordinationScope,
+				});
+				if (claim.outcome === "lost") {
+					const inboundPersistence = await this.persistInboundMemory(
+						newMessage,
+						message.id,
+					);
+					inboundMemoryCommitted = inboundPersistence !== "missing-id";
+					turnRecord = await this.closeTurnAsIngestOnly(turnRecord);
+					this.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							channelId: message.channel.id,
+							messageId: message.id,
+							holderAgentId: claim.lease.holderAgentId,
+						},
+						"Group coordination: another agent holds the speaker lease; ingesting silently",
+					);
+					return;
+				}
+				speakerLease = claim.lease;
+
+				const edgeAtClaim = await evaluateEdgeCurrency({
+					owner: this.runtime,
+					channelId: message.channel.id,
+					edgeMessageId: message.id,
+					coalescedMessageIds: coalescedEdgeIds,
+					explicitlyAddressed: isBotDirectlyAddressed,
+					scope: coordinationScope,
+				});
+				if (!edgeAtClaim.current) {
+					const inboundPersistence = await this.persistInboundMemory(
+						newMessage,
+						message.id,
+					);
+					inboundMemoryCommitted = inboundPersistence !== "missing-id";
+					turnRecord = await this.closeTurnAsIngestOnly(turnRecord);
+					// This claim will never produce a reply. Release the slot now
+					// instead of leaving it `claimed` until expiry, otherwise the crash
+					// sweeper re-dispatches an edge we deliberately abandoned.
+					await releaseSpeakerLease(
+						this.runtime,
+						claim.lease,
+						"stale-edge-at-claim",
+					);
+					speakerLease = undefined;
+					await emitCoordinationReceipt(this.runtime, {
+						kind: "stale-edge-abort",
+						channelId: message.channel.id,
+						edgeMessageId: message.id,
+						roomId,
+						entityId: newMessage.entityId,
+						worldId,
+						outcome: "claim-time",
+						edgeEpoch: edgeAtClaim.edgeEpoch,
+						detail: { latestEdgeMessageId: edgeAtClaim.latestEdgeMessageId },
+						scope: coordinationScope,
+					});
+					this.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							channelId: message.channel.id,
+							messageId: message.id,
+							latestEdgeMessageId: edgeAtClaim.latestEdgeMessageId,
+						},
+						"Group coordination: human edge superseded before dispatch; ingesting silently",
+					);
+					return;
+				}
+
+				// NOTE: the bot-lane budget needs no separate "consume" write. Winning
+				// the bot-lane slot IS the spend: the claim is a single atomic upsert,
+				// and shouldSuppressBotReply counts claimed/consumed/delivered bot-lane
+				// rows for the edge. A separate state='consumed' write here also broke
+				// the outbound fence, which requires state='claimed' to renew, so the
+				// agent aborted its own bot reply as a lost lease.
+			}
+
 			const messageId = newMessage.id;
 			const stalenessStartSequence = getDiscordChannelMessageSequence(
 				this,
@@ -1556,8 +2028,21 @@ export class MessageManager {
 
 			const sendFailureReply = async (text: string) => {
 				try {
-					await channel.send({
+					const fenced = await verifyFencedOutboundSend("failure-reply");
+					if (!fenced) {
+						return;
+					}
+					const sent = await channel.send({
 						content: text,
+						...(speakerLease
+							? {
+									nonce: deterministicCoordinationNonce(
+										speakerLease,
+										"failure",
+									),
+									enforceNonce: true,
+								}
+							: {}),
 						...(outboundReplyToMessageId && replyToMode !== "off"
 							? {
 									reply: {
@@ -1566,6 +2051,23 @@ export class MessageManager {
 								}
 							: {}),
 					});
+					if (speakerLease) {
+						await reconcileDiscordDelivery(this.runtime, speakerLease, sent.id);
+						await emitCoordinationReceipt(this.runtime, {
+							kind: "delivery-reconciled",
+							channelId: message.channel.id,
+							edgeMessageId: message.id,
+							roomId,
+							entityId: newMessage.entityId,
+							worldId,
+							outcome: "failure-reply",
+							generation: speakerLease.generation,
+							holderToken: speakerLease.contenderToken,
+							edgeEpoch: speakerLease.edgeEpoch,
+							detail: { deliveredMessageId: sent.id },
+							scope: coordinationScope,
+						});
+					}
 					responseEmitted = true;
 				} catch (sendError) {
 					this.runtime.logger.warn(
@@ -1580,6 +2082,99 @@ export class MessageManager {
 						"Failed to send Discord failure reply",
 					);
 				}
+			};
+
+			const verifyFencedOutboundSend = async (
+				outcome: "normal" | "failure-reply",
+			): Promise<boolean> => {
+				if (!speakerLease || !message.id) {
+					return true;
+				}
+				const renewed = await renewSpeakerLease(
+					this.runtime,
+					speakerLease,
+					coordination.leaseMs,
+				);
+				const leaseCheck = renewed
+					? await verifySpeakerLease(this.runtime, speakerLease)
+					: { held: false as const, reason: "expired" as const };
+				if (!leaseCheck.held) {
+					// The slot is already someone else's (or expired); do NOT release it,
+					// that would clear the new holder's claim. Just abort.
+					await emitCoordinationReceipt(this.runtime, {
+						kind: "lost-lease-abort",
+						channelId: message.channel.id,
+						edgeMessageId: message.id,
+						roomId,
+						entityId: newMessage.entityId,
+						worldId,
+						outcome: leaseCheck.reason,
+						generation: speakerLease.generation,
+						holderToken: speakerLease.contenderToken,
+						edgeEpoch: speakerLease.edgeEpoch,
+						detail: { sendPath: outcome },
+						scope: coordinationScope,
+					});
+					this.runtime.logger.warn(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							channelId: message.channel.id,
+							messageId: message.id,
+							reason: leaseCheck.reason,
+							sendPath: outcome,
+						},
+						"Group coordination: speaker lease no longer held; aborting before send",
+					);
+					return false;
+				}
+				const edgeAtSend = await evaluateEdgeCurrency({
+					owner: this.runtime,
+					channelId: message.channel.id,
+					edgeMessageId: message.id,
+					coalescedMessageIds: coalescedEdgeIds,
+					explicitlyAddressed: isBotDirectlyAddressed,
+					scope: coordinationScope,
+				});
+				if (!edgeAtSend.current) {
+					// We still hold the slot but will never use it: release so the edge is
+					// not resurrected by the sweeper and the bot lane's budget is not
+					// consumed by an attempt that produced no message.
+					await releaseSpeakerLease(
+						this.runtime,
+						speakerLease,
+						"stale-edge-pre-send",
+					);
+					await emitCoordinationReceipt(this.runtime, {
+						kind: "stale-edge-abort",
+						channelId: message.channel.id,
+						edgeMessageId: message.id,
+						roomId,
+						entityId: newMessage.entityId,
+						worldId,
+						outcome: outcome === "normal" ? "pre-send" : "failure-reply",
+						holderToken: speakerLease.contenderToken,
+						edgeEpoch: edgeAtSend.edgeEpoch,
+						detail: {
+							latestEdgeMessageId: edgeAtSend.latestEdgeMessageId,
+							sendPath: outcome,
+						},
+						scope: coordinationScope,
+					});
+					this.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							channelId: message.channel.id,
+							messageId: message.id,
+							latestEdgeMessageId: edgeAtSend.latestEdgeMessageId,
+							sendPath: outcome,
+						},
+						"Group coordination: human edge superseded; aborting before send",
+					);
+					return false;
+				}
+				return true;
 			};
 
 			const runResponseDispatch = async <T>(
@@ -1652,6 +2247,13 @@ export class MessageManager {
 						);
 					}
 					if (!stalenessDecision.shouldSend) {
+						typingController.stop();
+						statusReactions?.setDone();
+						await finalizePendingDraft();
+						return [];
+					}
+
+					if (!(await verifyFencedOutboundSend("normal"))) {
 						typingController.stop();
 						statusReactions?.setDone();
 						await finalizePendingDraft();
@@ -1911,6 +2513,16 @@ export class MessageManager {
 								(outcome) => {
 									providerSendFailure = outcome.failure;
 								},
+								speakerLease
+									? {
+											beforeSend: () => verifyFencedOutboundSend("normal"),
+											nonceForChunk: (chunkIndex) =>
+												deterministicCoordinationNonce(
+													speakerLease,
+													String(chunkIndex),
+												),
+										}
+									: undefined,
 							),
 						);
 					}
@@ -1921,6 +2533,32 @@ export class MessageManager {
 						throw new Error(
 							"Discord response callback completed without sending any messages",
 						);
+					}
+					// Coordination delivery reconciliation runs as soon as Discord
+					// accepted a chunk, BEFORE local persistence: the slot must record
+					// `delivered_message_id` even if memory writes later fail, otherwise
+					// the crash sweeper would treat a delivered edge as unanswered and
+					// re-dispatch it (double reply).
+					if (speakerLease && messages.length > 0) {
+						await reconcileDiscordDelivery(
+							this.runtime,
+							speakerLease,
+							messages[0]?.id ?? "",
+						);
+						await emitCoordinationReceipt(this.runtime, {
+							kind: "delivery-reconciled",
+							channelId: message.channel.id,
+							edgeMessageId: message.id,
+							roomId,
+							entityId: newMessage.entityId,
+							worldId,
+							outcome: "delivered",
+							generation: speakerLease.generation,
+							holderToken: speakerLease.contenderToken,
+							edgeEpoch: speakerLease.edgeEpoch,
+							detail: { deliveredMessageId: messages[0]?.id ?? "" },
+							scope: coordinationScope,
+						});
 					}
 					const memories: Memory[] = [];
 					for (const m of messages) {
@@ -2108,7 +2746,29 @@ export class MessageManager {
 			const generationAbortController = new AbortController();
 			const generationSignal = generationAbortController.signal;
 			let generationTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+			let coordinationHeartbeatHandle:
+				| ReturnType<typeof setInterval>
+				| undefined;
 			try {
+				if (speakerLease && coordination.heartbeatMs > 0) {
+					coordinationHeartbeatHandle = setInterval(() => {
+						void renewSpeakerLease(
+							this.runtime,
+							speakerLease as SpeakerLease,
+							coordination.leaseMs,
+						).catch((error) => {
+							this.runtime.reportError?.(
+								"discord:coordination.heartbeat",
+								error,
+								{
+									channelId: message.channel.id,
+									messageId: message.id,
+									contenderToken: speakerLease?.contenderToken,
+								},
+							);
+						});
+					}, coordination.heartbeatMs);
+				}
 				const generationPromise = (async () => {
 					if (messageService) {
 						this.runtime.logger.debug(
@@ -2266,12 +2926,26 @@ export class MessageManager {
 				if (generationTimeoutHandle) {
 					clearTimeout(generationTimeoutHandle);
 				}
+				if (coordinationHeartbeatHandle) {
+					clearInterval(coordinationHeartbeatHandle);
+				}
 			}
 
 			if (!responseEmitted) {
 				typingController.stop();
 				statusReactions?.setDone();
 				await finalizePendingDraft();
+				// Generation finished and the agent deliberately produced no reply
+				// (IGNORE/empty). The slot must be released: left `claimed` it expires
+				// and the crash sweeper re-dispatches an edge the agent CHOSE not to
+				// answer, which turns every IGNORE into a recurring redelivery.
+				if (speakerLease) {
+					await releaseSpeakerLease(
+						this.runtime,
+						speakerLease,
+						"no-response-emitted",
+					);
+				}
 			}
 
 			// Generation completed without throwing. Whether the agent emitted a
@@ -2299,6 +2973,11 @@ export class MessageManager {
 				},
 				"Error handling message",
 			);
+			this.runtime.reportError?.(DISCORD_COORDINATION_AUDIT_SCOPE, error, {
+				channelId: message.channel.id,
+				messageId: message.id,
+				accountId: this.accountId,
+			});
 		}
 	}
 

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -78,6 +78,7 @@
 		"@sapphire/snowflake": "3.5.5",
 		"discord-api-types": "^0.38.0",
 		"discord.js": "^14.26.4",
+		"drizzle-orm": "^0.45.1",
 		"fast-deep-equal": "3.1.3",
 		"fast-levenshtein": "^3.0.0",
 		"fluent-ffmpeg": "^2.1.3",

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -4025,6 +4025,7 @@ export class DiscordService extends Service implements IDiscordService {
 		for (const state of states) {
 			try {
 				state.voiceManager?.stop();
+				state.messageManager?.destroy();
 				this.voiceTargets.unregisterAccount(state.accountId);
 			} catch (error) {
 				this.runtime.logger.warn(

--- a/plugins/plugin-discord/test/group-coordination-pglite.test.ts
+++ b/plugins/plugin-discord/test/group-coordination-pglite.test.ts
@@ -1,0 +1,730 @@
+/**
+ * P4 group coordination against the real runtime/PGlite seam (no unit mocks).
+ *
+ * The speaker-lease protocol's safety argument rests on an agent-independent
+ * composite row key and an atomic SQL `INSERT ... ON CONFLICT DO NOTHING`.
+ * This suite proves that production query path against a real AgentRuntime and
+ * in-process PGlite database, with independent holder identities contending
+ * over the same durable store. PGlite does not enforce production PostgreSQL
+ * Row Level Security and is not an independent-process Postgres proof.
+ *
+ * Proven here:
+ *   - concurrent claim race    -> exactly one winner, one lease row, loser
+ *                                 observes the winner (no split-brain)
+ *   - idempotent retry         -> renewed, no second row, no double-claim
+ *   - holder crash + expiry    -> one successor reclaims the same budget slot
+ *   - stale revived holder     -> verify reports superseded; must abort
+ *   - receipts                 -> auditable rows in the coordination table
+ */
+import { randomUUID } from "node:crypto";
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import { ChannelType, stringToUuid } from "@elizaos/core";
+import { sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	claimSpeakerLease,
+	createDiscordContenderToken,
+	emitCoordinationReceipt,
+	MAX_SWEEP_RECOVERY_ATTEMPTS,
+	reconcileDiscordDelivery,
+	recordDiscordHumanEdge,
+	registerCoordinationTrustMember,
+	rearmSweptCoordinationSlot,
+	releaseSpeakerLease,
+	shouldSuppressBotReply,
+	sweepExpiredCoordinationSlots,
+	type CoordinationScope,
+	type SpeakerLeaseStore,
+	verifySpeakerLease,
+} from "../group-coordination.ts";
+import * as discordCoordinationSchema from "../coordination-schema.ts";
+import {
+	createTestRuntime,
+	type TestRuntimeResult,
+} from "./helpers/pglite-runtime.ts";
+
+const HOLDER_A = stringToUuid("pglite-holder-agent-a") as UUID;
+const HOLDER_B = stringToUuid("pglite-holder-agent-b") as UUID;
+const CHANNEL = "111222333444555666";
+const SERVER_ID = stringToUuid("pglite-discord-coordination-server") as UUID;
+const TRUST_GROUP_ID = "pglite-test-trust-group";
+const HOLDER_C = stringToUuid("pglite-holder-agent-c") as UUID;
+/** Operator roster: only these agents may join the trust group. */
+const TRUST_ROSTER = [HOLDER_A, HOLDER_B, HOLDER_C].join(",");
+
+let testRuntime: TestRuntimeResult;
+let runtime: AgentRuntime;
+let roomId: UUID;
+let entityId: UUID;
+
+/**
+ * A holder identity over the shared runtime database. WHO holds the lease is
+ * the contender token derived from account + agent + runtime-instance identity.
+ * This is exactly how independent managers sharing one coordination database
+ * contend: same agent-independent row, different holder tokens.
+ */
+function holderStore(
+	holderAgentId: UUID,
+): SpeakerLeaseStore & { getSetting: (key: string) => unknown } {
+	return {
+		agentId: holderAgentId,
+		db: runtime.db,
+		// Trust is operator-declared: registration checks this roster, so an
+		// agent absent from it cannot mint its own membership row.
+		getSetting: (key: string) =>
+			key === "DISCORD_COORDINATION_TRUST_MEMBERS" ? TRUST_ROSTER : undefined,
+	};
+}
+
+function holderScope(
+	holderAgentId: UUID,
+	runtimeInstanceId: string,
+	accountId = "default",
+): CoordinationScope {
+	return {
+		accountId,
+		serverId: SERVER_ID,
+		trustGroupId: TRUST_GROUP_ID,
+		runtimeInstanceId,
+		contenderToken: createDiscordContenderToken({
+			accountId,
+			agentId: holderAgentId,
+			runtimeInstanceId,
+		}),
+	};
+}
+
+beforeAll(async () => {
+	// Register the coordination schema through plugin-sql's real migration
+	// service. The production tables are owned by the plugin schema (never by
+	// runtime DDL) so plugin-sql's RLS pass applies the tenant policy; this
+	// suite must migrate them the same way rather than creating them ad hoc.
+	testRuntime = await createTestRuntime({
+		plugins: [
+			{
+				name: "discord-coordination-schema",
+				description:
+					"Discord group-room coordination tables (test registration)",
+				schema: discordCoordinationSchema,
+			},
+		],
+	});
+	runtime = testRuntime.runtime;
+	roomId = stringToUuid(`pglite-coord-room-${randomUUID()}`) as UUID;
+	entityId = stringToUuid(`pglite-coord-entity-${randomUUID()}`) as UUID;
+	await runtime.ensureConnection({
+		entityId,
+		roomId,
+		worldId: stringToUuid(`pglite-coord-world-${randomUUID()}`) as UUID,
+		userName: "shadow",
+		name: "Shadow",
+		source: "discord",
+		type: ChannelType.GROUP,
+	});
+	await registerCoordinationTrustMember(
+		holderStore(HOLDER_A),
+		holderScope(HOLDER_A, "runtime-a"),
+	);
+	await registerCoordinationTrustMember(
+		holderStore(HOLDER_B),
+		holderScope(HOLDER_B, "runtime-b"),
+	);
+}, 180_000);
+
+afterAll(async () => {
+	await testRuntime.cleanup();
+});
+
+function params(
+	edgeMessageId: string,
+	scope: CoordinationScope,
+	overrides: Record<string, unknown> = {},
+) {
+	return {
+		channelId: CHANNEL,
+		edgeMessageId,
+		roomId,
+		entityId,
+		leaseMs: 60_000,
+		scope,
+		...overrides,
+	};
+}
+
+describe("speaker lease on real PGlite", () => {
+	it("two holders racing one edge: exactly one wins, loser sees the winner", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const scopeB = holderScope(HOLDER_B, "runtime-b");
+		const [resultA, resultB] = await Promise.all([
+			claimSpeakerLease(holderStore(HOLDER_A), params(edge, scopeA)),
+			claimSpeakerLease(holderStore(HOLDER_B), params(edge, scopeB)),
+		]);
+
+		const outcomes = [resultA.outcome, resultB.outcome].sort();
+		expect(outcomes).toEqual(["lost", "won"]);
+		expect(resultA.lease.id).toBe(resultB.lease.id);
+		expect(resultA.lease.holderAgentId).toBe(resultB.lease.holderAgentId);
+
+		// The dedicated reply-slot row is the database source of truth.
+		const slot = await (
+			runtime.db as { execute(query: unknown): Promise<{ rows: unknown[] }> }
+		).execute(sql`
+			SELECT contender_token
+			FROM discord_coordination_reply_slots
+			WHERE channel_id = ${CHANNEL}
+				AND edge_epoch = ${edge}
+				AND slot_index = 0
+		`);
+		expect(slot.rows).toHaveLength(1);
+		expect((slot.rows[0] as Record<string, unknown>).contender_token).toBe(
+			resultA.lease.contenderToken,
+		);
+	});
+
+	it("same-agent independent managers still contend by runtime-instance token", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const workerA = holderScope(HOLDER_A, "runtime-a-worker-1");
+		const workerB = holderScope(HOLDER_A, "runtime-a-worker-2");
+		const [resultA, resultB] = await Promise.all([
+			claimSpeakerLease(holderStore(HOLDER_A), params(edge, workerA)),
+			claimSpeakerLease(holderStore(HOLDER_A), params(edge, workerB)),
+		]);
+
+		expect([resultA.outcome, resultB.outcome].sort()).toEqual(["lost", "won"]);
+		expect(resultA.lease.contenderToken).toBe(resultB.lease.contenderToken);
+		expect([workerA.contenderToken, workerB.contenderToken]).toContain(
+			resultA.lease.contenderToken,
+		);
+	});
+
+	it("two Discord accounts on one agent still contend on the same room row", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const primary = holderScope(HOLDER_A, "runtime-shared", "account-primary");
+		const secondary = holderScope(
+			HOLDER_A,
+			"runtime-shared",
+			"account-secondary",
+		);
+		await registerCoordinationTrustMember(holderStore(HOLDER_A), primary);
+		await registerCoordinationTrustMember(holderStore(HOLDER_A), secondary);
+
+		const [resultA, resultB] = await Promise.all([
+			claimSpeakerLease(holderStore(HOLDER_A), params(edge, primary)),
+			claimSpeakerLease(holderStore(HOLDER_A), params(edge, secondary)),
+		]);
+		expect([resultA.outcome, resultB.outcome].sort()).toEqual(["lost", "won"]);
+		expect(resultA.lease.contenderToken).toBe(resultB.lease.contenderToken);
+	});
+
+	it("winner's retry is renewed (idempotent), not a re-claim", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const storeA = holderStore(HOLDER_A);
+		const first = await claimSpeakerLease(
+			storeA,
+			params(edge, holderScope(HOLDER_A, "runtime-a")),
+		);
+		expect(first.outcome).toBe("won");
+		const retry = await claimSpeakerLease(
+			storeA,
+			params(edge, holderScope(HOLDER_A, "runtime-a")),
+		);
+		expect(retry.outcome).toBe("renewed");
+		expect(retry.lease.generation).toBe(0);
+		expect(retry.lease.generation).toBe(0);
+	});
+
+	it("holder crash -> expiry -> successor reclaims g+1; revived holder verifies superseded", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const t0 = Date.now() - 60_000;
+		const storeA = holderStore(HOLDER_A);
+		const storeB = holderStore(HOLDER_B);
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const scopeB = holderScope(HOLDER_B, "runtime-b");
+
+		// A claims a short lease at t0 and "crashes".
+		const claimA = await claimSpeakerLease(
+			storeA,
+			params(edge, scopeA, { leaseMs: 5_000, now: t0 }),
+		);
+		expect(claimA.outcome).toBe("won");
+
+		// After expiry, B atomically reclaims the same budget slot.
+		const claimB = await claimSpeakerLease(storeB, params(edge, scopeB));
+		expect(claimB.outcome).toBe("reclaimed");
+		expect(claimB.lease.generation).toBe(0);
+		expect(claimB.lease.holderAgentId).toBe(HOLDER_B);
+
+		// A revives and re-verifies its old lease before sending: the slot is now
+		// held by B.
+		const check = await verifySpeakerLease(storeA, claimA.lease, t0 + 4_000);
+		expect(check.held).toBe(false);
+		expect(check.reason).toBe("not-holder");
+
+		// B's lease verifies held.
+		const checkB = await verifySpeakerLease(storeB, claimB.lease);
+		expect(checkB.held).toBe(true);
+	});
+
+	it("two successors racing an expired lease: exactly one reclaims", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const t0 = Date.now() - 60_000;
+		await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, holderScope(HOLDER_A, "runtime-a"), {
+				leaseMs: 5_000,
+				now: t0,
+			}),
+		);
+		const holderC = HOLDER_C;
+		const scopeC = holderScope(holderC, "runtime-c");
+		await registerCoordinationTrustMember(holderStore(holderC), scopeC);
+		const [rB, rC] = await Promise.all([
+			claimSpeakerLease(
+				holderStore(HOLDER_B),
+				params(edge, holderScope(HOLDER_B, "runtime-b")),
+			),
+			claimSpeakerLease(holderStore(holderC), params(edge, scopeC)),
+		]);
+		const outcomes = [rB.outcome, rC.outcome].sort();
+		expect(outcomes).toEqual(["lost", "reclaimed"]);
+		const winner = rB.outcome === "reclaimed" ? rB : rC;
+		expect(winner.lease.generation).toBe(0);
+		expect(rB.lease.holderAgentId).toBe(rC.lease.holderAgentId);
+	});
+
+	it("coordination receipts persist as auditable rows in the real store", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const ok = await emitCoordinationReceipt(holderStore(HOLDER_A), {
+			kind: "lease-claim",
+			channelId: CHANNEL,
+			edgeMessageId: edge,
+			roomId,
+			entityId,
+			outcome: "won",
+			generation: 0,
+			scope: holderScope(HOLDER_A, "runtime-a"),
+		});
+		expect(ok).toBe(true);
+
+		const result = await (runtime.db as { execute(query: unknown): Promise<{ rows: unknown[] }> }).execute(sql`
+			SELECT kind, outcome, contender_token
+			FROM discord_coordination_receipts
+			WHERE edge_message_id = ${edge}
+		`);
+		const data = result.rows[0] as Record<string, unknown> | undefined;
+		expect(data).toBeDefined();
+		expect(data?.kind).toBe("lease-claim");
+		expect(data?.outcome).toBe("won");
+		expect(data?.contender_token).toContain(HOLDER_A);
+	});
+});
+
+describe("crash-recovery sweeper on real PGlite", () => {
+	it("recovers an expired undelivered claim exactly once (two sweepers race)", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const t0 = Date.now() - 60_000;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const scopeB = holderScope(HOLDER_B, "runtime-b");
+
+		// A wins the edge, then "crashes" before delivering (short lease at t0).
+		const claim = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, scopeA, { leaseMs: 5_000, now: t0 }),
+		);
+		expect(claim.outcome).toBe("won");
+
+		// Two independent sweepers race: the atomic UPDATE hands the slot to
+		// exactly one of them.
+		const [sweptA, sweptB] = await Promise.all([
+			sweepExpiredCoordinationSlots(holderStore(HOLDER_A), scopeA),
+			sweepExpiredCoordinationSlots(holderStore(HOLDER_B), scopeB),
+		]);
+		const mine = [...sweptA, ...sweptB].filter(
+			(slot) => slot.edgeEpoch === edge,
+		);
+		expect(mine).toHaveLength(1);
+		expect(mine[0].inboundMessageId).toBe(edge);
+		expect(mine[0].holderToken).toBe(scopeA.contenderToken);
+
+		// The slot is terminally expired: a later sweep finds nothing (negative
+		// proof: no double recovery).
+		const again = await sweepExpiredCoordinationSlots(
+			holderStore(HOLDER_B),
+			scopeB,
+		);
+		expect(again.filter((slot) => slot.edgeEpoch === edge)).toHaveLength(0);
+	});
+
+	it("never sweeps a live claim or a delivered slot (negative proof)", async () => {
+		const liveEdge = `edge-${randomUUID()}`;
+		const deliveredEdge = `edge-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+
+		// Live claim: unexpired.
+		const live = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(liveEdge, scopeA),
+		);
+		expect(live.outcome).toBe("won");
+
+		// Delivered slot: expired but reconciled with a delivered message id.
+		const delivered = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(deliveredEdge, scopeA, {
+				leaseMs: 5_000,
+				now: Date.now() - 60_000,
+			}),
+		);
+		expect(delivered.outcome).toBe("won");
+		await reconcileDiscordDelivery(
+			holderStore(HOLDER_A),
+			delivered.lease,
+			"990000000000000042",
+		);
+
+		const swept = await sweepExpiredCoordinationSlots(
+			holderStore(HOLDER_A),
+			scopeA,
+		);
+		const edges = swept.map((slot) => slot.edgeEpoch);
+		expect(edges).not.toContain(liveEdge);
+		expect(edges).not.toContain(deliveredEdge);
+	});
+
+	it("an untrusted contender cannot sweep (trust boundary holds for recovery too)", async () => {
+		const intruder = stringToUuid("pglite-holder-agent-intruder") as UUID;
+		const scopeIntruder = holderScope(intruder, "runtime-intruder");
+		// Never registered as a trust member.
+		await expect(
+			sweepExpiredCoordinationSlots(holderStore(intruder), scopeIntruder),
+		).rejects.toThrow(/not trusted/);
+	});
+});
+
+describe("reply lanes are budgeted independently", () => {
+	it("suppresses addressed bot traffic until a human establishes the epoch", async () => {
+		const channel = `channel-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const decision = await shouldSuppressBotReply({
+			owner: holderStore(HOLDER_A),
+			channelId: channel,
+			explicitlyAddressed: true,
+			budget: 1,
+			scope: scopeA,
+		});
+		expect(decision).toEqual({
+			suppress: true,
+			reason: "budget-exhausted",
+		});
+	});
+
+	it("one inbound bot message can win only one slot even when budget is two", async () => {
+		const channel = `channel-${randomUUID()}`;
+		const edge = "700000000000000000";
+		const botInbound = "700000000000000001";
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const scopeB = holderScope(HOLDER_B, "runtime-b");
+		await recordDiscordHumanEdge(
+			holderStore(HOLDER_A),
+			channel,
+			edge,
+			Date.now(),
+			scopeA,
+		);
+
+		const [first, second] = await Promise.all([
+			claimSpeakerLease(
+				holderStore(HOLDER_A),
+				params(botInbound, scopeA, {
+					channelId: channel,
+					lane: "bot",
+					slotCount: 2,
+				}),
+			),
+			claimSpeakerLease(
+				holderStore(HOLDER_B),
+				params(botInbound, scopeB, {
+					channelId: channel,
+					lane: "bot",
+					slotCount: 2,
+				}),
+			),
+		]);
+		expect([first.outcome, second.outcome].sort()).toEqual(["lost", "won"]);
+
+		const rows = await (
+			runtime.db as { execute(query: unknown): Promise<{ rows: unknown[] }> }
+		).execute(sql`
+			SELECT slot_index
+			FROM discord_coordination_reply_slots
+			WHERE channel_id = ${channel}
+				AND edge_epoch = ${edge}
+				AND lane = 'bot'
+				AND inbound_message_id = ${botInbound}
+		`);
+		expect(rows.rows).toHaveLength(1);
+	});
+
+	it("a human-lane claim does not consume the bot-lane budget for the same edge", async () => {
+		const channel = `channel-${randomUUID()}`;
+		const edge = "700000000000000001";
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		await recordDiscordHumanEdge(
+			holderStore(HOLDER_A),
+			channel,
+			edge,
+			Date.now(),
+			scopeA,
+		);
+
+		// Answer the human: human lane, budget 1.
+		const human = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, scopeA, { channelId: channel, lane: "human" }),
+		);
+		expect(human.outcome).toBe("won");
+		expect(human.lease.lane).toBe("human");
+
+		// The bot lane must still be free: with a shared lane the human answer
+		// above exhausted budget=1 and every addressed bot reply was suppressed.
+		const suppression = await shouldSuppressBotReply({
+			owner: holderStore(HOLDER_A),
+			channelId: channel,
+			explicitlyAddressed: true,
+			budget: 1,
+			scope: scopeA,
+		});
+		expect(suppression.suppress).toBe(false);
+
+		const bot = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, scopeA, { channelId: channel, lane: "bot" }),
+		);
+		expect(bot.outcome).toBe("won");
+		expect(bot.lease.lane).toBe("bot");
+
+		// Now the bot lane IS spent for this edge.
+		const second = await shouldSuppressBotReply({
+			owner: holderStore(HOLDER_A),
+			channelId: channel,
+			explicitlyAddressed: true,
+			budget: 1,
+			scope: scopeA,
+		});
+		expect(second.suppress).toBe(true);
+		expect(second.reason).toBe("budget-exhausted");
+	});
+});
+
+describe("terminal slots are never re-answered", () => {
+	it("a delivered slot cannot be reclaimed after its lease expires", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const scopeB = holderScope(HOLDER_B, "runtime-b");
+
+		// A wins with a short lease at t0, delivers, then the lease expires.
+		const claim = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, scopeA, { leaseMs: 5_000, now: Date.now() - 60_000 }),
+		);
+		expect(claim.outcome).toBe("won");
+		await reconcileDiscordDelivery(
+			holderStore(HOLDER_A),
+			claim.lease,
+			"990000000000000777",
+		);
+
+		// B arrives on a redelivery of the same edge. The reply already went out,
+		// so B must NOT be handed the slot (that is a duplicate reply).
+		const second = await claimSpeakerLease(
+			holderStore(HOLDER_B),
+			params(edge, scopeB),
+		);
+		expect(second.outcome).toBe("lost");
+	});
+
+	it("a released slot is reclaimable (abandoned attempt, no reply was sent)", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const scopeB = holderScope(HOLDER_B, "runtime-b");
+
+		const claim = await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, scopeA),
+		);
+		expect(claim.outcome).toBe("won");
+		await releaseSpeakerLease(holderStore(HOLDER_A), claim.lease, "test-abort");
+
+		// Nothing was delivered, so another contender may take the edge.
+		const second = await claimSpeakerLease(
+			holderStore(HOLDER_B),
+			params(edge, scopeB),
+		);
+		expect(second.outcome).toBe("reclaimed");
+
+		// And a released slot is not sweeper material (it is not `claimed`).
+		const swept = await sweepExpiredCoordinationSlots(
+			holderStore(HOLDER_A),
+			scopeA,
+		);
+		expect(swept.some((slot) => slot.edgeEpoch === edge)).toBe(false);
+	});
+});
+
+describe("sweeper recovery is bounded and reachability-scoped", () => {
+	it("stops recovering a poison slot after MAX_SWEEP_RECOVERY_ATTEMPTS", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const store = holderStore(HOLDER_A);
+
+		for (let attempt = 1; attempt <= MAX_SWEEP_RECOVERY_ATTEMPTS; attempt += 1) {
+			// Re-claim with an already-expired lease, simulating a holder that dies
+			// every time it picks this message up.
+			await claimSpeakerLease(
+				store,
+				params(edge, scopeA, { leaseMs: 1, now: Date.now() - 60_000 }),
+			);
+			const swept = await sweepExpiredCoordinationSlots(store, scopeA);
+			expect(swept.filter((slot) => slot.edgeEpoch === edge)).toHaveLength(1);
+		}
+
+		// One more crash cycle: the bound is reached, so the slot is retired
+		// (`abandoned`) instead of being re-dispatched forever.
+		await claimSpeakerLease(
+			store,
+			params(edge, scopeA, { leaseMs: 1, now: Date.now() - 60_000 }),
+		);
+		const finalSweep = await sweepExpiredCoordinationSlots(store, scopeA);
+		expect(finalSweep.filter((slot) => slot.edgeEpoch === edge)).toHaveLength(0);
+
+		const rows = await (
+			runtime.db as { execute(query: unknown): Promise<{ rows: unknown[] }> }
+		).execute(sql`
+			SELECT state FROM discord_coordination_reply_slots
+			WHERE edge_epoch = ${edge}
+		`);
+		expect((rows.rows[0] as Record<string, unknown>).state).toBe("abandoned");
+	});
+
+	it("re-arms an expired row when redispatch did not claim it", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		const store = holderStore(HOLDER_A);
+		await claimSpeakerLease(
+			store,
+			params(edge, scopeA, { leaseMs: 1, now: Date.now() - 60_000 }),
+		);
+		const [swept] = await sweepExpiredCoordinationSlots(store, scopeA);
+		expect(swept?.edgeEpoch).toBe(edge);
+
+		// Simulate Discord channel/message fetch failing before handleMessage can
+		// reclaim. The manager's finally block calls this guarded re-arm.
+		await expect(
+			rearmSweptCoordinationSlot(store, scopeA, swept, 1_000),
+		).resolves.toBe(true);
+		const retry = await sweepExpiredCoordinationSlots(
+			store,
+			scopeA,
+			Date.now() + 2_000,
+		);
+		expect(retry.some((slot) => slot.edgeEpoch === edge)).toBe(true);
+	});
+
+	it("keeps crash recovery on the Discord account that won the send", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const primary = holderScope(HOLDER_A, "runtime-a", "account-primary");
+		const secondary = holderScope(
+			HOLDER_B,
+			"runtime-b",
+			"account-secondary",
+		);
+		await registerCoordinationTrustMember(holderStore(HOLDER_A), primary);
+		await registerCoordinationTrustMember(holderStore(HOLDER_B), secondary);
+		await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, primary, { leaseMs: 1, now: Date.now() - 60_000 }),
+		);
+
+		// A different bot account cannot reclaim or sweep the winner's crash
+		// window: its provider nonce/idempotency scope is not authoritative.
+		const foreignClaim = await claimSpeakerLease(
+			holderStore(HOLDER_B),
+			params(edge, secondary),
+		);
+		expect(foreignClaim.outcome).toBe("lost");
+		expect(
+			await sweepExpiredCoordinationSlots(holderStore(HOLDER_B), secondary),
+		).toHaveLength(0);
+
+		// A replacement worker for the original account can recover it.
+		const replacement = {
+			...primary,
+			runtimeInstanceId: "runtime-a-replacement",
+			contenderToken: createDiscordContenderToken({
+				accountId: primary.accountId,
+				agentId: HOLDER_B,
+				runtimeInstanceId: "runtime-a-replacement",
+			}),
+		};
+		await registerCoordinationTrustMember(holderStore(HOLDER_B), replacement);
+		const recovered = await claimSpeakerLease(
+			holderStore(HOLDER_B),
+			params(edge, replacement),
+		);
+		expect(recovered.outcome).toBe("reclaimed");
+	});
+
+	it("never sweeps a channel this client cannot re-dispatch into", async () => {
+		const edge = `edge-${randomUUID()}`;
+		const channel = `channel-${randomUUID()}`;
+		const scopeA = holderScope(HOLDER_A, "runtime-a");
+		await claimSpeakerLease(
+			holderStore(HOLDER_A),
+			params(edge, scopeA, {
+				channelId: channel,
+				leaseMs: 5_000,
+				now: Date.now() - 60_000,
+			}),
+		);
+
+		// Reachable set excludes this channel: expiring the slot here would spend a
+		// recovery attempt while the re-dispatch silently fails, losing the edge.
+		const unreachable = await sweepExpiredCoordinationSlots(
+			holderStore(HOLDER_A),
+			scopeA,
+			Date.now(),
+			["some-other-channel"],
+		);
+		expect(unreachable.some((slot) => slot.edgeEpoch === edge)).toBe(false);
+
+		// Once the channel is reachable, recovery proceeds normally.
+		const reachable = await sweepExpiredCoordinationSlots(
+			holderStore(HOLDER_A),
+			scopeA,
+			Date.now(),
+			[channel],
+		);
+		expect(reachable.some((slot) => slot.edgeEpoch === edge)).toBe(true);
+	});
+});
+
+describe("trust membership is operator-declared, not self-minted", () => {
+	it("an agent absent from the roster cannot register itself", async () => {
+		const intruder = stringToUuid("pglite-holder-agent-rogue") as UUID;
+		await expect(
+			registerCoordinationTrustMember(
+				holderStore(intruder),
+				holderScope(intruder, "runtime-rogue"),
+			),
+		).rejects.toThrow(/not listed in DISCORD_COORDINATION_TRUST_MEMBERS/);
+
+		// And therefore cannot claim: knowing the ids is not enough.
+		await expect(
+			claimSpeakerLease(
+				holderStore(intruder),
+				params(`edge-${randomUUID()}`, holderScope(intruder, "runtime-rogue")),
+			),
+		).rejects.toThrow(/not trusted/);
+	});
+});

--- a/plugins/plugin-discord/test/messages-group-coordination-pglite.test.ts
+++ b/plugins/plugin-discord/test/messages-group-coordination-pglite.test.ts
@@ -1,0 +1,699 @@
+/**
+ * Manager-level coordination tests against the REAL durable path.
+ *
+ * Two real `MessageManager` instances (distinct agents, distinct Discord
+ * clients) share ONE plugin-sql/PGlite database and race the same guild
+ * message. Only the Discord network objects are stubbed; every coordination
+ * decision goes through the production `messages.ts` path against the migrated
+ * coordination schema and the real SQL executor.
+ *
+ * This suite deliberately lives on the SQL path rather than an in-process
+ * shared-map fake: the earlier mock-store version of these tests passed while
+ * `runtime.db` was absent, so it proved the WeakMap fallback (which the flag now
+ * refuses to use) instead of the durable protocol it claimed to cover.
+ *
+ * Covered here:
+ *   (a) two agents race one human edge   -> exactly one third-party send
+ *   (b) newer human edge mid-generation  -> holder aborts before send
+ *   (c) explicit mention                 -> addressed work is never dropped
+ *   (d) bot message not addressed        -> suppressed (no loop)
+ *   (e) bot-reply budget                 -> the human answer does NOT spend it
+ *   (f) redelivery/retry                 -> cannot double-send
+ *   (g) IGNORE/no-reply                  -> slot released, not resurrected
+ */
+import { randomUUID } from "node:crypto";
+import {
+	type Content,
+	ChannelType,
+	createUniqueUuid,
+	type Memory,
+	stringToUuid,
+	type UUID,
+} from "@elizaos/core";
+import type { Message as DiscordMessage } from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as discordCoordinationSchema from "../coordination-schema.ts";
+import { deterministicCoordinationNonce } from "../group-coordination.ts";
+import { MessageManager } from "../messages.ts";
+import type { ICompatRuntime, IDiscordService } from "../types.ts";
+import { createTestRuntime, type TestRuntimeResult } from "./helpers/pglite-runtime.ts";
+
+const AGENT_A = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa" as UUID;
+const AGENT_B = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb" as UUID;
+const HUMAN_ID = "555000111222333444";
+const OTHER_BOT_ID = "666000111222333444";
+const GUILD_ID = "888111000000000000";
+const CLIENT_A = "999000000000000001";
+const CLIENT_B = "999000000000000002";
+const SERVER_ID = stringToUuid("p4-manager-coordination-server") as UUID;
+const TRUST_GROUP_ID = "p4-manager-trust-group";
+
+let testRuntime: TestRuntimeResult;
+/** The single real SQL-backed runtime every contender writes through. */
+let baseRuntime: TestRuntimeResult["runtime"];
+
+interface Sent {
+	agent: UUID;
+	content: string;
+	nonce?: string | number;
+	enforceNonce?: boolean;
+}
+
+type SqlRunner = { execute(query: unknown): Promise<{ rows: unknown[] }> };
+
+function db(): SqlRunner {
+	return baseRuntime.db as unknown as SqlRunner;
+}
+
+beforeAll(async () => {
+	// The coordination tables are owned by the plugin schema (never runtime DDL)
+	// so plugin-sql's RLS pass can apply the tenant policy; migrate them through
+	// the real migration service exactly as production does.
+	testRuntime = await createTestRuntime({
+		plugins: [
+			{
+				name: "discord-coordination-schema",
+				description: "Discord group-room coordination tables (test registration)",
+				schema: discordCoordinationSchema,
+			},
+		],
+	});
+	baseRuntime = testRuntime.runtime;
+}, 180_000);
+
+afterAll(async () => {
+	await testRuntime.cleanup();
+});
+
+/**
+ * A contender runtime: its own agentId and runtime-instance identity, sharing
+ * the ONE real database. This is exactly the production shape of two agents
+ * coordinating over a common coordination schema.
+ */
+function makeRuntime(
+	agentId: UUID,
+	runtimeInstanceId: string,
+	options?: {
+		onGenerate?: (invocation: number) => Promise<void> | void;
+		replyText?: string | null;
+	},
+): ICompatRuntime {
+	let generateCalls = 0;
+	const memories = new Map<string, Memory>();
+	const runtime = {
+		agentId,
+		character: { name: `Agent-${agentId.slice(0, 4)}` },
+		db: baseRuntime.db,
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+		getSetting: (key: string) => {
+			const settings: Record<string, string> = {
+				ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false",
+				DISCORD_GROUP_COORDINATION_ENABLED: "true",
+				DISCORD_GROUP_COORDINATION_SERVER_ID: SERVER_ID,
+				DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID: TRUST_GROUP_ID,
+				// Operator-declared roster: trust is never self-minted.
+				DISCORD_COORDINATION_TRUST_MEMBERS: `${AGENT_A},${AGENT_B}`,
+				ELIZA_RUNTIME_INSTANCE_ID: runtimeInstanceId,
+				DISCORD_ENVELOPE_ENABLED: "false",
+				DISCORD_STATUS_REACTIONS: "none",
+				// The sweeper is exercised directly in the protocol suite; an
+				// interval here would race these assertions.
+				DISCORD_COORDINATION_SWEEP_MS: "0",
+			};
+			return settings[key];
+		},
+		getService: () => null,
+		reportError: vi.fn(),
+		emitEvent: vi.fn(),
+		ensureConnection: vi.fn(async () => {}),
+		getMemoryById: vi.fn(async (id: UUID) => memories.get(id as string) ?? null),
+		createMemory: vi.fn(async (memory: Memory, _table = "messages") => {
+			const id = (memory.id ?? randomUUID()) as string;
+			memories.set(id, { ...memory, id: id as UUID });
+			return id as UUID;
+		}),
+		getMemories: vi.fn(async () => []),
+		messageService: {
+			handleMessage: async (
+				_runtime: unknown,
+				_message: Memory,
+				callback: (content: Content) => Promise<unknown>,
+			) => {
+				generateCalls += 1;
+				await options?.onGenerate?.(generateCalls);
+				if (options?.replyText === null) {
+					// Deliberate no-reply (IGNORE), the shape that must release the slot.
+					return;
+				}
+				await callback({
+					text: options?.replyText ?? "coordinated reply",
+					source: "discord",
+				});
+			},
+		},
+	} as unknown as ICompatRuntime;
+	return runtime;
+}
+
+function makeGuildChannel(
+	agent: UUID,
+	clientId: string,
+	channelId: string,
+	sends: Sent[],
+) {
+	const guild = {
+		id: GUILD_ID,
+		name: "Coordination Guild",
+		ownerId: HUMAN_ID,
+		members: { cache: new Map([[clientId, { id: clientId }]]) },
+	};
+	const channel = {
+		id: channelId,
+		type: DiscordChannelType.GuildText,
+		name: "multiplayer",
+		guild,
+		client: { user: { id: clientId } },
+		isThread: () => false,
+		permissionsFor: () => ({ has: () => true }),
+		send: async (
+			options:
+				| string
+				| {
+						content?: string;
+						nonce?: string | number;
+						enforceNonce?: boolean;
+					},
+		) => {
+			const content =
+				typeof options === "string" ? options : (options.content ?? "");
+			sends.push({
+				agent,
+				content,
+				...(typeof options === "object"
+					? { nonce: options.nonce, enforceNonce: options.enforceNonce }
+					: {}),
+			});
+			const id = `9900000000000${sends.length}`;
+			return {
+				id,
+				content,
+				url: `https://discord.com/channels/${GUILD_ID}/${channelId}/${id}`,
+				createdTimestamp: Date.now(),
+				attachments: { size: 0 },
+			};
+		},
+	};
+	return { guild, channel };
+}
+
+function makeInbound(options: {
+	channel: unknown;
+	guild: unknown;
+	channelId: string;
+	messageId: string;
+	text?: string;
+	authorId?: string;
+	authorIsBot?: boolean;
+	mentionsBotId?: string;
+	createdTimestamp?: number;
+}): DiscordMessage {
+	const users = new Map<string, { id: string }>();
+	if (options.mentionsBotId) {
+		users.set(options.mentionsBotId, { id: options.mentionsBotId });
+	}
+	return {
+		id: options.messageId,
+		content:
+			options.text ??
+			(options.mentionsBotId
+				? `<@${options.mentionsBotId}> hello there`
+				: "hello there"),
+		createdTimestamp: options.createdTimestamp ?? Date.now(),
+		author: {
+			id: options.authorId ?? HUMAN_ID,
+			bot: options.authorIsBot ?? false,
+			username: options.authorIsBot ? "otherbot" : "shadow",
+			globalName: options.authorIsBot ? "OtherBot" : "Shadow",
+			displayName: options.authorIsBot ? "OtherBot" : "Shadow",
+			discriminator: "0",
+			displayAvatarURL: () => "https://cdn.example/avatar.png",
+		},
+		member: { displayName: options.authorIsBot ? "OtherBot" : "Shadow" },
+		channel: options.channel,
+		guild: options.guild,
+		interaction: null,
+		reference: undefined,
+		embeds: [],
+		stickers: { size: 0 },
+		attachments: { size: 0 },
+		mentions: { users, repliedUser: undefined },
+		react: async () => undefined,
+		reactions: { resolve: () => null },
+	} as unknown as DiscordMessage;
+}
+
+function makeService(
+	runtime: ICompatRuntime,
+	clientId: string,
+	channelId: string,
+	options?: { shouldIgnoreBotMessages?: boolean },
+): IDiscordService {
+	return {
+		client: {
+			user: { id: clientId },
+			// The sweeper only recovers channels this client can reach.
+			channels: { cache: new Map([[channelId, { id: channelId }]]) },
+		},
+		accountId: "default",
+		getChannelType: async () => ChannelType.GROUP,
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "open",
+			shouldIgnoreBotMessages: options?.shouldIgnoreBotMessages ?? true,
+			shouldIgnoreDirectMessages: false,
+			shouldRespondOnlyToMentions: false,
+			replyToMode: "off",
+		},
+		buildMemoryFromMessage: vi.fn(async (message: DiscordMessage) => ({
+			id: createUniqueUuid(runtime, message.id),
+			entityId: createUniqueUuid(runtime, message.author.id),
+			agentId: runtime.agentId,
+			roomId: createUniqueUuid(runtime, channelId),
+			content: { text: message.content, source: "discord" },
+		})),
+	} as unknown as IDiscordService;
+}
+
+async function receiptsFor(
+	channelId: string,
+	kind?: string,
+): Promise<Record<string, unknown>[]> {
+	const result = kind
+		? await db().execute(sql`
+				SELECT * FROM discord_coordination_receipts
+				WHERE channel_id = ${channelId} AND kind = ${kind}
+				ORDER BY created_at ASC
+			`)
+		: await db().execute(sql`
+				SELECT * FROM discord_coordination_receipts
+				WHERE channel_id = ${channelId}
+				ORDER BY created_at ASC
+			`);
+	return result.rows as Record<string, unknown>[];
+}
+
+async function slotsFor(channelId: string): Promise<Record<string, unknown>[]> {
+	const result = await db().execute(sql`
+		SELECT * FROM discord_coordination_reply_slots
+		WHERE channel_id = ${channelId}
+		ORDER BY lane ASC, slot_index ASC
+	`);
+	return result.rows as Record<string, unknown>[];
+}
+
+/** Distinct channel per test: the coordination state is channel-scoped. */
+function freshChannelId(): string {
+	return String(700000000000000000n + BigInt(Math.floor(Math.random() * 1e15)));
+}
+
+describe("group coordination on the real SQL path — two agents race one human edge", () => {
+	it("exactly one agent speaks; both leave lease-claim receipts, one slot row", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+
+		const runtimeA = makeRuntime(AGENT_A, "instance-a", {
+			onGenerate: () => new Promise((resolve) => setTimeout(resolve, 20)),
+		});
+		const runtimeB = makeRuntime(AGENT_B, "instance-b", {
+			onGenerate: () => new Promise((resolve) => setTimeout(resolve, 20)),
+		});
+		const chanA = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const chanB = makeGuildChannel(AGENT_B, CLIENT_B, channelId, sends);
+		const managerA = new MessageManager(
+			makeService(runtimeA, CLIENT_A, channelId),
+			runtimeA,
+		);
+		const managerB = new MessageManager(
+			makeService(runtimeB, CLIENT_B, channelId),
+			runtimeB,
+		);
+
+		const messageId = "222000000000000001";
+		await Promise.all([
+			managerA.handleMessage(
+				makeInbound({
+					channel: chanA.channel,
+					guild: chanA.guild,
+					channelId,
+					messageId,
+				}),
+			),
+			managerB.handleMessage(
+				makeInbound({
+					channel: chanB.channel,
+					guild: chanB.guild,
+					channelId,
+					messageId,
+				}),
+			),
+		]);
+
+		expect(sends).toHaveLength(1);
+		// The production Discord send is idempotency-fenced at the provider too:
+		// retries use the same deterministic nonce and Discord rejects duplicates.
+		expect(sends[0]?.enforceNonce).toBe(true);
+		expect(String(sends[0]?.nonce)).toHaveLength(24);
+
+		const claims = await receiptsFor(channelId, "lease-claim");
+		expect(claims).toHaveLength(2);
+		expect(claims.map((row) => row.outcome).sort()).toEqual(["lost", "won"]);
+		// Both contenders agree on the holder token recorded in the row.
+		expect(new Set(claims.map((row) => row.holder_token)).size).toBe(1);
+
+		// Exactly one human-lane slot row, and it is the delivered one.
+		const slots = await slotsFor(channelId);
+		expect(slots).toHaveLength(1);
+		expect(slots[0].lane).toBe("human");
+		expect(slots[0].state).toBe("delivered");
+		expect(slots[0].delivered_message_id).toBeTruthy();
+		expect(String(sends[0]?.nonce)).toBe(
+			deterministicCoordinationNonce(
+				{
+					serverId: String(slots[0].server_id) as UUID,
+					trustGroupId: String(slots[0].trust_group_id),
+					channelId: String(slots[0].channel_id),
+					edgeEpoch: String(slots[0].edge_epoch),
+					lane: String(slots[0].lane) === "bot" ? "bot" : "human",
+					generation: Number(slots[0].slot_index),
+				},
+				"0",
+			),
+		);
+	});
+});
+
+describe("group coordination on the real SQL path — latest-human-edge-wins", () => {
+	it("a newer human edge during generation aborts the send and releases the slot", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+
+		// Second agent's manager stands in for the gateway that observes the newer
+		// human message: noteHumanEdge is the production hook messageCreate calls.
+		const observerRuntime = makeRuntime(AGENT_B, "instance-observer");
+		const observer = new MessageManager(
+			makeService(observerRuntime, CLIENT_B, channelId),
+			observerRuntime,
+		);
+
+		const runtime = makeRuntime(AGENT_A, "instance-a", {
+			onGenerate: async () => {
+				await observer.noteHumanEdge(
+					channelId,
+					"222000000000000009",
+					Date.now() + 1,
+				);
+			},
+		});
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000002",
+			}),
+		);
+
+		expect(sends).toHaveLength(0);
+		const aborts = await receiptsFor(channelId, "stale-edge-abort");
+		expect(aborts).toHaveLength(1);
+		expect(aborts[0].outcome).toBe("pre-send");
+
+		// The abandoned claim is RELEASED, not left `claimed` to expire: otherwise
+		// the crash sweeper would resurrect an edge we deliberately dropped.
+		const slots = await slotsFor(channelId);
+		const abandoned = slots.find(
+			(slot) => slot.inbound_message_id === "222000000000000002",
+		);
+		expect(abandoned?.state).toBe("released");
+		expect(abandoned?.delivered_message_id).toBeNull();
+	});
+
+	it("fences the provider-error reply after a newer human edge", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		const observerRuntime = makeRuntime(AGENT_B, "instance-observer");
+		const observer = new MessageManager(
+			makeService(observerRuntime, CLIENT_B, channelId),
+			observerRuntime,
+		);
+		const runtime = makeRuntime(AGENT_A, "instance-a", {
+			onGenerate: async () => {
+				await observer.noteHumanEdge(
+					channelId,
+					"222000000000000029",
+					Date.now() + 1,
+				);
+				throw new Error("provider exploded");
+			},
+		});
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000020",
+			}),
+		);
+
+		// The normal callback never ran; this specifically proves the catch-path
+		// fallback is fenced immediately before channel.send.
+		expect(sends).toHaveLength(0);
+		const aborts = await receiptsFor(channelId, "stale-edge-abort");
+		expect(aborts).toHaveLength(1);
+		expect(aborts[0].outcome).toBe("failure-reply");
+		const slots = await slotsFor(channelId);
+		expect(slots[0]?.state).toBe("released");
+	});
+
+	it("explicit mention overrides edge staleness — addressed work still sends", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+
+		const observerRuntime = makeRuntime(AGENT_B, "instance-observer");
+		const observer = new MessageManager(
+			makeService(observerRuntime, CLIENT_B, channelId),
+			observerRuntime,
+		);
+		const runtime = makeRuntime(AGENT_A, "instance-a", {
+			onGenerate: async () => {
+				await observer.noteHumanEdge(
+					channelId,
+					"222000000000000019",
+					Date.now() + 1,
+				);
+			},
+		});
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000003",
+				mentionsBotId: CLIENT_A,
+			}),
+		);
+
+		expect(sends).toHaveLength(1);
+		expect(await receiptsFor(channelId, "stale-edge-abort")).toHaveLength(0);
+	});
+});
+
+describe("group coordination on the real SQL path — bot-to-bot loop prevention", () => {
+	it("suppresses an unaddressed bot message (ingest only, receipt written)", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		const runtime = makeRuntime(AGENT_A, "instance-a");
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId, {
+				shouldIgnoreBotMessages: false,
+			}),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000004",
+				authorId: OTHER_BOT_ID,
+				authorIsBot: true,
+			}),
+		);
+
+		expect(sends).toHaveLength(0);
+		const suppressions = await receiptsFor(channelId, "bot-loop-suppress");
+		expect(suppressions).toHaveLength(1);
+		expect(suppressions[0].outcome).toBe("not-addressed");
+	});
+
+	it("answering the human does NOT spend the bot-reply budget for that edge", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		const runtime = makeRuntime(AGENT_A, "instance-a");
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId, {
+				shouldIgnoreBotMessages: false,
+			}),
+			runtime,
+		);
+
+		// Human sets the edge and is answered: this consumes the HUMAN lane.
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000005",
+				createdTimestamp: 1_000,
+			}),
+		);
+		expect(sends).toHaveLength(1);
+
+		// First addressed bot message under the same edge: the bot lane is still
+		// free, so this must be answered. With a shared lane the human answer had
+		// already exhausted budget=1 and this reply was wrongly suppressed.
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000006",
+				authorId: OTHER_BOT_ID,
+				authorIsBot: true,
+				mentionsBotId: CLIENT_A,
+			}),
+		);
+		expect(sends).toHaveLength(2);
+
+		// Second addressed bot message before any human speaks: bot lane spent.
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000007",
+				authorId: OTHER_BOT_ID,
+				authorIsBot: true,
+				mentionsBotId: CLIENT_A,
+			}),
+		);
+		expect(sends).toHaveLength(2);
+		const suppressions = await receiptsFor(channelId, "bot-loop-suppress");
+		expect(suppressions).toHaveLength(1);
+		expect(suppressions[0].outcome).toBe("budget-exhausted");
+
+		// One slot per lane, both terminal.
+		const slots = await slotsFor(channelId);
+		expect(slots.map((slot) => slot.lane).sort()).toEqual(["bot", "human"]);
+	});
+});
+
+describe("group coordination on the real SQL path — retry and no-reply", () => {
+	it("redelivery after a successful send does not double-send", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		const runtime = makeRuntime(AGENT_A, "instance-a");
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const service = makeService(runtime, CLIENT_A, channelId);
+		const messageId = "222000000000000008";
+
+		const manager = new MessageManager(service, runtime);
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId,
+			}),
+		);
+		expect(sends).toHaveLength(1);
+
+		// Simulated restart: fresh manager (new runtime-instance identity), same
+		// durable rows. The delivered slot is terminal, so the redelivery cannot
+		// reclaim it and cannot send again.
+		const restartRuntime = makeRuntime(AGENT_A, "instance-a-restarted");
+		const restarted = new MessageManager(
+			makeService(restartRuntime, CLIENT_A, channelId),
+			restartRuntime,
+		);
+		await restarted.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId,
+			}),
+		);
+		expect(sends).toHaveLength(1);
+
+		const slots = await slotsFor(channelId);
+		expect(slots).toHaveLength(1);
+		expect(slots[0].state).toBe("delivered");
+	});
+
+	it("a deliberate no-reply releases the slot instead of leaving it claimed", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		// replyText null => the agent generates nothing (IGNORE).
+		const runtime = makeRuntime(AGENT_A, "instance-a", { replyText: null });
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000010",
+			}),
+		);
+
+		expect(sends).toHaveLength(0);
+		const slots = await slotsFor(channelId);
+		expect(slots).toHaveLength(1);
+		// Left `claimed`, this would expire and the sweeper would re-dispatch an
+		// edge the agent chose not to answer, forever.
+		expect(slots[0].state).toBe("released");
+	});
+});

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -569,6 +569,11 @@ function safeStringify(obj: unknown): string {
  */
 interface MessageSendOptions {
 	content: string;
+	// Mirrors discord.js `MessageCreateOptions.nonce`/`enforceNonce`: the
+	// coordination fence stamps a per-chunk nonce so Discord itself rejects a
+	// duplicate send if a retry races the lease, rather than posting twice.
+	nonce?: string | number;
+	enforceNonce?: boolean;
 	reply?: {
 		messageReference: string;
 	};
@@ -690,6 +695,10 @@ export async function sendMessageInChunks(
 	runtime?: IAgentRuntime,
 	replyToMode: ReplyToMode = "first",
 	outcomeObserver?: (outcome: DiscordChunkSendOutcome) => void,
+	fence?: {
+		beforeSend: (chunkIndex: number) => Promise<boolean>;
+		nonceForChunk: (chunkIndex: number) => string;
+	},
 ): Promise<DiscordMessage[]> {
 	const sentMessages: DiscordMessage[] = [];
 	let lastSendError: unknown = null;
@@ -718,9 +727,16 @@ export async function sendMessageInChunks(
 				(i === messages.length - 1 && files && files.length > 0) ||
 				(i === messages.length - 1 && components && components.length > 0)
 			) {
+				if (fence && !(await fence.beforeSend(i))) {
+					return sentMessages;
+				}
 				const options: MessageSendOptions = {
 					content: message.trim(),
 				};
+				if (fence) {
+					options.nonce = fence.nonceForChunk(i);
+					options.enforceNonce = true;
+				}
 
 				if (
 					inReplyTo &&
@@ -753,6 +769,9 @@ export async function sendMessageInChunks(
 						const optionsWithoutReply = { ...options };
 						delete optionsWithoutReply.reply;
 						try {
+							if (fence && !(await fence.beforeSend(i))) {
+								return sentMessages;
+							}
 							const m = await channel.send(
 								optionsWithoutReply as MessageCreateOptions,
 							);

--- a/plugins/plugin-sql/src/__tests__/migration/migration-before-1.6.5.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/migration-before-1.6.5.real.test.ts
@@ -801,6 +801,89 @@ describe("migrateToEntityRLS (pre-1.6.5 migration)", () => {
     });
   });
 
+  describe("Flow 9: Plugin-declared public server_id columns", () => {
+    beforeEach(async () => {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS agents (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          name TEXT NOT NULL,
+          created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )
+      `);
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS rooms (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          "agentId" UUID,
+          "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+          name TEXT,
+          source TEXT NOT NULL DEFAULT 'unknown',
+          type TEXT NOT NULL DEFAULT 'general'
+        )
+      `);
+      // Mirrors the production coordination row shape whose composite key
+      // depends on server_id. This table already exists on process restart,
+      // before RuntimeMigrator re-registers the Discord plugin schema.
+      await db.execute(sql`
+        CREATE TABLE discord_coordination_reply_slots (
+          server_id UUID NOT NULL,
+          trust_group_id TEXT NOT NULL,
+          channel_id TEXT NOT NULL,
+          edge_epoch TEXT NOT NULL,
+          lane TEXT NOT NULL,
+          slot_index INTEGER NOT NULL,
+          contender_token TEXT NOT NULL,
+          PRIMARY KEY (
+            server_id,
+            trust_group_id,
+            channel_id,
+            edge_epoch,
+            lane,
+            slot_index
+          )
+        )
+      `);
+      await db.execute(sql`
+        INSERT INTO discord_coordination_reply_slots (
+          server_id,
+          trust_group_id,
+          channel_id,
+          edge_epoch,
+          lane,
+          slot_index,
+          contender_token
+        ) VALUES (
+          '323e4567-e89b-12d3-a456-426614174000'::uuid,
+          'trusted-agents',
+          'discord-channel',
+          '1400000000000000001',
+          'human',
+          0,
+          'holder-a'
+        )
+      `);
+    });
+
+    it("preserves the Discord coordination tenant key and settled lease on restart", async () => {
+      await migrateToEntityRLS(mockAdapter);
+
+      const columns = await db.execute(sql`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'discord_coordination_reply_slots'
+      `);
+      expect(columns.rows.map((row: ColumnInfoRow) => row.column_name)).toContain("server_id");
+
+      const rows = await db.execute(sql`
+        SELECT server_id, contender_token
+        FROM discord_coordination_reply_slots
+      `);
+      expect(rows.rows).toHaveLength(1);
+      expect(rows.rows[0].server_id).toBe("323e4567-e89b-12d3-a456-426614174000");
+      expect(rows.rows[0].contender_token).toBe("holder-a");
+    });
+  });
+
   describe("Idempotency", () => {
     it("should be safe to run multiple times", async () => {
       // Create tables with camelCase

--- a/plugins/plugin-sql/src/migrations.ts
+++ b/plugins/plugin-sql/src/migrations.ts
@@ -343,6 +343,13 @@ export async function migrateToEntityRLS(adapter: IDatabaseAdapter): Promise<voi
             'worlds',               -- already handled above
             'rooms',                -- already handled above
             'server_agents',        -- server_id is part of composite key
+            -- Discord coordination tables declare server_id in their plugin
+            -- schema and use it in primary keys / RLS. Dropping it on restart
+            -- destroys the shared lease ledger before RuntimeMigrator runs.
+            'discord_coordination_trust_members',
+            'discord_coordination_human_edges',
+            'discord_coordination_reply_slots',
+            'discord_coordination_receipts',
             'drizzle_migrations',
             '__drizzle_migrations'
           )


### PR DESCRIPTION
## Summary

Implements P4 Discord group-room coordination on the **production connector path** behind a default-off flag:

- durable, agent-independent speaker slots shared through plugin-sql
- latest-human-edge-wins fencing immediately before every Discord send
- separate human and bot reply lanes with a bounded per-human-edge bot budget
- provider nonce + `enforce_nonce`, followed by durable Discord delivery reconciliation
- bounded, account-affine crash recovery with production sweeper trigger
- explicit operator trust roster, tenant keys, RLS-ready plugin schema, and audit receipts

Closes #17208.

## Production path

The implementation executes in the files production uses:

- `discord-events.ts`: every guild human `messageCreate` advances the durable edge before debounce/dispatch; bot messages never advance it.
- `messages.ts`: claim, model generation, pre-send fence, Discord send, delivery reconciliation, release, and sweeper recovery.
- `utils.ts`: the fence runs immediately before each `channel.send`; deterministic nonce and `enforceNonce` are applied there.
- `coordination-schema.ts` + `group-coordination.ts`: plugin-owned SQL schema and protocol, no runtime DDL and no WeakMap coordination fallback.
- `plugin-sql/src/migrations.ts`: restart migration preserves the coordination tables' explicit `server_id` tenant keys.

## Safety invariants

- Initial acquisition uses one agent-independent composite row and atomic `INSERT ... ON CONFLICT DO NOTHING`.
- Expiry reclaim is a separate guarded compare-and-set.
- Delivered/consumed/abandoned slots are terminal.
- Abandoned stale/IGNORE attempts release their slot instead of being resurrected.
- One inbound bot message can spend at most one bot-budget slot, even when budget > 1.
- Before the first human edge, automatic bot replies are suppressed rather than creating bot-authored epochs.
- Recovery is restricted to the Discord account that won the slot; replacement workers reproduce the same provider nonce.
- Failed or silent redispatch re-arms the expired row for a later bounded retry.
- Existing develop audience-gate behavior is unchanged.

## Configuration

The feature remains off unless all required settings are present:

```env
DISCORD_GROUP_COORDINATION_ENABLED=true
DISCORD_GROUP_COORDINATION_SERVER_ID=<tenant UUID> # ELIZA_SERVER_ID is also accepted
DISCORD_GROUP_COORDINATION_TRUST_GROUP_ID=<operator-defined group>
DISCORD_COORDINATION_TRUST_MEMBERS=<comma-separated agent UUID roster>
```

Optional:

```env
DISCORD_SPEAKER_LEASE_MS=180000
DISCORD_BOT_REPLY_BUDGET=1
DISCORD_COORDINATION_HEARTBEAT_MS=30000
DISCORD_COORDINATION_SWEEP_MS=60000 # 0 disables sweeper
```

Flag off is the default and preserves prior behavior.

## Review-request mapping

Addressed both Shaw reviews (`2534405477`, `2534430666`):

- removed fake shared-map / NODE_ENV fallback
- recut integration proof through real `MessageManager` + plugin-sql/PGlite
- added same-agent worker and multi-account contention proof
- added explicit trust boundary and audit failure reporting
- fenced normal, timeout/error, and chunk send paths
- added provider idempotency + durable delivery reconciliation
- fixed human/bot budget mixing and same-inbound multi-slot race
- added bounded production sweeper, reachable-channel filtering, failed-redispatch re-arm, and poison retry bound
- registered schema through plugin migration service and protected tenant keys across restart migration

No inline review threads were returned by the GitHub review-comments API; the review requests were top-level review bodies.

## Bidirectional proof

Every new behavior test was also run after locally reverting only its corresponding fix and failed on the unfixed behavior. Covered: lane budget separation, terminal delivered slots, recovery bound, channel reachability, trust roster, abandoned-slot release, gateway durable edge, bot claim accounting, no-human-edge suppression, restart tenant-key preservation, one inbound per bot slot, redispatch re-arm, account-affine recovery, and stable provider nonce.

## Verification

- plugin-discord full suite: **66 files, 536 tests passed**
- production-path PGlite coordination suites: **54/54 passed**
- plugin-discord build: **passed**
- plugin-sql real restart migration test: **passed**
- Biome + `git diff --check`: **passed**
- strict independent Codex review after fixes: **NO FINDINGS**
- workflow files: **none changed**

PGlite exercises the real plugin-sql adapter and production connector path, but does not implement production PostgreSQL RLS or prove independent-process Postgres scheduling. The schema is still registered through plugin migrations with explicit `server_id` tenant keys for production RLS.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Discord connector and database coordination change; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Discord connector and database coordination change; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow; behavior is concurrency and crash-recovery logic.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Discord credentials or multi-bot room are available in CI; production-path PGlite tests and CI logs are the executable evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, action, or generation policy changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no deployment artifact exists; durable slot, edge, receipt, and migration rows are asserted directly in the real plugin-sql/PGlite suites.

<!-- evidence-refresh:20260730-1159 -->
