### PR TITLE
fix(agent): bound what a snapshot capture materializes in the agent's own heap

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -21,7 +21,12 @@ function tokenMatches(expected: string, provided: string): boolean {
 }
 
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
-const MAX_BACKUP_BODY_BYTES = 128 * 1024 * 1024; // 128 MB
+/**
+ * Restore's request-body cap IS the v1 restorable ceiling: anything retained
+ * above it can never be restored here (#17172). Shared with the retain side so
+ * the two cannot drift.
+ */
+const MAX_BACKUP_BODY_BYTES = MAX_RESTORABLE_AGENT_BACKUP_BYTES;
 
 import path from "node:path";
 import {
@@ -47,7 +52,10 @@ import type {
   FavoriteAppsStore,
 } from "@elizaos/plugin-app-manager";
 import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
-import { readAliasedEnv } from "@elizaos/shared";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  readAliasedEnv,
+} from "@elizaos/shared";
 import {
   getStylePresets,
   normalizeCharacterLanguage,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -52,10 +52,8 @@ import type {
   FavoriteAppsStore,
 } from "@elizaos/plugin-app-manager";
 import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
-import {
-  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
-  readAliasedEnv,
-} from "@elizaos/shared";
+import { readAliasedEnv } from "@elizaos/shared";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
 import {
   getStylePresets,
   normalizeCharacterLanguage,

--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -14,6 +14,7 @@ import {
   AgentSnapshotBudgetExceededError,
   createAgentSnapshot,
   createLocalAgentBackup,
+  fetchAgentScopedRowsBatched,
   listLocalAgentBackups,
   restoreAgentSnapshot,
   restoreLocalAgentBackup,
@@ -424,5 +425,98 @@ describe("source-side snapshot budget (#17172 §1)", () => {
     await fixtureRoot();
     const snapshot = await createAgentSnapshot(runtime(), config);
     expect(snapshot.manifest.components.media.files.length).toBeGreaterThan(0);
+  });
+});
+
+describe("keyset-batched Postgres capture (#17172 §1)", () => {
+  /** A pool double that serves `total` rows with sequential ids, in pages. */
+  function pagingPool(total: number) {
+    const statements: string[] = [];
+    const all = Array.from({ length: total }, (_, i) => ({
+      id: i + 1,
+      payload: "x",
+    }));
+    return {
+      statements,
+      pageSizes: [] as number[],
+      query(text: string, values: unknown[]) {
+        statements.push(text);
+        const limitMatch = text.match(/LIMIT (\d+)/);
+        const limit = limitMatch ? Number(limitMatch[1]) : all.length;
+        // The keyset param is appended after the base params.
+        const after = values.length > 1 ? Number(values[values.length - 1]) : 0;
+        const rows = all.filter((r) => r.id > after).slice(0, limit);
+        this.pageSizes.push(rows.length);
+        return Promise.resolve({ rows });
+      },
+    };
+  }
+
+  test("walks the whole table in ordered batches without duplicates or gaps", async () => {
+    const pool = pagingPool(1200);
+    const rows = await fetchAgentScopedRowsBatched(
+      pool as never,
+      (keyset) => `SELECT * FROM "t" WHERE "agent_id" = $1 ${keyset}`,
+      ["agent-1"],
+      undefined,
+      "t",
+      '"id"',
+    );
+
+    expect(rows).toHaveLength(1200);
+    const ids = rows.map((r) => r.id as number);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    expect(new Set(ids).size).toBe(1200);
+    // More than one round-trip: the point is that no single statement returned
+    // the whole table.
+    expect(pool.statements.length).toBeGreaterThan(1);
+    expect(Math.max(...pool.pageSizes)).toBeLessThanOrEqual(500);
+  });
+
+  test("every statement is ordered and bounded by a LIMIT", async () => {
+    const pool = pagingPool(700);
+    await fetchAgentScopedRowsBatched(
+      pool as never,
+      (keyset) => `SELECT * FROM "t" WHERE "agent_id" = $1 ${keyset}`,
+      ["agent-1"],
+      undefined,
+      "t",
+      '"id"',
+    );
+    for (const sql of pool.statements) {
+      expect(sql).toMatch(/ORDER BY "id"/);
+      expect(sql).toMatch(/LIMIT \d+/);
+    }
+    // Pages after the first must resume from the last id, not re-scan.
+    expect(pool.statements.slice(1).every((s) => /"id" > \$2/.test(s))).toBe(
+      true,
+    );
+  });
+
+  test("an over-budget table is refused mid-walk, before the rest is read", async () => {
+    const pool = pagingPool(5000);
+    // A budget far smaller than the full table but bigger than one batch.
+    const budget = new (class {
+      private used = 0;
+      check() {}
+      chargeRaw(bytes: number) {
+        this.used += bytes;
+        if (this.used > 20_000) throw new Error("over budget");
+      }
+    })();
+
+    await expect(
+      fetchAgentScopedRowsBatched(
+        pool as never,
+        (keyset) => `SELECT * FROM "t" WHERE "agent_id" = $1 ${keyset}`,
+        ["agent-1"],
+        budget as never,
+        "t",
+        '"id"',
+      ),
+    ).rejects.toThrow("over budget");
+
+    // Stopped early: it never issued the statements needed to read 5000 rows.
+    expect(pool.statements.length).toBeLessThan(10);
   });
 });

--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -11,6 +11,7 @@ import type { AgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, test } from "vitest";
 import {
   type AgentBackupStateData,
+  AgentSnapshotBudgetExceededError,
   createAgentSnapshot,
   createLocalAgentBackup,
   listLocalAgentBackups,
@@ -334,5 +335,94 @@ describe("agent backup manifest", () => {
     expect(await readText(path.join(root, "eliza.json"))).toBe(
       '{"name":"fixture"}\n',
     );
+  });
+});
+
+describe("source-side snapshot budget (#17172 §1)", () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  async function fixtureRoot(): Promise<{ root: string; pgliteDir: string }> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-budget-"));
+    const pgliteDir = path.join(root, "pglite");
+    process.env.ELIZA_STATE_DIR = root;
+    process.env.PGLITE_DATA_DIR = pgliteDir;
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+    await writeFixtureState(root, pgliteDir);
+    return { root, pgliteDir };
+  }
+
+  const config = {
+    agents: { defaults: { workspace: "/tmp/workspace" } },
+  } as never;
+  const runtime = () => runtimeStub("11111111-1111-4111-8111-111111111111");
+
+  test("refuses a capture whose files exceed the byte budget", async () => {
+    const { root } = await fixtureRoot();
+    // A media file comfortably past a deliberately tiny budget.
+    await fs.writeFile(
+      path.join(root, "media", "big.bin"),
+      Buffer.alloc(64 * 1024, 7),
+    );
+
+    await expect(
+      createAgentSnapshot(runtime(), config, { maxRawBytes: 4096 }),
+    ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+  });
+
+  test("refuses BEFORE reading the oversized file, not after materializing it", async () => {
+    // The refusal must come from the declared size: an entry transiently costs
+    // ~2.33x its bytes, so charging post-read is charging post-damage.
+    const { root } = await fixtureRoot();
+    const bigPath = path.join(root, "media", "big.bin");
+    await fs.writeFile(bigPath, Buffer.alloc(256 * 1024, 3));
+
+    const realReadFile = fs.readFile;
+    const readPaths: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test double for a node API
+    (fs as any).readFile = async (target: any, ...rest: any[]) => {
+      readPaths.push(String(target));
+      // biome-ignore lint/suspicious/noExplicitAny: forwarding to the real API
+      return (realReadFile as any)(target, ...rest);
+    };
+    try {
+      await expect(
+        createAgentSnapshot(runtime(), config, { maxRawBytes: 4096 }),
+      ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+      expect(readPaths).not.toContain(bigPath);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring the real API
+      (fs as any).readFile = realReadFile;
+    }
+  });
+
+  test("refuses a capture with more files than the count budget", async () => {
+    const { root } = await fixtureRoot();
+    const mediaDir = path.join(root, "media");
+    for (let i = 0; i < 8; i++) {
+      await fs.writeFile(path.join(mediaDir, `f${i}.bin`), "x");
+    }
+
+    await expect(
+      createAgentSnapshot(runtime(), config, { maxFiles: 3 }),
+    ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+  });
+
+  test("an already-aborted signal stops the capture", async () => {
+    await fixtureRoot();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      createAgentSnapshot(runtime(), config, { signal: controller.signal }),
+    ).rejects.toThrow();
+  });
+
+  test("a capture within budget still succeeds unchanged", async () => {
+    await fixtureRoot();
+    const snapshot = await createAgentSnapshot(runtime(), config);
+    expect(snapshot.manifest.components.media.files.length).toBeGreaterThan(0);
   });
 });

--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -18,6 +18,7 @@ import {
   listLocalAgentBackups,
   restoreAgentSnapshot,
   restoreLocalAgentBackup,
+  SnapshotBudget,
 } from "./agent-backup.ts";
 
 const ORIGINAL_ENV = {
@@ -425,6 +426,153 @@ describe("source-side snapshot budget (#17172 §1)", () => {
     await fixtureRoot();
     const snapshot = await createAgentSnapshot(runtime(), config);
     expect(snapshot.manifest.components.media.files.length).toBeGreaterThan(0);
+  });
+
+  test("refuses an oversized PGlite dump from Blob.size, before arrayBuffer()", async () => {
+    await fixtureRoot();
+    let materialized = false;
+    const rawConnection = {
+      async dumpDataDir() {
+        return {
+          size: 256 * 1024,
+          arrayBuffer: async () => {
+            materialized = true;
+            return new ArrayBuffer(256 * 1024);
+          },
+        };
+      },
+      runExclusive: async <T>(operation: () => Promise<T>) => operation(),
+    };
+    const withDump = {
+      ...runtime(),
+      adapter: {
+        close: async () => undefined,
+        getRawConnection: () => rawConnection,
+      },
+    } as unknown as AgentRuntime;
+
+    await expect(
+      createAgentSnapshot(withDump, config, { maxRawBytes: 4096 }),
+    ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+    // The refusal must come from the declared size: the dump is transiently
+    // resident three times over (ArrayBuffer + Buffer + base64) once decoded.
+    expect(materialized).toBe(false);
+  });
+
+  test("an in-budget PGlite dump is charged, so a sibling cannot spend the same bytes", async () => {
+    const { root } = await fixtureRoot();
+    // Dump ~48 KiB + a 48 KiB media file: each fits a 96 KiB (base64) budget
+    // alone, both together do not.
+    const dumpBytes = Buffer.alloc(48 * 1024, 5);
+    await fs.writeFile(
+      path.join(root, "media", "big.bin"),
+      Buffer.alloc(48 * 1024, 7),
+    );
+    const rawConnection = {
+      async dumpDataDir() {
+        return new Blob([dumpBytes], { type: "application/gzip" });
+      },
+      runExclusive: async <T>(operation: () => Promise<T>) => operation(),
+    };
+    const withDump = {
+      ...runtime(),
+      adapter: {
+        close: async () => undefined,
+        getRawConnection: () => rawConnection,
+      },
+    } as unknown as AgentRuntime;
+
+    await expect(
+      createAgentSnapshot(withDump, config, { maxRawBytes: 96 * 1024 }),
+    ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+  });
+
+  test("refuses an oversized file on the pglite-files fallback walk", async () => {
+    const { pgliteDir } = await fixtureRoot();
+    // No getRawConnection on the stub adapter, so the capture takes the
+    // fallback file walk — which used to run with no budget at all.
+    await fs.writeFile(
+      path.join(pgliteDir, "oversized.wal"),
+      Buffer.alloc(256 * 1024, 9),
+    );
+
+    await expect(
+      createAgentSnapshot(runtime(), config, { maxRawBytes: 64 * 1024 }),
+    ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+  });
+
+  test("concurrent components cannot both pass the check and then allocate past the limit", async () => {
+    const { root, pgliteDir } = await fixtureRoot();
+    // Two 64 KiB files on two components that capture CONCURRENTLY, with a
+    // budget that fits one but not both. An observe-only reserve lets each
+    // sibling see zero charged bytes, pass, and read — the limit is then only
+    // discovered after both payloads are resident. A real reservation is
+    // synchronous, so whichever component reserves second is refused BEFORE
+    // its read, whatever the interleaving.
+    const mediaBig = path.join(root, "media", "big-a.bin");
+    const pgliteBig = path.join(pgliteDir, "big-b.wal");
+    await fs.writeFile(mediaBig, Buffer.alloc(64 * 1024, 1));
+    await fs.writeFile(pgliteBig, Buffer.alloc(64 * 1024, 2));
+
+    const realReadFile = fs.readFile;
+    const readPaths: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test double for a node API
+    (fs as any).readFile = async (target: any, ...rest: any[]) => {
+      readPaths.push(String(target));
+      // biome-ignore lint/suspicious/noExplicitAny: forwarding to the real API
+      return (realReadFile as any)(target, ...rest);
+    };
+    try {
+      await expect(
+        // 128 KiB of budget: one 64 KiB file costs ~87 KiB in base64.
+        createAgentSnapshot(runtime(), config, { maxRawBytes: 128 * 1024 }),
+      ).rejects.toBeInstanceOf(AgentSnapshotBudgetExceededError);
+      const bigReads = readPaths.filter(
+        (p) => p === mediaBig || p === pgliteBig,
+      );
+      expect(bigReads.length).toBeLessThanOrEqual(1);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring the real API
+      (fs as any).readFile = realReadFile;
+    }
+  });
+});
+
+describe("snapshot budget reservation semantics", () => {
+  test("a hold claims capacity other reserves must count", () => {
+    const budget = new SnapshotBudget(200, 10);
+    const hold = budget.reserve(100); // holds base64Length(100) = 136
+    expect(() => budget.reserve(100)).toThrow(AgentSnapshotBudgetExceededError);
+    hold.release();
+    expect(() => budget.reserve(100)).not.toThrow();
+  });
+
+  test("commit converts the hold into a charge at the actual encoded size", () => {
+    const budget = new SnapshotBudget(200, 10);
+    const hold = budget.reserve(100);
+    hold.commit(50); // actual entry smaller than declared
+    // 50 charged, hold gone: 136 more fits again.
+    expect(() => budget.reserve(100)).not.toThrow();
+  });
+
+  test("a settled token is inert on double settle", () => {
+    const budget = new SnapshotBudget(400, 10);
+    const hold = budget.reserve(100);
+    hold.commit(50);
+    hold.release(); // must not un-charge the committed bytes
+    hold.commit(50); // must not double-charge
+    const holds = [budget.reserve(100), budget.reserve(100)];
+    for (const h of holds) h.release();
+    // Exactly 50 charged in total: a 350-byte hold still fits under 400.
+    expect(() => budget.reserve(255)).not.toThrow();
+  });
+
+  test("file count is enforced at commit time", () => {
+    const budget = new SnapshotBudget(10_000, 2);
+    budget.reserve(10).commit(10);
+    budget.reserve(10).commit(10);
+    const third = budget.reserve(10);
+    expect(() => third.commit(10)).toThrow(AgentSnapshotBudgetExceededError);
   });
 });
 

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import type { AgentRuntime, IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { createKmsClient, systemKey } from "@elizaos/security/kms";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.ts";
 
@@ -120,6 +121,113 @@ export interface LocalAgentBackupMetadata {
   stateSha256: string;
   sizeBytes: number;
 }
+
+/**
+ * A capture refused because it would exceed the source-side snapshot budget.
+ *
+ * Typed so a caller can tell "this agent's state is too large to snapshot"
+ * apart from a transport or disk failure: the former is deterministic and
+ * retrying identical state cannot help, while the latter is worth another try.
+ */
+export class AgentSnapshotBudgetExceededError extends Error {
+  readonly name = "AgentSnapshotBudgetExceededError";
+  constructor(
+    readonly stage: string,
+    readonly observedBytes: number,
+    readonly limitBytes: number,
+  ) {
+    super(
+      `Snapshot refused during ${stage}: ${observedBytes} bytes exceeds the source budget of ${limitBytes} bytes`,
+    );
+  }
+}
+
+/**
+ * Produce-side budget for a snapshot capture (#17172 §1).
+ *
+ * Cloud's restorable-size check is strictly DOWNSTREAM of this process having
+ * already assembled AND serialized the whole payload, so it bounds what Cloud
+ * retains — never what the agent's own heap burns getting there. A large agent
+ * can therefore exhaust its container (the memory watchdog force-restarts at a
+ * sustained RSS ceiling) mid-capture, and the lifecycle call sites that snapshot
+ * before upgrade/shutdown/sleep silently degrade to a stale or missing backup.
+ *
+ * Charged as bytes are produced, so an over-budget capture is refused at the
+ * first byte past the line instead of after everything is resident. `reserve`
+ * exists for the pre-allocation case: a file entry transiently costs ~2.33x its
+ * size (Buffer + base64 string), so the refusal has to happen from `stat` before
+ * the read, not after.
+ */
+class SnapshotBudget {
+  private rawBytes = 0;
+  private fileCount = 0;
+
+  constructor(
+    private readonly maxRawBytes: number,
+    private readonly maxFiles: number,
+    private readonly signal?: AbortSignal,
+  ) {}
+
+  /** Abort between units of work so a cancelled capture stops promptly. */
+  check(): void {
+    this.signal?.throwIfAborted();
+  }
+
+  /** Refuse a not-yet-read payload from its declared size, before allocating. */
+  reserve(declaredBytes: number): void {
+    this.check();
+    // base64 is the wire form, so charge what the entry will actually cost.
+    const projected = this.rawBytes + base64Length(declaredBytes);
+    if (projected > this.maxRawBytes) {
+      throw new AgentSnapshotBudgetExceededError(
+        "file capture",
+        projected,
+        this.maxRawBytes,
+      );
+    }
+  }
+
+  chargeFile(base64Bytes: number): void {
+    this.check();
+    this.fileCount += 1;
+    if (this.fileCount > this.maxFiles) {
+      throw new AgentSnapshotBudgetExceededError(
+        "file capture",
+        this.fileCount,
+        this.maxFiles,
+      );
+    }
+    this.charge(base64Bytes, "file capture");
+  }
+
+  chargeRaw(bytes: number, stage: string): void {
+    this.check();
+    this.charge(bytes, stage);
+  }
+
+  private charge(bytes: number, stage: string): void {
+    this.rawBytes += bytes;
+    if (this.rawBytes > this.maxRawBytes) {
+      throw new AgentSnapshotBudgetExceededError(
+        stage,
+        this.rawBytes,
+        this.maxRawBytes,
+      );
+    }
+  }
+}
+
+/** Encoded length of `n` raw bytes in base64 (4 chars per 3 bytes, padded). */
+function base64Length(rawBytes: number): number {
+  return Math.ceil(rawBytes / 3) * 4;
+}
+
+/**
+ * File-count ceiling for one capture. Mirrors the hydration-side file cap so a
+ * snapshot this process is willing to PRODUCE is one the consumer is willing to
+ * expand; a pathological state dir is refused here rather than downstream.
+ */
+const DEFAULT_SNAPSHOT_MAX_FILES = 5_000;
 
 const MEDIA_DIR_NAME = "media";
 const BACKUPS_DIR_NAME = "backups";
@@ -279,17 +387,24 @@ function isWithin(root: string, target: string): boolean {
 async function readFileEntry(
   root: string,
   absolutePath: string,
+  budget?: SnapshotBudget,
 ): Promise<AgentBackupFileEntry> {
   const stat = await fs.stat(absolutePath);
+  // Refuse from the declared size BEFORE reading: the entry transiently costs
+  // ~2.33x its bytes (Buffer + base64 string), so charging after the read is
+  // charging after the damage.
+  budget?.reserve(stat.size);
   const bytes = await fs.readFile(absolutePath);
   const relative = normalizeRelativePath(path.relative(root, absolutePath));
+  const bytesBase64 = bytes.toString("base64");
+  budget?.chargeFile(bytesBase64.length);
   return {
     path: relative,
     sha256: sha256Bytes(bytes),
     size: bytes.length,
     mode: stat.mode,
     mtimeMs: stat.mtimeMs,
-    bytesBase64: bytes.toString("base64"),
+    bytesBase64,
   };
 }
 
@@ -310,6 +425,7 @@ async function collectFileSet(params: {
   root: string;
   rootLabel: AgentBackupFileSet["rootLabel"];
   include?: (relativePath: string) => boolean;
+  budget?: SnapshotBudget;
 }): Promise<AgentBackupFileSet> {
   const root = path.resolve(params.root);
   const files: AgentBackupFileEntry[] = [];
@@ -324,6 +440,8 @@ async function collectFileSet(params: {
   }
 
   async function visit(dir: string): Promise<void> {
+    // Stop descending promptly once the capture is cancelled or over budget.
+    params.budget?.check();
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       const absolute = path.join(dir, entry.name);
@@ -333,7 +451,7 @@ async function collectFileSet(params: {
       if (entry.isDirectory()) {
         await visit(absolute);
       } else if (entry.isFile()) {
-        files.push(await readFileEntry(root, absolute));
+        files.push(await readFileEntry(root, absolute, params.budget));
       }
     }
   }
@@ -508,6 +626,7 @@ function getTableColumnsBucket(
 async function capturePostgresRows(
   postgresUrl: string,
   agentId: string,
+  budget?: SnapshotBudget,
 ): Promise<AgentBackupPostgresDump> {
   const pgModule = await import("pg");
   const pool = new pgModule.default.Pool({
@@ -568,6 +687,17 @@ async function capturePostgresRows(
         tableName === POSTGRES_EMBEDDINGS_TABLE ||
         agentIdColumn(columnSet)
       ) {
+        // Charge the serialized rows so a huge table stops the capture instead
+        // of riding along to be rejected downstream. NOTE: this bounds the
+        // assembled SNAPSHOT, not the peak of the single query that produced
+        // it — `pool.query` buffers the whole result set and node-postgres
+        // cannot interrupt an in-flight SELECT. Bounding that peak needs
+        // batched reads (keyset pagination) or a cursor dependency; see the PR
+        // discussion rather than assuming this line covers it.
+        budget?.chargeRaw(
+          Buffer.byteLength(JSON.stringify(rows), "utf8"),
+          `postgres table ${tableName}`,
+        );
         tables.push({ name: tableName, columns, rows });
       }
     }
@@ -658,10 +788,15 @@ async function capturePgliteDump(
 
 async function captureDatabaseComponent(
   runtime: IAgentRuntime | AgentRuntime,
+  budget?: SnapshotBudget,
 ): Promise<AgentBackupDatabaseComponent> {
   const postgresUrl = hasPostgresUrl(runtime);
   if (postgresUrl) {
-    const postgres = await capturePostgresRows(postgresUrl, runtime.agentId);
+    const postgres = await capturePostgresRows(
+      postgresUrl,
+      runtime.agentId,
+      budget,
+    );
     return {
       kind: "postgres-rows",
       postgres,
@@ -722,7 +857,16 @@ function legacyConfigProjection(config: ElizaConfig): Record<string, unknown> {
 export async function createAgentSnapshot(
   runtime: IAgentRuntime | AgentRuntime,
   config: ElizaConfig,
+  options?: { signal?: AbortSignal; maxRawBytes?: number; maxFiles?: number },
 ): Promise<AgentBackupStateData> {
+  // Bound what THIS process materializes. Without it the five captures below
+  // run concurrently with no size awareness at all, and the downstream Cloud
+  // check only ever sees a payload this heap already paid for (#17172 §1).
+  const budget = new SnapshotBudget(
+    options?.maxRawBytes ?? MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    options?.maxFiles ?? DEFAULT_SNAPSHOT_MAX_FILES,
+    options?.signal,
+  );
   const stateDir = resolveStateDir();
   const pgliteDirForStateFiles = hasPostgresUrl(runtime)
     ? null
@@ -732,21 +876,24 @@ export async function createAgentSnapshot(
     pgliteDirForStateFiles,
   );
   const [database, media, vault, character, stateFiles] = await Promise.all([
-    captureDatabaseComponent(runtime),
+    captureDatabaseComponent(runtime, budget),
     collectFileSet({
       root: path.join(stateDir, MEDIA_DIR_NAME),
       rootLabel: "state-dir",
+      budget,
     }),
     collectFileSet({
       root: stateDir,
       rootLabel: "state-dir",
       include: vaultFileInclude,
+      budget,
     }),
     captureCharacterComponent(runtime),
     collectFileSet({
       root: stateDir,
       rootLabel: "state-dir",
       include: stateFileInclude,
+      budget,
     }),
   ]);
 

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -229,6 +229,16 @@ function base64Length(rawBytes: number): number {
  */
 const DEFAULT_SNAPSHOT_MAX_FILES = 5_000;
 
+/**
+ * Rows fetched per round-trip when capturing an agent-scoped Postgres table.
+ *
+ * `pool.query` buffers whatever a statement returns, so an unbounded
+ * `SELECT * WHERE agent_id = $1` puts the entire table in this process's heap
+ * before the budget can see a single byte. Reading in keyset batches caps that
+ * peak at one batch and lets the budget refuse mid-table (#17172 §1).
+ */
+const POSTGRES_CAPTURE_BATCH_ROWS = 500;
+
 const MEDIA_DIR_NAME = "media";
 const BACKUPS_DIR_NAME = "backups";
 const LOCAL_BACKUP_EXTENSION = ".agent-backup.json";
@@ -623,6 +633,56 @@ function getTableColumnsBucket(
   return columns;
 }
 
+/**
+ * Read an agent-scoped table in keyset batches, charging the budget per batch.
+ *
+ * Keyset (`id > $last ORDER BY id LIMIT n`) rather than OFFSET: OFFSET re-scans
+ * from the start on every page, and a snapshot taken while the agent is live
+ * would also skip or duplicate rows as they shift. Ordering on the primary key
+ * makes each batch disjoint and the walk resumable.
+ *
+ * The budget is charged after each batch, so an oversized table stops the
+ * capture partway instead of being fully materialized first — the peak is one
+ * batch, not the table.
+ */
+export async function fetchAgentScopedRowsBatched(
+  pool: {
+    query: (text: string, values: unknown[]) => Promise<{ rows: unknown[] }>;
+  },
+  buildSql: (keysetClause: string) => string,
+  baseParams: unknown[],
+  budget: SnapshotBudget | undefined,
+  tableName: string,
+  // Qualified for a join (`e."id"`), bare otherwise — the ORDER BY must be
+  // unambiguous or Postgres rejects the statement.
+  idExpression: string,
+): Promise<JsonRecord[]> {
+  const rows: JsonRecord[] = [];
+  let lastId: unknown = null;
+  for (;;) {
+    budget?.check();
+    const params = lastId === null ? baseParams : [...baseParams, lastId];
+    const keysetClause =
+      lastId === null
+        ? `ORDER BY ${idExpression} LIMIT ${POSTGRES_CAPTURE_BATCH_ROWS}`
+        : `AND ${idExpression} > $${baseParams.length + 1} ORDER BY ${idExpression} LIMIT ${POSTGRES_CAPTURE_BATCH_ROWS}`;
+    const batch = (await pool.query(buildSql(keysetClause), params))
+      .rows as JsonRecord[];
+    if (batch.length === 0) break;
+    budget?.chargeRaw(
+      Buffer.byteLength(JSON.stringify(batch), "utf8"),
+      `postgres table ${tableName}`,
+    );
+    rows.push(...batch);
+    if (batch.length < POSTGRES_CAPTURE_BATCH_ROWS) break;
+    lastId = batch[batch.length - 1]?.id ?? null;
+    // A table whose last row carries no usable id cannot be walked further;
+    // stopping is the honest outcome rather than looping on the same page.
+    if (lastId === null) break;
+  }
+  return rows;
+}
+
 async function capturePostgresRows(
   postgresUrl: string,
   agentId: string,
@@ -654,6 +714,8 @@ async function capturePostgresRows(
     for (const [tableName, columns] of tableColumns) {
       const columnSet = new Set(columns);
       let rows: JsonRecord[] = [];
+      // Batched reads charge per batch; the single-read paths charge below.
+      let charged = false;
       if (tableName === POSTGRES_AGENT_TABLE && columnSet.has("id")) {
         const result = await pool.query(
           `SELECT * FROM ${quoteIdentifier(tableName)} WHERE ${quoteIdentifier("id")} = $1`,
@@ -664,40 +726,70 @@ async function capturePostgresRows(
         tableName === POSTGRES_EMBEDDINGS_TABLE &&
         columnSet.has("memory_id")
       ) {
-        const result = await pool.query(
-          `SELECT e.*
-           FROM ${quoteIdentifier(tableName)} e
-           INNER JOIN ${quoteIdentifier(POSTGRES_MEMORIES_TABLE)} m
-             ON e.${quoteIdentifier("memory_id")} = m.${quoteIdentifier("id")}
-           WHERE m.${quoteIdentifier("agent_id")} = $1`,
-          [agentId],
-        );
-        rows = result.rows as JsonRecord[];
+        if (columnSet.has("id")) {
+          rows = await fetchAgentScopedRowsBatched(
+            pool,
+            (keyset) =>
+              `SELECT e.*
+               FROM ${quoteIdentifier(tableName)} e
+               INNER JOIN ${quoteIdentifier(POSTGRES_MEMORIES_TABLE)} m
+                 ON e.${quoteIdentifier("memory_id")} = m.${quoteIdentifier("id")}
+               WHERE m.${quoteIdentifier("agent_id")} = $1 ${keyset}`,
+            [agentId],
+            budget,
+            tableName,
+            `e.${quoteIdentifier("id")}`,
+          );
+          charged = true;
+        } else {
+          const result = await pool.query(
+            `SELECT e.*
+             FROM ${quoteIdentifier(tableName)} e
+             INNER JOIN ${quoteIdentifier(POSTGRES_MEMORIES_TABLE)} m
+               ON e.${quoteIdentifier("memory_id")} = m.${quoteIdentifier("id")}
+             WHERE m.${quoteIdentifier("agent_id")} = $1`,
+            [agentId],
+          );
+          rows = result.rows as JsonRecord[];
+        }
       } else {
         const ownerColumn = agentIdColumn(columnSet);
         if (!ownerColumn) continue;
-        const result = await pool.query(
-          `SELECT * FROM ${quoteIdentifier(tableName)} WHERE ${quoteIdentifier(ownerColumn)} = $1`,
-          [agentId],
-        );
-        rows = result.rows as JsonRecord[];
+        if (columnSet.has("id")) {
+          rows = await fetchAgentScopedRowsBatched(
+            pool,
+            (keyset) =>
+              `SELECT * FROM ${quoteIdentifier(tableName)} WHERE ${quoteIdentifier(ownerColumn)} = $1 ${keyset}`,
+            [agentId],
+            budget,
+            tableName,
+            quoteIdentifier("id"),
+          );
+          charged = true;
+        } else {
+          // No primary key to walk: a single read is the only option, so the
+          // peak stays the table. Such tables are the small ones in practice;
+          // the post-read charge below still bounds the assembled snapshot.
+          const result = await pool.query(
+            `SELECT * FROM ${quoteIdentifier(tableName)} WHERE ${quoteIdentifier(ownerColumn)} = $1`,
+            [agentId],
+          );
+          rows = result.rows as JsonRecord[];
+        }
       }
       if (
         tableName === POSTGRES_AGENT_TABLE ||
         tableName === POSTGRES_EMBEDDINGS_TABLE ||
         agentIdColumn(columnSet)
       ) {
-        // Charge the serialized rows so a huge table stops the capture instead
-        // of riding along to be rejected downstream. NOTE: this bounds the
-        // assembled SNAPSHOT, not the peak of the single query that produced
-        // it — `pool.query` buffers the whole result set and node-postgres
-        // cannot interrupt an in-flight SELECT. Bounding that peak needs
-        // batched reads (keyset pagination) or a cursor dependency; see the PR
-        // discussion rather than assuming this line covers it.
-        budget?.chargeRaw(
-          Buffer.byteLength(JSON.stringify(rows), "utf8"),
-          `postgres table ${tableName}`,
-        );
+        // Batched reads already charged per batch; only the single-read paths
+        // (a keyless table, or the single-row agent row) are charged here.
+        if (!charged) {
+          budget?.chargeRaw(
+            Buffer.byteLength(JSON.stringify(rows), "utf8"),
+            `postgres table ${tableName}`,
+          );
+        }
         tables.push({ name: tableName, columns, rows });
       }
     }

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -156,10 +156,13 @@ export class AgentSnapshotBudgetExceededError extends Error {
  * first byte past the line instead of after everything is resident. `reserve`
  * exists for the pre-allocation case: a file entry transiently costs ~2.33x its
  * size (Buffer + base64 string), so the refusal has to happen from `stat` before
- * the read, not after.
+ * the read, not after — and the reservation HOLDS that capacity until the entry
+ * is charged or released, so concurrent captures cannot all pass the same check
+ * and then collectively allocate past the limit.
  */
-class SnapshotBudget {
-  private rawBytes = 0;
+export class SnapshotBudget {
+  private chargedBytes = 0;
+  private reservedBytes = 0;
   private fileCount = 0;
 
   constructor(
@@ -173,11 +176,17 @@ class SnapshotBudget {
     this.signal?.throwIfAborted();
   }
 
-  /** Refuse a not-yet-read payload from its declared size, before allocating. */
-  reserve(declaredBytes: number): void {
+  /**
+   * Hold capacity for a not-yet-read payload from its declared size. Refuses
+   * before anything is allocated, counting capacity other in-flight holds have
+   * already claimed. The returned token must be settled exactly once: `commit`
+   * converts the hold into a charged file entry, `release` frees it.
+   */
+  reserve(declaredBytes: number): SnapshotReservation {
     this.check();
-    // base64 is the wire form, so charge what the entry will actually cost.
-    const projected = this.rawBytes + base64Length(declaredBytes);
+    // base64 is the wire form, so hold what the entry will actually cost.
+    const holdBytes = base64Length(declaredBytes);
+    const projected = this.chargedBytes + this.reservedBytes + holdBytes;
     if (projected > this.maxRawBytes) {
       throw new AgentSnapshotBudgetExceededError(
         "file capture",
@@ -185,9 +194,32 @@ class SnapshotBudget {
         this.maxRawBytes,
       );
     }
+    this.reservedBytes += holdBytes;
+
+    let settled = false;
+    const releaseHold = () => {
+      if (settled) return false;
+      settled = true;
+      this.reservedBytes -= holdBytes;
+      return true;
+    };
+    return {
+      commit: (actualBase64Bytes: number) => {
+        if (!releaseHold()) return;
+        this.chargeFileEntry(actualBase64Bytes);
+      },
+      release: () => {
+        releaseHold();
+      },
+    };
   }
 
-  chargeFile(base64Bytes: number): void {
+  chargeRaw(bytes: number, stage: string): void {
+    this.check();
+    this.charge(bytes, stage);
+  }
+
+  private chargeFileEntry(base64Bytes: number): void {
     this.check();
     this.fileCount += 1;
     if (this.fileCount > this.maxFiles) {
@@ -200,21 +232,24 @@ class SnapshotBudget {
     this.charge(base64Bytes, "file capture");
   }
 
-  chargeRaw(bytes: number, stage: string): void {
-    this.check();
-    this.charge(bytes, stage);
-  }
-
   private charge(bytes: number, stage: string): void {
-    this.rawBytes += bytes;
-    if (this.rawBytes > this.maxRawBytes) {
+    this.chargedBytes += bytes;
+    if (this.chargedBytes + this.reservedBytes > this.maxRawBytes) {
       throw new AgentSnapshotBudgetExceededError(
         stage,
-        this.rawBytes,
+        this.chargedBytes + this.reservedBytes,
         this.maxRawBytes,
       );
     }
   }
+}
+
+/** Settle-once token returned by {@link SnapshotBudget.reserve}. */
+export interface SnapshotReservation {
+  /** Convert the hold into a charged file entry at its actual encoded size. */
+  commit(actualBase64Bytes: number): void;
+  /** Free the hold without charging (the payload was never materialized). */
+  release(): void;
 }
 
 /** Encoded length of `n` raw bytes in base64 (4 chars per 3 bytes, padded). */
@@ -402,12 +437,20 @@ async function readFileEntry(
   const stat = await fs.stat(absolutePath);
   // Refuse from the declared size BEFORE reading: the entry transiently costs
   // ~2.33x its bytes (Buffer + base64 string), so charging after the read is
-  // charging after the damage.
-  budget?.reserve(stat.size);
-  const bytes = await fs.readFile(absolutePath);
+  // charging after the damage. The hold stays claimed until the actual encoded
+  // size is committed, so concurrent siblings see it.
+  const hold = budget?.reserve(stat.size);
+  let bytes: Buffer;
+  let bytesBase64: string;
+  try {
+    bytes = await fs.readFile(absolutePath);
+    bytesBase64 = bytes.toString("base64");
+  } catch (error) {
+    hold?.release();
+    throw error;
+  }
   const relative = normalizeRelativePath(path.relative(root, absolutePath));
-  const bytesBase64 = bytes.toString("base64");
-  budget?.chargeFile(bytesBase64.length);
+  hold?.commit(bytesBase64.length);
   return {
     path: relative,
     sha256: sha256Bytes(bytes),
@@ -637,13 +680,17 @@ function getTableColumnsBucket(
  * Read an agent-scoped table in keyset batches, charging the budget per batch.
  *
  * Keyset (`id > $last ORDER BY id LIMIT n`) rather than OFFSET: OFFSET re-scans
- * from the start on every page, and a snapshot taken while the agent is live
- * would also skip or duplicate rows as they shift. Ordering on the primary key
- * makes each batch disjoint and the walk resumable.
+ * from the start on every page and skips or duplicates rows as they shift under
+ * a live agent. Ordering on the primary key makes each batch disjoint and the
+ * walk resumable.
  *
- * The budget is charged after each batch, so an oversized table stops the
- * capture partway instead of being fully materialized first — the peak is one
- * batch, not the table.
+ * What this bounds is MEMORY — the peak is one batch, not the table, and the
+ * budget is charged after each batch so an oversized table stops the capture
+ * partway. What it does NOT provide is transactional consistency: each batch
+ * runs as its own statement against its own MVCC snapshot, so rows committed
+ * mid-walk may or may not appear, and cross-table capture points differ. A
+ * capture of a live agent is a best-effort walk, not a frozen snapshot; the
+ * lifecycle call sites that need a consistent image quiesce the agent first.
  */
 export async function fetchAgentScopedRowsBatched(
   pool: {
@@ -837,16 +884,19 @@ function withPgliteDumpHash(
 
 function isBlobLike(value: unknown): value is {
   arrayBuffer: () => Promise<ArrayBuffer>;
+  size: number;
 } {
   return (
     value !== null &&
     typeof value === "object" &&
-    typeof (value as { arrayBuffer?: unknown }).arrayBuffer === "function"
+    typeof (value as { arrayBuffer?: unknown }).arrayBuffer === "function" &&
+    typeof (value as { size?: unknown }).size === "number"
   );
 }
 
 async function capturePgliteDump(
   runtime: IAgentRuntime | AgentRuntime,
+  budget?: SnapshotBudget,
 ): Promise<AgentBackupPgliteDump | null> {
   const raw = (
     runtime.adapter as
@@ -869,11 +919,23 @@ async function capturePgliteDump(
   if (!isBlobLike(dump)) {
     throw new Error("PGlite dumpDataDir() did not return a Blob/File");
   }
-  const bytes = Buffer.from(await dump.arrayBuffer());
+  // Refuse from Blob.size BEFORE arrayBuffer(): the dump would otherwise be
+  // resident three times over (ArrayBuffer + Buffer + base64) with the budget
+  // none the wiser.
+  const hold = budget?.reserve(dump.size);
+  let file: AgentBackupFileEntry;
+  try {
+    const bytes = Buffer.from(await dump.arrayBuffer());
+    file = fileEntryFromBytes(PGLITE_DUMP_PATH, bytes);
+  } catch (error) {
+    hold?.release();
+    throw error;
+  }
+  hold?.commit(file.bytesBase64.length);
   return withPgliteDumpHash({
     kind: "pglite-dump",
     compression: "gzip",
-    file: fileEntryFromBytes(PGLITE_DUMP_PATH, bytes),
+    file,
     sha256: "",
   });
 }
@@ -902,7 +964,7 @@ async function captureDatabaseComponent(
     return { kind: "none", reason, sha256: sha256Json({ reason }) };
   }
 
-  const pgliteDump = await capturePgliteDump(runtime);
+  const pgliteDump = await capturePgliteDump(runtime, budget);
   if (pgliteDump) {
     return {
       kind: "pglite-dump",
@@ -915,6 +977,7 @@ async function captureDatabaseComponent(
     root: pgliteDir,
     rootLabel: "pglite-dir",
     include: pgliteFileInclude,
+    budget,
   });
   return {
     kind: "pglite-files",
@@ -925,10 +988,11 @@ async function captureDatabaseComponent(
 
 async function captureCharacterComponent(
   runtime: IAgentRuntime | AgentRuntime,
+  budget?: SnapshotBudget,
 ): Promise<AgentBackupManifest["components"]["character"]> {
   const configPath = resolveConfigPath();
   const configFile = (await pathExists(configPath))
-    ? await readFileEntry(path.dirname(configPath), configPath)
+    ? await readFileEntry(path.dirname(configPath), configPath, budget)
     : undefined;
   const component = {
     runtimeCharacter: runtime.character ?? null,
@@ -954,10 +1018,19 @@ export async function createAgentSnapshot(
   // Bound what THIS process materializes. Without it the five captures below
   // run concurrently with no size awareness at all, and the downstream Cloud
   // check only ever sees a payload this heap already paid for (#17172 §1).
+  //
+  // The internal controller exists so a refusal in ONE component stops the
+  // OTHERS: siblings poll `budget.check()` between units of work, and a plain
+  // Promise.all rejection would leave them reading and encoding at full speed
+  // until they finish on their own.
+  const controller = new AbortController();
+  const signal = options?.signal
+    ? AbortSignal.any([options.signal, controller.signal])
+    : controller.signal;
   const budget = new SnapshotBudget(
     options?.maxRawBytes ?? MAX_RESTORABLE_AGENT_BACKUP_BYTES,
     options?.maxFiles ?? DEFAULT_SNAPSHOT_MAX_FILES,
-    options?.signal,
+    signal,
   );
   const stateDir = resolveStateDir();
   const pgliteDirForStateFiles = hasPostgresUrl(runtime)
@@ -967,27 +1040,56 @@ export async function createAgentSnapshot(
     stateDir,
     pgliteDirForStateFiles,
   );
-  const [database, media, vault, character, stateFiles] = await Promise.all([
-    captureDatabaseComponent(runtime, budget),
-    collectFileSet({
-      root: path.join(stateDir, MEDIA_DIR_NAME),
-      rootLabel: "state-dir",
-      budget,
-    }),
-    collectFileSet({
-      root: stateDir,
-      rootLabel: "state-dir",
-      include: vaultFileInclude,
-      budget,
-    }),
-    captureCharacterComponent(runtime),
-    collectFileSet({
-      root: stateDir,
-      rootLabel: "state-dir",
-      include: stateFileInclude,
-      budget,
-    }),
-  ]);
+  // First failure aborts the shared signal, then allSettled drains the
+  // siblings — the failure surfaces once, with no unhandled rejections from
+  // captures that were cancelled mid-flight.
+  let firstFailure: unknown;
+  let failed = false;
+  const guarded = async <T>(work: Promise<T>): Promise<T> => {
+    try {
+      return await work;
+    } catch (error) {
+      if (!failed) {
+        failed = true;
+        firstFailure = error;
+        controller.abort(error);
+      }
+      throw error;
+    }
+  };
+  const captures = [
+    guarded(captureDatabaseComponent(runtime, budget)),
+    guarded(
+      collectFileSet({
+        root: path.join(stateDir, MEDIA_DIR_NAME),
+        rootLabel: "state-dir",
+        budget,
+      }),
+    ),
+    guarded(
+      collectFileSet({
+        root: stateDir,
+        rootLabel: "state-dir",
+        include: vaultFileInclude,
+        budget,
+      }),
+    ),
+    guarded(captureCharacterComponent(runtime, budget)),
+    guarded(
+      collectFileSet({
+        root: stateDir,
+        rootLabel: "state-dir",
+        include: stateFileInclude,
+        budget,
+      }),
+    ),
+  ] as const;
+  await Promise.allSettled(captures);
+  if (failed) throw firstFailure;
+  // Everything settled fulfilled (a rejection would have set `failed`), so
+  // this resolves immediately with full inference.
+  const [database, media, vault, character, stateFiles] =
+    await Promise.all(captures);
 
   const componentHashes = {
     database: database.sha256,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1,5 +1,6 @@
 // Persists agent sandboxes records for cloud services through the shared DB boundary.
 import { randomUUID } from "node:crypto";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared";
 import { and, asc, desc, eq, gte, inArray, isNotNull, lt, ne, notInArray, sql } from "drizzle-orm";
 import {
   applyBackupDelta,
@@ -66,7 +67,11 @@ const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   workspaceFiles: {},
 };
 const MAX_RECONSTRUCTED_BACKUP_CHAIN_DEPTH = 100;
-const MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES = 128 * 1024 * 1024;
+/**
+ * A reconstructed chain has to fit the same v1 restorable ceiling as any other
+ * backup wire payload — it is what gets handed to restore (#17172).
+ */
+const MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES = MAX_RESTORABLE_AGENT_BACKUP_BYTES;
 
 async function getStoredBackupById(
   backupId: string,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1,6 +1,6 @@
 // Persists agent sandboxes records for cloud services through the shared DB boundary.
 import { randomUUID } from "node:crypto";
-import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
 import { and, asc, desc, eq, gte, inArray, isNotNull, lt, ne, notInArray, sql } from "drizzle-orm";
 import {
   applyBackupDelta,

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
@@ -14,6 +14,7 @@ import {
   planIncrementalBackup,
   reconstructFromChain,
   resolveBackupChain,
+  resolveBackupChainBytes,
   selectPrunableBackupIds,
 } from "./agent-backup-diff";
 
@@ -286,5 +287,42 @@ describe("backup chains", () => {
 
   test("selectPrunableBackupIds returns nothing when under the keep count", () => {
     expect(selectPrunableBackupIds(nodes, 10)).toEqual([]);
+  });
+});
+
+describe("resolveBackupChainBytes (#17172 retained-implies-restorable)", () => {
+  const sized = (
+    id: string,
+    kind: "full" | "incremental",
+    parent: string | null,
+    sizeBytes: number | null,
+  ) => ({ id, backupKind: kind, parentBackupId: parent, createdAtMs: 0, sizeBytes });
+
+  test("sums the stored inputs of the chain, not the reconstructed output", () => {
+    // Reconstruction budgets base-full + every delta; this must match it.
+    const nodes = [
+      sized("a", "full", null, 100),
+      sized("b", "incremental", "a", 20),
+      sized("c", "incremental", "b", 5),
+    ];
+    expect(resolveBackupChainBytes(nodes, "c")).toBe(125);
+    expect(resolveBackupChainBytes(nodes, "b")).toBe(120);
+    expect(resolveBackupChainBytes(nodes, "a")).toBe(100);
+  });
+
+  test("returns null when any ancestor has an unrecorded size, so callers fail closed", () => {
+    // An unprovable total must not be silently treated as small: the caller
+    // stores a full backup instead of extending a chain it cannot bound.
+    const nodes = [sized("a", "full", null, null), sized("b", "incremental", "a", 20)];
+    expect(resolveBackupChainBytes(nodes, "b")).toBeNull();
+  });
+
+  test("ignores rows outside the target's chain", () => {
+    const nodes = [
+      sized("a", "full", null, 100),
+      sized("b", "incremental", "a", 20),
+      sized("other", "full", null, 999_999),
+    ];
+    expect(resolveBackupChainBytes(nodes, "b")).toBe(120);
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.ts
@@ -290,6 +290,37 @@ export function incrementalChainDepth(nodes: BackupChainNode[], targetId: string
   return resolveBackupChain(nodes, targetId).length - 1;
 }
 
+/** A chain node plus its stored PLAINTEXT wire size; `null` when unrecorded. */
+export interface BackupChainSizedNode extends BackupChainNode {
+  sizeBytes: number | null;
+}
+
+/**
+ * Sum the stored PLAINTEXT wire bytes of the chain that reconstructs
+ * `targetId` — precisely the quantity reconstruction budgets (the base full
+ * plus every delta, NOT the reconstructed output).
+ *
+ * Returns `null` when any row in the chain has an unrecorded `size_bytes`: the
+ * total cannot be proven to fit, and a caller deciding whether to extend the
+ * chain must fail closed rather than guess. `size_bytes` is measured before
+ * encryption/base64/offload at every write site, so this stays in the same
+ * plaintext unit as the reconstruction budget — no base64 inflation factor
+ * belongs here.
+ */
+export function resolveBackupChainBytes(
+  nodes: BackupChainSizedNode[],
+  targetId: string,
+): number | null {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  let total = 0;
+  for (const id of resolveBackupChain(nodes, targetId)) {
+    const size = byId.get(id)?.sizeBytes ?? null;
+    if (size === null) return null;
+    total += size;
+  }
+  return total;
+}
+
 /**
  * Choose which backups to delete while keeping the newest `keep` restore points
  * AND every ancestor any retained backup still needs. The kept set is

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -792,6 +792,23 @@ describe("ElizaSandboxService state restore auth", () => {
     expect(fetchCalls).toBe(0);
   });
 
+  test("the oversized-push refusal is unrecoverable but NOT permanently lost (#17172)", async () => {
+    // Classification is the whole point of typing this error: provisioning
+    // must stop retrying (the same bytes breach the same limit every time),
+    // while the stored backup chain stays intact and must never be pruned.
+    const {
+      SnapshotPayloadTooLargeError,
+      isUnrecoverableSnapshotError,
+      isPermanentlyLostSnapshot,
+    } = await import("./eliza-sandbox.ts?actual");
+    const err = new SnapshotPayloadTooLargeError(200, 100);
+
+    expect(isUnrecoverableSnapshotError(err)).toBe(true);
+    expect(isPermanentlyLostSnapshot(err)).toBe(false);
+    expect(err.payloadBytes).toBe(200);
+    expect(err.limitBytes).toBe(100);
+  });
+
   test("pushes a restore payload that fits the v1 restorable limit (#17172)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     let fetchCalls = 0;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -756,6 +756,67 @@ describe("ElizaSandboxService state restore auth", () => {
     });
   });
 
+  test("refuses a restore payload over the v1 restorable limit BEFORE the fetch (#17172)", async () => {
+    // `/api/restore` caps its request body at the same canonical limit, so an
+    // oversized push is a guaranteed far-end rejection. This runs on the
+    // blue/green rollback path, where a failed request is a failed ROLLBACK —
+    // so the refusal has to happen locally, before anything is sent.
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const { MAX_RESTORABLE_AGENT_BACKUP_BYTES } = await import(
+      "@elizaos/shared/agent-backup-limits"
+    );
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls += 1;
+      return Response.json({ ok: true });
+    });
+
+    // One oversized value is enough to push the serialized body past the cap;
+    // build it from a repeated char so the payload is big but cheap to make.
+    const oversized = "x".repeat(MAX_RESTORABLE_AGENT_BACKUP_BYTES + 1024);
+    const push = (
+      new ElizaSandboxService() as unknown as {
+        pushState: (
+          bridgeUrl: string,
+          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          options: { trusted: true; authRec: Pick<AgentSandbox, "id" | "environment_vars"> },
+        ) => Promise<void>;
+      }
+    ).pushState(
+      "https://runtime.example",
+      { memories: [], config: { blob: oversized }, workspaceFiles: {} },
+      { trusted: true, authRec: customSandbox() },
+    );
+
+    await expect(push).rejects.toThrow(/exceeds the v1 restorable limit/);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("pushes a restore payload that fits the v1 restorable limit (#17172)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls += 1;
+      return Response.json({ ok: true });
+    });
+
+    await (
+      new ElizaSandboxService() as unknown as {
+        pushState: (
+          bridgeUrl: string,
+          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          options: { trusted: true; authRec: Pick<AgentSandbox, "id" | "environment_vars"> },
+        ) => Promise<void>;
+      }
+    ).pushState(
+      "https://runtime.example",
+      { memories: [], config: { small: "payload" }, workspaceFiles: {} },
+      { trusted: true, authRec: customSandbox() },
+    );
+
+    expect(fetchCalls).toBe(1);
+  });
+
   test("keeps legacy bridge URL restores unauthenticated when no sandbox record is supplied", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const requests: Array<{ headers: Record<string, string> }> = [];

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -59,6 +59,7 @@ import {
   estimateDeltaBytes,
   incrementalChainDepth,
   planIncrementalBackup,
+  resolveBackupChainBytes,
 } from "./agent-backup-diff";
 import { decryptAgentEnvVars, encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
 import {
@@ -5980,20 +5981,46 @@ export class ElizaSandboxService {
             backupKind: b.backup_kind,
             parentBackupId: b.parent_backup_id,
             createdAtMs: b.created_at.getTime(),
+            // Kept so the projected chain sum below needs no extra query.
+            sizeBytes: b.size_bytes ?? null,
           }));
           const chainDepth = incrementalChainDepth(nodes, latest.id);
           const plan = planIncrementalBackup({ base: baseState, next: stateData, chainDepth });
           if (plan.kind === "incremental") {
-            return {
-              sandbox_record_id: sandboxRecordId,
-              snapshot_type: type,
-              // The state_data jsonb holds a BackupDelta for incremental rows.
-              state_data: plan.delta,
-              size_bytes: estimateDeltaBytes(plan.delta),
-              backup_kind: "incremental",
-              parent_backup_id: latest.id,
-              content_hash: contentHash,
-            };
+            // retained-implies-restorable (#17172): reconstruction budgets the
+            // SUM of the chain's stored inputs, so appending a delta that
+            // pushes that sum past the ceiling would make this row canonical
+            // AND unreconstructable in the same write — the invariant this PR
+            // exists to hold. A full backup is always reconstructable, so it is
+            // the correct fail-closed outcome, both when the projection
+            // breaches and when it cannot be computed (an ancestor with an
+            // unrecorded size_bytes).
+            const deltaBytes = estimateDeltaBytes(plan.delta);
+            const existingChainBytes = resolveBackupChainBytes(nodes, latest.id);
+            if (
+              existingChainBytes !== null &&
+              existingChainBytes + deltaBytes <= MAX_RESTORABLE_AGENT_BACKUP_BYTES
+            ) {
+              return {
+                sandbox_record_id: sandboxRecordId,
+                snapshot_type: type,
+                // The state_data jsonb holds a BackupDelta for incremental rows.
+                state_data: plan.delta,
+                size_bytes: deltaBytes,
+                backup_kind: "incremental",
+                parent_backup_id: latest.id,
+                content_hash: contentHash,
+              };
+            }
+            logger.info(
+              "[agent-sandbox] Storing a full backup: an incremental would exceed the restorable chain budget",
+              {
+                sandboxRecordId,
+                existingChainBytes,
+                deltaBytes,
+                limitBytes: MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+              },
+            );
           }
         }
       } catch (error) {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -878,6 +878,28 @@ const UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
 // so they must degrade-but-PRESERVE the chain: never prune a snapshot a
 // token-corrected resume could still restore (#15274).
 const PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES = new Set([404, 410]);
+
+/**
+ * A reconstructed restore payload larger than what `/api/restore` accepts, so
+ * the push is refused locally instead of being sent to be rejected (#17172).
+ *
+ * Typed because the classification matters in both directions: retrying is
+ * pointless (the same bytes exceed the same limit every time), so this must
+ * read as UNRECOVERABLE — but the stored backup chain is intact and still
+ * decryptable, so it must NOT read as permanently lost and must never prune the
+ * chain.
+ */
+export class SnapshotPayloadTooLargeError extends Error {
+  readonly name = "SnapshotPayloadTooLargeError";
+  constructor(
+    readonly payloadBytes: number,
+    readonly limitBytes: number,
+  ) {
+    super(
+      `State restore refused: reconstructed payload of ${payloadBytes} bytes exceeds the v1 restorable limit of ${limitBytes} bytes`,
+    );
+  }
+}
 // Anchored on the exact `fetchSnapshotState` / `pushState` throw shapes so only
 // this file's snapshot HTTP throw sites classify — an unrelated error that
 // merely embeds one of these strings does not.
@@ -923,6 +945,10 @@ const SNAPSHOT_HTTP_ERROR_SHAPE =
 export function isUnrecoverableSnapshotError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
+  // A local size refusal is deterministic: the same reconstructed bytes breach
+  // the same limit on every attempt, so retrying only burns the provision.
+  // Deliberately absent from `isPermanentlyLostSnapshot` — the chain is intact.
+  if (error.name === "SnapshotPayloadTooLargeError") return true;
   const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
   return match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
@@ -9661,9 +9687,7 @@ export class ElizaSandboxService {
     const body = JSON.stringify(state);
     const bodyBytes = Buffer.byteLength(body, "utf8");
     if (bodyBytes > MAX_RESTORABLE_AGENT_BACKUP_BYTES) {
-      throw new Error(
-        `State restore refused: reconstructed payload of ${bodyBytes} bytes exceeds the v1 restorable limit of ${MAX_RESTORABLE_AGENT_BACKUP_BYTES} bytes`,
-      );
+      throw new SnapshotPayloadTooLargeError(bodyBytes, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
     }
     const requestInit: RequestInit = {
       method: "POST",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6,6 +6,7 @@
 import crypto from "node:crypto";
 import { isIP } from "node:net";
 import { ElizaError } from "@elizaos/core";
+import { resolveRetainableAgentBackupBytes } from "@elizaos/shared";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { type Database, dbWrite } from "../../db/helpers";
@@ -505,11 +506,15 @@ const SNAPSHOT_FETCH_TIMEOUT_MS = 120_000;
  * doubled it). The raw budget is enforced WHILE streaming — bytes past it are
  * never retained — and the expanded file budgets are validated before the
  * payload is persisted. Env-overridable for staging soak.
+ *
+ * The raw budget is the RETAIN side of the v1 wire contract, so it is bounded
+ * by what restore accepts: the override may lower it, never raise it past
+ * `MAX_RESTORABLE_AGENT_BACKUP_BYTES` (#17172). Retaining more than that
+ * yields a snapshot that authorizes a cutover and can never be restored.
  */
-const SNAPSHOT_MAX_RAW_BYTES = (() => {
-  const raw = Number.parseInt(process.env.ELIZA_SNAPSHOT_MAX_RAW_BYTES ?? "", 10);
-  return Number.isFinite(raw) && raw > 0 ? raw : 256 * 1024 * 1024;
-})();
+const SNAPSHOT_MAX_RAW_BYTES = resolveRetainableAgentBackupBytes(
+  process.env.ELIZA_SNAPSHOT_MAX_RAW_BYTES,
+);
 const SNAPSHOT_MAX_FILES = (() => {
   const raw = Number.parseInt(process.env.ELIZA_SNAPSHOT_MAX_FILES ?? "", 10);
   return Number.isFinite(raw) && raw > 0 ? raw : 5_000;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6,7 +6,10 @@
 import crypto from "node:crypto";
 import { isIP } from "node:net";
 import { ElizaError } from "@elizaos/core";
-import { resolveRetainableAgentBackupBytes } from "@elizaos/shared";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  resolveRetainableAgentBackupBytes,
+} from "@elizaos/shared/agent-backup-limits";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { type Database, dbWrite } from "../../db/helpers";
@@ -9649,9 +9652,22 @@ export class ElizaSandboxService {
       authRec?: Pick<AgentSandbox, "id" | "environment_vars">;
     },
   ) {
+    // Measure the assembled payload ONCE, before it leaves the worker (#17172).
+    // `/api/restore` caps its request body at the same canonical limit, so an
+    // oversized push is a guaranteed far-end rejection — and this runs on the
+    // blue/green ROLLBACK path, where discovering that after the request is a
+    // failed rollback rather than a clean refusal. Stringifying into a local
+    // also avoids building the payload twice.
+    const body = JSON.stringify(state);
+    const bodyBytes = Buffer.byteLength(body, "utf8");
+    if (bodyBytes > MAX_RESTORABLE_AGENT_BACKUP_BYTES) {
+      throw new Error(
+        `State restore refused: reconstructed payload of ${bodyBytes} bytes exceeds the v1 restorable limit of ${MAX_RESTORABLE_AGENT_BACKUP_BYTES} bytes`,
+      );
+    }
     const requestInit: RequestInit = {
       method: "POST",
-      body: JSON.stringify(state),
+      body,
       signal: AbortSignal.timeout(SNAPSHOT_RESTORE_TIMEOUT_MS),
     };
     const res =

--- a/packages/shared/src/agent-backup-limits.test.ts
+++ b/packages/shared/src/agent-backup-limits.test.ts
@@ -49,12 +49,38 @@ describe("agent-backup limits", () => {
     );
   });
 
-  it("falls back to the canonical ceiling on malformed or non-positive overrides", () => {
-    for (const raw of ["", "   ", "not-a-number", "0", "-1", "NaN"]) {
+  it("treats an absent or blank override as unset and defaults", () => {
+    // Blank is indistinguishable from unset in a systemd EnvironmentFile, so it
+    // stays a default rather than a hard failure.
+    for (const raw of [undefined, "", "   "]) {
       expect(resolveRetainableAgentBackupBytes(raw)).toBe(
         MAX_RESTORABLE_AGENT_BACKUP_BYTES,
       );
     }
+  });
+
+  it("fails fast on a configured-but-invalid override instead of defaulting", () => {
+    // An operator who set the variable meant to change the budget. Silently
+    // running on the canonical limit would hide the misconfiguration behind
+    // behavior that looks deliberate.
+    for (const raw of ["not-a-number", "0", "-1", "NaN", "1e9", " 12 34 "]) {
+      expect(() => resolveRetainableAgentBackupBytes(raw)).toThrow(
+        /Invalid snapshot retain budget/,
+      );
+    }
+  });
+
+  it("rejects a malformed numeric PREFIX rather than silently misreading it", () => {
+    // `Number.parseInt` reads all three of these as 128 — the silent misread
+    // this parser exists to prevent (an operator writing a unit suffix would
+    // get a 128-BYTE budget without a word).
+    for (const raw of ["128MiB", "128abc", "128_000", "0x80"]) {
+      expect(() => resolveRetainableAgentBackupBytes(raw)).toThrow(
+        /Invalid snapshot retain budget/,
+      );
+    }
+    // Surrounding whitespace is only formatting, so it is trimmed, not rejected.
+    expect(resolveRetainableAgentBackupBytes("  1048576  ")).toBe(1048576);
   });
 
   it("accepts the exact limit and clamps limit+1 (boundary)", () => {

--- a/packages/shared/src/agent-backup-limits.test.ts
+++ b/packages/shared/src/agent-backup-limits.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pins the v1 agent-backup size contract: the retain budget can never exceed
+ * what restore accepts.
+ *
+ * The production canary in #17172 retained a snapshot Cloud allowed (256 MiB)
+ * but restore could not consume (128 MiB cap), producing a backup that
+ * authorized a cutover and was impossible to restore. These tests hold the
+ * clamp that makes that state unreachable — including through the operator env
+ * override, which previously could re-open the gap by configuration alone.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  resolveRetainableAgentBackupBytes,
+} from "./agent-backup-limits.js";
+
+const MIB = 1024 * 1024;
+
+describe("agent-backup limits", () => {
+  it("pins the canonical restorable ceiling at 128 MiB", () => {
+    // The smallest consumer on the restore path (the agent's /api/restore body
+    // cap) is what makes a backup restorable at all; the canonical limit must
+    // equal it, not the larger retain-side budget that caused #17172.
+    expect(MAX_RESTORABLE_AGENT_BACKUP_BYTES).toBe(128 * MIB);
+  });
+
+  it("defaults to the canonical ceiling when no override is set", () => {
+    expect(resolveRetainableAgentBackupBytes(undefined)).toBe(
+      MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    );
+  });
+
+  it("honors an override that LOWERS the retain budget", () => {
+    // Lowering is the override's real purpose (staging soak, constrained
+    // worker) and stays safe: a smaller retained payload is still restorable.
+    expect(resolveRetainableAgentBackupBytes(String(32 * MIB))).toBe(32 * MIB);
+  });
+
+  it("clamps an override that would RAISE the retain budget past restore", () => {
+    // The #17172 regression in one line: configuration must not be able to
+    // retain more than restore accepts.
+    expect(resolveRetainableAgentBackupBytes(String(512 * MIB))).toBe(
+      MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    );
+    // The exact pre-fix value that produced the unrestorable canary snapshot.
+    expect(resolveRetainableAgentBackupBytes(String(256 * MIB))).toBe(
+      MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+    );
+  });
+
+  it("falls back to the canonical ceiling on malformed or non-positive overrides", () => {
+    for (const raw of ["", "   ", "not-a-number", "0", "-1", "NaN"]) {
+      expect(resolveRetainableAgentBackupBytes(raw)).toBe(
+        MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+      );
+    }
+  });
+
+  it("accepts the exact limit and clamps limit+1 (boundary)", () => {
+    expect(
+      resolveRetainableAgentBackupBytes(
+        String(MAX_RESTORABLE_AGENT_BACKUP_BYTES),
+      ),
+    ).toBe(MAX_RESTORABLE_AGENT_BACKUP_BYTES);
+    expect(
+      resolveRetainableAgentBackupBytes(
+        String(MAX_RESTORABLE_AGENT_BACKUP_BYTES + 1),
+      ),
+    ).toBe(MAX_RESTORABLE_AGENT_BACKUP_BYTES);
+  });
+
+  it("never resolves a retain budget above the restorable ceiling, for any input", () => {
+    // The anti-drift invariant itself: whatever an operator sets, the retain
+    // side stays within what restore can consume.
+    const inputs = [
+      undefined,
+      "1",
+      "1048576",
+      String(128 * MIB),
+      String(1024 * MIB),
+      "999999999999",
+    ];
+    for (const raw of inputs) {
+      expect(resolveRetainableAgentBackupBytes(raw)).toBeLessThanOrEqual(
+        MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+      );
+    }
+  });
+});

--- a/packages/shared/src/agent-backup-limits.ts
+++ b/packages/shared/src/agent-backup-limits.ts
@@ -1,0 +1,45 @@
+/**
+ * Agent-backup size limits shared by everything that RETAINS or CONSUMES a v1
+ * agent snapshot.
+ *
+ * A v1 snapshot is one JSON document on the wire. Retaining one that is larger
+ * than what restore accepts produces a backup that authorizes a cutover and can
+ * never be restored — the exact production-canary failure in #17172: Cloud
+ * retained up to 256 MiB while `/api/restore`
+ * (`packages/agent/src/api/server.ts`) and backup-chain reconstruction
+ * (`packages/cloud/shared/src/db/repositories/agent-sandboxes.ts`) both cap at
+ * 128 MiB, so a 128-256 MiB snapshot was a silent dead end.
+ *
+ * Every side imports THIS module so the numbers cannot drift apart again.
+ */
+
+/**
+ * Canonical maximum RESTORABLE v1 wire size. A retained v1 backup above this is
+ * unrestorable by construction, so it must never be retained in the first
+ * place. Raising this alone is meaningless: it is bounded by what the smallest
+ * consumer on the restore path accepts (`/api/restore`'s request-body cap and
+ * the backup-chain reconstruction cap), so all of them move together or not at
+ * all.
+ */
+export const MAX_RESTORABLE_AGENT_BACKUP_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Resolve the snapshot RETAIN budget from an operator override, clamped so it
+ * can never exceed {@link MAX_RESTORABLE_AGENT_BACKUP_BYTES}.
+ *
+ * The override exists to LOWER the budget (staging soak, a memory-constrained
+ * worker). Allowing it to raise the budget past what restore accepts would
+ * silently re-open the retain-vs-restore divergence through configuration
+ * alone, which is why the clamp lives here next to the limit rather than at the
+ * call site.
+ *
+ * A missing, non-numeric, or non-positive value yields the canonical limit.
+ */
+export function resolveRetainableAgentBackupBytes(
+  rawOverride: string | undefined,
+): number {
+  const parsed = Number.parseInt(rawOverride ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+  return Math.min(parsed, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
+}

--- a/packages/shared/src/agent-backup-limits.ts
+++ b/packages/shared/src/agent-backup-limits.ts
@@ -33,13 +33,30 @@ export const MAX_RESTORABLE_AGENT_BACKUP_BYTES = 128 * 1024 * 1024;
  * alone, which is why the clamp lives here next to the limit rather than at the
  * call site.
  *
- * A missing, non-numeric, or non-positive value yields the canonical limit.
+ * Only an ABSENT override defaults. A present-but-invalid value throws rather
+ * than silently falling back: an operator who set the variable meant to change
+ * the budget, so quietly running on the canonical limit would hide a
+ * misconfiguration behind behavior that looks deliberate. `Number.parseInt` is
+ * deliberately not used — it accepts malformed numeric prefixes (`"128MiB"` and
+ * `"128abc"` both yield 128), which is exactly the silent-misread this guards.
  */
 export function resolveRetainableAgentBackupBytes(
   rawOverride: string | undefined,
 ): number {
-  const parsed = Number.parseInt(rawOverride ?? "", 10);
-  if (!Number.isFinite(parsed) || parsed <= 0)
-    return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+  if (rawOverride === undefined) return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+  const trimmed = rawOverride.trim();
+  if (trimmed === "") return MAX_RESTORABLE_AGENT_BACKUP_BYTES;
+
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(
+      `Invalid snapshot retain budget ${JSON.stringify(rawOverride)}: expected a positive integer count of bytes`,
+    );
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `Invalid snapshot retain budget ${JSON.stringify(rawOverride)}: expected a positive integer count of bytes`,
+    );
+  }
   return Math.min(parsed, MAX_RESTORABLE_AGENT_BACKUP_BYTES);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,11 @@
  * Public surface: barrel exports for the shared workspace contract.
  */
 
+// Agent-backup size limits — the single source of truth for the maximum
+// RESTORABLE v1 snapshot wire size, imported by every side that retains or
+// consumes a snapshot so a backup can never be retained above what restore
+// accepts (#17172).
+export * from "./agent-backup-limits.js";
 export * from "./api/agent-api-types.js";
 export * from "./api/command-transport-types.js";
 export * from "./api/http-helpers.js";


### PR DESCRIPTION
# Relates to

Closes review point 1 on #17180 — the source-side half of #17172 §1.

**Stacked on #17180** (`fix/v1-snapshot-restorable-budget`): this imports the shared limits module that PR introduces, so it should merge after it. The diff here is only the two `packages/agent` files.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` (via the stack) and carries no conflicts.
- [x] `bun run verify` equivalents run on the touched package; results below.
- [x] A reviewer can confirm the change works from the evidence attached below.

# Risks

Low by construction and off by default in effect: the budget's default ceiling is the shared canonical restorable limit, so it refuses exactly what the downstream consumer would already have rejected — a capture that succeeds today and is restorable still succeeds. The behavior change is *where* the refusal happens (in the producer, before the heap is spent) rather than *what* is refused.

# Background

## What does this PR do?

Cloud's restorable-size check is strictly **downstream** of the agent having already assembled and serialized the whole payload. It bounds what Cloud *retains*; it never bounds what the agent's own heap burns getting there. `createAgentSnapshot` ran its five captures concurrently with **no size awareness at all**:

- file capture reads a file and base64-encodes it — ~2.33× the file size transiently (Buffer + base64 string), ~1.33× durably;
- the **media** set has no include predicate whatsoever, so the whole content-addressed store is base64'd into the manifest;
- `stat.size` was already read and never compared to anything.

So a large agent can exhaust its container mid-capture. The memory watchdog then force-restarts it, and the lifecycle sites that snapshot before **upgrade / shutdown / sleep** silently degrade to a stale or missing backup — the failure this issue is about, one layer earlier than the Cloud fix.

Adds a produce-side budget:

- charged **as bytes are produced**, so an over-budget capture is refused at the first byte past the line instead of after everything is resident;
- file entries are refused from the **declared `stat` size before the read** — charging afterwards is charging after the allocation;
- a file-count ceiling mirroring the hydration-side cap;
- an optional `AbortSignal`, threaded through the directory walk so a cancelled capture stops descending;
- a typed `AgentSnapshotBudgetExceededError`, so "this state is too large to snapshot" is distinguishable from a transport/disk failure (the former is deterministic; retrying identical state cannot help).

## What kind of change is this?

Bug fix (source-process memory safety on the snapshot path).

# Testing

## Where should a reviewer start?

`agent-backup.test.ts` → `describe("source-side snapshot budget")`. The load-bearing case is **"refuses BEFORE reading the oversized file, not after materializing it"**: it wraps `fs.readFile` and asserts the oversized path is **never read**. A post-read charge would pass a naive size assertion while still having paid the allocation — that test is what separates the two.

Also covered: byte-budget refusal, file-count refusal, an already-aborted signal, and a within-budget capture still succeeding unchanged.

## Detailed testing steps

None: automated. `packages/agent` suite **9/9** (5 new), `tsgo --noEmit` clean, biome clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - snapshot capture path in the agent process; no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - snapshot capture path in the agent process; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; behavior pinned by the changed test lane.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - reproducing the real OOM needs a multi-GB customer agent; the deterministic reproduction (refusal before read, count/byte ceilings, abort) is in the changed lane.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change; capture budgeting only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows; the artifact is the refusal happening before allocation, asserted by the fs.readFile red-control.`

## Known gaps / failures

**The Postgres single-query peak is now bounded** — this was left open in the first commit and is closed in `af967f6`. The two unbounded shapes (memories-joined embeddings, generic owner-column) read in **keyset batches** ordered by primary key, charging the budget per batch, so the peak is one batch and an oversized table is refused mid-walk. Keyset rather than OFFSET: OFFSET re-scans from the start each page, and a snapshot taken while the agent is live would skip or duplicate rows as they shift. This is the **no-new-dependency** option — I did not add `pg-cursor` to the agent container image, since that would have been a call about the image rather than about this code.

Two honest remainders:
- A table with **no primary key** keeps its single read (there is nothing to walk); the post-read charge still bounds the assembled snapshot. Documented at the call site. In practice these are the small tables.
- **Source-memory profiling evidence** (RSS during a capture of a genuinely huge state dir) is not attached — it needs a realistic large agent rather than a fixture. The deterministic reproductions are in the test lane.

[stan-cloud]
