### PR TITLE
fix(runtime): await and report service startup

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4874,15 +4874,9 @@ export class AgentRuntime implements IAgentRuntime {
 			this.serviceRegistrationStatus.set(key, "registered");
 			return serviceInstance;
 		} catch (error) {
-			this.logger.error(
-				{
-					src: "agent",
-					agentId: this.agentId,
-					serviceType,
-					error: error instanceof Error ? error.message : String(error),
-				},
-				"Service start failed",
-			);
+			this.reportError("AgentRuntime.serviceStart", error, {
+				serviceType,
+			});
 			const handler = this.servicePromiseHandlers.get(serviceType);
 			if (handler) {
 				handler.reject(

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -140,6 +140,17 @@ describe("NotificationService", () => {
 			await expect(
 				failing.runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
 			).rejects.toThrow("Service notification not found or failed to start");
+			expect(failing.runtime.getRecentReportedErrors()).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						scope: "AgentRuntime.serviceStart",
+						message: "notification cache unavailable",
+						context: expect.objectContaining({
+							serviceType: ServiceType.NOTIFICATION,
+						}),
+					}),
+				]),
+			);
 			await expect(NotificationService.start(failing.runtime)).rejects.toThrow(
 				"notification cache unavailable",
 			);

--- a/plugins/plugin-agent-orchestrator/src/__tests__/tasks-service-readiness.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/tasks-service-readiness.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Verifies that the TASKS action survives the runtime's asynchronous service-start boundary.
+ */
+
+import type { IAgentRuntime, Memory, Service } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { tasksAction } from "../actions/tasks.ts";
+
+const ACP_SERVICE_TYPE = "ACP_SUBPROCESS_SERVICE";
+const LIST_AGENTS_MESSAGE = {
+  content: {
+    text: "List the active coding agents.",
+    action: "list_agents",
+  },
+} as unknown as Memory;
+
+describe("TASKS service readiness", () => {
+  it("waits for the registered ACP service before validating", async () => {
+    const acpService = {} as Service;
+    let loadCalls = 0;
+    const runtime = {
+      getService: () => null,
+      hasService: (type: string) => type === ACP_SERVICE_TYPE,
+      getServiceLoadPromise: async (type: string) => {
+        expect(type).toBe(ACP_SERVICE_TYPE);
+        loadCalls += 1;
+        return acpService;
+      },
+    } as unknown as IAgentRuntime;
+
+    await expect(
+      tasksAction.validate(runtime, LIST_AGENTS_MESSAGE),
+    ).resolves.toBe(true);
+    expect(loadCalls).toBe(1);
+  });
+
+  it("does not expose TASKS when ACP startup fails", async () => {
+    const runtime = {
+      getService: () => null,
+      hasService: (type: string) => type === ACP_SERVICE_TYPE,
+      getServiceLoadPromise: async () => {
+        throw new Error("startup failed");
+      },
+    } as unknown as IAgentRuntime;
+
+    await expect(
+      tasksAction.validate(runtime, LIST_AGENTS_MESSAGE),
+    ).resolves.toBe(false);
+  });
+
+  it("does not attempt startup when the ACP service is not registered", async () => {
+    let loadCalls = 0;
+    const runtime = {
+      getService: () => null,
+      hasService: () => false,
+      getServiceLoadPromise: async () => {
+        loadCalls += 1;
+        throw new Error("must not load");
+      },
+    } as unknown as IAgentRuntime;
+
+    await expect(
+      tasksAction.validate(runtime, LIST_AGENTS_MESSAGE),
+    ).resolves.toBe(false);
+    expect(loadCalls).toBe(0);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -98,6 +98,23 @@ export function getAcpService(
     undefined) as AcpActionService | undefined;
 }
 
+export async function getReadyAcpService(
+  runtime: IAgentRuntime,
+): Promise<AcpActionService | undefined> {
+  const existing = getAcpService(runtime);
+  if (existing) return existing;
+  if (!runtime.hasService("ACP_SUBPROCESS_SERVICE")) return undefined;
+
+  try {
+    return (await runtime.getServiceLoadPromise(
+      "ACP_SUBPROCESS_SERVICE",
+    )) as unknown as AcpActionService;
+  } catch {
+    // error-policy:J4 validation hides a capability whose registered service failed to start; the runtime reports the start failure.
+    return undefined;
+  }
+}
+
 export function logger(runtime: IAgentRuntime): IAgentRuntime["logger"] {
   return runtime.logger;
 }

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -74,6 +74,7 @@ import {
   errorResult,
   failureMessage,
   getAcpService,
+  getReadyAcpService,
   getTimeoutMs,
   type HandlerOptionsLike,
   hasExplicitPayload,
@@ -4263,8 +4264,10 @@ export const tasksAction: Action & {
   ],
   validate: async (runtime, message) => {
     const content = contentRecord(message);
-    // Always allow when ACP service is available — action switch handles dispatch.
-    if (!getAcpService(runtime)) {
+    // Registration starts services asynchronously. Validation is the first
+    // consumer on a cold plugin load, so it owns the readiness wait before the
+    // planner decides whether TASKS exists.
+    if (!(await getReadyAcpService(runtime))) {
       const taskService = runtime.getService?.(
         OrchestratorTaskService.serviceType,
       ) as OrchestratorTaskService | null | undefined;

--- a/plugins/plugin-birdclaw/src/actions/birdclaw.test.ts
+++ b/plugins/plugin-birdclaw/src/actions/birdclaw.test.ts
@@ -17,6 +17,8 @@ function runtimeWith(service: BirdclawService | null): IAgentRuntime {
     getSetting: () => undefined,
     getService: (type: string) =>
       type === BirdclawService.serviceType ? service : null,
+    hasService: (type: string) =>
+      type === BirdclawService.serviceType && service !== null,
   } as unknown as IAgentRuntime;
 }
 
@@ -51,6 +53,35 @@ describe("BIRDCLAW validate", () => {
     await expect(birdclawAction.validate(runtimeWith(null))).resolves.toBe(
       false,
     );
+  });
+
+  it("waits for a registered service that is still starting", async () => {
+    const installed = serviceWith(() => ({ stdout: "0.8.5" }));
+    let loadCalls = 0;
+    const runtime = {
+      getService: () => null,
+      hasService: (type: string) => type === BirdclawService.serviceType,
+      getServiceLoadPromise: async (type: string) => {
+        expect(type).toBe(BirdclawService.serviceType);
+        loadCalls += 1;
+        return installed;
+      },
+    } as unknown as IAgentRuntime;
+
+    await expect(birdclawAction.validate(runtime)).resolves.toBe(true);
+    expect(loadCalls).toBe(1);
+  });
+
+  it("stays unavailable when registered service startup fails", async () => {
+    const runtime = {
+      getService: () => null,
+      hasService: (type: string) => type === BirdclawService.serviceType,
+      getServiceLoadPromise: async () => {
+        throw new Error("startup failed");
+      },
+    } as unknown as IAgentRuntime;
+
+    await expect(birdclawAction.validate(runtime)).resolves.toBe(false);
   });
 
   it("is false when the binary is missing, true when installed", async () => {

--- a/plugins/plugin-birdclaw/src/actions/birdclaw.ts
+++ b/plugins/plugin-birdclaw/src/actions/birdclaw.ts
@@ -64,6 +64,23 @@ function getService(runtime: IAgentRuntime): BirdclawService | null {
   );
 }
 
+async function getReadyService(
+  runtime: IAgentRuntime,
+): Promise<BirdclawService | null> {
+  const existing = getService(runtime);
+  if (existing) return existing;
+  if (!runtime.hasService(BirdclawService.serviceType)) return null;
+
+  try {
+    return (await runtime.getServiceLoadPromise(
+      BirdclawService.serviceType,
+    )) as BirdclawService;
+  } catch {
+    // error-policy:J4 validation hides the unavailable archive capability; the runtime reports the service-start failure.
+    return null;
+  }
+}
+
 function getParams(options: unknown): BirdclawActionParameters {
   if (typeof options !== "object" || options === null) return {};
   const record = options as Record<string, unknown>;
@@ -312,7 +329,7 @@ export const birdclawAction = {
   contexts: ["social", "archive", "twitter"],
   roleGate: { minRole: "OWNER" as const },
   validate: async (runtime: IAgentRuntime): Promise<boolean> => {
-    const service = getService(runtime);
+    const service = await getReadyService(runtime);
     if (!service) return false;
     return service.isAvailable();
   },


### PR DESCRIPTION
## Summary

- wait for registered ACP and Birdclaw services during cold action validation
- keep unregistered or failed services unavailable without fabricating success
- route runtime service startup exceptions through `reportError` and `RECENT_ERRORS`
- add cold-start and observable-error regression coverage

Closes #17218

## Sync with develop

Based directly on `origin/develop` `fc1680043f448de7c652dfca38517e3a22727066`; stale-base guard passes.

## Testing

- Biome on all seven changed files
- 51 focused assertions across NotificationService, TASKS readiness, and BIRDCLAW
- core, agent-orchestrator, and Birdclaw package typechecks
- live Codex `gpt-5.5` planner trajectories for both cold-start paths
- `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - no rendered UI files or user-visible surfaces are changed`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no rendered UI files or user-visible surfaces are changed`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no frontend, native, or device interaction is changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend/service timing logs: [Birdclaw and TASKS service registration evidence](https://gist.github.com/lalalune/c2f11d6c7b6e4c58d84bb79836717983).
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request, console, or network behavior is changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectories: [reports and native JSONL for live Codex planner runs](https://gist.github.com/lalalune/c2f11d6c7b6e4c58d84bb79836717983).
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [action results, native trajectories, and service timing stacks](https://gist.github.com/lalalune/c2f11d6c7b6e4c58d84bb79836717983).

## Manual evidence review

Provider resolved as `cli://codex`, configured model `gpt-5.5`; proxy flags were disabled and strict privacy checks passed.

- `BIRDCLAW`: 1/1 passed. Validation entered while `BirdclawService` was registering, waited 37,960 ms in `getReadyService`, then executed the subprocess and parsed two archived posts. The scenario intentionally uses the stock fake Birdclaw executable, so it proves service/action/subprocess/parser behavior rather than access to a production Twitter archive.
- `TASKS_LIST_AGENTS`: 1/1 passed. Validation entered while `AcpService` was registering, waited 39,798 ms in `getReadyAcpService`, then read the real ACP session store and returned empty sessions/tasks successfully. It does not claim to prove spawning a coding subagent.

The stock prompts were not reliable under a live planner, so a `/tmp` harness imported the stock scenarios, explicitly requested each relevant action, and delayed actual service startup by 45 seconds. Both finalized with exit code 0. A post-evidence `runtime.stop()` cleanup timeout was observed and is not hidden; it occurred after reports finalized and does not affect the asserted action/service path.