### PR TITLE
test(model-tester): await ready metric status

### DIFF
--- a/plugins/app-model-tester/src/ModelTesterAppView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.test.tsx
@@ -185,8 +185,11 @@ describe("ModelTesterAppView populated render", () => {
     installFetch(() => ({ text: "ok" }));
     render(<ModelTesterAppView {...overlayContext()} />);
 
-    // Wait for the on-mount status fetch to populate.
-    await waitFor(() => expect(screen.getByText("TEXT_SMALL")).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.getByRole("status", { name: "Ready probes" }).textContent,
+      ).toContain("5/8"),
+    );
 
     expect(screen.getByTestId("model-tester-shell")).toBeTruthy();
     expect(
@@ -249,10 +252,11 @@ describe("ModelTesterAppView populated render", () => {
       }),
     );
     render(<ModelTesterAppView {...overlayContext()} />);
-    await waitFor(() => expect(screen.getByText("TEXT_SMALL")).toBeTruthy());
-
-    // text-small available (1) + vad default-ready (1) = 2/8.
-    expect(screen.getByText("2/8")).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("status", { name: "Ready probes" }).textContent,
+      ).toContain("2/8"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

The Model Tester view tests previously waited for a static label that rendered before the asynchronous status fetch completed, then raced the ready-count assertion. Await the accessible `Ready probes` status value itself in both availability cases.

Closes #17220

## Verification

- focused ModelTesterAppView suite: 12/12 assertions pass
- exact assertion now waits for the state transition under test instead of unrelated pre-fetch copy

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test synchronization only; no rendered UI source changes`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test synchronization only; no rendered UI source changes`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - production behavior and user flow are unchanged`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend code changes`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no production frontend code changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - test synchronization only; no domain output is produced`.