### PR TITLE
fix(ci): bound hosted typecheck concurrency

### DIFF
--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -126,7 +126,9 @@ jobs:
         run: bun run build
 
       - name: Run typecheck
-        run: bun run typecheck
+        # The full graph starts native TypeScript workers; eight concurrent
+        # processes can exhaust a four-vCPU hosted runner before diagnostics.
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=4
 
   build:
     name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1256,7 +1256,9 @@ jobs:
         run: bun run format:check
 
       - name: Repo-wide typecheck
-        run: bun run typecheck
+        # Match the bounded PR lane: the full graph otherwise starts enough
+        # native TypeScript workers to terminate a four-vCPU hosted runner.
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=4
 
       - name: Stale base guard
         env:


### PR DESCRIPTION
## Summary

Bound the full Turbo typecheck graph to four concurrent tasks in the hosted Quality Fork and Tests jobs. The graph, package coverage, and exit propagation remain unchanged; only simultaneous task pressure is reduced.

Closes #17224

## Verification

- Turbo wrapper relevant suite: 11/11
- exact workflow command assertions
- `actionlint` on both workflows
- Biome and `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - workflow-only change with no rendered UI`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - workflow-only change with no rendered UI`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user flow changes`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - GitHub Actions scheduling change, not a deployed backend path`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain output is produced`.