### PR TITLE
registry: add 4 x402 third-party plugins

### DIFF
--- a/packages/registry/entries/third-party/vohlsyr__plugin-chainscope.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-chainscope.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-chainscope",
+  "repository": "github:Vohlsyr/plugin-chainscope",
+  "kind": "plugin",
+  "description": "Multi-chain wallet and transaction intelligence with OFAC sanctions screening via ChainScope, paid per call in USDC on Base through x402.",
+  "homepage": "https://chainsscope.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "blockchain", "wallet", "multi-chain", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-concordance.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-concordance.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-concordance",
+  "repository": "github:Vohlsyr/plugin-concordance",
+  "kind": "plugin",
+  "description": "Cross-source search and claim corroboration across 18 real-time data sources via Concordance, paid per call in USDC on Base through x402 -- no API keys.",
+  "homepage": "https://concordancehq.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "search", "data", "corroboration", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-trading-strategy-data.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-trading-strategy-data.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-trading-strategy-data",
+  "repository": "github:Vohlsyr/plugin-trading-strategy-data",
+  "kind": "plugin",
+  "description": "Backtestable crypto trend signals and on-demand backtesting for BTC/ETH/SOL/XRP/ADA via Trading Strategy Data, paid per call in USDC on Base through x402.",
+  "homepage": "https://strategysignals.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "trading", "crypto", "backtest", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-trustfetch.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-trustfetch.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-trustfetch",
+  "repository": "github:Vohlsyr/plugin-trustfetch",
+  "kind": "plugin",
+  "description": "Prompt-injection scanning and clean webpage fetching for AI agents via TrustFetch, paid per call in USDC on Base through x402.",
+  "homepage": "https://trustfetch.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "security", "prompt-injection", "web-fetch", "payments"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -507,6 +507,186 @@
       "registryKind": "plugin",
       "directory": "adapters/eliza"
     },
+    "@vohlsyr/plugin-chainscope": {
+      "git": {
+        "repo": "Vohlsyr/plugin-chainscope",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-chainscope",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Multi-chain wallet and transaction intelligence with OFAC sanctions screening via ChainScope, paid per call in USDC on Base through x402.",
+      "homepage": "https://chainsscope.duckdns.org",
+      "topics": [
+        "x402",
+        "blockchain",
+        "wallet",
+        "multi-chain",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "@vohlsyr/plugin-concordance": {
+      "git": {
+        "repo": "Vohlsyr/plugin-concordance",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-concordance",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Cross-source search and claim corroboration across 18 real-time data sources via Concordance, paid per call in USDC on Base through x402 -- no API keys.",
+      "homepage": "https://concordancehq.duckdns.org",
+      "topics": [
+        "x402",
+        "search",
+        "data",
+        "corroboration",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "@vohlsyr/plugin-trading-strategy-data": {
+      "git": {
+        "repo": "Vohlsyr/plugin-trading-strategy-data",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-trading-strategy-data",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Backtestable crypto trend signals and on-demand backtesting for BTC/ETH/SOL/XRP/ADA via Trading Strategy Data, paid per call in USDC on Base through x402.",
+      "homepage": "https://strategysignals.duckdns.org",
+      "topics": [
+        "x402",
+        "trading",
+        "crypto",
+        "backtest",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "@vohlsyr/plugin-trustfetch": {
+      "git": {
+        "repo": "Vohlsyr/plugin-trustfetch",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-trustfetch",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Prompt-injection scanning and clean webpage fetching for AI agents via TrustFetch, paid per call in USDC on Base through x402.",
+      "homepage": "https://trustfetch.duckdns.org",
+      "topics": [
+        "x402",
+        "security",
+        "prompt-injection",
+        "web-fetch",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@wasmagent/eliza-rollout-plugin": {
       "git": {
         "repo": "WasmAgent/wasmagent-js",


### PR DESCRIPTION
Adds 4 community plugins to the third-party registry, each wrapping a real, live x402-payable service (USDC on Base, no API keys):

- **@vohlsyr/plugin-concordance** — cross-source search + claim corroboration across 18 real-time data sources
- **@vohlsyr/plugin-trading-strategy-data** — backtestable crypto trend signals + on-demand backtesting (BTC/ETH/SOL/XRP/ADA)
- **@vohlsyr/plugin-trustfetch** — prompt-injection scanning + clean webpage fetching
- **@vohlsyr/plugin-chainscope** — multi-chain wallet/tx intelligence with OFAC sanctions screening

All 4 are published on npm and have public source repos with real actions (not stubs), vitest suites, and a live-connectivity + live-x402-challenge demo script each.

Followed the README's "Adding a third-party plugin" steps exactly: added one `entries/third-party/<pkg>.json` per package, then `bun run --cwd packages/registry validate` (34 entries validated) and `bun run --cwd packages/registry generate` (regenerated `generated-registry.json`, pure additions only, no unrelated reformatting).

Repos:
- https://github.com/Vohlsyr/plugin-concordance
- https://github.com/Vohlsyr/plugin-trading-strategy-data
- https://github.com/Vohlsyr/plugin-trustfetch
- https://github.com/Vohlsyr/plugin-chainscope