### PR TITLE
fix(cloud): stop the stuck-provisioning sweeper erroring in-flight cold boots

### DIFF
--- a/packages/cloud/api/cron/cleanup-stuck-provisioning/route.ts
+++ b/packages/cloud/api/cron/cleanup-stuck-provisioning/route.ts
@@ -33,8 +33,21 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { verifyCronSecret } from "@/lib/auth/cron";
 import { logger } from "@/lib/utils/logger";
 
-/** How long an agent must be stuck before we reset it (ms). */
-const STUCK_THRESHOLD_MINUTES = 10;
+/**
+ * How long an agent must sit in `provisioning` before we call it abandoned.
+ *
+ * MUST stay above the longest cold-boot budget the daemon grants a job
+ * (`COLD_BOOT_STALE_JOB_THRESHOLD_MS`, 15 min), or this sweeper races a boot
+ * that is still legitimately running: a cold boot pays an image pull plus a
+ * container create plus a tailnet health poll, and nothing refreshes
+ * `updated_at` in between. At 10 minutes it flipped in-flight wake/resume rows
+ * to terminal `error` — and `error` is reapable by the orphan reconciler with
+ * no age grace, so the container was destroyed under the running job (#17215).
+ *
+ * The job-type exemption below is the primary guard; this margin is the belt
+ * for a row whose owning job row is missing entirely.
+ */
+const STUCK_THRESHOLD_MINUTES = 20;
 
 interface CleanupResult {
   agentId: string;

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-repo.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-repo.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The stuck-provisioning sweeper must never call an IN-FLIGHT cold boot
+ * abandoned (#17215), against the REAL Drizzle schema on in-process PGlite.
+ *
+ * `provisioning` is held by every job type that reaches `provision()` — not
+ * just `agent_provision`/`agent_restart`, but `agent_wake` and `agent_resume`
+ * too. A cold boot pays an image pull plus a container create plus a tailnet
+ * health poll and refreshes nothing in between, so a sweeper that exempts only
+ * some of those types flips a live boot to terminal `error`; `error` is then
+ * reapable by the orphan reconciler with no age grace, destroying the container
+ * under the running job. That is the mechanism behind 19 of the 44 agents
+ * stranded on 2026-07-13 (#17162).
+ *
+ * Harness mirrors `agent-sandboxes-fleet-candidate-repo.test.ts`: drizzle-kit
+ * `pushSchema` applies the exact DDL from the real schema objects to the same
+ * PGlite connection the repository queries through. Fails LOUDLY (never
+ * silently passes) when a shared non-PGlite Postgres is the ambient DATABASE_URL.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { apiKeys } from "../../schemas/api-keys";
+import { generations } from "../../schemas/generations";
+import { jobs } from "../../schemas/jobs";
+import { organizations } from "../../schemas/organizations";
+import { usageRecords } from "../../schemas/usage-records";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+import { AgentSandboxesRepository } from "../agent-sandboxes";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+let seq = 0;
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const repo = new AgentSandboxesRepository();
+
+/** Row age: older than the cutoff, so only the job-type exemption can save it. */
+const LONG_AGO = new Date(Date.now() - 60 * 60 * 1000);
+/** Sweep everything older than 20 minutes — LONG_AGO is well past it. */
+const SWEEP_CUTOFF = new Date(Date.now() - 20 * 60 * 1000);
+
+async function seedOrgAndUser(): Promise<{ organizationId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Sweeper Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { organizationId: org.id, userId: user.id };
+}
+
+async function seedProvisioningAgent(organizationId: string, userId: string): Promise<string> {
+  const [row] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: organizationId,
+      user_id: userId,
+      agent_name: uniq("agent"),
+      status: "provisioning",
+      execution_tier: "dedicated-always",
+      updated_at: LONG_AGO,
+    })
+    .returning();
+  return row.id;
+}
+
+async function seedInFlightJob(
+  organizationId: string,
+  agentId: string,
+  type: string,
+): Promise<void> {
+  await dbWrite.insert(jobs).values({
+    organization_id: organizationId,
+    agent_id: agentId,
+    type: type as never,
+    status: "in_progress",
+    data: {},
+  });
+}
+
+async function statusOf(agentId: string): Promise<string> {
+  const row = await repo.findById(agentId);
+  if (!row) throw new Error(`agent ${agentId} vanished`);
+  return row.status;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[agent-sandboxes-stuck-provisioning-repo.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+    );
+    return;
+  }
+  try {
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      // `jobs` carries FKs to these; pushSchema needs them or the DDL fails.
+      apiKeys,
+      usageRecords,
+      generations,
+      jobs,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[agent-sandboxes-stuck-provisioning-repo.test] PGlite/pushSchema unavailable — cannot drive AgentSandboxesRepository against a real DB. Failing all cases.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+beforeEach(() => {
+  if (!pgliteReady) throw new Error("PGlite harness unavailable");
+});
+
+describe("stuck-provisioning sweeper vs in-flight cold boots (#17215)", () => {
+  // Every type here reaches `provision()`, which is what parks the row in
+  // `provisioning`. `agent_wake` / `agent_resume` are the two the sweeper used
+  // to miss, so they are the regression; the other two are the guard that the
+  // widening did not lose what already worked.
+  for (const jobType of ["agent_wake", "agent_resume", "agent_provision", "agent_restart"]) {
+    test(`does not error a provisioning row owned by an in-flight ${jobType}`, async () => {
+      const { organizationId, userId } = await seedOrgAndUser();
+      const agentId = await seedProvisioningAgent(organizationId, userId);
+      await seedInFlightJob(organizationId, agentId, jobType);
+
+      const swept = await repo.markStuckProvisioningWithoutActiveJobAsError(SWEEP_CUTOFF);
+
+      expect(swept.map((row) => row.agentId)).not.toContain(agentId);
+      expect(await statusOf(agentId)).toBe("provisioning");
+    });
+  }
+
+  test("still errors a provisioning row with no owning job at all", async () => {
+    // The sweeper's actual purpose must survive the widening: a row whose job
+    // vanished is genuinely abandoned and has to be reclaimed.
+    const { organizationId, userId } = await seedOrgAndUser();
+    const agentId = await seedProvisioningAgent(organizationId, userId);
+
+    const swept = await repo.markStuckProvisioningWithoutActiveJobAsError(SWEEP_CUTOFF);
+
+    expect(swept.map((row) => row.agentId)).toContain(agentId);
+    expect(await statusOf(agentId)).toBe("error");
+  });
+
+  test("still errors a provisioning row whose owning job already settled", async () => {
+    const { organizationId, userId } = await seedOrgAndUser();
+    const agentId = await seedProvisioningAgent(organizationId, userId);
+    await dbWrite.insert(jobs).values({
+      organization_id: organizationId,
+      agent_id: agentId,
+      type: "agent_wake" as never,
+      status: "failed",
+      data: {},
+    });
+
+    const swept = await repo.markStuckProvisioningWithoutActiveJobAsError(SWEEP_CUTOFF);
+
+    expect(swept.map((row) => row.agentId)).toContain(agentId);
+    expect(await statusOf(agentId)).toBe("error");
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -13,6 +13,7 @@ import {
   configureElizaLifecycleTransaction,
   elizaProvisionAdvisoryLockSql,
 } from "../../lib/services/eliza-provision-lock";
+import { COLD_BOOT_JOB_TYPES_SQL_LIST } from "../../lib/services/provisioning-job-types";
 import { mergeWarmClaimEnvironmentVars } from "../../lib/services/warm-claim-character-push";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import { getObjectText, offloadJsonField } from "../../lib/storage/object-store";
@@ -357,7 +358,7 @@ export class AgentSandboxesRepository {
             SELECT 1 FROM ${jobs}
             WHERE  ${jobs.agent_id} = ${agentSandboxes.id}::text
             AND    ${jobs.organization_id} = ${agentSandboxes.organization_id}
-            AND    ${jobs.type} IN ('agent_provision', 'agent_restart')
+            AND    ${jobs.type} IN (${sql.raw(COLD_BOOT_JOB_TYPES_SQL_LIST)})
             AND    ${jobs.status} IN ('pending', 'in_progress')
           )`,
         ),
@@ -757,7 +758,7 @@ export class AgentSandboxesRepository {
             SELECT 1 FROM ${jobs}
             WHERE  ${jobs.agent_id} = ${agentSandboxes.id}::text
             AND    ${jobs.organization_id} = ${agentSandboxes.organization_id}
-            AND    ${jobs.type} IN ('agent_provision', 'agent_restart')
+            AND    ${jobs.type} IN (${sql.raw(COLD_BOOT_JOB_TYPES_SQL_LIST)})
             AND    ${jobs.status} IN ('pending', 'in_progress')
           )`,
         ),
@@ -1037,7 +1038,7 @@ export class AgentSandboxesRepository {
             SELECT 1 FROM ${jobs}
             WHERE  ${jobs.agent_id} = ${agentSandboxes.id}::text
             AND    ${jobs.organization_id} = ${agentSandboxes.organization_id}
-            AND    ${jobs.type} IN ('agent_provision', 'agent_restart')
+            AND    ${jobs.type} IN (${sql.raw(COLD_BOOT_JOB_TYPES_SQL_LIST)})
             AND    ${jobs.status} IN ('pending', 'in_progress')
           )`,
         ),

--- a/packages/cloud/shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-job-types.ts
@@ -197,3 +197,38 @@ export function resolveJobTypesForLanes(spec: string | undefined | null): Provis
   if (!matchedAnyLane) return all;
   return all.filter((t) => wanted.has(t));
 }
+
+/**
+ * Job types that legitimately hold `agent_sandboxes.status = 'provisioning'`
+ * while they run — every one of them reaches `provision()`, which sets that
+ * status and then does not touch the row again until the post-health-check
+ * flip. A cold boot here takes minutes (image pull + container create +
+ * tailnet health poll), which is why these carry the longer stale budget.
+ *
+ * This lives in the neutral constants module, NOT next to the daemon that
+ * schedules them, because the stuck-provisioning sweeper in the repository
+ * layer must exempt exactly this set. Two hand-maintained copies is precisely
+ * how #17215 happened: `agent_restart` was added to the sweeper's list when it
+ * started owning a provisioning row, and `agent_wake` / `agent_resume` — which
+ * do the same thing — were left behind, so a legitimate wake/resume was flipped
+ * to terminal `error` mid-flight.
+ */
+export const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_RESUME,
+  JOB_TYPES.AGENT_WAKE,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_UPGRADE,
+  JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+  JOB_TYPES.AGENT_DOWNGRADE,
+]);
+
+/**
+ * SQL literal list of {@link COLD_BOOT_JOB_TYPES}, for the repository
+ * predicates that must exempt in-flight cold boots. Derived from the same set
+ * so a new cold-boot type cannot reach the scheduler while staying invisible
+ * to the sweeper.
+ */
+export const COLD_BOOT_JOB_TYPES_SQL_LIST: string = [...COLD_BOOT_JOB_TYPES]
+  .map((type) => `'${type}'`)
+  .join(", ");

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -79,6 +79,7 @@ import {
   SNAPSHOT_ENDPOINT_UNSUPPORTED,
 } from "./eliza-sandbox";
 import {
+  COLD_BOOT_JOB_TYPES,
   EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES,
   JOB_TYPES,
   type ProvisioningJobType,
@@ -882,15 +883,6 @@ const COLD_BOOT_STALE_JOB_THRESHOLD_MS = 15 * 60 * 1000;
  * retry-pending row is not proof that execution is quiescent.
  */
 const DELETE_DETACHED_EXECUTION_QUIESCENCE_MS = COLD_BOOT_STALE_JOB_THRESHOLD_MS;
-const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
-  JOB_TYPES.AGENT_PROVISION,
-  JOB_TYPES.AGENT_RESUME,
-  JOB_TYPES.AGENT_WAKE,
-  JOB_TYPES.AGENT_RESTART,
-  JOB_TYPES.AGENT_UPGRADE,
-  JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
-  JOB_TYPES.AGENT_DOWNGRADE,
-]);
 /** Re-schedule delay for snapshot jobs claimed while the lane gate is off
  *  (#16639) — long enough not to spin, short enough to drain promptly once
  *  operators enable the lane. */


### PR DESCRIPTION
# Relates to

Closes #17215. Refs #17162 (the incident this explains 19 of).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, branched from current head, zero conflicts.
- [x] Typecheck + the changed suites run; results below.
- [x] A reviewer can confirm the change works from the evidence attached below.

# Risks

Low, and the direction is toward *not* destroying things: the sweeper does strictly less, and only for rows whose job is provably still in flight. Its actual purpose is unchanged and test-pinned — a row with no owning job, or whose job already settled, is still errored.

# Background

## What does this PR do?

`markStuckProvisioningWithoutActiveJobAsError` exempted only `agent_provision` and `agent_restart`. But `agent_wake` and `agent_resume` also reach `provision()`, which parks the row in `provisioning` and then doesn't touch it again until the post-health-check flip (the heartbeat cycle only walks RUNNING agents, so nothing refreshes `updated_at` during a boot).

Both are declared **cold boot with a 15-minute budget**, while the sweeper cutoff was **10 minutes** and fires every 5. So the window `10 < elapsed < 15` — a perfectly legitimate cold boot paying an image pull, a container create and a tailnet health poll — was flipped to terminal `error` **mid-flight**. `error` is in `TERMINAL_SANDBOX_STATUSES`, and the orphan reconciler reaps a terminal-status container with **no age grace**, so the container the job had just created was removed out from under it.

**This already happened.** The string this predicate writes — `Agent was stuck in provisioning state with no active provisioning job` — is carried by **19 of the 44 agents stranded on 2026-07-13** (#17162), across 42 orgs, 37 of which had no other running agent.

**The drift is the bug.** `agent_restart` was added to this list precisely because a warm-claim restart legitimately owns a provisioning row — the fix was right, it just stopped two types short. A second hand-maintained list would reproduce it. So:

- `COLD_BOOT_JOB_TYPES` moves to the neutral `provisioning-job-types` module. No import cycle: the repository cannot import the service (the service already imports the repository), but both can import the constants module, which has zero imports of its own.
- The daemon keeps consuming the same set, and all **three** copies of the predicate (`:360`, `:760`, `:1040`) now derive their SQL list from it. A new cold-boot type can no longer reach the scheduler while staying invisible to the sweeper.
- Threshold raised 10 → 20 min as a belt for the case the type exemption can't cover: a row whose job row is missing entirely. A sweeper shorter than the longest cold-boot budget it observes is racing a boot that is still running.

## What kind of change is this?

Bug fix (production data loss: agents destroyed mid-boot).

# Testing

## Where should a reviewer start?

`agent-sandboxes-stuck-provisioning-repo.test.ts` — it drives the **real repository** against in-process PGlite with the **real schema** (same harness as `agent-sandboxes-fleet-candidate-repo.test.ts`), not a mock of the query.

**Red control, which is the part worth checking:** with the old predicate restored, exactly the `agent_wake` and `agent_resume` cases fail and the other four pass. The test targets this defect precisely rather than asserting the implementation back to itself.

## Detailed testing steps

None: automated. New suite **6/6**; `provisioning-jobs-lanes` **5/5** (no regression from moving the constant); `tsgo --noEmit` clean on `packages/cloud/shared`; biome clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - repository predicate + cron threshold; no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - repository predicate + cron threshold; no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; behavior pinned by the real-schema PGlite suite.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `Live prod evidence is in #17162 - 19 of 44 stranded agents carry the exact error string this predicate writes. The deterministic reproduction is the red control in the changed suite.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `The artifact is agent_sandboxes.status staying 'provisioning' for an in-flight cold boot instead of flipping to terminal 'error' - asserted directly against the real table in the changed suite.`

## Known gaps / failures

- **Recovery of rows already stranded by this path is not in scope** and stays with #17162 (37 sole-agent orgs). Worth landing this first, though: without it, the same sweeper can strand a wake/resume *during* the recovery.
- The 20-minute threshold is a static margin over today's 15-minute cold-boot budget. If that budget ever grows, the two need to move together — the type exemption is the real guard, this is the belt.

[stan-cloud]
