### PR TITLE
fix(core): distinguish document list query misses

### DIFF
--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -46,7 +46,7 @@ function makeMessage(text: string): Memory {
 
 function makeService() {
 	return {
-		listDocuments: vi.fn(async () => []),
+		listDocuments: vi.fn(async (): Promise<Memory[]> => []),
 		searchDocuments: vi.fn(async () => []),
 		getDocumentById: vi.fn(async () => null),
 		addDocument: vi.fn(async () => ({
@@ -166,6 +166,58 @@ describe("documentAction.handler structured routing", () => {
 			expect(service[method]).toHaveBeenCalledTimes(1);
 		},
 	);
+
+	it("distinguishes a query miss from an empty document store", async () => {
+		const service = makeService();
+		const document = {
+			id: DOC_ID,
+			content: { text: "Launch is Friday." },
+			metadata: { title: "Launch Notes" },
+		} as Memory;
+		service.listDocuments
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([document]);
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list all documents"),
+			undefined,
+			options({ action: "list", query: "list all", limit: 10, offset: 2 }),
+		);
+
+		expect(service.listDocuments).toHaveBeenCalledTimes(2);
+		expect(service.listDocuments.mock.calls[0]?.[1]).toMatchObject({
+			query: "list all",
+			limit: 10,
+			offset: 2,
+		});
+		expect(service.listDocuments.mock.calls[1]?.[1]).toMatchObject({
+			query: undefined,
+			limit: 10,
+			offset: 2,
+		});
+		expect(res?.text).toBe(
+			`No documents matched "list all". Showing available documents instead:\nAvailable documents:\n1. Launch Notes (${DOC_ID})`,
+		);
+		expect(res?.data?.documents).toEqual([document]);
+	});
+
+	it("keeps the empty-store message when query fallback also finds nothing", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list all documents"),
+			undefined,
+			options({ action: "list", query: "list all" }),
+		);
+
+		expect(service.listDocuments).toHaveBeenCalledTimes(2);
+		expect(res?.text).toBe("No documents are available.");
+		expect(res?.data?.documents).toEqual([]);
+	});
 
 	it("extracts a missing search query instead of stripping English prose in the handler", async () => {
 		const service = makeService();

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -802,7 +802,7 @@ async function handleList(
 			? Math.floor(params.offset)
 			: undefined;
 
-	const documents = await service.listDocuments(message, {
+	const listOptions = {
 		limit: getLimit(params.limit, 25),
 		offset,
 		query: params.query,
@@ -812,11 +812,25 @@ async function handleList(
 		timeRangeStart,
 		timeRangeEnd,
 		tags: Array.isArray(params.tags) ? params.tags : undefined,
-	});
-	const text =
-		documents.length === 0
-			? "No documents are available."
-			: `Available documents:\n${documents
+	};
+	let documents = await service.listDocuments(message, listOptions);
+	const query = params.query?.trim();
+	let unmatchedQuery: string | undefined;
+
+	if (documents.length === 0 && query) {
+		const unfilteredDocuments = await service.listDocuments(message, {
+			...listOptions,
+			query: undefined,
+		});
+		if (unfilteredDocuments.length > 0) {
+			documents = unfilteredDocuments;
+			unmatchedQuery = query;
+		}
+	}
+
+	const availableDocumentsText =
+		documents.length > 0
+			? `Available documents:\n${documents
 					.map((document, index) => {
 						const metadata = document.metadata as
 							| Record<string, unknown>
@@ -829,7 +843,11 @@ async function handleList(
 									: `Document ${index + 1}`;
 						return `${index + 1}. ${title} (${document.id})`;
 					})
-					.join("\n")}`;
+					.join("\n")}`
+			: "No documents are available.";
+	const text = unmatchedQuery
+		? `No documents matched ${JSON.stringify(unmatchedQuery)}. Showing available documents instead:\n${availableDocumentsText}`
+		: availableDocumentsText;
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "list", {
 		values: { documents },


### PR DESCRIPTION
# Relates to

Closes #17138

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; exact unrelated blockers are recorded below.
- [x] A reviewer can confirm the behavior from the focused regression tests and command results below.

# Sync with develop

- [x] Rebased onto `develop` at `5188ead008`; zero conflicts.
- [x] Focused checks pass post-sync; repo-wide blockers are documented in **Known gaps / failures**.

# Risks

Low. The change adds one read-only fallback list call only when a non-empty query returns no documents. Other list filters and pagination are preserved. Successful query results and unfiltered list behavior are unchanged.

# Background

## What does this PR do?

When `DOCUMENT list` receives a query that matches no documents, it retries the same list request without only the query filter. If documents exist, the response now says the query had no matches and shows the available documents. If the fallback is also empty, it retains the true empty-store message.

The action result data mirrors the documents shown to the user.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required; this corrects existing action result semantics.

# Testing

## Where should a reviewer start?

- `packages/core/src/features/documents/actions.ts`, `handleList`
- `packages/core/src/features/documents/__tests__/actions-routing.test.ts`

## Detailed testing steps

```bash
bun run --cwd packages/core test -- src/features/documents/__tests__/actions-routing.test.ts
bun x @biomejs/biome check packages/core/src/features/documents/actions.ts packages/core/src/features/documents/__tests__/actions-routing.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/core build:node
bun run --cwd packages/core build
```

Results:
- Focused Vitest: 1 file passed, 14/14 tests passed.
- Biome: 2 files checked, no fixes required.
- Core typecheck: passed.
- Node-only build: passed.
- Node/browser/edge/testing build: passed.
- Full core run: 435/437 files and 4205 tests passed; two unrelated failures are detailed below.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only action result change; no UI surface or rendered source file changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only action result change; no UI surface or rendered source file changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the deterministic handler branch is covered directly by focused Vitest output above; no deployed backend is required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, network, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, provider, or inference behavior changed; the fix runs after structured parameters and service results are already resolved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the fallback is read-only and creates no DB rows, memories, files, or other artifacts.

# Evidence Details

## Real LLM-call trajectory

N/A - this is deterministic post-service result handling and does not invoke or alter an LLM path.

## Backend + frontend logs

Focused test result:

```text
Test Files  1 passed (1)
Tests       14 passed (14)
```

Frontend logs: N/A - no frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- `bun install --frozen-lockfile` completed most workspace packages but hung in an unrelated dependency `node install.js`; the cached `--ignore-scripts` retry reported 10 unrelated mobile/Swagger package link failures. All dependencies required for the focused core checks were available.
- Full core tests: `435/437` files and `4205` tests passed. `scripts/provider-latency-report.test.ts` could not resolve `@elizaos/plugin-sql` because of the incomplete unrelated workspace install. `src/services/message.transcript-visibility.test.ts` reproducibly failed its existing `persistedAtCallback` timing assertion; neither failure imports or exercises the changed document-list handler.
- `bun run verify` passed the AGENTS/CLAUDE identity check, Biome version check, stale-JS self-tests, and alias-read guard, then stopped in the unrelated `@elizaos/import-conversations#lint:check`: its tracked `conversations.json` fixture is not formatted according to the current Biome configuration, and its POSIX `find` command reports `File not found - *.d.ts` on Windows.
