### PR TITLE
fix(core): distinguish document list outcomes

### DIFF
--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -111,8 +111,25 @@ jobs:
           if command -v docker >/dev/null 2>&1; then
             docker rm -f develop-live-postgres 2>/dev/null || true
             docker run -d --name develop-live-postgres \
-              -e POSTGRES_USER=eliza_test -e POSTGRES_PASSWORD=test123 -e POSTGRES_DB=eliza_test \
-              -p 127.0.0.1:5433:5432 postgres:17
+              -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=eliza_test \
+              --health-cmd "pg_isready -U postgres -d eliza_test" \
+              --health-interval 1s --health-timeout 5s --health-retries 30 \
+              -p 127.0.0.1:5433:5432 pgvector/pgvector:pg16
+            for attempt in {1..30}; do
+              if [ "$(docker inspect --format '{{.State.Health.Status}}' develop-live-postgres)" = "healthy" ]; then
+                break
+              fi
+              if [ "$attempt" -eq 30 ]; then
+                docker logs develop-live-postgres
+                exit 1
+              fi
+              sleep 1
+            done
+            docker exec develop-live-postgres psql -v ON_ERROR_STOP=1 \
+              -U postgres -d eliza_test \
+              -c "CREATE ROLE eliza_test LOGIN PASSWORD 'test123'" \
+              -c "GRANT ALL PRIVILEGES ON DATABASE eliza_test TO eliza_test" \
+              -c "GRANT USAGE, CREATE ON SCHEMA public TO eliza_test"
             echo "POSTGRES_URL=postgresql://eliza_test:test123@127.0.0.1:5433/eliza_test" >> "$GITHUB_ENV"
           else
             echo "docker unavailable; plugin-sql Postgres real suites will self-skip"

--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Verifies strict document-list capability negotiation and integrity checks
+ * without allowing legacy pagination behavior to fabricate exact results.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { DocumentListQueryParams, Memory, UUID } from "../types";
+import { MemoryType } from "../types";
+import {
+	queryDocumentsInMemory,
+	queryDocumentsWithCapability,
+} from "./document-list-query";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e7" as UUID;
+const REQUESTER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
+
+const params: DocumentListQueryParams = {
+	agentId: AGENT_ID,
+	requesterEntityId: REQUESTER_ID,
+	requesterRoomIds: [],
+	requesterRole: "RUNTIME",
+	limit: 25,
+	offset: 0,
+};
+
+function document(index: number): Memory {
+	const id =
+		`10000000-0000-0000-0000-${index.toString(16).padStart(12, "0")}` as UUID;
+	return {
+		id,
+		agentId: AGENT_ID,
+		entityId: REQUESTER_ID,
+		roomId: ROOM_ID,
+		createdAt: 1_000 + index,
+		content: { text: `Document ${index}` },
+		metadata: { type: MemoryType.DOCUMENT, timestamp: 1_000 + index },
+	};
+}
+
+describe("document-list capability contract", () => {
+	it("fails before reading a legacy adapter whose 50-row cap would truncate 125 rows", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		Object.defineProperty(adapter, "documentListQueryCapability", {
+			configurable: true,
+			value: undefined,
+		});
+		const corpus = Array.from({ length: 125 }, (_, index) => document(index));
+		const getMemories = vi
+			.spyOn(adapter, "getMemories")
+			.mockResolvedValue(corpus.slice(0, 50));
+
+		await expect(
+			queryDocumentsWithCapability(adapter, params),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
+		});
+		expect(getMemories).not.toHaveBeenCalled();
+	});
+
+	it("does not enter a scan that can change underneath a concurrent insert", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		Object.defineProperty(adapter, "documentListQueryCapability", {
+			configurable: true,
+			value: undefined,
+		});
+		let reads = 0;
+		const getMemories = vi
+			.spyOn(adapter, "getMemories")
+			.mockImplementation(async () => {
+				reads += 1;
+				return [document(reads)];
+			});
+
+		await expect(
+			queryDocumentsWithCapability(adapter, params),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
+		});
+		expect(getMemories).not.toHaveBeenCalled();
+		expect(reads).toBe(0);
+	});
+
+	it("rejects duplicate document IDs instead of counting duplicate rows", () => {
+		const duplicate = document(1);
+		expect(() =>
+			queryDocumentsInMemory([duplicate, { ...duplicate }], params),
+		).toThrow(
+			expect.objectContaining({
+				code: "DOCUMENT_LIST_DUPLICATE_MEMORY",
+			}),
+		);
+	});
+
+	it("rejects malformed cursors before invoking a native adapter", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const queryDocuments = vi.spyOn(adapter, "queryDocuments");
+
+		await expect(
+			queryDocumentsWithCapability(adapter, {
+				...params,
+				cursor: { createdAt: 1_000, id: "not-a-uuid" as UUID },
+			}),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_INVALID_PAGINATION",
+		});
+		expect(queryDocuments).not.toHaveBeenCalled();
+	});
+
+	it("rejects wrong capability versions even when a query method exists", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		Object.defineProperty(adapter, "documentListQueryCapability", {
+			configurable: true,
+			value: 2,
+		});
+		const queryDocuments = vi.spyOn(adapter, "queryDocuments");
+
+		await expect(
+			queryDocumentsWithCapability(adapter, params),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
+			context: expect.objectContaining({
+				expectedVersion: 1,
+				advertisedVersion: 2,
+			}),
+		});
+		expect(queryDocuments).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -1,0 +1,438 @@
+/**
+ * Shared document-list contract enforcement and in-memory execution for
+ * database adapters. Native adapters advertise the versioned capability;
+ * older adapters use a bounded compatibility scan that returns exact results
+ * or fails before an incomplete corpus can impersonate a complete one.
+ */
+import { ElizaError } from "../errors";
+import {
+	type DocumentListCursor,
+	type DocumentListQueryParams,
+	type DocumentListQueryResult,
+	type IDatabaseAdapter,
+	type Memory,
+	MemoryType,
+	type UUID,
+} from "../types";
+
+export const DOCUMENT_LIST_QUERY_CAPABILITY_VERSION = 1 as const;
+export const DOCUMENT_LIST_MAX_LIMIT = 100;
+export const DOCUMENT_LIST_MAX_OFFSET = 10_000;
+export const DOCUMENT_LIST_MAX_QUERY_LENGTH = 512;
+export const DOCUMENT_LIST_MAX_TAGS = 32;
+export const DOCUMENT_LIST_MAX_TAG_LENGTH = 128;
+export const DOCUMENT_LIST_MAX_REQUESTER_ROOMS = 1_000;
+export const DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT = 10_000;
+
+export interface DocumentListQueryCapableAdapter {
+	readonly documentListQueryCapability: typeof DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
+	queryDocuments(
+		params: DocumentListQueryParams,
+	): Promise<DocumentListQueryResult>;
+}
+
+const DOCUMENT_LIST_ROLES = new Set([
+	"OWNER",
+	"ADMIN",
+	"USER",
+	"AGENT",
+	"RUNTIME",
+]);
+const DOCUMENT_LIST_SCOPES = new Set([
+	"global",
+	"owner-private",
+	"user-private",
+	"agent-private",
+]);
+const UUID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function invalidPagination(
+	message: string,
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, {
+		code: "DOCUMENT_LIST_INVALID_PAGINATION",
+		context,
+	});
+}
+
+function isUuid(value: unknown): value is UUID {
+	return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function documentCreatedAt(memory: Memory): number {
+	const createdAt = memory.createdAt ?? 0;
+	return Number.isFinite(createdAt) ? Math.trunc(createdAt) : 0;
+}
+
+function compareDocumentOrder(left: Memory, right: Memory): number {
+	const timeDifference = documentCreatedAt(right) - documentCreatedAt(left);
+	if (timeDifference !== 0) return timeDifference;
+	const leftId = left.id?.toLowerCase() ?? "";
+	const rightId = right.id?.toLowerCase() ?? "";
+	if (leftId === rightId) return 0;
+	return rightId < leftId ? -1 : 1;
+}
+
+function documentCursor(memory: Memory): DocumentListCursor {
+	if (!isUuid(memory.id)) {
+		throw new ElizaError("Stored document is missing a valid UUID", {
+			code: "DOCUMENT_LIST_INVALID_MEMORY",
+			context: { agentId: memory.agentId, documentId: memory.id },
+			severity: "fatal",
+		});
+	}
+	return { createdAt: documentCreatedAt(memory), id: memory.id };
+}
+
+function isAfterDocumentCursor(
+	memory: Memory,
+	cursor: DocumentListCursor,
+): boolean {
+	const createdAt = documentCreatedAt(memory);
+	if (createdAt !== cursor.createdAt) return createdAt < cursor.createdAt;
+	return (
+		typeof memory.id === "string" &&
+		memory.id.toLowerCase() < cursor.id.toLowerCase()
+	);
+}
+
+function isDocumentMemory(memory: Memory): boolean {
+	return memory.metadata?.type === MemoryType.DOCUMENT;
+}
+
+function isDocumentVisible(
+	memory: Memory,
+	params: DocumentListQueryParams,
+): boolean {
+	if (!params.requesterRoomIds.includes(memory.roomId)) return false;
+	if (
+		params.requesterRole === "OWNER" ||
+		params.requesterRole === "AGENT" ||
+		params.requesterRole === "RUNTIME"
+	) {
+		return true;
+	}
+
+	const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
+	const scope = typeof metadata.scope === "string" ? metadata.scope : "global";
+	if (scope === "global") return true;
+	if (scope !== "user-private") return false;
+
+	return (
+		metadata.scopedToEntityId === params.requesterEntityId ||
+		metadata.addedBy === params.requesterEntityId ||
+		memory.entityId === params.requesterEntityId
+	);
+}
+
+function matchesDocumentFilters(
+	memory: Memory,
+	params: DocumentListQueryParams,
+): boolean {
+	const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
+	if (params.scope && (metadata.scope ?? "global") !== params.scope) {
+		return false;
+	}
+	if (
+		params.scopedToEntityId &&
+		metadata.scopedToEntityId !== params.scopedToEntityId
+	) {
+		return false;
+	}
+	if (params.addedBy && metadata.addedBy !== params.addedBy) return false;
+
+	const timestamp =
+		typeof metadata.timestamp === "number"
+			? metadata.timestamp
+			: documentCreatedAt(memory);
+	if (
+		params.timeRangeStart !== undefined &&
+		timestamp < params.timeRangeStart
+	) {
+		return false;
+	}
+	if (params.timeRangeEnd !== undefined && timestamp > params.timeRangeEnd) {
+		return false;
+	}
+
+	if (params.tags?.length) {
+		const tags = Array.isArray(metadata.tags)
+			? metadata.tags.filter((tag): tag is string => typeof tag === "string")
+			: [];
+		if (!params.tags.every((tag) => tags.includes(tag))) return false;
+	}
+	return true;
+}
+
+function matchesDocumentQuery(memory: Memory, query: string): boolean {
+	const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
+	const haystack = [
+		memory.content.text,
+		metadata.title,
+		metadata.filename,
+		metadata.originalFilename,
+		metadata.source,
+	]
+		.filter((value): value is string => typeof value === "string")
+		.join("\n")
+		.toLowerCase();
+	return haystack.includes(query);
+}
+
+function paginateDocuments(
+	memories: Memory[],
+	params: DocumentListQueryParams,
+): {
+	documents: Memory[];
+	hasMore: boolean;
+	nextCursor?: DocumentListCursor;
+} {
+	const cursorFiltered = params.cursor
+		? memories.filter((memory) =>
+				isAfterDocumentCursor(memory, params.cursor as DocumentListCursor),
+			)
+		: memories;
+	const offset = params.cursor ? 0 : params.offset;
+	const page = cursorFiltered.slice(offset, offset + params.limit + 1);
+	const hasMore = page.length > params.limit;
+	const documents = page.slice(0, params.limit);
+	const last = documents.at(-1);
+	return {
+		documents,
+		hasMore,
+		...(hasMore && last ? { nextCursor: documentCursor(last) } : {}),
+	};
+}
+
+export function validateDocumentListQueryParams(
+	params: DocumentListQueryParams,
+): void {
+	if (!isUuid(params.agentId) || !isUuid(params.requesterEntityId)) {
+		invalidPagination("Document list requester identity is invalid", {
+			agentId: params.agentId,
+			requesterEntityId: params.requesterEntityId,
+		});
+	}
+	if (!DOCUMENT_LIST_ROLES.has(params.requesterRole)) {
+		invalidPagination("Document list requester role is invalid", {
+			requesterRole: params.requesterRole,
+		});
+	}
+	if (
+		!Array.isArray(params.requesterRoomIds) ||
+		params.requesterRoomIds.length > DOCUMENT_LIST_MAX_REQUESTER_ROOMS ||
+		params.requesterRoomIds.some((roomId) => !isUuid(roomId))
+	) {
+		invalidPagination("Document list requester rooms are invalid", {
+			roomCount: params.requesterRoomIds?.length,
+		});
+	}
+	if (
+		!Number.isSafeInteger(params.limit) ||
+		params.limit < 1 ||
+		params.limit > DOCUMENT_LIST_MAX_LIMIT
+	) {
+		invalidPagination(
+			`Document list limit must be an integer between 1 and ${DOCUMENT_LIST_MAX_LIMIT}`,
+			{ limit: params.limit },
+		);
+	}
+	if (
+		!Number.isSafeInteger(params.offset) ||
+		params.offset < 0 ||
+		params.offset > DOCUMENT_LIST_MAX_OFFSET
+	) {
+		invalidPagination(
+			`Document list offset must be an integer between 0 and ${DOCUMENT_LIST_MAX_OFFSET}`,
+			{ offset: params.offset },
+		);
+	}
+	if (
+		params.cursor &&
+		(!Number.isSafeInteger(params.cursor.createdAt) ||
+			!isUuid(params.cursor.id))
+	) {
+		invalidPagination("Document list cursor is invalid", {
+			cursor: params.cursor,
+		});
+	}
+	if (params.cursor && params.offset !== 0) {
+		invalidPagination(
+			"Document list cursor cannot be combined with a non-zero offset",
+			{ offset: params.offset },
+		);
+	}
+	if ((params.query?.length ?? 0) > DOCUMENT_LIST_MAX_QUERY_LENGTH) {
+		invalidPagination(
+			`Document list query cannot exceed ${DOCUMENT_LIST_MAX_QUERY_LENGTH} characters`,
+			{ queryLength: params.query?.length },
+		);
+	}
+	if (params.scope !== undefined && !DOCUMENT_LIST_SCOPES.has(params.scope)) {
+		invalidPagination("Document list scope is invalid", {
+			scope: params.scope,
+		});
+	}
+	if (
+		params.scopedToEntityId !== undefined &&
+		!isUuid(params.scopedToEntityId)
+	) {
+		invalidPagination("Document list scoped entity is invalid", {
+			scopedToEntityId: params.scopedToEntityId,
+		});
+	}
+	if (params.addedBy !== undefined && !isUuid(params.addedBy)) {
+		invalidPagination("Document list addedBy entity is invalid", {
+			addedBy: params.addedBy,
+		});
+	}
+	for (const [name, value] of [
+		["timeRangeStart", params.timeRangeStart],
+		["timeRangeEnd", params.timeRangeEnd],
+	] as const) {
+		if (value !== undefined && !Number.isSafeInteger(value)) {
+			invalidPagination(`Document list ${name} must be a safe integer`, {
+				[name]: value,
+			});
+		}
+	}
+	if (
+		params.timeRangeStart !== undefined &&
+		params.timeRangeEnd !== undefined &&
+		params.timeRangeStart > params.timeRangeEnd
+	) {
+		invalidPagination("Document list time range is inverted", {
+			timeRangeStart: params.timeRangeStart,
+			timeRangeEnd: params.timeRangeEnd,
+		});
+	}
+	if (
+		(params.tags?.length ?? 0) > DOCUMENT_LIST_MAX_TAGS ||
+		params.tags?.some(
+			(tag) =>
+				typeof tag !== "string" ||
+				tag.length === 0 ||
+				tag.length > DOCUMENT_LIST_MAX_TAG_LENGTH,
+		)
+	) {
+		invalidPagination("Document list tags exceed the supported bounds", {
+			tagCount: params.tags?.length,
+		});
+	}
+}
+
+export function queryDocumentsInMemory(
+	memories: Memory[],
+	params: DocumentListQueryParams,
+): DocumentListQueryResult {
+	validateDocumentListQueryParams(params);
+	const visibleDocuments = memories
+		.filter(
+			(memory) =>
+				memory.agentId === params.agentId &&
+				isDocumentMemory(memory) &&
+				isDocumentVisible(memory, params),
+		)
+		.sort(compareDocumentOrder);
+	const availableDocuments = visibleDocuments.filter((memory) =>
+		matchesDocumentFilters(memory, params),
+	);
+	const normalizedQuery = params.query?.trim().toLowerCase();
+	const matchedDocuments = normalizedQuery
+		? availableDocuments.filter((memory) =>
+				matchesDocumentQuery(memory, normalizedQuery),
+			)
+		: availableDocuments;
+	const matchedPage = paginateDocuments(matchedDocuments, params);
+	const availablePage =
+		normalizedQuery &&
+		matchedDocuments.length === 0 &&
+		availableDocuments.length > 0
+			? paginateDocuments(availableDocuments, params)
+			: { documents: [], hasMore: false };
+
+	return {
+		documents: matchedPage.documents,
+		availableDocuments: availablePage.documents,
+		totalVisible: visibleDocuments.length,
+		totalAvailable: availableDocuments.length,
+		totalMatched: matchedDocuments.length,
+		hasMore: matchedPage.hasMore,
+		availableHasMore: availablePage.hasMore,
+		...(matchedPage.nextCursor ? { nextCursor: matchedPage.nextCursor } : {}),
+		...(availablePage.nextCursor
+			? { availableNextCursor: availablePage.nextCursor }
+			: {}),
+	};
+}
+
+export function hasDocumentListQueryCapability(
+	adapter: IDatabaseAdapter,
+): adapter is IDatabaseAdapter & DocumentListQueryCapableAdapter {
+	const candidate = adapter as IDatabaseAdapter &
+		Partial<DocumentListQueryCapableAdapter>;
+	return (
+		candidate.documentListQueryCapability ===
+			DOCUMENT_LIST_QUERY_CAPABILITY_VERSION &&
+		typeof candidate.queryDocuments === "function"
+	);
+}
+
+async function queryDocumentsCompatibility(
+	adapter: IDatabaseAdapter,
+	params: DocumentListQueryParams,
+): Promise<DocumentListQueryResult> {
+	const memories: Memory[] = [];
+	const batchSize = DOCUMENT_LIST_MAX_LIMIT;
+	for (
+		let offset = 0;
+		offset < DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT;
+		offset += batchSize
+	) {
+		const page = await adapter.getMemories({
+			tableName: "documents",
+			agentId: params.agentId,
+			limit: batchSize,
+			offset,
+			includeEmbedding: false,
+		});
+		memories.push(...page);
+		if (page.length < batchSize) {
+			return queryDocumentsInMemory(memories, params);
+		}
+	}
+
+	const overflow = await adapter.getMemories({
+		tableName: "documents",
+		agentId: params.agentId,
+		limit: 1,
+		offset: DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT,
+		includeEmbedding: false,
+	});
+	if (overflow.length > 0) {
+		throw new ElizaError(
+			"Database adapter must implement native document listing for this corpus",
+			{
+				code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
+				context: {
+					adapter: adapter.constructor.name,
+					scanLimit: DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT,
+				},
+				severity: "fatal",
+			},
+		);
+	}
+	return queryDocumentsInMemory(memories, params);
+}
+
+export async function queryDocumentsWithCompatibility(
+	adapter: IDatabaseAdapter,
+	params: DocumentListQueryParams,
+): Promise<DocumentListQueryResult> {
+	validateDocumentListQueryParams(params);
+	return hasDocumentListQueryCapability(adapter)
+		? adapter.queryDocuments(params)
+		: queryDocumentsCompatibility(adapter, params);
+}

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -1,8 +1,8 @@
 /**
  * Shared document-list contract enforcement and in-memory execution for
  * database adapters. Native adapters advertise the versioned capability;
- * older adapters use a bounded compatibility scan that returns exact results
- * or fails before an incomplete corpus can impersonate a complete one.
+ * adapters without that exact contract fail before reading because pagination
+ * APIs cannot prove complete, duplicate-free, snapshot-coherent results.
  */
 import { ElizaError } from "../errors";
 import {
@@ -22,7 +22,6 @@ export const DOCUMENT_LIST_MAX_QUERY_LENGTH = 512;
 export const DOCUMENT_LIST_MAX_TAGS = 32;
 export const DOCUMENT_LIST_MAX_TAG_LENGTH = 128;
 export const DOCUMENT_LIST_MAX_REQUESTER_ROOMS = 1_000;
-export const DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT = 10_000;
 
 export interface DocumentListQueryCapableAdapter {
 	readonly documentListQueryCapability: typeof DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
@@ -62,8 +61,21 @@ function isUuid(value: unknown): value is UUID {
 }
 
 function documentCreatedAt(memory: Memory): number {
-	const createdAt = memory.createdAt ?? 0;
-	return Number.isFinite(createdAt) ? Math.trunc(createdAt) : 0;
+	if (
+		typeof memory.createdAt !== "number" ||
+		!Number.isSafeInteger(memory.createdAt)
+	) {
+		throw new ElizaError("Stored document is missing a valid creation time", {
+			code: "DOCUMENT_LIST_INVALID_MEMORY",
+			context: {
+				agentId: memory.agentId,
+				documentId: memory.id,
+				createdAt: memory.createdAt,
+			},
+			severity: "fatal",
+		});
+	}
+	return memory.createdAt;
 }
 
 function compareDocumentOrder(left: Memory, right: Memory): number {
@@ -102,18 +114,20 @@ function isDocumentMemory(memory: Memory): boolean {
 	return memory.metadata?.type === MemoryType.DOCUMENT;
 }
 
+export function documentRoleHasGlobalVisibility(
+	role: DocumentListQueryParams["requesterRole"],
+): boolean {
+	return role === "OWNER" || role === "AGENT" || role === "RUNTIME";
+}
+
 function isDocumentVisible(
 	memory: Memory,
 	params: DocumentListQueryParams,
 ): boolean {
-	if (!params.requesterRoomIds.includes(memory.roomId)) return false;
-	if (
-		params.requesterRole === "OWNER" ||
-		params.requesterRole === "AGENT" ||
-		params.requesterRole === "RUNTIME"
-	) {
+	if (documentRoleHasGlobalVisibility(params.requesterRole)) {
 		return true;
 	}
+	if (!params.requesterRoomIds.includes(memory.roomId)) return false;
 
 	const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
 	const scope = typeof metadata.scope === "string" ? metadata.scope : "global";
@@ -166,19 +180,51 @@ function matchesDocumentFilters(
 	return true;
 }
 
+function documentSearchLexemes(value: string): string[] {
+	return value.toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
 function matchesDocumentQuery(memory: Memory, query: string): boolean {
 	const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
-	const haystack = [
-		memory.content.text,
-		metadata.title,
-		metadata.filename,
-		metadata.originalFilename,
-		metadata.source,
-	]
-		.filter((value): value is string => typeof value === "string")
-		.join("\n")
-		.toLowerCase();
-	return haystack.includes(query);
+	const haystack = new Set(
+		documentSearchLexemes(
+			[
+				memory.content.text,
+				metadata.title,
+				metadata.filename,
+				metadata.originalFilename,
+				metadata.source,
+			]
+				.filter((value): value is string => typeof value === "string")
+				.join("\n"),
+		),
+	);
+	const queryLexemes = documentSearchLexemes(query);
+	return (
+		queryLexemes.length > 0 &&
+		queryLexemes.every((lexeme) => haystack.has(lexeme))
+	);
+}
+
+function assertUniqueDocumentIds(memories: Memory[]): void {
+	const ids = new Set<UUID>();
+	for (const memory of memories) {
+		if (!isUuid(memory.id)) {
+			throw new ElizaError("Stored document is missing a valid UUID", {
+				code: "DOCUMENT_LIST_INVALID_MEMORY",
+				context: { agentId: memory.agentId, documentId: memory.id },
+				severity: "fatal",
+			});
+		}
+		if (ids.has(memory.id)) {
+			throw new ElizaError("Document list adapter returned a duplicate UUID", {
+				code: "DOCUMENT_LIST_DUPLICATE_MEMORY",
+				context: { agentId: memory.agentId, documentId: memory.id },
+				severity: "fatal",
+			});
+		}
+		ids.add(memory.id);
+	}
 }
 
 function paginateDocuments(
@@ -328,6 +374,7 @@ export function queryDocumentsInMemory(
 	params: DocumentListQueryParams,
 ): DocumentListQueryResult {
 	validateDocumentListQueryParams(params);
+	assertUniqueDocumentIds(memories);
 	const visibleDocuments = memories
 		.filter(
 			(memory) =>
@@ -371,68 +418,37 @@ export function queryDocumentsInMemory(
 export function hasDocumentListQueryCapability(
 	adapter: IDatabaseAdapter,
 ): adapter is IDatabaseAdapter & DocumentListQueryCapableAdapter {
-	const candidate = adapter as IDatabaseAdapter &
-		Partial<DocumentListQueryCapableAdapter>;
 	return (
-		candidate.documentListQueryCapability ===
+		adapter.documentListQueryCapability ===
 			DOCUMENT_LIST_QUERY_CAPABILITY_VERSION &&
-		typeof candidate.queryDocuments === "function"
+		typeof adapter.queryDocuments === "function"
 	);
 }
 
-async function queryDocumentsCompatibility(
+function requireDocumentListQueryCapability(
 	adapter: IDatabaseAdapter,
-	params: DocumentListQueryParams,
-): Promise<DocumentListQueryResult> {
-	const memories: Memory[] = [];
-	const batchSize = DOCUMENT_LIST_MAX_LIMIT;
-	for (
-		let offset = 0;
-		offset < DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT;
-		offset += batchSize
-	) {
-		const page = await adapter.getMemories({
-			tableName: "documents",
-			agentId: params.agentId,
-			limit: batchSize,
-			offset,
-			includeEmbedding: false,
-		});
-		memories.push(...page);
-		if (page.length < batchSize) {
-			return queryDocumentsInMemory(memories, params);
-		}
-	}
-
-	const overflow = await adapter.getMemories({
-		tableName: "documents",
-		agentId: params.agentId,
-		limit: 1,
-		offset: DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT,
-		includeEmbedding: false,
-	});
-	if (overflow.length > 0) {
-		throw new ElizaError(
-			"Database adapter must implement native document listing for this corpus",
-			{
-				code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
-				context: {
-					adapter: adapter.constructor.name,
-					scanLimit: DOCUMENT_LIST_COMPATIBILITY_SCAN_LIMIT,
-				},
-				severity: "fatal",
+): asserts adapter is IDatabaseAdapter & DocumentListQueryCapableAdapter {
+	if (hasDocumentListQueryCapability(adapter)) return;
+	throw new ElizaError(
+		"Database adapter must implement the exact document-list query capability",
+		{
+			code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
+			context: {
+				adapter: adapter.constructor.name,
+				expectedVersion: DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+				advertisedVersion: adapter.documentListQueryCapability,
+				hasQueryMethod: typeof adapter.queryDocuments === "function",
 			},
-		);
-	}
-	return queryDocumentsInMemory(memories, params);
+			severity: "fatal",
+		},
+	);
 }
 
-export async function queryDocumentsWithCompatibility(
+export async function queryDocumentsWithCapability(
 	adapter: IDatabaseAdapter,
 	params: DocumentListQueryParams,
 ): Promise<DocumentListQueryResult> {
 	validateDocumentListQueryParams(params);
-	return hasDocumentListQueryCapability(adapter)
-		? adapter.queryDocuments(params)
-		: queryDocumentsCompatibility(adapter, params);
+	requireDocumentListQueryCapability(adapter);
+	return adapter.queryDocuments(params);
 }

--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -11,6 +11,7 @@ import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
 const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
 const roomId = "20000000-0000-0000-0000-000000000001" as UUID;
 const entityId = "10000000-0000-0000-0000-000000000001" as UUID;
+const otherEntityId = "10000000-0000-0000-0000-000000000002" as UUID;
 
 function msg(text: string, createdAt: number, id?: string): Memory {
 	return {
@@ -33,6 +34,24 @@ async function seed(messages: Memory[]): Promise<InMemoryDatabaseAdapter> {
 }
 
 describe("InMemoryDatabaseAdapter — textContains", () => {
+	it("treats entityId as requester context rather than a memory row predicate", async () => {
+		const adapter = await seed([
+			msg("requester-authored", 1),
+			{ ...msg("other-authored", 2), entityId: otherEntityId },
+		]);
+
+		const rows = await adapter.getMemories({
+			entityId,
+			agentId,
+			tableName: "messages",
+		});
+
+		expect(rows.map((memory) => memory.content.text)).toEqual([
+			"other-authored",
+			"requester-authored",
+		]);
+	});
+
 	it("filters to messages whose text contains the keyword (case-insensitive)", async () => {
 		const adapter = await seed([
 			msg("Let's ship the WebXR runtime today", 1),

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -29,6 +29,8 @@ import type {
 	CreateOAuthFlowStateParams,
 	DeleteConnectorAccountParams,
 	DeleteOAuthFlowStateParams,
+	DocumentListQueryParams,
+	DocumentListQueryResult,
 	EntitiesForRoomsResult,
 	Entity,
 	GetConnectorAccountCredentialRefParams,
@@ -66,6 +68,10 @@ import type {
 } from "../types";
 import { DEFAULT_UUID } from "../types/primitives";
 import { isPlainObject } from "../utils/type-guards";
+import {
+	DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+	queryDocumentsInMemory,
+} from "./document-list-query";
 
 function asUuid(id: string): UUID {
 	return id as UUID;
@@ -251,6 +257,7 @@ function dataContainsFilter(
 export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	Record<string, never>
 > {
+	readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
 	db: Record<string, never> = {};
 
 	private ready = false;
@@ -806,6 +813,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		// Components are already stored as whole records; patch operations are not modeled here.
 	}
 
+	async queryDocuments(
+		params: DocumentListQueryParams,
+	): Promise<DocumentListQueryResult> {
+		const documents = Array.from(this.memoriesByRoom.entries())
+			.filter(([key]) => key.startsWith("documents:"))
+			.flatMap(([, memories]) => memories);
+		return queryDocumentsInMemory(documents, params);
+	}
+
 	async getMemories(params: {
 		entityId?: UUID;
 		agentId?: UUID;
@@ -826,12 +842,23 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		accessContext?: AccessContext;
 	}): Promise<Memory[]> {
 		const effectiveLimit = params.limit ?? params.count ?? Infinity;
-		const roomId = params.roomId ?? DEFAULT_UUID;
 		const tableName = params.tableName;
-		let all = this.memoriesByRoom.get(roomTableKey(tableName, roomId)) ?? [];
+		let all =
+			params.roomId !== undefined
+				? (this.memoriesByRoom.get(roomTableKey(tableName, params.roomId)) ??
+					[])
+				: Array.from(this.memoriesByRoom.entries())
+						.filter(([key]) => key.startsWith(`${tableName}:`))
+						.flatMap(([, memories]) => memories);
 
 		if (params.worldId) {
 			all = all.filter((memory) => memory.worldId === params.worldId);
+		}
+		if (params.agentId) {
+			all = all.filter((memory) => memory.agentId === params.agentId);
+		}
+		if (params.unique) {
+			all = all.filter((memory) => memory.unique);
 		}
 
 		// Filter by timestamp range (start/end are timestamps in milliseconds)

--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -15,7 +15,7 @@ import type {
 	UUID,
 } from "../../../types";
 import { documentAction } from "../actions";
-import { DocumentService } from "../service";
+import { type DocumentListResult, DocumentService } from "../service";
 
 // ── Structured-routing tests ───────────────────────────────────────────────
 //
@@ -33,6 +33,25 @@ const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
 const DOC_ID = "11111111-2222-3333-4444-555555555555" as UUID;
 
+function listResult(
+	overrides: Partial<DocumentListResult> = {},
+): DocumentListResult {
+	return {
+		status: "empty_store",
+		documents: [],
+		availableDocuments: [],
+		limit: 25,
+		offset: 0,
+		totalVisible: 0,
+		totalAvailable: 0,
+		totalMatched: 0,
+		hasMore: false,
+		availableOffset: 0,
+		availableHasMore: false,
+		...overrides,
+	};
+}
+
 function makeMessage(text: string): Memory {
 	return {
 		id: "00000000-0000-0000-0000-0000000000aa" as UUID,
@@ -46,7 +65,7 @@ function makeMessage(text: string): Memory {
 
 function makeService() {
 	return {
-		listDocuments: vi.fn(async () => []),
+		listDocumentsDetailed: vi.fn(async () => listResult()),
 		searchDocuments: vi.fn(async () => []),
 		getDocumentById: vi.fn(async () => null),
 		addDocument: vi.fn(async () => ({
@@ -85,6 +104,8 @@ function makeRuntime(service: ReturnType<typeof makeService>): {
 			return found;
 		}),
 		getSetting: vi.fn(() => undefined),
+		getRoom: vi.fn(async () => null),
+		reportError: vi.fn(),
 		useModel,
 	} as unknown as IAgentRuntime;
 	return { runtime, useModel };
@@ -139,7 +160,7 @@ describe("documentAction.handler structured routing", () => {
 			options({ action: "list" }),
 		);
 		expect(useModel).not.toHaveBeenCalled();
-		expect(service.listDocuments).toHaveBeenCalledTimes(1);
+		expect(service.listDocumentsDetailed).toHaveBeenCalledTimes(1);
 		expect(service.deleteDocument).not.toHaveBeenCalled();
 		expect(res?.data).toMatchObject({
 			actionName: "DOCUMENT",
@@ -149,7 +170,7 @@ describe("documentAction.handler structured routing", () => {
 
 	it.each([
 		["search", "searchDocuments"],
-		["list", "listDocuments"],
+		["list", "listDocumentsDetailed"],
 	] as const)(
 		"routes the %s subaction to the matching service call",
 		async (action, method) => {
@@ -166,6 +187,134 @@ describe("documentAction.handler structured routing", () => {
 			expect(service[method]).toHaveBeenCalledTimes(1);
 		},
 	);
+
+	it("keeps query-miss fallback documents separate from matched documents", async () => {
+		const service = makeService();
+		const document = {
+			id: DOC_ID,
+			content: { text: "Launch is Friday." },
+			metadata: { title: "Launch Notes" },
+		} as Memory;
+		service.listDocumentsDetailed.mockResolvedValueOnce(
+			listResult({
+				status: "query_miss",
+				query: "list all",
+				availableDocuments: [document],
+				totalVisible: 1,
+				totalAvailable: 1,
+			}),
+		);
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list all documents"),
+			undefined,
+			options({ action: "list", query: "list all" }),
+		);
+
+		expect(res?.text).toBe(
+			`No documents matched "list all". Showing available documents instead:\nAvailable documents:\n1. Launch Notes (${DOC_ID})`,
+		);
+		expect(res?.data).toMatchObject({
+			status: "query_miss",
+			query: "list all",
+			documents: [],
+			availableDocuments: [document],
+			totalMatched: 0,
+			availableOffset: 0,
+			availableHasMore: false,
+		});
+	});
+
+	it("reports fallback pagination independently from query matches", async () => {
+		const service = makeService();
+		const document = {
+			id: DOC_ID,
+			content: { text: "Launch is Friday." },
+			metadata: { title: "Launch Notes" },
+		} as Memory;
+		service.listDocumentsDetailed.mockResolvedValueOnce(
+			listResult({
+				status: "query_miss",
+				query: "missing",
+				offset: 5,
+				availableOffset: 5,
+				availableDocuments: [document],
+				totalVisible: 10,
+				totalAvailable: 10,
+				availableHasMore: true,
+			}),
+		);
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list missing documents"),
+			undefined,
+			options({ action: "list", query: "missing", offset: 5 }),
+		);
+
+		expect(res?.text).toContain("available documents from offset 5");
+		expect(res?.data).toMatchObject({
+			hasMore: false,
+			availableOffset: 5,
+			availableHasMore: true,
+		});
+	});
+
+	it("reports an exhausted page without calling the store empty", async () => {
+		const service = makeService();
+		service.listDocumentsDetailed.mockResolvedValueOnce(
+			listResult({
+				status: "page_exhausted",
+				query: "launch",
+				offset: 2,
+				totalVisible: 2,
+				totalAvailable: 2,
+				totalMatched: 2,
+			}),
+		);
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list launch documents"),
+			undefined,
+			options({ action: "list", query: "launch", offset: 2 }),
+		);
+
+		expect(res?.text).toBe(
+			'Offset 2 is past the 2 documents matching "launch".',
+		);
+		expect(res?.data).toMatchObject({
+			status: "page_exhausted",
+			documents: [],
+			availableDocuments: [],
+			offset: 2,
+			totalMatched: 2,
+		});
+	});
+
+	it("uses empty-store semantics only when no visible documents exist", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list all documents"),
+			undefined,
+			options({ action: "list" }),
+		);
+
+		expect(res?.text).toBe("No documents are available.");
+		expect(res?.data).toMatchObject({
+			status: "empty_store",
+			totalVisible: 0,
+			documents: [],
+			availableDocuments: [],
+		});
+	});
 
 	it("extracts a missing search query instead of stripping English prose in the handler", async () => {
 		const service = makeService();

--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -105,6 +105,9 @@ function makeRuntime(service: ReturnType<typeof makeService>): {
 		}),
 		getSetting: vi.fn(() => undefined),
 		getRoom: vi.fn(async () => null),
+		getRoomsForParticipants: vi.fn(async () => {
+			throw new Error("room lookup is unavailable");
+		}),
 		reportError: vi.fn(),
 		useModel,
 	} as unknown as IAgentRuntime;
@@ -369,7 +372,9 @@ describe("documentAction.handler structured routing", () => {
 		expect(service.addDocument).toHaveBeenCalledTimes(1);
 		expect(service.addDocument.mock.calls[0]?.[0]).toMatchObject({
 			content: "Launch is Friday.",
+			addedByRole: "USER",
 		});
+		expect(runtime.getRoomsForParticipants).not.toHaveBeenCalled();
 		expect(res?.data).toMatchObject({ subaction: "write" });
 	});
 

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -147,6 +147,20 @@ function buildRuntime(opts: { hasEmbedding: boolean; fragments?: Memory[] }) {
 		}),
 		searchMemories: vi.fn(async (_params: unknown) => fragments),
 		getMemories: vi.fn(async (_params: unknown) => fragments),
+		getRoom: vi.fn(async () => ({
+			id: "room-1" as UUID,
+			agentId,
+			worldId: "world-1" as UUID,
+		})),
+		getWorld: vi.fn(async () => ({
+			id: "world-1" as UUID,
+			agentId,
+			metadata: {
+				roles: { "user-1": "USER", "user-2": "USER" },
+				roleSources: { "user-1": "manual", "user-2": "manual" },
+			},
+		})),
+		reportError: vi.fn(),
 	};
 }
 

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -34,7 +34,7 @@ import { addDocumentFromFilePath } from "./docs-loader.ts";
 import {
 	type DocumentListResult,
 	DocumentService,
-	resolveDocumentRequester,
+	resolveDocumentRequesterRole,
 	type SearchMode,
 } from "./service.ts";
 import type {
@@ -289,7 +289,7 @@ async function getAddedByRole(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): Promise<DocumentAddedByRole> {
-	return (await resolveDocumentRequester(runtime, message)).role;
+	return (await resolveDocumentRequesterRole(runtime, message)).role;
 }
 
 async function ensureWriteAccess(

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -16,7 +16,7 @@ import {
 	type SubactionsMap,
 } from "../../actions/resolve-action-args";
 import { logger } from "../../logger";
-import { checkSenderRole, hasRoleAccess, isAgentSelf } from "../../roles";
+import { hasRoleAccess, isAgentSelf } from "../../roles";
 import type {
 	Action,
 	ActionExample,
@@ -31,7 +31,12 @@ import type {
 	UUID,
 } from "../../types";
 import { addDocumentFromFilePath } from "./docs-loader.ts";
-import { DocumentService, type SearchMode } from "./service.ts";
+import {
+	type DocumentListResult,
+	DocumentService,
+	resolveDocumentRequester,
+	type SearchMode,
+} from "./service.ts";
 import type {
 	DocumentAddedByRole,
 	DocumentAddedFrom,
@@ -284,12 +289,7 @@ async function getAddedByRole(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): Promise<DocumentAddedByRole> {
-	if (!message.entityId) return "RUNTIME";
-	if (message.entityId === runtime.agentId) return "AGENT";
-	const role = await checkSenderRole(runtime, message).catch(() => null);
-	// The comparison narrows role.role to the returned union subset (OWNER|ADMIN).
-	if (role?.role === "OWNER" || role?.role === "ADMIN") return role.role;
-	return "USER";
+	return (await resolveDocumentRequester(runtime, message)).role;
 }
 
 async function ensureWriteAccess(
@@ -775,6 +775,43 @@ function parseTimestampParam(value: unknown): number | undefined {
 	return undefined;
 }
 
+function formatDocumentList(documents: Memory[]): string {
+	return `Available documents:\n${documents
+		.map((document, index) => {
+			const metadata = document.metadata as Record<string, unknown> | undefined;
+			const title =
+				typeof metadata?.title === "string"
+					? metadata.title
+					: typeof metadata?.filename === "string"
+						? metadata.filename
+						: `Document ${index + 1}`;
+			return `${index + 1}. ${title} (${document.id})`;
+		})
+		.join("\n")}`;
+}
+
+function formatDocumentListResult(result: DocumentListResult): string {
+	switch (result.status) {
+		case "empty_store":
+			return "No documents are available.";
+		case "filter_miss":
+			return "No documents matched the requested filters.";
+		case "query_miss":
+			if (result.availableDocuments.length === 0) {
+				return `No documents matched ${JSON.stringify(result.query)}. Available-document offset ${result.availableOffset} is past the ${result.totalAvailable} documents allowed by the requested filters.`;
+			}
+			return `No documents matched ${JSON.stringify(result.query)}. Showing available documents${result.availableOffset > 0 ? ` from offset ${result.availableOffset}` : ""} instead:\n${formatDocumentList(result.availableDocuments)}`;
+		case "page_exhausted": {
+			const matchDescription = result.query
+				? `documents matching ${JSON.stringify(result.query)}`
+				: "available documents";
+			return `Offset ${result.offset} is past the ${result.totalMatched} ${matchDescription}.`;
+		}
+		case "ok":
+			return formatDocumentList(result.documents);
+	}
+}
+
 async function handleList(
 	service: DocumentService,
 	message: Memory,
@@ -802,7 +839,7 @@ async function handleList(
 			? Math.floor(params.offset)
 			: undefined;
 
-	const documents = await service.listDocuments(message, {
+	const listResult = await service.listDocumentsDetailed(message, {
 		limit: getLimit(params.limit, 25),
 		offset,
 		query: params.query,
@@ -813,27 +850,29 @@ async function handleList(
 		timeRangeEnd,
 		tags: Array.isArray(params.tags) ? params.tags : undefined,
 	});
-	const text =
-		documents.length === 0
-			? "No documents are available."
-			: `Available documents:\n${documents
-					.map((document, index) => {
-						const metadata = document.metadata as
-							| Record<string, unknown>
-							| undefined;
-						const title =
-							typeof metadata?.title === "string"
-								? metadata.title
-								: typeof metadata?.filename === "string"
-									? metadata.filename
-									: `Document ${index + 1}`;
-						return `${index + 1}. ${title} (${document.id})`;
-					})
-					.join("\n")}`;
+	const text = formatDocumentListResult(listResult);
+	const listData = {
+		documents: listResult.documents,
+		availableDocuments: listResult.availableDocuments,
+		status: listResult.status,
+		...(listResult.query ? { query: listResult.query } : {}),
+		limit: listResult.limit,
+		offset: listResult.offset,
+		totalVisible: listResult.totalVisible,
+		totalAvailable: listResult.totalAvailable,
+		totalMatched: listResult.totalMatched,
+		hasMore: listResult.hasMore,
+		availableOffset: listResult.availableOffset,
+		availableHasMore: listResult.availableHasMore,
+		...(listResult.nextCursor ? { nextCursor: listResult.nextCursor } : {}),
+		...(listResult.availableNextCursor
+			? { availableNextCursor: listResult.availableNextCursor }
+			: {}),
+	};
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "list", {
-		values: { documents },
-		data: { documents },
+		values: listData,
+		data: listData,
 	});
 }
 

--- a/packages/core/src/features/documents/index.ts
+++ b/packages/core/src/features/documents/index.ts
@@ -56,8 +56,14 @@ export type { Bm25Document, Bm25Options, Bm25Score } from "./bm25";
 export { bm25Scores, normalizeBm25Scores, tokenize } from "./bm25";
 export { documentsProvider } from "./provider";
 export { aliasRecallQuery, embedRecallQuery } from "./recall-embed";
-export type { SearchMode } from "./service";
-export { DocumentService } from "./service";
+export type {
+	DocumentListOptions,
+	DocumentListResult,
+	DocumentListStatus,
+	DocumentRequester,
+	SearchMode,
+} from "./service";
+export { DocumentService, resolveDocumentRequester } from "./service";
 export * from "./types";
 export type {
 	FetchDocumentFromUrlOptions,

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -264,7 +264,7 @@ describe("DocumentService list semantics", () => {
 		expect(getWorld).toHaveBeenCalledTimes(1);
 	});
 
-	it("uses the bounded compatibility path for adapters without the native capability", async () => {
+	it("fails fast for adapters without the exact native capability", async () => {
 		const { adapter, runtime, service } = await makeHarness();
 		await seedDocuments(
 			runtime,
@@ -277,21 +277,67 @@ describe("DocumentService list semantics", () => {
 		const nativeQuery = vi.spyOn(adapter, "queryDocuments");
 		const getMemories = vi.spyOn(adapter, "getMemories");
 
-		const result = await service.listDocumentsDetailed(undefined, {
-			limit: 25,
-			offset: 100,
+		await expect(
+			service.listDocumentsDetailed(undefined, {
+				limit: 25,
+				offset: 100,
+			}),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_QUERY_CAPABILITY_REQUIRED",
+		});
+		expect(nativeQuery).not.toHaveBeenCalled();
+		expect(getMemories).not.toHaveBeenCalled();
+	});
+
+	it("keeps privileged roles global while USER remains room-limited", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await adapter.deleteParticipants([{ entityId: USER_ID, roomId: ROOM_B }]);
+		const roomADocument = documentMemory(2);
+		const roomBDocument = documentMemory(3);
+		await seedDocuments(runtime, [roomADocument, roomBDocument]);
+		const getRoomsForParticipants = vi.spyOn(
+			runtime,
+			"getRoomsForParticipants",
+		);
+		vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		const getWorld = vi.spyOn(runtime, "getWorld");
+
+		getWorld.mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
+		const userResult = await service.listDocumentsDetailed(userMessage());
+
+		getWorld.mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: {
+				roles: { [USER_ID]: "OWNER" },
+				roleSources: { [USER_ID]: "manual" },
+			},
+		} as World);
+		const ownerResult = await service.listDocumentsDetailed(userMessage());
+		const runtimeResult = await service.listDocumentsDetailed();
+		const agentResult = await service.listDocumentsDetailed({
+			...userMessage(),
+			entityId: AGENT_ID,
 		});
 
-		expect(result).toMatchObject({
-			status: "ok",
-			totalVisible: 125,
-			totalAvailable: 125,
-			totalMatched: 125,
-			hasMore: false,
-		});
-		expect(result.documents).toHaveLength(25);
-		expect(nativeQuery).not.toHaveBeenCalled();
-		expect(getMemories).toHaveBeenCalledTimes(2);
+		expect(userResult.documents.map((memory) => memory.id)).toEqual([
+			roomADocument.id,
+		]);
+		for (const result of [ownerResult, runtimeResult, agentResult]) {
+			expect(new Set(result.documents.map((memory) => memory.id))).toEqual(
+				new Set([roomADocument.id, roomBDocument.id]),
+			);
+			expect(result.totalVisible).toBe(2);
+		}
+		expect(getRoomsForParticipants).toHaveBeenCalledTimes(1);
 	});
 
 	it("matches room-scoped RLS semantics and ignores non-document rows", async () => {
@@ -379,7 +425,20 @@ describe("DocumentService list semantics", () => {
 			new Error("participant storage unavailable"),
 		);
 
-		await expect(service.listDocumentsDetailed()).rejects.toMatchObject({
+		vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		vi.spyOn(runtime, "getWorld").mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
+
+		await expect(
+			service.listDocumentsDetailed(userMessage()),
+		).rejects.toMatchObject({
 			name: "ElizaError",
 			code: "DOCUMENT_ROOM_LOOKUP_FAILED",
 			cause: expect.any(Error),

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Exercises document-list filtering and pagination through a real AgentRuntime,
+ * DocumentService, and InMemoryDatabaseAdapter with persisted memory records.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import {
+	type Character,
+	type Memory,
+	MemoryType,
+	type Room,
+	type UUID,
+	type World,
+} from "../../types";
+import { DocumentService } from "./service";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e7" as UUID;
+const OTHER_AGENT_ID = "00000000-0000-0000-0000-00000000b0b0" as UUID;
+const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const OTHER_USER_ID = "00000000-0000-0000-0000-00000000face" as UUID;
+const ROOM_A = "00000000-0000-0000-0000-00000000d00d" as UUID;
+const ROOM_B = "00000000-0000-0000-0000-00000000d00e" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-00000000abcd" as UUID;
+
+async function makeHarness(): Promise<{
+	adapter: InMemoryDatabaseAdapter;
+	runtime: AgentRuntime;
+	service: DocumentService;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		agentId: AGENT_ID,
+		character: {
+			name: "DocumentListIntegrationAgent",
+			bio: "Exercises document list storage semantics.",
+			settings: {},
+		} as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	await adapter.createRoomParticipants([AGENT_ID, USER_ID], ROOM_A);
+	await adapter.createRoomParticipants([AGENT_ID, USER_ID], ROOM_B);
+	return {
+		adapter,
+		runtime,
+		service: new DocumentService(runtime),
+	};
+}
+
+function documentMemory(
+	index: number,
+	overrides: Partial<Memory> & {
+		metadata?: Record<string, unknown>;
+	} = {},
+): Memory {
+	const { metadata, ...memoryOverrides } = overrides;
+	const id =
+		`10000000-0000-0000-0000-${index.toString(16).padStart(12, "0")}` as UUID;
+	return {
+		id,
+		agentId: AGENT_ID,
+		entityId: AGENT_ID,
+		roomId: index % 2 === 0 ? ROOM_A : ROOM_B,
+		worldId: WORLD_ID,
+		createdAt: 1_000,
+		content: { text: `Document body ${index}` },
+		metadata: {
+			type: MemoryType.DOCUMENT,
+			documentId: id,
+			title: `Document ${index}`,
+			scope: "global",
+			tags: ["archive"],
+			...metadata,
+		},
+		...memoryOverrides,
+	} as Memory;
+}
+
+async function seedDocuments(
+	runtime: AgentRuntime,
+	documents: Memory[],
+): Promise<void> {
+	await runtime.createMemories(
+		documents.map((memory) => ({ memory, tableName: "documents" })),
+	);
+}
+
+function userMessage(): Memory {
+	return {
+		id: "20000000-0000-0000-0000-000000000001" as UUID,
+		agentId: AGENT_ID,
+		entityId: USER_ID,
+		roomId: ROOM_A,
+		worldId: WORLD_ID,
+		createdAt: 2_000,
+		content: { text: "list documents" },
+	};
+}
+
+describe("DocumentService list semantics", () => {
+	it("filters and paginates through one bounded adapter query", async () => {
+		const { runtime, service } = await makeHarness();
+		const documents = Array.from({ length: 75 }, (_, index) =>
+			documentMemory(
+				index,
+				index === 0 ? { content: { text: "Deep archive needle" } } : undefined,
+			),
+		);
+		await seedDocuments(runtime, documents);
+		await seedDocuments(runtime, [
+			documentMemory(999, {
+				agentId: OTHER_AGENT_ID,
+				content: { text: "Other agent needle" },
+			}),
+		]);
+
+		const queryResult = await service.listDocumentsDetailed(undefined, {
+			query: "needle",
+			limit: 10,
+		});
+		expect(queryResult).toMatchObject({
+			status: "ok",
+			totalVisible: 75,
+			totalAvailable: 75,
+			totalMatched: 1,
+			offset: 0,
+			hasMore: false,
+		});
+		expect(queryResult.documents.map((document) => document.id)).toEqual([
+			documents[0]?.id,
+		]);
+
+		const page = await service.listDocumentsDetailed(undefined, {
+			query: "document",
+			limit: 10,
+			offset: 60,
+		});
+		expect(page).toMatchObject({
+			status: "ok",
+			totalMatched: 75,
+			offset: 60,
+			hasMore: true,
+		});
+		expect(page.documents).toHaveLength(10);
+
+		const exhausted = await service.listDocumentsDetailed(undefined, {
+			query: "document",
+			limit: 10,
+			offset: 75,
+		});
+		expect(exhausted).toMatchObject({
+			status: "page_exhausted",
+			totalMatched: 75,
+			offset: 75,
+			hasMore: false,
+			documents: [],
+			availableDocuments: [],
+		});
+	});
+
+	it("returns query alternatives separately from matched documents", async () => {
+		const { runtime, service } = await makeHarness();
+		const documents = Array.from({ length: 60 }, (_, index) =>
+			documentMemory(index),
+		);
+		await seedDocuments(runtime, documents);
+
+		const result = await service.listDocumentsDetailed(undefined, {
+			query: "does-not-exist",
+			limit: 5,
+			offset: 55,
+		});
+		expect(result).toMatchObject({
+			status: "query_miss",
+			totalVisible: 60,
+			totalAvailable: 60,
+			totalMatched: 0,
+			offset: 55,
+			documents: [],
+			availableOffset: 55,
+			availableHasMore: false,
+		});
+		expect(result.availableDocuments.map((document) => document.id)).toEqual(
+			documents
+				.slice(0, 5)
+				.reverse()
+				.map((document) => document.id),
+		);
+		await expect(
+			service.listDocuments(undefined, {
+				query: "does-not-exist",
+				limit: 5,
+				offset: 55,
+			}),
+		).resolves.toEqual([]);
+	});
+
+	it("uses id as the keyset tiebreaker when timestamps are equal", async () => {
+		const { runtime, service } = await makeHarness();
+		const documents = Array.from({ length: 151 }, (_, index) =>
+			documentMemory(index),
+		);
+		await seedDocuments(runtime, documents);
+
+		const seen: UUID[] = [];
+		let cursor: Awaited<
+			ReturnType<DocumentService["listDocumentsDetailed"]>
+		>["nextCursor"];
+		do {
+			const page = await service.listDocumentsDetailed(undefined, {
+				limit: 37,
+				...(cursor ? { cursor } : {}),
+			});
+			seen.push(
+				...page.documents
+					.map((document) => document.id)
+					.filter((id): id is UUID => typeof id === "string"),
+			);
+			cursor = page.nextCursor;
+			if (!page.hasMore) break;
+			expect(cursor).toBeDefined();
+		} while (cursor);
+
+		expect(seen).toHaveLength(151);
+		expect(new Set(seen).size).toBe(151);
+		expect(seen).toEqual(
+			documents
+				.map((document) => document.id)
+				.filter((id): id is UUID => typeof id === "string")
+				.sort((a, b) => b.localeCompare(a)),
+		);
+	});
+
+	it("keeps large-corpus work inside one adapter query and resolves role once", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(
+			runtime,
+			Array.from({ length: 1_000 }, (_, index) => documentMemory(index)),
+		);
+		const getMemories = vi.spyOn(adapter, "getMemories");
+		const queryDocuments = vi.spyOn(adapter, "queryDocuments");
+		const getRoom = vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		const getWorld = vi.spyOn(runtime, "getWorld").mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
+
+		const result = await service.listDocumentsDetailed(userMessage(), {
+			limit: 25,
+		});
+
+		expect(result.documents).toHaveLength(25);
+		expect(result.totalVisible).toBe(1_000);
+		expect(queryDocuments).toHaveBeenCalledTimes(1);
+		expect(getMemories).not.toHaveBeenCalled();
+		expect(getRoom).toHaveBeenCalledTimes(1);
+		expect(getWorld).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the bounded compatibility path for adapters without the native capability", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(
+			runtime,
+			Array.from({ length: 125 }, (_, index) => documentMemory(index)),
+		);
+		Object.defineProperty(adapter, "documentListQueryCapability", {
+			configurable: true,
+			value: undefined,
+		});
+		const nativeQuery = vi.spyOn(adapter, "queryDocuments");
+		const getMemories = vi.spyOn(adapter, "getMemories");
+
+		const result = await service.listDocumentsDetailed(undefined, {
+			limit: 25,
+			offset: 100,
+		});
+
+		expect(result).toMatchObject({
+			status: "ok",
+			totalVisible: 125,
+			totalAvailable: 125,
+			totalMatched: 125,
+			hasMore: false,
+		});
+		expect(result.documents).toHaveLength(25);
+		expect(nativeQuery).not.toHaveBeenCalled();
+		expect(getMemories).toHaveBeenCalledTimes(2);
+	});
+
+	it("matches room-scoped RLS semantics and ignores non-document rows", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await adapter.deleteParticipants([{ entityId: USER_ID, roomId: ROOM_B }]);
+		const roomADocument = documentMemory(2);
+		const roomBDocument = documentMemory(3);
+		const fragment = documentMemory(4, {
+			metadata: {
+				type: MemoryType.FRAGMENT,
+				documentId: roomADocument.id,
+				position: 0,
+			},
+		});
+		await seedDocuments(runtime, [roomADocument, roomBDocument, fragment]);
+		vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		vi.spyOn(runtime, "getWorld").mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
+
+		const userResult = await service.listDocumentsDetailed(userMessage());
+		const runtimeResult = await service.listDocumentsDetailed();
+
+		expect(userResult.totalVisible).toBe(1);
+		expect(userResult.documents.map((document) => document.id)).toEqual([
+			roomADocument.id,
+		]);
+		expect(runtimeResult.totalVisible).toBe(2);
+		expect(runtimeResult.documents.map((document) => document.id)).toEqual([
+			roomBDocument.id,
+			roomADocument.id,
+		]);
+	});
+
+	it("rejects offsets and query inputs outside the bounded contract", async () => {
+		const { service } = await makeHarness();
+
+		await expect(
+			service.listDocumentsDetailed(undefined, { offset: 10_001 }),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_INVALID_PAGINATION",
+		});
+		await expect(
+			service.listDocumentsDetailed(undefined, { offset: 1.5 }),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_INVALID_PAGINATION",
+		});
+		await expect(
+			service.listDocumentsDetailed(undefined, { query: "x".repeat(513) }),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_LIST_INVALID_PAGINATION",
+		});
+	});
+
+	it("reports and throws a typed role lookup failure", async () => {
+		const { runtime, service } = await makeHarness();
+		vi.spyOn(runtime, "getRoom").mockRejectedValue(
+			new Error("role storage unavailable"),
+		);
+
+		await expect(
+			service.listDocumentsDetailed(userMessage()),
+		).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "DOCUMENT_ROLE_LOOKUP_FAILED",
+			cause: expect.any(Error),
+		});
+		expect(runtime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({
+				scope: "DocumentService.resolveRequesterRole",
+				code: "DOCUMENT_ROLE_LOOKUP_FAILED",
+			}),
+		);
+	});
+
+	it("reports and throws a typed participant-room lookup failure", async () => {
+		const { runtime, service } = await makeHarness();
+		vi.spyOn(runtime, "getRoomsForParticipants").mockRejectedValue(
+			new Error("participant storage unavailable"),
+		);
+
+		await expect(service.listDocumentsDetailed()).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "DOCUMENT_ROOM_LOOKUP_FAILED",
+			cause: expect.any(Error),
+		});
+		expect(runtime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({
+				scope: "DocumentService.resolveRequesterRooms",
+				code: "DOCUMENT_ROOM_LOOKUP_FAILED",
+			}),
+		);
+	});
+
+	it("applies visibility before classifying filter misses", async () => {
+		const { runtime, service } = await makeHarness();
+		const hiddenDocuments = Array.from({ length: 55 }, (_, index) =>
+			documentMemory(index + 10, {
+				entityId: OTHER_USER_ID,
+				metadata: { scope: "owner-private" },
+			}),
+		);
+		await seedDocuments(runtime, [
+			...hiddenDocuments,
+			documentMemory(1),
+			documentMemory(3, {
+				entityId: USER_ID,
+				metadata: {
+					scope: "user-private",
+					scopedToEntityId: USER_ID,
+				},
+			}),
+			documentMemory(4, {
+				entityId: OTHER_USER_ID,
+				metadata: {
+					scope: "user-private",
+					scopedToEntityId: OTHER_USER_ID,
+				},
+			}),
+		]);
+
+		const result = await service.listDocumentsDetailed(userMessage(), {
+			tags: ["missing-tag"],
+		});
+		expect(result).toMatchObject({
+			status: "filter_miss",
+			totalVisible: 2,
+			totalAvailable: 0,
+			totalMatched: 0,
+			documents: [],
+			availableDocuments: [],
+		});
+	});
+
+	it("reports an empty store only when no documents are visible", async () => {
+		const { service } = await makeHarness();
+
+		await expect(
+			service.listDocumentsDetailed(userMessage(), { query: "anything" }),
+		).resolves.toMatchObject({
+			status: "empty_store",
+			totalVisible: 0,
+			totalAvailable: 0,
+			totalMatched: 0,
+			documents: [],
+			availableDocuments: [],
+		});
+	});
+});

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -21,7 +21,8 @@ import { filterByAccessContext } from "../../access-control/filter";
 import {
 	DOCUMENT_LIST_MAX_LIMIT,
 	DOCUMENT_LIST_MAX_OFFSET,
-	queryDocumentsWithCompatibility,
+	documentRoleHasGlobalVisibility,
+	queryDocumentsWithCapability,
 } from "../../database/document-list-query";
 import { createUniqueUuid } from "../../entities";
 import { ElizaError } from "../../errors";
@@ -160,7 +161,7 @@ export interface DocumentRequester {
 	role: DocumentListRequesterRole;
 }
 
-async function resolveDocumentRequesterRole(
+export async function resolveDocumentRequesterRole(
 	runtime: IAgentRuntime,
 	message?: Memory,
 ): Promise<Pick<DocumentRequester, "entityId" | "role">> {
@@ -206,6 +207,9 @@ export async function resolveDocumentRequester(
 	message?: Memory,
 ): Promise<DocumentRequester> {
 	const requester = await resolveDocumentRequesterRole(runtime, message);
+	if (documentRoleHasGlobalVisibility(requester.role)) {
+		return { ...requester, roomIds: [] };
+	}
 	try {
 		const roomIds = await runtime.getRoomsForParticipants([requester.entityId]);
 		return {
@@ -561,7 +565,7 @@ export class DocumentService extends Service {
 				: {}),
 			...(options.tags?.length ? { tags: options.tags } : {}),
 		};
-		const stored = await queryDocumentsWithCompatibility(
+		const stored = await queryDocumentsWithCapability(
 			this.runtime.adapter,
 			queryParams,
 		);

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -18,13 +18,22 @@
  */
 import { existsSync, statSync } from "node:fs";
 import { filterByAccessContext } from "../../access-control/filter";
+import {
+	DOCUMENT_LIST_MAX_LIMIT,
+	DOCUMENT_LIST_MAX_OFFSET,
+	queryDocumentsWithCompatibility,
+} from "../../database/document-list-query";
 import { createUniqueUuid } from "../../entities";
+import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { checkSenderRole } from "../../roles";
 import {
 	type AccessContext,
 	type Content,
 	type CustomMetadata,
+	type DocumentListCursor,
+	type DocumentListQueryParams,
+	type DocumentListRequesterRole,
 	type IAgentRuntime,
 	type Memory,
 	MemoryType,
@@ -75,6 +84,47 @@ import {
  */
 export type SearchMode = "hybrid" | "vector" | "keyword";
 
+/** Filters and pagination accepted by document list operations. */
+export interface DocumentListOptions {
+	limit?: number;
+	offset?: number;
+	cursor?: DocumentListCursor;
+	query?: string;
+	scope?: DocumentVisibilityScope;
+	scopedToEntityId?: UUID;
+	addedBy?: UUID;
+	timeRangeStart?: number;
+	timeRangeEnd?: number;
+	tags?: string[];
+}
+
+/** Machine-readable outcome of a document list request. */
+export type DocumentListStatus =
+	| "ok"
+	| "query_miss"
+	| "filter_miss"
+	| "page_exhausted"
+	| "empty_store";
+
+/** Complete document-list semantics after visibility, filtering, and pagination. */
+export interface DocumentListResult {
+	status: DocumentListStatus;
+	documents: Memory[];
+	availableDocuments: Memory[];
+	query?: string;
+	limit: number;
+	offset: number;
+	cursor?: DocumentListCursor;
+	totalVisible: number;
+	totalAvailable: number;
+	totalMatched: number;
+	hasMore: boolean;
+	availableOffset: number;
+	availableHasMore: boolean;
+	nextCursor?: DocumentListCursor;
+	availableNextCursor?: DocumentListCursor;
+}
+
 /** Weight given to the normalized vector score in hybrid mode. */
 const HYBRID_VECTOR_WEIGHT = 0.6;
 /** Weight given to the normalized BM25 score in hybrid mode. */
@@ -102,6 +152,86 @@ const DOCUMENT_ADDED_FROM_VALUES = new Set<DocumentAddedFrom>([
 	"default-seed",
 	"character",
 ]);
+
+/** Requester identity and role resolved once for document authorization. */
+export interface DocumentRequester {
+	entityId: UUID;
+	roomIds: UUID[];
+	role: DocumentListRequesterRole;
+}
+
+async function resolveDocumentRequesterRole(
+	runtime: IAgentRuntime,
+	message?: Memory,
+): Promise<Pick<DocumentRequester, "entityId" | "role">> {
+	if (!message?.entityId) {
+		return { entityId: runtime.agentId, role: "RUNTIME" };
+	}
+	if (message.entityId === runtime.agentId) {
+		return { entityId: runtime.agentId, role: "AGENT" };
+	}
+
+	try {
+		const result = await checkSenderRole(runtime, message);
+		return {
+			entityId: message.entityId,
+			role:
+				result?.role === "OWNER" || result?.role === "ADMIN"
+					? result.role
+					: "USER",
+		};
+	} catch (cause) {
+		// error-policy:J2 Preserve role-resolution context and fail the read/write.
+		const error = new ElizaError("Document requester role lookup failed", {
+			code: "DOCUMENT_ROLE_LOOKUP_FAILED",
+			cause,
+			context: {
+				agentId: runtime.agentId,
+				entityId: message.entityId,
+				roomId: message.roomId,
+			},
+			severity: "ephemeral",
+		});
+		runtime.reportError("DocumentService.resolveRequesterRole", error, {
+			agentId: runtime.agentId,
+			entityId: message.entityId,
+			roomId: message.roomId,
+		});
+		throw error;
+	}
+}
+
+export async function resolveDocumentRequester(
+	runtime: IAgentRuntime,
+	message?: Memory,
+): Promise<DocumentRequester> {
+	const requester = await resolveDocumentRequesterRole(runtime, message);
+	try {
+		const roomIds = await runtime.getRoomsForParticipants([requester.entityId]);
+		return {
+			...requester,
+			roomIds: [...new Set(roomIds)],
+		};
+	} catch (cause) {
+		// error-policy:J2 Preserve room-resolution context and fail the read.
+		const error = new ElizaError("Document requester room lookup failed", {
+			code: "DOCUMENT_ROOM_LOOKUP_FAILED",
+			cause,
+			context: {
+				agentId: runtime.agentId,
+				entityId: requester.entityId,
+				roomId: message?.roomId,
+			},
+			severity: "ephemeral",
+		});
+		runtime.reportError("DocumentService.resolveRequesterRooms", error, {
+			agentId: runtime.agentId,
+			entityId: requester.entityId,
+			roomId: message?.roomId,
+		});
+		throw error;
+	}
+}
 
 function normalizeDocumentScope(
 	scope: AddDocumentOptions["scope"] | undefined,
@@ -297,31 +427,15 @@ export class DocumentService extends Service {
 		return memory.metadata?.type === MemoryType.FRAGMENT;
 	}
 
-	private async getSenderDocumentRole(
-		message?: Memory,
-	): Promise<"OWNER" | "ADMIN" | "USER" | "AGENT" | "RUNTIME"> {
-		if (!message?.entityId) {
-			return "RUNTIME";
-		}
-		if (message.entityId === this.runtime.agentId) {
-			return "AGENT";
-		}
-
-		const role = await checkSenderRole(this.runtime, message).catch(() => null);
-		// Record OWNER/ADMIN provenance verbatim (the comparison narrows the return
-		// type to the DocumentAddedByRole subset); everyone else is a plain USER.
-		if (role?.role === "OWNER" || role?.role === "ADMIN") {
-			return role.role;
-		}
-		return "USER";
-	}
-
 	async canAccessDocument(memory: Memory, message?: Memory): Promise<boolean> {
 		if (!message?.entityId || message.entityId === this.runtime.agentId) {
 			return true;
 		}
 
-		const senderRole = await this.getSenderDocumentRole(message);
+		const { role: senderRole } = await resolveDocumentRequesterRole(
+			this.runtime,
+			message,
+		);
 		if (senderRole === "OWNER") return true;
 
 		const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
@@ -382,87 +496,107 @@ export class DocumentService extends Service {
 
 	async listDocuments(
 		message?: Memory,
-		options: {
-			limit?: number;
-			offset?: number;
-			query?: string;
-			scope?: DocumentVisibilityScope;
-			scopedToEntityId?: UUID;
-			addedBy?: UUID;
-			timeRangeStart?: number;
-			timeRangeEnd?: number;
-			tags?: string[];
-		} = {},
+		options: DocumentListOptions = {},
 	): Promise<Memory[]> {
-		const limit = Math.max(1, Math.min(options.limit ?? 25, 100));
-		const offset = Math.max(0, options.offset ?? 0);
-		const memories = await this.runtime.getMemories({
-			tableName: DOCUMENTS_TABLE,
+		return (await this.listDocumentsDetailed(message, options)).documents;
+	}
+
+	async listDocumentsDetailed(
+		message?: Memory,
+		options: DocumentListOptions = {},
+	): Promise<DocumentListResult> {
+		const limit =
+			typeof options.limit === "number" && Number.isFinite(options.limit)
+				? Math.max(
+						1,
+						Math.min(Math.floor(options.limit), DOCUMENT_LIST_MAX_LIMIT),
+					)
+				: 25;
+		const offset = options.offset ?? 0;
+		if (
+			!Number.isSafeInteger(offset) ||
+			offset < 0 ||
+			offset > DOCUMENT_LIST_MAX_OFFSET
+		) {
+			throw new ElizaError(
+				`Document list offset must be an integer between 0 and ${DOCUMENT_LIST_MAX_OFFSET}`,
+				{
+					code: "DOCUMENT_LIST_INVALID_PAGINATION",
+					context: { offset },
+				},
+			);
+		}
+		if (options.cursor && offset !== 0) {
+			throw new ElizaError(
+				"Document list cursor cannot be combined with a non-zero offset",
+				{
+					code: "DOCUMENT_LIST_INVALID_PAGINATION",
+					context: { offset },
+				},
+			);
+		}
+
+		const requester = await resolveDocumentRequester(this.runtime, message);
+		const query = options.query?.trim();
+		const normalizedQuery = query?.toLowerCase();
+		const queryParams: DocumentListQueryParams = {
 			agentId: this.runtime.agentId,
-			count: Math.max((limit + offset) * 4, 50),
-		});
-		const documents = await this.filterVisibleMemories(
-			memories.filter((memory) => this.isDocumentMemory(memory)),
-			message,
+			requesterEntityId: requester.entityId,
+			requesterRoomIds: requester.roomIds,
+			requesterRole: requester.role,
+			limit,
+			offset,
+			...(options.cursor ? { cursor: options.cursor } : {}),
+			...(normalizedQuery ? { query: normalizedQuery } : {}),
+			...(options.scope ? { scope: options.scope } : {}),
+			...(options.scopedToEntityId
+				? { scopedToEntityId: options.scopedToEntityId }
+				: {}),
+			...(options.addedBy ? { addedBy: options.addedBy } : {}),
+			...(options.timeRangeStart !== undefined
+				? { timeRangeStart: options.timeRangeStart }
+				: {}),
+			...(options.timeRangeEnd !== undefined
+				? { timeRangeEnd: options.timeRangeEnd }
+				: {}),
+			...(options.tags?.length ? { tags: options.tags } : {}),
+		};
+		const stored = await queryDocumentsWithCompatibility(
+			this.runtime.adapter,
+			queryParams,
 		);
-		const query = options.query?.trim().toLowerCase();
-		const filtered = documents.filter((memory) => {
-			const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
-			if (options.scope && metadata.scope !== options.scope) return false;
-			if (
-				options.scopedToEntityId &&
-				metadata.scopedToEntityId !== options.scopedToEntityId
-			) {
-				return false;
-			}
-			if (options.addedBy && metadata.addedBy !== options.addedBy) return false;
+		const status: DocumentListStatus =
+			stored.totalVisible === 0
+				? "empty_store"
+				: stored.totalAvailable === 0
+					? "filter_miss"
+					: normalizedQuery && stored.totalMatched === 0
+						? "query_miss"
+						: stored.documents.length === 0
+							? "page_exhausted"
+							: "ok";
 
-			if (options.tags && options.tags.length > 0) {
-				const docTags = Array.isArray(metadata.tags)
-					? (metadata.tags as unknown[]).filter(
-							(value): value is string => typeof value === "string",
-						)
-					: [];
-				const wanted = options.tags;
-				if (!wanted.every((tag) => docTags.includes(tag))) return false;
-			}
-
-			const docTimestamp =
-				typeof metadata.timestamp === "number"
-					? metadata.timestamp
-					: typeof memory.createdAt === "number"
-						? memory.createdAt
-						: 0;
-			if (
-				typeof options.timeRangeStart === "number" &&
-				docTimestamp < options.timeRangeStart
-			) {
-				return false;
-			}
-			if (
-				typeof options.timeRangeEnd === "number" &&
-				docTimestamp > options.timeRangeEnd
-			) {
-				return false;
-			}
-
-			if (query) {
-				const haystack = [
-					memory.content.text,
-					metadata.title,
-					metadata.filename,
-					metadata.originalFilename,
-					metadata.source,
-				]
-					.filter((value): value is string => typeof value === "string")
-					.join("\n")
-					.toLowerCase();
-				if (!haystack.includes(query)) return false;
-			}
-
-			return true;
-		});
-		return filtered.slice(offset, offset + limit);
+		return {
+			status,
+			documents: stored.documents,
+			availableDocuments:
+				status === "query_miss" ? stored.availableDocuments : [],
+			query,
+			limit,
+			offset,
+			...(options.cursor ? { cursor: options.cursor } : {}),
+			totalVisible: stored.totalVisible,
+			totalAvailable: stored.totalAvailable,
+			totalMatched: stored.totalMatched,
+			hasMore: stored.hasMore,
+			availableOffset: offset,
+			availableHasMore:
+				status === "query_miss" ? stored.availableHasMore : false,
+			...(stored.nextCursor ? { nextCursor: stored.nextCursor } : {}),
+			...(status === "query_miss" && stored.availableNextCursor
+				? { availableNextCursor: stored.availableNextCursor }
+				: {}),
+		};
 	}
 
 	async deleteDocument(documentId: UUID, message?: Memory): Promise<void> {

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -32,6 +32,7 @@ export * from "./connectors/connector-config";
 export * from "./connectors/oauth-role";
 export * from "./connectors/privacy";
 export * from "./database";
+export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
 // `isTruthyEnvValue` is pure string logic (no Node deps), so it is browser-safe

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -36,6 +36,7 @@ export {
 	LOCAL_MODEL_PROVIDERS,
 } from "./constants";
 export * from "./database";
+export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
 export * from "./errors";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -76,6 +76,7 @@ export {
 } from "./contracts/service-routing";
 export * from "./contracts/wallet";
 export * from "./database";
+export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
 export * from "./env-utils";

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1027,8 +1027,8 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	/**
 	 * Query visible documents with filtering, exact counts, and bounded pages.
 	 * Adapters advertise `documentListQueryCapability: 1` only when this method
-	 * implements the complete native contract. Older adapters remain compatible
-	 * through the bounded core fallback.
+	 * implements the complete native contract. Callers fail before reading when
+	 * an adapter omits the capability or advertises a different version.
 	 */
 	readonly documentListQueryCapability?: 1;
 	queryDocuments?(

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -14,7 +14,7 @@ import type {
 	Room,
 	World,
 } from "./environment";
-import type { Memory, MemoryMetadata } from "./memory";
+import type { Memory, MemoryMetadata, MemoryScope } from "./memory";
 import type {
 	PairingAllowlistEntry,
 	PairingChannel,
@@ -35,6 +35,60 @@ export interface MessageSearchHit {
 	memory: Memory;
 	ftsRank: number;
 	trigramSimilarity: number;
+}
+
+/** Stable newest-first cursor for document-list pagination. */
+export interface DocumentListCursor {
+	createdAt: number;
+	id: UUID;
+}
+
+/** Visibility scopes understood by the document-list storage query. */
+export type DocumentListScope = Extract<
+	MemoryScope,
+	"global" | "owner-private" | "user-private" | "agent-private"
+>;
+
+/** Requester roles used to enforce document visibility inside the adapter. */
+export type DocumentListRequesterRole =
+	| "OWNER"
+	| "ADMIN"
+	| "USER"
+	| "AGENT"
+	| "RUNTIME";
+
+/**
+ * Fully pushed-down document-list query. `requesterEntityId` is isolation
+ * context, never a row predicate; document ownership filters are explicit.
+ */
+export interface DocumentListQueryParams {
+	agentId: UUID;
+	requesterEntityId: UUID;
+	requesterRoomIds: UUID[];
+	requesterRole: DocumentListRequesterRole;
+	limit: number;
+	offset: number;
+	cursor?: DocumentListCursor;
+	query?: string;
+	scope?: DocumentListScope;
+	scopedToEntityId?: UUID;
+	addedBy?: UUID;
+	timeRangeStart?: number;
+	timeRangeEnd?: number;
+	tags?: string[];
+}
+
+/** Exact counts and bounded pages returned by a document-list adapter query. */
+export interface DocumentListQueryResult {
+	documents: Memory[];
+	availableDocuments: Memory[];
+	totalVisible: number;
+	totalAvailable: number;
+	totalMatched: number;
+	hasMore: boolean;
+	availableHasMore: boolean;
+	nextCursor?: DocumentListCursor;
+	availableNextCursor?: DocumentListCursor;
 }
 
 /** Run status enumeration (database). */
@@ -969,6 +1023,17 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;
+
+	/**
+	 * Query visible documents with filtering, exact counts, and bounded pages.
+	 * Adapters advertise `documentListQueryCapability: 1` only when this method
+	 * implements the complete native contract. Older adapters remain compatible
+	 * through the bounded core fallback.
+	 */
+	readonly documentListQueryCapability?: 1;
+	queryDocuments?(
+		params: DocumentListQueryParams,
+	): Promise<DocumentListQueryResult>;
 
 	getMemoriesByIds(ids: UUID[], tableName?: string): Promise<Memory[]>;
 

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -174,6 +174,25 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     expect(workflow).toContain("runner.temp }}/develop-live-evidence");
   });
 
+  test("the live PostgreSQL proof provisions the vector extension required by migrations", () => {
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, ".github/workflows/develop-live.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain("pgvector/pgvector:pg16");
+    expect(workflow).not.toMatch(/-p 127[.]0[.]0[.]1:5433:5432 postgres:/);
+    expect(workflow).toContain(
+      "-e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres",
+    );
+    expect(workflow).toContain(
+      "-c \"CREATE ROLE eliza_test LOGIN PASSWORD 'test123'\"",
+    );
+    expect(workflow).toContain(
+      "POSTGRES_URL=postgresql://eliza_test:test123@127.0.0.1:5433/eliza_test",
+    );
+  });
+
   test("Eliza Cloud streamed tool-call proof requires an explicit credentialed live run", () => {
     expect(
       manifest.find(

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -19,6 +19,9 @@ import {
   type Component,
   type Content,
   DatabaseAdapter,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  type DocumentListQueryParams,
+  type DocumentListQueryResult,
   type EntitiesForRoomsResult,
   type Entity,
   type IDatabaseAdapter,
@@ -28,7 +31,6 @@ import {
   logger,
   type Memory,
   type MemoryMetadata,
-  type MemoryTypeAlias,
   type MessageSearchHit,
   type Metadata,
   type PairingAllowlistEntry,
@@ -41,6 +43,7 @@ import {
   type ParticipantUpdateFields,
   type ParticipantUserState,
   type PatchOp,
+  queryDocumentsInMemory,
   type Relationship,
   type Room,
   rankMessageSearch,
@@ -66,6 +69,7 @@ interface StoredParticipant {
 
 interface StoredMemory {
   id?: string;
+  tableName?: string;
   entityId: string;
   agentId?: string;
   createdAt?: number;
@@ -111,6 +115,10 @@ function toMemory(stored: StoredMemory): Memory {
     similarity: stored.similarity,
     metadata: stored.metadata,
   };
+}
+
+function storedMemoryTableName(memory: StoredMemory): string | undefined {
+  return memory.tableName ?? memory.metadata?.type;
 }
 
 function relationshipFromStored(r: StoredRelationship, fallbackAgentId: UUID): Relationship {
@@ -199,6 +207,7 @@ function levenshtein(a: string, b: string): number {
 // ────────────────────────────────────────────────────────────────────────────
 
 export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
+  readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
   private storage: IStorage;
   private vectorIndex: EphemeralHNSW;
   private embeddingDimension = 384;
@@ -572,6 +581,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
 
   // ── Memory CRUD ───────────────────────────────────────────────────────
 
+  async queryDocuments(params: DocumentListQueryParams): Promise<DocumentListQueryResult> {
+    const memories = await this.storage.getWhere<StoredMemory>(
+      COLLECTIONS.MEMORIES,
+      (memory) => storedMemoryTableName(memory) === "documents"
+    );
+    return queryDocumentsInMemory(memories.map(toMemory), params);
+  }
+
   async getMemories(params: {
     entityId?: UUID;
     agentId?: UUID;
@@ -597,7 +614,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       if (params.agentId && m.agentId !== params.agentId) return false;
       if (params.roomId && m.roomId !== params.roomId) return false;
       if (params.worldId && m.worldId !== params.worldId) return false;
-      if (params.tableName && m.metadata?.type !== params.tableName) return false;
+      if (params.tableName && storedMemoryTableName(m) !== params.tableName) return false;
       if (params.start && m.createdAt && m.createdAt < params.start) return false;
       if (params.end && m.createdAt && m.createdAt > params.end) return false;
       if (params.unique && !m.unique) return false;
@@ -648,7 +665,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     const textContains = params.textContains?.trim().toLowerCase();
     const memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
       if (!roomSet.has(m.roomId as UUID)) return false;
-      if (params.tableName && m.metadata?.type !== params.tableName) return false;
+      if (params.tableName && storedMemoryTableName(m) !== params.tableName) return false;
       // Same case-insensitive `includes` semantics the SQL adapter pushes
       // down as ILIKE.
       if (
@@ -683,7 +700,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     const tableName = params.tableName ?? "messages";
     const stored = await this.storage.getWhere<StoredMemory>(
       COLLECTIONS.MEMORIES,
-      (m) => roomSet.has(m.roomId as UUID) && m.metadata?.type === tableName
+      (m) => roomSet.has(m.roomId as UUID) && storedMemoryTableName(m) === tableName
     );
     // The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
     // adapters' created_at range conditions.
@@ -711,7 +728,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     for (const id of memoryIds) {
       const m = await this.storage.get<StoredMemory>(COLLECTIONS.MEMORIES, id);
       if (!m) continue;
-      if (tableName && m.metadata?.type !== tableName) continue;
+      if (tableName && storedMemoryTableName(m) !== tableName) continue;
       memories.push(toMemory(m));
     }
     return memories;
@@ -727,7 +744,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   }): Promise<{ embedding: number[]; levenshtein_score: number }[]> {
     const memories = await this.storage.getWhere<StoredMemory>(
       COLLECTIONS.MEMORIES,
-      (m) => m.metadata?.type === params.query_table_name && !!m.embedding
+      (m) => storedMemoryTableName(m) === params.query_table_name && !!m.embedding
     );
 
     const results: { embedding: number[]; levenshtein_score: number }[] = [];
@@ -767,7 +784,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     for (const result of results) {
       const memory = await this.storage.get<StoredMemory>(COLLECTIONS.MEMORIES, result.id);
       if (!memory) continue;
-      if (params.tableName && memory.metadata?.type !== params.tableName) continue;
+      if (params.tableName && storedMemoryTableName(memory) !== params.tableName) continue;
       if (params.roomId && memory.roomId !== params.roomId) continue;
       if (params.worldId && memory.worldId !== params.worldId) continue;
       if (params.entityId && memory.entityId !== params.entityId) continue;
@@ -787,13 +804,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       const stored: StoredMemory = {
         ...memory,
         id,
+        tableName,
         agentId: memory.agentId ?? this.agentId,
         unique: unique || memory.unique,
         createdAt: memory.createdAt ?? Date.now(),
-        metadata: {
-          ...(memory.metadata ?? {}),
-          type: tableName as MemoryTypeAlias,
-        } as MemoryMetadata,
+        metadata: { ...(memory.metadata ?? {}) } as MemoryMetadata,
       };
       await this.storage.set(COLLECTIONS.MEMORIES, id, stored);
       if (memory.embedding && memory.embedding.length > 0) {
@@ -838,12 +853,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       const stored: StoredMemory = {
         ...(existing ?? {}),
         ...memory,
+        tableName,
         agentId: memory.agentId ?? existing?.agentId ?? this.agentId,
         createdAt: memory.createdAt ?? existing?.createdAt ?? Date.now(),
         metadata: {
           ...(existing?.metadata ?? {}),
           ...(memory.metadata ?? {}),
-          type: tableName as MemoryTypeAlias,
         } as MemoryMetadata,
       };
       await this.storage.set(COLLECTIONS.MEMORIES, memory.id, stored);
@@ -865,7 +880,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     const roomSet = new Set(roomIds);
     const memories = await this.storage.getWhere<StoredMemory>(
       COLLECTIONS.MEMORIES,
-      (m) => roomSet.has(m.roomId as UUID) && (tableName ? m.metadata?.type === tableName : true)
+      (m) =>
+        roomSet.has(m.roomId as UUID) && (tableName ? storedMemoryTableName(m) === tableName : true)
     );
     const ids = memories.map((m) => m.id).filter((id): id is string => id !== undefined) as UUID[];
     await this.deleteMemories(ids);
@@ -883,7 +899,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     return this.storage.count<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
       if (roomSet && !roomSet.has(m.roomId as UUID)) return false;
       if (params.unique && !m.unique) return false;
-      if (params.tableName && m.metadata?.type !== params.tableName) return false;
+      if (params.tableName && storedMemoryTableName(m) !== params.tableName) return false;
       if (params.entityId && m.entityId !== params.entityId) return false;
       if (params.agentId && m.agentId !== params.agentId) return false;
       if (params.metadata) {
@@ -906,7 +922,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       COLLECTIONS.MEMORIES,
       (m) =>
         (!worldSet || (m.worldId ? worldSet.has(m.worldId as UUID) : false)) &&
-        (params.tableName ? m.metadata?.type === params.tableName : true)
+        (params.tableName ? storedMemoryTableName(m) === params.tableName : true)
     );
     memories.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
     const sliced = params.limit ? memories.slice(0, params.limit) : memories;

--- a/plugins/plugin-inmemorydb/document-list.test.ts
+++ b/plugins/plugin-inmemorydb/document-list.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Exercises the native document-list capability against the first-party
+ * ephemeral adapter, including canonical metadata, room visibility, and
+ * stable keyset pagination without mocks.
+ */
+import {
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  type DocumentListCursor,
+  type DocumentListQueryParams,
+  type Memory,
+  MemoryType,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const AGENT_ID = "50000000-0000-0000-0000-000000000001" as UUID;
+const REQUESTER_ID = "50000000-0000-0000-0000-000000000002" as UUID;
+const ROOM_A = "50000000-0000-0000-0000-000000000003" as UUID;
+const ROOM_B = "50000000-0000-0000-0000-000000000004" as UUID;
+
+function memory(index: number, roomId: UUID, metadata: Record<string, unknown> = {}): Memory {
+  const id = `50000000-0000-0000-0000-${index.toString(16).padStart(12, "0")}` as UUID;
+  return {
+    id,
+    agentId: AGENT_ID,
+    entityId: REQUESTER_ID,
+    roomId,
+    createdAt: 1_000,
+    content: { text: `Document ${index}` },
+    metadata: {
+      type: MemoryType.DOCUMENT,
+      documentId: id,
+      timestamp: 1_000,
+      scope: "global",
+      ...metadata,
+    },
+  };
+}
+
+describe("InMemoryDatabaseAdapter document list capability", () => {
+  it("preserves document metadata and excludes mixed table types by room", async () => {
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+    await adapter.initialize();
+    const roomADocument = memory(1, ROOM_A);
+    const roomBDocument = memory(2, ROOM_B);
+    const fragment = memory(3, ROOM_A, {
+      type: MemoryType.FRAGMENT,
+      documentId: roomADocument.id,
+      position: 0,
+    });
+    await adapter.createMemories(
+      [roomADocument, roomBDocument, fragment].map((item) => ({
+        memory: item,
+        tableName: "documents",
+      }))
+    );
+
+    expect(adapter.documentListQueryCapability).toBe(DOCUMENT_LIST_QUERY_CAPABILITY_VERSION);
+    await expect(
+      adapter.getMemories({
+        tableName: "documents",
+        roomId: ROOM_A,
+        includeEmbedding: false,
+      })
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: roomADocument.id,
+          metadata: expect.objectContaining({ type: MemoryType.DOCUMENT }),
+        }),
+        expect.objectContaining({
+          id: fragment.id,
+          metadata: expect.objectContaining({ type: MemoryType.FRAGMENT }),
+        }),
+      ])
+    );
+
+    const result = await adapter.queryDocuments({
+      agentId: AGENT_ID,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [ROOM_A],
+      requesterRole: "USER",
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result.totalVisible).toBe(1);
+    expect(result.documents.map((document) => document.id)).toEqual([roomADocument.id]);
+  });
+
+  it("uses the id tiebreaker across complete keyset traversal", async () => {
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+    await adapter.initialize();
+    const documents = Array.from({ length: 11 }, (_, index) => memory(index, ROOM_A));
+    await adapter.createMemories(
+      documents.map((item) => ({ memory: item, tableName: "documents" }))
+    );
+    const params: DocumentListQueryParams = {
+      agentId: AGENT_ID,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [ROOM_A],
+      requesterRole: "RUNTIME",
+      limit: 3,
+      offset: 0,
+    };
+    const seen: UUID[] = [];
+    let cursor: DocumentListCursor | undefined;
+    do {
+      const page = await adapter.queryDocuments({
+        ...params,
+        ...(cursor ? { cursor } : {}),
+      });
+      seen.push(
+        ...page.documents
+          .map((document) => document.id)
+          .filter((id): id is UUID => typeof id === "string")
+      );
+      cursor = page.nextCursor;
+      if (!page.hasMore) break;
+    } while (cursor);
+
+    expect(seen).toEqual(
+      documents
+        .map((document) => document.id)
+        .filter((id): id is UUID => typeof id === "string")
+        .sort((left, right) => right.localeCompare(left))
+    );
+    expect(new Set(seen).size).toBe(documents.length);
+  });
+});

--- a/plugins/plugin-inmemorydb/document-list.test.ts
+++ b/plugins/plugin-inmemorydb/document-list.test.ts
@@ -88,6 +88,21 @@ describe("InMemoryDatabaseAdapter document list capability", () => {
 
     expect(result.totalVisible).toBe(1);
     expect(result.documents.map((document) => document.id)).toEqual([roomADocument.id]);
+
+    for (const requesterRole of ["OWNER", "RUNTIME", "AGENT"] as const) {
+      const privileged = await adapter.queryDocuments({
+        agentId: AGENT_ID,
+        requesterEntityId: REQUESTER_ID,
+        requesterRoomIds: [],
+        requesterRole,
+        limit: 10,
+        offset: 0,
+      });
+      expect(new Set(privileged.documents.map((document) => document.id))).toEqual(
+        new Set([roomADocument.id, roomBDocument.id])
+      );
+      expect(privileged.totalVisible).toBe(2);
+    }
   });
 
   it("uses the id tiebreaker across complete keyset traversal", async () => {

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -17,14 +17,16 @@ import {
 import { sql } from "drizzle-orm";
 import { v4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PgDatabaseAdapter } from "../../pg/adapter";
+import { PgDatabaseAdapter } from "../../pg/adapter";
 import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
 import { embeddingTable, memoryTable } from "../../schema";
+import { documentSearchVectorExpression } from "../../schema/memory";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
 const REQUESTER_ID = "10000000-0000-0000-0000-000000000001" as UUID;
 const OTHER_ENTITY_ID = "10000000-0000-0000-0000-000000000002" as UUID;
+const postgresIt = process.env.POSTGRES_URL ? it : it.skip;
 
 describe("document list query (real SQL parity)", () => {
   let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
@@ -238,6 +240,48 @@ describe("document list query (real SQL parity)", () => {
     });
   });
 
+  it("keeps OWNER, RUNTIME, and AGENT global while USER remains room-limited", async () => {
+    const otherRoomId = v4() as UUID;
+    await adapter.createRooms([
+      {
+        id: otherRoomId,
+        agentId,
+        worldId,
+        name: "other-documents",
+        source: "test",
+        type: ChannelType.DM,
+      } as Room,
+    ]);
+    const documents = [document(1), document(2, { roomId: otherRoomId })];
+    await seedSql(documents);
+    const inMemory = await seedInMemory(documents);
+    const baseParams: Omit<DocumentListQueryParams, "requesterRole"> = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      limit: 10,
+      offset: 0,
+    };
+
+    const userSql = await adapter.queryDocuments({ ...baseParams, requesterRole: "USER" });
+    const userMemory = await inMemory.queryDocuments({ ...baseParams, requesterRole: "USER" });
+    expect(userSql).toEqual(userMemory);
+    expect(ids(userSql.documents)).toEqual([documents[0]?.id]);
+
+    for (const requesterRole of ["OWNER", "RUNTIME", "AGENT"] as const) {
+      const roleParams = {
+        ...baseParams,
+        requesterRoomIds: [],
+        requesterRole,
+      };
+      const sqlResult = await adapter.queryDocuments(roleParams);
+      const memoryResult = await inMemory.queryDocuments(roleParams);
+      expect(sqlResult).toEqual(memoryResult);
+      expect(new Set(ids(sqlResult.documents))).toEqual(new Set(ids(documents)));
+      expect(sqlResult.totalVisible).toBe(2);
+    }
+  });
+
   it("does not skip or duplicate equal-timestamp rows across keyset pages", async () => {
     const documents = Array.from({ length: 151 }, (_, index) => document(index));
     await seedSql(documents);
@@ -388,20 +432,96 @@ describe("document list query (real SQL parity)", () => {
     });
   });
 
-  it("installs the composite index supporting document keyset order", async () => {
+  it("installs the document keyset and full-text indexes", async () => {
     const db = adapter.getDatabase() as DrizzleDatabase;
     const result = await db.execute(sql`
-      SELECT indexdef
+      SELECT indexname, indexdef
       FROM pg_indexes
-      WHERE indexname = 'idx_memories_document_list_order'
+      WHERE indexname IN (
+        'idx_memories_document_list_order',
+        'idx_memories_document_search'
+      )
+      ORDER BY indexname
     `);
-    const definition = String(result.rows[0]?.indexdef ?? "");
+    const definitions = new Map(
+      result.rows.map((row) => [String(row.indexname), String(row.indexdef)])
+    );
 
-    expect(result.rows).toHaveLength(1);
-    expect(definition).toContain("date_trunc");
-    expect(definition).toContain("metadata");
-    expect(definition).toContain("type");
+    expect(definitions.get("idx_memories_document_list_order")).toContain("date_trunc");
+    expect(definitions.get("idx_memories_document_list_order")).toContain("metadata");
+    expect(definitions.get("idx_memories_document_search")).toContain("USING gin");
+    expect(definitions.get("idx_memories_document_search")).toContain("to_tsvector");
   });
+
+  postgresIt(
+    "uses the document GIN index at 20k rows with bounded search latency",
+    async () => {
+      expect(adapter).toBeInstanceOf(PgDatabaseAdapter);
+      const db = adapter.getDatabase() as DrizzleDatabase;
+      await db.execute(sql`
+      INSERT INTO ${memoryTable} (
+        id,
+        type,
+        created_at,
+        content,
+        entity_id,
+        agent_id,
+        room_id,
+        world_id,
+        "unique",
+        metadata
+      )
+      SELECT
+        gen_random_uuid(),
+        'documents',
+        NOW() - (series.value * interval '1 millisecond'),
+        jsonb_build_object(
+          'text',
+          CASE
+            WHEN series.value = 19_999 THEN 'rareplanmarker release evidence'
+            ELSE 'ordinary archived document ' || series.value::text
+          END
+        ),
+        ${REQUESTER_ID}::uuid,
+        ${agentId}::uuid,
+        ${roomId}::uuid,
+        ${worldId}::uuid,
+        true,
+        jsonb_build_object(
+          'type',
+          'document',
+          'documentId',
+          gen_random_uuid()::text,
+          'timestamp',
+          series.value
+        )
+      FROM generate_series(1, 20_000) AS series(value)
+    `);
+      await db.execute(sql`ANALYZE ${memoryTable}`);
+
+      const explain = await db.execute(sql`
+      EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+      SELECT COUNT(*)
+      FROM ${memoryTable}
+      WHERE
+        ${memoryTable.type} = 'documents'
+        AND ${memoryTable.agentId} = ${agentId}
+        AND ${memoryTable.metadata}->>'type' = 'document'
+        AND ${documentSearchVectorExpression(
+          memoryTable.content,
+          memoryTable.metadata
+        )} @@ plainto_tsquery('simple', 'rareplanmarker')
+    `);
+      const plan = JSON.stringify(explain.rows[0]);
+      const executionTime = plan.match(/"Execution Time":\s*([0-9.]+)/)?.[1];
+
+      expect(plan).toContain("idx_memories_document_search");
+      expect(plan).toMatch(/Bitmap Index Scan|Index Scan/);
+      expect(executionTime).toBeDefined();
+      expect(Number(executionTime)).toBeLessThan(1_000);
+    },
+    120_000
+  );
 
   it("pushes metadata, text, and document timestamp filters down with parity", async () => {
     const documents = [

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Compares the bounded document-list query across real PGlite/Postgres and the
+ * core in-memory fallback, including RLS context, visibility, and keyset ties.
+ */
+import {
+  ChannelType,
+  type DocumentListCursor,
+  type DocumentListQueryParams,
+  type Entity,
+  InMemoryDatabaseAdapter,
+  type Memory,
+  MemoryType,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { sql } from "drizzle-orm";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { embeddingTable, memoryTable } from "../../schema";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const REQUESTER_ID = "10000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_ENTITY_ID = "10000000-0000-0000-0000-000000000002" as UUID;
+
+describe("document list query (real SQL parity)", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let agentId: UUID;
+  let roomId: UUID;
+  let worldId: UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("document_list_query");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    agentId = setup.testAgentId;
+    worldId = v4() as UUID;
+    roomId = v4() as UUID;
+
+    await adapter.createWorld({
+      id: worldId,
+      agentId,
+      name: "Document query world",
+      serverId: "document-query",
+    } as World);
+    await adapter.createRooms([
+      {
+        id: roomId,
+        agentId,
+        worldId,
+        name: "documents",
+        source: "test",
+        type: ChannelType.DM,
+      } as Room,
+    ]);
+    await adapter.createEntities([
+      {
+        id: REQUESTER_ID,
+        agentId,
+        names: ["Requester"],
+      } as Entity,
+      {
+        id: OTHER_ENTITY_ID,
+        agentId,
+        names: ["Other"],
+      } as Entity,
+    ]);
+    await adapter.addParticipant(REQUESTER_ID, roomId);
+    await adapter.addParticipant(OTHER_ENTITY_ID, roomId);
+  });
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  beforeEach(async () => {
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    await db.delete(embeddingTable);
+    await db.delete(memoryTable);
+  });
+
+  function document(
+    index: number,
+    overrides: Partial<Memory> & { metadata?: Record<string, unknown> } = {}
+  ): Memory {
+    const { metadata, ...memoryOverrides } = overrides;
+    const id = `30000000-0000-0000-0000-${index.toString(16).padStart(12, "0")}` as UUID;
+    return {
+      id,
+      agentId,
+      entityId: REQUESTER_ID,
+      roomId,
+      worldId,
+      createdAt: 10_000,
+      content: { text: `Document body ${index}` },
+      metadata: {
+        type: MemoryType.DOCUMENT,
+        documentId: id,
+        title: `Document ${index}`,
+        scope: "global",
+        timestamp: 10_000,
+        tags: ["archive"],
+        ...metadata,
+      },
+      ...memoryOverrides,
+    };
+  }
+
+  async function seedSql(documents: Memory[]): Promise<void> {
+    await adapter.createMemories(documents.map((memory) => ({ memory, tableName: "documents" })));
+  }
+
+  async function seedInMemory(documents: Memory[]): Promise<InMemoryDatabaseAdapter> {
+    const inMemory = new InMemoryDatabaseAdapter();
+    await inMemory.initialize();
+    await inMemory.createMemories(documents.map((memory) => ({ memory, tableName: "documents" })));
+    return inMemory;
+  }
+
+  const ids = (memories: Memory[]): UUID[] =>
+    memories.map((memory) => memory.id).filter((id): id is UUID => typeof id === "string");
+
+  it("keeps entityId as isolation context instead of a row predicate", async () => {
+    const documents = [document(1), document(2, { entityId: OTHER_ENTITY_ID })];
+    await seedSql(documents);
+    const inMemory = await seedInMemory(documents);
+
+    const sqlRows = await adapter.getMemories({
+      tableName: "documents",
+      agentId,
+      entityId: REQUESTER_ID,
+      includeEmbedding: false,
+    });
+    const inMemoryRows = await inMemory.getMemories({
+      tableName: "documents",
+      agentId,
+      entityId: REQUESTER_ID,
+      includeEmbedding: false,
+    });
+
+    expect(ids(sqlRows)).toEqual(ids(inMemoryRows));
+    expect(new Set(ids(sqlRows))).toEqual(new Set(ids(documents)));
+  });
+
+  it("matches visibility, filters, counts, and fallback pages across adapters", async () => {
+    const documents = [
+      document(1),
+      document(2, {
+        metadata: {
+          scope: "user-private",
+          scopedToEntityId: REQUESTER_ID,
+        },
+      }),
+      document(3, {
+        entityId: OTHER_ENTITY_ID,
+        metadata: {
+          scope: "user-private",
+          scopedToEntityId: OTHER_ENTITY_ID,
+        },
+      }),
+      document(4, { metadata: { scope: "owner-private" } }),
+      document(5, { metadata: { scope: "agent-private" } }),
+    ];
+    await seedSql(documents);
+    const inMemory = await seedInMemory(documents);
+    const params: DocumentListQueryParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "USER",
+      query: "missing",
+      limit: 1,
+      offset: 0,
+    };
+    const withEntityContext = vi.spyOn(
+      adapter as unknown as {
+        withEntityContext: (
+          entityId: UUID | null,
+          callback: (tx: unknown) => Promise<unknown>
+        ) => Promise<unknown>;
+      },
+      "withEntityContext"
+    );
+
+    const sqlResult = await adapter.queryDocuments(params);
+    const inMemoryResult = await inMemory.queryDocuments(params);
+
+    expect(withEntityContext).toHaveBeenCalledWith(REQUESTER_ID, expect.any(Function));
+    expect(sqlResult).toMatchObject({
+      totalVisible: 2,
+      totalAvailable: 2,
+      totalMatched: 0,
+      documents: [],
+      availableHasMore: true,
+    });
+    expect(sqlResult.availableNextCursor).toBeDefined();
+    expect(ids(sqlResult.availableDocuments)).toEqual(ids(inMemoryResult.availableDocuments));
+    expect(sqlResult).toEqual(inMemoryResult);
+
+    const secondSqlPage = await adapter.queryDocuments({
+      ...params,
+      offset: 1,
+    });
+    const secondInMemoryPage = await inMemory.queryDocuments({
+      ...params,
+      offset: 1,
+    });
+    expect(secondSqlPage).toMatchObject({
+      totalAvailable: 2,
+      availableHasMore: false,
+    });
+    expect(secondSqlPage).toEqual(secondInMemoryPage);
+    expect(ids(secondSqlPage.availableDocuments)).not.toEqual(ids(sqlResult.availableDocuments));
+
+    const cursorSqlPage = await adapter.queryDocuments({
+      ...params,
+      cursor: sqlResult.availableNextCursor,
+    });
+    expect(cursorSqlPage.availableDocuments).toEqual(secondSqlPage.availableDocuments);
+    expect(cursorSqlPage.availableHasMore).toBe(false);
+
+    const ownerResult = await adapter.queryDocuments({
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "OWNER",
+      limit: 10,
+      offset: 0,
+    });
+    expect(ownerResult).toMatchObject({
+      totalVisible: 5,
+      totalAvailable: 5,
+      totalMatched: 5,
+    });
+  });
+
+  it("does not skip or duplicate equal-timestamp rows across keyset pages", async () => {
+    const documents = Array.from({ length: 151 }, (_, index) => document(index));
+    await seedSql(documents);
+    const inMemory = await seedInMemory(documents);
+    const baseParams: DocumentListQueryParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "RUNTIME",
+      limit: 37,
+      offset: 0,
+    };
+
+    const collect = async (
+      query: (
+        params: DocumentListQueryParams
+      ) => Promise<{ documents: Memory[]; hasMore: boolean; nextCursor?: DocumentListCursor }>
+    ): Promise<UUID[]> => {
+      const seen: UUID[] = [];
+      let cursor: DocumentListCursor | undefined;
+      do {
+        const page = await query({
+          ...baseParams,
+          ...(cursor ? { cursor } : {}),
+        });
+        seen.push(...ids(page.documents));
+        cursor = page.nextCursor;
+        if (!page.hasMore) break;
+        expect(cursor).toBeDefined();
+      } while (cursor);
+      return seen;
+    };
+
+    const sqlIds = await collect((params) => adapter.queryDocuments(params));
+    const inMemoryIds = await collect((params) => inMemory.queryDocuments(params));
+
+    expect(sqlIds).toHaveLength(151);
+    expect(new Set(sqlIds).size).toBe(151);
+    expect(sqlIds).toEqual(inMemoryIds);
+  });
+
+  it("normalizes microsecond database timestamps before applying keyset cursors", async () => {
+    const documents = [document(1), document(2), document(3)];
+    await seedSql(documents);
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    await db.execute(
+      sql`UPDATE ${memoryTable}
+          SET created_at = CASE id
+            WHEN ${documents[0]?.id}::uuid THEN '2026-01-01 00:00:00.123900'::timestamp
+            WHEN ${documents[1]?.id}::uuid THEN '2026-01-01 00:00:00.123800'::timestamp
+            ELSE '2026-01-01 00:00:00.123700'::timestamp
+          END`
+    );
+    const params: DocumentListQueryParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "RUNTIME",
+      limit: 1,
+      offset: 0,
+    };
+    const seen: UUID[] = [];
+    let cursor: DocumentListCursor | undefined;
+    do {
+      const page = await adapter.queryDocuments({
+        ...params,
+        ...(cursor ? { cursor } : {}),
+      });
+      seen.push(...ids(page.documents));
+      cursor = page.nextCursor;
+      if (!page.hasMore) break;
+    } while (cursor);
+
+    expect(seen).toEqual(ids(documents).sort((left, right) => right.localeCompare(left)));
+    expect(new Set(seen).size).toBe(3);
+  });
+
+  it("excludes fragments stored in the documents table across adapters", async () => {
+    const canonical = document(1);
+    const fragment = document(2, {
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: canonical.id,
+        position: 0,
+        timestamp: 10_000,
+      },
+    });
+    await seedSql([canonical, fragment]);
+    const inMemory = await seedInMemory([canonical, fragment]);
+    const params: DocumentListQueryParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "RUNTIME",
+      limit: 10,
+      offset: 0,
+    };
+
+    const sqlResult = await adapter.queryDocuments(params);
+    const inMemoryResult = await inMemory.queryDocuments(params);
+
+    expect(ids(sqlResult.documents)).toEqual([canonical.id]);
+    expect(sqlResult).toEqual(inMemoryResult);
+    expect(sqlResult.totalVisible).toBe(1);
+  });
+
+  it("keeps each count and page coherent while writes race the query", async () => {
+    await seedSql(Array.from({ length: 10 }, (_, index) => document(index)));
+    const params: DocumentListQueryParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "RUNTIME",
+      limit: 100,
+      offset: 0,
+    };
+
+    const reads = await Promise.all(
+      Array.from({ length: 8 }, async (_, index) => {
+        const [result] = await Promise.all([
+          adapter.queryDocuments(params),
+          seedSql([document(100 + index)]),
+        ]);
+        return result;
+      })
+    );
+
+    for (const result of reads) {
+      expect(result.totalVisible).toBe(result.documents.length);
+      expect(result.totalAvailable).toBe(result.documents.length);
+      expect(result.totalMatched).toBe(result.documents.length);
+      expect(result.hasMore).toBe(false);
+    }
+  });
+
+  it("rejects unbounded offsets before issuing a database query", async () => {
+    await expect(
+      adapter.queryDocuments({
+        agentId,
+        requesterEntityId: REQUESTER_ID,
+        requesterRoomIds: [roomId],
+        requesterRole: "RUNTIME",
+        limit: 10,
+        offset: 10_001,
+      })
+    ).rejects.toMatchObject({
+      code: "DOCUMENT_LIST_INVALID_PAGINATION",
+    });
+  });
+
+  it("installs the composite index supporting document keyset order", async () => {
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    const result = await db.execute(sql`
+      SELECT indexdef
+      FROM pg_indexes
+      WHERE indexname = 'idx_memories_document_list_order'
+    `);
+    const definition = String(result.rows[0]?.indexdef ?? "");
+
+    expect(result.rows).toHaveLength(1);
+    expect(definition).toContain("date_trunc");
+    expect(definition).toContain("metadata");
+    expect(definition).toContain("type");
+  });
+
+  it("pushes metadata, text, and document timestamp filters down with parity", async () => {
+    const documents = [
+      document(1, {
+        metadata: {
+          title: "Quarterly Launch Needle",
+          scope: "global",
+          scopedToEntityId: REQUESTER_ID,
+          addedBy: REQUESTER_ID,
+          tags: ["archive", "launch"],
+          timestamp: 5_000,
+        },
+      }),
+      document(2, {
+        metadata: {
+          title: "Quarterly Launch Needle",
+          scope: "global",
+          scopedToEntityId: REQUESTER_ID,
+          addedBy: REQUESTER_ID,
+          tags: ["archive"],
+          timestamp: 5_000,
+        },
+      }),
+      document(3, {
+        metadata: {
+          title: "Quarterly Launch Needle",
+          scope: "global",
+          scopedToEntityId: REQUESTER_ID,
+          addedBy: REQUESTER_ID,
+          tags: ["archive", "launch"],
+          timestamp: 50_000,
+        },
+      }),
+    ];
+    await seedSql(documents);
+    const inMemory = await seedInMemory(documents);
+    const params: DocumentListQueryParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "RUNTIME",
+      query: "launch needle",
+      scope: "global",
+      scopedToEntityId: REQUESTER_ID,
+      addedBy: REQUESTER_ID,
+      tags: ["archive", "launch"],
+      timeRangeStart: 4_000,
+      timeRangeEnd: 6_000,
+      limit: 10,
+      offset: 0,
+    };
+
+    const sqlResult = await adapter.queryDocuments(params);
+    const inMemoryResult = await inMemory.queryDocuments(params);
+
+    expect(ids(sqlResult.documents)).toEqual([documents[0]?.id]);
+    expect(sqlResult).toEqual(inMemoryResult);
+    expect(sqlResult).toMatchObject({
+      totalVisible: 3,
+      totalAvailable: 1,
+      totalMatched: 1,
+      hasMore: false,
+    });
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
@@ -8,11 +8,12 @@
  * `set_config('app.entity_id', $1, true)` form — this exercises the real
  * production code path, not a raw-interpolation stand-in.
  */
-import { stringToUuid, type UUID } from "@elizaos/core";
+import { MemoryType, stringToUuid, type UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { Client } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PgDatabaseAdapter } from "../../../pg/adapter";
 import { PostgresConnectionManager } from "../../../pg/manager";
 import { bootstrapPostgresRlsSchema, toPostgresSuperuserUrl } from "./rls-test-helpers";
 
@@ -35,6 +36,8 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
   const room1Id = uuidv4();
   const room2Id = uuidv4();
   const agentId = uuidv4();
+  const room1DocumentId = uuidv4();
+  const room2DocumentId = uuidv4();
 
   beforeAll(async () => {
     await bootstrapPostgresRlsSchema(POSTGRES_URL);
@@ -158,7 +161,6 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
        VALUES (gen_random_uuid(), $1, $2, '{"text": "Message in room2"}', 'message', NOW())`,
       [agentId, room2Id]
     );
-
     console.log("[RLS Test] Test data setup complete");
   });
 
@@ -222,6 +224,63 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
     expect(result.rows).toHaveLength(2);
     expect(result.rows.map((r: { room_id: string }) => r.room_id)).toContain(room1Id);
     expect(result.rows.map((r: { room_id: string }) => r.room_id)).toContain(room2Id);
+  });
+
+  it("keeps document role visibility within real PostgreSQL room RLS", async () => {
+    await superuserClient.query(
+      `INSERT INTO memories (id, agent_id, room_id, content, type, metadata, created_at)
+       VALUES
+         ($1, $3, $4, '{"text": "Document in room1"}', 'documents',
+          '{"type":"document","timestamp":1000,"scope":"global"}'::jsonb, NOW()),
+         ($2, $3, $5, '{"text": "Document in room2"}', 'documents',
+          '{"type":"document","timestamp":1000,"scope":"global"}'::jsonb, NOW())`,
+      [room1DocumentId, room2DocumentId, agentId, room1Id, room2Id]
+    );
+    try {
+      const adapter = new PgDatabaseAdapter(agentId as UUID, manager);
+      const base = {
+        agentId: agentId as UUID,
+        requesterRole: "USER" as const,
+        limit: 10,
+        offset: 0,
+      };
+      const aliceRooms = await adapter.getRoomsForParticipants([aliceId as UUID]);
+      const bobRooms = await adapter.getRoomsForParticipants([bobId as UUID]);
+
+      const alice = await adapter.queryDocuments({
+        ...base,
+        requesterEntityId: aliceId as UUID,
+        requesterRoomIds: [room1Id as UUID],
+      });
+      const bob = await adapter.queryDocuments({
+        ...base,
+        requesterEntityId: bobId as UUID,
+        requesterRoomIds: [room1Id as UUID, room2Id as UUID],
+      });
+      const aliceOwner = await adapter.queryDocuments({
+        ...base,
+        requesterEntityId: aliceId as UUID,
+        requesterRoomIds: [room1Id as UUID, room2Id as UUID],
+        requesterRole: "OWNER",
+      });
+
+      expect(alice.documents.map((memory) => memory.id)).toEqual([room1DocumentId]);
+      expect(bob.documents.map((memory) => memory.id).sort()).toEqual(
+        [room1DocumentId, room2DocumentId].sort()
+      );
+      expect(aliceOwner.documents.map((memory) => memory.id)).toEqual([room1DocumentId]);
+      expect(aliceRooms).toEqual([room1Id]);
+      expect(bobRooms.sort()).toEqual([room1Id, room2Id].sort());
+      expect(alice.totalVisible).toBe(1);
+      expect(bob.totalVisible).toBe(2);
+      expect(aliceOwner.totalVisible).toBe(1);
+      expect(alice.documents[0]?.metadata?.type).toBe(MemoryType.DOCUMENT);
+    } finally {
+      await superuserClient.query(`DELETE FROM memories WHERE id IN ($1, $2)`, [
+        room1DocumentId,
+        room2DocumentId,
+      ]);
+    }
   });
 
   it("should allow Charlie to see ONLY room2 memories", async () => {

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
@@ -85,7 +85,8 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
          VALUES
            ($1, $4, ARRAY['Alice'], '{}'::jsonb, NOW()),
            ($2, $4, ARRAY['Bob'], '{}'::jsonb, NOW()),
-           ($3, $4, ARRAY['Charlie'], '{}'::jsonb, NOW())
+           ($3, $4, ARRAY['Charlie'], '{}'::jsonb, NOW()),
+           ($4, $4, ARRAY['Agent'], '{}'::jsonb, NOW())
          ON CONFLICT (id) DO UPDATE SET names = EXCLUDED.names
          RETURNING id`,
         [aliceId, bobId, charlieId, agentId]
@@ -110,8 +111,8 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
     );
 
     // Create participants (server_id is added dynamically by RLS)
-    // Room1: Alice + Bob
-    // Room2: Bob + Charlie
+    // The agent principal belongs to every room so trusted runtime/owner reads
+    // remain global without weakening STRICT entity RLS.
     try {
       const participantResult = await superuserClient.query(
         `INSERT INTO participants (id, entity_id, room_id, agent_id, created_at)
@@ -119,7 +120,9 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
            (gen_random_uuid(), $1, $2, $4, NOW()),
            (gen_random_uuid(), $3, $2, $4, NOW()),
            (gen_random_uuid(), $3, $5, $4, NOW()),
-           (gen_random_uuid(), $6, $5, $4, NOW())
+           (gen_random_uuid(), $6, $5, $4, NOW()),
+           (gen_random_uuid(), $4, $2, $4, NOW()),
+           (gen_random_uuid(), $4, $5, $4, NOW())
          ON CONFLICT DO NOTHING
          RETURNING id, entity_id`,
         [aliceId, room1Id, bobId, agentId, room2Id, charlieId]
@@ -176,10 +179,11 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
         room2Id,
       ]);
       await superuserClient.query(`DELETE FROM rooms WHERE id IN ($1, $2)`, [room1Id, room2Id]);
-      await superuserClient.query(`DELETE FROM entities WHERE id IN ($1, $2, $3)`, [
+      await superuserClient.query(`DELETE FROM entities WHERE id IN ($1, $2, $3, $4)`, [
         aliceId,
         bobId,
         charlieId,
+        agentId,
       ]);
       await superuserClient.query(`DELETE FROM agents WHERE id = $1`, [agentId]);
       await superuserClient.query(`DELETE FROM servers WHERE id = $1`, [serverId]);
@@ -260,20 +264,32 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
       const aliceOwner = await adapter.queryDocuments({
         ...base,
         requesterEntityId: aliceId as UUID,
-        requesterRoomIds: [room1Id as UUID, room2Id as UUID],
+        requesterRoomIds: [],
         requesterRole: "OWNER",
+      });
+      const runtime = await adapter.queryDocuments({
+        ...base,
+        requesterEntityId: agentId as UUID,
+        requesterRoomIds: [],
+        requesterRole: "RUNTIME",
       });
 
       expect(alice.documents.map((memory) => memory.id)).toEqual([room1DocumentId]);
       expect(bob.documents.map((memory) => memory.id).sort()).toEqual(
         [room1DocumentId, room2DocumentId].sort()
       );
-      expect(aliceOwner.documents.map((memory) => memory.id)).toEqual([room1DocumentId]);
+      expect(aliceOwner.documents.map((memory) => memory.id).sort()).toEqual(
+        [room1DocumentId, room2DocumentId].sort()
+      );
+      expect(runtime.documents.map((memory) => memory.id).sort()).toEqual(
+        [room1DocumentId, room2DocumentId].sort()
+      );
       expect(aliceRooms).toEqual([room1Id]);
       expect(bobRooms.sort()).toEqual([room1Id, room2Id].sort());
       expect(alice.totalVisible).toBe(1);
       expect(bob.totalVisible).toBe(2);
-      expect(aliceOwner.totalVisible).toBe(1);
+      expect(aliceOwner.totalVisible).toBe(2);
+      expect(runtime.totalVisible).toBe(2);
       expect(alice.documents[0]?.metadata?.type).toBe(MemoryType.DOCUMENT);
     } finally {
       await superuserClient.query(`DELETE FROM memories WHERE id IN ($1, $2)`, [

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -25,6 +25,10 @@ import {
   type CreateOAuthFlowStateParams,
   DatabaseAdapter,
   type DeleteConnectorAccountParams,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  type DocumentListCursor,
+  type DocumentListQueryParams,
+  type DocumentListQueryResult,
   ElizaError,
   type EntitiesForRoomsResult,
   type Entity,
@@ -60,6 +64,7 @@ import {
   type TaskMetadata,
   type UpsertConnectorAccountParams,
   type UUID,
+  validateDocumentListQueryParams,
   type World,
 } from "@elizaos/core";
 
@@ -170,6 +175,38 @@ function normalizeAgentBio(value: unknown): string[] | undefined {
 /** Escape an ILIKE literal so user keywords match literally (no `%`/`_` wildcards). */
 function escapeIlikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+function documentVisibilityCondition(params: DocumentListQueryParams): SQL | undefined {
+  if (
+    params.requesterRole === "OWNER" ||
+    params.requesterRole === "AGENT" ||
+    params.requesterRole === "RUNTIME"
+  ) {
+    return undefined;
+  }
+
+  return sql`(
+    COALESCE(${memoryTable.metadata}->>'scope', 'global') = 'global'
+    OR (
+      ${memoryTable.metadata}->>'scope' = 'user-private'
+      AND (
+        ${memoryTable.metadata}->>'scopedToEntityId' = ${params.requesterEntityId}
+        OR ${memoryTable.metadata}->>'addedBy' = ${params.requesterEntityId}
+        OR ${memoryTable.entityId} = ${params.requesterEntityId}
+      )
+    )
+  )`;
+}
+
+function documentTimestampExpression(): SQL {
+  return sql`COALESCE(
+    CASE
+      WHEN jsonb_typeof(${memoryTable.metadata}->'timestamp') = 'number'
+      THEN (${memoryTable.metadata}->>'timestamp')::double precision
+    END,
+    EXTRACT(EPOCH FROM ${memoryTable.createdAt}) * 1000
+  )`;
 }
 
 function isMessageSearchObjectsMissing(error: unknown): boolean {
@@ -333,6 +370,7 @@ import type { StoreContext } from "./stores/types";
 import type { DrizzleDatabase } from "./types";
 
 export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase> {
+  readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
   protected readonly maxRetries: number = 3;
   protected readonly baseDelay: number = 1000;
   protected readonly maxDelay: number = 10000;
@@ -1554,6 +1592,277 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async deleteComponent(componentId: UUID): Promise<void> {
     return this.withDatabase(async () => {
       await this.db.delete(componentTable).where(eq(componentTable.id, componentId));
+    });
+  }
+
+  async queryDocuments(params: DocumentListQueryParams): Promise<DocumentListQueryResult> {
+    validateDocumentListQueryParams(params);
+    return this.withEntityContext(params.requesterEntityId, async (tx) => {
+      const visibleConditions: SQL[] = [
+        eq(memoryTable.type, "documents"),
+        eq(memoryTable.agentId, params.agentId),
+        sql`${memoryTable.metadata}->>'type' = 'document'`,
+        params.requesterRoomIds.length > 0
+          ? inArray(memoryTable.roomId, params.requesterRoomIds)
+          : sql`false`,
+      ];
+      const visibility = documentVisibilityCondition(params);
+      if (visibility) visibleConditions.push(visibility);
+
+      const availableConditions: SQL[] = [];
+      if (params.scope) {
+        availableConditions.push(
+          sql`COALESCE(${memoryTable.metadata}->>'scope', 'global') = ${params.scope}`
+        );
+      }
+      if (params.scopedToEntityId) {
+        availableConditions.push(
+          sql`${memoryTable.metadata}->>'scopedToEntityId' = ${params.scopedToEntityId}`
+        );
+      }
+      if (params.addedBy) {
+        availableConditions.push(sql`${memoryTable.metadata}->>'addedBy' = ${params.addedBy}`);
+      }
+      if (params.timeRangeStart !== undefined) {
+        availableConditions.push(sql`${documentTimestampExpression()} >= ${params.timeRangeStart}`);
+      }
+      if (params.timeRangeEnd !== undefined) {
+        availableConditions.push(sql`${documentTimestampExpression()} <= ${params.timeRangeEnd}`);
+      }
+      if (params.tags?.length) {
+        availableConditions.push(
+          sql`COALESCE(${memoryTable.metadata}->'tags', '[]'::jsonb) @> ${JSON.stringify(
+            params.tags
+          )}::jsonb`
+        );
+      }
+      const availableCondition =
+        availableConditions.length > 0 ? and(...availableConditions) : sql`true`;
+
+      const normalizedQuery = params.query?.trim();
+      let queryCondition: SQL = sql`true`;
+      if (normalizedQuery) {
+        const pattern = `%${escapeIlikeLiteral(normalizedQuery)}%`;
+        queryCondition = sql`CONCAT_WS(
+            E'\n',
+            COALESCE(${memoryTable.content}->>'text', ''),
+            COALESCE(${memoryTable.metadata}->>'title', ''),
+            COALESCE(${memoryTable.metadata}->>'filename', ''),
+            COALESCE(${memoryTable.metadata}->>'originalFilename', ''),
+            COALESCE(${memoryTable.metadata}->>'source', '')
+          ) ILIKE ${pattern} ESCAPE '\\'`;
+      }
+
+      type DocumentRow = {
+        id: string;
+        type: string;
+        createdAt: Date | string;
+        cursorCreatedAt: Date | string;
+        content: unknown;
+        entityId: string | null;
+        agentId: string;
+        roomId: string | null;
+        worldId: string | null;
+        unique: boolean;
+        metadata: unknown;
+      };
+      const databaseTimestampToMs = (value: Date | string): number => {
+        const milliseconds =
+          value instanceof Date
+            ? value.getTime()
+            : Date.parse(
+                /(?:Z|[+-]\d{2}(?::?\d{2})?)$/i.test(value) ? value : `${value.replace(" ", "T")}Z`
+              );
+        if (!Number.isFinite(milliseconds)) {
+          throw new ElizaError("Document list query returned an invalid timestamp", {
+            code: "DOCUMENT_LIST_TIMESTAMP_INVALID",
+            context: { agentId: params.agentId, value },
+            severity: "fatal",
+          });
+        }
+        return milliseconds;
+      };
+      const mapDocument = (row: DocumentRow): Memory => ({
+        id: row.id as UUID,
+        createdAt: databaseTimestampToMs(row.createdAt),
+        content:
+          typeof row.content === "string"
+            ? JSON.parse(row.content)
+            : (row.content as Memory["content"]),
+        entityId: row.entityId as UUID,
+        agentId: row.agentId as UUID,
+        roomId: row.roomId as UUID,
+        worldId: (row.worldId ?? undefined) as UUID | undefined,
+        unique: row.unique,
+        metadata:
+          typeof row.metadata === "string"
+            ? JSON.parse(row.metadata)
+            : (row.metadata as MemoryMetadata),
+      });
+
+      type Page = {
+        documents: Memory[];
+        hasMore: boolean;
+        nextCursor?: DocumentListCursor;
+      };
+      const buildPage = (rows: DocumentRow[]): Page => {
+        const hasMore = rows.length > params.limit;
+        const pageRows = rows.slice(0, params.limit);
+        const documents = pageRows.map(mapDocument);
+        const last = pageRows.at(-1);
+        return {
+          documents,
+          hasMore,
+          ...(hasMore && last
+            ? {
+                nextCursor: {
+                  createdAt: databaseTimestampToMs(last.cursorCreatedAt),
+                  id: last.id as UUID,
+                },
+              }
+            : {}),
+        };
+      };
+
+      const cursorCondition = params.cursor
+        ? sql`(
+            cursor_created_at < (
+              timestamp 'epoch' + ${params.cursor.createdAt} * interval '1 millisecond'
+            )
+            OR (
+              cursor_created_at = (
+                timestamp 'epoch' + ${params.cursor.createdAt} * interval '1 millisecond'
+              )
+              AND id < ${params.cursor.id}::uuid
+            )
+          )`
+        : sql`true`;
+      const offsetClause = params.cursor ? sql`` : sql`OFFSET ${params.offset}`;
+      const pageSize = params.limit + 1;
+      const result = await tx.execute(sql`
+        WITH visible AS MATERIALIZED (
+          SELECT
+            ${memoryTable.id} AS id,
+            ${memoryTable.type} AS type,
+            ${memoryTable.createdAt} AS created_at,
+            date_trunc('milliseconds', ${memoryTable.createdAt}) AS cursor_created_at,
+            ${memoryTable.content} AS content,
+            ${memoryTable.entityId} AS entity_id,
+            ${memoryTable.agentId} AS agent_id,
+            ${memoryTable.roomId} AS room_id,
+            ${memoryTable.worldId} AS world_id,
+            ${memoryTable.unique} AS unique,
+            ${memoryTable.metadata} AS metadata,
+            (${availableCondition}) AS is_available,
+            ((${availableCondition}) AND (${queryCondition})) AS is_matched
+          FROM ${memoryTable}
+          WHERE ${and(...visibleConditions)}
+        ),
+        counts AS MATERIALIZED (
+          SELECT
+            COUNT(*) AS total_visible,
+            COUNT(*) FILTER (WHERE is_available) AS total_available,
+            COUNT(*) FILTER (WHERE is_matched) AS total_matched
+          FROM visible
+        ),
+        matched_page AS MATERIALIZED (
+          SELECT visible.*, 'matched'::text AS page_kind
+          FROM visible
+          WHERE is_matched AND ${cursorCondition}
+          ORDER BY cursor_created_at DESC, id DESC
+          LIMIT ${pageSize}
+          ${offsetClause}
+        ),
+        available_page AS MATERIALIZED (
+          SELECT visible.*, 'available'::text AS page_kind
+          FROM visible
+          CROSS JOIN counts
+          WHERE
+            ${Boolean(normalizedQuery)}
+            AND counts.total_matched = 0
+            AND is_available
+            AND ${cursorCondition}
+          ORDER BY cursor_created_at DESC, id DESC
+          LIMIT ${pageSize}
+          ${offsetClause}
+        ),
+        page_rows AS (
+          SELECT * FROM matched_page
+          UNION ALL
+          SELECT * FROM available_page
+        )
+        SELECT
+          counts.total_visible AS "totalVisible",
+          counts.total_available AS "totalAvailable",
+          counts.total_matched AS "totalMatched",
+          page_rows.page_kind AS "pageKind",
+          page_rows.id,
+          page_rows.type,
+          page_rows.created_at AS "createdAt",
+          page_rows.cursor_created_at AS "cursorCreatedAt",
+          page_rows.content,
+          page_rows.entity_id AS "entityId",
+          page_rows.agent_id AS "agentId",
+          page_rows.room_id AS "roomId",
+          page_rows.world_id AS "worldId",
+          page_rows.unique,
+          page_rows.metadata
+        FROM counts
+        LEFT JOIN page_rows ON true
+        ORDER BY
+          CASE page_rows.page_kind WHEN 'matched' THEN 0 ELSE 1 END,
+          page_rows.cursor_created_at DESC,
+          page_rows.id DESC
+      `);
+      type QueryRow = Partial<DocumentRow> & {
+        totalVisible: unknown;
+        totalAvailable: unknown;
+        totalMatched: unknown;
+        pageKind: "matched" | "available" | null;
+      };
+      const rows = result.rows as QueryRow[];
+      const countRow = rows[0];
+      if (!countRow) {
+        throw new ElizaError("Document list query returned no count row", {
+          code: "DOCUMENT_LIST_COUNT_MISSING",
+          context: { agentId: params.agentId },
+          severity: "fatal",
+        });
+      }
+      const parseCount = (value: unknown, label: string): number => {
+        const parsed = Number(value);
+        if (!Number.isSafeInteger(parsed) || parsed < 0) {
+          throw new ElizaError("Document list query returned an invalid count", {
+            code: "DOCUMENT_LIST_COUNT_INVALID",
+            context: { agentId: params.agentId, label, value: String(value) },
+            severity: "fatal",
+          });
+        }
+        return parsed;
+      };
+      const totalVisible = parseCount(countRow.totalVisible, "visible");
+      const totalAvailable = parseCount(countRow.totalAvailable, "available");
+      const totalMatched = parseCount(countRow.totalMatched, "matched");
+      const matchedRows = rows.filter(
+        (row): row is QueryRow & DocumentRow => row.pageKind === "matched"
+      );
+      const availableRows = rows.filter(
+        (row): row is QueryRow & DocumentRow => row.pageKind === "available"
+      );
+      const matchedPage = buildPage(matchedRows);
+      const availablePage = buildPage(availableRows);
+
+      return {
+        documents: matchedPage.documents,
+        availableDocuments: availablePage.documents,
+        totalVisible,
+        totalAvailable,
+        totalMatched,
+        hasMore: matchedPage.hasMore,
+        availableHasMore: availablePage.hasMore,
+        ...(matchedPage.nextCursor ? { nextCursor: matchedPage.nextCursor } : {}),
+        ...(availablePage.nextCursor ? { availableNextCursor: availablePage.nextCursor } : {}),
+      };
     });
   }
 
@@ -3333,17 +3642,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
    * @returns {Promise<UUID[]>} A Promise that resolves to an array of room IDs.
    */
   async getRoomsForParticipants(entityIds: UUID[]): Promise<UUID[]> {
-    return this.withDatabase(async () => {
-      const result = await this.db
-        .selectDistinct({ roomId: participantTable.roomId })
-        .from(participantTable)
-        .innerJoin(roomTable, eq(participantTable.roomId, roomTable.id))
-        .where(
-          and(inArray(participantTable.entityId, entityIds), eq(roomTable.agentId, this.agentId))
-        );
-
-      return result.map((row) => row.roomId as UUID);
-    });
+    const roomIds = new Set<UUID>();
+    for (const entityId of entityIds) {
+      const result = await this.withEntityContext(entityId, async (tx) =>
+        tx
+          .selectDistinct({ roomId: participantTable.roomId })
+          .from(participantTable)
+          .innerJoin(roomTable, eq(participantTable.roomId, roomTable.id))
+          .where(and(eq(participantTable.entityId, entityId), eq(roomTable.agentId, this.agentId)))
+      );
+      for (const row of result) roomIds.add(row.roomId as UUID);
+    }
+    return [...roomIds];
   }
 
   /**

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -29,6 +29,7 @@ import {
   type DocumentListCursor,
   type DocumentListQueryParams,
   type DocumentListQueryResult,
+  documentRoleHasGlobalVisibility,
   ElizaError,
   type EntitiesForRoomsResult,
   type Entity,
@@ -178,11 +179,7 @@ function escapeIlikeLiteral(value: string): string {
 }
 
 function documentVisibilityCondition(params: DocumentListQueryParams): SQL | undefined {
-  if (
-    params.requesterRole === "OWNER" ||
-    params.requesterRole === "AGENT" ||
-    params.requesterRole === "RUNTIME"
-  ) {
+  if (documentRoleHasGlobalVisibility(params.requesterRole)) {
     return undefined;
   }
 
@@ -310,6 +307,7 @@ import {
   taskTable,
   worldTable,
 } from "./schema/index";
+import { documentSearchVectorExpression } from "./schema/memory";
 
 type AgentRow = typeof agentTable.$inferSelect;
 type AgentMessageExamples = NonNullable<Agent["messageExamples"]>;
@@ -1597,15 +1595,21 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
   async queryDocuments(params: DocumentListQueryParams): Promise<DocumentListQueryResult> {
     validateDocumentListQueryParams(params);
-    return this.withEntityContext(params.requesterEntityId, async (tx) => {
+    const hasGlobalVisibility = documentRoleHasGlobalVisibility(params.requesterRole);
+    const entityContext = hasGlobalVisibility ? params.agentId : params.requesterEntityId;
+    return this.withEntityContext(entityContext, async (tx) => {
       const visibleConditions: SQL[] = [
         eq(memoryTable.type, "documents"),
         eq(memoryTable.agentId, params.agentId),
         sql`${memoryTable.metadata}->>'type' = 'document'`,
-        params.requesterRoomIds.length > 0
-          ? inArray(memoryTable.roomId, params.requesterRoomIds)
-          : sql`false`,
       ];
+      if (!hasGlobalVisibility) {
+        visibleConditions.push(
+          params.requesterRoomIds.length > 0
+            ? inArray(memoryTable.roomId, params.requesterRoomIds)
+            : sql`false`
+        );
+      }
       const visibility = documentVisibilityCondition(params);
       if (visibility) visibleConditions.push(visibility);
 
@@ -1642,15 +1646,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const normalizedQuery = params.query?.trim();
       let queryCondition: SQL = sql`true`;
       if (normalizedQuery) {
-        const pattern = `%${escapeIlikeLiteral(normalizedQuery)}%`;
-        queryCondition = sql`CONCAT_WS(
-            E'\n',
-            COALESCE(${memoryTable.content}->>'text', ''),
-            COALESCE(${memoryTable.metadata}->>'title', ''),
-            COALESCE(${memoryTable.metadata}->>'filename', ''),
-            COALESCE(${memoryTable.metadata}->>'originalFilename', ''),
-            COALESCE(${memoryTable.metadata}->>'source', '')
-          ) ILIKE ${pattern} ESCAPE '\\'`;
+        queryCondition = sql`${documentSearchVectorExpression(
+          memoryTable.content,
+          memoryTable.metadata
+        )} @@ plainto_tsquery('simple', ${normalizedQuery})`;
       }
 
       type DocumentRow = {
@@ -1724,28 +1723,50 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         };
       };
 
+      const cursorCreatedAt = sql`date_trunc('milliseconds', ${memoryTable.createdAt})`;
       const cursorCondition = params.cursor
         ? sql`(
-            cursor_created_at < (
+            ${cursorCreatedAt} < (
               timestamp 'epoch' + ${params.cursor.createdAt} * interval '1 millisecond'
             )
             OR (
-              cursor_created_at = (
+              ${cursorCreatedAt} = (
                 timestamp 'epoch' + ${params.cursor.createdAt} * interval '1 millisecond'
               )
-              AND id < ${params.cursor.id}::uuid
+              AND ${memoryTable.id} < ${params.cursor.id}::uuid
             )
           )`
         : sql`true`;
       const offsetClause = params.cursor ? sql`` : sql`OFFSET ${params.offset}`;
       const pageSize = params.limit + 1;
       const result = await tx.execute(sql`
-        WITH visible AS MATERIALIZED (
+        WITH counts AS MATERIALIZED (
+          SELECT
+            (
+              SELECT COUNT(*)
+              FROM ${memoryTable}
+              WHERE ${and(...visibleConditions)}
+            ) AS total_visible,
+            (
+              SELECT COUNT(*)
+              FROM ${memoryTable}
+              WHERE ${and(...visibleConditions)} AND ${availableCondition}
+            ) AS total_available,
+            (
+              SELECT COUNT(*)
+              FROM ${memoryTable}
+              WHERE
+                ${and(...visibleConditions)}
+                AND ${availableCondition}
+                AND ${queryCondition}
+            ) AS total_matched
+        ),
+        matched_page AS MATERIALIZED (
           SELECT
             ${memoryTable.id} AS id,
             ${memoryTable.type} AS type,
             ${memoryTable.createdAt} AS created_at,
-            date_trunc('milliseconds', ${memoryTable.createdAt}) AS cursor_created_at,
+            ${cursorCreatedAt} AS cursor_created_at,
             ${memoryTable.content} AS content,
             ${memoryTable.entityId} AS entity_id,
             ${memoryTable.agentId} AS agent_id,
@@ -1753,36 +1774,40 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             ${memoryTable.worldId} AS world_id,
             ${memoryTable.unique} AS unique,
             ${memoryTable.metadata} AS metadata,
-            (${availableCondition}) AS is_available,
-            ((${availableCondition}) AND (${queryCondition})) AS is_matched
+            'matched'::text AS page_kind
           FROM ${memoryTable}
-          WHERE ${and(...visibleConditions)}
-        ),
-        counts AS MATERIALIZED (
-          SELECT
-            COUNT(*) AS total_visible,
-            COUNT(*) FILTER (WHERE is_available) AS total_available,
-            COUNT(*) FILTER (WHERE is_matched) AS total_matched
-          FROM visible
-        ),
-        matched_page AS MATERIALIZED (
-          SELECT visible.*, 'matched'::text AS page_kind
-          FROM visible
-          WHERE is_matched AND ${cursorCondition}
-          ORDER BY cursor_created_at DESC, id DESC
+          WHERE
+            ${and(...visibleConditions)}
+            AND ${availableCondition}
+            AND ${queryCondition}
+            AND ${cursorCondition}
+          ORDER BY ${cursorCreatedAt} DESC, ${memoryTable.id} DESC
           LIMIT ${pageSize}
           ${offsetClause}
         ),
         available_page AS MATERIALIZED (
-          SELECT visible.*, 'available'::text AS page_kind
-          FROM visible
+          SELECT
+            ${memoryTable.id} AS id,
+            ${memoryTable.type} AS type,
+            ${memoryTable.createdAt} AS created_at,
+            ${cursorCreatedAt} AS cursor_created_at,
+            ${memoryTable.content} AS content,
+            ${memoryTable.entityId} AS entity_id,
+            ${memoryTable.agentId} AS agent_id,
+            ${memoryTable.roomId} AS room_id,
+            ${memoryTable.worldId} AS world_id,
+            ${memoryTable.unique} AS unique,
+            ${memoryTable.metadata} AS metadata,
+            'available'::text AS page_kind
+          FROM ${memoryTable}
           CROSS JOIN counts
           WHERE
             ${Boolean(normalizedQuery)}
             AND counts.total_matched = 0
-            AND is_available
+            AND ${and(...visibleConditions)}
+            AND ${availableCondition}
             AND ${cursorCondition}
-          ORDER BY cursor_created_at DESC, id DESC
+          ORDER BY ${cursorCreatedAt} DESC, ${memoryTable.id} DESC
           LIMIT ${pageSize}
           ${offsetClause}
         ),

--- a/plugins/plugin-sql/src/schema/memory.ts
+++ b/plugins/plugin-sql/src/schema/memory.ts
@@ -6,7 +6,7 @@
  * `fragment` and `document` metadata kinds without a dedicated column per
  * kind. Relations are defined in `embedding.ts` to avoid a circular import.
  */
-import { sql } from "drizzle-orm";
+import { type SQL, type SQLWrapper, sql } from "drizzle-orm";
 import {
   boolean,
   check,
@@ -21,6 +21,17 @@ import {
 import { agentTable } from "./agent";
 import { entityTable } from "./entity";
 import { roomTable } from "./room";
+
+export function documentSearchVectorExpression(content: SQLWrapper, metadata: SQLWrapper): SQL {
+  return sql`to_tsvector(
+    'simple',
+    COALESCE(${content}->>'text', '') || E'\n' ||
+    COALESCE(${metadata}->>'title', '') || E'\n' ||
+    COALESCE(${metadata}->>'filename', '') || E'\n' ||
+    COALESCE(${metadata}->>'originalFilename', '') || E'\n' ||
+    COALESCE(${metadata}->>'source', '')
+  )`;
+}
 
 export const memoryTable = pgTable(
   "memories",
@@ -71,6 +82,9 @@ export const memoryTable = pgTable(
       sql`date_trunc('milliseconds', ${table.createdAt})`,
       table.id
     ),
+    index("idx_memories_document_search")
+      .using("gin", documentSearchVectorExpression(table.content, table.metadata))
+      .where(sql`${table.type} = 'documents' AND ${table.metadata}->>'type' = 'document'`),
     index("idx_fragments_order").on(
       sql`((metadata->>'documentId'))`,
       sql`((metadata->>'position'))`

--- a/plugins/plugin-sql/src/schema/memory.ts
+++ b/plugins/plugin-sql/src/schema/memory.ts
@@ -64,6 +64,13 @@ export const memoryTable = pgTable(
     }).onDelete("cascade"),
     index("idx_memories_metadata_type").on(sql`((metadata->>'type'))`),
     index("idx_memories_document_id").on(sql`((metadata->>'documentId'))`),
+    index("idx_memories_document_list_order").on(
+      table.agentId,
+      table.type,
+      sql`((metadata->>'type'))`,
+      sql`date_trunc('milliseconds', ${table.createdAt})`,
+      table.id
+    ),
     index("idx_fragments_order").on(
       sql`((metadata->>'documentId'))`,
       sql`((metadata->>'position'))`


### PR DESCRIPTION
# Relates to

Closes #17138. Supersedes #17232 after review found pagination, visibility, fallback-result, adapter-parity, and scale defects.

## Summary
- move document visibility/filter/query/count/pagination into one versioned adapter capability
- execute SQL listing as one snapshot-coherent CTE with database-precision-safe cursor ordering
- use stable millisecond-truncated `(createdAt, id)` SQL cursors that cannot skip microsecond rows
- filter canonical DOCUMENT memories and enforce bounded limit/offset plus supporting indexes
- implement the exact capability in both first-party in-memory adapters and fail closed before reads when it is unavailable or version-mismatched
- return structured `ok`, `query_miss`, `filter_miss`, `page_exhausted`, and `empty_store` outcomes
- keep matched `documents` distinct from coherently paginated `availableDocuments` fallback pages
- restore global `entityId` parity while retaining SQL requester/RLS context
- resolve requester role once and fail fast with `ElizaError` plus `reportError`

## Root cause
The original action-only fallback solved one message while preserving a bounded-page blind spot. The first deeper rewrite then scanned the entire corpus and performed per-document authorization lookups. This head makes filtered listing a database contract: one bounded query, exact totals, stable cursors, and explicit outcome semantics consumed by the action.

## Validation
- exact head: `9471208660df6dcf753d6f3ef58de4edbb4b1f11`, based current `develop` `00d6f6cdaeb40d9d70e9664ebaccbd8169718f26`
- focused core document tests: 61 passed
- plugin-inmemorydb document tests: 2 passed
- real migrated PGlite document suite: 10 passed, with the PostgreSQL-only EXPLAIN case explicitly skipped
- core, plugin-sql, and plugin-inmemorydb builds and typechecks: passed
- Biome and diff checks: passed
- real PostgreSQL 16 RLS suite against an isolated non-superuser database: 9/9 passed, including document role/room visibility
- live-sweep PostgreSQL image corrected to the repo-standard pgvector image; static workflow contract: 16/16 passed
- fresh exact-head CI is running; independent re-review is pending

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend action/service behavior only; no rendered surface.

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend action/service behavior only; no rendered surface.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no frontend flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [Original failing live scenario run](https://github.com/elizaOS/eliza/actions/runs/30046774252) contains planner query `list all` and the false empty response; fresh exact-head deterministic and database logs pending.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend request or state path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: pending successful exact-head rerun; the available credential reached the real runtime but returned HTTP 402 before planner execution.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no deployed artifact is claimed; PGlite tests create and inspect document rows across requester, visibility, timestamp, cursor, filter, and query boundaries.

## Remaining evidence
This stays draft until a successful exact-head live-model trajectory is manually reviewed and the fresh independent re-review completes. Native PostgreSQL RLS now passes 9/9 against an isolated non-superuser database.

