### PR TITLE
fix(ci): make Windows contracts deterministic

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -354,7 +354,9 @@ describe("LP3 direct Cloud build flag", () => {
   });
 
   it("keeps runtime opt-in private and writable only through same-UID commands", () => {
-    const service = fs.readFileSync(servicePath, "utf8");
+    const service = fs
+      .readFileSync(servicePath, "utf8")
+      .replace(/\r\n?/g, "\n");
     const initializer = fs.readFileSync(initializerPath, "utf8");
     const readme = fs.readFileSync(readmePath, "utf8");
 

--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 import { Miniflare } from "miniflare";
 
 let miniflare: Miniflare;
@@ -11,10 +12,12 @@ let miniflare: Miniflare;
 beforeAll(async () => {
   const build = await Bun.build({
     entrypoints: [
-      new URL(
-        "../test/fixtures/inference-admission-gate-worker.ts",
-        import.meta.url,
-      ).pathname,
+      fileURLToPath(
+        new URL(
+          "../test/fixtures/inference-admission-gate-worker.ts",
+          import.meta.url,
+        ),
+      ),
     ],
     format: "esm",
     target: "browser",

--- a/packages/core/src/services/message.transcript-visibility.test.ts
+++ b/packages/core/src/services/message.transcript-visibility.test.ts
@@ -96,7 +96,6 @@ interface Harness {
 	callbacks: Content[];
 	sent: Content[];
 	voiceHandler: ReturnType<typeof vi.fn>;
-	persistedAtCallback: boolean[];
 }
 
 const activeRuntimes: AgentRuntime[] = [];
@@ -188,7 +187,6 @@ async function createHarness(finalText: string): Promise<Harness> {
 
 	const callbacks: Content[] = [];
 	const sent: Content[] = [];
-	const persistedAtCallback: boolean[] = [];
 	runtime.registerSendHandler(
 		"client_chat",
 		async (_runtime, _target, content) => {
@@ -199,17 +197,6 @@ async function createHarness(finalText: string): Promise<Harness> {
 
 	const callback: HandlerCallback = async (content: Content) => {
 		callbacks.push(content);
-		const stored = await runtime.getMemories({
-			roomId: runtime.agentId,
-			tableName: "messages",
-		});
-		persistedAtCallback.push(
-			stored.some(
-				(memory) =>
-					memory.entityId === runtime.agentId &&
-					memory.content.text === content.text,
-			),
-		);
 		await runtime.sendMessageToTarget(
 			{ source: "client_chat", roomId: runtime.agentId },
 			content,
@@ -224,7 +211,6 @@ async function createHarness(finalText: string): Promise<Harness> {
 		callbacks,
 		sent,
 		voiceHandler,
-		persistedAtCallback,
 	};
 }
 
@@ -307,15 +293,12 @@ describe("DefaultMessageService transcript visibility integration", () => {
 		expect(result.responseContent?.text).toBe(visibleSummary);
 		expect(result.responseContent?.transcriptVisibility).toBeUndefined();
 
+		// Delivery and persistence run concurrently; only their terminal
+		// guarantees are stable across adapters and operating-system schedulers.
 		const persisted = await assistantMemories(harness.runtime);
 		expect(persisted).toHaveLength(1);
 		expect(persisted[0]?.content.text).toBe(visibleSummary);
 		expect(persisted[0]?.content.transcriptVisibility).toBeUndefined();
-		// Core delivers the visible reply before persisting the response memory
-		// (#17105 took the write off the reply path); durability-before-terminal
-		// is the conversation route's contract, not the callback's. The summary
-		// is persisted by the time handleMessage resolves (asserted above).
-		expect(harness.persistedAtCallback).toEqual([false]);
 		expect(harness.callbacks).toHaveLength(1);
 		expect(harness.callbacks[0]?.text).toBe(visibleSummary);
 		expect(harness.sent).toHaveLength(1);

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -197,7 +197,7 @@ describe("managed dedicated canary diagnostic", () => {
     expect(canonical).not.toContain("managed-dedicated-canary-");
   });
 
-  test("writes the canonical artifact with owner-only permissions", () => {
+  function writeCanonicalArtifactFixture(): string {
     const directory = mkdtempSync(join(tmpdir(), "managed-canary-diagnostic-"));
     const rawPath = join(directory, "raw.json");
     const evidencePath = join(directory, "evidence.json");
@@ -208,11 +208,25 @@ describe("managed dedicated canary diagnostic", () => {
 
     writeManagedDedicatedCanaryDiagnostic(rawPath, evidencePath, SUFFIX);
 
-    expect(statSync(evidencePath).mode & 0o777).toBe(0o600);
+    return evidencePath;
+  }
+
+  test("writes the canonical artifact", () => {
+    const evidencePath = writeCanonicalArtifactFixture();
+
     expect(
       JSON.parse(readFileSync(evidencePath, "utf8")).jobs[0].errorCode,
     ).toBe("sandbox_stop_failed");
   });
+
+  test.skipIf(process.platform === "win32")(
+    "writes the canonical artifact with owner-only permissions",
+    () => {
+      const evidencePath = writeCanonicalArtifactFixture();
+
+      expect(statSync(evidencePath).mode & 0o777).toBe(0o600);
+    },
+  );
 
   test.each([
     ["invalid suffix", failedDeleteInput(), "r1a1", "suffix"],


### PR DESCRIPTION
## Summary
- normalize checked-out Java source line endings before asserting the LP3 contract
- convert fixture file URLs with `fileURLToPath` so Windows drive paths remain valid
- verify diagnostic artifact content everywhere while enforcing POSIX mode bits only on POSIX
- remove an invalid intermediate persistence-order assertion while preserving terminal delivery/persistence guarantees

Fixes #17237.

## Root cause
The failing contracts encoded POSIX checkout, URL, permission, and scheduler-order assumptions. Core intentionally runs delivery and persistence concurrently, so an intermediate storage observation after one async yield was not a supported invariant. The repaired assertions preserve product/security guarantees while testing representation and ordering only where the platform/runtime actually guarantees them.

## Validation
- LP3 contract: 15/15 passed
- managed dedicated canary diagnostic: 206/206 passed
- transcript visibility focused test: 2/2 passed in four runs
- exact-file Biome and diff checks: passed
- Miniflare test clears the original Windows path bug; local Bun 1.3.14 later hit an unrelated workerd `EPIPE`, while CI uses Bun 1.4.0-canary.1
- exact post-merge Windows CI remains required

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - test-only platform contract changes do not alter rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - test-only platform contract changes do not alter rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow changes.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [Exact develop Windows failures](https://github.com/elizaOS/eliza/actions/runs/30385665694) identify the CRLF, Windows-drive URL, mode-bit, and scheduler-order assertions.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend runtime behavior changes.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain output changes.
