### PR TITLE
fix(ui): restore chat visual policy gates

### DIFF
--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
@@ -96,10 +96,15 @@ describe("MessageSearchPanel", () => {
 
     const scroller = screen.getByTestId("message-search-scroll");
     const list = screen.getByTestId("message-search-results");
+    const input = screen.getByTestId("message-search-input");
     expect(scroller.hasAttribute("data-chat-sheet-scroll-region")).toBe(true);
     expect(scroller.className).toContain("touch-pan-y");
     expect(scroller.className).toContain("overflow-y-auto");
     expect(scroller.className).not.toContain("justify-end");
+    expect(input.className).not.toContain("backdrop-blur");
+    for (const searchResult of screen.getAllByTestId("message-search-result")) {
+      expect(searchResult.className).not.toContain("backdrop-blur");
+    }
     // Auto margin bottom-aligns a short list, but collapses to zero once the
     // list overflows so its first result remains reachable by native scrolling.
     expect(list.className).toContain("mt-auto");

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -135,7 +135,7 @@ export function MessageSearchPanel({
       // away when the results list above it is long.
       className={
         keyboardAnchored
-          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl placeholder:text-white/45"
+          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] placeholder:text-white/45"
           : undefined
       }
     />
@@ -196,7 +196,7 @@ export function MessageSearchPanel({
               variant="ghost"
               className={
                 keyboardAnchored
-                  ? "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-xl border border-white/10 bg-[rgba(12,16,18,0.86)] px-3 py-2 text-left font-normal shadow-[0_10px_28px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-xl hover:border-white/20 hover:bg-[rgba(18,22,24,0.92)]"
+                  ? "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-xl border border-white/10 bg-[rgba(12,16,18,0.86)] px-3 py-2 text-left font-normal shadow-[0_10px_28px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.06)] hover:border-white/20 hover:bg-[rgba(18,22,24,0.92)]"
                   : "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-md px-2 py-1.5 text-left font-normal hover:bg-muted/60"
               }
             >

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -115,6 +115,7 @@ describe("ChatMessageActions copy", () => {
       expect(button.className).toContain("hover:bg-transparent");
       expect(button.className).toContain("pointer-coarse:h-11");
       expect(button.className).not.toContain("bg-white/10");
+      expect(button.className).toContain("keyboard-focus-emphasis");
       expect(button.className).not.toContain("text-[rgb(255");
     }
     expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
@@ -126,6 +127,6 @@ describe("ChatMessageActions copy", () => {
     expect(surface.className).toContain("bg-black/55");
     expect(surface.className).toContain("border-white/25");
     expect(surface.style.backgroundImage).toContain("radial-gradient");
-    expect(surface.style.backdropFilter).toContain("blur");
+    expect(surface.style.backdropFilter).toBe("");
   });
 });

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -11,7 +11,6 @@ import type * as React from "react";
 
 import { cn } from "../../../lib/utils";
 import {
-  LIQUID_GLASS_BLUR,
   LIQUID_GLASS_EDGE_SHADOW,
   LIQUID_GLASS_SHEEN,
 } from "../../shell/liquid-glass";
@@ -62,8 +61,6 @@ export function ChatMessageActionSurface({
           : {
               backgroundImage: LIQUID_GLASS_SHEEN,
               boxShadow: LIQUID_GLASS_EDGE_SHADOW,
-              WebkitBackdropFilter: LIQUID_GLASS_BLUR,
-              backdropFilter: LIQUID_GLASS_BLUR,
               ...style,
             }
       }
@@ -103,9 +100,9 @@ function MessageActionButton({
         onClick();
       }}
       className={cn(
-        "bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
+        "keyboard-focus-emphasis bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
         bare
-          ? "h-5 w-5 rounded-none hover:bg-transparent active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55"
+          ? "h-5 w-5 rounded-none hover:bg-transparent active:bg-transparent"
           : "h-6 w-6 rounded-lg transition-[background-color,color,transform] hover:bg-white/10 active:bg-white/10",
         active &&
           (bare ? "text-white" : "bg-white/10 text-white hover:bg-white/15"),

--- a/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
@@ -63,6 +63,8 @@ describe("ChatMessage glass inline edit controls", () => {
     expect(save.textContent).toBe("");
     expect(cancel.className).toContain("pointer-coarse:h-11");
     expect(save.className).toContain("pointer-coarse:h-11");
+    expect(cancel.className).toContain("keyboard-focus-emphasis");
+    expect(save.className).toContain("keyboard-focus-emphasis");
   });
 
   it("restores the message action icons after Cancel", () => {

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -810,7 +810,7 @@ export const ChatMessage = memo(function ChatMessage({
               handleCancelEditing();
             }}
             disabled={savingEdit}
-            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+            className="keyboard-focus-emphasis h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
           >
             <X className="h-3.5 w-3.5" />
           </Button>
@@ -829,7 +829,7 @@ export const ChatMessage = memo(function ChatMessage({
               void handleSaveEdit();
             }}
             disabled={editSaveDisabled}
-            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+            className="keyboard-focus-emphasis h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
           >
             {savingEdit ? (
               <LoaderCircle
@@ -847,7 +847,7 @@ export const ChatMessage = memo(function ChatMessage({
             unstyled
             onClick={handleCancelEditing}
             disabled={savingEdit}
-            className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+            className="keyboard-focus-emphasis min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
           >
             {labels.cancel ?? "Cancel"}
           </Button>
@@ -856,7 +856,7 @@ export const ChatMessage = memo(function ChatMessage({
             unstyled
             onClick={() => void handleSaveEdit()}
             disabled={editSaveDisabled}
-            className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+            className="keyboard-focus-emphasis min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
           >
             {savingEdit
               ? (labels.saving ?? "Saving...")

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -475,6 +475,10 @@ kbd {
   outline: none !important;
   box-shadow: none !important;
 }
+
+.keyboard-focus-emphasis:focus-visible {
+  color: white;
+}
 /* biome-ignore-end lint/complexity/noImportantStyles: end focus-ring ban override */
 
 /*


### PR DESCRIPTION
## Summary
- remove unauthorized backdrop blur from message search and chat actions
- replace local focus-ring utilities with the shared keyboard-focus treatment
- add regression assertions for blur and keyboard focus behavior

Fixes #17239.

## Validation
- focused UI policy coverage: 14/14 suites, 29/29 tests passed
- `packages/ui` typecheck: passed
- exact-file Biome and diff checks: passed
- exact Client Tests and app visual audit are required before merge

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: pending capture of message search and chat actions.

<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: pending exact-head desktop/mobile capture.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: pending keyboard-focus and action-flow recording.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend runtime behavior changes.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: pending exact-head browser audit artifacts.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain output changes.

## Originating failure

https://github.com/elizaOS/eliza/actions/runs/30385664959/job/90364662058
