### PR TITLE
fix(app): repair browser shell contracts

### DIFF
--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -165,19 +165,20 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     readyChecks: [{ selector: "#root" }],
   },
   {
-    name: "apps catalog",
+    name: "my apps",
     path: "/apps",
-    // /apps renders the launcher grid (HomeScreenMount initialPage="launcher");
-    // the old text probes ("Views" / "No views available") predate that surface
-    // and never match it — anchor on the launcher's own testid.
-    readyChecks: [{ selector: '[data-testid="launcher"]' }],
+    // `/apps` is the canonical My Apps management surface. The launcher grid
+    // remains available at `/views`.
+    readyChecks: [{ text: "Install, create, and run your elizaOS apps." }],
     timeoutMs: 60_000,
+    requireViewHeader: true,
+    viewHeaderTitle: "My Apps",
   },
   {
     name: "automations",
     path: "/automations",
     readyChecks: [{ selector: '[data-testid="automations-shell"]' }],
-    viewHeaderWithin: '[data-testid="automations-shell"]',
+    viewHeaderTitle: "Automations",
     timeoutMs: 60_000,
     requireViewHeader: true,
   },
@@ -206,7 +207,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     name: "wallet",
     path: "/wallet",
     readyChecks: [{ selector: '[data-testid="wallet-shell"]' }],
-    viewHeaderWithin: '[data-testid="wallet-shell"]',
+    viewHeaderTitle: "Wallet",
     timeoutMs: 60_000,
     requireViewHeader: true,
   },
@@ -228,9 +229,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     name: "settings",
     path: "/settings",
     readyChecks: [{ selector: '[data-testid="settings-shell"]' }],
-    viewHeaderWithin: '[data-testid="settings-shell"]',
     timeoutMs: 60_000,
-    requireViewHeader: true,
   },
   // Phone / Messages / Contacts are `androidOnly: true` overlay apps. Their
   // side-effect registrations only fire when `isElizaOS()` is true (an AOSP
@@ -281,35 +280,37 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
   {
     name: "character documents deep link",
     path: "/character/documents",
-    readyChecks: [{ selector: '[data-testid="character-editor-view"]' }],
+    readyChecks: [{ selector: '[data-testid="documents-view"]' }],
     timeoutMs: 60_000,
+    requireViewHeader: true,
+    viewHeaderWithin: '[data-testid="documents-view"]',
+    viewHeaderTitle: "Knowledge",
   },
   {
-    // Promoted top-level character tabs (character-skills / experience) render
-    // dedicated views with a standard ViewHeader — anchor on the header shell
-    // plus the view title.
+    // Character Skills and Experience are headerless bodies under the shared
+    // Character section nav; the section header is the canonical route chrome.
     name: "character skills deep link",
     path: "/character/skills",
     readyChecks: [
-      { selector: '[data-testid="view-header"]' },
-      { text: "Skills" },
+      { selector: '[data-testid="section-nav-character"]' },
+      { text: "Character" },
     ],
     mode: "all",
     timeoutMs: 60_000,
     requireViewHeader: true,
-    viewHeaderTitle: "Skills",
+    viewHeaderTitle: "Character",
   },
   {
     name: "character experience deep link",
     path: "/character/experience",
     readyChecks: [
-      { selector: '[data-testid="view-header"]' },
-      { text: "Experience" },
+      { selector: '[data-testid="section-nav-character"]' },
+      { text: "Character" },
     ],
     mode: "all",
     timeoutMs: 60_000,
     requireViewHeader: true,
-    viewHeaderTitle: "Experience",
+    viewHeaderTitle: "Character",
   },
   {
     name: "automation node catalog deep link",
@@ -434,7 +435,7 @@ const SETTING_SECTIONS_TO_CLICK: readonly {
   { label: /^Background$/, expectedHash: "background" },
   { label: /^Wallet & RPC\b/, expectedHash: "wallet-rpc" },
   { label: /^Updates$/, expectedHash: "updates" },
-  { label: /^Backup & Reset$/, expectedHash: "advanced" },
+  { label: /^Backups$/, expectedHash: "advanced" },
   { label: /^Overview$/, expectedHash: "cloud-overview" },
   { label: /^Agents$/, expectedHash: "cloud-agents" },
 ];
@@ -1595,7 +1596,7 @@ async function clickSafeAllowlist(
   ).toBeVisible({ timeout: 60_000 });
   await expectNoPageIssues(issues, "chat safe toggle");
 
-  await probeRoute(page, coreRouteProbe("apps catalog"));
+  await probeRoute(page, coreRouteProbe("views catalog deep link"));
   const favoriteButton = page.getByRole("button", {
     name: "Add to favorites",
   });
@@ -1659,7 +1660,10 @@ test.beforeEach(async ({ page }) => {
   // pops over a routed view mid-sweep (it renders above the shell and its buttons
   // would otherwise be the first ones a header probe reaches). first-run is
   // already complete via DEFAULT_APP_STORAGE; this closes the other gate.
-  await seedAppStorage(page, { "eliza:permissions-primed": "1" });
+  await seedAppStorage(page, {
+    "eliza:permissions-primed": "1",
+    "eliza:developerMode": "1",
+  });
   await installSupplementalSafeRoutes(page);
   await installDefaultAppRoutes(page);
 });
@@ -1695,7 +1699,7 @@ test("visible safe app tiles and allowlisted buttons are click-safe", async ({
 
   for (const tile of SAFE_VIEW_TILES) {
     await test.step(tile.name, async () => {
-      await probeRoute(page, coreRouteProbe("apps catalog"));
+      await probeRoute(page, coreRouteProbe("views catalog deep link"));
       // A view may appear in both the "Pinned & recent" strip and a section
       // grid, so target the first matching card.
       const card = page.getByTestId(tile.testId).first();
@@ -1715,14 +1719,10 @@ test("shared ViewHeader back control navigates away without crashing (#13586)", 
   const issues = installPageIssueGuards(page);
   await page.setViewportSize(DESKTOP_PROBE.size);
 
-  // Settings is a canonical `normal` view with the shared ViewHeader. Open it,
-  // assert the icon-only-back contract on the SETTINGS shell's header (the route
-  // floats over the ambient home, which can carry its own header), then click
-  // back and assert the shell survives the navigation (no crash, no 404) and
-  // leaves the view.
-  const SETTINGS_SHELL = '[data-testid="settings-shell"]';
-  await probeRoute(page, coreRouteProbe("settings"));
-  await assertSharedViewHeaderContract(page, { within: SETTINGS_SHELL });
-  await clickViewHeaderBack(page, { within: SETTINGS_SHELL });
-  await expectNoPageIssues(issues, "settings view-header back");
+  // Wallet is a canonical shared-header view. Settings owns split-pane chrome
+  // and its sidebar back control, so it is intentionally outside this contract.
+  await probeRoute(page, coreRouteProbe("wallet"));
+  await assertSharedViewHeaderContract(page, { title: "Wallet" });
+  await clickViewHeaderBack(page, { title: "Wallet" });
+  await expectNoPageIssues(issues, "wallet view-header back");
 });

--- a/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
@@ -866,7 +866,6 @@ test("model tester route runs deterministic visible probes", async ({
     90_000,
   );
 
-  await expect(page.getByTestId("model-tester-shell")).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Model Tester" }),
   ).toBeVisible();
@@ -886,10 +885,7 @@ test("model tester route runs deterministic visible probes", async ({
     .poll(() => recorder.statusRequestCount())
     .toBeGreaterThan(statusRequestCount);
 
-  const textCard = page
-    .locator("section")
-    .filter({ has: page.getByRole("heading", { name: "Text" }) })
-    .first();
+  const textCard = page.locator('[data-agent-id="probe-text-small"]');
   await expect(textCard.getByText("TEXT_SMALL", { exact: true })).toBeVisible();
   await clickRequired(
     textCard.getByRole("button", { name: "Run" }),
@@ -905,10 +901,7 @@ test("model tester route runs deterministic visible probes", async ({
     .poll(() => recorder.runRequests().at(-1)?.prompt)
     .toBe(smokePrompt);
 
-  const imageCard = page
-    .locator("section")
-    .filter({ has: page.getByRole("heading", { name: "Image" }) })
-    .first();
+  const imageCard = page.locator('[data-agent-id="probe-image"]');
   await expect.poll(() => recorder.runRequestCount()).toBeGreaterThanOrEqual(1);
   await clickRequired(
     imageCard.getByRole("button", { name: "Run" }),

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -12,6 +12,7 @@ import {
   openAppPath,
   seedAppStorage,
 } from "./helpers";
+import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 
 const SCREENSHOT_DIR = path.join(
@@ -428,19 +429,6 @@ function assistantMicButton(page: Page) {
 
 function launcherTile(page: Page, viewId: string) {
   return page.getByTestId(`launcher-tile-${viewId}`).first();
-}
-
-async function openHomeLauncher(page: Page): Promise<void> {
-  const surface = page.getByTestId("home-launcher-surface");
-  await expect(surface).toBeVisible({ timeout: 15_000 });
-  // Home and apps share one combined surface: the launcher grid is embedded
-  // under the "Apps" region of the home column — scroll it into view the way
-  // a user would; there is no separate launcher page to navigate to.
-  const appsRegion = page.getByTestId("home-apps-scroll");
-  await expect(appsRegion).toBeVisible({ timeout: 15_000 });
-  const settingsTile = appsRegion.getByTestId("launcher-tile-settings");
-  await settingsTile.scrollIntoViewIfNeeded();
-  await expect(settingsTile).toBeVisible({ timeout: 15_000 });
 }
 
 function conversationLog(page: Page) {
@@ -940,18 +928,16 @@ test.describe("assistant home app flow", () => {
 
     await openReadyChat(page, "/chat");
 
-    // The home dashboard renders behind the floating chat. App launchers live
-    // on the embedded launcher grid of the combined home surface.
+    // The home dashboard renders behind the floating chat. The launcher is the
+    // second page of the shared Home/Launcher rail.
     await expect(page.getByTestId("home-launcher-surface")).toHaveAttribute(
       "data-page",
       "home",
     );
     await expect(page.getByTestId("home-screen")).toBeVisible();
 
-    await openHomeLauncher(page);
-    const settingsTile = page
-      .getByTestId("home-apps-scroll")
-      .getByTestId("launcher-tile-settings");
+    const launcher = await navigateHomeLauncher(page, "launcher");
+    const settingsTile = launcher.getByTestId("launcher-tile-settings");
     await expect(settingsTile).toBeVisible({ timeout: 15_000 });
 
     // Tapping the Settings tile navigates to the Settings view (setTab path).

--- a/packages/app/test/ui-smoke/auth-startup.spec.ts
+++ b/packages/app/test/ui-smoke/auth-startup.spec.ts
@@ -281,6 +281,16 @@ test("cloud bootstrap exchange stores the session bearer and resumes startup", a
   await page.getByRole("button", { name: "Activate" }).click();
 
   await expect.poll(() => exchangeRequests).toBe(1);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const stored = localStorage.getItem("elizaos:active-server");
+        if (!stored) return null;
+        const parsed = JSON.parse(stored) as { accessToken?: string };
+        return parsed.accessToken ?? null;
+      }),
+    )
+    .toBe("cloud-session");
   await expect.poll(() => authedAuthMeRequests).toBeGreaterThan(0);
   await expect(
     page.getByRole("heading", { name: "Finish setting up your container" }),

--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -672,8 +672,8 @@ test("automations overview empty state encourages creating tasks and workflows",
   await expect(
     page.getByRole("heading", { name: "Automations" }),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Tasks 0" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Workflows 0" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Prompts" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Workflows" })).toBeVisible();
   await expect(page.getByText("Nothing scheduled yet")).toBeVisible();
 
   await expect(page.getByRole("button", { name: "New" })).toHaveCount(0);
@@ -771,7 +771,7 @@ test("automations can list tasks, create a task, and inspect workflow JSON", asy
 
   await openAppPath(page, "/automations");
 
-  await expect(page.getByRole("button", { name: "Tasks 1" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Prompts 1" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Workflows 1" })).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Message triage" }),

--- a/packages/app/test/ui-smoke/builtin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/builtin-views-visual.spec.ts
@@ -11,6 +11,7 @@ import {
   seedAppStorage,
 } from "./helpers";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
+import { assertSharedViewHeaderContract } from "./helpers/view-header";
 
 /**
  * Visual coverage for the BUILTIN views — the pages rendered directly by the
@@ -28,7 +29,12 @@ import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality"
 // (packages/ui/src/navigation/index.ts), deduped by path. This is the live-run
 // + screenshot gate for ALL built-in views (not just a subset) so no built-in
 // surface ships without crash coverage at desktop + mobile.
-const BUILTIN_VIEW_CASES: Array<{ id: string; path: string }> = [
+const BUILTIN_VIEW_CASES: Array<{
+  id: string;
+  path: string;
+  readySelector?: string;
+  viewHeaderTitle?: string;
+}> = [
   { id: "chat", path: "/chat" },
   { id: "phone", path: "/phone" },
   { id: "messages", path: "/messages" },
@@ -37,13 +43,18 @@ const BUILTIN_VIEW_CASES: Array<{ id: string; path: string }> = [
   { id: "tasks", path: "/apps/tasks" },
   { id: "browser", path: "/browser" },
   { id: "stream", path: "/stream" },
-  { id: "apps", path: "/apps" },
+  { id: "my-apps", path: "/apps", viewHeaderTitle: "My Apps" },
   { id: "views", path: "/views" },
   { id: "character", path: "/character" },
   { id: "character-select", path: "/character/select" },
   { id: "automations", path: "/automations" },
   { id: "inventory", path: "/wallet" },
-  { id: "documents", path: "/character/documents" },
+  {
+    id: "documents",
+    path: "/character/documents",
+    readySelector: '[data-testid="documents-view"]',
+    viewHeaderTitle: "Knowledge",
+  },
   { id: "files", path: "/apps/files" },
   { id: "plugins", path: "/apps/plugins" },
   { id: "skills", path: "/apps/skills" },
@@ -101,6 +112,17 @@ test.describe("builtin views visual coverage (desktop + mobile)", () => {
           ? page.locator("main").first()
           : page.locator("body");
         await expect(viewRoot).toBeVisible({ timeout: 60_000 });
+        if (view.readySelector) {
+          await expect(page.locator(view.readySelector)).toBeVisible({
+            timeout: 60_000,
+          });
+        }
+        if (view.viewHeaderTitle) {
+          await assertSharedViewHeaderContract(page, {
+            requireTapTarget: vp.name === "mobile",
+            title: view.viewHeaderTitle,
+          });
+        }
         // A view is "rendered" if it shows readable text OR interactive/visual
         // content — input/canvas-heavy views (chat composer, the background
         // color picker) are legitimately light on static prose. A truly blank

--- a/packages/app/test/ui-smoke/chat-stream-render.spec.ts
+++ b/packages/app/test/ui-smoke/chat-stream-render.spec.ts
@@ -80,7 +80,7 @@ test.describe("chat client stream rendering", () => {
   }, testInfo) => {
     await seedChatRoutes(page);
     await openAppPath(page, "/chat");
-    await expect(page.getByTestId("continuous-chat-overlay")).toBeVisible({
+    await expect(page.getByTestId("chat-overlay")).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByTestId("chat-composer-textarea")).toBeVisible({

--- a/packages/app/test/ui-smoke/chat-streaming-thinking.spec.ts
+++ b/packages/app/test/ui-smoke/chat-streaming-thinking.spec.ts
@@ -1,6 +1,6 @@
 // Browser-level evidence for #10712: the shipped chat overlay consumes a
-// deterministic token stream, paints partial text before completion, and only
-// shows the Thinking disclosure after the terminal frame carries `thought`.
+// deterministic token stream, paints partial text before completion, and keeps
+// terminal-frame model reasoning out of the ambient overlay.
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
@@ -309,7 +309,7 @@ for (const viewport of [
   { name: "desktop", size: { width: 1280, height: 900 } },
   { name: "mobile", size: { width: 390, height: 844 } },
 ] as const) {
-  test(`chat overlay streams tokens and reveals Thinking on ${viewport.name}`, async ({
+  test(`chat overlay streams tokens without exposing reasoning on ${viewport.name}`, async ({
     page,
   }) => {
     const consoleLines: string[] = [];
@@ -346,19 +346,12 @@ for (const viewport of [
     await expect(
       page.getByTestId("thread-line").filter({ hasText: FINAL_TEXT }).first(),
     ).toBeVisible({ timeout: 20_000 });
-    const thinking = page
-      .getByTestId("chat-thread")
-      .getByRole("button", { name: "Thinking" });
-    await expect(thinking).toBeVisible({ timeout: 10_000 });
-    await expect(thinking).toHaveAttribute("aria-expanded", "false");
+    await expect(
+      page.getByTestId("chat-thread").getByRole("button", { name: "Thinking" }),
+    ).toHaveCount(0);
+    await expect(page.getByText(THOUGHT)).toHaveCount(0);
     await page.waitForTimeout(700);
-    await screenshot(page, `${viewport.name}-thinking-collapsed`);
-
-    await thinking.click();
-    await expect(thinking).toHaveAttribute("aria-expanded", "true");
-    await expect(page.getByText(THOUGHT)).toBeVisible();
-    await page.waitForTimeout(200);
-    await screenshot(page, `${viewport.name}-thinking-expanded`);
+    await screenshot(page, `${viewport.name}-reasoning-private`);
 
     expect(
       events

--- a/packages/app/test/ui-smoke/connectors.spec.ts
+++ b/packages/app/test/ui-smoke/connectors.spec.ts
@@ -254,8 +254,10 @@ test("connector settings list enabled connectors and expand setup panels", async
     page.getByRole("switch", { name: "Disable Discord" }),
   ).toBeChecked();
   await expandConnector(page, "discord");
+  const discord = page.locator('[data-connector="discord"]');
+  await discord.getByRole("button", { name: "Desktop App" }).click();
   await expect(
-    page.getByRole("button", { name: "Authorize Discord desktop" }),
+    discord.getByRole("button", { name: "Authorize Discord desktop" }),
   ).toBeVisible();
 });
 
@@ -269,8 +271,10 @@ test("cloud-connected connector settings keep local setup controls available", a
     page.getByRole("switch", { name: "Disable Discord" }),
   ).toBeChecked();
   await expandConnector(page, "discord");
+  const discord = page.locator('[data-connector="discord"]');
+  await discord.getByRole("button", { name: "Desktop App" }).click();
   await expect(
-    page.getByRole("button", { name: "Authorize Discord desktop" }),
+    discord.getByRole("button", { name: "Authorize Discord desktop" }),
   ).toBeVisible();
 });
 

--- a/packages/app/test/ui-smoke/documents-view.spec.ts
+++ b/packages/app/test/ui-smoke/documents-view.spec.ts
@@ -11,10 +11,11 @@ import {
   seedAppStorage,
 } from "./helpers";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
+import { assertSharedViewHeaderContract } from "./helpers/view-header";
 
 /**
- * Visual + smoke coverage for the BUILTIN "Knowledge" / Documents view
- * (/character/documents, #8876).
+ * Visual + smoke coverage for the builtin standalone Knowledge surface at
+ * `/character/documents` (#8876).
  *
  * This is the surface where files become knowledge: documents list from
  * `GET /api/documents` and carry provenance (uploaded file vs learned vs a
@@ -167,11 +168,16 @@ test.describe("Knowledge/Documents view visual + smoke (desktop + mobile)", () =
 
       await openAppPath(page, "/character/documents");
 
-      // The knowledge surface mounts as <DocumentsView> inside the Character
-      // editor (the /apps/documents path collides with a decomposed PA view);
-      // assert its stable testid, mirroring transcript-realaudio.spec.ts.
+      // Knowledge owns a standalone route and header outside the Character
+      // editor. Anchor both so an unrelated character shell cannot satisfy the
+      // visual probe.
       const viewRoot = page.getByTestId("documents-view");
       await expect(viewRoot).toBeVisible({ timeout: 60_000 });
+      await assertSharedViewHeaderContract(page, {
+        requireTapTarget: vp.name === "mobile",
+        within: '[data-testid="documents-view"]',
+        title: "Knowledge",
+      });
       await expect
         .poll(
           async () =>

--- a/packages/app/test/ui-smoke/drag-and-drop.spec.ts
+++ b/packages/app/test/ui-smoke/drag-and-drop.spec.ts
@@ -42,6 +42,7 @@ import {
   realMouseDrag,
   textDataTransfer,
 } from "./helpers/dnd-gestures";
+import { launcherGrid } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 
 // Capture artifacts land under the repo-level test-results tree; the suite cwd
@@ -501,7 +502,10 @@ test.describe("chat overlay — real DataTransfer file drop", () => {
 
     // The dropped file lands in the SAME pending-attachment strip that paste
     // and the attach button feed (alt = file name).
-    const pendingThumb = page.locator('img[alt="dropped.png"]');
+    const pendingThumb = page
+      .getByRole("button", { name: "remove dropped.png" })
+      .locator("..")
+      .getByRole("img", { name: "dropped.png" });
     await expect(pendingThumb).toBeVisible({ timeout: 10_000 });
     await evidenceShot(page, "chat-01-dropped-pending-thumbnail");
 
@@ -536,7 +540,9 @@ test.describe("chat overlay — real DataTransfer file drop", () => {
       }),
     );
 
-    // Send clears the pending strip.
+    // Send clears the composer strip while the same image remains visible in
+    // the sent message. Scope this assertion through the remove control so the
+    // delivered attachment cannot be mistaken for pending state.
     await expect(pendingThumb).toHaveCount(0, { timeout: 10_000 });
     await evidenceShot(page, "chat-02-sent-after-drop");
     expect(pageErrors).toEqual([]);
@@ -856,8 +862,7 @@ test.describe("knowledge view — real DataTransfer file drop", () => {
  * ──────────────────────────────────────────────────────────────────────────── */
 
 async function launcherTileIds(page: Page): Promise<string[]> {
-  return page
-    .getByTestId("launcher-page-0")
+  return launcherGrid(page)
     .locator('[data-testid^="launcher-tile-"]')
     .evaluateAll((nodes) =>
       nodes
@@ -889,9 +894,9 @@ test.describe("production launcher — curated pages, reorder disabled by design
 
     await openAppPath(page, "/views");
     await expect(page.getByTestId("launcher")).toBeVisible({ timeout: 60_000 });
-    const firstPage = page.getByTestId("launcher-page-0");
+    const grid = launcherGrid(page);
     await expect(
-      firstPage.locator('[data-testid^="launcher-tile-"]').first(),
+      grid.locator('[data-testid^="launcher-tile-"]').first(),
     ).toBeVisible({ timeout: 15_000 });
 
     const initialIds = await launcherTileIds(page);
@@ -900,9 +905,7 @@ test.describe("production launcher — curated pages, reorder disabled by design
     // REAL long-press: press and hold well past the 450ms threshold without
     // moving. In the curated production launcher this must NOT enter edit mode
     // (no jiggle animation, no pin/unpin chips).
-    const firstTile = firstPage
-      .locator('[data-testid^="launcher-tile-"]')
-      .first();
+    const firstTile = grid.locator('[data-testid^="launcher-tile-"]').first();
     const tileBox = await firstTile.boundingBox();
     if (!tileBox) throw new Error("launcher tile has no layout box");
     await page.mouse.move(
@@ -921,7 +924,7 @@ test.describe("production launcher — curated pages, reorder disabled by design
 
     // REAL drag of one tile onto a tile in another row: curated pages render
     // no Reorder wrapper, so the grid order must be unchanged.
-    const tiles = firstPage.locator('[data-testid^="launcher-tile-"]');
+    const tiles = grid.locator('[data-testid^="launcher-tile-"]');
     const dragTargetIndex = Math.min(initialIds.length - 1, 4);
     await realMouseDrag(page, tiles.first(), tiles.nth(dragTargetIndex), {
       pathSegments: 6,

--- a/packages/app/test/ui-smoke/gesture-matrix.spec.ts
+++ b/packages/app/test/ui-smoke/gesture-matrix.spec.ts
@@ -12,16 +12,15 @@
  *      compat click after a long press passed the `!editing` guard and
  *      ghost-launched the tile).
  *   2. Inline notification inbox (`home-notification-center`, rendered directly
- *      on the home column) — a seeded inbox renders its rows; a row tap marks it
- *      read IN PLACE (order ignores read state, so the row never moves under the
- *      pointer); the per-row hover-X and the right-click menu each dismiss; there
- *      is no bulk clear-all.
+ *      on the home column) — the rested shade shows interrupt-tier rows, expands
+ *      to every priority, and supports platform-style tap acknowledgement and
+ *      horizontal dismiss.
  *   3. Chat sheet flick/drag detents — a fast upward flick on the grabber
  *      snaps the sheet open; a slow sub-threshold drag leaves it closed.
  *   4. Drag-through prevention — dragging the sheet grabber must not deliver
  *      pointer events into (or scroll) the home screen beneath.
- *   5. (touch) Rail flick home→launcher with a genuine CDP touch swipe must
- *      not ghost-launch the tile under the finger.
+ *   5. (touch) A genuine CDP touch rail flick that starts on a launcher tile
+ *      must return home without ghost-launching that tile.
  *   6. (touch) A vertical pan over `home-notification-list` is contained to the
  *      inbox (the list is `overscroll-y-contain`) — it must not flip the
  *      home↔launcher rail, chain into the home column beneath, or ghost-tap the
@@ -45,6 +44,7 @@ import {
   mousePointerDrag,
   readLeakedEvents,
 } from "./helpers/gesture-inputs";
+import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 
 const REPO_ROOT = process.cwd().endsWith(path.join("packages", "app"))
@@ -85,27 +85,13 @@ async function openHome(page: Page): Promise<void> {
   });
 }
 
-/** Bring the embedded launcher grid into view (setup, not the gesture under
- *  test). Home and apps share one combined surface — the grid lives under the
- *  "Apps" region on the home column; scrolling it into view is what a user
- *  does, there is no separate launcher page to navigate to. */
-async function revealLauncherGrid(page: Page): Promise<void> {
-  const appsRegion = page.getByTestId("home-apps-scroll");
-  await expect(appsRegion).toBeVisible({ timeout: 15_000 });
-  const settingsTile = appsRegion.getByTestId("launcher-tile-settings");
-  await settingsTile.scrollIntoViewIfNeeded();
-  await expect(settingsTile).toBeVisible({ timeout: 15_000 });
-}
-
 test("launcher tile: tap launches, long press does NOT ghost-launch on release", async ({
   page,
 }) => {
   await openHome(page);
-  await revealLauncherGrid(page);
+  const grid = await navigateHomeLauncher(page, "launcher");
 
-  const settingsTile = page
-    .getByTestId("home-apps-scroll")
-    .getByTestId("launcher-tile-settings");
+  const settingsTile = grid.getByTestId("launcher-tile-settings");
   await expect(settingsTile).toBeVisible({ timeout: 15_000 });
   const tileButton = settingsTile.getByRole("button").first();
   await evidenceShot(page, "tile-press-before");
@@ -124,7 +110,7 @@ test("launcher tile: tap launches, long press does NOT ghost-launch on release",
   await expect(page.getByTestId("settings-shell")).toHaveCount(0);
   await expect(page.getByTestId("home-launcher-surface")).toHaveAttribute(
     "data-page",
-    "home",
+    "launcher",
   );
   await evidenceShot(page, "tile-longpress-no-launch");
 
@@ -318,9 +304,9 @@ async function rowTitleOrder(center: Locator): Promise<string[]> {
 /**
  * Fan the rested shade open so every seeded row renders flat. The inbox is
  * priority-triaged: at rest only interrupt-tier rows (high/urgent) show,
- * Z-stacked by view group, so a mixed-priority seed collapses to a single
- * visible row. The notification-count button is the keyboard-accessible form
- * of the same pull-to-expand transition, fanning all rows out.
+ * Z-stacked by producer. The notification-count button is the
+ * keyboard-accessible form of the same pull-to-expand transition, fanning all
+ * priorities out.
  */
 async function expandNotificationShade(page: Page): Promise<void> {
   await page.getByTestId("notifications-count-button").click();
@@ -330,97 +316,67 @@ async function expandNotificationShade(page: Page): Promise<void> {
   );
 }
 
-test("dashboard notification center: row tap marks read in place, hover-X dismiss removes, context menu dismisses, no clear-all", async ({
+test("dashboard notification center: rested priority, expansion, tap acknowledgement, and horizontal dismiss", async ({
   page,
 }, testInfo) => {
-  // The hover-X and right-click paths are MOUSE affordances (the X is
-  // `pointer-coarse:hidden`; touch has no right-click). The touch equivalents —
-  // sideways swipe + long-press menu — are covered by the real-touch describe
-  // below, so this pointer test only runs on the non-touch projects.
+  // This test drives the mouse implementation of horizontal dismiss. The same
+  // interaction runs through genuine CDP touch in the real-touch describe.
   test.skip(
     Boolean(testInfo.project.use?.hasTouch),
-    "mouse-pointer paths (hover-X, right-click); touch paths live in the real-touch describe",
+    "mouse-pointer path; touch dismissal lives in the real-touch describe",
   );
   await installSeededInboxRoutes(page, seedInboxNotifications());
   await openHome(page);
 
-  // (a) The inbox renders INLINE on the home column (no shade, no hint pill):
-  // it carries every seeded row in priority-bucket-then-recency order, and the
-  // unread badge counts the six unread rows.
+  // At rest the inline center shows only interrupt-tier rows while preserving
+  // the full inbox count as the explicit expand affordance.
   const center = page.getByTestId("home-notification-center");
   await expect(center).toBeVisible({ timeout: 15_000 });
-  // Inline on the same layer — inside the home scroller, not a portal shade.
   await expect(page.getByTestId("notifications-shade")).toHaveCount(0);
   await expect(
     page.getByTestId("home-screen").getByTestId("home-notification-center"),
   ).toBeVisible();
-  await expect(center.getByTestId("notification-row")).toHaveCount(8, {
+  await expect(center.getByTestId("notification-row")).toHaveCount(2, {
     timeout: 15_000,
   });
-  await expect(center.getByTestId("notifications-unread-badge")).toHaveText(
-    "6",
+  expect(await rowTitleOrder(center)).toEqual(SEEDED_ORDER.slice(0, 2));
+  await expect(center.getByTestId("notifications-count-button")).toHaveText(
+    "8 Notifications",
   );
-  expect(await rowTitleOrder(center)).toEqual(SEEDED_ORDER);
-  await evidenceShot(page, "notification-center-seeded");
 
-  // (b) Tapping a row marks it read WITHOUT moving it. The tapped row is the
-  // top (urgent, unread) one — under an unread-first inbox sort it would sink
-  // below the six remaining unread rows, so an identical order is a real
-  // no-reshuffle proof, not a tautology.
+  await expandNotificationShade(page);
+  await expect(center.getByTestId("notification-row")).toHaveCount(8);
+  expect(await rowTitleOrder(center)).toEqual(SEEDED_ORDER);
+  await evidenceShot(page, "notification-center-expanded");
+
+  // Platform-shade acknowledgement clears a row after acting on its safe
+  // destination. This fixture has no destination, so the tap only clears.
   const urgentRow = center
     .getByTestId("notification-row")
     .filter({ hasText: "Payment failed" });
-  await expect(urgentRow).toHaveAttribute("data-unread", "true");
   await urgentRow.click();
-  await expect(urgentRow).not.toHaveAttribute("data-unread", "true", {
-    timeout: 10_000,
-  });
-  await expect(center.getByTestId("notifications-unread-badge")).toHaveText(
-    "5",
-  );
-  expect(await rowTitleOrder(center)).toEqual(SEEDED_ORDER);
-  // The tap had no deepLink: the home surface must not have navigated.
+  await expect(urgentRow).toHaveCount(0, { timeout: 10_000 });
+  await expect(center.getByTestId("notification-row")).toHaveCount(7);
   await expect(page.getByTestId("home-screen")).toBeVisible();
   await expect(page.getByTestId("chat-overlay")).not.toHaveAttribute(
     "data-open",
     "true",
   );
-  await evidenceShot(page, "notification-center-row-read-in-place");
+  await evidenceShot(page, "notification-center-row-acknowledged");
 
-  // (c) The per-row X removes exactly that row.
-  await center
+  // A genuine pointer drag uses the row's shipped horizontal-dismiss path.
+  const approvalRow = center
     .locator("li[data-notif-row]")
     .filter({ hasText: "Approval needed" })
-    .getByTestId("notification-row-dismiss")
-    .click();
+    .getByTestId("notification-row-swipe");
+  await mousePointerDrag(page, approvalRow, -140, 0, { steps: 8 });
   await expect(
     center
       .getByTestId("notification-row")
       .filter({ hasText: "Approval needed" }),
   ).toHaveCount(0, { timeout: 10_000 });
-  await expect(center.getByTestId("notification-row")).toHaveCount(7);
-
-  // (d) There is no bulk clear-all trash button any more — rows are dismissed
-  // one at a time. The right-click contextual menu is a second per-row path:
-  // open it on a remaining row and dismiss from it.
-  await expect(center.getByTestId("notifications-clear-all")).toHaveCount(0);
-  // Right-click the row button; the contextmenu bubbles to the row li, which
-  // opens the menu.
-  const menuTarget = center
-    .getByTestId("notification-row")
-    .filter({ hasText: "Payment failed" });
-  await menuTarget.click({ button: "right" });
-  await expect(page.getByTestId("notification-row-menu")).toBeVisible({
-    timeout: 10_000,
-  });
-  await page.getByTestId("notification-menu-dismiss").click();
-  await expect(
-    center
-      .getByTestId("notification-row")
-      .filter({ hasText: "Payment failed" }),
-  ).toHaveCount(0, { timeout: 10_000 });
   await expect(center.getByTestId("notification-row")).toHaveCount(6);
-  await evidenceShot(page, "notification-center-row-menu-dismiss");
+  await evidenceShot(page, "notification-center-row-drag-dismiss");
 });
 
 test("chat sheet: fast flick snaps open, slow sub-threshold drag stays closed, and the drag never leaks under the sheet", async ({
@@ -476,7 +432,7 @@ test("chat sheet: fast flick snaps open, slow sub-threshold drag stays closed, a
 });
 
 test.describe("real touch (hasTouch project)", () => {
-  test("horizontal flick over the launcher grid via CDP touch does not ghost-launch the tile under the finger", async ({
+  test("rail flick starting on a launcher tile via CDP touch returns home without ghost-launching it", async ({
     page,
     browserName,
   }, testInfo) => {
@@ -489,17 +445,23 @@ test.describe("real touch (hasTouch project)", () => {
 
     await openHome(page);
     const surface = page.getByTestId("home-launcher-surface");
-    await revealLauncherGrid(page);
-    const appsRegion = page.getByTestId("home-apps-scroll");
 
-    // Genuine touch flick LEFT across the embedded grid. Home and apps share
-    // one combined surface: there is no rail to pan, so the flick must be a
-    // no-op navigation-wise…
-    await cdpTouchDrag(page, appsRegion, -220, 4, 10);
-    await evidenceShot(page, "touch-grid-flick");
+    // The shared helper uses genuine CDP touch and refuses a mouse fallback.
+    const grid = await navigateHomeLauncher(page, "launcher", {
+      input: "touch",
+    });
+    await evidenceShot(page, "touch-rail-flick-to-launcher");
 
-    // …and, GHOST-CLICK: the release must not tap-launch whatever tile ended
-    // up under the finger — no view opened, the combined home still showing.
+    // Start the return flick on the actual Settings control. A swipe from empty
+    // rail space proves navigation, but cannot catch the compat-click regression
+    // this case owns.
+    const settingsButton = grid
+      .getByTestId("launcher-tile-settings")
+      .getByRole("button", { name: "Settings" });
+    await expect(settingsButton).toBeVisible({ timeout: 15_000 });
+    await cdpTouchDrag(page, settingsButton, 220, 4, 10);
+
+    // GHOST-CLICK: release must not launch the tile where the finger started.
     await page.waitForTimeout(500);
     await expect(page.getByTestId("settings-shell")).toHaveCount(0);
     await expect(surface).toHaveAttribute("data-page", "home");
@@ -507,13 +469,7 @@ test.describe("real touch (hasTouch project)", () => {
       "data-open",
       "true",
     );
-
-    // The paired opposite flick is equally inert.
-    await cdpTouchDrag(page, appsRegion, 220, 4, 10);
-    await page.waitForTimeout(500);
-    await expect(page.getByTestId("settings-shell")).toHaveCount(0);
-    await expect(surface).toHaveAttribute("data-page", "home");
-    await evidenceShot(page, "touch-grid-flick-back");
+    await evidenceShot(page, "touch-rail-flick-back-home");
   });
 
   test("vertical pan over the notification list is contained — no rail flip, no home scroll, no ghost row-tap", async ({

--- a/packages/app/test/ui-smoke/helpers/launcher-navigation.ts
+++ b/packages/app/test/ui-smoke/helpers/launcher-navigation.ts
@@ -1,0 +1,147 @@
+/**
+ * Real-input navigation and stable locators for the composed Home/Launcher
+ * surface used by app UI-smoke specs.
+ */
+import { expect, type Locator, type Page } from "@playwright/test";
+
+type LauncherPage = "home" | "launcher";
+type LauncherInput = "auto" | "mouse" | "touch";
+
+export function launcherGrid(page: Page): Locator {
+  return page
+    .getByTestId("home-launcher-launcher-page")
+    .getByTestId("launcher-page-window");
+}
+
+async function railGestureY(
+  page: Page,
+  target: Locator,
+  currentPage: LauncherPage,
+): Promise<number> {
+  const box = await target.boundingBox();
+  if (!box) throw new Error(`${currentPage} launcher page has no bounding box`);
+  if (currentPage === "launcher") return box.y + box.height * 0.14;
+
+  // Notification rows own their own horizontal dismiss gesture. Starting in
+  // the header keeps launcher navigation on the parent rail on narrow screens.
+  const notificationCenter = page.getByTestId("home-notification-center");
+  const notificationBox =
+    (await notificationCenter.count()) > 0
+      ? await notificationCenter.boundingBox()
+      : null;
+  return notificationBox && notificationBox.y > box.y
+    ? (box.y + notificationBox.y) / 2
+    : box.y + box.height * 0.14;
+}
+
+async function dragRail(
+  page: Page,
+  currentPage: LauncherPage,
+  input: LauncherInput,
+): Promise<void> {
+  const target = page.getByTestId(`home-launcher-${currentPage}-page`);
+  await expect(target).toBeVisible({ timeout: 15_000 });
+  const box = await target.boundingBox();
+  if (!box) throw new Error(`${currentPage} launcher page has no bounding box`);
+
+  const direction = currentPage === "home" ? -1 : 1;
+  const startX = box.x + box.width * (currentPage === "home" ? 0.72 : 0.28);
+  const endX = startX + direction * box.width * 0.54;
+  const y = await railGestureY(page, target, currentPage);
+  const touchCapable = await page.evaluate(
+    () =>
+      navigator.maxTouchPoints > 0 ||
+      window.matchMedia("(pointer: coarse)").matches,
+  );
+  if (input === "touch" && !touchCapable) {
+    throw new Error(
+      "launcher navigation requested touch input in a non-touch context",
+    );
+  }
+
+  if (input === "touch" || (input === "auto" && touchCapable)) {
+    const client = await page.context().newCDPSession(page);
+    try {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchStart",
+        touchPoints: [{ x: startX, y, id: 1, radiusX: 4, radiusY: 4 }],
+      });
+      for (let step = 1; step <= 8; step += 1) {
+        await client.send("Input.dispatchTouchEvent", {
+          type: "touchMove",
+          touchPoints: [
+            {
+              x: startX + ((endX - startX) * step) / 8,
+              y,
+              id: 1,
+              radiusX: 4,
+              radiusY: 4,
+            },
+          ],
+        });
+      }
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchEnd",
+        touchPoints: [],
+      });
+    } finally {
+      await client.detach();
+    }
+    return;
+  }
+
+  await page.mouse.move(startX, y);
+  await page.mouse.down();
+  for (let step = 1; step <= 8; step += 1) {
+    await page.mouse.move(startX + ((endX - startX) * step) / 8, y);
+  }
+  await page.mouse.up();
+}
+
+export async function navigateHomeLauncher(
+  page: Page,
+  targetPage: LauncherPage,
+  options: { input?: LauncherInput } = {},
+): Promise<Locator> {
+  const surface = page.getByTestId("home-launcher-surface");
+  await expect(surface).toBeVisible({ timeout: 15_000 });
+  const currentPage = await surface.getAttribute("data-page");
+  if (currentPage !== "home" && currentPage !== "launcher") {
+    throw new Error(`unexpected Home/Launcher page state: ${currentPage}`);
+  }
+
+  if (currentPage !== targetPage) {
+    await dragRail(page, currentPage, options.input ?? "auto");
+  }
+
+  await expect(surface).toHaveAttribute("data-page", targetPage, {
+    timeout: 10_000,
+  });
+  const target = page.getByTestId(`home-launcher-${targetPage}-page`);
+  await expect(target).toBeVisible({ timeout: 15_000 });
+
+  // Store state updates before the visual settle. Geometry is the screenshot
+  // contract; descendant widgets can carry intentionally infinite animations.
+  await page.waitForFunction(
+    (pageName) => {
+      const rail = document.querySelector('[data-testid="home-launcher-rail"]');
+      const surface = document.querySelector(
+        '[data-testid="home-launcher-surface"]',
+      );
+      if (!rail || !surface) return false;
+      const expectedLeft = pageName === "launcher" ? -surface.clientWidth : 0;
+      return Math.abs(rail.getBoundingClientRect().left - expectedLeft) <= 1;
+    },
+    targetPage,
+    { timeout: 5_000 },
+  );
+
+  if (targetPage === "launcher") {
+    const grid = launcherGrid(page);
+    await expect(
+      grid.locator('[data-testid^="launcher-tile-"]').first(),
+    ).toBeVisible({ timeout: 15_000 });
+    return grid;
+  }
+  return target;
+}

--- a/packages/app/test/ui-smoke/home-widget-priority.spec.ts
+++ b/packages/app/test/ui-smoke/home-widget-priority.spec.ts
@@ -12,6 +12,7 @@ import {
   openAppPath,
   seedAppStorage,
 } from "./helpers";
+import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 
 // #9143 — the home launcher mounts <WidgetHost slot="home"> and ranks the
@@ -739,17 +740,14 @@ test.describe("home widget priority (#9143)", () => {
     });
     await screenshot(page, "mobile");
 
-    // Launcher capture — the widgets and the launcher tiles share ONE combined
-    // home surface (HomeScreen with the embedded LauncherSurface grid under the
-    // "Apps" region; there is no home↔launcher rail). Scroll the grid into
-    // view the way a user would and capture the consolidated pair.
-    const surface = page.getByTestId("home-launcher-surface");
-    await expect(surface).toHaveAttribute("data-page", "home");
-    const appsRegion = page.getByTestId("home-apps-scroll");
-    await expect(appsRegion).toBeVisible({ timeout: 15_000 });
-    const settingsTile = appsRegion.getByTestId("launcher-tile-settings");
-    await settingsTile.scrollIntoViewIfNeeded();
-    await expect(settingsTile).toBeVisible({ timeout: 15_000 });
+    // Home and Launcher are paired rail pages. Exercise the real rail before
+    // capturing the launcher half at the mobile viewport.
+    const grid = await navigateHomeLauncher(page, "launcher", {
+      input: "mouse",
+    });
+    await expect(grid.getByTestId("launcher-tile-settings")).toBeVisible({
+      timeout: 15_000,
+    });
     await screenshot(page, "launcher");
   });
 });

--- a/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
@@ -183,7 +183,6 @@ async function bootLauncher(
 }
 
 const cloudTile = (page: Page) => page.getByTestId("launcher-tile-cloud-apps");
-const chatTile = (page: Page) => page.getByTestId("launcher-tile-chat");
 const myAppsTile = (page: Page) => page.getByTestId("launcher-tile-my-apps");
 
 test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
@@ -194,7 +193,6 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
       await bootLauncher(page, viewport, { connected: false });
       // The catalog HAS the cloud-apps view (injected above); the launcher must
       // still not surface it — My Apps is the one apps destination.
-      await expect(chatTile(page)).toBeVisible();
       await expect(myAppsTile(page)).toBeVisible();
       await expect(cloudTile(page)).toHaveCount(0);
       await screenshot(
@@ -210,7 +208,6 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
       await bootLauncher(page, viewport, { connected: true });
       // Signed in changes nothing for the studio tile: it is consolidated into
       // My Apps (the MyAppsView Eliza Cloud row + the /cloud-apps deep link).
-      await expect(chatTile(page)).toBeVisible();
       await expect(myAppsTile(page)).toBeVisible();
       await expect(cloudTile(page)).toHaveCount(0);
       await screenshot(

--- a/packages/app/test/ui-smoke/onboarding-to-home-mobile.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home-mobile.spec.ts
@@ -15,21 +15,21 @@ import {
   completeCloudOnboardingToHome,
   completeOnboardingToHome,
   completeOtherProviderSettingsHandoff,
-  expectInlineLauncher,
   injectCloudAuthToken,
   injectFullCapabilityHost,
   installCloudRoutes,
   installHomeRoutes,
   makeScreenshotter,
+  openPostOnboardingLauncher,
   settleHomeEntrance,
 } from "./onboarding-to-home.shared";
 
 // Mobile-viewport counterpart of onboarding-to-home.spec.ts. Same keyless flow —
 // fresh device → real Local/on-device onboarding → completeFirstRun("chat") →
-// home with seeded widgets and the embedded launcher grid — but driven through
-// a Pixel-class Chromium context with `hasTouch: true, isMobile: true` and a
-// touch viewport, so the onboarding cards are TAPPED at the exact WebView
-// viewport size that ships on Capacitor iOS/Android. This is the
+// home with seeded widgets → swipe-left → launcher — but driven through a
+// Pixel-class Chromium context with `hasTouch: true, isMobile: true` and a touch
+// viewport, so the onboarding cards and launcher rail use real touch at the
+// exact WebView viewport size that ships on Capacitor iOS/Android. This is the
 // desktop-Chromium-with-mobile-emulation lane; the real installed Capacitor
 // WebView lane lives in test/android/onboarding-to-home.android.spec.ts
 // (driven by mobile-e2e.yml).
@@ -57,9 +57,7 @@ test.describe("onboarding → home → launcher (mobile viewport)", () => {
     await expectNoPageDiagnostics(page, testInfo.title);
   });
 
-  test("first-run → home → inline launcher grid with touch", async ({
-    page,
-  }) => {
+  test("first-run → home → Launcher pager with touch", async ({ page }) => {
     await rm(SCREENSHOT_DIR, { force: true, recursive: true });
     await injectFullCapabilityHost(page);
     const state = await installHomeRoutes(page);
@@ -84,16 +82,14 @@ test.describe("onboarding → home → launcher (mobile viewport)", () => {
     // WebView, inside the same floating ChatOverlay. The shared flow
     // also asserts the onboarding lock (disabled composer, Escape gated) and
     // the auto-collapse on completion.
-    const { surface } = await completeOnboardingToHome(
-      page,
-      (locator: Locator) => locator.tap(),
-      { state, tutorial: "skip" },
-    );
+    await completeOnboardingToHome(page, (locator: Locator) => locator.tap(), {
+      state,
+      tutorial: "skip",
+    });
 
     // Restated at the spec level: completion settled the sheet to the HALF
     // detent (open, home revealed behind the top half — #15339) and unlocked the
-    // composer. expectInlineLauncher collapses the open sheet before asserting
-    // the embedded launcher grid.
+    // composer. The launcher helper collapses the open sheet before swiping.
     await expect(page.getByTestId("chat-sheet")).toHaveAttribute(
       "data-detent",
       "half",
@@ -108,8 +104,7 @@ test.describe("onboarding → home → launcher (mobile viewport)", () => {
     await settleHomeEntrance(page);
     await screenshot(page, "home");
 
-    // The launcher grid is embedded on the combined home surface (no rail).
-    await expectInlineLauncher(page, surface);
+    await openPostOnboardingLauncher(page, { input: "touch" });
     await screenshot(page, "launcher");
   });
 

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -6,6 +6,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, type Page, type Route } from "@playwright/test";
 import { installDefaultAppRoutes } from "./helpers";
+import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 import {
   seedStewardSession,
@@ -1312,30 +1313,20 @@ export async function collapseChatOverlay(page: Page): Promise<void> {
 }
 
 /**
- * Assert the launcher is reachable from the post-onboarding home. The home and
- * launcher are ONE combined surface now (App.tsx renders HomeScreen with the
- * embedded LauncherSurface grid under the "Apps" region — there is no
- * horizontal rail and no swipe-to-launcher gesture anymore), so this asserts a
- * real launcher tile on the combined page instead of flicking a pager.
+ * Collapse onboarding chrome, then drive the shared Home/Launcher rail through
+ * the same real input path used by the other app interaction specs.
  */
-export async function expectInlineLauncher(
+export async function openPostOnboardingLauncher(
   page: Page,
-  surface: Locator,
+  options: { input?: "mouse" | "touch" | "auto" } = {},
 ): Promise<void> {
   // Post-onboarding the overlay already auto-collapsed; this guard only closes
-  // a sheet a previous step deliberately opened, so the launcher grid is not
-  // hidden behind the chat scrim. The permission-priming modal (#12331) also
-  // arms on the completion edge — skip it the way a user would.
+  // a sheet a previous step deliberately opened, so the rail receives the
+  // gesture. Permission priming can arm on the same edge and intercept it.
   await dismissPermissionPrimingIfShown(page);
   await collapseChatOverlay(page);
-  await expect(surface).toBeVisible();
-  await expect(surface).toHaveAttribute("data-page", "home");
-  // The embedded launcher grid ("Apps" region) carries the real tiles.
-  const appsRegion = page.getByTestId("home-apps-scroll");
-  await expect(appsRegion).toBeVisible({ timeout: 15_000 });
-  const settingsTile = appsRegion.getByTestId("launcher-tile-settings");
-  // On short viewports the grid can sit below the fold; bring it into view
-  // the way a user scrolling the home column would.
-  await settingsTile.scrollIntoViewIfNeeded();
-  await expect(settingsTile).toBeVisible({ timeout: 15_000 });
+  const grid = await navigateHomeLauncher(page, "launcher", options);
+  await expect(grid.getByTestId("launcher-tile-settings")).toBeVisible({
+    timeout: 15_000,
+  });
 }

--- a/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
@@ -17,13 +17,13 @@ import {
   completeOtherProviderSettingsHandoff,
   connectRemoteFirstRunToHome,
   expectChatFirstOnboarding,
-  expectInlineLauncher,
   injectCloudAuthToken,
   injectFullCapabilityHost,
   installCloudRoutes,
   installHomeRoutes,
   makeScreenshotter,
   type OnboardingRouteState,
+  openPostOnboardingLauncher,
   settleHomeEntrance,
 } from "./onboarding-to-home.shared";
 
@@ -67,7 +67,7 @@ test.describe("in-chat onboarding → home → launcher", () => {
     ]);
   });
 
-  test("Local onboarding lands on the home with the launcher tiles inline", async ({
+  test("Local onboarding lands on home and opens the Launcher pager", async ({
     page,
   }) => {
     await rm(SCREENSHOT_DIR, { force: true, recursive: true });
@@ -96,7 +96,7 @@ test.describe("in-chat onboarding → home → launcher", () => {
     );
     await screenshot(page, "onboarding-chat-first");
 
-    const { surface } = await completeOnboardingToHome(page, desktopClick, {
+    await completeOnboardingToHome(page, desktopClick, {
       state,
       tutorial: "skip",
     });
@@ -104,7 +104,7 @@ test.describe("in-chat onboarding → home → launcher", () => {
     // Completion settled the sheet from the pinned FULL detent down to the HALF
     // detent (#15339 / ChatOverlay.firstrun.test): the sheet stays
     // OPEN with the home revealed behind its top half, and the composer unlocks.
-    // expectInlineLauncher collapses the open sheet before asserting the grid.
+    // openPostOnboardingLauncher collapses the open sheet before the rail drag.
     await expect(page.getByTestId("chat-sheet")).toHaveAttribute(
       "data-detent",
       "half",
@@ -117,7 +117,7 @@ test.describe("in-chat onboarding → home → launcher", () => {
 
     // Post-login permission priming (#12331) can open over the home on the
     // completion edge; completeOnboardingToHome already drove its "Skip for now"
-    // dismissal (dismissPermissionPrimingIfShown), and expectInlineLauncher
+    // dismissal (dismissPermissionPrimingIfShown), and the launcher helper
     // clears any residual first — so no separate dismissal step is needed here
     // (a second one races the helper's and flakes).
 
@@ -125,7 +125,7 @@ test.describe("in-chat onboarding → home → launcher", () => {
     await settleHomeEntrance(page);
     await screenshot(page, "home");
 
-    await expectInlineLauncher(page, surface);
+    await openPostOnboardingLauncher(page, { input: "mouse" });
     await screenshot(page, "launcher");
   });
 

--- a/packages/app/test/ui-smoke/perf-interaction-kpi.spec.ts
+++ b/packages/app/test/ui-smoke/perf-interaction-kpi.spec.ts
@@ -369,8 +369,17 @@ test.describe("dashboard shell interaction framerate", () => {
     // --- Scenario E: /chat -> another-view transition -------------------------
     const viewTransitionSummary = await measureFrames(page, async () => {
       await page.evaluate(() => {
-        window.history.pushState(null, "", "/settings");
-        window.dispatchEvent(new PopStateEvent("popstate"));
+        window.dispatchEvent(
+          new CustomEvent("eliza:navigate:view", {
+            detail: {
+              viewId: "settings",
+              viewPath: "/settings",
+              viewLabel: "Settings",
+              viewType: "gui",
+              alwaysOnTop: false,
+            },
+          }),
+        );
       });
       await expect(page.getByTestId("settings-shell")).toBeVisible({
         timeout: 20_000,

--- a/packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts
@@ -1,29 +1,13 @@
-// Extended runtime bridge inventory for the plugin-backed app pages that the
-// original `plugin-view-agent-bridge-inventory.spec.ts` did NOT cover
-// (#11356). The sibling spec drives only `wallet.inventory`, `orchestrator`,
-// and `feed`; #10722 enumerates ~16 more instrumented plugin views that chat /
-// voice must be able to address through `window.__ELIZA_BRIDGE__.viewInteract`.
-//
-// This spec mirrors the established pattern EXACTLY: it opens each real view
-// through the preview harness, waits for the agent bridge, and asserts that
-// `list-elements` returns the concrete id/role/label/fillable/clickable shape
-// for the view's known controls against the REAL rendered DOM. It also
-// generalizes the `unwiredControls` scan from `settings-chat-control.spec.ts`:
-// any CONTROL-role element that renders without a `data-agent-id` (on itself or
-// an ancestor) is a real "chat can't reach this control" gap and fails.
-//
-// Coverage / honest accounting (see the PR body for the full table):
-//   Covered here: calendar, contacts, phone, messages, health, finances,
-//     inbox, goals, todos, polymarket, hyperliquid, training, screenshare,
-//     shopify, vector-browser (15).
-//   Skipped: facewear — its device config lives under Settings → Wearables, so
-//     there is no standalone GUI route that mounts an agent-bridge surface to
-//     inventory. Its controls are covered by the comms/device interaction specs.
-//
-// The fixture backends for every view below already live in
-// `installDefaultAppRoutes` (helpers.ts) — this spec adds NO new stubs; it only
-// reuses the deterministic keyless smoke data the other decomposed-view specs
-// already rely on.
+/**
+ * Runtime bridge inventory for plugin views that mount in the browser shell.
+ *
+ * Each target opens its real rendered route and proves that chat and voice can
+ * enumerate every interactive control through `viewInteract`. Native-OS Phone,
+ * Contacts, and Messages are exercised on device rather than through the web
+ * shell; Shopify has no shipped view declaration, and facewear lives inside
+ * Settings. The sibling inventory covers wallet inventory, orchestrator, and
+ * feed.
+ */
 
 import { expect, type Page, test } from "@playwright/test";
 import {
@@ -83,48 +67,24 @@ type PluginViewTarget = {
   requiredIds: readonly string[];
 };
 
-// Ordered roughly by surface family (comms → lifeops → markets → tooling) so a
-// failure localizes to a cohesive group.
+// Ordered by surface family so a failure localizes to a cohesive group.
 const PLUGIN_VIEW_TARGETS: readonly PluginViewTarget[] = [
-  // --- Comms surfaces (plugin-phone / plugin-contacts / plugin-messages) ---
-  {
-    label: "Phone",
-    path: "/phone",
-    viewId: "phone",
-    // phone-refresh + phone-call are declared unconditionally in the PhoneView
-    // body (useAgentElement), so both register on mount regardless of data.
-    requiredIds: ["phone-refresh", "phone-call"],
-  },
-  {
-    label: "Contacts",
-    path: "/contacts",
-    viewId: "contacts",
-    ready: { testId: "contacts-shell" },
-    // Default mode is "list": nav-back + action-new render on mount.
-    requiredIds: ["nav-back", "action-new"],
-  },
-  {
-    label: "Messages",
-    path: "/messages",
-    viewId: "messages",
-    // messages-refresh + messages-send are unconditional useAgentElement
-    // controls in the MessagesView body.
-    requiredIds: ["messages-refresh", "messages-send"],
-  },
   // --- LifeOps decomposed views (spatial `Button agent=…` + DomSection ids) ---
   {
     label: "Calendar",
     path: "/calendar",
     viewId: "calendar",
-    // The calendar mock (installDefaultAppRoutes) seeds "Design sync"; the
-    // CalendarSection period-nav + view-mode controls always render.
+    // The dynamic route mounts CalendarSpatialView, whose spatial `agent`
+    // values are the canonical bridge ids.
     ready: { text: "Design sync" },
     requiredIds: [
-      "calendar-prev",
-      "calendar-today",
-      "calendar-next",
-      "calendar-new-event",
-      "calendar-view-mode",
+      "prev",
+      "today",
+      "next",
+      "new",
+      "mode:day",
+      "mode:week",
+      "mode:month",
     ],
   },
   {
@@ -205,13 +165,6 @@ const PLUGIN_VIEW_TARGETS: readonly PluginViewTarget[] = [
     requiredIds: ["polymarket-refresh"],
   },
   {
-    label: "Shopify",
-    path: "/shopify",
-    viewId: "shopify",
-    ready: { selector: '[aria-label="Shopify controls"]' },
-    requiredIds: ["shopify-refresh", "shopify-product-search"],
-  },
-  {
     label: "Screenshare",
     path: "/screenshare",
     viewId: "screenshare",
@@ -244,6 +197,7 @@ const PLUGIN_VIEW_TARGETS: readonly PluginViewTarget[] = [
       "vector-view-list",
       "vector-search",
       "vector-search-run",
+      "vector-memory:memory-smoke-1",
     ],
   },
 ];
@@ -348,13 +302,10 @@ function assertElementShape(elements: AgentElement[], label: string): void {
  * Generalized `unwiredControls` scan (from settings-chat-control.spec.ts): every
  * interactive CONTROL rendered inside the mounted view region that has no
  * `data-agent-id` on itself or an ancestor is a real "chat can't reach this"
- * gap. There is no single DOM wrapper attribute for a plugin view surface, so
- * the scan scopes to the tightest region that actually contains the view's
- * bridged controls: the nearest common ancestor of every `[data-agent-id]`
- * node. Shell chrome (nav rail, tab bar, hidden chat composer) lives outside
- * that subtree, so it is excluded without an allowlist; genuinely-unwired
- * controls rendered ALONGSIDE the view's wired controls are still caught.
- * Empty/absent sections contribute nothing, so this is robust to keyless data.
+ * gap. DynamicViewLoader gives each plugin one `data-spatial-surface`; choosing
+ * the surface with the most registered nodes keeps wallet/header and hidden
+ * chat controls out while still catching controls beside the view's wired
+ * controls.
  */
 async function scanUnwiredControls(page: Page, label: string): Promise<void> {
   const unwired = await page.evaluate(() => {
@@ -366,17 +317,17 @@ async function scanUnwiredControls(page: Page, label: string): Promise<void> {
     });
     if (agentNodes.length === 0) return [] as string[];
 
-    // Nearest common ancestor of all visible bridged nodes = the view region.
-    let scope: HTMLElement = agentNodes[0];
-    for (const node of agentNodes.slice(1)) {
-      while (scope && !scope.contains(node)) {
-        scope = scope.parentElement as HTMLElement;
-        if (!scope) break;
+    const surfaceCounts = new Map<HTMLElement, number>();
+    for (const node of agentNodes) {
+      const surface = node.closest<HTMLElement>("[data-spatial-surface]");
+      if (surface) {
+        surfaceCounts.set(surface, (surfaceCounts.get(surface) ?? 0) + 1);
       }
-      if (!scope) break;
     }
-    const root: HTMLElement =
-      scope ?? document.getElementById("root") ?? document.body;
+    const root =
+      [...surfaceCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ??
+      document.getElementById("root") ??
+      document.body;
 
     const selector =
       'button:not([disabled]), [role="button"], input:not([type="hidden"]):not([disabled]):not([readonly]), textarea:not([disabled]), [role="switch"], [role="combobox"], [role="tab"], select:not([disabled])';

--- a/packages/app/test/ui-smoke/reset-returns-to-onboarding.spec.ts
+++ b/packages/app/test/ui-smoke/reset-returns-to-onboarding.spec.ts
@@ -1,7 +1,5 @@
-/**
- * Playwright UI-smoke spec for the Reset Returns To Onboarding app flow using
- * the real renderer fixture.
- */
+/** Playwright coverage for the intentionally non-destructive Backups surface. */
+
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
@@ -10,123 +8,24 @@ import {
   seedAppStorage,
 } from "./helpers";
 
-const FIRST_RUN_OPTIONS = {
-  names: [],
-  styles: [],
-  providers: [],
-  cloudProviders: [],
-  models: {},
-  inventoryProviders: [],
-  sharedStyleRules: "",
-};
-
 test.beforeEach(async ({ page }) => {
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
-
-  // The reset endpoints the renderer hits after the user confirms the modal.
-  // The server-side wipe is unit-tested elsewhere; here we only need it to
-  // succeed so the renderer runs its local wipe → first-run path.
-  await page.route("**/api/agent/reset", async (route) => {
-    if (route.request().method() !== "POST") {
-      await route.fallback();
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ ok: true }),
-    });
-  });
-
-  await page.route("**/api/first-run/options", async (route) => {
-    if (route.request().method() !== "GET") {
-      await route.fallback();
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(FIRST_RUN_OPTIONS),
-    });
-  });
-
-  await page.route("**/api/agent/restart", async (route) => {
-    if (route.request().method() !== "POST") {
-      await route.fallback();
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        status: { state: "running", agentName: "Playwright Smoke" },
-      }),
-    });
-  });
 });
 
-test("Reset Everything wipes the agent and returns to first-run onboarding", async ({
+test("Backups offers backup and restore without an in-app destructive reset", async ({
   page,
 }) => {
   await openAppPath(page, "/settings");
-  await openSettingsSection(page, "Backup & Reset");
+  await openSettingsSection(page, "Backups");
 
-  // Opening the danger-zone warning must not run the destructive action.
-  const resetRequest = page.waitForRequest(
-    (request) =>
-      request.method() === "POST" && request.url().endsWith("/api/agent/reset"),
-    { timeout: 15_000 },
-  );
-
-  await page.getByRole("button", { name: "Reset Everything" }).click();
-
-  const dialog = page.getByRole("dialog");
-  await expect(dialog.getByText("Reset everything?")).toBeVisible();
   await expect(
-    dialog.getByText(/Everything will be deleted and destroyed/),
+    page.getByRole("button", { name: /Back up agent/i }),
   ).toBeVisible();
-
-  await dialog.getByRole("button", { name: "Delete everything" }).click();
-
-  // The reset actually fires against the server...
-  await resetRequest;
-
-  // ...and the renderer returns to pre-agent in-chat first-run.
-  const chatOverlay = page.getByTestId("chat-overlay");
-  await expect(chatOverlay).toBeVisible({ timeout: 20_000 });
-  await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
   await expect(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-  ).toBeVisible({
-    timeout: 15_000,
-  });
-});
-
-test("cancelling the Reset Everything warning leaves the agent untouched", async ({
-  page,
-}) => {
-  let resetCalled = false;
-  page.on("request", (request) => {
-    if (
-      request.method() === "POST" &&
-      request.url().endsWith("/api/agent/reset")
-    ) {
-      resetCalled = true;
-    }
-  });
-
-  await openAppPath(page, "/settings");
-  await openSettingsSection(page, "Backup & Reset");
-
-  await page.getByRole("button", { name: "Reset Everything" }).click();
-
-  const dialog = page.getByRole("dialog");
-  await expect(dialog.getByText("Reset everything?")).toBeVisible();
-  await dialog.getByRole("button", { name: "Cancel" }).click();
-
-  await expect(dialog).toBeHidden();
-  // Still on the settings shell — no onboarding redirect, no reset call.
-  await expect(page.getByTestId("settings-shell")).toBeVisible();
-  expect(resetCalled).toBe(false);
+    page.getByRole("button", { name: /Restore agent/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Reset Everything" }),
+  ).toHaveCount(0);
 });

--- a/packages/app/test/ui-smoke/shell-view-agent-bridge-inventory.spec.ts
+++ b/packages/app/test/ui-smoke/shell-view-agent-bridge-inventory.spec.ts
@@ -127,7 +127,7 @@ const SHELL_VIEW_TARGETS: readonly {
     path: "/apps/transcripts",
     viewId: "transcripts",
     readyTestId: "live-meeting-page",
-    requiredIds: [`transcript-${TRANSCRIPT_ID}`],
+    requiredIds: ["meeting-url", "meeting-bot-name", "meeting-join"],
   },
   {
     label: "Files",

--- a/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
@@ -37,6 +37,10 @@ function todosView(page: Page): Locator {
   return page.getByText(/Today \(\d+\)/).first();
 }
 
+function walletView(page: Page): Locator {
+  return page.getByTestId("wallet-shell").first();
+}
+
 // The exact `eliza:navigate:view` detail the renderer's WS handler emits for a
 // plain `show`/navigate frame (startup-phase-hydrate.ts:417-442): a navigate
 // frame with no `action` and no `alwaysOnTop` normalizes to action:undefined,
@@ -118,11 +122,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "show my wallet",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'PASSIVE: "what\'s on my calendar" opens the calendar view',
@@ -186,11 +186,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "montre-moi mon portefeuille",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'PASSIVE (es): "revisa mi correo" opens the inbox',
@@ -270,11 +266,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "abra minha carteira",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'ACTIVE (de): "öffne meine brieftasche" opens the wallet view',
@@ -282,11 +274,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "öffne meine brieftasche",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'ACTIVE (ja): "ウォレットを開いて" opens the wallet view',
@@ -294,11 +282,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "ウォレットを開いて",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'ACTIVE (ko): "지갑 열어" opens the wallet view',
@@ -306,11 +290,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "지갑 열어",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'ACTIVE (vi): "mở ví" opens the wallet view',
@@ -318,11 +298,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "mở ví",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
   {
     name: 'ACTIVE (tl): "buksan ang wallet" opens the wallet view',
@@ -330,11 +306,7 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     command: "buksan ang wallet",
     view: { id: "wallet", path: "/wallet", label: "Wallet" },
     expectedPath: "/wallet",
-    onView: (page) =>
-      page
-        .getByTestId("wallet-shell")
-        .first()
-        .or(page.getByRole("heading", { name: "Wallet" }).first()),
+    onView: walletView,
   },
 ];
 
@@ -641,17 +613,14 @@ for (const testCase of VIEW_SWITCH_CASES) {
   });
 }
 
-// Regression guard for the navigate-event normalization contract the renderer
-// relies on: a raw agent navigate (viewId only, no viewPath) must still resolve
-// to `/apps/<viewId>` via pathForNavigateViewDetail(). This is the fallback path
-// the live agent uses when it sends only a view id. Runs in both tiers because
-// it dispatches the same DOM event the WS handler emits.
-test("agent navigate by viewId-only resolves to /apps/<viewId>", async ({
+// A viewId-only navigate must resolve through the loaded registry so plugin
+// views use their declared canonical route instead of the unknown-view fallback.
+test("agent navigate by viewId-only resolves the registered canonical path", async ({
   page,
 }) => {
   test.skip(
     LIVE_STACK,
-    "viewId-only fallback is a renderer-normalization guard; the live agent path is covered by the cases above",
+    "viewId-only registry resolution is a renderer guard; the live agent path is covered by the cases above",
   );
   await openAppPath(page, "/chat");
   await sendChatCommand(page, "open the model tester");
@@ -663,10 +632,10 @@ test("agent navigate by viewId-only resolves to /apps/<viewId>", async ({
     alwaysOnTop: false,
   });
 
-  await expect(page).toHaveURL(/\/apps\/model-tester(?:[?#]|$)/, {
+  await expect(page).toHaveURL(/\/model-tester(?:[?#]|$)/, {
     timeout: 30_000,
   });
-  await expect(page.getByTestId("model-tester-shell").first()).toBeVisible({
+  await expect(page.locator('[data-agent-id="run-all"]').first()).toBeVisible({
     timeout: 60_000,
   });
 });

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -2,6 +2,8 @@
  * Playwright UI-smoke spec for the Walkthrough Capture Smoke app flow using
  * the real renderer fixture.
  */
+
+import { FIRST_RUN_SIGN_IN_PROMPT } from "@elizaos/ui/first-run/first-run-greeting";
 import {
   expect,
   type Page,
@@ -227,11 +229,9 @@ test.describe("walkthrough capture smoke", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     const onboarding = page.getByTestId("chat-overlay");
     await expect(onboarding).toBeVisible({ timeout: 20_000 });
-    await expect(
-      page.getByText("Sign in to Eliza Cloud and I'll get you set up.", {
-        exact: false,
-      }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(FIRST_RUN_SIGN_IN_PROMPT)).toBeVisible({
+      timeout: 15_000,
+    });
     await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
     await expect(
       page.getByTestId("choice-__first_run__:runtime:cloud"),

--- a/packages/ui/PERF.md
+++ b/packages/ui/PERF.md
@@ -9,7 +9,7 @@ suite that locks it.
 
 ## Where the cost is
 
-Two things run on every streamed token:
+Two things run on every streamed paint:
 
 1. **`MessageContent` re-parses the message body.** It scans the growing text
    for code fences, `[CONFIG]`/`[CHOICE]`/`[FORM]`/`[WORKFLOW]`/`[TASK]` markers,
@@ -23,6 +23,13 @@ Two things run on every streamed token:
    that body, the inline widgets are memoized on their data props
    (`widget-equality.ts`), so a widget already on screen does not re-render as
    the surrounding prose grows.
+
+Transport events can arrive faster than the overlay can paint. `useChatSend`
+shows the first snapshot immediately, parks later cumulative snapshots, and
+paints them at a 64 ms cadence; terminal and abort paths synchronously flush the
+latest snapshot. This preserves responsive incremental text without spending a
+full overlay render on every model token. The browser perf fixture uses the same
+cadence while feeding token events once per animation frame.
 
 ## Memoized inline widgets
 

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -16,8 +16,11 @@ import {
 } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentButton, getViewRegistry } from "./agent-surface";
+import { registerAppShellPage } from "./app-shell-registry";
 import { DEFAULT_BOOT_CONFIG, setBootConfig } from "./config/boot-config";
 import type { ViewRegistryEntry } from "./hooks/useAvailableViews";
+import { resetUiRegistryHostForTests } from "./registry-host";
 
 const appState = vi.hoisted(() => ({
   firstRunComplete: true,
@@ -187,6 +190,16 @@ const documentsView = {
   pluginName: "@elizaos/plugin-documents",
   path: "/documents",
   bundleUrl: "/api/views/documents/bundle.js",
+  viewType: "gui" as const,
+};
+
+const walletMarketView = {
+  id: "wallet-market-test",
+  label: "Wallet Market Test",
+  available: true,
+  pluginName: "@local/plugin-wallet-market",
+  path: "/wallet-market-test",
+  bundleUrl: "/api/views/wallet-market-test/bundle.js",
   viewType: "gui" as const,
 };
 
@@ -525,6 +538,7 @@ describe("App navigate-view event wiring", () => {
 
   afterEach(() => {
     cleanup();
+    resetUiRegistryHostForTests();
     vi.unstubAllGlobals();
   });
 
@@ -672,6 +686,98 @@ describe("App navigate-view event wiring", () => {
     expect(getByTestId("app-opaque-background")).toBeTruthy();
     expect(queryByTestId("app-background-shader")).toBeNull();
   });
+
+  it("prefers an exact remote plugin route over its native wallet fallback", async () => {
+    mockAvailableViews.push(walletMarketView);
+    registerAppShellPage({
+      id: walletMarketView.id,
+      pluginId: walletMarketView.pluginName,
+      label: walletMarketView.label,
+      path: walletMarketView.path,
+      tabAffinity: "inventory",
+      Component: () => <div data-testid="native-wallet-fallback" />,
+    });
+    appState.tab = "inventory";
+    window.history.replaceState(null, "", walletMarketView.path);
+
+    const { getByTestId, queryByTestId } = render(<App />);
+
+    await waitFor(() => getByTestId("dynamic-view-loader"));
+    expect(
+      getByTestId("dynamic-view-loader").getAttribute("data-view-id"),
+    ).toBe(walletMarketView.id);
+    expect(queryByTestId("native-wallet-fallback")).toBeNull();
+  });
+
+  it("gives an in-process wallet page a live agent-surface registry", async () => {
+    registerAppShellPage({
+      id: "wallet.inventory",
+      pluginId: "@elizaos/plugin-wallet-ui",
+      label: "Wallet",
+      path: "/inventory",
+      tabAffinity: "inventory",
+      Component: () => (
+        <AgentButton agentId="wallet-refresh">Refresh wallet</AgentButton>
+      ),
+    });
+    appState.tab = "inventory";
+    window.history.replaceState(null, "", "/inventory");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(getViewRegistry("wallet.inventory", "gui")?.size()).toBe(1);
+    });
+    expect(
+      getViewRegistry("wallet.inventory", "gui")?.describe("wallet-refresh")
+        ?.label,
+    ).toBe("Refresh wallet");
+  });
+
+  it.each(["/inventory", "/hyperliquid", "/polymarket"])(
+    "does not canonicalize a cold exact wallet-family route through tab affinity: %s",
+    async (path) => {
+      appState.tab = "views";
+      window.history.replaceState(null, "", path);
+      const registrations = [
+        {
+          id: "wallet.inventory",
+          pluginId: "@elizaos/plugin-wallet-ui",
+          label: "Wallet",
+          path: "/inventory",
+        },
+        {
+          id: "hyperliquid",
+          pluginId: "@elizaos/plugin-hyperliquid",
+          label: "Perps",
+          path: "/hyperliquid",
+        },
+        {
+          id: "polymarket",
+          pluginId: "@elizaos/plugin-polymarket",
+          label: "Predictions",
+          path: "/polymarket",
+        },
+      ];
+      const owningRegistration = registrations.find(
+        (registration) => registration.path === path,
+      );
+      if (!owningRegistration) {
+        throw new Error(`Missing test registration for ${path}`);
+      }
+
+      registerAppShellPage({
+        ...owningRegistration,
+        tabAffinity: "inventory",
+        Component: () => null,
+      });
+
+      render(<App />);
+
+      expect(window.location.pathname).toBe(path);
+      expect(appState.setTab).not.toHaveBeenCalled();
+    },
+  );
 
   it("lets a fullscreen plugin view fill behind the floating composer", async () => {
     mockAvailableViews.push(simpleCalendarView);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -92,14 +92,15 @@ import { useKioskViewSurfaces } from "./components/shell/useKioskViewSurfaces";
 import { VoiceCaptureHud } from "./components/shell/VoiceCaptureHud";
 import { Button } from "./components/ui/button";
 import { KeepAliveViewHost } from "./components/views/KeepAliveViewHost";
+import { ShellViewAgentSurface } from "./components/views/ShellViewAgentSurface";
 import { ViewErrorBoundary } from "./components/views/ViewErrorBoundary";
 import { AppWorkspaceChrome } from "./components/workspace/AppWorkspaceChrome";
 import { useBootConfig } from "./config/boot-config-react.hooks";
 import {
-  CONNECT_EVENT,
   dispatchNavigateViewEvent,
   FOCUS_CONNECTOR_EVENT,
   type FocusConnectorEventDetail,
+  listenForConnectRequests,
   NAVIGATE_VIEW_EVENT,
 } from "./events";
 import { adoptRemoteAgentFirstRun } from "./first-run/adopt-remote-first-run";
@@ -121,6 +122,7 @@ import {
   getWindowNavigationPath,
   isAospShellEnabled,
   isRouteRootPath,
+  NATIVE_OS_VIEW_IDS,
   pathForTab,
   shouldUseHashNavigation,
   TAB_PATHS,
@@ -770,12 +772,12 @@ function RegisteredAppShellPage({
 }: {
   registration: AppShellPageRegistration;
 }) {
+  let content: ReactNode;
   if (registration.Component) {
     const Component = registration.Component;
-    return <Component />;
-  }
-  if (registration.loader) {
-    return (
+    content = <Component />;
+  } else if (registration.loader) {
+    content = (
       <RetainedLazyComponent
         loader={registration.loader}
         cacheKey={registration.id}
@@ -792,11 +794,21 @@ function RegisteredAppShellPage({
         )}
       />
     );
+  } else {
+    content = (
+      <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center text-sm text-muted">
+        {registration.label} is not available in this build.
+      </div>
+    );
   }
+
+  // In-process plugin pages bypass DynamicViewLoader, so the shell owns the
+  // capability bridge for them. This keeps registry pages and remote bundles
+  // equivalent: controls registered with useAgentElement are live immediately.
   return (
-    <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center text-sm text-muted">
-      {registration.label} is not available in this build.
-    </div>
+    <ShellViewAgentSurface viewId={registration.id}>
+      {content}
+    </ShellViewAgentSurface>
   );
 }
 
@@ -1151,17 +1163,19 @@ function findRemoteViewForRoute(
 ): ViewRegistryEntry | undefined {
   const normalizedPath = trimmedNavigationPath(navigationPath);
   if (SHELL_RESERVED_PATHS.has(normalizedPath)) return undefined;
+  // Exact plugin paths own their route even when they share a reserved tab
+  // affinity such as Wallet. This lets web/desktop mount the agent-served
+  // bundle while native shells still fall back to their in-process page.
+  const exactMatch = views.find(
+    (view) => remoteViewAvailable(view) && view.path === normalizedPath,
+  );
+  if (exactMatch) return exactMatch;
   if (tab !== "views" && tab !== "apps" && SHELL_RESERVED_TABS.has(tab)) {
     return undefined;
   }
-  return (
-    views.find(
-      (view) => remoteViewAvailable(view) && view.path === normalizedPath,
-    ) ??
-    views.find(
-      (view) =>
-        remoteViewAvailable(view) && remoteViewMatchesTab(view, tab, appSlug),
-    )
+  return views.find(
+    (view) =>
+      remoteViewAvailable(view) && remoteViewMatchesTab(view, tab, appSlug),
   );
 }
 
@@ -1565,6 +1579,53 @@ function renderViewRouterContent({
   settingsNavigatePayload?: unknown;
   settingsNavigateSequence?: number;
 }): ReactNode {
+  // Path ownership is more specific than tab affinity. Wallet-family plugins
+  // intentionally share the `inventory` tab, but their exact routes must mount
+  // their own registrations before that affinity resolves to the wallet root.
+  const walletNav = isWalletSectionPath(navigationPath) ? (
+    <WalletSectionNav activePath={navigationPath} />
+  ) : undefined;
+  // The AOSP system surfaces are host-owned because they coordinate privileged
+  // device APIs beyond the narrower plugin views. Keep them stable when remote
+  // metadata or a late in-process registration for the same path arrives.
+  if (
+    nativeOsSurfaceEnabled &&
+    (NATIVE_OS_VIEW_IDS as readonly string[]).includes(resolveBuiltinTabId(tab))
+  ) {
+    return renderStaticViewRouterTab({
+      tab,
+      nativeOsSurfaceEnabled,
+      navigationPath,
+      settingsInitialSection,
+      settingsNavigatePayload,
+      settingsNavigateSequence,
+      walletNav,
+    });
+  }
+  const remoteView = findRemoteViewForRoute(
+    availableViews,
+    navigationPath,
+    tab,
+    appSlug,
+  );
+  if (remoteView?.bundleUrl || remoteView?.frameUrl) {
+    return renderRemoteView(remoteView, walletNav);
+  }
+  const appShellPageForRoute = findAppShellPageForRoute(navigationPath);
+  if (
+    appShellPageForRoute &&
+    isViewVisible(appShellPageForRoute, enabledKinds)
+  ) {
+    return (
+      <TabContentView
+        nav={walletNav}
+        reserveChatClearance={!surfaceOwnsViewport(appShellPageForRoute)}
+      >
+        <RegisteredAppShellPage registration={appShellPageForRoute} />
+      </TabContentView>
+    );
+  }
+
   if (visibleDynamicPage(dynamicPage, enabledKinds)) {
     return (
       <TabContentView
@@ -1583,11 +1644,6 @@ function renderViewRouterContent({
       </TabContentView>
     );
   }
-  // Wallet-family routes share one sub-nav rendered in the workspace chrome
-  // nav slot. Plugins join it by registering app-shell pages with group=wallet.
-  const walletNav = isWalletSectionPath(navigationPath) ? (
-    <WalletSectionNav activePath={navigationPath} />
-  ) : undefined;
 
   // Character-family routes (Personality/Relationships/Skills/Experience) share
   // one "Character" header + section strip in the same nav slot (#13591). Unlike
@@ -1596,29 +1652,6 @@ function renderViewRouterContent({
     <CharacterSectionNav activePath={navigationPath} />
   ) : undefined;
 
-  const appShellPageForRoute = findAppShellPageForRoute(navigationPath);
-  if (
-    appShellPageForRoute &&
-    isViewVisible(appShellPageForRoute, enabledKinds)
-  ) {
-    return (
-      <TabContentView
-        nav={walletNav}
-        reserveChatClearance={!surfaceOwnsViewport(appShellPageForRoute)}
-      >
-        <RegisteredAppShellPage registration={appShellPageForRoute} />
-      </TabContentView>
-    );
-  }
-  const remoteView = findRemoteViewForRoute(
-    availableViews,
-    navigationPath,
-    tab,
-    appSlug,
-  );
-  if (remoteView?.bundleUrl || remoteView?.frameUrl) {
-    return renderRemoteView(remoteView, walletNav);
-  }
   return renderStaticViewRouterTab({
     tab,
     nativeOsSurfaceEnabled,
@@ -1648,33 +1681,15 @@ function ViewRouter({
   settingsNavigateSequence?: number;
 }) {
   const activeTab = useAppSelector((s) => s.tab);
-  const setActiveTab = useAppSelector((s) => s.setTab);
   const tab = routeOverride?.tab ?? activeTab;
   // Phone / messages / contacts are AOSP-fork-only native-OS surfaces (like
   // camera + the home tiles + the launcher tiles) — never rendered on web,
   // desktop, iOS, or stock Play-Store Android, even via a deep link.
   const nativeOsSurfaceEnabled = isAospShellEnabled();
+  // AppProvider owns late path-to-tab reconciliation through setTabRaw. Doing
+  // it here through the public setTab command would rewrite exact plugin paths
+  // to a shared affinity's canonical path (for example /hyperliquid → /wallet).
   const dynamicPage = useResolvedDynamicPage(tab);
-  // Late plugin registrations can land AFTER the boot path→tab resolution: a
-  // direct deep link to a plugin-owned page (e.g. /phone-companion) resolves
-  // to the "views" fallback because registerAppShellPage runs on the deferred
-  // idle pump, after first paint. Re-derive the tab for the current path on
-  // every registry change and adopt the now-registered page. Correcting only
-  // away from the "views" fallback means user navigation is never fought —
-  // for a fixed path, tabFromPath's answer only changes when a registration
-  // lands.
-  const shellPageRegistryVersion = useAppShellPageRegistryVersion();
-  useEffect(() => {
-    // The version is the re-run trigger (same pattern as useResolvedDynamicPage).
-    void shellPageRegistryVersion;
-    if (routeOverride) return;
-    if (activeTab !== "views") return;
-    if (typeof window === "undefined") return;
-    const resolved = tabFromPath(getWindowNavigationPath());
-    if (resolved && resolved !== "views") {
-      setActiveTab(resolved);
-    }
-  }, [shellPageRegistryVersion, routeOverride, activeTab, setActiveTab]);
   const [navigationPath, setNavigationPath] = useState(
     () =>
       routeOverride?.navigationPath ??
@@ -2093,6 +2108,7 @@ function AppContent() {
     tab,
     setTab,
     setState,
+    completeFirstRun,
     setActionNotice,
     actionNotice,
     activeOverlayApp,
@@ -2111,6 +2127,7 @@ function AppContent() {
     tab: s.tab,
     setTab: s.setTab,
     setState: s.setState,
+    completeFirstRun: s.completeFirstRun,
     setActionNotice: s.setActionNotice,
     actionNotice: s.actionNotice,
     activeOverlayApp: s.activeOverlayApp,
@@ -2157,22 +2174,13 @@ function AppContent() {
   useEffect(() => {
     if (!isShellPaintableNow) return;
 
-    const handleConnect = async (event: Event): Promise<void> => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      const payload =
-        detail && typeof detail === "object" && !Array.isArray(detail)
-          ? (detail as {
-              gatewayUrl?: unknown;
-              token?: unknown;
-              completeFirstRun?: unknown;
-              skipConfirm?: unknown;
-            })
-          : null;
-      if (typeof payload?.gatewayUrl !== "string") {
-        return;
-      }
-
-      const completeFirstRun = payload.completeFirstRun === true;
+    const handleConnect = async (payload: {
+      gatewayUrl: string;
+      token?: string;
+      completeFirstRun?: boolean;
+      skipConfirm?: boolean;
+    }): Promise<void> => {
+      const shouldCompleteFirstRun = payload.completeFirstRun === true;
       const skipConfirm = payload.skipConfirm === true;
       if (!skipConfirm && !isLoopbackGatewayHost(payload.gatewayUrl)) {
         const approved = await confirmDesktopAction({
@@ -2202,14 +2210,13 @@ function AppContent() {
         setState("firstRunRemoteToken", connection.token ?? "");
         setState("firstRunRemoteConnected", true);
         setState("firstRunRemoteError", null);
-        if (completeFirstRun) {
+        if (shouldCompleteFirstRun) {
           await adoptRemoteAgentFirstRun(client, {
             apiBase: connection.apiBase,
             token: connection.token,
             uiLanguage,
           });
-          setState("firstRunComplete", true);
-          startupCoordinator.dispatch({ type: "FIRST_RUN_COMPLETE" });
+          completeFirstRun();
         }
         setActionNotice("Connected to remote backend.", "success", 4200);
         retryStartup();
@@ -2224,14 +2231,13 @@ function AppContent() {
       }
     };
 
-    document.addEventListener(CONNECT_EVENT, handleConnect);
-    return () => document.removeEventListener(CONNECT_EVENT, handleConnect);
+    return listenForConnectRequests(handleConnect);
   }, [
+    completeFirstRun,
     isShellPaintableNow,
     retryStartup,
     setActionNotice,
     setState,
-    startupCoordinator.dispatch,
     uiLanguage,
   ]);
 

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -796,7 +796,7 @@ declare module "./client-base" {
       models: ProviderModelRecord[];
       catalog: ModelCatalog;
     }>;
-    getModelsCatalog(): Promise<{
+    getModelsCatalog(init?: RequestInit): Promise<{
       providers: Record<string, ProviderModelRecord[]>;
       catalog: ModelCatalog;
     }>;
@@ -2908,12 +2908,15 @@ ElizaClient.prototype.fetchModels = async function (
   return this.fetch(`/api/models?${params.toString()}`);
 };
 
-ElizaClient.prototype.getModelsCatalog = async function (this: ElizaClient) {
+ElizaClient.prototype.getModelsCatalog = async function (
+  this: ElizaClient,
+  init,
+) {
   // catalogOnly skips the server's all-providers model-list fan-out, which
   // takes tens of seconds on a cold cache — far past the client's 10s fetch
   // budget. Catalog consumers (settings panel, slash completions) only need
   // the validated catalog, which is local static tables + one file read.
-  return this.fetch("/api/models?catalogOnly=1");
+  return this.fetch("/api/models?catalogOnly=1", init);
 };
 
 ElizaClient.prototype.getModelsConfig = async function (this: ElizaClient) {

--- a/packages/ui/src/api/client-skills.ts
+++ b/packages/ui/src/api/client-skills.ts
@@ -307,8 +307,11 @@ declare module "./client-base" {
     ): Promise<AppSessionActionResult>;
     listRegistryPlugins(): Promise<RegistryPluginItem[]>;
     searchRegistryPlugins(query: string): Promise<RegistryPluginItem[]>;
-    listCommands(surface?: CommandSurface): Promise<SlashCommandCatalogItem[]>;
-    listCustomActions(): Promise<CustomActionDef[]>;
+    listCommands(
+      surface?: CommandSurface,
+      init?: RequestInit,
+    ): Promise<SlashCommandCatalogItem[]>;
+    listCustomActions(init?: RequestInit): Promise<CustomActionDef[]>;
     createCustomAction(
       action: Omit<CustomActionDef, "id" | "createdAt" | "updatedAt">,
     ): Promise<CustomActionDef>;
@@ -1076,17 +1079,23 @@ ElizaClient.prototype.searchRegistryPlugins = async function (
 ElizaClient.prototype.listCommands = async function (
   this: ElizaClient,
   surface,
+  init,
 ) {
   const query = surface ? `?surface=${encodeURIComponent(surface)}` : "";
   const data = await this.fetch<CommandsCatalogResponse>(
     `/api/commands${query}`,
+    init,
   );
   return data.commands;
 };
 
-ElizaClient.prototype.listCustomActions = async function (this: ElizaClient) {
+ElizaClient.prototype.listCustomActions = async function (
+  this: ElizaClient,
+  init,
+) {
   const data = await this.fetch<{ actions: CustomActionDef[] }>(
     "/api/custom-actions",
+    init,
   );
   return data.actions;
 };

--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -24,14 +24,21 @@ import { ApiError } from "../api/client-types-core";
 
 const { listCommands, listCustomActions } = vi.hoisted(() => ({
   listCommands:
-    vi.fn<(surface?: string) => Promise<SlashCommandCatalogItem[]>>(),
-  listCustomActions: vi.fn<() => Promise<CustomActionDef[]>>(),
+    vi.fn<
+      (
+        surface?: string,
+        init?: RequestInit,
+      ) => Promise<SlashCommandCatalogItem[]>
+    >(),
+  listCustomActions:
+    vi.fn<(init?: RequestInit) => Promise<CustomActionDef[]>>(),
 }));
 
 vi.mock("../api", () => ({
   client: {
-    listCommands: (surface?: string) => listCommands(surface),
-    listCustomActions: () => listCustomActions(),
+    listCommands: (surface?: string, init?: RequestInit) =>
+      listCommands(surface, init),
+    listCustomActions: (init?: RequestInit) => listCustomActions(init),
   },
 }));
 vi.mock("../config/boot-config-react.hooks", () => ({
@@ -118,7 +125,10 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
     const { result } = renderHook(() => useSlashCommandController());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(listCommands).toHaveBeenCalledWith(GUI);
+    expect(listCommands).toHaveBeenCalledWith(
+      GUI,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(result.current.commands.map((c) => c.key)).toEqual(["settings"]);
     expect(result.current.isAuthorized).toBe(false);
     expect(result.current.isElevated).toBe(false);
@@ -281,6 +291,32 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
     expect(result.current.error).toBe(true);
     consoleError.mockRestore();
   });
+
+  it("aborts catalog requests quietly when the composer unmounts during navigation", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockResolvedValue([]);
+    listCustomActions.mockImplementation(
+      (init) =>
+        new Promise<CustomActionDef[]>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Navigation aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+
+    const { unmount } = renderHook(() => useSlashCommandController());
+    await waitFor(() => expect(listCustomActions).toHaveBeenCalledOnce());
+    unmount();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
 });
 
 describe("useSlashCommandController — protected-probe gate (#16242)", () => {
@@ -342,7 +378,10 @@ describe("useSlashCommandController — protected-probe gate (#16242)", () => {
       },
     });
     await waitFor(() => {
-      expect(listCommands).toHaveBeenCalledWith(GUI);
+      expect(listCommands).toHaveBeenCalledWith(
+        GUI,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
       expect(listCustomActions).toHaveBeenCalled();
     });
   });

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -234,6 +234,19 @@ function isExpectedCatalogAuthError(error: unknown): boolean {
   return isApiError(error) && (error.status === 401 || error.status === 403);
 }
 
+function isExpectedCatalogCancellation(
+  error: unknown,
+  signal: AbortSignal,
+  cancelled: boolean,
+): boolean {
+  return (
+    cancelled ||
+    signal.aborted ||
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
 /** Merge catalogs, keeping the first definition for any duplicated alias. */
 function mergeByAlias(
   groups: SlashCommandCatalogItem[][],
@@ -305,6 +318,7 @@ export function useSlashCommandController(
       return;
     }
     let cancelled = false;
+    const abortController = new AbortController();
     setLoading(true);
     setLoadError(false);
     void (async () => {
@@ -316,10 +330,19 @@ export function useSlashCommandController(
       // show a distinguishable degraded state, not a false healthy-empty.
       let loadFailed = false;
       const catalog: SlashCommandCatalogItem[] = await client
-        .listCommands("gui")
+        .listCommands("gui", { signal: abortController.signal })
         // error-policy:J4 degrade to an empty catalog with the failure logged
         // + flagged (not fabricated as a healthy-empty catalog).
         .catch((error: unknown) => {
+          if (
+            isExpectedCatalogCancellation(
+              error,
+              abortController.signal,
+              cancelled,
+            )
+          ) {
+            return [];
+          }
           // A 401/403 means the viewer isn't authenticated (or the agent
           // session lapsed) — the catalog is legitimately unavailable, not a
           // diagnosable failure. Degrade quietly rather than console.error-
@@ -336,9 +359,18 @@ export function useSlashCommandController(
           return [];
         });
       const customActions: CustomActionDef[] = await client
-        .listCustomActions()
+        .listCustomActions({ signal: abortController.signal })
         // error-policy:J4 omit custom actions with the failure logged + flagged.
         .catch((error: unknown) => {
+          if (
+            isExpectedCatalogCancellation(
+              error,
+              abortController.signal,
+              cancelled,
+            )
+          ) {
+            return [];
+          }
           // See above: an unauthenticated 401/403 is expected, not a failure —
           // degrade quietly instead of logging (#14663).
           if (isExpectedCatalogAuthError(error)) {
@@ -362,12 +394,21 @@ export function useSlashCommandController(
         )
       ) {
         void client
-          .getModelsCatalog()
+          .getModelsCatalog({ signal: abortController.signal })
           .then((models) => {
             if (!cancelled)
               setModelCatalog(resolveModelCatalogProviders(models));
           })
           .catch((error: unknown) => {
+            if (
+              isExpectedCatalogCancellation(
+                error,
+                abortController.signal,
+                cancelled,
+              )
+            ) {
+              return;
+            }
             // error-policy:J4 model completions degrade to none with the
             // failure logged; an unauthenticated 401/403 is expected (#14663).
             if (isExpectedCatalogAuthError(error)) return;
@@ -390,6 +431,7 @@ export function useSlashCommandController(
     })();
     return () => {
       cancelled = true;
+      abortController.abort();
     };
   }, [probesEnabled]);
 

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -810,7 +810,7 @@ export const ChatMessage = memo(function ChatMessage({
               handleCancelEditing();
             }}
             disabled={savingEdit}
-            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+            className="keyboard-focus-emphasis h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
           >
             <X className="h-3.5 w-3.5" />
           </Button>
@@ -829,7 +829,7 @@ export const ChatMessage = memo(function ChatMessage({
               void handleSaveEdit();
             }}
             disabled={editSaveDisabled}
-            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+            className="keyboard-focus-emphasis h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
           >
             {savingEdit ? (
               <LoaderCircle
@@ -847,7 +847,7 @@ export const ChatMessage = memo(function ChatMessage({
             unstyled
             onClick={handleCancelEditing}
             disabled={savingEdit}
-            className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+            className="keyboard-focus-emphasis min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
           >
             {labels.cancel ?? "Cancel"}
           </Button>
@@ -856,7 +856,7 @@ export const ChatMessage = memo(function ChatMessage({
             unstyled
             onClick={() => void handleSaveEdit()}
             disabled={editSaveDisabled}
-            className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+            className="keyboard-focus-emphasis min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
           >
             {savingEdit
               ? (labels.saving ?? "Saving...")
@@ -1219,6 +1219,7 @@ export const ChatMessage = memo(function ChatMessage({
               <MessageRowFooter className="flex items-center p-0 text-white/70">
                 <motion.div
                   key={accessoryMode}
+                  className="flex"
                   initial={reduceMotion ? false : { opacity: 0, y: 2 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{

--- a/packages/ui/src/components/pages/DocumentsView.tsx
+++ b/packages/ui/src/components/pages/DocumentsView.tsx
@@ -1012,6 +1012,7 @@ export function DocumentsView({
   const facetStrip = (
     <SectionTabStrip
       testId="knowledge-facets"
+      agentIdPrefix="facet"
       ariaLabel={t("knowledgehub.facetsLabel", {
         defaultValue: "Filter knowledge by media type",
       })}
@@ -1021,6 +1022,7 @@ export function DocumentsView({
         const Icon = knowledgeFacetIcon(value);
         return {
           id: value,
+          agentLabel: knowledgeFacetLabel(value, t),
           label: (
             <span
               className="inline-flex items-center gap-1.5"
@@ -1052,6 +1054,7 @@ export function DocumentsView({
   const scopeStrip = (
     <SectionTabStrip
       testId="knowledge-scope"
+      agentIdPrefix="scope"
       ariaLabel={t("knowledgehub.scopeLabel", {
         defaultValue: "Filter knowledge by scope",
       })}
@@ -1062,6 +1065,7 @@ export function DocumentsView({
         ({ value, labelKey, defaultLabel }) => ({
           id: value,
           label: t(labelKey, { defaultValue: defaultLabel }),
+          agentLabel: t(labelKey, { defaultValue: defaultLabel }),
         }),
       )}
     />

--- a/packages/ui/src/components/setup/BootstrapStep.tsx
+++ b/packages/ui/src/components/setup/BootstrapStep.tsx
@@ -5,8 +5,9 @@
  * once on mount, scrubbed from the URL, and exchanged automatically — no
  * paste required. Otherwise the manual paste form is shown as a fallback.
  *
- * On success the returned session id is written to
- * sessionStorage["eliza_session"] and the `onAdvance` callback fires.
+ * On success the returned session id is persisted through the active-server
+ * credential path, mirrored to sessionStorage["eliza_session"], and installed
+ * on the live client before the `onAdvance` callback fires.
  *
  * P1 will migrate the session to an HttpOnly cookie and retire sessionStorage.
  * The key name is kept in sync with the cookie name planned for P1
@@ -24,6 +25,7 @@ import { client } from "../../api";
 import type { BootstrapExchangeResult } from "../../api/client-agent";
 import { cn } from "../../lib/utils";
 import { startFreshFirstRunReload } from "../../platform";
+import { persistActiveServerCredential } from "../../state/active-server-credential";
 import {
   type TranslationContextValue,
   useTranslation,
@@ -186,6 +188,7 @@ export function BootstrapStep({ onAdvance, exchangeFn }: BootstrapStepProps) {
         // sessionStorage unavailable (e.g. private browsing on some browsers).
         // Session is still in memory for this page load; startup can advance.
       }
+      persistActiveServerCredential(result.sessionId);
       client.setToken(result.sessionId);
 
       setSubmitState({ phase: "success" });

--- a/packages/ui/src/components/shared/SectionNav.test.tsx
+++ b/packages/ui/src/components/shared/SectionNav.test.tsx
@@ -8,14 +8,27 @@
  *  - a single-member section renders NO strip (one tab is not a nav),
  *  - `isSectionPath` matches the section's tabs + aliases and rejects others.
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AgentSurfaceProvider,
+  getViewRegistry,
+  handleAgentSurfaceCapability,
+} from "../../agent-surface";
 import { registerAppShellPage } from "../../app-shell-registry";
 import { resetUiRegistryHostForTests } from "../../registry-host";
 import {
   isSectionPath,
   SectionNav,
   type SectionPathRewrite,
+  SectionTabStrip,
 } from "./SectionNav";
 
 const GROUP = "wallet";
@@ -192,5 +205,66 @@ describe("SectionNav", () => {
       <SectionNav group="nonexistent" activePath="/x" />,
     );
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("SectionTabStrip agent surface", () => {
+  it("registers scope tabs and activates them through the live bridge", () => {
+    function ScopeFixture() {
+      const [activeId, setActiveId] = useState("all");
+      return (
+        <AgentSurfaceProvider viewId="documents" viewType="gui">
+          <SectionTabStrip
+            entries={[
+              { id: "all", label: "All", agentLabel: "All knowledge" },
+              {
+                id: "shared",
+                label: "Shared",
+                agentLabel: "Shared knowledge",
+              },
+            ]}
+            activeId={activeId}
+            onSelect={setActiveId}
+            ariaLabel="Knowledge scope"
+            agentIdPrefix="scope"
+          />
+        </AgentSurfaceProvider>
+      );
+    }
+
+    render(<ScopeFixture />);
+    const registry = getViewRegistry("documents", "gui");
+    if (!registry) throw new Error("documents registry missing");
+
+    const elements = handleAgentSurfaceCapability(
+      registry,
+      "list-elements",
+      undefined,
+    ) as Array<{ id: string; role: string; status?: string }>;
+    expect(elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "scope-all",
+          role: "tab",
+          status: "active",
+        }),
+        expect.objectContaining({
+          id: "scope-shared",
+          role: "tab",
+          status: "inactive",
+        }),
+      ]),
+    );
+
+    act(() => {
+      handleAgentSurfaceCapability(registry, "agent-click", {
+        id: "scope-shared",
+      });
+    });
+    expect(
+      screen
+        .getByRole("button", { name: "Shared" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
   });
 });

--- a/packages/ui/src/components/shared/SectionNav.tsx
+++ b/packages/ui/src/components/shared/SectionNav.tsx
@@ -19,6 +19,7 @@
  */
 
 import { useSyncExternalStore } from "react";
+import { useAgentElement } from "../../agent-surface";
 import {
   type AppShellPageRegistration,
   getAppShellPageRegistrySnapshot,
@@ -147,14 +148,56 @@ export function SectionNavTab({
   label,
   isActive,
   onSelect,
+  agentId,
+  agentLabel,
+  agentGroup,
 }: {
   label: React.ReactNode;
   isActive: boolean;
   onSelect: () => void;
+  agentId?: string;
+  agentLabel?: string;
+  agentGroup?: string;
+}): React.JSX.Element {
+  if (agentId && agentLabel) {
+    return (
+      <AgentSectionNavTab
+        label={label}
+        isActive={isActive}
+        onSelect={onSelect}
+        agentId={agentId}
+        agentLabel={agentLabel}
+        agentGroup={agentGroup}
+      />
+    );
+  }
+  return (
+    <SectionNavTabButton
+      label={label}
+      isActive={isActive}
+      onSelect={onSelect}
+    />
+  );
+}
+
+function SectionNavTabButton({
+  label,
+  isActive,
+  onSelect,
+  agentRef,
+  agentProps,
+}: {
+  label: React.ReactNode;
+  isActive: boolean;
+  onSelect: () => void;
+  agentRef?: React.Ref<HTMLButtonElement>;
+  agentProps?: Record<string, string>;
 }): React.JSX.Element {
   return (
     <Button
+      ref={agentRef}
       aria-current={isActive ? "page" : undefined}
+      aria-pressed={isActive}
       onClick={() => {
         if (!isActive) onSelect();
       }}
@@ -166,9 +209,46 @@ export function SectionNavTab({
           ? "bg-accent/15 text-accent"
           : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
       )}
+      {...agentProps}
     >
       {label}
     </Button>
+  );
+}
+
+function AgentSectionNavTab({
+  label,
+  isActive,
+  onSelect,
+  agentId,
+  agentLabel,
+  agentGroup,
+}: {
+  label: React.ReactNode;
+  isActive: boolean;
+  onSelect: () => void;
+  agentId: string;
+  agentLabel: string;
+  agentGroup?: string;
+}): React.JSX.Element {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: agentId,
+    role: "tab",
+    label: agentLabel,
+    group: agentGroup,
+    status: isActive ? "active" : "inactive",
+    onActivate: () => {
+      if (!isActive) onSelect();
+    },
+  });
+  return (
+    <SectionNavTabButton
+      label={label}
+      isActive={isActive}
+      onSelect={onSelect}
+      agentRef={ref}
+      agentProps={agentProps}
+    />
   );
 }
 
@@ -190,8 +270,13 @@ export function SectionTabStrip({
   testId,
   ariaLabel,
   className,
+  agentIdPrefix,
 }: {
-  entries: readonly { id: string; label: React.ReactNode }[];
+  entries: readonly {
+    id: string;
+    label: React.ReactNode;
+    agentLabel?: string;
+  }[];
   activeId: string;
   onSelect: (id: string) => void;
   /** `data-testid` for the nav landmark (e.g. `section-nav-wallet`). */
@@ -199,6 +284,8 @@ export function SectionTabStrip({
   /** Accessible name for the nav landmark. */
   ariaLabel: string;
   className?: string;
+  /** Prefix that opts each tab into the enclosing view's agent surface. */
+  agentIdPrefix?: string;
 }): React.JSX.Element | null {
   // A single-entry section is just its header; no secondary nav to render.
   if (entries.length < 2) return null;
@@ -217,6 +304,9 @@ export function SectionTabStrip({
           label={entry.label}
           isActive={entry.id === activeId}
           onSelect={() => onSelect(entry.id)}
+          agentId={agentIdPrefix ? `${agentIdPrefix}-${entry.id}` : undefined}
+          agentLabel={entry.agentLabel}
+          agentGroup={agentIdPrefix}
         />
       ))}
     </nav>

--- a/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
@@ -18,16 +18,17 @@
 // Paired with run-chat-perf-gate.mjs and run-perf-gate-e2e.mjs.
 //
 // STREAMING DRIVER: the harness also exposes `window.__ELIZA_PERF_STREAM__` — a
-// function the perf gate calls once per simulated token to append a character
-// to the tail assistant message (flipping `responding` to true) and force a
-// REAL transcript re-render, so the gate can measure the frame budget of the
-// hot path the memoized widgets protect: streaming into the open chat. Driving
-// it from the fixture keeps ChatOverlay itself untouched.
+// function the perf gate calls once per simulated token to append characters
+// to the tail assistant message. The driver receives token events at rAF speed
+// but paints cumulative snapshots at the same bounded cadence as useChatSend,
+// so the gate measures the production hot path instead of an impossible
+// per-token paint loop. Driving it here keeps ChatOverlay itself untouched.
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 
 import { MockAppProvider } from "../../../storybook/mock-providers";
+import { streamingRenderDelayMs } from "../../../state/streaming-render-cadence";
 import { ChatOverlay } from "../ChatOverlay";
 import type { ConversationNav } from "../conversation-nav";
 import type { ShellMessage } from "../shell-state";
@@ -78,7 +79,6 @@ function longThread(): ShellMessage[] {
 const TAIL_WIDGET_PREFIX =
   "Here is my answer so far, streaming in token by token. " +
   "[CHOICE:disambiguate id=perf-choice]\nyes=Yes, proceed\nno=No, cancel\n[/CHOICE]\n";
-
 declare global {
   interface Window {
     __ELIZA_PERF_STREAM__?: (chars?: number) => void;
@@ -90,11 +90,12 @@ function Harness(): React.JSX.Element {
   const [responding, setResponding] = React.useState(false);
   // The streamed tail turn is appended once, then grows character-by-character.
   const streamedRef = React.useRef("");
+  const lastStreamPaintRef = React.useRef<number | null>(null);
+  const pendingStreamPaintRef = React.useRef<number | null>(null);
 
-  // Expose a token driver the perf gate calls. Each call appends `chars` more
-  // characters of the streamed body (everything AFTER the widget prefix) and
-  // flips `responding`, producing the same reference-changing message-array
-  // update the real chat container emits per streamed token.
+  // Expose the transport-facing token driver. Calls append to the cumulative
+  // body immediately; trailing paints overwrite the parked snapshot, matching
+  // useChatSend while still producing real message-array updates.
   React.useEffect(() => {
     const tailId = "a-stream";
     const streamedBody =
@@ -114,21 +115,37 @@ function Harness(): React.JSX.Element {
         },
       ];
     });
-    window.__ELIZA_PERF_STREAM__ = (chars = 1) => {
-      streamedRef.current = streamedBody.slice(
-        0,
-        Math.min(streamedBody.length, streamedRef.current.length + chars),
-      );
+    const paintStream = () => {
+      pendingStreamPaintRef.current = null;
+      lastStreamPaintRef.current = performance.now();
       const nextContent = TAIL_WIDGET_PREFIX + streamedRef.current;
       setResponding(true);
-      // New array + new tail object each tick (matches the real container).
       setMessages((prev) =>
         prev.map((m) =>
           m.id === tailId ? { ...m, content: nextContent } : m,
         ),
       );
     };
+    window.__ELIZA_PERF_STREAM__ = (chars = 1) => {
+      streamedRef.current = streamedBody.slice(
+        0,
+        Math.min(streamedBody.length, streamedRef.current.length + chars),
+      );
+      if (pendingStreamPaintRef.current !== null) return;
+      const delayMs = streamingRenderDelayMs(
+        lastStreamPaintRef.current,
+        performance.now(),
+      );
+      if (delayMs === 0) {
+        paintStream();
+        return;
+      }
+      pendingStreamPaintRef.current = window.setTimeout(paintStream, delayMs);
+    };
     return () => {
+      if (pendingStreamPaintRef.current !== null) {
+        window.clearTimeout(pendingStreamPaintRef.current);
+      }
       window.__ELIZA_PERF_STREAM__ = undefined;
     };
   }, []);

--- a/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
@@ -53,9 +53,10 @@ const FRAME_BUDGET_OPTIONS = {
   droppedFrameRatio: 0.25, // >25% frames over budget = visible jank
   reportOnLongTask: false, // long tasks are noisy on shared CI runners
 };
-// Streaming intentionally updates once per animation frame, making its dropped
-// ratio sensitive to runner contention. Pair each streaming window with an
-// immediately preceding zero-token window so the gate measures incremental work.
+// Streaming transport events intentionally arrive once per animation frame.
+// The fixture applies the production cumulative-snapshot paint cadence, then
+// each streaming window is paired with an immediately preceding zero-token
+// window so the gate measures incremental render work.
 const FRAME_GATE_STREAMING = {
   p95BudgetFactor: 2.5,
   reportOnLongTask: false,
@@ -362,9 +363,9 @@ await runBrowserFixtureE2E(
     // landing into the OPEN chat. The fixture's tail turn carries a CHOICE
     // widget, so streaming into it is the exact condition where an unmemoized
     // widget would re-render on every token. We drive the fixture's token
-    // driver ~one token per animation frame, harvest the SAME real frame
-    // samples, and hold them to a frame budget — plus prove the widget stayed
-    // mounted (never remounted/torn) across the whole stream.
+    // driver ~one token per animation frame. The fixture coalesces cumulative
+    // snapshots at the production paint cadence; the gate harvests the SAME
+    // real frame samples and proves the widget stays mounted across the stream.
     const hasStreamDriver = await page.evaluate(
       () => typeof window.__ELIZA_PERF_STREAM__ === "function",
     );
@@ -397,10 +398,10 @@ await runBrowserFixtureE2E(
     // window (a GC pause, a co-tenant CI process stealing the core) must not
     // redden the lane, but a real regression — an unmemoized widget re-rendering
     // on every token — janks EVERY window, so the median still trips. Each window
-    // resets the sampled buffers, drives ~120 tokens (a few chars each, one batch
-    // per animation frame — a sustained stream, not a burst) entirely in the page
-    // so the rAF cadence is real, then harvests the SAME real frame + shift +
-    // reflow entries and feeds them to the SAME shared detector.
+    // resets the sampled buffers, drives ~120 transport events (a few chars each,
+    // one per animation frame — a sustained stream, not a synchronous burst)
+    // entirely in the page, then harvests the SAME real frame + shift + reflow
+    // entries and feeds them to the SAME shared detector.
     const streamWindows = [];
     const reflowAll = [];
     for (let w = 0; w < STREAM_WINDOWS; w += 1) {

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -1421,6 +1421,53 @@ describe("useShellController — transcription mode", () => {
     return sessions;
   }
 
+  it("drains the hands-free recorder through transcription before opening its replacement", async () => {
+    const { result } = renderHook(() => useShellController());
+    const sessions = sinkSessions(result);
+    await act(async () => result.current.toggleHandsFree());
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+    const handsFreeOptions = lastCaptureOpts;
+    let releaseDrain: (() => void) | undefined;
+    const drainReleased = new Promise<void>((resolve) => {
+      releaseDrain = resolve;
+    });
+    captureHandles[0]?.stop.mockImplementation(async () => {
+      await drainReleased;
+      handsFreeOptions?.onTranscript?.({
+        text: "captured during the mode handoff",
+        final: true,
+        backend: "local-inference",
+        audioWav: makeWav(1200),
+      });
+      handsFreeOptions?.onStateChange?.("stopped");
+    });
+
+    let enterTranscription: Promise<void> | undefined;
+    await act(async () => {
+      enterTranscription = Promise.resolve(
+        result.current.toggleTranscriptionMode(),
+      );
+      await Promise.resolve();
+    });
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      releaseDrain?.();
+      await enterTranscription;
+    });
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(2);
+    expect(captureHandles[0]?.dispose).toHaveBeenCalledTimes(1);
+    expect(captureHandles[1]?.start).toHaveBeenCalledTimes(1);
+
+    await act(async () => result.current.toggleTranscriptionMode());
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.segments.map((segment) => segment.text)).toEqual([
+      "captured during the mode handoff",
+    ]);
+    expect(sessions[0]?.audioWav?.byteLength).toBeGreaterThan(1000);
+  });
+
   it("accumulates finals into ONE recording session, not per-utterance DMs", async () => {
     const { result } = renderHook(() => useShellController());
     const sessions = sinkSessions(result);

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -992,7 +992,11 @@ export function useShellController(): ShellController {
             setTranscript("");
             return;
           }
-          if (intent === "transcription") {
+          // A hands-free recorder can finish draining after the user has
+          // switched modes. Once transcription owns the session, route that
+          // final into the recording instead of letting the stale converse
+          // intent send it as a chat turn.
+          if (intent === "transcription" || transcriptionModeRef.current) {
             // Long-form record-only. Run exit detection on every final.
             if (isTranscriptionExitPhrase(text)) {
               // Fold any preceding non-exit content into the session, then close
@@ -1652,12 +1656,15 @@ export function useShellController(): ShellController {
       setIsOpen(true);
       voiceOutput.unlockAudio();
       beginTranscriptSession();
-      if (captureRef.current) stopCapture();
+      // The outgoing hands-free recorder owns the WAV chunks captured before
+      // this mode switch. Drain it before opening the transcription recorder so
+      // both captures reach ASR in order and the old handle cannot dispose the
+      // new capture's state.
+      if (captureRef.current) await stopCaptureAndDrain();
       startCapture("transcription");
     }
   }, [
     startCapture,
-    stopCapture,
     stopCaptureAndDrain,
     voiceOutput,
     beginTranscriptSession,

--- a/packages/ui/src/components/transcripts/MeetingJoinBar.test.tsx
+++ b/packages/ui/src/components/transcripts/MeetingJoinBar.test.tsx
@@ -6,8 +6,17 @@
  */
 
 import type { MeetingSession } from "@elizaos/shared";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentSurfaceProvider } from "../../agent-surface/AgentSurfaceContext";
+import { handleAgentSurfaceCapability } from "../../agent-surface/capabilities";
+import { getViewRegistry } from "../../agent-surface/registry";
 import { MeetingJoinBar } from "./MeetingJoinBar";
 
 afterEach(cleanup);
@@ -135,5 +144,45 @@ describe("MeetingJoinBar", () => {
   it("renders the join error", () => {
     renderBar({ error: "Bot could not join" });
     expect(screen.getByRole("alert").textContent).toBe("Bot could not join");
+  });
+
+  it("exposes the live meeting form through the agent bridge", async () => {
+    const onJoin = vi.fn();
+    render(
+      <AgentSurfaceProvider viewId="transcripts" viewType="gui">
+        <MeetingJoinBar activeMeetings={[]} onJoin={onJoin} onStop={vi.fn()} />
+      </AgentSurfaceProvider>,
+    );
+    const registry = getViewRegistry("transcripts", "gui");
+    if (!registry) throw new Error("transcripts registry missing");
+
+    expect(
+      handleAgentSurfaceCapability(registry, "list-elements", undefined),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "meeting-url", fillable: true }),
+        expect.objectContaining({ id: "meeting-bot-name", fillable: true }),
+        expect.objectContaining({ id: "meeting-join", clickable: true }),
+      ]),
+    );
+    await act(async () => {
+      expect(
+        handleAgentSurfaceCapability(registry, "agent-fill", {
+          id: "meeting-url",
+          value: "https://meet.google.com/abc-defg-hij",
+        }),
+      ).toMatchObject({ ok: true });
+    });
+    await act(async () => {
+      expect(
+        handleAgentSurfaceCapability(registry, "agent-click", {
+          id: "meeting-join",
+        }),
+      ).toMatchObject({ ok: true });
+    });
+    expect(onJoin).toHaveBeenCalledWith({
+      platform: "google_meet",
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+    });
   });
 });

--- a/packages/ui/src/components/transcripts/MeetingJoinBar.tsx
+++ b/packages/ui/src/components/transcripts/MeetingJoinBar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@elizaos/shared";
 import { Video } from "lucide-react";
 import * as React from "react";
+import { useAgentElement } from "../../agent-surface";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -54,6 +55,29 @@ export function MeetingJoinBar({
     [url],
   );
   const showInvalid = url.trim().length > 0 && parsed === null;
+  const meetingUrlAgent = useAgentElement<HTMLInputElement>({
+    id: "meeting-url",
+    role: "text-input",
+    label: "Meeting URL",
+    group: "meeting-join",
+    getValue: () => url,
+    onFill: setUrl,
+  });
+  const botNameAgent = useAgentElement<HTMLInputElement>({
+    id: "meeting-bot-name",
+    role: "text-input",
+    label: "Bot name",
+    group: "meeting-join",
+    getValue: () => botName,
+    onFill: setBotName,
+  });
+  const joinMeetingAgent = useAgentElement<HTMLButtonElement>({
+    id: "meeting-join",
+    role: "button",
+    label: "Join meeting",
+    group: "meeting-join",
+    status: joining ? "joining" : parsed ? "ready" : "disabled",
+  });
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -76,6 +100,8 @@ export function MeetingJoinBar({
       >
         <div className="relative min-w-48 flex-1">
           <Input
+            ref={meetingUrlAgent.ref}
+            {...meetingUrlAgent.agentProps}
             data-testid="meeting-url-input"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
@@ -95,6 +121,8 @@ export function MeetingJoinBar({
           ) : null}
         </div>
         <Input
+          ref={botNameAgent.ref}
+          {...botNameAgent.agentProps}
           data-testid="meeting-bot-name"
           value={botName}
           onChange={(e) => setBotName(e.target.value)}
@@ -103,6 +131,8 @@ export function MeetingJoinBar({
           className="w-48"
         />
         <Button
+          ref={joinMeetingAgent.ref}
+          {...joinMeetingAgent.agentProps}
           type="submit"
           size="sm"
           data-testid="meeting-join-submit"

--- a/packages/ui/src/events/connect-request.test.ts
+++ b/packages/ui/src/events/connect-request.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+/**
+ * Connection-event handoff coverage for native deep links that can arrive
+ * before React mounts a startup or live-shell consumer.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatchConnectRequest, listenForConnectRequests } from "./index";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+describe("connect request handoff", () => {
+  it("replays a request dispatched before the consumer mounts", async () => {
+    const listener = vi.fn();
+
+    dispatchConnectRequest({
+      gatewayUrl: "http://127.0.0.1:31337",
+      completeFirstRun: true,
+    });
+    cleanups.push(listenForConnectRequests(listener));
+    await Promise.resolve();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gatewayUrl: "http://127.0.0.1:31337",
+        completeFirstRun: true,
+      }),
+    );
+  });
+
+  it("lets only one startup/shell consumer claim a queued request", async () => {
+    const startupListener = vi.fn();
+    const shellListener = vi.fn();
+
+    dispatchConnectRequest({ gatewayUrl: "http://127.0.0.1:31337" });
+    cleanups.push(listenForConnectRequests(startupListener));
+    cleanups.push(listenForConnectRequests(shellListener));
+    await Promise.resolve();
+
+    expect(startupListener).toHaveBeenCalledOnce();
+    expect(shellListener).not.toHaveBeenCalled();
+  });
+
+  it("delivers requests immediately after a consumer mounts", () => {
+    const listener = vi.fn();
+    cleanups.push(listenForConnectRequests(listener));
+
+    dispatchConnectRequest({ gatewayUrl: "https://agent.example.com" });
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -10,9 +10,10 @@
  * `dispatchAppEvent` / `dispatchWindowEvent` accept them.
  */
 
-import type {
-  ElizaDocumentEventName as SharedDocumentEventName,
-  ElizaWindowEventName as SharedWindowEventName,
+import {
+  CONNECT_EVENT,
+  type ElizaDocumentEventName as SharedDocumentEventName,
+  type ElizaWindowEventName as SharedWindowEventName,
 } from "@elizaos/shared/events";
 
 export {
@@ -247,6 +248,81 @@ export function dispatchAppEvent(
   detail?: unknown,
 ): void {
   document.dispatchEvent(new CustomEvent(name, { detail }));
+}
+
+export interface ConnectRequestDetail {
+  gatewayUrl: string;
+  token?: string;
+  completeFirstRun?: boolean;
+  skipConfirm?: boolean;
+}
+
+type ConnectRequestListener = (
+  detail: ConnectRequestDetail,
+) => void | Promise<void>;
+
+const connectRequestClaims = new WeakMap<object, () => boolean>();
+let pendingConnectRequest: ConnectRequestDetail | null = null;
+
+function emitConnectRequest(detail: ConnectRequestDetail): void {
+  document.dispatchEvent(new CustomEvent(CONNECT_EVENT, { detail }));
+}
+
+/**
+ * Dispatches a connection request without losing native deep links that arrive
+ * while React is replacing the startup screen with the live shell. The latest
+ * unclaimed request is replayed when a consumer mounts; a synchronous claim
+ * guarantees that the startup and shell listeners cannot both adopt it.
+ */
+export function dispatchConnectRequest(detail: ConnectRequestDetail): void {
+  let claimed = false;
+  const request: ConnectRequestDetail = {
+    ...detail,
+  };
+  connectRequestClaims.set(request, () => {
+    if (claimed) return false;
+    claimed = true;
+    if (pendingConnectRequest === request) {
+      pendingConnectRequest = null;
+    }
+    return true;
+  });
+  pendingConnectRequest = request;
+  emitConnectRequest(request);
+}
+
+/**
+ * Subscribes to connection requests and immediately replays one that arrived
+ * before this listener mounted. Legacy CustomEvents outside this helper remain
+ * supported for browser tests and third-party in-app producers.
+ */
+export function listenForConnectRequests(
+  listener: ConnectRequestListener,
+): () => void {
+  const handle = (event: Event): void => {
+    const detail = (event as CustomEvent<unknown>).detail;
+    if (
+      !detail ||
+      typeof detail !== "object" ||
+      Array.isArray(detail) ||
+      typeof (detail as { gatewayUrl?: unknown }).gatewayUrl !== "string"
+    ) {
+      return;
+    }
+
+    const request = detail as ConnectRequestDetail;
+    const claim = connectRequestClaims.get(request);
+    if (claim && !claim()) return;
+    void listener(request);
+  };
+
+  document.addEventListener(CONNECT_EVENT, handle);
+  queueMicrotask(() => {
+    if (pendingConnectRequest) {
+      emitConnectRequest(pendingConnectRequest);
+    }
+  });
+  return () => document.removeEventListener(CONNECT_EVENT, handle);
 }
 
 /** Dispatch a typed custom event on `window`. */

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -319,8 +319,10 @@ describe("useRealtimeVoiceSession", () => {
 
   it("fails a black-holed connect into a retryable transport error instead of hanging (ready timeout)", async () => {
     const { options, ws, mint } = makeOptions();
-    const { result } = renderHook(() =>
-      useRealtimeVoiceSession({ ...options, readyTimeoutMs: 30 }),
+    const { result, rerender } = renderHook(
+      ({ readyTimeoutMs }) =>
+        useRealtimeVoiceSession({ ...options, readyTimeoutMs }),
+      { initialProps: { readyTimeoutMs: 30 } },
     );
 
     const firstStart = beginStart(result);
@@ -345,7 +347,10 @@ describe("useRealtimeVoiceSession", () => {
     await waitFor(() => expect(first.closed).not.toBeNull());
 
     // Retry on the next tap: a fresh start clears the error, re-mints with a
-    // fresh consent nonce, and can reach live.
+    // fresh consent nonce, and can reach live. The timeout behavior is already
+    // proven above; the retry uses the production budget so a loaded CI event
+    // loop cannot turn this independent assertion into another timeout test.
+    rerender({ readyTimeoutMs: 15_000 });
     const retryStart = beginStart(result);
     await flushAsync();
     expect(result.current.error).toBeNull();

--- a/packages/ui/src/spatial/ir.ts
+++ b/packages/ui/src/spatial/ir.ts
@@ -124,6 +124,8 @@ export interface SpatialButtonNode extends SpatialCommon {
   label: string;
   tone?: SpatialTone;
   disabled?: boolean;
+  /** Selection state for toggle-like button groups. */
+  pressed?: boolean;
   /** Visual emphasis: solid fill vs. outline vs. text-only. */
   variant?: "solid" | "outline" | "ghost";
 }

--- a/packages/ui/src/spatial/primitives.tsx
+++ b/packages/ui/src/spatial/primitives.tsx
@@ -119,6 +119,7 @@ export interface TextProps extends CommonProps {
 export interface ButtonProps extends CommonProps {
   tone?: SpatialTone;
   disabled?: boolean;
+  pressed?: boolean;
   variant?: "solid" | "outline" | "ghost";
   onPress?: () => void;
   children?: ReactNode;
@@ -231,6 +232,7 @@ export function buildButtonSpec(
     label,
     tone: props.tone,
     disabled: props.disabled,
+    pressed: props.pressed,
     variant: props.variant,
     grow: props.grow,
     shrink: props.shrink,
@@ -538,6 +540,8 @@ export const Button = brand<ButtonProps>("button", function Button(props) {
       variant="ghost"
       data-spatial-kind="button"
       disabled={spec.disabled}
+      aria-label={spec.agent?.label}
+      aria-pressed={spec.pressed}
       style={css}
       onClick={() => {
         if (spec.disabled) return;

--- a/packages/ui/src/state/active-server-credential.test.ts
+++ b/packages/ui/src/state/active-server-credential.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+/**
+ * Shared active-server credential persistence over real jsdom localStorage,
+ * covering the durable server and profile records without network mocks.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { persistActiveServerCredential } from "./active-server-credential";
+import { getActiveProfile } from "./agent-profiles";
+import {
+  createPersistedActiveServer,
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
+
+describe("persistActiveServerCredential", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("updates the active remote server and its active profile", () => {
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "cloud",
+        id: "cloud:test",
+        label: "Cloud Test",
+        apiBase: "https://runtime.example.test",
+      }),
+    );
+
+    persistActiveServerCredential("session-token");
+
+    expect(loadPersistedActiveServer()?.accessToken).toBe("session-token");
+    expect(getActiveProfile()?.accessToken).toBe("session-token");
+  });
+});

--- a/packages/ui/src/state/active-server-credential.ts
+++ b/packages/ui/src/state/active-server-credential.ts
@@ -1,0 +1,23 @@
+/**
+ * Persists a newly issued bearer credential across the active server and its
+ * matching profile so every reconnect path observes the same authenticated
+ * target. Pairing and bootstrap exchange both route through this boundary.
+ */
+
+import { getActiveProfile, updateAgentProfile } from "./agent-profiles";
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
+
+export function persistActiveServerCredential(token: string): void {
+  const activeServer = loadPersistedActiveServer();
+  if (activeServer && activeServer.kind !== "local") {
+    savePersistedActiveServer({ ...activeServer, accessToken: token });
+  }
+
+  const activeProfile = getActiveProfile();
+  if (activeProfile && activeProfile.kind !== "local") {
+    updateAgentProfile(activeProfile.id, { accessToken: token });
+  }
+}

--- a/packages/ui/src/state/streaming-render-cadence.test.ts
+++ b/packages/ui/src/state/streaming-render-cadence.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit coverage for the chat stream paint cadence, including first-paint,
+ * in-window delay, elapsed-window, and monotonic-clock edge behavior.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  STREAMING_RENDER_INTERVAL_MS,
+  streamingRenderDelayMs,
+} from "./streaming-render-cadence";
+
+describe("streamingRenderDelayMs", () => {
+  it("paints the first snapshot immediately", () => {
+    expect(streamingRenderDelayMs(null, 100)).toBe(0);
+  });
+
+  it("returns the remaining cadence delay", () => {
+    expect(streamingRenderDelayMs(100, 110)).toBe(
+      STREAMING_RENDER_INTERVAL_MS - 10,
+    );
+  });
+
+  it("paints immediately once the cadence window elapsed", () => {
+    expect(
+      streamingRenderDelayMs(100, 100 + STREAMING_RENDER_INTERVAL_MS),
+    ).toBe(0);
+  });
+
+  it("waits a full interval if the monotonic clock moves backward", () => {
+    expect(streamingRenderDelayMs(100, 90)).toBe(STREAMING_RENDER_INTERVAL_MS);
+  });
+});

--- a/packages/ui/src/state/streaming-render-cadence.ts
+++ b/packages/ui/src/state/streaming-render-cadence.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared cadence for cumulative chat-stream paints. Transport callbacks may
+ * arrive faster than the overlay can render, so intermediate snapshots are
+ * bounded while the first token and terminal state remain immediate.
+ */
+
+/** Roughly 16 paints/second, comfortably below the 100 ms response threshold. */
+export const STREAMING_RENDER_INTERVAL_MS = 64;
+
+/** Delay until the next intermediate stream snapshot may paint. */
+export function streamingRenderDelayMs(
+  lastPaintAtMs: number | null,
+  nowMs: number,
+): number {
+  if (lastPaintAtMs === null) return 0;
+  const elapsedMs = Math.max(0, nowMs - lastPaintAtMs);
+  return Math.max(0, STREAMING_RENDER_INTERVAL_MS - elapsedMs);
+}

--- a/packages/ui/src/state/use-startup-shell-controller.ts
+++ b/packages/ui/src/state/use-startup-shell-controller.ts
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../api";
 import type { StartupShellView } from "../components/shell/startup-shell-types";
-import { CONNECT_EVENT } from "../events";
+import { listenForConnectRequests } from "../events";
 import { adoptRemoteAgentFirstRun } from "../first-run/adopt-remote-first-run";
 import { ensureStoreBuildWorkspaceFolder } from "../first-run/ensure-store-build-workspace-folder";
 import { persistMobileRuntimeModeForServerTarget } from "../first-run/mobile-runtime-mode";
@@ -113,6 +113,7 @@ export function useStartupShellController(): StartupShellController {
     retryStartup,
     setActionNotice,
     setState,
+    completeFirstRun,
     t,
     uiLanguage,
   } = useAppSelectorShallow((s) => ({
@@ -122,6 +123,7 @@ export function useStartupShellController(): StartupShellController {
     retryStartup: s.retryStartup,
     setActionNotice: s.setActionNotice,
     setState: s.setState,
+    completeFirstRun: s.completeFirstRun,
     t: s.t,
     uiLanguage: s.uiLanguage,
   }));
@@ -135,25 +137,16 @@ export function useStartupShellController(): StartupShellController {
   coordinatorStateRef.current = startupCoordinator.state;
 
   useEffect(() => {
-    const handleConnect = async (event: Event): Promise<void> => {
-      const detail = (event as CustomEvent<unknown>).detail;
-      const payload =
-        detail && typeof detail === "object" && !Array.isArray(detail)
-          ? (detail as {
-              gatewayUrl?: unknown;
-              token?: unknown;
-              completeFirstRun?: unknown;
-              skipConfirm?: unknown;
-            })
-          : null;
-      if (typeof payload?.gatewayUrl !== "string") {
-        return;
-      }
-
+    const handleConnect = async (payload: {
+      gatewayUrl: string;
+      token?: string;
+      completeFirstRun?: boolean;
+      skipConfirm?: boolean;
+    }): Promise<void> => {
       // `completeFirstRun` marks the connected remote as this device's finished
       // first-run target (device/desktop remote-connect-at-URL onboarding), so
       // it lands on home instead of re-showing onboarding on the next launch.
-      const completeFirstRun = payload.completeFirstRun === true;
+      const shouldCompleteFirstRun = payload.completeFirstRun === true;
       // `skipConfirm` is set ONLY by trusted in-app callers (the Settings
       // "Connect a remote agent" entry, where the user just typed the URL).
       // OS-delivered deep links never set it, so they keep the confirmation.
@@ -193,7 +186,7 @@ export function useStartupShellController(): StartupShellController {
         setState("firstRunRemoteToken", connection.token ?? "");
         setState("firstRunRemoteConnected", true);
         setState("firstRunRemoteError", null);
-        if (completeFirstRun) {
+        if (shouldCompleteFirstRun) {
           // Adopt the remote as this device's completed first-run target. Probes
           // first, so an already-configured host is used as-is (no clobber) and
           // a fresh host is marked complete — either way the startup re-poll
@@ -203,8 +196,7 @@ export function useStartupShellController(): StartupShellController {
             token: connection.token,
             uiLanguage,
           });
-          setState("firstRunComplete", true);
-          coordinatorDispatchRef.current({ type: "FIRST_RUN_COMPLETE" });
+          completeFirstRun();
         }
         setActionNotice("Connected to remote backend.", "success", 4200);
         retryStartup();
@@ -219,9 +211,8 @@ export function useStartupShellController(): StartupShellController {
       }
     };
 
-    document.addEventListener(CONNECT_EVENT, handleConnect);
-    return () => document.removeEventListener(CONNECT_EVENT, handleConnect);
-  }, [retryStartup, setActionNotice, setState, uiLanguage]);
+    return listenForConnectRequests(handleConnect);
+  }, [completeFirstRun, retryStartup, setActionNotice, setState, uiLanguage]);
 
   useEffect(() => {
     void ensureStoreBuildWorkspaceFolder();
@@ -274,9 +265,8 @@ export function useStartupShellController(): StartupShellController {
 
   const handleBootstrapAdvance = useCallback(() => {
     setShowBootstrap(false);
-    setState("firstRunComplete", true);
-    coordinatorDispatchRef.current({ type: "FIRST_RUN_COMPLETE" });
-  }, [setState]);
+    retryStartup();
+  }, [retryStartup]);
 
   let startupErrorState: StartupErrorState | null = null;
   if (phase === "error") {

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -60,6 +60,7 @@ import {
   clearPendingChatTurn,
   persistPendingChatTurn,
 } from "./pending-chat-turns";
+import { streamingRenderDelayMs } from "./streaming-render-cadence";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -653,16 +654,17 @@ export function useChatSend(deps: UseChatSendDeps) {
   // when `preferSharedCloudTier` is off, since no `migrating` phase ever fires).
   const handoffFrozenRef = useRef(false);
 
-  // Streaming-commit coalescer.
+  // Streaming-paint coalescer.
   // The SSE stream fires three per-event callbacks that each trigger a state
   // commit: `onToken` (cumulative text, often >60/sec on a fast model),
   // `onStatus` (live turn phase), and `onToolEvent` (inline tool-call steps).
-  // Committing each one synchronously means up to three React renders per SSE
-  // event; instead every callback parks its latest value here and one microtask
-  // commits the burst. A frame callback is not a delivery clock: browsers can
-  // defer rAF for seconds in a hidden or resource-constrained tab, making an
-  // active SSE stream appear frozen. Microtasks remain prompt and React still
-  // batches the related state writes into one commit.
+  // A microtask merges callbacks decoded from one transport event, but a fast
+  // model still delivers separate events faster than the full chat overlay can
+  // render them. Park cumulative snapshots and paint the first one immediately,
+  // then at a bounded cadence. Terminal/abort paths synchronously flush the
+  // latest snapshot, so throttling cannot lose text. A timeout is the delivery
+  // clock rather than rAF because hidden/resource-constrained tabs may defer
+  // animation frames for seconds.
   //
   // `pendingStatus` uses the NO_PENDING_STATUS sentinel = "no status update
   // parked", distinct from a parked `null` (an explicit clear-the-status
@@ -675,6 +677,8 @@ export function useChatSend(deps: UseChatSendDeps) {
     pendingToolEvents: ChatToolCallEvent[];
     flushScheduled: boolean;
     flushGeneration: number;
+    flushTimer: ReturnType<typeof setTimeout> | null;
+    lastFlushAtMs: number | null;
   }>({
     conversationId: null,
     messageId: "",
@@ -683,6 +687,8 @@ export function useChatSend(deps: UseChatSendDeps) {
     pendingToolEvents: [],
     flushScheduled: false,
     flushGeneration: 0,
+    flushTimer: null,
+    lastFlushAtMs: null,
   });
 
   const isConversationCommitActive = useCallback(
@@ -811,6 +817,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       buffer.pendingStatus = NO_PENDING_STATUS;
       return;
     }
+    let committed = false;
     if (buffer.pendingText !== null) {
       const fullText = buffer.pendingText;
       buffer.pendingText = null;
@@ -819,6 +826,7 @@ export function useChatSend(deps: UseChatSendDeps) {
         mode: "replace",
         fullText,
       });
+      committed = true;
     }
     if (buffer.pendingToolEvents.length > 0) {
       const toolEvents = buffer.pendingToolEvents;
@@ -830,27 +838,33 @@ export function useChatSend(deps: UseChatSendDeps) {
           event,
         });
       }
+      committed = true;
     }
     if (buffer.pendingStatus !== NO_PENDING_STATUS) {
       const status = buffer.pendingStatus;
       buffer.pendingStatus = NO_PENDING_STATUS;
       setServerTurnStatus(status);
+      committed = true;
     }
+    if (committed) buffer.lastFlushAtMs = performance.now();
   }, [
     isConversationCommitActive,
     setConversationMessages,
     setServerTurnStatus,
   ]);
 
-  // Apply whatever streaming state is parked for the in-flight turn NOW
-  // (synchronously) and invalidate the pending microtask — called before every terminal
-  // / abort transition so no token, tool row, or status is lost. Safe when
-  // nothing is pending (no-op).
+  // Apply whatever streaming state is parked for the in-flight turn NOW and
+  // invalidate its pending microtask/timer. Called before every terminal/abort
+  // transition so no token, tool row, or status is lost.
   const flushStreamingText = useCallback(() => {
     const buffer = streamingFlushRef.current;
     if (buffer.flushScheduled) {
       buffer.flushGeneration += 1;
       buffer.flushScheduled = false;
+    }
+    if (buffer.flushTimer !== null) {
+      clearTimeout(buffer.flushTimer);
+      buffer.flushTimer = null;
     }
     commitStreamingBuffer();
   }, [commitStreamingBuffer]);
@@ -867,27 +881,43 @@ export function useChatSend(deps: UseChatSendDeps) {
       )
         return;
       if (buffer.flushScheduled) buffer.flushGeneration += 1;
+      if (buffer.flushTimer !== null) {
+        clearTimeout(buffer.flushTimer);
+        buffer.flushTimer = null;
+      }
       buffer.conversationId = conversationId;
       buffer.messageId = messageId;
       buffer.pendingText = null;
       buffer.pendingStatus = NO_PENDING_STATUS;
       buffer.pendingToolEvents = [];
       buffer.flushScheduled = false;
+      buffer.lastFlushAtMs = null;
     },
     [],
   );
 
-  // Ensure one microtask is scheduled for the current synchronous SSE burst.
+  // The first snapshot paints in a microtask; later snapshots within the
+  // cadence window share one trailing timer and overwrite the cumulative text.
   const ensureStreamingFlush = useCallback(() => {
     const buffer = streamingFlushRef.current;
     if (buffer.flushScheduled) return;
     buffer.flushScheduled = true;
     const generation = buffer.flushGeneration;
-    queueMicrotask(() => {
+    const commitScheduled = () => {
       if (buffer.flushGeneration !== generation) return;
+      buffer.flushTimer = null;
       buffer.flushScheduled = false;
       commitStreamingBuffer();
-    });
+    };
+    const delayMs = streamingRenderDelayMs(
+      buffer.lastFlushAtMs,
+      performance.now(),
+    );
+    if (delayMs === 0) {
+      queueMicrotask(commitScheduled);
+      return;
+    }
+    buffer.flushTimer = setTimeout(commitScheduled, delayMs);
   }, [commitStreamingBuffer]);
 
   // Park the latest cumulative text for `messageId`. Synchronous callbacks from
@@ -936,6 +966,10 @@ export function useChatSend(deps: UseChatSendDeps) {
     return () => {
       buffer.flushGeneration += 1;
       buffer.flushScheduled = false;
+      if (buffer.flushTimer !== null) {
+        clearTimeout(buffer.flushTimer);
+        buffer.flushTimer = null;
+      }
       buffer.pendingText = null;
       buffer.conversationId = null;
       buffer.pendingStatus = NO_PENDING_STATUS;
@@ -1005,7 +1039,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     activeTurn?.controller.abort();
     chatAbortRef.current?.abort();
     // Commit any parked partial text (so a stopped turn keeps what the user saw)
-    // and invalidate the pending microtask so it can't fire after the stop.
+    // and invalidate the pending scheduled flush so it can't fire after stop.
     flushStreamingText();
     activeChatTurnRef.current = null;
     chatAbortRef.current = null;
@@ -2427,7 +2461,7 @@ export function useChatSend(deps: UseChatSendDeps) {
             });
           }
         } finally {
-          // Belt-and-braces: invalidate any pending microtask (idempotent).
+          // Belt-and-braces: invalidate any pending scheduled flush (idempotent).
           flushStreamingText();
           if (chatAbortRef.current === controller) {
             chatAbortRef.current = null;

--- a/packages/ui/src/state/useNavigationPathSync.test.tsx
+++ b/packages/ui/src/state/useNavigationPathSync.test.tsx
@@ -1,14 +1,9 @@
 // @vitest-environment jsdom
 
-// Regression for the app-shell deep-link boot race. App-shell pages are loaded
-// from idle-scheduled side-effect modules (main.tsx
-// `scheduleSideEffectAppModuleLoads`). A deep link or page refresh can therefore
-// boot before the matching registration exists; `tabFromPath` then falls through
-// to the `apps` catalog. Without registry reactivity that misresolution is
-// sticky (the sync effect only re-runs on tab/navigation change), so the page
-// renders the apps grid instead of the deep-linked view forever.
-// `useNavigationPathSync` now re-resolves the active tab when the app-shell
-// registry version bumps.
+/**
+ * App-shell cold deep links reconcile against idle-loaded registrations while
+ * preserving the browser path that names the exact owning page.
+ */
 
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -68,4 +63,99 @@ describe("useNavigationPathSync — app-shell registry reactivity", () => {
     // routeTab === tab, so no redundant reconciliation is dispatched.
     expect(setTabRaw).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      path: "/inventory",
+      registrations: [
+        {
+          id: "hyperliquid",
+          pluginId: "@elizaos/plugin-hyperliquid",
+          label: "Perps",
+          path: "/hyperliquid",
+        },
+        {
+          id: "polymarket",
+          pluginId: "@elizaos/plugin-polymarket",
+          label: "Predictions",
+          path: "/polymarket",
+        },
+        {
+          id: "wallet.inventory",
+          pluginId: "@elizaos/plugin-wallet-ui",
+          label: "Wallet",
+          path: "/inventory",
+        },
+      ],
+    },
+    {
+      path: "/hyperliquid",
+      registrations: [
+        {
+          id: "wallet.inventory",
+          pluginId: "@elizaos/plugin-wallet-ui",
+          label: "Wallet",
+          path: "/inventory",
+        },
+        {
+          id: "polymarket",
+          pluginId: "@elizaos/plugin-polymarket",
+          label: "Predictions",
+          path: "/polymarket",
+        },
+        {
+          id: "hyperliquid",
+          pluginId: "@elizaos/plugin-hyperliquid",
+          label: "Perps",
+          path: "/hyperliquid",
+        },
+      ],
+    },
+    {
+      path: "/polymarket",
+      registrations: [
+        {
+          id: "hyperliquid",
+          pluginId: "@elizaos/plugin-hyperliquid",
+          label: "Perps",
+          path: "/hyperliquid",
+        },
+        {
+          id: "wallet.inventory",
+          pluginId: "@elizaos/plugin-wallet-ui",
+          label: "Wallet",
+          path: "/inventory",
+        },
+        {
+          id: "polymarket",
+          pluginId: "@elizaos/plugin-polymarket",
+          label: "Predictions",
+          path: "/polymarket",
+        },
+      ],
+    },
+  ])(
+    "keeps $path until its exact wallet-family owner registers",
+    ({ path, registrations }) => {
+      window.history.replaceState(null, "", path);
+      const setTabRaw = vi.fn();
+      renderHook(() =>
+        useNavigationPathSync({ tab: "views" as Tab, setTabRaw }),
+      );
+
+      for (const registration of registrations) {
+        act(() => {
+          registerAppShellPage({
+            ...registration,
+            tabAffinity: "inventory",
+            loader: async () => ({ default: () => null }),
+          });
+        });
+        expect(window.location.pathname).toBe(path);
+      }
+
+      expect(setTabRaw).toHaveBeenCalledTimes(1);
+      expect(setTabRaw).toHaveBeenLastCalledWith("inventory");
+    },
+  );
 });

--- a/packages/ui/src/state/usePairingState.ts
+++ b/packages/ui/src/state/usePairingState.ts
@@ -8,23 +8,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import { client } from "../api";
-import { getActiveProfile, updateAgentProfile } from "./agent-profiles";
-import {
-  loadPersistedActiveServer,
-  savePersistedActiveServer,
-} from "./persistence";
-
-export function persistPairedToken(token: string): void {
-  const activeServer = loadPersistedActiveServer();
-  if (activeServer && activeServer.kind !== "local") {
-    savePersistedActiveServer({ ...activeServer, accessToken: token });
-  }
-
-  const activeProfile = getActiveProfile();
-  if (activeProfile && activeProfile.kind !== "local") {
-    updateAgentProfile(activeProfile.id, { accessToken: token });
-  }
-}
+import { persistActiveServerCredential } from "./active-server-credential";
 
 export function usePairingState() {
   const [pairingEnabled, setPairingEnabled] = useState(false);
@@ -46,7 +30,7 @@ export function usePairingState() {
     setPairingBusy(true);
     try {
       const { token } = await client.pair(code);
-      persistPairedToken(token);
+      persistActiveServerCredential(token);
       client.setToken(token);
       window.location.reload();
     } catch (err) {

--- a/packages/ui/src/state/useStreamingText.incremental-render.test.tsx
+++ b/packages/ui/src/state/useStreamingText.incremental-render.test.tsx
@@ -26,6 +26,7 @@ import type {
   ImageAttachment,
 } from "../api";
 import type { LoadConversationMessagesResult } from "./internal";
+import { STREAMING_RENDER_INTERVAL_MS } from "./streaming-render-cadence";
 import { useChatSend } from "./useChatSend";
 import { applyStreamingTextModification } from "./useStreamingText";
 
@@ -304,15 +305,15 @@ function makeChatSendDeps() {
 }
 
 /**
- * Integration proof for the streaming-commit coalescer (`useChatSend`'s
- * microtask seam, distinct from the reducer tested above). The reducer tests
- * prove a commit paints incrementally; this proves callbacks decoded in one
- * synchronous transport burst collapse into one prompt commit while callbacks
- * from later tasks remain visible without depending on browser paint cadence.
+ * Integration proof for the streaming-paint coalescer in `useChatSend`,
+ * distinct from the reducer tested above. The reducer tests prove a commit
+ * paints incrementally; these prove synchronous transport bursts collapse,
+ * separate fast events stay bounded, and terminal text flushes without loss.
  */
-describe("streaming → useChatSend microtask token coalescing", () => {
+describe("streaming → useChatSend paint coalescing", () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
@@ -373,5 +374,84 @@ describe("streaming → useChatSend microtask token coalescing", () => {
       await sendPromise;
     });
     expect(assistantText()).toBe("Hello there, friend");
+  });
+
+  it("bounds paints across separate fast token events and flushes terminal text immediately", async () => {
+    vi.useFakeTimers();
+    let onToken!: (token: string, accumulatedText?: string) => void;
+    let resolveStream!: (data: { text: string; completed: boolean }) => void;
+    apiMocks.client.sendConversationMessageStream.mockImplementation(
+      (
+        _id: string,
+        _text: string,
+        token: (t: string, acc?: string) => void,
+      ) => {
+        onToken = token;
+        return new Promise((resolve) => {
+          resolveStream = resolve;
+        });
+      },
+    );
+
+    const { deps, setConversationMessages, conversationMessagesRef } =
+      makeChatSendDeps();
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("hi", {
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    setConversationMessages.mockClear();
+
+    const assistantText = () =>
+      conversationMessagesRef.current.find((m) => m.role === "assistant")
+        ?.text ?? "";
+
+    await act(async () => {
+      onToken("", "A");
+      await Promise.resolve();
+    });
+    expect(setConversationMessages).toHaveBeenCalledTimes(1);
+    expect(assistantText()).toBe("A");
+
+    const fastSnapshots = ["AB", "ABC", "ABCD", "ABCDE", "ABCDEF", "ABCDEFG"];
+    for (const snapshot of fastSnapshots) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10);
+        onToken("", snapshot);
+        await Promise.resolve();
+      });
+    }
+
+    // Six transport events arrived in 60 ms, inside one paint interval. Their
+    // cumulative text is parked without six expensive overlay commits.
+    expect(setConversationMessages).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(STREAMING_RENDER_INTERVAL_MS);
+    });
+    expect(setConversationMessages).toHaveBeenCalledTimes(2);
+    expect(assistantText()).toBe("ABCDEFG");
+
+    const commitsBeforeTerminal = setConversationMessages.mock.calls.length;
+    await act(async () => {
+      onToken("", "ABCDEFGH");
+      resolveStream({ text: "ABCDEFGHI", completed: true });
+      await sendPromise;
+    });
+    expect(assistantText()).toBe("ABCDEFGHI");
+    expect(setConversationMessages.mock.calls.length).toBeGreaterThan(
+      commitsBeforeTerminal,
+    );
+
+    const commitsAfterTerminal = setConversationMessages.mock.calls.length;
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(setConversationMessages).toHaveBeenCalledTimes(commitsAfterTerminal);
+    vi.useRealTimers();
   });
 });

--- a/plugins/app-model-tester/src/ModelTesterView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.test.tsx
@@ -102,6 +102,9 @@ describe("ModelTesterView — unified GUI wrapper", () => {
     expect(screen.getByText("Text")).toBeTruthy();
     expect(screen.getByText("Activity")).toBeTruthy();
     expect(screen.getByText("Run all")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Refresh model status" }),
+    ).toBeTruthy();
   });
 
   it("fetches status once on mount and again on refresh-status", async () => {
@@ -145,6 +148,19 @@ describe("ModelTesterView — unified GUI wrapper", () => {
     expect(run?.body?.prompt).toBe(
       "Describe the attached image in one compact sentence.",
     );
+  });
+
+  it("marks only the selected prompt preset as pressed", async () => {
+    render(React.createElement(ModelTesterView));
+    await screen.findByText("6 ready");
+
+    expect(button("preset-smoke").getAttribute("aria-pressed")).toBe("true");
+    expect(button("preset-vision").getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(button("preset-vision"));
+
+    expect(button("preset-smoke").getAttribute("aria-pressed")).toBe("false");
+    expect(button("preset-vision").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("Back invokes the provided exitToApps callback", async () => {

--- a/plugins/app-model-tester/src/ModelTesterView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.tsx
@@ -287,6 +287,11 @@ export function ModelTesterView({
 
   const snapshot: ModelTesterSnapshot = {
     prompt,
+    activePreset: (
+      Object.entries(PROMPT_BY_PRESET) as Array<
+        [NonNullable<ModelTesterSnapshot["activePreset"]>, string]
+      >
+    ).find(([, presetPrompt]) => presetPrompt === prompt)?.[0],
     probes,
     readyCount: probes.filter((probe) => probe.available).length,
     runningCount: probes.filter((probe) => probe.running).length,

--- a/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
+++ b/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
@@ -52,6 +52,8 @@ export interface ModelTesterProbeRow {
 export interface ModelTesterSnapshot {
   /** Active prompt text. */
   prompt: string;
+  /** Preset matching the active prompt, absent for a custom prompt. */
+  activePreset?: "smoke" | "vision" | "voice";
   /** All 8 probes in display order. */
   probes: ModelTesterProbeRow[];
   /** Number of probes with a registered provider. */
@@ -68,7 +70,11 @@ export interface ModelTesterSnapshot {
   error?: string | null;
 }
 
-const PROMPT_PRESETS = ["Smoke", "Vision", "Voice"] as const;
+const PROMPT_PRESETS = [
+  { id: "smoke", label: "Smoke" },
+  { id: "vision", label: "Vision" },
+  { id: "voice", label: "Voice" },
+] as const;
 
 function probeTone(probe: ModelTesterProbeRow): SpatialTone {
   if (probe.running) return "primary";
@@ -115,7 +121,10 @@ export function ModelTesterSpatialView({
         <Text style="caption" tone="muted" grow={1}>
           {snapshot.completeCount} done
         </Text>
-        <Button agent="refresh-status" onPress={dispatch("refresh-status")}>
+        <Button
+          agent={{ id: "refresh-status", label: "Refresh model status" }}
+          onPress={dispatch("refresh-status")}
+        >
           Refresh
         </Button>
         <Button
@@ -141,14 +150,15 @@ export function ModelTesterSpatialView({
       <HStack gap={1} wrap>
         {PROMPT_PRESETS.map((preset) => (
           <Button
-            key={preset}
+            key={preset.id}
             variant="ghost"
             tone="default"
             grow={1}
-            agent={`preset-${preset.toLowerCase()}`}
-            onPress={dispatch(`preset:${preset.toLowerCase()}`)}
+            agent={`preset-${preset.id}`}
+            pressed={snapshot.activePreset === preset.id}
+            onPress={dispatch(`preset:${preset.id}`)}
           >
-            {preset}
+            {preset.label}
           </Button>
         ))}
       </HStack>

--- a/plugins/app-model-tester/vitest.config.ts
+++ b/plugins/app-model-tester/vitest.config.ts
@@ -29,6 +29,15 @@ export default defineConfig({
     dedupe: ["react", "react-dom"],
     alias: [
       {
+        // Preset accessibility is implemented by the spatial primitive itself;
+        // exercise source rather than a previously-built workspace dist.
+        find: /^@elizaos\/ui\/spatial$/,
+        replacement: new URL(
+          "../../packages/ui/src/spatial/index.ts",
+          import.meta.url,
+        ).pathname,
+      },
+      {
         // @elizaos/ui DynamicViewLoader statically imports this plugin-health
         // subpath; anchor it to source (no built plugin-health dist in the
         // keyless lane). Self-contained so it needs no config-local path vars.

--- a/plugins/plugin-phone/src/register-phone-page.test.ts
+++ b/plugins/plugin-phone/src/register-phone-page.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Registration coverage for the bundled native Phone route. The test inspects
+ * the app-shell contract without loading a remote view bundle.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const registration = vi.hoisted(() => ({
+  register: vi.fn(),
+}));
+const platform = vi.hoisted(() => ({ current: "android" }));
+
+vi.mock("@elizaos/ui/app-shell-registry", () => ({
+  registerAppShellPage: registration.register,
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { getPlatform: () => platform.current },
+}));
+
+describe("native Phone page registration", () => {
+  beforeEach(() => {
+    registration.register.mockClear();
+    platform.current = "android";
+    vi.resetModules();
+  });
+
+  it("registers /phone with a bundled PhoneView loader", async () => {
+    await import("./register-phone-page");
+
+    expect(registration.register).toHaveBeenCalledOnce();
+    expect(registration.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "phone",
+        pluginId: "@elizaos/plugin-phone",
+        path: "/phone",
+        tabAffinity: "phone",
+        loader: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not expose native call controls on web hosts", async () => {
+    platform.current = "web";
+    await import("./register-phone-page");
+    expect(registration.register).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-phone/src/register-phone-page.ts
+++ b/plugins/plugin-phone/src/register-phone-page.ts
@@ -1,0 +1,23 @@
+/**
+ * Registers the native dialer and recent-calls surface with the app shell.
+ * Android packages this component in-process, where remote view bundles are
+ * intentionally unavailable.
+ */
+
+import { Capacitor } from "@capacitor/core";
+import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
+
+if (Capacitor.getPlatform() === "android") {
+  registerAppShellPage({
+    id: "phone",
+    pluginId: "@elizaos/plugin-phone",
+    label: "Phone",
+    icon: "Phone",
+    path: "/phone",
+    tabAffinity: "phone",
+    loader: () =>
+      import("./components/PhoneView.tsx").then((module) => ({
+        default: module.PhoneView,
+      })),
+  });
+}

--- a/plugins/plugin-phone/src/register.ts
+++ b/plugins/plugin-phone/src/register.ts
@@ -1,10 +1,10 @@
 /**
  * Side-effect entry point for bundled phone surfaces.
  *
- * The Phone Companion is an app-shell page and must register on every host
- * where the app shell can route to `/phone-companion`. The dialer + recent-calls
- * surface ships as the unified `phone` plugin view (PhoneView), so there is no
- * separate overlay-app registration here.
+ * Both native Phone surfaces register in-process so mobile builds never depend
+ * on loading a remote JavaScript bundle. Web hosts may still resolve the
+ * manifest bundle first; the registry is the supported native fallback.
  */
 
+import "./register-phone-page";
 import "./register-companion-page";

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
@@ -183,6 +183,33 @@ describe("CockpitInteractiveTerminal — spawn → attach wiring", () => {
 });
 
 describe("CockpitInteractiveTerminal — session death (pty-exit)", () => {
+  it("preserves an exit that arrives before the spawn response exposes its session id", async () => {
+    let resolveSpawn: ((value: { sessionId: string }) => void) | undefined;
+    mocks.spawnPtySession.mockImplementation(
+      () =>
+        new Promise<{ sessionId: string }>((resolve) => {
+          resolveSpawn = resolve;
+        }),
+    );
+    render(<CockpitInteractiveTerminal tier="fast" />);
+    await waitFor(() => expect(mocks.onWsEvent).toHaveBeenCalled());
+
+    act(() => {
+      mocks.emitWsEvent("pty-exit", {
+        type: "pty-exit",
+        sessionId: "sess-fast-exit",
+        exitCode: 1,
+      });
+      resolveSpawn?.({ sessionId: "sess-fast-exit" });
+    });
+
+    const ended = await screen.findByTestId("cockpit-terminal-ended");
+    expect(ended.textContent).toContain("exit 1");
+    expect(screen.getByTestId("pty-pane").getAttribute("data-visible")).toBe(
+      "false",
+    );
+  });
+
   it("shows the ended state when the session's pty-exit arrives (was: stuck 'ready' forever)", async () => {
     mocks.spawnPtySession.mockResolvedValue({ sessionId: "sess-exit" });
     render(<CockpitInteractiveTerminal tier="fast" />);

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
@@ -61,7 +61,9 @@ export function CockpitInteractiveTerminal({
   const [error, setError] = useState<string | null>(null);
   const [exitCode, setExitCode] = useState<number | null>(null);
   const spawnStartedRef = useRef(false);
+  const spawnInFlightRef = useRef(false);
   const activeSessionRef = useRef<string | null>(null);
+  const preResponseExitsRef = useRef(new Map<string, number | null>());
 
   // The cerebras tier only means something to eliza-code; the vendor CLIs
   // pick their own models.
@@ -74,16 +76,27 @@ export function CockpitInteractiveTerminal({
     setPhase("spawning");
     setError(null);
     setExitCode(null);
+    spawnInFlightRef.current = true;
     try {
       const { sessionId: id } = await ptyClient.spawnPtySession({
         kind,
         ...(kind === "eliza-code" ? { tier } : {}),
         ...(cwd ? { cwd } : {}),
       });
+      spawnInFlightRef.current = false;
       activeSessionRef.current = id;
       setSessionId(id);
-      setPhase("ready");
+      if (preResponseExitsRef.current.has(id)) {
+        activeSessionRef.current = null;
+        setExitCode(preResponseExitsRef.current.get(id) ?? null);
+        setPhase("ended");
+      } else {
+        setPhase("ready");
+      }
+      preResponseExitsRef.current.clear();
     } catch (e) {
+      spawnInFlightRef.current = false;
+      preResponseExitsRef.current.clear();
       setError(
         e instanceof Error
           ? e.message
@@ -104,18 +117,25 @@ export function CockpitInteractiveTerminal({
   // as a `pty-exit` WS event; without this the pane stays "ready" forever over
   // a dead session (nothing echoes, input goes nowhere).
   useEffect(() => {
-    if (!sessionId) return;
     return ptyClient.onWsEvent("pty-exit", (data: Record<string, unknown>) => {
-      if (data.sessionId !== sessionId) return;
+      const exitedSessionId =
+        typeof data.sessionId === "string" ? data.sessionId : null;
+      if (!exitedSessionId || activeSessionRef.current !== exitedSessionId) {
+        if (exitedSessionId && spawnInFlightRef.current) {
+          preResponseExitsRef.current.set(
+            exitedSessionId,
+            typeof data.exitCode === "number" ? data.exitCode : null,
+          );
+        }
+        return;
+      }
       // The process is already dead — clear the ref so unmount/close doesn't
       // issue a redundant stop against a reaped session.
-      if (activeSessionRef.current === sessionId) {
-        activeSessionRef.current = null;
-      }
+      activeSessionRef.current = null;
       setExitCode(typeof data.exitCode === "number" ? data.exitCode : null);
       setPhase("ended");
     });
-  }, [sessionId]);
+  }, []);
 
   // Kill the session when the terminal goes away — eliza-code is a REPL and
   // won't exit on its own, so an unclosed session would leave an orphan process.

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.header-agent.test.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.header-agent.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+/**
+ * Capability-level coverage for the Orchestrator header in its empty state.
+ * The real agent registry drives the accounts toggle rendered by the header.
+ */
+
+import {
+  AgentSurfaceProvider,
+  getViewRegistry,
+  handleAgentSurfaceCapability,
+} from "@elizaos/ui/agent-surface";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkbenchHeader } from "./OrchestratorWorkbench";
+
+afterEach(cleanup);
+
+describe("WorkbenchHeader agent surface", () => {
+  it("exposes and activates accounts even when no orchestrator status exists", () => {
+    const onToggleAccounts = vi.fn();
+    render(
+      <AgentSurfaceProvider viewId="orchestrator" viewType="gui">
+        <WorkbenchHeader
+          status={null}
+          busy={false}
+          isMobile={false}
+          onPauseAll={vi.fn()}
+          onResumeAll={vi.fn()}
+          accountsOpen={false}
+          onToggleAccounts={onToggleAccounts}
+          t={(_key, options) => options?.defaultValue ?? ""}
+        />
+      </AgentSurfaceProvider>,
+    );
+
+    const registry = getViewRegistry("orchestrator", "gui");
+    if (!registry) throw new Error("orchestrator registry missing");
+    const elements = handleAgentSurfaceCapability(
+      registry,
+      "list-elements",
+      undefined,
+    ) as Array<{ id: string; role: string; status?: string }>;
+    expect(elements).toContainEqual(
+      expect.objectContaining({
+        id: "header-accounts-toggle",
+        role: "toggle",
+        status: "inactive",
+      }),
+    );
+
+    handleAgentSurfaceCapability(registry, "agent-click", {
+      id: "header-accounts-toggle",
+    });
+    expect(onToggleAccounts).toHaveBeenCalledOnce();
+  });
+});

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -262,7 +262,7 @@ function InspectorSection({
   );
 }
 
-function WorkbenchHeader({
+export function WorkbenchHeader({
   status,
   busy,
   isMobile,
@@ -367,8 +367,19 @@ function WorkbenchHeader({
   const accountsLabel = t("orchestrator.toggleAccounts", {
     defaultValue: "Coding accounts & pool health",
   });
+  const { ref: accountsRef, agentProps: accountsAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "header-accounts-toggle",
+      role: "toggle",
+      label: accountsLabel,
+      group: "orchestrator-header",
+      description: "Show or hide coding account and pool health",
+      status: accountsOpen ? "active" : "inactive",
+      onActivate: onToggleAccounts,
+    });
   const accountsToggle = (
     <Button
+      ref={accountsRef}
       variant="ghost"
       size="sm"
       onClick={onToggleAccounts}
@@ -377,6 +388,7 @@ function WorkbenchHeader({
       aria-pressed={accountsOpen}
       title={accountsLabel}
       data-testid="orchestrator-accounts-toggle"
+      {...accountsAgentProps}
     >
       <Gauge className="h-3.5 w-3.5" />
     </Button>

--- a/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
@@ -1,3 +1,8 @@
+/**
+ * Vector Browser view for inspecting memory rows and their embedding geometry.
+ * The list, search, detail, and graph controls register with the host agent
+ * surface so chat and voice can drive the same interactions as pointer input.
+ */
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client, type QueryResult, type TableInfo } from "@elizaos/ui/api";
 import { PagePanel } from "@elizaos/ui/components/composites/page-panel";
@@ -122,6 +127,67 @@ function formatMemoryDate(value: string | null | undefined): string {
     month: "short",
     day: "numeric",
   });
+}
+
+function MemoryListRow({
+  memory,
+  active,
+  createdLabel,
+  onOpen,
+}: {
+  memory: MemoryRecord;
+  active: boolean;
+  createdLabel: string;
+  onOpen: (memory: MemoryRecord) => void;
+}) {
+  const identity =
+    memory.id || `${memory.createdAt ?? "undated"}:${memory.content}`;
+  const openControl = useAgentElement<HTMLButtonElement>({
+    id: `vector-memory:${encodeURIComponent(identity)}`,
+    role: "button",
+    label: `Open memory: ${memory.content || "(empty)"}`,
+    group: "vector-browser-memories",
+    status: active ? "active" : "inactive",
+    description: "Open this memory in the detail panel",
+    onActivate: () => onOpen(memory),
+  });
+
+  return (
+    <button
+      ref={openControl.ref}
+      {...openControl.agentProps}
+      type="button"
+      onClick={() => onOpen(memory)}
+      className={`flex w-full items-center gap-3 px-2 py-2 text-left transition-colors ${
+        active ? "bg-accent/12 text-txt" : "hover:bg-bg-hover"
+      }`}
+    >
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center text-xs font-semibold uppercase text-muted">
+        {memory.type && memory.type !== "undefined"
+          ? memory.type.slice(0, 1)
+          : "M"}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="line-clamp-1 block text-sm font-medium text-txt">
+          {memory.content || "(empty)"}
+        </span>
+        <span className="mt-1 flex flex-wrap gap-1.5 text-2xs text-muted">
+          {memory.embedding ? (
+            <span className="inline-flex items-center gap-1 px-1 py-0.5">
+              <Layers3 className="h-3 w-3" aria-hidden />
+              {memory.embedding.length}D
+            </span>
+          ) : null}
+          {createdLabel ? (
+            <span className="inline-flex items-center gap-1 px-1 py-0.5">
+              <Clock3 className="h-3 w-3" aria-hidden />
+              {createdLabel}
+            </span>
+          ) : null}
+        </span>
+      </span>
+    </button>
+  );
 }
 
 function VectorMetric({
@@ -1343,10 +1409,10 @@ export function VectorBrowserRichView({
   });
 
   // Selecting a record in list mode swaps the single column over to its detail.
-  const openDetail = (mem: MemoryRecord) => {
+  const openDetail = useCallback((mem: MemoryRecord) => {
     setSelectedMemory(mem);
     setDetailOpen(true);
-  };
+  }, []);
 
   const summaryHeader = (
     <div className="flex flex-col gap-2">
@@ -1525,39 +1591,13 @@ export function VectorBrowserRichView({
           const isActive = selectedMemory?.id === mem.id;
           const createdLabel = formatMemoryDate(mem.createdAt);
           return (
-            <button
-              type="button"
+            <MemoryListRow
               key={mem.id || `${mem.content.slice(0, 30)}-${mem.createdAt}`}
-              onClick={() => openDetail(mem)}
-              className={`flex w-full items-center gap-3 px-2 py-2 text-left transition-colors ${
-                isActive ? "bg-accent/12 text-txt" : "hover:bg-bg-hover"
-              }`}
-            >
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center text-xs font-semibold uppercase text-muted">
-                {mem.type && mem.type !== "undefined"
-                  ? mem.type.slice(0, 1)
-                  : "M"}
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="line-clamp-1 block text-sm font-medium text-txt">
-                  {mem.content || "(empty)"}
-                </span>
-                <span className="mt-1 flex flex-wrap gap-1.5 text-2xs text-muted">
-                  {mem.embedding ? (
-                    <span className="inline-flex items-center gap-1 px-1 py-0.5">
-                      <Layers3 className="h-3 w-3" aria-hidden />
-                      {mem.embedding.length}D
-                    </span>
-                  ) : null}
-                  {createdLabel ? (
-                    <span className="inline-flex items-center gap-1 px-1 py-0.5">
-                      <Clock3 className="h-3 w-3" aria-hidden />
-                      {createdLabel}
-                    </span>
-                  ) : null}
-                </span>
-              </span>
-            </button>
+              memory={mem}
+              active={isActive}
+              createdLabel={createdLabel}
+              onOpen={openDetail}
+            />
           );
         })
       )}

--- a/plugins/plugin-vector-browser/test/VectorBrowserView.test.tsx
+++ b/plugins/plugin-vector-browser/test/VectorBrowserView.test.tsx
@@ -192,9 +192,14 @@ vi.mock("@elizaos/ui/config", () => ({
   }),
 }));
 
-vi.mock("@elizaos/ui/agent-surface", () => ({
-  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+const agentSurface = vi.hoisted(() => ({
+  useAgentElement: vi.fn(() => ({
+    ref: { current: null },
+    agentProps: {},
+  })),
 }));
+
+vi.mock("@elizaos/ui/agent-surface", () => agentSurface);
 
 // Thin passthrough layout / panel / skeleton.
 vi.mock("@elizaos/ui/layouts", () => ({
@@ -359,6 +364,7 @@ beforeEach(() => {
   backend.calls = [];
   getDatabaseTables.mockClear();
   executeDatabaseQuery.mockClear();
+  agentSurface.useAgentElement.mockClear();
 });
 
 afterEach(() => {
@@ -409,6 +415,20 @@ describe("VectorBrowserView — populated list", () => {
     });
     // "2" appears for total + unique metric values
     expect(screen.getAllByText("2").length).toBeGreaterThanOrEqual(1);
+    expect(agentSurface.useAgentElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "vector-memory:m-0",
+        role: "button",
+        status: "active",
+      }),
+    );
+    expect(agentSurface.useAgentElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "vector-memory:m-1",
+        role: "button",
+        status: "inactive",
+      }),
+    );
   });
 
   it("shows the empty state when there are no records", async () => {


### PR DESCRIPTION
## Summary
- preserve exact cold deep links and current `/apps` versus `/views` route ownership
- retain authenticated server credentials through startup and pairing
- queue native connection requests across the startup-to-live-shell listener handoff, with single-consumer claiming
- restore chat footer geometry and bounded streaming render cadence
- preserve real-touch launcher paging and navigate perf tests through shell events
- align browser coverage with current launcher, native-only surfaces, Calendar bridge IDs, notification collapse, Model Tester readiness, and route hierarchy
- make PTY spawn/exit ordering deterministic, including exits that arrive before the spawn response

Fixes #17240.

## Exact candidate
- head: `3221079afe870244e6e5cc26664646cdd4af67e2`
- base: `00d6f6cdaeb40d9d70e9664ebaccbd8169718f26`

## Root cause
The develop browser matrix combined real product regressions with stale UI contracts. The product fixes are kept with the tests that prove them: route reconciliation, credential persistence, replay-safe connect adoption, chat footer layout, streaming cadence, touch paging, and PTY lifecycle ordering. Removed or renamed UI contracts are updated only where the current product behavior is intentional and independently covered.

The prior exact candidate omitted `packages/ui/src/events/index.ts` and its regression test while retaining imports of `listenForConnectRequests`; exact-head typecheck and Pages build correctly failed. This candidate restores those source paths. Local UI typecheck, focused replay tests, and the production web build now pass.

## Local validation
- task-coordinator PTY/orchestrator: 13 passed
- focused UI suites: 120 passed
- voice: 22 passed
- model tester: 7 passed
- phone: 16 passed
- wallet/canonical route: 9 passed
- model tester browser: 1 passed
- Android system app: 1 passed
- shell inventory: 2 passed
- replay-safe connect request Vitest: 3 passed
- UI and affected plugin typechecks: passed
- app `build:web`: passed
- Biome and diff checks: passed

A full audit of the cumulative shared checkout captured 254 views with no broken render and 253 Playwright passes, but its strict gate found eight composer-clearance findings from UI commits outside this exact-base candidate. It is not claimed as exact-head evidence. The PR remains draft pending fresh exact-head browser, typecheck/build, and visual jobs plus independent review.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: pending attachment from failing develop artifacts.

<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: pending exact-head app audit desktop/mobile captures.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: pending exact-head route/auth/chat/touch walkthrough.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend service behavior changes.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: pending exact-head browser lane artifacts.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain output changes.

## Originating runs
- https://github.com/elizaOS/eliza/actions/runs/30384397932
- https://github.com/elizaOS/eliza/actions/runs/30385664894