### PR TITLE
fix(agent): preserve action callback telemetry

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -3067,12 +3067,12 @@ async function generateChatResponseWithTiming(
                     const visibleChunk = isInternalStructuredStreamText(chunk)
                       ? ""
                       : chunk;
-                    if (!visibleChunk) return [];
-                    if (!claimStreamSource("callback")) return [];
                     recordActionCallback(
                       extractCallbackActionTag(content),
-                      true,
+                      Boolean(visibleChunk),
                     );
+                    if (!visibleChunk) return [];
+                    if (!claimStreamSource("callback")) return [];
                     applyCallbackTextUpdate(content, visibleChunk);
                     return [];
                   },
@@ -3487,7 +3487,9 @@ async function generateChatResponseWithTiming(
       ...(failureKind ? { failureKind } : {}),
       ...(accountConnect ? { accountConnect } : {}),
       ...(localInference ? { localInference } : {}),
-      ...(result?.mode === "actions" ? { usedActionCallbacks: true } : {}),
+      ...(actionCallbacksSeen > 0 || result?.mode === "actions"
+        ? { usedActionCallbacks: true }
+        : {}),
       ...(actionCallbackHistory.length > 0
         ? { actionCallbackHistory: [...actionCallbackHistory] }
         : {}),

--- a/packages/agent/test/api/chat-routes-usage.test.ts
+++ b/packages/agent/test/api/chat-routes-usage.test.ts
@@ -186,6 +186,8 @@ describe("generateChatResponse usage reporting", () => {
       isEstimated: true,
       llmCalls: 0,
     });
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
   });
 
   it("marks visible action callbacks even when handlers only set actions", async () => {
@@ -488,10 +490,44 @@ describe("generateChatResponse usage reporting", () => {
     );
 
     expect(result.text).toBe("Action completed by core.");
+    expect(result.usedActionCallbacks).toBe(true);
+    expect(result.actionCallbackHistory).toBeUndefined();
     expect(runtime.logger.error).not.toHaveBeenCalledWith(
       expect.anything(),
       "[eliza-api] Unexecuted action payload detected; failing closed",
     );
+  });
+
+  it("reports mixed callback and core action execution once", async () => {
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({
+            text: "Mixed action reply",
+            actions: ["SENSITIVE_ACTION"],
+          });
+          return {
+            didRespond: true,
+            mode: "actions",
+            responseContent: {
+              text: "Mixed action reply",
+              actions: ["SENSITIVE_ACTION"],
+            },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("run the mixed action"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.usedActionCallbacks).toBe(true);
+    expect(result.actionCallbackHistory).toEqual(["Mixed action reply"]);
   });
 
   it("does not fail closed when action result records an alias for the runtime action", async () => {


### PR DESCRIPTION
## Summary

- retain direct callback observation when deriving `usedActionCallbacks`
- retain explicit `result.mode === "actions"` support for action-only responses
- keep usage and token telemetry single-counted across mixed paths
- cover direct, mode-only, empty, action-only, and mixed execution contracts

Fixes #17243.

## Root cause

Commit `8132bc67366` narrowed action usage detection from observed callbacks to `result?.mode === "actions"`. Direct callbacks do not necessarily set a response mode, so successful action execution disappeared from structured usage telemetry and broke the full Server Tests lane.

## Validation

- exact failing `chat-routes-usage` suite: 18/18 passed
- `packages/agent` typecheck: passed
- `packages/agent` build: passed
- exact-file Biome: passed

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend usage telemetry only.

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing interaction flow changes.

<!-- evidence-row:backend-logs -->
- [x] Backend/test logs: [exact Server Tests failure](https://github.com/elizaOS/eliza/actions/runs/30389407533/job/90377175143) reproduces the two direct-callback telemetry assertions repaired here.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend path.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - planner/model behavior is unchanged; this preserves execution telemetry.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain output changes; focused real chat-route payload assertions cover direct, mode-only, empty, action-only, and mixed paths.

