### PR TITLE
fix(agent): preserve trustworthy action callback telemetry

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -372,10 +372,10 @@ function createPersistedCallbackMessageService(
   const text = "Calendar is ready.";
   return {
     async handleMessage(_runtime, _message, callback) {
-      await callback?.({ text });
+      await callback?.({ text, actions: ["CALENDAR"] }, "CALENDAR");
       return {
         didRespond: true,
-        responseContent: { text },
+        responseContent: { text, actions: ["CALENDAR"] },
         responseMessages: [
           {
             id: messageId,
@@ -388,12 +388,53 @@ function createPersistedCallbackMessageService(
         ],
         persistedResponseMessageIds: [messageId],
         mode: "actions" as const,
+        actionResults: [
+          {
+            success: true,
+            text,
+            data: { actionName: "CALENDAR" },
+          },
+        ],
       };
     },
     shouldRespond: () => ({
       shouldRespond: true,
       skipEvaluation: true,
       reason: "persisted-callback-stream-contract-test",
+    }),
+    deleteMessage: async () => undefined,
+    clearChannel: async () => undefined,
+  } satisfies NonNullable<AgentRuntime["messageService"]>;
+}
+
+function createGenericPersistedCallbackMessageService(
+  messageId: UUID,
+): NonNullable<AgentRuntime["messageService"]> {
+  const text = "Simple delivery is ready.";
+  return {
+    async handleMessage(_runtime, _message, callback) {
+      await callback?.({ text, actions: ["REPLY"] });
+      return {
+        didRespond: true,
+        responseContent: { text, actions: ["REPLY"] },
+        responseMessages: [
+          {
+            id: messageId,
+            entityId: AGENT_ID,
+            agentId: AGENT_ID,
+            roomId: ROOM_ID,
+            content: { text, actions: ["REPLY"] },
+            createdAt: Date.now(),
+          },
+        ],
+        persistedResponseMessageIds: [messageId],
+        mode: "simple" as const,
+      };
+    },
+    shouldRespond: () => ({
+      shouldRespond: true,
+      skipEvaluation: true,
+      reason: "generic-persisted-callback-stream-contract-test",
     }),
     deleteMessage: async () => undefined,
     clearChannel: async () => undefined,
@@ -1017,6 +1058,29 @@ describe("conversation stream SSE contract (#10712)", () => {
     expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
   });
 
+  it("does not request transcript reload for a generic persisted delivery callback", async () => {
+    const responseId = stringToUuid("generic-persisted-callback") as UUID;
+    const { ctx, record, state } = createCtx(
+      createGenericPersistedCallbackMessageService(responseId),
+    );
+    const runtime = state.runtime;
+    if (!runtime) throw new Error("runtime fixture missing");
+    runtime.updateMemory = vi.fn(async () => true);
+
+    await handleConversationRoutes(ctx);
+
+    const done = parseSsePayloads(record.writes).find(
+      (payload) => payload.type === "done",
+    );
+    expect(done).toMatchObject({
+      type: "done",
+      fullText: "Simple delivery is ready.",
+      messageId: responseId,
+    });
+    expect(done).not.toHaveProperty("historyRefreshRequired");
+    expect(runtime.updateMemory).not.toHaveBeenCalled();
+  });
+
   it("reuses the exact message-service commit without a route read or write", async () => {
     const { ctx, record, state } = createCtx(
       createPersistedReplyMessageService(),
@@ -1251,12 +1315,7 @@ describe("conversation stream SSE contract (#10712)", () => {
       expect(messageId).not.toBe(persistedEarlyId);
       expect(messageId).not.toBe(transientFinalId);
       expect(routeOwnedMemory?.id).toBe(messageId);
-      expect(updateMemory).toHaveBeenCalledWith(
-        expect.objectContaining({ id: messageId }),
-      );
-      expect(updateMemory).not.toHaveBeenCalledWith(
-        expect.objectContaining({ id: persistedEarlyId }),
-      );
+      expect(updateMemory).not.toHaveBeenCalled();
     },
   );
 

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -1500,31 +1500,224 @@ function readRuntimeActionResults(
   }
 }
 
-function listExecutedRuntimeActions(
+function readActionResultName(result: unknown): string {
+  if (!result || typeof result !== "object") {
+    return "";
+  }
+  const record = result as Record<string, unknown>;
+  if (typeof record.actionName === "string") {
+    return normalizeActionName(record.actionName);
+  }
+  const data =
+    record.data && typeof record.data === "object"
+      ? (record.data as Record<string, unknown>)
+      : null;
+  return normalizeActionName(data?.actionName);
+}
+
+function listSuccessfulActionNames(
   runtime: AgentRuntime,
   messageId: UUID | undefined,
+  turnActionResults: readonly unknown[] | undefined,
+  actionNameLookup: ReadonlyMap<string, string>,
 ): Set<string> {
-  return new Set(
-    readRuntimeActionResults(runtime, messageId)
-      .map((result) => {
-        if (typeof result === "string") {
-          return normalizeActionName(result);
-        }
-        if (!result || typeof result !== "object") {
-          return "";
-        }
-        const record = result as Record<string, unknown>;
-        if (typeof record.actionName === "string") {
-          return normalizeActionName(record.actionName);
-        }
-        const data =
-          record.data && typeof record.data === "object"
-            ? (record.data as Record<string, unknown>)
-            : null;
-        return normalizeActionName(data?.actionName);
-      })
-      .filter((name) => name.length > 0),
+  const successfulNames = new Set<string>();
+  for (const result of listSuccessfulActionResults(
+    runtime,
+    messageId,
+    turnActionResults,
+  )) {
+    const normalizedName = readActionResultName(result);
+    if (!normalizedName) {
+      continue;
+    }
+    successfulNames.add(actionNameLookup.get(normalizedName) ?? normalizedName);
+  }
+  return successfulNames;
+}
+
+function listSuccessfulActionResults(
+  runtime: AgentRuntime,
+  messageId: UUID | undefined,
+  turnActionResults: readonly unknown[] | undefined,
+): unknown[] {
+  return [
+    ...(turnActionResults ?? []),
+    ...readRuntimeActionResults(runtime, messageId),
+  ].filter((result) => {
+    if (
+      !result ||
+      typeof result !== "object" ||
+      (result as Record<string, unknown>).success !== true
+    ) {
+      return false;
+    }
+    return Boolean(readActionResultName(result));
+  });
+}
+
+function isProgressActionCallback(content: Content): boolean {
+  const status = normalizeActionName(
+    (content as Record<string, unknown>).actionStatus,
   );
+  return (
+    status === "PENDING" ||
+    status === "QUEUED" ||
+    status === "RUNNING" ||
+    status === "IN_PROGRESS" ||
+    status === "PROGRESS"
+  );
+}
+
+type WalletAttributedOperation =
+  | "APPROVE"
+  | "BALANCE"
+  | "BUY"
+  | "EXECUTE"
+  | "SELL"
+  | "SWAP"
+  | "TRADE"
+  | "TRANSFER";
+
+const WALLET_ROUTER_SUBACTION_OPERATIONS = new Map<
+  string,
+  readonly WalletAttributedOperation[]
+>([
+  ["TRANSFER", ["TRANSFER"]],
+  ["SWAP", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["BRIDGE", ["TRANSFER"]],
+  ["GOV", []],
+  ["PUMP_FUN_BUY", ["BUY", "TRADE"]],
+  ["TOKEN_INFO", []],
+  ["SEARCH_ADDRESS", ["BALANCE"]],
+]);
+
+const WALLET_GOV_OP_OPERATIONS = new Map<
+  string,
+  readonly WalletAttributedOperation[]
+>([
+  ["PROPOSE", []],
+  ["VOTE", ["APPROVE"]],
+  ["QUEUE", []],
+  ["EXECUTE", ["EXECUTE"]],
+]);
+
+// This fail-closed boundary intentionally duplicates the wallet plugin's public
+// action names and similes so an unrelated action cannot gain wallet authority
+// merely by containing a financial verb.
+const WALLET_ACTION_OPERATIONS = new Map<
+  string,
+  readonly WalletAttributedOperation[]
+>([
+  ["EVM_TRANSFER", ["TRANSFER"]],
+  ["SOLANA_TRANSFER", ["TRANSFER"]],
+  ["CROSS_CHAIN_TRANSFER", ["TRANSFER"]],
+  ["TRANSFER", ["TRANSFER"]],
+  ["TRANSFER_TOKEN", ["TRANSFER"]],
+  ["TRANSFER_TOKENS", ["TRANSFER"]],
+  ["TRANSFER_SOL", ["TRANSFER"]],
+  ["WALLET_TRANSFER", ["TRANSFER"]],
+  ["SEND_TOKEN", ["TRANSFER"]],
+  ["SEND_TOKENS", ["TRANSFER"]],
+  ["SEND_SOL", ["TRANSFER"]],
+  ["PREPARE_TRANSFER", ["TRANSFER"]],
+  ["PAY", ["TRANSFER"]],
+  ["EVM_SWAP", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["SOLANA_SWAP", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["SWAP", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["SWAP_SOL", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["SWAP_SOLANA", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["SWAP_TOKEN", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["SWAP_TOKENS", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["WALLET_SWAP", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["TOKEN_SWAP", ["BUY", "SELL", "SWAP", "TRADE"]],
+  ["TRADE", ["TRADE", "BUY", "SELL"]],
+  ["PUMP_FUN_BUY", ["BUY", "TRADE"]],
+  ["PUMPFUN_BUY", ["BUY", "TRADE"]],
+  ["BUY_PUMP_FUN", ["BUY", "TRADE"]],
+  ["BUY_PUMPFUN", ["BUY", "TRADE"]],
+  ["CHECK_BALANCE", ["BALANCE"]],
+  ["WALLET_SEARCH_ADDRESS", ["BALANCE"]],
+  ["BIRDEYE_SEARCH", ["BALANCE"]],
+  ["BIRDEYE_LOOKUP", ["BALANCE"]],
+]);
+
+function walletActionMatchesIntent(
+  prompt: string,
+  successfulActionName: string,
+  result?: unknown,
+): boolean {
+  const actionName = normalizeActionName(successfulActionName);
+  if (!actionName) return false;
+  const record =
+    result && typeof result === "object"
+      ? (result as Record<string, unknown>)
+      : null;
+  const data =
+    record?.data && typeof record.data === "object"
+      ? (record.data as Record<string, unknown>)
+      : null;
+  const values =
+    record?.values && typeof record.values === "object"
+      ? (record.values as Record<string, unknown>)
+      : null;
+  const metadata =
+    data?.metadata && typeof data.metadata === "object"
+      ? (data.metadata as Record<string, unknown>)
+      : null;
+  const walletSubaction = normalizeActionName(
+    data?.subaction ??
+      data?.walletSubaction ??
+      values?.walletSubaction ??
+      values?.subaction,
+  );
+  const walletGovOp = normalizeActionName(
+    data?.op ?? metadata?.op ?? values?.walletGovOp,
+  );
+  const tradeHasExecutionEvidence =
+    values?.tradeActionPrepared === true ||
+    values?.tradeActionSucceeded === true ||
+    normalizeActionName(values?.tradeOutcome) === "SUBMITTED" ||
+    normalizeActionName(data?.outcome) === "SUBMITTED";
+  const attributedOperations =
+    actionName === "WALLET"
+      ? walletSubaction === "GOV"
+        ? WALLET_GOV_OP_OPERATIONS.get(walletGovOp)
+        : WALLET_ROUTER_SUBACTION_OPERATIONS.get(walletSubaction)
+      : actionName === "TRADE"
+        ? tradeHasExecutionEvidence
+          ? WALLET_ACTION_OPERATIONS.get(actionName)
+          : undefined
+        : WALLET_ACTION_OPERATIONS.get(actionName);
+  if (!attributedOperations) return false;
+  const matches = (operation: WalletAttributedOperation) =>
+    attributedOperations.includes(operation);
+
+  if (/\b(send|transfer)\b/i.test(prompt)) {
+    return matches("TRANSFER");
+  }
+  if (/\bswap\b/i.test(prompt)) {
+    return matches("SWAP");
+  }
+  if (/\btrade\b/i.test(prompt)) {
+    return matches("TRADE") || matches("BUY") || matches("SELL");
+  }
+  if (/\bbuy\b/i.test(prompt)) {
+    return matches("BUY");
+  }
+  if (/\bsell\b/i.test(prompt)) {
+    return matches("SELL");
+  }
+  if (/\bapprove\b/i.test(prompt)) {
+    return matches("APPROVE");
+  }
+  if (/\bexecute\b/i.test(prompt)) {
+    return matches("EXECUTE");
+  }
+  if (/\b(balance|portfolio|holdings|funds)\b/i.test(prompt)) {
+    return matches("BALANCE");
+  }
+  return attributedOperations.length > 0;
 }
 
 function sanitizeActionResultValue(value: unknown, depth = 0): unknown {
@@ -2649,7 +2842,11 @@ async function generateChatResponseWithTiming(
     let forcedWalletExecutionText = false;
     let blockedUnexecutedActionPayload = false;
     let activeStreamSource: StreamSource = "unset";
-    const actionCallbackHistory: string[] = [];
+    let visibleCallbackDeliveries = 0;
+    const deliveredActionCallbacks: Array<{
+      actionName: string;
+      text?: string;
+    }> = [];
     // Snapshot of `responseText` at the moment the first action callback runs.
     // WHY: LLM streaming genuinely appends token deltas. Action handlers that
     // call HandlerCallback multiple times (Discord "progressive message" pattern)
@@ -2733,15 +2930,8 @@ async function generateChatResponseWithTiming(
         preCallbackText = responseText;
       }
     };
-    const recordActionCallbackText = (incoming: string): void => {
-      const normalized = normalizeActionCallbackText(incoming);
-      if (!normalized) return;
-      if (actionCallbackHistory.at(-1) === normalized) return;
-      actionCallbackHistory.push(normalized);
-    };
     /** Latest action callback wins: replaces prior callback text, keeps LLM prefix. */
     const replaceCallbackText = (incoming: string): void => {
-      recordActionCallbackText(incoming);
       captureCallbackBaseline();
       const baseline = preCallbackText ?? "";
       const separator = baseline.length > 0 ? "\n\n" : "";
@@ -2769,7 +2959,6 @@ async function generateChatResponseWithTiming(
     ): void => {
       captureCallbackBaseline();
       if (resolveCallbackMergeMode(content) === "append") {
-        recordActionCallbackText(incoming);
         appendIncomingText(incoming);
         return;
       }
@@ -2854,50 +3043,44 @@ async function generateChatResponseWithTiming(
         >
       | undefined;
     let capturedUsage: CapturedModelUsage | null = null;
-    let actionCallbacksSeen = 0;
-    const seenActionTags = new Set<string>();
     const recordActionCallback = (
       actionTag: string,
       hasText: boolean,
+      text?: string,
     ): void => {
-      actionCallbacksSeen += 1;
       const normalizedActionTag = normalizeActionName(actionTag);
-      if (normalizedActionTag) {
-        seenActionTags.add(normalizedActionTag);
+      if (!normalizedActionTag) {
+        return;
       }
-      // The reply is now coming from an action handler, not raw LLM streaming —
-      // surface it as `running_action`, carrying the concrete action name (when
-      // it is a real action rather than the generic VISIBLE_CALLBACK tag) so the
-      // status reads e.g. "Running SEND_MESSAGE" instead of generic "Working".
+      const normalizedText =
+        hasText && text ? normalizeActionCallbackText(text) : "";
+      if (
+        normalizedText &&
+        !deliveredActionCallbacks.some(
+          (entry) =>
+            entry.actionName === normalizedActionTag &&
+            entry.text === normalizedText,
+        )
+      ) {
+        deliveredActionCallbacks.push({
+          actionName: normalizedActionTag,
+          text: normalizedText,
+        });
+      }
       emitStatus({
         kind: "running_action",
-        ...(normalizedActionTag && normalizedActionTag !== "VISIBLE_CALLBACK"
-          ? { actionName: normalizedActionTag }
-          : {}),
+        actionName: normalizedActionTag,
       });
       runtime.logger.info(
         {
           src: "eliza-api",
-          action: normalizedActionTag || actionTag,
+          action: normalizedActionTag,
           hasText,
         },
-        `[eliza-api] Action callback fired: ${normalizedActionTag || actionTag}`,
+        `[eliza-api] Action callback fired: ${normalizedActionTag}`,
       );
     };
-    const extractCallbackActionTag = (content: Content): string => {
-      const record = content as Record<string, unknown>;
-      if (typeof record.action === "string" && record.action.length > 0) {
-        return record.action;
-      }
-      if (Array.isArray(record.actions)) {
-        const firstAction = record.actions.find(
-          (action): action is string =>
-            typeof action === "string" && action.trim().length > 0,
-        );
-        if (firstAction) return firstAction;
-      }
-      return "VISIBLE_CALLBACK";
-    };
+    const fallbackSuccessfulActionNames = new Set<string>();
 
     const generationCapture = await withModelUsageCapture(runtime, () =>
       withTimeout(
@@ -3053,7 +3236,7 @@ async function generateChatResponseWithTiming(
                 runtime.messageService?.handleMessage(
                   runtime,
                   generationMessage,
-                  async (content: Content) => {
+                  async (content: Content, actionName?: string) => {
                     if (generationTimedOut) {
                       throw createChatGenerationTimeoutError(
                         generationTimeoutMs,
@@ -3067,13 +3250,32 @@ async function generateChatResponseWithTiming(
                     const visibleChunk = isInternalStructuredStreamText(chunk)
                       ? ""
                       : chunk;
-                    recordActionCallback(
-                      extractCallbackActionTag(content),
-                      Boolean(visibleChunk),
-                    );
-                    if (!visibleChunk) return [];
-                    if (!claimStreamSource("callback")) return [];
+                    const attributedActionName =
+                      normalizeActionName(actionName);
+                    const progressCallback = isProgressActionCallback(content);
+                    if (!visibleChunk) {
+                      if (attributedActionName) {
+                        recordActionCallback(attributedActionName, false);
+                      }
+                      return [];
+                    }
+                    if (!claimStreamSource("callback")) {
+                      if (attributedActionName) {
+                        recordActionCallback(attributedActionName, false);
+                      }
+                      return [];
+                    }
+                    if (!progressCallback) {
+                      visibleCallbackDeliveries += 1;
+                    }
                     applyCallbackTextUpdate(content, visibleChunk);
+                    if (attributedActionName) {
+                      recordActionCallback(
+                        attributedActionName,
+                        !progressCallback,
+                        progressCallback ? undefined : visibleChunk,
+                      );
+                    }
                     return [];
                   },
                   {
@@ -3208,18 +3410,13 @@ async function generateChatResponseWithTiming(
                 modelText,
               );
               const actionNameLookup = buildRuntimeActionNameLookup(runtime);
-              const executedRuntimeActions = listExecutedRuntimeActions(
+              const successfulActionNames = listSuccessfulActionNames(
                 runtime,
                 typeof message.id === "string" ? message.id : undefined,
-              );
-              const executedActionNames = new Set(
-                [...executedRuntimeActions, ...seenActionTags]
-                  .map((name) => actionNameLookup.get(name) ?? name)
-                  .filter((name) => name.length > 0),
+                result.actionResults,
+                actionNameLookup,
               );
 
-              // Only run fallback execution when the core did NOT dispatch actions itself.
-              const coreHandledActions = resultRecord?.mode === "actions";
               const executableFallbackActions = parsedFallbackActions.filter(
                 (action) => {
                   if (!isExecutableFallbackAction(action)) {
@@ -3228,10 +3425,10 @@ async function generateChatResponseWithTiming(
                   const canonicalName =
                     actionNameLookup.get(normalizeActionName(action.name)) ??
                     normalizeActionName(action.name);
-                  return !executedActionNames.has(canonicalName);
+                  return !successfulActionNames.has(canonicalName);
                 },
               );
-              if (!coreHandledActions && executableFallbackActions.length > 0) {
+              if (executableFallbackActions.length > 0) {
                 const selfControlFallbackActions =
                   executableFallbackActions.filter((action) => {
                     const canonicalName =
@@ -3239,10 +3436,10 @@ async function generateChatResponseWithTiming(
                       normalizeActionName(action.name);
                     return canonicalName === "BLOCK";
                   });
-                const callbacksBeforeFallback = actionCallbacksSeen;
+                let successfulFallbackActions = new Set<string>();
 
                 if (selfControlFallbackActions.length > 0) {
-                  await executeFallbackParsedActions(
+                  const fallbackExecutions = await executeFallbackParsedActions(
                     runtime,
                     message,
                     selfControlFallbackActions,
@@ -3252,17 +3449,31 @@ async function generateChatResponseWithTiming(
                       getCurrentText: () => responseText || modelText,
                     },
                   );
+                  successfulFallbackActions = new Set(
+                    fallbackExecutions
+                      .filter((execution) => execution.success)
+                      .map((execution) => {
+                        const normalizedName = normalizeActionName(
+                          execution.actionName,
+                        );
+                        return (
+                          actionNameLookup.get(normalizedName) ?? normalizedName
+                        );
+                      })
+                      .filter((name) => name.length > 0),
+                  );
+                  for (const actionName of successfulFallbackActions) {
+                    fallbackSuccessfulActionNames.add(actionName);
+                  }
                 }
 
-                const selfControlFallbackExecuted =
-                  actionCallbacksSeen > callbacksBeforeFallback;
                 const remainingExecutableFallbackActions =
                   executableFallbackActions.filter((action) => {
                     const canonicalName =
                       actionNameLookup.get(normalizeActionName(action.name)) ??
                       normalizeActionName(action.name);
                     if (canonicalName === "BLOCK") {
-                      return !selfControlFallbackExecuted;
+                      return !successfulFallbackActions.has(canonicalName);
                     }
                     return true;
                   });
@@ -3318,6 +3529,21 @@ async function generateChatResponseWithTiming(
         phase: "post-model",
       },
     );
+    const actionNameLookup = buildRuntimeActionNameLookup(runtime);
+    const successfulActionNames = listSuccessfulActionNames(
+      runtime,
+      typeof message.id === "string" ? message.id : undefined,
+      result?.actionResults,
+      actionNameLookup,
+    );
+    for (const actionName of fallbackSuccessfulActionNames) {
+      successfulActionNames.add(actionName);
+    }
+    const successfulTurnActionResults = listSuccessfulActionResults(
+      runtime,
+      typeof message.id === "string" ? message.id : undefined,
+      result?.actionResults,
+    );
 
     const responseMessageText = getLatestVisibleResponseMessageText(
       result?.responseMessages,
@@ -3344,7 +3570,7 @@ async function generateChatResponseWithTiming(
         emitChunk(resultText);
       }
     } else if (
-      actionCallbacksSeen === 0 &&
+      visibleCallbackDeliveries === 0 &&
       resultText &&
       resultTextVisibility !== "internal" &&
       resultText !== responseText &&
@@ -3352,7 +3578,7 @@ async function generateChatResponseWithTiming(
     ) {
       emitChunk(resultText.slice(responseText.length));
     } else if (
-      actionCallbacksSeen === 0 &&
+      visibleCallbackDeliveries === 0 &&
       resultText &&
       resultTextVisibility !== "internal" &&
       resultText !== responseText &&
@@ -3367,8 +3593,17 @@ async function generateChatResponseWithTiming(
     }
 
     if (
-      actionCallbacksSeen === 0 &&
-      isWalletActionRequiredIntent(originalUserText)
+      isWalletActionRequiredIntent(originalUserText) &&
+      !successfulTurnActionResults.some((actionResult) => {
+        const normalizedName = readActionResultName(actionResult);
+        const canonicalName =
+          actionNameLookup.get(normalizedName) ?? normalizedName;
+        return walletActionMatchesIntent(
+          originalUserText,
+          canonicalName,
+          actionResult,
+        );
+      })
     ) {
       const failureText = buildWalletActionNotExecutedReply(
         runtime,
@@ -3475,6 +3710,39 @@ async function generateChatResponseWithTiming(
       typeof message.id === "string" ? message.id : undefined,
       result?.actionResults,
     );
+    const successfulDeliveredActionCallbacks = deliveredActionCallbacks.filter(
+      (entry) => {
+        const canonicalName =
+          actionNameLookup.get(entry.actionName) ?? entry.actionName;
+        return successfulActionNames.has(canonicalName);
+      },
+    );
+    const actionCallbackHistory = successfulDeliveredActionCallbacks.reduce<
+      string[]
+    >((history, entry) => {
+      if (entry.text && history.at(-1) !== entry.text) {
+        history.push(entry.text);
+      }
+      return history;
+    }, []);
+    const declaredResultActionNames = new Set(
+      (Array.isArray(result?.responseContent?.actions)
+        ? result.responseContent.actions
+        : []
+      )
+        .map((actionName) => {
+          const normalizedName = normalizeActionName(actionName);
+          return actionNameLookup.get(normalizedName) ?? normalizedName;
+        })
+        .filter((actionName) => actionName.length > 0),
+    );
+    const successfulActionMode =
+      result?.mode === "actions" &&
+      [...declaredResultActionNames].some((actionName) =>
+        successfulActionNames.has(actionName),
+      );
+    const usedActionCallbacks =
+      successfulDeliveredActionCallbacks.length > 0 || successfulActionMode;
 
     return {
       text: finalText,
@@ -3487,9 +3755,7 @@ async function generateChatResponseWithTiming(
       ...(failureKind ? { failureKind } : {}),
       ...(accountConnect ? { accountConnect } : {}),
       ...(localInference ? { localInference } : {}),
-      ...(actionCallbacksSeen > 0 || result?.mode === "actions"
-        ? { usedActionCallbacks: true }
-        : {}),
+      ...(usedActionCallbacks ? { usedActionCallbacks: true } : {}),
       ...(actionCallbackHistory.length > 0
         ? { actionCallbackHistory: [...actionCallbackHistory] }
         : {}),

--- a/packages/agent/src/api/fallback-action-helpers.test.ts
+++ b/packages/agent/src/api/fallback-action-helpers.test.ts
@@ -52,7 +52,7 @@ describe("executeFallbackParsedActions", () => {
     const appended: string[] = [];
     const callbacks: Array<{ actionTag: string; hasText: boolean }> = [];
 
-    await executeFallbackParsedActions(
+    const executions = await executeFallbackParsedActions(
       runtime,
       message,
       [{ name: "CUSTOM_FALLBACK", parameters: { target: "example.com" } }],
@@ -63,6 +63,9 @@ describe("executeFallbackParsedActions", () => {
     expect(appended).toEqual(["I turned on the block for example.com."]);
     expect(callbacks).toEqual([
       { actionTag: "CUSTOM_FALLBACK", hasText: true },
+    ]);
+    expect(executions).toEqual([
+      { actionName: "CUSTOM_FALLBACK", success: true },
     ]);
     expect(runtime.useModel).toHaveBeenCalledWith(
       ModelType.TEXT_SMALL,

--- a/packages/agent/src/api/fallback-action-helpers.ts
+++ b/packages/agent/src/api/fallback-action-helpers.ts
@@ -147,7 +147,8 @@ export async function executeFallbackParsedActions(
     getCurrentText?: () => string;
     onCallbackText?: (incoming: string) => void;
   },
-): Promise<void> {
+): Promise<Array<{ actionName: string; success: boolean }>> {
+  const executionResults: Array<{ actionName: string; success: boolean }> = [];
   const runtimeActions = Array.isArray(
     (runtime as { actions?: unknown[] }).actions,
   )
@@ -224,14 +225,21 @@ export async function executeFallbackParsedActions(
         [],
       ),
     );
+    const actionSucceeded = Boolean(
+      actionResult &&
+        typeof actionResult === "object" &&
+        "success" in actionResult &&
+        actionResult.success === true,
+    );
+    executionResults.push({
+      actionName:
+        typeof action.name === "string" && action.name.trim()
+          ? action.name
+          : parsed.name,
+      success: actionSucceeded,
+    });
     if (!callbackSeen) {
       const currentText = options?.getCurrentText?.() ?? "";
-      const actionSucceeded =
-        actionResult &&
-        typeof actionResult === "object" &&
-        "success" in actionResult
-          ? actionResult.success === true
-          : undefined;
       const fallbackText =
         actionResult && typeof actionResult === "object"
           ? typeof actionResult.text === "string"
@@ -263,4 +271,5 @@ export async function executeFallbackParsedActions(
       }
     }
   }
+  return executionResults;
 }

--- a/packages/agent/test/api/chat-routes-usage.test.ts
+++ b/packages/agent/test/api/chat-routes-usage.test.ts
@@ -59,6 +59,14 @@ function createChatMessage(text: string) {
   });
 }
 
+function actionResult(actionName: string, success = true, text?: string) {
+  return {
+    success,
+    ...(text ? { text } : {}),
+    data: { actionName },
+  };
+}
+
 describe("generateChatResponse usage reporting", () => {
   it("returns actual provider usage when a provider event is emitted", async () => {
     let runtime: AgentRuntime;
@@ -190,7 +198,7 @@ describe("generateChatResponse usage reporting", () => {
     expect(result.actionCallbackHistory).toBeUndefined();
   });
 
-  it("marks visible action callbacks even when handlers only set actions", async () => {
+  it("does not attribute generic simple delivery callbacks from content actions", async () => {
     const runtime = createRuntime({
       messageService: {
         handleMessage: vi.fn(async (_runtime, _message, callback) => {
@@ -213,20 +221,28 @@ describe("generateChatResponse usage reporting", () => {
 
     expect(result).toMatchObject({
       text: "callback reply",
-      usedActionCallbacks: true,
-      actionCallbackHistory: ["callback reply"],
     });
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
   });
 
-  it("counts action-only callbacks without adding visible callback history", async () => {
+  it("records an attributed visible callback only when its action succeeded", async () => {
     const runtime = createRuntime({
       messageService: {
         handleMessage: vi.fn(async (_runtime, _message, callback) => {
-          await callback?.({ actions: ["SEARCHING"] });
+          await callback?.(
+            { text: "callback reply", actions: ["SENSITIVE_ACTION"] },
+            "SENSITIVE_ACTION",
+          );
           return {
             didRespond: true,
-            responseContent: { text: "final reply" },
+            mode: "actions",
+            responseContent: {
+              text: "callback reply",
+              actions: ["SENSITIVE_ACTION"],
+            },
             responseMessages: [],
+            actionResults: [actionResult("SENSITIVE_ACTION")],
           };
         }),
       } as NonNullable<AgentRuntime["messageService"]>,
@@ -240,11 +256,176 @@ describe("generateChatResponse usage reporting", () => {
     );
 
     expect(result).toMatchObject({
-      text: "final reply",
+      text: "callback reply",
       usedActionCallbacks: true,
+      actionCallbackHistory: ["callback reply"],
     });
+  });
+
+  it("does not count an attributed textless callback as delivered execution evidence", async () => {
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({ actions: ["SEARCHING"] }, "SEARCHING");
+          return {
+            didRespond: true,
+            responseContent: { text: "final reply" },
+            responseMessages: [],
+            actionResults: [actionResult("SEARCHING")],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("hello"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toBe("final reply");
+    expect(result.usedActionCallbacks).toBeUndefined();
     expect(result.actionCallbackHistory).toBeUndefined();
   });
+
+  it("keeps early, terminal, attachment, and voice deliveries generic", async () => {
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({ text: "early reply", actions: ["REPLY"] });
+          await callback?.({ actions: ["IGNORE"] });
+          await callback?.({ attachments: [] });
+          await callback?.({ text: "", attachments: [], source: "voice" });
+          await callback?.({ text: "final reply", actions: ["REPLY"] });
+          return {
+            didRespond: true,
+            responseContent: { text: "final reply", actions: ["REPLY"] },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("hello"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toBe("final reply");
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
+  });
+
+  it("does not treat a losing attributed callback as delivered action evidence", async () => {
+    const onChunk = vi.fn();
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback, options) => {
+          await options?.onStreamChunk?.(
+            "streamed final",
+            undefined,
+            "streamed final",
+          );
+          await callback?.(
+            { text: "losing callback", actions: ["SEARCH"] },
+            "SEARCH",
+          );
+          return {
+            didRespond: true,
+            responseContent: { text: "streamed final" },
+            responseMessages: [],
+            actionResults: [actionResult("SEARCH")],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("search"),
+      "Chat Agent",
+      { timeoutDuration: 5_000, onChunk },
+    );
+
+    expect(result.text).toBe("streamed final");
+    expect(onChunk).toHaveBeenCalledWith("streamed final");
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
+  });
+
+  it("replaces progress delivery with the final result without action evidence", async () => {
+    const onSnapshot = vi.fn();
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.(
+            {
+              text: "Searching...",
+              actions: ["SEARCH"],
+              actionStatus: "in_progress",
+            },
+            "SEARCH",
+          );
+          return {
+            didRespond: true,
+            responseContent: { text: "Search complete." },
+            responseMessages: [],
+            actionResults: [actionResult("SEARCH")],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("search"),
+      "Chat Agent",
+      { timeoutDuration: 5_000, onSnapshot },
+    );
+
+    expect(result.text).toBe("Search complete.");
+    expect(onSnapshot).toHaveBeenLastCalledWith("Search complete.");
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
+  });
+
+  it.each([
+    ["a failed action result", actionResult("SENSITIVE_ACTION", false)],
+    ["an unrelated successful result", actionResult("OTHER_ACTION")],
+  ])(
+    "drops callback history when an attributed callback is followed by %s",
+    async (_label, executionResult) => {
+      const runtime = createRuntime({
+        messageService: {
+          handleMessage: vi.fn(async (_runtime, _message, callback) => {
+            await callback?.(
+              { text: "claimed success", actions: ["SENSITIVE_ACTION"] },
+              "SENSITIVE_ACTION",
+            );
+            return {
+              didRespond: true,
+              responseContent: { text: "claimed success" },
+              responseMessages: [],
+              actionResults: [executionResult],
+            };
+          }),
+        } as NonNullable<AgentRuntime["messageService"]>,
+      });
+
+      const result = await generateChatResponse(
+        runtime,
+        createChatMessage("run it"),
+        "Chat Agent",
+        { timeoutDuration: 5_000 },
+      );
+
+      expect(result.usedActionCallbacks).toBeUndefined();
+      expect(result.actionCallbackHistory).toBeUndefined();
+    },
+  );
 
   it("keeps an exact internal action inventory out of chat while retaining diagnostics", async () => {
     const inventory = "available_views:\nviews[1]{id,label}: notes,Notes";
@@ -441,7 +622,10 @@ describe("generateChatResponse usage reporting", () => {
       actions: [{ name: "SENSITIVE_ACTION" }],
       messageService: {
         handleMessage: vi.fn(async (_runtime, _message, callback) => {
-          await callback?.({ actions: ["SEARCHING"] });
+          await callback?.(
+            { text: "Searching...", actions: ["SEARCHING"] },
+            "SEARCHING",
+          );
           return {
             didRespond: true,
             responseContent: {
@@ -466,7 +650,46 @@ describe("generateChatResponse usage reporting", () => {
     expect(result.text).not.toContain("sent the funds");
   });
 
-  it("does not fail closed when core reports actions mode", async () => {
+  it("fails closed when a matching attributed callback is followed by failure", async () => {
+    const runtime = createRuntime({
+      actions: [{ name: "SENSITIVE_ACTION" }],
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.(
+            {
+              text: "Attempting the sensitive action.",
+              actions: ["SENSITIVE_ACTION"],
+            },
+            "SENSITIVE_ACTION",
+          );
+          return {
+            didRespond: true,
+            mode: "actions",
+            responseContent: {
+              text: "Done, I sent the funds.",
+              actions: ["SENSITIVE_ACTION"],
+            },
+            responseMessages: [],
+            actionResults: [actionResult("SENSITIVE_ACTION", false)],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("send funds"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toContain("actions that were not executed");
+    expect(result.text).toContain("SENSITIVE_ACTION");
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
+  });
+
+  it("does not fail closed when actions mode has a matching successful result", async () => {
     const runtime = createRuntime({
       actions: [{ name: "SENSITIVE_ACTION" }],
       messageService: {
@@ -478,6 +701,7 @@ describe("generateChatResponse usage reporting", () => {
             actions: ["SENSITIVE_ACTION"],
           },
           responseMessages: [],
+          actionResults: [actionResult("SENSITIVE_ACTION")],
         })),
       } as NonNullable<AgentRuntime["messageService"]>,
     });
@@ -498,14 +722,51 @@ describe("generateChatResponse usage reporting", () => {
     );
   });
 
+  it.each([
+    ["no result", []],
+    ["a failed result", [actionResult("SENSITIVE_ACTION", false)]],
+    ["an unrelated result", [actionResult("OTHER_ACTION")]],
+  ])("fails closed when actions mode has %s", async (_label, actionResults) => {
+    const runtime = createRuntime({
+      actions: [{ name: "SENSITIVE_ACTION" }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          mode: "actions",
+          responseContent: {
+            text: "Action completed by core.",
+            actions: ["SENSITIVE_ACTION"],
+          },
+          responseMessages: [],
+          actionResults,
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("send funds"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toContain("actions that were not executed");
+    expect(result.usedActionCallbacks).toBeUndefined();
+    expect(result.actionCallbackHistory).toBeUndefined();
+  });
+
   it("reports mixed callback and core action execution once", async () => {
     const runtime = createRuntime({
+      actions: [{ name: "SENSITIVE_ACTION" }],
       messageService: {
         handleMessage: vi.fn(async (_runtime, _message, callback) => {
-          await callback?.({
-            text: "Mixed action reply",
-            actions: ["SENSITIVE_ACTION"],
-          });
+          await callback?.(
+            {
+              text: "Mixed action reply",
+              actions: ["SENSITIVE_ACTION"],
+            },
+            "SENSITIVE_ACTION",
+          );
           return {
             didRespond: true,
             mode: "actions",
@@ -514,6 +775,7 @@ describe("generateChatResponse usage reporting", () => {
               actions: ["SENSITIVE_ACTION"],
             },
             responseMessages: [],
+            actionResults: [actionResult("SENSITIVE_ACTION")],
           };
         }),
       } as NonNullable<AgentRuntime["messageService"]>,
@@ -534,7 +796,9 @@ describe("generateChatResponse usage reporting", () => {
     const message = createChatMessage("send funds");
     const runtime = createRuntime({
       actions: [{ name: "SENSITIVE_ACTION", similes: ["TRANSFER_FUNDS"] }],
-      getActionResults: vi.fn(() => [{ actionName: "TRANSFER_FUNDS" }]),
+      getActionResults: vi.fn(() => [
+        { success: true, actionName: "TRANSFER_FUNDS" },
+      ]),
       messageService: {
         handleMessage: vi.fn(async () => ({
           didRespond: true,
@@ -562,7 +826,9 @@ describe("generateChatResponse usage reporting", () => {
     const message = createChatMessage("send funds");
     const runtime = createRuntime({
       actions: [{ name: "SENSITIVE_ACTION" }],
-      getActionResults: vi.fn(() => [{ actionName: "SENSITIVE_ACTION" }]),
+      getActionResults: vi.fn(() => [
+        { success: true, actionName: "SENSITIVE_ACTION" },
+      ]),
       messageService: {
         handleMessage: vi.fn(async () => ({
           didRespond: true,
@@ -586,6 +852,367 @@ describe("generateChatResponse usage reporting", () => {
       "[eliza-api] Unexecuted action payload detected; failing closed",
     );
   });
+
+  it("accepts a wallet reply only when a matching wallet action succeeded", async () => {
+    const persistedId = stringToUuid("wallet-balance-response");
+    const runtime = createRuntime({
+      actions: [{ name: "CHECK_BALANCE" }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          mode: "actions",
+          responseContent: {
+            text: "Your wallet balance is 4 SOL.",
+            actions: ["CHECK_BALANCE"],
+          },
+          responseMessages: [],
+          persistedResponseMessageIds: [persistedId],
+          actionResults: [
+            actionResult("CHECK_BALANCE", true, "Balance loaded."),
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+    const message = createChatMessage("check my wallet balance");
+
+    const result = await generateChatResponse(runtime, message, "Chat Agent", {
+      timeoutDuration: 5_000,
+    });
+
+    expect(result.text).toBe("Your wallet balance is 4 SOL.");
+    expect(result.persistedResponseMessageIds).toEqual([persistedId]);
+    expect(result.actionResults).toEqual([
+      expect.objectContaining({
+        actionName: "CHECK_BALANCE",
+        success: true,
+        text: "Balance loaded.",
+      }),
+    ]);
+    expect(result.usage).toMatchObject({
+      promptTokens: estimateTokenCount("check my wallet balance"),
+      completionTokens: estimateTokenCount("Your wallet balance is 4 SOL."),
+      isEstimated: true,
+      llmCalls: 0,
+    });
+  });
+
+  it("matches a successful WALLET router subaction to the requested operation", async () => {
+    const runtime = createRuntime({
+      actions: [
+        {
+          name: "WALLET",
+          similes: ["TRANSFER", "SWAP"],
+        },
+      ],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          mode: "actions",
+          responseContent: {
+            text: "The transfer was submitted.",
+            actions: ["TRANSFER"],
+          },
+          responseMessages: [],
+          actionResults: [
+            {
+              success: true,
+              data: { actionName: "WALLET", subaction: "transfer" },
+            },
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("send 1 SOL to this wallet"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toBe("The transfer was submitted.");
+    expect(result.usedActionCallbacks).toBe(true);
+  });
+
+  it.each([
+    ["buy ETH with USDC", "The purchase swap was submitted."],
+    ["sell ETH for USDC", "The sale swap was submitted."],
+  ])(
+    "matches a successful WALLET swap for %s",
+    async (prompt, responseText) => {
+      const runtime = createRuntime({
+        actions: [{ name: "WALLET", similes: ["SWAP"] }],
+        messageService: {
+          handleMessage: vi.fn(async () => ({
+            didRespond: true,
+            mode: "actions",
+            responseContent: {
+              text: responseText,
+              actions: ["SWAP"],
+            },
+            responseMessages: [],
+            actionResults: [
+              {
+                success: true,
+                data: { actionName: "WALLET", subaction: "swap" },
+              },
+            ],
+          })),
+        } as NonNullable<AgentRuntime["messageService"]>,
+      });
+
+      const result = await generateChatResponse(
+        runtime,
+        createChatMessage(prompt),
+        "Chat Agent",
+        { timeoutDuration: 5_000 },
+      );
+
+      expect(result.text).toBe(responseText);
+      expect(result.usedActionCallbacks).toBe(true);
+    },
+  );
+
+  it("rejects a successful TRADE inspection as evidence that an order ran", async () => {
+    const runtime = createRuntime({
+      actions: [{ name: "TRADE" }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          responseContent: { text: "The Hyperliquid order was submitted." },
+          responseMessages: [],
+          actionResults: [
+            {
+              success: true,
+              data: { actionName: "TRADE", account: {} },
+              values: { tradeOutcome: "not_attempted" },
+            },
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("buy ETH on Hyperliquid"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toContain("no wallet action actually ran");
+    expect(result.text).not.toContain("order was submitted");
+  });
+
+  it.each([
+    ["prepared", { tradeActionPrepared: true }],
+    ["submitted", { tradeActionSucceeded: true }],
+  ])("accepts a TRADE order that was %s", async (_status, values) => {
+    const runtime = createRuntime({
+      actions: [{ name: "TRADE" }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          mode: "actions",
+          responseContent: {
+            text: "The Hyperliquid order flow is active.",
+            actions: ["TRADE"],
+          },
+          responseMessages: [],
+          actionResults: [
+            {
+              success: true,
+              data: { actionName: "TRADE" },
+              values,
+            },
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("buy ETH on Hyperliquid"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toBe("The Hyperliquid order flow is active.");
+    expect(result.usedActionCallbacks).toBe(true);
+  });
+
+  it("matches a successful WALLET governance execution", async () => {
+    const runtime = createRuntime({
+      actions: [{ name: "WALLET", similes: ["WALLET_GOV"] }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          mode: "actions",
+          responseContent: {
+            text: "The governance proposal was executed.",
+            actions: ["WALLET_GOV"],
+          },
+          responseMessages: [],
+          actionResults: [
+            {
+              success: true,
+              data: {
+                actionName: "WALLET",
+                subaction: "gov",
+                metadata: { op: "execute" },
+              },
+            },
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("execute this onchain governance proposal"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toBe("The governance proposal was executed.");
+    expect(result.usedActionCallbacks).toBe(true);
+  });
+
+  it("rejects a different WALLET governance operation", async () => {
+    const runtime = createRuntime({
+      actions: [{ name: "WALLET", similes: ["WALLET_GOV"] }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          responseContent: {
+            text: "The governance proposal was executed.",
+          },
+          responseMessages: [],
+          actionResults: [
+            {
+              success: true,
+              data: {
+                actionName: "WALLET",
+                subaction: "gov",
+                metadata: { op: "queue" },
+              },
+            },
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("execute this onchain governance proposal"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toContain("no wallet action actually ran");
+    expect(result.text).not.toContain("proposal was executed");
+  });
+
+  it("rejects a successful but unrelated WALLET router subaction", async () => {
+    const runtime = createRuntime({
+      actions: [{ name: "WALLET", similes: ["TRANSFER", "SWAP"] }],
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          responseContent: { text: "The transfer was submitted." },
+          responseMessages: [],
+          actionResults: [
+            {
+              success: true,
+              data: { actionName: "WALLET", subaction: "swap" },
+            },
+          ],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("send 1 SOL to this wallet"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.text).toContain("no wallet action actually ran");
+    expect(result.text).not.toContain("transfer was submitted");
+  });
+
+  it.each([
+    ["SEND_MESSAGE action", "SEND_MESSAGE", undefined],
+    ["SEND_EMAIL action", "SEND_EMAIL", undefined],
+    ["malformed WALLET subaction", "WALLET", "send_message"],
+  ])(
+    "rejects a successful %s for a wallet transfer",
+    async (_label, actionName, subaction) => {
+      const runtime = createRuntime({
+        actions:
+          actionName === "WALLET"
+            ? [{ name: "WALLET", similes: ["TRANSFER"] }]
+            : [{ name: actionName }],
+        messageService: {
+          handleMessage: vi.fn(async () => ({
+            didRespond: true,
+            responseContent: { text: "The transfer was submitted." },
+            responseMessages: [],
+            actionResults: [
+              {
+                success: true,
+                data: {
+                  actionName,
+                  ...(subaction ? { subaction } : {}),
+                },
+              },
+            ],
+          })),
+        } as NonNullable<AgentRuntime["messageService"]>,
+      });
+
+      const result = await generateChatResponse(
+        runtime,
+        createChatMessage("send 1 SOL to this wallet"),
+        "Chat Agent",
+        { timeoutDuration: 5_000 },
+      );
+
+      expect(result.text).toContain("no wallet action actually ran");
+      expect(result.text).not.toContain("transfer was submitted");
+    },
+  );
+
+  it.each([
+    ["a failed wallet result", actionResult("CHECK_BALANCE", false)],
+    ["an unrelated successful result", actionResult("SEARCH", true)],
+  ])(
+    "fails wallet execution closed for %s",
+    async (_label, executionResult) => {
+      const runtime = createRuntime({
+        actions: [{ name: "CHECK_BALANCE" }, { name: "SEARCH" }],
+        messageService: {
+          handleMessage: vi.fn(async () => ({
+            didRespond: true,
+            responseContent: { text: "Your wallet balance is 4 SOL." },
+            responseMessages: [],
+            actionResults: [executionResult],
+          })),
+        } as NonNullable<AgentRuntime["messageService"]>,
+      });
+
+      const result = await generateChatResponse(
+        runtime,
+        createChatMessage("check my wallet balance"),
+        "Chat Agent",
+        { timeoutDuration: 5_000 },
+      );
+
+      expect(result.text).toContain("no wallet action actually ran");
+      expect(result.text).not.toContain("4 SOL");
+      expect(result.usedActionCallbacks).toBeUndefined();
+    },
+  );
 });
 
 describe("local inference chat command intent detection", () => {

--- a/packages/core/src/services/__tests__/outbound-sanitize-boundary.test.ts
+++ b/packages/core/src/services/__tests__/outbound-sanitize-boundary.test.ts
@@ -119,6 +119,23 @@ describe("outbound sanitization at the visible-callback boundary", () => {
 		expect(recorded).toEqual([]);
 	});
 
+	it.each([
+		["early", { text: "Early reply.", actions: ["REPLY"] }],
+		["terminal", { text: "", actions: ["IGNORE"] }],
+		["attachment", { attachments: [] }],
+		["voice", { text: "", attachments: [], source: "voice" }],
+	] satisfies Array<[string, Content]>)(
+		"keeps %s message-service delivery unattributed",
+		async (_kind, content) => {
+			const { delivered, wrapped } = buildHarness();
+
+			await wrapped(content);
+
+			expect(delivered).toHaveLength(1);
+			expect(delivered[0].actionName).toBeUndefined();
+		},
+	);
+
 	it("delivers an all-machine-syntax turn as empty text for the connector to degrade", async () => {
 		const { delivered, wrapped } = buildHarness();
 

--- a/packages/core/src/services/message.deliver-then-persist.test.ts
+++ b/packages/core/src/services/message.deliver-then-persist.test.ts
@@ -237,12 +237,14 @@ describe("simple-path deliver-then-persist ordering", () => {
 	it("fires the delivery callback before the reply persist completes, then still persists it", async () => {
 		const h = await createHarness();
 		let repliesVisibleAtDelivery = -1;
+		let deliveryActionName: string | undefined;
 
 		const result = await h.service.handleMessage(
 			h.runtime,
 			h.makeMessage(),
-			async () => {
+			async (_content, actionName) => {
 				h.order.push("callback");
+				deliveryActionName = actionName;
 				// Direct proof delivery precedes persistence: at delivery time the
 				// reply row is not yet readable from the real adapter.
 				repliesVisibleAtDelivery = (await h.storedReplies()).length;
@@ -253,8 +255,10 @@ describe("simple-path deliver-then-persist ordering", () => {
 		expect(result.didRespond).toBe(true);
 		expect(result.mode).toBe("simple");
 		expect(result.responseContent?.text).toBe(h.replyText);
+		expect(deliveryActionName).toBeUndefined();
 		expect(repliesVisibleAtDelivery).toBe(0);
 		expect(h.order).toEqual(["stage1:1", "callback", "persist:reply"]);
+		expect(result.persistedResponseMessageIds).toHaveLength(1);
 
 		// The persist completed before handleMessage resolved: an immediate
 		// next-turn-style read sees exactly one stored reply — no drop, no

--- a/packages/core/src/services/message.transcript-visibility.test.ts
+++ b/packages/core/src/services/message.transcript-visibility.test.ts
@@ -94,13 +94,17 @@ interface Harness {
 	actionHandler: ReturnType<typeof vi.fn>;
 	callback: HandlerCallback;
 	callbacks: Content[];
+	callbackActionNames: Array<string | undefined>;
 	sent: Content[];
 	voiceHandler: ReturnType<typeof vi.fn>;
 }
 
 const activeRuntimes: AgentRuntime[] = [];
 
-async function createHarness(finalText: string): Promise<Harness> {
+async function createHarness(
+	finalText: string,
+	actionCallbackText?: string,
+): Promise<Harness> {
 	const runtime = new AgentRuntime({
 		character: createCharacter({
 			id: AGENT_ID,
@@ -127,12 +131,28 @@ async function createHarness(finalText: string): Promise<Harness> {
 		} as State;
 	}) as AgentRuntime["composeState"];
 
-	const actionHandler = vi.fn(async () => ({
-		success: true,
-		text: INTERNAL_DIAGNOSTIC,
-		transcriptVisibility: "internal" as const,
-		data: { views: [] },
-	}));
+	const actionHandler = vi.fn(
+		async (
+			_runtime,
+			_message,
+			_state,
+			_options,
+			actionCallback?: HandlerCallback,
+		) => {
+			if (actionCallbackText) {
+				await actionCallback?.({
+					text: actionCallbackText,
+					actions: ["VIEWS"],
+				});
+			}
+			return {
+				success: true,
+				text: INTERNAL_DIAGNOSTIC,
+				transcriptVisibility: "internal" as const,
+				data: { views: [] },
+			};
+		},
+	);
 	const viewsAction: Action = {
 		name: "VIEWS",
 		description: "Lists the available application views.",
@@ -186,6 +206,7 @@ async function createHarness(finalText: string): Promise<Harness> {
 	);
 
 	const callbacks: Content[] = [];
+	const callbackActionNames: Array<string | undefined> = [];
 	const sent: Content[] = [];
 	runtime.registerSendHandler(
 		"client_chat",
@@ -195,8 +216,9 @@ async function createHarness(finalText: string): Promise<Harness> {
 		},
 	);
 
-	const callback: HandlerCallback = async (content: Content) => {
+	const callback: HandlerCallback = async (content: Content, actionName) => {
 		callbacks.push(content);
+		callbackActionNames.push(actionName);
 		await runtime.sendMessageToTarget(
 			{ source: "client_chat", roomId: runtime.agentId },
 			content,
@@ -209,6 +231,7 @@ async function createHarness(finalText: string): Promise<Harness> {
 		actionHandler,
 		callback,
 		callbacks,
+		callbackActionNames,
 		sent,
 		voiceHandler,
 	};
@@ -301,8 +324,28 @@ describe("DefaultMessageService transcript visibility integration", () => {
 		expect(persisted[0]?.content.transcriptVisibility).toBeUndefined();
 		expect(harness.callbacks).toHaveLength(1);
 		expect(harness.callbacks[0]?.text).toBe(visibleSummary);
+		expect(harness.callbackActionNames).toEqual([undefined]);
 		expect(harness.sent).toHaveLength(1);
 		expect(harness.sent[0]?.text).toBe(visibleSummary);
 		expect(harness.voiceHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves action attribution through the real message-service callback", async () => {
+		const visibleSummary = "The available views are ready.";
+		const harness = await createHarness(visibleSummary, visibleSummary);
+		const result = await new DefaultMessageService().handleMessage(
+			harness.runtime,
+			makeMessage(harness.runtime, "List the available apps."),
+			harness.callback,
+		);
+
+		expect(result.actionResults).toEqual([
+			expect.objectContaining({
+				success: true,
+				data: expect.objectContaining({ actionName: "VIEWS" }),
+			}),
+		]);
+		expect(harness.callbacks).not.toHaveLength(0);
+		expect(harness.callbackActionNames).toContain("VIEWS");
 	});
 });

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -234,8 +234,10 @@ export interface EvaluationResult {
 }
 
 /**
- * Callback function type for handlers. actionName is optional so callers can attribute
- * the response to the action that produced it without parsing content (backward compatible).
+ * Delivers handler output to a transport. `actionName` is present only when an
+ * executing action produced the callback; message-service deliveries such as
+ * simple, early, terminal, attachment, and voice output omit it. Consumers must
+ * not infer action provenance from `Content.actions`.
  */
 export type HandlerCallback = (
 	response: Content,


### PR DESCRIPTION
## Summary

- preserve action callback attribution only when an explicit callback action name has a matching successful action result
- keep generic, progress, textless, losing, and failed callbacks out of execution evidence and persisted callback history
- fail wallet claims closed against explicit operation mappings, including result-sensitive TRADE attribution that rejects read-only inspections
- preserve callback delivery history, response persistence, SSE ordering, refresh metadata, and token accounting

Closes #17247.

## Root cause

The merged #17244 patch recovered callback telemetry by treating callback observation as execution evidence, but callbacks are also used for generic delivery, progress, and read-only action responses. That allowed unrelated or non-executing callbacks to suppress the route boundary that rejects claims about wallet actions that did not run.

This repair separates visible delivery from attributable execution. A callback only contributes action evidence when it names the action explicitly and the action has a matching `success: true` result. Wallet claims additionally require an operation-specific action/result shape.

## Validation

- `packages/agent/test/api/chat-routes-usage.test.ts`: 43/43 passed
- `packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts`: 26/26 passed
- core delivery/persistence suites: 20/20 passed
- `bun run --cwd packages/agent typecheck`: passed
- exact-file Biome: passed
- independent adversarial review of exact-develop candidate: MERGE, no blockers

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend action-attribution boundary only.

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no frontend interaction surface changed.

<!-- evidence-row:backend-logs -->
- [x] Backend/test logs: [full exact-head Tests workflow](https://github.com/elizaOS/eliza/actions/runs/30398846901) plus the focused 43/43 route, 26/26 SSE, and 20/20 core delivery/persistence results above cover successful, failed, unrelated, losing, generic, progress, wallet router, governance, swap, transfer, TRADE inspection, prepared-order, and submitted-order outcomes.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend path.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - prompts, model selection, planner logic, and action handlers are unchanged; this is a deterministic post-execution attribution boundary.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no domain storage shape changes; persisted response IDs, callback history, refresh metadata, and usage DTOs are asserted directly in the focused suites.