### PR TITLE
fix(ui): remove gate-banned backdrop blur and focus-ring utilities from chat surfaces

### DIFF
--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -135,7 +135,7 @@ export function MessageSearchPanel({
       // away when the results list above it is long.
       className={
         keyboardAnchored
-          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl placeholder:text-white/45"
+          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] placeholder:text-white/45"
           : undefined
       }
     />
@@ -196,7 +196,7 @@ export function MessageSearchPanel({
               variant="ghost"
               className={
                 keyboardAnchored
-                  ? "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-xl border border-white/10 bg-[rgba(12,16,18,0.86)] px-3 py-2 text-left font-normal shadow-[0_10px_28px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-xl hover:border-white/20 hover:bg-[rgba(18,22,24,0.92)]"
+                  ? "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-xl border border-white/10 bg-[rgba(12,16,18,0.86)] px-3 py-2 text-left font-normal shadow-[0_10px_28px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.06)] hover:border-white/20 hover:bg-[rgba(18,22,24,0.92)]"
                   : "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-md px-2 py-1.5 text-left font-normal hover:bg-muted/60"
               }
             >

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -115,6 +115,7 @@ describe("ChatMessageActions copy", () => {
       expect(button.className).toContain("hover:bg-transparent");
       expect(button.className).toContain("pointer-coarse:h-11");
       expect(button.className).not.toContain("bg-white/10");
+      expect(button.className).toContain("keyboard-focus-emphasis");
       expect(button.className).not.toContain("text-[rgb(255");
     }
     expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
@@ -126,6 +127,6 @@ describe("ChatMessageActions copy", () => {
     expect(surface.className).toContain("bg-black/55");
     expect(surface.className).toContain("border-white/25");
     expect(surface.style.backgroundImage).toContain("radial-gradient");
-    expect(surface.style.backdropFilter).toContain("blur");
+    expect(surface.style.backdropFilter).toBe("");
   });
 });

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -11,7 +11,6 @@ import type * as React from "react";
 
 import { cn } from "../../../lib/utils";
 import {
-  LIQUID_GLASS_BLUR,
   LIQUID_GLASS_EDGE_SHADOW,
   LIQUID_GLASS_SHEEN,
 } from "../../shell/liquid-glass";
@@ -62,8 +61,6 @@ export function ChatMessageActionSurface({
           : {
               backgroundImage: LIQUID_GLASS_SHEEN,
               boxShadow: LIQUID_GLASS_EDGE_SHADOW,
-              WebkitBackdropFilter: LIQUID_GLASS_BLUR,
-              backdropFilter: LIQUID_GLASS_BLUR,
               ...style,
             }
       }
@@ -103,9 +100,9 @@ function MessageActionButton({
         onClick();
       }}
       className={cn(
-        "bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
+        "keyboard-focus-emphasis bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:text-white active:scale-95 pointer-coarse:h-11 pointer-coarse:w-11",
         bare
-          ? "h-5 w-5 rounded-none hover:bg-transparent active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55"
+          ? "h-5 w-5 rounded-none hover:bg-transparent active:bg-transparent"
           : "h-6 w-6 rounded-lg transition-[background-color,color,transform] hover:bg-white/10 active:bg-white/10",
         active &&
           (bare ? "text-white" : "bg-white/10 text-white hover:bg-white/15"),

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -810,7 +810,7 @@ export const ChatMessage = memo(function ChatMessage({
               handleCancelEditing();
             }}
             disabled={savingEdit}
-            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+            className="keyboard-focus-emphasis h-7 w-7 rounded-none bg-transparent p-0 text-white/60 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
           >
             <X className="h-3.5 w-3.5" />
           </Button>
@@ -829,7 +829,7 @@ export const ChatMessage = memo(function ChatMessage({
               void handleSaveEdit();
             }}
             disabled={editSaveDisabled}
-            className="h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/55 disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
+            className="keyboard-focus-emphasis h-7 w-7 rounded-none bg-transparent p-0 text-white/80 transition-[color,transform] duration-150 hover:bg-transparent hover:text-white active:scale-95 active:bg-transparent disabled:text-white/30 pointer-coarse:h-11 pointer-coarse:w-11"
           >
             {savingEdit ? (
               <LoaderCircle
@@ -847,7 +847,7 @@ export const ChatMessage = memo(function ChatMessage({
             unstyled
             onClick={handleCancelEditing}
             disabled={savingEdit}
-            className="min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+            className="keyboard-focus-emphasis min-h-7 px-2 py-1 text-xs font-medium text-white/60 transition-colors duration-150 hover:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
           >
             {labels.cancel ?? "Cancel"}
           </Button>
@@ -856,7 +856,7 @@ export const ChatMessage = memo(function ChatMessage({
             unstyled
             onClick={() => void handleSaveEdit()}
             disabled={editSaveDisabled}
-            className="min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
+            className="keyboard-focus-emphasis min-h-7 px-2 py-1 text-xs font-medium text-white/85 transition-colors duration-150 hover:text-white disabled:text-white/30 pointer-coarse:min-h-touch"
           >
             {savingEdit
               ? (labels.saving ?? "Saving...")

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -475,6 +475,10 @@ kbd {
   outline: none !important;
   box-shadow: none !important;
 }
+
+.keyboard-focus-emphasis:focus-visible {
+  color: white;
+}
 /* biome-ignore-end lint/complexity/noImportantStyles: end focus-ring ban override */
 
 /*


### PR DESCRIPTION
## Summary

Develop's Tests workflow ([run 30398014368](https://github.com/elizaOS/eliza/actions/runs/30398014368)) fails its Client Tests lane on exactly two UI source gates:

- `src/no-backdrop-blur-gate.test.ts` — backdrop-filter found in `MessageSearchPanel.tsx` and `chat-message-actions.tsx`
- `src/no-focus-ring-gate.test.ts` — 16 `focus-visible:*` ring/outline utilities in `chat-message-actions.tsx` / `chat-message.tsx`

The violations landed with direct pushes `85f3d3fa05` ("port approved chat interaction polish") and `a6992d5a02` ("restore polished chat search"), whose component test even asserted the banned blur — source and test were internally consistent but contradict the repo visual policy gates.

## Fix

Extracted **verbatim** from the in-flight #17205 repair (credit to that lane — this unblocks the Tests workflow without waiting for the full 60-file draft to rebase):

- drop `backdrop-blur-xl` / `LIQUID_GLASS_BLUR` from the two non-allowlisted surfaces,
- replace local `focus-visible:` ring/outline utilities with the centralized `.keyboard-focus-emphasis` policy (new rule in `styles.css`) — **note the before-state ring was already invisible**: the global focus-ring ban in styles.css (`outline/box-shadow: none !important`) suppressed the utility, so keyboard focus had NO visible indicator; the policy class restores a visible one (measured below),
- update `chat-message-actions.test.tsx` to pin the gate-compliant contract.

Scope note: the one unrelated hunk in #17205's version of `chat-message.tsx` (`className="flex"` on the footer accessory motion.div) is deliberately NOT taken.

## Verification

- Both gates reproduced the exact CI failures locally before the fix (same offender lists), and pass after: 5 test files / 21 tests green, 6/6 consecutive clean runs (Windows).
- Real-browser measurement (headless Chromium, real Tab keypress): focused control color **before** `rgba(255,255,255,0.6)` (no visible focus change — ring banned globally), **after** `≈rgba(255,255,255,0.93)` (visible emphasis). Boxed surface `backdropFilter`: before `blur(16px) saturate(1.4)`, after `none`.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots (real Chromium, compiled `@elizaos/ui` Tailwind v4 theme + shipped focus-policy CSS, desktop 1280w + mobile 390w, 2x): [desktop](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-rest.jpg) · [mobile](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-mobile-rest.jpg) · [rail keyboard-focus closeup](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-rail-keyboard-focus.jpg) · [action surface closeup](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-surface-section.jpg) · [search panel closeup](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-search-section.jpg) · [search mobile](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-mobile-search-section.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After screenshots (same fixture/harness at this head): [desktop](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-rest.jpg) · [mobile](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-mobile-rest.jpg) · [rail keyboard-focus closeup](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-rail-keyboard-focus.jpg) · [action surface closeup](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-surface-section.jpg) · [search panel closeup](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-search-section.jpg) · [search mobile](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-mobile-search-section.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [walkthrough-tour.mp4](https://raw.githubusercontent.com/elizaOS/eliza/554030833663163b1c40a707ee4707f9cd284caa/walkthrough-tour.mp4) — one continuous real-Chromium session touring the BEFORE fixture then the AFTER fixture (banner on screen names the state): keyboard-Tab across all four rail controls, hover tour, and typing into the keyboard-anchored search. Reviewed frame-by-frame; see the legibility note below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - frontend-only source-scan gate repair; no backend path.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console logs: [console-logs.txt](https://raw.githubusercontent.com/elizaOS/eliza/554030833663163b1c40a707ee4707f9cd284caa/console-logs.txt) — every console message + pageerror captured during the recorded tour of both states (clean; the only entries are React DevTools info lines). No network activity in these components.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: gate test outputs (fail→pass, offender lists identical to CI), the [OCR text readout](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/ocr-readout.txt) of every capture, and the develop Tests run 30398014368 this repairs.

### OCR visual text review

OCR readout (Windows.Media.Ocr) over all 12 captures: [ocr-readout.txt](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/ocr-readout.txt) — section headings, search results, and the `quarterly` query text all recognized; reviewed by hand against the renders.

### Before / After (key pairs)

Keyboard focus on the glass rail (before: no visible focus indicator; after: focused control brightens):

**Before:** ![before rail](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-rail-keyboard-focus.jpg)
**After:** ![after rail](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-rail-keyboard-focus.jpg)

Boxed action surface over a striped backdrop (before: blur(16px) smears the stripes; after: no backdrop-filter):

**Before:** ![before surface](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-surface-section.jpg)
**After:** ![after surface](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-surface-section.jpg)

Keyboard-anchored message search (before: `backdrop-blur-xl` on input + result rows; after: removed, dark 0.86 fills keep contrast):

**Before:** ![before search](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/before-desktop-search-section.jpg)
**After:** ![after search](https://raw.githubusercontent.com/elizaOS/eliza/c5245099f51438c45bd46c599e0c92e10877b3b0/after-desktop-search-section.jpg)


### Reviewer note — legibility trade-off observed in the captures

Over the adversarial striped backdrop, the before-state's `blur(16px)` visibly aided text contrast on the 55%-black surfaces; the after-state's un-blurred `bg-black/55` lets busy backdrop detail bleed through (see the surface closeups). The blur ban (#9141, battery) is settled policy and this PR matches #17205 verbatim, so no fill compensation is added here — flagging so the #17205 lane / owner can decide whether the non-allowlisted glass surfaces should darken their fills (e.g. `bg-black/70`) as a follow-on to the policy sweep.
