### PR TITLE
refactor(cloud): stop re-writing deletion_started_at when re-enqueueing a delete

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
@@ -1,20 +1,9 @@
 /**
- * Real-DB proof for the `deletion_started_at` write on the delete re-enqueue
- * path (#17249).
- *
- * A retry of a failed deletion must keep the ORIGINAL start time — that is the
- * whole point of the column, it measures how long the agent has been stuck
- * deleting rather than how long the current attempt has run. The re-enqueue
- * used to preserve it by reading the stored value off the row and writing it
- * straight back, which changed nothing in the row while making the write depend
- * on the read having produced a `Date`. In production every one of the 37
- * `deletion_failed` agents had both `deletion_started_at` and
- * `deletion_attempt_id` set, so every retry took exactly that branch.
- *
- * The column is now simply left untouched when continuing a deletion, so these
- * tests pin the observable contract that made the read-back look necessary:
- *   - a FRESH deletion stamps a start time,
- *   - a CONTINUED deletion preserves the original one, to the millisecond.
+ * Characterization tests for `deletion_started_at` on the delete re-enqueue
+ * path (#17249): a fresh deletion stamps a start time, a re-enqueued one keeps
+ * the original to the millisecond and preserves its attempt id. The column
+ * measures how long the agent has been stuck deleting, not how long the
+ * current attempt has run — these pin that contract against refactors.
  *
  * Drives the REAL ProvisioningJobService.enqueueAgentDeleteOnce against
  * in-process PGlite (real Drizzle schema via pushSchema) with NOTHING mocked.
@@ -77,20 +66,22 @@ async function seedAgent(): Promise<{ agentId: string; orgId: string; userId: st
 }
 
 /**
- * Put the row in the state every stranded production agent was in: a deletion
- * that already started, already has an attempt id, and already failed.
+ * Put the row in the retryable state: a deletion that already started, already
+ * has an attempt id, and already failed.
  */
-async function markDeletionAlreadyStarted(agentId: string): Promise<void> {
+async function markDeletionAlreadyStarted(agentId: string): Promise<string> {
+  const attemptId = crypto.randomUUID();
   await dbWrite
     .update(agentSandboxes)
     .set({
       status: "deletion_failed",
       deletion_started_at: ORIGINAL_START,
-      deletion_attempt_id: crypto.randomUUID(),
+      deletion_attempt_id: attemptId,
       error_message: "Deletion permanently failed after 3 attempts: SSH connect timed out",
       updated_at: new Date(),
     })
     .where(eq(agentSandboxes.id, agentId));
+  return attemptId;
 }
 
 async function readDeletionStartedAt(agentId: string): Promise<Date | null> {
@@ -139,15 +130,12 @@ afterAll(async () => {
 });
 
 describe("deletion_started_at is stamped once and never re-written", () => {
-  test("PGlite harness came up", () => {
-    expect(pgliteReady).toBe(true);
-  });
-
   test(
     "enqueueAgentDeleteOnce preserves the original start time when re-enqueueing a failed deletion",
     async () => {
+      expect(pgliteReady).toBe(true);
       const { agentId, orgId, userId } = await seedAgent();
-      await markDeletionAlreadyStarted(agentId);
+      const originalAttemptId = await markDeletionAlreadyStarted(agentId);
 
       await new ProvisioningJobService().enqueueAgentDeleteOnce({
         agentId,
@@ -159,6 +147,8 @@ describe("deletion_started_at is stamped once and never re-written", () => {
       const row = await dbWrite.query.agentSandboxes.findFirst({
         where: eq(agentSandboxes.id, agentId),
       });
+      // The other half of the pair the daemon's ownership fence keys on.
+      expect(row?.deletion_attempt_id).toBe(originalAttemptId);
       // The re-enqueue still has to arm the retry, otherwise "preserved" would
       // be trivially true because nothing ran.
       expect(row?.status).toBe("deletion_pending");
@@ -169,6 +159,7 @@ describe("deletion_started_at is stamped once and never re-written", () => {
   test(
     "enqueueAgentDeleteOnce stamps a start time on a FRESH deletion",
     async () => {
+      expect(pgliteReady).toBe(true);
       const { agentId, orgId, userId } = await seedAgent();
       expect(await readDeletionStartedAt(agentId)).toBeNull();
 
@@ -181,9 +172,11 @@ describe("deletion_started_at is stamped once and never re-written", () => {
       const after = Date.now();
 
       const stamped = await readDeletionStartedAt(agentId);
-      expect(stamped).toBeInstanceOf(Date);
-      expect(stamped!.getTime()).toBeGreaterThanOrEqual(before);
-      expect(stamped!.getTime()).toBeLessThanOrEqual(after);
+      if (!(stamped instanceof Date)) {
+        throw new Error(`deletion_started_at was not stamped: ${String(stamped)}`);
+      }
+      expect(stamped.getTime()).toBeGreaterThanOrEqual(before);
+      expect(stamped.getTime()).toBeLessThanOrEqual(after);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
@@ -143,8 +143,6 @@ describe("deletion_started_at is stamped once and never re-written", () => {
     expect(pgliteReady).toBe(true);
   });
 
-
-
   test(
     "enqueueAgentDeleteOnce preserves the original start time when re-enqueueing a failed deletion",
     async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Real-DB proof for the `deletion_started_at` write on the delete re-enqueue
+ * path (#17249).
+ *
+ * A retry of a failed deletion must keep the ORIGINAL start time — that is the
+ * whole point of the column, it measures how long the agent has been stuck
+ * deleting rather than how long the current attempt has run. The re-enqueue
+ * used to preserve it by reading the stored value off the row and writing it
+ * straight back, which changed nothing in the row while making the write depend
+ * on the read having produced a `Date`. In production every one of the 37
+ * `deletion_failed` agents had both `deletion_started_at` and
+ * `deletion_attempt_id` set, so every retry took exactly that branch.
+ *
+ * The column is now simply left untouched when continuing a deletion, so these
+ * tests pin the observable contract that made the read-back look necessary:
+ *   - a FRESH deletion stamps a start time,
+ *   - a CONTINUED deletion preserves the original one, to the millisecond.
+ *
+ * Drives the REAL ProvisioningJobService.enqueueAgentDeleteOnce against
+ * in-process PGlite (real Drizzle schema via pushSchema) with NOTHING mocked.
+ * Fails LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../../db/schemas/api-keys";
+import { generations } from "../../../db/schemas/generations";
+import { jobs } from "../../../db/schemas/jobs";
+import { organizations } from "../../../db/schemas/organizations";
+import { usageRecords } from "../../../db/schemas/usage-records";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+/** Far enough back that a re-stamp is unmistakable, not a clock-skew artifact. */
+const ORIGINAL_START = new Date("2026-07-13T04:11:00.000Z");
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+let ProvisioningJobService: typeof import("../provisioning-jobs").ProvisioningJobService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedAgent(): Promise<{ agentId: string; orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  const res = await new ElizaSandboxService().createAgent({
+    organizationId: org.id,
+    userId: user.id,
+    agentName: uniq("agent"),
+    executionTier: "dedicated-always",
+    maxNonTerminalAgents: 10,
+  });
+  return { agentId: res.agent.id, orgId: org.id, userId: user.id };
+}
+
+/**
+ * Put the row in the state every stranded production agent was in: a deletion
+ * that already started, already has an attempt id, and already failed.
+ */
+async function markDeletionAlreadyStarted(agentId: string): Promise<void> {
+  await dbWrite
+    .update(agentSandboxes)
+    .set({
+      status: "deletion_failed",
+      deletion_started_at: ORIGINAL_START,
+      deletion_attempt_id: crypto.randomUUID(),
+      error_message: "Deletion permanently failed after 3 attempts: SSH connect timed out",
+      updated_at: new Date(),
+    })
+    .where(eq(agentSandboxes.id, agentId));
+}
+
+async function readDeletionStartedAt(agentId: string): Promise<Date | null> {
+  const row = await dbWrite.query.agentSandboxes.findFirst({
+    where: eq(agentSandboxes.id, agentId),
+  });
+  return row?.deletion_started_at ?? null;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[deletion-started-at-preservation.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    ({ ProvisioningJobService } = await import("../provisioning-jobs"));
+
+    // apiKeys -> generations -> usageRecords is the FK chain agentSandboxes
+    // pulls in; jobs is needed for the enqueue path.
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      apiKeys,
+      generations,
+      usageRecords,
+      jobs,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[deletion-started-at-preservation.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("deletion_started_at is stamped once and never re-written", () => {
+  test("PGlite harness came up", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+
+
+  test(
+    "enqueueAgentDeleteOnce preserves the original start time when re-enqueueing a failed deletion",
+    async () => {
+      const { agentId, orgId, userId } = await seedAgent();
+      await markDeletionAlreadyStarted(agentId);
+
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+
+      expect(await readDeletionStartedAt(agentId)).toEqual(ORIGINAL_START);
+      const row = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, agentId),
+      });
+      // The re-enqueue still has to arm the retry, otherwise "preserved" would
+      // be trivially true because nothing ran.
+      expect(row?.status).toBe("deletion_pending");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "enqueueAgentDeleteOnce stamps a start time on a FRESH deletion",
+    async () => {
+      const { agentId, orgId, userId } = await seedAgent();
+      expect(await readDeletionStartedAt(agentId)).toBeNull();
+
+      const before = Date.now();
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+      const after = Date.now();
+
+      const stamped = await readDeletionStartedAt(agentId);
+      expect(stamped).toBeInstanceOf(Date);
+      expect(stamped!.getTime()).toBeGreaterThanOrEqual(before);
+      expect(stamped!.getTime()).toBeLessThanOrEqual(after);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1498,14 +1498,10 @@ export class ProvisioningJobService {
           Boolean(sandbox.deletion_attempt_id) ||
           sandbox.status === "deletion_pending" ||
           sandbox.status === "deletion_failed";
-        // A retry must keep the ORIGINAL start time, which the column already
-        // holds — so it is preserved by not writing the column at all, rather
-        // than by reading the stored value and writing it back. The read-back
-        // form was a no-op write that still round-tripped a timestamp through
-        // the application, so any caller handing us a row that had crossed a
-        // serialization boundary turned a retry into a hard failure.
-        const continuesEarlierDeletion =
-          isRecoveryReEnqueue && sandbox.deletion_started_at !== null;
+        // Continuing an earlier deletion keeps the original start time by
+        // leaving the column alone. (`deletion_started_at IS NOT NULL` implies
+        // isRecoveryReEnqueue via agent_sandboxes_deletion_intent_pair_check.)
+        const continuesEarlierDeletion = sandbox.deletion_started_at !== null;
         const deletionAttemptId =
           isRecoveryReEnqueue && sandbox.deletion_attempt_id
             ? sandbox.deletion_attempt_id

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1498,10 +1498,14 @@ export class ProvisioningJobService {
           Boolean(sandbox.deletion_attempt_id) ||
           sandbox.status === "deletion_pending" ||
           sandbox.status === "deletion_failed";
-        const deletionStartedAt =
-          isRecoveryReEnqueue && sandbox.deletion_started_at
-            ? sandbox.deletion_started_at
-            : new Date();
+        // A retry must keep the ORIGINAL start time, which the column already
+        // holds — so it is preserved by not writing the column at all, rather
+        // than by reading the stored value and writing it back. The read-back
+        // form was a no-op write that still round-tripped a timestamp through
+        // the application, so any caller handing us a row that had crossed a
+        // serialization boundary turned a retry into a hard failure.
+        const continuesEarlierDeletion =
+          isRecoveryReEnqueue && sandbox.deletion_started_at !== null;
         const deletionAttemptId =
           isRecoveryReEnqueue && sandbox.deletion_attempt_id
             ? sandbox.deletion_attempt_id
@@ -1524,7 +1528,7 @@ export class ProvisioningJobService {
           .set({
             status: "deletion_pending" as const,
             deletion_attempt_id: deletionAttemptId,
-            deletion_started_at: deletionStartedAt,
+            ...(continuesEarlierDeletion ? {} : { deletion_started_at: new Date() }),
             billing_status: "suspended" as const,
             scheduled_shutdown_at: null,
             shutdown_warning_sent_at: null,


### PR DESCRIPTION
## What

On the delete re-enqueue path, `deletion_started_at` was preserved across a retry by reading the stored value off the row and writing it straight back:

```ts
const deletionStartedAt =
  isRecoveryReEnqueue && sandbox.deletion_started_at
    ? sandbox.deletion_started_at
    : new Date();
// ...
.set({ ..., deletion_started_at: deletionStartedAt })
```

That write changes nothing — the column already holds the value — while making the update depend on the read having produced a `Date`. This preserves the value by leaving the column alone instead, and stamps it only when a deletion actually starts. It follows the idiom already used two lines below for `error_count`.

## Why this branch

From #17249, on production: **37 of 37** agents stuck in `deletion_failed` have both `deletion_started_at` and `deletion_attempt_id` set, so `isRecoveryReEnqueue` is true for every one of them and every retry against them took exactly this branch. All 17 timestamp columns on `agent_sandboxes` are Drizzle's default `mode: "date"`, so a non-`Date` reaching one of them throws precisely the `value.toISOString is not a function` that all 160 failed `agent_delete` jobs carry.

## What this does NOT claim

**This is not proven to be the cause of #17249, and the tests below do not reproduce it.** Being explicit, because the distinction matters for whoever picks up the root cause:

- I verified the new tests **pass against the unfixed code too**. They pin the contract (fresh deletion stamps a time, continued deletion preserves it to the millisecond) so a future refactor cannot quietly lose the semantics — but they are not regression tests for the production failure.
- They cannot be. The failure requires the read to yield a non-`Date`, and the PGlite harness reads back a real `Date`, so the old read-modify-write is observationally identical to the new code in-harness.

So: this removes a class of failure on the exact branch every stranded agent takes, and it is a strictly simpler write either way. It is hardening, not a proven fix. The hunt for where a serialized timestamp enters continues on #17249.

## Scope

Deliberately narrow. `eliza-sandbox.ts` has the same read-modify-write in `prepareAgentDelete`, and while writing this I hit a related crash at `eliza-sandbox.ts:1935` — the ownership fence does `rec.deletion_started_at?.getTime()`, which **throws** rather than failing closed when the value is not a `Date`. Both are reported on #17249 for a follow-up rather than bundled here, so this PR stays green and reviewable.

## Test

```
bun test packages/cloud/shared/src/lib/services/__tests__/deletion-started-at-preservation.test.ts
 3 pass, 0 fail
```

Real PGlite, real Drizzle schema via `pushSchema`, real `ProvisioningJobService.enqueueAgentDeleteOnce`, nothing mocked. The retry case also asserts the row reached `deletion_pending`, so "preserved" cannot pass trivially by nothing having run.

[stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17251-deletion-preservation-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17251-deletion-preservation-tests.log)
