### PR TITLE
fix(ci): retry the Windows 0xC0000142 turbo child-process crash once from cache

### DIFF
--- a/packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts
+++ b/packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts
@@ -94,7 +94,9 @@ describe("run-turbo Windows init-crash retry", () => {
     expect(await attempts(attemptsFile)).toBe(2);
     expect(result.stderr).toContain("STATUS_DLL_INIT_FAILED");
     expect(result.stderr).toContain("Retrying once");
-  });
+    // Real sequential node subprocesses (up to 2 per invoke) overrun bun's
+    // 5s default under CI/AV load — every test in this file gets 30s.
+  }, 30_000);
 
   test("a persistent crash still fails after the single retry", async () => {
     const { fakeTurbo, attemptsFile } = await fixture(["crash", "crash"]);
@@ -103,7 +105,7 @@ describe("run-turbo Windows init-crash retry", () => {
 
     expect(result.exitCode).toBe(1);
     expect(await attempts(attemptsFile)).toBe(2);
-  });
+  }, 30_000);
 
   test("an ordinary failure without the signature is never retried", async () => {
     const { fakeTurbo, attemptsFile } = await fixture(["fail", "ok"]);
@@ -113,7 +115,7 @@ describe("run-turbo Windows init-crash retry", () => {
     expect(result.exitCode).toBe(1);
     expect(await attempts(attemptsFile)).toBe(1);
     expect(result.stderr).not.toContain("Retrying once");
-  });
+  }, 30_000);
 
   test("success passes through on the first attempt", async () => {
     const { fakeTurbo, attemptsFile } = await fixture(["ok"]);
@@ -122,7 +124,7 @@ describe("run-turbo Windows init-crash retry", () => {
 
     expect(result.exitCode).toBe(0);
     expect(await attempts(attemptsFile)).toBe(1);
-  });
+  }, 30_000);
 
   test("turbo output still streams through to the caller", async () => {
     const { fakeTurbo } = await fixture(["fail"]);
@@ -130,7 +132,7 @@ describe("run-turbo Windows init-crash retry", () => {
     const result = await invoke(fakeTurbo);
 
     expect(result.stdout).toContain("real compile error");
-  });
+  }, 30_000);
 
   test("RUN_TURBO_NO_INIT_CRASH_RETRY=1 disables the retry entirely", async () => {
     const { fakeTurbo, attemptsFile } = await fixture(["crash", "ok"]);
@@ -141,7 +143,7 @@ describe("run-turbo Windows init-crash retry", () => {
 
     expect(result.exitCode).toBe(1);
     expect(await attempts(attemptsFile)).toBe(1);
-  });
+  }, 30_000);
 
   test("without the force flag the retry stays Windows-only", async () => {
     const { fakeTurbo, attemptsFile } = await fixture(["crash", "ok"]);
@@ -161,5 +163,5 @@ describe("run-turbo Windows init-crash retry", () => {
       expect(child.exitCode).toBe(1);
       expect(await attempts(attemptsFile)).toBe(1);
     }
-  });
+  }, 30_000);
 });

--- a/packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts
+++ b/packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Proves run-turbo's bounded retry for the Windows 0xC0000142
+ * (STATUS_DLL_INIT_FAILED) child-process crash class: exactly one retry, only
+ * when the crash signature is present in Turbo output, resumable from the
+ * Turbo cache, loud on stderr, and off by default on non-Windows platforms.
+ * Real subprocesses via the RUN_TURBO_BIN seam — the fake turbo records each
+ * invocation so attempt counts are observable, no mocks.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const runTurbo = join(repoRoot, "packages/scripts/run-turbo.mjs");
+const tempDirs: string[] = [];
+
+/**
+ * Fake turbo: appends one line to the attempts file per invocation, then
+ * follows a per-attempt script of exit behaviors — "crash" prints the
+ * 0xC0000142 failure line Turbo emits and exits 1, "fail" exits 1 with an
+ * ordinary error line, "ok" exits 0.
+ */
+async function fixture(behaviors: Array<"crash" | "fail" | "ok">) {
+  const dir = await mkdtemp(join(tmpdir(), "run-turbo-init-crash-"));
+  tempDirs.push(dir);
+  const attemptsFile = join(dir, "attempts.txt");
+  const fakeTurbo = join(dir, "fake-turbo.mjs");
+  await writeFile(
+    fakeTurbo,
+    [
+      'import { appendFileSync, readFileSync } from "node:fs";',
+      `const attemptsFile = ${JSON.stringify(attemptsFile)};`,
+      'appendFileSync(attemptsFile, "x");',
+      'const attempt = readFileSync(attemptsFile, "utf8").length;',
+      `const behaviors = ${JSON.stringify(behaviors)};`,
+      'const behavior = behaviors[attempt - 1] ?? "ok";',
+      'if (behavior === "crash") {',
+      '  console.log("@elizaos/plugin-example#build:  ERROR  command (D:/a/eliza) bun.exe run build exited (-1073741502)");',
+      "  process.exit(1);",
+      "}",
+      'if (behavior === "fail") {',
+      '  console.log("@elizaos/plugin-example#build:  ERROR  command failed: real compile error");',
+      "  process.exit(1);",
+      "}",
+      "process.exit(0);",
+    ].join("\n"),
+  );
+  return { fakeTurbo, attemptsFile };
+}
+
+async function invoke(fakeTurbo: string, env: Record<string, string> = {}) {
+  const child = Bun.spawn([process.execPath, runTurbo, "run", "lint"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      RUN_TURBO_BIN: fakeTurbo,
+      RUN_TURBO_FORCE_INIT_CRASH_RETRY: "1",
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await child.exited;
+  return {
+    exitCode: child.exitCode,
+    stdout: await new Response(child.stdout).text(),
+    stderr: await new Response(child.stderr).text(),
+  };
+}
+
+async function attempts(attemptsFile: string): Promise<number> {
+  try {
+    return (await readFile(attemptsFile, "utf8")).length;
+  } catch {
+    return 0;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("run-turbo Windows init-crash retry", () => {
+  test("retries exactly once on the 0xC0000142 signature and succeeds from the second attempt", async () => {
+    const { fakeTurbo, attemptsFile } = await fixture(["crash", "ok"]);
+
+    const result = await invoke(fakeTurbo);
+
+    expect(result.exitCode).toBe(0);
+    expect(await attempts(attemptsFile)).toBe(2);
+    expect(result.stderr).toContain("STATUS_DLL_INIT_FAILED");
+    expect(result.stderr).toContain("Retrying once");
+  });
+
+  test("a persistent crash still fails after the single retry", async () => {
+    const { fakeTurbo, attemptsFile } = await fixture(["crash", "crash"]);
+
+    const result = await invoke(fakeTurbo);
+
+    expect(result.exitCode).toBe(1);
+    expect(await attempts(attemptsFile)).toBe(2);
+  });
+
+  test("an ordinary failure without the signature is never retried", async () => {
+    const { fakeTurbo, attemptsFile } = await fixture(["fail", "ok"]);
+
+    const result = await invoke(fakeTurbo);
+
+    expect(result.exitCode).toBe(1);
+    expect(await attempts(attemptsFile)).toBe(1);
+    expect(result.stderr).not.toContain("Retrying once");
+  });
+
+  test("success passes through on the first attempt", async () => {
+    const { fakeTurbo, attemptsFile } = await fixture(["ok"]);
+
+    const result = await invoke(fakeTurbo);
+
+    expect(result.exitCode).toBe(0);
+    expect(await attempts(attemptsFile)).toBe(1);
+  });
+
+  test("turbo output still streams through to the caller", async () => {
+    const { fakeTurbo } = await fixture(["fail"]);
+
+    const result = await invoke(fakeTurbo);
+
+    expect(result.stdout).toContain("real compile error");
+  });
+
+  test("RUN_TURBO_NO_INIT_CRASH_RETRY=1 disables the retry entirely", async () => {
+    const { fakeTurbo, attemptsFile } = await fixture(["crash", "ok"]);
+
+    const result = await invoke(fakeTurbo, {
+      RUN_TURBO_NO_INIT_CRASH_RETRY: "1",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(await attempts(attemptsFile)).toBe(1);
+  });
+
+  test("without the force flag the retry stays Windows-only", async () => {
+    const { fakeTurbo, attemptsFile } = await fixture(["crash", "ok"]);
+
+    const child = Bun.spawn([process.execPath, runTurbo, "run", "lint"], {
+      cwd: repoRoot,
+      env: { ...process.env, RUN_TURBO_BIN: fakeTurbo },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await child.exited;
+
+    if (process.platform === "win32") {
+      expect(child.exitCode).toBe(0);
+      expect(await attempts(attemptsFile)).toBe(2);
+    } else {
+      expect(child.exitCode).toBe(1);
+      expect(await attempts(attemptsFile)).toBe(1);
+    }
+  });
+});

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -149,39 +149,106 @@ if (
   turboArgs.splice(runIndex + 1, 0, "--log-order=stream");
 }
 
-const turboCommand = turboShim ?? process.execPath;
-const turboCommandArgs = turboShim
-  ? turboArgs
-  : [turboPackageBin, ...turboArgs];
+// Test seam: RUN_TURBO_BIN points at a Node script that stands in for the
+// turbo binary so the retry contract below is provable with real
+// subprocesses (see __tests__/run-turbo-windows-init-crash-retry.test.ts).
+const turboBinOverride = process.env.RUN_TURBO_BIN
+  ? path.resolve(process.env.RUN_TURBO_BIN)
+  : null;
+const turboCommand = turboBinOverride
+  ? process.execPath
+  : (turboShim ?? process.execPath);
+const turboCommandArgs = turboBinOverride
+  ? [turboBinOverride, ...turboArgs]
+  : turboShim
+    ? turboArgs
+    : [turboPackageBin, ...turboArgs];
 
-if (!turboShim && !fs.existsSync(turboPackageBin)) {
+if (!turboBinOverride && !turboShim && !fs.existsSync(turboPackageBin)) {
   console.error(
     `Unable to find turbo. Expected one of ${turboShimCandidates.join(", ")} or ${turboPackageBin}.`,
   );
   process.exit(1);
 }
 
-let child;
-try {
-  child = spawn(turboCommand, turboCommandArgs, {
-    cwd: process.cwd(),
-    env: process.env,
-    stdio: "inherit",
+// 0xC0000142 (STATUS_DLL_INIT_FAILED) as the signed 32-bit exit code Turbo
+// prints when a Windows child process dies before its entry point runs —
+// desktop-heap/session-resource exhaustion on busy CI runners, not a property
+// of the task. The task emits no output at all, so the only observable
+// signature is Turbo's own failure line. One bounded retry resumes from the
+// Turbo cache (completed tasks skip), and the retry is announced loudly so a
+// deterministic failure can never hide behind it.
+const WINDOWS_PROCESS_INIT_CRASH = "exited (-1073741502)";
+// The retry is live on Windows only (the crash class is a Windows runner
+// failure); RUN_TURBO_FORCE_INIT_CRASH_RETRY lets the contract tests exercise
+// the loop on every platform, RUN_TURBO_NO_INIT_CRASH_RETRY turns it off.
+const maxTurboAttempts =
+  process.env.RUN_TURBO_NO_INIT_CRASH_RETRY === "1"
+    ? 1
+    : process.platform === "win32" ||
+        process.env.RUN_TURBO_FORCE_INIT_CRASH_RETRY === "1"
+      ? 2
+      : 1;
+
+function runTurboOnce() {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(turboCommand, turboCommandArgs, {
+        cwd: process.cwd(),
+        env: process.env,
+        // Piped (not inherited) stdio so the crash signature is observable;
+        // --ui=stream/--log-order=stream are already forced above, so Turbo's
+        // output does not depend on TTY detection.
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+    } catch (error) {
+      console.error(`Failed to start turbo: ${error.message}`);
+      process.exit(1);
+    }
+
+    let sawInitCrash = false;
+    // The signature could straddle a chunk boundary; carry a tail shorter than
+    // the marker across writes.
+    const scan = (carry, chunk) => {
+      const text = carry + chunk.toString("utf8");
+      if (text.includes(WINDOWS_PROCESS_INIT_CRASH)) sawInitCrash = true;
+      return text.slice(-WINDOWS_PROCESS_INIT_CRASH.length);
+    };
+    let outCarry = "";
+    let errCarry = "";
+    child.stdout.on("data", (chunk) => {
+      outCarry = scan(outCarry, chunk);
+      process.stdout.write(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      errCarry = scan(errCarry, chunk);
+      process.stderr.write(chunk);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      resolve({ code: code ?? 1, sawInitCrash });
+    });
+
+    child.on("error", (error) => {
+      console.error(`Failed to start turbo: ${error.message}`);
+      process.exit(1);
+    });
   });
-} catch (error) {
-  console.error(`Failed to start turbo: ${error.message}`);
-  process.exit(1);
 }
 
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
+for (let attempt = 1; attempt <= maxTurboAttempts; attempt += 1) {
+  const { code, sawInitCrash } = await runTurboOnce();
+  if (code === 0) process.exit(0);
+  if (attempt < maxTurboAttempts && sawInitCrash) {
+    console.error(
+      `[run-turbo] A task child process died with 0xC0000142 (STATUS_DLL_INIT_FAILED) — a Windows runner resource crash, not task output. Retrying once from the Turbo cache (attempt ${attempt + 1}/${maxTurboAttempts}).`,
+    );
+    continue;
   }
-  process.exit(code ?? 1);
-});
-
-child.on("error", (error) => {
-  console.error(`Failed to start turbo: ${error.message}`);
-  process.exit(1);
-});
+  process.exit(code);
+}


### PR DESCRIPTION
## Summary

Windows CI's three turbo-invoking shards (`core-runtime`, `app-and-cli`, `build-and-helper-smokes`) fail intermittently with **zero diagnostic output**: a task child process dies with `0xC0000142` (`STATUS_DLL_INIT_FAILED`) before its entry point runs — a Windows runner desktop-heap/resource crash, not a property of the task. The two pure-bun-test shards pass in the same runs.

Evidence from develop run [30398014310](https://github.com/elizaOS/eliza/actions/runs/30398014310) (both attempts, same head `22c301e6a0`):
- attempt 2, build-and-helper-smokes: `@elizaos/plugin-coding-tools#build:  ERROR  command … bun.exe run build exited (-1073741502)` → `run failed`
- attempt 2, core-runtime: the `typecheck` invocation emits its last task output at 22:14:58, then dies at 22:16:51 with no task error and no turbo summary — the same crash class with the output lost entirely
- attempt 1: same three shards, different tasks, same silent "Command failed with exit code 1"
- the failing tests differ run-to-run (18:03 → a vitest test, 19:25 → core-runtime green, 20:49 → typecheck dead) — the moving-target signature of a runner resource crash, not a code failure

## Fix

`run-turbo.mjs` now pipes turbo output through a signature scanner and retries the whole invocation **once** when a task died with `-1073741502` — the Turbo cache makes the retry resume from the crashed task, so completed work is not repeated. The retry is:

- **loud** — announced on stderr with the crash code and attempt count, so a deterministic failure can never hide behind it;
- **narrow** — only that exact failure signature; an ordinary task failure is never retried;
- **bounded** — one retry, then the original exit code propagates;
- **Windows-only** by default (`RUN_TURBO_NO_INIT_CRASH_RETRY=1` disables; the tests force the loop cross-platform via `RUN_TURBO_FORCE_INIT_CRASH_RETRY`).

Piped (not inherited) stdio is safe here because run-turbo already forces `--ui=stream --log-order=stream`, so turbo's output shape does not depend on TTY detection.

## Verification

New `packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts` — same real-subprocess pattern as the existing run-turbo contract tests (no mocks), via a new `RUN_TURBO_BIN` seam whose fake turbo records every invocation:

- crash → retry once → success (exit 0, exactly 2 attempts, loud stderr)
- persistent crash → still fails after the single retry (exit 1, 2 attempts)
- ordinary failure without the signature → never retried (1 attempt)
- success → 1 attempt; output passthrough preserved
- `RUN_TURBO_NO_INIT_CRASH_RETRY=1` → disabled; without the force flag the retry stays Windows-only (asserted per-platform)

`bun test packages/scripts/__tests__/run-turbo-windows-init-crash-retry.test.ts` → 7/7 (this Windows box, 3 consecutive runs). Existing `run-turbo-typecheck-prerequisite.test.ts` (11) and `windows-ci-workflow.test.ts` still pass; `ci-turbo-cache-contract.test.ts` has one pre-existing local failure that reproduces identically **without** this change (verified by stash-baseline).



- [x] Before screenshots: N/A - CI infrastructure script; the linked run logs above are the before-state.
- [x] After screenshots: N/A - same.
- [x] Walkthrough video: N/A - no UI surface.
- [x] Backend logs: the run-log excerpts quoted above (runs 30398014310 attempts 1+2), plus the local 7/7 contract-test output.
- [x] Frontend console and network logs: N/A - no frontend.
- [x] Real-LLM trajectory: N/A - no agent/model behavior.
- [x] Domain artifacts: the contract test's per-attempt invocation records (attempts file) prove retry-once/no-retry/disable semantics with real subprocesses; the closing artifact is the next Windows CI run on develop after merge.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI infrastructure script (run-turbo.mjs); no rendered UI surface. The linked develop run logs are the before-state.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - same; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no UI flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [winci-crash-excerpts.txt](https://raw.githubusercontent.com/elizaOS/eliza/37712e6f1ded9c469189e57d0f66009660211e9e/winci-crash-excerpts.txt) — the exact 0xC0000142 failure lines from develop Windows CI run 30398014310 attempt 2 (both shards), plus the [contract-test-run.txt](https://raw.githubusercontent.com/elizaOS/eliza/37712e6f1ded9c469189e57d0f66009660211e9e/contract-test-run.txt) transcript (7/7 on this Windows box).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [contract-test-run.txt](https://raw.githubusercontent.com/elizaOS/eliza/37712e6f1ded9c469189e57d0f66009660211e9e/contract-test-run.txt) — real-subprocess run transcript proving retry-once / persistent-crash-still-fails / no-retry-without-signature / disable-flag / platform-gating semantics via per-attempt invocation records; the closing artifact is the next Windows CI run on develop after merge.

