### PR TITLE
fix(ci): expose Windows and script test failures

### DIFF
--- a/.github/ci-windows-command-inventory.json
+++ b/.github/ci-windows-command-inventory.json
@@ -1,7 +1,9 @@
 {
   "$comment": "Coverage floor for the Windows CI lane (#13402). Every command here must stay wired in some jobs.windows.strategy.matrix.include[].commands list in .github/workflows/windows-ci.yml. The Windows lane is a deliberately narrow subset of the Linux gates (see WINDOWS.md), so these suites are the only Windows proof for the runtime/dashboard/shared TypeScript packages — dropping one silently regresses coverage with a still-green pipeline. Enforced by packages/scripts/ci-windows-command-coverage-contract.mjs: adding a command is always allowed (this is a floor, not an exact match); to intentionally retire one, delete it from the matrix AND from this list in the SAME PR so the reduction is reviewable in the diff.",
   "commands": [
-    "node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4",
+    "bun run --cwd packages/core typecheck",
+    "bun run --cwd packages/shared typecheck",
+    "bun run --cwd packages/cloud/shared typecheck",
     "bun run --cwd packages/core test",
     "bun run --cwd packages/shared test",
     "bun run --cwd packages/app-core test",
@@ -18,7 +20,8 @@
     "bun run --cwd plugins/plugin-app-control test",
     "bun run --cwd plugins/plugin-task-coordinator test",
     "bun run --cwd plugins/plugin-browser test",
-    "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4",
+    "bun run --cwd plugins/plugin-coding-tools build",
+    "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=1",
     "node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh",
     "node packages/scripts/run-python.mjs --version",
     "node packages/scripts/test-cloud-run.mjs",

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -99,7 +99,11 @@ jobs:
           - lane: core-runtime
             timeout: 75
             commands:
-              - node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4
+              # Keep each package attributable and avoid expanding typecheck
+              # through Turbo's `^build` graph on resource-constrained Windows.
+              - bun run --cwd packages/core typecheck
+              - bun run --cwd packages/shared typecheck
+              - bun run --cwd packages/cloud/shared typecheck
               - bun run --cwd packages/core test
               - bun run --cwd packages/shared test
           - lane: app-and-cli
@@ -127,7 +131,10 @@ jobs:
           - lane: build-and-helper-smokes
             timeout: 90
             commands:
-              - node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4
+              # Prove the process that hit STATUS_DLL_INIT_FAILED in isolation,
+              # then retain agent's dependency build graph at serial pressure.
+              - bun run --cwd plugins/plugin-coding-tools build
+              - node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=1
               - node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh
               - node packages/scripts/run-python.mjs --version
               - node packages/scripts/test-cloud-run.mjs

--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -3,48 +3,98 @@
  * real Durable Object storage and request serialization preserve spend holds.
  */
 
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { fileURLToPath } from "node:url";
 import { Miniflare } from "miniflare";
 
-let miniflare: Miniflare;
+const ADMISSION_RUNTIME_BOUNDARY_FILTERS = {
+  dbClient:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]db[\\/]client\.ts$/,
+  cloudBindings:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]runtime[\\/]cloud-bindings\.ts$/,
+  admissionRecovery:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]services[\\/]inference-admission-recovery\.ts$/,
+  logger:
+    /(?:^|[\\/])packages[\\/]cloud[\\/]shared[\\/]src[\\/]lib[\\/]utils[\\/]logger\.ts$/,
+} as const;
 
-beforeAll(async () => {
-  const build = await Bun.build({
-    entrypoints: [
-      fileURLToPath(
-        new URL(
-          "../test/fixtures/inference-admission-gate-worker.ts",
-          import.meta.url,
-        ),
+const ADMISSION_RUNTIME_BOUNDARY_PATHS = [
+  {
+    name: "database client",
+    filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.dbClient,
+    relative: "packages/cloud/shared/src/db/client.ts",
+  },
+  {
+    name: "cloud bindings",
+    filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.cloudBindings,
+    relative: "packages/cloud/shared/src/lib/runtime/cloud-bindings.ts",
+  },
+  {
+    name: "admission recovery",
+    filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.admissionRecovery,
+    relative:
+      "packages/cloud/shared/src/lib/services/inference-admission-recovery.ts",
+  },
+  {
+    name: "logger",
+    filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.logger,
+    relative: "packages/cloud/shared/src/lib/utils/logger.ts",
+  },
+] as const;
+
+for (const { name, filter, relative } of ADMISSION_RUNTIME_BOUNDARY_PATHS) {
+  test(`build filter matches the ${name} on POSIX and Windows only`, () => {
+    expect(filter.test(`/work/eliza/${relative}`)).toBe(true);
+    expect(
+      filter.test(`D:\\work\\eliza\\${relative.replaceAll("/", "\\")}`),
+    ).toBe(true);
+    expect(filter.test(`/work/eliza-fork/${relative}.backup`)).toBe(false);
+    expect(
+      filter.test(
+        `/work/eliza/${relative.replace("/shared/", "/shared-sibling/")}`,
       ),
-    ],
-    format: "esm",
-    target: "browser",
-    conditions: ["worker", "browser"],
-    plugins: [
-      {
-        name: "admission-runtime-boundaries",
-        setup(build) {
-          build.onLoad(
-            { filter: /packages\/cloud\/shared\/src\/db\/client\.ts$/ },
-            () => ({
-              loader: "ts",
-              contents: `
+    ).toBe(false);
+  });
+}
+
+describe("Miniflare Durable Object integration", () => {
+  let miniflare: Miniflare;
+
+  beforeAll(async () => {
+    const build = await Bun.build({
+      entrypoints: [
+        fileURLToPath(
+          new URL(
+            "../test/fixtures/inference-admission-gate-worker.ts",
+            import.meta.url,
+          ),
+        ),
+      ],
+      format: "esm",
+      target: "browser",
+      conditions: ["worker", "browser"],
+      plugins: [
+        {
+          name: "admission-runtime-boundaries",
+          setup(build) {
+            build.onLoad(
+              { filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.dbClient },
+              () => ({
+                loader: "ts",
+                contents: `
               export async function runWithDbCacheAsync<T>(operation: () => Promise<T>): Promise<T> {
                 return await operation();
               }
             `,
-            }),
-          );
-          build.onLoad(
-            {
-              filter:
-                /packages\/cloud\/shared\/src\/lib\/runtime\/cloud-bindings\.ts$/,
-            },
-            () => ({
-              loader: "ts",
-              contents: `
+              }),
+            );
+            build.onLoad(
+              {
+                filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.cloudBindings,
+              },
+              () => ({
+                loader: "ts",
+                contents: `
                 export async function runWithCloudBindingsAsync<T>(
                   _bindings: Record<string, unknown>,
                   operation: () => Promise<T>,
@@ -52,27 +102,26 @@ beforeAll(async () => {
                   return await operation();
                 }
               `,
-            }),
-          );
-          build.onLoad(
-            {
-              filter:
-                /packages\/cloud\/shared\/src\/lib\/services\/inference-admission-recovery\.ts$/,
-            },
-            () => ({
-              loader: "ts",
-              contents: `
+              }),
+            );
+            build.onLoad(
+              {
+                filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.admissionRecovery,
+              },
+              () => ({
+                loader: "ts",
+                contents: `
                 export async function recoverExpiredInferenceAdmissionLease(): Promise<never> {
                   throw new Error("alarm recovery is outside this serialization test");
                 }
               `,
-            }),
-          );
-          build.onLoad(
-            { filter: /packages\/cloud\/shared\/src\/lib\/utils\/logger\.ts$/ },
-            () => ({
-              loader: "ts",
-              contents: `
+              }),
+            );
+            build.onLoad(
+              { filter: ADMISSION_RUNTIME_BOUNDARY_FILTERS.logger },
+              () => ({
+                loader: "ts",
+                contents: `
                 export const logger = {
                   debug() {},
                   info() {},
@@ -80,113 +129,115 @@ beforeAll(async () => {
                   error() {},
                 };
               `,
-            }),
-          );
+              }),
+            );
+          },
+        },
+      ],
+    });
+    if (!build.success) {
+      throw new AggregateError(
+        build.logs,
+        "Failed to bundle admission test Worker",
+      );
+    }
+    const output = build.outputs[0];
+    if (!output)
+      throw new Error("Admission test Worker bundle was not emitted");
+
+    miniflare = new Miniflare({
+      compatibilityDate: "2026-06-01",
+      compatibilityFlags: ["nodejs_compat"],
+      modules: true,
+      script: await output.text(),
+      durableObjects: {
+        TEST_ADMISSION_GATE: {
+          className: "InferenceAdmissionGate",
+          useSQLite: true,
         },
       },
-    ],
+    });
   });
-  if (!build.success) {
-    throw new AggregateError(
-      build.logs,
-      "Failed to bundle admission test Worker",
-    );
-  }
-  const output = build.outputs[0];
-  if (!output) throw new Error("Admission test Worker bundle was not emitted");
 
-  miniflare = new Miniflare({
-    compatibilityDate: "2026-06-01",
-    compatibilityFlags: ["nodejs_compat"],
-    modules: true,
-    script: await output.text(),
-    durableObjects: {
-      TEST_ADMISSION_GATE: {
-        className: "InferenceAdmissionGate",
-        useSQLite: true,
+  afterAll(async () => {
+    await miniflare?.dispose();
+  });
+
+  async function post(
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<{ readonly status: number; text(): Promise<string> }> {
+    const response = await miniflare.dispatchFetch(`https://gate.test${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-organization-id": "org-miniflare",
       },
-    },
-  });
-});
+      body: JSON.stringify(body),
+    });
+    return {
+      status: response.status,
+      text: async () => await response.text(),
+    };
+  }
 
-afterAll(async () => {
-  await miniflare?.dispose();
-});
+  test("real Durable Object serialization prevents concurrent overspend", async () => {
+    expect(
+      (
+        await post("/hydrate", {
+          balanceUsd: 10,
+          balanceAt: Date.now(),
+          balanceRevision: "1",
+        })
+      ).status,
+    ).toBe(200);
 
-async function post(
-  path: string,
-  body: Record<string, unknown>,
-): Promise<{ readonly status: number; text(): Promise<string> }> {
-  const response = await miniflare.dispatchFetch(`https://gate.test${path}`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-test-organization-id": "org-miniflare",
-    },
-    body: JSON.stringify(body),
-  });
-  return {
-    status: response.status,
-    text: async () => await response.text(),
-  };
-}
-
-test("real Durable Object serialization prevents concurrent overspend", async () => {
-  expect(
-    (
-      await post("/hydrate", {
-        balanceUsd: 10,
-        balanceAt: Date.now(),
-        balanceRevision: "1",
-      })
-    ).status,
-  ).toBe(200);
-
-  const [first, second] = await Promise.all([
-    post("/lease", {
-      organizationId: "org-miniflare",
-      requestId: "request-a",
-      balanceUsd: 10,
-      balanceRevision: "1",
-      estimatedCostUsd: 7,
-      recovery: {
-        version: 1,
-        kind: "organization",
+    const [first, second] = await Promise.all([
+      post("/lease", {
         organizationId: "org-miniflare",
-        userId: "00000000-0000-0000-0000-000000000002",
         requestId: "request-a",
-        model: "test-model",
-        provider: "test-provider",
-        billingSource: "test",
-        description: "Miniflare admission test",
-        accounting: { kind: "direct_debit" },
-      },
-    }),
-    post("/lease", {
-      organizationId: "org-miniflare",
-      requestId: "request-b",
-      balanceUsd: 10,
-      balanceRevision: "1",
-      estimatedCostUsd: 7,
-      recovery: {
-        version: 1,
-        kind: "organization",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 7,
+        recovery: {
+          version: 1,
+          kind: "organization",
+          organizationId: "org-miniflare",
+          userId: "00000000-0000-0000-0000-000000000002",
+          requestId: "request-a",
+          model: "test-model",
+          provider: "test-provider",
+          billingSource: "test",
+          description: "Miniflare admission test",
+          accounting: { kind: "direct_debit" },
+        },
+      }),
+      post("/lease", {
         organizationId: "org-miniflare",
-        userId: "00000000-0000-0000-0000-000000000002",
         requestId: "request-b",
-        model: "test-model",
-        provider: "test-provider",
-        billingSource: "test",
-        description: "Miniflare admission test",
-        accounting: { kind: "direct_debit" },
-      },
-    }),
-  ]);
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 7,
+        recovery: {
+          version: 1,
+          kind: "organization",
+          organizationId: "org-miniflare",
+          userId: "00000000-0000-0000-0000-000000000002",
+          requestId: "request-b",
+          model: "test-model",
+          provider: "test-provider",
+          billingSource: "test",
+          description: "Miniflare admission test",
+          accounting: { kind: "direct_debit" },
+        },
+      }),
+    ]);
 
-  if (first.status === 400 || second.status === 400) {
-    throw new Error(
-      `Unexpected gate validation response: ${first.status} ${await first.text()} / ${second.status} ${await second.text()}`,
-    );
-  }
-  expect([first.status, second.status].sort()).toEqual([200, 402]);
-}, 30_000);
+    if (first.status === 400 || second.status === 400) {
+      throw new Error(
+        `Unexpected gate validation response: ${first.status} ${await first.text()} / ${second.status} ${await second.text()}`,
+      );
+    }
+    expect([first.status, second.status].sort()).toEqual([200, 402]);
+  }, 30_000);
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -1,19 +1,13 @@
 /**
- * Table DDL for the tier-upgrade single-flight PGlite suites, mirroring the
- * Drizzle schemas the flows read and write (organizations, users,
- * user_characters, agent_sandboxes, api_keys, jobs). Executed as plain
- * statements instead of drizzle-kit `pushSchema` because drizzle-kit reacts to
- * internal errors with a silent `process.exit(1)`, which kills the whole
- * multi-file `bun test` process the coverage lane runs changed suites in
- * (#15943). Column lists were introspected from a real `pushSchema` apply;
- * every column of each Drizzle schema must exist here or `select()` fails
- * loudly with "column does not exist" — extend this file alongside any schema
- * change. Foreign keys are intentionally omitted (same as the harness in
- * `db/repositories/__tests__/jobs-recovery.test.ts`): the suites exercise
- * service invariants, not referential constraints.
+ * Table DDL for provisioning-job PGlite suites, mirroring the Drizzle schemas
+ * their service flows read and write. Plain statements avoid drizzle-kit's
+ * silent `process.exit(1)` on internal errors, which otherwise kills a
+ * multi-file Bun test process (#15943). Every selected Drizzle column must
+ * exist here so schema drift fails loudly; foreign keys are omitted because
+ * these suites exercise service invariants rather than referential constraints.
  */
 
-export const TIER_UPGRADE_TEST_TABLES: readonly string[] = [
+export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   `CREATE TABLE IF NOT EXISTS "organizations" (
   "id" uuid NOT NULL DEFAULT gen_random_uuid(),
   "name" text NOT NULL,
@@ -159,6 +153,8 @@ export const TIER_UPGRADE_TEST_TABLES: readonly string[] = [
   "character_id" uuid,
   "sandbox_id" text,
   "status" text NOT NULL DEFAULT 'pending'::text,
+  "lifecycle_job_id" uuid,
+  "lifecycle_execution_generation" uuid,
   "deletion_attempt_id" uuid,
   "deletion_started_at" timestamptz,
   "execution_tier" text NOT NULL DEFAULT 'shared'::text,
@@ -265,9 +261,13 @@ export const TIER_UPGRADE_TEST_TABLES: readonly string[] = [
   "estimated_completion_at" timestamp,
   "scheduled_for" timestamp NOT NULL DEFAULT now(),
   "started_at" timestamp,
+  "execution_generation" uuid,
+  "execution_quiesced_at" timestamp,
   "completed_at" timestamp,
   "created_at" timestamp NOT NULL DEFAULT now(),
   "updated_at" timestamp NOT NULL DEFAULT now(),
   PRIMARY KEY ("id")
 )`,
 ];
+
+export const TIER_UPGRADE_TEST_TABLES = PROVISIONING_JOB_TEST_TABLES;

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -13,10 +13,10 @@
  * exclusions the scan already enforces (non-running, warm-pool, null-bridge,
  * recently-backed-up) and the maxAgents cap.
  *
- * Harness mirrors `provisioning-jobs-wake-enqueue.test.ts`: drizzle-kit
- * `pushSchema` applies the real DDL (jobs + its FK closure) to the PGlite
- * connection the service queries through, and fails LOUDLY when the ambient
- * DATABASE_URL is a shared non-PGlite Postgres.
+ * The harness applies the shared provisioning-job DDL directly to the PGlite
+ * connection the service queries through. This keeps the proof isolated from
+ * drizzle-kit's process-level failure behavior and fails loudly when the
+ * ambient DATABASE_URL is a shared non-PGlite Postgres.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
@@ -30,16 +30,12 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
-import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
-import { apiKeys } from "../../db/schemas/api-keys";
-import { generations } from "../../db/schemas/generations";
 import { jobs } from "../../db/schemas/jobs";
 import { organizations } from "../../db/schemas/organizations";
-import { usageRecords } from "../../db/schemas/usage-records";
-import { userCharacters } from "../../db/schemas/user-characters";
 import { users } from "../../db/schemas/users";
+import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-schema";
 import { JOB_TYPES } from "./provisioning-job-types";
 import { provisioningJobService } from "./provisioning-jobs";
 
@@ -107,29 +103,18 @@ beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
     console.warn(
-      "[provisioning-jobs-scheduled-backup-sentinel.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+      "[provisioning-jobs-scheduled-backup-sentinel.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails because its fixture DDL would mutate the shared schema.",
     );
     return;
   }
   try {
-    // The jobs table's FK closure: jobs → apiKeys/generations, generations →
-    // usageRecords, agentSandboxes → userCharacters.
-    const schema = {
-      organizations,
-      users,
-      userCharacters,
-      apiKeys,
-      usageRecords,
-      generations,
-      agentSandboxes,
-      jobs,
-    };
-    const { apply } = await pushSchema(schema as never, dbWrite as never);
-    await apply();
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      await dbWrite.execute(sql.raw(ddl));
+    }
   } catch (error) {
     pgliteReady = false;
     console.error(
-      "[provisioning-jobs-scheduled-backup-sentinel.test] PGlite/pushSchema unavailable — cannot drive the scheduled-backup scan against a real DB. Failing all cases.",
+      "[provisioning-jobs-scheduled-backup-sentinel.test] PGlite/DDL unavailable — cannot drive the scheduled-backup scan against a real DB. Failing all cases.",
       error,
     );
   }
@@ -584,7 +569,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(1);
   });
 
-  test("conditional delete cancels a retry-pending job only after its quiescence window", async () => {
+  test("conditional delete cancels a retry-pending job after execution quiescence is acknowledged", async () => {
     const { orgId, userId } = await seedOwner();
     const createdAt = new Date(Date.now() - 20 * 60 * 1000);
     const agentName = "managed-dedicated-canary-r30081355987a1";
@@ -611,6 +596,8 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
       .set({
         status: "pending",
         started_at: createdAt,
+        execution_generation: "55555555-5555-4555-8555-555555555555",
+        execution_quiesced_at: createdAt,
         updated_at: createdAt,
       })
       .where(eq(jobs.id, provision.job.id));
@@ -632,7 +619,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     expect(await jobsOfType(sandbox.id, JOB_TYPES.AGENT_DELETE)).toHaveLength(1);
   });
 
-  for (const activeStatus of ["pending", "in_progress", "failed", "cancelled"] as const) {
+  for (const activeStatus of ["in_progress", "failed", "cancelled"] as const) {
     test(`conditional delete refuses a non-quiescent ${activeStatus} lifecycle job`, async () => {
       const { orgId, userId } = await seedOwner();
       const createdAt = new Date();
@@ -660,6 +647,8 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         .set({
           status: activeStatus,
           started_at: createdAt,
+          execution_generation: "55555555-5555-4555-8555-555555555555",
+          execution_quiesced_at: null,
           updated_at: createdAt,
         })
         .where(eq(jobs.id, provision.job.id));

--- a/packages/scripts/__tests__/script-test-inventory.test.ts
+++ b/packages/scripts/__tests__/script-test-inventory.test.ts
@@ -422,6 +422,69 @@ jobs:
     ).toBeLessThan(command.indexOf("packages/scripts/example.test.ts"));
   });
 
+  test("records Bun child and JUnit evidence exits independently", () => {
+    const file = "packages/scripts/example.test.ts";
+    const synthetic = inventory([file]);
+    const reports: Array<{
+      execution: {
+        childExitCode?: number | null;
+        evidenceExitCode?: number | null;
+        exitCode?: number;
+        junit?: { status: string };
+        status: string;
+      };
+    }> = [];
+    const status = runScriptTests({
+      inventory: synthetic,
+      junitPath: "reports/script-tests/separate-exits.xml",
+      reportPath: "reports/script-tests/separate-exits.json",
+      spawn: () => ({ error: undefined, signal: null, status: 0 }),
+      readJunit: () =>
+        `<testsuites tests="1" assertions="1" failures="0" skipped="0">
+          <testsuite name="${file}" file="${file}" tests="1" assertions="1" failures="0" skipped="0">
+            <unsupported />
+            <testcase name="works" file="${file}" assertions="1" />
+          </testsuite>
+        </testsuites>`,
+      writeReport: (_path: string, report: (typeof reports)[number]) => {
+        reports.push(report);
+      },
+    });
+    expect(status).toBe(1);
+    expect(reports.at(-1)?.execution).toMatchObject({
+      status: "failed",
+      exitCode: 1,
+      childExitCode: 0,
+      evidenceExitCode: 1,
+      junit: { status: "invalid" },
+    });
+
+    reports.length = 0;
+    const childFailure = runScriptTests({
+      inventory: synthetic,
+      junitPath: "reports/script-tests/child-failure.xml",
+      reportPath: "reports/script-tests/child-failure.json",
+      spawn: () => ({ error: undefined, signal: null, status: 19 }),
+      readJunit: () =>
+        `<testsuites tests="1" assertions="1" failures="0" skipped="0">
+          <testsuite name="${file}" file="${file}" tests="1" assertions="1" failures="0" skipped="0">
+            <testcase name="works" file="${file}" assertions="1" />
+          </testsuite>
+        </testsuites>`,
+      writeReport: (_path: string, report: (typeof reports)[number]) => {
+        reports.push(report);
+      },
+    });
+    expect(childFailure).toBe(19);
+    expect(reports.at(-1)?.execution).toMatchObject({
+      status: "failed",
+      exitCode: 19,
+      childExitCode: 19,
+      evidenceExitCode: 0,
+      junit: { status: "valid" },
+    });
+  });
+
   test("contains generated evidence under canonical reports paths", () => {
     expect(
       resolveReportArtifactPath(
@@ -683,6 +746,120 @@ jobs:
         "reports/junit.xml",
       ),
     ).toThrow("unexpected CDATA");
+  });
+
+  test("accepts exact Bun CI properties and rejects metadata smuggling", () => {
+    const file = "packages/scripts/example.test.ts";
+    const base = `<?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="bun test" tests="1" assertions="2" failures="0" skipped="0" time="0.1">
+        <testsuite name="${file}" file="${file}" tests="1" assertions="2" failures="0" skipped="0" time="0.1" hostname="runnervmvrwv9">
+          METADATA
+          <testcase name="works" classname="" time="0.01" file="${file}" line="1" assertions="2" />
+        </testsuite>
+      </testsuites>`;
+    const exactBunCiMetadata = `<properties>
+      <property name="ci" value="https://github.com/elizaOS/eliza/actions/runs/30391860793" />
+      <property name="commit" value="5276c1b2ba32a51a938e8489b87a8c92e5ca03d8" />
+    </properties>`;
+    const documentWith = (metadata: string) =>
+      base.replace("METADATA", metadata);
+
+    expect(
+      validateJunitEvidence(
+        documentWith(exactBunCiMetadata),
+        [file],
+        "reports/junit.xml",
+      ),
+    ).toMatchObject({
+      status: "valid",
+      tests: 1,
+      assertions: 2,
+      suiteFileCount: 1,
+    });
+
+    const invalidMetadata = [
+      {
+        name: "root location",
+        xml: documentWith("").replace(
+          "<testsuites ",
+          `${exactBunCiMetadata}<testsuites `,
+        ),
+      },
+      {
+        name: "property outside its container",
+        xml: documentWith('<property name="ci" value="run" />'),
+      },
+      {
+        name: "duplicate container",
+        xml: documentWith(`${exactBunCiMetadata}${exactBunCiMetadata}`),
+      },
+      {
+        name: "duplicate property name",
+        xml: documentWith(
+          '<properties><property name="ci" value="run" /><property name="ci" value="other" /></properties>',
+        ),
+      },
+      {
+        name: "missing name",
+        xml: documentWith('<properties><property value="run" /></properties>'),
+      },
+      {
+        name: "blank name",
+        xml: documentWith(
+          '<properties><property name="  " value="run" /></properties>',
+        ),
+      },
+      {
+        name: "missing value",
+        xml: documentWith('<properties><property name="ci" /></properties>'),
+      },
+      {
+        name: "blank value",
+        xml: documentWith(
+          '<properties><property name="ci" value="  " /></properties>',
+        ),
+      },
+      {
+        name: "extra property attribute",
+        xml: documentWith(
+          '<properties><property name="ci" value="run" file="smuggled.test.ts" /></properties>',
+        ),
+      },
+      {
+        name: "container attribute",
+        xml: documentWith(
+          '<properties tests="1"><property name="ci" value="run" /></properties>',
+        ),
+      },
+      {
+        name: "text content",
+        xml: documentWith(
+          '<properties>smuggled<property name="ci" value="run" /></properties>',
+        ),
+      },
+      {
+        name: "nested properties",
+        xml: documentWith(
+          '<properties><properties><property name="ci" value="run" /></properties></properties>',
+        ),
+      },
+      {
+        name: "testcase smuggling",
+        xml: documentWith(
+          `<properties><property name="ci" value="run"><testcase name="hidden" file="${file}" assertions="99" /></property></properties>`,
+        ),
+      },
+    ];
+    expect(
+      invalidMetadata.map(({ name, xml }) => {
+        try {
+          validateJunitEvidence(xml, [file], "reports/junit.xml");
+          return { name, rejected: false };
+        } catch {
+          return { name, rejected: true };
+        }
+      }),
+    ).toEqual(invalidMetadata.map(({ name }) => ({ name, rejected: true })));
   });
 
   test("binds JUnit skip evidence to the real conditional-skip classifier", () => {

--- a/packages/scripts/__tests__/windows-ci-workflow.test.ts
+++ b/packages/scripts/__tests__/windows-ci-workflow.test.ts
@@ -8,6 +8,27 @@ const workflowText = readFileSync(
   new URL("../../../.github/workflows/windows-ci.yml", import.meta.url),
   "utf8",
 );
+const provisioningCompositeText = readFileSync(
+  new URL(
+    "../../cloud/shared/src/lib/services/provisioning-jobs-16639-lane.test.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const scheduledBackupText = readFileSync(
+  new URL(
+    "../../cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const provisioningDdlText = readFileSync(
+  new URL(
+    "../../cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
 
 const EXPECTED_LANES = [
   "core-runtime",
@@ -18,7 +39,9 @@ const EXPECTED_LANES = [
 ];
 
 const EXPECTED_COMMANDS = [
-  "node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4",
+  "bun run --cwd packages/core typecheck",
+  "bun run --cwd packages/shared typecheck",
+  "bun run --cwd packages/cloud/shared typecheck",
   "bun run --cwd packages/core test",
   "bun run --cwd packages/shared test",
   "bun run --cwd packages/app-core test",
@@ -35,7 +58,8 @@ const EXPECTED_COMMANDS = [
   "bun run --cwd plugins/plugin-app-control test",
   "bun run --cwd plugins/plugin-task-coordinator test",
   "bun run --cwd plugins/plugin-browser test",
-  "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4",
+  "bun run --cwd plugins/plugin-coding-tools build",
+  "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=1",
   "node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh",
   "node packages/scripts/run-python.mjs --version",
   "node packages/scripts/test-cloud-run.mjs",
@@ -65,11 +89,48 @@ describe("Windows CI workflow", () => {
     expect(new Set(commands).size).toBe(commands.length);
   });
 
+  test("keeps typecheck failures attributable and Windows builds serial", () => {
+    expect(workflowText).not.toContain(
+      "run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared",
+    );
+    expect(workflowText).not.toContain(
+      "run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4",
+    );
+    for (const command of [
+      "bun run --cwd packages/core typecheck",
+      "bun run --cwd packages/shared typecheck",
+      "bun run --cwd packages/cloud/shared typecheck",
+      "bun run --cwd plugins/plugin-coding-tools build",
+      "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=1",
+    ]) {
+      expect(workflowText).toContain(command);
+    }
+  });
+
   test("delegates the Windows PGlite quarantine to the package runner", () => {
     expect(workflowText).not.toContain("--path-ignore-patterns");
     expect(workflowText).not.toContain("Retry-isolated tenant-db PGlite suite");
     expect(workflowText).not.toContain(
       "bun run --cwd packages/cloud/shared test $suite",
     );
+  });
+
+  test("keeps the 16639 composite on plain PGlite DDL", () => {
+    expect(provisioningCompositeText).toContain(
+      'import "./provisioning-jobs-scheduled-backup-sentinel.test.ts"',
+    );
+    expect(scheduledBackupText).toContain(
+      'import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-schema"',
+    );
+    expect(scheduledBackupText).not.toContain("drizzle-kit/api");
+    expect(scheduledBackupText).not.toContain("pushSchema");
+    expect(provisioningDdlText).toContain(
+      "export const PROVISIONING_JOB_TEST_TABLES",
+    );
+    expect(provisioningDdlText).toContain(
+      '"lifecycle_execution_generation" uuid',
+    );
+    expect(provisioningDdlText).toContain('"execution_generation" uuid');
+    expect(provisioningDdlText).toContain('"execution_quiesced_at" timestamp');
   });
 });

--- a/packages/scripts/run-script-tests.mjs
+++ b/packages/scripts/run-script-tests.mjs
@@ -120,9 +120,15 @@ function parseJunitDocument(xml) {
   });
   parser.on("opentag", (tag) => {
     if (
-      !["testsuites", "testsuite", "testcase", "failure", "skipped"].includes(
-        tag.name,
-      )
+      ![
+        "testsuites",
+        "testsuite",
+        "properties",
+        "property",
+        "testcase",
+        "failure",
+        "skipped",
+      ].includes(tag.name)
     ) {
       throw new Error(
         `JUnit artifact contains unsupported <${tag.name}> element`,
@@ -133,6 +139,8 @@ function parseJunitDocument(xml) {
       (tag.name === "testsuites" && parent === undefined) ||
       (tag.name === "testsuite" &&
         (parent?.name === "testsuites" || parent?.name === "testsuite")) ||
+      (tag.name === "properties" && parent?.name === "testsuite") ||
+      (tag.name === "property" && parent?.name === "properties") ||
       (tag.name === "testcase" && parent?.name === "testsuite") ||
       ((tag.name === "failure" || tag.name === "skipped") &&
         parent?.name === "testcase");
@@ -145,6 +153,48 @@ function parseJunitDocument(xml) {
       throw new Error(
         "JUnit artifact must contain one complete testsuites root",
       );
+    }
+    if (tag.name === "properties") {
+      if (Object.keys(tag.attributes).length > 0) {
+        throw new Error("JUnit properties container may not have attributes");
+      }
+      if (parent.children.some(({ name }) => name === "properties")) {
+        throw new Error(
+          "JUnit testsuite may contain only one properties container",
+        );
+      }
+    }
+    if (tag.name === "property") {
+      const attributeNames = Object.keys(tag.attributes).sort();
+      if (
+        attributeNames.length !== 2 ||
+        attributeNames[0] !== "name" ||
+        attributeNames[1] !== "value"
+      ) {
+        throw new Error(
+          "JUnit property must contain only name and value attributes",
+        );
+      }
+      const name = tag.attributes.name;
+      const value = tag.attributes.value;
+      if (
+        typeof name !== "string" ||
+        name.trim().length === 0 ||
+        typeof value !== "string" ||
+        value.trim().length === 0
+      ) {
+        throw new Error(
+          "JUnit property must have nonempty name and value attributes",
+        );
+      }
+      if (
+        parent.children.some(
+          (child) =>
+            child.name === "property" && child.attributes.name === name,
+        )
+      ) {
+        throw new Error(`JUnit properties contains duplicate name ${name}`);
+      }
     }
     const node = {
       name: tag.name,
@@ -219,6 +269,7 @@ function reconcileSuite(suite, inheritedFile, identities) {
 
   const actual = { tests: 0, assertions: 0, failures: 0, skipped: 0 };
   for (const child of suite.children) {
+    if (child.name === "properties") continue;
     const counts =
       child.name === "testcase"
         ? reconcileTestcase(child, file)
@@ -340,6 +391,7 @@ export function runScriptTests(options = {}) {
   const reportPath = options.reportPath;
   const junitPath = options.junitPath;
   const writeReport = options.writeReport ?? atomicWriteJson;
+  const readJunit = options.readJunit ?? ((file) => readFileSync(file, "utf8"));
   const resolvedReport = reportPath
     ? resolveReportArtifactPath(REPO_ROOT, reportPath, {
         extension: ".json",
@@ -377,6 +429,8 @@ export function runScriptTests(options = {}) {
       normalizedReportPath,
       reportRecord(inventory, {
         status: "running",
+        childExitCode: null,
+        evidenceExitCode: null,
         command: ["bun", ...bunArgs],
         junit:
           normalizedJunitPath === undefined
@@ -399,6 +453,8 @@ export function runScriptTests(options = {}) {
         reportRecord(inventory, {
           status: "failed",
           exitCode: 1,
+          childExitCode: null,
+          evidenceExitCode: null,
           signal: null,
           spawnError: result.error.message,
           command: ["bun", ...bunArgs],
@@ -413,19 +469,20 @@ export function runScriptTests(options = {}) {
       cause: result.error,
     });
   }
-  let status =
+  const childExitCode =
     typeof result.status === "number" && result.signal === null
       ? result.status
       : 1;
+  let evidenceExitCode = absoluteJunitPath ? 0 : null;
   let junit = null;
   if (absoluteJunitPath && normalizedJunitPath) {
     try {
       junit = validateJunitEvidence(
-        readFileSync(absoluteJunitPath, "utf8"),
+        readJunit(absoluteJunitPath),
         inventory.files.map(({ file }) => file),
         normalizedJunitPath,
       );
-      if (junit.failures > 0) status = status || 1;
+      if (junit.failures > 0) evidenceExitCode = 1;
     } catch (error) {
       // error-policy:J3 malformed, unreadable, or policy-violating JUnit
       // evidence becomes an explicit "invalid" record and a failing exit code
@@ -435,22 +492,25 @@ export function runScriptTests(options = {}) {
         path: normalizedJunitPath,
         error: error instanceof Error ? error.message : String(error),
       };
-      status = status || 1;
+      evidenceExitCode = 1;
     }
   }
+  const exitCode = childExitCode || evidenceExitCode || 0;
   if (normalizedReportPath) {
     writeReport(
       normalizedReportPath,
       reportRecord(inventory, {
-        status: status === 0 ? "passed" : "failed",
-        exitCode: status,
+        status: exitCode === 0 ? "passed" : "failed",
+        exitCode,
+        childExitCode,
+        evidenceExitCode,
         signal: result.signal ?? null,
         command: ["bun", ...bunArgs],
         junit,
       }),
     );
   }
-  return status;
+  return exitCode;
 }
 
 function printUsage() {


### PR DESCRIPTION
Relates #16336 and #13402.

## Root cause

Two develop failures were opaque rather than product failures:

- Bun completed the full `packages/scripts` sweep with 1,236 tests and 24,494 assertions, but its valid CI `<properties>` metadata was rejected by the strict JUnit parser. The runner then collapsed the Bun child exit and evidence-validation exit into one code.
- Windows grouped multiple typechecks/builds into concurrent Turbo processes, hiding the failing package and triggering `STATUS_DLL_INIT_FAILED` under resource pressure. The scheduled-backup PGlite fixture also used drizzle-kit `pushSchema`, whose internal `process.exit(1)` could terminate the entire multi-file runner.

## Repair

- accept Bun’s exact `properties/property` JUnit shape while rejecting duplicate, nested, attributed, textual, or testcase-smuggling metadata
- record child and evidence exit codes independently and derive the final exit without losing either cause
- run Windows typechecks per package for attribution
- prove `plugin-coding-tools` independently, then run the remaining Turbo build graph serially
- use shared plain PGlite DDL for scheduled-backup coverage
- make Miniflare build filters separator-portable and sibling-safe

## Validation

- exact head: `f8a1bc92b471ce6854be8dcef82fbad86506cccf`
- exact base: `00d6f6cdaeb40d9d70e9664ebaccbd8169718f26`
- exact failed-job artifact independently validates 1,236 tests, 24,494 assertions, 123 suites, zero failures
- runner/JUnit focused tests: 19 relevant assertions passed; the dirty checkout-only repository inventory case is blocked by large untracked benchmark trees, while clean CI evidence validates
- Windows workflow contracts: 5/5 passed
- Miniflare separator contracts: 4/4 passed
- scheduled-backup PGlite: 29/29 passed
- tier-upgrade PGlite: 15/15 passed
- core/shared/cloud-shared typechecks, plugin-coding-tools build, and serial Turbo dependency build passed
- focused Biome and diff checks passed

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - CI/test-runner behavior only.

<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing interaction flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend/CI logs: [develop Scenario run](https://github.com/elizaOS/eliza/actions/runs/30398015951) and [develop Windows run](https://github.com/elizaOS/eliza/actions/runs/30398014310) contain the reproduced failures; fresh exact-head logs pending.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - CI runner metadata and exit attribution only; no product domain object is created or mutated.

## Remaining evidence

This stays draft until exact-head Windows and Scenario workflows pass and an independent review confirms the workflow decomposition has not reduced coverage.
