### PR TITLE
fix(cloud): make orphan reaping ownership-safe

### DIFF
--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -141,6 +141,17 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
   `);
 
   await dbWrite.execute(sql`
+    CREATE INDEX IF NOT EXISTS "agent_sandboxes_container_name_idx"
+      ON "agent_sandboxes" ("container_name")
+  `);
+
+  await dbWrite.execute(sql`
+    CREATE INDEX IF NOT EXISTS "agent_sandboxes_replacement_cleanup_container_name_idx"
+      ON "agent_sandboxes" ("replacement_cleanup_container_name")
+      WHERE "replacement_cleanup_container_name" IS NOT NULL
+  `);
+
+  await dbWrite.execute(sql`
     CREATE INDEX IF NOT EXISTS "agent_sandboxes_replacement_cleanup_pending_idx"
       ON "agent_sandboxes" ("replacement_cleanup_created_at")
       WHERE "replacement_cleanup_sandbox_id" IS NOT NULL

--- a/packages/cloud/shared/src/db/migrations/0186_agent_sandbox_physical_name_indexes.sql
+++ b/packages/cloud/shared/src/db/migrations/0186_agent_sandbox_physical_name_indexes.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS "agent_sandboxes_container_name_idx"
+	ON "agent_sandboxes" USING btree ("container_name");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sandboxes_replacement_cleanup_container_name_idx"
+	ON "agent_sandboxes" USING btree ("replacement_cleanup_container_name")
+	WHERE "replacement_cleanup_container_name" IS NOT NULL;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1296,6 +1296,13 @@
       "when": 1785384000000,
       "tag": "0185_job_execution_interruptions",
       "breakpoints": true
+    },
+    {
+      "idx": 185,
+      "version": "7",
+      "when": 1785528000000,
+      "tag": "0186_agent_sandbox_physical_name_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -229,6 +229,7 @@ export const agentSandboxes = pgTable(
     status_idx: index("agent_sandboxes_status_idx").on(table.status),
     character_idx: index("agent_sandboxes_character_idx").on(table.character_id),
     sandbox_id_idx: index("agent_sandboxes_sandbox_id_idx").on(table.sandbox_id),
+    container_name_idx: index("agent_sandboxes_container_name_idx").on(table.container_name),
     billing_status_idx: index("agent_sandboxes_billing_status_idx").on(table.billing_status),
     deleted_at_idx: index("agent_sandboxes_deleted_at_idx").on(table.deleted_at),
     lifecycle_execution_pair_check: check(
@@ -319,6 +320,11 @@ export const agentSandboxes = pgTable(
     replacement_cleanup_pending_idx: index("agent_sandboxes_replacement_cleanup_pending_idx")
       .on(table.replacement_cleanup_created_at)
       .where(sql`${table.replacement_cleanup_sandbox_id} IS NOT NULL`),
+    replacement_cleanup_container_name_idx: index(
+      "agent_sandboxes_replacement_cleanup_container_name_idx",
+    )
+      .on(table.replacement_cleanup_container_name)
+      .where(sql`${table.replacement_cleanup_container_name} IS NOT NULL`),
   }),
 );
 

--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
@@ -3,12 +3,13 @@
  * containers (#17253 §1).
  *
  * A container claimed from the warm pool keeps the name it was born with —
- * `agent-<pool id>` — while the pool row it points at is deleted at claim time.
- * The claimed USER row records the provenance in `warm_claim_source_pool_id`.
- * Resolving node-side keys against `id` alone maps every claimed customer
- * container to a deleted row, and the sweep reaps it as `no_db_row` while the
- * customer is talking to it. The loader must therefore surface a placement for
- * the POOL key whenever a row claims it as its source.
+ * `agent-<pool id>` — for its WHOLE life, while the pool row it points at is
+ * deleted at claim time and `warm_claim_source_pool_id` is NULLed once the
+ * credential handoff finalizes. The durable link is `container_name`, persisted
+ * on the claimed row at claim time. Resolving node-side keys against `id`
+ * alone maps every claimed customer container to a deleted row, and the sweep
+ * reaps it as `no_db_row` while the customer is talking to it — including the
+ * steady state every SUCCESSFULLY claimed agent settles into.
  *
  * Drives the REAL loadSandboxStatusesByIds against in-process PGlite (real
  * Drizzle schema via pushSchema) with NOTHING mocked. Fails LOUDLY if
@@ -99,6 +100,7 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
           execution_tier: "dedicated-always",
           node_id: "node-7",
           warm_claim_source_pool_id: poolId,
+          container_name: `agent-${poolId}`,
         })
         .returning();
 
@@ -110,6 +112,40 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
       expect(forPoolKey[0]?.status).toBe("running");
       expect(forPoolKey[0]?.nodeId).toBe("node-7");
       // The row's own key is still protected too.
+      expect(placements.some((p) => p.key === row.id)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the FINALIZED steady state stays protected: pool id NULLed, name alone links the container",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const poolId = crypto.randomUUID();
+      // What finalizeWarmClaimCredentialHandoff leaves behind for every
+      // successfully claimed agent, for the rest of its life: container still
+      // named agent-<poolId>, warm_claim_source_pool_id NULL.
+      const [row] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("finalized"),
+          status: "running",
+          execution_tier: "dedicated-always",
+          node_id: "node-7",
+          warm_claim_source_pool_id: null,
+          container_name: `agent-${poolId}`,
+        })
+        .returning();
+
+      const placements = await loadSandboxStatusesByIds([poolId]);
+
+      const forPoolKey = placements.filter((p) => p.key === poolId);
+      expect(forPoolKey.length).toBeGreaterThanOrEqual(1);
+      expect(forPoolKey[0]?.status).toBe("running");
+      expect(forPoolKey[0]?.nodeId).toBe("node-7");
       expect(placements.some((p) => p.key === row.id)).toBe(true);
     },
     PGLITE_TIMEOUT,
@@ -141,6 +177,7 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
           execution_tier: "dedicated-always",
           node_id: "node-7",
           warm_claim_source_pool_id: poolId,
+          container_name: `agent-${poolId}`,
           // Full locator: the pair CHECK requires the whole tuple or none.
           replacement_cleanup_sandbox_id: crypto.randomUUID(),
           replacement_cleanup_node_id: "node-8",

--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
@@ -1,26 +1,11 @@
 /**
- * Real-DB proof that the orphan reaper's key resolution protects warm-claimed
- * containers (#17253 §1).
- *
- * A container claimed from the warm pool keeps the name it was born with —
- * `agent-<pool id>` — for its WHOLE life, while the pool row it points at is
- * deleted at claim time and `warm_claim_source_pool_id` is NULLed once the
- * credential handoff finalizes. The durable link is `container_name`, persisted
- * on the claimed row at claim time. Resolving node-side keys against `id`
- * alone maps every claimed customer container to a deleted row, and the sweep
- * reaps it as `no_db_row` while the customer is talking to it — including the
- * steady state every SUCCESSFULLY claimed agent settles into.
- *
- * Drives the REAL loadSandboxStatusesByIds against in-process PGlite (real
- * Drizzle schema via pushSchema) with NOTHING mocked. Fails LOUDLY if
- * PGlite/pushSchema is unavailable (never silently passes).
+ * Exercises warm-claim and cleanup-fence name resolution against an in-process
+ * PGlite schema so physical container ownership cannot be mistaken for absence.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
@@ -33,7 +18,6 @@ import { users } from "../../../db/schemas/users";
 
 const PGLITE_TIMEOUT = 60_000;
 
-let pgliteReady = true;
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let loadSandboxStatusesByIds: typeof import("../docker-node-workloads").loadSandboxStatusesByIds;
@@ -57,24 +41,14 @@ async function seedOwner(): Promise<{ orgId: string; userId: string }> {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    console.warn("[orphan-reaper-warm-claim-keys.test] non-PGlite DATABASE_URL; failing.");
-    return;
+  if (AMBIENT_DATABASE_URL !== "" && !AMBIENT_DATABASE_URL.startsWith("pglite")) {
+    throw new Error("This suite requires an isolated PGlite DATABASE_URL");
   }
-  try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
-    ({ loadSandboxStatusesByIds } = await import("../docker-node-workloads"));
-    const schema = { organizations, users, userCharacters, agentSandboxes };
-    const { apply } = await pushSchema(schema as never, dbWrite as never);
-    await apply();
-  } catch (error) {
-    pgliteReady = false;
-    console.error(
-      "[orphan-reaper-warm-claim-keys.test] PGlite/pushSchema unavailable — failing.",
-      error,
-    );
-  }
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  ({ loadSandboxStatusesByIds } = await import("../docker-node-workloads"));
+  const schema = { organizations, users, userCharacters, agentSandboxes };
+  const { apply } = await pushSchema(schema as never, dbWrite as never);
+  await apply();
 }, PGLITE_TIMEOUT);
 
 afterAll(async () => {
@@ -85,11 +59,8 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
   test(
     "a pool key resolves to the live claimed row, on the row's node",
     async () => {
-      expect(pgliteReady).toBe(true);
       const { orgId, userId } = await seedOwner();
       const poolId = crypto.randomUUID();
-      // The claimed USER row: its own id differs from the pool id its
-      // container is named after; the pool row itself no longer exists.
       const [row] = await dbWrite
         .insert(agentSandboxes)
         .values({
@@ -104,28 +75,22 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
         })
         .returning();
 
-      // The reaper resolves the key it parsed from `agent-<pool id>`.
       const placements = await loadSandboxStatusesByIds([poolId]);
 
       const forPoolKey = placements.filter((p) => p.key === poolId);
       expect(forPoolKey.length).toBeGreaterThanOrEqual(1);
       expect(forPoolKey[0]?.status).toBe("running");
       expect(forPoolKey[0]?.nodeId).toBe("node-7");
-      // The row's own key is still protected too.
       expect(placements.some((p) => p.key === row.id)).toBe(true);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "the FINALIZED steady state stays protected: pool id NULLed, name alone links the container",
+    "the finalized steady state resolves by physical name after the source id is cleared",
     async () => {
-      expect(pgliteReady).toBe(true);
       const { orgId, userId } = await seedOwner();
       const poolId = crypto.randomUUID();
-      // What finalizeWarmClaimCredentialHandoff leaves behind for every
-      // successfully claimed agent, for the rest of its life: container still
-      // named agent-<poolId>, warm_claim_source_pool_id NULL.
       const [row] = await dbWrite
         .insert(agentSandboxes)
         .values({
@@ -152,9 +117,8 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
   );
 
   test(
-    "a pool id claimed by NO row yields no placement (a true orphan still reaps)",
+    "an unclaimed pool id yields no placement",
     async () => {
-      expect(pgliteReady).toBe(true);
       const placements = await loadSandboxStatusesByIds([crypto.randomUUID()]);
       expect(placements).toEqual([]);
     },
@@ -162,38 +126,41 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
   );
 
   test(
-    "a replacement placement is mirrored onto the pool key as well",
+    "a cleanup-fenced physical name protects only its own placement",
     async () => {
-      expect(pgliteReady).toBe(true);
       const { orgId, userId } = await seedOwner();
-      const poolId = crypto.randomUUID();
+      const rowId = crypto.randomUUID();
+      const cleanupNameId = crypto.randomUUID();
       await dbWrite
         .insert(agentSandboxes)
         .values({
+          id: rowId,
           organization_id: orgId,
           user_id: userId,
           agent_name: uniq("claimed"),
           status: "running",
           execution_tier: "dedicated-always",
           node_id: "node-7",
-          warm_claim_source_pool_id: poolId,
-          container_name: `agent-${poolId}`,
-          // Full locator: the pair CHECK requires the whole tuple or none.
+          container_name: `agent-${rowId}`,
           replacement_cleanup_sandbox_id: crypto.randomUUID(),
           replacement_cleanup_node_id: "node-8",
-          replacement_cleanup_container_name: "agent-old-twin",
+          replacement_cleanup_container_name: `agent-${cleanupNameId}`,
           replacement_cleanup_attempt_id: crypto.randomUUID(),
           replacement_cleanup_allocation_counted: true,
           replacement_cleanup_created_at: new Date(),
         })
         .returning();
 
-      const placements = await loadSandboxStatusesByIds([poolId]);
-      const replacementForPool = placements.filter(
-        (p) => p.key === poolId && p.status === "replacement_cleanup_owned",
-      );
-      expect(replacementForPool).toHaveLength(1);
-      expect(replacementForPool[0]?.nodeId).toBe("node-8");
+      const placements = await loadSandboxStatusesByIds([cleanupNameId]);
+      const forCleanupName = placements.filter((placement) => placement.key === cleanupNameId);
+      expect(forCleanupName).toEqual([
+        {
+          key: cleanupNameId,
+          status: "replacement_cleanup_owned",
+          nodeId: "node-8",
+          updatedAtMs: expect.any(Number),
+        },
+      ]);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Real-DB proof that the orphan reaper's key resolution protects warm-claimed
+ * containers (#17253 §1).
+ *
+ * A container claimed from the warm pool keeps the name it was born with —
+ * `agent-<pool id>` — while the pool row it points at is deleted at claim time.
+ * The claimed USER row records the provenance in `warm_claim_source_pool_id`.
+ * Resolving node-side keys against `id` alone maps every claimed customer
+ * container to a deleted row, and the sweep reaps it as `no_db_row` while the
+ * customer is talking to it. The loader must therefore surface a placement for
+ * the POOL key whenever a row claims it as its source.
+ *
+ * Drives the REAL loadSandboxStatusesByIds against in-process PGlite (real
+ * Drizzle schema via pushSchema) with NOTHING mocked. Fails LOUDLY if
+ * PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { organizations } from "../../../db/schemas/organizations";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let loadSandboxStatusesByIds: typeof import("../docker-node-workloads").loadSandboxStatusesByIds;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "1.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[orphan-reaper-warm-claim-keys.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ loadSandboxStatusesByIds } = await import("../docker-node-workloads"));
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[orphan-reaper-warm-claim-keys.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("orphan reaper key resolution for warm-claimed containers", () => {
+  test(
+    "a pool key resolves to the live claimed row, on the row's node",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const poolId = crypto.randomUUID();
+      // The claimed USER row: its own id differs from the pool id its
+      // container is named after; the pool row itself no longer exists.
+      const [row] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("claimed"),
+          status: "running",
+          execution_tier: "dedicated-always",
+          node_id: "node-7",
+          warm_claim_source_pool_id: poolId,
+        })
+        .returning();
+
+      // The reaper resolves the key it parsed from `agent-<pool id>`.
+      const placements = await loadSandboxStatusesByIds([poolId]);
+
+      const forPoolKey = placements.filter((p) => p.key === poolId);
+      expect(forPoolKey.length).toBeGreaterThanOrEqual(1);
+      expect(forPoolKey[0]?.status).toBe("running");
+      expect(forPoolKey[0]?.nodeId).toBe("node-7");
+      // The row's own key is still protected too.
+      expect(placements.some((p) => p.key === row.id)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a pool id claimed by NO row yields no placement (a true orphan still reaps)",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const placements = await loadSandboxStatusesByIds([crypto.randomUUID()]);
+      expect(placements).toEqual([]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a replacement placement is mirrored onto the pool key as well",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const poolId = crypto.randomUUID();
+      await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("claimed"),
+          status: "running",
+          execution_tier: "dedicated-always",
+          node_id: "node-7",
+          warm_claim_source_pool_id: poolId,
+          // Full locator: the pair CHECK requires the whole tuple or none.
+          replacement_cleanup_sandbox_id: crypto.randomUUID(),
+          replacement_cleanup_node_id: "node-8",
+          replacement_cleanup_container_name: "agent-old-twin",
+          replacement_cleanup_attempt_id: crypto.randomUUID(),
+          replacement_cleanup_allocation_counted: true,
+          replacement_cleanup_created_at: new Date(),
+        })
+        .returning();
+
+      const placements = await loadSandboxStatusesByIds([poolId]);
+      const replacementForPool = placements.filter(
+        (p) => p.key === poolId && p.status === "replacement_cleanup_owned",
+      );
+      expect(replacementForPool).toHaveLength(1);
+      expect(replacementForPool[0]?.nodeId).toBe("node-8");
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -1,11 +1,6 @@
 /**
- * Tests for the APP orphan-container reconciler. The diff and orchestration
- * loop now live in the shared `orphan-container-reconciler.ts`; this suite pins
- * the APP-specific wiring: the `appContainerKeyOf` keyOf (the diff key IS the
- * container name), the app terminal-status vocab, and the fail-safe
- * group-by-key diff (#9307) that protects a live app sharing an `app-<slug>`
- * name with stale stopped/failed rows. The orchestration tests pin the "never
- * reap on an unreachable node" and "reap by immutable id, not name" invariants.
+ * Covers the app-specific name, status, duplicate-row, and orchestration rules
+ * supplied to the shared Docker orphan reconciler.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -19,7 +14,6 @@ import {
   reconcileOrphanContainers,
 } from "./orphan-container-reconciler";
 
-/** The app reconciler's pure-diff deltas (matches the production config). */
 const APP_DIFF: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
   keyOf: appContainerKeyOf,
   terminalStatuses: new Set(["stopped", "failed", "deleted"]),
@@ -33,7 +27,6 @@ describe("appContainerKeyOf", () => {
   test("rejects names without the app- prefix", () => {
     expect(appContainerKeyOf("postgres")).toBeNull();
     expect(appContainerKeyOf("agent-abc")).toBeNull();
-    // substring match elsewhere in the name must NOT count
     expect(appContainerKeyOf("my-app-x")).toBeNull();
   });
 
@@ -49,9 +42,6 @@ describe("appContainerKeyOf", () => {
 
 describe("computeOrphanContainersToReap (app diff)", () => {
   const live = (key: string, status: string): LiveContainerRef => ({ key, status });
-  // Containers age 10 minutes by default — past the no_db_row grace window
-  // (deliberately shared with the agent reconciler: it also covers dbRead
-  // replica lag for apps), so the historical reaping decisions hold.
   const NOW_MS = 10 * 60_000;
   const container = (name: string, id: string): NodeContainerRef => ({
     name,
@@ -61,7 +51,7 @@ describe("computeOrphanContainersToReap (app diff)", () => {
   const compute = (containers: readonly NodeContainerRef[], rows: readonly LiveContainerRef[]) =>
     computeOrphanContainersToReap(containers, rows, APP_DIFF, undefined, NOW_MS);
 
-  test("reaps a container whose name has NO db row", () => {
+  test("reaps a container whose name has no database row", () => {
     const orphans = compute([container("app-gone", "c1")], []);
     expect(orphans).toEqual([{ name: "app-gone", id: "c1", key: "app-gone", reason: "no_db_row" }]);
   });
@@ -75,7 +65,7 @@ describe("computeOrphanContainersToReap (app diff)", () => {
     }
   });
 
-  test("does NOT reap a container with a live (running) db row", () => {
+  test("retains a container with a live database row", () => {
     const orphans = compute([container("app-live", "c3")], [live("app-live", "running")]);
     expect(orphans).toEqual([]);
   });
@@ -242,7 +232,7 @@ describe("reconcileOrphanContainers (app orchestration)", () => {
     expect(result).toEqual({ nodesScanned: 1, nodesSkipped: 0, reaped: 1, reapFailed: 0 });
   });
 
-  test("SKIPS a node whose container listing failed — never reaps on a blind node", async () => {
+  test("skips a node whose container listing failed", async () => {
     const removeContainer = mock(async () => {});
     const node = makeNode({ listContainers: mock(async () => null), removeContainer });
 
@@ -255,7 +245,7 @@ describe("reconcileOrphanContainers (app orchestration)", () => {
     expect(result).toEqual({ nodesScanned: 0, nodesSkipped: 1, reaped: 0, reapFailed: 0 });
   });
 
-  test("SKIPS a non-healthy node (defensive: caller should pre-filter)", async () => {
+  test("skips a non-healthy node before listing containers", async () => {
     const listContainers = mock(async () => [] as NodeContainerRef[]);
     const node = makeNode({ status: "offline", listContainers });
 

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -49,9 +49,17 @@ describe("appContainerKeyOf", () => {
 
 describe("computeOrphanContainersToReap (app diff)", () => {
   const live = (key: string, status: string): LiveContainerRef => ({ key, status });
-  const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+  // Containers age 10 minutes by default — past the no_db_row grace window
+  // (deliberately shared with the agent reconciler: it also covers dbRead
+  // replica lag for apps), so the historical reaping decisions hold.
+  const NOW_MS = 10 * 60_000;
+  const container = (name: string, id: string): NodeContainerRef => ({
+    name,
+    id,
+    createdAtMs: 0,
+  });
   const compute = (containers: readonly NodeContainerRef[], rows: readonly LiveContainerRef[]) =>
-    computeOrphanContainersToReap(containers, rows, APP_DIFF);
+    computeOrphanContainersToReap(containers, rows, APP_DIFF, undefined, NOW_MS);
 
   test("reaps a container whose name has NO db row", () => {
     const orphans = compute([container("app-gone", "c1")], []);
@@ -219,8 +227,8 @@ describe("reconcileOrphanContainers (app orchestration)", () => {
     const removeContainer = mock(async () => {});
     const node = makeNode({
       listContainers: mock(async () => [
-        { name: "app-orphan", id: "c-orph" },
-        { name: "app-live", id: "c-live" },
+        { name: "app-orphan", id: "c-orph", createdAtMs: 0 },
+        { name: "app-live", id: "c-live", createdAtMs: 0 },
       ]),
       removeContainer,
     });
@@ -264,8 +272,8 @@ describe("reconcileOrphanContainers (app orchestration)", () => {
   test("counts a failed removal as reapFailed without aborting the rest", async () => {
     const node = makeNode({
       listContainers: mock(async () => [
-        { name: "app-a", id: "ca" },
-        { name: "app-b", id: "cb" },
+        { name: "app-a", id: "ca", createdAtMs: 0 },
+        { name: "app-b", id: "cb", createdAtMs: 0 },
       ]),
       removeContainer: mock(async (id: string) => {
         if (id === "ca") throw new Error("ssh broke");

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -10,7 +10,7 @@
  */
 
 import { inArray } from "drizzle-orm";
-import { dbRead } from "../../db/helpers";
+import { dbWrite } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
 import { APP_DB_AMBASSADOR_NAME_PREFIX, appContainerNameForAmbassador } from "./app-db-ambassador";
 import {
@@ -20,8 +20,6 @@ import {
   reconcileOrphanContainersOnNodes,
 } from "./orphan-container-reconciler";
 
-// Re-export the shared result type so existing importers (the daemon) keep
-// `AppOrphanReconcileResult` from this module.
 export type { OrphanReconcileResult as AppOrphanReconcileResult } from "./orphan-container-reconciler";
 
 /**
@@ -75,14 +73,15 @@ export function appContainerKeyOf(name: string): string | null {
  * deterministic `app-<first 12 of app id>` with no unique constraint, so an app
  * accumulates one row per deploy. The shared diff groups these per key and only
  * reaps when every row is terminal, so returning the full (unordered) set here
- * is correct and fail-safe.
+ * is correct and fail-safe. The query uses the primary because replica lag
+ * cannot be allowed to make a live workload appear rowless.
  */
 async function loadContainerStatusesByNames(names: readonly string[]): Promise<LiveContainerRef[]> {
   if (names.length === 0) return [];
-  return dbRead
+  return dbWrite
     .select({ key: containers.name, status: containers.status })
     .from(containers)
-    .where(inArray(containers.name, names as string[]));
+    .where(inArray(containers.name, [...names]));
 }
 
 /** The three app-specific deltas injected into the shared reconciler. */

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -14,6 +14,7 @@ import { dbWrite } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
 import { APP_DB_AMBASSADOR_NAME_PREFIX, appContainerNameForAmbassador } from "./app-db-ambassador";
 import {
+  DEFAULT_ROWLESS_GRACE_MS,
   type LiveContainerRef,
   type OrphanReconcileResult,
   type OrphanReconcilerConfig,
@@ -91,6 +92,7 @@ const APP_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   terminalStatuses: TERMINAL_CONTAINER_STATUSES,
   loadStatuses: loadContainerStatusesByNames,
   logScope: "app-orphan-reconciler",
+  rowlessGraceMs: DEFAULT_ROWLESS_GRACE_MS,
 };
 
 /**

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
@@ -1,20 +1,10 @@
 /**
- * Tests for the AGENT orphan-container reconciler. The diff and orchestration
- * loop now live in the shared `orphan-container-reconciler.ts`; this suite pins
- * the AGENT-specific wiring: the `agentIdFromContainerName` keyOf (parse the id
- * out of `agent-<id>`), the agent terminal-status vocab, and that the shared
- * diff reaps an agent container ONLY when its id has no live DB row (or a
- * terminal one) and NEVER when the name does not match the managed pattern. The
- * orchestration test pins the "never reap on an unreachable node" invariant
- * (SSH listing returned null → skip, not reap).
- *
- * Because `agent_sandboxes.id` is a PRIMARY KEY, each agent id maps to AT MOST
- * one DB row, so the shared group-by-key `every-terminal` diff reduces to a
- * plain single-status check here — identical reaping decisions to the previous
- * per-agent `Map<id,status>` last-write-wins implementation.
+ * Covers the agent-specific name, status, placement, and orchestration rules
+ * supplied to the shared Docker orphan reconciler.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { logger } from "../utils/logger";
 import { agentIdFromContainerName } from "./docker-node-workloads";
 import {
   computeOrphanContainersToReap,
@@ -25,7 +15,6 @@ import {
   reconcileOrphanContainers,
 } from "./orphan-container-reconciler";
 
-/** The agent reconciler's pure-diff deltas (matches the production config). */
 const AGENT_DIFF: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
   keyOf: agentIdFromContainerName,
   terminalStatuses: new Set(["stopped", "error", "sleeping", "deletion_failed"]),
@@ -48,8 +37,6 @@ describe("agentIdFromContainerName", () => {
 
 describe("computeOrphanContainersToReap (agent diff)", () => {
   const live = (key: string, status: string): LiveContainerRef => ({ key, status });
-  // Containers age 10 minutes by default — past the 5-minute grace window, so
-  // the historical reaping decisions hold. Grace behavior gets its own tests.
   const NOW_MS = 10 * 60_000;
   const container = (name: string, id: string): NodeContainerRef => ({
     name,
@@ -59,15 +46,12 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
   const compute = (containers: readonly NodeContainerRef[], rows: readonly LiveContainerRef[]) =>
     computeOrphanContainersToReap(containers, rows, AGENT_DIFF, undefined, NOW_MS);
 
-  test("reaps a container whose agent id has NO db row", () => {
+  test("reaps a container whose agent id has no database row", () => {
     const orphans = compute([container("agent-gone", "c1")], []);
     expect(orphans).toEqual([{ name: "agent-gone", id: "c1", key: "gone", reason: "no_db_row" }]);
   });
 
-  test("no_db_row waits out the grace window: a young container is never reaped", () => {
-    // What an orphan looks like is ALSO what an in-flight creation looks like
-    // from the wrong side of a commit. An orphan is permanent — it can wait
-    // five minutes to be provably one.
+  test("retains a young container without a database row during the grace window", () => {
     const young: NodeContainerRef = {
       name: "agent-gone",
       id: "c1",
@@ -76,14 +60,14 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
     expect(computeOrphanContainersToReap([young], [], AGENT_DIFF, undefined, NOW_MS)).toEqual([]);
   });
 
-  test("no_db_row with an UNKNOWN container age is never reaped", () => {
+  test("retains a rowless container when Docker did not provide its age", () => {
     const unknownAge: NodeContainerRef = { name: "agent-gone", id: "c1" };
     expect(computeOrphanContainersToReap([unknownAge], [], AGENT_DIFF, undefined, NOW_MS)).toEqual(
       [],
     );
   });
 
-  test("no_db_row without a clock is never reaped", () => {
+  test("retains a rowless container when no classification clock is available", () => {
     expect(computeOrphanContainersToReap([container("agent-gone", "c1")], [], AGENT_DIFF)).toEqual(
       [],
     );
@@ -104,7 +88,7 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
     }
   });
 
-  test("does NOT reap a container with a live (running) db row", () => {
+  test("retains a container with a live database row", () => {
     const orphans = compute([container("agent-live", "c3")], [live("live", "running")]);
     expect(orphans).toEqual([]);
   });
@@ -150,7 +134,7 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
     ).toEqual([{ name: "agent-same", id: "ghost", key: "same", reason: "wrong_node" }]);
   });
 
-  test("does NOT reap a row in deletion_pending (delete job owns teardown)", () => {
+  test("retains deletion_pending while the delete job owns teardown", () => {
     const orphans = compute(
       [container("agent-deleting", "c4")],
       [live("deleting", "deletion_pending")],
@@ -158,7 +142,7 @@ describe("computeOrphanContainersToReap (agent diff)", () => {
     expect(orphans).toEqual([]);
   });
 
-  test("does NOT reap provisioning / pending / disconnected rows", () => {
+  test("retains provisioning, pending, and disconnected rows", () => {
     for (const status of ["provisioning", "pending", "disconnected"]) {
       const orphans = compute([container("agent-x", "cx")], [live("x", status)]);
       expect(orphans).toEqual([]);
@@ -226,7 +210,48 @@ describe("reconcileOrphanContainers (agent orchestration)", () => {
     expect(result).toEqual({ nodesScanned: 1, nodesSkipped: 0, reaped: 1, reapFailed: 0 });
   });
 
-  test("SKIPS a node whose container listing failed — never reaps on a blind node", async () => {
+  test("logs structured retain and reap decisions", async () => {
+    const debugLog = spyOn(logger, "debug").mockImplementation(() => {});
+    const infoLog = spyOn(logger, "info").mockImplementation(() => {});
+    const node = makeNode({
+      listContainers: mock(async () => [
+        { name: "agent-live", id: "c-live", createdAtMs: 0 },
+        { name: "agent-stopped", id: "c-stopped", createdAtMs: 0 },
+      ]),
+    });
+
+    try {
+      await reconcileOrphanContainers(
+        [node],
+        makeConfig(async () => [
+          { key: "live", status: "running" },
+          { key: "stopped", status: "stopped" },
+        ]),
+      );
+
+      expect(debugLog).toHaveBeenCalledWith(
+        "[orphan-reconciler] Retained container",
+        expect.objectContaining({
+          containerId: "c-live",
+          decision: "retain",
+          reason: "live_db_row",
+        }),
+      );
+      expect(infoLog).toHaveBeenCalledWith(
+        "[orphan-reconciler] Reaped orphan container",
+        expect.objectContaining({
+          containerId: "c-stopped",
+          decision: "reap",
+          reason: "terminal_db_row",
+        }),
+      );
+    } finally {
+      debugLog.mockRestore();
+      infoLog.mockRestore();
+    }
+  });
+
+  test("skips a node whose container listing failed", async () => {
     const removeContainer = mock(async () => {});
     const node = makeNode({ listContainers: mock(async () => null), removeContainer });
 
@@ -239,7 +264,7 @@ describe("reconcileOrphanContainers (agent orchestration)", () => {
     expect(result).toEqual({ nodesScanned: 0, nodesSkipped: 1, reaped: 0, reapFailed: 0 });
   });
 
-  test("SKIPS a non-healthy node (defensive: caller should pre-filter)", async () => {
+  test("skips a non-healthy node before listing containers", async () => {
     const listContainers = mock(async () => [] as NodeContainerRef[]);
     const node = makeNode({ status: "offline", listContainers });
 

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts
@@ -48,13 +48,45 @@ describe("agentIdFromContainerName", () => {
 
 describe("computeOrphanContainersToReap (agent diff)", () => {
   const live = (key: string, status: string): LiveContainerRef => ({ key, status });
-  const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+  // Containers age 10 minutes by default — past the 5-minute grace window, so
+  // the historical reaping decisions hold. Grace behavior gets its own tests.
+  const NOW_MS = 10 * 60_000;
+  const container = (name: string, id: string): NodeContainerRef => ({
+    name,
+    id,
+    createdAtMs: 0,
+  });
   const compute = (containers: readonly NodeContainerRef[], rows: readonly LiveContainerRef[]) =>
-    computeOrphanContainersToReap(containers, rows, AGENT_DIFF);
+    computeOrphanContainersToReap(containers, rows, AGENT_DIFF, undefined, NOW_MS);
 
   test("reaps a container whose agent id has NO db row", () => {
     const orphans = compute([container("agent-gone", "c1")], []);
     expect(orphans).toEqual([{ name: "agent-gone", id: "c1", key: "gone", reason: "no_db_row" }]);
+  });
+
+  test("no_db_row waits out the grace window: a young container is never reaped", () => {
+    // What an orphan looks like is ALSO what an in-flight creation looks like
+    // from the wrong side of a commit. An orphan is permanent — it can wait
+    // five minutes to be provably one.
+    const young: NodeContainerRef = {
+      name: "agent-gone",
+      id: "c1",
+      createdAtMs: NOW_MS - 1_000,
+    };
+    expect(computeOrphanContainersToReap([young], [], AGENT_DIFF, undefined, NOW_MS)).toEqual([]);
+  });
+
+  test("no_db_row with an UNKNOWN container age is never reaped", () => {
+    const unknownAge: NodeContainerRef = { name: "agent-gone", id: "c1" };
+    expect(computeOrphanContainersToReap([unknownAge], [], AGENT_DIFF, undefined, NOW_MS)).toEqual(
+      [],
+    );
+  });
+
+  test("no_db_row without a clock is never reaped", () => {
+    expect(computeOrphanContainersToReap([container("agent-gone", "c1")], [], AGENT_DIFF)).toEqual(
+      [],
+    );
   });
 
   test("reaps a container whose db row is in a terminal state", () => {
@@ -180,8 +212,8 @@ describe("reconcileOrphanContainers (agent orchestration)", () => {
     const removeContainer = mock(async () => {});
     const node = makeNode({
       listContainers: mock(async () => [
-        { name: "agent-orphan", id: "c-orph" },
-        { name: "agent-live", id: "c-live" },
+        { name: "agent-orphan", id: "c-orph", createdAtMs: 0 },
+        { name: "agent-live", id: "c-live", createdAtMs: 0 },
       ]),
       removeContainer,
     });
@@ -224,8 +256,8 @@ describe("reconcileOrphanContainers (agent orchestration)", () => {
   test("counts a failed removal as reapFailed without aborting the rest", async () => {
     const node = makeNode({
       listContainers: mock(async () => [
-        { name: "agent-a", id: "ca" },
-        { name: "agent-b", id: "cb" },
+        { name: "agent-a", id: "ca", createdAtMs: 0 },
+        { name: "agent-b", id: "cb", createdAtMs: 0 },
       ]),
       removeContainer: mock(async (id: string) => {
         if (id === "ca") throw new Error("ssh broke");

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -98,10 +98,17 @@ export function agentIdFromContainerName(name: string): string | null {
  *
  * A key seen on a node is matched against `warm_claim_source_pool_id` as well
  * as the primary key: a container claimed from the warm pool keeps the name it
- * was born with — `agent-<pool id>` — while the pool row it points at is
- * deleted at claim time. Matching only `id` maps every claimed customer
- * container to a deleted row, and the sweep reaps it as `no_db_row` while the
- * customer is talking to it.
+ * was born with — `agent-<pool id>` — for its WHOLE life, while the pool row
+ * that id points at is deleted at claim time. Matching only `id` maps every
+ * claimed customer container to a deleted row, and the sweep reaps it as
+ * `no_db_row` while the customer is talking to it.
+ *
+ * The durable match is `container_name`: `claimWarmContainer` persists it on
+ * the claimed row in the same write as `warm_claim_source_pool_id`, and unlike
+ * the pool id — which `finalizeWarmClaimCredentialHandoff` NULLs once the
+ * credential handoff completes — the name stays for the row's lifetime, so it
+ * covers the steady state every successfully claimed agent settles into, not
+ * just the transient handoff window. It strictly subsumes a pool-id match.
  */
 export async function loadSandboxStatusesByIds(
   agentIds: readonly string[],
@@ -111,7 +118,7 @@ export async function loadSandboxStatusesByIds(
   const rows = await dbRead
     .select({
       key: agentSandboxes.id,
-      warmClaimSourcePoolId: agentSandboxes.warm_claim_source_pool_id,
+      containerName: agentSandboxes.container_name,
       status: agentSandboxes.status,
       nodeId: agentSandboxes.node_id,
       updatedAt: agentSandboxes.updated_at,
@@ -122,7 +129,10 @@ export async function loadSandboxStatusesByIds(
     .where(
       or(
         inArray(agentSandboxes.id, agentIds as string[]),
-        inArray(agentSandboxes.warm_claim_source_pool_id, agentIds as string[]),
+        inArray(
+          agentSandboxes.container_name,
+          agentIds.map((id) => `${AGENT_CONTAINER_NAME_PREFIX}${id}`),
+        ),
       ),
     );
   return rows.flatMap((row) => {
@@ -144,11 +154,15 @@ export async function loadSandboxStatusesByIds(
           : undefined,
       });
     }
-    if (row.warmClaimSourcePoolId && queriedIds.has(row.warmClaimSourcePoolId)) {
-      // The physical container carries the POOL id in its name: every
-      // placement protecting this row must protect that key too.
+    const nameKey = row.containerName?.startsWith(AGENT_CONTAINER_NAME_PREFIX)
+      ? row.containerName.slice(AGENT_CONTAINER_NAME_PREFIX.length)
+      : null;
+    if (nameKey && nameKey !== row.key && queriedIds.has(nameKey)) {
+      // The physical container carries the id embedded in its NAME — for a
+      // warm-claimed row that is the birth pool's id, forever. Every placement
+      // protecting this row must protect that key too.
       for (const placement of [...placements]) {
-        placements.push({ ...placement, key: row.warmClaimSourcePoolId });
+        placements.push({ ...placement, key: nameKey });
       }
     }
     return placements;

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -15,6 +15,8 @@ import {
 } from "./docker-node-workload-queries";
 import { AGENT_CONTAINER_NAME_PREFIX } from "./docker-sandbox-utils";
 import {
+  DEFAULT_NODE_MOVE_GRACE_MS,
+  DEFAULT_ROWLESS_GRACE_MS,
   type LiveContainerRef,
   type OrphanReconcileResult,
   type OrphanReconcilerConfig,
@@ -193,6 +195,8 @@ const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   loadStatuses: loadSandboxStatusesByIds,
   logScope: "orphan-reconciler",
   nodeAware: true,
+  rowlessGraceMs: DEFAULT_ROWLESS_GRACE_MS,
+  nodeMoveGraceMs: DEFAULT_NODE_MOVE_GRACE_MS,
 };
 
 /**

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -1,5 +1,5 @@
 // Coordinates cloud service docker node workloads behavior behind route handlers.
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
@@ -95,12 +95,23 @@ export function agentIdFromContainerName(name: string): string | null {
  * ids. A replacement fence owns a second real container until its exact remote
  * retirement and capacity release complete, so both primary and replacement
  * nodes must protect that key from the orphan reaper.
+ *
+ * A key seen on a node is matched against `warm_claim_source_pool_id` as well
+ * as the primary key: a container claimed from the warm pool keeps the name it
+ * was born with — `agent-<pool id>` — while the pool row it points at is
+ * deleted at claim time. Matching only `id` maps every claimed customer
+ * container to a deleted row, and the sweep reaps it as `no_db_row` while the
+ * customer is talking to it.
  */
-async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<LiveContainerRef[]> {
+export async function loadSandboxStatusesByIds(
+  agentIds: readonly string[],
+): Promise<LiveContainerRef[]> {
   if (agentIds.length === 0) return [];
+  const queriedIds = new Set(agentIds);
   const rows = await dbRead
     .select({
       key: agentSandboxes.id,
+      warmClaimSourcePoolId: agentSandboxes.warm_claim_source_pool_id,
       status: agentSandboxes.status,
       nodeId: agentSandboxes.node_id,
       updatedAt: agentSandboxes.updated_at,
@@ -108,7 +119,12 @@ async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<Li
       replacementCreatedAt: agentSandboxes.replacement_cleanup_created_at,
     })
     .from(agentSandboxes)
-    .where(inArray(agentSandboxes.id, agentIds as string[]));
+    .where(
+      or(
+        inArray(agentSandboxes.id, agentIds as string[]),
+        inArray(agentSandboxes.warm_claim_source_pool_id, agentIds as string[]),
+      ),
+    );
   return rows.flatMap((row) => {
     const placements: LiveContainerRef[] = [
       {
@@ -127,6 +143,13 @@ async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<Li
           ? new Date(row.replacementCreatedAt).getTime()
           : undefined,
       });
+    }
+    if (row.warmClaimSourcePoolId && queriedIds.has(row.warmClaimSourcePoolId)) {
+      // The physical container carries the POOL id in its name: every
+      // placement protecting this row must protect that key too.
+      for (const placement of [...placements]) {
+        placements.push({ ...placement, key: row.warmClaimSourcePoolId });
+      }
     }
     return placements;
   });

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -4,8 +4,9 @@
  * canonical and cleanup-fenced physical container names because warm claims
  * and blue/green swaps can make either name differ from the sandbox row ID.
  */
+import { ElizaError } from "@elizaos/core";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
-import { dbRead } from "../../db/helpers";
+import { dbRead, dbWrite } from "../../db/helpers";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
 import {
@@ -20,13 +21,16 @@ import {
   reconcileOrphanContainersOnNodes as reconcileOrphanContainersOnNodesShared,
 } from "./orphan-container-reconciler";
 
-// Re-export the shared result type so existing importers (the daemon) keep
-// `OrphanReconcileResult` from this module.
 export type { OrphanReconcileResult } from "./orphan-container-reconciler";
 
 async function countRows(query: Promise<Array<{ count: number }>>): Promise<number> {
   const [row] = await query;
-  return row?.count ?? 0;
+  if (!row) {
+    throw new ElizaError("Workload count query returned no aggregate row", {
+      code: "DOCKER_NODE_WORKLOAD_COUNT_MISSING",
+    });
+  }
+  return row.count;
 }
 
 /**
@@ -52,10 +56,9 @@ const TERMINAL_SANDBOX_STATUS_SET = new Set<string>(TERMINAL_SANDBOX_STATUSES);
  *
  * The agent side excludes the same {@link TERMINAL_SANDBOX_STATUSES} the orphan
  * reconciler uses to decide a container "should NOT be running" — a row in one
- * of those states holds no live slot. Excluding only `('stopped','error')` here
- * (the previous behaviour) left `sleeping`/`deletion_failed` rows inflating
- * `allocated_count` above a node's real load, which made the autoscaler read
- * bare-metal robots as full and bill new Hetzner-cloud nodes instead (#15378).
+ * of those states holds no live slot. Including `sleeping` or
+ * `deletion_failed` would inflate `allocated_count`, make bare-metal nodes
+ * appear full, and trigger unnecessary Hetzner capacity (#15378).
  * `disconnected` is deliberately NOT excluded: it is non-terminal (the
  * container is up but unreachable) and still occupies the slot.
  */
@@ -106,7 +109,8 @@ export function agentIdFromContainerName(name: string): string | null {
  * deleted and the transient source ID is cleared. A cleanup-fenced container
  * likewise keeps its old physical name across a blue/green cutover. Each name
  * aliases only its own placement so unrelated containers on the other node do
- * not inherit protection.
+ * not inherit protection. This destructive ownership check reads the primary:
+ * replica lag must never turn a live row into an apparent orphan.
  */
 export async function loadSandboxStatusesByIds(
   agentIds: readonly string[],
@@ -115,7 +119,7 @@ export async function loadSandboxStatusesByIds(
   const queriedIds = new Set(agentIds);
   const queriedKeys = [...queriedIds];
   const queriedContainerNames = queriedKeys.map((id) => `${AGENT_CONTAINER_NAME_PREFIX}${id}`);
-  const rows = await dbRead
+  const rows = await dbWrite
     .select({
       key: agentSandboxes.id,
       containerName: agentSandboxes.container_name,

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -1,4 +1,9 @@
-// Coordinates cloud service docker node workloads behavior behind route handlers.
+/**
+ * Supplies workload accounting and agent-specific ownership resolution for the
+ * shared Docker-node control plane. The orphan-reaper adapter preserves both
+ * canonical and cleanup-fenced physical container names because warm claims
+ * and blue/green swaps can make either name differ from the sandbox row ID.
+ */
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
@@ -96,25 +101,20 @@ export function agentIdFromContainerName(name: string): string | null {
  * retirement and capacity release complete, so both primary and replacement
  * nodes must protect that key from the orphan reaper.
  *
- * A key seen on a node is matched against `warm_claim_source_pool_id` as well
- * as the primary key: a container claimed from the warm pool keeps the name it
- * was born with — `agent-<pool id>` — for its WHOLE life, while the pool row
- * that id points at is deleted at claim time. Matching only `id` maps every
- * claimed customer container to a deleted row, and the sweep reaps it as
- * `no_db_row` while the customer is talking to it.
- *
- * The durable match is `container_name`: `claimWarmContainer` persists it on
- * the claimed row in the same write as `warm_claim_source_pool_id`, and unlike
- * the pool id — which `finalizeWarmClaimCredentialHandoff` NULLs once the
- * credential handoff completes — the name stays for the row's lifetime, so it
- * covers the steady state every successfully claimed agent settles into, not
- * just the transient handoff window. It strictly subsumes a pool-id match.
+ * Physical names are durable ownership keys in addition to the sandbox row ID.
+ * A warm-claimed container keeps `agent-<pool id>` after the pool row is
+ * deleted and the transient source ID is cleared. A cleanup-fenced container
+ * likewise keeps its old physical name across a blue/green cutover. Each name
+ * aliases only its own placement so unrelated containers on the other node do
+ * not inherit protection.
  */
 export async function loadSandboxStatusesByIds(
   agentIds: readonly string[],
 ): Promise<LiveContainerRef[]> {
   if (agentIds.length === 0) return [];
   const queriedIds = new Set(agentIds);
+  const queriedKeys = [...queriedIds];
+  const queriedContainerNames = queriedKeys.map((id) => `${AGENT_CONTAINER_NAME_PREFIX}${id}`);
   const rows = await dbRead
     .select({
       key: agentSandboxes.id,
@@ -123,47 +123,53 @@ export async function loadSandboxStatusesByIds(
       nodeId: agentSandboxes.node_id,
       updatedAt: agentSandboxes.updated_at,
       replacementNodeId: agentSandboxes.replacement_cleanup_node_id,
+      replacementContainerName: agentSandboxes.replacement_cleanup_container_name,
       replacementCreatedAt: agentSandboxes.replacement_cleanup_created_at,
     })
     .from(agentSandboxes)
     .where(
       or(
-        inArray(agentSandboxes.id, agentIds as string[]),
-        inArray(
-          agentSandboxes.container_name,
-          agentIds.map((id) => `${AGENT_CONTAINER_NAME_PREFIX}${id}`),
-        ),
+        inArray(agentSandboxes.id, queriedKeys),
+        inArray(agentSandboxes.container_name, queriedContainerNames),
+        inArray(agentSandboxes.replacement_cleanup_container_name, queriedContainerNames),
       ),
     );
   return rows.flatMap((row) => {
-    const placements: LiveContainerRef[] = [
+    const placements: LiveContainerRef[] = [];
+    const appendPlacement = (
+      placement: LiveContainerRef,
+      physicalContainerName: string | null,
+    ): void => {
+      placements.push(placement);
+      const nameKey = physicalContainerName
+        ? agentIdFromContainerName(physicalContainerName)
+        : null;
+      if (nameKey && nameKey !== row.key && queriedIds.has(nameKey)) {
+        placements.push({ ...placement, key: nameKey });
+      }
+    };
+
+    appendPlacement(
       {
         key: row.key,
         status: row.status,
         nodeId: row.nodeId ?? undefined,
         updatedAtMs: row.updatedAt ? new Date(row.updatedAt).getTime() : undefined,
       },
-    ];
+      row.containerName,
+    );
     if (row.replacementNodeId) {
-      placements.push({
-        key: row.key,
-        status: "replacement_cleanup_owned",
-        nodeId: row.replacementNodeId,
-        updatedAtMs: row.replacementCreatedAt
-          ? new Date(row.replacementCreatedAt).getTime()
-          : undefined,
-      });
-    }
-    const nameKey = row.containerName?.startsWith(AGENT_CONTAINER_NAME_PREFIX)
-      ? row.containerName.slice(AGENT_CONTAINER_NAME_PREFIX.length)
-      : null;
-    if (nameKey && nameKey !== row.key && queriedIds.has(nameKey)) {
-      // The physical container carries the id embedded in its NAME — for a
-      // warm-claimed row that is the birth pool's id, forever. Every placement
-      // protecting this row must protect that key too.
-      for (const placement of [...placements]) {
-        placements.push({ ...placement, key: nameKey });
-      }
+      appendPlacement(
+        {
+          key: row.key,
+          status: "replacement_cleanup_owned",
+          nodeId: row.replacementNodeId,
+          updatedAtMs: row.replacementCreatedAt
+            ? new Date(row.replacementCreatedAt).getTime()
+            : undefined,
+        },
+        row.replacementContainerName,
+      );
     }
     return placements;
   });

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -54,15 +54,19 @@ describe("parseNodeContainerList", () => {
     ).toEqual([{ name: "agent-live", id: "id-live" }]);
   });
 
-  test("rejects substring matches and malformed listing rows", () => {
-    const output = [
-      "my-agent-live|wrong-prefix|2026-07-07 16:45:01 +0000 UTC",
-      "agent-no-id||2026-07-07 16:45:01 +0000 UTC",
-      "agent-extra|id-extra|2026-07-07 16:45:01 +0000 UTC|extra",
-      "",
-    ].join("\n");
+  test("rejects substring matches without treating them as managed", () => {
+    expect(
+      parseNodeContainerList("my-agent-live|wrong-prefix|2026-07-07 16:45:01 +0000 UTC", "agent-"),
+    ).toEqual([]);
+  });
 
-    expect(parseNodeContainerList(output, "agent-")).toEqual([]);
+  test("surfaces malformed managed rows so the node is skipped", () => {
+    expect(() =>
+      parseNodeContainerList("agent-no-id||2026-07-07 16:45:01 +0000 UTC", "agent-"),
+    ).toThrow("invalid managed-container listing row");
+    expect(() =>
+      parseNodeContainerList("agent-extra|id-extra|2026-07-07 16:45:01 +0000 UTC|extra", "agent-"),
+    ).toThrow("invalid managed-container listing row");
   });
 });
 
@@ -172,6 +176,38 @@ describe("retention decision reasons", () => {
       { id: "live", action: "retain", reason: "live_db_row" },
       { id: "postgres", action: "retain", reason: "unmanaged_name" },
     ]);
+  });
+
+  test("retains rowless containers when any age input is non-finite", () => {
+    const decisions = classifyContainersForReconciliation(
+      [
+        { name: "agent-created-nan", id: "created-nan", createdAtMs: Number.NaN },
+        container("agent-clock-nan", "clock-nan"),
+      ],
+      [],
+      diff,
+      undefined,
+      Number.NaN,
+    );
+
+    expect(decisions.map(({ action, reason }) => ({ action, reason }))).toEqual([
+      { action: "retain", reason: "no_db_row_age_unknown" },
+      { action: "retain", reason: "no_db_row_age_unknown" },
+    ]);
+  });
+
+  test("rejects invalid grace configuration before classifying a container", () => {
+    for (const nodeMoveGraceMs of [Number.NaN, -1]) {
+      expect(() =>
+        classifyContainersForReconciliation(
+          [container("agent-live", "live")],
+          [live("live", "running")],
+          { ...diff, nodeMoveGraceMs },
+          undefined,
+          AGED_NOW_MS,
+        ),
+      ).toThrow("grace must be a non-negative duration");
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -1,34 +1,18 @@
 /**
- * Tests for the SHARED orphan-container reconciler — the single implementation
- * behind both the agent (`docker-node-workloads.ts`) and app
- * (`app-container-orphan-reconciler.ts`) paths.
- *
- * The per-path suites cover each path's wiring; this suite proves the shared
- * diff handles BOTH key modes correctly:
- *
- *   1. UNIQUE keys (agents): `agent_sandboxes.id` is a PRIMARY KEY, so each key
- *      maps to at most ONE row. The group-by-key `every-terminal` fold then
- *      reduces to a plain single-status check — identical to the previous
- *      per-agent last-write-wins `Map<id,status>`. This is the behavior-
- *      preservation proof: same inputs → same reaping decisions.
- *
- *   2. DUPLICATE keys (apps): `containers.name` has NO unique constraint, so one
- *      key maps to MANY rows. The #9307 fail-safe protects a live container that
- *      shares a key with stale terminal rows — a key is reaped ONLY when EVERY
- *      row is terminal, order-independently.
+ * Covers Docker-list parsing and fail-closed ownership classification shared
+ * by the agent and app orphan reconcilers.
  */
 
 import { describe, expect, test } from "bun:test";
 import {
+  classifyContainersForReconciliation,
   computeOrphanContainersToReap,
   type LiveContainerRef,
   type NodeContainerRef,
   type OrphanReconcilerConfig,
+  parseNodeContainerList,
 } from "./orphan-container-reconciler";
 
-// Containers are born aged (created at epoch) so the no_db_row grace window —
-// which exists to spare in-flight creations — never masks the decision under
-// test. Grace behavior itself is pinned in docker-node-workloads.test.ts.
 const AGED_NOW_MS = 10 * 60_000;
 const container = (name: string, id: string): NodeContainerRef => ({
   name,
@@ -37,18 +21,57 @@ const container = (name: string, id: string): NodeContainerRef => ({
 });
 const live = (key: string, status: string): LiveContainerRef => ({ key, status });
 
-describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins)", () => {
-  // keyOf parses the id out of `k-<id>`; terminal vocab is arbitrary here.
+describe("parseNodeContainerList", () => {
+  test("parses Docker timestamps by their numeric offsets", () => {
+    const output = [
+      "agent-utc|id-utc|2026-07-07 16:45:01 +0000 UTC",
+      "agent-pacific|id-pacific|2026-07-07 09:45:01 -0700 PDT",
+      "agent-india|id-india|2026-07-07 22:15:01.250 +0530 IST",
+    ].join("\n");
+
+    expect(parseNodeContainerList(output, "agent-")).toEqual([
+      {
+        name: "agent-utc",
+        id: "id-utc",
+        createdAtMs: Date.UTC(2026, 6, 7, 16, 45, 1),
+      },
+      {
+        name: "agent-pacific",
+        id: "id-pacific",
+        createdAtMs: Date.UTC(2026, 6, 7, 16, 45, 1),
+      },
+      {
+        name: "agent-india",
+        id: "id-india",
+        createdAtMs: Date.UTC(2026, 6, 7, 16, 45, 1, 250),
+      },
+    ]);
+  });
+
+  test("retains an entry without age when Docker emits an invalid timestamp", () => {
+    expect(
+      parseNodeContainerList("agent-live|id-live|2026-02-30 10:00:00 +0000 UTC", "agent-"),
+    ).toEqual([{ name: "agent-live", id: "id-live" }]);
+  });
+
+  test("rejects substring matches and malformed listing rows", () => {
+    const output = [
+      "my-agent-live|wrong-prefix|2026-07-07 16:45:01 +0000 UTC",
+      "agent-no-id||2026-07-07 16:45:01 +0000 UTC",
+      "agent-extra|id-extra|2026-07-07 16:45:01 +0000 UTC|extra",
+      "",
+    ].join("\n");
+
+    expect(parseNodeContainerList(output, "agent-")).toEqual([]);
+  });
+});
+
+describe("shared diff with unique agent keys", () => {
   const diff: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
     keyOf: (name) => (name.startsWith("k-") && name.length > 2 ? name.slice(2) : null),
     terminalStatuses: new Set(["stopped", "error"]),
   };
 
-  // For a UNIQUE key there is at most one status. `every(terminal)` over a
-  // singleton list `[s]` is exactly `terminal.has(s)`, and a missing key is
-  // `no_db_row` either way. So for every single-row input the group-by-key fold
-  // produces the SAME decision the old last-write-wins map would. We assert that
-  // equivalence directly over the full decision table.
   const singleStatusReference = (status: string | undefined) => {
     if (status === undefined) return "no_db_row";
     return diff.terminalStatuses.has(status) ? "terminal_db_row" : null;
@@ -81,7 +104,6 @@ describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wi
       undefined,
       AGED_NOW_MS,
     );
-    // a=running → keep; b=stopped → reap; c=missing → reap.
     expect(orphans.map((o) => `${o.key}:${o.reason}`).sort()).toEqual([
       "b:terminal_db_row",
       "c:no_db_row",
@@ -89,14 +111,13 @@ describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wi
   });
 });
 
-describe("shared diff — DUPLICATE-key mode (app, #9307 every-terminal fail-safe)", () => {
-  // keyOf is identity (the name IS the key), matching the app path.
+describe("shared diff with duplicate app keys", () => {
   const diff: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
     keyOf: (name) => (name.startsWith("app-") && name.length > 4 ? name : null),
     terminalStatuses: new Set(["stopped", "failed", "deleted"]),
   };
 
-  test("ANY non-terminal row among duplicates protects the key (both orders)", () => {
+  test("a non-terminal row among duplicates protects the key in either order", () => {
     expect(
       computeOrphanContainersToReap(
         [container("app-dup", "c")],
@@ -113,7 +134,7 @@ describe("shared diff — DUPLICATE-key mode (app, #9307 every-terminal fail-saf
     ).toEqual([]);
   });
 
-  test("reaps only when EVERY duplicate row is terminal", () => {
+  test("reaps only when every duplicate row is terminal", () => {
     const orphans = computeOrphanContainersToReap(
       [container("app-dead", "c")],
       [live("app-dead", "stopped"), live("app-dead", "failed"), live("app-dead", "deleted")],
@@ -125,8 +146,36 @@ describe("shared diff — DUPLICATE-key mode (app, #9307 every-terminal fail-saf
   });
 });
 
-describe("node-aware diff (#15228 — reap the stale twin a re-provision left behind)", () => {
-  // Agent config: node-aware, 5-min grace. keyOf parses `agent-<id>`.
+describe("retention decision reasons", () => {
+  const diff: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
+    keyOf: (name) => (name.startsWith("agent-") ? name.slice("agent-".length) : null),
+    terminalStatuses: new Set(["stopped"]),
+  };
+
+  test("distinguishes unknown age, grace, live ownership, and unmanaged names", () => {
+    const decisions = classifyContainersForReconciliation(
+      [
+        { name: "agent-unknown", id: "unknown" },
+        { name: "agent-young", id: "young", createdAtMs: AGED_NOW_MS - 1_000 },
+        container("agent-live", "live"),
+        container("postgres", "postgres"),
+      ],
+      [live("live", "running")],
+      diff,
+      undefined,
+      AGED_NOW_MS,
+    );
+
+    expect(decisions.map(({ id, action, reason }) => ({ id, action, reason }))).toEqual([
+      { id: "unknown", action: "retain", reason: "no_db_row_age_unknown" },
+      { id: "young", action: "retain", reason: "no_db_row_within_grace" },
+      { id: "live", action: "retain", reason: "live_db_row" },
+      { id: "postgres", action: "retain", reason: "unmanaged_name" },
+    ]);
+  });
+});
+
+describe("node-aware stale-twin classification", () => {
   const cfg: Pick<
     OrphanReconcilerConfig,
     "keyOf" | "terminalStatuses" | "nodeAware" | "nodeMoveGraceMs"
@@ -148,16 +197,13 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     nodeId,
     updatedAtMs: NOW - ageMs,
   });
-  // Containers default to OLD (past grace) so each test isolates the row-side
-  // condition; the container-age race has its own cases below.
   const c = (id: string, containerAgeMs = 60 * 60_000): NodeContainerRef => ({
     name: `agent-${id}`,
     id: `docker-${id}`,
     createdAtMs: NOW - containerAgeMs,
   });
 
-  test("live row points at a DIFFERENT node, stable past grace → reap as wrong_node", () => {
-    // container observed on nodeA; the agent's live row says it lives on nodeB.
+  test("reaps a stable container whose live row points at a different node", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
       [onNode("x", "running", "nodeB", 10 * 60_000)],
@@ -168,11 +214,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans).toEqual([{ name: "agent-x", id: `docker-x`, key: "x", reason: "wrong_node" }]);
   });
 
-  test("FRESH container + stale wrong-node row → keep (re-placement in flight)", () => {
-    // The worker creates the container on the new node BEFORE updating the row,
-    // so mid-provision the old row (old timestamp, old node) is exactly what a
-    // legitimate re-placement looks like. Caught live: a 29-second-old container
-    // drew a wrong_node verdict against a 12-day-old row.
+  test("retains a fresh container while placement is in flight", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x", 29_000)],
       [onNode("x", "running", "nodeB", 12 * 24 * 60 * 60_000)],
@@ -183,7 +225,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans).toEqual([]);
   });
 
-  test("container age unknown → never wrong_node-reaped (fail safe)", () => {
+  test("retains a container with unknown age", () => {
     const orphans = computeOrphanContainersToReap(
       [{ name: "agent-x", id: "docker-x" }],
       [onNode("x", "running", "nodeB", 10 * 60_000)],
@@ -194,7 +236,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans).toEqual([]);
   });
 
-  test("live row points at THIS node → keep (this is the canonical container)", () => {
+  test("retains the container on its canonical node", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
       [onNode("x", "running", "nodeA", 10 * 60_000)],
@@ -205,9 +247,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans).toEqual([]);
   });
 
-  test("mismatch but WITHIN grace → keep (protects the mid-provision race)", () => {
-    // row just moved to nodeB 30s ago; a container still on nodeA might be the
-    // draining old one OR a race — do not reap until it is stably wrong.
+  test("retains a node mismatch within the row grace window", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
       [onNode("x", "running", "nodeB", 30_000)],
@@ -218,7 +258,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans).toEqual([]);
   });
 
-  test("row missing nodeId → cannot prove elsewhere → keep", () => {
+  test("retains a row whose placement evidence is incomplete", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
       [{ key: "x", status: "running" }],
@@ -240,7 +280,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans[0]?.reason).toBe("terminal_db_row");
   });
 
-  test("no nodeId arg (non-node-aware call) → node logic inert, legacy behavior", () => {
+  test("retains when the caller omits node context", () => {
     const orphans = computeOrphanContainersToReap(
       [c("x")],
       [onNode("x", "running", "nodeB", 10 * 60_000)],
@@ -251,7 +291,7 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     expect(orphans).toEqual([]);
   });
 
-  test("nodeAware off → a wrong-node container is NEVER reaped (apps semantics)", () => {
+  test("retains a wrong-node container when node awareness is disabled", () => {
     const appsCfg = { ...cfg, nodeAware: false };
     const orphans = computeOrphanContainersToReap(
       [c("x")],

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -26,7 +26,15 @@ import {
   type OrphanReconcilerConfig,
 } from "./orphan-container-reconciler";
 
-const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+// Containers are born aged (created at epoch) so the no_db_row grace window —
+// which exists to spare in-flight creations — never masks the decision under
+// test. Grace behavior itself is pinned in docker-node-workloads.test.ts.
+const AGED_NOW_MS = 10 * 60_000;
+const container = (name: string, id: string): NodeContainerRef => ({
+  name,
+  id,
+  createdAtMs: 0,
+});
 const live = (key: string, status: string): LiveContainerRef => ({ key, status });
 
 describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins)", () => {
@@ -49,7 +57,13 @@ describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wi
   for (const status of [undefined, "running", "stopped", "error", "pending"] as const) {
     test(`status=${String(status)} → matches single-status check`, () => {
       const rows = status === undefined ? [] : [live("id1", status)];
-      const orphans = computeOrphanContainersToReap([container("k-id1", "c1")], rows, diff);
+      const orphans = computeOrphanContainersToReap(
+        [container("k-id1", "c1")],
+        rows,
+        diff,
+        undefined,
+        AGED_NOW_MS,
+      );
       const expected = singleStatusReference(status);
       if (expected === null) {
         expect(orphans).toEqual([]);
@@ -64,6 +78,8 @@ describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wi
       [container("k-a", "ca"), container("k-b", "cb"), container("k-c", "cc")],
       [live("a", "running"), live("b", "stopped")],
       diff,
+      undefined,
+      AGED_NOW_MS,
     );
     // a=running → keep; b=stopped → reap; c=missing → reap.
     expect(orphans.map((o) => `${o.key}:${o.reason}`).sort()).toEqual([

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -197,16 +197,18 @@ describe("retention decision reasons", () => {
   });
 
   test("rejects invalid grace configuration before classifying a container", () => {
-    for (const nodeMoveGraceMs of [Number.NaN, -1]) {
-      expect(() =>
-        classifyContainersForReconciliation(
-          [container("agent-live", "live")],
-          [live("live", "running")],
-          { ...diff, nodeMoveGraceMs },
-          undefined,
-          AGED_NOW_MS,
-        ),
-      ).toThrow("grace must be a non-negative duration");
+    for (const graceKind of ["rowlessGraceMs", "nodeMoveGraceMs"] as const) {
+      for (const graceMs of [Number.NaN, -1]) {
+        expect(() =>
+          classifyContainersForReconciliation(
+            [container("agent-live", "live")],
+            [live("live", "running")],
+            { ...diff, [graceKind]: graceMs },
+            undefined,
+            AGED_NOW_MS,
+          ),
+        ).toThrow("grace must be a non-negative duration");
+      }
     }
   });
 });
@@ -237,6 +239,28 @@ describe("node-aware stale-twin classification", () => {
     name: `agent-${id}`,
     id: `docker-${id}`,
     createdAtMs: NOW - containerAgeMs,
+  });
+
+  test("tunes rowless and wrong-node evidence windows independently", () => {
+    const independentGrace = {
+      ...cfg,
+      rowlessGraceMs: 20 * 60_000,
+      nodeMoveGraceMs: 5 * 60_000,
+    };
+    const tenMinutesOld = c("x", 10 * 60_000);
+
+    expect(
+      computeOrphanContainersToReap([tenMinutesOld], [], independentGrace, "nodeA", NOW),
+    ).toEqual([]);
+    expect(
+      computeOrphanContainersToReap(
+        [tenMinutesOld],
+        [onNode("x", "running", "nodeB", 10 * 60_000)],
+        independentGrace,
+        "nodeA",
+        NOW,
+      ),
+    ).toEqual([{ name: "agent-x", id: "docker-x", key: "x", reason: "wrong_node" }]);
   });
 
   test("reaps a stable container whose live row points at a different node", () => {

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -1,38 +1,9 @@
 /**
- * Shared orphan-container reconciler for the shared Hetzner-Docker pool.
- *
- * ONE generic sweep used by BOTH workload kinds that run on the pool:
- *   - AGENT containers (`agent-<id>`, backed by `agent_sandboxes`) — wired in
- *     `docker-node-workloads.ts`.
- *   - APP containers (`app-<slug>`, backed by `containers`) — wired in
- *     `app-container-orphan-reconciler.ts`.
- *
- * THE GAP THIS CLOSES
- * A managed container on a node whose DB row has been deleted (or moved to a
- * terminal state) is an orphan: it holds a compute slot and host volume forever
- * because nothing in the provisioner / deploy lifecycle will ever reap it again.
- * The delete job removes the container as part of deletion, but if that SSH step
- * fails terminally or the row is hard-deleted out from under a still-running
- * container, the leak goes unnoticed. This reconciler closes that gap with a
- * low-cadence sweep over HEALTHY nodes.
- *
- * SAFETY INVARIANTS (a wrong reaper kills a live customer workload):
- *   1. Only `status === "healthy"` nodes are touched.
- *   2. If the SSH container listing returns null (listing failed) → SKIP the
- *      node, never reap (a misread empty list must not reap live containers).
- *   3. Reap by the IMMUTABLE container ID captured in the same listing — NEVER
- *      by name (avoids the delete+recreate race where the name resolves to the
- *      new live container).
- *   4. Hard per-call SSH timeouts on both the list and the rm.
- *   5. Every reap, skip, and failure is logged.
- *   6. When unsure whether a container is an orphan → DO NOT reap.
- *
- * THE ONLY THINGS THAT DIFFER between the agent and app paths are injected via
- * `OrphanReconcilerConfig`: the container-name `prefix`, the `keyOf` that maps a
- * name to its DB diff key (agents parse the id out of `agent-<id>`; apps use the
- * name itself), the `terminalStatuses` vocab, the `loadStatuses` DB query, and a
- * `logScope` tag. Everything else — the orchestration loop, the SSH wiring, the
- * timeouts, the reap-by-id rm — is identical and lives here once.
+ * Reconciles managed agent and app containers against their durable database
+ * ownership on the shared Docker pool. The sweep fails closed whenever age,
+ * placement, health, or SSH evidence is incomplete, and removes only the
+ * immutable container ID captured by the same listing it classified. Workload
+ * adapters supply their name parser, status vocabulary, and ownership query.
  */
 
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
@@ -96,6 +67,36 @@ export interface OrphanContainer {
    */
   reason: "no_db_row" | "terminal_db_row" | "wrong_node";
 }
+
+/** Why a managed container was deliberately retained during this sweep. */
+export type RetainedContainerReason =
+  | "unmanaged_name"
+  | "no_db_row_age_unknown"
+  | "no_db_row_within_grace"
+  | "live_db_row"
+  | "node_context_unavailable"
+  | "live_on_node"
+  | "wrong_node_evidence_incomplete"
+  | "wrong_node_age_unknown"
+  | "wrong_node_container_within_grace"
+  | "wrong_node_row_within_grace";
+
+/** Complete, observable classification for one container in a node listing. */
+export type ContainerReconcileDecision =
+  | {
+      action: "retain";
+      name: string;
+      id: string;
+      key: string | null;
+      reason: RetainedContainerReason;
+    }
+  | {
+      action: "reap";
+      name: string;
+      id: string;
+      key: string;
+      reason: OrphanContainer["reason"];
+    };
 
 /** Per-node SSH surface the reconciler needs. Lets tests inject a fake node. */
 export interface OrphanReconcilerNode {
@@ -178,8 +179,7 @@ export interface OrphanReconcilerConfig {
 export const DEFAULT_NODE_MOVE_GRACE_MS = 5 * 60_000;
 
 /**
- * Pure diff: given the containers present on a node and the DB rows that exist
- * for those container keys, decide which containers to reap.
+ * Classify every listed container as retained or reapable.
  *
  * A container is an orphan when EITHER:
  *   - no DB row exists for its key (`no_db_row`), OR
@@ -213,10 +213,10 @@ export const DEFAULT_NODE_MOVE_GRACE_MS = 5 * 60_000;
  * When any live row points at THIS node, the container is the canonical one and
  * is kept.
  *
- * `nowMs` is injected (not read from the clock) so this function performs NO I/O
- * and can be unit-tested exhaustively.
+ * `nowMs` is injected so classification remains deterministic. Missing time is
+ * treated as incomplete evidence and therefore retains the container.
  */
-export function computeOrphanContainersToReap(
+export function classifyContainersForReconciliation(
   containersOnNode: readonly NodeContainerRef[],
   liveRows: readonly LiveContainerRef[],
   config: Pick<
@@ -225,7 +225,7 @@ export function computeOrphanContainersToReap(
   >,
   nodeId?: string,
   nowMs?: number,
-): OrphanContainer[] {
+): ContainerReconcileDecision[] {
   // Group the full row objects per key (a key can have >1 DB rows for apps —
   // there is no unique constraint on containers.name; for agents the key is a PK
   // so the list is always a singleton).
@@ -239,10 +239,19 @@ export function computeOrphanContainersToReap(
   const nodeAware = config.nodeAware === true && nodeId !== undefined;
   const graceMs = config.nodeMoveGraceMs ?? DEFAULT_NODE_MOVE_GRACE_MS;
 
-  const orphans: OrphanContainer[] = [];
+  const decisions: ContainerReconcileDecision[] = [];
   for (const container of containersOnNode) {
     const key = config.keyOf(container.name);
-    if (key === null) continue;
+    if (key === null) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key: null,
+        reason: "unmanaged_name",
+      });
+      continue;
+    }
 
     const rows = rowsByKey.get(key);
     if (rows === undefined || rows.length === 0) {
@@ -253,14 +262,44 @@ export function computeOrphanContainersToReap(
       // CONTAINER itself must be older than the grace window, and an unknown
       // container age never reaps. An orphan is permanent; it can wait five
       // minutes to be provably one.
-      if (container.createdAtMs === undefined) continue;
-      if (nowMs === undefined || nowMs - container.createdAtMs < graceMs) continue;
-      orphans.push({ name: container.name, id: container.id, key, reason: "no_db_row" });
+      if (container.createdAtMs === undefined || nowMs === undefined) {
+        decisions.push({
+          action: "retain",
+          name: container.name,
+          id: container.id,
+          key,
+          reason: "no_db_row_age_unknown",
+        });
+        continue;
+      }
+      if (nowMs - container.createdAtMs < graceMs) {
+        decisions.push({
+          action: "retain",
+          name: container.name,
+          id: container.id,
+          key,
+          reason: "no_db_row_within_grace",
+        });
+        continue;
+      }
+      decisions.push({
+        action: "reap",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "no_db_row",
+      });
       continue;
     }
     if (rows.every((r) => config.terminalStatuses.has(r.status))) {
       // Reap ONLY when EVERY row is terminal — any live row protects the key.
-      orphans.push({ name: container.name, id: container.id, key, reason: "terminal_db_row" });
+      decisions.push({
+        action: "reap",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "terminal_db_row",
+      });
       continue;
     }
 
@@ -268,33 +307,131 @@ export function computeOrphanContainersToReap(
     // stale twin iff NONE of the live rows point at this node — the canonical
     // container lives elsewhere. Require the newest such mismatching row to have
     // been stable past the grace window before reaping.
-    if (nodeAware) {
-      const liveRows_ = rows.filter((r) => !config.terminalStatuses.has(r.status));
-      const anyOnThisNode = liveRows_.some((r) => r.nodeId === nodeId);
-      if (anyOnThisNode) continue;
-      // Only reap if every live row carries a node (else we can't prove
-      // elsewhere) and the freshest is older than the grace window.
-      const stamps = liveRows_.map((r) => r.updatedAtMs);
-      const allHaveNodeAndStamp = liveRows_.every(
-        (r) => r.nodeId !== undefined && r.updatedAtMs !== undefined,
-      );
-      if (!allHaveNodeAndStamp) continue;
-      // The CONTAINER must also be older than the grace window. A row's age
-      // alone cannot protect an in-flight re-placement: the worker creates the
-      // container on the new node BEFORE updating the row, so mid-provision the
-      // stale row (old timestamp, old node) makes a seconds-old container look
-      // reapable — the row-age check would even pass MORE easily. Caught live
-      // in the prod dry-run: a 29-second-old container drew a wrong_node
-      // verdict against a 12-day-old row. Unknown container age → never reap.
-      if (container.createdAtMs === undefined) continue;
-      if (nowMs !== undefined && nowMs - container.createdAtMs < graceMs) continue;
-      const newest = Math.max(...(stamps as number[]));
-      if (nowMs !== undefined && nowMs - newest >= graceMs) {
-        orphans.push({ name: container.name, id: container.id, key, reason: "wrong_node" });
-      }
+    if (!config.nodeAware) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "live_db_row",
+      });
+      continue;
     }
+    if (!nodeAware) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "node_context_unavailable",
+      });
+      continue;
+    }
+
+    const liveRows_ = rows.filter((r) => !config.terminalStatuses.has(r.status));
+    if (liveRows_.some((r) => r.nodeId === nodeId)) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "live_on_node",
+      });
+      continue;
+    }
+    const completePlacements = liveRows_.filter(
+      (
+        row,
+      ): row is LiveContainerRef & {
+        nodeId: string;
+        updatedAtMs: number;
+      } => row.nodeId !== undefined && row.updatedAtMs !== undefined,
+    );
+    if (completePlacements.length !== liveRows_.length) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "wrong_node_evidence_incomplete",
+      });
+      continue;
+    }
+    if (container.createdAtMs === undefined || nowMs === undefined) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "wrong_node_age_unknown",
+      });
+      continue;
+    }
+    if (nowMs - container.createdAtMs < graceMs) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "wrong_node_container_within_grace",
+      });
+      continue;
+    }
+    const newest = Math.max(...completePlacements.map((row) => row.updatedAtMs));
+    if (nowMs - newest < graceMs) {
+      decisions.push({
+        action: "retain",
+        name: container.name,
+        id: container.id,
+        key,
+        reason: "wrong_node_row_within_grace",
+      });
+      continue;
+    }
+    decisions.push({
+      action: "reap",
+      name: container.name,
+      id: container.id,
+      key,
+      reason: "wrong_node",
+    });
   }
-  return orphans;
+  return decisions;
+}
+
+/**
+ * Compatibility view for callers that only need containers approved for
+ * removal. Reconciliation uses the full decision set so retained workloads
+ * remain observable.
+ */
+export function computeOrphanContainersToReap(
+  containersOnNode: readonly NodeContainerRef[],
+  liveRows: readonly LiveContainerRef[],
+  config: Pick<
+    OrphanReconcilerConfig,
+    "keyOf" | "terminalStatuses" | "nodeAware" | "nodeMoveGraceMs"
+  >,
+  nodeId?: string,
+  nowMs?: number,
+): OrphanContainer[] {
+  return classifyContainersForReconciliation(
+    containersOnNode,
+    liveRows,
+    config,
+    nodeId,
+    nowMs,
+  ).flatMap((decision) =>
+    decision.action === "reap"
+      ? [
+          {
+            name: decision.name,
+            id: decision.id,
+            key: decision.key,
+            reason: decision.reason,
+          },
+        ]
+      : [],
+  );
 }
 
 /**
@@ -324,6 +461,11 @@ export async function reconcileOrphanContainers(
       // Defensive: callers should already filter, but never reap on a node we
       // have not confirmed reachable.
       result.nodesSkipped += 1;
+      logger.warn(`[${config.logScope}] Skipping unhealthy node`, {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+        nodeStatus: node.status,
+      });
       continue;
     }
 
@@ -340,21 +482,34 @@ export async function reconcileOrphanContainers(
     }
     result.nodesScanned += 1;
 
-    const keys = containersOnNode
-      .map((c) => config.keyOf(c.name))
-      .filter((key): key is string => key !== null);
-    if (keys.length === 0) continue;
-
-    const liveRows = await config.loadStatuses(keys);
-    const orphans = computeOrphanContainersToReap(
+    const keys = [
+      ...new Set(
+        containersOnNode
+          .map((container) => config.keyOf(container.name))
+          .filter((key): key is string => key !== null),
+      ),
+    ];
+    const liveRows = keys.length === 0 ? [] : await config.loadStatuses(keys);
+    const decisions = classifyContainersForReconciliation(
       containersOnNode,
       liveRows,
       config,
       node.node_id,
       Date.now(),
     );
+    for (const retained of decisions.filter((decision) => decision.action === "retain")) {
+      logger.debug(`[${config.logScope}] Retained container`, {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+        containerName: retained.name,
+        containerId: retained.id,
+        key: retained.key,
+        decision: retained.action,
+        reason: retained.reason,
+      });
+    }
 
-    for (const orphan of orphans) {
+    for (const orphan of decisions.filter((decision) => decision.action === "reap")) {
       try {
         // Reap by the IMMUTABLE container ID (`orphan.id`), never the name. The
         // id was captured in the same SSH listing that found the orphan, so it
@@ -371,16 +526,23 @@ export async function reconcileOrphanContainers(
           nodeId: node.node_id,
           hostname: node.hostname,
           containerName: orphan.name,
+          containerId: orphan.id,
           key: orphan.key,
+          decision: orphan.action,
           reason: orphan.reason,
         });
       } catch (error) {
+        // error-policy:J6 orphan cleanup is best-effort per container; the
+        // failed decision remains visible and the sweep continues to other IDs.
         result.reapFailed += 1;
         logger.warn(`[${config.logScope}] Failed to reap orphan container`, {
           nodeId: node.node_id,
           hostname: node.hostname,
           containerName: orphan.name,
+          containerId: orphan.id,
           key: orphan.key,
+          decision: orphan.action,
+          reason: orphan.reason,
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -393,6 +555,88 @@ export async function reconcileOrphanContainers(
 /** Hard per-call SSH budgets so a hung node can never wedge the reconciler. */
 const ORPHAN_LIST_TIMEOUT_MS = 15_000;
 const ORPHAN_RM_TIMEOUT_MS = 30_000;
+
+const DOCKER_CREATED_AT_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?\s+([+-])(\d{2})(\d{2})(?:\s+\S+)?$/;
+
+function parseDockerCreatedAt(raw: string): number | undefined {
+  const match = DOCKER_CREATED_AT_PATTERN.exec(raw.trim());
+  if (!match) return undefined;
+  const [
+    ,
+    yearRaw,
+    monthRaw,
+    dayRaw,
+    hourRaw,
+    minuteRaw,
+    secondRaw,
+    fraction = "",
+    sign,
+    offsetHourRaw,
+    offsetMinuteRaw,
+  ] = match;
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  const hour = Number(hourRaw);
+  const minute = Number(minuteRaw);
+  const second = Number(secondRaw);
+  const millisecond = Number(fraction.padEnd(3, "0").slice(0, 3));
+  const offsetHour = Number(offsetHourRaw);
+  const offsetMinute = Number(offsetMinuteRaw);
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    return undefined;
+  }
+
+  const local = new Date(0);
+  local.setUTCFullYear(year, month - 1, day);
+  local.setUTCHours(hour, minute, second, millisecond);
+  if (
+    local.getUTCFullYear() !== year ||
+    local.getUTCMonth() !== month - 1 ||
+    local.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+  const offsetMs = (offsetHour * 60 + offsetMinute) * 60_000;
+  return local.getTime() - (sign === "+" ? offsetMs : -offsetMs);
+}
+
+/**
+ * Parses the exact Docker listing consumed by the reconciler. Malformed ages
+ * remain represented without `createdAtMs`, which makes destructive decisions
+ * fail closed instead of silently treating an unparseable timestamp as old.
+ */
+export function parseNodeContainerList(output: string, prefix: string): NodeContainerRef[] {
+  const containers: NodeContainerRef[] = [];
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const fields = line.split("|");
+    if (fields.length !== 3) continue;
+    const [rawName = "", rawId = "", createdAtRaw = ""] = fields;
+    const name = rawName.trim();
+    const id = rawId.trim();
+    if (!name.startsWith(prefix) || !name || !id) continue;
+    const createdAtMs = parseDockerCreatedAt(createdAtRaw);
+    containers.push({
+      name,
+      id,
+      ...(createdAtMs === undefined ? {} : { createdAtMs }),
+    });
+  }
+  return containers;
+}
 
 /**
  * Production wiring for the orphan-container reconciler: enumerate enabled,
@@ -431,28 +675,10 @@ export async function reconcileOrphanContainersOnNodes(
             `docker ps -a --format '{{.Names}}|{{.ID}}|{{.CreatedAt}}' --filter name=${shellQuote(config.prefix)}`,
             ORPHAN_LIST_TIMEOUT_MS,
           );
-          return (
-            output
-              .split("\n")
-              .map((line) => line.trim())
-              .filter(Boolean)
-              // `--filter name=` is a substring match, so re-check the prefix to
-              // exclude any container that merely contains the prefix mid-name.
-              .filter((line) => line.startsWith(config.prefix))
-              .map((line) => {
-                const [name = "", id = "", createdAtRaw = ""] = line.split("|");
-                // docker's CreatedAt: "2026-07-07 16:45:01 +0000 UTC" — Date
-                // rejects the trailing " UTC" but parses the "+0000" offset.
-                const createdAt = Date.parse(createdAtRaw.replace(" UTC", "").trim());
-                return {
-                  name,
-                  id,
-                  ...(Number.isFinite(createdAt) ? { createdAtMs: createdAt } : {}),
-                };
-              })
-              .filter((c) => c.name && c.id)
-          );
+          return parseNodeContainerList(output, config.prefix);
         } catch (error) {
+          // error-policy:J1 the SSH adapter translates a transport failure into
+          // the explicit null signal that makes the sweep skip the whole node.
           logger.warn(`[${config.logScope}] Container listing failed over SSH`, {
             nodeId: node.node_id,
             hostname: node.hostname,

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -246,6 +246,15 @@ export function computeOrphanContainersToReap(
 
     const rows = rowsByKey.get(key);
     if (rows === undefined || rows.length === 0) {
+      // A key with no row is what an orphan looks like — and ALSO what an
+      // in-flight creation looks like from the wrong side of a commit, and
+      // what a key-resolution gap looks like from the wrong side of a rename.
+      // Same rule wrong_node learned from the prod dry-run below: the
+      // CONTAINER itself must be older than the grace window, and an unknown
+      // container age never reaps. An orphan is permanent; it can wait five
+      // minutes to be provably one.
+      if (container.createdAtMs === undefined) continue;
+      if (nowMs === undefined || nowMs - container.createdAtMs < graceMs) continue;
       orphans.push({ name: container.name, id: container.id, key, reason: "no_db_row" });
       continue;
     }

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -163,6 +163,13 @@ export interface OrphanReconcilerConfig {
    */
   nodeAware?: boolean;
   /**
+   * How long a container with no matching ownership row must exist before it
+   * may be reaped. This protects the create-before-row-commit window for every
+   * workload type, including apps. Defaults to
+   * `DEFAULT_ROWLESS_GRACE_MS` when unset.
+   */
+  rowlessGraceMs?: number;
+  /**
    * How long a `nodeId` mismatch must persist before the twin is reaped
    * (epoch-ms delta against the row's `updatedAtMs`). Guards the provision race
    * where a container is healthy on its new node before the DB row catches up.
@@ -178,6 +185,12 @@ export interface OrphanReconcilerConfig {
  * NEW container is never mistaken for the twin during its own creation window.
  */
 export const DEFAULT_NODE_MOVE_GRACE_MS = 5 * 60_000;
+
+/**
+ * A rowless container must outlive the normal create-and-commit window before
+ * absence of durable ownership is treated as conclusive.
+ */
+export const DEFAULT_ROWLESS_GRACE_MS = 5 * 60_000;
 
 /**
  * Classify every listed container as retained or reapable.
@@ -222,7 +235,7 @@ export function classifyContainersForReconciliation(
   liveRows: readonly LiveContainerRef[],
   config: Pick<
     OrphanReconcilerConfig,
-    "keyOf" | "terminalStatuses" | "nodeAware" | "nodeMoveGraceMs"
+    "keyOf" | "terminalStatuses" | "nodeAware" | "rowlessGraceMs" | "nodeMoveGraceMs"
   >,
   nodeId?: string,
   nowMs?: number,
@@ -238,11 +251,18 @@ export function classifyContainersForReconciliation(
   }
 
   const nodeAware = config.nodeAware === true && nodeId !== undefined;
-  const graceMs = config.nodeMoveGraceMs ?? DEFAULT_NODE_MOVE_GRACE_MS;
-  if (!Number.isFinite(graceMs) || graceMs < 0) {
-    throw new ElizaError("Orphan reconciliation grace must be a non-negative duration", {
+  const rowlessGraceMs = config.rowlessGraceMs ?? DEFAULT_ROWLESS_GRACE_MS;
+  const nodeMoveGraceMs = config.nodeMoveGraceMs ?? DEFAULT_NODE_MOVE_GRACE_MS;
+  if (!Number.isFinite(rowlessGraceMs) || rowlessGraceMs < 0) {
+    throw new ElizaError("Rowless reconciliation grace must be a non-negative duration", {
       code: "ORPHAN_RECONCILER_INVALID_GRACE",
-      context: { graceMs },
+      context: { graceKind: "rowless", graceMs: rowlessGraceMs },
+    });
+  }
+  if (!Number.isFinite(nodeMoveGraceMs) || nodeMoveGraceMs < 0) {
+    throw new ElizaError("Node-move reconciliation grace must be a non-negative duration", {
+      code: "ORPHAN_RECONCILER_INVALID_GRACE",
+      context: { graceKind: "node_move", graceMs: nodeMoveGraceMs },
     });
   }
 
@@ -280,7 +300,7 @@ export function classifyContainersForReconciliation(
         });
         continue;
       }
-      if (nowMs - container.createdAtMs < graceMs) {
+      if (nowMs - container.createdAtMs < rowlessGraceMs) {
         decisions.push({
           action: "retain",
           name: container.name,
@@ -383,7 +403,7 @@ export function classifyContainersForReconciliation(
       });
       continue;
     }
-    if (nowMs - container.createdAtMs < graceMs) {
+    if (nowMs - container.createdAtMs < nodeMoveGraceMs) {
       decisions.push({
         action: "retain",
         name: container.name,
@@ -394,7 +414,7 @@ export function classifyContainersForReconciliation(
       continue;
     }
     const newest = Math.max(...completePlacements.map((row) => row.updatedAtMs));
-    if (nowMs - newest < graceMs) {
+    if (nowMs - newest < nodeMoveGraceMs) {
       decisions.push({
         action: "retain",
         name: container.name,
@@ -425,7 +445,7 @@ export function computeOrphanContainersToReap(
   liveRows: readonly LiveContainerRef[],
   config: Pick<
     OrphanReconcilerConfig,
-    "keyOf" | "terminalStatuses" | "nodeAware" | "nodeMoveGraceMs"
+    "keyOf" | "terminalStatuses" | "nodeAware" | "rowlessGraceMs" | "nodeMoveGraceMs"
   >,
   nodeId?: string,
   nowMs?: number,

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -6,6 +6,7 @@
  * adapters supply their name parser, status vocabulary, and ownership query.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { logger } from "../utils/logger";
 import { shellQuote } from "./docker-sandbox-utils";
@@ -238,6 +239,12 @@ export function classifyContainersForReconciliation(
 
   const nodeAware = config.nodeAware === true && nodeId !== undefined;
   const graceMs = config.nodeMoveGraceMs ?? DEFAULT_NODE_MOVE_GRACE_MS;
+  if (!Number.isFinite(graceMs) || graceMs < 0) {
+    throw new ElizaError("Orphan reconciliation grace must be a non-negative duration", {
+      code: "ORPHAN_RECONCILER_INVALID_GRACE",
+      context: { graceMs },
+    });
+  }
 
   const decisions: ContainerReconcileDecision[] = [];
   for (const container of containersOnNode) {
@@ -255,14 +262,15 @@ export function classifyContainersForReconciliation(
 
     const rows = rowsByKey.get(key);
     if (rows === undefined || rows.length === 0) {
-      // A key with no row is what an orphan looks like — and ALSO what an
-      // in-flight creation looks like from the wrong side of a commit, and
-      // what a key-resolution gap looks like from the wrong side of a rename.
-      // Same rule wrong_node learned from the prod dry-run below: the
-      // CONTAINER itself must be older than the grace window, and an unknown
-      // container age never reaps. An orphan is permanent; it can wait five
-      // minutes to be provably one.
-      if (container.createdAtMs === undefined || nowMs === undefined) {
+      // A missing row is also observable before an in-flight create commits.
+      // Requiring a finite container age gives that write time to become
+      // visible and makes malformed Docker timestamps non-destructive.
+      if (
+        container.createdAtMs === undefined ||
+        !Number.isFinite(container.createdAtMs) ||
+        nowMs === undefined ||
+        !Number.isFinite(nowMs)
+      ) {
         decisions.push({
           action: "retain",
           name: container.name,
@@ -345,7 +353,10 @@ export function classifyContainersForReconciliation(
       ): row is LiveContainerRef & {
         nodeId: string;
         updatedAtMs: number;
-      } => row.nodeId !== undefined && row.updatedAtMs !== undefined,
+      } =>
+        row.nodeId !== undefined &&
+        row.updatedAtMs !== undefined &&
+        Number.isFinite(row.updatedAtMs),
     );
     if (completePlacements.length !== liveRows_.length) {
       decisions.push({
@@ -357,7 +368,12 @@ export function classifyContainersForReconciliation(
       });
       continue;
     }
-    if (container.createdAtMs === undefined || nowMs === undefined) {
+    if (
+      container.createdAtMs === undefined ||
+      !Number.isFinite(container.createdAtMs) ||
+      nowMs === undefined ||
+      !Number.isFinite(nowMs)
+    ) {
       decisions.push({
         action: "retain",
         name: container.name,
@@ -532,8 +548,9 @@ export async function reconcileOrphanContainers(
           reason: orphan.reason,
         });
       } catch (error) {
-        // error-policy:J6 orphan cleanup is best-effort per container; the
-        // failed decision remains visible and the sweep continues to other IDs.
+        // error-policy:J1 each Docker removal is an independent transport
+        // boundary; return its explicit failure count after processing the
+        // remaining immutable IDs.
         result.reapFailed += 1;
         logger.warn(`[${config.logScope}] Failed to reap orphan container`, {
           nodeId: node.node_id,
@@ -623,11 +640,16 @@ export function parseNodeContainerList(output: string, prefix: string): NodeCont
     const line = rawLine.trim();
     if (!line) continue;
     const fields = line.split("|");
-    if (fields.length !== 3) continue;
     const [rawName = "", rawId = "", createdAtRaw = ""] = fields;
     const name = rawName.trim();
+    if (!name.startsWith(prefix)) continue;
     const id = rawId.trim();
-    if (!name.startsWith(prefix) || !name || !id) continue;
+    if (fields.length !== 3 || !id) {
+      throw new ElizaError("Docker returned an invalid managed-container listing row", {
+        code: "ORPHAN_RECONCILER_INVALID_LISTING",
+        context: { name, prefix, fieldCount: fields.length },
+      });
+    }
     const createdAtMs = parseDockerCreatedAt(createdAtRaw);
     containers.push({
       name,


### PR DESCRIPTION
## Review finding

The original PR found a real destructive bug: a warm-claimed container retains the physical name `agent-<pool id>` after the pool row is deleted, so primary-key-only lookup could classify the live customer container as rowless.

Matching only `warm_claim_source_pool_id` and adding a grace period was not complete, however. The source ID is cleared in the finalized steady state, replacement cleanup has a second physical name and placement, read-replica lag can hide current ownership, malformed Docker timestamps made age ambiguous, and broad aliasing could accidentally protect the same name on an unrelated node.

## Fix

This rewrite makes destructive reconciliation fail closed:

- resolves ownership by durable `container_name` and `replacement_cleanup_container_name`, as well as the sandbox ID;
- aliases each physical name only to its own primary or replacement placement;
- reads ownership from the write primary so replica lag cannot fabricate an orphan;
- gives rowless containers a grace window and refuses removal when container age or classification time is missing/non-finite;
- validates Docker listing structure and numeric-offset timestamps, skipping the whole node on malformed managed rows;
- requires complete node, row-age, and container-age evidence before reaping a wrong-node twin;
- emits a typed retain/reap decision for every listed managed container and removes only the immutable Docker ID captured by that listing;
- fails workload aggregate reads when their required row is missing instead of fabricating zero.

The existing per-container removal boundary remains explicit: one failed immutable-ID removal increments `reapFailed` and does not hide or prevent the independently classified removals that follow.

## Validation

Exact PR head `c380a18456fc67b2794a0a07ce62b8f1aa901aea`, rebased onto `develop` at `b29eedc9ef3a4e7d54b043beff4ea6f9d71c17e7`:

- deterministic parser, classification, agent/app orchestration, and failure-path suites: **69 pass / 0 fail / 104 assertions**;
- real in-process PGlite schema and repository ownership resolution: **4 pass / 0 fail / 10 assertions**;
- migration journal registration: **3 pass / 0 fail / 4 assertions**;
- Drizzle schema/migration consistency check: pass;
- `@elizaos/cloud-shared` typecheck: pass;
- `bun run audit:scripts`: pass;
- Biome on all nine touched TypeScript files plus journal JSON validation: pass;
- `git diff --check origin/develop...HEAD`: pass.

The PGlite evidence exercises the real schema, queries, finalized warm-claim name, replacement cleanup name, and absent-owner case. The Docker/SSH boundary is exercised through the production reconciliation interface with injected node transports; no live customer node or destructive real-Docker removal was used for safety.

Refs #17253 §1

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only destructive reconciliation; no visual surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only destructive reconciliation; no visual surface

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser request path

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or evaluator behavior

<!-- evidence-row:domain-artifacts -->
- [x] [PGlite durable physical-ownership proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17256-pr-17256-orphan-reaper-pglite-0e5.log)

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual evidence

<!-- evidence-row:backend-logs -->
- [x] [Parser, classification, orchestration, and failure-path validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17256-pr-17256-orphan-reaper-unit-0e5.log)
- [x] [PGlite repository validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17256-pr-17256-orphan-reaper-pglite-0e5.log)
