### PR TITLE
fix(android): reject relocated privileged AAB components

### DIFF
--- a/packages/app-core/scripts/lib/android-cloud-artifact-audit.mjs
+++ b/packages/app-core/scripts/lib/android-cloud-artifact-audit.mjs
@@ -117,11 +117,27 @@ function isSafeModuleName(moduleName) {
   );
 }
 
-function qualifyComponent(appId, component) {
-  const normalized = component.replace(/\.java$/, "");
-  if (normalized.startsWith(".")) return `${appId}${normalized}`;
-  if (normalized.includes(".")) return normalized;
-  return `${appId}.${normalized}`;
+function androidClassBasename(className) {
+  let normalized = requireNonEmptyString(
+    className,
+    "stripped Android class name",
+  ).replace(/\.java$/, "");
+  if (normalized.startsWith("L") && normalized.endsWith(";")) {
+    normalized = normalized.slice(1, -1);
+  }
+  const separatorIndex = Math.max(
+    normalized.lastIndexOf("."),
+    normalized.lastIndexOf("/"),
+  );
+  return normalized.slice(separatorIndex + 1);
+}
+
+function matchesAndroidClassBasename(candidate, classBasename) {
+  return (
+    candidate === classBasename ||
+    candidate.endsWith(`.${classBasename}`) ||
+    candidate.endsWith(`/${classBasename}`)
+  );
 }
 
 function qualifyPermission(permission) {
@@ -719,10 +735,8 @@ export function assertAabManifestPolicy({
     );
   }
 
-  const forbiddenComponents = uniqueSorted(
-    strippedComponents.map((component) =>
-      qualifyComponent(resolvedAppId, component),
-    ),
+  const forbiddenComponentClasses = uniqueSorted(
+    strippedComponents.map(androidClassBasename),
   );
   const forbiddenPermissions = uniqueSorted([
     ...strippedPermissions.map(qualifyPermission),
@@ -772,28 +786,43 @@ export function assertAabManifestPolicy({
         );
       }
     }
-    const manifestComponents = androidAttributeValues(
-      MANIFEST_COMPONENT_ELEMENTS,
-      "name",
+    const componentTags = tags.filter((tag) =>
+      MANIFEST_COMPONENT_ELEMENTS.includes(tag.name),
     );
-    const qualifiedManifestComponents = manifestComponents.map((component) =>
-      qualifyComponent(resolvedAppId, component),
-    );
-    for (const component of forbiddenComponents) {
-      if (qualifiedManifestComponents.includes(component)) {
+    for (const tag of componentTags) {
+      for (const attributeName of [
+        "permission",
+        "readPermission",
+        "writePermission",
+      ]) {
+        const permission = readXmlAttribute(
+          tag,
+          ANDROID_XML_NAMESPACE,
+          attributeName,
+        );
+        if (permission && forbiddenPermissions.includes(permission)) {
+          findings.push(
+            `android-cloud AAB module ${moduleName} contains forbidden component ${attributeName}: ${permission}`,
+          );
+        }
+      }
+    }
+    const manifestComponents = componentTags
+      .map((tag) => readXmlAttribute(tag, ANDROID_XML_NAMESPACE, "name"))
+      .filter(Boolean);
+    for (const component of manifestComponents) {
+      const forbiddenClass = forbiddenComponentClasses.find((className) =>
+        matchesAndroidClassBasename(component, className),
+      );
+      if (forbiddenClass) {
         findings.push(
           `android-cloud AAB module ${moduleName} contains forbidden component: ${component}`,
         );
       }
-    }
-    for (const component of manifestComponents) {
-      const privateClass = ANDROID_LP3_POLICY_CLASSES.find(
-        (className) =>
-          component === className ||
-          component.endsWith(`.${className}`) ||
-          component.endsWith(`/${className}`),
+      const privateClass = ANDROID_LP3_POLICY_CLASSES.find((className) =>
+        matchesAndroidClassBasename(component, className),
       );
-      if (privateClass) {
+      if (!forbiddenClass && privateClass) {
         findings.push(
           `android-cloud AAB module ${moduleName} contains forbidden LP3 component: ${component}`,
         );
@@ -855,31 +884,46 @@ function normalizeDexBuffers(dexEntries, dexBuffers) {
 }
 
 /**
- * Scans all module DEX files for private LP3 implementation and control-plane
- * markers, including features that a universal APK can omit.
+ * Scans every DEX payload for stripped repo-owned classes and private LP3
+ * control-plane markers, including features that a universal APK can omit.
  */
-export function assertAabDexPolicy({ appId, dexEntries, dexBuffers }) {
-  const resolvedAppId = requireNonEmptyString(appId, "Android application ID");
+export function assertAabDexPolicy({
+  appId,
+  dexEntries,
+  dexBuffers,
+  strippedComponents,
+}) {
+  requireNonEmptyString(appId, "Android application ID");
   requireStringArray(dexEntries, "Android App Bundle DEX entries");
+  requireStringArray(strippedComponents, "stripped Android components");
   const buffers = normalizeDexBuffers(dexEntries, dexBuffers);
-  const packagePath = resolvedAppId.replaceAll(".", "/");
-  const forbiddenMarkers = uniqueSorted(
-    [
-      ...ANDROID_LP3_POLICY_CLASSES.flatMap((className) => [
-        `${packagePath}/${className}`,
-        `${resolvedAppId}.${className}`,
-        `/${className};`,
-        `L${className};`,
-      ]),
-      ...ANDROID_LP3_PRIVATE_ACTIONS,
-      ...ANDROID_LP3_POLICY_MARKERS,
-    ],
-    (left, right) => right.length - left.length || left.localeCompare(right),
+  const forbiddenClasses = uniqueSorted(
+    [...strippedComponents, ...ANDROID_LP3_POLICY_CLASSES].map(
+      androidClassBasename,
+    ),
   );
+  const forbiddenClassDescriptors = forbiddenClasses.flatMap((className) => [
+    { className, marker: Buffer.from(`/${className};`, "utf8") },
+    { className, marker: Buffer.from(`L${className};`, "utf8") },
+  ]);
+  const forbiddenLp3Markers = uniqueSorted([
+    ...ANDROID_LP3_PRIVATE_ACTIONS,
+    ...ANDROID_LP3_POLICY_MARKERS,
+  ]).map((marker) => ({
+    marker,
+    payload: Buffer.from(marker, "utf8"),
+  }));
 
   for (let index = 0; index < buffers.length; index += 1) {
-    for (const marker of forbiddenMarkers) {
-      if (buffers[index].includes(Buffer.from(marker, "utf8"))) {
+    for (const { className, marker } of forbiddenClassDescriptors) {
+      if (buffers[index].includes(marker)) {
+        throw androidAabAuditError(
+          `[mobile-build] android-cloud AAB DEX ${dexEntries[index]} contains forbidden stripped component class: ${className}`,
+        );
+      }
+    }
+    for (const { marker, payload } of forbiddenLp3Markers) {
+      if (buffers[index].includes(payload)) {
         throw androidAabAuditError(
           `[mobile-build] android-cloud AAB DEX ${dexEntries[index]} contains forbidden LP3 marker: ${marker}`,
         );
@@ -1054,7 +1098,12 @@ export function inspectAndroidAppBundle(
     artifact: resolvedArtifact,
     javaHome,
   });
-  assertAabDexPolicy({ appId, dexEntries, dexBuffers });
+  assertAabDexPolicy({
+    appId,
+    dexEntries,
+    dexBuffers,
+    strippedComponents,
+  });
 
   return {
     appId: requireNonEmptyString(appId, "Android application ID"),

--- a/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
@@ -3,6 +3,7 @@
  * with deterministic manifest and DEX payloads.
  */
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -86,6 +87,17 @@ const REAL_AAB_FIXTURE = fileURLToPath(
   ),
 );
 const REAL_AAB_PACKAGE = "com.google.android.samples.dynamicfeatures.ondemand";
+const REAL_AAB_MANIFEST_MUTATOR = fileURLToPath(
+  new URL(
+    "../test/fixtures/android/RelocateAndroidManifestFixture.java",
+    import.meta.url,
+  ),
+);
+const RELOCATED_STRIPPED_CLASS = "ElizaAccessibilityService";
+const RELOCATED_STRIPPED_COMPONENT =
+  "com.feature.relocated.security.component.abc.ElizaAccessibilityService";
+const RELOCATED_STRIPPED_DESCRIPTOR =
+  "Lcom/feature/relocated/security/component/abc/ElizaAccessibilityService;";
 // Generic app-core CI lanes do not all provision a JDK or permit downloads.
 // Opt in only after the caller has provisioned the Android/JDK toolchain.
 const RUN_REAL_AAB_TEST = process.env.ELIZA_ANDROID_RUN_REAL_AAB_TEST === "1";
@@ -309,6 +321,51 @@ function writeMutatedRealAab(temporaryDir, name, mutate) {
   return { archive, artifact };
 }
 
+function replaceExactBytes(bytes, original, replacement) {
+  const source = Buffer.from(original, "utf8");
+  const target = Buffer.from(replacement, "utf8");
+  if (source.byteLength !== target.byteLength) {
+    throw new Error("real AAB fixture replacements must preserve byte length");
+  }
+  const offset = bytes.indexOf(source);
+  if (offset === -1 || bytes.indexOf(source, offset + 1) !== -1) {
+    throw new Error(
+      `expected exactly one real AAB fixture marker: ${original}`,
+    );
+  }
+  const rewritten = Buffer.from(bytes);
+  target.copy(rewritten, offset);
+  return rewritten;
+}
+
+function rewriteRealFeatureManifest(temporaryDir, archive) {
+  const input = path.join(temporaryDir, "feature-manifest.pb");
+  const output = path.join(temporaryDir, "relocated-feature-manifest.pb");
+  fs.writeFileSync(input, archive["java/manifest/AndroidManifest.xml"]);
+  const java = path.join(
+    process.env.JAVA_HOME,
+    "bin",
+    process.platform === "win32" ? "java.exe" : "java",
+  );
+  const result = spawnSync(
+    java,
+    [
+      "--class-path",
+      realBundletoolJar,
+      REAL_AAB_MANIFEST_MUTATOR,
+      input,
+      output,
+    ],
+    { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `real AAB manifest fixture mutation failed: ${result.stderr || result.stdout}`,
+    );
+  }
+  archive["java/manifest/AndroidManifest.xml"] = fs.readFileSync(output);
+}
+
 describe("Android App Bundle entry discovery", () => {
   it("distinguishes APKs and AABs and rejects other artifact types", () => {
     expect(resolveAndroidArtifactKind("/artifacts/app-debug.APK")).toBe("apk");
@@ -434,6 +491,64 @@ describeRealAab("real multi-module bundletool regression", () => {
           `module java contains forbidden component: ${escapedComponent}`,
       ),
     );
+  });
+
+  it("rejects a relocated non-LP3 service and its privileged binding in a real feature manifest", () => {
+    const temporaryDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-real-aab-manifest-policy-"),
+    );
+    try {
+      const { archive, artifact } = writeMutatedRealAab(
+        temporaryDir,
+        "relocated-privileged-service.aab",
+        (entries) => rewriteRealFeatureManifest(temporaryDir, entries),
+      );
+
+      expect(() =>
+        inspectAndroidAppBundle({
+          ...realAabInspectionOptions(artifact, archive),
+          strippedComponents: [RELOCATED_STRIPPED_CLASS],
+          strippedPermissions: ["BIND_ACCESSIBILITY_SERVICE"],
+        }),
+      ).toThrow(
+        new RegExp(
+          `module java contains forbidden component permission: android\\.permission\\.BIND_ACCESSIBILITY_SERVICE[\\s\\S]*` +
+            `module java contains forbidden component: ${RELOCATED_STRIPPED_COMPONENT.replaceAll(".", String.raw`\.`)}`,
+        ),
+      );
+    } finally {
+      fs.rmSync(temporaryDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a relocated non-LP3 class in a real feature DEX", () => {
+    const temporaryDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-real-aab-relocated-dex-"),
+    );
+    try {
+      const { archive, artifact } = writeMutatedRealAab(
+        temporaryDir,
+        "relocated-feature-class.aab",
+        (entries) => {
+          entries["java/dex/classes.dex"] = replaceExactBytes(
+            Buffer.from(entries["java/dex/classes.dex"]),
+            "Lcom/google/android/samples/dynamicfeatures/ondemand/JavaSampleActivity;",
+            RELOCATED_STRIPPED_DESCRIPTOR,
+          );
+        },
+      );
+
+      expect(() =>
+        inspectAndroidAppBundle({
+          ...realAabInspectionOptions(artifact, archive),
+          strippedComponents: [RELOCATED_STRIPPED_CLASS],
+        }),
+      ).toThrow(
+        "java/dex/classes.dex contains forbidden stripped component class: ElizaAccessibilityService",
+      );
+    } finally {
+      fs.rmSync(temporaryDir, { force: true, recursive: true });
+    }
   });
 
   it("rejects a forbidden marker found only in a real feature DEX", () => {
@@ -1072,12 +1187,9 @@ describe("Android artifact boundary selection", () => {
     );
 
     expect(() =>
-      readAndroidArtifactEntryBuffers(
-        "/artifact.aab",
-        [entry],
-        JAVA_HOME,
-        { artifactBytes: archive },
-      ),
+      readAndroidArtifactEntryBuffers("/artifact.aab", [entry], JAVA_HOME, {
+        artifactBytes: archive,
+      }),
     ).toThrow(
       expect.objectContaining({ code: "ANDROID_ARTIFACT_ENTRY_TOO_LARGE" }),
     );
@@ -1801,6 +1913,11 @@ describe("inspectAndroidAppBundle", () => {
       "forbidden component",
     ],
     [
+      "relocated non-LP3 stripped component",
+      '<manifest xmlns:android="http://schemas.android.com/apk/res/android"><application><service android:name="com.feature.ElizaAgentService"/></application></manifest>',
+      "forbidden component",
+    ],
+    [
       "relocated private LP3 component",
       '<manifest xmlns:a="http://schemas.android.com/apk/res/android"><application><service a:name="com.attacker.Lp3ColorPolicyService"/></application></manifest>',
       "forbidden LP3 component",
@@ -1834,6 +1951,52 @@ describe("inspectAndroidAppBundle", () => {
         harness.deps,
       ),
     ).toThrow(new RegExp(`module feature contains ${message}`));
+  });
+
+  it.each(["permission", "readPermission", "writePermission"])(
+    "rejects a forbidden component android:%s binding in any module",
+    (attributeName) => {
+      const manifest =
+        '<manifest xmlns:a="http://schemas.android.com/apk/res/android"><application>' +
+        `<provider a:name="com.feature.ElizaAgentService" a:${attributeName}="android.permission.WRITE_SECURE_SETTINGS"/>` +
+        "</application></manifest>";
+      const harness = successfulToolHarness(
+        new Map([
+          ["base", CLEAN_MANIFEST],
+          ["feature", manifest],
+        ]),
+      );
+
+      expect(() =>
+        inspectAndroidAppBundle(
+          inspectOptions({ entries: MULTI_MODULE_ENTRIES }),
+          harness.deps,
+        ),
+      ).toThrow(
+        `module feature contains forbidden component ${attributeName}: android.permission.WRITE_SECURE_SETTINGS`,
+      );
+    },
+  );
+
+  it("does not reject manifest class-name lookalikes", () => {
+    const manifest =
+      '<manifest xmlns:a="http://schemas.android.com/apk/res/android"><application>' +
+      '<service a:name="com.feature.SafeElizaAgentService"/>' +
+      '<service a:name="com.feature.ElizaAgentServiceProxy"/>' +
+      "</application></manifest>";
+    const harness = successfulToolHarness(
+      new Map([
+        ["base", CLEAN_MANIFEST],
+        ["feature", manifest],
+      ]),
+    );
+
+    expect(() =>
+      inspectAndroidAppBundle(
+        inspectOptions({ entries: MULTI_MODULE_ENTRIES }),
+        harness.deps,
+      ),
+    ).not.toThrow();
   });
 
   it("rejects an LP3 marker found only in a feature module DEX", () => {
@@ -1891,6 +2054,58 @@ describe("inspectAndroidAppBundle", () => {
     );
   });
 
+  it.each(["feature/dex/classes2.dex", "base/assets/classes.dex"])(
+    "rejects a relocated non-LP3 stripped class in %s",
+    (offendingEntry) => {
+      const entries = offendingEntry.startsWith("feature/")
+        ? MULTI_MODULE_ENTRIES
+        : [...BASE_ENTRIES, offendingEntry];
+      const manifests = offendingEntry.startsWith("feature/")
+        ? new Map([
+            ["base", CLEAN_MANIFEST],
+            ["feature", CLEAN_MANIFEST],
+          ])
+        : new Map([["base", CLEAN_MANIFEST]]);
+      const harness = successfulToolHarness(manifests);
+      const readDexEntries = (dexEntries) =>
+        dexEntries.map((entry) =>
+          Buffer.from(
+            entry === offendingEntry
+              ? RELOCATED_STRIPPED_DESCRIPTOR
+              : "clean base dex",
+            "utf8",
+          ),
+        );
+
+      expect(() =>
+        inspectAndroidAppBundle(
+          inspectOptions({
+            entries,
+            readDexEntries,
+            strippedComponents: [RELOCATED_STRIPPED_CLASS],
+          }),
+          harness.deps,
+        ),
+      ).toThrow(
+        `${offendingEntry} contains forbidden stripped component class: ${RELOCATED_STRIPPED_CLASS}`,
+      );
+    },
+  );
+
+  it("does not reject DEX class-name lookalikes", () => {
+    const harness = successfulToolHarness();
+    const readDexEntries = () => [
+      Buffer.from(
+        "Lcom/feature/SafeElizaAgentService;Lcom/feature/ElizaAgentServiceProxy;",
+        "utf8",
+      ),
+    ];
+
+    expect(() =>
+      inspectAndroidAppBundle(inspectOptions({ readDexEntries }), harness.deps),
+    ).not.toThrow();
+  });
+
   it("rejects LP3 class descriptors even when the caller omits LP3 strip entries", () => {
     const harness = successfulToolHarness();
     const readDexEntries = () => [
@@ -1907,7 +2122,7 @@ describe("inspectAndroidAppBundle", () => {
         harness.deps,
       ),
     ).toThrow(
-      "base/dex/classes.dex contains forbidden LP3 marker: ai/elizaos/app/Lp3ColorPolicyService",
+      "base/dex/classes.dex contains forbidden stripped component class: Lp3ColorPolicyService",
     );
   });
 
@@ -1927,7 +2142,7 @@ describe("inspectAndroidAppBundle", () => {
         harness.deps,
       ),
     ).toThrow(
-      "base/dex/classes.dex contains forbidden LP3 marker: /Lp3ColorPolicyService;",
+      "base/dex/classes.dex contains forbidden stripped component class: Lp3ColorPolicyService",
     );
   });
 
@@ -1947,7 +2162,7 @@ describe("inspectAndroidAppBundle", () => {
         harness.deps,
       ),
     ).toThrow(
-      "base/dex/classes.dex contains forbidden LP3 marker: /Lp3ColorPolicyInitializer;",
+      "base/dex/classes.dex contains forbidden stripped component class: Lp3ColorPolicyInitializer",
     );
   });
 

--- a/packages/app-core/test/fixtures/android/README.md
+++ b/packages/app-core/test/fixtures/android/README.md
@@ -17,7 +17,11 @@ The copied fixture is kept byte-identical to upstream:
 
 The opt-in real-AAB test runs bundletool itself against this fixture, exercises
 a known dynamic-feature component as forbidden policy input, and checks copied
-bundles with a feature-DEX marker or truncated bytes. The default unit lane
-stays network- and JDK-independent; set
+bundles with adversarial feature manifests, relocated feature-DEX classes,
+feature-DEX markers, or truncated bytes. `RelocateAndroidManifestFixture.java`
+uses bundletool's own generated AAPT protobuf classes to turn the fixture's
+feature activity into a relocated privileged service while preserving a
+bundletool-valid multi-module AAB. The default unit lane stays network- and
+JDK-independent; set
 `ELIZA_ANDROID_RUN_REAL_AAB_TEST=1`, `ELIZA_ANDROID_BUNDLETOOL_JAR`, and
 `JAVA_HOME` to run the real tool boundary.

--- a/packages/app-core/test/fixtures/android/RelocateAndroidManifestFixture.java
+++ b/packages/app-core/test/fixtures/android/RelocateAndroidManifestFixture.java
@@ -1,0 +1,64 @@
+/**
+ * Rewrites the real bundletool feature fixture into a privileged relocated-component adversary.
+ */
+
+import com.android.aapt.Resources;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class RelocateAndroidManifestFixture {
+  private static final String ANDROID_NAMESPACE =
+      "http://schemas.android.com/apk/res/android";
+  private static final String ORIGINAL_CLASS = "JavaSampleActivity";
+  private static final String RELOCATED_CLASS =
+      "com.feature.relocated.security.component.abc.ElizaAccessibilityService";
+  private static final String FORBIDDEN_PERMISSION =
+      "android.permission.BIND_ACCESSIBILITY_SERVICE";
+
+  private static Resources.XmlNode rewriteNode(Resources.XmlNode node) {
+    if (!node.hasElement()) {
+      return node;
+    }
+
+    Resources.XmlElement.Builder element = node.getElement().toBuilder();
+    for (int index = 0; index < element.getChildCount(); index += 1) {
+      element.setChild(index, rewriteNode(element.getChild(index)));
+    }
+
+    boolean target = element.getAttributeList().stream()
+        .anyMatch(
+            attribute ->
+                attribute.getNamespaceUri().equals(ANDROID_NAMESPACE)
+                    && attribute.getName().equals("name")
+                    && attribute.getValue().endsWith("." + ORIGINAL_CLASS));
+    if (target) {
+      element.setName("service");
+      for (int index = element.getAttributeCount() - 1; index >= 0; index -= 1) {
+        Resources.XmlAttribute attribute = element.getAttribute(index);
+        if (attribute.getNamespaceUri().equals(ANDROID_NAMESPACE)
+            && attribute.getName().equals("splitName")) {
+          element.removeAttribute(index);
+        } else if (attribute.getNamespaceUri().equals(ANDROID_NAMESPACE)
+            && attribute.getName().equals("name")) {
+          element.setAttribute(index, attribute.toBuilder().setValue(RELOCATED_CLASS));
+        }
+      }
+      element.addAttribute(
+          Resources.XmlAttribute.newBuilder()
+              .setNamespaceUri(ANDROID_NAMESPACE)
+              .setName("permission")
+              .setResourceId(0x01010006)
+              .setValue(FORBIDDEN_PERMISSION));
+    }
+
+    return node.toBuilder().setElement(element).build();
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 2) {
+      throw new IllegalArgumentException("expected input and output manifest paths");
+    }
+    Resources.XmlNode manifest = Resources.XmlNode.parseFrom(Files.readAllBytes(Path.of(args[0])));
+    Files.write(Path.of(args[1]), rewriteNode(manifest).toByteArray());
+  }
+}


### PR DESCRIPTION
## Summary

- reject stripped Android components even when a feature module relocates them outside the application package
- inspect component `permission`, `readPermission`, and `writePermission` bindings
- scan every discovered or smuggled DEX entry for exact stripped-class descriptors
- add lookalike-negative coverage and bundletool-backed multi-module adversaries

## Root cause

The release AAB audit qualified configured stripped-component names against the application ID and scanned DEX only for four LP3 classes. A privileged class moved to another package or feature module could therefore survive the release policy, and component-level privileged permission bindings were not inspected.

The new boundary uses exact Java class basenames at `.`/`/` boundaries, so relocation is rejected without broad substring false positives.

## Impact

Release AAB policy now fails closed when repo-owned privileged components or their Android permission bindings are relocated into any module. Debug/LP3 development behavior is unchanged; this is a release-artifact audit only.

## Validation

- `bunx vitest run packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs --pool=forks --maxWorkers=1` — 79 passed, 7 opt-in skipped
- targeted bundletool-backed real AAB lane — 4 passed, 82 filtered
- Biome changed-file check — clean
- `git diff --check origin/develop...HEAD` — clean
- package typecheck — attempted with 120s and 300s bounds; produced no diagnostics but did not terminate within either bound

## Evidence

- Real artifact: bundletool-valid, multi-module AAB fixture rewritten at test time into a relocated `ElizaAccessibilityService` with `BIND_ACCESSIBILITY_SERVICE`; audit rejects both the manifest component/binding and the relocated feature DEX descriptor.
- Screenshots/video: N/A — build-time artifact policy has no user-facing UI.
- Frontend/backend runtime logs: N/A — no runtime request path changes.
- Live-model trajectory: N/A — no agent/model behavior changes.

Fixes #17255

<!-- evidence-row:before-screenshots -->
- [ ] N/A - build-time Android artifact policy has no affected UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - build-time Android artifact policy has no affected UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changes; validation is at the release artifact boundary

<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime backend request path changes; focused policy tests exercise the artifact boundary

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network behavior changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the bundletool-valid multi-module AAB fixture and adversarial mutator are reproducible in the committed test lane
