### PR TITLE
fix(cloud): stop worker restarts from spending a job's retry budget

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -409,8 +409,11 @@ describe("jobsRepository.recoverStaleJobs", () => {
     const current = rows.find((row) => row.id === currentJobId);
     expect(interrupted).toMatchObject({
       status: "pending",
-      attempts: 1,
-      error: "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
+      // A restart is an infrastructure event: it spends the interruption
+      // budget, never an attempt.
+      attempts: 0,
+      error:
+        "Job interrupted by worker restart - recovered for retry (interruption 1/5; attempts untouched)",
     });
     expect(current).toMatchObject({
       status: "in_progress",
@@ -442,7 +445,9 @@ describe("jobsRepository.recoverStaleJobs", () => {
       startedBefore: new Date(),
     });
 
-    expect(recovered).toBe(1);
+    // Both come back: the committed cutover via its exemption, the pre-cutover
+    // job via the interruption budget (a restart no longer spends attempts).
+    expect(recovered).toBe(2);
     const rows = await dbWrite.select().from(jobs).orderBy(jobs.id);
     expect(rows.find((row) => row.id === committedJobId)).toMatchObject({
       status: "pending",
@@ -451,11 +456,84 @@ describe("jobsRepository.recoverStaleJobs", () => {
       error: expect.stringContaining("without consuming a terminal attempt"),
     });
     expect(rows.find((row) => row.id === preCutoverJobId)).toMatchObject({
-      status: "failed",
-      attempts: 1,
+      // Not exempt as a committed cutover — but a restart interruption still
+      // never spends an attempt; it draws on the interruption budget instead.
+      status: "pending",
+      attempts: 0,
       result: null,
-      error: expect.stringContaining("max attempts reached"),
+      error: expect.stringContaining("interruption 1/5"),
     });
+  });
+
+  test("interruptions accumulate in the payload and exhaust their own budget, not attempts", async () => {
+    expect(pgliteReady).toBe(true);
+    const nearBudgetId = "00000000-0000-4000-8000-000000160854";
+    const overBudgetId = "00000000-0000-4000-8000-000000170854";
+    await seedJob({
+      id: nearBudgetId,
+      maxAttempts: 3,
+      data: { agentId: "a", __worker_interruptions: 1 },
+    });
+    await seedJob({
+      id: overBudgetId,
+      maxAttempts: 3,
+      data: { agentId: "a", __worker_interruptions: 5 },
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "agent_message",
+      startedBefore: new Date(),
+    });
+
+    // Only the near-budget job comes back as recoverable.
+    expect(recovered).toBe(1);
+    const rows = await dbWrite
+      .select({
+        id: jobs.id,
+        status: jobs.status,
+        attempts: jobs.attempts,
+        error: jobs.error,
+        data: jobs.data,
+      })
+      .from(jobs)
+      .orderBy(jobs.id);
+
+    expect(rows.find((row) => row.id === nearBudgetId)).toMatchObject({
+      status: "pending",
+      attempts: 0,
+      error:
+        "Job interrupted by worker restart - recovered for retry (interruption 2/5; attempts untouched)",
+      data: { agentId: "a", __worker_interruptions: 2 },
+    });
+    // The 6th interruption is terminal — and the failure message blames the
+    // interruptions, not the job's attempts.
+    expect(rows.find((row) => row.id === overBudgetId)).toMatchObject({
+      status: "failed",
+      attempts: 0,
+      error: "Job interrupted by worker restart 6 times - interruption budget exhausted",
+    });
+  });
+
+  test("an offloaded payload cannot carry the counter and errs toward retrying", async () => {
+    expect(pgliteReady).toBe(true);
+    const offloadedId = "00000000-0000-4000-8000-000000180854";
+    await seedJob({
+      id: offloadedId,
+      maxAttempts: 3,
+      dataStorage: "r2",
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "agent_message",
+      startedBefore: new Date(),
+    });
+
+    expect(recovered).toBe(1);
+    const [row] = await dbWrite
+      .select({ status: jobs.status, attempts: jobs.attempts })
+      .from(jobs)
+      .where(eq(jobs.id, offloadedId));
+    expect(row).toMatchObject({ status: "pending", attempts: 0 });
   });
 
   test("mismatched canary audit, data, storage, and row identities consume the ordinary terminal attempt", async () => {

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -60,30 +60,18 @@ function lacksRecoveryProtectedExecutionLease(): SQL {
 }
 
 function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
-  return (
-    updates.data !== undefined ||
-    updates.result !== undefined ||
-    updates.error !== undefined
-  );
+  return updates.data !== undefined || updates.result !== undefined || updates.error !== undefined;
 }
 
 function stringField(
   data: Record<string, unknown>,
-  field:
-    | "agentId"
-    | "agentName"
-    | "appId"
-    | "characterId"
-    | "organizationId"
-    | "userId",
+  field: "agentId" | "agentName" | "appId" | "characterId" | "organizationId" | "userId",
 ): string | null {
   const value = data[field];
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function indexedJobFields(
-  data: Record<string, unknown>,
-): Pick<Job, "agent_id" | "character_id"> {
+function indexedJobFields(data: Record<string, unknown>): Pick<Job, "agent_id" | "character_id"> {
   return {
     agent_id: stringField(data, "agentId"),
     character_id: stringField(data, "characterId"),
@@ -114,19 +102,12 @@ function timestampMillis(value: Date | string | null): number | null {
       : Date.parse(String(value));
 }
 
-function sameTimestamp(
-  left: Date | string | null,
-  right: Date | string | null,
-): boolean {
+function sameTimestamp(left: Date | string | null, right: Date | string | null): boolean {
   return timestampMillis(left) === timestampMillis(right);
 }
 
 function normalizedTimestamp(value: Date | string | null): Date | null {
-  return value === null
-    ? null
-    : value instanceof Date
-      ? value
-      : new Date(value);
+  return value === null ? null : value instanceof Date ? value : new Date(value);
 }
 
 function hasValidTimestamp(value: string): boolean {
@@ -154,25 +135,13 @@ const INTERRUPTION_COUNT_KEY = "__worker_interruptions";
  * interruption budget again, which errs on the side of retrying.
  */
 function readInterruptionCount(job: Job): number {
-  if (
-    job.data_storage !== "inline" ||
-    job.data === null ||
-    typeof job.data !== "object"
-  )
-    return 0;
+  if (job.data_storage !== "inline" || job.data === null || typeof job.data !== "object") return 0;
   const raw = (job.data as Record<string, unknown>)[INTERRUPTION_COUNT_KEY];
   return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : 0;
 }
 
-function withInterruptionCount(
-  job: Job,
-  count: number,
-): Record<string, unknown> | null {
-  if (
-    job.data_storage !== "inline" ||
-    job.data === null ||
-    typeof job.data !== "object"
-  ) {
+function withInterruptionCount(job: Job, count: number): Record<string, unknown> | null {
+  if (job.data_storage !== "inline" || job.data === null || typeof job.data !== "object") {
     return null;
   }
   return {
@@ -304,8 +273,7 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
       : left.data_key === right.data_key;
   const sameResult =
     left.result_storage === "inline"
-      ? JSON.stringify(left.result ?? null) ===
-        JSON.stringify(right.result ?? null)
+      ? JSON.stringify(left.result ?? null) === JSON.stringify(right.result ?? null)
       : left.result_key === right.result_key;
   const sameError =
     left.error_storage === "inline"
@@ -395,11 +363,7 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
   data: T,
   context: Pick<Job, "id" | "organization_id" | "created_at">,
 ): Promise<T> {
-  if (
-    data.data_storage === "r2" ||
-    data.result_storage === "r2" ||
-    data.error_storage === "r2"
-  ) {
+  if (data.data_storage === "r2" || data.result_storage === "r2" || data.error_storage === "r2") {
     return {
       ...data,
       ...(data.data !== undefined ? indexedJobFields(data.data) : {}),
@@ -526,11 +490,7 @@ export class JobsRepository {
    * @returns Job record or undefined.
    */
   async findById(id: string): Promise<Job | undefined> {
-    const [job] = await dbRead
-      .select()
-      .from(jobs)
-      .where(eq(jobs.id, id))
-      .limit(1);
+    const [job] = await dbRead.select().from(jobs).where(eq(jobs.id, id)).limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -541,10 +501,7 @@ export class JobsRepository {
    * @param organizationId - Owning organization ID.
    * @returns Job record or undefined.
    */
-  async findByIdAndOrg(
-    id: string,
-    organizationId: string,
-  ): Promise<Job | undefined> {
+  async findByIdAndOrg(id: string, organizationId: string): Promise<Job | undefined> {
     const [job] = await dbRead
       .select()
       .from(jobs)
@@ -558,11 +515,7 @@ export class JobsRepository {
    * derive a compensating operation from a terminal job.
    */
   async findByIdForWrite(id: string): Promise<Job | undefined> {
-    const [job] = await dbWrite
-      .select()
-      .from(jobs)
-      .where(eq(jobs.id, id))
-      .limit(1);
+    const [job] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -570,19 +523,11 @@ export class JobsRepository {
    * Reads every durable job in one admin canary rollout from the primary.
    * Canary payloads are forced inline, so the JSON predicate is authoritative.
    */
-  async findAdminCanaryRolloutForWrite(
-    type: string,
-    rolloutId: string,
-  ): Promise<Job[]> {
+  async findAdminCanaryRolloutForWrite(type: string, rolloutId: string): Promise<Job[]> {
     const rows = await dbWrite
       .select()
       .from(jobs)
-      .where(
-        and(
-          eq(jobs.type, type),
-          sql`${jobs.data}->>'rolloutId' = ${rolloutId}`,
-        ),
-      )
+      .where(and(eq(jobs.type, type), sql`${jobs.data}->>'rolloutId' = ${rolloutId}`))
       .orderBy(jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
@@ -639,13 +584,9 @@ export class JobsRepository {
     // Build query in one chain to avoid TypeScript inference issues
     const query = dbRead.select().from(jobs).$dynamic();
 
-    const rows = await (
-      conditions.length > 0 ? query.where(and(...conditions)) : query
-    )
+    const rows = await (conditions.length > 0 ? query.where(and(...conditions)) : query)
       .limit(filters.limit || 1000)
-      .orderBy(
-        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
-      );
+      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -704,9 +645,7 @@ export class JobsRepository {
           dataFieldFilter,
         ),
       )
-      .orderBy(
-        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
-      );
+      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -800,11 +739,7 @@ export class JobsRepository {
     executionOwnerId?: string;
     executionLeaseMs?: number;
   }): Promise<Job[]> {
-    if (
-      filters.sharedTypes.length === 0 ||
-      filters.maxRunning < 1 ||
-      filters.limit < 1
-    ) {
+    if (filters.sharedTypes.length === 0 || filters.maxRunning < 1 || filters.limit < 1) {
       return [];
     }
 
@@ -818,21 +753,11 @@ export class JobsRepository {
       const [running] = await tx
         .select({ count: sql<number>`count(*)::int` })
         .from(jobs)
-        .where(
-          and(
-            inArray(jobs.type, filters.sharedTypes),
-            eq(jobs.status, "in_progress"),
-          ),
-        );
+        .where(and(inArray(jobs.type, filters.sharedTypes), eq(jobs.status, "in_progress")));
       if (!running) {
-        throw new Error(
-          "Shared image-change capacity query returned no aggregate row",
-        );
+        throw new Error("Shared image-change capacity query returned no aggregate row");
       }
-      const claimLimit = Math.min(
-        filters.limit,
-        Math.max(0, filters.maxRunning - running.count),
-      );
+      const claimLimit = Math.min(filters.limit, Math.max(0, filters.maxRunning - running.count));
       if (claimLimit === 0) return [];
 
       const orgFilter = filters.organizationId
@@ -1020,9 +945,7 @@ export class JobsRepository {
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const newAttempts = resumeCommittedCanary
-        ? job.attempts
-        : (job.attempts || 0) + 1;
+      const newAttempts = resumeCommittedCanary ? job.attempts : (job.attempts || 0) + 1;
       const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
       const isFailed = !resumeCommittedCanary && newAttempts >= maxAttempts;
       const timeoutError = resumeCommittedCanary
@@ -1030,9 +953,7 @@ export class JobsRepository {
         : isFailed
           ? `Job timed out ${newAttempts} times - max attempts reached`
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
-      const recoveryFence = resumeCommittedCanary
-        ? adminCanaryRecoveryFence(job)
-        : sql`TRUE`;
+      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
       const updated = await this.recoverJobFromSnapshot({
         job,
         startedBefore: staleThreshold,
@@ -1098,9 +1019,7 @@ export class JobsRepository {
         : isFailed
           ? `Job interrupted by worker restart ${interruptions} times - interruption budget exhausted`
           : `Job interrupted by worker restart - recovered for retry (interruption ${interruptions}/${MAX_JOB_INTERRUPTIONS}; attempts untouched)`;
-      const recoveryFence = resumeCommittedCanary
-        ? adminCanaryRecoveryFence(job)
-        : sql`TRUE`;
+      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
       const dataWithCount = resumeCommittedCanary
         ? null
         : withInterruptionCount(job, interruptions);
@@ -1256,11 +1175,7 @@ export class JobsRepository {
   async update(id: string, updates: Partial<Job>): Promise<Job> {
     let updateData = updates;
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite
-        .select()
-        .from(jobs)
-        .where(eq(jobs.id, id))
-        .limit(1);
+      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1320,11 +1235,7 @@ export class JobsRepository {
    * @param status - New status.
    * @param additionalFields - Optional additional fields to update.
    */
-  async updateStatus(
-    id: string,
-    status: string,
-    additionalFields?: Partial<Job>,
-  ): Promise<void> {
+  async updateStatus(id: string, status: string, additionalFields?: Partial<Job>): Promise<void> {
     let updates: Partial<Job> = {
       status,
       updated_at: new Date(),
@@ -1339,11 +1250,7 @@ export class JobsRepository {
     }
 
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite
-        .select()
-        .from(jobs)
-        .where(eq(jobs.id, id))
-        .limit(1);
+      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1764,12 +1671,7 @@ export class JobsRepository {
     const rows = await dbRead
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(
-        and(
-          eq(jobs.type, type),
-          sql`${jobs.status} IN ('pending', 'in_progress')`,
-        ),
-      );
+      .where(and(eq(jobs.type, type), sql`${jobs.status} IN ('pending', 'in_progress')`));
     return rows[0]?.count ?? 0;
   }
 
@@ -1782,12 +1684,7 @@ export class JobsRepository {
     const rows = await dbWrite
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(
-        and(
-          inArray(jobs.type, types),
-          sql`${jobs.status} IN ('pending', 'in_progress')`,
-        ),
-      );
+      .where(and(inArray(jobs.type, types), sql`${jobs.status} IN ('pending', 'in_progress')`));
     const [aggregate] = rows;
     if (!aggregate) {
       throw new Error("Image-change in-flight query returned no aggregate row");

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -60,18 +60,30 @@ function lacksRecoveryProtectedExecutionLease(): SQL {
 }
 
 function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
-  return updates.data !== undefined || updates.result !== undefined || updates.error !== undefined;
+  return (
+    updates.data !== undefined ||
+    updates.result !== undefined ||
+    updates.error !== undefined
+  );
 }
 
 function stringField(
   data: Record<string, unknown>,
-  field: "agentId" | "agentName" | "appId" | "characterId" | "organizationId" | "userId",
+  field:
+    | "agentId"
+    | "agentName"
+    | "appId"
+    | "characterId"
+    | "organizationId"
+    | "userId",
 ): string | null {
   const value = data[field];
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function indexedJobFields(data: Record<string, unknown>): Pick<Job, "agent_id" | "character_id"> {
+function indexedJobFields(
+  data: Record<string, unknown>,
+): Pick<Job, "agent_id" | "character_id"> {
   return {
     agent_id: stringField(data, "agentId"),
     character_id: stringField(data, "characterId"),
@@ -102,16 +114,71 @@ function timestampMillis(value: Date | string | null): number | null {
       : Date.parse(String(value));
 }
 
-function sameTimestamp(left: Date | string | null, right: Date | string | null): boolean {
+function sameTimestamp(
+  left: Date | string | null,
+  right: Date | string | null,
+): boolean {
   return timestampMillis(left) === timestampMillis(right);
 }
 
 function normalizedTimestamp(value: Date | string | null): Date | null {
-  return value === null ? null : value instanceof Date ? value : new Date(value);
+  return value === null
+    ? null
+    : value instanceof Date
+      ? value
+      : new Date(value);
 }
 
 function hasValidTimestamp(value: string): boolean {
   return Number.isFinite(Date.parse(value));
+}
+
+/**
+ * How many worker-restart interruptions one job may survive before it is
+ * failed. Distinct from `max_attempts` on purpose: a restart is an
+ * infrastructure event, not evidence against the job, so it must not spend the
+ * job's retry budget — but it cannot be exempted UNBOUNDED either, because a
+ * job that CAUSES the restart (a capture that OOMs the worker, #17154) would
+ * then loop forever, taking every co-scheduled job down on each cycle. The
+ * bound converts that loop into a terminal failure whose message names the
+ * interruptions instead of blaming the job's attempts.
+ */
+const MAX_JOB_INTERRUPTIONS = 5;
+
+const INTERRUPTION_COUNT_KEY = "__worker_interruptions";
+
+/**
+ * Interruption count carried in the job's inline JSONB payload — a dedicated
+ * column would need a shared-DB migration for what is a small bounded counter.
+ * Unreadable/offloaded payloads count as zero: those jobs simply get the full
+ * interruption budget again, which errs on the side of retrying.
+ */
+function readInterruptionCount(job: Job): number {
+  if (
+    job.data_storage !== "inline" ||
+    job.data === null ||
+    typeof job.data !== "object"
+  )
+    return 0;
+  const raw = (job.data as Record<string, unknown>)[INTERRUPTION_COUNT_KEY];
+  return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : 0;
+}
+
+function withInterruptionCount(
+  job: Job,
+  count: number,
+): Record<string, unknown> | null {
+  if (
+    job.data_storage !== "inline" ||
+    job.data === null ||
+    typeof job.data !== "object"
+  ) {
+    return null;
+  }
+  return {
+    ...(job.data as Record<string, unknown>),
+    [INTERRUPTION_COUNT_KEY]: count,
+  };
 }
 
 // A committed canary cutover is already the serving generation, so recovery
@@ -237,7 +304,8 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
       : left.data_key === right.data_key;
   const sameResult =
     left.result_storage === "inline"
-      ? JSON.stringify(left.result ?? null) === JSON.stringify(right.result ?? null)
+      ? JSON.stringify(left.result ?? null) ===
+        JSON.stringify(right.result ?? null)
       : left.result_key === right.result_key;
   const sameError =
     left.error_storage === "inline"
@@ -327,7 +395,11 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
   data: T,
   context: Pick<Job, "id" | "organization_id" | "created_at">,
 ): Promise<T> {
-  if (data.data_storage === "r2" || data.result_storage === "r2" || data.error_storage === "r2") {
+  if (
+    data.data_storage === "r2" ||
+    data.result_storage === "r2" ||
+    data.error_storage === "r2"
+  ) {
     return {
       ...data,
       ...(data.data !== undefined ? indexedJobFields(data.data) : {}),
@@ -402,9 +474,19 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
         }
       : {}),
     ...(result
-      ? { result: result.value, result_storage: result.storage, result_key: result.key }
+      ? {
+          result: result.value,
+          result_storage: result.storage,
+          result_key: result.key,
+        }
       : {}),
-    ...(error ? { error: error.value, error_storage: error.storage, error_key: error.key } : {}),
+    ...(error
+      ? {
+          error: error.value,
+          error_storage: error.storage,
+          error_key: error.key,
+        }
+      : {}),
   };
 }
 
@@ -444,7 +526,11 @@ export class JobsRepository {
    * @returns Job record or undefined.
    */
   async findById(id: string): Promise<Job | undefined> {
-    const [job] = await dbRead.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+    const [job] = await dbRead
+      .select()
+      .from(jobs)
+      .where(eq(jobs.id, id))
+      .limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -455,7 +541,10 @@ export class JobsRepository {
    * @param organizationId - Owning organization ID.
    * @returns Job record or undefined.
    */
-  async findByIdAndOrg(id: string, organizationId: string): Promise<Job | undefined> {
+  async findByIdAndOrg(
+    id: string,
+    organizationId: string,
+  ): Promise<Job | undefined> {
     const [job] = await dbRead
       .select()
       .from(jobs)
@@ -469,7 +558,11 @@ export class JobsRepository {
    * derive a compensating operation from a terminal job.
    */
   async findByIdForWrite(id: string): Promise<Job | undefined> {
-    const [job] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+    const [job] = await dbWrite
+      .select()
+      .from(jobs)
+      .where(eq(jobs.id, id))
+      .limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -477,11 +570,19 @@ export class JobsRepository {
    * Reads every durable job in one admin canary rollout from the primary.
    * Canary payloads are forced inline, so the JSON predicate is authoritative.
    */
-  async findAdminCanaryRolloutForWrite(type: string, rolloutId: string): Promise<Job[]> {
+  async findAdminCanaryRolloutForWrite(
+    type: string,
+    rolloutId: string,
+  ): Promise<Job[]> {
     const rows = await dbWrite
       .select()
       .from(jobs)
-      .where(and(eq(jobs.type, type), sql`${jobs.data}->>'rolloutId' = ${rolloutId}`))
+      .where(
+        and(
+          eq(jobs.type, type),
+          sql`${jobs.data}->>'rolloutId' = ${rolloutId}`,
+        ),
+      )
       .orderBy(jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
@@ -538,9 +639,13 @@ export class JobsRepository {
     // Build query in one chain to avoid TypeScript inference issues
     const query = dbRead.select().from(jobs).$dynamic();
 
-    const rows = await (conditions.length > 0 ? query.where(and(...conditions)) : query)
+    const rows = await (
+      conditions.length > 0 ? query.where(and(...conditions)) : query
+    )
       .limit(filters.limit || 1000)
-      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
+      .orderBy(
+        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
+      );
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -599,7 +704,9 @@ export class JobsRepository {
           dataFieldFilter,
         ),
       )
-      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
+      .orderBy(
+        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
+      );
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -693,7 +800,11 @@ export class JobsRepository {
     executionOwnerId?: string;
     executionLeaseMs?: number;
   }): Promise<Job[]> {
-    if (filters.sharedTypes.length === 0 || filters.maxRunning < 1 || filters.limit < 1) {
+    if (
+      filters.sharedTypes.length === 0 ||
+      filters.maxRunning < 1 ||
+      filters.limit < 1
+    ) {
       return [];
     }
 
@@ -707,11 +818,21 @@ export class JobsRepository {
       const [running] = await tx
         .select({ count: sql<number>`count(*)::int` })
         .from(jobs)
-        .where(and(inArray(jobs.type, filters.sharedTypes), eq(jobs.status, "in_progress")));
+        .where(
+          and(
+            inArray(jobs.type, filters.sharedTypes),
+            eq(jobs.status, "in_progress"),
+          ),
+        );
       if (!running) {
-        throw new Error("Shared image-change capacity query returned no aggregate row");
+        throw new Error(
+          "Shared image-change capacity query returned no aggregate row",
+        );
       }
-      const claimLimit = Math.min(filters.limit, Math.max(0, filters.maxRunning - running.count));
+      const claimLimit = Math.min(
+        filters.limit,
+        Math.max(0, filters.maxRunning - running.count),
+      );
       if (claimLimit === 0) return [];
 
       const orgFilter = filters.organizationId
@@ -899,7 +1020,9 @@ export class JobsRepository {
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const newAttempts = resumeCommittedCanary ? job.attempts : (job.attempts || 0) + 1;
+      const newAttempts = resumeCommittedCanary
+        ? job.attempts
+        : (job.attempts || 0) + 1;
       const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
       const isFailed = !resumeCommittedCanary && newAttempts >= maxAttempts;
       const timeoutError = resumeCommittedCanary
@@ -907,7 +1030,9 @@ export class JobsRepository {
         : isFailed
           ? `Job timed out ${newAttempts} times - max attempts reached`
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
-      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
+      const recoveryFence = resumeCommittedCanary
+        ? adminCanaryRecoveryFence(job)
+        : sql`TRUE`;
       const updated = await this.recoverJobFromSnapshot({
         job,
         startedBefore: staleThreshold,
@@ -960,21 +1085,32 @@ export class JobsRepository {
 
     for (const job of interruptedJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const newAttempts = resumeCommittedCanary ? job.attempts : (job.attempts || 0) + 1;
-      const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
-      const isFailed = !resumeCommittedCanary && newAttempts >= maxAttempts;
+      // A worker restart is an infrastructure event, not evidence against the
+      // job: it consumes the INTERRUPTION budget, never an attempt. Two
+      // restarts used to burn 2 of 3 attempts and permanently fail jobs that
+      // had done nothing wrong (381 agent_snapshot rows in one prod week).
+      const interruptions = readInterruptionCount(job) + 1;
+      const interruptionsExhausted = interruptions > MAX_JOB_INTERRUPTIONS;
+      const newAttempts = job.attempts || 0;
+      const isFailed = !resumeCommittedCanary && interruptionsExhausted;
       const error = resumeCommittedCanary
         ? "Admin canary cutover cleanup interrupted by worker restart - recovered without consuming a terminal attempt"
         : isFailed
-          ? `Job interrupted by worker restart ${newAttempts} times - max attempts reached`
-          : `Job interrupted by worker restart - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
-      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
+          ? `Job interrupted by worker restart ${interruptions} times - interruption budget exhausted`
+          : `Job interrupted by worker restart - recovered for retry (interruption ${interruptions}/${MAX_JOB_INTERRUPTIONS}; attempts untouched)`;
+      const recoveryFence = resumeCommittedCanary
+        ? adminCanaryRecoveryFence(job)
+        : sql`TRUE`;
+      const dataWithCount = resumeCommittedCanary
+        ? null
+        : withInterruptionCount(job, interruptions);
       const updated = await this.recoverJobFromSnapshot({
         job,
         startedBefore: filters.startedBefore,
         isFailed,
         newAttempts,
         error,
+        ...(dataWithCount !== null ? { data: dataWithCount } : {}),
         recoveryFence,
       });
       if (updated && !isFailed) {
@@ -991,9 +1127,17 @@ export class JobsRepository {
     isFailed: boolean;
     newAttempts: number;
     error: string;
+    /** Replacement inline payload (e.g. carrying the interruption count). */
+    data?: Record<string, unknown>;
     recoveryFence: SQL;
   }): Promise<boolean> {
-    const payload = await prepareJobPayload({ error: params.error }, params.job);
+    const payload = await prepareJobPayload(
+      {
+        error: params.error,
+        ...(params.data !== undefined ? { data: params.data } : {}),
+      },
+      params.job,
+    );
     const requiresExecutionLease = hasDetachedProvisioningExecution(params.job.type);
     return dbWrite.transaction(async (tx) => {
       if (hasAgentLifecycleFence(params.job)) {
@@ -1112,7 +1256,11 @@ export class JobsRepository {
   async update(id: string, updates: Partial<Job>): Promise<Job> {
     let updateData = updates;
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+      const [existing] = await dbWrite
+        .select()
+        .from(jobs)
+        .where(eq(jobs.id, id))
+        .limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1172,7 +1320,11 @@ export class JobsRepository {
    * @param status - New status.
    * @param additionalFields - Optional additional fields to update.
    */
-  async updateStatus(id: string, status: string, additionalFields?: Partial<Job>): Promise<void> {
+  async updateStatus(
+    id: string,
+    status: string,
+    additionalFields?: Partial<Job>,
+  ): Promise<void> {
     let updates: Partial<Job> = {
       status,
       updated_at: new Date(),
@@ -1187,7 +1339,11 @@ export class JobsRepository {
     }
 
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+      const [existing] = await dbWrite
+        .select()
+        .from(jobs)
+        .where(eq(jobs.id, id))
+        .limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1608,7 +1764,12 @@ export class JobsRepository {
     const rows = await dbRead
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(and(eq(jobs.type, type), sql`${jobs.status} IN ('pending', 'in_progress')`));
+      .where(
+        and(
+          eq(jobs.type, type),
+          sql`${jobs.status} IN ('pending', 'in_progress')`,
+        ),
+      );
     return rows[0]?.count ?? 0;
   }
 
@@ -1621,7 +1782,12 @@ export class JobsRepository {
     const rows = await dbWrite
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(and(inArray(jobs.type, types), sql`${jobs.status} IN ('pending', 'in_progress')`));
+      .where(
+        and(
+          inArray(jobs.type, types),
+          sql`${jobs.status} IN ('pending', 'in_progress')`,
+        ),
+      );
     const [aggregate] = rows;
     if (!aggregate) {
       throw new Error("Image-change in-flight query returned no aggregate row");

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -882,6 +882,7 @@ describe("managed dedicated canary diagnostic", () => {
   test.each([
     "Job timed out 3 times - max attempts reached",
     "Job interrupted by worker restart 3 times - max attempts reached",
+    "Job interrupted by worker restart 6 times - interruption budget exhausted",
   ])("rejects a recovery-generated terminal job as wrapper source", (cause) => {
     expect(() =>
       sanitizeManagedDedicatedCanaryDiagnostic(
@@ -1369,6 +1370,8 @@ describe("managed dedicated canary diagnostic", () => {
     "Job interrupted by worker restart 0 times - max attempts reached",
     "Job interrupted by worker restart 1000 times - max attempts reached",
     "Job interrupted by worker restart 3 times - max attempts reached trailing",
+    "Job interrupted by worker restart 0 times - interruption budget exhausted",
+    "Job interrupted by worker restart 6 times - interruption budget exhausted trailing",
   ])("rejects a noncanonical worker-restart message", (error) => {
     const input = failedDeleteInput();
     const agent = input.agent as Record<string, unknown>;

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -24,8 +24,11 @@ const TIMEOUT_ERROR_PATTERN = /(?:timed out|timeout)/i;
 const PERMANENT_DELETE_PREFIX = "Deletion permanently failed";
 const PERMANENT_DELETE_PATTERN =
   /^Deletion permanently failed after ([1-9][0-9]{0,2}) attempts: ([\s\S]+)$/;
+// Two suffixes: "max attempts reached" is the historical form still present on
+// stored rows; "interruption budget exhausted" is emitted since interruptions
+// stopped consuming attempts. Both classify identically.
 const WORKER_RESTART_TERMINAL_PATTERN =
-  /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - max attempts reached$/;
+  /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - (?:max attempts reached|interruption budget exhausted)$/;
 const TIMEOUT_TERMINAL_PATTERN =
   /^Job timed out ([1-9][0-9]{0,2}) times - max attempts reached$/;
 
@@ -73,6 +76,12 @@ interface RecoveryClassification {
 interface TerminalFailureClassification {
   code: Extract<ErrorCode, "timeout" | "worker_restart_interrupted">;
   attempts: number;
+  /**
+   * Whether the counted number IS the job's attempts counter. False for the
+   * "interruption budget exhausted" form, whose count is independent of
+   * attempts — the counters-agree cross-check must not compare those.
+   */
+  countsAttempts?: boolean;
 }
 
 type ErrorLengthBucket = "1_64" | "65_128" | "129_256" | "257_512" | "513_2000";
@@ -233,6 +242,10 @@ function classifyTerminalFailure(
     return {
       code: "worker_restart_interrupted",
       attempts: Number(workerRestart[1]),
+      // The historical suffix counted ATTEMPTS (restarts consumed them); the
+      // "interruption budget exhausted" form counts interruptions, which are
+      // independent of the job's attempts counter by design.
+      countsAttempts: value.endsWith("max attempts reached"),
     };
   }
   return null;
@@ -719,8 +732,9 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     if (
       terminalFailure &&
       (job.status !== "failed" ||
-        terminalFailure.attempts !== attempts ||
-        terminalFailure.attempts !== maxAttempts)
+        (terminalFailure.countsAttempts !== false &&
+          (terminalFailure.attempts !== attempts ||
+            terminalFailure.attempts !== maxAttempts)))
     ) {
       throw new Error(`jobs[${index}] terminal counters disagree`);
     }


### PR DESCRIPTION
## What

From #17249 part 2: a worker restart consumed one of the interrupted job's `attempts`. Two restarts against the default `max_attempts` of 3 and the job was permanently failed with `Job interrupted by worker restart 2 times - max attempts reached` — **381 `agent_snapshot` jobs in one production week** died exactly this way, without anything about the job itself ever failing.

## Design

Startup recovery (`recoverInProgressJobsStartedBefore`) now draws on a **separate, bounded interruption budget** (5), carried in the job's inline JSONB payload — a dedicated column would need a shared-DB migration for what is a small bounded counter. `attempts` are left untouched by an interruption; the sixth interruption fails the job with a message that names the interruptions (`interruption budget exhausted`) instead of blaming its attempts.

The bound matters as much as the exemption, and is why "just exempt snapshots" (the obvious fix) was rejected on the issue: an unbounded exemption lets a job that *causes* the restart — a capture that OOMs the worker, #17154 — loop forever, taking every co-scheduled job down on each cycle. Five interruptions converts that loop into a terminal, honestly-labeled failure.

Deliberately unchanged:
- **Timeout recovery** (`recoverStaleJobs`) still consumes attempts — running too long is attributable to the job, and a hung job type must terminate.
- The **committed canary cutover** exemption keeps its own fence and never counts either budget.
- **Offloaded (r2) payloads** cannot carry the counter and err toward retrying — those jobs get a fresh interruption budget per restart, disclosed in the code rather than hidden.

Payload safety: job data parsers are structural type guards (not `.strict()` schemas), verified before choosing the JSONB carrier — the `__worker_interruptions` key cannot make a retried job's own executor reject its payload.

## Tests

`11 pass / 0 fail` on the real-PGlite `jobs-recovery` suite; **4 fail on the previous head** (verified by stashing the source change). New coverage: the counter accumulates across recoveries and persists in the payload; the 6th interruption is terminal with attempts still at 0; an offloaded payload recovers without a counter; and the two updated existing tests pin the new contract (interruption never spends an attempt, including for non-exempt canary jobs).

Ops note: the message family still starts with `Job interrupted by worker restart` so existing log/DB greps keep matching; only the terminal suffix changed, from the misattributing `max attempts reached` to `interruption budget exhausted`. [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17258-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17258-tests.log)
