### PR TITLE
fix(ui): make the cloud-settings token scan allowlist match on Windows

### DIFF
--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -82,7 +82,10 @@ function collectFiles(path: string): string[] {
   if (statSync(fullPath).isFile()) return [path];
 
   return readdirSync(fullPath).flatMap((entry) => {
-    const child = join(path, entry);
+    // POSIX-style child paths so the ALLOWED_EXPLICIT_BLACK_CONTROLS lookup
+    // (forward-slash keys) also matches on a Windows checkout, where join()
+    // would produce backslash separators and silently void the allowlist.
+    const child = `${path}/${entry}`;
     const childFullPath = join(ROOT, child);
     if (statSync(childFullPath).isDirectory()) return collectFiles(child);
     return child.endsWith(".tsx") ? [child] : [];


### PR DESCRIPTION
## Summary

`packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts` fails on every Windows checkout while Linux CI stays green: `collectFiles` builds child paths with `join()`, so Windows produces backslash-separated keys (`billing\components\direct-crypto-credit-card.tsx`) that never match the forward-slash `ALLOWED_EXPLICIT_BLACK_CONTROLS` allowlist — the allowlisted file surfaces 13 false offenders.

## Fix

POSIX-style child concatenation in `collectFiles` (`${path}/${entry}`) keeps the allowlist lookup and offender output separator-stable on both platforms; `join(ROOT, child)` still resolves fine on Windows with forward slashes.

## Verification

- Before: 13 offenders, all `billing\components\direct-crypto-credit-card.tsx: …` (Windows, this box).
- After: 2/2 tests pass on Windows; behavior on Linux is byte-identical (paths were already forward-slash there).

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - test-only fix; no rendered UI surface. The 13-offender assertion output above is the before-state.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - test-only fix.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no UI flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - vitest source-scan test; the fail→pass runs in the summary are the artifact.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend runtime.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the test's own offender list (13 → 0 on Windows) is the domain artifact, quoted in the summary.
