### PR TITLE
fix(cloud): unbreak deletion retries crashing on raw-row string timestamps

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression proof for #17249: retrying a failed deletion crashed with
+ * `value.toISOString is not a function` on EVERY attempt, trapping the agent
+ * in `deletion_failed` forever (37 agents, 160/160 delete jobs in prod).
+ *
+ * Root cause: `getAgentForLifecycleMutation` is a RAW `SELECT * FOR UPDATE`,
+ * and raw drizzle rows carry timestamptz as STRINGS despite the Date type.
+ * A first deletion (column NULL) wrote `new Date()` and worked; every retry
+ * read the string back and pushed it through the typed update builder, which
+ * throws in `mapToDriverValue`. The ownership fence's `?.getTime()` was the
+ * same class of crash one step later.
+ *
+ * PGlite's raw rows are strings exactly like production's — this harness
+ * reproduces the incident faithfully (verified against the live CP stack
+ * trace), so these tests fail on the pre-fix code with the production error.
+ *
+ * Drives the REAL ElizaSandboxService.executeDeletion against in-process
+ * PGlite (real Drizzle schema via pushSchema) with NOTHING mocked. Fails
+ * LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../../db/schemas/api-keys";
+import { generations } from "../../../db/schemas/generations";
+import { jobs } from "../../../db/schemas/jobs";
+import { organizations } from "../../../db/schemas/organizations";
+import { usageRecords } from "../../../db/schemas/usage-records";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORIGINAL_START = new Date("2026-07-13T04:11:00.000Z");
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[delete-retry-string-timestamp.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      apiKeys,
+      generations,
+      usageRecords,
+      jobs,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[delete-retry-string-timestamp.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("deletion retries survive raw-row string timestamps (#17249)", () => {
+  test(
+    "retrying a FAILED deletion completes instead of crashing on the read-back timestamp",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      // The exact production shape of the 37 trapped agents: deletion already
+      // started and failed, both intent columns set, no container left.
+      const [rec] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("trapped"),
+          status: "deletion_failed",
+          execution_tier: "dedicated-always",
+          deletion_started_at: ORIGINAL_START,
+          deletion_attempt_id: crypto.randomUUID(),
+          error_message: "Deletion permanently failed after 3 attempts: SSH connect timed out",
+        })
+        .returning();
+
+      const result = await new ElizaSandboxService().executeDeletion(rec.id, orgId);
+
+      // Pre-fix this crashed in prepareAgentDelete with
+      // `value.toISOString is not a function` before anything ran.
+      expect(result.success).toBe(true);
+      const gone = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, rec.id),
+      });
+      expect(gone).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a FRESH deletion still completes and clears the row",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const [rec] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("fresh"),
+          status: "stopped",
+          execution_tier: "dedicated-always",
+        })
+        .returning();
+
+      const result = await new ElizaSandboxService().executeDeletion(rec.id, orgId);
+
+      expect(result.success).toBe(true);
+      const gone = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, rec.id),
+      });
+      expect(gone).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1858,13 +1858,19 @@ export class ElizaSandboxService {
         return { ok: false as const, error: "Agent provisioning is in progress" };
       }
       const deletionAttemptId = rec.deletion_attempt_id ?? crypto.randomUUID();
-      const deletionStartedAt = rec.deletion_started_at ?? new Date();
+      // `rec` comes from a RAW `SELECT * FOR UPDATE` (getAgentForLifecycleMutation),
+      // and raw drizzle rows carry timestamptz as STRINGS, not Dates. Writing
+      // `rec.deletion_started_at` back through the typed builder therefore threw
+      // `value.toISOString is not a function` on EVERY retry of a failed
+      // deletion — the #17249 production incident (160/160 delete jobs failing,
+      // 37 agents trapped). A continuation keeps the original start time by
+      // leaving the column alone; only a fresh deletion stamps it.
       const [owned] = await tx
         .update(agentSandboxes)
         .set({
           status: "deletion_pending",
           deletion_attempt_id: deletionAttemptId,
-          deletion_started_at: deletionStartedAt,
+          ...(rec.deletion_started_at === null ? { deletion_started_at: new Date() } : {}),
           updated_at: new Date(),
         })
         .where(
@@ -1926,10 +1932,16 @@ export class ElizaSandboxService {
       }
 
       const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      // `rec` is a RAW row: its timestamptz fields are strings at runtime
+      // despite the Date type, so `.getTime()` on them throws. Normalize both
+      // sides to epoch through the Date constructor (which accepts either)
+      // before comparing — a mismatch must fail the fence, not crash it.
+      const recDeletionStartedAtMs =
+        rec.deletion_started_at === null ? null : new Date(rec.deletion_started_at).getTime();
       if (
         rec.status !== "deletion_pending" ||
         rec.deletion_attempt_id !== ownership.deletionAttemptId ||
-        rec.deletion_started_at?.getTime() !== ownership.deletionStartedAt.getTime() ||
+        recDeletionStartedAtMs !== ownership.deletionStartedAt.getTime() ||
         rec.sandbox_id !== ownership.sandboxId ||
         rec.environment_revision !== ownership.environmentRevision ||
         hasActiveProvisionJob


### PR DESCRIPTION
## What

The P0 from #17249: **every retry of a failed agent deletion crashes before doing anything** — `value.toISOString is not a function`, 160/160 delete jobs failing in production, 37 agents trapped in `deletion_failed` and growing ~17/day, each holding node capacity and billing.

## Root cause — proven, not inferred

Full chain on the issue ([RCA comment](https://github.com/elizaOS/eliza/issues/17249#issuecomment-5111495174)). Short form:

- `getAgentForLifecycleMutation` is a RAW `SELECT * ... FOR UPDATE` cast to `AgentSandbox`. **Raw drizzle rows carry timestamptz as strings** — drizzle neutralizes the driver's parsers and re-maps only typed builders/projections. Verified live on the CP: bare `pg.Client` returns `Date`, `dbWrite.execute(sql...)` returns `"2026-07-28 22:54:37.33+00"`.
- A **first** deletion (column NULL) hits `?? new Date()` → a real `Date` → works. This is why deletions worked for months.
- Every **retry** reads the string back and pushes it through the typed update builder → `mapToDriverValue` throws. Live stack trace captured on the CP via a one-shot instrumented retry (state `deletion_failed` → `deletion_failed`, unchanged): `PgTimestamp.mapToDriverValue ← SQL.buildQueryFromSourceParams ← QueryPromise._prepare (update.ts)`.

## Fix (minimal, targeted)

- `prepareAgentDelete`: a continuation keeps the original start time by **leaving the column alone**; only a fresh deletion stamps it. Same pattern #17251 applied to the enqueue site — this is the site it deliberately left out, which turned out to be the incident.
- `commitAgentRowDelete`'s ownership fence: normalize both sides to epoch through the `Date` constructor (accepts either form) instead of `.getTime()` on a runtime string — a mismatch must fail the fence, not crash it.

## Deliberately NOT here: the root fix

Typing the lifecycle read itself (select builder + `.for("update")`) fixes the whole class — but several existing comparisons across sleep/shutdown/wake consumers may pass today **only because both sides are strings**. Flipping the type under them without auditing each consumer trades one 100%-reproducible bug for unknown ones. That audit + root fix is follow-up work on #17249, not a bundle-in here.

## Tests

`2 pass / 0 fail` new + `164 pass` (eliza-sandbox suite) + `6 pass` (deletion-quota suite), all real PGlite, nothing mocked. On the pre-fix code the new tests fail with **the exact production error** — the PGlite harness returns raw rows as strings just like production, so this is a faithful reproduction, not an approximation (verified: `0 pass / 2 fail`, `value.toISOString is not a function`).

## After merge

Deploy to the CP, then re-enqueue the 37 `deletion_failed` rows (they retry through the fixed path and complete), then reassess the 45 `error` rows per #17162's recovery constraints. I can run that recovery once this lands.

Fixes #17249 · Related: #17251 (enqueue-site refactor), #17215/#17231 (sweeper interplay) [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17260-delete-retry-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17260-delete-retry-tests.log)
