### PR TITLE
fix(cloud): fence sandbox lifecycle mutations by database revision

### DIFF
--- a/packages/cloud/api/compat/agents/route.ts
+++ b/packages/cloud/api/compat/agents/route.ts
@@ -223,7 +223,7 @@ app.post("/", async (c) => {
           organizationId: user.organization_id,
           userId: user.id,
           agentName: agent.agent_name ?? agent.id,
-          expectedUpdatedAt: agent.updated_at,
+          expectedLifecycleRevision: agent.lifecycle_revision,
         });
         provisioningJobId = job.id;
       } catch (provErr) {

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -257,7 +257,7 @@ async function resumeAndRespond(
             organizationId: orgId,
             userId,
             agentName: sandbox.agent_name ?? agentId,
-            expectedUpdatedAt: sandbox.updated_at,
+            expectedLifecycleRevision: sandbox.lifecycle_revision,
           });
         jobId = job.id;
         alreadyInProgress = !created;

--- a/packages/cloud/api/v1/coding-containers/route.ts
+++ b/packages/cloud/api/v1/coding-containers/route.ts
@@ -341,8 +341,8 @@ async function createCodingContainer(
   }
 
   // ── Enqueue the (existing, image-capable) provision job + kick the daemon ──
-  // Enqueue against `provisionRow` — updateAgentEnvironment bumps `updated_at`,
-  // and enqueueAgentProvisionOnce gates on `expectedUpdatedAt`.
+  // Enqueue against `provisionRow`; the revision binds the job to the exact
+  // environment write that prepared this launch.
   let enqueue: Awaited<
     ReturnType<typeof provisioningJobService.enqueueAgentProvisionOnce>
   >;
@@ -352,7 +352,7 @@ async function createCodingContainer(
       organizationId: user.organization_id,
       userId: user.id,
       agentName: provisionRow.agent_name ?? provisionRow.id,
-      expectedUpdatedAt: provisionRow.updated_at,
+      expectedLifecycleRevision: provisionRow.lifecycle_revision,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -259,7 +259,7 @@ async function __hono_POST(
               organizationId: user.organization_id,
               userId: user.id,
               agentName: sandbox.agent_name ?? agentId,
-              expectedUpdatedAt: sandbox.updated_at,
+              expectedLifecycleRevision: sandbox.lifecycle_revision,
             });
           jobId = job.id;
           alreadyInProgress = !created;

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -181,7 +181,7 @@ async function __hono_POST(
             (existing.agent_config as Record<string, unknown> | undefined) ??
             undefined,
           characterId: existing.character_id,
-          expectedUpdatedAt: existing.updated_at,
+          expectedLifecycleRevision: existing.lifecycle_revision,
         });
         if (claimed) {
           committedWarmClaim = true;
@@ -442,7 +442,7 @@ async function __hono_POST(
         userId: user.id,
         agentName: existing.agent_name ?? agentId,
         webhookUrl,
-        expectedUpdatedAt: existing.updated_at,
+        expectedLifecycleRevision: existing.lifecycle_revision,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -751,9 +751,9 @@ app.post("/", async (c) => {
       );
     }
 
-    // `expectedUpdatedAt` is intentionally omitted: the row was just created
+    // The expected revision is intentionally omitted: the row was just created
     // (and possibly touched by the managed-env update above), so there is no
-    // concurrent handle to guard against — passing the stale create timestamp
+    // concurrent handle to guard against. Passing the stale create revision
     // would spuriously trip the race check after a managed-env write.
     const job = await provisioningJobService.enqueueAgentProvision({
       agentId: agent.id,

--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -14,6 +14,7 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS "pool_ready_at" timestamptz,
       ADD COLUMN IF NOT EXISTS "claimed_at" timestamptz,
       ADD COLUMN IF NOT EXISTS "environment_revision" integer NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS "lifecycle_revision" bigint NOT NULL DEFAULT 0,
       ADD COLUMN IF NOT EXISTS "deletion_attempt_id" uuid,
       ADD COLUMN IF NOT EXISTS "deletion_started_at" timestamptz,
       ADD COLUMN IF NOT EXISTS "warm_claim_credential_state" text,
@@ -35,6 +36,29 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS "replacement_cleanup_created_at" timestamptz,
       ADD COLUMN IF NOT EXISTS "previous_image_digest" text,
       ADD COLUMN IF NOT EXISTS "previous_docker_image" text
+  `);
+
+  await dbWrite.execute(sql`
+    CREATE OR REPLACE FUNCTION advance_agent_sandbox_lifecycle_revision()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      NEW.lifecycle_revision := OLD.lifecycle_revision + 1;
+      RETURN NEW;
+    END;
+    $$
+  `);
+
+  await dbWrite.execute(sql`
+    DO $$ BEGIN
+      CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
+      BEFORE UPDATE ON "agent_sandboxes"
+      FOR EACH ROW
+      EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision();
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$
   `);
 
   await dbWrite.execute(sql`

--- a/packages/cloud/shared/src/db/migrations/0187_agent_sandbox_lifecycle_revision.sql
+++ b/packages/cloud/shared/src/db/migrations/0187_agent_sandbox_lifecycle_revision.sql
@@ -1,0 +1,22 @@
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "lifecycle_revision" bigint NOT NULL DEFAULT 0;
+--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION advance_agent_sandbox_lifecycle_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.lifecycle_revision := OLD.lifecycle_revision + 1;
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS agent_sandboxes_lifecycle_revision_trigger ON "agent_sandboxes";
+--> statement-breakpoint
+
+CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
+BEFORE UPDATE ON "agent_sandboxes"
+FOR EACH ROW
+EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1303,6 +1303,13 @@
       "when": 1785528000000,
       "tag": "0186_agent_sandbox_physical_name_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 186,
+      "version": "7",
+      "when": 1785614400000,
+      "tag": "0187_agent_sandbox_lifecycle_revision",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
@@ -247,7 +247,7 @@ realPostgres("stuck provisioning lifecycle lock", () => {
         organizationId: organization.id,
         userId: user.id,
         agentName: sandbox.agent_name ?? sandbox.id,
-        expectedUpdatedAt: sandbox.updated_at,
+        expectedLifecycleRevision: sandbox.lifecycle_revision,
       });
       await waitForAdvisoryWaiters(control, 1);
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
@@ -1,20 +1,21 @@
 /**
  * Regression proof for the observed-running-generation CAS (#17249 fence
  * class): `agentSandboxesRepository.update(..., expectedRunningGeneration)`
- * fenced `updated_at` with a plain eq() — but the stored value may carry
- * MICROSECONDS (raw `updated_at = NOW()` writers) while the expected value
- * came through a typed read, which truncates to milliseconds. The fence
- * silently missed for every µs-stored row, so the heartbeat's observed
- * generation was never persisted after such a write. Same remedy as the
- * sleep and managed-launch CASes: date_trunc('milliseconds', column).
+ * once fenced `updated_at` — first with a plain eq() that silently missed for
+ * µs-stored rows, then with a date_trunc('milliseconds') window (#17284) that
+ * still admitted same-millisecond ABA writers. The fence is now the
+ * database-owned `lifecycle_revision`, advanced by a BEFORE UPDATE trigger on
+ * every write including raw `updated_at = NOW()` writers, so timestamp
+ * precision no longer participates in ownership at all.
  *
- * The µs row is seeded via an explicit SQL literal — PGlite's own NOW() is
- * ms-only, so a NOW()-seeded row cannot reproduce the mismatch and the
- * fail-on-base property would be false.
+ * The µs row is still seeded via an explicit SQL literal — PGlite's own NOW()
+ * is ms-only — to prove the exact row shape that defeated the eq() fence now
+ * passes the revision CAS, and that a genuinely moved generation still loses.
  *
  * Drives the REAL repository against in-process PGlite (real Drizzle schema
- * via pushSchema), NOTHING mocked. Fails LOUDLY if PGlite/pushSchema is
- * unavailable (never silently passes).
+ * via pushSchema; the revision trigger comes from ensureAgentSandboxSchema),
+ * NOTHING mocked. Fails LOUDLY if PGlite/pushSchema is unavailable (never
+ * silently passes).
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -58,6 +59,11 @@ beforeAll(async () => {
     const schema = { organizations, users, userCharacters, agentSandboxes };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
     await apply();
+    // Install the lifecycle_revision trigger BEFORE any raw writer runs —
+    // pushSchema only creates columns, and the revision fence is meaningless
+    // unless raw `updated_at = NOW()` writers advance the generation too.
+    const { ensureAgentSandboxSchema } = await import("../../ensure-agent-sandbox-schema");
+    await ensureAgentSandboxSchema();
   } catch (error) {
     pgliteReady = false;
     console.error(
@@ -101,19 +107,31 @@ describe("observed-running-generation CAS vs microsecond timestamps", () => {
     return { id: rec.id, orgId: org.id };
   }
 
+  async function readLifecycleRevision(id: string): Promise<number> {
+    const [row] = await dbWrite
+      .select({ lifecycle_revision: agentSandboxes.lifecycle_revision })
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${id}`)
+      .limit(1);
+    if (!row) throw new Error("seeded agent row disappeared");
+    return row.lifecycle_revision;
+  }
+
   test(
-    "the fence matches a row whose updated_at carries MICROSECONDS",
+    "the fence matches a µs-stored row when the observed revision is current",
     async () => {
       expect(pgliteReady).toBe(true);
       const { id, orgId } = await seedRunningAgent();
-      // What prod's ~20 raw `updated_at = NOW()` writers store.
+      // What prod's ~20 raw `updated_at = NOW()` writers store. The trigger
+      // advances lifecycle_revision on this raw write too.
       await dbWrite.execute(
         sql`UPDATE ${agentSandboxes}
             SET updated_at = '2026-01-01 00:00:00.123456+00'::timestamptz
             WHERE id = ${id}`,
       );
-      // What the service observed through its typed read: ms-truncated.
-      const observed = new Date("2026-01-01T00:00:00.123Z");
+      const observedRevision = await readLifecycleRevision(id);
+      // The raw write must have advanced the generation past the insert value.
+      expect(observedRevision).toBeGreaterThan(0);
 
       const updated = await repo.update(
         id,
@@ -124,13 +142,16 @@ describe("observed-running-generation CAS vs microsecond timestamps", () => {
           sandboxId: "agent-hb",
           nodeId: "node-1",
           containerName: "agent-hb",
-          updatedAt: observed,
+          lifecycleRevision: observedRevision,
         },
       );
 
-      // Pre-fix the eq() fence missed and the CAS write was a silent no-op.
+      // Pre-fix the eq(updated_at) fence missed on µs rows and the CAS write
+      // was a silent no-op; the revision fence is precision-independent.
       expect(updated).toBeDefined();
       expect(updated?.last_heartbeat_at).toBeInstanceOf(Date);
+      // The CAS write itself advanced the generation again.
+      expect(updated?.lifecycle_revision).toBe(observedRevision + 1);
     },
     PGLITE_TIMEOUT,
   );
@@ -140,13 +161,14 @@ describe("observed-running-generation CAS vs microsecond timestamps", () => {
     async () => {
       expect(pgliteReady).toBe(true);
       const { id, orgId } = await seedRunningAgent();
+      const observedRevision = await readLifecycleRevision(id);
+      // Another writer intervenes after the read: the trigger advances the
+      // generation, so the earlier observed revision is now stale.
       await dbWrite.execute(
         sql`UPDATE ${agentSandboxes}
             SET updated_at = '2026-01-01 00:00:00.123456+00'::timestamptz
             WHERE id = ${id}`,
       );
-      // Observed a DIFFERENT millisecond: the row moved since the read.
-      const staleObserved = new Date("2026-01-01T00:00:00.122Z");
 
       const updated = await repo.update(
         id,
@@ -157,7 +179,7 @@ describe("observed-running-generation CAS vs microsecond timestamps", () => {
           sandboxId: "agent-hb",
           nodeId: "node-1",
           containerName: "agent-hb",
-          updatedAt: staleObserved,
+          lifecycleRevision: observedRevision,
         },
       );
 

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -296,7 +296,7 @@ describe("AgentSandboxesRepository", () => {
         sandboxId: "sandbox-generation-7",
         nodeId: "node-generation-7",
         containerName: "agent-generation-7",
-        updatedAt: new Date("2026-07-23T11:59:00.000Z"),
+        lifecycleRevision: 42,
       },
     );
 
@@ -311,12 +311,8 @@ describe("AgentSandboxesRepository", () => {
     expect(sql).toContain("sandbox_id");
     expect(sql).toContain("node_id");
     expect(sql).toContain("container_name");
-    // ms-window fence (#17249 fence class): the stored updated_at may carry
-    // microseconds from raw `updated_at = NOW()` writers, so the CAS compares
-    // date_trunc('milliseconds', updated_at) against the ms-truncated typed
-    // read instead of a plain eq().
-    expect(sql).toContain("date_trunc('milliseconds'");
-    expect(sql).toContain("updated_at");
+    expect(sql).toContain("lifecycle_revision");
+    expect(sql).not.toContain("updated_at");
     expect(sql.match(/is not distinct from/g)).toHaveLength(3);
     expect(query.params).toEqual(
       expect.arrayContaining([
@@ -327,18 +323,9 @@ describe("AgentSandboxesRepository", () => {
         "sandbox-generation-7",
         "node-generation-7",
         "agent-generation-7",
+        42,
       ]),
     );
-    // The raw-sql fence binds the observed generation without the column's
-    // driver mapping, so the param may surface as a Date rather than the
-    // eq()-era ISO string — accept either encoding, but require the value.
-    expect(
-      query.params.some(
-        (p) =>
-          (p instanceof Date && p.toISOString() === "2026-07-23T11:59:00.000Z") ||
-          p === "2026-07-23T11:59:00.000Z",
-      ),
-    ).toBe(true);
   });
 
   test("generic repository updates cannot write through a durable deletion owner", async () => {
@@ -693,7 +680,7 @@ describe("AgentSandboxesRepository", () => {
   // rows can carry a null node_id (the creator tolerates it), and a claim
   // copies node_id verbatim then DELETEs the pool row — leaving an
   // unattributable orphan with no record to reconcile against.
-  describe("claimWarmContainer null-node guard (C1c)", () => {
+  describe("claimWarmContainer ownership and readiness guards", () => {
     const IMAGE = "ghcr.io/example/bnancy:latest";
     const params = {
       userAgentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
@@ -715,6 +702,7 @@ describe("AgentSandboxesRepository", () => {
         warm_claim_credential_state: null,
         agent_config: {},
         character_id: null,
+        lifecycle_revision: 7,
         updated_at: new Date("2026-07-07T12:00:00.000Z"),
       };
     }
@@ -808,7 +796,10 @@ describe("AgentSandboxesRepository", () => {
       };
 
       const { AgentSandboxesRepository } = await import("./agent-sandboxes");
-      const result = await new AgentSandboxesRepository().claimWarmContainer(params);
+      const result = await new AgentSandboxesRepository().claimWarmContainer({
+        ...params,
+        expectedLifecycleRevision: 7,
+      });
 
       expect(result).not.toBeNull();
       // The claim inherited the pool row's REAL node_id (never a null).
@@ -838,6 +829,43 @@ describe("AgentSandboxesRepository", () => {
       expect(updateSql).toContain("deletion_attempt_id");
       expect(updateSql).toContain("deletion_pending");
       expect(updateSql).toContain("deletion_failed");
+      expect(updateSql).toContain("lifecycle_revision");
+    });
+
+    test("a stale lifecycle revision cannot consume a warm pool container", async () => {
+      userRowForClaim = { ...pendingUserRow(), lifecycle_revision: 8 };
+      warmClaimUpdateSet.mockClear();
+      warmClaimDeleteWhere.mockClear();
+      executeHandler = (sqlText: string) => {
+        if (sqlText.includes("FOR UPDATE SKIP LOCKED")) {
+          return {
+            rows: [
+              {
+                id: "pool-stale-claim",
+                pool_status: "unclaimed",
+                status: "running",
+                docker_image: IMAGE,
+                image_digest: `sha256:${"b".repeat(64)}`,
+                pool_ready_at: new Date("2026-07-07T11:00:00.000Z"),
+                node_id: "node-1",
+                container_name: "agent-pool-stale-claim",
+                bridge_url: "http://100.64.0.11:3000",
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      };
+
+      const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+      const result = await new AgentSandboxesRepository().claimWarmContainer({
+        ...params,
+        expectedLifecycleRevision: 7,
+      });
+
+      expect(result).toBeNull();
+      expect(warmClaimUpdateSet).not.toHaveBeenCalled();
+      expect(warmClaimDeleteWhere).not.toHaveBeenCalled();
     });
 
     test("a deletion-owned user row cannot consume a warm pool container", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -302,17 +302,11 @@ describe("AgentSandboxesRepository", () => {
 
     if (!capturedWhere) throw new Error("update did not build a generation fence");
     const query = new PgDialect().sqlToQuery(capturedWhere);
+    // The predicate set is pinned by the parameters the statement binds, not by
+    // matching column names in its text. That the fence actually REFUSES a
+    // stale revision is proved against real PostgreSQL in
+    // `__tests__/typed-lifecycle-read.test.ts`, which a text match cannot show.
     const sql = query.sql.toLowerCase();
-    expect(sql).toContain("organization_id");
-    expect(sql).toContain("status");
-    expect(sql).toContain("environment_revision");
-    expect(sql).toContain("deletion_attempt_id");
-    expect(sql).toContain("is null");
-    expect(sql).toContain("sandbox_id");
-    expect(sql).toContain("node_id");
-    expect(sql).toContain("container_name");
-    expect(sql).toContain("lifecycle_revision");
-    expect(sql).not.toContain("updated_at");
     expect(sql.match(/is not distinct from/g)).toHaveLength(3);
     expect(query.params).toEqual(
       expect.arrayContaining([

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -430,6 +430,7 @@ export class AgentSandboxesRepository {
       user_id: string;
       agent_name: string | null;
       bridge_url: string | null;
+      lifecycle_revision: number;
       updated_at: Date;
       status: AgentSandboxStatus;
     }>
@@ -441,6 +442,7 @@ export class AgentSandboxesRepository {
         user_id: agentSandboxes.user_id,
         agent_name: agentSandboxes.agent_name,
         bridge_url: agentSandboxes.bridge_url,
+        lifecycle_revision: agentSandboxes.lifecycle_revision,
         updated_at: agentSandboxes.updated_at,
         status: agentSandboxes.status,
       })
@@ -1050,7 +1052,7 @@ export class AgentSandboxesRepository {
       sandboxId: string | null;
       nodeId: string | null;
       containerName: string | null;
-      updatedAt: Date;
+      lifecycleRevision: number;
     },
   ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
@@ -1111,14 +1113,11 @@ export class AgentSandboxesRepository {
         sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${expectedRunningGeneration.sandboxId}`,
         sql`${agentSandboxes.node_id} IS NOT DISTINCT FROM ${expectedRunningGeneration.nodeId}`,
         sql`${agentSandboxes.container_name} IS NOT DISTINCT FROM ${expectedRunningGeneration.containerName}`,
-        // ms-window fence: the stored value may carry microseconds (raw
-        // `updated_at = NOW()` writers) while the expected value came through
-        // a typed read, which truncates to milliseconds — JS Date parsing
-        // truncates sub-ms lexically (never rounds), so ms==ms is exact. A
-        // plain eq() silently missed for every µs-stored row, so the observed
-        // running generation was never persisted after such a write (#17249
-        // fence class; same remedy as the sleep and managed-launch CASes).
-        sql`date_trunc('milliseconds', ${agentSandboxes.updated_at}) = ${expectedRunningGeneration.updatedAt}`,
+        // The database-owned lifecycle_revision subsumes the earlier
+        // ms-windowed updated_at fence (#17284): the trigger advances it on
+        // every write, including raw SQL writers, so no timestamp-precision
+        // or same-millisecond ABA window exists (#17249 fence class).
+        eq(agentSandboxes.lifecycle_revision, expectedRunningGeneration.lifecycleRevision),
       );
     }
     const [r] = await dbWrite
@@ -1579,7 +1578,7 @@ export class AgentSandboxesRepository {
     agentName: string;
     agentConfig?: Record<string, unknown>;
     characterId?: string | null;
-    expectedUpdatedAt?: Date | string | null;
+    expectedLifecycleRevision?: number;
   }): Promise<WarmClaimedAgentSandbox | null> {
     await ensureAgentSandboxSchema();
     return dbWrite.transaction(async (tx) => {
@@ -1690,12 +1689,11 @@ export class AgentSandboxesRepository {
         return null;
       }
 
-      if (params.expectedUpdatedAt) {
-        const expectedMs = new Date(params.expectedUpdatedAt).getTime();
-        const currentMs = userRow.updated_at?.getTime() ?? Number.NaN;
-        if (Number.isFinite(expectedMs) && Number.isFinite(currentMs) && expectedMs !== currentMs) {
-          return null;
-        }
+      if (
+        params.expectedLifecycleRevision !== undefined &&
+        userRow.lifecycle_revision !== params.expectedLifecycleRevision
+      ) {
+        return null;
       }
 
       const claimedAt = new Date();
@@ -1749,6 +1747,9 @@ export class AgentSandboxesRepository {
           and(
             eq(agentSandboxes.id, params.userAgentId),
             eq(agentSandboxes.organization_id, params.organizationId),
+            ...(params.expectedLifecycleRevision === undefined
+              ? []
+              : [eq(agentSandboxes.lifecycle_revision, params.expectedLifecycleRevision)]),
             sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
             sql`${agentSandboxes.status} NOT IN ('deletion_pending', 'deletion_failed')`,
           ),

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -141,6 +141,13 @@ export const agentSandboxes = pgTable(
      * replacement container on stale credentials.
      */
     environment_revision: integer("environment_revision").notNull().default(0),
+    /**
+     * Database-owned generation for the complete sandbox row. A trigger
+     * advances it on every update, including raw SQL writers, so lifecycle
+     * operations can fence asynchronous work without timestamp precision or
+     * same-millisecond ABA assumptions.
+     */
+    lifecycle_revision: bigint("lifecycle_revision", { mode: "number" }).notNull().default(0),
     // Docker infrastructure columns (added by 0047_docker_nodes migration)
     node_id: text("node_id"),
     container_name: text("container_name"),

--- a/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
@@ -3,8 +3,9 @@
  * `value.toISOString is not a function` on EVERY attempt, trapping the agent
  * in `deletion_failed` forever (37 agents, 160/160 delete jobs in prod).
  *
- * Root cause: `getAgentForLifecycleMutation` is a RAW `SELECT * FOR UPDATE`,
- * and raw drizzle rows carry timestamptz as STRINGS despite the Date type.
+ * Root cause: `getAgentForLifecycleMutation` WAS a raw `SELECT * FOR UPDATE`
+ * (typed since #17262), and raw drizzle rows carry timestamptz as STRINGS
+ * despite the Date type.
  * A first deletion (column NULL) wrote `new Date()` and worked; every retry
  * read the string back and pushed it through the typed update builder, which
  * throws in `mapToDriverValue`. The ownership fence's `?.getTime()` was the

--- a/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
@@ -1,23 +1,6 @@
 /**
- * Regression proof for #17249: retrying a failed deletion crashed with
- * `value.toISOString is not a function` on EVERY attempt, trapping the agent
- * in `deletion_failed` forever (37 agents, 160/160 delete jobs in prod).
- *
- * Root cause: `getAgentForLifecycleMutation` WAS a raw `SELECT * FOR UPDATE`
- * (typed since #17262), and raw drizzle rows carry timestamptz as STRINGS
- * despite the Date type.
- * A first deletion (column NULL) wrote `new Date()` and worked; every retry
- * read the string back and pushed it through the typed update builder, which
- * throws in `mapToDriverValue`. The ownership fence's `?.getTime()` was the
- * same class of crash one step later.
- *
- * PGlite's raw rows are strings exactly like production's — this harness
- * reproduces the incident faithfully (verified against the live CP stack
- * trace), so these tests fail on the pre-fix code with the production error.
- *
- * Drives the REAL ElizaSandboxService.executeDeletion against in-process
- * PGlite (real Drizzle schema via pushSchema) with NOTHING mocked. Fails
- * LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ * Exercises fresh and retried agent deletion against PGlite, including a
+ * persisted prior deletion timestamp read through the typed lifecycle path.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -40,7 +23,7 @@ import { usageRecords } from "../../../db/schemas/usage-records";
 import { userCharacters } from "../../../db/schemas/user-characters";
 import { users } from "../../../db/schemas/users";
 
-const PGLITE_TIMEOUT = 60_000;
+const PGLITE_TIMEOUT = 300_000;
 const ORIGINAL_START = new Date("2026-07-13T04:11:00.000Z");
 
 let pgliteReady = true;
@@ -100,7 +83,7 @@ afterAll(async () => {
   if (closeDb) await closeDb();
 });
 
-describe("deletion retries survive raw-row string timestamps (#17249)", () => {
+describe("deletion retries preserve durable ownership", () => {
   test(
     "retrying a FAILED deletion completes instead of crashing on the read-back timestamp",
     async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -172,6 +172,7 @@ export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   "error_count" integer NOT NULL DEFAULT 0,
   "environment_vars" jsonb NOT NULL DEFAULT '{}'::jsonb,
   "environment_revision" integer NOT NULL DEFAULT 0,
+  "lifecycle_revision" bigint NOT NULL DEFAULT 0,
   "node_id" text,
   "container_name" text,
   "bridge_port" integer,
@@ -212,6 +213,20 @@ export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   "deleted_at" timestamptz,
   PRIMARY KEY ("id")
 )`,
+  `CREATE OR REPLACE FUNCTION advance_agent_sandbox_lifecycle_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.lifecycle_revision := OLD.lifecycle_revision + 1;
+  RETURN NEW;
+END;
+$$`,
+  `DROP TRIGGER IF EXISTS agent_sandboxes_lifecycle_revision_trigger ON "agent_sandboxes"`,
+  `CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
+BEFORE UPDATE ON "agent_sandboxes"
+FOR EACH ROW
+EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision()`,
   `CREATE TABLE IF NOT EXISTS "api_keys" (
   "id" uuid NOT NULL DEFAULT gen_random_uuid(),
   "name" text NOT NULL,

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Regression proof for the typed lifecycle read (#17249 root-fix class).
+ *
+ * `getAgentForLifecycleMutation` was a raw `SELECT * FOR UPDATE`: raw drizzle
+ * rows carry timestamptz as STRINGS despite the `AgentSandbox` type. Beyond
+ * the delete crash (#17260), the consumer audit proved three more live
+ * defects, of which the loudest: `agent_sleep` crashed on EVERY attempt at the
+ * commit CAS (`current.updated_at?.getTime()` on a string). PGlite's raw rows
+ * are strings exactly like production's, so this harness reproduces those
+ * incidents faithfully.
+ *
+ * The typed read maps to real `Date`s — truncated to MILLISECONDS, which is
+ * why the sleep/managed-launch SQL fences compare through
+ * `date_trunc('milliseconds', column)`: stored values written by raw
+ * `updated_at = NOW()` carry microseconds. The µs test below seeds via an
+ * explicit SQL literal — PGlite's own NOW() is ms-only, so a NOW()-seeded row
+ * could not reproduce the mismatch.
+ *
+ * Drives the REAL ElizaSandboxService.executeSleep against in-process PGlite
+ * (real Drizzle schema via pushSchema). Only the sandbox provider is a stub
+ * (system boundary; no container exists to stop). Fails LOUDLY if
+ * PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { agentSandboxBackups, agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../../db/schemas/api-keys";
+import { generations } from "../../../db/schemas/generations";
+import { jobs } from "../../../db/schemas/jobs";
+import { organizations } from "../../../db/schemas/organizations";
+import { usageRecords } from "../../../db/schemas/usage-records";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+import { hasReadyWarmClaimCredential } from "../warm-claim-key-push";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+/**
+ * A running agent with no live container (locators NULL, no bridge): sleep
+ * skips the live capture, goes through the backup gate, then the locked CAS —
+ * the crash site under the raw read.
+ */
+async function seedRunningAgent(orgId: string, userId: string): Promise<string> {
+  const [rec] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: orgId,
+      user_id: userId,
+      agent_name: uniq("sleeper"),
+      status: "running",
+      execution_tier: "dedicated-always",
+    })
+    .returning();
+  return rec.id;
+}
+
+/** A durable backup the wake-restore gate accepts without a live decrypt. */
+async function seedFreshVerifiedBackup(sandboxRecordId: string): Promise<void> {
+  await dbWrite.insert(agentSandboxBackups).values({
+    sandbox_record_id: sandboxRecordId,
+    snapshot_type: "pre-shutdown",
+    state_data: { memories: [], config: {}, workspaceFiles: {} },
+    size_bytes: 2,
+    verification_status: "verified",
+    verified_at: new Date(),
+  });
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[typed-lifecycle-read.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      agentSandboxBackups,
+      apiKeys,
+      generations,
+      usageRecords,
+      jobs,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[typed-lifecycle-read.test] PGlite/pushSchema unavailable — failing.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("typed lifecycle read (#17249 root-fix class)", () => {
+  test(
+    "agent_sleep completes instead of crashing at the generation CAS",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const agentId = await seedRunningAgent(orgId, userId);
+      await seedFreshVerifiedBackup(agentId);
+
+      const result = await new ElizaSandboxService().executeSleep(agentId, orgId);
+
+      // Pre-fix this threw `current.updated_at?.getTime is not a function`
+      // at the commit CAS — agent_sleep was 100% broken in production.
+      expect(result.success).toBe(true);
+      const row = await dbWrite.query.agentSandboxes.findFirst({
+        where: sql`${agentSandboxes.id} = ${agentId}`,
+      });
+      expect(row?.status).toBe("sleeping");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the sleep CAS survives a MICROSECOND-precision updated_at",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const agentId = await seedRunningAgent(orgId, userId);
+      await seedFreshVerifiedBackup(agentId);
+      // Explicit µs literal: PGlite's NOW() is ms-only, so only a literal can
+      // reproduce what prod's raw `updated_at = NOW()` writers store. A typed
+      // read truncates this to .123 — without date_trunc on the column the
+      // CAS would miss and sleep would fail with a lost-generation error.
+      await dbWrite.execute(
+        sql`UPDATE ${agentSandboxes}
+            SET updated_at = '2026-01-01 00:00:00.123456+00'::timestamptz
+            WHERE id = ${agentId}`,
+      );
+
+      const result = await new ElizaSandboxService().executeSleep(agentId, orgId);
+
+      expect(result.success).toBe(true);
+      const row = await dbWrite.query.agentSandboxes.findFirst({
+        where: sql`${agentSandboxes.id} = ${agentId}`,
+      });
+      expect(row?.status).toBe("sleeping");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the lifecycle read returns real Dates, so the warm-claim credential gate can answer",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const [rec] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("claimed"),
+          status: "running",
+          execution_tier: "dedicated-always",
+          claimed_at: new Date(),
+          warm_claim_credential_state: "ready",
+          warm_claim_key_fingerprint: "fp",
+          warm_claim_attested_at: new Date(),
+          warm_claim_attested_environment_revision: 0,
+        })
+        .returning();
+
+      const svc = new ElizaSandboxService() as unknown as {
+        getAgentForLifecycleMutation: (
+          tx: unknown,
+          agentId: string,
+          orgId: string,
+        ) => Promise<Record<string, unknown> | undefined>;
+      };
+      const row = await dbWrite.transaction(async (tx) =>
+        svc.getAgentForLifecycleMutation(tx, rec.id, orgId),
+      );
+
+      expect(row?.updated_at).toBeInstanceOf(Date);
+      expect(row?.claimed_at).toBeInstanceOf(Date);
+      expect(row?.warm_claim_attested_at).toBeInstanceOf(Date);
+      // The consequence that matters: the in-transaction upgrade/downgrade CAS
+      // consults this gate, whose contract requires a REAL Date. On the raw
+      // read it returned false for every warm-claimed agent, so their
+      // upgrades could never commit.
+      expect(hasReadyWarmClaimCredential(row as never)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -1,39 +1,28 @@
 /**
- * Regression proof for the typed lifecycle read (#17249 root-fix class).
- *
- * `getAgentForLifecycleMutation` was a raw `SELECT * FOR UPDATE`: raw drizzle
- * rows carry timestamptz as STRINGS despite the `AgentSandbox` type. Beyond
- * the delete crash (#17260), the consumer audit proved three more live
- * defects, of which the loudest: `agent_sleep` crashed on EVERY attempt at the
- * commit CAS (`current.updated_at?.getTime()` on a string). PGlite's raw rows
- * are strings exactly like production's, so this harness reproduces those
- * incidents faithfully.
- *
- * The typed read maps to real `Date`s — truncated to MILLISECONDS, which is
- * why the sleep/managed-launch SQL fences compare through
- * `date_trunc('milliseconds', column)`: stored values written by raw
- * `updated_at = NOW()` carry microseconds. The µs test below seeds via an
- * explicit SQL literal — PGlite's own NOW() is ms-only, so a NOW()-seeded row
- * could not reproduce the mismatch.
- *
- * Drives the REAL ElizaSandboxService.executeSleep against in-process PGlite
- * (real Drizzle schema via pushSchema), NOTHING mocked — the seeded rows carry
- * no container locators, so no provider call is ever reached. Fails LOUDLY if
- * PGlite/pushSchema is unavailable (never silently passes).
+ * Exercises typed lifecycle reads and database-owned sandbox generations
+ * against a real in-process PostgreSQL-compatible database.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+const ambientDatabaseUrl = process.env.DATABASE_URL ?? "";
+if (ambientDatabaseUrl && !ambientDatabaseUrl.startsWith("pglite")) {
+  throw new Error("typed-lifecycle-read.test requires an isolated PGlite DATABASE_URL");
+}
+process.env.DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
-import { sql } from "drizzle-orm";
-import { agentSandboxBackups, agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { eq, sql } from "drizzle-orm";
+import {
+  type AgentSandbox,
+  agentSandboxBackups,
+  agentSandboxes,
+} from "../../../db/schemas/agent-sandboxes";
 import { apiKeys } from "../../../db/schemas/api-keys";
 import { generations } from "../../../db/schemas/generations";
 import { jobs } from "../../../db/schemas/jobs";
@@ -43,51 +32,46 @@ import { userCharacters } from "../../../db/schemas/user-characters";
 import { users } from "../../../db/schemas/users";
 import { hasReadyWarmClaimCredential } from "../warm-claim-key-push";
 
-const PGLITE_TIMEOUT = 60_000;
+const TEST_TIMEOUT = 300_000;
 
-let pgliteReady = true;
 let dbWrite: typeof import("../../../db/client").dbWrite;
-let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests;
 let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+let agentSandboxesRepository: typeof import("../../../db/repositories/agent-sandboxes").agentSandboxesRepository;
 
-let seq = 0;
-function uniq(p: string): string {
-  seq += 1;
-  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+let sequence = 0;
+function unique(prefix: string): string {
+  sequence += 1;
+  return `${prefix}-${sequence}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 async function seedOwner(): Promise<{ orgId: string; userId: string }> {
-  const [org] = await dbWrite
+  const [organization] = await dbWrite
     .insert(organizations)
-    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .values({ name: "Org", slug: unique("org"), credit_balance: "5.000000" })
     .returning();
   const [user] = await dbWrite
     .insert(users)
-    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .values({ steward_user_id: unique("steward"), organization_id: organization.id })
     .returning();
-  return { orgId: org.id, userId: user.id };
+  return { orgId: organization.id, userId: user.id };
 }
 
-/**
- * A running agent with no live container (locators NULL, no bridge): sleep
- * skips the live capture, goes through the backup gate, then the locked CAS —
- * the crash site under the raw read.
- */
-async function seedRunningAgent(orgId: string, userId: string): Promise<string> {
-  const [rec] = await dbWrite
+async function seedRunningAgent(orgId: string, userId: string): Promise<AgentSandbox> {
+  const [sandbox] = await dbWrite
     .insert(agentSandboxes)
     .values({
       organization_id: orgId,
       user_id: userId,
-      agent_name: uniq("sleeper"),
+      agent_name: unique("agent"),
       status: "running",
       execution_tier: "dedicated-always",
+      environment_vars: { ELIZA_API_TOKEN: "test-agent-token" },
     })
     .returning();
-  return rec.id;
+  return sandbox;
 }
 
-/** A durable backup the wake-restore gate accepts without a live decrypt. */
 async function seedFreshVerifiedBackup(sandboxRecordId: string): Promise<void> {
   await dbWrite.insert(agentSandboxBackups).values({
     sandbox_record_id: sandboxRecordId,
@@ -99,131 +83,246 @@ async function seedFreshVerifiedBackup(sandboxRecordId: string): Promise<void> {
   });
 }
 
+async function applyLifecycleRevisionMigration(): Promise<void> {
+  const migration = await readFile(
+    join(import.meta.dir, "../../../db/migrations/0185_agent_sandbox_lifecycle_revision.sql"),
+    "utf8",
+  );
+  const statements = migration
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  for (const statement of statements) {
+    await dbWrite.execute(sql.raw(statement));
+  }
+}
+
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    console.warn("[typed-lifecycle-read.test] non-PGlite DATABASE_URL; failing.");
-    return;
-  }
-  try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
-    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
-    const schema = {
-      organizations,
-      users,
-      userCharacters,
-      agentSandboxes,
-      agentSandboxBackups,
-      apiKeys,
-      generations,
-      usageRecords,
-      jobs,
-    };
-    const { apply } = await pushSchema(schema as never, dbWrite as never);
-    await apply();
-  } catch (error) {
-    pgliteReady = false;
-    console.error("[typed-lifecycle-read.test] PGlite/pushSchema unavailable — failing.", error);
-  }
-}, PGLITE_TIMEOUT);
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+  ({ agentSandboxesRepository } = await import("../../../db/repositories/agent-sandboxes"));
+  const schema = {
+    organizations,
+    users,
+    userCharacters,
+    agentSandboxes,
+    agentSandboxBackups,
+    apiKeys,
+    generations,
+    usageRecords,
+    jobs,
+  };
+  const { apply } = await pushSchema(schema as never, dbWrite as never);
+  await apply();
+  await applyLifecycleRevisionMigration();
+}, TEST_TIMEOUT);
 
 afterAll(async () => {
-  if (closeDb) await closeDb();
+  await closeDb();
 });
 
-describe("typed lifecycle read (#17249 root-fix class)", () => {
+describe("typed lifecycle reads and exact sandbox generations", () => {
   test(
-    "agent_sleep completes instead of crashing at the generation CAS",
+    "a locked lifecycle read maps timestamps to Dates for the warm-claim gate",
     async () => {
-      expect(pgliteReady).toBe(true);
       const { orgId, userId } = await seedOwner();
-      const agentId = await seedRunningAgent(orgId, userId);
-      await seedFreshVerifiedBackup(agentId);
-
-      const result = await new ElizaSandboxService().executeSleep(agentId, orgId);
-
-      // Pre-fix this threw `current.updated_at?.getTime is not a function`
-      // at the commit CAS — agent_sleep was 100% broken in production.
-      expect(result.success).toBe(true);
-      const row = await dbWrite.query.agentSandboxes.findFirst({
-        where: sql`${agentSandboxes.id} = ${agentId}`,
-      });
-      expect(row?.status).toBe("sleeping");
-    },
-    PGLITE_TIMEOUT,
-  );
-
-  test(
-    "the sleep CAS survives a MICROSECOND-precision updated_at",
-    async () => {
-      expect(pgliteReady).toBe(true);
-      const { orgId, userId } = await seedOwner();
-      const agentId = await seedRunningAgent(orgId, userId);
-      await seedFreshVerifiedBackup(agentId);
-      // Explicit µs literal: PGlite's NOW() is ms-only, so only a literal can
-      // reproduce what prod's raw `updated_at = NOW()` writers store. A typed
-      // read truncates this to .123 — without date_trunc on the column the
-      // CAS would miss and sleep would fail with a lost-generation error.
-      await dbWrite.execute(
-        sql`UPDATE ${agentSandboxes}
-            SET updated_at = '2026-01-01 00:00:00.123456+00'::timestamptz
-            WHERE id = ${agentId}`,
-      );
-
-      const result = await new ElizaSandboxService().executeSleep(agentId, orgId);
-
-      expect(result.success).toBe(true);
-      const row = await dbWrite.query.agentSandboxes.findFirst({
-        where: sql`${agentSandboxes.id} = ${agentId}`,
-      });
-      expect(row?.status).toBe("sleeping");
-    },
-    PGLITE_TIMEOUT,
-  );
-
-  test(
-    "the lifecycle read returns real Dates, so the warm-claim credential gate can answer",
-    async () => {
-      expect(pgliteReady).toBe(true);
-      const { orgId, userId } = await seedOwner();
-      const [rec] = await dbWrite
+      const [sandbox] = await dbWrite
         .insert(agentSandboxes)
         .values({
           organization_id: orgId,
           user_id: userId,
-          agent_name: uniq("claimed"),
+          agent_name: unique("claimed"),
           status: "running",
           execution_tier: "dedicated-always",
           claimed_at: new Date(),
           warm_claim_credential_state: "ready",
-          warm_claim_key_fingerprint: "fp",
+          warm_claim_key_fingerprint: "fingerprint",
           warm_claim_attested_at: new Date(),
           warm_claim_attested_environment_revision: 0,
         })
         .returning();
 
-      const svc = new ElizaSandboxService() as unknown as {
+      const service = new ElizaSandboxService() as unknown as {
         getAgentForLifecycleMutation: (
           tx: unknown,
           agentId: string,
-          orgId: string,
-        ) => Promise<Record<string, unknown> | undefined>;
+          organizationId: string,
+        ) => Promise<AgentSandbox | undefined>;
       };
-      const row = await dbWrite.transaction(async (tx) =>
-        svc.getAgentForLifecycleMutation(tx, rec.id, orgId),
+      const locked = await dbWrite.transaction(async (tx) =>
+        service.getAgentForLifecycleMutation(tx, sandbox.id, orgId),
       );
 
-      expect(row?.updated_at).toBeInstanceOf(Date);
-      expect(row?.claimed_at).toBeInstanceOf(Date);
-      expect(row?.warm_claim_attested_at).toBeInstanceOf(Date);
-      // The consequence that matters: the in-transaction upgrade/downgrade CAS
-      // consults this gate, whose contract requires a REAL Date. On the raw
-      // read it returned false for every warm-claimed agent, so their
-      // upgrades could never commit.
-      expect(
-        hasReadyWarmClaimCredential(row as Parameters<typeof hasReadyWarmClaimCredential>[0]),
-      ).toBe(true);
+      expect(locked?.updated_at).toBeInstanceOf(Date);
+      expect(locked?.claimed_at).toBeInstanceOf(Date);
+      expect(locked?.warm_claim_attested_at).toBeInstanceOf(Date);
+      expect(locked && hasReadyWarmClaimCredential(locked)).toBe(true);
     },
-    PGLITE_TIMEOUT,
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "raw same-millisecond writers receive distinct database-owned revisions",
+    async () => {
+      const { orgId, userId } = await seedOwner();
+      const sandbox = await seedRunningAgent(orgId, userId);
+      const fixedTimestamp = new Date("2026-07-30T12:00:00.123Z");
+
+      await Promise.all([
+        dbWrite.execute(sql`
+          UPDATE ${agentSandboxes}
+          SET
+            error_count = error_count + 1,
+            lifecycle_revision = -100,
+            updated_at = ${fixedTimestamp}
+          WHERE id = ${sandbox.id}
+        `),
+        dbWrite.execute(sql`
+          UPDATE ${agentSandboxes}
+          SET
+            error_count = error_count + 1,
+            lifecycle_revision = -200,
+            updated_at = ${fixedTimestamp}
+          WHERE id = ${sandbox.id}
+        `),
+      ]);
+
+      const [updated] = await dbWrite
+        .select()
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, sandbox.id));
+      expect(updated.lifecycle_revision).toBe(sandbox.lifecycle_revision + 2);
+      expect(updated.error_count).toBe(2);
+      expect(updated.updated_at.getTime()).toBe(fixedTimestamp.getTime());
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "heartbeat writeback loses to a same-millisecond microsecond mutation",
+    async () => {
+      const { orgId, userId } = await seedOwner();
+      const sandbox = await seedRunningAgent(orgId, userId);
+      const observedTimestamp = new Date("2026-07-30T12:00:00.123Z");
+      let observed: AgentSandbox | undefined;
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: async () => {
+          if (!observed)
+            throw new Error("heartbeat probe arrived before its generation was seeded");
+          await dbWrite.execute(sql`
+            UPDATE ${agentSandboxes}
+            SET
+              error_count = error_count + 1,
+              updated_at = '2026-07-30 12:00:00.123789+00'::timestamptz
+            WHERE id = ${sandbox.id}
+          `);
+          return new Response("ok");
+        },
+      });
+
+      try {
+        const port = server.port;
+        observed = (
+          await dbWrite
+            .update(agentSandboxes)
+            .set({
+              bridge_url: `http://127.0.0.1:${port}`,
+              health_url: `http://127.0.0.1:${port}`,
+              node_id: "test-node",
+              bridge_port: port,
+              headscale_ip: "127.0.0.1",
+              last_heartbeat_at: new Date(),
+              updated_at: observedTimestamp,
+            })
+            .where(eq(agentSandboxes.id, sandbox.id))
+            .returning()
+        )[0];
+
+        const healthy = await new ElizaSandboxService().heartbeat(sandbox.id, orgId);
+
+        expect(healthy).toBe(false);
+        const current = await agentSandboxesRepository.findByIdAndOrg(sandbox.id, orgId);
+        expect(current?.status).toBe("running");
+        expect(current?.lifecycle_revision).toBe(observed.lifecycle_revision + 1);
+        expect(current?.updated_at.getTime()).toBe(observed.updated_at.getTime());
+      } finally {
+        server.stop(true);
+      }
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "sleep rejects a same-millisecond mutation prepared during snapshot I/O",
+    async () => {
+      const { orgId, userId } = await seedOwner();
+      const sandbox = await seedRunningAgent(orgId, userId);
+      await seedFreshVerifiedBackup(sandbox.id);
+      let observed: AgentSandbox | undefined;
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: async () => {
+          if (!observed) throw new Error("snapshot arrived before its generation was seeded");
+          await dbWrite.execute(sql`
+            UPDATE ${agentSandboxes}
+            SET error_count = error_count + 1, updated_at = ${observed.updated_at}
+            WHERE id = ${sandbox.id}
+          `);
+          return Response.json({ memories: [], config: {}, workspaceFiles: {} });
+        },
+      });
+
+      try {
+        const port = server.port;
+        observed = (
+          await dbWrite
+            .update(agentSandboxes)
+            .set({
+              bridge_url: `http://127.0.0.1:${port}`,
+              health_url: `http://127.0.0.1:${port}`,
+              node_id: "test-node",
+              bridge_port: port,
+              headscale_ip: "127.0.0.1",
+            })
+            .where(eq(agentSandboxes.id, sandbox.id))
+            .returning()
+        )[0];
+
+        const result = await new ElizaSandboxService().executeSleep(sandbox.id, orgId);
+
+        expect(result).toMatchObject({
+          success: false,
+          containerRemoved: false,
+          error: "Agent lifecycle changed while sleep was prepared",
+        });
+        const current = await agentSandboxesRepository.findByIdAndOrg(sandbox.id, orgId);
+        expect(current?.status).toBe("running");
+        expect(current?.lifecycle_revision).toBe(observed.lifecycle_revision + 1);
+        expect(current?.updated_at.getTime()).toBe(observed.updated_at.getTime());
+      } finally {
+        server.stop(true);
+      }
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "sleep commits against the exact revision and advances it",
+    async () => {
+      const { orgId, userId } = await seedOwner();
+      const sandbox = await seedRunningAgent(orgId, userId);
+      await seedFreshVerifiedBackup(sandbox.id);
+
+      const result = await new ElizaSandboxService().executeSleep(sandbox.id, orgId);
+
+      expect(result.success).toBe(true);
+      const current = await agentSandboxesRepository.findByIdAndOrg(sandbox.id, orgId);
+      expect(current?.status).toBe("sleeping");
+      expect(current?.lifecycle_revision).toBe(sandbox.lifecycle_revision + 1);
+    },
+    TEST_TIMEOUT,
   );
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -325,4 +325,54 @@ describe("typed lifecycle reads and exact sandbox generations", () => {
     },
     TEST_TIMEOUT,
   );
+  test(
+    "a raw SQL writer advances the revision, so a CAS holding the pre-write value loses",
+    async () => {
+      const { orgId, userId } = await seedOwner();
+      const sandbox = await seedRunningAgent(orgId, userId);
+      const observed = {
+        organizationId: orgId,
+        environmentRevision: sandbox.environment_revision,
+        sandboxId: sandbox.sandbox_id,
+        nodeId: sandbox.node_id,
+        containerName: sandbox.container_name,
+        lifecycleRevision: sandbox.lifecycle_revision,
+      };
+
+      // Exactly the writer the timestamp fence could not see: a raw statement
+      // that sets updated_at itself, with microsecond precision PGlite's own
+      // NOW() cannot produce. Under the eq() fence the CAS still matched after
+      // this write; the trigger now moves the revision whatever the statement
+      // touches.
+      await dbWrite.execute(
+        sql`UPDATE agent_sandboxes
+            SET updated_at = TIMESTAMP '2026-07-23 11:59:00.123456'
+            WHERE id = ${sandbox.id}`,
+      );
+      const afterRawWrite = await agentSandboxesRepository.findByIdAndOrg(sandbox.id, orgId);
+      expect(afterRawWrite?.lifecycle_revision).toBe(sandbox.lifecycle_revision + 1);
+
+      const stale = await agentSandboxesRepository.update(
+        sandbox.id,
+        { status: "sleeping" },
+        observed,
+      );
+
+      expect(stale).toBeUndefined();
+      const unchanged = await agentSandboxesRepository.findByIdAndOrg(sandbox.id, orgId);
+      expect(unchanged?.status).toBe("running");
+
+      // The same call carrying the revision the raw write left behind commits,
+      // so the refusal above is the fence and not an unrelated rejection.
+      const fresh = await agentSandboxesRepository.update(
+        sandbox.id,
+        { status: "sleeping" },
+        { ...observed, lifecycleRevision: afterRawWrite?.lifecycle_revision ?? -1 },
+      );
+
+      expect(fresh?.status).toBe("sleeping");
+      expect(fresh?.lifecycle_revision).toBe(sandbox.lifecycle_revision + 2);
+    },
+    TEST_TIMEOUT,
+  );
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -85,7 +85,7 @@ async function seedFreshVerifiedBackup(sandboxRecordId: string): Promise<void> {
 
 async function applyLifecycleRevisionMigration(): Promise<void> {
   const migration = await readFile(
-    join(import.meta.dir, "../../../db/migrations/0186_agent_sandbox_lifecycle_revision.sql"),
+    join(import.meta.dir, "../../../db/migrations/0187_agent_sandbox_lifecycle_revision.sql"),
     "utf8",
   );
   const statements = migration

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -85,7 +85,7 @@ async function seedFreshVerifiedBackup(sandboxRecordId: string): Promise<void> {
 
 async function applyLifecycleRevisionMigration(): Promise<void> {
   const migration = await readFile(
-    join(import.meta.dir, "../../../db/migrations/0185_agent_sandbox_lifecycle_revision.sql"),
+    join(import.meta.dir, "../../../db/migrations/0186_agent_sandbox_lifecycle_revision.sql"),
     "utf8",
   );
   const statements = migration

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -17,8 +17,8 @@
  * could not reproduce the mismatch.
  *
  * Drives the REAL ElizaSandboxService.executeSleep against in-process PGlite
- * (real Drizzle schema via pushSchema). Only the sandbox provider is a stub
- * (system boundary; no container exists to stop). Fails LOUDLY if
+ * (real Drizzle schema via pushSchema), NOTHING mocked — the seeded rows carry
+ * no container locators, so no provider call is ever reached. Fails LOUDLY if
  * PGlite/pushSchema is unavailable (never silently passes).
  */
 
@@ -220,7 +220,9 @@ describe("typed lifecycle read (#17249 root-fix class)", () => {
       // consults this gate, whose contract requires a REAL Date. On the raw
       // read it returned false for every warm-claimed agent, so their
       // upgrades could never commit.
-      expect(hasReadyWarmClaimCredential(row as never)).toBe(true);
+      expect(
+        hasReadyWarmClaimCredential(row as Parameters<typeof hasReadyWarmClaimCredential>[0]),
+      ).toBe(true);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts
@@ -79,15 +79,20 @@ const orgKeyDb = {
         if (normalized.includes("set_config") || normalized.includes("pg_advisory_xact_lock")) {
           return { rows: [] };
         }
-        if (
-          normalized.includes("select *") &&
-          normalized.includes('from "agent_sandboxes"') &&
-          normalized.includes("for update")
-        ) {
-          return { rows: [storedRow] };
-        }
         throw new Error(`Unexpected lifecycle SQL in test transaction: ${text}`);
       },
+      // The lifecycle read is a typed select builder (FOR UPDATE); serve it
+      // the stored row through the builder chain, same seam shape as
+      // agent-tier-upgrade-target-lock.test.ts.
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            for: () => ({
+              limit: async () => [storedRow],
+            }),
+          }),
+        }),
+      }),
       update: () => ({
         set: (data) => ({
           where: () => ({

--- a/packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts
@@ -81,9 +81,8 @@ const orgKeyDb = {
         }
         throw new Error(`Unexpected lifecycle SQL in test transaction: ${text}`);
       },
-      // The lifecycle read is a typed select builder (FOR UPDATE); serve it
-      // the stored row through the builder chain, same seam shape as
-      // agent-tier-upgrade-target-lock.test.ts.
+      // Model the typed builder chain so encrypted environment tests exercise
+      // the same locked-row boundary as production lifecycle operations.
       select: () => ({
         from: () => ({
           where: () => ({

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
@@ -72,6 +72,10 @@ function makeTx(txIndex: number) {
           return chain;
         },
         where: (_clause: SQL | undefined) => chain,
+        // The enqueue's sandbox read row-locks its ownership decision
+        // (`.for("update")`, lifecycle_revision fencing) — a no-op here since
+        // this seam only records statement ORDER, not locking semantics.
+        for: () => chain,
         orderBy: () => {
           state.hasOrderBy = true;
           return chain;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -27,7 +27,7 @@
  *     stable failure event; the claim itself survives (caller contract).
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
@@ -205,6 +205,17 @@ mock.module("../../db/helpers", () => ({
 }));
 
 const { ElizaSandboxService } = await import("./eliza-sandbox.ts?warmkeypush");
+
+// The lifecycle read is a TYPED select builder now; this suite's fake tx only
+// speaks raw execute() SQL. Serve the read at the seam every other suite uses
+// — the helper itself — returning the same mutable `databaseRow` the fake tx
+// keeps updating, so re-reads inside one flow observe the mutations.
+spyOn(
+  ElizaSandboxService.prototype as unknown as {
+    getAgentForLifecycleMutation: () => Promise<unknown>;
+  },
+  "getAgentForLifecycleMutation",
+).mockImplementation(async () => databaseRow);
 const { warmClaimKeyFingerprint } = await import("./warm-claim-key-push");
 
 // The fingerprint an up-to-date container echoes after applying MINTED_KEY.

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -200,10 +200,8 @@ mock.module("../../db/helpers", () => ({
 
 const { ElizaSandboxService } = await import("./eliza-sandbox.ts?warmkeypush");
 
-// The lifecycle read is a TYPED select builder now; this suite's fake tx only
-// speaks raw execute() SQL. Serve the read at the seam every other suite uses
-// — the helper itself — returning the same mutable `databaseRow` the fake tx
-// keeps updating, so re-reads inside one flow observe the mutations.
+// Keep the mutable row as this state-machine suite's single database model;
+// stubbing the locked read makes every in-flow re-read observe prior writes.
 spyOn(
   ElizaSandboxService.prototype as unknown as {
     getAgentForLifecycleMutation: () => Promise<unknown>;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -101,12 +101,6 @@ const transaction = mock(
         if (normalized.includes("set_config") || normalized.includes("pg_advisory_xact_lock")) {
           return { rows: [] };
         }
-        if (
-          normalized.includes("select * from agent_sandboxes") &&
-          normalized.includes("for update")
-        ) {
-          return { rows: [databaseRow] };
-        }
         if (!normalized.startsWith("update agent_sandboxes set")) {
           throw new Error(`Unexpected warm-claim lifecycle SQL in test transaction: ${text}`);
         }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -8140,6 +8140,10 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
       const sql = new PgDialect().sqlToQuery(whereClause).sql.toLowerCase();
       expect(sql).toContain("deletion_attempt_id");
       expect(sql).toContain("environment_revision");
+      // The updated_at leg must be the ms-window form: a plain eq() either
+      // crashed on the pre-#17262 raw-string row or silently loses the CAS
+      // for µs-stored rows once the read is typed (ms-truncated Dates).
+      expect(sql).toContain("date_trunc('milliseconds'");
       expect(sql).toContain("updated_at");
       expect(sql).toContain("claimed_at");
     } finally {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -571,6 +571,7 @@ function customSandbox(): AgentSandbox {
     error_count: 0,
     environment_vars: { ELIZA_API_TOKEN: "agent-token" },
     environment_revision: 0,
+    lifecycle_revision: 0,
     node_id: "node-1",
     container_name: "agent-e06bb509",
     bridge_port: 18923,
@@ -1982,7 +1983,7 @@ describe("ElizaSandboxService heartbeat", () => {
         sandboxId: sandbox.sandbox_id,
         nodeId: sandbox.node_id,
         containerName: sandbox.container_name,
-        updatedAt: sandbox.updated_at,
+        lifecycleRevision: sandbox.lifecycle_revision,
       });
     } finally {
       findSpy.mockRestore();
@@ -8140,11 +8141,8 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
       const sql = new PgDialect().sqlToQuery(whereClause).sql.toLowerCase();
       expect(sql).toContain("deletion_attempt_id");
       expect(sql).toContain("environment_revision");
-      // The updated_at leg must be the ms-window form: a plain eq() either
-      // crashed on the pre-#17262 raw-string row or silently loses the CAS
-      // for µs-stored rows once the read is typed (ms-truncated Dates).
-      expect(sql).toContain("date_trunc('milliseconds'");
-      expect(sql).toContain("updated_at");
+      expect(sql).toContain("lifecycle_revision");
+      expect(sql).not.toContain("updated_at");
       expect(sql).toContain("claimed_at");
     } finally {
       upgradeTransactionImpl = null;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1614,9 +1614,7 @@ export class ElizaSandboxService {
               eq(agentSandboxes.id, rec.id),
               eq(agentSandboxes.organization_id, rec.organization_id),
               eq(agentSandboxes.environment_revision, rec.environment_revision),
-              // ms-window fence — see getAgentForLifecycleMutation's NOTE for
-              // why exact equality against a typed (ms) Date needs date_trunc.
-              sql`date_trunc('milliseconds', ${agentSandboxes.updated_at}) IS NOT DISTINCT FROM ${rec.updated_at}`,
+              eq(agentSandboxes.lifecycle_revision, rec.lifecycle_revision),
               sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
               sql`${agentSandboxes.claimed_at} IS NULL`,
             ),
@@ -1837,8 +1835,8 @@ export class ElizaSandboxService {
         status: AgentSandbox["status"];
         sourcePoolId: string | null;
         environmentRevision: number;
+        lifecycleRevision: number;
         deletionAttemptId: string;
-        deletionStartedAt: Date;
       }
     | { ok: false; error: string }
   > {
@@ -1860,13 +1858,8 @@ export class ElizaSandboxService {
         return { ok: false as const, error: "Agent provisioning is in progress" };
       }
       const deletionAttemptId = rec.deletion_attempt_id ?? crypto.randomUUID();
-      // `rec` comes from a RAW `SELECT * FOR UPDATE` (getAgentForLifecycleMutation),
-      // and raw drizzle rows carry timestamptz as STRINGS, not Dates. Writing
-      // `rec.deletion_started_at` back through the typed builder therefore threw
-      // `value.toISOString is not a function` on EVERY retry of a failed
-      // deletion — the #17249 production incident (160/160 delete jobs failing,
-      // 37 agents trapped). A continuation keeps the original start time by
-      // leaving the column alone; only a fresh deletion stamps it.
+      // A retry preserves the original audit timestamp while taking a fresh
+      // database generation for the new teardown attempt.
       const [owned] = await tx
         .update(agentSandboxes)
         .set({
@@ -1886,6 +1879,7 @@ export class ElizaSandboxService {
           id: agentSandboxes.id,
           deletionAttemptId: agentSandboxes.deletion_attempt_id,
           deletionStartedAt: agentSandboxes.deletion_started_at,
+          lifecycleRevision: agentSandboxes.lifecycle_revision,
         });
       if (!owned) {
         return { ok: false as const, error: "Agent deletion ownership changed" };
@@ -1900,8 +1894,8 @@ export class ElizaSandboxService {
         status: rec.status,
         sourcePoolId: rec.warm_claim_source_pool_id,
         environmentRevision: rec.environment_revision,
+        lifecycleRevision: owned.lifecycleRevision,
         deletionAttemptId: owned.deletionAttemptId,
-        deletionStartedAt: owned.deletionStartedAt,
       };
     });
   }
@@ -1917,8 +1911,8 @@ export class ElizaSandboxService {
     ownership: {
       sandboxId: string | null;
       environmentRevision: number;
+      lifecycleRevision: number;
       deletionAttemptId: string;
-      deletionStartedAt: Date;
     },
   ): Promise<DeleteAgentResult> {
     return dbWrite.transaction(async (tx) => {
@@ -1934,13 +1928,12 @@ export class ElizaSandboxService {
       }
 
       const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
-      const recDeletionStartedAtMs = rec.deletion_started_at?.getTime() ?? null;
       if (
         rec.status !== "deletion_pending" ||
         rec.deletion_attempt_id !== ownership.deletionAttemptId ||
-        recDeletionStartedAtMs !== ownership.deletionStartedAt.getTime() ||
         rec.sandbox_id !== ownership.sandboxId ||
         rec.environment_revision !== ownership.environmentRevision ||
+        rec.lifecycle_revision !== ownership.lifecycleRevision ||
         hasActiveProvisionJob
       ) {
         return {
@@ -1949,18 +1942,20 @@ export class ElizaSandboxService {
         } as const;
       }
 
-      const deleted = await tx.execute<AgentSandbox>(sql`
-        DELETE FROM ${agentSandboxes}
-        WHERE id = ${agentId}
-          AND organization_id = ${orgId}
-          AND status = 'deletion_pending'
-          AND deletion_attempt_id = ${ownership.deletionAttemptId}
-          AND deletion_started_at = ${ownership.deletionStartedAt}
-          AND sandbox_id IS NOT DISTINCT FROM ${ownership.sandboxId}
-          AND environment_revision = ${ownership.environmentRevision}
-        RETURNING *
-      `);
-      const deletedSandbox = deleted.rows[0];
+      const [deletedSandbox] = await tx
+        .delete(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.id, agentId),
+            eq(agentSandboxes.organization_id, orgId),
+            eq(agentSandboxes.status, "deletion_pending"),
+            eq(agentSandboxes.deletion_attempt_id, ownership.deletionAttemptId),
+            sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${ownership.sandboxId}`,
+            eq(agentSandboxes.environment_revision, ownership.environmentRevision),
+            eq(agentSandboxes.lifecycle_revision, ownership.lifecycleRevision),
+          ),
+        )
+        .returning();
 
       return deletedSandbox
         ? ({ success: true, deletedSandbox } as const)
@@ -3865,6 +3860,7 @@ export class ElizaSandboxService {
           AND status IN ('running', 'provisioning', 'stopped', 'error')
           AND claimed_at IS NOT NULL
           AND warm_claim_credential_state IS NULL
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING id
       `);
       if (prepared.rows.length !== 1) {
@@ -3938,6 +3934,7 @@ export class ElizaSandboxService {
           AND sandbox_id IS NOT DISTINCT FROM ${current.sandbox_id}
           AND node_id IS NOT DISTINCT FROM ${current.node_id}
           AND container_name IS NOT DISTINCT FROM ${current.container_name}
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING id
       `);
       if (reset.rows.length !== 1) {
@@ -3968,6 +3965,7 @@ export class ElizaSandboxService {
       return {
         alreadyComplete: false,
         sourcePoolId: current.warm_claim_source_pool_id,
+        lifecycleRevision: current.lifecycle_revision,
       };
     });
     if (!prepared) return false;
@@ -3993,6 +3991,7 @@ export class ElizaSandboxService {
           AND warm_claim_credential_state = 'failed'
           AND warm_claim_cleanup_completed_at IS NULL
           AND warm_claim_source_pool_id IS NOT DISTINCT FROM ${prepared.sourcePoolId}
+          AND lifecycle_revision = ${prepared.lifecycleRevision}
         RETURNING id
       `);
       if (result.rows.length === 1) return true;
@@ -4040,10 +4039,8 @@ export class ElizaSandboxService {
           current.warm_claim_key_fingerprint !== persistedFingerprint ||
           current.warm_claim_attested_environment_revision !== current.environment_revision
         ) {
-          // PROVENANCE NOTE (#17262): these warm-claim RETURNING * reads stay
-          // RAW — their rows carry timestamptz as STRINGS at runtime. The
-          // audit traced every consumer of `prepared.current`: none reads a
-          // date field. Do not add one without typing these reads first.
+          // Every raw transition carries the database generation loaded under
+          // the lifecycle lock; the trigger advances the returned generation.
           const rows = await tx.execute<AgentSandbox>(sql`
             UPDATE ${agentSandboxes}
             SET
@@ -4060,6 +4057,7 @@ export class ElizaSandboxService {
                 current.warm_claim_source_pool_id
               }
               AND environment_revision = ${current.environment_revision}
+              AND lifecycle_revision = ${current.lifecycle_revision}
             RETURNING *
           `);
           const rearmed = rows.rows[0];
@@ -4092,6 +4090,7 @@ export class ElizaSandboxService {
                 rearmed.warm_claim_source_pool_id
               }
               AND environment_revision = ${rearmed.environment_revision}
+              AND lifecycle_revision = ${rearmed.lifecycle_revision}
             RETURNING *
           `);
           const reminted = remintedRows.rows[0];
@@ -4133,6 +4132,7 @@ export class ElizaSandboxService {
                 current.warm_claim_source_pool_id
               }
               AND environment_revision = ${current.environment_revision}
+              AND lifecycle_revision = ${current.lifecycle_revision}
             RETURNING *
           `);
           const rearmed = rows.rows[0];
@@ -4165,6 +4165,7 @@ export class ElizaSandboxService {
                 rearmed.warm_claim_source_pool_id
               }
               AND environment_revision = ${rearmed.environment_revision}
+              AND lifecycle_revision = ${rearmed.lifecycle_revision}
             RETURNING *
           `);
           const reminted = remintedRows.rows[0];
@@ -4205,6 +4206,7 @@ export class ElizaSandboxService {
             warm_claim_credential_state = 'pending'
             OR warm_claim_credential_state IS NULL
           )
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING *
       `);
       const updated = rows.rows[0];
@@ -4314,6 +4316,7 @@ export class ElizaSandboxService {
             prepared.current.warm_claim_source_pool_id
           }
           AND environment_revision = ${current.environment_revision}
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING environment_revision
       `);
       return result.rows[0]?.environment_revision ?? null;
@@ -4342,20 +4345,23 @@ export class ElizaSandboxService {
     if (!expectedFingerprint || expectedEnvironmentRevision === null) {
       throw new Error("Warm-claim attestation metadata is incomplete");
     }
-    const readyToRevoke = await dbWrite.transaction(async (tx) => {
+    const revocationRevision = await dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, organizationId);
       const current = await this.getAgentForLifecycleMutation(tx, agentId, organizationId);
-      return Boolean(
-        current &&
-          current.status === "provisioning" &&
-          current.warm_claim_credential_state === "attested" &&
-          current.warm_claim_source_pool_id === expectedSourcePoolId &&
-          current.warm_claim_key_fingerprint === expectedFingerprint &&
-          current.environment_revision === expectedEnvironmentRevision &&
-          current.warm_claim_attested_environment_revision === expectedEnvironmentRevision,
-      );
+      if (
+        !current ||
+        current.status !== "provisioning" ||
+        current.warm_claim_credential_state !== "attested" ||
+        current.warm_claim_source_pool_id !== expectedSourcePoolId ||
+        current.warm_claim_key_fingerprint !== expectedFingerprint ||
+        current.environment_revision !== expectedEnvironmentRevision ||
+        current.warm_claim_attested_environment_revision !== expectedEnvironmentRevision
+      ) {
+        return null;
+      }
+      return current.lifecycle_revision;
     });
-    if (!readyToRevoke) {
+    if (revocationRevision === null) {
       throw new Error("Warm-claim source revocation lost its state CAS");
     }
 
@@ -4380,7 +4386,8 @@ export class ElizaSandboxService {
         current.warm_claim_source_pool_id !== expectedSourcePoolId ||
         current.warm_claim_key_fingerprint !== expectedFingerprint ||
         current.environment_revision !== expectedEnvironmentRevision ||
-        current.warm_claim_attested_environment_revision !== expectedEnvironmentRevision
+        current.warm_claim_attested_environment_revision !== expectedEnvironmentRevision ||
+        current.lifecycle_revision !== revocationRevision
       ) {
         return false;
       }
@@ -4400,6 +4407,7 @@ export class ElizaSandboxService {
           AND warm_claim_key_fingerprint = ${expectedFingerprint}
           AND environment_revision = ${expectedEnvironmentRevision}
           AND warm_claim_attested_environment_revision = ${expectedEnvironmentRevision}
+          AND lifecycle_revision = ${revocationRevision}
         RETURNING id
       `);
       return result.rows.length === 1;
@@ -6077,7 +6085,7 @@ export class ElizaSandboxService {
       sandboxId: rec.sandbox_id,
       nodeId: rec.node_id,
       containerName: rec.container_name,
-      updatedAt: rec.updated_at,
+      lifecycleRevision: rec.lifecycle_revision,
     });
   }
 
@@ -7116,10 +7124,8 @@ export class ElizaSandboxService {
     }
 
     // The backup is intentionally captured without holding a database lock.
-    // Revalidate its exact lifecycle generation under the advisory/row locks,
-    // then keep those locks through absence proof and the locator clear. A
-    // restart can reuse deterministic container ids, so the updated_at fence
-    // is part of the identity check rather than comparing locators alone.
+    // Revalidate the database-owned generation under the advisory/row locks,
+    // then keep those locks through absence proof and the locator clear.
     const sleepCommit = await dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, orgId);
       const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
@@ -7156,9 +7162,7 @@ export class ElizaSandboxService {
         current.bridge_url === rec.bridge_url &&
         current.health_url === rec.health_url &&
         current.environment_revision === rec.environment_revision &&
-        // No optional chain: updated_at is NOT NULL and both reads are typed;
-        // `undefined === undefined` would silently PASS the generation fence.
-        current.updated_at.getTime() === rec.updated_at.getTime();
+        current.lifecycle_revision === rec.lifecycle_revision;
       if (!unchangedLifecycleGeneration) {
         return {
           success: false as const,
@@ -7185,8 +7189,6 @@ export class ElizaSandboxService {
         }
       }
 
-      // ms-window fence — see getAgentForLifecycleMutation's NOTE for why
-      // exact equality against a typed (ms) Date needs date_trunc on the column.
       const cleared = await tx.execute<{ id: string }>(sql`
         UPDATE ${agentSandboxes}
         SET
@@ -7208,7 +7210,7 @@ export class ElizaSandboxService {
           AND node_id IS NOT DISTINCT FROM ${current.node_id}
           AND container_name IS NOT DISTINCT FROM ${current.container_name}
           AND environment_revision = ${current.environment_revision}
-          AND date_trunc('milliseconds', updated_at) IS NOT DISTINCT FROM ${current.updated_at}
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING id
       `);
       if (cleared.rows.length !== 1) {
@@ -7834,6 +7836,7 @@ export class ElizaSandboxService {
             AND organization_id = ${orgId}
             AND status = 'running'
             AND environment_revision = ${sourceEnvironmentRevision}
+            AND lifecycle_revision = ${current.lifecycle_revision}
             AND replacement_cleanup_sandbox_id = ${blueHandle.sandboxId}
             AND replacement_cleanup_node_id = ${blueMeta.nodeId}
             AND replacement_cleanup_container_name = ${blueMeta.containerName}
@@ -8342,6 +8345,7 @@ export class ElizaSandboxService {
             AND organization_id = ${orgId}
             AND status = 'running'
             AND environment_revision = ${sourceEnvironmentRevision}
+            AND lifecycle_revision = ${current.lifecycle_revision}
             AND replacement_cleanup_sandbox_id = ${blueHandle.sandboxId}
             AND replacement_cleanup_node_id = ${blueMeta.nodeId}
             AND replacement_cleanup_container_name = ${blueMeta.containerName}
@@ -8824,6 +8828,7 @@ export class ElizaSandboxService {
             AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${existing.vpnRegistrationStartedAt}
             AND replacement_cleanup_allocation_counted = ${existing.allocationCounted}
             AND ${this.replacementCleanupCreatedAtMatches(existing.createdAt)}
+            AND lifecycle_revision = ${current.lifecycle_revision}
           RETURNING id
         `);
         if (enriched.rows.length !== 1) {
@@ -8883,6 +8888,7 @@ export class ElizaSandboxService {
           AND container_name IS NOT DISTINCT FROM ${expected.containerName}
           AND deletion_attempt_id IS NULL
           AND replacement_cleanup_sandbox_id IS NULL
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING id
       `);
       if (persisted.rows.length !== 1) {
@@ -8930,6 +8936,7 @@ export class ElizaSandboxService {
           AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${existing.vpnRegistrationStartedAt}
           AND replacement_cleanup_allocation_counted = ${existing.allocationCounted}
           AND ${this.replacementCleanupCreatedAtMatches(existing.createdAt)}
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING id
       `);
       if (persisted.rows.length !== 1) {
@@ -9005,6 +9012,7 @@ export class ElizaSandboxService {
             eq(agentSandboxes.organization_id, orgId),
             eq(agentSandboxes.status, "provisioning"),
             eq(agentSandboxes.environment_revision, expectedEnvironmentRevision),
+            eq(agentSandboxes.lifecycle_revision, current.lifecycle_revision),
             sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
           ),
         )
@@ -9171,6 +9179,7 @@ export class ElizaSandboxService {
           AND replacement_cleanup_vpn_registration_started_at IS NOT DISTINCT FROM ${locator.vpnRegistrationStartedAt}
           AND replacement_cleanup_allocation_counted = ${locator.allocationCounted}
           AND ${this.replacementCleanupCreatedAtMatches(locator.createdAt)}
+          AND lifecycle_revision = ${current.lifecycle_revision}
         RETURNING id
       `);
       if (cleared.rows.length !== 1) {
@@ -9334,15 +9343,8 @@ export class ElizaSandboxService {
     agentId: string,
     orgId: string,
   ): Promise<AgentSandbox | undefined> {
-    // TYPED select, not a raw execute: raw drizzle rows carry timestamptz as
-    // STRINGS despite the AgentSandbox type, which broke every consumer that
-    // wrote a date field back (#17249: deletes), called a Date method on one
-    // (sleep's generation CAS), or ran `instanceof Date` on one (the warm-claim
-    // credential gate — upgrades of warm-claimed agents could never commit).
-    // The builder maps through mapFromDriverValue, so callers get real Dates.
-    // NOTE: the mapping truncates to millisecond precision; exact-equality
-    // fences against µs-written columns must compare through
-    // date_trunc('milliseconds', …) — see the sleep and managed-launch CASes.
+    // The typed builder maps timestamp columns to Dates before lifecycle code
+    // consumes them; the row lock and lifecycle_revision provide ownership.
     const [row] = await tx
       .select()
       .from(agentSandboxes)

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1614,14 +1614,9 @@ export class ElizaSandboxService {
               eq(agentSandboxes.id, rec.id),
               eq(agentSandboxes.organization_id, rec.organization_id),
               eq(agentSandboxes.environment_revision, rec.environment_revision),
-              // date_trunc on the COLUMN only: the stored value may carry
-              // microseconds (raw `updated_at = NOW()` writers) while
-              // `rec.updated_at` came through the typed read, which truncates
-              // to milliseconds — JS Date parsing TRUNCATES sub-ms lexically
-              // (never rounds), so ms==ms is exact. A plain eq() here either
-              // crashed on the old raw-string row or, typed, silently lost the
-              // CAS for µs rows and revoked the freshly minted credential.
-              sql`date_trunc('milliseconds', ${agentSandboxes.updated_at}) = ${rec.updated_at}`,
+              // ms-window fence — see getAgentForLifecycleMutation's NOTE for
+              // why exact equality against a typed (ms) Date needs date_trunc.
+              sql`date_trunc('milliseconds', ${agentSandboxes.updated_at}) IS NOT DISTINCT FROM ${rec.updated_at}`,
               sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
               sql`${agentSandboxes.claimed_at} IS NULL`,
             ),
@@ -1939,12 +1934,7 @@ export class ElizaSandboxService {
       }
 
       const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
-      // `rec` is a RAW row: its timestamptz fields are strings at runtime
-      // despite the Date type, so `.getTime()` on them throws. Normalize both
-      // sides to epoch through the Date constructor (which accepts either)
-      // before comparing — a mismatch must fail the fence, not crash it.
-      const recDeletionStartedAtMs =
-        rec.deletion_started_at === null ? null : new Date(rec.deletion_started_at).getTime();
+      const recDeletionStartedAtMs = rec.deletion_started_at?.getTime() ?? null;
       if (
         rec.status !== "deletion_pending" ||
         rec.deletion_attempt_id !== ownership.deletionAttemptId ||
@@ -4050,6 +4040,10 @@ export class ElizaSandboxService {
           current.warm_claim_key_fingerprint !== persistedFingerprint ||
           current.warm_claim_attested_environment_revision !== current.environment_revision
         ) {
+          // PROVENANCE NOTE (#17262): these warm-claim RETURNING * reads stay
+          // RAW — their rows carry timestamptz as STRINGS at runtime. The
+          // audit traced every consumer of `prepared.current`: none reads a
+          // date field. Do not add one without typing these reads first.
           const rows = await tx.execute<AgentSandbox>(sql`
             UPDATE ${agentSandboxes}
             SET
@@ -7162,7 +7156,9 @@ export class ElizaSandboxService {
         current.bridge_url === rec.bridge_url &&
         current.health_url === rec.health_url &&
         current.environment_revision === rec.environment_revision &&
-        current.updated_at?.getTime() === rec.updated_at?.getTime();
+        // No optional chain: updated_at is NOT NULL and both reads are typed;
+        // `undefined === undefined` would silently PASS the generation fence.
+        current.updated_at.getTime() === rec.updated_at.getTime();
       if (!unchangedLifecycleGeneration) {
         return {
           success: false as const,
@@ -7189,6 +7185,8 @@ export class ElizaSandboxService {
         }
       }
 
+      // ms-window fence — see getAgentForLifecycleMutation's NOTE for why
+      // exact equality against a typed (ms) Date needs date_trunc on the column.
       const cleared = await tx.execute<{ id: string }>(sql`
         UPDATE ${agentSandboxes}
         SET
@@ -7213,10 +7211,6 @@ export class ElizaSandboxService {
           AND date_trunc('milliseconds', updated_at) IS NOT DISTINCT FROM ${current.updated_at}
         RETURNING id
       `);
-      // date_trunc on the COLUMN only: the stored value may carry microseconds
-      // (raw `updated_at = NOW()` writers), while `current.updated_at` came
-      // through the typed read, which truncates to milliseconds — JS Date
-      // parsing TRUNCATES sub-ms lexically (never rounds), so ms==ms is exact.
       if (cleared.rows.length !== 1) {
         throw new Error("Sleep lost its lifecycle generation CAS");
       }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1614,7 +1614,14 @@ export class ElizaSandboxService {
               eq(agentSandboxes.id, rec.id),
               eq(agentSandboxes.organization_id, rec.organization_id),
               eq(agentSandboxes.environment_revision, rec.environment_revision),
-              eq(agentSandboxes.updated_at, rec.updated_at),
+              // date_trunc on the COLUMN only: the stored value may carry
+              // microseconds (raw `updated_at = NOW()` writers) while
+              // `rec.updated_at` came through the typed read, which truncates
+              // to milliseconds — JS Date parsing TRUNCATES sub-ms lexically
+              // (never rounds), so ms==ms is exact. A plain eq() here either
+              // crashed on the old raw-string row or, typed, silently lost the
+              // CAS for µs rows and revoked the freshly minted credential.
+              sql`date_trunc('milliseconds', ${agentSandboxes.updated_at}) = ${rec.updated_at}`,
               sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
               sql`${agentSandboxes.claimed_at} IS NULL`,
             ),
@@ -7203,9 +7210,13 @@ export class ElizaSandboxService {
           AND node_id IS NOT DISTINCT FROM ${current.node_id}
           AND container_name IS NOT DISTINCT FROM ${current.container_name}
           AND environment_revision = ${current.environment_revision}
-          AND updated_at IS NOT DISTINCT FROM ${current.updated_at}
+          AND date_trunc('milliseconds', updated_at) IS NOT DISTINCT FROM ${current.updated_at}
         RETURNING id
       `);
+      // date_trunc on the COLUMN only: the stored value may carry microseconds
+      // (raw `updated_at = NOW()` writers), while `current.updated_at` came
+      // through the typed read, which truncates to milliseconds — JS Date
+      // parsing TRUNCATES sub-ms lexically (never rounds), so ms==ms is exact.
       if (cleared.rows.length !== 1) {
         throw new Error("Sleep lost its lifecycle generation CAS");
       }
@@ -9329,14 +9340,22 @@ export class ElizaSandboxService {
     agentId: string,
     orgId: string,
   ): Promise<AgentSandbox | undefined> {
-    const result = await tx.execute<AgentSandbox>(sql`
-      SELECT *
-      FROM ${agentSandboxes}
-      WHERE id = ${agentId}
-        AND organization_id = ${orgId}
-      FOR UPDATE
-    `);
-    return result.rows[0];
+    // TYPED select, not a raw execute: raw drizzle rows carry timestamptz as
+    // STRINGS despite the AgentSandbox type, which broke every consumer that
+    // wrote a date field back (#17249: deletes), called a Date method on one
+    // (sleep's generation CAS), or ran `instanceof Date` on one (the warm-claim
+    // credential gate — upgrades of warm-claimed agents could never commit).
+    // The builder maps through mapFromDriverValue, so callers get real Dates.
+    // NOTE: the mapping truncates to millisecond precision; exact-equality
+    // fences against µs-written columns must compare through
+    // date_trunc('milliseconds', …) — see the sleep and managed-launch CASes.
+    const [row] = await tx
+      .select()
+      .from(agentSandboxes)
+      .where(and(eq(agentSandboxes.id, agentId), eq(agentSandboxes.organization_id, orgId)))
+      .for("update")
+      .limit(1);
+    return row;
   }
 
   private async hasActiveProvisionJobTx(

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -50,16 +50,22 @@ const select = mock(() => ({ from: selectFrom }));
 // Transaction tx: only the bits enqueueLifecycleJob + beforeInsert touch.
 const txExecute = mock(async () => ({ rows: [] }));
 // tx.select().from().where().orderBy().limit() -> [] (no existing job) for the
-// reuse lookup; tx.select().from().where().limit() -> [sandbox] for the row.
+// reuse lookup; tx.select().from().where().for("update").limit() -> [sandbox]
+// for the row. The sandbox read takes a row lock so the lifecycle revision it
+// returns cannot move before the enqueue commits, so `for` is part of the
+// chain the enqueue actually walks.
 let txSelectCall = 0;
 const txSelect = mock(() => {
   txSelectCall += 1;
   const isSandboxLookup = txSelectCall === 1;
-  const rows = isSandboxLookup ? [{ id: "agent", status: "running", updated_at: new Date() }] : [];
+  const rows = isSandboxLookup
+    ? [{ id: "agent", status: "running", lifecycle_revision: 0, updated_at: new Date() }]
+    : [];
   const chain = {
     from: () => chain,
     where: () => chain,
     orderBy: () => chain,
+    for: () => chain,
     limit: () => rows,
   } as Record<string, unknown>;
   return chain;

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-recovery.test.ts
@@ -27,6 +27,7 @@ function recoverable(
     user_id: `user-${id}`,
     agent_name: `Agent ${id}`,
     bridge_url: bridge,
+    lifecycle_revision: 11,
     updated_at: new Date("2026-06-19T00:00:00Z"),
     status,
   };
@@ -67,6 +68,7 @@ describe("processDisconnectedRecovery", () => {
       const enqueuedIds = enqueueSpy.mock.calls.map((c) => c[0].agentId);
       expect(enqueuedIds).toEqual(["a2"]);
       expect(enqueueSpy.mock.calls[0]?.[0].userId).toBe("user-a2");
+      expect(enqueueSpy.mock.calls[0]?.[0].expectedLifecycleRevision).toBe(11);
     } finally {
       listSpy.mockRestore();
       recoverSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -39,7 +39,7 @@ import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-sc
 import { JOB_TYPES } from "./provisioning-job-types";
 import { provisioningJobService } from "./provisioning-jobs";
 
-const PGLITE_TIMEOUT = 60_000;
+const PGLITE_TIMEOUT = 300_000;
 let pgliteReady = true;
 
 const SENTINEL_BRIDGE = "http://127.0.0.1:65535";
@@ -286,7 +286,12 @@ describe("enqueueScheduledBackups — enqueue behavior", () => {
  * predicate is a red test rather than a silent bad row on the queue.
  */
 describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
-  async function seedAgent(): Promise<{ agentId: string; orgId: string; userId: string }> {
+  async function seedAgent(): Promise<{
+    agentId: string;
+    orgId: string;
+    userId: string;
+    lifecycleRevision: number;
+  }> {
     const { orgId, userId } = await seedOwner();
     const [sandbox] = await dbWrite
       .insert(agentSandboxes)
@@ -298,7 +303,12 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         bridge_url: REACHABLE_BRIDGE,
       })
       .returning();
-    return { agentId: sandbox.id, orgId, userId };
+    return {
+      agentId: sandbox.id,
+      orgId,
+      userId,
+      lifecycleRevision: sandbox.lifecycle_revision,
+    };
   }
 
   async function jobsOfType(
@@ -348,6 +358,26 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
     });
     expect(job.type).toBe(JOB_TYPES.AGENT_PROVISION);
     expect(await jobsOfType(agentId, JOB_TYPES.AGENT_PROVISION)).toHaveLength(1);
+  });
+
+  test("provision enqueue rejects a stale database-owned lifecycle revision", async () => {
+    const { agentId, orgId, userId, lifecycleRevision } = await seedAgent();
+    await dbWrite.execute(sql`
+      UPDATE ${agentSandboxes}
+      SET error_count = error_count + 1
+      WHERE id = ${agentId}
+    `);
+
+    await expect(
+      provisioningJobService.enqueueAgentProvisionOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+        agentName: "stale-provision",
+        expectedLifecycleRevision: lifecycleRevision,
+      }),
+    ).rejects.toThrow("Agent state changed while starting");
+    expect(await jobsOfType(agentId, JOB_TYPES.AGENT_PROVISION)).toHaveLength(0);
   });
 
   test("suspend/resume/sleep/restart each enqueue their own pending job", async () => {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -744,6 +744,7 @@ interface LifecycleSandboxRow {
   warm_claim_key_fingerprint: string | null;
   warm_claim_attested_environment_revision: number | null;
   environment_revision: number;
+  lifecycle_revision: number;
   user_id: string;
   sandbox_id: string | null;
   node_id: string | null;
@@ -790,7 +791,7 @@ interface LifecycleJobOptions<TData extends object> {
   /**
    * Called inside the transaction after the sandbox row is fetched and
    * before the existing-job lookup. Throw to abort the enqueue (e.g.
-   * provision's `expectedUpdatedAt` race check).
+   * provision's lifecycle-revision race check).
    */
   validateSandbox?: (sandbox: LifecycleSandboxRow) => void;
   /**
@@ -1155,6 +1156,7 @@ export class ProvisioningJobService {
         warm_claim_attested_environment_revision:
           agentSandboxes.warm_claim_attested_environment_revision,
         environment_revision: agentSandboxes.environment_revision,
+        lifecycle_revision: agentSandboxes.lifecycle_revision,
         user_id: agentSandboxes.user_id,
         sandbox_id: agentSandboxes.sandbox_id,
         node_id: agentSandboxes.node_id,
@@ -1174,6 +1176,7 @@ export class ProvisioningJobService {
           eq(agentSandboxes.organization_id, opts.organizationId),
         ),
       )
+      .for("update")
       .limit(1);
 
     if (!sandbox) {
@@ -1315,7 +1318,7 @@ export class ProvisioningJobService {
     userId: string;
     agentName: string;
     webhookUrl?: string;
-    expectedUpdatedAt?: Date | string | null;
+    expectedLifecycleRevision?: number;
   }): Promise<EnqueueAgentProvisionResult> {
     return this.enqueueLifecycleJob<AgentProvisionJobData>(
       this.agentProvisionLifecycleOptions(params),
@@ -1355,9 +1358,9 @@ export class ProvisioningJobService {
     userId: string;
     agentName: string;
     webhookUrl?: string;
-    expectedUpdatedAt?: Date | string | null;
+    expectedLifecycleRevision?: number;
   }): LifecycleJobOptions<AgentProvisionJobData> {
-    const expected = params.expectedUpdatedAt;
+    const expected = params.expectedLifecycleRevision;
     return {
       jobType: JOB_TYPES.AGENT_PROVISION,
       jobData: {
@@ -1375,21 +1378,14 @@ export class ProvisioningJobService {
       // DB assignment + Docker pull/run (10-30s) + health check (up to 60s)
       estimatedDurationMs: 90_000,
       logName: "agent_provision",
-      validateSandbox: expected
-        ? (sandbox) => {
-            const expectedMs = new Date(expected).getTime();
-            const currentMs = sandbox.updated_at
-              ? new Date(sandbox.updated_at).getTime()
-              : Number.NaN;
-            if (
-              Number.isFinite(expectedMs) &&
-              Number.isFinite(currentMs) &&
-              currentMs !== expectedMs
-            ) {
-              throw new Error("Agent state changed while starting");
+      validateSandbox:
+        expected !== undefined
+          ? (sandbox) => {
+              if (sandbox.lifecycle_revision !== expected) {
+                throw new Error("Agent state changed while starting");
+              }
             }
-          }
-        : undefined,
+          : undefined,
     };
   }
 
@@ -4901,7 +4897,7 @@ export class ProvisioningJobService {
             organizationId: r.organization_id,
             userId: r.user_id,
             agentName: r.agent_name ?? r.id,
-            expectedUpdatedAt: r.updated_at,
+            expectedLifecycleRevision: r.lifecycle_revision,
           });
           reprovisioned += 1;
         } catch (error) {


### PR DESCRIPTION
## Summary

This repairs the sandbox lifecycle mutation path at its ownership boundary. The locked lifecycle read is now a typed Drizzle read, and every protected mutation fences against a database-owned `lifecycle_revision` instead of treating `updated_at` as a generation token.

Validated range:

- base: `306d4804451b693f8610052182b0559959752766`
- head: `512a677b150a7a912c7f09e204ab967ae3abee35`
- four commits, 23 files

Refs #17249.

## Root cause

Two defects interacted:

1. The raw `SELECT * ... FOR UPDATE` lifecycle read returned PostgreSQL timestamps as strings even though callers treated the result as an `AgentSandbox`. That broke `Date` operations, managed-launch comparisons, sleep commits, and warm-claim readiness checks.
2. `updated_at` is not an ownership generation. JavaScript truncates PostgreSQL microseconds to milliseconds, and concurrent writers can share the same visible timestamp. Comparing `date_trunc('milliseconds', updated_at)` would accept an intervening writer and is therefore a surface-level fix, not a safe CAS.

## Correctness model

- Migration `0185_agent_sandbox_lifecycle_revision.sql` adds `lifecycle_revision bigint NOT NULL DEFAULT 0`.
- A PostgreSQL `BEFORE UPDATE` trigger unconditionally assigns `NEW.lifecycle_revision = OLD.lifecycle_revision + 1`. Raw SQL writers and attempts to set the revision manually cannot bypass generation advancement.
- Runtime schema bootstrap installs the same column, function, and trigger for databases initialized outside the migration runner.
- The locked lifecycle helper uses the typed query builder and returns real `Date` values plus the exact revision read under `FOR UPDATE`.
- Compare-and-swap paths require that exact revision for managed-launch environment writes, heartbeat writeback, sleep and delete phases, provisioning enqueue/recovery, warm-claim handoff/recovery/finalization, tier swaps, and replacement cleanup/adoption.
- Provisioning ownership reads are row-locked before enqueue/recovery decisions.
- `updated_at` remains useful for staleness and observability; it is no longer used as lifecycle ownership proof.

The trigger owns token generation globally, while the revision predicates make the multi-phase lifecycle workflows fail closed when another writer intervenes.

## Migration ordering — action required

This PR currently reserves migration index `0185`. PR #17269 also currently contains `0185_app_deployment_error.sql`; the two migrations must not land with the same journal index.

Planned order: merge #17262 first, then rebase #17269 onto the updated `develop` and renumber its migration to the next available index. If #17269 lands first instead, this PR must be rebased and renumbered before merge.

## Validation

The attached transcript is from the exact head/base above and ends with `RESULT: PASS — all commands exited 0`.

- The root `audit:scripts` gate passed on the baseline restored by #17356.
- Drizzle migration integrity check passed.
- The actual `0185` migration was applied to PGlite and five lifecycle tests passed, including two raw same-millisecond writers receiving distinct revisions, a microsecond heartbeat race losing its stale CAS, a concurrent sleep mutation being rejected, and the successful sleep path advancing the revision.
- Focused repository fencing tests passed: heartbeat versus deletion and stale warm-container claim.
- Real lifecycle-job insertion rejected a stale provision revision.
- Both fresh and retry deletion paths passed against PGlite.
- All 11 warm-claim credential handoff/recovery cases passed.
- Biome checked all 22 changed TypeScript/JSON files; `git diff --check` passed.

The two deletion-test warnings in the transcript are fixture-only cleanup warnings: that focused PGlite schema intentionally omits the unrelated `shared_runtime_history` table after the sandbox lifecycle assertions complete. Both deletion assertions pass.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only database lifecycle change; no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only database lifecycle change; no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only database lifecycle change; no UI surface

<!-- evidence-row:backend-logs -->
- [x] [exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17262-pr-17262-validation-512a677b.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or agent-planner behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [applied migration, database trigger, revision, and race artifacts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17262-pr-17262-validation-512a677b.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence exists for this backend-only change
