### PR TITLE
fix(cloud): settle dependent rows when recovery flips a job to failed

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -409,8 +409,11 @@ describe("jobsRepository.recoverStaleJobs", () => {
     const current = rows.find((row) => row.id === currentJobId);
     expect(interrupted).toMatchObject({
       status: "pending",
-      attempts: 1,
-      error: "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
+      // A restart is an infrastructure event: it spends the interruption
+      // budget, never an attempt.
+      attempts: 0,
+      error:
+        "Job interrupted by worker restart - recovered for retry (interruption 1/5; attempts untouched)",
     });
     expect(current).toMatchObject({
       status: "in_progress",
@@ -442,7 +445,9 @@ describe("jobsRepository.recoverStaleJobs", () => {
       startedBefore: new Date(),
     });
 
-    expect(recovered).toBe(1);
+    // Both come back: the committed cutover via its exemption, the pre-cutover
+    // job via the interruption budget (a restart no longer spends attempts).
+    expect(recovered).toBe(2);
     const rows = await dbWrite.select().from(jobs).orderBy(jobs.id);
     expect(rows.find((row) => row.id === committedJobId)).toMatchObject({
       status: "pending",
@@ -451,11 +456,84 @@ describe("jobsRepository.recoverStaleJobs", () => {
       error: expect.stringContaining("without consuming a terminal attempt"),
     });
     expect(rows.find((row) => row.id === preCutoverJobId)).toMatchObject({
-      status: "failed",
-      attempts: 1,
+      // Not exempt as a committed cutover — but a restart interruption still
+      // never spends an attempt; it draws on the interruption budget instead.
+      status: "pending",
+      attempts: 0,
       result: null,
-      error: expect.stringContaining("max attempts reached"),
+      error: expect.stringContaining("interruption 1/5"),
     });
+  });
+
+  test("interruptions accumulate in the payload and exhaust their own budget, not attempts", async () => {
+    expect(pgliteReady).toBe(true);
+    const nearBudgetId = "00000000-0000-4000-8000-000000160854";
+    const overBudgetId = "00000000-0000-4000-8000-000000170854";
+    await seedJob({
+      id: nearBudgetId,
+      maxAttempts: 3,
+      data: { agentId: "a", __worker_interruptions: 1 },
+    });
+    await seedJob({
+      id: overBudgetId,
+      maxAttempts: 3,
+      data: { agentId: "a", __worker_interruptions: 5 },
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "agent_message",
+      startedBefore: new Date(),
+    });
+
+    // Only the near-budget job comes back as recoverable.
+    expect(recovered).toBe(1);
+    const rows = await dbWrite
+      .select({
+        id: jobs.id,
+        status: jobs.status,
+        attempts: jobs.attempts,
+        error: jobs.error,
+        data: jobs.data,
+      })
+      .from(jobs)
+      .orderBy(jobs.id);
+
+    expect(rows.find((row) => row.id === nearBudgetId)).toMatchObject({
+      status: "pending",
+      attempts: 0,
+      error:
+        "Job interrupted by worker restart - recovered for retry (interruption 2/5; attempts untouched)",
+      data: { agentId: "a", __worker_interruptions: 2 },
+    });
+    // The 6th interruption is terminal — and the failure message blames the
+    // interruptions, not the job's attempts.
+    expect(rows.find((row) => row.id === overBudgetId)).toMatchObject({
+      status: "failed",
+      attempts: 0,
+      error: "Job interrupted by worker restart 6 times - interruption budget exhausted",
+    });
+  });
+
+  test("an offloaded payload cannot carry the counter and errs toward retrying", async () => {
+    expect(pgliteReady).toBe(true);
+    const offloadedId = "00000000-0000-4000-8000-000000180854";
+    await seedJob({
+      id: offloadedId,
+      maxAttempts: 3,
+      dataStorage: "r2",
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "agent_message",
+      startedBefore: new Date(),
+    });
+
+    expect(recovered).toBe(1);
+    const [row] = await dbWrite
+      .select({ status: jobs.status, attempts: jobs.attempts })
+      .from(jobs)
+      .where(eq(jobs.id, offloadedId));
+    expect(row).toMatchObject({ status: "pending", attempts: 0 });
   });
 
   test("mismatched canary audit, data, storage, and row identities consume the ordinary terminal attempt", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -940,18 +940,21 @@ describe("recovery failure writeback (#17253 §3)", () => {
       data: { appId: APP_ID, __worker_interruptions: 5 },
     });
 
-    const recovered = await repo.recoverInProgressJobsStartedBefore({
-      type: "app_deploy",
-      startedBefore: new Date(),
-      buildFailureWriteback: () => async () => {
-        throw new Error("dependent write refused");
-      },
-    });
+    // A single-job batch where that job fails IS the every-job-failed case,
+    // so the sweep rethrows after logging — the outage signal callers alert
+    // on (a partial batch would swallow, count, and continue instead).
+    await expect(
+      repo.recoverInProgressJobsStartedBefore({
+        type: "app_deploy",
+        startedBefore: new Date(),
+        buildFailureWriteback: () => async () => {
+          throw new Error("dependent write refused");
+        },
+      }),
+    ).rejects.toThrow("failed for every job in the batch");
 
-    // The per-job catch swallowed the failure and the sweep continued…
-    expect(recovered).toBe(0);
-    // …but the transaction rolled back BOTH writes: the job stays claimable
-    // by the next sweep, and the app was not half-settled.
+    // The transaction rolled back BOTH writes: the job stays claimable by
+    // the next sweep, and the app was not half-settled.
     const [job] = await dbWrite
       .select({ status: jobs.status })
       .from(jobs)
@@ -999,16 +1002,76 @@ describe("recovery failure writeback (#17253 §3)", () => {
       data: { appId: APP_ID, __worker_interruptions: 5 },
     });
 
-    const seen: Array<{ id: string; status: string }> = [];
+    const seen: Array<{ id: string; status: string; committedStatus: string | undefined }> = [];
     await repo.recoverInProgressJobsStartedBefore({
       type: "app_deploy",
       startedBefore: new Date(),
       onPermanentFailure: async (job) => {
-        seen.push({ id: job.id, status: job.status });
+        // Post-commit-ness, actually asserted: a fresh read on the main
+        // connection must already see the flip while the hook runs.
+        const [row] = await dbWrite
+          .select({ status: jobs.status })
+          .from(jobs)
+          .where(eq(jobs.id, job.id));
+        seen.push({ id: job.id, status: job.status, committedStatus: row?.status });
       },
     });
 
-    expect(seen).toEqual([{ id: jobId, status: "failed" }]);
+    expect(seen).toEqual([{ id: jobId, status: "failed", committedStatus: "failed" }]);
+  });
+
+  test("stale AGENT_DELETE recovery drives the REAL builder: deletion_failed + error_count", async () => {
+    // The real buildPermanentFailureWriteback, via the established private
+    // cast — its AGENT_DELETE case flips the sandbox to deletion_failed and
+    // bumps error_count, which feeds reEnqueueFailedDeletions' circuit
+    // breaker; recovery-driven failures must keep feeding it.
+    const { ProvisioningJobService } = await import("../../../lib/services/provisioning-jobs");
+    const svc = new ProvisioningJobService() as unknown as {
+      buildPermanentFailureWriteback: (
+        job: Job,
+        error: string,
+      ) => ((tx: unknown, failedJob: Job) => Promise<void>) | undefined;
+    };
+
+    const sandboxId = "00000000-0000-4000-8000-000000260854";
+    const jobId = "00000000-0000-4000-8000-000000270854";
+    await dbWrite.insert(agentSandboxes).values({
+      id: sandboxId,
+      organization_id: ORG_ID,
+      user_id: ACTOR_ID,
+      agent_name: "recovery-delete-target",
+      status: "deletion_pending",
+      execution_tier: "dedicated-always",
+      deletion_started_at: new Date("2026-07-13T04:11:00.000Z"),
+      deletion_attempt_id: "00000000-0000-4000-8000-000000280854",
+      error_count: 1,
+    });
+    await seedJob({
+      id: jobId,
+      type: "agent_delete",
+      maxAttempts: 1,
+      data: { agentId: sandboxId, organizationId: ORG_ID, userId: ACTOR_ID },
+    });
+
+    const recovered = await repo.recoverStaleJobs({
+      type: "agent_delete",
+      staleThresholdMs: 5 * 60 * 1000,
+      buildFailureWriteback: (job, error) =>
+        svc.buildPermanentFailureWriteback(job, error) as never,
+    });
+
+    expect(recovered).toBe(0); // maxAttempts 1 → terminal
+    const [job] = await dbWrite
+      .select({ status: jobs.status })
+      .from(jobs)
+      .where(eq(jobs.id, jobId));
+    expect(job?.status).toBe("failed");
+    const [sandbox] = await dbWrite
+      .select({ status: agentSandboxes.status, error_count: agentSandboxes.error_count })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandboxId));
+    expect(sandbox?.status).toBe("deletion_failed");
+    expect(sandbox?.error_count).toBe(2);
   });
 
   test("stale recovery drives the same writeback contract", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -7,8 +7,24 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { eq, type SQL } from "drizzle-orm";
 import { jobExecutionLeases } from "../../schemas/job-execution-leases";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { apiKeys } from "../../schemas/api-keys";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  userDatabaseStatusEnum,
+} from "../../schemas/apps";
+import { generations } from "../../schemas/generations";
 import { type Job, jobs } from "../../schemas/jobs";
+import { organizations } from "../../schemas/organizations";
+import { usageRecords } from "../../schemas/usage-records";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
 
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS ||= "1";
@@ -123,58 +139,54 @@ function pendingCutoverAudit(jobId: string): Record<string, unknown> {
 }
 
 beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[jobs-recovery] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
     ({ jobsRepository: repo } = await import("../jobs"));
-    await dbWrite.execute(
-      `CREATE TABLE IF NOT EXISTS jobs (
-				id uuid PRIMARY KEY,
-				type text NOT NULL,
-				status text NOT NULL DEFAULT 'pending',
-				data jsonb NOT NULL,
-				data_storage text NOT NULL DEFAULT 'inline',
-				data_key text,
-				agent_id text,
-				character_id text,
-				result jsonb,
-				result_storage text NOT NULL DEFAULT 'inline',
-				result_key text,
-				error text,
-				error_storage text NOT NULL DEFAULT 'inline',
-				error_key text,
-				attempts integer NOT NULL DEFAULT 0,
-				max_attempts integer NOT NULL DEFAULT 3,
-				organization_id uuid NOT NULL,
-				user_id uuid,
-				api_key_id uuid,
-				generation_id uuid,
-				webhook_url text,
-				webhook_status text,
-				estimated_completion_at timestamp,
-				scheduled_for timestamp NOT NULL DEFAULT now(),
-				started_at timestamp,
-				execution_generation uuid,
-				execution_quiesced_at timestamp,
-				completed_at timestamp,
-				created_at timestamp NOT NULL DEFAULT now(),
-				updated_at timestamp NOT NULL DEFAULT now()
-			);`,
-    );
-    await dbWrite.execute(
-      `ALTER TABLE jobs
-        ADD COLUMN IF NOT EXISTS execution_generation uuid,
-        ADD COLUMN IF NOT EXISTS execution_quiesced_at timestamp;`,
-    );
-    await dbWrite.execute(
-      `CREATE TABLE IF NOT EXISTS job_execution_leases (
-        job_id uuid PRIMARY KEY REFERENCES jobs(id) ON DELETE CASCADE,
-        execution_generation uuid NOT NULL,
-        owner_id uuid NOT NULL,
-        expires_at timestamp NOT NULL,
-        heartbeat_at timestamp NOT NULL DEFAULT now(),
-        created_at timestamp NOT NULL DEFAULT now()
-      );`,
-    );
+    // Real drizzle schema via pushSchema (hand-rolled DDL diverges from the
+    // FK/enum reality the writeback tests need). Enums must be IN the map or
+    // the apps table references a missing type.
+    const { pushSchema } = await import("drizzle-kit/api");
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      apiKeys,
+      usageRecords,
+      generations,
+      agentSandboxes,
+      jobs,
+      jobExecutionLeases,
+      apps,
+      appDeploymentStatusEnum,
+      appReviewStatusEnum,
+      userDatabaseStatusEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+    // The jobs FKs need these parents; seeded once with the fixture ids the
+    // whole suite already uses.
+    await dbWrite
+      .insert(organizations)
+      .values({ id: ORG_ID, name: "Org", slug: "jobs-recovery-org", credit_balance: "5.000000" })
+      .onConflictDoNothing();
+    await dbWrite
+      .insert(users)
+      .values({ id: ACTOR_ID, steward_user_id: "steward-jobs-recovery", organization_id: ORG_ID })
+      .onConflictDoNothing();
+    // The canary identity-mismatch cases seed jobs owned by a second actor.
+    await dbWrite
+      .insert(users)
+      .values({
+        id: "00000000-0000-4000-8000-000000001899",
+        steward_user_id: "steward-jobs-recovery-other",
+        organization_id: ORG_ID,
+      })
+      .onConflictDoNothing();
   } catch (error) {
     pgliteReady = false;
     console.warn("[jobs-recovery] PGlite unavailable, skipping:", error);
@@ -190,6 +202,8 @@ describe("jobsRepository.recoverStaleJobs", () => {
     expect(pgliteReady).toBe(true);
     await dbWrite.delete(jobExecutionLeases);
     await dbWrite.execute("DELETE FROM jobs;");
+    await dbWrite.execute("DELETE FROM apps;");
+    await dbWrite.execute("DELETE FROM agent_sandboxes;");
   });
 
   test("two live processors cannot reclaim one another before the winning lease expires", async () => {
@@ -851,5 +865,172 @@ describe("jobsRepository.recoverStaleJobs", () => {
       replicaSpy.mockRestore();
       primarySpy.mockRestore();
     }
+  });
+});
+
+describe("recovery failure writeback (#17253 §3)", () => {
+  const APP_ID = "00000000-0000-4000-8000-000000200854";
+
+  beforeEach(async () => {
+    expect(pgliteReady).toBe(true);
+    await dbWrite.execute("DELETE FROM jobs;");
+    await dbWrite.execute("DELETE FROM apps;");
+  });
+
+  async function seedBuildingApp(): Promise<void> {
+    await dbWrite.insert(apps).values({
+      id: APP_ID,
+      name: "App",
+      slug: `app-${APP_ID.slice(-6)}`,
+      organization_id: ORG_ID,
+      created_by_user_id: ACTOR_ID,
+      app_url: "https://app.example",
+      deployment_status: "building",
+    });
+  }
+
+  async function appStatus(): Promise<string | undefined> {
+    const [row] = await dbWrite
+      .select({ status: apps.deployment_status })
+      .from(apps)
+      .where(eq(apps.id, APP_ID));
+    return row?.status ?? undefined;
+  }
+
+  test("a recovery flip to failed settles the dependent row in the SAME transaction", async () => {
+    const jobId = "00000000-0000-4000-8000-000000210854";
+    await seedBuildingApp();
+    await seedJob({
+      id: jobId,
+      type: "app_deploy",
+      maxAttempts: 3,
+      data: { appId: APP_ID, __worker_interruptions: 5 },
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "app_deploy",
+      startedBefore: new Date(),
+      buildFailureWriteback: (hydrated, _error) => async (tx) => {
+        const data = hydrated.data as { appId?: string };
+        if (!data.appId) throw new Error("no appId");
+        await tx
+          .update(apps)
+          .set({ deployment_status: "failed", updated_at: new Date() })
+          .where(eq(apps.id, data.appId));
+      },
+    });
+
+    expect(recovered).toBe(0); // the 6th interruption is terminal
+    const [job] = await dbWrite
+      .select({ status: jobs.status })
+      .from(jobs)
+      .where(eq(jobs.id, jobId));
+    expect(job?.status).toBe("failed");
+    // The whole point: the app is settled, not stranded BUILDING forever.
+    expect(await appStatus()).toBe("failed");
+  });
+
+  test("a writeback that throws at EXECUTION rolls back BOTH writes", async () => {
+    const jobId = "00000000-0000-4000-8000-000000220854";
+    await seedBuildingApp();
+    await seedJob({
+      id: jobId,
+      type: "app_deploy",
+      maxAttempts: 3,
+      data: { appId: APP_ID, __worker_interruptions: 5 },
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "app_deploy",
+      startedBefore: new Date(),
+      buildFailureWriteback: () => async () => {
+        throw new Error("dependent write refused");
+      },
+    });
+
+    // The per-job catch swallowed the failure and the sweep continued…
+    expect(recovered).toBe(0);
+    // …but the transaction rolled back BOTH writes: the job stays claimable
+    // by the next sweep, and the app was not half-settled.
+    const [job] = await dbWrite
+      .select({ status: jobs.status })
+      .from(jobs)
+      .where(eq(jobs.id, jobId));
+    expect(job?.status).toBe("in_progress");
+    expect(await appStatus()).toBe("building");
+  });
+
+  test("a BUILD-time throw degrades to flipping the job WITHOUT a writeback", async () => {
+    const jobId = "00000000-0000-4000-8000-000000230854";
+    await seedBuildingApp();
+    await seedJob({
+      id: jobId,
+      type: "app_deploy",
+      maxAttempts: 3,
+      data: { appId: APP_ID, __worker_interruptions: 5 },
+    });
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "app_deploy",
+      startedBefore: new Date(),
+      buildFailureWriteback: () => {
+        throw new Error("malformed payload");
+      },
+    });
+
+    expect(recovered).toBe(0);
+    // The flip must NOT be held hostage by an unbuildable writeback — the
+    // job fails (backstop sweeps own the row), it does not wedge in_progress.
+    const [job] = await dbWrite
+      .select({ status: jobs.status })
+      .from(jobs)
+      .where(eq(jobs.id, jobId));
+    expect(job?.status).toBe("failed");
+    expect(await appStatus()).toBe("building");
+  });
+
+  test("onPermanentFailure fires post-commit with the hydrated failed job", async () => {
+    const jobId = "00000000-0000-4000-8000-000000240854";
+    await seedBuildingApp();
+    await seedJob({
+      id: jobId,
+      type: "app_deploy",
+      maxAttempts: 3,
+      data: { appId: APP_ID, __worker_interruptions: 5 },
+    });
+
+    const seen: Array<{ id: string; status: string }> = [];
+    await repo.recoverInProgressJobsStartedBefore({
+      type: "app_deploy",
+      startedBefore: new Date(),
+      onPermanentFailure: async (job) => {
+        seen.push({ id: job.id, status: job.status });
+      },
+    });
+
+    expect(seen).toEqual([{ id: jobId, status: "failed" }]);
+  });
+
+  test("stale recovery drives the same writeback contract", async () => {
+    const jobId = "00000000-0000-4000-8000-000000250854";
+    await seedBuildingApp();
+    await seedJob({ id: jobId, type: "app_deploy", maxAttempts: 1, data: { appId: APP_ID } });
+
+    const recovered = await repo.recoverStaleJobs({
+      type: "app_deploy",
+      staleThresholdMs: 5 * 60 * 1000,
+      buildFailureWriteback: (hydrated) => async (tx) => {
+        const data = hydrated.data as { appId?: string };
+        if (data.appId) {
+          await tx
+            .update(apps)
+            .set({ deployment_status: "failed", updated_at: new Date() })
+            .where(eq(apps.id, data.appId));
+        }
+      },
+    });
+
+    expect(recovered).toBe(0); // maxAttempts 1 → timeout is terminal
+    expect(await appStatus()).toBe("failed");
   });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -6,7 +6,6 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { eq, type SQL } from "drizzle-orm";
-import { jobExecutionLeases } from "../../schemas/job-execution-leases";
 import { agentSandboxes } from "../../schemas/agent-sandboxes";
 import { apiKeys } from "../../schemas/api-keys";
 import {
@@ -16,6 +15,7 @@ import {
   userDatabaseStatusEnum,
 } from "../../schemas/apps";
 import { generations } from "../../schemas/generations";
+import { jobExecutionLeases } from "../../schemas/job-execution-leases";
 import { type Job, jobs } from "../../schemas/jobs";
 import { organizations } from "../../schemas/organizations";
 import { usageRecords } from "../../schemas/usage-records";

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -19,6 +19,7 @@ import {
   offloadJsonField,
   offloadTextField,
 } from "../../lib/storage/object-store";
+import { logger } from "../../lib/utils/logger";
 import type { DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -58,6 +59,20 @@ function hasRecoveryProtectedExecutionLease(): SQL {
 function lacksRecoveryProtectedExecutionLease(): SQL {
   return sql`NOT (${hasRecoveryProtectedExecutionLease()})`;
 }
+
+/**
+ * Builds the dependent-row settlement for a job a RECOVERY path flips to
+ * `failed` — the same shape incrementAttempt's onFailedInTx consumes. Called
+ * with the HYDRATED job (offloaded payloads resolved) BEFORE the recovery
+ * transaction opens: builders read job data eagerly and may throw on a
+ * malformed payload, and a build-time throw inside the transaction would roll
+ * back the status flip and wedge the job in_progress forever. A build failure
+ * degrades to flipping the job without a writeback, loudly logged.
+ */
+export type RecoveryFailureWritebackBuilder = (
+  hydratedJob: Job,
+  error: string,
+) => ((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined;
 
 function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
   return updates.data !== undefined || updates.result !== undefined || updates.error !== undefined;
@@ -912,6 +927,8 @@ export class JobsRepository {
     organizationId?: string;
     staleThresholdMs: number;
     maxAttempts?: number;
+    buildFailureWriteback?: RecoveryFailureWritebackBuilder;
+    onPermanentFailure?: (failedJob: Job) => Promise<void>;
   }): Promise<number> {
     const staleThreshold = new Date(Date.now() - filters.staleThresholdMs);
     const conditions = [
@@ -954,16 +971,33 @@ export class JobsRepository {
           ? `Job timed out ${newAttempts} times - max attempts reached`
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
       const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
-      const updated = await this.recoverJobFromSnapshot({
-        job,
-        startedBefore: staleThreshold,
-        isFailed,
-        newAttempts,
-        error: timeoutError,
-        recoveryFence,
-      });
-      if (updated && !isFailed) {
-        recoveredCount++;
+      // Per-job isolation: one poisoned payload or failing dependent write
+      // must not starve the rest of the sweep.
+      try {
+        const onFailedInTx = isFailed
+          ? await this.buildRecoveryWriteback(job, timeoutError, filters.buildFailureWriteback)
+          : undefined;
+        const recovered = await this.recoverJobFromSnapshot({
+          job,
+          startedBefore: staleThreshold,
+          isFailed,
+          newAttempts,
+          error: timeoutError,
+          recoveryFence,
+          onFailedInTx,
+        });
+        if (recovered && !isFailed) {
+          recoveredCount++;
+        }
+        if (recovered && isFailed && filters.onPermanentFailure) {
+          await filters.onPermanentFailure(recovered);
+        }
+      } catch (error) {
+        logger.error("[jobs] Stale-job recovery failed for one job; continuing sweep", {
+          jobId: job.id,
+          type: job.type,
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     }
 
@@ -971,6 +1005,42 @@ export class JobsRepository {
   }
 
   /**
+   * Build the dependent-row writeback OUTSIDE the recovery transaction, from
+   * the HYDRATED job: builders read payloads eagerly and may throw on a
+   * malformed or unhydratable one, and a build-time throw inside the
+   * transaction would roll back the status flip and wedge the job
+   * in_progress forever. A build failure degrades to flipping the job with
+   * no writeback — the dependent row then falls to the backstop sweeps.
+   */
+  private async buildRecoveryWriteback(
+    job: Job,
+    error: string,
+    build: RecoveryFailureWritebackBuilder | undefined,
+  ): Promise<((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined> {
+    if (!build) return undefined;
+    try {
+      return build(await hydrateJob(job), error);
+    } catch (buildError) {
+      logger.error(
+        "[jobs] Failure-writeback build threw; flipping the job WITHOUT settling its dependent row",
+        {
+          jobId: job.id,
+          type: job.type,
+          error: buildError instanceof Error ? buildError.message : String(buildError),
+        },
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Recovers in-progress jobs that were already claimed before a replacement
+   * worker process started. This is intentionally separate from
+   * `recoverStaleJobs`: the stale threshold protects slow cold boots during
+   * normal operation, while daemon startup is the one point where the previous
+   * process is known to have been replaced by systemd and its claims need to
+   * be made visible again immediately.
+   *
    * Recovers pre-start claims only after their renewable owner lease and
    * takeover grace have expired. Process start time scopes the scan but is not
    * ownership evidence: overlapping workers may both be live during rollout.
@@ -980,6 +1050,8 @@ export class JobsRepository {
     organizationId?: string;
     startedBefore: Date;
     maxAttempts?: number;
+    buildFailureWriteback?: RecoveryFailureWritebackBuilder;
+    onPermanentFailure?: (failedJob: Job) => Promise<void>;
   }): Promise<number> {
     const conditions = [
       eq(jobs.type, filters.type),
@@ -1023,17 +1095,34 @@ export class JobsRepository {
       const dataWithCount = resumeCommittedCanary
         ? null
         : withInterruptionCount(job, interruptions);
-      const updated = await this.recoverJobFromSnapshot({
-        job,
-        startedBefore: filters.startedBefore,
-        isFailed,
-        newAttempts,
-        error,
-        ...(dataWithCount !== null ? { data: dataWithCount } : {}),
-        recoveryFence,
-      });
-      if (updated && !isFailed) {
-        recoveredCount++;
+      // Per-job isolation: one poisoned payload or failing dependent write
+      // must not starve the rest of the startup sweep.
+      try {
+        const onFailedInTx = isFailed
+          ? await this.buildRecoveryWriteback(job, error, filters.buildFailureWriteback)
+          : undefined;
+        const recovered = await this.recoverJobFromSnapshot({
+          job,
+          startedBefore: filters.startedBefore,
+          isFailed,
+          newAttempts,
+          error,
+          ...(dataWithCount !== null ? { data: dataWithCount } : {}),
+          recoveryFence,
+          onFailedInTx,
+        });
+        if (recovered && !isFailed) {
+          recoveredCount++;
+        }
+        if (recovered && isFailed && filters.onPermanentFailure) {
+          await filters.onPermanentFailure(recovered);
+        }
+      } catch (loopError) {
+        logger.error("[jobs] Startup recovery failed for one job; continuing sweep", {
+          jobId: job.id,
+          type: job.type,
+          error: loopError instanceof Error ? loopError.message : String(loopError),
+        });
       }
     }
 
@@ -1049,7 +1138,16 @@ export class JobsRepository {
     /** Replacement inline payload (e.g. carrying the interruption count). */
     data?: Record<string, unknown>;
     recoveryFence: SQL;
-  }): Promise<boolean> {
+    /**
+     * Dependent-row settlement for a job this recovery flips to `failed` —
+     * the SAME contract as incrementAttempt's onFailedInTx: runs inside the
+     * recovery transaction, only after the CAS matched, and a throw rolls
+     * back BOTH the status flip and the dependent write. Without it a
+     * recovered-to-failed APP_DEPLOY left its app 'building' forever
+     * (#17253 §3) — the exact stranding the normal failure path prevents.
+     */
+    onFailedInTx?: (tx: DbTransaction, failedJob: Job) => Promise<void>;
+  }): Promise<Job | undefined> {
     const payload = await prepareJobPayload(
       {
         error: params.error,
@@ -1084,7 +1182,7 @@ export class JobsRepository {
         )
         .for("update")
         .limit(1);
-      if (!lockedJob) return false;
+      if (!lockedJob) return undefined;
       if (requiresExecutionLease && params.job.execution_generation) {
         const [liveLease] = await tx
           .select({ jobId: jobExecutionLeases.job_id })
@@ -1098,7 +1196,7 @@ export class JobsRepository {
             ),
           )
           .limit(1);
-        if (liveLease) return false;
+        if (liveLease) return undefined;
       }
       const [updated] = await tx
         .update(jobs)
@@ -1130,8 +1228,8 @@ export class JobsRepository {
               : sql`TRUE`,
           ),
         )
-        .returning({ id: jobs.id });
-      if (!updated) return false;
+        .returning();
+      if (!updated) return undefined;
       if (requiresExecutionLease) {
         await tx
           .delete(jobExecutionLeases)
@@ -1160,7 +1258,11 @@ export class JobsRepository {
             ),
           );
       }
-      return true;
+      const hydrated = await hydrateJob(updated);
+      if (params.isFailed && params.onFailedInTx) {
+        await params.onFailedInTx(tx, hydrated);
+      }
+      return hydrated;
     });
   }
 

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -60,30 +60,18 @@ function lacksRecoveryProtectedExecutionLease(): SQL {
 }
 
 function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
-  return (
-    updates.data !== undefined ||
-    updates.result !== undefined ||
-    updates.error !== undefined
-  );
+  return updates.data !== undefined || updates.result !== undefined || updates.error !== undefined;
 }
 
 function stringField(
   data: Record<string, unknown>,
-  field:
-    | "agentId"
-    | "agentName"
-    | "appId"
-    | "characterId"
-    | "organizationId"
-    | "userId",
+  field: "agentId" | "agentName" | "appId" | "characterId" | "organizationId" | "userId",
 ): string | null {
   const value = data[field];
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function indexedJobFields(
-  data: Record<string, unknown>,
-): Pick<Job, "agent_id" | "character_id"> {
+function indexedJobFields(data: Record<string, unknown>): Pick<Job, "agent_id" | "character_id"> {
   return {
     agent_id: stringField(data, "agentId"),
     character_id: stringField(data, "characterId"),
@@ -114,19 +102,12 @@ function timestampMillis(value: Date | string | null): number | null {
       : Date.parse(String(value));
 }
 
-function sameTimestamp(
-  left: Date | string | null,
-  right: Date | string | null,
-): boolean {
+function sameTimestamp(left: Date | string | null, right: Date | string | null): boolean {
   return timestampMillis(left) === timestampMillis(right);
 }
 
 function normalizedTimestamp(value: Date | string | null): Date | null {
-  return value === null
-    ? null
-    : value instanceof Date
-      ? value
-      : new Date(value);
+  return value === null ? null : value instanceof Date ? value : new Date(value);
 }
 
 function hasValidTimestamp(value: string): boolean {
@@ -154,25 +135,13 @@ const INTERRUPTION_COUNT_KEY = "__worker_interruptions";
  * interruption budget again, which errs on the side of retrying.
  */
 function readInterruptionCount(job: Job): number {
-  if (
-    job.data_storage !== "inline" ||
-    job.data === null ||
-    typeof job.data !== "object"
-  )
-    return 0;
+  if (job.data_storage !== "inline" || job.data === null || typeof job.data !== "object") return 0;
   const raw = (job.data as Record<string, unknown>)[INTERRUPTION_COUNT_KEY];
   return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : 0;
 }
 
-function withInterruptionCount(
-  job: Job,
-  count: number,
-): Record<string, unknown> | null {
-  if (
-    job.data_storage !== "inline" ||
-    job.data === null ||
-    typeof job.data !== "object"
-  ) {
+function withInterruptionCount(job: Job, count: number): Record<string, unknown> | null {
+  if (job.data_storage !== "inline" || job.data === null || typeof job.data !== "object") {
     return null;
   }
   return {
@@ -304,8 +273,7 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
       : left.data_key === right.data_key;
   const sameResult =
     left.result_storage === "inline"
-      ? JSON.stringify(left.result ?? null) ===
-        JSON.stringify(right.result ?? null)
+      ? JSON.stringify(left.result ?? null) === JSON.stringify(right.result ?? null)
       : left.result_key === right.result_key;
   const sameError =
     left.error_storage === "inline"
@@ -395,11 +363,7 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
   data: T,
   context: Pick<Job, "id" | "organization_id" | "created_at">,
 ): Promise<T> {
-  if (
-    data.data_storage === "r2" ||
-    data.result_storage === "r2" ||
-    data.error_storage === "r2"
-  ) {
+  if (data.data_storage === "r2" || data.result_storage === "r2" || data.error_storage === "r2") {
     return {
       ...data,
       ...(data.data !== undefined ? indexedJobFields(data.data) : {}),
@@ -526,11 +490,7 @@ export class JobsRepository {
    * @returns Job record or undefined.
    */
   async findById(id: string): Promise<Job | undefined> {
-    const [job] = await dbRead
-      .select()
-      .from(jobs)
-      .where(eq(jobs.id, id))
-      .limit(1);
+    const [job] = await dbRead.select().from(jobs).where(eq(jobs.id, id)).limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -541,10 +501,7 @@ export class JobsRepository {
    * @param organizationId - Owning organization ID.
    * @returns Job record or undefined.
    */
-  async findByIdAndOrg(
-    id: string,
-    organizationId: string,
-  ): Promise<Job | undefined> {
+  async findByIdAndOrg(id: string, organizationId: string): Promise<Job | undefined> {
     const [job] = await dbRead
       .select()
       .from(jobs)
@@ -558,11 +515,7 @@ export class JobsRepository {
    * derive a compensating operation from a terminal job.
    */
   async findByIdForWrite(id: string): Promise<Job | undefined> {
-    const [job] = await dbWrite
-      .select()
-      .from(jobs)
-      .where(eq(jobs.id, id))
-      .limit(1);
+    const [job] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -570,19 +523,11 @@ export class JobsRepository {
    * Reads every durable job in one admin canary rollout from the primary.
    * Canary payloads are forced inline, so the JSON predicate is authoritative.
    */
-  async findAdminCanaryRolloutForWrite(
-    type: string,
-    rolloutId: string,
-  ): Promise<Job[]> {
+  async findAdminCanaryRolloutForWrite(type: string, rolloutId: string): Promise<Job[]> {
     const rows = await dbWrite
       .select()
       .from(jobs)
-      .where(
-        and(
-          eq(jobs.type, type),
-          sql`${jobs.data}->>'rolloutId' = ${rolloutId}`,
-        ),
-      )
+      .where(and(eq(jobs.type, type), sql`${jobs.data}->>'rolloutId' = ${rolloutId}`))
       .orderBy(jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
@@ -639,13 +584,9 @@ export class JobsRepository {
     // Build query in one chain to avoid TypeScript inference issues
     const query = dbRead.select().from(jobs).$dynamic();
 
-    const rows = await (
-      conditions.length > 0 ? query.where(and(...conditions)) : query
-    )
+    const rows = await (conditions.length > 0 ? query.where(and(...conditions)) : query)
       .limit(filters.limit || 1000)
-      .orderBy(
-        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
-      );
+      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -704,9 +645,7 @@ export class JobsRepository {
           dataFieldFilter,
         ),
       )
-      .orderBy(
-        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
-      );
+      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -800,11 +739,7 @@ export class JobsRepository {
     executionOwnerId?: string;
     executionLeaseMs?: number;
   }): Promise<Job[]> {
-    if (
-      filters.sharedTypes.length === 0 ||
-      filters.maxRunning < 1 ||
-      filters.limit < 1
-    ) {
+    if (filters.sharedTypes.length === 0 || filters.maxRunning < 1 || filters.limit < 1) {
       return [];
     }
 
@@ -818,21 +753,11 @@ export class JobsRepository {
       const [running] = await tx
         .select({ count: sql<number>`count(*)::int` })
         .from(jobs)
-        .where(
-          and(
-            inArray(jobs.type, filters.sharedTypes),
-            eq(jobs.status, "in_progress"),
-          ),
-        );
+        .where(and(inArray(jobs.type, filters.sharedTypes), eq(jobs.status, "in_progress")));
       if (!running) {
-        throw new Error(
-          "Shared image-change capacity query returned no aggregate row",
-        );
+        throw new Error("Shared image-change capacity query returned no aggregate row");
       }
-      const claimLimit = Math.min(
-        filters.limit,
-        Math.max(0, filters.maxRunning - running.count),
-      );
+      const claimLimit = Math.min(filters.limit, Math.max(0, filters.maxRunning - running.count));
       if (claimLimit === 0) return [];
 
       const orgFilter = filters.organizationId
@@ -1020,9 +945,7 @@ export class JobsRepository {
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const newAttempts = resumeCommittedCanary
-        ? job.attempts
-        : (job.attempts || 0) + 1;
+      const newAttempts = resumeCommittedCanary ? job.attempts : (job.attempts || 0) + 1;
       const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
       const isFailed = !resumeCommittedCanary && newAttempts >= maxAttempts;
       const timeoutError = resumeCommittedCanary
@@ -1030,9 +953,7 @@ export class JobsRepository {
         : isFailed
           ? `Job timed out ${newAttempts} times - max attempts reached`
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
-      const recoveryFence = resumeCommittedCanary
-        ? adminCanaryRecoveryFence(job)
-        : sql`TRUE`;
+      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
       const updated = await this.recoverJobFromSnapshot({
         job,
         startedBefore: staleThreshold,
@@ -1098,9 +1019,7 @@ export class JobsRepository {
         : isFailed
           ? `Job interrupted by worker restart ${interruptions} times - interruption budget exhausted`
           : `Job interrupted by worker restart - recovered for retry (interruption ${interruptions}/${MAX_JOB_INTERRUPTIONS}; attempts untouched)`;
-      const recoveryFence = resumeCommittedCanary
-        ? adminCanaryRecoveryFence(job)
-        : sql`TRUE`;
+      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
       const dataWithCount = resumeCommittedCanary
         ? null
         : withInterruptionCount(job, interruptions);
@@ -1256,11 +1175,7 @@ export class JobsRepository {
   async update(id: string, updates: Partial<Job>): Promise<Job> {
     let updateData = updates;
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite
-        .select()
-        .from(jobs)
-        .where(eq(jobs.id, id))
-        .limit(1);
+      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1320,11 +1235,7 @@ export class JobsRepository {
    * @param status - New status.
    * @param additionalFields - Optional additional fields to update.
    */
-  async updateStatus(
-    id: string,
-    status: string,
-    additionalFields?: Partial<Job>,
-  ): Promise<void> {
+  async updateStatus(id: string, status: string, additionalFields?: Partial<Job>): Promise<void> {
     let updates: Partial<Job> = {
       status,
       updated_at: new Date(),
@@ -1339,11 +1250,7 @@ export class JobsRepository {
     }
 
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite
-        .select()
-        .from(jobs)
-        .where(eq(jobs.id, id))
-        .limit(1);
+      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1764,12 +1671,7 @@ export class JobsRepository {
     const rows = await dbRead
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(
-        and(
-          eq(jobs.type, type),
-          sql`${jobs.status} IN ('pending', 'in_progress')`,
-        ),
-      );
+      .where(and(eq(jobs.type, type), sql`${jobs.status} IN ('pending', 'in_progress')`));
     return rows[0]?.count ?? 0;
   }
 
@@ -1782,12 +1684,7 @@ export class JobsRepository {
     const rows = await dbWrite
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(
-        and(
-          inArray(jobs.type, types),
-          sql`${jobs.status} IN ('pending', 'in_progress')`,
-        ),
-      );
+      .where(and(inArray(jobs.type, types), sql`${jobs.status} IN ('pending', 'in_progress')`));
     const [aggregate] = rows;
     if (!aggregate) {
       throw new Error("Image-change in-flight query returned no aggregate row");

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -60,19 +60,18 @@ function lacksRecoveryProtectedExecutionLease(): SQL {
   return sql`NOT (${hasRecoveryProtectedExecutionLease()})`;
 }
 
-/**
- * Builds the dependent-row settlement for a job a RECOVERY path flips to
- * `failed` — the same shape incrementAttempt's onFailedInTx consumes. Called
- * with the HYDRATED job (offloaded payloads resolved) BEFORE the recovery
- * transaction opens: builders read job data eagerly and may throw on a
- * malformed payload, and a build-time throw inside the transaction would roll
- * back the status flip and wedge the job in_progress forever. A build failure
- * degrades to flipping the job without a writeback, loudly logged.
- */
+
+/** In-transaction dependent-row settlement — the contract incrementAttempt's
+ * onFailedInTx already speaks; recovery is its second caller. */
+export type JobFailureWriteback = (tx: DbTransaction, failedJob: Job) => Promise<void>;
+
+/** Builds the {@link JobFailureWriteback} for a job a RECOVERY path flips to
+ * `failed`, or undefined for types with no dependent row. See
+ * buildRecoveryWriteback for the build-outside-the-transaction rationale. */
 export type RecoveryFailureWritebackBuilder = (
-  hydratedJob: Job,
+  job: Job,
   error: string,
-) => ((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined;
+) => JobFailureWriteback | undefined;
 
 function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
   return updates.data !== undefined || updates.result !== undefined || updates.error !== undefined;
@@ -958,6 +957,7 @@ export class JobsRepository {
       .where(and(...conditions));
 
     let recoveredCount = 0;
+    let sweepFailures = 0;
 
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
@@ -972,7 +972,9 @@ export class JobsRepository {
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
       const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
       // Per-job isolation: one poisoned payload or failing dependent write
-      // must not starve the rest of the sweep.
+      // must not starve the rest of the sweep — but a batch where EVERY job
+      // failed is an infrastructure outage, and that signal must keep
+      // propagating to the caller (cron status codes alert on it).
       try {
         const onFailedInTx = isFailed
           ? await this.buildRecoveryWriteback(job, timeoutError, filters.buildFailureWriteback)
@@ -990,14 +992,36 @@ export class JobsRepository {
           recoveredCount++;
         }
         if (recovered && isFailed && filters.onPermanentFailure) {
-          await filters.onPermanentFailure(recovered);
+          try {
+            await filters.onPermanentFailure(recovered);
+          } catch (hookError) {
+            // The recovery itself committed; only the post-commit hook failed.
+            logger.warn("[jobs] Post-failure hook failed after a committed recovery", {
+              jobId: job.id,
+              type: job.type,
+              error: hookError instanceof Error ? hookError.message : String(hookError),
+            });
+          }
         }
       } catch (error) {
+        sweepFailures++;
         logger.error("[jobs] Stale-job recovery failed for one job; continuing sweep", {
           jobId: job.id,
           type: job.type,
           error: error instanceof Error ? error.message : String(error),
         });
+      }
+    }
+
+    if (sweepFailures > 0) {
+      logger.error("[jobs] Stale-job sweep finished degraded", {
+        swept: staleJobs.length,
+        failed: sweepFailures,
+      });
+      if (sweepFailures === staleJobs.length) {
+        throw new Error(
+          `Stale-job recovery failed for every job in the batch (${sweepFailures}/${staleJobs.length})`,
+        );
       }
     }
 
@@ -1016,8 +1040,22 @@ export class JobsRepository {
     job: Job,
     error: string,
     build: RecoveryFailureWritebackBuilder | undefined,
-  ): Promise<((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined> {
+  ): Promise<JobFailureWriteback | undefined> {
     if (!build) return undefined;
+    // Probe with the RAW row first: types with no dependent row return
+    // undefined without touching the payload, so the sweep stays a DB-only
+    // operation for them — including agent_snapshot, whose lane is
+    // fail-closed out of claiming precisely because hydration can exhaust
+    // the worker heap (#16639). Only a builder that THROWS on the raw row
+    // (an offloaded payload whose reader needs R2-only fields) pays for a
+    // hydration, outside the transaction; a second throw degrades to
+    // flipping the job without a writeback, loudly logged, instead of
+    // wedging it in_progress forever.
+    try {
+      return build(job, error);
+    } catch {
+      // fall through to the hydrated attempt
+    }
     try {
       return build(await hydrateJob(job), error);
     } catch (buildError) {
@@ -1075,6 +1113,7 @@ export class JobsRepository {
       .where(and(...conditions));
 
     let recoveredCount = 0;
+    let sweepFailures = 0;
 
     for (const job of interruptedJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
@@ -1095,8 +1134,8 @@ export class JobsRepository {
       const dataWithCount = resumeCommittedCanary
         ? null
         : withInterruptionCount(job, interruptions);
-      // Per-job isolation: one poisoned payload or failing dependent write
-      // must not starve the rest of the startup sweep.
+      // Per-job isolation with the outage signal preserved — see the stale
+      // sweep for the rationale; identical policy.
       try {
         const onFailedInTx = isFailed
           ? await this.buildRecoveryWriteback(job, error, filters.buildFailureWriteback)
@@ -1115,14 +1154,35 @@ export class JobsRepository {
           recoveredCount++;
         }
         if (recovered && isFailed && filters.onPermanentFailure) {
-          await filters.onPermanentFailure(recovered);
+          try {
+            await filters.onPermanentFailure(recovered);
+          } catch (hookError) {
+            logger.warn("[jobs] Post-failure hook failed after a committed recovery", {
+              jobId: job.id,
+              type: job.type,
+              error: hookError instanceof Error ? hookError.message : String(hookError),
+            });
+          }
         }
       } catch (loopError) {
+        sweepFailures++;
         logger.error("[jobs] Startup recovery failed for one job; continuing sweep", {
           jobId: job.id,
           type: job.type,
           error: loopError instanceof Error ? loopError.message : String(loopError),
         });
+      }
+    }
+
+    if (sweepFailures > 0) {
+      logger.error("[jobs] Startup recovery sweep finished degraded", {
+        swept: interruptedJobs.length,
+        failed: sweepFailures,
+      });
+      if (sweepFailures === interruptedJobs.length) {
+        throw new Error(
+          `Startup recovery failed for every job in the batch (${sweepFailures}/${interruptedJobs.length})`,
+        );
       }
     }
 
@@ -1146,7 +1206,7 @@ export class JobsRepository {
      * recovered-to-failed APP_DEPLOY left its app 'building' forever
      * (#17253 §3) — the exact stranding the normal failure path prevents.
      */
-    onFailedInTx?: (tx: DbTransaction, failedJob: Job) => Promise<void>;
+    onFailedInTx?: JobFailureWriteback;
   }): Promise<Job | undefined> {
     const payload = await prepareJobPayload(
       {
@@ -1258,10 +1318,13 @@ export class JobsRepository {
             ),
           );
       }
+      // Hydrate ONLY when a writeback will consume the row: the common
+      // retry-to-pending path stays a DB-only operation (no R2 I/O inside
+      // this transaction), and an R2 outage cannot roll back recoveries
+      // that never needed the payload.
+      if (!(params.isFailed && params.onFailedInTx)) return updated;
       const hydrated = await hydrateJob(updated);
-      if (params.isFailed && params.onFailedInTx) {
-        await params.onFailedInTx(tx, hydrated);
-      }
+      await params.onFailedInTx(tx, hydrated);
       return hydrated;
     });
   }

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -60,18 +60,30 @@ function lacksRecoveryProtectedExecutionLease(): SQL {
 }
 
 function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
-  return updates.data !== undefined || updates.result !== undefined || updates.error !== undefined;
+  return (
+    updates.data !== undefined ||
+    updates.result !== undefined ||
+    updates.error !== undefined
+  );
 }
 
 function stringField(
   data: Record<string, unknown>,
-  field: "agentId" | "agentName" | "appId" | "characterId" | "organizationId" | "userId",
+  field:
+    | "agentId"
+    | "agentName"
+    | "appId"
+    | "characterId"
+    | "organizationId"
+    | "userId",
 ): string | null {
   const value = data[field];
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function indexedJobFields(data: Record<string, unknown>): Pick<Job, "agent_id" | "character_id"> {
+function indexedJobFields(
+  data: Record<string, unknown>,
+): Pick<Job, "agent_id" | "character_id"> {
   return {
     agent_id: stringField(data, "agentId"),
     character_id: stringField(data, "characterId"),
@@ -102,16 +114,71 @@ function timestampMillis(value: Date | string | null): number | null {
       : Date.parse(String(value));
 }
 
-function sameTimestamp(left: Date | string | null, right: Date | string | null): boolean {
+function sameTimestamp(
+  left: Date | string | null,
+  right: Date | string | null,
+): boolean {
   return timestampMillis(left) === timestampMillis(right);
 }
 
 function normalizedTimestamp(value: Date | string | null): Date | null {
-  return value === null ? null : value instanceof Date ? value : new Date(value);
+  return value === null
+    ? null
+    : value instanceof Date
+      ? value
+      : new Date(value);
 }
 
 function hasValidTimestamp(value: string): boolean {
   return Number.isFinite(Date.parse(value));
+}
+
+/**
+ * How many worker-restart interruptions one job may survive before it is
+ * failed. Distinct from `max_attempts` on purpose: a restart is an
+ * infrastructure event, not evidence against the job, so it must not spend the
+ * job's retry budget — but it cannot be exempted UNBOUNDED either, because a
+ * job that CAUSES the restart (a capture that OOMs the worker, #17154) would
+ * then loop forever, taking every co-scheduled job down on each cycle. The
+ * bound converts that loop into a terminal failure whose message names the
+ * interruptions instead of blaming the job's attempts.
+ */
+const MAX_JOB_INTERRUPTIONS = 5;
+
+const INTERRUPTION_COUNT_KEY = "__worker_interruptions";
+
+/**
+ * Interruption count carried in the job's inline JSONB payload — a dedicated
+ * column would need a shared-DB migration for what is a small bounded counter.
+ * Unreadable/offloaded payloads count as zero: those jobs simply get the full
+ * interruption budget again, which errs on the side of retrying.
+ */
+function readInterruptionCount(job: Job): number {
+  if (
+    job.data_storage !== "inline" ||
+    job.data === null ||
+    typeof job.data !== "object"
+  )
+    return 0;
+  const raw = (job.data as Record<string, unknown>)[INTERRUPTION_COUNT_KEY];
+  return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : 0;
+}
+
+function withInterruptionCount(
+  job: Job,
+  count: number,
+): Record<string, unknown> | null {
+  if (
+    job.data_storage !== "inline" ||
+    job.data === null ||
+    typeof job.data !== "object"
+  ) {
+    return null;
+  }
+  return {
+    ...(job.data as Record<string, unknown>),
+    [INTERRUPTION_COUNT_KEY]: count,
+  };
 }
 
 // A committed canary cutover is already the serving generation, so recovery
@@ -237,7 +304,8 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
       : left.data_key === right.data_key;
   const sameResult =
     left.result_storage === "inline"
-      ? JSON.stringify(left.result ?? null) === JSON.stringify(right.result ?? null)
+      ? JSON.stringify(left.result ?? null) ===
+        JSON.stringify(right.result ?? null)
       : left.result_key === right.result_key;
   const sameError =
     left.error_storage === "inline"
@@ -327,7 +395,11 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
   data: T,
   context: Pick<Job, "id" | "organization_id" | "created_at">,
 ): Promise<T> {
-  if (data.data_storage === "r2" || data.result_storage === "r2" || data.error_storage === "r2") {
+  if (
+    data.data_storage === "r2" ||
+    data.result_storage === "r2" ||
+    data.error_storage === "r2"
+  ) {
     return {
       ...data,
       ...(data.data !== undefined ? indexedJobFields(data.data) : {}),
@@ -402,9 +474,19 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
         }
       : {}),
     ...(result
-      ? { result: result.value, result_storage: result.storage, result_key: result.key }
+      ? {
+          result: result.value,
+          result_storage: result.storage,
+          result_key: result.key,
+        }
       : {}),
-    ...(error ? { error: error.value, error_storage: error.storage, error_key: error.key } : {}),
+    ...(error
+      ? {
+          error: error.value,
+          error_storage: error.storage,
+          error_key: error.key,
+        }
+      : {}),
   };
 }
 
@@ -444,7 +526,11 @@ export class JobsRepository {
    * @returns Job record or undefined.
    */
   async findById(id: string): Promise<Job | undefined> {
-    const [job] = await dbRead.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+    const [job] = await dbRead
+      .select()
+      .from(jobs)
+      .where(eq(jobs.id, id))
+      .limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -455,7 +541,10 @@ export class JobsRepository {
    * @param organizationId - Owning organization ID.
    * @returns Job record or undefined.
    */
-  async findByIdAndOrg(id: string, organizationId: string): Promise<Job | undefined> {
+  async findByIdAndOrg(
+    id: string,
+    organizationId: string,
+  ): Promise<Job | undefined> {
     const [job] = await dbRead
       .select()
       .from(jobs)
@@ -469,7 +558,11 @@ export class JobsRepository {
    * derive a compensating operation from a terminal job.
    */
   async findByIdForWrite(id: string): Promise<Job | undefined> {
-    const [job] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+    const [job] = await dbWrite
+      .select()
+      .from(jobs)
+      .where(eq(jobs.id, id))
+      .limit(1);
     return job ? await hydrateJob(job) : undefined;
   }
 
@@ -477,11 +570,19 @@ export class JobsRepository {
    * Reads every durable job in one admin canary rollout from the primary.
    * Canary payloads are forced inline, so the JSON predicate is authoritative.
    */
-  async findAdminCanaryRolloutForWrite(type: string, rolloutId: string): Promise<Job[]> {
+  async findAdminCanaryRolloutForWrite(
+    type: string,
+    rolloutId: string,
+  ): Promise<Job[]> {
     const rows = await dbWrite
       .select()
       .from(jobs)
-      .where(and(eq(jobs.type, type), sql`${jobs.data}->>'rolloutId' = ${rolloutId}`))
+      .where(
+        and(
+          eq(jobs.type, type),
+          sql`${jobs.data}->>'rolloutId' = ${rolloutId}`,
+        ),
+      )
       .orderBy(jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }
@@ -538,9 +639,13 @@ export class JobsRepository {
     // Build query in one chain to avoid TypeScript inference issues
     const query = dbRead.select().from(jobs).$dynamic();
 
-    const rows = await (conditions.length > 0 ? query.where(and(...conditions)) : query)
+    const rows = await (
+      conditions.length > 0 ? query.where(and(...conditions)) : query
+    )
       .limit(filters.limit || 1000)
-      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
+      .orderBy(
+        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
+      );
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -599,7 +704,9 @@ export class JobsRepository {
           dataFieldFilter,
         ),
       )
-      .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
+      .orderBy(
+        filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at,
+      );
     return await Promise.all(rows.map(hydrateJob));
   }
 
@@ -693,7 +800,11 @@ export class JobsRepository {
     executionOwnerId?: string;
     executionLeaseMs?: number;
   }): Promise<Job[]> {
-    if (filters.sharedTypes.length === 0 || filters.maxRunning < 1 || filters.limit < 1) {
+    if (
+      filters.sharedTypes.length === 0 ||
+      filters.maxRunning < 1 ||
+      filters.limit < 1
+    ) {
       return [];
     }
 
@@ -707,11 +818,21 @@ export class JobsRepository {
       const [running] = await tx
         .select({ count: sql<number>`count(*)::int` })
         .from(jobs)
-        .where(and(inArray(jobs.type, filters.sharedTypes), eq(jobs.status, "in_progress")));
+        .where(
+          and(
+            inArray(jobs.type, filters.sharedTypes),
+            eq(jobs.status, "in_progress"),
+          ),
+        );
       if (!running) {
-        throw new Error("Shared image-change capacity query returned no aggregate row");
+        throw new Error(
+          "Shared image-change capacity query returned no aggregate row",
+        );
       }
-      const claimLimit = Math.min(filters.limit, Math.max(0, filters.maxRunning - running.count));
+      const claimLimit = Math.min(
+        filters.limit,
+        Math.max(0, filters.maxRunning - running.count),
+      );
       if (claimLimit === 0) return [];
 
       const orgFilter = filters.organizationId
@@ -899,7 +1020,9 @@ export class JobsRepository {
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const newAttempts = resumeCommittedCanary ? job.attempts : (job.attempts || 0) + 1;
+      const newAttempts = resumeCommittedCanary
+        ? job.attempts
+        : (job.attempts || 0) + 1;
       const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
       const isFailed = !resumeCommittedCanary && newAttempts >= maxAttempts;
       const timeoutError = resumeCommittedCanary
@@ -907,7 +1030,9 @@ export class JobsRepository {
         : isFailed
           ? `Job timed out ${newAttempts} times - max attempts reached`
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
-      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
+      const recoveryFence = resumeCommittedCanary
+        ? adminCanaryRecoveryFence(job)
+        : sql`TRUE`;
       const updated = await this.recoverJobFromSnapshot({
         job,
         startedBefore: staleThreshold,
@@ -960,21 +1085,32 @@ export class JobsRepository {
 
     for (const job of interruptedJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const newAttempts = resumeCommittedCanary ? job.attempts : (job.attempts || 0) + 1;
-      const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
-      const isFailed = !resumeCommittedCanary && newAttempts >= maxAttempts;
+      // A worker restart is an infrastructure event, not evidence against the
+      // job: it consumes the INTERRUPTION budget, never an attempt. Two
+      // restarts used to burn 2 of 3 attempts and permanently fail jobs that
+      // had done nothing wrong (381 agent_snapshot rows in one prod week).
+      const interruptions = readInterruptionCount(job) + 1;
+      const interruptionsExhausted = interruptions > MAX_JOB_INTERRUPTIONS;
+      const newAttempts = job.attempts || 0;
+      const isFailed = !resumeCommittedCanary && interruptionsExhausted;
       const error = resumeCommittedCanary
         ? "Admin canary cutover cleanup interrupted by worker restart - recovered without consuming a terminal attempt"
         : isFailed
-          ? `Job interrupted by worker restart ${newAttempts} times - max attempts reached`
-          : `Job interrupted by worker restart - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
-      const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
+          ? `Job interrupted by worker restart ${interruptions} times - interruption budget exhausted`
+          : `Job interrupted by worker restart - recovered for retry (interruption ${interruptions}/${MAX_JOB_INTERRUPTIONS}; attempts untouched)`;
+      const recoveryFence = resumeCommittedCanary
+        ? adminCanaryRecoveryFence(job)
+        : sql`TRUE`;
+      const dataWithCount = resumeCommittedCanary
+        ? null
+        : withInterruptionCount(job, interruptions);
       const updated = await this.recoverJobFromSnapshot({
         job,
         startedBefore: filters.startedBefore,
         isFailed,
         newAttempts,
         error,
+        ...(dataWithCount !== null ? { data: dataWithCount } : {}),
         recoveryFence,
       });
       if (updated && !isFailed) {
@@ -991,9 +1127,17 @@ export class JobsRepository {
     isFailed: boolean;
     newAttempts: number;
     error: string;
+    /** Replacement inline payload (e.g. carrying the interruption count). */
+    data?: Record<string, unknown>;
     recoveryFence: SQL;
   }): Promise<boolean> {
-    const payload = await prepareJobPayload({ error: params.error }, params.job);
+    const payload = await prepareJobPayload(
+      {
+        error: params.error,
+        ...(params.data !== undefined ? { data: params.data } : {}),
+      },
+      params.job,
+    );
     const requiresExecutionLease = hasDetachedProvisioningExecution(params.job.type);
     return dbWrite.transaction(async (tx) => {
       if (hasAgentLifecycleFence(params.job)) {
@@ -1112,7 +1256,11 @@ export class JobsRepository {
   async update(id: string, updates: Partial<Job>): Promise<Job> {
     let updateData = updates;
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+      const [existing] = await dbWrite
+        .select()
+        .from(jobs)
+        .where(eq(jobs.id, id))
+        .limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1172,7 +1320,11 @@ export class JobsRepository {
    * @param status - New status.
    * @param additionalFields - Optional additional fields to update.
    */
-  async updateStatus(id: string, status: string, additionalFields?: Partial<Job>): Promise<void> {
+  async updateStatus(
+    id: string,
+    status: string,
+    additionalFields?: Partial<Job>,
+  ): Promise<void> {
     let updates: Partial<Job> = {
       status,
       updated_at: new Date(),
@@ -1187,7 +1339,11 @@ export class JobsRepository {
     }
 
     if (hasPayloadUpdates(updates)) {
-      const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
+      const [existing] = await dbWrite
+        .select()
+        .from(jobs)
+        .where(eq(jobs.id, id))
+        .limit(1);
       if (!existing) {
         throw new Error(`Job not found: ${id}`);
       }
@@ -1608,7 +1764,12 @@ export class JobsRepository {
     const rows = await dbRead
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(and(eq(jobs.type, type), sql`${jobs.status} IN ('pending', 'in_progress')`));
+      .where(
+        and(
+          eq(jobs.type, type),
+          sql`${jobs.status} IN ('pending', 'in_progress')`,
+        ),
+      );
     return rows[0]?.count ?? 0;
   }
 
@@ -1621,7 +1782,12 @@ export class JobsRepository {
     const rows = await dbWrite
       .select({ count: sql<number>`count(*)::int` })
       .from(jobs)
-      .where(and(inArray(jobs.type, types), sql`${jobs.status} IN ('pending', 'in_progress')`));
+      .where(
+        and(
+          inArray(jobs.type, types),
+          sql`${jobs.status} IN ('pending', 'in_progress')`,
+        ),
+      );
     const [aggregate] = rows;
     if (!aggregate) {
       throw new Error("Image-change in-flight query returned no aggregate row");

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -60,7 +60,6 @@ function lacksRecoveryProtectedExecutionLease(): SQL {
   return sql`NOT (${hasRecoveryProtectedExecutionLease()})`;
 }
 
-
 /** In-transaction dependent-row settlement — the contract incrementAttempt's
  * onFailedInTx already speaks; recovery is its second caller. */
 export type JobFailureWriteback = (tx: DbTransaction, failedJob: Job) => Promise<void>;

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -995,7 +995,8 @@ export class JobsRepository {
           try {
             await filters.onPermanentFailure(recovered);
           } catch (hookError) {
-            // The recovery itself committed; only the post-commit hook failed.
+            // error-policy:J7 observed-and-bounded — the recovery itself
+            // committed; only the post-commit hook failed.
             logger.warn("[jobs] Post-failure hook failed after a committed recovery", {
               jobId: job.id,
               type: job.type,
@@ -1004,6 +1005,8 @@ export class JobsRepository {
           }
         }
       } catch (error) {
+        // error-policy:J1/J7 per-job isolation with the outage signal kept:
+        // counted, logged, and rethrown below when EVERY job failed.
         sweepFailures++;
         logger.error("[jobs] Stale-job recovery failed for one job; continuing sweep", {
           jobId: job.id,
@@ -1054,11 +1057,15 @@ export class JobsRepository {
     try {
       return build(job, error);
     } catch {
-      // fall through to the hydrated attempt
+      // error-policy:J5 deferred observation — a raw-row probe throw is
+      // expected for offloaded payloads; the SAME error is observed and
+      // logged by the hydrated attempt below if it persists.
     }
     try {
       return build(await hydrateJob(job), error);
     } catch (buildError) {
+      // error-policy:J4/J7 degrade-with-signal — the flip must not be held
+      // hostage by an unbuildable writeback; backstop sweeps own the row.
       logger.error(
         "[jobs] Failure-writeback build threw; flipping the job WITHOUT settling its dependent row",
         {
@@ -1157,6 +1164,8 @@ export class JobsRepository {
           try {
             await filters.onPermanentFailure(recovered);
           } catch (hookError) {
+            // error-policy:J7 observed-and-bounded — the recovery committed;
+            // only the post-commit hook failed.
             logger.warn("[jobs] Post-failure hook failed after a committed recovery", {
               jobId: job.id,
               type: job.type,
@@ -1165,6 +1174,8 @@ export class JobsRepository {
           }
         }
       } catch (loopError) {
+        // error-policy:J1/J7 per-job isolation with the outage signal kept:
+        // counted, logged, and rethrown below when EVERY job failed.
         sweepFailures++;
         logger.error("[jobs] Startup recovery failed for one job; continuing sweep", {
           jobId: job.id,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts
@@ -95,3 +95,55 @@ describe("recoverStaleJobs threshold by job type", () => {
     }
   });
 });
+
+describe("recovery failure-writeback wiring (#17253 §3)", () => {
+  test("both recovery paths hand the repository the REAL permanent-failure builder", async () => {
+    const { ProvisioningJobService } = await import("./provisioning-jobs");
+    const { jobsRepository } = await import("../../db/repositories/jobs");
+    const svc = new ProvisioningJobService();
+
+    const captured: Array<Record<string, unknown>> = [];
+    const stale = spyOn(jobsRepository, "recoverStaleJobs").mockImplementation(
+      async (filters: Record<string, unknown>) => {
+        captured.push(filters);
+        return 0;
+      },
+    );
+    const startup = spyOn(jobsRepository, "recoverInProgressJobsStartedBefore").mockImplementation(
+      async (filters: Record<string, unknown>) => {
+        captured.push(filters);
+        return 0;
+      },
+    );
+    try {
+      await (svc as unknown as { recoverStaleJobs: () => Promise<void> }).recoverStaleJobs();
+      await svc.recoverInterruptedJobsOnStartup();
+
+      expect(captured.length).toBeGreaterThanOrEqual(2);
+      for (const filters of captured) {
+        expect(typeof filters.buildFailureWriteback).toBe("function");
+        expect(typeof filters.onPermanentFailure).toBe("function");
+        // The builder is the real one: for an APP_DEPLOY job it produces a
+        // writeback closure; for a type with no dependent row it produces
+        // undefined — the exact contract of buildPermanentFailureWriteback.
+        const build = filters.buildFailureWriteback as (
+          job: Record<string, unknown>,
+          error: string,
+        ) => unknown;
+        const appDeployJob = {
+          id: "00000000-0000-4000-8000-000000000001",
+          type: "app_deploy",
+          data: { appId: "00000000-0000-4000-8000-000000000002" },
+          data_storage: "inline",
+          max_attempts: 3,
+        };
+        expect(typeof build(appDeployJob, "boom")).toBe("function");
+        const inertJob = { ...appDeployJob, type: "agent_message", data: {} };
+        expect(build(inertJob, "boom")).toBeUndefined();
+      }
+    } finally {
+      stale.mockRestore();
+      startup.mockRestore();
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -3047,6 +3047,8 @@ export class ProvisioningJobService {
         }
       }
     } catch (error) {
+      // error-policy:J7 observed-and-bounded — the DB flip already committed;
+      // the read cache is TTL-bounded, so a failed evict degrades to staleness.
       logger.warn("[provisioning-jobs] Post-failure cache eviction skipped", {
         jobId: job.id,
         type: job.type,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -2846,6 +2846,9 @@ export class ProvisioningJobService {
 
     for (const jobType of this.filterSnapshotLane(jobTypes, "startup-recovery")) {
       const recovered = await jobsRepository.recoverInProgressJobsStartedBefore({
+        // Same dependent-row settlement as the runner's failure path (#17253 §3).
+        buildFailureWriteback: (job, error) => this.buildPermanentFailureWriteback(job, error),
+        onPermanentFailure: async (job) => this.evictFailureCaches(job),
         type: jobType,
         startedBefore,
       });
@@ -3008,29 +3011,45 @@ export class ProvisioningJobService {
       ),
     );
 
-    // app_deploy keeps a post-commit cache invalidation (the apps read
-    // cache is invalidated outside the DB transaction); the row flip
-    // itself already committed atomically inside onFailedInTx above.
-    if (updated?.status === "failed" && job.type === JOB_TYPES.APP_DEPLOY) {
-      const { appId } = readAppDeployJobData(job);
-      await appsService.invalidateCache(appId);
+    // Post-commit cache eviction (outside the DB transaction); the row
+    // flip itself already committed atomically inside onFailedInTx above.
+    if (updated?.status === "failed") {
+      await this.evictFailureCaches(job);
     }
-    // container_provision flips apps.deployment_status with a raw in-tx
-    // update (bypassing the appsService cache), so evict the app read cache
-    // here too — otherwise the cache-backed deploy-status route keeps
-    // reporting `building` until the 5-min TTL. The in-tx writeback already
-    // org-scoped the flip; an appId that matched no app is a harmless evict.
-    if (updated?.status === "failed" && job.type === JOB_TYPES.CONTAINER_PROVISION) {
-      const { containerId } = readContainerProvisionJobData(job);
-      const [row] = await dbWrite
-        .select({ projectName: containers.project_name })
-        .from(containers)
-        .where(eq(containers.id, containerId))
-        .limit(1);
-      const appId = row?.projectName;
-      if (appId && isValidUUID(appId)) {
+  }
+
+  /**
+   * Post-commit app-cache eviction for a job that permanently failed. The
+   * dependent-row flip happens in-transaction (onFailedInTx); the apps READ
+   * cache lives outside the DB, so without this the cache-backed
+   * deploy-status route keeps reporting `building` until the 5-min TTL.
+   * Shared by the runner's failure path and the recovery sweeps. An appId
+   * that matches no app is a harmless evict; a malformed payload logs and
+   * skips rather than failing the caller.
+   */
+  private async evictFailureCaches(job: Job): Promise<void> {
+    try {
+      if (job.type === JOB_TYPES.APP_DEPLOY) {
+        const { appId } = readAppDeployJobData(job);
         await appsService.invalidateCache(appId);
+      } else if (job.type === JOB_TYPES.CONTAINER_PROVISION) {
+        const { containerId } = readContainerProvisionJobData(job);
+        const [row] = await dbWrite
+          .select({ projectName: containers.project_name })
+          .from(containers)
+          .where(eq(containers.id, containerId))
+          .limit(1);
+        const appId = row?.projectName;
+        if (appId && isValidUUID(appId)) {
+          await appsService.invalidateCache(appId);
+        }
       }
+    } catch (error) {
+      logger.warn("[provisioning-jobs] Post-failure cache eviction skipped", {
+        jobId: job.id,
+        type: job.type,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -5054,6 +5073,13 @@ export class ProvisioningJobService {
     // handles org-agnostic recovery, so we can do this in one pass.
     for (const jobType of jobTypes) {
       const recovered = await jobsRepository.recoverStaleJobs({
+        // A recovery flip to `failed` settles its dependent row atomically —
+        // the same writeback the runner's own failure path uses (#17253 §3).
+        // No UpgradeFailedError exists on a recovery, which lands on the
+        // rollback-safe default: re-armable marker, never status='error' on a
+        // possibly-live agent.
+        buildFailureWriteback: (job, error) => this.buildPermanentFailureWriteback(job, error),
+        onPermanentFailure: async (job) => this.evictFailureCaches(job),
         type: jobType,
         staleThresholdMs: COLD_BOOT_JOB_TYPES.has(jobType)
           ? COLD_BOOT_STALE_JOB_THRESHOLD_MS

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -2784,9 +2784,11 @@ export class ProvisioningJobService {
     // snapshot lane is gated out of CLAIMING (fail-closed, #16639) and, when
     // enabled, forced sequential (batch 1) so phases settle before another
     // payload is allocated. The stale sweep below deliberately keeps the
-    // full lane list: flipping a stuck in_progress row back to pending is a
-    // DB-only operation with no hydration, and gated rows simply wait as
-    // pending until operators enable the lane.
+    // full lane list: flipping a stuck in_progress row back to pending stays
+    // a DB-only operation — recovery hydrates a payload ONLY for a job it
+    // flips to failed whose type has a dependent-row writeback, and
+    // agent_snapshot has none — so gated rows simply wait as pending until
+    // operators enable the lane.
     for (const jobType of this.filterSnapshotLane(jobTypes, "claim")) {
       const laneBatch = jobType === JOB_TYPES.AGENT_SNAPSHOT ? 1 : batchSize;
       await this.processJobType(jobType, laneBatch, result);

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -882,6 +882,7 @@ describe("managed dedicated canary diagnostic", () => {
   test.each([
     "Job timed out 3 times - max attempts reached",
     "Job interrupted by worker restart 3 times - max attempts reached",
+    "Job interrupted by worker restart 6 times - interruption budget exhausted",
   ])("rejects a recovery-generated terminal job as wrapper source", (cause) => {
     expect(() =>
       sanitizeManagedDedicatedCanaryDiagnostic(
@@ -1369,6 +1370,8 @@ describe("managed dedicated canary diagnostic", () => {
     "Job interrupted by worker restart 0 times - max attempts reached",
     "Job interrupted by worker restart 1000 times - max attempts reached",
     "Job interrupted by worker restart 3 times - max attempts reached trailing",
+    "Job interrupted by worker restart 0 times - interruption budget exhausted",
+    "Job interrupted by worker restart 6 times - interruption budget exhausted trailing",
   ])("rejects a noncanonical worker-restart message", (error) => {
     const input = failedDeleteInput();
     const agent = input.agent as Record<string, unknown>;

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -24,8 +24,11 @@ const TIMEOUT_ERROR_PATTERN = /(?:timed out|timeout)/i;
 const PERMANENT_DELETE_PREFIX = "Deletion permanently failed";
 const PERMANENT_DELETE_PATTERN =
   /^Deletion permanently failed after ([1-9][0-9]{0,2}) attempts: ([\s\S]+)$/;
+// Two suffixes: "max attempts reached" is the historical form still present on
+// stored rows; "interruption budget exhausted" is emitted since interruptions
+// stopped consuming attempts. Both classify identically.
 const WORKER_RESTART_TERMINAL_PATTERN =
-  /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - max attempts reached$/;
+  /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - (?:max attempts reached|interruption budget exhausted)$/;
 const TIMEOUT_TERMINAL_PATTERN =
   /^Job timed out ([1-9][0-9]{0,2}) times - max attempts reached$/;
 
@@ -73,6 +76,12 @@ interface RecoveryClassification {
 interface TerminalFailureClassification {
   code: Extract<ErrorCode, "timeout" | "worker_restart_interrupted">;
   attempts: number;
+  /**
+   * Whether the counted number IS the job's attempts counter. False for the
+   * "interruption budget exhausted" form, whose count is independent of
+   * attempts — the counters-agree cross-check must not compare those.
+   */
+  countsAttempts?: boolean;
 }
 
 type ErrorLengthBucket = "1_64" | "65_128" | "129_256" | "257_512" | "513_2000";
@@ -233,6 +242,10 @@ function classifyTerminalFailure(
     return {
       code: "worker_restart_interrupted",
       attempts: Number(workerRestart[1]),
+      // The historical suffix counted ATTEMPTS (restarts consumed them); the
+      // "interruption budget exhausted" form counts interruptions, which are
+      // independent of the job's attempts counter by design.
+      countsAttempts: value.endsWith("max attempts reached"),
     };
   }
   return null;
@@ -719,8 +732,9 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     if (
       terminalFailure &&
       (job.status !== "failed" ||
-        terminalFailure.attempts !== attempts ||
-        terminalFailure.attempts !== maxAttempts)
+        (terminalFailure.countsAttempts !== false &&
+          (terminalFailure.attempts !== attempts ||
+            terminalFailure.attempts !== maxAttempts)))
     ) {
       throw new Error(`jobs[${index}] terminal counters disagree`);
     }


### PR DESCRIPTION
## What — #17253 §3

**Depends on #17258** (branched on top; the commit beyond it is this PR).

The runner's permanent-failure path settles dependent rows **atomically** — `incrementAttempt(…, onFailedInTx)` flips an APP_DEPLOY's app off `building` in the same transaction as the job's `failed` write. Both **recovery** paths (stale sweep, startup interruption recovery) flipped jobs to `failed` with none of that: `recoverJobFromSnapshot` was a bare update. A recovered-to-failed APP_DEPLOY left its app **`building` forever** — the deploy-status endpoint reports BUILDING indefinitely and every redeploy 409s "A deployment is already in progress" until manual SQL. The code documents this gap itself (the `reEnqueueFailedDeletions` rationale names it verbatim) and explicitly rejects sweeps as the primary signal — so recovery now speaks the runner's own contract instead.

## Design (survived an adversarial plan review: NO-GO as first drafted → GO with 5 amendments, all applied)

- **Same contract, second caller**: `recoverJobFromSnapshot` runs in a transaction, keeps the exact CAS untouched, and invokes the writeback only after the CAS matched — a throw rolls back BOTH writes, mirroring `incrementAttempt` line for line.
- **The landmine the review caught**: writeback builders read payloads **eagerly** and throw on malformed ones — and an offloaded CONTAINER_PROVISION payload keeps `containerId` only in R2. Built inside the transaction, that throw would roll back the flip and wedge the job `in_progress` forever, re-throwing every sweep. The builder therefore runs OUTSIDE the transaction on the **hydrated** job; a build failure degrades to flipping without a writeback, loudly logged.
- **Per-job isolation** in both loops: one poisoned payload rolls back its own job only, never starving the rest of the sweep.
- **No return-shape change**: the recoveries still return a number (~25 call/mock/assertion sites would have broken). Post-commit app-cache eviction rides an optional `onPermanentFailure` hook fed the hydrated failed job; the eviction logic is now one private helper shared with the runner's failure path.
- Recovery has no `UpgradeFailedError`, which lands AGENT_UPGRADE on the **rollback-safe default**: re-armable marker, never `status='error'` on a possibly-live agent.

## Tests

`16 pass / 0 fail` on the rebuilt jobs-recovery harness (hand-rolled DDL replaced with the real drizzle schema via `pushSchema`, apps + its three enums, FK parents seeded, isolated-PGlite loud-skip guard) plus `3 pass` service-side. Verified on the pre-fix code: **4 of the 5 new tests fail** — atomic settle, execution-throw rollback (job back to claimable `in_progress`, app untouched), post-commit hook, stale-path settle. Disclosed: the build-time-throw test pins the *degraded* mode (flip without writeback) and passes on base too, since the old code produced that outcome by accident; it exists to keep the degradation deliberate.

Wiring is tested at the service seam: both recovery paths hand the repository the REAL `buildPermanentFailureWriteback` (produces a closure for APP_DEPLOY, `undefined` for types with no dependent row).

Refs #17253 · Depends on #17258 [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17263-17264-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17263-17264-tests.log)
