### PR TITLE
fix(ui): clear the six chronic story-gate regressions and the Windows vacuous-green gate guard

### DIFF
--- a/packages/ui/src/components/shell/NotificationsHomeCenter.stories.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.stories.tsx
@@ -44,8 +44,13 @@ function Seeded({
     return () => __resetNotificationStoreForTests();
   }, [notifications]);
   if (!ready) return null;
+  // Definite width AND height: the centered story layout shrink-wraps its
+  // item, so `w-full`/`max-w-md` resolve against a zero-width parent and the
+  // center (whose rows take width from their container) collapses to a
+  // 0x480 column — the "blank-render: single-color" gate verdict. 28rem is
+  // max-w-md's value as a definite width.
   return (
-    <div className="max-w-md">
+    <div className="flex h-[480px] w-[28rem] flex-col">
       <NotificationsHomeCenter />
     </div>
   );

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -60,9 +60,9 @@
   --accent-hover: #ff7d3a;
   --accent-muted: #c94400;
   --accent-subtle: rgba(255, 106, 31, 0.14);
-  --accent-foreground: var(--brand-white);
+  --accent-foreground: var(--brand-black);
   --primary: var(--brand-orange);
-  --primary-foreground: var(--brand-white);
+  --primary-foreground: var(--brand-black);
 
   /* Status */
   --ok: #22c55e;
@@ -70,7 +70,7 @@
   --ok-muted: rgba(34, 197, 94, 0.72);
   --ok-subtle: rgba(34, 197, 94, 0.12);
   --destructive: var(--brand-orange);
-  --destructive-foreground: var(--brand-white);
+  --destructive-foreground: var(--brand-black);
   --destructive-subtle: rgba(255, 106, 31, 0.12);
   --warn: var(--brand-orange);
   --warn-muted: rgba(255, 106, 31, 0.72);
@@ -229,16 +229,16 @@
   --accent-hover: #ff7d3a;
   --accent-muted: #c94400;
   --accent-subtle: rgba(255, 106, 31, 0.16);
-  --accent-foreground: var(--brand-white);
+  --accent-foreground: var(--brand-black);
   --primary: var(--brand-orange);
-  --primary-foreground: var(--brand-white);
+  --primary-foreground: var(--brand-black);
 
   --ok: #4ade80;
   --ok-foreground: var(--ok);
   --ok-muted: rgba(74, 222, 128, 0.7);
   --ok-subtle: rgba(74, 222, 128, 0.12);
   --destructive: var(--brand-orange);
-  --destructive-foreground: var(--brand-white);
+  --destructive-foreground: var(--brand-black);
   --destructive-subtle: rgba(255, 106, 31, 0.12);
   --warn: var(--brand-orange);
   --warn-muted: rgba(255, 106, 31, 0.7);

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -30,10 +30,10 @@
   --scrim: rgba(0, 0, 0, 0.7);
   --accent: var(--brand-orange);
   --accent-rgb: 255, 106, 31;
-  --accent-foreground: var(--brand-white);
+  --accent-foreground: var(--brand-black);
   --accent-subtle: rgba(255, 106, 31, 0.14);
   --destructive: var(--brand-orange);
-  --destructive-foreground: var(--brand-white);
+  --destructive-foreground: var(--brand-black);
   --destructive-subtle: rgba(255, 106, 31, 0.12);
   --status-success: #22c55e;
   --status-success-bg: rgba(34, 197, 94, 0.12);
@@ -82,10 +82,10 @@
   --scrim: rgba(0, 0, 0, 0.72);
   --accent: var(--brand-orange);
   --accent-rgb: 255, 106, 31;
-  --accent-foreground: var(--brand-white);
+  --accent-foreground: var(--brand-black);
   --accent-subtle: rgba(255, 106, 31, 0.14);
   --destructive: var(--brand-orange);
-  --destructive-foreground: var(--brand-white);
+  --destructive-foreground: var(--brand-black);
   --destructive-subtle: rgba(255, 106, 31, 0.12);
   --status-success: #4ade80;
   --status-success-bg: rgba(74, 222, 128, 0.16);

--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -40,7 +40,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
 import { dirname, extname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { chromium } from "playwright";
 import { determinismShim, FROZEN_EPOCH_MS } from "./determinism-shim.mjs";
 import { attachLogCapture } from "./log-capture.mjs";
@@ -1014,8 +1014,14 @@ async function writeManualReview(dir, results, failures) {
 }
 
 // Only auto-run as a CLI; importing this module (e.g. from the classifier unit
-// test) must NOT launch a browser run.
-if (import.meta.url === `file://${process.argv[1]}`) {
+// test) must NOT launch a browser run. pathToFileURL, not string concat: a
+// Windows argv[1] is backslash-separated and drive-lettered, so the naive
+// `file://${argv[1]}` comparison never matches and the CLI silently exits 0
+// — a vacuous green, the worst failure mode a gate can have.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((err) => {
     console.error("story-gate: fatal", err);
     process.exit(1);


### PR DESCRIPTION
## Summary

The **UI Story Gate** workflow (and the same gate inside the Develop Exhaustive Lane) has failed every develop run since 7/25 on exactly six regressions ([run 30409569328](https://github.com/elizaOS/eliza/actions/runs/30409569328); identical list in every earlier run). This PR clears all six and fixes a Windows vacuous-green bug in the gate runner found during verification.

### 1. NotificationsHomeCenter — 5 × `blank-render: single-color`

Root cause (established by DOM-probing the built story in real Chromium): Storybook's centered layout **shrink-wraps** the story item, so the Seeded wrapper's `w-full`/`max-w-md` resolve against a zero-width parent, and the center — whose rows take width from their container — paints a 0×480 column: a solid-black screenshot with zero console/page errors. The in-flight #17205 fixture change (`h-[480px] w-full`) fixes height but **not** the width collapse — verified by building the catalog at that state and running the real gate: still 5 × blank. The fix is a **definite width**: `w-[28rem]`.

### 2. AppRouteNotFound — `new-a11y-violation: color-contrast`

The default Button paints `--primary-foreground` (brand-white) on brand-orange — **measured 2.75:1** in real Chromium against the compiled shipped theme (fails WCAG-AA 4.5:1; exactly the axe violation CI reports). `--accent/--primary/--destructive-foreground` flip to brand-black in both themes (extracted verbatim from #17205; matches the black-on-orange direction already shipped in cloud-ui) — **measured 7.33:1 PASS**.

### 3. Gate runner — Windows vacuous green

`run-story-gate.mjs`'s CLI guard compares `import.meta.url` to `file://\{argv[1]}` — never equal on Windows backslash paths, so invoking the gate **silently exits 0 having run zero stories**. `pathToFileURL` fixes the comparison on both platforms; module imports (the classifier unit test) still don't launch a browser run.

## Verification (real story-gate machinery, this head's built catalog)

- `--grep notificationshomecenter` → **good=5 | broken=0** ([transcript](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/gate-run-notifcenter-pass.txt))
- `--grep approutenotfound` → **good=2 | a11y=0** ([transcript](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/gate-run-approutenotfound-pass.txt))
- Before the fix, the same local gate reproduced CI's exact 5 × blank verdicts.
- Contrast measured computationally in-page (`getComputedStyle` + WCAG luminance): before `rgb(253,250,247)` on `rgb(255,106,31)` = 2.75:1 FAIL; after `rgb(0,0,0)` = 7.33:1 PASS — pixels match ([before](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/before-buttons-contrast.jpg) / [after](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/after-buttons-contrast.jpg)).

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [blank story under the gate shim](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/before-notifcenter-story-blank.jpg) · [white-on-orange buttons + 404 view (desktop)](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/before-buttons-contrast.jpg) · [mobile](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/before-buttons-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [rendered mixed-priorities story from the passing gate run](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/after-notifcenter-story-rendered.jpg) · [black-on-orange buttons + 404 view (desktop)](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/after-buttons-contrast.jpg) · [mobile](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/after-buttons-mobile.jpg) · [old-vs-fixed wrapper side-by-side](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/wrapper-old-vs-fixed-sidebyside.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [storygate-walkthrough.mp4](https://raw.githubusercontent.com/elizaOS/eliza/341d1feda959ef22d4817ebb6f1ea95e70b7a1f2/storygate-walkthrough.mp4) — a 48s continuous real-Chromium tour: all six repaired stories served from this head's built catalog (banner names each stop), then the BEFORE (2.75:1 FAIL) and AFTER (7.33:1 PASS) token fixture pages. Reviewed frame-by-frame.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - frontend-only; the story-gate PASS transcripts above are the run logs.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console logs: [storygate-console-logs.txt](https://raw.githubusercontent.com/elizaOS/eliza/341d1feda959ef22d4817ebb6f1ea95e70b7a1f2/storygate-console-logs.txt) — every console message + pageerror captured during the recorded tour (clean: tour markers only, zero errors), corroborating the gate's per-story logCapture (0 console / 0 page errors across all 7 stories).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the two gate PASS transcripts, and the [OCR readout](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/ocr-readout.txt) of every capture (Windows.Media.Ocr), reviewed by hand.

### OCR visual text review

OCR readout over all 7 captures: [ocr-readout.txt](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/ocr-readout.txt) — button labels, 404 copy, notification titles, and the in-page contrast report all recognized and reviewed against the renders.

**Before (story under the gate shim):** ![before](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/before-notifcenter-story-blank.jpg)
**After (from the passing gate run):** ![after](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/after-notifcenter-story-rendered.jpg)
**Contrast before:** ![before contrast](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/before-buttons-contrast.jpg)
**Contrast after:** ![after contrast](https://raw.githubusercontent.com/elizaOS/eliza/6d9bc5a7fcff0793cd1dc64328d0dd17da83acff/after-buttons-contrast.jpg)

Note for the #17205 lane: this supersedes only your `NotificationsHomeCenter.stories.tsx` + foreground-token hunks (with the width correction); everything else in #17205 remains yours.

