### PR TITLE
fix(core): preserve in-memory memory uniqueness

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -132,4 +132,51 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 		).toBe(true);
 		expect(elapsed).toBeLessThan(1000); // bounded — no pathological blowup
 	});
+
+	it("preserves batch uniqueness overrides and defaults unspecified memories to unique", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		await adapter.createMemories([
+			{
+				memory: { ...msg("entry wins true", 1), unique: false },
+				tableName: "messages",
+				unique: true,
+			},
+			{
+				memory: { ...msg("entry wins false", 2), unique: true },
+				tableName: "messages",
+				unique: false,
+			},
+			{
+				memory: { ...msg("memory stays false", 3), unique: false },
+				tableName: "messages",
+			},
+			{
+				memory: msg("default is unique", 4),
+				tableName: "messages",
+			},
+		]);
+
+		const all = await adapter.getMemories({ roomId, tableName: "messages" });
+		expect(
+			Object.fromEntries(
+				all.map((memory) => [(memory.content as { text: string }).text, memory.unique]),
+			),
+		).toEqual({
+			"entry wins true": true,
+			"entry wins false": false,
+			"memory stays false": false,
+			"default is unique": true,
+		});
+
+		const unique = await adapter.getMemories({
+			roomId,
+			tableName: "messages",
+			unique: true,
+		});
+		expect(unique.map((memory) => (memory.content as { text: string }).text)).toEqual([
+			"default is unique",
+			"entry wins true",
+		]);
+	});
 });

--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -160,7 +160,10 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 		const all = await adapter.getMemories({ roomId, tableName: "messages" });
 		expect(
 			Object.fromEntries(
-				all.map((memory) => [(memory.content as { text: string }).text, memory.unique]),
+				all.map((memory) => [
+					(memory.content as { text: string }).text,
+					memory.unique,
+				]),
 			),
 		).toEqual({
 			"entry wins true": true,
@@ -174,9 +177,8 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 			tableName: "messages",
 			unique: true,
 		});
-		expect(unique.map((memory) => (memory.content as { text: string }).text)).toEqual([
-			"default is unique",
-			"entry wins true",
-		]);
+		expect(
+			unique.map((memory) => (memory.content as { text: string }).text),
+		).toEqual(["default is unique", "entry wins true"]);
 	});
 });

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1212,7 +1212,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
 	): Promise<UUID[]> {
 		const ids: UUID[] = [];
-		for (const { memory, tableName } of memories) {
+		for (const { memory, tableName, unique } of memories) {
 			const gen =
 				typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
 					? crypto.randomUUID()
@@ -1221,6 +1221,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			const stored: Memory = {
 				...memory,
 				id: asUuid(id),
+				unique: unique ?? memory.unique ?? true,
 			};
 			this.memoriesById.set(id, stored);
 			const roomId = memory.roomId;


### PR DESCRIPTION
## Summary

- Preserve the per-entry `unique` flag in `InMemoryDatabaseAdapter.createMemories`.
- Default an unspecified uniqueness flag to `true`, matching the SQL adapter.
- Add a real adapter regression that covers entry precedence, explicit `false`, and the default.

## Root cause

The in-memory batch write discarded its entry-level `unique` value and persisted an unspecified flag as `undefined`. A later `getMemories({ unique: true })` query therefore omitted rows that SQL treats as unique by default.

## Validation

- `bunx @biomejs/biome@2.5.5 format --write` on both changed files.
- `bunx @biomejs/biome@2.5.5 check` on both changed files.
- Direct Bun execution against the real `InMemoryDatabaseAdapter`: passed all four persistence cases and the `unique: true` retrieval assertion.
- The focused Vitest regression is included in the core test suite. GitHub requires a maintainer to approve workflows for this external-fork PR before its required checks can run.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - this is a non-visual in-memory storage adapter.

<!-- evidence-row:after-screenshots -->
N/A - this is a non-visual in-memory storage adapter.

<!-- evidence-row:walkthrough-video -->
N/A - the direct adapter regression has no interactive user flow.

<!-- evidence-row:backend-logs -->
N/A - the test calls the process-local adapter directly; no server boundary runs.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code changes.

<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, action, or provider path changes.

<!-- evidence-row:domain-artifacts -->
The manually reviewed direct-adapter run persisted all four Map-backed rows, preserved both explicit overrides and `memory.unique: false`, defaulted the omitted flag to `true`, and returned only the two expected rows from `unique: true` retrieval.
