### PR TITLE
fix(cloud): backport #17260 to main — unbreak deletion retries (P0 #17249)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/delete-retry-string-timestamp.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression proof for #17249: retrying a failed deletion crashed with
+ * `value.toISOString is not a function` on EVERY attempt, trapping the agent
+ * in `deletion_failed` forever (37 agents, 160/160 delete jobs in prod).
+ *
+ * Root cause: `getAgentForLifecycleMutation` is a RAW `SELECT * FOR UPDATE`,
+ * and raw drizzle rows carry timestamptz as STRINGS despite the Date type.
+ * A first deletion (column NULL) wrote `new Date()` and worked; every retry
+ * read the string back and pushed it through the typed update builder, which
+ * throws in `mapToDriverValue`. The ownership fence's `?.getTime()` was the
+ * same class of crash one step later.
+ *
+ * PGlite's raw rows are strings exactly like production's — this harness
+ * reproduces the incident faithfully (verified against the live CP stack
+ * trace), so these tests fail on the pre-fix code with the production error.
+ *
+ * Drives the REAL ElizaSandboxService.executeDeletion against in-process
+ * PGlite (real Drizzle schema via pushSchema) with NOTHING mocked. Fails
+ * LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../../db/schemas/api-keys";
+import { generations } from "../../../db/schemas/generations";
+import { jobs } from "../../../db/schemas/jobs";
+import { organizations } from "../../../db/schemas/organizations";
+import { usageRecords } from "../../../db/schemas/usage-records";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORIGINAL_START = new Date("2026-07-13T04:11:00.000Z");
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[delete-retry-string-timestamp.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      apiKeys,
+      generations,
+      usageRecords,
+      jobs,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[delete-retry-string-timestamp.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("deletion retries survive raw-row string timestamps (#17249)", () => {
+  test(
+    "retrying a FAILED deletion completes instead of crashing on the read-back timestamp",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      // The exact production shape of the 37 trapped agents: deletion already
+      // started and failed, both intent columns set, no container left.
+      const [rec] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("trapped"),
+          status: "deletion_failed",
+          execution_tier: "dedicated-always",
+          deletion_started_at: ORIGINAL_START,
+          deletion_attempt_id: crypto.randomUUID(),
+          error_message: "Deletion permanently failed after 3 attempts: SSH connect timed out",
+        })
+        .returning();
+
+      const result = await new ElizaSandboxService().executeDeletion(rec.id, orgId);
+
+      // Pre-fix this crashed in prepareAgentDelete with
+      // `value.toISOString is not a function` before anything ran.
+      expect(result.success).toBe(true);
+      const gone = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, rec.id),
+      });
+      expect(gone).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a FRESH deletion still completes and clears the row",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { orgId, userId } = await seedOwner();
+      const [rec] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: orgId,
+          user_id: userId,
+          agent_name: uniq("fresh"),
+          status: "stopped",
+          execution_tier: "dedicated-always",
+        })
+        .returning();
+
+      const result = await new ElizaSandboxService().executeDeletion(rec.id, orgId);
+
+      expect(result.success).toBe(true);
+      const gone = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, rec.id),
+      });
+      expect(gone).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1857,13 +1857,19 @@ export class ElizaSandboxService {
         return { ok: false as const, error: "Agent provisioning is in progress" };
       }
       const deletionAttemptId = rec.deletion_attempt_id ?? crypto.randomUUID();
-      const deletionStartedAt = rec.deletion_started_at ?? new Date();
+      // `rec` comes from a RAW `SELECT * FOR UPDATE` (getAgentForLifecycleMutation),
+      // and raw drizzle rows carry timestamptz as STRINGS, not Dates. Writing
+      // `rec.deletion_started_at` back through the typed builder therefore threw
+      // `value.toISOString is not a function` on EVERY retry of a failed
+      // deletion — the #17249 production incident (160/160 delete jobs failing,
+      // 37 agents trapped). A continuation keeps the original start time by
+      // leaving the column alone; only a fresh deletion stamps it.
       const [owned] = await tx
         .update(agentSandboxes)
         .set({
           status: "deletion_pending",
           deletion_attempt_id: deletionAttemptId,
-          deletion_started_at: deletionStartedAt,
+          ...(rec.deletion_started_at === null ? { deletion_started_at: new Date() } : {}),
           updated_at: new Date(),
         })
         .where(
@@ -1925,10 +1931,16 @@ export class ElizaSandboxService {
       }
 
       const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      // `rec` is a RAW row: its timestamptz fields are strings at runtime
+      // despite the Date type, so `.getTime()` on them throws. Normalize both
+      // sides to epoch through the Date constructor (which accepts either)
+      // before comparing — a mismatch must fail the fence, not crash it.
+      const recDeletionStartedAtMs =
+        rec.deletion_started_at === null ? null : new Date(rec.deletion_started_at).getTime();
       if (
         rec.status !== "deletion_pending" ||
         rec.deletion_attempt_id !== ownership.deletionAttemptId ||
-        rec.deletion_started_at?.getTime() !== ownership.deletionStartedAt.getTime() ||
+        recDeletionStartedAtMs !== ownership.deletionStartedAt.getTime() ||
         rec.sandbox_id !== ownership.sandboxId ||
         rec.environment_revision !== ownership.environmentRevision ||
         hasActiveProvisionJob


### PR DESCRIPTION
## Backport of #17260 to main (production)

Clean cherry-pick of the delete-retry fix onto `main` — the branch production actually runs (`/opt/eliza` on the prod CP tracks main + backports).

## Why this backport is urgent

#17249: **160/160 agent deletions failing in production**, 37 agents trapped in `deletion_failed` (+17/day), each holding node capacity and billing. Root cause proven with a live stack trace on the prod CP: raw drizzle rows carry timestamptz as strings, so every RETRY of a failed deletion crashed in `prepareAgentDelete` before doing anything — agents were trapped forever after any single transient failure.

## Staging validation (develop = staging), just executed

Fabricated the exact production trap on staging — a `deletion_failed` row with `deletion_started_at` + `deletion_attempt_id` set — then drove the REAL `executeDeletion` through the fixed path:

```
pre : deletion_failed | started_at set: true
result: {"success":true,"containerStopped":true}
post: ROW DELETED ✓
```

Pre-fix, this identical call crashed with `value.toISOString is not a function` (reproduced live on the prod CP with a one-shot instrumented retry before the fix was written).

## After merge + prod deploy

The `agent-backups` cron re-arms `deletion_failed` rows every 6 h through `reEnqueueFailedDeletions` — the 37 trapped agents drain **automatically** through the fixed path; no manual DB surgery. I'll verify the drain per the runbook (deletion_failed count → 0, first `agent_delete completed` in the prod journal in weeks).

Original PR: #17260 (merged to develop as fb26ec15f2) · Incident: #17249 [stan-cloud]
