### PR TITLE
fix(cloud): ms-window the observed-running-generation CAS

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression proof for the observed-running-generation CAS (#17249 fence
+ * class): `agentSandboxesRepository.update(..., expectedRunningGeneration)`
+ * fenced `updated_at` with a plain eq() — but the stored value may carry
+ * MICROSECONDS (raw `updated_at = NOW()` writers) while the expected value
+ * came through a typed read, which truncates to milliseconds. The fence
+ * silently missed for every µs-stored row, so the heartbeat's observed
+ * generation was never persisted after such a write. Same remedy as the
+ * sleep and managed-launch CASes: date_trunc('milliseconds', column).
+ *
+ * The µs row is seeded via an explicit SQL literal — PGlite's own NOW() is
+ * ms-only, so a NOW()-seeded row cannot reproduce the mismatch and the
+ * fail-on-base property would be false.
+ *
+ * Drives the REAL repository against in-process PGlite (real Drizzle schema
+ * via pushSchema), NOTHING mocked. Fails LOUDLY if PGlite/pushSchema is
+ * unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../agent-sandboxes").agentSandboxesRepository;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[heartbeat-generation-us-fence.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ agentSandboxesRepository: repo } = await import("../agent-sandboxes"));
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[heartbeat-generation-us-fence.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("observed-running-generation CAS vs microsecond timestamps", () => {
+  async function seedRunningAgent(): Promise<{
+    id: string;
+    orgId: string;
+  }> {
+    const [org] = await dbWrite
+      .insert(organizations)
+      .values({ name: "Org", slug: uniq("org"), credit_balance: "1.000000" })
+      .returning();
+    const [user] = await dbWrite
+      .insert(users)
+      .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+      .returning();
+    const [rec] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: org.id,
+        user_id: user.id,
+        agent_name: uniq("hb"),
+        status: "running",
+        execution_tier: "dedicated-always",
+        environment_revision: 3,
+        sandbox_id: "agent-hb",
+        node_id: "node-1",
+        container_name: "agent-hb",
+      })
+      .returning();
+    return { id: rec.id, orgId: org.id };
+  }
+
+  test(
+    "the fence matches a row whose updated_at carries MICROSECONDS",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { id, orgId } = await seedRunningAgent();
+      // What prod's ~20 raw `updated_at = NOW()` writers store.
+      await dbWrite.execute(
+        sql`UPDATE ${agentSandboxes}
+            SET updated_at = '2026-01-01 00:00:00.123456+00'::timestamptz
+            WHERE id = ${id}`,
+      );
+      // What the service observed through its typed read: ms-truncated.
+      const observed = new Date("2026-01-01T00:00:00.123Z");
+
+      const updated = await repo.update(
+        id,
+        { last_heartbeat_at: new Date() },
+        {
+          organizationId: orgId,
+          environmentRevision: 3,
+          sandboxId: "agent-hb",
+          nodeId: "node-1",
+          containerName: "agent-hb",
+          updatedAt: observed,
+        },
+      );
+
+      // Pre-fix the eq() fence missed and the CAS write was a silent no-op.
+      expect(updated).toBeDefined();
+      expect(updated?.last_heartbeat_at).toBeInstanceOf(Date);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a genuinely moved generation still loses the fence",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { id, orgId } = await seedRunningAgent();
+      await dbWrite.execute(
+        sql`UPDATE ${agentSandboxes}
+            SET updated_at = '2026-01-01 00:00:00.123456+00'::timestamptz
+            WHERE id = ${id}`,
+      );
+      // Observed a DIFFERENT millisecond: the row moved since the read.
+      const staleObserved = new Date("2026-01-01T00:00:00.122Z");
+
+      const updated = await repo.update(
+        id,
+        { last_heartbeat_at: new Date() },
+        {
+          organizationId: orgId,
+          environmentRevision: 3,
+          sandboxId: "agent-hb",
+          nodeId: "node-1",
+          containerName: "agent-hb",
+          updatedAt: staleObserved,
+        },
+      );
+
+      expect(updated).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -335,8 +335,7 @@ describe("AgentSandboxesRepository", () => {
     expect(
       query.params.some(
         (p) =>
-          (p instanceof Date &&
-            p.toISOString() === "2026-07-23T11:59:00.000Z") ||
+          (p instanceof Date && p.toISOString() === "2026-07-23T11:59:00.000Z") ||
           p === "2026-07-23T11:59:00.000Z",
       ),
     ).toBe(true);

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -311,6 +311,11 @@ describe("AgentSandboxesRepository", () => {
     expect(sql).toContain("sandbox_id");
     expect(sql).toContain("node_id");
     expect(sql).toContain("container_name");
+    // ms-window fence (#17249 fence class): the stored updated_at may carry
+    // microseconds from raw `updated_at = NOW()` writers, so the CAS compares
+    // date_trunc('milliseconds', updated_at) against the ms-truncated typed
+    // read instead of a plain eq().
+    expect(sql).toContain("date_trunc('milliseconds'");
     expect(sql).toContain("updated_at");
     expect(sql.match(/is not distinct from/g)).toHaveLength(3);
     expect(query.params).toEqual(
@@ -322,9 +327,19 @@ describe("AgentSandboxesRepository", () => {
         "sandbox-generation-7",
         "node-generation-7",
         "agent-generation-7",
-        "2026-07-23T11:59:00.000Z",
       ]),
     );
+    // The raw-sql fence binds the observed generation without the column's
+    // driver mapping, so the param may surface as a Date rather than the
+    // eq()-era ISO string — accept either encoding, but require the value.
+    expect(
+      query.params.some(
+        (p) =>
+          (p instanceof Date &&
+            p.toISOString() === "2026-07-23T11:59:00.000Z") ||
+          p === "2026-07-23T11:59:00.000Z",
+      ),
+    ).toBe(true);
   });
 
   test("generic repository updates cannot write through a durable deletion owner", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1009,7 +1009,14 @@ export class AgentSandboxesRepository {
         sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${expectedRunningGeneration.sandboxId}`,
         sql`${agentSandboxes.node_id} IS NOT DISTINCT FROM ${expectedRunningGeneration.nodeId}`,
         sql`${agentSandboxes.container_name} IS NOT DISTINCT FROM ${expectedRunningGeneration.containerName}`,
-        eq(agentSandboxes.updated_at, expectedRunningGeneration.updatedAt),
+        // ms-window fence: the stored value may carry microseconds (raw
+        // `updated_at = NOW()` writers) while the expected value came through
+        // a typed read, which truncates to milliseconds — JS Date parsing
+        // truncates sub-ms lexically (never rounds), so ms==ms is exact. A
+        // plain eq() silently missed for every µs-stored row, so the observed
+        // running generation was never persisted after such a write (#17249
+        // fence class; same remedy as the sleep and managed-launch CASes).
+        sql`date_trunc('milliseconds', ${agentSandboxes.updated_at}) = ${expectedRunningGeneration.updatedAt}`,
       );
     }
     const [r] = await dbWrite


### PR DESCRIPTION
## What

Third member of the #17249 fence class, disclosed on #17262 as the known follow-up: `agentSandboxesRepository.update`'s `expectedRunningGeneration` fenced `updated_at` with a plain `eq()`. The stored value may carry **microseconds** (raw `updated_at = NOW()` writers, ~20 sites) while the expected value came through a typed read, which truncates to **milliseconds** — so the fence silently missed for every µs-stored row, and the heartbeat's observed running generation was never persisted after such a write.

Same remedy as the sleep and managed-launch CASes in #17262: `date_trunc('milliseconds', column)` against the ms-truncated expectation. The invariant this rests on (JS `Date` parsing truncates sub-ms lexically, never rounds) was verified definitively during #17262's plan review — live probes on V8, JSC, and PGlite.

## Tests

`2 pass / 0 fail` (real PGlite, real repository, nothing mocked) + the full `eliza-sandbox` suite green (164). Fail-on-base verified: on the pre-fix code, the µs test fails exactly (`1 pass / 1 fail`) — the fence missed and the CAS write was a silent no-op. The µs row is seeded via an explicit SQL literal because PGlite's own `NOW()` is ms-only and cannot reproduce the miss. The second test pins that a genuinely moved generation (different millisecond) still loses the fence — the widening is µs-only, exactly like the two #17262 fences.

Refs #17249 · Follow-up of #17262 [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17284-hb-ev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17284-hb-ev.log)
