### PR TITLE
fix(cloud): make warm-pool readiness atomic

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression proof for #17253 §5: a crash between `provision()` committing
+ * `running` and `markPoolEntryReady` strands a warm-pool row at
+ * `unclaimed / running / pool_ready_at NULL` — refused by claimWarmContainer,
+ * skipped by drain, invisible to the stuck-finder, yet COUNTED as ready
+ * capacity, permanently suppressing one slot of replenishment while the
+ * container bills forever.
+ *
+ * Two fixes pinned here: the ready count requires the readiness stamp, and
+ * findStuckPoolProvisioning now matches the stranded shape so the reap path
+ * can reclaim it once wired.
+ *
+ * Drives the REAL repository against in-process PGlite (real Drizzle schema
+ * via pushSchema), NOTHING mocked. Fails LOUDLY if PGlite/pushSchema is
+ * unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../agent-sandboxes").agentSandboxesRepository;
+let poolOrgId: string;
+let poolUserId: string;
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[warm-pool-stranded-readiness.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ agentSandboxesRepository: repo } = await import("../agent-sandboxes"));
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+    const [org] = await dbWrite
+      .insert(organizations)
+      .values({
+        name: "Pool",
+        slug: "warm-pool-stranded",
+        credit_balance: "0.000000",
+      })
+      .returning();
+    poolOrgId = org.id;
+    const [user] = await dbWrite
+      .insert(users)
+      .values({ steward_user_id: "steward-warm-pool-stranded", organization_id: org.id })
+      .returning();
+    poolUserId = user.id;
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[warm-pool-stranded-readiness.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+async function seedPoolRow(params: {
+  status: "running" | "provisioning";
+  poolReadyAt: Date | null;
+  updatedAt: string;
+}): Promise<string> {
+  const [rec] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: poolOrgId,
+      user_id: poolUserId,
+      agent_name: `pool-${Math.random().toString(36).slice(2, 10)}`,
+      status: params.status,
+      execution_tier: "dedicated-always",
+      pool_status: "unclaimed",
+      pool_ready_at: params.poolReadyAt,
+      node_id: "node-1",
+    })
+    .returning();
+  await dbWrite.execute(
+    sql`UPDATE ${agentSandboxes}
+        SET updated_at = ${params.updatedAt}::timestamptz
+        WHERE id = ${rec.id}`,
+  );
+  return rec.id;
+}
+
+describe("warm-pool stranded readiness (#17253 §5)", () => {
+  test(
+    "a running row WITHOUT the readiness stamp does not count as ready capacity",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      await dbWrite.execute(sql`DELETE FROM ${agentSandboxes}`);
+      // The crash-window shape: provision committed running, readiness never
+      // stamped.
+      await seedPoolRow({
+        status: "running",
+        poolReadyAt: null,
+        updatedAt: "2026-07-01 00:00:00+00",
+      });
+      // A genuinely ready sibling.
+      await seedPoolRow({
+        status: "running",
+        poolReadyAt: new Date(),
+        updatedAt: "2026-07-01 00:00:00+00",
+      });
+
+      const counts = await repo.countAllPoolEntries();
+
+      // Pre-fix: ready === 2 and the replenisher believed the pool was full.
+      expect(counts.ready).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the stuck-finder now surfaces the stranded running+NULL shape",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      await dbWrite.execute(sql`DELETE FROM ${agentSandboxes}`);
+      const strandedId = await seedPoolRow({
+        status: "running",
+        poolReadyAt: null,
+        updatedAt: "2026-07-01 00:00:00+00",
+      });
+      // A healthy ready row and a FRESH stranded row must both stay out.
+      await seedPoolRow({
+        status: "running",
+        poolReadyAt: new Date(),
+        updatedAt: "2026-07-01 00:00:00+00",
+      });
+      const freshId = await seedPoolRow({
+        status: "running",
+        poolReadyAt: null,
+        updatedAt: new Date().toISOString(),
+      });
+
+      const stuck = await repo.findStuckPoolProvisioning(60 * 60 * 1000);
+      const ids = stuck.map((r) => r.id);
+
+      // Pre-fix: the stranded shape matched NOTHING — invisible to the sweep.
+      expect(ids).toContain(strandedId);
+      expect(ids).not.toContain(freshId);
+      expect(ids).toHaveLength(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -1,21 +1,15 @@
 /**
- * Regression proof for #17253 §5: a crash between `provision()` committing
- * `running` and `markPoolEntryReady` strands a warm-pool row at
- * `unclaimed / running / pool_ready_at NULL` — refused by claimWarmContainer,
- * skipped by drain, invisible to the stuck-finder, yet COUNTED as ready
- * capacity, permanently suppressing one slot of replenishment while the
- * container bills forever.
- *
- * Two fixes pinned here: the ready count requires the readiness stamp, and
- * findStuckPoolProvisioning now matches the stranded shape so the reap path
- * can reclaim it once wired.
- *
- * Drives the REAL repository against in-process PGlite (real Drizzle schema
- * via pushSchema), NOTHING mocked. Fails LOUDLY if PGlite/pushSchema is
- * unavailable (never silently passes).
+ * Proves warm-pool readiness, claim, and crash reconciliation against real
+ * Drizzle queries on isolated PGlite, with a live HTTP health endpoint.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+import { eq, sql } from "drizzle-orm";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
 
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
@@ -23,145 +17,319 @@ const CAN_USE_ISOLATED_PGLITE =
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
-
-import { pushSchema } from "drizzle-kit/api";
-import { sql } from "drizzle-orm";
-import { agentSandboxes } from "../../schemas/agent-sandboxes";
-import { organizations } from "../../schemas/organizations";
-import { userCharacters } from "../../schemas/user-characters";
-import { users } from "../../schemas/users";
+process.env.WARM_POOL_ENABLED = "1";
 
 const PGLITE_TIMEOUT = 60_000;
+const IMAGE = "ghcr.io/elizaos/eliza:atomic-ready";
+const OTHER_IMAGE = "ghcr.io/elizaos/eliza:stale";
+const USER_ORG_ID = "10000000-0000-4000-8000-000000000001";
+const USER_ID = "10000000-0000-4000-8000-000000000002";
 
-let pgliteReady = true;
 let dbWrite: typeof import("../../client").dbWrite;
-let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
-let repo: typeof import("../agent-sandboxes").agentSandboxesRepository;
-let poolOrgId: string;
-let poolUserId: string;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests;
+let repository: InstanceType<typeof import("../agent-sandboxes").AgentSandboxesRepository>;
+let healthServer: ReturnType<typeof Bun.serve>;
 
 beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    console.warn("[warm-pool-stranded-readiness.test] non-PGlite DATABASE_URL; failing.");
-    return;
-  }
-  try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
-    ({ agentSandboxesRepository: repo } = await import("../agent-sandboxes"));
-    const schema = { organizations, users, userCharacters, agentSandboxes };
-    const { apply } = await pushSchema(schema as never, dbWrite as never);
-    await apply();
-    const [org] = await dbWrite
-      .insert(organizations)
-      .values({
-        name: "Pool",
-        slug: "warm-pool-stranded",
-        credit_balance: "0.000000",
-      })
-      .returning();
-    poolOrgId = org.id;
-    const [user] = await dbWrite
-      .insert(users)
-      .values({ steward_user_id: "steward-warm-pool-stranded", organization_id: org.id })
-      .returning();
-    poolUserId = user.id;
-  } catch (error) {
-    pgliteReady = false;
-    console.error(
-      "[warm-pool-stranded-readiness.test] PGlite/pushSchema unavailable — failing.",
-      error,
+    throw new Error(
+      `warm-pool readiness proof requires isolated PGlite, received ${AMBIENT_DATABASE_URL}`,
     );
   }
+
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+  const repositoryModule = await import("../agent-sandboxes");
+  repository = new repositoryModule.AgentSandboxesRepository();
+
+  const schema = { organizations, users, userCharacters, agentSandboxes };
+  const { apply } = await pushSchema(schema as never, dbWrite as never);
+  await apply();
+  await repository.countAllPoolEntries({ image: IMAGE });
+
+  await dbWrite.insert(organizations).values({
+    id: USER_ORG_ID,
+    name: "Warm Pool Claim Test",
+    slug: "warm-pool-claim-test",
+    credit_balance: "0.000000",
+  });
+  await dbWrite.insert(users).values({
+    id: USER_ID,
+    name: "Warm Pool Claim User",
+    steward_user_id: "steward:warm-pool-claim-test",
+    organization_id: USER_ORG_ID,
+  });
+
+  healthServer = Bun.serve({
+    port: 0,
+    fetch: () => Response.json({ status: "ok" }),
+  });
 }, PGLITE_TIMEOUT);
 
+beforeEach(async () => {
+  await dbWrite.delete(agentSandboxes);
+});
+
 afterAll(async () => {
+  if (healthServer) await healthServer.stop(true);
   if (closeDb) await closeDb();
 });
 
-async function seedPoolRow(params: {
-  status: "running" | "provisioning";
-  poolReadyAt: Date | null;
-  updatedAt: string;
-}): Promise<string> {
-  const [rec] = await dbWrite
-    .insert(agentSandboxes)
-    .values({
-      organization_id: poolOrgId,
-      user_id: poolUserId,
-      agent_name: `pool-${Math.random().toString(36).slice(2, 10)}`,
-      status: params.status,
-      execution_tier: "dedicated-always",
-      pool_status: "unclaimed",
-      pool_ready_at: params.poolReadyAt,
-      node_id: "node-1",
-    })
-    .returning();
-  await dbWrite.execute(
-    sql`UPDATE ${agentSandboxes}
-        SET updated_at = ${params.updatedAt}::timestamptz
-        WHERE id = ${rec.id}`,
-  );
-  return rec.id;
+function healthUrl(): string {
+  return `http://127.0.0.1:${healthServer.port}/health`;
 }
 
-describe("warm-pool stranded readiness (#17253 §5)", () => {
+async function seedPoolEntry(
+  overrides: Partial<typeof agentSandboxes.$inferInsert> = {},
+): Promise<typeof agentSandboxes.$inferSelect> {
+  return repository.createPoolEntry({
+    agent_name: `pool-${crypto.randomUUID().slice(0, 8)}`,
+    status: "running",
+    execution_tier: "dedicated-always",
+    database_status: "ready",
+    sandbox_id: `sandbox-${crypto.randomUUID()}`,
+    node_id: "node-1",
+    container_name: `agent-${crypto.randomUUID()}`,
+    bridge_url: "http://100.64.0.10:3000",
+    health_url: healthUrl(),
+    docker_image: IMAGE,
+    image_digest: `sha256:${"a".repeat(64)}`,
+    pool_ready_at: new Date("2026-07-30T00:00:00.000Z"),
+    ...overrides,
+  });
+}
+
+async function seedUserAgent(): Promise<string> {
+  const [row] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: USER_ORG_ID,
+      user_id: USER_ID,
+      agent_name: `claim-${crypto.randomUUID().slice(0, 8)}`,
+      status: "pending",
+      execution_tier: "dedicated-always",
+      database_status: "none",
+    })
+    .returning({ id: agentSandboxes.id });
+  if (!row) throw new Error("failed to seed claim target");
+  return row.id;
+}
+
+describe("one claimable-capacity predicate", () => {
   test(
-    "a running row WITHOUT the readiness stamp does not count as ready capacity",
+    "counts, image inventory, and the claim transaction agree on the exact row",
     async () => {
-      expect(pgliteReady).toBe(true);
-      await dbWrite.execute(sql`DELETE FROM ${agentSandboxes}`);
-      // The crash-window shape: provision committed running, readiness never
-      // stamped.
-      await seedPoolRow({
-        status: "running",
-        poolReadyAt: null,
-        updatedAt: "2026-07-01 00:00:00+00",
-      });
-      // A genuinely ready sibling.
-      await seedPoolRow({
-        status: "running",
-        poolReadyAt: new Date(),
-        updatedAt: "2026-07-01 00:00:00+00",
+      const valid = await seedPoolEntry();
+      await seedPoolEntry({ pool_ready_at: null });
+      await seedPoolEntry({ bridge_url: null });
+      await seedPoolEntry({ node_id: null });
+      await seedPoolEntry({ container_name: null });
+      await seedPoolEntry({ health_url: null });
+      await seedPoolEntry({ docker_image: OTHER_IMAGE });
+      await seedPoolEntry({
+        status: "provisioning",
+        pool_ready_at: null,
+        sandbox_id: null,
+        node_id: null,
+        container_name: null,
+        bridge_url: null,
+        health_url: null,
       });
 
-      const counts = await repo.countAllPoolEntries();
+      expect(await repository.countUnclaimedPool({ image: IMAGE })).toBe(1);
+      expect(await repository.countReadyPoolEntriesForImage(IMAGE)).toBe(1);
+      expect(await repository.countAllPoolEntries({ image: IMAGE })).toEqual({
+        ready: 1,
+        provisioning: 1,
+      });
+      expect((await repository.listClaimablePool({ image: IMAGE })).map((row) => row.id)).toEqual([
+        valid.id,
+      ]);
 
-      // Pre-fix: ready === 2 and the replenisher believed the pool was full.
-      expect(counts.ready).toBe(1);
+      const userAgentId = await seedUserAgent();
+      const claimed = await repository.claimWarmContainer({
+        userAgentId,
+        organizationId: USER_ORG_ID,
+        image: IMAGE,
+        agentName: "claimed",
+      });
+      expect(claimed?.warm_pool_row_id).toBe(valid.id);
+      expect(claimed?.status).toBe("provisioning");
+      expect(await repository.countUnclaimedPool({ image: IMAGE })).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "the stuck-finder now surfaces the stranded running+NULL shape",
+    "two concurrent users cannot claim the same ready row",
     async () => {
-      expect(pgliteReady).toBe(true);
-      await dbWrite.execute(sql`DELETE FROM ${agentSandboxes}`);
-      const strandedId = await seedPoolRow({
-        status: "running",
-        poolReadyAt: null,
-        updatedAt: "2026-07-01 00:00:00+00",
-      });
-      // A healthy ready row and a FRESH stranded row must both stay out.
-      await seedPoolRow({
-        status: "running",
-        poolReadyAt: new Date(),
-        updatedAt: "2026-07-01 00:00:00+00",
-      });
-      const freshId = await seedPoolRow({
-        status: "running",
-        poolReadyAt: null,
-        updatedAt: new Date().toISOString(),
+      const pool = await seedPoolEntry();
+      const [firstUserAgentId, secondUserAgentId] = await Promise.all([
+        seedUserAgent(),
+        seedUserAgent(),
+      ]);
+
+      const claims = await Promise.all([
+        repository.claimWarmContainer({
+          userAgentId: firstUserAgentId,
+          organizationId: USER_ORG_ID,
+          image: IMAGE,
+          agentName: "first",
+        }),
+        repository.claimWarmContainer({
+          userAgentId: secondUserAgentId,
+          organizationId: USER_ORG_ID,
+          image: IMAGE,
+          agentName: "second",
+        }),
+      ]);
+
+      const winners = claims.filter((claim) => claim !== null);
+      expect(winners).toHaveLength(1);
+      expect(winners[0]?.warm_pool_row_id).toBe(pool.id);
+      expect(await repository.findById(pool.id)).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("atomic readiness transition", () => {
+  test(
+    "only one final provision generation can commit running and readiness",
+    async () => {
+      const provisioning = await seedPoolEntry({
+        status: "provisioning",
+        pool_ready_at: null,
       });
 
-      const stuck = await repo.findStuckPoolProvisioning(60 * 60 * 1000);
-      const ids = stuck.map((r) => r.id);
+      const results = await Promise.all([
+        repository.commitPoolEntryReady(provisioning),
+        repository.commitPoolEntryReady(provisioning),
+      ]);
+      expect(results.filter(Boolean)).toHaveLength(1);
 
-      // Pre-fix: the stranded shape matched NOTHING — invisible to the sweep.
-      expect(ids).toContain(strandedId);
-      expect(ids).not.toContain(freshId);
-      expect(ids).toHaveLength(1);
+      const stored = await repository.findById(provisioning.id);
+      expect(stored?.status).toBe("running");
+      expect(stored?.pool_ready_at).toBeInstanceOf(Date);
+      expect(await repository.countUnclaimedPool({ image: IMAGE })).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a generation missing a required locator cannot become ready",
+    async () => {
+      const provisioning = await seedPoolEntry({
+        status: "provisioning",
+        pool_ready_at: null,
+        bridge_url: null,
+      });
+
+      expect(await repository.commitPoolEntryReady(provisioning)).toBeUndefined();
+      const stored = await repository.findById(provisioning.id);
+      expect(stored?.status).toBe("provisioning");
+      expect(stored?.pool_ready_at).toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("production crash reconciliation", () => {
+  test(
+    "a fresh legacy running generation is not promoted during its restore tail",
+    async () => {
+      const activeRestore = await seedPoolEntry({
+        pool_ready_at: null,
+        created_at: new Date(),
+      });
+
+      expect(await repository.listWarmPoolReconciliationCandidates(15 * 60 * 1000)).toEqual([]);
+      expect((await repository.findById(activeRestore.id))?.pool_ready_at).toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "replenish promotes a healthy stranded row even while heartbeat timestamps stay fresh",
+    async () => {
+      const stranded = await seedPoolEntry({
+        pool_ready_at: null,
+        created_at: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      await dbWrite.execute(
+        sql`UPDATE ${agentSandboxes}
+            SET last_heartbeat_at = NOW(), updated_at = NOW()
+            WHERE id = ${stranded.id}`,
+      );
+
+      const { HetznerPoolContainerCreator } = await import(
+        "../../../lib/services/containers/agent-warm-pool-creator"
+      );
+      const { WarmPoolManager } = await import("../../../lib/services/containers/agent-warm-pool");
+      const manager = new WarmPoolManager(new HetznerPoolContainerCreator());
+      const result = await manager.replenish(IMAGE);
+
+      expect(result.reconciliation).toMatchObject({
+        scanned: 1,
+        probed: 1,
+        promoted: [stranded.id],
+        reaped: [],
+        deferred: [],
+        failed: [],
+      });
+      expect(result.decision.toCreate).toBe(0);
+      expect(result.state.readyCount).toBe(1);
+
+      const stored = await repository.findById(stranded.id);
+      expect(stored?.status).toBe("running");
+      expect(stored?.pool_ready_at).toBeInstanceOf(Date);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a stale probe can either promote or fence a generation, never do both",
+    async () => {
+      const stranded = await seedPoolEntry({ pool_ready_at: null });
+      const [promoted, reserved] = await Promise.all([
+        repository.promoteStrandedPoolEntryReady(stranded),
+        repository.reserveUnclaimablePoolEntryForReap(stranded, "readiness probe failed"),
+      ]);
+
+      expect(Number(Boolean(promoted)) + Number(Boolean(reserved))).toBe(1);
+      const stored = await repository.findById(stranded.id);
+      if (promoted) {
+        expect(stored?.status).toBe("running");
+        expect(stored?.pool_ready_at).toBeInstanceOf(Date);
+      } else {
+        expect(stored?.status).toBe("deletion_failed");
+        expect(stored?.pool_ready_at).toBeNull();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the stale finder does not mistake a heartbeat-refreshed running row for an in-flight provision",
+    async () => {
+      const stranded = await seedPoolEntry({
+        pool_ready_at: null,
+        created_at: new Date(Date.now() - 60_000),
+      });
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          updated_at: new Date("2026-07-30T00:00:00.000Z"),
+          last_heartbeat_at: new Date("2026-07-30T00:00:00.000Z"),
+        })
+        .where(eq(agentSandboxes.id, stranded.id));
+
+      const stuck = await repository.findStuckPoolProvisioning(1);
+      expect(stuck.map((row) => row.id)).not.toContain(stranded.id);
+      expect(
+        (await repository.listWarmPoolReconciliationCandidates(1)).map(
+          (candidate) => candidate.sandbox.id,
+        ),
+      ).toContain(stranded.id);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -1,4 +1,4 @@
-// Exercises cloud DB agent sandboxes behavior with deterministic repository fixtures.
+/** Exercises sandbox repository behavior with deterministic database fixtures. */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SQL, SQLWrapper } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
@@ -869,6 +869,7 @@ describe("AgentSandboxesRepository", () => {
       // replenisher sees a full pool while every claim skips it (starvation).
       capturedWhere = undefined;
       selectRows = [{ count: 0 }];
+      useWriteSelectMock = true;
 
       const { AgentSandboxesRepository } = await import("./agent-sandboxes");
       await new AgentSandboxesRepository().countUnclaimedPool({ image: IMAGE });
@@ -890,7 +891,16 @@ describe("AgentSandboxesRepository", () => {
           return { rows: [] };
         }
         // Skip-count query: two null-node rows were left behind.
-        return { rows: [{ count: 2 }] };
+        return {
+          rows: [
+            {
+              count: 2,
+              missing_bridge: 0,
+              missing_node: 2,
+              missing_readiness: 0,
+            },
+          ],
+        };
       };
 
       const { AgentSandboxesRepository } = await import("./agent-sandboxes");
@@ -901,8 +911,14 @@ describe("AgentSandboxesRepository", () => {
       expect(result).toBeNull();
       // Observability: the skip is warned (not silent) with the counter event.
       const warned = warnLog.mock.calls.some((c) => {
-        const meta = c[1] as { event?: string; skippedNullNodeCount?: number } | undefined;
-        return meta?.event === "warm_pool.null_node_skipped" && meta?.skippedNullNodeCount === 2;
+        const meta = c[1] as
+          | { event?: string; skippedCount?: number; missingNodeCount?: number }
+          | undefined;
+        return (
+          meta?.event === "warm_pool.unclaimable_entries_skipped" &&
+          meta.skippedCount === 2 &&
+          meta.missingNodeCount === 2
+        );
       });
       expect(warned).toBe(true);
     });

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1,5 +1,10 @@
-// Persists agent sandboxes records for cloud services through the shared DB boundary.
+/**
+ * Persists managed-agent lifecycle, warm-pool, and backup records through the
+ * shared database boundary. Warm-pool capacity and claim operations share one
+ * eligibility predicate so scheduling never counts a row it cannot transfer.
+ */
 import { randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import {
   and,
   asc,
@@ -8,6 +13,7 @@ import {
   gte,
   inArray,
   isNotNull,
+  isNull,
   lt,
   ne,
   notInArray,
@@ -80,6 +86,32 @@ export type AgentSandboxBackupMetadata = Omit<StoredAgentSandboxBackup, "state_d
  */
 export type WarmClaimedAgentSandbox = AgentSandbox & { warm_pool_row_id: string };
 
+/**
+ * Identifies the exact container generation observed by a warm-pool
+ * reconciler. Heartbeats intentionally do not participate: they update
+ * liveness timestamps without changing the container generation.
+ */
+export type WarmPoolRuntimeGeneration = Pick<
+  AgentSandbox,
+  | "id"
+  | "organization_id"
+  | "status"
+  | "environment_revision"
+  | "sandbox_id"
+  | "node_id"
+  | "container_name"
+  | "bridge_url"
+  | "health_url"
+  | "docker_image"
+  | "image_digest"
+  | "pool_ready_at"
+>;
+
+export interface WarmPoolReconciliationCandidate {
+  sandbox: AgentSandbox;
+  canPromote: boolean;
+}
+
 const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   memories: [],
   config: {},
@@ -111,6 +143,76 @@ function hasNoProvisioningOwnerJob(ownerJobTypes: readonly ProvisioningJobType[]
 
 function hasNoProvisioningStatusOwnerJob(): SQL {
   return hasNoProvisioningOwnerJob([...PROVISIONING_STATUS_OWNER_JOB_TYPES]);
+}
+
+/**
+ * Runtime fields every capacity reader and claimant requires. Keeping this as
+ * one SQL fragment prevents a row from counting as capacity on one path while
+ * another path refuses to claim it.
+ */
+function warmPoolRuntimeLocatorConditions(): SQL[] {
+  return [
+    sql`${agentSandboxes.sandbox_id} IS NOT NULL AND btrim(${agentSandboxes.sandbox_id}) <> ''`,
+    sql`${agentSandboxes.node_id} IS NOT NULL AND btrim(${agentSandboxes.node_id}) <> ''`,
+    sql`${agentSandboxes.container_name} IS NOT NULL AND btrim(${agentSandboxes.container_name}) <> ''`,
+    sql`${agentSandboxes.bridge_url} IS NOT NULL AND btrim(${agentSandboxes.bridge_url}) <> ''`,
+    sql`${agentSandboxes.health_url} IS NOT NULL AND btrim(${agentSandboxes.health_url}) <> ''`,
+    sql`${agentSandboxes.docker_image} IS NOT NULL AND btrim(${agentSandboxes.docker_image}) <> ''`,
+    isNull(agentSandboxes.deleted_at),
+    isNull(agentSandboxes.deletion_attempt_id),
+    isNull(agentSandboxes.replacement_cleanup_sandbox_id),
+  ];
+}
+
+function warmPoolRuntimeReadyConditions(): SQL[] {
+  return [isNotNull(agentSandboxes.pool_ready_at), ...warmPoolRuntimeLocatorConditions()];
+}
+
+function claimableWarmPoolConditions(filter: { image?: string } = {}): SQL[] {
+  const conditions: SQL[] = [
+    eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+    eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+    eq(agentSandboxes.pool_status, "unclaimed"),
+    eq(agentSandboxes.status, "running"),
+    ...warmPoolRuntimeReadyConditions(),
+  ];
+  if (filter.image !== undefined) {
+    conditions.push(eq(agentSandboxes.docker_image, filter.image));
+  }
+  return conditions;
+}
+
+function inFlightWarmPoolConditions(filter: { image?: string } = {}): SQL[] {
+  const conditions: SQL[] = [
+    eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+    eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+    eq(agentSandboxes.pool_status, "unclaimed"),
+    inArray(agentSandboxes.status, ["pending", "provisioning"]),
+    isNull(agentSandboxes.deleted_at),
+    isNull(agentSandboxes.deletion_attempt_id),
+    sql`${agentSandboxes.docker_image} IS NOT NULL AND btrim(${agentSandboxes.docker_image}) <> ''`,
+  ];
+  if (filter.image !== undefined) {
+    conditions.push(eq(agentSandboxes.docker_image, filter.image));
+  }
+  return conditions;
+}
+
+function warmPoolGenerationConditions(expected: WarmPoolRuntimeGeneration): SQL[] {
+  return [
+    eq(agentSandboxes.id, expected.id),
+    eq(agentSandboxes.organization_id, expected.organization_id),
+    eq(agentSandboxes.status, expected.status),
+    eq(agentSandboxes.environment_revision, expected.environment_revision),
+    sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${expected.sandbox_id}`,
+    sql`${agentSandboxes.node_id} IS NOT DISTINCT FROM ${expected.node_id}`,
+    sql`${agentSandboxes.container_name} IS NOT DISTINCT FROM ${expected.container_name}`,
+    sql`${agentSandboxes.bridge_url} IS NOT DISTINCT FROM ${expected.bridge_url}`,
+    sql`${agentSandboxes.health_url} IS NOT DISTINCT FROM ${expected.health_url}`,
+    sql`${agentSandboxes.docker_image} IS NOT DISTINCT FROM ${expected.docker_image}`,
+    sql`${agentSandboxes.image_digest} IS NOT DISTINCT FROM ${expected.image_digest}`,
+    sql`${agentSandboxes.pool_ready_at} IS NOT DISTINCT FROM ${expected.pool_ready_at}`,
+  ];
 }
 
 export interface ReconciliationBatchResult<T> {
@@ -1189,71 +1291,52 @@ export class AgentSandboxesRepository {
 
   // ── Warm pool ─────────────────────────────────────────────────────────
 
-  /**
-   * Count ready pool entries (status='running' AND pool_status='unclaimed').
-   * Optionally filter by image so a stale image doesn't inflate the count.
-   *
-   * Attribution guard (audit §C1c): a pool row with a null/empty `node_id` is
-   * NOT usable capacity — `claimWarmContainer` refuses to claim it (claiming
-   * would mint an unattributable running/null-node orphan). Counting such rows
-   * as "ready" would let a poisoned pool report full while every claim skips
-   * them and falls through to cold provisioning — permanent starvation. So the
-   * ready count MUST match the claimable set: exclude null/empty node_id.
-   */
+  /** Count entries that the claim transaction can transfer immediately. */
   async countUnclaimedPool(filter: { image?: string } = {}): Promise<number> {
     await ensureAgentSandboxSchema();
-    const conditions = [
-      eq(agentSandboxes.pool_status, "unclaimed"),
-      eq(agentSandboxes.status, "running"),
-      isNotNull(agentSandboxes.pool_ready_at),
-      isNotNull(agentSandboxes.node_id),
-      sql`${agentSandboxes.node_id} <> ''`,
-    ];
-    if (filter.image) conditions.push(eq(agentSandboxes.docker_image, filter.image));
-    const [row] = await dbRead
+    const [row] = await dbWrite
       .select({ count: sql<number>`count(*)::int` })
       .from(agentSandboxes)
-      .where(and(...conditions));
-    return row?.count ?? 0;
+      .where(and(...claimableWarmPoolConditions(filter)));
+    if (!row) {
+      throw new ElizaError("Warm-pool capacity query returned no aggregate row", {
+        code: "WARM_POOL_CAPACITY_READ_FAILED",
+        context: { image: filter.image },
+      });
+    }
+    return row.count;
   }
 
   /**
-   * Count pool entries by status — including not-yet-ready ones (still
-   * provisioning). Used to size in-flight replenish work.
+   * Count claimable and in-flight entries for one desired image. Image-scoped
+   * sizing prevents stale-image or otherwise unclaimable rows from suppressing
+   * replacement capacity.
    */
-  async countAllPoolEntries(): Promise<{ ready: number; provisioning: number }> {
+  async countAllPoolEntries(
+    filter: { image?: string } = {},
+  ): Promise<{ ready: number; provisioning: number }> {
     await ensureAgentSandboxSchema();
-    const [ready] = await dbRead
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.pool_status, "unclaimed"),
-          eq(agentSandboxes.status, "running"),
-          // Attribution guard (audit §C1c): only claimable rows are "ready".
-          // A null/empty-node_id pool row can't be claimed, so it must not
-          // count toward ready capacity or it masks a starving pool from the
-          // replenisher (see countUnclaimedPool).
-          isNotNull(agentSandboxes.node_id),
-          sql`${agentSandboxes.node_id} <> ''`,
-          // #17253 §5: a crash between provision() committing `running` and
-          // markPoolEntryReady strands the row running with pool_ready_at
-          // NULL — unclaimable (claimWarmContainer requires the stamp), so
-          // counting it as ready capacity permanently suppresses one slot of
-          // replenishment while the container bills forever.
-          isNotNull(agentSandboxes.pool_ready_at),
-        ),
-      );
-    const [provisioning] = await dbRead
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.pool_status, "unclaimed"),
-          sql`${agentSandboxes.status} in ('pending','provisioning')`,
-        ),
-      );
-    return { ready: ready?.count ?? 0, provisioning: provisioning?.count ?? 0 };
+    const claimable = and(...claimableWarmPoolConditions(filter));
+    const inFlight = and(...inFlightWarmPoolConditions(filter));
+    if (!claimable || !inFlight) {
+      throw new ElizaError("Warm-pool inventory predicate was empty", {
+        code: "WARM_POOL_PREDICATE_INVALID",
+        severity: "fatal",
+      });
+    }
+    const [inventory] = await dbWrite
+      .select({
+        ready: sql<number>`count(*) FILTER (WHERE ${claimable})::int`,
+        provisioning: sql<number>`count(*) FILTER (WHERE ${inFlight})::int`,
+      })
+      .from(agentSandboxes);
+    if (!inventory) {
+      throw new ElizaError("Warm-pool inventory query returned no aggregate row", {
+        code: "WARM_POOL_CAPACITY_READ_FAILED",
+        context: { image: filter.image },
+      });
+    }
+    return inventory;
   }
 
   /**
@@ -1263,22 +1346,11 @@ export class AgentSandboxesRepository {
    * merely ineligible for a claim (already running / already has a DB). A
    * `warm_pool.empty_on_claim` observability event fires only when this returns
    * 0, so a re-provision falling through doesn't pollute the starvation signal.
-   * Best-effort read (mirrors the claim query's readiness predicate).
+   * This delegates to the same authoritative predicate as every other capacity
+   * reader and the claim transaction.
    */
   async countReadyPoolEntriesForImage(image: string): Promise<number> {
-    await ensureAgentSandboxSchema();
-    const [row] = await dbRead
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.pool_status, "unclaimed"),
-          eq(agentSandboxes.status, "running"),
-          eq(agentSandboxes.docker_image, image),
-          isNotNull(agentSandboxes.pool_ready_at),
-        ),
-      );
-    return row?.count ?? 0;
+    return this.countUnclaimedPool({ image });
   }
 
   /**
@@ -1378,36 +1450,100 @@ export class AgentSandboxesRepository {
     return buckets;
   }
 
-  /** All ready unclaimed pool rows — for health probing and image rollout. */
-  async listUnclaimedPool(): Promise<AgentSandbox[]> {
+  /** Claimable rows, ordered by the same FIFO stamp used by the claim path. */
+  async listClaimablePool(filter: { image?: string } = {}): Promise<AgentSandbox[]> {
     await ensureAgentSandboxSchema();
-    return dbRead
+    return dbWrite
       .select()
       .from(agentSandboxes)
-      .where(and(eq(agentSandboxes.pool_status, "unclaimed"), eq(agentSandboxes.status, "running")))
+      .where(and(...claimableWarmPoolConditions(filter)))
       .orderBy(agentSandboxes.pool_ready_at);
   }
 
   /**
-   * Pool rows that started provisioning but never became ready. Used to
-   * reap stuck containers so the pool replenisher can retry.
+   * Running pool rows that cannot be claimed. A row with complete runtime
+   * locators but no readiness stamp can be promoted after a live probe; all
+   * other shapes require fenced teardown. The stable creation-time grace
+   * prevents a rolling-deploy overlap from reconciling an old worker's
+   * still-active restore tail; heartbeat writes cannot postpone genuinely
+   * stranded generations because they do not change `created_at`.
    */
-  async findStuckPoolProvisioning(staleThresholdMs: number): Promise<AgentSandbox[]> {
+  async listWarmPoolReconciliationCandidates(
+    minimumGenerationAgeMs: number,
+  ): Promise<WarmPoolReconciliationCandidate[]> {
     await ensureAgentSandboxSchema();
-    const cutoff = new Date(Date.now() - staleThresholdMs);
-    return dbRead
+    if (!Number.isFinite(minimumGenerationAgeMs) || minimumGenerationAgeMs <= 0) {
+      throw new ElizaError("Warm-pool reconciliation age must be positive", {
+        code: "WARM_POOL_RECONCILIATION_AGE_INVALID",
+        context: { minimumGenerationAgeMs },
+        severity: "fatal",
+      });
+    }
+    const createdBefore = new Date(Date.now() - minimumGenerationAgeMs);
+    const runtimeReady = and(...warmPoolRuntimeLocatorConditions());
+    if (!runtimeReady) {
+      throw new ElizaError("Warm-pool runtime predicate was empty", {
+        code: "WARM_POOL_PREDICATE_INVALID",
+        severity: "fatal",
+      });
+    }
+    return dbWrite
+      .select({
+        sandbox: agentSandboxes,
+        canPromote: sql<boolean>`${agentSandboxes.pool_ready_at} IS NULL AND ${runtimeReady}`,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          eq(agentSandboxes.status, "running"),
+          lt(agentSandboxes.created_at, createdBefore),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.deletion_attempt_id),
+          sql`NOT (${and(...warmPoolRuntimeReadyConditions())})`,
+        ),
+      )
+      .orderBy(agentSandboxes.created_at);
+  }
+
+  /** All live pool rows used for health reporting and image rollout. */
+  async listAllRunningPoolEntries(): Promise<AgentSandbox[]> {
+    await ensureAgentSandboxSchema();
+    return dbWrite
       .select()
       .from(agentSandboxes)
       .where(
         and(
+          eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
           eq(agentSandboxes.pool_status, "unclaimed"),
-          // running + pool_ready_at NULL is the crash window between
-          // provision() and markPoolEntryReady (#17253 §5): unclaimable,
-          // undrainable, and previously invisible to every sweep.
-          sql`(
-            ${agentSandboxes.status} in ('pending','provisioning','error')
-            OR (${agentSandboxes.status} = 'running' AND ${agentSandboxes.pool_ready_at} IS NULL)
-          )`,
+          eq(agentSandboxes.status, "running"),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.deletion_attempt_id),
+        ),
+      )
+      .orderBy(agentSandboxes.pool_ready_at);
+  }
+
+  /**
+   * Pool rows whose provision never reached the final atomic ready transition.
+   * Running rows are reconciled separately without an `updated_at` cutoff
+   * because successful heartbeats continually refresh that timestamp.
+   */
+  async findStuckPoolProvisioning(staleThresholdMs: number): Promise<AgentSandbox[]> {
+    await ensureAgentSandboxSchema();
+    const cutoff = new Date(Date.now() - staleThresholdMs);
+    return dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          inArray(agentSandboxes.status, ["pending", "provisioning", "error", "deletion_failed"]),
           lt(agentSandboxes.updated_at, cutoff),
         ),
       );
@@ -1442,44 +1578,23 @@ export class AgentSandboxesRepository {
     return dbWrite.transaction(async (tx) => {
       await configureElizaLifecycleTransaction(tx);
       await tx.execute(elizaProvisionAdvisoryLockSql(params.organizationId, params.userAgentId));
-      // Attribution guard (audit §C1c): NEVER claim a pool row whose node_id is
-      // null/empty. createPoolContainer provisions via the same provision() path
-      // as dedicated agents and the pool creator explicitly tolerates a null
-      // node_id (agent-warm-pool-creator.ts:51: `?? null`), so unclaimed pool
-      // rows CAN carry a null node_id. Claiming one copies that null verbatim
-      // into a user-facing running row and DELETEs the pool row in the same
-      // transaction — minting an unattributable orphan with no remaining record
-      // to reconcile against (undercounts the node recount → #15378; the orphan
-      // reconciler provably cannot reap it → audit §C5). Filtering node_id IS NOT
-      // NULL (and non-empty) in the SELECT means we naturally skip such entries
-      // and claim the next valid candidate; a starved-because-only-null pool
-      // returns null cleanly and the caller falls through to the cold provision
-      // path (which itself enforces the C1b guard). The skipped null-node rows
-      // are left unclaimed for the drain/reap sweeps to clear.
-      // F2 (warm-pool flip report): claim readiness must require a resolved
-      // BRIDGE URL, not just docker-health. `pool_ready_at` is stamped at
-      // docker-health, but a pool entry whose bridge URL never resolved (or
-      // whose tailnet session rotted before the bridge URL was persisted) is
-      // unreachable — claiming it hands the user a dead container (observed:
-      // flip-report runs 1-3 claimed tailnet-dead / `health: starting`
-      // entries). Gating on `bridge_url IS NOT NULL AND <> ''` at selection
-      // means such entries are skipped and the next reachable candidate is
-      // claimed; a pool with only unreachable rows returns null and the caller
-      // falls through to the cold path. Deeper liveness (a booted-then-rotted
-      // tailnet session) remains the health sweep's job (healthProbe reaps it).
+      const claimablePool = and(...claimableWarmPoolConditions({ image: params.image }));
+      if (!claimablePool) {
+        throw new ElizaError("Warm-pool claim predicate was empty", {
+          code: "WARM_POOL_PREDICATE_INVALID",
+          severity: "fatal",
+        });
+      }
+      // The raw SELECT is retained because SKIP LOCKED is the concurrency
+      // primitive: competing claims must choose different rows without waiting.
+      // Its eligibility expression is exactly the one used by every capacity
+      // reader, so no counted row can be refused here for a hidden requirement.
       const poolRows = await sqlRows<AgentSandbox>(
         tx,
         sql`
           SELECT *
           FROM ${agentSandboxes}
-          WHERE ${agentSandboxes.pool_status} = 'unclaimed'
-            AND ${agentSandboxes.status} = 'running'
-            AND ${agentSandboxes.docker_image} = ${params.image}
-            AND ${agentSandboxes.pool_ready_at} IS NOT NULL
-            AND ${agentSandboxes.node_id} IS NOT NULL
-            AND ${agentSandboxes.node_id} <> ''
-            AND ${agentSandboxes.bridge_url} IS NOT NULL
-            AND ${agentSandboxes.bridge_url} <> ''
+          WHERE ${claimablePool}
           ORDER BY ${agentSandboxes.pool_ready_at} ASC
           FOR UPDATE SKIP LOCKED
           LIMIT 1
@@ -1487,32 +1602,50 @@ export class AgentSandboxesRepository {
       );
       const pool = poolRows[0];
       if (!pool) {
-        // Observability: distinguish "pool genuinely empty" from "pool had only
-        // null-node entries we refused to claim". The latter is a real defect
-        // signal (a poisoned pool created via the C1b path) that would otherwise
-        // be invisible — the caller just sees a cold-path fallthrough.
-        const skippedNullNode = await sqlRows<{ count: number }>(
+        const skipped = await sqlRows<{
+          count: number;
+          missing_bridge: number;
+          missing_node: number;
+          missing_readiness: number;
+        }>(
           tx,
           sql`
-            SELECT COUNT(*)::int AS count
+            SELECT
+              COUNT(*)::int AS count,
+              COUNT(*) FILTER (
+                WHERE ${agentSandboxes.bridge_url} IS NULL
+                   OR btrim(${agentSandboxes.bridge_url}) = ''
+              )::int AS missing_bridge,
+              COUNT(*) FILTER (
+                WHERE ${agentSandboxes.node_id} IS NULL
+                   OR btrim(${agentSandboxes.node_id}) = ''
+              )::int AS missing_node,
+              COUNT(*) FILTER (
+                WHERE ${agentSandboxes.pool_ready_at} IS NULL
+              )::int AS missing_readiness
             FROM ${agentSandboxes}
-            WHERE ${agentSandboxes.pool_status} = 'unclaimed'
+            WHERE ${agentSandboxes.organization_id} = ${WARM_POOL_ORG_ID}
+              AND ${agentSandboxes.user_id} = ${WARM_POOL_USER_ID}
+              AND ${agentSandboxes.pool_status} = 'unclaimed'
               AND ${agentSandboxes.status} = 'running'
               AND ${agentSandboxes.docker_image} = ${params.image}
-              AND ${agentSandboxes.pool_ready_at} IS NOT NULL
-              AND (${agentSandboxes.node_id} IS NULL OR ${agentSandboxes.node_id} = '')
+              AND ${agentSandboxes.deleted_at} IS NULL
+              AND NOT (${claimablePool})
           `,
         );
-        const nullNodeCount = skippedNullNode[0]?.count ?? 0;
-        if (nullNodeCount > 0) {
+        const skippedRow = skipped[0];
+        if (skippedRow && skippedRow.count > 0) {
           logger.warn(
-            "[agent-sandbox] Warm-pool claim skipped null-node entries; falling through to cold path",
+            "[agent-sandbox] Warm-pool claim skipped unclaimable entries; falling through to cold path",
             {
-              event: "warm_pool.null_node_skipped",
+              event: "warm_pool.unclaimable_entries_skipped",
               image: params.image,
               userAgentId: params.userAgentId,
               organizationId: params.organizationId,
-              skippedNullNodeCount: nullNodeCount,
+              skippedCount: skippedRow.count,
+              missingBridgeCount: skippedRow.missing_bridge,
+              missingNodeCount: skippedRow.missing_node,
+              missingReadinessCount: skippedRow.missing_readiness,
             },
           );
         }
@@ -1649,24 +1782,160 @@ export class AgentSandboxesRepository {
     await ensureAgentSandboxSchema();
     const r = await dbWrite
       .delete(agentSandboxes)
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.pool_status, "unclaimed")))
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.organization_id, WARM_POOL_ORG_ID),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+        ),
+      )
       .returning({ id: agentSandboxes.id });
     return r.length > 0;
   }
 
-  /** Mark a pool entry ready (called after health check passes post-provision). */
-  async markPoolEntryReady(id: string): Promise<AgentSandbox | undefined> {
+  /**
+   * Commit the final `provisioning` → claimable transition in one write after
+   * the container, runtime bootstrap, and restore path have all succeeded.
+   */
+  async commitPoolEntryReady(
+    expected: WarmPoolRuntimeGeneration,
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
-    const [r] = await dbWrite
+    if (expected.organization_id !== WARM_POOL_ORG_ID || expected.pool_ready_at !== null) {
+      return undefined;
+    }
+    return dbWrite.transaction(async (tx) => {
+      await configureElizaLifecycleTransaction(tx);
+      await tx.execute(elizaProvisionAdvisoryLockSql(WARM_POOL_ORG_ID, expected.id));
+      const now = new Date();
+      const [ready] = await tx
+        .update(agentSandboxes)
+        .set({
+          status: "running",
+          pool_ready_at: now,
+          last_heartbeat_at: now,
+          error_message: null,
+          updated_at: now,
+        })
+        .where(
+          and(
+            ...warmPoolGenerationConditions(expected),
+            eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+            eq(agentSandboxes.pool_status, "unclaimed"),
+            eq(agentSandboxes.status, "provisioning"),
+            isNull(agentSandboxes.pool_ready_at),
+            ...warmPoolRuntimeLocatorConditions(),
+          ),
+        )
+        .returning();
+      return ready;
+    });
+  }
+
+  /**
+   * Recover a pre-fix row whose container reached `running` before its readiness
+   * stamp was committed. The generation CAS prevents a stale health probe from
+   * promoting a replacement container.
+   */
+  async promoteStrandedPoolEntryReady(
+    expected: WarmPoolRuntimeGeneration,
+  ): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    if (expected.organization_id !== WARM_POOL_ORG_ID || expected.pool_ready_at !== null) {
+      return undefined;
+    }
+    const now = new Date();
+    const [ready] = await dbWrite
       .update(agentSandboxes)
       .set({
-        status: "running",
-        pool_ready_at: new Date(),
+        pool_ready_at: now,
+        last_heartbeat_at: now,
+        error_message: null,
+        updated_at: now,
+      })
+      .where(
+        and(
+          ...warmPoolGenerationConditions(expected),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          eq(agentSandboxes.status, "running"),
+          isNull(agentSandboxes.pool_ready_at),
+          ...warmPoolRuntimeLocatorConditions(),
+        ),
+      )
+      .returning();
+    return ready;
+  }
+
+  /**
+   * Fence an unclaimable generation before remote teardown. A concurrent ready
+   * commit or locator change makes the CAS lose, so reconciliation never
+   * destroys a row based on a stale probe.
+   */
+  async reserveUnclaimablePoolEntryForReap(
+    expected: WarmPoolRuntimeGeneration,
+    reason: string,
+  ): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    if (expected.organization_id !== WARM_POOL_ORG_ID) return undefined;
+    const [reserved] = await dbWrite
+      .update(agentSandboxes)
+      .set({
+        // `deletion_failed` is deliberately outside trySetProvisioning's
+        // admitted states. deleteAgent can take ownership from it, while a
+        // provision retry cannot revive the fenced generation first.
+        status: "deletion_failed",
+        error_message: reason,
         updated_at: new Date(),
       })
-      .where(and(eq(agentSandboxes.id, id), eq(agentSandboxes.pool_status, "unclaimed")))
+      .where(
+        and(
+          ...warmPoolGenerationConditions(expected),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          eq(agentSandboxes.status, "running"),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.deletion_attempt_id),
+          sql`NOT (${and(...warmPoolRuntimeReadyConditions())})`,
+        ),
+      )
       .returning();
-    return r;
+    return reserved;
+  }
+
+  /**
+   * Fence a stale non-running provision before its remote resources are
+   * destroyed. The cutoff and generation are rechecked in the write, closing
+   * the finder → teardown race with a legitimate provision retry.
+   */
+  async reserveStuckPoolEntryForReap(
+    expected: WarmPoolRuntimeGeneration,
+    staleThresholdMs: number,
+  ): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    if (expected.organization_id !== WARM_POOL_ORG_ID) return undefined;
+    const cutoff = new Date(Date.now() - staleThresholdMs);
+    const [reserved] = await dbWrite
+      .update(agentSandboxes)
+      .set({
+        status: "deletion_failed",
+        error_message: "Warm-pool provision exceeded its reconciliation deadline",
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          ...warmPoolGenerationConditions(expected),
+          eq(agentSandboxes.user_id, WARM_POOL_USER_ID),
+          eq(agentSandboxes.pool_status, "unclaimed"),
+          inArray(agentSandboxes.status, ["pending", "provisioning", "error", "deletion_failed"]),
+          lt(agentSandboxes.updated_at, cutoff),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.deletion_attempt_id),
+        ),
+      )
+      .returning();
+    return reserved;
   }
 
   // Backups

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1236,6 +1236,12 @@ export class AgentSandboxesRepository {
           // replenisher (see countUnclaimedPool).
           isNotNull(agentSandboxes.node_id),
           sql`${agentSandboxes.node_id} <> ''`,
+          // #17253 §5: a crash between provision() committing `running` and
+          // markPoolEntryReady strands the row running with pool_ready_at
+          // NULL — unclaimable (claimWarmContainer requires the stamp), so
+          // counting it as ready capacity permanently suppresses one slot of
+          // replenishment while the container bills forever.
+          isNotNull(agentSandboxes.pool_ready_at),
         ),
       );
     const [provisioning] = await dbRead
@@ -1395,7 +1401,13 @@ export class AgentSandboxesRepository {
       .where(
         and(
           eq(agentSandboxes.pool_status, "unclaimed"),
-          sql`${agentSandboxes.status} in ('pending','provisioning','error')`,
+          // running + pool_ready_at NULL is the crash window between
+          // provision() and markPoolEntryReady (#17253 §5): unclaimable,
+          // undrainable, and previously invisible to every sweep.
+          sql`(
+            ${agentSandboxes.status} in ('pending','provisioning','error')
+            OR (${agentSandboxes.status} = 'running' AND ${agentSandboxes.pool_ready_at} IS NULL)
+          )`,
           lt(agentSandboxes.updated_at, cutoff),
         ),
       );

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -19,7 +19,12 @@ import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { type Job, jobsRepository } from "../../db/repositories/jobs";
-import { type AgentSandboxBackup, agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import {
+  type AgentSandboxBackup,
+  agentSandboxes,
+  WARM_POOL_ORG_ID,
+  WARM_POOL_USER_ID,
+} from "../../db/schemas/agent-sandboxes";
 import { apiKeys } from "../../db/schemas/api-keys";
 import { dockerNodes } from "../../db/schemas/docker-nodes";
 import { generations } from "../../db/schemas/generations";
@@ -1623,6 +1628,17 @@ describe("admin agent image rollout on primary PGlite", () => {
     const userAgentId = "00000000-0000-4000-8000-000000000091";
     const poolRowId = "00000000-0000-4000-8000-000000000092";
     const poolEnv = { ELIZA_API_TOKEN: "transport-token" };
+    await dbWrite.insert(organizations).values({
+      id: WARM_POOL_ORG_ID,
+      name: "Warm Pool (system)",
+      slug: uniq("warm-pool-org"),
+      is_active: false,
+    });
+    await dbWrite.insert(users).values({
+      id: WARM_POOL_USER_ID,
+      steward_user_id: uniq("warm-pool-user"),
+      organization_id: WARM_POOL_ORG_ID,
+    });
     await dbWrite.insert(agentSandboxes).values([
       {
         id: userAgentId,
@@ -1633,8 +1649,8 @@ describe("admin agent image rollout on primary PGlite", () => {
       },
       {
         id: poolRowId,
-        organization_id: seeded.organizationId,
-        user_id: seeded.actorUserId,
+        organization_id: WARM_POOL_ORG_ID,
+        user_id: WARM_POOL_USER_ID,
         agent_name: "Warm Pool",
         status: "running",
         pool_status: "unclaimed",

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
@@ -36,7 +36,6 @@ const WARM_POOL_ORG_ID = "warm-pool-sentinel-org";
 const repo = {
   createPoolEntry: mock(),
   update: mock(),
-  markPoolEntryReady: mock(),
   findById: mock(),
   deletePoolEntry: mock(),
 };
@@ -149,25 +148,47 @@ describe("createPoolContainer fail-closed", () => {
     sandbox.provision.mockResolvedValue({ success: false, error: "no capacity" });
 
     const creator = getHetznerPoolContainerCreator();
-    await expect(creator.createPoolContainer("img:latest")).rejects.toThrow(
-      /pool provision failed: no capacity/,
-    );
+    await expect(creator.createPoolContainer("img:latest")).rejects.toThrow(/no capacity/);
     expect(repo.update).toHaveBeenCalledWith("row-1", {
       status: "error",
       error_message: "no capacity",
     });
-    expect(repo.markPoolEntryReady).not.toHaveBeenCalled();
   });
 
   test("successful provision returns the real id + nodeId — the healthy path stays intact", async () => {
     repo.createPoolEntry.mockResolvedValue({ id: "row-2" });
-    sandbox.provision.mockResolvedValue({ success: true, sandboxRecord: { node_id: "node-9" } });
-    repo.markPoolEntryReady.mockResolvedValue({ node_id: "node-9", bridge_url: "http://x" });
+    sandbox.provision.mockResolvedValue({
+      success: true,
+      sandboxRecord: {
+        status: "running",
+        pool_ready_at: new Date("2026-07-30T00:00:00.000Z"),
+        node_id: "node-9",
+        bridge_url: "http://x",
+      },
+    });
 
     const creator = getHetznerPoolContainerCreator();
     await expect(creator.createPoolContainer("img:latest")).resolves.toEqual({
       id: "row-2",
       nodeId: "node-9",
+    });
+  });
+
+  test("a success response without the atomic readiness stamp fails closed", async () => {
+    repo.createPoolEntry.mockResolvedValue({ id: "row-unready" });
+    sandbox.provision.mockResolvedValue({
+      success: true,
+      sandboxRecord: {
+        status: "running",
+        pool_ready_at: null,
+        node_id: "node-9",
+        bridge_url: "http://x",
+      },
+    });
+
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.createPoolContainer("img:latest")).rejects.toMatchObject({
+      code: "WARM_POOL_READINESS_INVARIANT_BROKEN",
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
@@ -14,6 +14,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
 import { WARM_POOL_ORG_ID } from "../../../db/schemas/agent-sandboxes";
 import { logger } from "../../utils/logger";
@@ -32,32 +33,45 @@ export class HetznerPoolContainerCreator implements PoolContainerCreator {
       environment_vars: {},
     });
 
-    try {
-      const result = await elizaSandboxService.provision(row.id, WARM_POOL_ORG_ID);
-      if (!result.success) {
-        // Leave the row in 'error' state — health-check cron will reap it.
-        await agentSandboxesRepository.update(row.id, {
-          status: "error",
-          error_message: result.error,
-        });
-        throw new Error(`pool provision failed: ${result.error}`);
-      }
-      const ready = await agentSandboxesRepository.markPoolEntryReady(row.id);
-      logger.info("[warm-pool/creator] pool entry ready", {
-        poolId: row.id,
-        nodeId: ready?.node_id ?? null,
-        bridgeUrl: ready?.bridge_url ?? null,
+    const result = await elizaSandboxService.provision(row.id, WARM_POOL_ORG_ID);
+    if (!result.success) {
+      // The row stays available to the production reconciliation sweep, while
+      // the explicit error state prevents it from contributing capacity.
+      await agentSandboxesRepository.update(row.id, {
+        status: "error",
+        error_message: result.error,
       });
-      return { id: row.id, nodeId: ready?.node_id ?? result.sandboxRecord.node_id ?? null };
-    } catch (err) {
-      // error-policy:J7 diagnostic warn adding poolId context; rethrows the
-      // original error so the provision failure still surfaces to replenish().
-      logger.warn("[warm-pool/creator] pool entry creation failed", {
-        poolId: row.id,
-        error: err instanceof Error ? err.message : String(err),
+      throw new ElizaError(`Pool provision failed: ${result.error}`, {
+        code: "WARM_POOL_PROVISION_FAILED",
+        context: { poolId: row.id, image },
+        severity: result.retryable ? "ephemeral" : "fatal",
       });
-      throw err;
     }
+    const ready = result.sandboxRecord;
+    if (
+      ready.status !== "running" ||
+      ready.pool_ready_at === null ||
+      ready.node_id === null ||
+      ready.bridge_url === null
+    ) {
+      throw new ElizaError("Pool provision returned success without claimable readiness", {
+        code: "WARM_POOL_READINESS_INVARIANT_BROKEN",
+        context: {
+          poolId: row.id,
+          status: ready.status,
+          hasReadyStamp: ready.pool_ready_at !== null,
+          hasNodeId: ready.node_id !== null,
+          hasBridgeUrl: ready.bridge_url !== null,
+        },
+        severity: "fatal",
+      });
+    }
+    logger.info("[warm-pool/creator] pool entry ready", {
+      poolId: row.id,
+      nodeId: ready.node_id,
+      bridgeUrl: ready.bridge_url,
+    });
+    return { id: row.id, nodeId: ready.node_id };
   }
 
   async destroyPoolContainer(poolId: string): Promise<void> {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
@@ -18,7 +18,11 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { PoolContainerCreator } from "./agent-warm-pool";
 
 const repo = {
-  listUnclaimedPool: mock(async () => [] as Array<{ id: string }>),
+  listClaimablePool: mock(async () => [] as Array<{ id: string }>),
+  listWarmPoolReconciliationCandidates: mock(async () => []),
+  promoteStrandedPoolEntryReady: mock(async () => undefined),
+  reserveUnclaimablePoolEntryForReap: mock(async () => undefined),
+  reserveStuckPoolEntryForReap: mock(async () => undefined),
   findStuckPoolProvisioning: mock(async () => [] as Array<{ id: string }>),
   countAllPoolEntries: mock(async () => ({ ready: 0, provisioning: 0 })),
   countUserProvisionsByHour: mock(async () => [] as number[]),
@@ -60,7 +64,9 @@ function fakeCreator(overrides: Partial<PoolContainerCreator> = {}): {
 
 beforeEach(() => {
   warmPoolEnabled = true;
-  repo.listUnclaimedPool.mockReset();
+  repo.listClaimablePool.mockReset();
+  repo.listWarmPoolReconciliationCandidates.mockReset();
+  repo.listWarmPoolReconciliationCandidates.mockResolvedValue([]);
   repo.findStuckPoolProvisioning.mockReset();
   repo.findStuckPoolProvisioning.mockResolvedValue([]);
 });
@@ -72,7 +78,7 @@ afterEach(() => {
 describe("healthCheck fails closed on an internal probe failure", () => {
   test("a probe THROW propagates and destroys NOTHING", async () => {
     const { WarmPoolManager } = await load();
-    repo.listUnclaimedPool.mockResolvedValue([{ id: "row-1" }, { id: "row-2" }]);
+    repo.listClaimablePool.mockResolvedValue([{ id: "row-1" }, { id: "row-2" }]);
 
     const dbError = new Error("findById: connection reset");
     const destroy = mock(async () => undefined);
@@ -92,7 +98,7 @@ describe("healthCheck fails closed on an internal probe failure", () => {
 describe("healthCheck designed paths stay distinct from the failure", () => {
   test("a designed `false` (unreachable) reaps the row — destroy IS called", async () => {
     const { WarmPoolManager } = await load();
-    repo.listUnclaimedPool.mockResolvedValue([{ id: "dead-1" }]);
+    repo.listClaimablePool.mockResolvedValue([{ id: "dead-1" }]);
 
     const destroy = mock(async () => undefined);
     const probe = mock(async () => false);
@@ -108,7 +114,7 @@ describe("healthCheck designed paths stay distinct from the failure", () => {
 
   test("a `true` probe keeps the row alive — destroy NOT called", async () => {
     const { WarmPoolManager } = await load();
-    repo.listUnclaimedPool.mockResolvedValue([{ id: "healthy-1" }]);
+    repo.listClaimablePool.mockResolvedValue([{ id: "healthy-1" }]);
 
     const destroy = mock(async () => undefined);
     const probe = mock(async () => true);
@@ -124,7 +130,7 @@ describe("healthCheck designed paths stay distinct from the failure", () => {
 
   test("J6 teardown: a destroy failure on a dead row is RECORDED, not thrown", async () => {
     const { WarmPoolManager } = await load();
-    repo.listUnclaimedPool.mockResolvedValue([{ id: "dead-2" }]);
+    repo.listClaimablePool.mockResolvedValue([{ id: "dead-2" }]);
 
     const probe = mock(async () => false);
     const destroy = mock(async () => {
@@ -151,8 +157,20 @@ describe("healthCheck honors the disabled no-op", () => {
     const manager = new WarmPoolManager(creator);
 
     const result = await manager.healthCheck();
-    expect(result).toEqual({ probed: 0, alive: 0, removed: [] });
-    expect(repo.listUnclaimedPool).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      probed: 0,
+      alive: 0,
+      reconciliation: {
+        scanned: 0,
+        probed: 0,
+        promoted: [],
+        reaped: [],
+        deferred: [],
+        failed: [],
+      },
+      removed: [],
+    });
+    expect(repo.listClaimablePool).not.toHaveBeenCalled();
     expect(destroy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.replenish.test.ts
@@ -21,7 +21,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { PoolContainerCreator } from "./agent-warm-pool";
 
 const repo = {
-  listUnclaimedPool: mock(async () => [] as Array<{ id: string }>),
+  listClaimablePool: mock(async () => [] as Array<{ id: string }>),
+  listWarmPoolReconciliationCandidates: mock(async () => []),
+  promoteStrandedPoolEntryReady: mock(async () => undefined),
+  reserveUnclaimablePoolEntryForReap: mock(async () => undefined),
   findStuckPoolProvisioning: mock(async () => [] as Array<{ id: string }>),
   countAllPoolEntries: mock(async () => ({ ready: 0, provisioning: 0 })),
   countUserProvisionsByHour: mock(async () => [] as number[]),
@@ -63,8 +66,10 @@ function fakeCreator(overrides: Partial<PoolContainerCreator> = {}): {
 
 beforeEach(() => {
   warmPoolEnabled = true;
-  repo.listUnclaimedPool.mockReset();
-  repo.listUnclaimedPool.mockResolvedValue([]);
+  repo.listClaimablePool.mockReset();
+  repo.listClaimablePool.mockResolvedValue([]);
+  repo.listWarmPoolReconciliationCandidates.mockReset();
+  repo.listWarmPoolReconciliationCandidates.mockResolvedValue([]);
   repo.findStuckPoolProvisioning.mockReset();
   repo.findStuckPoolProvisioning.mockResolvedValue([]);
   repo.countAllPoolEntries.mockReset();
@@ -122,7 +127,8 @@ describe("replenish honors the disabled no-op", () => {
 
     expect(create).not.toHaveBeenCalled();
     expect(repo.countAllPoolEntries).not.toHaveBeenCalled();
-    expect(repo.listUnclaimedPool).not.toHaveBeenCalled();
+    expect(repo.listClaimablePool).not.toHaveBeenCalled();
+    expect(repo.listWarmPoolReconciliationCandidates).not.toHaveBeenCalled();
     expect(result.created).toEqual([]);
     expect(result.decision.toCreate).toBe(0);
     expect(result.decision.reason).toContain("WARM_POOL_ENABLED=false");

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -137,8 +137,9 @@ export interface PoolContainerCreator {
    *   1. Insert a pool entry via `agentSandboxesRepository.createPoolEntry`
    *      with status='pending', `docker_image` set, `pool_status='unclaimed'`.
    *   2. Allocate a node and start the container.
-   *   3. On health-check pass, call `markPoolEntryReady(id)`.
-   *   4. On failure, mark status='error' (the stuck-reaper will delete it).
+   *   3. Complete the provision path, whose final repository CAS commits
+   *      status='running' and `pool_ready_at` together.
+   *   4. On failure, leave a non-claimable row for reconciliation.
    */
   createPoolContainer(image: string): Promise<{ id: string; nodeId: string | null }>;
 
@@ -158,6 +159,7 @@ export interface PoolContainerCreator {
 export interface ReplenishResult {
   decision: ReplenishDecision;
   state: PoolStateSnapshot;
+  reconciliation: WarmPoolReconciliationResult;
   created: Array<{ id: string; nodeId: string | null }>;
   failed: Array<{ error: string }>;
 }
@@ -171,7 +173,17 @@ export interface DrainResult {
 export interface HealthCheckResult {
   probed: number;
   alive: number;
+  reconciliation: WarmPoolReconciliationResult;
   removed: Array<{ id: string; reason: string }>;
+}
+
+export interface WarmPoolReconciliationResult {
+  scanned: number;
+  probed: number;
+  promoted: string[];
+  reaped: Array<{ id: string; reason: string }>;
+  deferred: string[];
+  failed: Array<{ id: string; error: string }>;
 }
 
 export interface RolloutResult {
@@ -191,8 +203,8 @@ export class WarmPoolManager {
    * Compute current pool state + forecast. Pure-ish: only reads.
    */
   async snapshot(image: string): Promise<PoolStateSnapshot> {
-    const counts = await agentSandboxesRepository.countAllPoolEntries();
-    const unclaimedRows = await agentSandboxesRepository.listUnclaimedPool();
+    const counts = await agentSandboxesRepository.countAllPoolEntries({ image });
+    const unclaimedRows = await agentSandboxesRepository.listClaimablePool({ image });
 
     const buckets = await this.collectHourlyBuckets(this.policy.forecastWindowHours);
     const forecast = computeForecast({
@@ -206,15 +218,13 @@ export class WarmPoolManager {
     return {
       readyCount: counts.ready,
       provisioningCount: counts.provisioning,
-      unclaimedRows: unclaimedRows
-        .filter((r) => r.docker_image === image || r.docker_image === null)
-        .map((r) => ({
-          id: r.id,
-          pool_ready_at: r.pool_ready_at,
-          docker_image: r.docker_image,
-          node_id: r.node_id,
-          health_url: r.health_url,
-        })),
+      unclaimedRows: unclaimedRows.map((r) => ({
+        id: r.id,
+        pool_ready_at: r.pool_ready_at,
+        docker_image: r.docker_image,
+        node_id: r.node_id,
+        health_url: r.health_url,
+      })),
       predictedRate: forecast.predictedRate,
       targetPoolSize: forecast.targetPoolSize,
     };
@@ -225,11 +235,16 @@ export class WarmPoolManager {
       return {
         decision: { toCreate: 0, reason: "WARM_POOL_ENABLED=false (no-op)" },
         state: emptyState(),
+        reconciliation: emptyReconciliation(),
         created: [],
         failed: [],
       };
     }
 
+    // Reconciliation runs on the production replenish path, not only the
+    // manually-invoked health route. A stranded row is repaired or fenced
+    // before the capacity snapshot decides whether to create a replacement.
+    const reconciliation = await this.reconcileUnclaimable();
     const state = await this.snapshot(image);
     const decision = decideReplenish(state, this.policy);
     const created: Array<{ id: string; nodeId: string | null }> = [];
@@ -259,8 +274,14 @@ export class WarmPoolManager {
       target: state.targetPoolSize,
       created: created.length,
       failed: failed.length,
+      reconciled: {
+        promoted: reconciliation.promoted.length,
+        reaped: reconciliation.reaped.length,
+        deferred: reconciliation.deferred.length,
+        failed: reconciliation.failed.length,
+      },
     });
-    return { decision, state, created, failed };
+    return { decision, state, reconciliation, created, failed };
   }
 
   async drainIdle(image: string): Promise<DrainResult> {
@@ -299,12 +320,18 @@ export class WarmPoolManager {
 
   async healthCheck(): Promise<HealthCheckResult> {
     if (!containersEnv.warmPoolEnabled()) {
-      return { probed: 0, alive: 0, removed: [] };
+      return {
+        probed: 0,
+        alive: 0,
+        reconciliation: emptyReconciliation(),
+        removed: [],
+      };
     }
 
-    const rows = await agentSandboxesRepository.listUnclaimedPool();
-    const removed: Array<{ id: string; reason: string }> = [];
-    let alive = 0;
+    const rows = await agentSandboxesRepository.listClaimablePool();
+    const reconciliation = await this.reconcileUnclaimable();
+    const removed: Array<{ id: string; reason: string }> = [...reconciliation.reaped];
+    let alive = reconciliation.promoted.length;
 
     for (const row of rows) {
       // `healthProbe` is contracted to return false for an unreachable
@@ -335,6 +362,11 @@ export class WarmPoolManager {
       this.policy.stuckProvisioningMs,
     );
     for (const row of stuck) {
+      const reserved = await agentSandboxesRepository.reserveStuckPoolEntryForReap(
+        row,
+        this.policy.stuckProvisioningMs,
+      );
+      if (!reserved) continue;
       try {
         await this.creator.destroyPoolContainer(row.id);
         removed.push({ id: row.id, reason: "stuck in provisioning past threshold" });
@@ -353,8 +385,19 @@ export class WarmPoolManager {
       alive,
       removed: removed.length,
       stuck: stuck.length,
+      reconciled: {
+        promoted: reconciliation.promoted.length,
+        reaped: reconciliation.reaped.length,
+        deferred: reconciliation.deferred.length,
+        failed: reconciliation.failed.length,
+      },
     });
-    return { probed: rows.length, alive, removed };
+    return {
+      probed: rows.length + reconciliation.probed,
+      alive,
+      reconciliation,
+      removed,
+    };
   }
 
   async rollout(image: string): Promise<RolloutResult> {
@@ -366,7 +409,7 @@ export class WarmPoolManager {
       };
     }
 
-    const rows = await agentSandboxesRepository.listUnclaimedPool();
+    const rows = await agentSandboxesRepository.listAllRunningPoolEntries();
     const decision = decideRollout(rows, image);
     const replaced: string[] = [];
     const failed: Array<{ id: string; error: string }> = [];
@@ -393,7 +436,7 @@ export class WarmPoolManager {
 
   async rolloutStatus(image: string): Promise<ImageRolloutSummary> {
     const rows = containersEnv.warmPoolEnabled()
-      ? await agentSandboxesRepository.listUnclaimedPool()
+      ? await agentSandboxesRepository.listAllRunningPoolEntries()
       : [];
     return summarizeImageRollout({
       desiredImage: image,
@@ -411,6 +454,59 @@ export class WarmPoolManager {
   private async collectHourlyBuckets(windowHours: number): Promise<number[]> {
     return agentSandboxesRepository.countUserProvisionsByHour(windowHours);
   }
+
+  /**
+   * Repair the historical running-without-readiness crash shape and fence every
+   * other unclaimable running generation before teardown. Probe results are
+   * committed through generation CAS operations so stale network observations
+   * cannot promote or destroy a replacement container.
+   */
+  private async reconcileUnclaimable(): Promise<WarmPoolReconciliationResult> {
+    const candidates = await agentSandboxesRepository.listWarmPoolReconciliationCandidates(
+      this.policy.stuckProvisioningMs,
+    );
+    const result = emptyReconciliation();
+    result.scanned = candidates.length;
+
+    for (const candidate of candidates) {
+      const row = candidate.sandbox;
+      if (candidate.canPromote) {
+        result.probed += 1;
+        const alive = await this.creator.healthProbe(row.id);
+        if (alive) {
+          const promoted = await agentSandboxesRepository.promoteStrandedPoolEntryReady(row);
+          if (promoted) result.promoted.push(row.id);
+          else result.deferred.push(row.id);
+          continue;
+        }
+      }
+
+      const reason = candidate.canPromote
+        ? "Warm-pool readiness probe failed during reconciliation"
+        : "Warm-pool row is missing a required claim locator";
+      const reserved = await agentSandboxesRepository.reserveUnclaimablePoolEntryForReap(
+        row,
+        reason,
+      );
+      if (!reserved) {
+        result.deferred.push(row.id);
+        continue;
+      }
+      try {
+        await this.creator.destroyPoolContainer(row.id);
+        result.reaped.push({ id: row.id, reason });
+      } catch (error) {
+        // error-policy:J6 best-effort teardown — the durable deletion_failed
+        // fence prevents reuse, and the stuck sweep retries this exact row.
+        result.failed.push({
+          id: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return result;
+  }
 }
 
 function emptyState(): PoolStateSnapshot {
@@ -420,6 +516,17 @@ function emptyState(): PoolStateSnapshot {
     unclaimedRows: [],
     predictedRate: 0,
     targetPoolSize: 0,
+  };
+}
+
+function emptyReconciliation(): WarmPoolReconciliationResult {
+  return {
+    scanned: 0,
+    probed: 0,
+    promoted: [],
+    reaped: [],
+    deferred: [],
+    failed: [],
   };
 }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -27,7 +27,11 @@ import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes"
 import type { DockerNode } from "../../db/repositories/docker-nodes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-runtime-history";
-import type { StoredAgentSandboxBackup } from "../../db/schemas/agent-sandboxes";
+import {
+  type StoredAgentSandboxBackup,
+  WARM_POOL_ORG_ID,
+  WARM_POOL_USER_ID,
+} from "../../db/schemas/agent-sandboxes";
 import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
@@ -4570,6 +4574,87 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       apiKeySpy.mockRestore();
       ensureStartedSpy.mockRestore();
       getProviderSpy.mockRestore();
+    }
+  });
+
+  test("a warm-pool provision becomes running only through the final readiness CAS", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const handle = providerHandle();
+    const row: AgentSandbox = {
+      ...provisioningReadyRow(),
+      organization_id: WARM_POOL_ORG_ID,
+      user_id: WARM_POOL_USER_ID,
+      execution_tier: "dedicated-always",
+      pool_status: "unclaimed",
+    };
+    const adoptedRow: AgentSandbox = {
+      ...row,
+      status: "provisioning",
+      sandbox_id: handle.sandboxId,
+      node_id: handle.metadata.nodeId,
+      container_name: handle.metadata.containerName,
+      bridge_url: handle.bridgeUrl,
+      health_url: handle.healthUrl,
+      docker_image: handle.metadata.dockerImage,
+      image_digest: handle.metadata.imageDigest,
+    };
+    const readyRow: AgentSandbox = {
+      ...adoptedRow,
+      status: "running",
+      pool_ready_at: new Date("2026-07-30T12:00:00.000Z"),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(row);
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => (data.status === "provisioning" ? adoptedRow : row),
+    );
+    const commitReadySpy = spyOn(
+      agentSandboxesRepository,
+      "commitPoolEntryReady",
+    ).mockResolvedValue(readyRow);
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const provider: SandboxProvider = {
+      create: mock(async () => handle),
+      stop: mock(async () => {}),
+      checkHealth: async () => true,
+    };
+    const svc = new ElizaSandboxService(provider);
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+
+    try {
+      const result = await svc.provision(AGENT, WARM_POOL_ORG_ID);
+
+      expect(result.success).toBe(true);
+      expect(result.sandboxRecord).toBe(readyRow);
+      expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+      expect(commitReadySpy).toHaveBeenCalledTimes(1);
+      expect(commitReadySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "provisioning",
+          pool_ready_at: null,
+          sandbox_id: handle.sandboxId,
+          node_id: handle.metadata.nodeId,
+          bridge_url: handle.bridgeUrl,
+        }),
+      );
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      updateSpy.mockRestore();
+      commitReadySpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
     }
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2196,6 +2196,8 @@ export class ElizaSandboxService {
       rec.claimed_at !== null &&
       (rec.warm_claim_credential_state === "pending" ||
         rec.warm_claim_credential_state === "attested");
+    const isWarmPoolProvision =
+      rec.organization_id === WARM_POOL_ORG_ID && rec.pool_status === "unclaimed";
     const containerLaunch = resolveSandboxContainerLaunchConfig(rec.agent_config);
 
     // Every claimed row carries the exact managed key owned by its durable
@@ -2430,21 +2432,19 @@ export class ElizaSandboxService {
 
         await this.ensureRuntimeAgentStarted(runtimeRec);
 
-        // 4. Mark running + persist provider-specific metadata.
+        // 4. Persist the reachable container and provider-specific metadata.
         //
-        // This write happens BEFORE the backup restore on purpose: the status
-        // column is the reachability gate — the dedicated-agent proxy
-        // synthesizes a 202 "starting" for EVERY request (including the
-        // launcher's /api/status poll) until status='running'. The container is
-        // serving from this moment (health checked, runtime agent started), so
-        // gating the flip on the restore tail made a responsive agent read as
-        // "waking" for the whole restore — the launcher escalated to "taking
-        // longer than usual" while chat already answered (#14038). A restore
-        // failure still flips the row out of 'running' via the catch below
-        // (ghost cleanup → retry or markError), so 'running' never sticks on a
-        // failed provision.
+        // User rows flip to `running` before restore because that status is the
+        // proxy reachability gate; delaying it made a responsive agent render
+        // as "waking" throughout restore (#14038). Unclaimed pool rows are the
+        // exception: exposing them as claimable before the restore tail
+        // succeeds recreates the readiness crash window, so they stay
+        // `provisioning` until the final status+stamp CAS below.
         const updateData: Parameters<typeof agentSandboxesRepository.update>[1] = {
-          status: recoveringPendingWarmClaim ? "provisioning" : "running",
+          // Pool rows stay non-claimable until the entire provision tail
+          // succeeds. Their final status+readiness stamp is one repository CAS
+          // below; user rows retain the early reachability flip.
+          status: recoveringPendingWarmClaim || isWarmPoolProvision ? "provisioning" : "running",
           sandbox_id: handle.sandboxId,
           bridge_url: handle.bridgeUrl,
           health_url: handle.healthUrl,
@@ -2595,6 +2595,25 @@ export class ElizaSandboxService {
           });
         }
 
+        let completed = updated;
+        if (isWarmPoolProvision) {
+          const ready = await agentSandboxesRepository.commitPoolEntryReady(updated);
+          if (!ready) {
+            throw new ElizaError("Warm-pool readiness generation changed before final commit", {
+              code: "WARM_POOL_READINESS_CAS_MISSED",
+              context: {
+                poolId: updated.id,
+                environmentRevision: updated.environment_revision,
+                sandboxId: updated.sandbox_id,
+                nodeId: updated.node_id,
+                containerName: updated.container_name,
+              },
+              severity: "ephemeral",
+            });
+          }
+          completed = ready;
+        }
+
         logger.info("[agent-sandbox] Provisioned", {
           agentId: rec.id,
           sandboxId: handle.sandboxId,
@@ -2602,7 +2621,7 @@ export class ElizaSandboxService {
         });
         return {
           success: true,
-          sandboxRecord: updated!,
+          sandboxRecord: completed,
           bridgeUrl: handle.bridgeUrl,
           healthUrl: handle.healthUrl,
         };


### PR DESCRIPTION
## Problem

The original count-only change identified a real failure mode but stopped at the symptom. Excluding `running / pool_ready_at NULL` rows from one capacity count prevents one kind of over-counting, but it does not close the crash window that creates those rows, does not make every capacity reader agree with the claim transaction, and does not give production a safe way to recover or remove the stranded container.

The proposed stale-row lookup was also ineffective for the observed shape: successful heartbeats refresh `updated_at`, so a live-but-unclaimable row never becomes stale by that clock. Its cleanup path was only reached from `healthCheck`, while the production daemon invokes `replenish`. Finally, a read-then-destroy sweep could act on an obsolete probe after the container generation changed.

## Fix

- Define one claimable-capacity predicate and use it for global/image counts, claimable-row listing, and the `FOR UPDATE SKIP LOCKED` claim query. A claimable row must have sentinel pool ownership, `unclaimed / running`, the readiness stamp, complete non-empty runtime locators, the requested image when scoped, and no deletion or replacement-cleanup fence.
- Read ready and in-flight image capacity in one aggregate statement so replenishment sees one database snapshot.
- Keep new pool provisions in `provisioning` through runtime startup and restore, then commit `status = running` and `pool_ready_at` together through a generation compare-and-set. A success result without that committed readiness fails closed.
- Run stranded-row reconciliation on the production `replenish` path. A stable `created_at` grace avoids promoting an old worker's still-active restore tail, while heartbeat updates cannot hide a genuinely stranded generation.
- Probe a promotable stranded row live, then use exact-generation CAS to promote it. Invalid or unhealthy rows are CAS-fenced as `deletion_failed` before remote teardown, so a stale observation cannot destroy a replacement generation. Stuck non-running provisions use the same reserve-before-destroy discipline.
- Surface invariant and capacity failures with `ElizaError`; teardown remains an explicit, observable best-effort boundary.

## Validation

The attached passing transcript is from repaired head `8e3ea84236d23b610992b5251b3dd251763c4102` rebased on `develop` at `0e862b1308f14fddeee5da16451d792a0f060d1a`.

- Full admin image-rollout PGlite suite, including sentinel-owned warm claim and digest transfer: **47 passed / 0 failed**.
- Real isolated PGlite plus a live local HTTP health endpoint: **8 passed / 0 failed**. This covers count/list/claim agreement, a two-user claim race, duplicate readiness commits, missing-locator refusal, rolling-deploy grace, heartbeat-fresh stranded-row recovery through public `replenish`, promote-vs-fence concurrency, and the split between running reconciliation and stuck provisioning.
- Repository, decision, replenishment, and error-policy neighbors: **43 passed / 0 failed**.
- Pool creator fail-closed coverage: **12 passed / 0 failed**.
- Real `provision()` orchestration body with deterministic provider fixtures: **1 passed / 0 failed**.
- Total focused tests: **111 passed / 0 failed**, 671 assertions.
- `bun run --cwd packages/cloud/shared typecheck`: passed.
- `bun run --cwd packages/cloud/api typecheck`: passed, including the production Wrangler dry-run bundle.
- `bun run audit:scripts`: passed.
- Biome on all 10 touched files and `git diff --check`: passed.

## Provider boundary

This validation did **not** create or destroy a real Hetzner container, Neon branch, or Headscale registration, and did not exercise SSH against the managed provider fleet. Those operations require staging/provider credentials. The evidence covers real PostgreSQL semantics through PGlite, real concurrent repository transactions, a live HTTP probe, and the production service/replenishment orchestration up to that external provider boundary.

Refs #17253

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only lifecycle change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only lifecycle change with no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing visual flow changed

<!-- evidence-row:backend-logs -->
- [x] [17286-warm-pool-atomic-8e3ea84-passing.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17286-warm-pool-atomic-8e3ea84-passing.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - repository row transitions are asserted in the attached PGlite transcript; no external provider artifact was created

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to review
