### PR TITLE
fix(cloud): make fence-less replacement adoption reachable

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Regression proof for #17253 §4: the preserve-and-adopt mechanism was dead
+ * code. `transferReplacementToPrimary` built the handle's replacement locator
+ * BEFORE checking whether a durable fence exists — and
+ * `replacementLocatorFromHandle` THROWS on any handle without replacement
+ * metadata, which is every ADOPTED handle (a preserved container from a
+ * provision retry, #15310 §6). Every adoption therefore died on "no durable
+ * Docker placement metadata", the healthy container was torn down, and the
+ * agent hard-failed — the exact SSH-blip scenario the mechanism was built for.
+ *
+ * Drives the REAL private method against in-process PGlite (real Drizzle
+ * schema via pushSchema; the established private-access cast). Fails LOUDLY
+ * if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { organizations } from "../../../db/schemas/organizations";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+
+type AdoptionInternals = {
+  transferReplacementToPrimary: (
+    agentId: string,
+    orgId: string,
+    handle: {
+      sandboxId: string;
+      bridgeUrl: string;
+      healthUrl: string;
+      metadata?: Record<string, unknown>;
+    },
+    expectedEnvironmentRevision: number,
+    updateData: Record<string, unknown>,
+  ) => Promise<{ id: string; status: string }>;
+};
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedProvisioningAgent(params: {
+  sandboxId: string | null;
+}): Promise<{ id: string; orgId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "1.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  const [rec] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: org.id,
+      user_id: user.id,
+      agent_name: uniq("adopt"),
+      status: "provisioning",
+      execution_tier: "dedicated-always",
+      environment_revision: 0,
+      sandbox_id: params.sandboxId,
+    })
+    .returning();
+  return { id: rec.id, orgId: org.id };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[replacement-adoption-fenceless.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[replacement-adoption-fenceless.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("fence-less replacement adoption (#17253 §4)", () => {
+  test(
+    "an ADOPTED handle (no replacement metadata) completes the transfer",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { id, orgId } = await seedProvisioningAgent({ sandboxId: "agent-preserved" });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      // The preserved container's handle: docker-backed, same sandboxId the
+      // row already owns, and — by construction of adoption — NO replacement
+      // metadata for replacementLocatorFromHandle to read.
+      const adopted = await svc.transferReplacementToPrimary(
+        id,
+        orgId,
+        {
+          sandboxId: "agent-preserved",
+          bridgeUrl: "https://runtime.example",
+          healthUrl: "https://runtime.example/health",
+          metadata: { provider: "docker", nodeId: "node-1", containerName: "agent-preserved" },
+        },
+        0,
+        { status: "running" },
+      );
+
+      // Pre-fix this threw "no durable Docker placement metadata" before the
+      // fence-less branch could run, and the healthy container was torn down.
+      expect(adopted.status).toBe("running");
+      const row = await dbWrite.query.agentSandboxes.findFirst({
+        where: sql`${agentSandboxes.id} = ${id}`,
+      });
+      expect(row?.status).toBe("running");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a fence-less docker handle whose sandboxId does NOT match is still refused",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { id, orgId } = await seedProvisioningAgent({ sandboxId: "agent-original" });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      await expect(
+        svc.transferReplacementToPrimary(
+          id,
+          orgId,
+          {
+            sandboxId: "agent-imposter",
+            bridgeUrl: "https://runtime.example",
+            healthUrl: "https://runtime.example/health",
+            metadata: { provider: "docker", nodeId: "node-1", containerName: "agent-imposter" },
+          },
+          0,
+          { status: "running" },
+        ),
+      ).rejects.toThrow("Docker replacement has no durable cleanup ownership");
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8933,8 +8933,15 @@ export class ElizaSandboxService {
       }
 
       const locator = this.getReplacementCleanupLocator(current);
-      const incoming = this.replacementLocatorFromHandle(handle);
       if (locator) {
+        // Built ONLY when a durable fence exists to prove identity against:
+        // replacementLocatorFromHandle THROWS on a handle without replacement
+        // metadata, and an ADOPTED handle (a preserved container from a
+        // provision retry, #15310 §6) never carries any — building it
+        // unconditionally made the whole preserve-and-adopt mechanism
+        // unreachable: every adoption died on "no durable Docker placement
+        // metadata" and the healthy container was torn down (#17253 §4).
+        const incoming = this.replacementLocatorFromHandle(handle);
         this.assertSameReplacementIdentity(locator, incoming);
         if (
           locator.containerId !== incoming.containerId ||


### PR DESCRIPTION
## What — #17253 §4 (verified HIGH)

The preserve-and-adopt mechanism (#15310 §6 — keep a healthy container across a provision retry after an SSH blip) was **dead code**. `transferReplacementToPrimary` built the handle's replacement locator BEFORE checking whether a durable fence exists — and `replacementLocatorFromHandle` throws on any handle without replacement metadata, which is **every adopted handle by construction**. Every adoption died on `no durable Docker placement metadata` before the fence-less branch designed for it could run: the healthy container was torn down, the agent hard-failed, and the customer watched a woken agent sit at `provisioning` then die — the exact scenario the mechanism existed to prevent.

## Fix

One move: the locator is built only inside the `if (locator)` branch, where it is needed to prove identity against the durable fence. The fence-less path keeps its own guard untouched — a docker handle whose `sandboxId` does not match the row is still refused (`Docker replacement has no durable cleanup ownership`).

## Tests

The audit called out that existing coverage exercised a **prototype stand-in**, which is why this stayed invisible. The new PGlite test drives the REAL private method (established private-access cast, real schema via pushSchema, nothing mocked):
- adoption of a matching preserved handle completes the transfer to `running` — **fails on the pre-fix code with the exact production error** (`0 pass / 2 fail`, `Replacement sandbox agent-preserved has no durable Docker placement metadata`);
- an imposter `sandboxId` is still refused — the legitimate guard survives the fix.

Full `eliza-sandbox` suite green (164).

Refs #17253 §4 [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17287-ad-ev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17287-ad-ev.log)
