### PR TITLE
fix(core): restore the subtractive AccessContext gate searchDocuments dropped

### DIFF
--- a/packages/agent/src/api/chat-augmentation.access-context.test.ts
+++ b/packages/agent/src/api/chat-augmentation.access-context.test.ts
@@ -84,7 +84,14 @@ function makeRuntime(fragments: Memory[]): {
     getEntityById: vi.fn(async () => null),
     getRelationships: vi.fn(async () => []),
     getSetting: vi.fn(() => undefined),
-    // documents search backing
+    // documents search backing. The service's keyword path reads fragments
+    // through the adapter contract (runtime.adapter.queryDocumentFragments);
+    // returning EVERY fragment regardless of requester keeps the suite's
+    // point sharp — access control must come from the service's own
+    // AccessContext post-filter, never from the storage query.
+    adapter: {
+      queryDocumentFragments: vi.fn(async () => fragments),
+    },
     getModel: vi.fn(() => undefined),
     getMemories: vi.fn(async () => fragments),
     searchMemories: vi.fn(async () => fragments),

--- a/packages/core/src/access-control/filter.test.ts
+++ b/packages/core/src/access-control/filter.test.ts
@@ -259,4 +259,33 @@ describe("filterByAccessContext", () => {
 		const ctx: AccessContext = { requesterEntityId: SELF, role: "USER" };
 		expect(filterByAccessContext([noScope], ctx, AGENT)).toHaveLength(1);
 	});
+
+	it("preserves the concrete shape of document-search results", () => {
+		const result = {
+			entityId: SELF,
+			content: { text: "private result" },
+			metadata: { scope: "user-private", scopedToEntityId: SELF },
+			similarity: 0.91,
+		};
+		const [visible] = filterByAccessContext(
+			[result],
+			{ requesterEntityId: SELF, role: "USER" },
+			AGENT,
+		);
+		expect(visible?.similarity).toBe(0.91);
+	});
+
+	it("fails closed on a malformed runtime scope", () => {
+		const malformed = {
+			entityId: SELF,
+			metadata: { scope: "not-a-scope" },
+		};
+		expect(
+			filterByAccessContext(
+				[malformed],
+				{ requesterEntityId: SELF, role: "USER" },
+				AGENT,
+			),
+		).toEqual([]);
+	});
 });

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -1,8 +1,8 @@
 /**
- * Read-side access-control filter for memories: maps an {@link AccessContext}
- * to a scope-ladder actor, decides whether that actor may read a memory of a
- * given {@link MemoryScope}, and subtractively filters a memory array down to
- * the readable set.
+ * Read-side access-control filter for memory-shaped retrieval records: maps an
+ * {@link AccessContext} to a scope-ladder actor, decides whether that actor may
+ * read a record of a given {@link MemoryScope}, and subtractively filters a
+ * result array down to the readable set.
  *
  * Composes with — never duplicates — Postgres RLS: RLS gates on
  * `entity_id`/`server_id`, this gates on `metadata.scope`. For the four
@@ -12,7 +12,31 @@
  * least-privileged `USER` tier.
  */
 import { isAdminRank, type RoleName } from "../roles";
-import type { AccessContext, Memory, MemoryScope, UUID } from "../types";
+import type { AccessContext, MemoryScope, UUID } from "../types";
+
+interface AccessScopedRecord {
+	entityId?: UUID;
+	metadata?: {
+		scope?: unknown;
+		scopedToEntityId?: unknown;
+		addedBy?: unknown;
+	};
+}
+
+function isMemoryScope(value: unknown): value is MemoryScope {
+	switch (value) {
+		case "shared":
+		case "private":
+		case "room":
+		case "global":
+		case "owner-private":
+		case "user-private":
+		case "agent-private":
+			return true;
+		default:
+			return false;
+	}
+}
 
 /**
  * Read-side actor role: the core {@link RoleName} widened with the machine
@@ -91,22 +115,27 @@ export function canReadScope(
 }
 
 /**
- * Filter memories down to those `ctx`'s requester may read. A pure, strictly
- * subtractive `.filter()`: it composes with (never duplicates) Postgres RLS,
- * which gates on `entity_id`/`server_id` while this gates on `metadata.scope`.
- * Scope defaults to `global` when absent; the owning entity is taken from
- * `metadata.scopedToEntityId`, else `metadata.addedBy`, else `memory.entityId`
+ * Filter retrieval records down to those `ctx`'s requester may read. A pure,
+ * strictly subtractive `.filter()`: it composes with (never duplicates)
+ * Postgres RLS, which gates on `entity_id`/`server_id` while this gates on
+ * `metadata.scope`. Scope defaults to `global` only when absent; malformed
+ * scopes fail closed. The owning entity is taken from
+ * `metadata.scopedToEntityId`, else `metadata.addedBy`, else `entityId`
  * (mirroring the documents plugin).
  */
-export function filterByAccessContext(
-	memories: Memory[],
+export function filterByAccessContext<T extends AccessScopedRecord>(
+	memories: T[],
 	ctx: AccessContext,
 	agentId: UUID,
-): Memory[] {
+): T[] {
 	const actor = actorFromAccessContext(ctx, agentId);
 	return memories.filter((memory) => {
-		const scope = memory.metadata?.scope ?? "global";
-		const meta = memory.metadata as Record<string, unknown> | undefined;
+		const rawScope = memory.metadata?.scope;
+		if (rawScope !== undefined && !isMemoryScope(rawScope)) {
+			return false;
+		}
+		const scope = rawScope ?? "global";
+		const meta = memory.metadata;
 		const scopedTo = meta?.scopedToEntityId;
 		const addedBy = meta?.addedBy;
 		const scopedEntityId =

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -15,6 +15,7 @@
  * also migrates the legacy `knowledge` partition into the document partitions.
  */
 import { existsSync, statSync } from "node:fs";
+import { filterByAccessContext } from "../../access-control/filter";
 import {
 	canRequesterMutateDocument,
 	DOCUMENT_LIST_MAX_LIMIT,
@@ -25,7 +26,6 @@ import {
 	readDocumentMutationSnapshot,
 } from "../../database/document-list-query";
 import { createUniqueUuid } from "../../entities";
-import { filterByAccessContext } from "../../access-control/filter";
 import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { checkSenderRole } from "../../roles";
@@ -1116,11 +1116,7 @@ export class DocumentService extends Service {
 		// the deny side of scoped reads (fail closed). Pinned by
 		// packages/agent/src/api/chat-augmentation.access-context.test.ts.
 		if (!accessContext) return results;
-		return filterByAccessContext(
-			results as unknown as Memory[],
-			accessContext,
-			this.runtime.agentId,
-		) as unknown as StoredDocument[];
+		return filterByAccessContext(results, accessContext, this.runtime.agentId);
 	}
 
 	/** Pure vector (cosine-similarity) search. */
@@ -1159,6 +1155,7 @@ export class DocumentService extends Service {
 			.filter((fragment) => fragment.id !== undefined)
 			.map((fragment) => ({
 				id: fragment.id as UUID,
+				entityId: fragment.entityId,
 				content: fragment.content as Content,
 				similarity: fragment.similarity,
 				metadata: fragment.metadata,
@@ -1200,6 +1197,7 @@ export class DocumentService extends Service {
 		return valid
 			.map((fragment) => ({
 				id: fragment.id as UUID,
+				entityId: fragment.entityId,
 				content: fragment.content as Content,
 				similarity: scoreMap.get(fragment.id as string) ?? 0,
 				metadata: fragment.metadata,
@@ -1286,6 +1284,7 @@ export class DocumentService extends Service {
 					HYBRID_VECTOR_WEIGHT * vectorNorm + HYBRID_BM25_WEIGHT * bm25Norm;
 				return {
 					id: fragment.id as UUID,
+					entityId: fragment.entityId,
 					content: fragment.content as Content,
 					similarity: combined,
 					metadata: fragment.metadata,

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -25,6 +25,7 @@ import {
 	readDocumentMutationSnapshot,
 } from "../../database/document-list-query";
 import { createUniqueUuid } from "../../entities";
+import { filterByAccessContext } from "../../access-control/filter";
 import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { checkSenderRole } from "../../roles";
@@ -1057,7 +1058,7 @@ export class DocumentService extends Service {
 		message: Memory,
 		scope?: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		searchMode?: SearchMode,
-		_accessContext?: AccessContext,
+		accessContext?: AccessContext,
 		options?: { turnMessageId?: UUID; signal?: AbortSignal },
 	): Promise<StoredDocument[]> {
 		if (!message.content.text || message.content.text.trim().length === 0) {
@@ -1084,12 +1085,20 @@ export class DocumentService extends Service {
 			effectiveMode = "keyword";
 		}
 
+		let results: StoredDocument[];
 		if (effectiveMode === "keyword") {
-			return this._keywordSearch(queryText, filterScope, requester);
-		}
-
-		if (effectiveMode === "vector") {
-			return this._vectorSearch(
+			results = await this._keywordSearch(queryText, filterScope, requester);
+		} else if (effectiveMode === "vector") {
+			results = await this._vectorSearch(
+				queryText,
+				filterScope,
+				requester,
+				options?.turnMessageId,
+				options?.signal,
+			);
+		} else {
+			// hybrid: vector + BM25 combined
+			results = await this._hybridSearch(
 				queryText,
 				filterScope,
 				requester,
@@ -1098,14 +1107,20 @@ export class DocumentService extends Service {
 			);
 		}
 
-		// hybrid: vector + BM25 combined
-		return this._hybridSearch(
-			queryText,
-			filterScope,
-			requester,
-			options?.turnMessageId,
-			options?.signal,
-		);
+		// The caller-supplied AccessContext stays a second, strictly-subtractive
+		// gate on top of the adapter-level requester filtering. The adapter query
+		// filters by who the MESSAGE says is asking; a caller whose identity
+		// differs from the message identity (an agent-initiated search on behalf
+		// of a user) must still be narrowed to ITS view, and no caller can widen
+		// its view by threading a context. Fragments missing an entityId fall to
+		// the deny side of scoped reads (fail closed). Pinned by
+		// packages/agent/src/api/chat-augmentation.access-context.test.ts.
+		if (!accessContext) return results;
+		return filterByAccessContext(
+			results as unknown as Memory[],
+			accessContext,
+			this.runtime.agentId,
+		) as unknown as StoredDocument[];
 	}
 
 	/** Pure vector (cosine-similarity) search. */

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -29,6 +29,7 @@ export type StoredDocumentMetadata = Record<string, unknown>;
  */
 export interface StoredDocument {
 	id: UUID;
+	entityId?: UUID;
 	content: Content;
 	metadata?: StoredDocumentMetadata;
 	worldId?: UUID;


### PR DESCRIPTION
## Summary

Develop's Server Tests lane stayed red after the #17212 revert. The remaining
`chat augmentation honors the requester's AccessContext` failures had a
different source: the documents series is green through `cdaff81871`, then red
at direct push `02beecd1bb` (`fix(documents): unify authorization and mutation
contracts`).

That push moved document filtering into the adapter query keyed on the
**message-derived** requester and renamed `searchDocuments`' caller-supplied
`accessContext` to `_accessContext`. An agent-initiated search on behalf of a
user could therefore regain the message identity's wider view. The production
chat augmentation caller already supplies the narrower context and expects it
to remain a non-bypassable gate.

## Fix

- Apply the caller's `AccessContext` after every document-search mode as a
  second, strictly subtractive gate. Omitting it preserves the adapter-only
  behavior; supplying it can only remove results.
- Make `filterByAccessContext` generic over the minimal ownership-bearing
  record shape. This removes the double `unknown` cast from the authorization
  boundary while preserving the concrete `StoredDocument` result type.
- Carry each fragment's `entityId` into `StoredDocument`, so the canonical
  `scopedToEntityId -> addedBy -> entityId` ownership fallback remains intact.
- Treat a malformed runtime scope as unreadable instead of silently treating it
  as public.
- Give the agent test runtime the adapter query surface introduced by
  `02beecd1bb`; it deliberately returns the full corpus so the service gate,
  rather than the test double, is proven causal.

## Verification

- Bisect: `07d136b592` ✅ → `a9d09bf9ac` ✅ → `d898af4e77` ✅ →
  `cdaff81871` ✅ → `02beecd1bb` ❌.
- Core document, access-filter, and agent end-to-end augmentation suites:
  **11 files, 176 tests, 176 passed**.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/agent typecheck`: passed.
- Root `bun run typecheck`: **343/343 tasks passed**.
- Biome check for all five changed/test files: passed with no fixes.
- `git diff --check`: passed.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - runtime authorization change; no UI surface.
  The red Server Tests runs 30495305650 and 30507594104 are the before-state.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no UI flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic authorization code; the bisect and
  fail-to-pass test results prove the boundary behavior.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model behavior; the test uses real
  deterministic BM25 recall and the production authorization filter.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - deterministic authorization output; the 4-case
  augmentation suite proves OWNER access, USER denial, blank-requester
  fail-closed behavior, and the explicit AccessContext's causal narrowing.
