### PR TITLE
fix(agent): stop mirroring vault:// connector secrets into process.env

### DIFF
--- a/packages/agent/src/runtime/connector-vault-refs.test.ts
+++ b/packages/agent/src/runtime/connector-vault-refs.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Connector `vault://` refs stay out of process.env and resolve into the
+ * runtime settings map only.
+ *
+ * Covers the boot chain for connector credentials (audit gap #3,
+ * ELIZA-VAULT-AUDIT-2026-07-30):
+ *   config.connectors → applyConnectorSecretsToEnv (env mirror, plain values
+ *   only) → collectConnectorEnvVars → resolveConnectorSecretSettings (vault
+ *   read) → buildRuntimeSettingsProjection (settings overlay).
+ *
+ * Bidirectional proof:
+ *   1. vault ref resolves → plugin-visible setting carries the plaintext AND
+ *      process.env stays clean after the full boot-path env application.
+ *   2. plain value unchanged → env mirror + settings behave exactly as before.
+ *   3. missing/invalid ref → fail-closed: no setting, no env var, no secret
+ *      material or vault internals in the reported failure strings.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import { collectConnectorEnvVars } from "../config/env-vars.ts";
+import { applyConnectorSecretsToEnv } from "./eliza.ts";
+import {
+  formatVaultRef,
+  isVaultRef,
+  resolveConnectorSecretSettings,
+  type VaultLike,
+} from "./operations/vault-bridge.ts";
+import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+
+const SECRET = "mfa.discord-bot-token-plaintext-1234567890";
+const VAULT_KEY = "connectors.discord.token";
+
+const ENV_KEYS = [
+  "DISCORD_API_TOKEN",
+  "DISCORD_BOT_TOKEN",
+  "DISCORD_APPLICATION_ID",
+  "TELEGRAM_BOT_TOKEN",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+function fakeVault(entries: Record<string, string>): VaultLike {
+  return {
+    has: (key: string) => Promise.resolve(key in entries),
+    get: (key: string) => {
+      const value = entries[key];
+      if (value === undefined) {
+        return Promise.reject(
+          new Error(`vault internal: no row for ${key} in pglite store`),
+        );
+      }
+      return Promise.resolve(value);
+    },
+  };
+}
+
+function throwingVault(): VaultLike {
+  return {
+    has: () => Promise.resolve(true),
+    get: () =>
+      Promise.reject(
+        new Error(`vault backend exploded while decrypting ${SECRET}`),
+      ),
+  };
+}
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("applyConnectorSecretsToEnv with vault refs", () => {
+  it("never mirrors a vault:// ref (or its resolved value) into process.env", () => {
+    const config = {
+      connectors: {
+        discord: { token: formatVaultRef(VAULT_KEY) },
+      },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+
+    expect(process.env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(process.env.DISCORD_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("does not mirror a ref supplied through the botToken alias either", () => {
+    const config = {
+      connectors: {
+        discord: { botToken: formatVaultRef(VAULT_KEY) },
+      },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+
+    expect(process.env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(process.env.DISCORD_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("keeps mirroring plain token values exactly as before (backward compat)", () => {
+    const config = {
+      connectors: {
+        discord: { token: "plain-discord-token" },
+        telegram: { botToken: "plain-telegram-token" },
+      },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+
+    expect(process.env.DISCORD_API_TOKEN).toBe("plain-discord-token");
+    expect(process.env.DISCORD_BOT_TOKEN).toBe("plain-discord-token");
+    expect(process.env.TELEGRAM_BOT_TOKEN).toBe("plain-telegram-token");
+  });
+
+  it("still mirrors non-secret connector fields when the token is a ref", () => {
+    const config = {
+      connectors: {
+        discord: {
+          token: formatVaultRef(VAULT_KEY),
+          applicationId: "1234567890",
+        },
+      },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+
+    expect(process.env.DISCORD_APPLICATION_ID).toBe("1234567890");
+    expect(process.env.DISCORD_API_TOKEN).toBeUndefined();
+  });
+});
+
+describe("resolveConnectorSecretSettings", () => {
+  it("resolves a discord token ref for both env aliases from one vault entry", async () => {
+    const config = {
+      connectors: { discord: { token: formatVaultRef(VAULT_KEY) } },
+    } as unknown as ElizaConfig;
+    const connectorEnvVars = collectConnectorEnvVars(config);
+
+    const { resolved, failures } = await resolveConnectorSecretSettings(
+      connectorEnvVars,
+      fakeVault({ [VAULT_KEY]: SECRET }),
+    );
+
+    expect(resolved.DISCORD_API_TOKEN).toBe(SECRET);
+    expect(resolved.DISCORD_BOT_TOKEN).toBe(SECRET);
+    expect(failures).toEqual([]);
+    // Resolution must not have touched the environment.
+    expect(process.env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(process.env.DISCORD_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("passes plain values through untouched (they are not vault reads)", async () => {
+    const { resolved, failures } = await resolveConnectorSecretSettings(
+      { TELEGRAM_BOT_TOKEN: "plain-token" },
+      fakeVault({}),
+    );
+
+    expect(resolved).toEqual({});
+    expect(failures).toEqual([]);
+  });
+
+  it("fails closed on a missing vault entry: no value, key names only", async () => {
+    const { resolved, failures } = await resolveConnectorSecretSettings(
+      { DISCORD_API_TOKEN: formatVaultRef("connectors.discord.missing") },
+      fakeVault({}),
+    );
+
+    expect(resolved).toEqual({});
+    expect(failures).toEqual([
+      "DISCORD_API_TOKEN (vault://connectors.discord.missing)",
+    ]);
+  });
+
+  it("fails closed on a malformed ref without echoing secret material", async () => {
+    const { resolved, failures } = await resolveConnectorSecretSettings(
+      { DISCORD_API_TOKEN: "vault://" },
+      fakeVault({ [VAULT_KEY]: SECRET }),
+    );
+
+    // `vault://` with no key is not a valid ref, so it is treated as a plain
+    // string by isVaultRef and skipped by the resolver entirely.
+    expect(isVaultRef("vault://")).toBe(false);
+    expect(resolved).toEqual({});
+    expect(failures).toEqual([]);
+  });
+
+  it("redacts vault backend errors: failure strings carry no secret and no vault internals", async () => {
+    const { resolved, failures } = await resolveConnectorSecretSettings(
+      { DISCORD_API_TOKEN: formatVaultRef(VAULT_KEY) },
+      throwingVault(),
+    );
+
+    expect(resolved).toEqual({});
+    expect(failures).toHaveLength(1);
+    const serialized = JSON.stringify(failures);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("exploded");
+    expect(serialized).not.toContain("pglite");
+    expect(failures[0]).toBe(`DISCORD_API_TOKEN (vault://${VAULT_KEY})`);
+  });
+});
+
+describe("buildRuntimeSettingsProjection with connector refs", () => {
+  it("delivers the resolved overlay to settings and drops unresolved sentinels", () => {
+    const config = {
+      connectors: {
+        discord: { token: formatVaultRef(VAULT_KEY) },
+        telegram: { botToken: formatVaultRef("connectors.telegram.missing") },
+      },
+    } as unknown as ElizaConfig;
+
+    const settings = buildRuntimeSettingsProjection(config, {
+      env: {} as NodeJS.ProcessEnv,
+      connectorSecretsOverlay: {
+        DISCORD_API_TOKEN: SECRET,
+        DISCORD_BOT_TOKEN: SECRET,
+        // telegram ref failed to resolve → deliberately absent
+      },
+    });
+
+    // Resolved ref → plugin sees the plaintext via runtime settings.
+    expect(settings.DISCORD_API_TOKEN).toBe(SECRET);
+    expect(settings.DISCORD_BOT_TOKEN).toBe(SECRET);
+    // Unresolved ref → fail-closed: neither the sentinel literal nor any
+    // partial value reaches a plugin.
+    expect(settings.TELEGRAM_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("keeps plain connector values in settings unchanged (backward compat)", () => {
+    const config = {
+      connectors: { discord: { token: "plain-discord-token" } },
+    } as unknown as ElizaConfig;
+
+    const settings = buildRuntimeSettingsProjection(config, {
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(settings.DISCORD_API_TOKEN).toBe("plain-discord-token");
+    expect(settings.DISCORD_BOT_TOKEN).toBe("plain-discord-token");
+  });
+});
+
+describe("end-to-end boot-shaped flow", () => {
+  it("ref config: settings carry the secret, process.env is provably clean", async () => {
+    const config = {
+      connectors: { discord: { token: formatVaultRef(VAULT_KEY) } },
+    } as unknown as ElizaConfig;
+
+    // Boot step 2: env mirror (must skip the ref).
+    applyConnectorSecretsToEnv(config);
+    // Boot: overlay resolution (settings-only, mirrors
+    // resolveConnectorSecretsOverlayForBoot without the host bridge).
+    const { resolved } = await resolveConnectorSecretSettings(
+      collectConnectorEnvVars(config),
+      fakeVault({ [VAULT_KEY]: SECRET }),
+    );
+    // Boot step 7: runtime settings projection.
+    const settings = buildRuntimeSettingsProjection(config, {
+      env: {} as NodeJS.ProcessEnv,
+      connectorSecretsOverlay: resolved,
+    });
+
+    expect(settings.DISCORD_API_TOKEN).toBe(SECRET);
+    expect(settings.DISCORD_BOT_TOKEN).toBe(SECRET);
+    // The whole point: nothing along the path wrote the secret (or the
+    // sentinel) into the process environment.
+    for (const key of ENV_KEYS) {
+      expect(process.env[key]).toBeUndefined();
+    }
+    for (const value of Object.values(process.env)) {
+      expect(value).not.toBe(SECRET);
+    }
+  });
+
+  it("plain config: legacy env mirror still works end to end", async () => {
+    const config = {
+      connectors: { discord: { token: "plain-discord-token" } },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+    const { resolved } = await resolveConnectorSecretSettings(
+      collectConnectorEnvVars(config),
+      fakeVault({}),
+    );
+    const settings = buildRuntimeSettingsProjection(config, {
+      env: {} as NodeJS.ProcessEnv,
+      connectorSecretsOverlay: resolved,
+    });
+
+    expect(process.env.DISCORD_API_TOKEN).toBe("plain-discord-token");
+    expect(process.env.DISCORD_BOT_TOKEN).toBe("plain-discord-token");
+    expect(settings.DISCORD_API_TOKEN).toBe("plain-discord-token");
+  });
+});

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -36,7 +36,11 @@ import { BootTimer } from "./boot-timer.ts";
 import { maybeInjectFault } from "./crash-injection.ts";
 import { runFirstTimeSetup } from "./first-time-setup.ts";
 import { startMemoryWatchdog } from "./memory-watchdog.ts";
-import { resolveConfigEnvForProcess } from "./operations/vault-bridge.ts";
+import {
+  isVaultRef,
+  resolveConfigEnvForProcess,
+  resolveConnectorSecretSettings,
+} from "./operations/vault-bridge.ts";
 import { OPTIONAL_PLUGIN_IMPORTERS } from "./optional-plugin-imports.generated.ts";
 import {
   OPTIONAL_STATIC_PLUGIN_OVERRIDES,
@@ -266,7 +270,10 @@ import {
   type ElizaConfig,
   loadElizaConfig,
 } from "../config/config.ts";
-import { CONNECTOR_ENV_MAP } from "../config/env-vars.ts";
+import {
+  CONNECTOR_ENV_MAP,
+  collectConnectorEnvVars,
+} from "../config/env-vars.ts";
 import { resolveStateDir, resolveUserPath } from "../config/paths.ts";
 import {
   createHookEvent,
@@ -1893,6 +1900,11 @@ function isElizaCloudManagedProcessEnvKey(key: string): boolean {
 /**
  * Propagate channel credentials from Eliza config into process.env so
  * that elizaOS plugins can find them.
+ *
+ * `vault://` refs are NEVER mirrored: the plaintext for a ref is resolved by
+ * {@link resolveConnectorSecretsOverlayForBoot} into the in-memory runtime
+ * settings map only, so a vault-held connector secret does not leak into the
+ * process environment (child processes, co-tenant agents, `/proc` readers).
  */
 /** @internal Exported for testing. */
 export function applyConnectorSecretsToEnv(config: ElizaConfig): void {
@@ -1911,7 +1923,7 @@ export function applyConnectorSecretsToEnv(config: ElizaConfig): void {
         (typeof configObj.token === "string" && configObj.token.trim()) ||
         (typeof configObj.botToken === "string" && configObj.botToken.trim()) ||
         "";
-      if (tokenValue) {
+      if (tokenValue && !isVaultRef(tokenValue)) {
         process.env.DISCORD_API_TOKEN = tokenValue;
         process.env.DISCORD_BOT_TOKEN = tokenValue;
       }
@@ -1924,7 +1936,11 @@ export function applyConnectorSecretsToEnv(config: ElizaConfig): void {
       const value = configObj[configField];
       if (typeof value === "boolean" || typeof value === "number") {
         process.env[envKey] = String(value);
-      } else if (typeof value === "string" && value.trim()) {
+      } else if (
+        typeof value === "string" &&
+        value.trim() &&
+        !isVaultRef(value)
+      ) {
         process.env[envKey] = value;
       }
     }
@@ -1985,15 +2001,65 @@ export function applyConnectorSecretsToEnv(config: ElizaConfig): void {
 }
 
 /**
- * Auto-resolve Discord Application ID from the bot token via Discord API.
- * Called during async runtime init so that users only need a bot token.
+ * Resolve `vault://` connector refs into a settings-only overlay for boot.
+ *
+ * Runs on the same self-gating pattern as the config.env sentinel hydration:
+ * zero vault calls when no refs are present, so plain-value configs pay
+ * nothing. Skipped on mobile (no libsecret) and cloud-provisioned containers
+ * (daemon-injected env; vault-pglite init has hung the health check there) —
+ * refs in those environments fail closed with a key-name-only error.
+ *
+ * The returned overlay feeds ONLY `buildRuntimeSettings` — by design nothing
+ * here or downstream writes these values into `process.env`.
  */
 /** @internal Exported for testing. */
-export async function autoResolveDiscordAppId(): Promise<void> {
+export async function resolveConnectorSecretsOverlayForBoot(
+  config: ElizaConfig,
+): Promise<Record<string, string>> {
+  const connectorEnvVars = collectConnectorEnvVars(config);
+  const refKeys = Object.entries(connectorEnvVars)
+    .filter(([, value]) => isVaultRef(value))
+    .map(([key]) => key);
+  if (refKeys.length === 0) return {};
+
+  if (isMobilePlatform() || readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1") {
+    logger.error(
+      `[vault-bootstrap] connector vault ref(s) present but the vault is unavailable on this platform (fail-closed): ${refKeys.join(", ")}`,
+    );
+    return {};
+  }
+
+  const { sharedVault } = importAppCoreRuntime();
+  const { resolved, failures } = await resolveConnectorSecretSettings(
+    connectorEnvVars,
+    sharedVault(),
+  );
+  if (failures.length > 0) {
+    // Key names only — never values, never the underlying vault error.
+    logger.error(
+      `[vault-bootstrap] connector vault ref(s) failed to resolve (fail-closed): ${failures.join(", ")}`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Auto-resolve Discord Application ID from the bot token via Discord API.
+ * Called during async runtime init so that users only need a bot token.
+ *
+ * `tokenOverride` carries a vault-resolved token that deliberately lives
+ * outside `process.env` (see resolveConnectorSecretsOverlayForBoot).
+ */
+/** @internal Exported for testing. */
+export async function autoResolveDiscordAppId(
+  tokenOverride?: string,
+): Promise<void> {
   if (process.env.DISCORD_APPLICATION_ID) return;
 
   const discordToken =
-    process.env.DISCORD_API_TOKEN || process.env.DISCORD_BOT_TOKEN;
+    tokenOverride ||
+    process.env.DISCORD_API_TOKEN ||
+    process.env.DISCORD_BOT_TOKEN;
   if (!discordToken) return;
 
   try {
@@ -3669,7 +3735,16 @@ export async function startEliza(
   // autoFetchCloudGithubToken needs the cloud agent id. config.cloud?.agentId
   // is available now; the function falls back to its own skip guards (no cloud
   // key / no managed namespace) when the id is absent this early.
-  const discordAppIdPromise = autoResolveDiscordAppId();
+  //
+  // Connector secrets configured as `vault://` refs resolve here into a
+  // settings-only overlay (never process.env). Self-gating: zero vault calls
+  // when no refs are present. Resolved before the Discord app-id prefetch so
+  // a vault-held token still feeds the lookup.
+  const connectorSecretsOverlay =
+    await resolveConnectorSecretsOverlayForBoot(config);
+  const discordAppIdPromise = autoResolveDiscordAppId(
+    connectorSecretsOverlay.DISCORD_API_TOKEN,
+  );
   const cloudGithubTokenPromise = autoFetchCloudGithubToken(
     config.cloud?.agentId?.trim(),
   );
@@ -4382,6 +4457,7 @@ export async function startEliza(
       managedSkillsDir,
       bundledSkillsDir,
       workspaceSkillsDir,
+      connectorSecretsOverlay,
     }),
   });
   installRuntimeMethodBindings(runtime);
@@ -5617,7 +5693,11 @@ export async function startEliza(
           // because the config may have changed (e.g. cloud enabled during
           // first-run setup).
           applyConnectorSecretsToEnv(freshConfig);
-          await autoResolveDiscordAppId();
+          const freshConnectorSecretsOverlay =
+            await resolveConnectorSecretsOverlayForBoot(freshConfig);
+          await autoResolveDiscordAppId(
+            freshConnectorSecretsOverlay.DISCORD_API_TOKEN,
+          );
           applyCloudConfigToEnv(freshConfig);
           applyX402ConfigToEnv(freshConfig);
           applyDatabaseConfigToEnv(freshConfig);
@@ -5724,6 +5804,7 @@ export async function startEliza(
               managedSkillsDir,
               bundledSkillsDir,
               workspaceSkillsDir: freshWorkspaceSkillsDir,
+              connectorSecretsOverlay: freshConnectorSecretsOverlay,
             }),
           });
           installRuntimeMethodBindings(newRuntime);

--- a/packages/agent/src/runtime/operations/index.ts
+++ b/packages/agent/src/runtime/operations/index.ts
@@ -39,6 +39,7 @@ export {
   parseVaultRef,
   persistProviderApiKey,
   resolveConfigEnvForProcess,
+  resolveConnectorSecretSettings,
   resolveProviderApiKey,
   type VaultLike,
   vaultKeyForProviderApiKey,

--- a/packages/agent/src/runtime/operations/vault-bridge.ts
+++ b/packages/agent/src/runtime/operations/vault-bridge.ts
@@ -96,6 +96,65 @@ export async function resolveConfigEnvForProcess(
   return { resolved, missing };
 }
 
+/**
+ * Resolve `vault://<key>` sentinels found in connector env projections
+ * (the output of `collectConnectorEnvVars`) into an env-key → plaintext
+ * overlay for the runtime-settings projection.
+ *
+ * The overlay is delivered ONLY to the in-memory runtime settings map
+ * (`AgentRuntime.settings`, read via `runtime.getSetting()`); callers MUST
+ * NOT write resolved values into `process.env` — mirroring a resolved
+ * connector secret into the environment leaks it to every child process and
+ * co-tenant agent (the same invariant core's `getSetting()` documents).
+ *
+ * Fail-closed: a sentinel that cannot be resolved is reported in `failures`
+ * by env key + vault key ONLY — never any value, and never the underlying
+ * vault error (which could echo storage internals) — and the env key is
+ * omitted from the overlay, so downstream consumers see the connector as
+ * unconfigured instead of receiving the sentinel literal or a partial value.
+ *
+ * Non-sentinel entries are ignored here; the legacy plain-value path is
+ * responsible for them (backward compatible by construction — the `vault://`
+ * scheme is opt-in per value).
+ */
+export async function resolveConnectorSecretSettings(
+  connectorEnvVars: Record<string, string>,
+  vault: VaultLike,
+): Promise<{ resolved: Record<string, string>; failures: string[] }> {
+  const resolved: Record<string, string> = {};
+  const failures: string[] = [];
+  // Discord's token mirrors to two env keys from one vault entry — cache so
+  // one vault read (and one audit record) covers both aliases.
+  const cache = new Map<string, string | null>();
+
+  for (const [envKey, value] of Object.entries(connectorEnvVars)) {
+    if (!isVaultRef(value)) continue;
+    const vaultKey = parseVaultRef(value);
+    if (!vaultKey) {
+      failures.push(`${envKey} (malformed vault ref)`);
+      continue;
+    }
+    let secret = cache.get(vaultKey);
+    if (secret === undefined) {
+      try {
+        secret = (await vault.has(vaultKey)) ? await vault.get(vaultKey) : null;
+      } catch {
+        // Redacted on purpose: the caught error is dropped, not rethrown or
+        // stringified — key names are the only material that may surface.
+        secret = null;
+      }
+      cache.set(vaultKey, secret);
+    }
+    if (secret === null || secret.length === 0) {
+      failures.push(`${envKey} (vault://${vaultKey})`);
+      continue;
+    }
+    resolved[envKey] = secret;
+  }
+
+  return { resolved, failures };
+}
+
 /** Stable vault key for a provider API key. */
 export function vaultKeyForProviderApiKey(normalizedProvider: string): string {
   if (!normalizedProvider || normalizedProvider.includes(".")) {

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -8,6 +8,7 @@ import {
   collectConfigEnvVars,
   collectConnectorEnvVars,
 } from "../config/env-vars.ts";
+import { isVaultRef } from "./operations/vault-bridge.ts";
 
 export interface RuntimeSettingsProjectionOptions {
   preferredProviderId?: string;
@@ -17,6 +18,13 @@ export interface RuntimeSettingsProjectionOptions {
   workspaceSkillsDir?: string | null;
   walletSettings?: Record<string, string>;
   env?: NodeJS.ProcessEnv;
+  /**
+   * Connector secrets resolved from `vault://` refs at boot
+   * (see `resolveConnectorVaultOverlay` in eliza.ts). Delivered ONLY into the
+   * runtime settings map — never process.env — so `runtime.getSetting()` hands
+   * plugins the plaintext while the environment stays clean.
+   */
+  connectorSecretsOverlay?: Record<string, string>;
 }
 
 /**
@@ -67,7 +75,15 @@ export function buildRuntimeSettingsProjection(
         isEnvKeyAllowedForForwarding(key),
       ),
     ),
-    ...collectConnectorEnvVars(config),
+    // Drop unresolved `vault://` sentinels so a plugin never receives the ref
+    // literal as a credential; the resolved overlay below supplies the real
+    // value for refs the vault could serve (fail-closed for the rest).
+    ...Object.fromEntries(
+      Object.entries(collectConnectorEnvVars(config)).filter(
+        ([, value]) => !isVaultRef(value),
+      ),
+    ),
+    ...(options.connectorSecretsOverlay ?? {}),
     ...(options.preferredProviderId
       ? { MODEL_PROVIDER: options.preferredProviderId }
       : {}),


### PR DESCRIPTION
## Problem (audit gap #3, agent-boot lane)

`applyConnectorSecretsToEnv` (packages/agent/src/runtime/eliza.ts) mirrors every connector credential — including the Discord bot token — into `process.env` at boot. Anything in the environment leaks to child processes, co-tenant agents in the same process, and `/proc/<pid>/environ` readers. Core's own `getSetting()` invariant documents exactly why runtime settings must not round-trip through env, but connector secrets still did.

## Fix

Connector credentials may now be configured as `vault://<key>` refs — the **existing** sentinel scheme `operations/vault-bridge.ts` already defines for provider API keys (no new scheme invented). Refs resolve through `@elizaos/vault` into a **settings-only overlay**:

- `applyConnectorSecretsToEnv` + the Discord token alias mirror now **skip** vault refs — the ref literal and the resolved plaintext never touch `process.env`.
- New `resolveConnectorSecretSettings` (vault-bridge) resolves refs in the connector env projection; one vault read covers both `DISCORD_API_TOKEN`/`DISCORD_BOT_TOKEN` aliases.
- New `resolveConnectorSecretsOverlayForBoot` (eliza.ts) wires it into cold boot **and** the hot-reload restart path; the overlay feeds `buildRuntimeSettings` → `AgentRuntime.settings`, so plugins read the token via `runtime.getSetting("DISCORD_API_TOKEN")` exactly as today (plugin-discord already does — `plugins/plugin-discord/index.ts:76`).
- `autoResolveDiscordAppId` accepts a token override so the app-id prefetch works for vault-held tokens without env writes.

### Fail-closed + redaction
- Unresolvable / missing refs: the env key is omitted (connector appears unconfigured), failure strings carry **key names only** — vault backend errors are swallowed, never echoed, so no secret material or storage internals reach logs.
- Mobile / cloud-provisioned containers (vault unavailable): refs fail closed with a key-name-only error instead of half-resolving.
- Unresolved sentinels are also filtered out of the settings projection, so a plugin can never receive the literal `vault://…` string as a credential.

### Backward compatibility
Plain string values behave byte-for-byte as before (env mirror + settings). The scheme is opt-in by construction — no flag needed.

## Live-path proof

Production boot chain (verified on `develop` @ ea7ea2de5fd):
`eliza start` → `cli/index.ts:81 startEliza({serverOnly})` → `eliza.ts:3653 applyConnectorSecretsToEnv` (the env mirror, formerly unconditional) → `eliza.ts buildRuntimeSettings` → `AgentRuntime.settings` → `plugin-discord getSetting("DISCORD_API_TOKEN")`. Hot-reload repeats the mirror at the `onRestart` site; both are patched.

## Tests

`packages/agent/src/runtime/connector-vault-refs.test.ts` — 13 tests, bidirectional:
- ref resolves → settings carry plaintext, `process.env` asserted clean across every key **and** every env value
- plain value → legacy env mirror + settings unchanged
- missing/malformed ref → fail-closed, failure strings asserted to contain no secret and no vault-internal error text
- one vault read serves both Discord env aliases

`vitest run connector-vault-refs.test.ts` → 13/13 green; neighboring suites (eliza-cloud-config, eliza-database-config, build-character-config, plugin-collector-channel-map) → 33/33 green; `tsc --noEmit` clean; biome clean.

Companion lanes (separate PRs): Steward KMS routes, cloud provisioning env elimination, Soliza wiring.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend boot-path change (agent runtime settings/vault overlay); no rendered UI surface touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend boot-path change; no rendered UI surface touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the observable behavior is which values reach process.env and runtime settings, pinned by the boot-path tests below.
<!-- evidence-row:backend-logs -->
- [x] [17302-pr17302-local-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17302-pr17302-local-verify.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action/provider/prompt/model behavior changed; this gates which credential values reach plugin settings at boot.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact; the deliverable is the absence of vault:// literals and plaintext mirrors in process.env, asserted directly by the tests above.

