### PR TITLE
fix(app-control): keep explicit show/home navigation out of foreground capability inference

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-show-home.repro.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-show-home.repro.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Regression for #17299: an explicit VIEWS `show/home` request issued while
+ * Notes is the foreground view must execute Home navigation. It must never be
+ * rewritten into the foreground view's `get-notes` capability, which printed
+ * the user's note contents as a verified, turn-completing tool result.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createViewsAction } from "./views.js";
+import type { ViewSummary } from "./views-client.js";
+
+const coreMock = vi.hoisted(() => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+	ModelType: { TEXT_SMALL: "TEXT_SMALL" },
+	resolveServerOnlyPort: vi.fn(() => 3456),
+	formatError: (error: unknown): string =>
+		error instanceof Error ? error.message : String(error),
+	spawnWithTrajectoryLink: vi.fn(
+		async (
+			_runtime: unknown,
+			_source: unknown,
+			run: (trajectory: {
+				parentStepId: string;
+				linkChild: (sessionId: string) => Promise<void>;
+			}) => Promise<unknown>,
+		) => run({ parentStepId: "p1", linkChild: vi.fn(async () => {}) }),
+	),
+	hasOwnerAccess: vi.fn(async () => true),
+}));
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@elizaos/core")>();
+	return {
+		...coreMock,
+		ElizaError: actual.ElizaError,
+		findCodingDelegationActionName: actual.findCodingDelegationActionName,
+		getUserMessageText: actual.getUserMessageText,
+		resolveStateDir: actual.resolveStateDir,
+	};
+});
+
+function message(text: string, roomId = "room-1") {
+	return { entityId: "user-1", roomId, agentId: "agent-1", content: { text } };
+}
+
+function createRuntime() {
+	return {
+		runtime: {
+			agentId: "agent-1",
+			getSetting: vi.fn(() => undefined),
+			getTasks: vi.fn(async () => []),
+			createTask: vi.fn(async () => {}),
+			deleteTask: vi.fn(async () => {}),
+			useModel: vi.fn(async () => ""),
+		},
+	};
+}
+
+// Production-shape registry: the real plugin-simple-views Notes + Calendar
+// catalog entries (labels, tags, capability ids/descriptions) plus the builtin
+// chat/home surface.
+const notesView = (): ViewSummary =>
+	({
+		id: "notes",
+		label: "Notes",
+		viewType: "gui",
+		path: "/notes",
+		description:
+			"Durable notes that the user and agent can create, read, update, and delete.",
+		tags: ["notes", "notepad", "sticky notes", "scratchpad", "view switching"],
+		capabilities: [
+			{
+				id: "get-notes",
+				description: "List every sticky note as structured data.",
+			},
+			{ id: "get-note", description: "Read one sticky note by id." },
+			{ id: "create-note", description: "Create a durable sticky note." },
+			{
+				id: "update-note",
+				description: "Update one or more fields on a sticky note.",
+			},
+			{
+				id: "delete-note",
+				description:
+					"Delete one sticky note by id, exact title, or unique query.",
+			},
+		],
+	}) as unknown as ViewSummary;
+
+const calendarView = (): ViewSummary =>
+	({
+		id: "simple-calendar",
+		label: "Calendar",
+		viewType: "gui",
+		path: "/simple-calendar",
+		description:
+			"A durable Cloud calendar for agent-driven events and view switching.",
+		tags: [
+			"calendar",
+			"calender",
+			"simple calendar",
+			"events",
+			"schedule",
+			"view switching",
+		],
+		capabilities: [
+			{
+				id: "get-calendar-state",
+				description:
+					"Read selected date and calendar events as structured data.",
+			},
+		],
+	}) as unknown as ViewSummary;
+
+const chatView = (): ViewSummary =>
+	({
+		id: "chat",
+		label: "Chat",
+		viewType: "gui",
+		path: "/",
+		// Deliberately no "home" token anywhere: in the live repro the registry
+		// could not resolve "home" by id/label/tag/description, which is what
+		// forced the foreground-view fallback.
+		description: "Main chat.",
+		tags: ["chat"],
+		capabilities: [],
+	}) as unknown as ViewSummary;
+
+function makeAction(views: ViewSummary[]) {
+	const fetchMock = vi.fn(
+		async () =>
+			({
+				ok: true,
+				status: 200,
+				text: async () => "",
+				json: async () => ({
+					success: true,
+					result: {
+						text: "Check Twitter: Check Twitter 1x a day.",
+						success: true,
+					},
+				}),
+			}) as unknown as Response,
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	const action = createViewsAction({
+		client: {
+			listViews: vi.fn(async () => views),
+			getCurrentView: vi.fn(async () => ({
+				viewId: "notes",
+				viewLabel: "Notes",
+				viewType: "gui" as const,
+				viewPath: "/notes",
+			})),
+		},
+		hasOwnerAccess: vi.fn(async () => true),
+	});
+	return { action, fetchMock };
+}
+
+// The composed retrieval prompt shape some runtimes hand the action instead of
+// the raw user message. The contextual documents carry note-flavored text, so
+// token-overlap capability scoring is maximally tempted toward Notes.
+function composedPrompt(userRequest: string): string {
+	return [
+		"Answer the user request using the contextual documents below as the source of truth.",
+		"",
+		"<contextual_documents>",
+		'<source title="sticky notes" similarity="1.000">',
+		"Check Twitter: Check Twitter 1x a day. Sticky note wall notes list.",
+		"</source>",
+		"</contextual_documents>",
+		"",
+		"<user_request>",
+		userRequest,
+		"</user_request>",
+	].join("\n");
+}
+
+async function runCase(
+	text: string,
+	options: Record<string, unknown>,
+	views: ViewSummary[],
+) {
+	const { runtime } = createRuntime();
+	const callback = vi.fn();
+	const { action, fetchMock } = makeAction(views);
+	const result = (await action.handler(
+		runtime as never,
+		message(text) as never,
+		undefined,
+		options,
+		callback,
+	)) as { values?: Record<string, unknown>; text?: string };
+	return { result, fetchMock, callback };
+}
+
+describe("VIEWS show/home with Notes foreground (#17299)", () => {
+	const fullRegistry = () => [chatView(), notesView(), calendarView()];
+	const noHomeRegistry = () => [notesView(), calendarView()];
+
+	const cases: Array<{
+		name: string;
+		text: string;
+		options: Record<string, unknown>;
+		views: () => ViewSummary[];
+	}> = [
+		// Bidirectional-proof cases: these misrouted to notes:get-notes on
+		// develop before the fix (effectiveMode=interact,
+		// resolvedCapability=notes:get-notes).
+		{
+			name: "'show home' with explicit show/home target",
+			text: "show home",
+			options: { action: "show", view: "home" },
+			views: fullRegistry,
+		},
+		{
+			name: "'show home' with explicit target and no registered home view",
+			text: "show home",
+			options: { action: "show", view: "home" },
+			views: noHomeRegistry,
+		},
+		{
+			name: "composed retrieval prompt around 'go home'",
+			text: composedPrompt("go home"),
+			options: { action: "show", view: "home" },
+			views: fullRegistry,
+		},
+		// Guardrail cases: correct before and after; pinned so the routing seam
+		// cannot regress in the other direction.
+		{
+			name: "'go home' with explicit show/home target",
+			text: "go home",
+			options: { action: "show", view: "home" },
+			views: fullRegistry,
+		},
+		{
+			name: "'go home' with inferred target",
+			text: "go home",
+			options: { action: "show" },
+			views: fullRegistry,
+		},
+		{
+			name: "typo 'go homw' normalized by the planner to show/home",
+			text: "go homw",
+			options: { action: "show", view: "home" },
+			views: fullRegistry,
+		},
+	];
+
+	for (const testCase of cases) {
+		it(`${testCase.name} never invokes a Notes capability`, async () => {
+			const { result, fetchMock } = await runCase(
+				testCase.text,
+				testCase.options,
+				testCase.views(),
+			);
+			const interactCalls = fetchMock.mock.calls.filter(([url]) =>
+				String(url).includes("/interact"),
+			);
+			expect(interactCalls).toEqual([]);
+			expect(result?.values?.mode).not.toBe("interact");
+			expect(String(result?.text ?? "")).not.toContain("Check Twitter");
+		});
+	}
+
+	it("navigates to the registered chat view for show/home", async () => {
+		const { result, fetchMock } = await runCase(
+			"show home",
+			{ action: "show", view: "home" },
+			fullRegistry(),
+		);
+		expect(result?.values).toMatchObject({ mode: "show", viewId: "chat" });
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/chat/navigate",
+			expect.objectContaining({ method: "POST" }),
+		);
+	});
+
+	it("still reaches Notes through an explicit interact capability request", async () => {
+		const { result } = await runCase(
+			"show me my notes",
+			{ action: "interact", view: "notes", capability: "get-notes" },
+			fullRegistry(),
+		);
+		expect(result?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "get-notes",
+		});
+	});
+});

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -26,6 +26,7 @@ import {
 	STANDARD_CAPABILITIES,
 } from "@elizaos/shared";
 import { normalizeActionOptions, readStringOption } from "../params.js";
+import { matchViewCommand } from "./view-command-matcher.js";
 import {
 	createViewsClient,
 	parseViewInteractionResponse,
@@ -918,6 +919,15 @@ function isViewNavigationRequest(
 	) {
 		return true;
 	}
+	// "go home" / "home" / "show home" resolve to the chat/home surface in the
+	// rigid multilingual matcher. That surface is pure navigation (it exposes no
+	// capabilities), so a request that targets it can never be a foreground-view
+	// capability read (#17299).
+	if (matchViewCommand(viewRequestText(text)) === "chat") return true;
+	const explicitTarget = readViewTargetOption(options);
+	if (explicitTarget && matchViewCommand(explicitTarget) === "chat") {
+		return true;
+	}
 	if (
 		(mode === "show" || mode === "list") &&
 		/\b(view|views|app|apps|panel|panels|tab|tabs|window|windows)\b/i.test(
@@ -966,10 +976,14 @@ function resolveViewCapability({
 		!!explicitAction &&
 		(MODES as readonly string[]).includes(explicitAction.trim().toLowerCase());
 	const actionToken = actionIsMode ? null : explicitAction;
-	const requestedView = resolveViewTarget(readViewTargetOption(options), views);
+	const requestedTarget = readViewTargetOption(options);
+	const requestedView = resolveViewTarget(requestedTarget, views);
 	// A resolved planner target is authoritative. Foreground UI state is only a
-	// fallback for requests that do not identify a registered view.
-	const currentView = requestedView
+	// fallback for requests that name NO explicit target at all: a planner that
+	// names a target this deployment cannot resolve (e.g. show/home) must not
+	// have its request silently rebound to whatever view happens to be
+	// foregrounded (#17299).
+	const currentView = requestedTarget
 		? null
 		: (views.find((view) => view.id === currentViewId) ?? null);
 	const candidates = capabilityCandidates(views, viewType);


### PR DESCRIPTION
## Problem

#17299: with Notes foregrounded and exposing `get-notes`, an explicit VIEWS `{ action: "show", view: "home" }` was rewritten to `interact` against Notes. The result was marked `verifiedUserFacing`/`turnComplete`, so **go home** printed the user's note contents instead of navigating Home.

## Root cause

Two seams in `plugins/plugin-app-control/src/actions/views.ts`:

1. `isViewNavigationRequest` recognized `go to` but not `go home`/`show home`, so `shouldResolveModeAsCapability` still ran capability inference for an explicit `show` targeting the home surface.
2. `resolveViewCapability` treated a **named but unresolvable** planner target ("home" is a matcher alias, not a registry id) as if no target had been named. The foreground-view fallback then bound the request to Notes, and `get-notes` cleared the score threshold, flipping `effectiveMode` to `interact` before `runViewsShow`'s canonical Home matcher (`SHARED_NAV_TARGETS`) could run.

## Fix

- A text or explicit target the rigid multilingual matcher resolves to the chat/home surface is always classified as navigation. That surface exposes no capabilities, so such a request can never be a foreground capability read.
- The foreground-view fallback in `resolveViewCapability` now requires that the planner named no target at all. A named-but-unresolvable target no longer silently rebinds to the foregrounded view.

Focused diff: 17 insertions / 3 deletions in `views.ts`, plus the regression suite.

## Bidirectional proof

Regression tests use the production-shape `plugin-simple-views` Notes/Calendar catalog entries (real labels, tags, capability ids) with Notes reported as the current view, matching the live repro.

On develop (ea7ea2de5fd), 4 of 8 cases fail with the exact live misroute (`effectiveMode=interact resolvedCapability=notes:get-notes`):
- `show home` + explicit `show/home` target (registered chat view)
- `show home` + explicit target with **no** registered home view
- composed retrieval-prompt shape around `go home`
- the `show/home` → chat navigation assertion

With the fix, all 8 pass. Guardrails pinned:
- `go home", `go homw` (planner-normalized typo), inferred-target `show` still navigate
- `show/home` navigates to the registered chat view via `/api/views/chat/navigate`
- explicit `interact` + `capability: get-notes` against Notes still works

## Acceptance criteria from #17299

- [x] Current view Notes + `get-notes` + explicit `show/home` navigates Home and never calls Notes `/interact`
- [x] `go home", `home` alias, and planner-normalized typo follow that path
- [x] Structured `show` target authority cannot be overwritten by stale foreground-view capability inference
- [x] Genuine Notes reads still work through explicit `interact`/capability requests
- [x] Focused regression suite with bidirectional proof (4 red on develop → 8 green with fix)

## Verification

- `bunx vitest run` in `plugins/plugin-app-control`: 47 files, 1581 tests, all green
- `tsc --noEmit`: clean (module-resolution noise from unbuilt sibling packages resolved by building logger/contracts/cloud-routing first, same as `prebuild`)
- Biome check: clean

## Evidence rows

- UI screenshots/video: N/A — action-routing seam, no rendered UI change; the issue's transcript documents the wrong behavior and the regression test pins the repaired route.
- Real-LLM trajectory: N/A — the fix is below the planner; the tests replay the exact tool input the live trajectory recorded (`{action:"show", view:"home"}`).
- Backend logs: the regression tests assert on the same `requestedMode/effectiveMode/resolvedCapability` log line the issue captured.

Closes #17299

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - action-routing seam in plugin-app-control; no rendered UI change. The issue transcript documents the wrong behavior.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; the regression suite pins the repaired route.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend action routing only.

<!-- evidence-row:backend-logs -->
- [x] N/A - the regression tests assert on the exact requestedMode/effectiveMode/resolvedCapability log line the issue captured (4 red on develop ea7ea2de5fd, 8 green with the fix).

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path involved.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - fix is below the planner; the tests replay the exact recorded tool input {action:"show", view:"home"} from the issue trajectory.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - vitest bidirectional proof in the PR description: 4 failed on develop, 8 passed with fix; full plugin suite 1581/1581 green.
