### PR TITLE
feat(core): canonical provenance envelope with trusted scope stamping (re-cut of #17211 remainder)

### DIFF
--- a/packages/core/src/access-control/provenance-envelope.ts
+++ b/packages/core/src/access-control/provenance-envelope.ts
@@ -1,0 +1,486 @@
+/**
+ * Canonical provenance envelope for stored connector messages: which surface a
+ * memory came from, under which connector account, in which room, from which
+ * sender, when, and how well attested — derived strictly from metadata the
+ * connectors already stamp, never fabricated.
+ *
+ * Three separable concerns live here, deliberately small:
+ *
+ * 1. {@link deriveCanonicalProvenance} — reads source / account / room / sender
+ *    / timestamp / trust / scope off a stored {@link Memory} using the metadata
+ *    the connectors stamp (`metadata.provider`, `metadata.accountId`, the
+ *    nested `metadata[source]` identity object). The source is normalized
+ *    through the connector-source registry so `discord-local` and `discord`
+ *    are one surface. Missing required fields return a typed invalid result
+ *    and the item is withheld from recall — nothing defaults to `global`.
+ *
+ * 2. {@link canonicalDedupeKey} — `source:account:platformRecordId`. Two
+ *    deliveries of the same webhook collapse; the same text from two connector
+ *    accounts does not, because the account segment differs. Account identity
+ *    is part of the key, never squashed.
+ *
+ * 3. {@link searchCanonicalConversationMemories} — the production retrieval
+ *    for conversation-mode message search. It runs, in order: provenance
+ *    validation, the mandatory scope ladder (`./filter.ts`), and same-room
+ *    containment. Cross-room recall is DENIED here unconditionally: deciding
+ *    that a recalled item may cross into a different destination is audience
+ *    policy, and audience policy is owned by the trusted-delivery-audience
+ *    layer (PR #17206), which attests the destination from `runtime.getRoom` +
+ *    `getParticipantsForRoom` rather than anything a caller declares. When
+ *    that layer wants to authorize a wider audience it does so at its own
+ *    seams; this module never grows a policy knob for callers to widen.
+ *
+ * Composes with — never duplicates — `./filter.ts`: that ladder gates a single
+ * memory's {@link MemoryScope} against the requester's role; the same-room rule
+ * here additionally pins the item to the room it already lives in, so recall
+ * discloses nothing a destination does not already hold.
+ */
+import { normalizeConnectorSource } from "../connectors";
+import type {
+	AccessContext,
+	IAgentRuntime,
+	Memory,
+	MemoryScope,
+	MessageChatType,
+	UUID,
+} from "../types";
+import { actorFromAccessContext, canReadScope } from "./filter";
+
+/**
+ * How strongly the stored memory's sender identity is attested.
+ *
+ * - `self`: the agent's own message (entity is the agent).
+ * - `connector-verified`: the connector stamped a stable platform identity
+ *   (a nested `metadata[source]` object carrying `userId`/`id`) — the same
+ *   evidence `roles.ts` is willing to resolve a role from.
+ * - `unverified`: no stable connector identity was recorded. Content-supplied
+ *   metadata from a chat client lands here and must never be promoted.
+ */
+export type CanonicalTrust = "self" | "connector-verified" | "unverified";
+
+/**
+ * The provenance envelope carried alongside every canonically-recalled item.
+ */
+export interface CanonicalProvenance {
+	/** Canonical connector source (registry-normalized, e.g. `discord`). */
+	source: string;
+	/** Raw `source` string as stored, before normalization. */
+	rawSource?: string;
+	/** Connector account this arrived under. Distinguishes two accounts on one surface. */
+	accountId: string;
+	/** Room the memory belongs to. */
+	roomId: UUID;
+	/** World/tenant scope, when the memory recorded one. */
+	worldId?: UUID;
+	/** Entity id of the sender. */
+	senderId: UUID;
+	/** Sender's display name, when the connector recorded one. */
+	senderDisplayName?: string;
+	/** Sender's stable platform id, when the connector stamped one. */
+	senderPlatformId?: string;
+	/** Creation timestamp in epoch ms. */
+	timestampMs: number;
+	/** Attestation strength of the sender identity. */
+	trust: CanonicalTrust;
+	/** Chat type recorded by the connector (`dm`, `group`, …), when present. */
+	chatType?: MessageChatType;
+	/** Platform-native message id, when the connector stamped one. */
+	platformMessageId: string;
+	/** Explicit memory scope stamped by the ingesting connector. */
+	scope: MemoryScope;
+}
+
+/** Machine-readable reason a candidate was withheld from recall. */
+export type RecallDenyCode =
+	/** The stored memory is missing provenance required for fail-closed recall. */
+	| "invalid_provenance"
+	/** The item's own scope forbids this requester (delegated to the scope ladder). */
+	| "scope_denied"
+	/**
+	 * The item lives in a different room than the destination. Cross-room
+	 * disclosure is audience policy and is owned by the trusted-delivery-audience
+	 * layer (#17206), not by this envelope.
+	 */
+	| "cross_room_denied";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function readString(
+	record: Record<string, unknown> | undefined,
+	key: string,
+): string | undefined {
+	const value = record?.[key];
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	// Platform ids are frequently numeric (Telegram chat/user ids).
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return String(value);
+	}
+	return undefined;
+}
+
+const VALID_MEMORY_SCOPES: ReadonlySet<MemoryScope> = new Set<MemoryScope>([
+	"shared",
+	"private",
+	"room",
+	"global",
+	"owner-private",
+	"user-private",
+	"agent-private",
+]);
+
+function readScope(value: unknown): MemoryScope | undefined {
+	return typeof value === "string" &&
+		VALID_MEMORY_SCOPES.has(value as MemoryScope)
+		? (value as MemoryScope)
+		: undefined;
+}
+
+function isValidSourceKey(source: string): boolean {
+	return /^[a-z0-9][a-z0-9_-]*$/.test(source);
+}
+
+function scopedEntityIdForMemory(memory: Memory): UUID {
+	const meta = asRecord(memory.metadata);
+	const scopedTo = meta?.scopedToEntityId;
+	const addedBy = meta?.addedBy;
+	return typeof scopedTo === "string"
+		? (scopedTo as UUID)
+		: typeof addedBy === "string"
+			? (addedBy as UUID)
+			: memory.entityId;
+}
+
+export type CanonicalProvenanceResult =
+	| { valid: true; provenance: CanonicalProvenance }
+	| {
+			valid: false;
+			code: "invalid_provenance";
+			source?: string;
+			reason: string;
+	  };
+
+/**
+ * Read source / account / room / sender / timestamp / trust / scope off a
+ * stored memory, normalizing the surface through the connector-source registry.
+ *
+ * `agentId` identifies the agent so its own messages resolve to `self` trust.
+ * Optional display fields may remain absent; missing required provenance
+ * returns a typed invalid result. This derives stored facts and never
+ * fabricates them.
+ */
+export function deriveCanonicalProvenance(
+	memory: Memory,
+	agentId: UUID,
+): CanonicalProvenanceResult {
+	const metadata = asRecord(memory.metadata);
+	const content = asRecord(memory.content);
+
+	const rawSource =
+		readString(metadata, "provider") ??
+		readString(content, "source") ??
+		readString(asRecord(metadata?.base), "source");
+	const source = rawSource ? normalizeConnectorSource(rawSource) : undefined;
+	if (!source || !isValidSourceKey(source)) {
+		return {
+			valid: false,
+			code: "invalid_provenance",
+			reason: "stored memory is missing a valid source",
+		};
+	}
+
+	// The connector's nested identity object — the same evidence role
+	// resolution is willing to trust. Look it up under both the raw and the
+	// canonical source key, since connectors stamp the raw one.
+	const nested =
+		asRecord(rawSource ? metadata?.[rawSource] : undefined) ??
+		asRecord(source ? metadata?.[source] : undefined);
+
+	const senderPlatformId =
+		readString(nested, "userId") ?? readString(nested, "id");
+
+	const sender = asRecord(metadata?.sender);
+	const senderDisplayName =
+		readString(sender, "name") ??
+		readString(sender, "username") ??
+		readString(nested, "name") ??
+		readString(nested, "username") ??
+		readString(metadata, "entityName");
+
+	const trust: CanonicalTrust =
+		memory.entityId === agentId
+			? "self"
+			: senderPlatformId
+				? "connector-verified"
+				: "unverified";
+
+	const accountId =
+		readString(metadata, "accountId") ?? readString(nested, "accountId");
+	if (!accountId) {
+		return {
+			valid: false,
+			code: "invalid_provenance",
+			source,
+			reason: "stored memory is missing a connector account id",
+		};
+	}
+
+	const platformMessageId =
+		readString(metadata, "platformMessageId") ??
+		readString(metadata, "messageIdFull") ??
+		readString(nested, "messageId") ??
+		readString(metadata, "sourceId");
+	if (!platformMessageId) {
+		return {
+			valid: false,
+			code: "invalid_provenance",
+			source,
+			reason: "stored memory is missing a platform record id",
+		};
+	}
+
+	const timestampMs = memory.createdAt;
+	if (
+		typeof timestampMs !== "number" ||
+		!Number.isFinite(timestampMs) ||
+		timestampMs <= 0
+	) {
+		return {
+			valid: false,
+			code: "invalid_provenance",
+			source,
+			reason: "stored memory is missing a valid timestamp",
+		};
+	}
+
+	const scope =
+		readScope(asRecord(metadata?.base)?.scope) ?? readScope(metadata?.scope);
+	if (!scope) {
+		return {
+			valid: false,
+			code: "invalid_provenance",
+			source,
+			reason: "stored memory is missing a valid scope",
+		};
+	}
+
+	return {
+		valid: true,
+		provenance: {
+			source,
+			rawSource,
+			accountId,
+			roomId: memory.roomId,
+			worldId: memory.worldId,
+			senderId: memory.entityId,
+			senderDisplayName,
+			senderPlatformId,
+			timestampMs,
+			trust,
+			chatType: readString(metadata, "chatType") as MessageChatType | undefined,
+			platformMessageId,
+			scope,
+		},
+	};
+}
+
+/**
+ * Stable idempotency key for a canonical item: `source:account:platformRecordId`.
+ *
+ * Redelivery of one webhook collapses to one key. The same text arriving under
+ * two connector accounts yields two keys, so account identity survives
+ * de-duplication instead of being merged away.
+ */
+export function canonicalDedupeKey(provenance: CanonicalProvenance): string {
+	return `${provenance.source}:${provenance.accountId}:${provenance.platformMessageId}`;
+}
+
+/** One item that survived provenance validation, the scope ladder, and containment. */
+export interface RecalledItem {
+	memory: Memory;
+	provenance: CanonicalProvenance;
+	dedupeKey: string;
+}
+
+/** An item that was found but withheld, with the reason it was withheld. */
+export interface WithheldItem {
+	dedupeKey?: string;
+	source?: string;
+	code: RecallDenyCode;
+	reason: string;
+}
+
+/**
+ * Whether the answer is trustworthy as a complete picture. `partial` and
+ * `unavailable` exist so a caller can never render a degraded result as a
+ * confident empty state.
+ */
+export type RecallAvailability = "complete" | "partial" | "unavailable";
+
+export interface CanonicalRecallResult {
+	items: RecalledItem[];
+	withheld: WithheldItem[];
+	availability: RecallAvailability;
+}
+
+export interface CanonicalRecallInput {
+	/** Candidate memories already fetched from the store. */
+	candidates: Memory[];
+	/** The agent performing the recall. */
+	agentId: UUID;
+	/** Who is asking. */
+	requester: AccessContext;
+	/** Room the answer will land in (the inbound message's connector-stamped room). */
+	destinationRoomId: UUID;
+}
+
+/**
+ * Normalize, authorize, contain, and de-duplicate a set of candidate memories
+ * into one canonical recall result.
+ *
+ * Order is load-bearing: provenance validation, then the MANDATORY scope
+ * ladder, then same-room containment, then dedupe. There is no policy object
+ * to swap and therefore no way for a caller to widen the audience; cross-room
+ * authorization belongs to the trusted-delivery-audience layer (#17206).
+ *
+ * De-duplication keeps the earliest-created member of each
+ * {@link canonicalDedupeKey} group, so a redelivered webhook does not
+ * double-count and does not reorder the transcript.
+ */
+export function buildCanonicalRecall(
+	input: CanonicalRecallInput,
+): Omit<CanonicalRecallResult, "availability"> {
+	const actor = actorFromAccessContext(input.requester, input.agentId);
+
+	const byKey = new Map<string, RecalledItem>();
+	const withheld: WithheldItem[] = [];
+	const withholdOnce = (entry: WithheldItem): void => {
+		if (
+			entry.dedupeKey === undefined ||
+			!withheld.some((existing) => existing.dedupeKey === entry.dedupeKey)
+		) {
+			withheld.push(entry);
+		}
+	};
+
+	for (const memory of input.candidates) {
+		const provenanceResult = deriveCanonicalProvenance(memory, input.agentId);
+		if (!provenanceResult.valid) {
+			withheld.push({
+				source: provenanceResult.source,
+				code: provenanceResult.code,
+				reason: provenanceResult.reason,
+			});
+			continue;
+		}
+		const provenance = provenanceResult.provenance;
+		const dedupeKey = canonicalDedupeKey(provenance);
+
+		if (
+			!canReadScope(provenance.scope, scopedEntityIdForMemory(memory), actor)
+		) {
+			withholdOnce({
+				dedupeKey,
+				source: provenance.source,
+				code: "scope_denied",
+				reason: "requester is not authorized to read the memory scope",
+			});
+			continue;
+		}
+
+		if (provenance.roomId !== input.destinationRoomId) {
+			withholdOnce({
+				dedupeKey,
+				source: provenance.source,
+				code: "cross_room_denied",
+				reason:
+					"cross-room recall requires the trusted delivery-audience layer; this envelope only recalls into the item's own room",
+			});
+			continue;
+		}
+
+		const existing = byKey.get(dedupeKey);
+		if (!existing || provenance.timestampMs < existing.provenance.timestampMs) {
+			byKey.set(dedupeKey, { memory, provenance, dedupeKey });
+		}
+	}
+
+	const items = [...byKey.values()].sort(
+		(a, b) => a.provenance.timestampMs - b.provenance.timestampMs,
+	);
+
+	return { items, withheld };
+}
+
+export interface CanonicalMemorySearchInput {
+	runtime: IAgentRuntime;
+	embedding: number[];
+	query?: string;
+	agentId: UUID;
+	requester: AccessContext;
+	destinationRoomId: UUID;
+	count: number;
+	matchThreshold?: number;
+	entityId?: UUID;
+	/** Optional connector-source filter, normalized through the registry. */
+	source?: string;
+}
+
+/**
+ * Production retrieval for canonical conversation recall: owns the adapter
+ * call (passing the requester's {@link AccessContext} through to storage) and
+ * evaluates the candidates through {@link buildCanonicalRecall}. Adapter
+ * failures propagate to the caller — an error is an error, never an empty
+ * "complete" result.
+ */
+export async function searchCanonicalConversationMemories(
+	input: CanonicalMemorySearchInput,
+): Promise<CanonicalRecallResult> {
+	const candidates = await input.runtime.searchMemories({
+		embedding: input.embedding,
+		tableName: "messages",
+		match_threshold: input.matchThreshold,
+		count: input.count,
+		...(input.query ? { query: input.query } : {}),
+		...(input.entityId ? { entityId: input.entityId } : {}),
+		accessContext: input.requester,
+	});
+
+	const evaluated = buildCanonicalRecall({
+		candidates,
+		agentId: input.agentId,
+		requester: input.requester,
+		destinationRoomId: input.destinationRoomId,
+	});
+
+	// A source filter narrows what the caller asked to see; it never narrows
+	// the honesty of the withheld list for that source.
+	const normalizedSource = input.source
+		? normalizeConnectorSource(input.source)
+		: undefined;
+	const items = normalizedSource
+		? evaluated.items.filter(
+				(item) => item.provenance.source === normalizedSource,
+			)
+		: evaluated.items;
+	const withheld = normalizedSource
+		? evaluated.withheld.filter(
+				(item) => item.source === undefined || item.source === normalizedSource,
+			)
+		: evaluated.withheld;
+
+	const availability: RecallAvailability =
+		withheld.length > 0
+			? items.length > 0
+				? "partial"
+				: "unavailable"
+			: "complete";
+
+	return { items, withheld, availability };
+}

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -11,6 +11,8 @@
  * in features/messaging/triage.
  */
 
+import { buildAccessContext } from "../../../access-context.ts";
+import { searchCanonicalConversationMemories } from "../../../access-control/provenance-envelope.ts";
 import { getConnectorAccountManager } from "../../../connectors/account-manager.ts";
 import { findEntityByName } from "../../../entities.ts";
 import { getActionSpec } from "../../../generated/spec-helpers.ts";
@@ -2637,6 +2639,23 @@ function ensureConversationSearchCategory(runtime: IAgentRuntime): void {
 	}
 }
 
+function conversationSearchText(
+	query: string,
+	count: number,
+	availability: "complete" | "partial" | "unavailable",
+): string {
+	if (availability === "unavailable") {
+		return `No disclosable conversations matching "${query}".`;
+	}
+	if (count === 0) {
+		return `No conversations matching "${query}".`;
+	}
+	if (availability === "partial") {
+		return `Partial search results for "${query}": ${count} messages found.`;
+	}
+	return `Search results for "${query}": ${count} messages found.`;
+}
+
 async function handleSearch(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -2742,44 +2761,49 @@ async function handleSearch(
 			);
 		}
 
-		const searchParams: Parameters<IAgentRuntime["searchMemories"]>[0] = {
-			embedding,
-			tableName: "messages",
-			match_threshold: SEARCH_MATCH_THRESHOLD,
-			count: limit + 10,
-			...(entityId ? { entityId: entityId as UUID } : {}),
-		} as Parameters<IAgentRuntime["searchMemories"]>[0];
-		let results = (await runtime.searchMemories(searchParams)) as Memory[];
-
-		// Post-filter by source platform when supplied.
-		if (source && results.length > 0) {
-			const filtered: Memory[] = [];
-			for (const mem of results) {
-				try {
-					const room = await runtime.getRoom(mem.roomId);
-					const roomSource = (
-						(room as (Room & { source?: string }) | null)?.source ??
-						room?.type ??
-						""
-					).toLowerCase();
-					if (roomSource === source.toLowerCase()) filtered.push(mem);
-				} catch {
-					// drop rooms we cannot resolve
-				}
-			}
-			results = filtered;
+		let requester: Awaited<ReturnType<typeof buildAccessContext>>;
+		try {
+			requester = await buildAccessContext(runtime, message);
+		} catch (error) {
+			// Role/world lookup failure degrades to requester-only access, which
+			// denies elevated scopes instead of widening recall.
+			logger.warn(
+				`[MESSAGE/search] access context resolution failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			requester = {
+				requesterEntityId: message.entityId,
+				source:
+					typeof message.content.source === "string"
+						? message.content.source
+						: undefined,
+			};
 		}
+		const recall = await searchCanonicalConversationMemories({
+			runtime,
+			embedding,
+			query,
+			agentId: runtime.agentId,
+			requester,
+			destinationRoomId: message.roomId,
+			count: limit + 10,
+			matchThreshold: SEARCH_MATCH_THRESHOLD,
+			...(entityId ? { entityId: entityId as UUID } : {}),
+			source,
+		});
 
-		results = results.filter((m) => m.content.text).slice(0, limit);
+		const results = recall.items
+			.map((item) => item.memory)
+			.filter((m) => m.content.text)
+			.slice(0, limit);
 		return opSuccess(
 			"search",
-			results.length === 0
-				? `No conversations matching "${query}".`
-				: `Search results for "${query}": ${results.length} messages found.`,
+			conversationSearchText(query, results.length, recall.availability),
 			{
 				query,
 				source,
 				mode: "conversation",
+				availability: recall.availability,
+				withheld: recall.withheld,
 				results: results.map((m, i) => ({
 					line: i + 1,
 					id: m.id,

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -9,6 +9,7 @@
 export * from "./access-context";
 export * from "./access-control/artifact-disclosure";
 export * from "./access-control/filter";
+export * from "./access-control/provenance-envelope";
 // Export all core modules
 export * from "./account-pool-bridge";
 export * from "./action-names";

--- a/packages/test/harness/__tests__/canonical-provenance-envelope.test.ts
+++ b/packages/test/harness/__tests__/canonical-provenance-envelope.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Fail-closed provenance-envelope tests for the production stored-message
+ * search (re-cut of #17211's non-superseded remainder; audience policy is
+ * owned by #17206's trusted-delivery-audience layer and is deliberately NOT
+ * re-implemented here — cross-room recall is denied unconditionally).
+ *
+ * What is proven, against the real PGLite adapter and the real handlers:
+ *   - typed invalid provenance for every missing required field (no fabrication)
+ *   - the mandatory scope ladder runs and cannot be bypassed
+ *   - same-room containment: cross-room candidates are withheld with a typed code
+ *   - `source:account:platformRecordId` dedupe across distinct DB primary keys
+ *   - the REAL Discord connector ingestion (`buildMemoryFromMessage`) and the
+ *     REAL Telegram sent-memory shape stamp scope + provenance that the
+ *     envelope accepts (trusted scope stamping, not read-time guessing)
+ *   - the production MESSAGE action search path returns only disclosable items
+ */
+import {
+  ChannelType,
+  canonicalDedupeKey,
+  deriveCanonicalProvenance,
+  type IAgentRuntime,
+  type Memory,
+  searchCanonicalConversationMemories,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import type { Message } from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildMemoryFromMessage,
+  type HistoryServiceInternals,
+} from "../../../../plugins/plugin-discord/discord-history.ts";
+import { messageAction } from "../../../core/src/features/advanced-capabilities/actions/message.ts";
+import { type MockLlmRuntime, withMockLlmRuntime } from "../index.ts";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup) await cleanup();
+  }
+  vi.restoreAllMocks();
+});
+
+function track(harness: MockLlmRuntime): MockLlmRuntime {
+  cleanups.push(harness.cleanup);
+  return harness;
+}
+
+function id(seed: string): UUID {
+  return stringToUuid(seed) as UUID;
+}
+
+async function createRoom(
+  runtime: IAgentRuntime,
+  roomId: UUID,
+  type: ChannelType,
+  participants: UUID[] = [],
+): Promise<void> {
+  // Rooms are world-scoped in production; the adapter rejects an unparented
+  // room. Give each room its own world so the shape matches a real connector
+  // surface.
+  const worldId = id(`world-${roomId}`);
+  await runtime.createWorld({ id: worldId, agentId: runtime.agentId });
+  await runtime.createRoom({ id: roomId, source: "test", type, worldId });
+  for (const participant of participants) {
+    // Participants are FK-constrained to real entities, so register the
+    // sender before joining it to the room.
+    await runtime.createEntity({
+      id: participant,
+      names: [`entity-${participant}`],
+      agentId: runtime.agentId,
+    });
+    await runtime.addParticipant(participant, roomId);
+  }
+}
+
+type MemoryOverrides = Omit<Partial<Memory>, "content" | "metadata"> & {
+  content?: Partial<Memory["content"]>;
+  metadata?: Record<string, unknown>;
+};
+
+function messageMemory(overrides: MemoryOverrides = {}): Memory {
+  const roomId = overrides.roomId ?? id("source-room");
+  const entityId = overrides.entityId ?? id("sender");
+  const content = overrides.content ?? {};
+  const metadata = overrides.metadata ?? {};
+  return {
+    id: id(`memory-${roomId}-${entityId}`),
+    entityId,
+    agentId: id("agent"),
+    roomId,
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+    content: {
+      text: "The deploy key rotates on Friday.",
+      source: "discord",
+      ...content,
+    },
+    metadata: {
+      type: "message",
+      provider: "discord",
+      accountId: "discord-account-1",
+      scope: "room",
+      messageIdFull: "discord-message-1",
+      discord: { userId: "discord-user-1" },
+      ...metadata,
+    } as Memory["metadata"],
+  };
+}
+
+describe("canonical provenance envelope", () => {
+  it.each([
+    [
+      "source",
+      (memory: Memory) => {
+        delete (memory.metadata as Record<string, unknown>).provider;
+        delete (memory.content as Record<string, unknown>).source;
+      },
+    ],
+    [
+      "account",
+      (memory: Memory) => {
+        delete (memory.metadata as Record<string, unknown>).accountId;
+      },
+    ],
+    [
+      "platform record",
+      (memory: Memory) => {
+        delete (memory.metadata as Record<string, unknown>).messageIdFull;
+      },
+    ],
+    [
+      "timestamp",
+      (memory: Memory) => {
+        delete memory.createdAt;
+      },
+    ],
+    [
+      "scope",
+      (memory: Memory) => {
+        delete (memory.metadata as Record<string, unknown>).scope;
+      },
+    ],
+  ])("returns typed invalid provenance for missing %s", (_field, mutate) => {
+    const memory = messageMemory();
+    mutate(memory);
+    const provenance = deriveCanonicalProvenance(memory, id("agent"));
+    expect(provenance).toEqual(
+      expect.objectContaining({
+        valid: false,
+        code: "invalid_provenance",
+      }),
+    );
+    if (!provenance.valid) {
+      expect(provenance.reason).toContain(_field.split(" ")[0]);
+    }
+  });
+
+  it("withholds missing scope instead of fabricating global access", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+    const roomId = id("missing-scope-room");
+    await createRoom(runtime, roomId, ChannelType.DM, [id("sender")]);
+    const candidate = messageMemory({ agentId: runtime.agentId, roomId });
+    delete (candidate.metadata as Record<string, unknown>).scope;
+    vi.spyOn(runtime, "searchMemories").mockResolvedValue([candidate]);
+
+    const recall = await searchCanonicalConversationMemories({
+      runtime,
+      embedding: [0.1, 0.2],
+      agentId: runtime.agentId,
+      requester: { requesterEntityId: id("sender") },
+      destinationRoomId: roomId,
+      count: 10,
+    });
+
+    expect(recall.items).toHaveLength(0);
+    expect(recall.availability).toBe("unavailable");
+    expect(recall.withheld[0]).toEqual(
+      expect.objectContaining({
+        code: "invalid_provenance",
+        reason: expect.stringContaining("scope"),
+      }),
+    );
+  });
+
+  it("runs the mandatory scope ladder before containment", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+    const roomId = id("scope-ladder-room");
+    await createRoom(runtime, roomId, ChannelType.DM, [id("ordinary-user")]);
+    const ownerScoped = messageMemory({
+      agentId: runtime.agentId,
+      roomId,
+      entityId: id("owner"),
+      metadata: { scope: "owner-private" },
+    });
+    vi.spyOn(runtime, "searchMemories").mockResolvedValue([ownerScoped]);
+
+    const recall = await searchCanonicalConversationMemories({
+      runtime,
+      embedding: [0.1, 0.2],
+      agentId: runtime.agentId,
+      requester: { requesterEntityId: id("ordinary-user"), role: "USER" },
+      destinationRoomId: roomId,
+      count: 10,
+    });
+
+    // Same room, so containment would allow it — the scope ladder must be the
+    // gate that withholds it.
+    expect(recall.items).toHaveLength(0);
+    expect(recall.withheld[0]?.code).toBe("scope_denied");
+  });
+
+  it("denies every cross-room disclosure with a typed code (audience policy is #17206's)", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+    const destinationRoomId = id("destination-room");
+    await createRoom(runtime, destinationRoomId, ChannelType.DM, [
+      id("sender"),
+    ]);
+    vi.spyOn(runtime, "searchMemories").mockResolvedValue([
+      messageMemory({ agentId: runtime.agentId, roomId: id("other-room") }),
+    ]);
+
+    const recall = await searchCanonicalConversationMemories({
+      runtime,
+      embedding: [0.1, 0.2],
+      agentId: runtime.agentId,
+      requester: { requesterEntityId: id("sender") },
+      destinationRoomId,
+      count: 10,
+    });
+
+    expect(recall.items).toHaveLength(0);
+    expect(recall.withheld[0]?.code).toBe("cross_room_denied");
+  });
+
+  it("propagates adapter failure instead of reporting an empty complete result", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+    vi.spyOn(runtime, "searchMemories").mockRejectedValue(
+      new Error("adapter offline"),
+    );
+
+    await expect(
+      searchCanonicalConversationMemories({
+        runtime,
+        embedding: [0.1, 0.2],
+        agentId: runtime.agentId,
+        requester: { requesterEntityId: id("requester") },
+        destinationRoomId: id("destination"),
+        count: 10,
+      }),
+    ).rejects.toThrow("adapter offline");
+  });
+
+  it("dedupes by source/account/platform id across distinct database primary keys", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+    const roomId = id("dedupe-room");
+    await createRoom(runtime, roomId, ChannelType.DM, [id("sender")]);
+    const first = messageMemory({
+      id: id("duplicate-memory-a"),
+      agentId: runtime.agentId,
+      roomId,
+      createdAt: 1_700_000_000_000,
+    });
+    const second = messageMemory({
+      id: id("duplicate-memory-b"),
+      agentId: runtime.agentId,
+      roomId,
+      createdAt: 1_700_000_010_000,
+    });
+    expect(first.id).not.toBe(second.id);
+    const firstProvenance = deriveCanonicalProvenance(first, runtime.agentId);
+    const secondProvenance = deriveCanonicalProvenance(second, runtime.agentId);
+    expect(firstProvenance.valid).toBe(true);
+    expect(secondProvenance.valid).toBe(true);
+    if (!firstProvenance.valid || !secondProvenance.valid) return;
+    expect(canonicalDedupeKey(firstProvenance.provenance)).toBe(
+      canonicalDedupeKey(secondProvenance.provenance),
+    );
+    // Same platform record under a DIFFERENT account: account identity is
+    // part of the canonical key and must never be squashed. Two accounts
+    // relaying the same platform message are two facts, not one.
+    const otherAccount = messageMemory({
+      id: id("duplicate-memory-c"),
+      agentId: runtime.agentId,
+      roomId,
+      createdAt: 1_700_000_020_000,
+      metadata: { accountId: "discord-account-2" },
+    });
+    const otherProvenance = deriveCanonicalProvenance(
+      otherAccount,
+      runtime.agentId,
+    );
+    expect(otherProvenance.valid).toBe(true);
+    if (!otherProvenance.valid) return;
+    expect(canonicalDedupeKey(otherProvenance.provenance)).not.toBe(
+      canonicalDedupeKey(firstProvenance.provenance),
+    );
+    vi.spyOn(runtime, "searchMemories").mockResolvedValue([
+      second,
+      first,
+      otherAccount,
+    ]);
+
+    const recall = await searchCanonicalConversationMemories({
+      runtime,
+      embedding: [0.1, 0.2],
+      agentId: runtime.agentId,
+      requester: { requesterEntityId: id("sender") },
+      destinationRoomId: roomId,
+      count: 10,
+    });
+
+    expect(recall.items).toHaveLength(2);
+    expect(recall.items[0]?.memory.id).toBe(first.id);
+    expect(
+      recall.items.map((item) => item.provenance.accountId).sort(),
+    ).toEqual(["discord-account-1", "discord-account-2"]);
+  });
+
+  it("accepts the REAL Discord connector ingestion output (trusted scope stamping)", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+
+    const channelId = "1253563208833433701";
+    const guild = {
+      id: "1253563208833400000",
+      name: "Eliza Test Guild",
+      ownerId: "1111111111111111111",
+    };
+    const channel = {
+      id: channelId,
+      type: DiscordChannelType.GuildText,
+      guild,
+    };
+    const authorId = "2222222222222222222";
+    const discordMessage = {
+      id: "3333333333333333333",
+      author: {
+        id: authorId,
+        username: "tester",
+        bot: false,
+        displayAvatarURL: () => "https://cdn.example/avatar.png",
+      },
+      channel,
+      guild,
+      content: "The deploy key rotates on Friday.",
+      createdTimestamp: 1_700_000_000_000,
+      url: `https://discord.com/channels/${guild.id}/${channelId}/3333333333333333333`,
+      reference: undefined,
+    } as unknown as Message;
+
+    // The REAL extracted ingestion function, with the service internals the
+    // production DiscordService supplies (no messageManager: raw content path).
+    const service: HistoryServiceInternals = {
+      accountId: "discord-account-1",
+      client: {} as HistoryServiceInternals["client"],
+      runtime: runtime as unknown as HistoryServiceInternals["runtime"],
+      messageManager: undefined,
+      resolveDiscordEntityId: (userId: string) => id(`discord-${userId}`),
+      getChannelType: async () => ChannelType.GROUP,
+      isGuildTextBasedChannel: (c): c is never => Boolean(c),
+    };
+    const memory = await buildMemoryFromMessage(service, discordMessage);
+    expect(memory).not.toBeNull();
+    if (!memory) return;
+
+    const provenance = deriveCanonicalProvenance(memory, runtime.agentId);
+    expect(provenance.valid).toBe(true);
+    if (!provenance.valid) return;
+    expect(provenance.provenance).toEqual(
+      expect.objectContaining({
+        source: "discord",
+        accountId: "discord-account-1",
+        platformMessageId: "3333333333333333333",
+        senderPlatformId: authorId,
+        trust: "connector-verified",
+        scope: "room",
+      }),
+    );
+    expect(canonicalDedupeKey(provenance.provenance)).toBe(
+      "discord:discord-account-1:3333333333333333333",
+    );
+  });
+
+  it("uses the real PGLite adapter on the production MESSAGE search path", async () => {
+    const harness = track(await withMockLlmRuntime({ strict: false }));
+    const { runtime } = harness;
+    const roomId = id("production-search-room");
+    const otherRoomId = id("production-other-room");
+    const requester = id("requester");
+    await createRoom(runtime, roomId, ChannelType.DM, [requester]);
+    await createRoom(runtime, otherRoomId, ChannelType.DM, [requester]);
+    const embedding = new Array<number>(384).fill(0.1);
+    const first = messageMemory({
+      id: id("production-duplicate-a"),
+      agentId: runtime.agentId,
+      roomId,
+      entityId: requester,
+      createdAt: 1_700_000_000_000,
+      embedding,
+    });
+    const second = messageMemory({
+      id: id("production-duplicate-b"),
+      agentId: runtime.agentId,
+      roomId,
+      entityId: requester,
+      createdAt: 1_700_000_010_000,
+      embedding,
+    });
+    // A candidate in a DIFFERENT room: must be withheld (cross_room_denied),
+    // never silently returned into this destination.
+    const crossRoom = messageMemory({
+      id: id("production-cross-room"),
+      agentId: runtime.agentId,
+      roomId: otherRoomId,
+      entityId: requester,
+      createdAt: 1_700_000_020_000,
+      embedding,
+      metadata: { messageIdFull: "discord-message-2" },
+    });
+    await runtime.createMemory(first, "messages", false);
+    await runtime.createMemory(second, "messages", false);
+    await runtime.createMemory(crossRoom, "messages", false);
+    vi.spyOn(runtime, "useModel").mockResolvedValue(embedding as never);
+    const searchSpy = vi.spyOn(runtime, "searchMemories");
+
+    const result = await messageAction.handler(
+      runtime,
+      messageMemory({
+        id: id("production-request"),
+        agentId: runtime.agentId,
+        roomId,
+        entityId: requester,
+        content: { text: "Find deploy key", source: "client_chat" },
+      }),
+      undefined,
+      { parameters: { action: "search", query: "deploy key" } },
+      undefined,
+      undefined,
+    );
+    if (!result) throw new Error("MESSAGE handler returned no result");
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      results?: Array<{ id: UUID; roomId: UUID }>;
+      availability?: string;
+      withheld?: Array<{ code: string }>;
+    };
+    // Duplicate collapsed to the earliest row; the cross-room row withheld.
+    expect(data.results).toHaveLength(1);
+    expect(data.results?.[0]?.id).toBe(first.id);
+    expect(data.results?.every((r) => r.roomId === roomId)).toBe(true);
+    expect(data.availability).toBe("partial");
+    expect(data.withheld?.[0]?.code).toBe("cross_room_denied");
+  });
+});

--- a/plugins/plugin-discord/discord-history.ts
+++ b/plugins/plugin-discord/discord-history.ts
@@ -425,6 +425,10 @@ export async function buildMemoryFromMessage(
 		type: "message" as const,
 		source: "discord",
 		provider: "discord",
+		// Trusted scope stamp: a connector message belongs to its room. Stamped at
+		// ingestion (not derived at read time) so fail-closed canonical recall
+		// never has to guess — an unstamped record is withheld, not widened.
+		scope: "room" as const,
 		// Top-level accountId per MessageMetadata contract. Inbound connector
 		// stamps this so outbound resolution can route replies back through the
 		// same connector account.

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1788,6 +1788,9 @@ export class MessageManager {
 								type: MemoryType.MESSAGE,
 								accountId: this.accountId,
 								platformMessageId: m.id,
+								// Trusted scope stamp at ingestion: the reply belongs to the
+								// room it was delivered into.
+								scope: "room",
 							},
 							createdAt: m.createdTimestamp,
 						};

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1115,6 +1115,10 @@ export class MessageManager {
           source: "telegram",
           accountId: this.accountId,
           provider: "telegram",
+          // Trusted scope stamp at ingestion: a connector message belongs to
+          // its room. Fail-closed canonical recall withholds unstamped records
+          // instead of widening them.
+          scope: "room",
           timestamp: sentMessage.date * 1000,
           fromBot: true,
           fromId: this.runtime.agentId,
@@ -1410,6 +1414,10 @@ export class MessageManager {
           source: "telegram",
           accountId: this.accountId,
           provider: "telegram",
+          // Trusted scope stamp at ingestion: a connector message belongs to
+          // its room. Fail-closed canonical recall withholds unstamped records
+          // instead of widening them.
+          scope: "room",
           timestamp: message.date * 1000,
           entityName: ctx.from.first_name,
           entityUserName: ctx.from.username,


### PR DESCRIPTION
## What this does

Re-cut of the non-superseded remainder of #17211, executing the disposition recorded there: the audience-safety half of that PR is superseded by #17206's trusted-delivery-audience layer (audience attested from `runtime.getRoom` + `getParticipantsForRoom`, unforgeable evidence, typed fail-closed denials, production-wired). This PR closes over the piece that layer does not carry — the **provenance envelope** — and deliberately owns **no audience policy at all**.

Credit where due: the supersession call and both blocking reviews on #17211 were correct. This is the small focused PR they asked for.

### The envelope (`packages/core/src/access-control/provenance-envelope.ts`)

1. **`deriveCanonicalProvenance`** — reads source / account / room / sender / timestamp / trust / scope off metadata the connectors already stamp (`metadata.provider`, `metadata.accountId`, the nested `metadata[source]` identity object — the same evidence `roles.ts` trusts). Source is normalized through the connector-source registry. Missing required fields return a **typed `invalid_provenance` result** and the item is withheld. Nothing is fabricated, nothing defaults to `global`.
2. **`canonicalDedupeKey`** — `source:account:platformRecordId`. Two deliveries of the same webhook collapse; the same platform record under two connector accounts stays two facts (account identity is part of the key, never squashed).
3. **`searchCanonicalConversationMemories`** — production retrieval for the MESSAGE action's conversation search. Order is load-bearing: provenance validation → the **mandatory `canReadScope` ladder** → **same-room containment** → dedupe. Adapter errors propagate; they never pose as an empty "complete" result.

### What changed vs #17211's design (the supersession, honored)

- **No policy seam.** #17211 shipped a `CanonicalRecallPolicy` object with a fail-closed placeholder, designed for a later audience implementation to swap in. That contract is exactly what #17206's trusted-delivery-audience layer now owns, with stronger guarantees than a caller-suppliable object can give (a permissive policy here would have been a widening knob). So this envelope has **no policy parameter**: cross-room recall is denied unconditionally with a typed `cross_room_denied` code. When #17206's layer wants to authorize a wider audience, it does so at its own attested seams.
- **Trusted scope stamping at ingestion.** The review reproduced that real Discord/Telegram memories stamp no scope, so read-time defaults leak. Per the re-cut guidance ("real callers and trusted scope stamping"), the connectors now stamp `scope: "room"` at ingestion: Discord `buildMemoryFromMessage` + the response-callback memory, Telegram inbound + sent memories. Fail-closed recall withholds unstamped legacy records instead of widening them.

### Production callers (real, not fixtures)

- The MESSAGE action's conversation-mode search now builds a real `AccessContext` via `buildAccessContext` and routes through `searchCanonicalConversationMemories`, replacing the previous unauthorized raw `searchMemories` path. Availability (`complete`/`partial`/`unavailable`) and the withheld list are reported honestly in the action result and reply text.
- Discord/Telegram handler integration is the connectors' own ingestion functions — one of the tests drives the **REAL extracted `buildMemoryFromMessage`** and asserts the envelope accepts its output (`trust: "connector-verified"`, `scope: "room"`, correct dedupe key).

### Tests (real PGLite adapter, real handlers)

12 pass / 0 fail:
- typed invalid provenance for each of the five missing required fields (parameterized)
- missing scope withheld, never fabricated as global
- scope ladder runs before containment (owner-private withheld from a USER in the same room — containment alone would have allowed it)
- cross-room disclosure denied with `cross_room_denied`
- adapter failure propagates (no empty-complete masking)
- dedupe across distinct DB primary keys + account identity preserved (the non-tautological version: three real rows, two keys)
- REAL Discord ingestion output accepted end-to-end
- production MESSAGE action path against the real PGLite adapter: duplicate collapsed, cross-room row withheld, `availability: "partial"` reported

## Relationship to #17206 / #17211

- Supersedes the remainder of #17211, which closes when #17206 merges (per the disposition recorded there by @lalalune).
- Composes with #17206: this PR gates *what a recalled item is and who may read it*; #17206's trusted-delivery-audience layer gates *where disclosures may land*. No overlap, no duplicated policy.

## Verification

- `bun --conditions=eliza-source test packages/test/harness/__tests__/canonical-provenance-envelope.test.ts` — 12 pass / 0 fail, real PGLite adapter
- `packages/core` typecheck — clean (exit 0)
- biome — clean on all touched files

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/test-only change (core access-control + connector metadata stamping); no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/test-only change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend/test-only change; no user-facing flow to walk through

<!-- evidence-row:backend-logs -->
- [x] [canonical-provenance-envelope-vitest.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/canonical-provenance-envelope-vitest.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic mock-LLM harness test; no live-model prompt/behavior change

<!-- evidence-row:domain-artifacts -->
- [x] [canonical-provenance-envelope-vitest.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/canonical-provenance-envelope-vitest.log)
