### PR TITLE
fix(audit): bind audit:ocr to the same resolved audit directory as capture

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,7 +37,7 @@
     "mvp:visual-verify:overflow-demo": "node scripts/mvp-visual-verify/overflow-invariant-demo.mjs",
     "audit:app:verify": "bun run audit:app:capture && ELIZA_MVP_OCR_ENGINE=packaged bun run audit:ocr && ELIZA_MVP_OCR_ENGINE=packaged bun run mvp:visual-verify -- --strict --require-baseline-states",
     "audit:views": "node scripts/audit-views-soak.mjs",
-    "audit:ocr": "bun scripts/ocr-triage.ts --audit-dir aesthetic-audit-output --baseline test/ui-smoke/ocr-triage-baseline.json",
+    "audit:ocr": "bun scripts/ocr-triage.ts --baseline test/ui-smoke/ocr-triage-baseline.json",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
     "test:desktop:packaged:windows": "node scripts/run-desktop-packaged-windows.mjs",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -260,7 +260,15 @@ export function validateImportedOcrRecords(
 
 export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
   const args = parseArgs(argv);
-  const auditDir = args["audit-dir"] ?? "aesthetic-audit-output";
+  // Directory precedence mirrors the capture stage exactly (#17128): an
+  // explicit CLI --audit-dir is authoritative, otherwise the same
+  // ELIZA_AUDIT_APP_DIR the Playwright capture honored, otherwise the default.
+  // Without the env tier, an isolated `audit:app` run captured into
+  // ELIZA_AUDIT_APP_DIR while OCR silently analyzed whatever stale artifacts
+  // sat in the default directory — a false evidence binding.
+  const auditDir =
+    args["audit-dir"] ??
+    (process.env.ELIZA_AUDIT_APP_DIR?.trim() || "aesthetic-audit-output");
   const outPath = args.out ?? join(auditDir, "ocr-triage.json");
 
   // Baseline = `slug::viewport` keys of regressions already tracked by an issue.

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -120,6 +120,91 @@ describe("authorizedShots (report-authoritative selection)", () => {
   });
 });
 
+describe("audit directory resolution (#17128)", () => {
+  let root: string;
+  let isolated: string;
+  let staleDefault: string;
+  let previousCwd: string;
+  let previousEnv: string | undefined;
+
+  function seedCapture(dir: string, slug: string, text: string): void {
+    const rows: ReportEntry[] = [
+      { slug, viewport: "desktop-landscape", verdict: "good" },
+    ];
+    shot(dir, "desktop-landscape", slug);
+    writeFileSync(join(dir, "report.json"), JSON.stringify(rows));
+    writeFileSync(
+      join(dir, "ocr.ndjson"),
+      ocrLine("desktop-landscape", slug, text),
+    );
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "ocr-dir-"));
+    isolated = join(root, "isolated-run");
+    staleDefault = join(root, "aesthetic-audit-output");
+    mkdirSync(isolated);
+    mkdirSync(staleDefault);
+    seedCapture(isolated, "builtin-chat", "Chat messages composer");
+    // A populated default directory from an earlier run. If resolution ever
+    // falls back here while ELIZA_AUDIT_APP_DIR is set, the assertions below
+    // catch the false evidence binding.
+    seedCapture(staleDefault, "builtin-phone", "Phone dialer keypad");
+    previousCwd = process.cwd();
+    previousEnv = process.env.ELIZA_AUDIT_APP_DIR;
+    process.chdir(root);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (previousEnv === undefined) {
+      delete process.env.ELIZA_AUDIT_APP_DIR;
+    } else {
+      process.env.ELIZA_AUDIT_APP_DIR = previousEnv;
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reads ELIZA_AUDIT_APP_DIR when no --audit-dir is passed and leaves the stale default untouched", async () => {
+    process.env.ELIZA_AUDIT_APP_DIR = isolated;
+
+    const result = await runOcrTriage(["--ocr", join(isolated, "ocr.ndjson")]);
+
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["builtin-chat"]);
+    expect(existsSync(join(isolated, "ocr-triage.json"))).toBe(true);
+    expect(existsSync(join(staleDefault, "ocr-triage.json"))).toBe(false);
+  });
+
+  it("keeps an explicit --audit-dir authoritative over ELIZA_AUDIT_APP_DIR", async () => {
+    process.env.ELIZA_AUDIT_APP_DIR = staleDefault;
+
+    const result = await runOcrTriage([
+      "--audit-dir",
+      isolated,
+      "--ocr",
+      join(isolated, "ocr.ndjson"),
+    ]);
+
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["builtin-chat"]);
+    expect(existsSync(join(isolated, "ocr-triage.json"))).toBe(true);
+    expect(existsSync(join(staleDefault, "ocr-triage.json"))).toBe(false);
+  });
+
+  it("falls back to the default directory when neither source is set", async () => {
+    delete process.env.ELIZA_AUDIT_APP_DIR;
+
+    const result = await runOcrTriage([
+      "--ocr",
+      join(staleDefault, "ocr.ndjson"),
+    ]);
+
+    expect(result.entries.map((entry) => entry.slug)).toEqual([
+      "builtin-phone",
+    ]);
+    expect(existsSync(join(staleDefault, "ocr-triage.json"))).toBe(true);
+  });
+});
+
 describe("ocr-triage CLI (end-to-end provenance)", () => {
   let dir: string;
   beforeEach(() => {


### PR DESCRIPTION
## Problem

#17128: `bun run --cwd packages/app audit:app` supports isolated output through `ELIZA_AUDIT_APP_DIR` and the Playwright capture honors it, but the chained `audit:ocr` script passed the literal `aesthetic-audit-output`. OCR silently analyzed whichever default-directory artifacts happened to exist instead of the just-captured run, and the overall command exited green — false evidence binding.

## Fix

`runOcrTriage` (`packages/app/scripts/ocr-triage.ts`) now resolves the audit directory with the same precedence the capture stage uses:

1. explicit CLI `--audit-dir` (authoritative, unchanged)
2. `ELIZA_AUDIT_APP_DIR` (new tier — same env var `run-ui-playwright.mjs`, the audit spec, and `mvp-visual-verify` already honor)
3. the `aesthetic-audit-output` default (unchanged)

The `audit:ocr` package script drops its hardcoded `--audit-dir aesthetic-audit-output` so the env tier is reachable; with no env var set, resolution is byte-identical to before. A missing `report.json` in the resolved directory still throws — there is no fallback to the default directory, satisfying the fail-closed criterion.

## Acceptance criteria from #17128

- [x] `audit:ocr` uses the same resolved audit directory as the capture stage, including `ELIZA_AUDIT_APP_DIR` (pure `path.resolve`/`process.env` logic, platform-independent)
- [x] An explicit CLI `--audit-dir` remains authoritative
- [x] Regression test proves a non-default isolated directory is read and receives `ocr-triage.json`, while a populated stale default directory is not touched
- [x] Missing/mismatched inputs fail closed; no fallback to the default directory (existing provenance tests unchanged and still green)

## Bidirectional proof

New `audit directory resolution (#17128)` describe block seeds an isolated capture AND a populated stale `aesthetic-audit-output` next to it:

- env-only resolution reads the isolated run, writes `ocr-triage.json` there, and leaves the stale default untouched — **fails on develop before the fix** (OCR reads the stale default), passes after
- explicit `--audit-dir` beats a conflicting `ELIZA_AUDIT_APP_DIR`
- no-config fallback still reads the default directory

## Verification

- `bunx vitest run test/audit/ocr-triage-provenance.test.ts`: 17/17 green on a clean worktree at develop head; the env-tier case red without the script change (16/17)
- Diff: 95 insertions / 2 deletions across the script, package.json, and the test

## Evidence rows

- UI screenshots/video: N/A — evidence-pipeline script only, no rendered UI change
- Real-LLM trajectory: N/A — no model behavior
- Domain artifact: the regression tests assert on the exact `ocr-triage.json` placement and stale-directory non-touch that constituted the false binding

Note on the issue's last criterion (full isolated `audit:app` rerun with manually reviewed hashes): the full 254-case Playwright capture requires the packaged app build environment; the directory-resolution contract itself is fully covered by the function-boundary tests here. Happy to attach a full isolated run from the CI lane on request.

Closes #17128

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - evidence-pipeline script only; no rendered UI change.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - CLI script directory-resolution contract only.

<!-- evidence-row:backend-logs -->
- [x] N/A - regression tests assert the exact ocr-triage.json placement and stale-directory non-touch that constituted the false binding.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - vitest bidirectional proof in the PR description: env-tier case fails on develop (16/17), 17/17 with fix on a clean worktree.
