### PR TITLE
fix(lifeops-bench): repair the develop-red Benchmark Bridge lane

### DIFF
--- a/packages/lifeops-bench/src/trusted-parent-contract-evidence.ts
+++ b/packages/lifeops-bench/src/trusted-parent-contract-evidence.ts
@@ -154,6 +154,8 @@ async function ensureHouseholdEntity(
     entityId: string;
     preferredName: string;
     role: "child" | "current_partner";
+    /** Set for household-scoped scenarios; school-source fixtures have none. */
+    householdId?: string;
     subjectEntityIds: readonly string[];
     attributes?: Record<string, EntityAttribute>;
   },
@@ -189,6 +191,10 @@ async function ensureHouseholdEntity(
     type: input.role === "child" ? "parent_of" : "partner_of",
     metadata: {
       householdRole: input.role,
+      // The membership guard matches role AND household, so a household-scoped
+      // fixture must carry the id or every scoped operation is refused. Absent
+      // for fixtures that never take a household path.
+      ...(input.householdId ? { householdId: input.householdId } : {}),
       householdSubjectEntityIds: [...input.subjectEntityIds],
     },
     state: {},
@@ -368,6 +374,7 @@ function operationsProvenance(input: {
 async function prepareG30(runtime: AgentRuntime): Promise<void> {
   await ensureHouseholdEntity(runtime, {
     entityId: G30_CHILD_ENTITY_ID,
+    householdId: G30_HOUSEHOLD_ID,
     preferredName: "Lee",
     role: "child",
     subjectEntityIds: [G30_CHILD_ENTITY_ID],
@@ -473,6 +480,7 @@ function responsibilityDefinition(
 async function prepareG38(runtime: AgentRuntime): Promise<void> {
   await ensureHouseholdEntity(runtime, {
     entityId: G38_PARTNER_ENTITY_ID,
+    householdId: G38_HOUSEHOLD_ID,
     preferredName: "Household partner",
     role: "current_partner",
     subjectEntityIds: [],

--- a/packages/lifeops-bench/src/type-boundary.test.ts
+++ b/packages/lifeops-bench/src/type-boundary.test.ts
@@ -31,6 +31,12 @@ describe("LifeOps bench type boundary", () => {
       "@elizaos/plugin-local-inference/runtime": [
         "../../plugins/plugin-local-inference/dist/runtime/index.d.ts",
       ],
+      "@elizaos/plugin-personal-assistant": [
+        "../../plugins/plugin-personal-assistant/dist/index.d.ts",
+      ],
+      "@elizaos/plugin-personal-assistant/lifeops/owner/fact-store": [
+        "../../plugins/plugin-personal-assistant/dist/lifeops/owner/fact-store.d.ts",
+      ],
     });
   });
 });

--- a/packages/lifeops-bench/tsconfig.json
+++ b/packages/lifeops-bench/tsconfig.json
@@ -11,10 +11,10 @@
     "resolveJsonModule": true,
     "paths": {
       "@elizaos/plugin-personal-assistant": [
-        "../../plugins/plugin-personal-assistant/src/index.ts"
+        "../../plugins/plugin-personal-assistant/dist/index.d.ts"
       ],
       "@elizaos/plugin-personal-assistant/lifeops/owner/fact-store": [
-        "../../plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts"
+        "../../plugins/plugin-personal-assistant/dist/lifeops/owner/fact-store.d.ts"
       ],
       "@elizaos/agent/runtime/core-plugins": [
         "../agent/dist/runtime/core-plugins.d.ts"


### PR DESCRIPTION
## Summary

`Benchmark Bridge Tests` went red on develop with the parent-suite merge (`a233a3e56af`). It passed on the preceding commit `8f674a8b139`. Three failures, all attributable to the merged branch, all fixed here. The original branch was recut directly onto current `develop` so this PR now contains only the intended three-file patch.

## The type-boundary regression is the one worth reading

`packages/lifeops-bench/tsconfig.json` had two `@elizaos/plugin-personal-assistant` paths pointing at plugin **source** (`src/index.ts`, `src/lifeops/owner/fact-store.ts`). That is precisely what `type-boundary.test.ts` exists to prevent — its header states the bench typecheck must resolve through built declarations rather than traverse a plugin's source graph.

Both now point at `dist/*.d.ts`. The test expectation is extended to cover them, and the assertion still contains **no non-`.d.ts` path**, so the guard's intent is intact rather than relaxed to accommodate the violation. The `@elizaos/lifeops-bench#typecheck` turbo override already depends on `plugin-personal-assistant#build`, so the declarations are guaranteed present.

## G30 / G38: a relationship belonging to no household

Both failed with `HOUSEHOLD_OPERATIONS_RELATIONSHIP_REQUIRED`. `ensureHouseholdEntity` created the relationship with `householdRole` but no `householdId`, while `requireHouseholdMember` matches role **and** household. The relationship was real and correctly roled, but belonged to no household, so every scoped operation was refused.

The fixture now carries the id. It is optional, because the G15 school-source fixture has no household and never takes that path — adding a household constant there would have invented state the scenario does not have.

The guard itself is correct authorization hardening and is unchanged.

## Verification

Original exact patch:

```text
bunx vitest run --config vitest.config.ts --root packages/lifeops-bench
Test Files  18 passed (18)
     Tests  179 passed (179)
```

Recut verification:

```text
bun test src/type-boundary.test.ts
1 pass
0 fail

git diff --check
pass
```

The recut package-wide typecheck could not be used as an isolated-worktree signal because generated declaration artifacts from unrelated workspaces were not synchronized there; required CI rebuilds those artifacts and is authoritative.

Reported on #17206.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - benchmark fixture and TypeScript declaration-boundary repair; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - benchmark fixture and TypeScript declaration-boundary repair; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changes.

<!-- evidence-row:backend-logs -->
- [x] N/A - no server or transport boundary changes; the benchmark suite exercises the real PGlite-backed path directly.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or planner behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the benchmark uses ephemeral PGlite fixtures and produces no persistent artifact; G30/G38 authorization and the declaration boundary are directly asserted.
