### PR TITLE
fix: repair the develop-red CI lanes (3 product defects + 2 test drifts)

### DIFF
--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -15,6 +15,7 @@ import {
 	resolveActionArgs,
 	type SubactionsMap,
 } from "../../actions/resolve-action-args";
+import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { hasRoleAccess, isAgentSelf } from "../../roles";
 import type {
@@ -684,7 +685,33 @@ async function handleDelete(
 		return result(false, text, "delete", { values: { error: "invalid_id" } });
 	}
 
-	await service.deleteDocument(documentId, message);
+	// error-policy:J1 boundary translation — the action IS the boundary between
+	// the document service's typed errors and the model-visible ActionResult. An
+	// escaping ElizaError aborts the whole turn, so the two outcomes a caller can
+	// legitimately provoke (no such document, not allowed to delete it) become
+	// structured refusals the planner can read. Anything else still propagates:
+	// an adapter/transport fault is not a refusal and must not be reported as one.
+	try {
+		await service.deleteDocument(documentId, message);
+	} catch (error) {
+		const code = error instanceof ElizaError ? error.code : undefined;
+		if (code === "DOCUMENT_MUTATION_FORBIDDEN") {
+			const text =
+				"Only the owner can edit or delete global and owner-private documents.";
+			await emit(callback, { text });
+			return result(false, text, "delete", {
+				values: { error: "forbidden", documentId },
+			});
+		}
+		if (code === "DOCUMENT_NOT_FOUND") {
+			const text = `No document ${documentId} to delete.`;
+			await emit(callback, { text });
+			return result(false, text, "delete", {
+				values: { error: "not_found", documentId },
+			});
+		}
+		throw error;
+	}
 	const text = `Deleted document ${documentId}.`;
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "delete", { values: { documentId } });

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -617,6 +617,22 @@ export class DocumentService extends Service {
 			requesterRole: requester.role,
 		});
 		if (!document) {
+			// The read above is scoped to the requester, so a document the caller
+			// cannot READ is indistinguishable from one that does not exist — and
+			// reporting NOT_FOUND here made the adapter's `forbidden` verdict
+			// unreachable for exactly the case it exists for (a non-owner trying to
+			// delete a global / owner-private document). Distinguish the two with an
+			// unscoped existence probe so the mutation wall renders the real reason.
+			const existsUnscoped = await this.runtime.getMemoryById(documentId);
+			if (existsUnscoped) {
+				throw new ElizaError(
+					`Document ${documentId} cannot be deleted by this requester`,
+					{
+						code: "DOCUMENT_MUTATION_FORBIDDEN",
+						context: { documentId, requesterRole: requester.role },
+					},
+				);
+			}
 			throw new ElizaError(`Document ${documentId} not found`, {
 				code: "DOCUMENT_NOT_FOUND",
 				context: { documentId },

--- a/packages/shared/src/loopback-trust.ts
+++ b/packages/shared/src/loopback-trust.ts
@@ -274,12 +274,24 @@ function localAuthRequired(options: LoopbackTrustOptions): boolean {
  * policy gates; the host/origin/proxy classification is identical for all.
  */
 export function isTrustedLocalRequest(
-  req: Pick<http.IncomingMessage, "headers" | "socket">,
+  // `socket` is declared optional because it genuinely can be absent: Node nulls
+  // it once a connection is destroyed, and in-process route dispatch (tests, the
+  // embedded mobile transport) invokes handlers with a synthetic request that
+  // never had one. The type used to promise a socket, so the access below threw
+  // a TypeError instead of reaching a trust decision.
+  req: Pick<http.IncomingMessage, "headers"> & {
+    socket?: Pick<http.IncomingMessage["socket"], "remoteAddress"> | null;
+  },
   options: LoopbackTrustOptions,
 ): boolean {
   if (localAuthRequired(options)) return false;
   if (cloudBlocksLocalTrust(options.cloudCheck)) return false;
-  if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) return false;
+  // No socket means the peer address cannot be established, so loopback cannot
+  // be PROVEN — fail closed and treat the request as untrusted. This is an
+  // explicit deny, not a defaulted success: isLoopbackRemoteAddress(undefined)
+  // is already false, and granting local trust on an unverifiable peer would
+  // hand out the no-password local bypass to any synthetic request.
+  if (!isLoopbackRemoteAddress(req.socket?.remoteAddress)) return false;
   if (proxyClientHeaderBlocksLocalTrust(req.headers)) return false;
 
   const host = firstHeaderValue(req.headers.host);

--- a/packages/ui/src/api/client-agent-models-config.test.ts
+++ b/packages/ui/src/api/client-agent-models-config.test.ts
@@ -27,8 +27,27 @@ describe("ElizaClient.getModelsCatalog", () => {
     const result = await client.getModelsCatalog();
     // catalogOnly skips the server's all-providers model-list fan-out, which
     // exceeds the client's 10s fetch budget on a cold cache.
-    expect(fetchMock).toHaveBeenCalledWith("/api/models?catalogOnly=1");
+    // The second argument is the RequestInit passthrough — absent here, so it
+    // arrives as undefined rather than being omitted from the call.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/models?catalogOnly=1",
+      undefined,
+    );
     expect(result.catalog).toEqual({ providers: {} });
+  });
+
+  it("forwards a caller's RequestInit (abort signal) to the transport", async () => {
+    const { client, fetchMock } = clientWithBody({
+      providers: {},
+      catalog: { providers: {} },
+    });
+    // Callers pass an AbortSignal to cancel a slow catalog read on unmount;
+    // dropping it would leak the request past the component's lifetime.
+    const controller = new AbortController();
+    await client.getModelsCatalog({ signal: controller.signal });
+    expect(fetchMock).toHaveBeenCalledWith("/api/models?catalogOnly=1", {
+      signal: controller.signal,
+    });
   });
 });
 

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -2701,15 +2701,28 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							!viewId && !forcedResolvedCapability
 								? await getCurrentView()
 								: null;
+						// Only INFER a target from the message text when the caller did not
+						// name both a view and a capability. An explicit `view` +
+						// `capability` is a structured planner decision, and
+						// resolveViewCapability is a text heuristic that overwrites both on
+						// a match — so `interact view=scenario-active-ledger
+						// capability=agent-click` was being dispatched onto an unrelated
+						// surface (task-coordinator's "list-sessions"), which then rejected
+						// the caller's own params. Skipping the heuristic here leaves the
+						// explicit view to the `matches`/alias resolution below, which is
+						// already scoped to that one view.
+						const shouldInferTarget = !viewId || !capability;
 						let resolvedCapability =
 							forcedResolvedCapability ??
-							resolveViewCapability({
-								views,
-								text,
-								options: actionOptions,
-								viewType,
-								currentViewId: viewId ?? currentViewForResolution?.viewId,
-							});
+							(shouldInferTarget
+								? resolveViewCapability({
+										views,
+										text,
+										options: actionOptions,
+										viewType,
+										currentViewId: viewId ?? currentViewForResolution?.viewId,
+									})
+								: null);
 						if (!resolvedCapability && (!viewId || !capability)) {
 							const currentView = await getCurrentView();
 							resolvedCapability = resolveViewCapability({

--- a/plugins/plugin-personal-assistant/test/native-parameters.test.ts
+++ b/plugins/plugin-personal-assistant/test/native-parameters.test.ts
@@ -30,7 +30,14 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@elizaos/agent", () => ({
+// Layer the hasOwnerAccess override on the shared agent stub rather than
+// replacing the module with a one-key object: `approval-queue.types.ts` is in
+// this test's module graph and SUBCLASSES `ApprovalStateTransitionError`, so a
+// narrow mock leaves it extending `undefined` and the whole suite fails to LOAD
+// ("no tests"). The stub re-exports the real class, keeping `instanceof` genuine
+// for the subclass — same pattern as first-run-provider.test.ts.
+vi.mock("@elizaos/agent", async () => ({
+  ...(await import("./stubs/agent.ts")),
   hasOwnerAccess: mocks.hasOwnerAccess,
 }));
 
@@ -151,7 +158,9 @@ describe("LifeOps native options.parameters migration", () => {
       success: true,
       data: { requestId: "req-1", state: "rejected" },
     });
-    expect(mocks.queue.reject).toHaveBeenCalledWith("req-1", {
+    // reject(requestId, subjectUserId, resolution) — the subject is passed
+    // explicitly so the store scopes the transition to that owner.
+    expect(mocks.queue.reject).toHaveBeenCalledWith("req-1", "owner-1", {
       resolvedBy: "owner-1",
       resolutionReason: "not now",
     });
@@ -197,7 +206,7 @@ describe("LifeOps native options.parameters migration", () => {
       success: true,
       data: { requestId: "req-1", state: "rejected" },
     });
-    expect(mocks.queue.reject).toHaveBeenCalledWith("req-1", {
+    expect(mocks.queue.reject).toHaveBeenCalledWith("req-1", "owner-1", {
       resolvedBy: "owner-1",
       resolutionReason:
         "Wait - which Chris? There are two. Don't send it, reject that for now.",


### PR DESCRIPTION
`develop` has been red for a while — the `Tests` workflow was already failing several commits before this branch existed, which blocks the develop→main release (#17300). This clears the root causes I could reproduce.

## Product defects (the lanes were right)

**VIEWS interact dispatched across an unrelated surface.** `resolveViewCapability` is a *text* heuristic, but it ran even when the caller named BOTH a view and a capability, and its match overwrote them. `interact view=scenario-active-ledger capability=agent-click params={id}` was re-targeted onto `task-coordinator`'s `list-sessions`, which then rejected the caller's own parameter. The code immediately below already takes care to "keep the view target fixed so this cannot dispatch across an unrelated surface" — the heuristic above had already crossed. Inference now runs only when view or capability is unspecified.

**Document delete could never report `forbidden`.** `deleteDocument`'s pre-read is scoped to the requester, so a document the caller cannot READ was indistinguishable from one that does not exist. The adapter implements a `forbidden` status and the service maps it to `DOCUMENT_MUTATION_FORBIDDEN` — but it was unreachable for exactly the case it exists for (a non-owner deleting a global document), which reported NOT_FOUND instead, and the `ElizaError` escaped the action and aborted the whole turn. The service now distinguishes the two with an unscoped existence probe; the action translates both into typed refusals at its boundary and still propagates anything else (an adapter fault is not a refusal).

**`isTrustedLocalRequest` threw on a socketless request.** `socket` is genuinely optional — Node nulls it on a destroyed connection, and in-process dispatch passes a synthetic request that never had one — but the type promised it, so the access raised a `TypeError` instead of reaching a trust decision. Now typed optional and failing **closed**: an unverifiable peer is untrusted, because granting local trust there would hand the no-password local bypass to any synthetic request.

## Test drift (asserting contracts the code no longer has)

**`native-parameters.test.ts`** — three layers stacked behind each other: a `vi.mock("@elizaos/agent")` returning a one-key object while `approval-queue.types.ts` *subclasses* `ApprovalStateTransitionError` (so it extended `undefined` and the suite could not load); a fake queue missing `byId`, which `resolveApprovalRequest` now calls; and assertions still on the old 2-arg `reject()` instead of `(requestId, subjectUserId, resolution)`.

**`client-agent-models-config.test.ts`** — `getModelsCatalog` now forwards `init` to the transport, so the call carries a second argument the one-arg assertion could not match. Rather than only widening it, added a case proving an `AbortSignal` reaches the transport — dropping it would leak a slow catalog read past the calling component's lifetime.

## Verification

```
pr-deterministic scenario lane:  40 passed, 0 failed, 0 skipped of 40
  (was 39/1; before the document fix the lane ABORTED on a thrown error)
native-parameters.test.ts:        5/5
client-agent-models-config.ts:    9/9
loopback-trust:                  68/68
agent-message-route.test.ts:     no failures (was 9x TypeError)
```

typecheck clean: `packages/core`, `packages/shared`, `plugins/plugin-app-control`. Biome clean on all changed files.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - no UI diff; the changes are runtime/service/test files. Failure state is captured in backend-logs.
<!-- evidence-row:after-screenshots --> N/A - no rendered surface changed.
<!-- evidence-row:walkthrough-video --> N/A - no user-facing flow changed; the observable behavior is the scenario lane going green, captured in domain-artifacts.
<!-- evidence-row:backend-logs --> https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17292-backend-route-tests.log
<!-- evidence-row:frontend-logs --> N/A - no frontend behavior changed; the one UI-adjacent change is a client unit test assertion.
<!-- evidence-row:llm-trajectory --> N/A - the scenario lane runs the deterministic LLM proxy by design (SCENARIO_LLM_PROXY_STRICT=1); no live-model behavior is touched by these fixes.
<!-- evidence-row:domain-artifacts --> https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17292-domain-artifacts-responses.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
