### PR TITLE
fix(cloud): dev targets staging, start targets production

### DIFF
--- a/packages/app-core/src/cli/program/register.auth.cloud-api-base.test.ts
+++ b/packages/app-core/src/cli/program/register.auth.cloud-api-base.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for `resolveCloudApiBase()` — the web-host → API-host mapping the cloud
+ * auth commands use to decide WHICH Eliza Cloud deployment they authenticate
+ * against.
+ *
+ * The environment boundary is the whole point: a blanket "any *.elizacloud.ai →
+ * api.elizacloud.ai" rewrite sent staging hosts to PRODUCTION, so
+ * `dev-login --cloud https://api-staging.elizacloud.ai` minted a prod key and
+ * reported success — a staging credential was unobtainable and you could not
+ * tell. These cases pin each environment to itself so that cannot regress
+ * silently.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCloudApiBase } from "./register.auth";
+
+const ORIGINAL_ENV = process.env.ELIZAOS_CLOUD_BASE_URL;
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  else process.env.ELIZAOS_CLOUD_BASE_URL = ORIGINAL_ENV;
+});
+
+describe("resolveCloudApiBase", () => {
+  it("maps every production web host to the production API host", () => {
+    for (const host of [
+      "elizacloud.ai",
+      "www.elizacloud.ai",
+      "app.elizacloud.ai",
+      "dev.elizacloud.ai",
+      "api.elizacloud.ai",
+    ]) {
+      expect(resolveCloudApiBase(`https://${host}`)).toBe(
+        "https://api.elizacloud.ai",
+      );
+    }
+  });
+
+  it("keeps staging hosts on staging instead of redirecting to production", () => {
+    for (const host of [
+      "staging.elizacloud.ai",
+      "app-staging.elizacloud.ai",
+      "api-staging.elizacloud.ai",
+    ]) {
+      expect(resolveCloudApiBase(`https://${host}`)).toBe(
+        "https://api-staging.elizacloud.ai",
+      );
+    }
+  });
+
+  it("never crosses the staging/production boundary in either direction", () => {
+    expect(resolveCloudApiBase("https://api-staging.elizacloud.ai")).not.toBe(
+      "https://api.elizacloud.ai",
+    );
+    expect(resolveCloudApiBase("https://elizacloud.ai")).not.toBe(
+      "https://api-staging.elizacloud.ai",
+    );
+  });
+
+  it("strips a trailing /api/v1 — SIWE endpoints live at the origin", () => {
+    expect(
+      resolveCloudApiBase("https://api-staging.elizacloud.ai/api/v1"),
+    ).toBe("https://api-staging.elizacloud.ai");
+    expect(resolveCloudApiBase("https://elizacloud.ai/api/v1/")).toBe(
+      "https://api.elizacloud.ai",
+    );
+  });
+
+  it("leaves a self-hosted or loopback base exactly as given", () => {
+    expect(resolveCloudApiBase("https://cloud.example.com")).toBe(
+      "https://cloud.example.com",
+    );
+    // Port and scheme must survive — a local cloud stack runs on http+port.
+    expect(resolveCloudApiBase("http://127.0.0.1:8787")).toBe(
+      "http://127.0.0.1:8787",
+    );
+  });
+
+  it("falls back to ELIZAOS_CLOUD_BASE_URL, then production, when no input is given", () => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.elizacloud.ai";
+    expect(resolveCloudApiBase()).toBe("https://api-staging.elizacloud.ai");
+
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    expect(resolveCloudApiBase()).toBe("https://api.elizacloud.ai");
+  });
+
+  it("an explicit argument outranks the environment variable", () => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://elizacloud.ai";
+    expect(resolveCloudApiBase("https://api-staging.elizacloud.ai")).toBe(
+      "https://api-staging.elizacloud.ai",
+    );
+  });
+
+  it("returns an unparseable base trimmed rather than throwing", () => {
+    expect(resolveCloudApiBase("not a url///")).toBe("not a url");
+  });
+});

--- a/packages/app-core/src/cli/program/register.auth.ts
+++ b/packages/app-core/src/cli/program/register.auth.ts
@@ -275,10 +275,30 @@ export async function runElizaAuthReset(
 const DEFAULT_CLOUD_API_BASE = "https://api.elizacloud.ai";
 
 /**
- * Rewrite any elizacloud.ai web host to the API host, mirroring the app's
- * `resolveDirectCloudAuthApiBase`. Keeps a non-elizacloud (self-hosted) base as-is.
+ * Web host → API host for each Eliza Cloud deployment, mirroring the app's
+ * `resolveDirectCloudAuthApiBase` (`ui/src/api/client-cloud.ts`).
+ *
+ * An explicit map, not a pattern rewrite: a blanket "any *.elizacloud.ai →
+ * api.elizacloud.ai" rule silently redirected `api-staging`/`staging` to
+ * PRODUCTION, so `dev-login --cloud https://api-staging.elizacloud.ai` minted a
+ * prod key while reporting success — making it impossible to obtain a staging
+ * credential and easy to believe you had one. Each environment's hosts map only
+ * within that environment; an unlisted host (self-hosted, loopback) is left
+ * exactly as given.
  */
-function resolveCloudApiBase(input?: string): string {
+const CLOUD_API_BASE_BY_WEB_HOST = new Map<string, string>([
+  ["elizacloud.ai", "api.elizacloud.ai"],
+  ["www.elizacloud.ai", "api.elizacloud.ai"],
+  ["app.elizacloud.ai", "api.elizacloud.ai"],
+  ["dev.elizacloud.ai", "api.elizacloud.ai"],
+  ["api.elizacloud.ai", "api.elizacloud.ai"],
+  ["staging.elizacloud.ai", "api-staging.elizacloud.ai"],
+  ["app-staging.elizacloud.ai", "api-staging.elizacloud.ai"],
+  ["api-staging.elizacloud.ai", "api-staging.elizacloud.ai"],
+]);
+
+/** @internal Exported for testing. */
+export function resolveCloudApiBase(input?: string): string {
   const raw = (
     input ||
     process.env.ELIZAOS_CLOUD_BASE_URL ||
@@ -286,12 +306,8 @@ function resolveCloudApiBase(input?: string): string {
   ).trim();
   try {
     const u = new URL(raw);
-    if (
-      /(^|\.)elizacloud\.ai$/.test(u.hostname) &&
-      u.hostname !== "api.elizacloud.ai"
-    ) {
-      u.hostname = "api.elizacloud.ai";
-    }
+    const mapped = CLOUD_API_BASE_BY_WEB_HOST.get(u.hostname.toLowerCase());
+    if (mapped) u.hostname = mapped;
     // Strip a trailing /api/v1 etc. — the SIWE endpoints live at the origin.
     return `${u.protocol}//${u.host}`;
   } catch {

--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -7,7 +7,12 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
-import { normalizeCloudSiteUrl, resolveCloudApiBaseUrl } from "./base-url";
+import {
+  defaultCloudSiteUrl,
+  isDevCloudTarget,
+  normalizeCloudSiteUrl,
+  resolveCloudApiBaseUrl,
+} from "./base-url";
 
 describe("Eliza Cloud base URL normalization", () => {
   const savedConfig = getBootConfig();
@@ -76,5 +81,80 @@ describe("Eliza Cloud base URL normalization", () => {
 
     expect(resolveCloudApiBaseUrl()).toBe("https://branded.example.com/api/v1");
     expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
+  });
+});
+
+/**
+ * The dev/production cloud split. `bun run dev` must not exercise production
+ * credentials, billing, or agent state by default, so the unconfigured default
+ * follows the entrypoint: staging from dev, production everywhere else. Staging
+ * is a separate deployment with its own database and keys — crossing the
+ * boundary by accident is the failure these cases exist to prevent.
+ */
+describe("default cloud target by environment", () => {
+  const savedDevSource = process.env.ELIZA_DEV_SOURCE;
+
+  afterEach(() => {
+    if (savedDevSource === undefined) delete process.env.ELIZA_DEV_SOURCE;
+    else process.env.ELIZA_DEV_SOURCE = savedDevSource;
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    delete process.env.NODE_ENV;
+  });
+
+  it("defaults to staging under the dev entrypoint", () => {
+    process.env.ELIZA_DEV_SOURCE = "1";
+    expect(isDevCloudTarget()).toBe(true);
+    expect(defaultCloudSiteUrl()).toBe("https://staging.elizacloud.ai");
+    expect(resolveCloudApiBaseUrl()).toBe(
+      "https://staging.elizacloud.ai/api/v1",
+    );
+  });
+
+  it("defaults to production when the dev flag is absent", () => {
+    delete process.env.ELIZA_DEV_SOURCE;
+    expect(isDevCloudTarget()).toBe(false);
+    expect(defaultCloudSiteUrl()).toBe("https://elizacloud.ai");
+    expect(resolveCloudApiBaseUrl()).toBe("https://elizacloud.ai/api/v1");
+  });
+
+  it("ignores NODE_ENV=development — only the explicit dev flag counts", () => {
+    // Test runners, benchmarks, and assorted tooling set NODE_ENV=development;
+    // none of them should be silently re-pointed at staging.
+    process.env.NODE_ENV = "development";
+    delete process.env.ELIZA_DEV_SOURCE;
+    expect(isDevCloudTarget()).toBe(false);
+    expect(defaultCloudSiteUrl()).toBe("https://elizacloud.ai");
+  });
+
+  it('treats any value other than exactly "1" as not-dev', () => {
+    for (const value of ["0", "", "true", "yes"]) {
+      process.env.ELIZA_DEV_SOURCE = value;
+      expect(isDevCloudTarget()).toBe(false);
+    }
+  });
+
+  it("lets ELIZAOS_CLOUD_BASE_URL override the default in both directions", () => {
+    // dev run pinned back to production
+    process.env.ELIZA_DEV_SOURCE = "1";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://elizacloud.ai";
+    expect(resolveCloudApiBaseUrl()).toBe("https://elizacloud.ai/api/v1");
+
+    // non-dev run pointed at staging
+    delete process.env.ELIZA_DEV_SOURCE;
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://staging.elizacloud.ai";
+    expect(resolveCloudApiBaseUrl()).toBe(
+      "https://staging.elizacloud.ai/api/v1",
+    );
+  });
+
+  it("does not collapse staging into the production apex", () => {
+    // api/www/apex are production aliases that normalize to the apex; staging
+    // must NOT be swept into that set or dev would silently hit production.
+    expect(normalizeCloudSiteUrl("https://staging.elizacloud.ai")).toBe(
+      "https://staging.elizacloud.ai",
+    );
+    expect(normalizeCloudSiteUrl("https://api-staging.elizacloud.ai")).toBe(
+      "https://api-staging.elizacloud.ai",
+    );
   });
 });

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -4,7 +4,40 @@
 
 import { readAliasedEnv } from "../utils/env.js";
 
-const DEFAULT_CLOUD_SITE_URL = "https://elizacloud.ai";
+const PRODUCTION_CLOUD_SITE_URL = "https://elizacloud.ai";
+const STAGING_CLOUD_SITE_URL = "https://staging.elizacloud.ai";
+
+/**
+ * True when this process was started from the repo's dev entrypoint.
+ *
+ * `bun run dev` sets `ELIZA_DEV_SOURCE=1` (root `package.json`) and nothing
+ * else does; `bun run start` sets neither it nor `NODE_ENV=development`. We key
+ * on the explicit flag rather than `NODE_ENV` because `NODE_ENV=development`
+ * is set by many harnesses (tests, benchmarks, tooling) that should keep
+ * talking to whatever cloud they were configured for.
+ */
+export function isDevCloudTarget(): boolean {
+  return readAliasedEnv("ELIZA_DEV_SOURCE") === "1";
+}
+
+/**
+ * The Eliza Cloud deployment an unconfigured process talks to: **staging from
+ * `bun run dev`, production otherwise**.
+ *
+ * Local development must not exercise production credentials, billing, or agent
+ * state by default. `ELIZAOS_CLOUD_BASE_URL` still overrides this in either
+ * direction (see `normalizeCloudSiteUrl`), so pointing a dev run at production
+ * — or a deployed process at staging — stays a one-variable change.
+ *
+ * Staging is a separate deployment with its own database and its own API keys:
+ * a production `ELIZAOS_CLOUD_API_KEY` does NOT authenticate against it. Mint a
+ * staging key with `eliza auth dev-login --cloud https://api-staging.elizacloud.ai`.
+ */
+export function defaultCloudSiteUrl(): string {
+  return isDevCloudTarget()
+    ? STAGING_CLOUD_SITE_URL
+    : PRODUCTION_CLOUD_SITE_URL;
+}
 
 const LEGACY_CLOUD_HOST_ALIASES = new Set([
   "api.elizacloud.ai",
@@ -45,7 +78,7 @@ function normalizeMalformedCandidate(candidate: string): string {
 export function normalizeCloudSiteUrl(rawUrl?: string): string {
   // Allow cloud-provisioned containers to override the base URL via env var
   const envOverride = readAliasedEnv("ELIZAOS_CLOUD_BASE_URL");
-  const candidate = envOverride || rawUrl?.trim() || DEFAULT_CLOUD_SITE_URL;
+  const candidate = envOverride || rawUrl?.trim() || defaultCloudSiteUrl();
 
   try {
     const parsed = new URL(candidate);

--- a/plugins/plugin-elizacloud/src/cloud/cloud-api-key.ts
+++ b/plugins/plugin-elizacloud/src/cloud/cloud-api-key.ts
@@ -13,9 +13,23 @@
  * `cloud/` matches their actual ownership.
  */
 
+import { defaultCloudSiteUrl } from "@elizaos/shared";
+
 import type { ElizaConfig } from "../lib/config-like";
 
-export const DEFAULT_CLOUD_API_BASE_URL = "https://elizacloud.ai/api/v1";
+/**
+ * The cloud API an unconfigured agent talks to. Environment-dependent: `bun run
+ * dev` targets staging, everything else production — see
+ * `defaultCloudSiteUrl()` in `@elizaos/shared`, which owns that decision for the
+ * whole repo so the agent, the CLI, and the web bundles cannot disagree.
+ *
+ * A function, not a constant: the dev flag is read from the environment at call
+ * time, and a module-load constant would freeze whichever value happened to be
+ * set when this module was first imported.
+ */
+export function defaultCloudApiBaseUrl(): string {
+  return `${defaultCloudSiteUrl()}/api/v1`;
+}
 
 export type CloudApiKeyRuntimeLike = {
   getSetting?: (key: string) => unknown;
@@ -51,7 +65,7 @@ export function resolveCloudApiBaseUrl(
 ): string | null {
   const candidate =
     normalizeCloudSecret(rawBaseUrl ?? process.env.ELIZAOS_CLOUD_BASE_URL) ??
-    DEFAULT_CLOUD_API_BASE_URL;
+    defaultCloudApiBaseUrl();
   try {
     const parsed = new URL(candidate);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {


### PR DESCRIPTION
Local development ran against **production** Eliza Cloud by default — real credentials, real billing, real agent state. This points the unconfigured default at staging when the process came from the dev entrypoint.

## The split

`defaultCloudSiteUrl()` in `@elizaos/shared` owns the decision for the whole repo (agent, CLI, plugin) so the surfaces cannot disagree:

| Entry | Cloud target |
|---|---|
| `bun run dev` | `https://staging.elizacloud.ai/api/v1` |
| `bun run start` / deployed | `https://elizacloud.ai/api/v1` |

It keys on `ELIZA_DEV_SOURCE=1`, which the root `dev` script sets and nothing else does — deliberately **not** `NODE_ENV`, which tests, benchmarks, and assorted tooling set and which should keep talking to whatever cloud they were configured for. `ELIZAOS_CLOUD_BASE_URL` still overrides in both directions, so pinning a dev run at production stays a one-variable change.

## Getting a staging key was impossible, and silently so

Staging is a separate deployment with its own database and its own keys, so a production key does not authenticate against it. `auth dev-login --cloud https://api-staging.elizacloud.ai` is the intended way to mint one — except `resolveCloudApiBase()` rewrote **any** `*.elizacloud.ai` host to `api.elizacloud.ai`. It therefore minted a **production** key and reported success. You could not tell from the output.

Replaced the pattern rewrite with an explicit per-environment host map, mirroring the app's `resolveDirectCloudAuthApiBase`. Unlisted hosts (self-hosted, loopback) pass through untouched, including scheme and port.

## Verified against the live deployments

```
dev-login --cloud https://api-staging.elizacloud.ai  ->  minted a staging key (new staging account)
that key  ->  200 on api-staging.elizacloud.ai/api/v1/eliza/agents
that key  ->  401 on api.elizacloud.ai/api/v1/eliza/agents      <- environments genuinely isolated
both staging.elizacloud.ai/api/v1 and api-staging.elizacloud.ai/api/v1 serve the API
```

Runtime flip proven both ways: `ELIZA_DEV_SOURCE=1` resolves `https://staging.elizacloud.ai/api/v1`; unset resolves `https://elizacloud.ai/api/v1`.

Tests: `base-url.test.ts` 13/13 (includes "ignores NODE_ENV=development", "any value other than exactly 1 is not-dev", override-in-both-directions, and "does not collapse staging into the production apex"); `register.auth.cloud-api-base.test.ts` 8/8 (each environment pinned to itself, boundary never crossed in either direction, self-hosted/loopback preserved). typecheck clean on `packages/shared`, `packages/app-core`, `plugins/plugin-elizacloud`; Biome clean.

## Operator note

A developer who wants cloud features locally now needs a staging key. It is one non-interactive command, ~2s, no browser:

```bash
bun --conditions=eliza-source packages/app-core/src/entry.ts \
  auth dev-login --cloud https://api-staging.elizacloud.ai --no-save --json
```

Store it as `ELIZA_DEV_CLOUD_API_KEY` (gitignored `.env`) — `entry.ts` promotes it to `ELIZAOS_CLOUD_API_KEY` only when `NODE_ENV !== "production"`, so a production credential in `eliza.json` stays untouched and the two coexist.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - no UI surface; this changes which cloud host an unconfigured process resolves.
<!-- evidence-row:after-screenshots --> N/A - no UI surface.
<!-- evidence-row:walkthrough-video --> N/A - no rendered flow; the observable behavior is the resolved base URL, captured as the runtime flip above.
<!-- evidence-row:backend-logs --> N/A - the operative proof is the live HTTP verification above (200 on staging / 401 on production with the same key), not a log line.
<!-- evidence-row:frontend-logs --> N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory --> N/A - no agent, action, prompt, or model behavior touched; this is URL resolution.
<!-- evidence-row:domain-artifacts --> N/A - no schema or DB change. The domain artifact is the minted staging credential + its isolation check, which is inline above and deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)