### PR TITLE
fix(ci): rebaseline the calendar view bundle after the multi-provider rewrite

### DIFF
--- a/packages/benchmarks/view-bundle-size/budgets.json
+++ b/packages/benchmarks/view-bundle-size/budgets.json
@@ -31,9 +31,10 @@
       "gzipBudgetBytes": 2500
     },
     "plugin-calendar": {
-      "measuredRawBytes": 13708,
-      "measuredGzipBytes": 4350,
-      "gzipBudgetBytes": 5000
+      "measuredRawBytes": 32164,
+      "measuredGzipBytes": 8861,
+      "gzipBudgetBytes": 9900,
+      "baselineReason": "#17206 grew the calendar view from one Google-only agenda into the shipped multi-provider surface: Microsoft Graph calendars, watch-channel state, conflict detection, and travel-reservation events. The old 4350-byte baseline predates all of it, so the overshoot is delivered functionality rather than drift — the total gzip budget still passes with ~33 kB of headroom. Ratchet back down if the provider surfaces are code-split."
     },
     "plugin-contacts": {
       "measuredRawBytes": 33859,


### PR DESCRIPTION
`build view bundles + budget regression gate` is red on develop and blocking the release promote (#17300):

```
plugin-calendar    8.7 kB gzip    budget 4.9 kB    31.4 kB raw    FAIL
```

## Why the ceiling is wrong, not the bundle

The 4350-byte measured baseline predates the bundle it is measuring. #17206 grew the calendar view from a Google-only agenda into the shipped multi-provider surface — Microsoft Graph calendars, watch-channel state, conflict detection, travel-reservation events — across 107 files and ~36k lines. The 78% overshoot is delivered functionality, not drift, so shrinking to fit the old ceiling would mean removing shipped features.

Rebaselined to the measured **8861 gzip / 32164 raw** with ~12% headroom, following this file's own stated convention ("set from the MEASURED baseline plus ~10-15% headroom") and carrying a `baselineReason`, matching the app-control rebaseline precedent in #16852.

The **total** gzip budget is deliberately untouched — it still passes at 274.2 kB / 307.6 kB with ~33 kB of headroom. So this widens exactly one bundle's ceiling without loosening the aggregate guard that catches repo-wide creep.

## Verified locally

```
before:  plugin-calendar  8.7 kB  /  4.9 kB   FAIL      result: FAIL
after:   plugin-calendar  8.7 kB  /  9.7 kB   PASS      result: PASS
         PASS  total.gzipBytes: 274.2 kB / <= 307.6 kB   (unchanged)
```

Exact bytes read from the harness result JSON (`rawBytes: 32164, gzipBytes: 8861`), not the rounded table.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - no UI change; this is a CI budget ceiling. The calendar view's rendered output is byte-identical before and after.
<!-- evidence-row:after-screenshots --> N/A - no UI change.
<!-- evidence-row:walkthrough-video --> N/A - no user-facing flow; the change is one JSON ceiling.
<!-- evidence-row:backend-logs --> N/A - no runtime code path touched; the operative proof is the harness FAIL -> PASS transition in domain-artifacts.
<!-- evidence-row:frontend-logs --> N/A - no frontend behavior changed; only the size ceiling the gate compares against.
<!-- evidence-row:llm-trajectory --> N/A - no agent, action, prompt, or model behavior involved.
<!-- evidence-row:domain-artifacts --> https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17292-domain-artifacts-responses.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)