### PR TITLE
fix(scenario-runner): stop the canonical-JSON guard aborting every run

### DIFF
--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -87,9 +87,40 @@ export function providerQualifiedRunFailure(
 const CLI_EXTERNAL_QUALIFICATION_REASON =
   "external-controller-decision:missing" as const;
 
+/**
+ * Drop keys whose value is literally `undefined`, recursively.
+ *
+ * `canonicalJsonValue` rejects `undefined` on purpose: a canonical encoding must
+ * be unambiguous, and `{ text: undefined }` and `{}` hash differently as objects
+ * while serializing identically as JSON. The report builders, though, assign
+ * `undefined` to absent optional fields (`text`, `error`, `screenshot`, …) — the
+ * ordinary TypeScript way to say "not present" — so a perfectly well-formed
+ * report aborted the run with "contains executable or non-JSON data (undefined)".
+ *
+ * Omitting those keys is semantically lossless: absent and undefined mean the
+ * same thing here, and `JSON.stringify` already erases the distinction. This
+ * deliberately does NOT touch functions, symbols, bigints, or cycles — those
+ * still reach the validator and still fail the run, which is the guard's actual
+ * purpose. Normalizing them away would hide executable data leaking into an
+ * attestable artifact.
+ */
+function omitUndefinedDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(omitUndefinedDeep);
+  if (value === null || typeof value !== "object") return value;
+  // Only plain objects: a class instance's prototype is itself a signal the
+  // validator should see, not something to quietly rebuild into a bare object.
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    if (item === undefined) continue;
+    out[key] = omitUndefinedDeep(item);
+  }
+  return out;
+}
+
 function snapshotScenarioReport(report: ScenarioReport): ScenarioReport {
   return canonicalJsonValue(
-    report,
+    omitUndefinedDeep(report),
     "scenarioReport",
   ) as unknown as ScenarioReport;
 }
@@ -243,7 +274,7 @@ function writeScenarioEvidence(params: {
 }): void {
   const { aggregate, reports, paths, finalize, dependencies } = params;
   const persistedAggregate = redactForScenarioReport(
-    canonicalJsonValue(aggregate, "aggregateReport"),
+    canonicalJsonValue(omitUndefinedDeep(aggregate), "aggregateReport"),
   ) as AggregateReport;
 
   // Checkpoints deliberately write only the bounded evidence needed for crash

--- a/packages/scenario-runner/src/interceptor.ts
+++ b/packages/scenario-runner/src/interceptor.ts
@@ -49,6 +49,62 @@ function isCallable(value: unknown): value is (...args: unknown[]) => unknown {
   return typeof value === "function";
 }
 
+/**
+ * Snapshot a handler's options as pure JSON data.
+ *
+ * The captured trace is serialized into the scenario report, and the
+ * provider-qualified manifest rejects anything executable or non-JSON — so
+ * recording the LIVE options object fails the run: `actionContext` carries
+ * `getPreviousResult`, a closure over the planner's result list, and the
+ * manifest aborts with "contains executable or non-JSON data (function)".
+ * Holding that closure would also pin the planner's state alive for the whole
+ * report.
+ *
+ * Functions, symbols, and undefined are dropped rather than stringified —
+ * substituting a placeholder would put a value in the trace that the action was
+ * never called with. Cycles resolve to null (the options graph is data, so a
+ * cycle means runtime plumbing leaked in), and depth is capped so a deeply
+ * self-referential object cannot stall serialization.
+ */
+const MAX_CAPTURED_PARAM_DEPTH = 12;
+
+function toJsonSafe(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): unknown {
+  if (value === null) return null;
+  const kind = typeof value;
+  if (kind === "function" || kind === "symbol" || kind === "undefined") {
+    return undefined;
+  }
+  if (kind === "bigint") return (value as bigint).toString();
+  if (kind !== "object") return value;
+  if (depth >= MAX_CAPTURED_PARAM_DEPTH) return null;
+
+  const obj = value as object;
+  if (seen.has(obj)) return null;
+  seen.add(obj);
+  try {
+    if (value instanceof Date) return value.toISOString();
+    if (Array.isArray(value)) {
+      // A dropped element must not shift the surrounding indices, so holes
+      // become null instead of collapsing the array.
+      return value.map((item) => toJsonSafe(item, seen, depth + 1) ?? null);
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      const safe = toJsonSafe(item, seen, depth + 1);
+      if (safe !== undefined) out[key] = safe;
+    }
+    return out;
+  } finally {
+    seen.delete(obj);
+  }
+}
+
 function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
@@ -352,7 +408,8 @@ export function attachInterceptor(runtime: IAgentRuntime): ActionInterceptor {
       ];
       const entry: CapturedAction = {
         actionName: action.name,
-        parameters: options,
+        // Snapshot, never the live object — see toJsonSafe.
+        parameters: toJsonSafe(options) as Record<string, unknown> | undefined,
       };
       const wrappedArgs = [...args];
       if (isCallable(callback)) {
@@ -380,7 +437,11 @@ export function attachInterceptor(runtime: IAgentRuntime): ActionInterceptor {
           const resultForReport = suppressResult
             ? { ...r, data: redactedResult, values: redactedResult }
             : r;
-          entry.result = {
+          // Same JSON contract as `parameters`: the ternaries below assign
+          // `undefined` to absent fields, and `raw` is the live result object,
+          // so this is snapshotted too — an explicit `error: undefined` key is
+          // rejected by the manifest just as a function is.
+          entry.result = toJsonSafe({
             success: typeof r.success === "boolean" ? r.success : undefined,
             data: suppressResult ? redactedResult : r.data,
             values: suppressResult ? redactedResult : r.values,
@@ -396,7 +457,7 @@ export function attachInterceptor(runtime: IAgentRuntime): ActionInterceptor {
             path: typeof r.path === "string" ? r.path : undefined,
             exists: typeof r.exists === "boolean" ? r.exists : undefined,
             raw: resultForReport,
-          };
+          }) as CapturedAction["result"];
           captureArtifactsFromValue(
             artifacts,
             action.name,


### PR DESCRIPTION
`Zero-Key scenario runner` and `Zero-Key Deterministic E2E` are red on develop, blocking the release promote (#17300). They do not fail an assertion — they **abort**:

```
fatal: provider-qualified manifest scenarioReport.actionsCalled[0]
       .parameters.actionContext.getPreviousResult
       contains executable or non-JSON data (function)
```

Two distinct producers feed non-canonical data into what is meant to be an attestable artifact.

## 1. The interceptor captured live runtime objects

`interceptor.ts` recorded the **live** handler options as `parameters`, so `actionContext.getPreviousResult` — a closure over the planner's result list — landed in the report; likewise the raw result object. Beyond failing the guard, retaining that closure pins the planner's state alive for the lifetime of the report.

Both are now snapshotted to JSON-safe data. Functions, symbols, and `undefined` are **dropped, not stringified** — substituting `"[Function]"` would put a value in the trace that the action was never called with. Cycles resolve to null and depth is capped.

## 2. `undefined` optional fields vs a canonical encoder

The report builders assign `undefined` to absent optional fields (`text`, `error`, `screenshot`, …) — ordinary TypeScript for "not present". `canonicalJsonValue` rejects `undefined` **on purpose**: `{ text: undefined }` and `{}` hash differently as objects while serializing identically as JSON, which would break canonicalization determinism.

Those keys are now omitted before validation. The normalization is semantically lossless (`JSON.stringify` already erases the distinction) and deliberately does **not** touch functions, symbols, bigints, or cycles — those still reach the validator and still fail the run. Normalizing them away would hide executable data leaking into a signed artifact, which is the guard's whole reason to exist.

## This is a crash fix, not a green-washing one

With the abort removed the lane runs to completion for the first time:

```
before (develop):  fatal abort, no scenario totals at all
after:             Totals: 37 passed, 3 failed, 0 skipped of 40
```

The 3 failures are **genuine, pre-existing assertion failures the crash was hiding** — `deterministic-lifeops-scheduled-tasks` and `deterministic-lifeops-multiday-journey` routing to REPLY instead of `SCHEDULED_TASKS`, and `deterministic-workflow-actions-routes` node runData. They are NOT fixed here; they were simply unreachable before, and they belong to their own lanes. Verified by stashing this change and re-running: the baseline aborts on the fatal before those assertions are ever evaluated.

scenario-runner unit suite: **373 passed**. typecheck clean, Biome clean.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - no UI surface; this is report serialization in a test harness.
<!-- evidence-row:after-screenshots --> N/A - no UI surface.
<!-- evidence-row:walkthrough-video --> N/A - no user-facing flow; the observable change is the lane reaching completion instead of aborting.
<!-- evidence-row:backend-logs --> N/A - the operative proof is the fatal-abort -> 37/40-with-totals transition quoted above, reproduced locally both with and without the change.
<!-- evidence-row:frontend-logs --> N/A - no frontend involvement.
<!-- evidence-row:llm-trajectory --> N/A - the lane runs the deterministic LLM proxy by design (SCENARIO_LLM_PROXY_STRICT=1); no live-model behavior is touched. This change alters how a trajectory is SERIALIZED, not what the model did.
<!-- evidence-row:domain-artifacts --> N/A - the domain artifact here IS the scenario report, and its shape change is described above: functions dropped at capture, undefined-valued keys omitted before canonicalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)