### PR TITLE
fix(lifeops-bench): make the action manifest host-independent

### DIFF
--- a/scripts/lifeops-bench/export-action-manifest.ts
+++ b/scripts/lifeops-bench/export-action-manifest.ts
@@ -12,6 +12,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promoteSubactionsToActions } from "../../packages/core/src/actions/promote-subactions.ts";
 import { buildPlannerToolsFromActions } from "../../packages/core/src/actions/to-tool.ts";
 import type { Action } from "../../packages/core/src/types/components.ts";
 import type { Plugin } from "../../packages/core/src/types/plugin.ts";
@@ -19,6 +20,7 @@ import blueBubblesPlugin from "../../plugins/plugin-bluebubbles/src/index.ts";
 import { calendarSourcesAction } from "../../plugins/plugin-calendar/src/actions/calendar-sources.ts";
 import { appContactsPlugin } from "../../plugins/plugin-contacts/src/plugin.ts";
 import imessagePlugin from "../../plugins/plugin-imessage/src/index.ts";
+import { ownerScreenTimeAction } from "../../plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts";
 import { personalAssistantPlugin } from "../../plugins/plugin-personal-assistant/src/plugin.ts";
 import { appPhonePlugin } from "../../plugins/plugin-phone/src/plugin.ts";
 import { todosPlugin } from "../../plugins/plugin-todos/src/index.ts";
@@ -448,10 +450,36 @@ function main(): void {
       "Calendar source administration exported without the overlapping event action.",
     actions: [calendarSourcesAction],
   };
+  // The manifest is a HOST-INDEPENDENT catalog of the action surface, so it must
+  // not vary with the machine that generated it. personalAssistantPlugin gates
+  // the owner-screentime umbrella behind `isDarwin()` at module load (the native
+  // activity tracker is macOS-only), so exporting on Linux silently dropped all
+  // 11 OWNER_SCREENTIME* actions and the committed macOS-generated manifest could
+  // never match a Linux CI regeneration — `Verify lifeops action manifest is up
+  // to date` failed on every run, unfixably, because both sides were "correct"
+  // for their own host.
+  //
+  // Contribute the gated umbrella explicitly instead of touching the runtime
+  // gate: production planners on non-Darwin hosts must still never see these
+  // actions. Names already contributed by the plugin (i.e. when generating ON
+  // macOS) are skipped, so the output is identical on either host.
+  const screenTimeActions = promoteSubactionsToActions(ownerScreenTimeAction);
+  const pluginActionNames = new Set(
+    (personalAssistantPlugin.actions ?? []).map((action) => action.name),
+  );
+  const platformIndependentScreenTimePlugin: Plugin = {
+    name: "@elizaos/plugin-personal-assistant",
+    description:
+      "Platform-gated owner-screentime umbrella, exported regardless of the generating host.",
+    actions: screenTimeActions.filter(
+      (action) => !pluginActionNames.has(action.name),
+    ),
+  };
   const sourcePlugins = [
     appContactsPlugin,
     calendarSourcePlugin,
     personalAssistantPlugin,
+    platformIndependentScreenTimePlugin,
     appPhonePlugin,
     blueBubblesPlugin,
     imessagePlugin,
@@ -461,7 +489,9 @@ function main(): void {
   const manifest: Manifest = {
     schemaVersion: 1,
     generator: "scripts/lifeops-bench/export-action-manifest.ts",
-    sourcePlugins: sourcePlugins.map((plugin) => plugin.name),
+    // Deduped: the platform-gated screentime contributor is the same package as
+    // personalAssistantPlugin, so it must not appear twice in the provenance list.
+    sourcePlugins: [...new Set(sourcePlugins.map((plugin) => plugin.name))],
     filters: {
       domains: options.domains,
       capabilities: options.capabilities,


### PR DESCRIPTION
`Verify lifeops action manifest is up to date` cannot pass on develop, and regenerating does not fix it — both sides are "correct" for their own host.

## The trap

`personalAssistantPlugin` gates the owner-screentime umbrella behind `isDarwin()` at module load, because the native activity tracker is macOS-only. So:

- The committed manifest was generated on **macOS**: 222 actions.
- CI regenerates on **ubuntu**: 211 actions. Diff fails, every run.
- Regenerating locally on Linux "fixes" the gate by **deleting all 11 `OWNER_SCREENTIME*` entries** — an 802-line silent truncation of the catalog.

That last path is the dangerous one, and it looks completely clean in review: a green-looking diff that quietly removes an entire platform's action surface. I hit it myself while trying to fix this gate and reverted it.

## The fix

The manifest is a **host-independent** description of the action surface, so the exporter now contributes the gated umbrella explicitly — following the same synthetic-`Plugin` pattern already used for calendar sources. Names the plugin already supplied (i.e. when generating *on* macOS) are filtered out, and the provenance list is deduped, so the output is identical on either host.

**The runtime gate is deliberately untouched.** Planners on non-Darwin hosts must still never see these actions; only the exporter's view is widened. This is a provenance/reporting fix, not a behavior change.

## Verification

```
before, regenerating on Linux:  222 -> 211 actions, -802 lines
after,  regenerating on Linux:  222 actions, `git diff` EMPTY
```

The committed macOS-generated manifest is now reproduced byte-for-byte on Linux, which is the actual contract the gate is trying to enforce.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; this changes a benchmark manifest generator script.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; the change is one exporter code path.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime behavior changes. The operative proof is the byte-identical regeneration recorded in domain-artifacts.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend involvement.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - the exporter enumerates action metadata statically; no model is invoked.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the manifest IS the artifact and this change asserts it does not move; regenerating on Linux now yields an empty git diff against the committed 222-action file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

