### PR TITLE
fix(core): preserve in-memory memory uniqueness

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -132,4 +132,51 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 		).toBe(true);
 		expect(elapsed).toBeLessThan(1000); // bounded — no pathological blowup
 	});
+
+	it("preserves batch uniqueness overrides and defaults unspecified memories to unique", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		await adapter.createMemories([
+			{
+				memory: { ...msg("entry wins true", 1), unique: false },
+				tableName: "messages",
+				unique: true,
+			},
+			{
+				memory: { ...msg("entry wins false", 2), unique: true },
+				tableName: "messages",
+				unique: false,
+			},
+			{
+				memory: { ...msg("memory stays false", 3), unique: false },
+				tableName: "messages",
+			},
+			{
+				memory: msg("default is unique", 4),
+				tableName: "messages",
+			},
+		]);
+
+		const all = await adapter.getMemories({ roomId, tableName: "messages" });
+		expect(
+			Object.fromEntries(
+				all.map((memory) => [(memory.content as { text: string }).text, memory.unique]),
+			),
+		).toEqual({
+			"entry wins true": true,
+			"entry wins false": false,
+			"memory stays false": false,
+			"default is unique": true,
+		});
+
+		const unique = await adapter.getMemories({
+			roomId,
+			tableName: "messages",
+			unique: true,
+		});
+		expect(unique.map((memory) => (memory.content as { text: string }).text)).toEqual([
+			"default is unique",
+			"entry wins true",
+		]);
+	});
 });

--- a/packages/core/src/database/inMemoryAdapter.message-search.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.message-search.test.ts
@@ -160,7 +160,10 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 		const all = await adapter.getMemories({ roomId, tableName: "messages" });
 		expect(
 			Object.fromEntries(
-				all.map((memory) => [(memory.content as { text: string }).text, memory.unique]),
+				all.map((memory) => [
+					(memory.content as { text: string }).text,
+					memory.unique,
+				]),
 			),
 		).toEqual({
 			"entry wins true": true,
@@ -174,9 +177,8 @@ describe("InMemoryDatabaseAdapter — textContains", () => {
 			tableName: "messages",
 			unique: true,
 		});
-		expect(unique.map((memory) => (memory.content as { text: string }).text)).toEqual([
-			"default is unique",
-			"entry wins true",
-		]);
+		expect(
+			unique.map((memory) => (memory.content as { text: string }).text),
+		).toEqual(["default is unique", "entry wins true"]);
 	});
 });

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1212,7 +1212,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
 	): Promise<UUID[]> {
 		const ids: UUID[] = [];
-		for (const { memory, tableName } of memories) {
+		for (const { memory, tableName, unique } of memories) {
 			const gen =
 				typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
 					? crypto.randomUUID()
@@ -1221,6 +1221,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			const stored: Memory = {
 				...memory,
 				id: asUuid(id),
+				unique: unique ?? memory.unique ?? true,
 			};
 			this.memoriesById.set(id, stored);
 			const roomId = memory.roomId;


### PR DESCRIPTION
## Summary

- Preserve the per-entry `unique` flag in `InMemoryDatabaseAdapter.createMemories`.
- Default an unspecified uniqueness flag to `true`, matching the SQL adapter.
- Add a real adapter regression covering entry precedence, explicit `false`, and the default.

This is a same-repository recut of #17270 onto current `develop`. The original external-fork PR could not create the repository's required workflow runs, so its aggregate gate timed out waiting for seven checks that never existed. The original author's two commits and attribution are preserved.

## Root cause

The in-memory batch write discarded its entry-level `unique` value and persisted an unspecified flag as `undefined`. A later `getMemories({ unique: true })` query therefore omitted rows that SQL treats as unique by default.

## Verification

```text
bunx vitest run packages/core/src/database/inMemoryAdapter.message-search.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - process-local storage adapter; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - process-local storage adapter; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changes.

<!-- evidence-row:backend-logs -->
- [x] N/A - no server or transport boundary runs; the process-local adapter is exercised directly by the focused real-adapter test.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or planner behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the adapter is intentionally ephemeral and produces no persistent domain artifact; the regression directly inspects its four Map-backed rows and filtered retrieval result.

Supersedes #17270.
