### PR TITLE
chore(registry): update elizaos-plugin-yieldsignal to 0.2.2

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
@@ -2,8 +2,8 @@
   "package": "elizaos-plugin-yieldsignal",
   "repository": "github:Stakemate369/plugin-yieldsignal",
   "kind": "plugin",
-  "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification and schema validation.",
+  "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted ETH liquid staking APY plus USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification, schema validation and partial-reading disclosure.",
   "homepage": "https://yieldsignal.vercel.app",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "tags": ["defi", "x402", "yield", "base", "payments"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1040,14 +1040,14 @@
         "repo": "elizaos-plugin-yieldsignal",
         "v0": null,
         "v1": null,
-        "v2": "0.2.0"
+        "v2": "0.2.2"
       },
       "supports": {
         "v0": false,
         "v1": false,
         "v2": true
       },
-      "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification and schema validation.",
+      "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted ETH liquid staking APY plus USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification, schema validation and partial-reading disclosure.",
       "homepage": "https://yieldsignal.vercel.app",
       "topics": [
         "defi",


### PR DESCRIPTION
Version bump for the already-listed third-party entry (merged in #17141). `elizaos-plugin-yieldsignal@0.2.2` is live on npm.

### What changed in the plugin

- **Partial readings are now surfaced to the consuming agent.** The upstream service reports which protocols it could not read (`omittedProtocols` / `coverage`) plus any protocol whose incentive component is unknown; 0.2.1 silently dropped all of it, so an agent allocating capital could not tell "best protocol" from "best of whatever answered". That case is live right now: the Euler USDC pool on Base reads mute, so the response is honestly `coverage: { read: 5, expected: 6 }`. The action states it inline in its reply text, not only in `data`.
- All new fields are **optional and validated**: an older deployment that omits them still parses, and a malformed block is dropped rather than throwing on an otherwise valid paid response. A regression test pins that 0.2.1's parser also accepts the newer server fields, using a real reduced production body.
- The entry description was missing **ETH liquid staking**, supported since 0.2.1 and the asset with the strongest verified record of the three.

### Verification

- `bun run --cwd packages/registry src/validate-cli.ts` → `[registry] 30 third-party entries validated`
- `bun run --cwd packages/registry src/generate.ts` → regenerated `generated-registry.json`, committed alongside (diff is the two fields only, no hand edits)
- Plugin repo: 31 tests, typecheck + build clean — https://github.com/Stakemate369/plugin-yieldsignal
- npm: https://www.npmjs.com/package/elizaos-plugin-yieldsignal/v/0.2.2

Public, unpaid endpoint anyone can check the service against: https://yieldsignal.vercel.app/accuracy.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
