### PR TITLE
fix(audit): bind audit:ocr to the resolved audit directory

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,7 +37,7 @@
     "mvp:visual-verify:overflow-demo": "node scripts/mvp-visual-verify/overflow-invariant-demo.mjs",
     "audit:app:verify": "bun run audit:app:capture && ELIZA_MVP_OCR_ENGINE=packaged bun run audit:ocr && ELIZA_MVP_OCR_ENGINE=packaged bun run mvp:visual-verify -- --strict --require-baseline-states",
     "audit:views": "node scripts/audit-views-soak.mjs",
-    "audit:ocr": "bun scripts/ocr-triage.ts --audit-dir aesthetic-audit-output --baseline test/ui-smoke/ocr-triage-baseline.json",
+    "audit:ocr": "bun scripts/ocr-triage.ts --baseline test/ui-smoke/ocr-triage-baseline.json",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
     "test:desktop:packaged:windows": "node scripts/run-desktop-packaged-windows.mjs",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -260,7 +260,15 @@ export function validateImportedOcrRecords(
 
 export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
   const args = parseArgs(argv);
-  const auditDir = args["audit-dir"] ?? "aesthetic-audit-output";
+  // Directory precedence mirrors the capture stage exactly (#17128): an
+  // explicit CLI --audit-dir is authoritative, otherwise the same
+  // ELIZA_AUDIT_APP_DIR the Playwright capture honored, otherwise the default.
+  // Without the env tier, an isolated `audit:app` run captured into
+  // ELIZA_AUDIT_APP_DIR while OCR silently analyzed whatever stale artifacts
+  // sat in the default directory — a false evidence binding.
+  const auditDir =
+    args["audit-dir"] ??
+    (process.env.ELIZA_AUDIT_APP_DIR?.trim() || "aesthetic-audit-output");
   const outPath = args.out ?? join(auditDir, "ocr-triage.json");
 
   // Baseline = `slug::viewport` keys of regressions already tracked by an issue.

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -120,6 +120,91 @@ describe("authorizedShots (report-authoritative selection)", () => {
   });
 });
 
+describe("audit directory resolution (#17128)", () => {
+  let root: string;
+  let isolated: string;
+  let staleDefault: string;
+  let previousCwd: string;
+  let previousEnv: string | undefined;
+
+  function seedCapture(dir: string, slug: string, text: string): void {
+    const rows: ReportEntry[] = [
+      { slug, viewport: "desktop-landscape", verdict: "good" },
+    ];
+    shot(dir, "desktop-landscape", slug);
+    writeFileSync(join(dir, "report.json"), JSON.stringify(rows));
+    writeFileSync(
+      join(dir, "ocr.ndjson"),
+      ocrLine("desktop-landscape", slug, text),
+    );
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "ocr-dir-"));
+    isolated = join(root, "isolated-run");
+    staleDefault = join(root, "aesthetic-audit-output");
+    mkdirSync(isolated);
+    mkdirSync(staleDefault);
+    seedCapture(isolated, "builtin-chat", "Chat messages composer");
+    // A populated default directory from an earlier run. If resolution ever
+    // falls back here while ELIZA_AUDIT_APP_DIR is set, the assertions below
+    // catch the false evidence binding.
+    seedCapture(staleDefault, "builtin-phone", "Phone dialer keypad");
+    previousCwd = process.cwd();
+    previousEnv = process.env.ELIZA_AUDIT_APP_DIR;
+    process.chdir(root);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (previousEnv === undefined) {
+      delete process.env.ELIZA_AUDIT_APP_DIR;
+    } else {
+      process.env.ELIZA_AUDIT_APP_DIR = previousEnv;
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reads ELIZA_AUDIT_APP_DIR when no --audit-dir is passed and leaves the stale default untouched", async () => {
+    process.env.ELIZA_AUDIT_APP_DIR = isolated;
+
+    const result = await runOcrTriage(["--ocr", join(isolated, "ocr.ndjson")]);
+
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["builtin-chat"]);
+    expect(existsSync(join(isolated, "ocr-triage.json"))).toBe(true);
+    expect(existsSync(join(staleDefault, "ocr-triage.json"))).toBe(false);
+  });
+
+  it("keeps an explicit --audit-dir authoritative over ELIZA_AUDIT_APP_DIR", async () => {
+    process.env.ELIZA_AUDIT_APP_DIR = staleDefault;
+
+    const result = await runOcrTriage([
+      "--audit-dir",
+      isolated,
+      "--ocr",
+      join(isolated, "ocr.ndjson"),
+    ]);
+
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["builtin-chat"]);
+    expect(existsSync(join(isolated, "ocr-triage.json"))).toBe(true);
+    expect(existsSync(join(staleDefault, "ocr-triage.json"))).toBe(false);
+  });
+
+  it("falls back to the default directory when neither source is set", async () => {
+    delete process.env.ELIZA_AUDIT_APP_DIR;
+
+    const result = await runOcrTriage([
+      "--ocr",
+      join(staleDefault, "ocr.ndjson"),
+    ]);
+
+    expect(result.entries.map((entry) => entry.slug)).toEqual([
+      "builtin-phone",
+    ]);
+    expect(existsSync(join(staleDefault, "ocr-triage.json"))).toBe(true);
+  });
+});
+
 describe("ocr-triage CLI (end-to-end provenance)", () => {
   let dir: string;
   beforeEach(() => {


### PR DESCRIPTION
## Summary

`audit:app` supports isolated output through `ELIZA_AUDIT_APP_DIR`, but its chained OCR stage passed a literal default directory. OCR could therefore analyze stale artifacts from another run and still exit green.

This same-repository recut preserves #17305's original author commit and rebases it onto current `develop`; the contributor fork allows maintainer edits in GitHub but does not grant Git push access needed for the repository's rebase policy.

## Fix

`runOcrTriage` resolves the audit directory with the same precedence as capture:

1. explicit CLI `--audit-dir`
2. `ELIZA_AUDIT_APP_DIR`
3. `aesthetic-audit-output`

The package script no longer hardcodes the default, so the environment tier is reachable. Missing `report.json` in the resolved directory still throws; there is no fallback to stale default artifacts.

## Verification

On the rebased exact tree:

```text
bunx vitest run packages/app/test/audit/ocr-triage-provenance.test.ts -t "audit directory resolution"
3 passed
0 failed
```

The complete file ran 16/17 locally; its unrelated Playwright-list cleanup case timed out after 46 seconds in this environment. The three changed directory-resolution cases pass and required CI is authoritative for the full suite.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - evidence-pipeline script only; no rendered UI change.

<!-- evidence-row:after-screenshots -->
- [x] N/A - evidence-pipeline script only; no rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - CLI directory-resolution contract only.

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend or transport boundary changes; the CLI function contract is exercised directly by the regression suite.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or planner behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the regression creates only temporary test artifacts and deletes them; it directly asserts `ocr-triage.json` placement, CLI precedence, and default fallback.

Closes #17128. Supersedes #17305.
