### PR TITLE
chore(registry): update elizaos-plugin-yieldsignal to 0.2.2

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-yieldsignal.json
@@ -2,8 +2,8 @@
   "package": "elizaos-plugin-yieldsignal",
   "repository": "github:Stakemate369/plugin-yieldsignal",
   "kind": "plugin",
-  "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification and schema validation.",
+  "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted ETH liquid staking APY plus USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification, schema validation and partial-reading disclosure.",
   "homepage": "https://yieldsignal.vercel.app",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "tags": ["defi", "x402", "yield", "base", "payments"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1040,14 +1040,14 @@
         "repo": "elizaos-plugin-yieldsignal",
         "v0": null,
         "v1": null,
-        "v2": "0.2.0"
+        "v2": "0.2.2"
       },
       "supports": {
         "v0": false,
         "v1": false,
         "v2": true
       },
-      "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification and schema validation.",
+      "description": "Buyer-side GET_YIELD_SIGNAL action: risk-weighted ETH liquid staking APY plus USDC/WETH lending APY on Base via x402, with client-side spend controls, EIP-712 response verification, schema validation and partial-reading disclosure.",
       "homepage": "https://yieldsignal.vercel.app",
       "topics": [
         "defi",


### PR DESCRIPTION
## Summary

Update the existing `elizaos-plugin-yieldsignal` community-registry entry from 0.2.0 to 0.2.2 and describe its ETH liquid-staking support and partial-reading disclosure. The generated wire registry is regenerated from the source entry.

This same-repository recut preserves #17318's original author commit while allowing the required repository workflows to run; the external-fork head created only the aggregate gate and two ancillary checks.

## Primary-source verification

- npm serves 0.2.2 with repository `github.com/Stakemate369/plugin-yieldsignal`: https://www.npmjs.com/package/elizaos-plugin-yieldsignal/v/0.2.2
- upstream package manifest declares 0.2.2: https://github.com/Stakemate369/plugin-yieldsignal/blob/main/package.json
- upstream README documents ETH liquid staking and Base USDC/WETH lending: https://github.com/Stakemate369/plugin-yieldsignal
- the action text surfaces omitted protocols and coverage in the agent-visible reply: https://github.com/Stakemate369/plugin-yieldsignal/blob/main/src/actions/get-yield-signal.ts

## Verification

```text
bun run --cwd packages/registry validate
[registry] 30 third-party entries validated

bun run --cwd packages/registry generate
30 entries generated; git diff --exit-code passed

bun run --cwd packages/registry test
8 files passed, 33 tests passed

bun run --cwd packages/registry typecheck
passed
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - registry metadata only; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - registry metadata only; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changes.

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changes.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or planner code changes in this repository.

<!-- evidence-row:domain-artifacts -->
- [x] Published npm artifact: https://www.npmjs.com/package/elizaos-plugin-yieldsignal/v/0.2.2

Supersedes #17318.
