### PR TITLE
fix(scenario-runner): stamp agentId on turns and stop truncating captured data

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -1553,6 +1553,14 @@ async function executeMessageTurn(
   const message: Memory = createMessageMemory({
     id: crypto.randomUUID() as UUID,
     entityId: room.userId,
+    // Real transports stamp the receiving agent on every inbound turn, and the
+    // owner-private disclosure gate REQUIRES it: an absent `agentId` is denied
+    // as `agent_mismatch`, which silently drops every owner-private action from
+    // the planner's tool surface. The planner is then handed an empty tool list
+    // and the turn degrades to REPLY, so a scenario asserting an owner action
+    // fails with no visible cause. Also flips memory scope to `private`, which
+    // is what a one-to-one owner turn actually is.
+    agentId: runtime.agentId,
     roomId: room.roomId,
     content: {
       ...turnContent,
@@ -1675,6 +1683,9 @@ async function executeActionTurn(
   const message: Memory = createMessageMemory({
     id: crypto.randomUUID() as UUID,
     entityId: room.userId,
+    // See the message-turn construction above: the owner-private disclosure
+    // gate denies an agentId-less turn as `agent_mismatch`.
+    agentId: runtime.agentId,
     roomId: room.roomId,
     content: {
       ...turnContent,

--- a/packages/scenario-runner/src/interceptor.ts
+++ b/packages/scenario-runner/src/interceptor.ts
@@ -62,11 +62,17 @@ function isCallable(value: unknown): value is (...args: unknown[]) => unknown {
  *
  * Functions, symbols, and undefined are dropped rather than stringified —
  * substituting a placeholder would put a value in the trace that the action was
- * never called with. Cycles resolve to null (the options graph is data, so a
- * cycle means runtime plumbing leaked in), and depth is capped so a deeply
- * self-referential object cannot stall serialization.
+ * never called with. Cycles resolve to null: `seen` tracks ancestors only, so
+ * recursion always terminates on a cyclic graph without truncating siblings.
+ *
+ * The depth cap is a backstop ABOVE the downstream limit, never below it:
+ * `canonicalJsonValue` rejects nesting past 128, so anything it would accept
+ * must survive sanitization intact. An earlier cap of 12 silently rewrote real
+ * data to null — a captured workflow execution nests
+ * `data.resultData.runData.<node>.0.data.main.0.0.json` well past that, and the
+ * truncated `null` looked exactly like a genuine empty node result.
  */
-const MAX_CAPTURED_PARAM_DEPTH = 12;
+const MAX_CAPTURED_PARAM_DEPTH = 128;
 
 function toJsonSafe(
   value: unknown,


### PR DESCRIPTION
Takes the `pr-deterministic` lane from **37/40 to 40/40**. Two independent defects.

## 1. Owner-private actions were invisible to the planner

Every turn the executor built went through `createMessageMemory` **without an `agentId`** — which real transports always stamp. The owner-private disclosure gate denies an agentId-less turn as `agent_mismatch`, so `canActionRun` rejected every owner-private action while building the planner surface. The planner was then invoked with an **empty tool list**, no tool call was emitted, and the turn degraded to `REPLY`.

The symptom was maximally misleading: `assertTurn: expected SCHEDULED_TASKS action, saw REPLY`, with nothing indicating a *security gate* — not the planner — had made the decision. Instrumenting the gate was the only way to see it:

```
__GATE__ SCHEDULED_TASKS_CREATE roles=["OWNER"] ctx=["tasks"]
        reason=Owner-private disclosure denied: agent_mismatch
```

Roles and contexts were already correct; only the agent binding was missing. Passing `agentId` also flips memory scope to `private`, which is what a one-to-one owner turn actually is.

Fixes `deterministic-lifeops-scheduled-tasks` and `deterministic-lifeops-multiday-journey`.

## 2. My own regression from #17314 — the sanitizer truncated real data

The capture sanitizer I added capped nesting at **12** and returned `null` beyond it. A captured workflow execution nests `data.resultData.runData.<node>.0.data.main.0.0.json` well past that, so the Set node's output item was rewritten to `null` — **indistinguishable from a genuine empty node result**, which is exactly what `deterministic-workflow-actions-routes` reported.

Confirmed by causation test: this scenario passed in a lane run before #17314 and failed after.

Cycle detection already guarantees termination (`seen` tracks ancestors only), so the shallow cap bought nothing and cost data. Raised to **128** to sit *at* the downstream limit rather than below it — `canonicalJsonValue` rejects nesting past 128, so anything it would accept now survives sanitization intact.

## Verification

```
pr-deterministic lane:  40 passed, 0 failed, 0 skipped of 40   (exit 0)
                        was 37 passed / 3 failed
scenario-runner units:  373 passed
typecheck: clean        biome: clean
```

## Evidence

<!-- evidence-row:before-screenshots --> N/A - no UI surface; this is the scenario harness.
<!-- evidence-row:after-screenshots --> N/A - no UI surface.
<!-- evidence-row:walkthrough-video --> N/A - no user-facing flow; the observable change is the lane result quoted above.
<!-- evidence-row:backend-logs --> N/A - the operative proof is the instrumented gate output quoted above plus the 37/40 to 40/40 lane transition, both reproduced locally.
<!-- evidence-row:frontend-logs --> N/A - no frontend involvement.
<!-- evidence-row:llm-trajectory --> N/A - the lane runs the deterministic LLM proxy by design (SCENARIO_LLM_PROXY_STRICT=1). This changes which tools reach the planner and how a trajectory is captured, not live-model behavior.
<!-- evidence-row:domain-artifacts --> N/A - the artifact is the scenario report; the shape change is that deep captured values (workflow runData) are no longer rewritten to null at depth 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)