### PR TITLE
docs(lifeops-bench): record why the full pytest sweep looks hung

### DIFF
--- a/packages/benchmarks/lifeops-bench/README.md
+++ b/packages/benchmarks/lifeops-bench/README.md
@@ -344,6 +344,19 @@ python3 -m pytest tests/ -v
 python3 -m eliza_lifeops_bench.corpus_audit --output corpus-audit.json
 ```
 
+`pytest tests/` collects 25,967 tests across 44 files and takes 70+ minutes of CPU, so
+it looks hung long before it is. Of those, 24,589 come from
+`test_conformance.py` alone, which parameterizes one PerfectAgent-scores-1.0
+and two WrongAgent-scores-0 invariants across `ALL_SCENARIOS` — a registry of
+16,511 scenarios. The count is expected, not a runaway.
+
+For local work, run the files covering what you changed; the full sweep belongs
+in CI rather than in an edit loop:
+
+```bash
+python3 -m pytest tests/test_hermes_agent.py tests/test_budget.py -q
+```
+
 Regenerate `manifests/actions.manifest.json` and `manifests/actions.summary.md`
 after changing LifeOps or todo action metadata:
 


### PR DESCRIPTION
## Summary

`pytest tests/` in `packages/benchmarks/lifeops-bench` collects **25,967 tests across 44 files** and burns **70+ minutes of CPU**. It reads as hung long before it finishes, and there is currently nothing in the README saying otherwise.

**24,589 of those come from `test_conformance.py` alone**, which parameterizes one PerfectAgent-scores-1.0 and two WrongAgent-scores-0 invariants across `ALL_SCENARIOS` — a registry of **16,511** scenarios. The count is expected, not a runaway.

Adds that to the Tests section, and points at running the files covering what you changed for local work.

## Numbers are measured, not estimated

All three verified on develop `b8ac8ded800`:

```text
pytest tests/ --collect-only -q                    → 25,967 across 44 files
pytest tests/test_conformance.py --collect-only -q → tests/test_conformance.py: 24589
len(ALL_SCENARIOS)                                 → 16511
```

I was handed 25,955 for the total and re-measured before publishing; the real figure is 25,967.

## Why

Came out of the parent-suite work (#17206), where the full sweep's runtime made a changed-area lane the only practical local gate — and it was not obvious from the docs that this was expected rather than something wedged.

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - documentation-only change with no rendered product UI.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - documentation-only change with no rendered product UI.

<!-- evidence-row:walkthrough-video -->
Video walkthrough: N/A - documentation-only change with no user-exercisable flow.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - documentation-only change does not execute a backend path.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - documentation-only change does not execute a frontend path.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectories: N/A - no agent, action, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - the change records measured collection counts and creates no runtime artifact.
