### PR TITLE
fix(app-control): make first-build app verification actually winnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1409,3 +1409,7 @@ packages/ui/src/components/shell/__e2e__/output-home-locale/
 # both are build output and must never be committed (#16970 review).
 /fused-lib/
 /.fused-lib/
+
+# App-create scaffolds: the workspace app root the APP create flow builds into
+# (<checkout>/eliza/apps/<dir>). Generated per-user app workdirs, never repo code.
+/eliza/

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -730,14 +730,23 @@ async function createNewApp({
 	}
 
 	const task = dispatch.agents[0];
-	const text = `Started app create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification will run when it emits APP_CREATE_DONE.`;
+	// Chat gets one human sentence; the dispatch detail (workdir, session id,
+	// completion event) stays planner-facing in the result text — internal
+	// identifiers in a user-visible message read as a malfunction. The
+	// verified+turnComplete contract makes the callback the turn's single
+	// delivery (the gated evaluator skip), same as LIST_CLOUD_APPS.
+	const text = `Building ${displayName} now — I'll post the link once it's live (usually takes a few minutes).`;
+	const dispatchDetail = `Started app create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification runs when it emits APP_CREATE_DONE.`;
 	await callback?.({ text });
 	logger.info(
 		`[plugin-app-control] APP/create new name=${name} workdir=${workdir} dir=${appDirName} session=${task.sessionId}`,
 	);
 	return {
 		success: true,
-		text,
+		text: dispatchDetail,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "create",
 			subMode: "new",
@@ -814,14 +823,19 @@ async function editExistingApp({
 	}
 
 	const task = dispatch.agents[0];
-	const text = `Started app edit task for ${app.displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification will run when it emits APP_CREATE_DONE.`;
+	// Same single-human-sentence contract as the create path above.
+	const text = `Updating ${app.displayName} now — I'll post the link once the changes are live (usually takes a few minutes).`;
+	const dispatchDetail = `Started app edit task for ${app.displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification runs when it emits APP_CREATE_DONE.`;
 	await callback?.({ text });
 	logger.info(
 		`[plugin-app-control] APP/create edit appName=${app.name} workdir=${workdir} session=${task.sessionId}`,
 	);
 	return {
 		success: true,
-		text,
+		text: dispatchDetail,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "create",
 			subMode: "edit",

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -990,7 +990,22 @@ export async function runCreate({
 		});
 	}
 
-	const installed = await appClient.listInstalledApps();
+	// error-policy:J4 designed degrade — this list only powers the optional
+	// "edit an existing app?" offer. On a cold registry cache the server's
+	// load (network fetch + workspace scans) exceeds the 2s loopback read
+	// deadline and this read aborts; failing the whole create over it turned
+	// every first post-restart build into "The operation timed out." Degrade
+	// to create-new instead; the load-bearing edit-path reads stay strict.
+	let installed: InstalledAppInfo[] = [];
+	try {
+		installed = await appClient.listInstalledApps();
+	} catch (err) {
+		logger.warn(
+			`[plugin-app-control] APP/create could not list installed apps (${
+				err instanceof Error ? err.message : String(err)
+			}); proceeding to create-new`,
+		);
+	}
 	const matches = rankMatches(intent, installed);
 
 	if (matches.length === 0) {

--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -184,6 +184,45 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 	);
 
 	itIf(pkgManagerAvailable)(
+		"proves the vitest summary through ANSI-colorized test output",
+		async () => {
+			const workdir = mkdtempSync(path.join(tmpdir(), "verify-ansi-proof-"));
+			writeMinimalTsProject(workdir, PASS_TS);
+			// The live failure shape: vitest colorizes because the spawn env's
+			// FORCE_COLOR/CI PRESENCE forces color on in tinyrainbow, burying the
+			// `Tests` summary line under escapes. This shim ignores NO_COLOR, so
+			// the case specifically exercises the combineOutput ANSI strip.
+			writeFileSync(
+				path.join(workdir, "test-shim.mjs"),
+				`process.stdout.write("\\x1b[2m Tests\\x1b[22m \\x1b[1m2 passed\\x1b[22m\\x1b[90m (2)\\x1b[39m\\n"); process.exit(0);\n`,
+				"utf8",
+			);
+
+			const result = await service.verifyPlugin({
+				workdir,
+				profile: "full",
+				runId: "int-ansi-proof",
+				packageManager: "npm",
+				structuredProof: {
+					kind: "PLUGIN_CREATE_DONE",
+					pluginName: "verify-ansi-fixture",
+					files: ["src.ts"],
+					typecheck: "ok",
+					lint: "ok",
+					tests: { passed: 2, failed: 0 },
+				},
+			});
+
+			expect(result.verdict).toBe("pass");
+			expect(
+				result.checks.find((check) => check.kind === "structured-proof")
+					?.passed,
+			).toBe(true);
+		},
+		120_000,
+	);
+
+	itIf(pkgManagerAvailable)(
 		"returns verdict=fail with non-empty diagnostics when TS has a type error",
 		async () => {
 			const workdir = mkdtempSync(path.join(tmpdir(), "verify-int-fail-"));

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -189,6 +189,19 @@ function packageScriptCommand(
 	return { file: "npm", args: ["run", "--silent", script] };
 }
 
+// Non-interactive child env (no TTY prompts, no color). NO_COLOR is the only
+// lever color libs honor by PRESENCE alone — tinyrainbow (vitest) treats the
+// mere presence of FORCE_COLOR or CI as force-ON, so `FORCE_COLOR: "0"`
+// cannot disable color by itself.
+function nonInteractiveEnv(): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		CI: process.env.CI ?? "1",
+		FORCE_COLOR: "0",
+		NO_COLOR: "1",
+	};
+}
+
 async function runScript(
 	pm: PackageManager,
 	script: string,
@@ -200,16 +213,7 @@ async function runScript(
 		cwd: workdir,
 		timeout: timeoutMs,
 		maxBuffer: EXEC_BUFFER,
-		// Ensure non-interactive child processes (no TTY prompts). NO_COLOR is
-		// the only lever color libs honor by PRESENCE alone — tinyrainbow
-		// (vitest) treats the mere presence of FORCE_COLOR or CI as force-ON,
-		// so `FORCE_COLOR: "0"` cannot disable color by itself.
-		env: {
-			...process.env,
-			CI: process.env.CI ?? "1",
-			FORCE_COLOR: "0",
-			NO_COLOR: "1",
-		},
+		env: nonInteractiveEnv(),
 		// On Windows, `npm` resolves to `npm.cmd` and `bun` to `bun.exe`.
 		// Without `shell: true`, Node's execFile won't apply PATHEXT and
 		// fails with ENOENT. Enabling the shell is the standard Windows
@@ -341,15 +345,7 @@ async function runTests(
 		cwd: workdir,
 		timeout: TIMEOUTS.test,
 		maxBuffer: EXEC_BUFFER,
-		// Same color-suppression contract as runScript above: NO_COLOR is the
-		// presence-honored lever; FORCE_COLOR/CI presence would otherwise
-		// force vitest's color on and bury the parsed `Tests` summary line.
-		env: {
-			...process.env,
-			CI: process.env.CI ?? "1",
-			FORCE_COLOR: "0",
-			NO_COLOR: "1",
-		},
+		env: nonInteractiveEnv(),
 	};
 	let stdout = "";
 	let stderr = "";

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -25,6 +25,7 @@ import {
 	parseEslintOutput,
 	parseTscOutput,
 	parseVitestOutput,
+	stripAnsi,
 	truncate,
 } from "./verification-helpers.js";
 
@@ -198,8 +199,16 @@ async function runScript(
 		cwd: workdir,
 		timeout: timeoutMs,
 		maxBuffer: EXEC_BUFFER,
-		// Ensure non-interactive child processes (no TTY prompts).
-		env: { ...process.env, CI: process.env.CI ?? "1", FORCE_COLOR: "0" },
+		// Ensure non-interactive child processes (no TTY prompts). NO_COLOR is
+		// the only lever color libs honor by PRESENCE alone — tinyrainbow
+		// (vitest) treats the mere presence of FORCE_COLOR or CI as force-ON,
+		// so `FORCE_COLOR: "0"` cannot disable color by itself.
+		env: {
+			...process.env,
+			CI: process.env.CI ?? "1",
+			FORCE_COLOR: "0",
+			NO_COLOR: "1",
+		},
 		// On Windows, `npm` resolves to `npm.cmd` and `bun` to `bun.exe`.
 		// Without `shell: true`, Node's execFile won't apply PATHEXT and
 		// fails with ENOENT. Enabling the shell is the standard Windows
@@ -243,7 +252,12 @@ async function persistOutput(
 	return outputPath;
 }
 
-function combineOutput(stdout: string, stderr: string): string {
+function combineOutput(rawStdout: string, rawStderr: string): string {
+	// Every parsed check (typecheck/lint/test/build) funnels through here
+	// before persistence and parsing — the one place stripping ANSI protects
+	// all the line-anchored parsers at once.
+	const stdout = stripAnsi(rawStdout);
+	const stderr = stripAnsi(rawStderr);
 	if (!stdout) return stderr;
 	if (!stderr) return stdout;
 	return `${stdout}\n--- stderr ---\n${stderr}`;
@@ -326,7 +340,15 @@ async function runTests(
 		cwd: workdir,
 		timeout: TIMEOUTS.test,
 		maxBuffer: EXEC_BUFFER,
-		env: { ...process.env, CI: process.env.CI ?? "1", FORCE_COLOR: "0" },
+		// Same color-suppression contract as runScript above: NO_COLOR is the
+		// presence-honored lever; FORCE_COLOR/CI presence would otherwise
+		// force vitest's color on and bury the parsed `Tests` summary line.
+		env: {
+			...process.env,
+			CI: process.env.CI ?? "1",
+			FORCE_COLOR: "0",
+			NO_COLOR: "1",
+		},
 	};
 	let stdout = "";
 	let stderr = "";

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -21,6 +21,7 @@ import {
 	describeScreenshotWithVision,
 	detectPackageManager,
 	ensureVerificationDir,
+	loadAppFromWorkdir,
 	type PackageManager,
 	parseEslintOutput,
 	parseTscOutput,
@@ -1195,6 +1196,18 @@ export class AppVerificationService extends Service {
 					if (!client) {
 						throw new Error(
 							"Launch check requested but AppControlClient was not initialized",
+						);
+					}
+					// Register-before-launch: launch resolves through the runtime's
+					// registry, but a freshly built app used to be registered only by
+					// the PASS-path room bridge — circular with this check, so a
+					// first-build launch check could never pass. Same idempotent
+					// load-from-directory the bridge uses; when registration fails the
+					// launch check itself reports the unresolvable name.
+					const load = await loadAppFromWorkdir(opts.workdir);
+					if (!load.ok) {
+						logger.warn(
+							`[AppVerificationService] pre-launch app registration failed: ${load.error}`,
 						);
 					}
 					result = await runLaunchCheck(dir, client, check.appName, launchCtx);

--- a/plugins/plugin-app-control/src/services/verification-helpers.ts
+++ b/plugins/plugin-app-control/src/services/verification-helpers.ts
@@ -11,8 +11,13 @@ import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
-import { ModelType, resolveStateDir } from "@elizaos/core";
+import {
+	ModelType,
+	resolveServerOnlyPort,
+	resolveStateDir,
+} from "@elizaos/core";
 import { resolveApiToken, resolveDesktopApiPort } from "@elizaos/shared";
+import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
 
 export type Diagnostic = {
 	file: string;
@@ -41,6 +46,73 @@ export function detectPackageManager(workdir: string): PackageManager {
 		current = parent;
 	}
 	return "npm";
+}
+
+export interface RegisteredAppItem {
+	slug: string;
+	canonicalName: string;
+}
+
+/**
+ * Register a freshly built app into the running runtime via the loopback agent
+ * API so a subsequent `launch <name>` resolves. The
+ * `/api/apps/load-from-directory` route scans a *parent* directory for app
+ * subdirs and registers each valid one through the AppRegistryService
+ * (`trust: "external"`), so we pass the workdir's parent, not the workdir
+ * itself. That register is idempotent by slug and the worker host returns the
+ * existing worker for an already-registered sibling, so re-scanning the shared
+ * apps dir does not churn unrelated apps. Returns the registered items so
+ * callers can confirm the app is actually launchable instead of promising a
+ * `launch` that would fail with "No installed app matches". Used by the
+ * verification launch check (register-before-launch) and by the room bridge's
+ * pass message.
+ */
+export async function loadAppFromWorkdir(
+	workdir: string,
+): Promise<
+	{ ok: true; items: RegisteredAppItem[] } | { ok: false; error: string }
+> {
+	const port = resolveServerOnlyPort(process.env);
+	const directory = path.dirname(workdir);
+	try {
+		const resp = await fetch(
+			`http://127.0.0.1:${port}/api/apps/load-from-directory`,
+			{
+				method: "POST",
+				headers: createViewsRequestHeaders(),
+				body: JSON.stringify({ directory }),
+				signal: AbortSignal.timeout(30_000),
+			},
+		);
+		const body = (await resp.json().catch(() => ({}))) as Record<
+			string,
+			unknown
+		>;
+		if (resp.ok && body.ok === true) {
+			const items = Array.isArray(body.items)
+				? body.items.filter(
+						(item): item is RegisteredAppItem =>
+							typeof item === "object" &&
+							item !== null &&
+							typeof (item as RegisteredAppItem).slug === "string" &&
+							typeof (item as RegisteredAppItem).canonicalName === "string",
+					)
+				: [];
+			return { ok: true, items };
+		}
+		return {
+			ok: false,
+			error:
+				typeof body.error === "string"
+					? body.error
+					: `register returned HTTP ${resp.status}`,
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
 }
 
 /**

--- a/plugins/plugin-app-control/src/services/verification-helpers.ts
+++ b/plugins/plugin-app-control/src/services/verification-helpers.ts
@@ -44,6 +44,17 @@ export function detectPackageManager(workdir: string): PackageManager {
 }
 
 /**
+ * Removes ANSI escape sequences (colors, cursor moves) so the line-anchored
+ * parsers below see plain text. Vitest's color lib (tinyrainbow) enables color
+ * on the PRESENCE of `FORCE_COLOR`/`CI` in the env regardless of value, so
+ * captured output can carry escapes even from a non-TTY pipe.
+ */
+export function stripAnsi(text: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI ESC is the target
+	return text.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
+}
+
+/**
  * UTF-8 safe truncation. Appends a `...truncated N chars` suffix when the
  * input exceeds `max`.
  */

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -33,7 +33,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 import type { IAgentRuntime, Memory, SwarmEvent, UUID } from "@elizaos/core";
 import {
 	getSwarmCoordinatorService,
@@ -42,6 +41,7 @@ import {
 	Service,
 } from "@elizaos/core";
 import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
+import { loadAppFromWorkdir } from "./verification-helpers.js";
 
 export const VERIFICATION_ROOM_BRIDGE_SERVICE_TYPE = "verification-room-bridge";
 
@@ -208,70 +208,6 @@ async function loadPluginFromWorkdir(
 				typeof body.error === "string"
 					? body.error
 					: `load returned HTTP ${resp.status}`,
-		};
-	} catch (err) {
-		return {
-			ok: false,
-			error: err instanceof Error ? err.message : String(err),
-		};
-	}
-}
-
-interface RegisteredAppItem {
-	slug: string;
-	canonicalName: string;
-}
-
-/**
- * Register a freshly built app into the running runtime via the loopback agent
- * API so a subsequent `launch <name>` resolves. The
- * `/api/apps/load-from-directory` route scans a *parent* directory for app
- * subdirs and registers each valid one through the AppRegistryService
- * (`trust: "external"`), so we pass the workdir's parent, not the workdir
- * itself. That register is idempotent by slug and the worker host returns the
- * existing worker for an already-registered sibling, so re-scanning the shared
- * apps dir does not churn unrelated apps. Returns the registered items so the
- * verdict message can confirm the app is actually launchable instead of
- * promising a `launch` that would fail with "No installed app matches".
- */
-async function loadAppFromWorkdir(
-	workdir: string,
-): Promise<
-	{ ok: true; items: RegisteredAppItem[] } | { ok: false; error: string }
-> {
-	const port = resolveServerOnlyPort(process.env);
-	const directory = path.dirname(workdir);
-	try {
-		const resp = await fetch(
-			`http://127.0.0.1:${port}/api/apps/load-from-directory`,
-			{
-				method: "POST",
-				headers: createViewsRequestHeaders(),
-				body: JSON.stringify({ directory }),
-				signal: AbortSignal.timeout(30_000),
-			},
-		);
-		const body = (await resp.json().catch(() => ({}))) as Record<
-			string,
-			unknown
-		>;
-		if (resp.ok && body.ok === true) {
-			const items = Array.isArray(body.items)
-				? body.items.filter(
-						(item): item is RegisteredAppItem =>
-							isRecord(item) &&
-							typeof item.slug === "string" &&
-							typeof item.canonicalName === "string",
-					)
-				: [];
-			return { ok: true, items };
-		}
-		return {
-			ok: false,
-			error:
-				typeof body.error === "string"
-					? body.error
-					: `register returned HTTP ${resp.status}`,
 		};
 	} catch (err) {
 		return {


### PR DESCRIPTION
## Problem

A freshly created app could not pass `profile: "full"` verification, and the create flow leaked internals to chat. Four distinct causes, all reproduced live:

1. **Circular launch check**: the launch check resolves the app through the runtime registry, but a new app was registered only by the PASS-path room bridge (#11954) — register-after-pass vs launch-check-needs-registration = a first build can never pass. A live claude sub-agent burned 15 minutes proving the check unwinnable before we stopped it.
2. **ANSI false-fail on the structured proof**: the verifier's own spawn env (`FORCE_COLOR: "0"`, `CI: "1"`) force-ENABLES color in vitest — tinyrainbow checks those vars by *presence*, not value — so the `^\s*Tests` proof parser never matches through the escapes and every build "cannot prove tests.passed".
3. **Cold-registry dispatch death**: the create flow's optional "edit an existing app?" list read aborts at the 2s loopback deadline whenever the server registry cache is cold (2.5s upstream fetch + workspace scans), surfacing as a bare "The operation timed out." on the first build after every restart (trajectory latency ≈ 2018ms = the deadline, twice reproduced).
4. **Jargon in chat**: the visible dispatch callback carried the absolute workdir, task-session UUID, and the `APP_CREATE_DONE` event name; the planner then re-rendered it as a second friendlier bubble.

## Fix

- **Register-before-launch**: the launch check runs the same idempotent `load-from-directory` registration the pass-path bridge uses (hoisted to `verification-helpers`, one implementation, both callers) before launching.
- **Color off at the source + defense in depth**: `NO_COLOR=1` in both spawn envs (the only presence-honored off switch), plus `stripAnsi` at the `combineOutput` choke point so all four line-anchored parsers see plain text regardless of what a child emits.
- **Fail-soft the optional read** (`error-policy:J4` designed degrade): a cold-cache abort degrades to create-new instead of killing the dispatch; the load-bearing edit-path reads stay strict.
- **One human sentence in chat**; the dispatch detail stays planner-facing in the result. `verifiedUserFacing` + `turnComplete` make the callback the turn's single delivery (same contract as LIST_CLOUD_APPS).
- `.gitignore` for the `eliza/apps/` scaffold root the create flow builds into.

## Testing

- Plugin suite **1574 pass**, typecheck + lint clean. The ANSI regression test drives a shim that ignores `NO_COLOR` (exercising the strip leg) and is mutation-checked: strip disabled → test fails.
- **Live end-to-end on a production Discord bot**: "make a small app called vibecheck3" → one clean chat message → claude sub-agent builds → verification passes → bot posts the live URL, ~75 seconds request-to-link, URL independently probed 200.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime change only; no rendered-UI source in this repo touched (core/agent/plugin .ts). The user-visible surface is the Discord client rendering bot messages, evidenced under domain artifacts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime change only; no rendered-UI source in this repo touched (core/agent/plugin .ts). The user-visible surface is the Discord client rendering bot messages, evidenced under domain artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no repo UI flow to record; the user-facing behavior is Discord messages, evidenced via logs/trajectories/domain artifacts below.
<!-- evidence-row:backend-logs -->
- [x] <details><summary>live log excerpts</summary><pre>BEFORE: [AppVerificationService] structured-proof: Cannot prove tests.passed because the test output did not contain a Vitest Tests summary line (test.log contains ANSI: \x1b[2m Tests\x1b[22m …)
BEFORE: APP create → "The operation timed out." at ~2018ms (= 2s loopback read deadline, cold registry)
AFTER:  [plugin-app-control] APP/create new name=vibecheck3 … session=6534c9c8 (agentType claude)
AFTER:  verification verdict=pass; bot posts live URL</pre></details> ANSI case is mutation-checked in [app-verification.integration.test.ts](https://github.com/elizaOS/eliza/blob/fix/app-control-verification/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface in this change; no console/network activity exists for it.
<!-- evidence-row:llm-trajectory -->
- [x] Live claude sub-agent transcript root-caused both false-fails while building a real app (its own narration: vitest colorizes under the verifier env; discovery never scans the scaffold root — the launch check was circular). Post-fix live run: request → build → verify pass → link, ~75s, producing [vibecheck3](https://nubilio.org/apps/vibecheck3/). Regression contract: [app-verification.integration.test.ts](https://github.com/elizaOS/eliza/blob/fix/app-control-verification/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts).
<!-- evidence-row:domain-artifacts -->
- [x] Live app built end-to-end by the fixed pipeline: [nubilio.org/apps/vibecheck3](https://nubilio.org/apps/vibecheck3/) (HTTP 200, independently probed; title `Vibecheck3`). Earlier build the bug bit: [nubilio.org/apps/eliza-showcase](https://nubilio.org/apps/eliza-showcase/) — live since the builder deployed it, yet verification false-failed it for 15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
