### PR TITLE
fix(orchestrator): sub-agent lifecycle honesty — verify false-fails, digest storms, monologue leaks

### DIFF
--- a/packages/agent/src/api/coordinator-wiring.ts
+++ b/packages/agent/src/api/coordinator-wiring.ts
@@ -48,7 +48,9 @@ export interface WireResult {
 }
 
 const POLL_INTERVAL_MS = 2_000;
-const POLL_TIMEOUT_MS = 90_000;
+/** After this long the poll slows to POLL_SLOW_INTERVAL_MS and logs once. */
+const POLL_SLOW_AFTER_MS = 90_000;
+const POLL_SLOW_INTERVAL_MS = 10_000;
 const RETRY_DELAY_MS = 500;
 const MAX_RETRIES = 5;
 
@@ -139,43 +141,52 @@ export async function wireCoordinatorBridgesWhenReady<S extends WirableState>(
       return result;
     }
 
-    const deadline = Date.now() + POLL_TIMEOUT_MS;
-    let serviceFound = false;
+    // No hard deadline: the coordinator ships in a DEFERRED plugin whose
+    // resolution starts only after all deferred boot work completes, so its
+    // arrival time is unbounded — a heavy boot (deferred vault-hydration alone
+    // ran ~94s in one restart) pushes it past any fixed timeout, permanently
+    // disabling the bridges until the next restart (which hits the same race).
+    // The poll is a cheap service-map lookup; slow it after POLL_SLOW_AFTER_MS
+    // and stop only when this wiring call is stale (runtime swapped —
+    // onRuntimeSwapped starts a fresh call for the replacement runtime).
+    const pollStart = Date.now();
+    let slowLogged = false;
 
-    while (Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    while (state.runtime === runtime) {
+      const slow = Date.now() - pollStart >= POLL_SLOW_AFTER_MS;
+      if (slow && !slowLogged) {
+        slowLogged = true;
+        const pluginPresent =
+          runtime.hasService?.(SWARM_COORDINATOR_SERVICE_TYPE) ?? false;
+        if (pluginPresent) {
+          logger.warn(
+            `[eliza-api] coordinator service registered but not yet ` +
+              `discoverable after ${POLL_SLOW_AFTER_MS / 1000}s (${context}) — ` +
+              `still polling; coding-agent features stay disabled until it appears.`,
+          );
+        } else {
+          logger.debug?.(
+            `[eliza-api] coordinator not available after ${POLL_SLOW_AFTER_MS / 1000}s (${context}) — ` +
+              `still polling (deferred plugin may not have loaded yet).`,
+          );
+        }
+      }
+      await new Promise((r) => {
+        const timer = setTimeout(r, slow ? POLL_SLOW_INTERVAL_MS : POLL_INTERVAL_MS);
+        timer.unref?.();
+      });
 
       const svc = discoverCoordinator(runtime);
       if (svc) {
-        serviceFound = true;
         logger.debug?.(`[eliza-api] coordinator service detected (${context})`);
         break;
       }
     }
 
-    if (!serviceFound) {
-      // Service never appeared. Distinguish the two very different causes so
-      // this isn't a generic "disabled" that hides a real degradation:
-      //   (a) The orchestrator plugin isn't installed/enabled at all — normal
-      //       for non-coding deployments → debug.
-      //   (b) The plugin IS installed but the coordinator never registered or
-      //       never bound its ACP stream (the bind race) → warn, with the
-      //       coordinator's own actionable reason if it exposes one.
-      const pluginPresent =
-        runtime.hasService?.(SWARM_COORDINATOR_SERVICE_TYPE) ?? false;
-      if (pluginPresent) {
-        logger.warn(
-          `[eliza-api] coordinator service registered but never became ` +
-            `discoverable after ${POLL_TIMEOUT_MS / 1000}s (${context}) — ` +
-            `coding-agent supervision DEGRADED. This usually means the ` +
-            `orchestrator's SWARM_COORDINATOR service failed to start; ` +
-            `check the service-start logs above.`,
-        );
-      } else {
-        logger.debug?.(
-          `[eliza-api] coordinator not available after ${POLL_TIMEOUT_MS / 1000}s (${context}) — coding agent features disabled`,
-        );
-      }
+    if (state.runtime !== runtime) {
+      logger.debug?.(
+        `[eliza-api] coordinator polling superseded by runtime swap (${context})`,
+      );
       return result;
     }
 

--- a/packages/agent/src/api/coordinator-wiring.ts
+++ b/packages/agent/src/api/coordinator-wiring.ts
@@ -172,7 +172,10 @@ export async function wireCoordinatorBridgesWhenReady<S extends WirableState>(
         }
       }
       await new Promise((r) => {
-        const timer = setTimeout(r, slow ? POLL_SLOW_INTERVAL_MS : POLL_INTERVAL_MS);
+        const timer = setTimeout(
+          r,
+          slow ? POLL_SLOW_INTERVAL_MS : POLL_INTERVAL_MS,
+        );
         timer.unref?.();
       });
 

--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -8,10 +8,10 @@
  * Deterministic: in-memory runtime/state stubs with real temp-dir files for the
  * artifact cases.
  */
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleSwarmSynthesis,
   routeAutonomyTextToUser,
@@ -69,7 +69,15 @@ describe("handleSwarmSynthesis", () => {
   // A stopped Claude session's newest jsonl ends mid-turn: its last assistant
   // text is inner monologue, not a result. Seed the REAL reader path
   // (~/.claude/projects/<sanitized-workdir>/) with such a transcript and prove
-  // the non-completed status gate keeps it out of the routed text.
+  // the non-completed status gate keeps it out of the routed text. Seeded dirs
+  // live in the developer's real ~/.claude/projects, so track and remove them.
+  const seededProjectDirs: string[] = [];
+  afterEach(async () => {
+    while (seededProjectDirs.length > 0) {
+      const dir = seededProjectDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
   async function seedClaudeTranscript(narration: string): Promise<string> {
     const workdir = await mkdtemp(path.join(tmpdir(), "swarm-stop-"));
     const projectDir = path.join(
@@ -78,11 +86,15 @@ describe("handleSwarmSynthesis", () => {
       "projects",
       workdir.replace(/[/.]/g, "-"),
     );
+    seededProjectDirs.push(projectDir);
     await mkdir(projectDir, { recursive: true });
     await writeFile(
       path.join(projectDir, "session.jsonl"),
       `${JSON.stringify({
-        message: { role: "assistant", content: [{ type: "text", text: narration }] },
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: narration }],
+        },
       })}\n`,
       "utf8",
     );
@@ -120,9 +132,7 @@ describe("handleSwarmSynthesis", () => {
       },
     );
 
-    expect(routed).toEqual([
-      "verification failed: launch check did not pass",
-    ]);
+    expect(routed).toEqual(["verification failed: launch check did not pass"]);
   });
 
   it("falls back to a lifecycle line for a stopped Claude task with no verdict", async () => {

--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -9,7 +9,7 @@
  * artifact cases.
  */
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -64,6 +64,100 @@ describe("handleSwarmSynthesis", () => {
     );
 
     expect(routed).toEqual(["https://example.com/apps/breath-ring/"]);
+  });
+
+  // A stopped Claude session's newest jsonl ends mid-turn: its last assistant
+  // text is inner monologue, not a result. Seed the REAL reader path
+  // (~/.claude/projects/<sanitized-workdir>/) with such a transcript and prove
+  // the non-completed status gate keeps it out of the routed text.
+  async function seedClaudeTranscript(narration: string): Promise<string> {
+    const workdir = await mkdtemp(path.join(tmpdir(), "swarm-stop-"));
+    const projectDir = path.join(
+      homedir(),
+      ".claude",
+      "projects",
+      workdir.replace(/[/.]/g, "-"),
+    );
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      path.join(projectDir, "session.jsonl"),
+      `${JSON.stringify({
+        message: { role: "assistant", content: [{ type: "text", text: narration }] },
+      })}\n`,
+      "utf8",
+    );
+    return workdir;
+  }
+
+  it("relays only the verification verdict for a stopped Claude task, never the transcript tail", async () => {
+    const narration =
+      "Now let me read the launch check itself to see exactly how it resolves the app.";
+    const workdir = await seedClaudeTranscript(narration);
+    const routed: string[] = [];
+
+    await handleSwarmSynthesis(
+      { runtime },
+      {
+        tasks: [
+          {
+            sessionId: "pty-stopped",
+            label: "app",
+            agentType: "claude",
+            originalTask: "make an app showcasing eliza",
+            status: "stopped",
+            completionSummary: "raw lastOutput that must not relay either",
+            validationSummary: "verification failed: launch check did not pass",
+            workdir,
+          },
+        ],
+        total: 1,
+        completed: 0,
+        stopped: 1,
+        errored: 0,
+      },
+      async (text) => {
+        routed.push(text);
+      },
+    );
+
+    expect(routed).toEqual([
+      "verification failed: launch check did not pass",
+    ]);
+  });
+
+  it("falls back to a lifecycle line for a stopped Claude task with no verdict", async () => {
+    const workdir = await seedClaudeTranscript(
+      "Let me grep the registry cache next.",
+    );
+    const routed: string[] = [];
+
+    await handleSwarmSynthesis(
+      { runtime },
+      {
+        tasks: [
+          {
+            sessionId: "pty-stopped-2",
+            label: "app",
+            agentType: "claude",
+            originalTask: "make an app showcasing eliza",
+            status: "stopped",
+            completionSummary: "",
+            workdir,
+          },
+        ],
+        total: 1,
+        completed: 0,
+        stopped: 1,
+        errored: 0,
+      },
+      async (text) => {
+        routed.push(text);
+      },
+    );
+
+    expect(routed).toEqual([
+      "make an app showcasing eliza — stopped before completion.",
+    ]);
   });
 
   it("strips captured tool-output envelopes from the completionSummary, preserving evidence URLs (#11578)", async () => {

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -424,10 +424,26 @@ async function buildTaskResultLine(task: {
   originalTask: string;
   completionSummary: string;
   validationSummary?: string;
+  status: string;
   agentType: string;
   workdir?: string;
 }): Promise<string> {
   const validationSummary = task.validationSummary?.trim();
+  // Lifecycle-only relay for any task that did not complete cleanly. A
+  // stopped/errored session's transcript tail is mid-task inner monologue and
+  // its completionSummary can carry raw lastOutput — neither is a result the
+  // user should see. The verification verdict (validationSummary) is the one
+  // user-actionable payload such a task owns; otherwise state what happened.
+  if (task.status !== "completed") {
+    if (validationSummary) return validationSummary;
+    return `${task.originalTask} — ${task.status} before completion.`;
+  }
+  // Lifecycle-only relay for any task that did not complete cleanly. A
+  // stopped/errored session's transcript tail is mid-task inner monologue and
+  // its completionSummary can carry raw lastOutput — neither is a result the
+  // user should see. The verification verdict (validationSummary) is the one
+  // user-actionable payload such a task owns; otherwise state what happened.
+
   // Defense-in-depth for issue elizaOS/eliza#11578: strip any captured
   // `[tool output: …]` envelope blocks from the completionSummary before it is
   // relayed VERBATIM to the connector. The coordinator now sanitizes at the

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -438,12 +438,6 @@ async function buildTaskResultLine(task: {
     if (validationSummary) return validationSummary;
     return `${task.originalTask} — ${task.status} before completion.`;
   }
-  // Lifecycle-only relay for any task that did not complete cleanly. A
-  // stopped/errored session's transcript tail is mid-task inner monologue and
-  // its completionSummary can carry raw lastOutput — neither is a result the
-  // user should see. The verification verdict (validationSummary) is the one
-  // user-actionable payload such a task owns; otherwise state what happened.
-
   // Defense-in-depth for issue elizaOS/eliza#11578: strip any captured
   // `[tool output: …]` envelope blocks from the completionSummary before it is
   // relayed VERBATIM to the connector. The coordinator now sanitizes at the

--- a/plugins/plugin-agent-orchestrator/__tests__/setup.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/setup.ts
@@ -4,6 +4,8 @@
  * and integration glue are tested directly in smithers-task suites, while
  * production defaults remain enabled through shouldUseSmithersTaskRunner.
  */
+import { tmpdir } from "node:os";
+
 if (process.env.ELIZA_ORCHESTRATOR_SMITHERS === undefined) {
   process.env.ELIZA_ORCHESTRATOR_SMITHERS = "0";
 }
@@ -17,4 +19,17 @@ if (process.env.ELIZA_ORCHESTRATOR_SMITHERS === undefined) {
 // REAL temp git workspaces.
 if (process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE === undefined) {
   process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE = "0";
+}
+
+// The residuals gate and change-set capture probe a session's workdir with real
+// git (`git rev-parse --is-inside-work-tree`, `git ls-files --others`). Tests
+// build throwaway workdirs under the OS temp dir; on a host where an ANCESTOR of
+// the temp dir is itself a git work tree (a stray `/.git`, which exists on some
+// CI/VPS images), git discovery walks up past the fixture into that repo and its
+// dirt leaks in — a non-git fixture reads as "inside a work tree", and pre-seeded
+// files get scooped into change sets. Cap discovery at the temp root so fixtures
+// are hermetic regardless of the host's ambient git layout. Fixtures that create
+// their own repo under the temp dir still find it before hitting the ceiling.
+if (process.env.GIT_CEILING_DIRECTORIES === undefined) {
+  process.env.GIT_CEILING_DIRECTORIES = tmpdir();
 }

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   OrchestratorTaskService,
   residualsOrchestratorOwnedArtifacts,
+  residualsSpawnBaseline,
 } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import {
@@ -2814,5 +2815,40 @@ describe("OrchestratorTaskService — residuals owned-artifact resolution", () =
         },
       }),
     ).toEqual([]);
+  });
+});
+
+describe("residualsSpawnBaseline — spawn-time metadata classification", () => {
+  it("contributes nothing for an absent session or metadata without the keys", () => {
+    expect(residualsSpawnBaseline(undefined)).toEqual({});
+    expect(residualsSpawnBaseline({ metadata: {} })).toEqual({});
+  });
+
+  it("parses the tracked-dirty-at-spawn baseline, dropping non-string entries", () => {
+    expect(
+      residualsSpawnBaseline({
+        metadata: { codingBaselineDirty: ["a.ts", 42, "b.ts", ""] },
+      }),
+    ).toEqual({ baselineDirtyPaths: ["a.ts", "b.ts"] });
+  });
+
+  it("classifies a route-mapped, non-isolated workdir as shared", () => {
+    expect(
+      residualsSpawnBaseline({ metadata: { workdirRouteId: "agent-home" } }),
+    ).toEqual({ sharedRouteWorkdir: true });
+  });
+
+  it("never classifies an isolated per-session workdir as shared, route or not", () => {
+    expect(
+      residualsSpawnBaseline({
+        metadata: { workdirRouteId: "agent-home", isolatedWorkdir: true },
+      }),
+    ).toEqual({});
+  });
+
+  it("ignores a blank route id", () => {
+    expect(
+      residualsSpawnBaseline({ metadata: { workdirRouteId: "   " } }),
+    ).toEqual({});
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1640,10 +1640,13 @@ describe("SubAgentRouter", () => {
         if (String(input) === cdnUrl) {
           return new Response("not found", { status: 404 });
         }
-        return new Response(`<!doctype html><img src="${cdnUrl}" alt="Sticker">`, {
-          status: 200,
-          headers: { "content-type": "text/html" },
-        });
+        return new Response(
+          `<!doctype html><img src="${cdnUrl}" alt="Sticker">`,
+          {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          },
+        );
       });
       stubFetch(fetchMock);
       session = sessionWithTask(`build and verify ${appUrl}`);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1629,6 +1629,45 @@ describe("SubAgentRouter", () => {
       expect(fetchMock).toHaveBeenCalledWith(imageUrl, expect.anything());
     });
 
+    it("degrades a dead cross-origin third-party sub-resource to an info note, not a build failure", async () => {
+      // A font-CDN / analytics host that 404s a bare probe is not evidence the
+      // build tanked (the driftwave regression). The page itself probes 200, so
+      // completion must POST — with a single "[verification note:" line, never
+      // the "[verification:" failure marker — and no verify-retry may fire.
+      const appUrl = "https://example.test/apps/permit-garden/";
+      const cdnUrl = "https://cdn.example.test/permit-garden/sticker.png";
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === cdnUrl) {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response(`<!doctype html><img src="${cdnUrl}" alt="Sticker">`, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      });
+      stubFetch(fetchMock);
+      session = sessionWithTask(`build and verify ${appUrl}`);
+      acp = makeAcpService(session);
+      const { runtime, handleMessage, spawnSession } = makeRuntime({
+        acp: acp.service,
+        setting: { ELIZA_URL_VERIFY_SETTLE_MS: "0" },
+      });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "task_complete", {
+        response: `Done — live at ${appUrl}`,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(spawnSession).not.toHaveBeenCalled();
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      const posted = handleMessage.mock.calls[0]?.[1];
+      expect(posted?.content?.text).toContain(appUrl);
+      expect(posted?.content?.text).toContain("[verification note:");
+      expect(posted?.content?.text).not.toContain("[verification:");
+      expect(fetchMock).toHaveBeenCalledWith(cdnUrl, expect.anything());
+    });
+
     it("does not reject a served-200 mapped app URL for stale local mtime (GAP-C: live 200 is authoritative)", async () => {
       // A deploy step that copies a build into place preserves the source
       // file's mtime, so a healthy app can have files older than the session.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1586,9 +1586,14 @@ describe("SubAgentRouter", () => {
       expect(verified ?? []).toEqual([]);
     });
 
-    it("rejects generated app pages that reference unreachable image assets", async () => {
+    it("rejects generated app pages that reference unreachable same-origin image assets", async () => {
+      // Same-origin sub-resources are part of the artifact under verification:
+      // a missing sticker.png on the deploy origin IS a broken build and must
+      // still fail-and-retry. (Dead THIRD-PARTY sub-resources — font-CDN roots,
+      // hallucinated cross-origin paths — degrade to an info note instead;
+      // covered by the companion test below.)
       const appUrl = "https://example.test/apps/permit-garden/";
-      const imageUrl = "https://cdn.example.test/permit-garden/sticker.png";
+      const imageUrl = "https://example.test/apps/permit-garden/sticker.png";
       const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
         if (String(input) === imageUrl) {
           return new Response("not found", { status: 404 });
@@ -2170,6 +2175,37 @@ describe("extractSubResources", () => {
       (_, i) => `<script src="s${i}.js"></script>`,
     ).join("");
     expect(extractSubResources(many, PAGE).length).toBe(10);
+  });
+
+  it("skips <link> hint rels but keeps the real stylesheet they accompany", () => {
+    // zai-glm-4.7 emits Google-Fonts boilerplate: preconnect hints name bare
+    // CDN roots that 404 by design and must never be probed as dependencies,
+    // while the css2 stylesheet on the same hinted origin is a real one.
+    const html = `<!doctype html><html><head>
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+      <link rel="dns-prefetch" href="https://cdn.example.com">
+      <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+      <link rel="stylesheet" href="style.css">
+      </head><body></body></html>`;
+    expect(extractSubResources(html, PAGE).sort()).toEqual([
+      "https://example.test/apps/bmi/style.css",
+      "https://fonts.googleapis.com/css2?family=Inter&display=swap",
+    ]);
+  });
+
+  it("skips modulepreload/prefetch/prerender hints across quoting styles", () => {
+    const html = `<link rel=modulepreload href="/mod.js"><link rel='prefetch' href="/next.html"><link rel="prerender" href="/after.html"><link rel="stylesheet" href="/app.css">`;
+    expect(extractSubResources(html, PAGE)).toEqual([
+      "https://example.test/app.css",
+    ]);
+  });
+
+  it("never yields a bare cross-origin root, whatever element carried it", () => {
+    const html = `<script src="https://cdn.jsdelivr.net/"></script><script src="https://cdn.jsdelivr.net/npm/chart.js"></script>`;
+    expect(extractSubResources(html, PAGE)).toEqual([
+      "https://cdn.jsdelivr.net/npm/chart.js",
+    ]);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -9,6 +9,7 @@ import {
   type SupervisorTaskView,
   statusEmoji,
   supervisorStalenessLabel,
+  taskOldEnoughForDigest,
   TaskSupervisorService,
 } from "../../src/services/task-supervisor-service.js";
 
@@ -239,6 +240,7 @@ describe("TaskSupervisorService.runOnce resilience", () => {
             status: "active",
             activeSessionCount: 1,
             latestSessionLabel: "codex",
+            createdAt: new Date(Date.now() - 120_000).toISOString(),
           },
         ],
         getTaskOriginTarget: async () => ({
@@ -249,6 +251,160 @@ describe("TaskSupervisorService.runOnce resilience", () => {
     );
     const result = await svc.runOnce();
     expect(result.posted).toEqual([ROOM_A]);
+    await svc.stop();
+  });
+});
+
+describe("digest damping (uncoordinated-messages burst)", () => {
+  // Unlike runtimeWith above, the supervisor stays ENABLED here:
+  // noteTaskCompletion deliberately no-ops on a disabled supervisor, and
+  // these tests exercise the note path. start() arms the unref'd interval
+  // timer; svc.stop() clears it before the test ends.
+  function enabledRuntimeWith(taskSvc: unknown) {
+    return {
+      getService: (type: string) =>
+        type === "ORCHESTRATOR_TASK_SERVICE" ? taskSvc : undefined,
+      sendMessageToTarget: async () => undefined,
+      getSetting: () => undefined,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+    } as never;
+  }
+
+  it("gates the first digest on min task-age > tick interval (pure helper)", () => {
+    const t0 = 1_000_000_000_000;
+    const iso = (agoMs: number) => new Date(t0 - agoMs).toISOString();
+    expect(taskOldEnoughForDigest(iso(10_000), t0, 45_000)).toBe(false);
+    expect(taskOldEnoughForDigest(iso(45_000), t0, 45_000)).toBe(true);
+    expect(taskOldEnoughForDigest(iso(90_000), t0, 45_000)).toBe(true);
+    // Fail-open: an unparseable timestamp must not mute a task forever.
+    expect(taskOldEnoughForDigest("not-a-date", t0, 45_000)).toBe(true);
+  });
+
+  it("runOnce posts no stale 'active' digest for a sub-tick-interval task", async () => {
+    const svc = await TaskSupervisorService.start(
+      enabledRuntimeWith({
+        listTasks: async () => [
+          {
+            id: "young",
+            title: "inline build",
+            status: "active",
+            activeSessionCount: 1,
+            latestSessionLabel: "codex",
+            createdAt: new Date(Date.now() - 5_000).toISOString(),
+          },
+        ],
+        getTaskOriginTarget: async () => ({
+          roomId: ROOM_A,
+          source: "discord",
+        }),
+      }),
+    );
+    const result = await svc.runOnce();
+    expect(result.posted).toEqual([]);
+    await svc.stop();
+  });
+
+  it("suppresses the room digest in the tick window after a completion relay; only a CHANGE re-posts", async () => {
+    const send = vi.fn(async () => undefined);
+    const seen = new Map<string, string>();
+    const first = await runSupervisorTick(
+      [view({ id: "t1", status: "validating", recentlyRelayed: true })],
+      send,
+      seen,
+    );
+    expect(first.posted).toEqual([]);
+    expect(first.skipped).toEqual([ROOM_A]);
+    expect(send).not.toHaveBeenCalled();
+    // Relay window over, digest unchanged → still silent (dedup owns it).
+    const second = await runSupervisorTick(
+      [view({ id: "t1", status: "validating" })],
+      send,
+      seen,
+    );
+    expect(second.posted).toEqual([]);
+    // A real status transition still posts.
+    const third = await runSupervisorTick(
+      [view({ id: "t1", status: "blocked" })],
+      send,
+      seen,
+    );
+    expect(third.posted).toEqual([ROOM_A]);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("freezes the line of a task held un-done after reporting completion (no retry-churn re-posts)", async () => {
+    const digest = composeRoomDigest([
+      view({
+        id: "t1",
+        label: "build-app",
+        status: "active",
+        activeSessions: 1,
+        sessionLabel: "codex · acct-2",
+        staleness: "⏳ idle 8m+",
+        heldAfterCompletion: true,
+      }),
+    ]);
+    expect(digest).toContain(`${statusEmoji("active")} build-app — active`);
+    expect(digest).not.toContain("running");
+    expect(digest).not.toContain("codex");
+    expect(digest).not.toContain("idle");
+    // Verify-retry churn (new session label, escalating staleness) no longer
+    // mutates the digest, so the tick dedups instead of re-posting.
+    const send = vi.fn(async () => undefined);
+    const seen = new Map<string, string>();
+    await runSupervisorTick(
+      [
+        view({
+          id: "t1",
+          label: "build-app",
+          sessionLabel: "retry-1",
+          heldAfterCompletion: true,
+        }),
+      ],
+      send,
+      seen,
+    );
+    const second = await runSupervisorTick(
+      [
+        view({
+          id: "t1",
+          label: "build-app",
+          sessionLabel: "retry-2",
+          staleness: "⏳ idle 3m+",
+          heldAfterCompletion: true,
+        }),
+      ],
+      send,
+      seen,
+    );
+    expect(second.posted).toEqual([]);
+    expect(second.skipped).toEqual([ROOM_A]);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("noteTaskCompletion drives relay suppression through runOnce", async () => {
+    const svc = await TaskSupervisorService.start(
+      enabledRuntimeWith({
+        listTasks: async () => [
+          {
+            id: "t-done",
+            title: "site build",
+            status: "validating",
+            activeSessionCount: 0,
+            latestSessionLabel: null,
+            createdAt: new Date(Date.now() - 120_000).toISOString(),
+          },
+        ],
+        getTaskOriginTarget: async () => ({
+          roomId: ROOM_A,
+          source: "discord",
+        }),
+      }),
+    );
+    svc.noteTaskCompletion("t-done");
+    const result = await svc.runOnce();
+    expect(result.posted).toEqual([]);
+    expect(result.skipped).toEqual([ROOM_A]);
     await svc.stop();
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -131,18 +131,19 @@ describe("runSupervisorTick (#8900)", () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
-  it("a delivery failure doesn't poison dedup (retries next tick)", async () => {
-    const send = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("connector down"))
-      .mockResolvedValueOnce(undefined);
+  it("damps a permanent delivery failure: remembers it undeliverable, no same-digest retry (ebdc4bc storm guard)", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("connector down"));
     const seen = new Map<string, string>();
     const views = [view({ id: "t1" })];
     const first = await runSupervisorTick(views, send, seen);
-    expect(first.posted).toEqual([]); // failed, not recorded
-    expect(seen.has(ROOM_A)).toBe(false);
+    expect(first.posted).toEqual([]); // failed, nothing posted
+    // A failed digest is REMEMBERED as `undeliverable:<digest>` so the loop does
+    // not re-hammer a permanently-dead target every tick (the ~1871 warns/day
+    // storm ebdc4bc fixed). It re-posts only when the digest CHANGES — staleness
+    // bands mutate it within minutes; covered by the escalation test below.
+    expect(seen.get(ROOM_A)?.startsWith("undeliverable:")).toBe(true);
     const second = await runSupervisorTick(views, send, seen);
-    expect(second.posted).toEqual([ROOM_A]); // retried successfully
+    expect(second.posted).toEqual([]); // same digest still dead → damped, not retried
   });
 
   it("re-posts a STUCK task when its staleness band escalates (not deduped silent)", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -9,8 +9,8 @@ import {
   type SupervisorTaskView,
   statusEmoji,
   supervisorStalenessLabel,
-  taskOldEnoughForDigest,
   TaskSupervisorService,
+  taskOldEnoughForDigest,
 } from "../../src/services/task-supervisor-service.js";
 
 const ROOM_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/completion-residuals.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/completion-residuals.test.ts
@@ -507,6 +507,95 @@ describe("collectCompletionResiduals — envelope legs (no workspace)", () => {
   });
 });
 
+describe("collectCompletionResiduals — spawn-time baseline + shared route workdirs", () => {
+  it("does not count tracked paths already dirty at spawn (pre-existing churn)", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "README.md"), "pre-existing churn\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineDirtyPaths: ["README.md"],
+    });
+    expect(result.status).toBe("clean");
+    expect(result.residuals).toEqual([]);
+    expect(result.gitLegsSkipped).toBeUndefined();
+  });
+
+  it("still counts run-produced paths alongside baseline-dirty ones", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "README.md"), "pre-existing churn\n");
+    writeFileSync(join(workdir, "run-output.ts"), "export {};\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineDirtyPaths: ["README.md"],
+    });
+    expect(result.status).toBe("residuals");
+    const residual = result.residuals.find(
+      (row) => row.kind === "uncommitted_changes",
+    );
+    expect(residual?.detail).toContain("1 uncommitted path(s)");
+    expect(residual?.items).toEqual(["?? run-output.ts"]);
+  });
+
+  it("never exempts an untracked path via the baseline (spawn baseline is tracked-only)", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "untracked.ts"), "export {};\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineDirtyPaths: ["untracked.ts"],
+    });
+    expect(result.status).toBe("residuals");
+  });
+
+  it("shared route workdir: skips the git legs on a dirty, unpushed shared checkout and records the skip", async () => {
+    const { workdir } = makeRepo();
+    // Pre-existing shared-checkout state: an unpushed commit + untracked dirt
+    // the reporting session never touched (the agent-home shape).
+    writeFileSync(join(workdir, "stale.txt"), "pre-existing\n");
+    git(workdir, "add", "stale.txt");
+    git(workdir, "commit", "-q", "-m", "pre-existing unpushed");
+    writeFileSync(join(workdir, "dirt.txt"), "dirt\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: false,
+      sharedRouteWorkdir: true,
+    });
+    expect(result.status).toBe("clean");
+    expect(result.residuals).toEqual([]);
+    expect(result.gitLegsSkipped).toBe("shared_route_workdir");
+  });
+
+  it("shared route workdir still applies the envelope legs", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "dirt.txt"), "dirt\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: false,
+      sharedRouteWorkdir: true,
+      testResults: [{ command: "bun test", exitCode: 1, summary: "1 failed" }],
+    });
+    expect(result.status).toBe("residuals");
+    expect(result.residuals.map((row) => row.kind)).toEqual([
+      "failing_tests_reported",
+    ]);
+    expect(result.gitLegsSkipped).toBe("shared_route_workdir");
+  });
+
+  it("an explicit repo claim overrides the shared-route exemption (task-provisioned strictness)", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "wip.ts"), "// wip\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      sharedRouteWorkdir: true,
+    });
+    expect(result.status).toBe("residuals");
+    expect(result.gitLegsSkipped).toBeUndefined();
+  });
+});
+
 describe("residualsGateEnabled", () => {
   const prev = process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE;
   afterEach(() => {

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -313,8 +313,10 @@ function stripRouterAnnotations(text: string): string {
   const lines = text.replace(/\r\n/g, "\n").split("\n");
   const body =
     lines[0]?.startsWith("[sub-agent:") === true ? lines.slice(1) : lines;
-  const annotationIndex = body.findIndex((line) =>
-    line.startsWith("[verification:"),
+  const annotationIndex = body.findIndex(
+    (line) =>
+      line.startsWith("[verification:") ||
+      line.startsWith("[verification note:"),
   );
   return (annotationIndex >= 0 ? body.slice(0, annotationIndex) : body)
     .join("\n")

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -860,6 +860,7 @@ function stripToolTranscripts(raw: string): string {
     if (insideToolOutput) continue;
     if (trimmed.startsWith("[sub-agent:")) continue;
     if (trimmed.startsWith("[verification:")) continue;
+    if (trimmed.startsWith("[verification note:")) continue;
     if (/^\/[^\s]+/.test(trimmed)) continue;
     out.push(line);
   }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -424,7 +424,9 @@ const ACP_SCRATCH_DIR_NAME_RE =
 export function isAcpScratchDirName(name: string): boolean {
   return ACP_SCRATCH_DIR_NAME_RE.test(name);
 }
-const ACP_METADATA_ISOLATED_WORKDIR = "isolatedWorkdir";
+// Exported for the residuals gate's workdir-class check: a route-mapped dir
+// only counts as "shared" when the session did NOT get its own isolated subdir.
+export const ACP_METADATA_ISOLATED_WORKDIR = "isolatedWorkdir";
 const ACP_METADATA_WORKDIR_ROOT = "workdirRoot";
 const ACP_METADATA_GIT_INDEX_FILE = "gitIndexFile";
 const ACP_METADATA_GIT_INDEX_BASE_FILE = "gitIndexBaseFile";

--- a/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
@@ -97,6 +97,11 @@ export interface CompletionResidualsResult {
    * incentive inverts and the disclosure disappears. Surfaced to the user as
    * caveats on the relayed completion instead. */
   disclosedRisks?: string[];
+  /** Present when the git legs were DELIBERATELY skipped because the session
+   * ran in a shared route-mapped checkout whose git state is not attributable
+   * to this run. Rides the persisted snapshot so the exemption is auditable,
+   * never a silent pass. */
+  gitLegsSkipped?: "shared_route_workdir";
   workdir?: string;
   checkedAt: number;
 }
@@ -120,6 +125,19 @@ export interface CompletionResidualsInput {
    * skips them (envelope legs still apply) instead of blocking promotion.
    */
   repoExpected: boolean;
+  /** Paths already dirty when the reporting session spawned (session metadata
+   * `codingBaselineDirty`, captured by `AcpService.spawnSession` as
+   * `git diff --name-only HEAD`). The uncommitted-changes leg subtracts them:
+   * pre-existing churn was not produced by this run. Tracked modifications
+   * only — untracked paths are never baseline-exempt. */
+  baselineDirtyPaths?: readonly string[];
+  /** True when the session ran in a SHARED, route-mapped app checkout
+   * (`TASK_AGENT_WORKDIR_ROUTES`) rather than a task-provisioned workspace.
+   * A shared checkout carries dirt and unpushed commits from before the run
+   * and from sibling tasks, so its git facts are not attributable to this
+   * session; the git legs are skipped (envelope legs still apply). Ignored
+   * when `repoExpected` — an explicit repo claim keeps full strictness. */
+  sharedRouteWorkdir?: boolean;
   testResults?: ReadonlyArray<{
     command: string;
     exitCode: number;
@@ -188,6 +206,23 @@ function ownedArtifactsByPath(
   );
 }
 
+/** Whether a porcelain line names only paths that were ALREADY dirty when the
+ * session spawned. The spawn baseline (`codingBaselineDirty`) records tracked
+ * modifications only (`git diff --name-only HEAD`), so untracked (`??`) lines
+ * never match — a path untracked at completion is genuinely new work. A rename
+ * line is exempt only when BOTH sides were baseline-dirty. */
+function isBaselineDirtyLine(
+  line: string,
+  baselineDirtyPaths: ReadonlySet<string>,
+): boolean {
+  if (baselineDirtyPaths.size === 0) return false;
+  if (line.startsWith("?? ")) return false;
+  const paths = porcelainPaths(line);
+  return (
+    paths.length > 0 && paths.every((path) => baselineDirtyPaths.has(path))
+  );
+}
+
 /**
  * Run every applicable residuals leg and aggregate the verdict. Purely
  * deterministic — no model call, no network; the only side effects are the
@@ -202,6 +237,19 @@ export async function collectCompletionResiduals(
   const orchestratorOwnedArtifacts = ownedArtifactsByPath(
     input.orchestratorOwnedArtifacts ?? [],
   );
+  // Shared route-mapped app checkouts (TASK_AGENT_WORKDIR_ROUTES → e.g. an
+  // agent-home static-apps dir) are pre-existing directories shared by every
+  // task the route matches: their dirty paths and unpushed commits predate the
+  // run or belong to sibling tasks, so git facts there are not attributable to
+  // the reporting session — counting them blocks every completion in that
+  // checkout forever. Skip the git legs for that class (envelope legs still
+  // apply) and record the skip on the snapshot so the exemption is auditable.
+  // An explicit repo claim always wins: a repo-bound task never gets the
+  // exemption, so genuinely incomplete work on a task-provisioned workspace
+  // still blocks.
+  const sharedWorkdirExempt =
+    input.sharedRouteWorkdir === true && !input.repoExpected;
+  let gitLegsSkipped: CompletionResidualsResult["gitLegsSkipped"];
 
   // Envelope legs apply regardless of workspace presence: a self-reported
   // failing test contradicts "done" even for a Q&A task.
@@ -325,6 +373,11 @@ export async function collectCompletionResiduals(
     }
     // Unbound + missing/non-git scratch dir: skip the git legs; the envelope
     // legs above still decide the verdict.
+  } else if (workdir !== undefined && sharedWorkdirExempt) {
+    // A real worktree, but a shared route-mapped checkout (see
+    // sharedWorkdirExempt above): deliberately not inspected. The marker rides
+    // the persisted snapshot so the skip is visible, never a silent pass.
+    gitLegsSkipped = "shared_route_workdir";
   } else if (workdir !== undefined) {
     const status = runGit(workdir, ["status", "--porcelain"]);
     if (!status.ok) {
@@ -333,6 +386,15 @@ export async function collectCompletionResiduals(
         `git status failed in ${workdir}: ${status.stderr.trim() || "unknown error"}`,
       );
     }
+    // Pre-existing tracked churn (paths already dirty when the session
+    // spawned) is not this run's leftover work — subtract the spawn baseline
+    // before counting. The baseline is orchestrator-stamped at spawn, never
+    // worker-writable, so the exemption cannot be forged by the agent.
+    const baselineDirtyPaths = new Set(
+      (input.baselineDirtyPaths ?? [])
+        .map((path) => path.trim())
+        .filter((path) => path.length > 0),
+    );
     const dirty = status.stdout
       .split("\n")
       .map((line) => line.trimEnd())
@@ -344,7 +406,8 @@ export async function collectCompletionResiduals(
             workdir,
             orchestratorOwnedArtifacts,
           ),
-      );
+      )
+      .filter((line) => !isBaselineDirtyLine(line, baselineDirtyPaths));
     if (dirty.length > 0) {
       residuals.push({
         kind: "uncommitted_changes",
@@ -388,6 +451,7 @@ export async function collectCompletionResiduals(
 
   return {
     status: residuals.length > 0 ? "residuals" : "clean",
+    ...(gitLegsSkipped !== undefined ? { gitLegsSkipped } : {}),
     ...base,
   };
 }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -48,7 +48,10 @@ import {
   type OrchestratorTaskType,
   shouldRequireGoalContract,
 } from "./acceptance-criteria.js";
-import { AcpService } from "./acp-service.js";
+import {
+  ACP_METADATA_ISOLATED_WORKDIR,
+  AcpService,
+} from "./acp-service.js";
 import {
   type AdmissionRecord,
   orderQueue,
@@ -86,6 +89,7 @@ import {
 import {
   COMPLETION_RESIDUALS_METADATA_KEY,
   COMPLETION_RESIDUALS_VERIFIER_NAME,
+  type CompletionResidualsInput,
   type CompletionResidualsResult,
   collectCompletionResiduals,
   residualDetails,
@@ -197,6 +201,10 @@ import {
   configureSpendLedger,
   createTaskStoreSpendLedger,
 } from "./spend-allowance.js";
+import {
+  TASK_SUPERVISOR_SERVICE_TYPE,
+  type TaskSupervisorService,
+} from "./task-supervisor-service.js";
 import {
   AdmissionQueueFullError,
   type ApprovalPreset,
@@ -683,6 +691,36 @@ export function residualsOrchestratorOwnedArtifacts(
   return live.length > 0
     ? live
     : readOwnedArtifactsFromMetadata(session.metadata);
+}
+
+/** Spawn-time residuals context, parsed structurally from the reporting
+ * session's metadata — every key is orchestrator-stamped at spawn
+ * (`AcpService.spawnSession` / the TASKS spawn path), never worker-writable.
+ * `codingBaselineDirty` (tracked files already dirty at spawn) becomes the
+ * gate's pre-existing-churn baseline; a `workdirRouteId` on a NON-isolated
+ * session marks a shared route-mapped app checkout
+ * (`TASK_AGENT_WORKDIR_ROUTES`, e.g. agent-home) whose git state is shared
+ * across tasks and must not block every completion there. Absent/foreign
+ * metadata contributes nothing — prior behavior is unchanged. Exported for
+ * direct unit coverage. */
+export function residualsSpawnBaseline(
+  session: Pick<OrchestratorTaskSession, "metadata"> | undefined,
+): Pick<CompletionResidualsInput, "baselineDirtyPaths" | "sharedRouteWorkdir"> {
+  const meta = session?.metadata;
+  if (!isRecord(meta)) return {};
+  const baselineDirtyPaths = Array.isArray(meta.codingBaselineDirty)
+    ? meta.codingBaselineDirty.filter(
+        (path): path is string => typeof path === "string" && path.length > 0,
+      )
+    : [];
+  const sharedRouteWorkdir =
+    typeof meta.workdirRouteId === "string" &&
+    meta.workdirRouteId.trim().length > 0 &&
+    meta[ACP_METADATA_ISOLATED_WORKDIR] !== true;
+  return {
+    ...(baselineDirtyPaths.length > 0 ? { baselineDirtyPaths } : {}),
+    ...(sharedRouteWorkdir ? { sharedRouteWorkdir: true } : {}),
+  };
 }
 
 /** Envelope-derived residuals legs from the VALID CompletionEnvelope stamped
@@ -1614,6 +1652,19 @@ export class OrchestratorTaskService extends Service {
           );
         }
         await this.advanceTaskStatus(taskId, "completion_reported");
+        // Cross-surface arbitration for the digest emitter: stamp this
+        // completion on the supervisor BEFORE its next tick, so the room's
+        // status digest yields to the completion relay the router posts for
+        // this same event instead of adding another uncoordinated message.
+        // Structural guard, not blind optional-chaining: the supervisor is a
+        // genuinely optional service, and the stamp is observability — a
+        // shape mismatch must never abort the completion pipeline.
+        const digestSupervisor = this.runtime.getService<TaskSupervisorService>(
+          TASK_SUPERVISOR_SERVICE_TYPE,
+        );
+        if (typeof digestSupervisor?.noteTaskCompletion === "function") {
+          digestSupervisor.noteTaskCompletion(taskId);
+        }
         // Issue #8124: the orchestrator should always behave like `/goal` —
         // confirm the sub-agent met every acceptance criterion before marking
         // the task done. Feed the verifier REAL completion evidence (git
@@ -3226,6 +3277,7 @@ export class OrchestratorTaskService extends Service {
             acp,
             workspaceSession,
           ),
+          ...residualsSpawnBaseline(workspaceSession),
           ...envelopeResidualLegs(doc.task.metadata),
         })
       : undefined;
@@ -3567,6 +3619,7 @@ export class OrchestratorTaskService extends Service {
             acp,
             reportingSession,
           ),
+          ...residualsSpawnBaseline(reportingSession),
           ...(parse.present && parse.ok
             ? {
                 testResults: parse.envelope.testResults,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -48,10 +48,7 @@ import {
   type OrchestratorTaskType,
   shouldRequireGoalContract,
 } from "./acceptance-criteria.js";
-import {
-  ACP_METADATA_ISOLATED_WORKDIR,
-  AcpService,
-} from "./acp-service.js";
+import { ACP_METADATA_ISOLATED_WORKDIR, AcpService } from "./acp-service.js";
 import {
   type AdmissionRecord,
   orderQueue,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -3493,6 +3493,11 @@ export async function annotateUnverifiedUrls(
     return result;
   };
   const dead: DeadUrl[] = [];
+  // Dead sub-resources on a THIRD-PARTY origin (font-CDN roots, analytics
+  // beacons, preconnect hint origins) are collected separately: their bare
+  // roots routinely 404 by design, so their unreachability must never read
+  // as "the build did not complete". Deploy-scoped dead URLs stay in `dead`.
+  const deadThirdParty: DeadUrl[] = [];
   await Promise.all(
     urls.map(async (url) => {
       const result = await probe(url);
@@ -3517,7 +3522,16 @@ export async function annotateUnverifiedUrls(
           subResources.map(async (subUrl) => {
             const subResult = await probe(subUrl);
             if (subResult.status !== null) {
-              dead.push({ url: subUrl, status: subResult.status, via: url });
+              // Same-origin and route-mapped (deploy-host) sub-resources are
+              // part of the artifact under verification — a missing style.css
+              // IS a broken build. A cross-origin third party is not; keyed on
+              // structured URL origins, never on narration text.
+              const entry = { url: subUrl, status: subResult.status, via: url };
+              if (isThirdPartySubResource(subUrl, url, routeVerification)) {
+                deadThirdParty.push(entry);
+              } else {
+                dead.push(entry);
+              }
               return;
             }
             const subLocalStatus = verifyMappedLocalUrl(
@@ -3533,12 +3547,28 @@ export async function annotateUnverifiedUrls(
       }
     }),
   );
+  // Tally page-level dead against the mentioned set and sub-resource dead
+  // separately: sub-resources are DISCOVERED from page HTML, not mentioned,
+  // so folding them into one "N dead of M mentioned" count let N exceed M.
+  const pageDeadCount = dead.filter((d) => d.via === undefined).length;
   log?.(
-    `[verify] done @ ${new Date().toISOString()} — ${dead.length} dead of ${urls.length} mentioned`,
+    `[verify] done @ ${new Date().toISOString()} — ${pageDeadCount} dead of ${urls.length} mentioned, ${dead.length - pageDeadCount} dead sub-resource(s), ${deadThirdParty.length} third-party sub-resource(s) unreachable (informational)`,
   );
   if (dead.length === 0) {
+    // Only third-party sub-resources (if anything) failed to respond: every
+    // claimed page probed live, so completion proceeds with all verified URLs
+    // intact. A single-line note keeps the signal observable to the planner
+    // and the trajectory WITHOUT instructing the model to report a failure
+    // that did not happen. Single line by contract: the completion-summary
+    // and annotation strippers key on the "[verification note:" line prefix,
+    // which is deliberately disjoint from the "[verification:" failure marker
+    // the completion evaluator treats as a failed build.
+    const annotated =
+      deadThirdParty.length === 0
+        ? text
+        : `${text}\n\n[verification note: referenced page URL(s) verified reachable. ${deadThirdParty.length} cross-origin third-party sub-resource(s) did not respond to a probe (${deadThirdParty.map((d) => `${d.url} → ${d.status}`).join(", ")}) — common by design for font/CDN/analytics hosts; this is not a build failure]`;
     return {
-      text,
+      text: annotated,
       dead,
       verifiedUrls: canonicalUserFacingVerifiedUrls(urls, routeVerification),
     };
@@ -3560,6 +3590,42 @@ export async function annotateUnverifiedUrls(
       routeVerification,
     ),
   };
+}
+
+// Scope verification FAILURE semantics to the deploy surface. A dead
+// sub-resource is deploy-scoped — a hard verification failure — only when it
+// shares the referencing page's origin or lands on a configured route-mapping
+// origin (the deploy host or its public/loopback alias). Any other
+// cross-origin target (a Google-Fonts preconnect hint origin, a beacon, a CDN
+// root) is outside the build: those roots routinely 404 or refuse GETs by
+// design, and treating them as build failures produced false "not live"
+// reports for pages that themselves probed 200. Keys only on structured URL
+// origins and the route-mapping shape — never on prose or hostname lists.
+function isThirdPartySubResource(
+  subUrl: string,
+  pageUrl: string,
+  routeVerification: RouteUrlVerification | undefined,
+): boolean {
+  let sub: URL;
+  let page: URL;
+  try {
+    sub = new URL(subUrl);
+    page = new URL(pageUrl);
+  } catch {
+    // error-policy:J3 URL parse of untrusted probe targets; an unclassifiable
+    // ref keeps the strict (hard-failure) path rather than silently degrading.
+    return false;
+  }
+  if (sub.origin === page.origin) return false;
+  if (!routeVerification) return true;
+  return !routeVerification.mappings.some((mapping) => {
+    try {
+      return new URL(mapping.urlPrefix).origin === sub.origin;
+    } catch {
+      // error-policy:J3 URL parse of an untrusted route prefix; no match.
+      return false;
+    }
+  });
 }
 
 // A reachable URL is only a user-facing *deliverable* when it is a routed
@@ -3763,18 +3829,46 @@ async function detectCachedMiss(
     : null;
 }
 
+// <link> rel values that declare network hints — origins the browser MAY
+// warm up — rather than resources the page needs to render. A hint href is
+// typically a bare third-party root (https://fonts.googleapis.com) that 404s
+// by design, so probing it fails verification of a perfectly healthy build.
+const HINT_LINK_RELS = new Set([
+  "preconnect",
+  "dns-prefetch",
+  "prefetch",
+  "prerender",
+  "modulepreload",
+]);
+
 /**
  * Extract the sub-resource URLs an HTML document declares via common
  * resource-bearing attributes, resolved absolute against the page URL.
  * Mechanical extraction from a structured document — not intent
- * classification. Skips in-page anchors and data:/mailto: refs, and caps
+ * classification. Skips in-page anchors, data:/mailto: refs, and <link>
+ * hint rels (a preconnect origin is not a page dependency), and caps
  * the result so a pathological page can't fan out unbounded probes.
  */
 export function extractSubResources(html: string, pageUrl: string): string[] {
   const refs = new Set<string>();
-  const attrRe =
-    /<(?:link|script|img|source|video|audio|iframe)\b[^>]*?\b(?:href|src)\s*=\s*["']([^"']+)["']/gi;
+  // Tags are matched whole (name + attribute chunk) rather than jumping
+  // straight to href/src: a <link>'s meaning depends on its rel attribute,
+  // so the extractor must see the full attribute list before following.
+  const tagRe = /<(link|script|img|source|video|audio|iframe)\b([^>]*)/gi;
+  const urlAttrRe = /\b(?:href|src)\s*=\s*["']([^"']+)["']/i;
+  const relAttrRe = /\brel\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i;
   const srcsetRe = /<(?:img|source)\b[^>]*?\bsrcset\s*=\s*["']([^"']+)["']/gi;
+  // Anchors the bare-root guard in addRef below; an unparseable page URL
+  // leaves it null, so every absolute bare-root ref reads as cross-origin —
+  // the conservative direction for that guard. In practice pageUrl was
+  // already fetched successfully by the caller, so it always parses.
+  let pageOrigin: string | null = null;
+  try {
+    pageOrigin = new URL(pageUrl).origin;
+  } catch {
+    // error-policy:J3 URL parse of the caller-supplied page URL; relative
+    // refs already fail to resolve in addRef when it is unparseable.
+  }
   const addRef = (rawRef: string | undefined) => {
     const ref = rawRef?.trim();
     if (
@@ -3787,9 +3881,17 @@ export function extractSubResources(html: string, pageUrl: string): string[] {
     }
     try {
       const resolved = new URL(ref, pageUrl);
-      if (resolved.protocol === "http:" || resolved.protocol === "https:") {
-        refs.add(resolved.toString());
+      if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+        return;
       }
+      // Belt-and-braces under the rel filter: a bare cross-origin root is
+      // never a real page dependency (no site serves an app asset at "/"),
+      // whatever element carried it — it is the origin half of a hint or
+      // weak-model boilerplate, and CDN roots commonly 404 by design.
+      if (resolved.pathname === "/" && resolved.origin !== pageOrigin) {
+        return;
+      }
+      refs.add(resolved.toString());
     } catch {
       // error-policy:J3 URL parse of an untrusted HTML ref; unparseable → skip.
       // unparseable ref — skip
@@ -3797,8 +3899,18 @@ export function extractSubResources(html: string, pageUrl: string): string[] {
   };
   let match: RegExpExecArray | null;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
-  while ((match = attrRe.exec(html)) !== null) {
-    addRef(match[1]);
+  while ((match = tagRe.exec(html)) !== null) {
+    if ((match[1] ?? "").toLowerCase() === "link") {
+      const relMatch = relAttrRe.exec(match[2] ?? "");
+      const rel = (relMatch?.[1] ?? relMatch?.[2] ?? relMatch?.[3] ?? "")
+        .toLowerCase();
+      // rel is a space-separated token list; any hint token disqualifies —
+      // a rel mixing a hint with a real keyword is malformed boilerplate.
+      if (rel.split(/\s+/).some((token) => HINT_LINK_RELS.has(token))) {
+        continue;
+      }
+    }
+    addRef(urlAttrRe.exec(match[2] ?? "")?.[1]);
     if (refs.size >= 10) break;
   }
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -3902,8 +3902,12 @@ export function extractSubResources(html: string, pageUrl: string): string[] {
   while ((match = tagRe.exec(html)) !== null) {
     if ((match[1] ?? "").toLowerCase() === "link") {
       const relMatch = relAttrRe.exec(match[2] ?? "");
-      const rel = (relMatch?.[1] ?? relMatch?.[2] ?? relMatch?.[3] ?? "")
-        .toLowerCase();
+      const rel = (
+        relMatch?.[1] ??
+        relMatch?.[2] ??
+        relMatch?.[3] ??
+        ""
+      ).toLowerCase();
       // rel is a space-separated token list; any hint token disqualifies —
       // a rel mixing a hint with a real keyword is malformed boilerplate.
       if (rel.split(/\s+/).some((token) => HINT_LINK_RELS.has(token))) {

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -9,6 +9,14 @@
  *
  * The tick logic is a pure function (`runSupervisorTick`) over injected views so
  * it unit-tests without timers, services, or a runtime.
+ *
+ * Damping, layered on the change-driven dedup: a task younger than one tick
+ * interval is not digested yet (a sub-interval inline build finishes before a
+ * digest could say anything its completion relay won't say better), a room
+ * whose task just relayed a completion is suppressed for that tick (the digest
+ * must not be a second uncoordinated message about the same event), and a task
+ * held un-done by a verification gate after reporting completion digests on
+ * status transitions only. See noteTaskCompletion for the cross-surface half.
  */
 
 import type {
@@ -69,6 +77,20 @@ export interface SupervisorTaskView {
   /** True when the task is parked in the admission queue (waiting for a session
    *  slot). Folded into the digest as a queued count, not a per-task line. */
   queued?: boolean;
+  /** True when this task reported completion within the CURRENT tick window.
+   *  The router relays that completion to the origin room the moment it fires,
+   *  so a digest on its heels is a second uncoordinated message about the same
+   *  event — the tick suppresses the room instead, and change-driven dedup
+   *  owns any later re-post. */
+  recentlyRelayed?: boolean;
+  /** True when this task has reported completion at least once but is still
+   *  held un-done by a verification gate (URL-verify retry, residuals). The
+   *  verify-retry respawns churn session labels/counts and the staleness bands
+   *  escalate while the gate holds — each mutation would re-post "still
+   *  active" noise after the user already received the completion relay. The
+   *  digest line freezes to structural status for such tasks; a real status
+   *  transition still changes the digest and posts. */
+  heldAfterCompletion?: boolean;
 }
 
 // Coarse staleness bands (minutes → label), highest first. Bucketed on purpose:
@@ -105,6 +127,23 @@ const PROGRESS_EXPECTED_STATUSES: ReadonlySet<OrchestratorTaskStatus> = new Set(
   ["active", "validating"],
 );
 
+/** Whether a task is old enough to appear in a digest at all. A task younger
+ *  than one tick interval either finishes before the digest could say anything
+ *  its completion relay won't say better (the sub-interval inline build), or
+ *  survives into the next tick and posts then — so the FIRST digest is gated
+ *  on min task-age > tick interval. Fail-open on an unparseable timestamp:
+ *  this is a burst damper, and silently muting a task's digests forever would
+ *  be worse than one early post. */
+export function taskOldEnoughForDigest(
+  createdAt: string,
+  nowMs: number,
+  minAgeMs: number,
+): boolean {
+  const createdMs = Date.parse(createdAt);
+  if (!Number.isFinite(createdMs)) return true;
+  return nowMs - createdMs >= minAgeMs;
+}
+
 /** Compose the digest body for one room's set of live tasks. Deterministic.
  * Queued (admission-parked) tasks are summarized as a count line, not per-task
  * rows, so a backlog of waiting tasks doesn't flood the digest. */
@@ -119,6 +158,12 @@ export function composeRoomDigest(views: SupervisorTaskView[]): string {
     .slice()
     .sort((a, b) => a.label.localeCompare(b.label))
     .map((v) => {
+      // Post-completion hold: only the structural status may drive a re-post
+      // (see heldAfterCompletion) — session churn and staleness escalation on
+      // a gate-held task are noise, not news.
+      if (v.heldAfterCompletion) {
+        return `${statusEmoji(v.status)} ${v.label} — ${v.status}`;
+      }
       const detail = v.sessionLabel ? ` · ${v.sessionLabel}` : "";
       const sessions =
         v.activeSessions > 0 ? ` (${v.activeSessions} running)` : "";
@@ -183,6 +228,16 @@ export async function runSupervisorTick(
       skipped.push(roomId);
       continue;
     }
+    // Cross-surface arbitration: a completion relay for a task in this room
+    // already posted within the current tick window, so this digest would be
+    // a second uncoordinated message about the same event. Record the digest
+    // as seen so only a future CHANGE re-posts — the same change-driven
+    // contract the permanent-failure damper below uses.
+    if (roomViews.some((v) => v.recentlyRelayed)) {
+      seen.set(roomId, digest);
+      skipped.push(roomId);
+      continue;
+    }
     try {
       await send({ source, roomId: roomId as UUID }, { text: digest, source });
       seen.set(roomId, digest);
@@ -236,6 +291,7 @@ interface TaskServiceLike {
       activeSessionCount: number;
       latestSessionLabel: string | null;
       latestActivityAt: number | null;
+      createdAt: string;
       admission?: { state: "queued" } | undefined;
     }>
   >;
@@ -256,6 +312,14 @@ export class TaskSupervisorService extends Service {
   private ticking = false;
   /** roomId → last-posted digest, for change-driven dedup. */
   private readonly seen = new Map<string, string>();
+  /** taskId → ms timestamp of the task's most recent reported completion.
+   *  Stamped by the task service's task_complete event bridge via
+   *  noteTaskCompletion — the same event whose result the router relays to
+   *  the origin room — so the tick can yield to that relay instead of
+   *  double-messaging the room, and can freeze the line of a task a
+   *  verification gate is holding un-done. Pruned each tick against the live
+   *  task list. */
+  private readonly completionNotes = new Map<string, number>();
   private readonly digestSinks = new Map<
     string,
     Set<TaskSupervisorDigestSink>
@@ -292,6 +356,19 @@ export class TaskSupervisorService extends Service {
     }, this.intervalMs());
     // The digest loop must never, by itself, keep the process alive.
     (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  /** Record that a completion was reported for a task (called from the task
+   *  service's task_complete event bridge). This is the digest emitter's half
+   *  of cross-surface arbitration: the router relays that completion to the
+   *  origin room, so digests for the room yield within the same tick window
+   *  and the task's line freezes to structural status while a verification
+   *  gate holds it un-done. */
+  noteTaskCompletion(taskId: string): void {
+    // A disabled supervisor never ticks, so nothing would prune the notes —
+    // don't accumulate them.
+    if (!this.enabled()) return;
+    this.completionNotes.set(taskId, Date.now());
   }
 
   registerDigestSink(
@@ -356,27 +433,54 @@ export class TaskSupervisorService extends Service {
     // calls this fire-and-forget) — noisy, and fatal under strict handling.
     try {
       const tasks = await taskSvc.listTasks({ includeArchived: false });
-      // Live tasks drive per-task lines; admission-parked tasks (status `open`
-      // with an admission record) drive the queued-count line.
-      const surfaced = tasks.filter(
-        (t) => LIVE_STATUSES.has(t.status) || t.admission?.state === "queued",
-      );
       const now = Date.now();
+      const tickMs = this.intervalMs();
+      // Live tasks drive per-task lines; admission-parked tasks (status `open`
+      // with an admission record) drive the queued-count line. Tasks younger
+      // than one tick interval are held out entirely: a sub-interval inline
+      // build would otherwise draw a stale "active" digest AFTER its
+      // completion relay already told the user the outcome.
+      const surfaced = tasks.filter(
+        (t) =>
+          (LIVE_STATUSES.has(t.status) || t.admission?.state === "queued") &&
+          taskOldEnoughForDigest(t.createdAt, now, tickMs),
+      );
+      // Completion notes live only while their task can still surface in a
+      // digest; a terminal or vanished task frees its note so a later reopen
+      // starts clean. Young (age-gated) tasks keep theirs — a sub-interval
+      // build that completed before its first digest still needs the hold.
+      const noteEligibleIds = new Set(
+        tasks
+          .filter((t) => LIVE_STATUSES.has(t.status) || t.status === "open")
+          .map((t) => t.id),
+      );
+      for (const taskId of [...this.completionNotes.keys()]) {
+        if (!noteEligibleIds.has(taskId)) this.completionNotes.delete(taskId);
+      }
       const views: SupervisorTaskView[] = await Promise.all(
-        surfaced.map(async (t) => ({
-          id: t.id,
-          label: t.title,
-          status: t.status,
-          activeSessions: t.activeSessionCount,
-          sessionLabel: t.latestSessionLabel,
-          // Surface a stall only for progress-expected statuses; waiting_on_user
-          // / blocked are legitimately idle.
-          staleness: PROGRESS_EXPECTED_STATUSES.has(t.status)
-            ? supervisorStalenessLabel(t.latestActivityAt, now)
-            : undefined,
-          origin: await taskSvc.getTaskOriginTarget(t.id),
-          queued: t.admission?.state === "queued",
-        })),
+        surfaced.map(async (t) => {
+          const completionAt = this.completionNotes.get(t.id);
+          return {
+            id: t.id,
+            label: t.title,
+            status: t.status,
+            activeSessions: t.activeSessionCount,
+            sessionLabel: t.latestSessionLabel,
+            // Surface a stall only for progress-expected statuses; waiting_on_user
+            // / blocked are legitimately idle.
+            staleness: PROGRESS_EXPECTED_STATUSES.has(t.status)
+              ? supervisorStalenessLabel(t.latestActivityAt, now)
+              : undefined,
+            origin: await taskSvc.getTaskOriginTarget(t.id),
+            queued: t.admission?.state === "queued",
+            ...(typeof completionAt === "number"
+              ? {
+                  recentlyRelayed: now - completionAt < tickMs,
+                  heldAfterCompletion: true,
+                }
+              : {}),
+          };
+        }),
       );
       const result = await runSupervisorTick(
         views,
@@ -408,6 +512,7 @@ export class TaskSupervisorService extends Service {
       this.timer = undefined;
     }
     this.seen.clear();
+    this.completionNotes.clear();
     this.digestSinks.clear();
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -178,7 +178,8 @@ export async function runSupervisorTick(
   const skipped: string[] = [];
   for (const [roomId, { source, views: roomViews }] of byRoom) {
     const digest = composeRoomDigest(roomViews);
-    if (seen.get(roomId) === digest) {
+    const last = seen.get(roomId);
+    if (last === digest || last === `undeliverable:${digest}`) {
       skipped.push(roomId);
       continue;
     }
@@ -187,15 +188,19 @@ export async function runSupervisorTick(
       seen.set(roomId, digest);
       posted.push(roomId);
     } catch (error) {
-      // error-policy:J7 per-room send loop must not die on one delivery failure;
-      // seen is left unset so the next tick retries — warn-observable, self-healing.
-      // A delivery failure must not abort the rest of the tick or poison the
-      // dedup cache (so the next tick retries this room).
+      // error-policy:J7 per-room send loop must not die on one delivery failure —
+      // warn-observable; a failure must not abort the rest of the tick.
       logger.warn(
         `[TaskSupervisorService] digest delivery failed for room ${roomId}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
+      // Permanent-failure damper: remember the digest that failed so the loop
+      // retries only when the digest CHANGES — staleness bands mutate the digest
+      // over time and room pruning resets state on task turnover, so stalled
+      // tasks still re-attempt without warn-looping every tick against a
+      // permanently undeliverable target.
+      seen.set(roomId, `undeliverable:${digest}`);
     }
   }
   return { posted, skipped };


### PR DESCRIPTION
## Problem

Four sub-agent lifecycle defects observed live on a production bot:

1. **App-build verify false-failed on third-party sub-resources**: reachability probing treated cross-origin/preconnect assets (font CDNs) as the app being down.
2. **Task-completion message spam + retry storms**: TaskSupervisor digests re-fired on permanent delivery failures, and completion residual checks flagged spawn-time dirt as the agent's changes.
3. **Coordinator wiring gave up at 90s**: a one-shot deadline where an open-ended poll (with backoff) is correct — long provisions were falsely orphaned.
4. **Inner monologue leaked to chat**: for a *stopped* claude task, swarm synthesis relayed the newest workdir transcript's LAST assistant text verbatim — for an interrupted session that's mid-task narration ("Now let me read the launch check itself…", relayed to a real user's Discord). Root-caused forensically: replaying the reader against the stopped session's jsonl reproduces the exact leaked string.

## Fix

- Verify treats third-party sub-resource failures as degraded, not dead (with a cross-origin degrade test).
- Digest damping: yields to the completion relay, stops retry-storms on permanent failure; residuals baseline captures spawn-time dirt.
- Coordinator wiring polls open-ended with slow-phase backoff instead of a one-shot deadline.
- **Status-keyed lifecycle relay** (never text-matched): a non-`completed` task relays its verification verdict when present, else "<task> — <status> before completion."; the transcript tail and raw lastOutput never relay. Completed tasks are untouched — a cleanly finished run's final message IS the user-facing result.

## Testing

- server-helpers-swarm suite **20 pass** — the new regression tests seed the REAL reader path (`~/.claude/projects/<sanitized-workdir>/` jsonl) with narration and prove it stays out of routed text; mutation-checked (gate removed → both fail). Seeded dirs are cleaned up after each test.
- Orchestrator suite **2622 pass**; the 2 remaining failures are a pre-existing env-sensitive test that fails identically on pristine develop (verified by baselining this exact environment against `origin/develop`).
- Live: the leak reproduced on a stopped app-build session pre-fix; post-fix restarts + builds produce lifecycle/verdict messages only.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime change only; no rendered-UI source in this repo touched (core/agent/plugin .ts). The user-visible surface is the Discord client rendering bot messages, evidenced under domain artifacts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime change only; no rendered-UI source in this repo touched (core/agent/plugin .ts). The user-visible surface is the Discord client rendering bot messages, evidenced under domain artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no repo UI flow to record; the user-facing behavior is Discord messages, evidenced via logs/trajectories/domain artifacts below.
<!-- evidence-row:backend-logs -->
- [x] <details><summary>live log excerpts</summary><pre>LEAK (before): swarm synthesis routed a STOPPED task's transcript tail to the origin room: "Now let me read the launch check itself to see exactly how it resolves the app." (source: swarm_synthesis)
AFTER: non-completed tasks relay verdict/lifecycle only: "&lt;task&gt; — stopped before completion."</pre></details> Gate + regression tests: [server-helpers-swarm.test.ts](https://github.com/elizaOS/eliza/blob/fix/orchestrator-subagent-lifecycle/packages/agent/src/api/server-helpers-swarm.test.ts) (mutation-checked: gate removed → both fail).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface in this change; no console/network activity exists for it.
<!-- evidence-row:llm-trajectory -->
- [x] Forensic proof in the PR description: replaying `readAgentFinalAssistantMessage` against the stopped session's real `~/.claude/projects/…` jsonl returns the exact leaked string. Third-party verify degrade covered by [sub-agent-router.test.ts](https://github.com/elizaOS/eliza/blob/fix/orchestrator-subagent-lifecycle/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts).
<!-- evidence-row:domain-artifacts -->
- [x] The leaked Discord message (user-visible, quoted verbatim in the description) and post-fix lifecycle-only relays; orchestrator suite 2622 pass on this branch (2 remaining failures are a pre-existing env-sensitive test failing identically on pristine develop). Gate contract: [server-helpers-swarm.test.ts](https://github.com/elizaOS/eliza/blob/fix/orchestrator-subagent-lifecycle/packages/agent/src/api/server-helpers-swarm.test.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
