### PR TITLE
fix(ci): confirm watchdog scenario delivery

### DIFF
--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-watchdog-stall.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-watchdog-stall.scenario.ts
@@ -125,7 +125,21 @@ async function runWatchdogStall(): Promise<WatchdogScenarioResult> {
         source: target.source,
         text: content.text ?? "",
       });
-      return undefined;
+      // The production watchdog records cap warnings only after the connector
+      // confirms provider acceptance, so the scenario boundary must model the
+      // same delivery contract instead of treating an attempted send as proof.
+      return {
+        kind: "delivered" as const,
+        receipt: {
+          providerMessageIds: [`watchdog-warning-${posts.length}`],
+          acceptedAt: NOW,
+          persistence: {
+            status: "persisted" as const,
+            memoryIds: [],
+          },
+        },
+        memories: [],
+      };
     },
   } as unknown as IAgentRuntime;
 


### PR DESCRIPTION
# Relates to

Fixes #17337.

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Reviewer-visible deterministic evidence is recorded below.

# Sync with develop

- [x] Rebased onto the current `develop` tip with zero conflicts.
- [x] Focused checks passed; the unrelated live-service failure is documented below.

# Risks

Low. This changes only a deterministic scenario fake. Production watchdog delivery validation is unchanged.

# Background

## What does this PR do?

Makes `orchestrator-watchdog-stall` return a structural delivered receipt from its fake `sendMessageToTarget`. The real watchdog requires confirmed provider acceptance before recording cap-warning state; returning `undefined` made the fixture claim an attempted send without delivery evidence.

## What kind of change is this?

Bug fix for a develop-red deterministic CI fixture.

# Documentation changes needed?

N/A - no user-facing or production contract changed.

# Testing

## Where should a reviewer start?

Develop failure:
https://github.com/elizaOS/eliza/actions/runs/30596071907/job/91048750234

## Detailed testing steps

- Exact `orchestrator-watchdog-stall` scenario: 1/1 passed through the real `TaskWatchdogService`.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`: passed.
- Biome check on the changed scenario: passed.
- Full plugin Vitest: 2,598 passed, 13 skipped; one unrelated live Cerebras test failed because the account returned HTTP 402 quota.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - no UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no UI changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no interactive flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - deterministic fixture-only change; focused passing output is summarized above.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - deterministic keyless fixture only; no model or prompt behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - no production artifact is created.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a deterministic zero-key connector-boundary fixture.

## Backend + frontend logs

Focused run emitted confirmed round-trip and spend warning logs, then `orchestrator-watchdog-stall passed`.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changed.

## Audio / voice walkthrough

N/A - no voice behavior changed.

## Known gaps / failures

The full plugin suite's only failure is `orchestrator-grilling-live-gemma.test.ts`, where the external Cerebras API returned HTTP 402 `payment_required`; 2,598 other tests passed. This is unrelated to the deterministic fixture and cannot be repaired in code without account quota.
