### PR TITLE
fix(cloud): answer an unlinked Discord DM instead of dropping it

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -178,8 +178,8 @@ function routeArgs(overrides: Record<string, unknown> = {}) {
   };
 }
 
-// Shared across both describes: reset at file level so isolation never depends
-// on describe declaration order (the discord suite leaves guild fixtures set).
+// These collaborators span phone and Discord cases, so file-level reset keeps
+// either suite valid when test ordering or filtering changes.
 beforeEach(() => {
   findByDiscordIdWithOrganization.mockReset();
   findByManagedDiscordGuildId.mockReset();
@@ -664,7 +664,6 @@ describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
   });
 
   test("an authenticated user with ZERO sandboxes continues onboarding under their identity", async () => {
-    // Web login created the account; provisioning never happened.
     findByDiscordIdWithOrganization.mockResolvedValue({
       id: "user-1",
       organization_id: "org-1",
@@ -690,8 +689,8 @@ describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
   });
 
   test("GUILD context never onboards — the login URL must not land in a public channel", async () => {
-    // Guild-linked sandbox owned by the sender, gateway-bound, but no user
-    // row: the resolver yields unknown_owner in GUILD context.
+    // This fixture reaches unknown_owner through the guild resolver, proving
+    // the DM guard is enforced on the shared reason rather than assumed.
     findByManagedDiscordGuildId.mockResolvedValue([
       { id: "sb-1", agent_config: {}, organization_id: "org-1" },
     ]);

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -12,6 +12,9 @@ const listOwnerSessions = mock();
 const routeToSession = mock();
 const bridge = mock();
 const runOnboardingChat = mock();
+const findByDiscordIdWithOrganization = mock();
+const readManagedAgentDiscordBinding = mock(() => null as unknown);
+const readManagedAgentDiscordGateway = mock(() => null as unknown);
 
 let selectResults: Array<Array<Record<string, unknown>>> = [];
 let selectErrors: unknown[] = [];
@@ -63,7 +66,7 @@ mock.module("../../db/repositories/users", () => ({
   usersRepository: {
     findByPhoneNumberWithOrganization,
     findByEmailWithOrganization: mock(),
-    findByDiscordIdWithOrganization: mock(),
+    findByDiscordIdWithOrganization,
     findByTelegramIdWithOrganization: mock(),
     findByPrivyDidWithOrganization: mock(),
   },
@@ -77,6 +80,11 @@ const findRunningSandboxSpy = spyOn(
   agentSandboxesRepository,
   "findRunningSandbox",
 ).mockImplementation((...args) => findRunningSandbox(...args) as never);
+const findByManagedDiscordGuildId = mock();
+const findByManagedDiscordGuildIdSpy = spyOn(
+  agentSandboxesRepository,
+  "findByManagedDiscordGuildId",
+).mockImplementation((...args) => findByManagedDiscordGuildId(...args) as never);
 
 mock.module("../../db/schemas", () => ({
   ...realDbSchemas,
@@ -141,13 +149,14 @@ const bridgeSpy = spyOn(elizaSandboxService, "bridge").mockImplementation(
 );
 
 mock.module("./eliza-agent-config", () => ({
-  readManagedAgentDiscordBinding: mock(() => null),
-  readManagedAgentDiscordGateway: mock(() => null),
+  readManagedAgentDiscordBinding,
+  readManagedAgentDiscordGateway,
 }));
 
 afterAll(() => {
   listByOrganizationSpy.mockRestore();
   findRunningSandboxSpy.mockRestore();
+  findByManagedDiscordGuildIdSpy.mockRestore();
   bridgeSpy.mockRestore();
 });
 
@@ -598,6 +607,115 @@ describe("AgentGatewayRouterService phone routing", () => {
       organizationId: "owner-org",
       userId: "owner-user",
     });
+    expect(runOnboardingChat).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
+  beforeEach(() => {
+    findByDiscordIdWithOrganization.mockReset();
+    findByManagedDiscordGuildId.mockReset();
+    readManagedAgentDiscordBinding.mockReset();
+    readManagedAgentDiscordBinding.mockReturnValue(null);
+    readManagedAgentDiscordGateway.mockReset();
+    readManagedAgentDiscordGateway.mockReturnValue(null);
+    listOwnerSessions.mockReset();
+    listByOrganization.mockReset();
+    runOnboardingChat.mockReset();
+  });
+
+  function discordArgs(overrides: Record<string, unknown> = {}) {
+    return {
+      guildId: null,
+      channelId: "chan-1",
+      messageId: "msg-1",
+      content: "hi eliza",
+      sender: { id: "discord-user-1", username: "newuser", displayName: "New User" },
+      ...overrides,
+    };
+  }
+
+  test("a first-contact DM onboards instead of silence", async () => {
+    findByDiscordIdWithOrganization.mockResolvedValue(null);
+    runOnboardingChat.mockResolvedValue({
+      reply: "Welcome! Here is your login link.",
+      session: { userId: undefined, organizationId: undefined },
+      provisioning: { agentId: null },
+    });
+
+    const result = await newRouter().routeDiscordMessage(discordArgs());
+
+    expect(result.handled).toBe(true);
+    expect(result.replyText).toBe("Welcome! Here is your login link.");
+    expect(runOnboardingChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "discord",
+        platformUserId: "discord-user-1",
+        platformDisplayName: "New User",
+        sessionId: "platform:discord:discord-user-1",
+        trustedPlatformIdentity: true,
+      }),
+    );
+  });
+
+  test("an authenticated user with ZERO sandboxes continues onboarding under their identity", async () => {
+    // Web login created the account; provisioning never happened.
+    findByDiscordIdWithOrganization.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    listOwnerSessions.mockResolvedValue([]);
+    listByOrganization.mockResolvedValue([]);
+    runOnboardingChat.mockResolvedValue({
+      reply: "Let's finish setting up your agent.",
+      session: { userId: "user-1", organizationId: "org-1" },
+      provisioning: { agentId: null },
+    });
+
+    const result = await newRouter().routeDiscordMessage(discordArgs());
+
+    expect(result.handled).toBe(true);
+    expect(result.replyText).toBe("Let's finish setting up your agent.");
+    expect(runOnboardingChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "discord",
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      }),
+    );
+  });
+
+  test("GUILD context never onboards — the login URL must not land in a public channel", async () => {
+    // Guild-linked sandbox owned by the sender, gateway-bound, but no user
+    // row: the resolver yields unknown_owner in GUILD context.
+    findByManagedDiscordGuildId.mockResolvedValue([
+      { id: "sb-1", agent_config: {}, organization_id: "org-1" },
+    ]);
+    readManagedAgentDiscordBinding.mockReturnValue({ adminDiscordUserId: "discord-user-1" });
+    readManagedAgentDiscordGateway.mockReturnValue({ gateway: true });
+    findByDiscordIdWithOrganization.mockResolvedValue(null);
+
+    const result = await newRouter().routeDiscordMessage(discordArgs({ guildId: "guild-9" }));
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe("unknown_owner");
+    expect(runOnboardingChat).not.toHaveBeenCalled();
+  });
+
+  test("a stopped-agent owner keeps today's silence (parity with the phone path)", async () => {
+    findByDiscordIdWithOrganization.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    listOwnerSessions.mockResolvedValue([]);
+    listByOrganization.mockResolvedValue([
+      { id: "sb-stopped", status: "stopped", user_id: "user-1", agent_config: {} },
+    ]);
+
+    const result = await newRouter().routeDiscordMessage(discordArgs());
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe("owner_agent_not_running");
+    expect(result.agentId).toBe("sb-stopped");
     expect(runOnboardingChat).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -178,6 +178,17 @@ function routeArgs(overrides: Record<string, unknown> = {}) {
   };
 }
 
+// Shared across both describes: reset at file level so isolation never depends
+// on describe declaration order (the discord suite leaves guild fixtures set).
+beforeEach(() => {
+  findByDiscordIdWithOrganization.mockReset();
+  findByManagedDiscordGuildId.mockReset();
+  readManagedAgentDiscordBinding.mockReset();
+  readManagedAgentDiscordBinding.mockReturnValue(null);
+  readManagedAgentDiscordGateway.mockReset();
+  readManagedAgentDiscordGateway.mockReturnValue(null);
+});
+
 describe("AgentGatewayRouterService phone routing", () => {
   beforeEach(() => {
     findByPhoneNumberWithOrganization.mockReset();
@@ -613,12 +624,6 @@ describe("AgentGatewayRouterService phone routing", () => {
 
 describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
   beforeEach(() => {
-    findByDiscordIdWithOrganization.mockReset();
-    findByManagedDiscordGuildId.mockReset();
-    readManagedAgentDiscordBinding.mockReset();
-    readManagedAgentDiscordBinding.mockReturnValue(null);
-    readManagedAgentDiscordGateway.mockReset();
-    readManagedAgentDiscordGateway.mockReturnValue(null);
     listOwnerSessions.mockReset();
     listByOrganization.mockReset();
     runOnboardingChat.mockReset();

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -213,6 +213,7 @@ export class AgentGatewayRouterService {
     reason?: AgentGatewayRouteReason;
     agentId?: string;
     userId?: string;
+    organizationId?: string;
   }> {
     const localSessions = await agentGatewayRelayService.listOwnerSessions(organizationId, userId);
     if (localSessions.length >= 1) {
@@ -223,6 +224,7 @@ export class AgentGatewayRouterService {
           sessions: localSessions,
         },
         userId,
+        organizationId,
       };
     }
 
@@ -231,6 +233,7 @@ export class AgentGatewayRouterService {
     return {
       ...resolved,
       userId,
+      organizationId,
     };
   }
 
@@ -242,6 +245,7 @@ export class AgentGatewayRouterService {
     reason?: AgentGatewayRouteReason;
     agentId?: string;
     userId?: string;
+    organizationId?: string;
   }> {
     const senderDiscordUserId = args.senderDiscordUserId.trim();
 
@@ -637,11 +641,72 @@ export class AgentGatewayRouterService {
     });
 
     if (!resolved.target) {
+      // DM-GATED on purpose: `unknown_owner` also fires in guild context, and
+      // onboarding there would post the login URL — whose session id embeds
+      // the guessable `platform:discord:<senderId>` — into a public channel.
+      const isDm = !args.guildId?.trim();
+
+      if (isDm && resolved.reason === "unknown_owner") {
+        // First contact: same onboarding the phone path runs, so a new user
+        // who DMs the bot gets the pitch + login link instead of silence.
+        const onboarding = await this.runOnboardingChat({
+          message: args.content,
+          platform: "discord",
+          platformUserId: args.sender.id,
+          platformDisplayName: args.sender.displayName ?? args.sender.username,
+          sessionId: `platform:discord:${args.sender.id}`,
+          trustedPlatformIdentity: true,
+        });
+        return {
+          handled: true,
+          replyText: onboarding.reply,
+          reason: resolved.reason,
+          userId: onboarding.session.userId,
+          organizationId: onboarding.session.organizationId,
+          agentId: onboarding.provisioning.agentId ?? undefined,
+        };
+      }
+
+      if (
+        isDm &&
+        resolved.reason === "owner_agent_not_running" &&
+        resolved.userId &&
+        resolved.organizationId &&
+        !resolved.agentId
+      ) {
+        // Authenticated user with ZERO sandboxes: the web login created the
+        // account but provisioning never happened (dropped off mid-funnel).
+        // Continue onboarding under their identity, mirroring the phone path.
+        const onboarding = await this.runOnboardingChat({
+          message: args.content,
+          platform: "discord",
+          platformUserId: args.sender.id,
+          platformDisplayName: args.sender.displayName ?? args.sender.username,
+          sessionId: `platform:discord:${args.sender.id}`,
+          authenticatedUser: {
+            userId: resolved.userId,
+            organizationId: resolved.organizationId,
+          },
+        });
+        return {
+          handled: true,
+          replyText: onboarding.reply,
+          reason: resolved.reason,
+          userId: resolved.userId,
+          organizationId: resolved.organizationId,
+          agentId: onboarding.provisioning.agentId ?? undefined,
+        };
+      }
+
+      // Everything else keeps today's behavior — including stopped-agent
+      // owners (agentId present), where parity with the phone path is
+      // deliberate silence, not a status reply.
       return {
         handled: false,
         reason: resolved.reason,
         agentId: resolved.agentId,
         userId: resolved.userId,
+        organizationId: resolved.organizationId,
       };
     }
 

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -748,6 +748,7 @@ export class AgentGatewayRouterService {
     return {
       ...routed,
       userId: resolved.userId,
+      organizationId: routed.organizationId ?? resolved.organizationId,
     };
   }
 

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -641,14 +641,13 @@ export class AgentGatewayRouterService {
     });
 
     if (!resolved.target) {
-      // DM-GATED on purpose: `unknown_owner` also fires in guild context, and
-      // onboarding there would post the login URL — whose session id embeds
-      // the guessable `platform:discord:<senderId>` — into a public channel.
+      // Unknown-owner resolution also occurs for guild traffic. Keeping the
+      // onboarding credential in a DM prevents disclosure in a public channel.
       const isDm = !args.guildId?.trim();
 
       if (isDm && resolved.reason === "unknown_owner") {
-        // First contact: same onboarding the phone path runs, so a new user
-        // who DMs the bot gets the pitch + login link instead of silence.
+        // All messaging entry points share one onboarding transcript and
+        // provisioning path so channel choice cannot change account setup.
         const onboarding = await this.runOnboardingChat({
           message: args.content,
           platform: "discord",
@@ -674,9 +673,8 @@ export class AgentGatewayRouterService {
         resolved.organizationId &&
         !resolved.agentId
       ) {
-        // Authenticated user with ZERO sandboxes: the web login created the
-        // account but provisioning never happened (dropped off mid-funnel).
-        // Continue onboarding under their identity, mirroring the phone path.
+        // A known owner without any sandbox has no runtime target, so the
+        // authenticated onboarding path must finish provisioning instead.
         const onboarding = await this.runOnboardingChat({
           message: args.content,
           platform: "discord",
@@ -698,9 +696,8 @@ export class AgentGatewayRouterService {
         };
       }
 
-      // Everything else keeps today's behavior — including stopped-agent
-      // owners (agentId present), where parity with the phone path is
-      // deliberate silence, not a status reply.
+      // A stopped agent remains a resolved owner resource, not an onboarding
+      // candidate; silently provisioning another agent would duplicate it.
       return {
         handled: false,
         reason: resolved.reason,

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -3,6 +3,14 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "b
 import * as realCloudBindings from "../../runtime/cloud-bindings";
 import type { OnboardingChatMessage, OnboardingSession } from "./onboarding-chat";
 
+function continuationToken(result: { loginUrl: string }): string {
+  const token = new URL(result.loginUrl).searchParams.get("onboardingSession");
+  if (!token) {
+    throw new Error("onboarding login URL has no continuation token");
+  }
+  return token;
+}
+
 const sessionCache = new Map<string, unknown>();
 const ensureElizaAppProvisioning = mock();
 const getElizaAppProvisioningStatus = mock();
@@ -155,9 +163,11 @@ describe("runOnboardingChat", () => {
 
     expect(result.requiresLogin).toBe(true);
     expect(result.provisioning.status).toBe("none");
-    expect(result.loginUrl).toContain(
-      "/get-started/?onboardingSession=platform%3Ablooio%3A%2B14155550123",
+    expect(continuationToken(result)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+    expect(result.loginUrl).not.toContain("platform%3A");
+    expect(result.loginUrl).not.toContain("14155550123");
     expect(result.reply).toContain("Connect Eliza Cloud here:");
     expect(result.reply).toContain(result.loginUrl);
     expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
@@ -410,7 +420,7 @@ describe("runOnboardingChat", () => {
       const continued = await runOnboardingChat({
         platform: "blooio",
         platformUserId: "+14155550123",
-        sessionId: "platform:blooio:+14155550123",
+        sessionId: continuationToken(result),
         authenticatedUser: {
           userId: "user-1",
           organizationId: "org-1",
@@ -436,7 +446,7 @@ describe("runOnboardingChat", () => {
       sandbox: null,
     });
 
-    await runOnboardingChat({
+    const gatewayTurn = await runOnboardingChat({
       message: "My name is Sam",
       platform: "blooio",
       platformUserId: "+14155550123",
@@ -453,7 +463,7 @@ describe("runOnboardingChat", () => {
 
     const result = await runOnboardingChat({
       platform: "blooio",
-      sessionId: "platform:blooio:+14155550123",
+      sessionId: continuationToken(gatewayTurn),
       authenticatedUser: {
         userId: "phone-user",
         organizationId: "phone-org",
@@ -587,6 +597,27 @@ describe("runOnboardingChat", () => {
       expect(linkPhoneToUser).not.toHaveBeenCalled();
     });
 
+    test("an authenticated caller cannot claim an existing unbound session by public platform id", async () => {
+      const victim = await runTrustedPhoneTurn("My name is Sam");
+      const victimSnapshot = JSON.stringify(getCachedSession(PLATFORM_SESSION));
+      ensureElizaAppProvisioning.mockResolvedValue(noProvisioning());
+      getElizaAppProvisioningStatus.mockResolvedValue(noProvisioning());
+
+      const attacker = await runOnboardingChat({
+        sessionId: PLATFORM_SESSION,
+        authenticatedUser: { userId: "attacker-user", organizationId: "attacker-org" },
+      });
+
+      expect(attacker.session.id).not.toBe(PLATFORM_SESSION);
+      expect(attacker.session.id).toMatch(UUID_PATTERN);
+      expect(attacker.session.name).toBeUndefined();
+      expect(
+        attacker.session.history.map((message: OnboardingChatMessage) => message.content),
+      ).not.toContain("My name is Sam");
+      expect(JSON.stringify(getCachedSession(PLATFORM_SESSION))).toBe(victimSnapshot);
+      expect(continuationToken(victim)).toMatch(UUID_PATTERN);
+    });
+
     test("a session bound to one user never carries over to a different authenticated user", async () => {
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "provisioning",
@@ -596,9 +627,9 @@ describe("runOnboardingChat", () => {
       });
       getElizaAppProvisioningStatus.mockResolvedValue(noProvisioning());
 
-      await runTrustedPhoneTurn("My name is Sam");
+      const victim = await runTrustedPhoneTurn("My name is Sam");
       const victimBound = await runOnboardingChat({
-        sessionId: PLATFORM_SESSION,
+        sessionId: continuationToken(victim),
         platform: "blooio",
         authenticatedUser: { userId: "victim-user", organizationId: "victim-org" },
       });
@@ -621,7 +652,7 @@ describe("runOnboardingChat", () => {
       expect(linkPhoneToUser).not.toHaveBeenCalledWith("attacker-user", PHONE);
     });
 
-    test("a web continuation cannot mutate the platform identity and still links the phone", async () => {
+    test("an opaque web continuation cannot mutate the platform identity and still links the phone", async () => {
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "provisioning",
         agentId: "agent-1",
@@ -629,9 +660,9 @@ describe("runOnboardingChat", () => {
         sandbox: null,
       });
 
-      await runTrustedPhoneTurn("My name is Sam");
+      const gatewayTurn = await runTrustedPhoneTurn("My name is Sam");
       const continued = await runOnboardingChat({
-        sessionId: PLATFORM_SESSION,
+        sessionId: continuationToken(gatewayTurn),
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
       });
@@ -943,11 +974,12 @@ describe("runOnboardingChat", () => {
         expect(first.reply).toContain("finishing the handoff");
         expect(first.reply).not.toContain("copied this onboarding chat");
         expect(rememberCalls).toBe(1);
+        const browserContinuation = continuationToken(first);
 
         rememberStatus = 200;
         const second = await runOnboardingChat({
           platform: "blooio",
-          sessionId: PLATFORM_SESSION,
+          sessionId: browserContinuation,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
         });
         expect(second.handoffComplete).toBe(true);
@@ -956,7 +988,7 @@ describe("runOnboardingChat", () => {
 
         const third = await runOnboardingChat({
           platform: "blooio",
-          sessionId: PLATFORM_SESSION,
+          sessionId: browserContinuation,
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
         });
         expect(third.handoffComplete).toBe(true);

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -24,6 +24,12 @@ export interface OnboardingChatMessage {
 
 export interface OnboardingSession {
   id: string;
+  /**
+   * Opaque credential carried by browser continuation links. Messaging
+   * transports keep the deterministic platform session id private because
+   * platform user ids are commonly public or guessable.
+   */
+  continuationToken?: string;
   createdAt: string;
   updatedAt: string;
   platform?: OnboardingPlatform;
@@ -87,6 +93,10 @@ function sessionCacheKey(sessionId: string): string {
   return `eliza-app:onboarding:${sessionId}`;
 }
 
+function continuationCacheKey(token: string): string {
+  return `eliza-app:onboarding-continuation:${token}`;
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -110,13 +120,10 @@ function redactSessionIdForLog(sessionId: string): string {
 
 /**
  * Platform-scoped session ids (`platform:<platform>:<platformUserId>`) are
- * derived from messaging identities (usually phone numbers), so they are
- * guessable. Only two callers may present one:
- * - a trusted transport (internal gateway auth, `trustedPlatformIdentity`);
- * - an authenticated user continuing a session from their login link.
- * Anonymous callers with a malformed or platform-scoped id get a fresh
- * random session instead, so a forged id can never read or mutate another
- * user's onboarding state.
+ * derived from public or guessable messaging identities. Only a trusted
+ * transport may present one. Browser continuations use a separate opaque
+ * credential, so authentication alone never grants access to a session whose
+ * platform id an attacker can derive.
  */
 function sanitizeSessionId(value: string | undefined, input: OnboardingChatInput): string {
   const trimmed = value?.trim();
@@ -124,7 +131,7 @@ function sanitizeSessionId(value: string | undefined, input: OnboardingChatInput
     if (!trimmed.startsWith(PLATFORM_SESSION_PREFIX)) {
       return trimmed;
     }
-    if (input.trustedPlatformIdentity === true || input.authenticatedUser) {
+    if (input.trustedPlatformIdentity === true) {
       return trimmed;
     }
     logger.warn(
@@ -140,11 +147,49 @@ function sanitizeSessionId(value: string | undefined, input: OnboardingChatInput
   return crypto.randomUUID();
 }
 
+interface OnboardingContinuation {
+  sessionId: string;
+}
+
+function isOnboardingContinuation(value: unknown): value is OnboardingContinuation {
+  if (!value || typeof value !== "object" || !("sessionId" in value)) {
+    return false;
+  }
+  const sessionId = value.sessionId;
+  return (
+    typeof sessionId === "string" &&
+    SESSION_ID_PATTERN.test(sessionId) &&
+    sessionId.startsWith(PLATFORM_SESSION_PREFIX)
+  );
+}
+
+async function resolveSessionId(input: OnboardingChatInput): Promise<string> {
+  const sessionId = sanitizeSessionId(input.sessionId, input);
+  if (
+    input.authenticatedUser &&
+    input.trustedPlatformIdentity !== true &&
+    input.sessionId?.trim() === sessionId
+  ) {
+    const continuation = await cache.get<unknown>(continuationCacheKey(sessionId));
+    if (isOnboardingContinuation(continuation)) {
+      return continuation.sessionId;
+    }
+  }
+  return sessionId;
+}
+
 async function loadSession(sessionId: string): Promise<OnboardingSession | null> {
   return cache.get<OnboardingSession>(sessionCacheKey(sessionId));
 }
 
 async function saveSession(session: OnboardingSession): Promise<void> {
+  if (session.continuationToken && session.id.startsWith(PLATFORM_SESSION_PREFIX)) {
+    await cache.set(
+      continuationCacheKey(session.continuationToken),
+      { sessionId: session.id } satisfies OnboardingContinuation,
+      SESSION_TTL_SECONDS,
+    );
+  }
   await cache.set(sessionCacheKey(session.id), session, SESSION_TTL_SECONDS);
 }
 
@@ -591,6 +636,7 @@ function newSession(id: string, input: OnboardingChatInput): OnboardingSession {
   const createdAt = nowIso();
   return {
     id,
+    continuationToken: id.startsWith(PLATFORM_SESSION_PREFIX) ? crypto.randomUUID() : undefined,
     createdAt,
     updatedAt: createdAt,
     platform: input.platform,
@@ -601,13 +647,11 @@ function newSession(id: string, input: OnboardingChatInput): OnboardingSession {
 }
 
 export async function runOnboardingChat(input: OnboardingChatInput): Promise<OnboardingChatResult> {
-  let sessionId = sanitizeSessionId(input.sessionId, input);
+  let sessionId = await resolveSessionId(input);
   let session = await loadSession(sessionId);
 
-  // Authenticated web callers may CONTINUE a platform-scoped session (they
-  // carry its id from a login link the gateway texted out), but they may not
-  // CREATE one — that would let any signed-in user pre-bind a messaging
-  // identity they do not own.
+  // An untrusted caller must never create a platform-scoped session. Opaque
+  // browser credentials resolve to an existing platform session above.
   if (
     !session &&
     sessionId.startsWith(PLATFORM_SESSION_PREFIX) &&
@@ -621,6 +665,9 @@ export async function runOnboardingChat(input: OnboardingChatInput): Promise<Onb
   }
 
   session = session ?? newSession(sessionId, input);
+  if (session.id.startsWith(PLATFORM_SESSION_PREFIX) && !session.continuationToken) {
+    session = { ...session, continuationToken: crypto.randomUUID() };
+  }
 
   // A session already bound to one cloud account never carries over to a
   // different authenticated account: the second account gets a fresh session
@@ -717,7 +764,9 @@ export async function runOnboardingChat(input: OnboardingChatInput): Promise<Onb
   }
 
   const loginUrl = onboardingAppPath(
-    `/get-started/?onboardingSession=${encodeURIComponent(session.id)}`,
+    `/get-started/?onboardingSession=${encodeURIComponent(
+      session.continuationToken ?? session.id,
+    )}`,
   );
   const panelUrl = controlPanelUrl(session.agentId);
   const reply = await generateOnboardingReply({


### PR DESCRIPTION
## What — #17341

A first-time user who DMs the Eliza Discord bot currently gets silence. This
change routes unresolved Discord DMs into the same onboarding and provisioning
path used by phone:

1. `unknown_owner` starts onboarding with a trusted Discord identity.
2. A known owner with no sandbox continues onboarding under their authenticated
   user and organization.

Guild traffic is explicitly excluded, and a known owner whose agent is stopped
remains silent rather than receiving a duplicate agent.

## Underlying security fix

The review found that onboarding links exposed
`platform:discord:<public Discord user id>` as the browser continuation
credential. Authentication did not make that deterministic identifier secret:
another authenticated user who knew a Discord ID could construct the URL and
claim an unbound transcript.

Browser links now carry an opaque UUID credential which resolves server-side to
the transport-owned platform session. Only a trusted messaging transport may
present deterministic `platform:*` session IDs. Existing platform sessions
self-heal an opaque token on their next trusted turn, and the mapping expires
with the same 14-day TTL as the session.

An adversarial regression proves that an authenticated caller presenting a
victim's public platform session ID receives a fresh session and cannot read,
mutate, or bind the victim transcript.

## Verification

- focused onboarding/router lane: 59 passed, 0 failed, 280 assertions
- full `@elizaos/cloud-shared` suite: 5,853 passed, 72 explicit skips, 0 failed
  across 628 files
- `bun run --cwd packages/cloud/shared typecheck`: passed
- Biome check on all four changed files: passed
- post-rebase `bun run verify`: 579/579 workspace tasks passed; 8,821 test
  files passed the focused/skip audit; 28/28 dist consumers typechecked
- live Cerebras onboarding call: produced a coherent Discord onboarding reply,
  included the $5 credit offer and an opaque UUID continuation URL; the URL
  returned HTTP 200 and did not expose the Discord user ID

`ELIZA_APP_DISCORD_BOT_TOKEN` was not available in the review environment, so
the live-model proof exercises the production onboarding generation path but
does not claim a live Discord gateway connection.

Refs #17341 · Part of the eliza.app onboarding work (#17323, #17340)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime changed

<!-- evidence-row:llm-trajectory -->
- [x] [Live Cerebras production onboarding result and manual review](https://github.com/elizaOS/eliza/pull/17349#issuecomment-5140991773)

<!-- evidence-row:domain-artifacts -->
- [x] [Opaque-token, session-history, and HTTP 200 artifact checks](https://github.com/elizaOS/eliza/pull/17349#issuecomment-5140991773)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [Original gateway test log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17349-gw-final.log), plus [full-suite and focused-lane review results](https://github.com/elizaOS/eliza/pull/17349#issuecomment-5140991773)
