### PR TITLE
fix(registry): support and certify Ruby High app launch

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3296,6 +3296,19 @@ async function handleRequest(
     const appManager = ctx?.getAppManager
       ? await ctx.getAppManager()
       : (state.appManager as AppManagerLike);
+    const installPluginForApp = async (
+      ...args: Parameters<typeof installPluginDirect>
+    ) => {
+      const result = await installPluginDirect(...args);
+      if (result.success) {
+        // The direct installer persists plugins.installs to eliza.json. Keep
+        // this server's in-memory config aligned so the immediately-following
+        // GET /api/apps/installed reflects a clean first install without
+        // waiting for a process restart.
+        state.config = loadElizaConfig();
+      }
+      return result;
+    };
     // #12087 Item 13: single boundary-role collapse (no inline OWNER/GUEST ternary).
     const appActorRole: AppsRouteActorRole = resolveBoundaryRole(req);
     if (
@@ -3341,7 +3354,7 @@ async function handleRequest(
               runtime && typeof runtime === "object"
                 ? (runtime as IAgentRuntime)
                 : null,
-              installPluginDirect,
+              installPluginForApp,
             ),
           stop: (pluginManager, name, runId, runtime) =>
             appManager.stop(
@@ -3369,7 +3382,7 @@ async function handleRequest(
           read: () => readFavoriteAppsFromConfig(state.config),
           write: (apps) => writeFavoriteAppsToConfig(state.config, apps),
         } satisfies FavoriteAppsStore,
-        installPluginDirect,
+        installPluginDirect: installPluginForApp,
       })
     ) {
       return;

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -4,7 +4,7 @@ import {
   execFileSync,
   spawn,
 } from "node:child_process";
-import { existsSync } from "node:fs";
+import { appendFileSync, existsSync } from "node:fs";
 import {
   access,
   cp,
@@ -64,12 +64,15 @@ const REAL_LOCAL_AGENT_SCRIPT = path.join(
   import.meta.dirname,
   "serve-real-local-agent.ts",
 );
+const NODE_TSX_RUNNER = path.join(import.meta.dirname, "run-node-tsx.mjs");
 const READY_TIMEOUT_MS = 180_000;
 const API_PORT = Number(process.env.ELIZA_UI_SMOKE_API_PORT ?? "31337");
 const UI_PORT = Number(process.env.ELIZA_UI_SMOKE_PORT ?? "2138");
 const UI_SMOKE_RUN_ID = process.env.ELIZA_UI_SMOKE_RUN_ID?.trim() ?? "";
 const LIVE_PROVIDER = await selectLiveProviderAsync();
 const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
+const REAL_LOCAL_BACKEND_LOG_PATH =
+  process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
 // Precedence (force-stub > live opt-in > CI default) lives in one tested helper.
 // The key behavior: ELIZA_UI_SMOKE_LIVE_STACK=1 overrides the CI-based stub force
 // so a genuinely-real lane is possible (GitHub Actions always sets CI=true, which
@@ -428,6 +431,63 @@ async function fetchApiWithRetry(
   throw lastError;
 }
 
+async function proxyBackendRequest(args: {
+  apiBase: string;
+  fallThroughOnNotFound: boolean;
+  request: IncomingMessage;
+  requestUrl: URL;
+  response: ServerResponse<IncomingMessage>;
+}): Promise<boolean> {
+  const body = await readRequestBody(args.request);
+  const headers: Record<string, string> = {};
+  for (const name of ["accept", "authorization", "content-type", "cookie"]) {
+    const value = args.request.headers[name];
+    if (typeof value === "string") headers[name] = value;
+  }
+
+  const upstream = await fetchApiWithRetry(
+    `${args.apiBase}${args.requestUrl.pathname}${args.requestUrl.search}`,
+    {
+      body: body.byteLength > 0 ? body : undefined,
+      headers,
+      method: args.request.method ?? "GET",
+    },
+  );
+  if (args.fallThroughOnNotFound && upstream.status === 404) {
+    await upstream.body?.cancel().catch(() => undefined);
+    return false;
+  }
+
+  const proxyHeaders: Record<string, string> = {};
+  upstream.headers.forEach((value, key) => {
+    if (key.toLowerCase() !== "transfer-encoding") {
+      proxyHeaders[key] = value;
+    }
+  });
+  args.response.writeHead(upstream.status, proxyHeaders);
+  if (!upstream.body) {
+    args.response.end();
+    return true;
+  }
+
+  const reader = upstream.body.getReader();
+  try {
+    while (!args.response.writableEnded) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!args.response.write(value)) {
+        await new Promise<void>((resolve) => {
+          args.response.once("drain", resolve);
+        });
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  args.response.end();
+  return true;
+}
+
 async function proxyUiRequest(args: {
   apiBase: string;
   request: IncomingMessage;
@@ -437,52 +497,11 @@ async function proxyUiRequest(args: {
   const requestUrl = new URL(args.request.url ?? "/", "http://127.0.0.1");
 
   if (requestUrl.pathname.startsWith("/api/")) {
-    const body = await readRequestBody(args.request);
-    const headers: Record<string, string> = {};
-    const contentType = args.request.headers["content-type"];
-    if (typeof contentType === "string") {
-      headers["content-type"] = contentType;
-    }
-    const authorization = args.request.headers.authorization;
-    if (typeof authorization === "string") {
-      headers.authorization = authorization;
-    }
-
-    const upstream = await fetchApiWithRetry(
-      `${args.apiBase}${requestUrl.pathname}${requestUrl.search}`,
-      {
-        body: body.byteLength > 0 ? body : undefined,
-        headers,
-        method: args.request.method ?? "GET",
-      },
-    );
-    const proxyHeaders: Record<string, string> = {};
-    upstream.headers.forEach((value, key) => {
-      if (key.toLowerCase() === "transfer-encoding") {
-        return;
-      }
-      proxyHeaders[key] = value;
+    await proxyBackendRequest({
+      ...args,
+      requestUrl,
+      fallThroughOnNotFound: false,
     });
-    args.response.writeHead(upstream.status, proxyHeaders);
-    if (!upstream.body) {
-      args.response.end();
-      return;
-    }
-    const reader = upstream.body.getReader();
-    try {
-      while (!args.response.writableEnded) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (!args.response.write(value)) {
-          await new Promise<void>((resolve) => {
-            args.response.once("drain", resolve);
-          });
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-    args.response.end();
     return;
   }
 
@@ -494,6 +513,15 @@ async function proxyUiRequest(args: {
     resolveDistAssetPath(requestedPath, args.uiDistDir) ??
     resolveCompanionPublicAssetPath(requestedPath);
   const isAssetRequest = path.extname(requestedPath).length > 0;
+  if (!filePath && requestUrl.pathname !== "/") {
+    const forwarded = await proxyBackendRequest({
+      ...args,
+      requestUrl,
+      fallThroughOnNotFound:
+        args.request.method === "GET" || args.request.method === "HEAD",
+    });
+    if (forwarded) return;
+  }
   const indexHtmlPath = path.join(args.uiDistDir, "index.html");
   if (!filePath && isAssetRequest) {
     args.response.writeHead(404, {
@@ -1075,27 +1103,43 @@ async function startRealLocalStack(): Promise<StartedStack> {
   let apiChild: ChildProcessWithoutNullStreams | null = null;
   let uiServer: Server | null = null;
   try {
+    const backendLogPath = REAL_LOCAL_BACKEND_LOG_PATH
+      ? path.resolve(REPO_ROOT, REAL_LOCAL_BACKEND_LOG_PATH)
+      : null;
+    if (backendLogPath) {
+      await mkdir(path.dirname(backendLogPath), { recursive: true });
+      await writeFile(backendLogPath, "", "utf8");
+    }
     const uiDistDir = await snapshotUiDist(stateDir);
     const apiBase = `http://127.0.0.1:${API_PORT}`;
-    apiChild = spawn(resolveBunCommand(), ["--bun", REAL_LOCAL_AGENT_SCRIPT], {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        FORCE_COLOR: "0",
-        ELIZA_API_PORT: String(API_PORT),
-        ELIZA_PORT: String(API_PORT),
-        ELIZA_PAIRING_DISABLED: "1",
-        ELIZA_E2E_MODEL_STREAM_CHUNK_SIZE: "8",
-        ELIZA_E2E_MODEL_STREAM_INTERVAL_MS: "16",
+    apiChild = spawn(
+      process.execPath,
+      [NODE_TSX_RUNNER, REAL_LOCAL_AGENT_SCRIPT],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          FORCE_COLOR: "0",
+          ELIZA_API_PORT: String(API_PORT),
+          ELIZA_PORT: String(API_PORT),
+          ELIZA_STATE_DIR: stateDir,
+          ELIZA_PAIRING_DISABLED: "1",
+          ELIZA_E2E_MODEL_STREAM_CHUNK_SIZE: "8",
+          ELIZA_E2E_MODEL_STREAM_INTERVAL_MS: "16",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
       },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    );
 
     apiChild.stdout.on("data", (chunk) => {
-      process.stdout.write(`[ui-smoke][real-local] ${chunk}`);
+      const output = `[ui-smoke][real-local] ${chunk}`;
+      process.stdout.write(output);
+      if (backendLogPath) appendFileSync(backendLogPath, output);
     });
     apiChild.stderr.on("data", (chunk) => {
-      process.stdout.write(`[ui-smoke][real-local-err] ${chunk}`);
+      const output = `[ui-smoke][real-local-err] ${chunk}`;
+      process.stdout.write(output);
+      if (backendLogPath) appendFileSync(backendLogPath, output);
     });
 
     await waitForJsonPredicate<{ state?: string }>(

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -7,7 +7,8 @@
  * WebView tests reach it through adb reverse as a "remote" first-run target.
  */
 
-import { ModelType } from "@elizaos/core";
+import { readFile } from "node:fs/promises";
+import { ModelType, type Route } from "@elizaos/core";
 import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
 import { createDeterministicLlmProxyPlugin } from "../../test/mocks/helpers/llm-proxy-plugin.ts";
 import { startApiServer } from "../src/api/server.ts";
@@ -23,6 +24,126 @@ const deviceE2eUploadImageRoute = {
 const STREAM_E2E_REPLY =
   "STREAM_E2E_OK The dashboard receives this reply through the real model callback, runtime message loop, HTTP SSE route, browser parser, and React transcript. " +
   "Each chunk is intentionally small and evenly paced so the browser lane can measure token-to-paint latency, frame cadence, layout stability, and DOM identity while the visible answer grows.";
+const GENERATED_REGISTRY_URL =
+  "https://plugins.elizacloud.ai/generated-registry.json";
+const CLOUD_API_PROBE_URL = "https://elizacloud.ai/api/v1";
+const RUBY_HIGH_EVIDENCE_ACTIONS = new Set([
+  "CONNECT_RUBY_HIGH",
+  "ENROLL_RUBY_HIGH",
+]);
+
+const rubyHighEvidenceActionRoute: Route = {
+  type: "POST",
+  path: "/api/device-e2e/ruby-high/action",
+  rawPath: true,
+  name: "device-e2e-ruby-high-action",
+  routeHandler: async (ctx) => {
+    const json = (status: number, body: unknown) => ({
+      status,
+      headers: { "content-type": "application/json; charset=utf-8" },
+      body,
+    });
+    if (process.env.ELIZA_UI_SMOKE_RUBY_HIGH_JOURNEY !== "1") {
+      return json(404, { error: "Ruby High evidence actions are disabled." });
+    }
+    const body =
+      ctx.body && typeof ctx.body === "object" && !Array.isArray(ctx.body)
+        ? (ctx.body as Record<string, unknown>)
+        : {};
+    const actionName =
+      typeof body.actionName === "string" ? body.actionName.trim() : "";
+    if (!RUBY_HIGH_EVIDENCE_ACTIONS.has(actionName)) {
+      return json(400, { error: "Unsupported Ruby High evidence action." });
+    }
+    const action = ctx.runtime.actions.find(
+      (candidate) => candidate.name === actionName,
+    );
+    if (!action) {
+      return json(409, {
+        error: `${actionName} is not registered on the runtime.`,
+      });
+    }
+    const parameters =
+      body.parameters &&
+      typeof body.parameters === "object" &&
+      !Array.isArray(body.parameters)
+        ? (body.parameters as Record<string, unknown>)
+        : {};
+    const message = {
+      content: {
+        text: `Run ${actionName} for the connected-agent evidence journey.`,
+        source: "client_chat",
+      },
+    };
+    const options = { parameters };
+    const valid = await action.validate(
+      ctx.runtime,
+      message as never,
+      undefined,
+      options as never,
+    );
+    if (!valid) {
+      return json(409, {
+        error: `${actionName} is not valid in the current state.`,
+      });
+    }
+    const callbacks: string[] = [];
+    const result = await action.handler(
+      ctx.runtime,
+      message as never,
+      undefined,
+      options as never,
+      async (content) => {
+        if (typeof content.text === "string") callbacks.push(content.text);
+      },
+    );
+    return json(200, { ok: true, actionName, callbacks, result });
+  },
+};
+
+/**
+ * Let an opt-in real-local UI smoke consume the generated registry from the
+ * exact checkout under test. Only the canonical generated-registry request is
+ * intercepted; npm downloads and every other network boundary stay real.
+ */
+async function installGeneratedRegistryFixture(): Promise<() => void> {
+  const fixturePath =
+    process.env.ELIZA_UI_SMOKE_GENERATED_REGISTRY_FIXTURE?.trim();
+  if (!fixturePath) return () => {};
+
+  const body = await readFile(fixturePath, "utf8");
+  JSON.parse(body);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const method =
+      init?.method ??
+      (typeof input === "string" || input instanceof URL
+        ? undefined
+        : input.method);
+    if (url === CLOUD_API_PROBE_URL && method?.toUpperCase() === "HEAD") {
+      return new Response(null, { status: 204 });
+    }
+    if (url === GENERATED_REGISTRY_URL) {
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return originalFetch(input, init);
+  }) as typeof globalThis.fetch;
+  console.log(
+    `[device-e2e-host-agent] serving generated registry fixture: ${fixturePath}`,
+  );
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
 
 function resolvePort(): number {
   const raw = process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "31337";
@@ -52,6 +173,7 @@ function resolvePositiveIntegerEnv(name: string, fallback: string): number {
 
 async function main(): Promise<void> {
   const t0 = Date.now();
+  const restoreRegistryFetch = await installGeneratedRegistryFixture();
   const port = resolvePort();
   const streamIntervalMs = resolveNonNegativeIntegerEnv(
     "ELIZA_E2E_MODEL_STREAM_INTERVAL_MS",
@@ -74,9 +196,7 @@ async function main(): Promise<void> {
     failOnUnhandledAction: false,
     stream: deterministicStream,
     resolve(call) {
-      if (call.modelType !== ModelType.RESPONSE_HANDLER) {
-        return null;
-      }
+      if (call.modelType !== ModelType.RESPONSE_HANDLER) return null;
       const args = {
         shouldRespond: "RESPOND",
         contexts: ["simple"],
@@ -94,12 +214,28 @@ async function main(): Promise<void> {
   const mediaRoutesPlugin = {
     name: "device-e2e-media-routes",
     description: "No-secret media-store routes for mobile device smokes.",
-    routes: [backgroundUploadImageRoute, deviceE2eUploadImageRoute],
+    routes: [
+      backgroundUploadImageRoute,
+      deviceE2eUploadImageRoute,
+      rubyHighEvidenceActionRoute,
+    ],
   };
   const runtimeResult = await createRealTestRuntime({
     characterName: "DeviceE2EHostAgent",
     plugins: [proxy, mediaRoutesPlugin],
   });
+  if (process.env.ELIZA_UI_SMOKE_RUBY_HIGH_JOURNEY === "1") {
+    const rubyHighUrl = process.env.RUBY_HIGH_URL?.trim();
+    if (!rubyHighUrl) {
+      throw new Error(
+        "RUBY_HIGH_URL is required for the Ruby High evidence journey.",
+      );
+    }
+    runtimeResult.runtime.setSetting("RUBY_HIGH_URL", rubyHighUrl, false);
+    console.log(
+      `[device-e2e-host-agent] Ruby High evidence URL: ${rubyHighUrl}`,
+    );
+  }
   const server = await startApiServer({
     port,
     runtime: runtimeResult.runtime,
@@ -120,6 +256,7 @@ async function main(): Promise<void> {
     await server.close().catch(() => undefined);
     await runtimeResult.cleanup().catch(() => undefined);
     await configEnv.restore().catch(() => undefined);
+    restoreRegistryFetch();
   };
 
   for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,8 @@
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "test:e2e:chat-stream-real": "ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 ELIZA_UI_SMOKE_DISABLE_VIDEO=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/chat-stream-real-runtime-perf.spec.ts",
+    "test:e2e:ruby-high": "ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 ELIZA_UI_SMOKE_GENERATED_REGISTRY_FIXTURE=packages/registry/generated-registry.json ELIZA_UI_SMOKE_BACKEND_LOG_PATH=e2e-recordings/ruby-high/backend.log E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/ruby-high-clean-install.spec.ts",
+    "test:e2e:ruby-high-connected": "ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 ELIZA_UI_SMOKE_RUBY_HIGH_JOURNEY=1 ELIZA_UI_SMOKE_GENERATED_REGISTRY_FIXTURE=packages/registry/generated-registry.json ELIZA_UI_SMOKE_BACKEND_LOG_PATH=e2e-recordings/ruby-high-connected/backend.log E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/ruby-high-connected-journey.spec.ts",
     "test:e2e:human": "ELIZA_UI_PLAYWRIGHT_SLOWMO=250 E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --headed",
     "test:e2e:record": "E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "test:e2e:accounts-ui": "node e2e/accounts-ui/run-accounts-ui-e2e.mjs",

--- a/packages/app/test/ui-smoke/ruby-high-clean-install.spec.ts
+++ b/packages/app/test/ui-smoke/ruby-high-clean-install.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * Clean-install proof for the registry's first third-party app entry.
+ *
+ * This lane intentionally uses the real local runtime, the exact generated
+ * registry from the checkout, npm installation, runtime plugin registration,
+ * and the production renderer. It records desktop/mobile catalog and viewer
+ * renders plus browser/network/backend logs for review.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  expect,
+  type Locator,
+  type Page,
+  type TestInfo,
+  test,
+} from "@playwright/test";
+import { openAppPath, seedAppStorage } from "./helpers";
+import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
+
+const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
+const REGISTRY_FIXTURE =
+  process.env.ELIZA_UI_SMOKE_GENERATED_REGISTRY_FIXTURE?.trim();
+const APP_NAME = "@rati-osf/plugin-ruby-high";
+const VIEWER_PATH = "/ruby-high/viewer";
+const APP_ICON =
+  "https://unpkg.com/@rati-osf/plugin-ruby-high@0.1.5/images/ruby-high-app-icon.png";
+const APP_HERO =
+  "https://unpkg.com/@rati-osf/plugin-ruby-high@0.1.5/images/ruby-eliza-plugin-launch.jpg";
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+
+type RubyHighCatalogEntry = {
+  appMeta?: {
+    category?: string;
+    heroImage?: string;
+    icon?: string;
+    launchType?: string;
+    viewer?: { url?: string };
+  };
+  category?: string;
+  homepage?: string;
+  launchType?: string;
+  name?: string;
+  npm?: { package?: string; v2Version?: string | null };
+  viewer?: { url?: string };
+};
+
+type RubyHighLaunch = {
+  displayName?: string;
+  launchType?: string;
+  needsRestart?: boolean;
+  pluginInstalled?: boolean;
+  run?: {
+    appName?: string;
+    runId?: string;
+    viewer?: { url?: string };
+  };
+  viewer?: { url?: string };
+};
+
+async function capture(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const screenshotPath = testInfo.outputPath(`${name}.jpg`);
+  await mkdir(testInfo.outputDir, { recursive: true });
+  await captureScreenshotWithQualityRetry(page, name, {
+    path: screenshotPath,
+    type: "jpeg",
+    quality: 92,
+    fullPage: true,
+    attempts: 4,
+  });
+  await testInfo.attach(name, {
+    path: screenshotPath,
+    contentType: "image/jpeg",
+  });
+}
+
+async function expectImagesLoaded(scope: Locator): Promise<void> {
+  const images = scope.locator("img");
+  await expect
+    .poll(
+      async () => {
+        if ((await images.count()) === 0) return false;
+        return images.evaluateAll((nodes) =>
+          nodes.every((node) => {
+            const image = node as HTMLImageElement;
+            return image.complete && image.naturalWidth > 0;
+          }),
+        );
+      },
+      { timeout: 60_000 },
+    )
+    .toBe(true);
+}
+
+test.describe("Ruby High clean-install catalog and launch", () => {
+  test.skip(!REAL_LOCAL_STACK, "requires ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1");
+  test.skip(!REGISTRY_FIXTURE, "requires the exact-head registry fixture");
+  test.setTimeout(420_000);
+
+  test("installs once and opens the declared viewer on desktop and mobile", async ({
+    page,
+  }, testInfo) => {
+    const consoleLines: string[] = [];
+    const pageErrors: string[] = [];
+    const requestFailures: string[] = [];
+    const httpErrors: string[] = [];
+    page.on("console", (message) => {
+      consoleLines.push(`${message.type()}: ${message.text()}`);
+    });
+    page.on("pageerror", (error) =>
+      pageErrors.push(error.stack ?? error.message),
+    );
+    page.on("requestfailed", (request) => {
+      requestFailures.push(
+        `${request.method()} ${request.url()} — ${
+          request.failure()?.errorText ?? "unknown error"
+        }`,
+      );
+    });
+    page.on("response", (response) => {
+      if (response.status() < 400) return;
+      httpErrors.push(
+        `${response.status()} ${response.request().method()} ${response.url()}`,
+      );
+    });
+
+    const installedBeforeResponse = await page.request.get(
+      "/api/apps/installed",
+    );
+    expect(installedBeforeResponse.ok()).toBe(true);
+    const installedBefore = (await installedBeforeResponse.json()) as Array<{
+      name?: string;
+    }>;
+    expect(installedBefore.some((app) => app.name === APP_NAME)).toBe(false);
+
+    const catalogResponse = await page.request.get("/api/apps");
+    expect(catalogResponse.ok()).toBe(true);
+    const catalog = (await catalogResponse.json()) as RubyHighCatalogEntry[];
+    const rubyHigh = catalog.find((app) => app.name === APP_NAME);
+    expect(rubyHigh).toMatchObject({
+      name: APP_NAME,
+      homepage: "https://ruby-high.ai",
+      category: "education",
+      launchType: "connect",
+      npm: {
+        package: APP_NAME,
+        v2Version: "0.1.5",
+      },
+      viewer: { url: VIEWER_PATH },
+      appMeta: {
+        category: "education",
+        heroImage: APP_HERO,
+        icon: APP_ICON,
+        launchType: "connect",
+        viewer: { url: VIEWER_PATH },
+      },
+    });
+
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await seedAppStorage(page);
+    await openAppPath(page, "/views");
+    await expect(page.getByTestId("launcher")).toBeVisible({
+      timeout: 60_000,
+    });
+    const rubyTile = page.getByRole("button", { name: "Ruby High" });
+    await expect(rubyTile).toBeVisible({ timeout: 60_000 });
+    await rubyTile.scrollIntoViewIfNeeded();
+    await expectImagesLoaded(rubyTile);
+    await capture(page, testInfo, "desktop-clean-catalog");
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await rubyTile.scrollIntoViewIfNeeded();
+    await expect(rubyTile).toBeVisible();
+    await capture(page, testInfo, "mobile-clean-catalog");
+
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await rubyTile.scrollIntoViewIfNeeded();
+    const launchResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/apps/launch",
+      { timeout: 300_000 },
+    );
+    await rubyTile.click();
+    const launchResponse = await launchResponsePromise;
+    const launchBody = (await launchResponse.json()) as
+      | RubyHighLaunch
+      | { error?: string };
+    expect(
+      launchResponse.ok(),
+      `launch failed: ${JSON.stringify(launchBody)}`,
+    ).toBe(true);
+    const launch = launchBody as RubyHighLaunch;
+    expect(launch).toMatchObject({
+      displayName: "Ruby High",
+      launchType: "connect",
+      pluginInstalled: true,
+      viewer: { url: VIEWER_PATH },
+      run: {
+        appName: APP_NAME,
+        viewer: { url: VIEWER_PATH },
+      },
+    });
+    expect(typeof launch.needsRestart).toBe("boolean");
+
+    const viewer = page.getByTestId("game-view-iframe");
+    await expect(viewer).toBeVisible({ timeout: 60_000 });
+    await expect
+      .poll(async () => {
+        const src = await viewer.getAttribute("src");
+        return new URL(src ?? "", page.url()).pathname;
+      })
+      .toBe(VIEWER_PATH);
+    const viewerFrame = page.frameLocator('[data-testid="game-view-iframe"]');
+    await expect(
+      viewerFrame.getByRole("heading", { name: "Ruby High" }),
+    ).toBeVisible({ timeout: 60_000 });
+    await expect(
+      viewerFrame.getByText("Agents go to school here."),
+    ).toBeVisible();
+    await expectImagesLoaded(viewerFrame.locator("body"));
+    await capture(page, testInfo, "desktop-first-launch-viewer");
+
+    const installedAfterResponse = await page.request.get(
+      "/api/apps/installed",
+    );
+    expect(installedAfterResponse.ok()).toBe(true);
+    const installedAfter = (await installedAfterResponse.json()) as Array<{
+      name?: string;
+    }>;
+    expect(installedAfter.some((app) => app.name === APP_NAME)).toBe(true);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(viewer).toBeVisible();
+    await expect(
+      viewerFrame.getByRole("heading", { name: "Ruby High" }),
+    ).toBeVisible();
+    await capture(page, testInfo, "mobile-first-launch-viewer");
+
+    const unexpectedRequestFailures = requestFailures.filter((line) => {
+      if (!line.endsWith("— net::ERR_ABORTED")) return true;
+      const url = line.match(/^GET (\S+) —/)?.[1];
+      if (!url) return true;
+      const pathname = new URL(url).pathname;
+      return !(
+        pathname === "/views" ||
+        pathname.startsWith("/assets/") ||
+        pathname === "/api/local-inference/downloads/stream"
+      );
+    });
+    const frontendEvidence = {
+      appName: APP_NAME,
+      catalog: rubyHigh,
+      installedBefore,
+      installedAfter,
+      launch,
+      finalUrl: page.url(),
+      consoleLines,
+      pageErrors,
+      requestFailures,
+      unexpectedRequestFailures,
+      httpErrors,
+    };
+    const frontendLogPath = testInfo.outputPath("frontend-and-network.json");
+    await writeFile(
+      frontendLogPath,
+      `${JSON.stringify(frontendEvidence, null, 2)}\n`,
+      "utf8",
+    );
+    await testInfo.attach("frontend and network log", {
+      path: frontendLogPath,
+      contentType: "application/json",
+    });
+
+    const backendLogSetting =
+      process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
+    expect(backendLogSetting).toBeTruthy();
+    const backendLogPath = path.resolve(
+      REPO_ROOT,
+      backendLogSetting ?? "e2e-recordings/ruby-high/backend.log",
+    );
+    const backendLog = await readFile(backendLogPath, "utf8");
+    expect(backendLog).toContain("serving generated registry fixture");
+    expect(backendLog).toContain("[registry-client] Fetching plugin registry");
+    expect(backendLog).toContain("Loaded ");
+    expect(backendLog).toContain(
+      `[app-manager] Installing plugin for app: ${APP_NAME}`,
+    );
+    expect(backendLog).toContain(
+      `[app-manager] Plugin installed: ${APP_NAME} v0.1.5`,
+    );
+    expect(backendLog).not.toContain("[plugin-installer] npm failed");
+    await testInfo.attach("backend log", {
+      path: backendLogPath,
+      contentType: "text/plain",
+    });
+
+    expect(pageErrors, "no uncaught frontend errors").toEqual([]);
+    expect(
+      unexpectedRequestFailures,
+      "no unexpected failed frontend requests",
+    ).toEqual([]);
+    expect(
+      httpErrors.filter((line) => line.includes("ruby-high")),
+      "no Ruby High HTTP errors",
+    ).toEqual([]);
+  });
+});

--- a/packages/app/test/ui-smoke/ruby-high-connected-journey.spec.ts
+++ b/packages/app/test/ui-smoke/ruby-high-connected-journey.spec.ts
@@ -1,0 +1,463 @@
+/**
+ * Connected-agent proof for Ruby High's complete elizaOS journey.
+ *
+ * The lane installs the published package from the exact generated registry,
+ * invokes its real published actions through the local runtime action registry,
+ * completes Ruby High's approval-bound device flow in a browser session,
+ * enrolls the connected agent, launches its scoped school viewer, and advances
+ * that same agent through grades 9–12 using Ruby High's development accelerator.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  expect,
+  type FrameLocator,
+  type Page,
+  type TestInfo,
+  test,
+} from "@playwright/test";
+import { openAppPath, seedAppStorage } from "./helpers";
+import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
+
+const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
+const RUBY_HIGH_JOURNEY = process.env.ELIZA_UI_SMOKE_RUBY_HIGH_JOURNEY === "1";
+const REGISTRY_FIXTURE =
+  process.env.ELIZA_UI_SMOKE_GENERATED_REGISTRY_FIXTURE?.trim();
+const RUBY_HIGH_URL = (
+  process.env.RUBY_HIGH_URL ?? "http://127.0.0.1:3100"
+).replace(/\/$/, "");
+const APP_NAME = "@rati-osf/plugin-ruby-high";
+const VIEWER_PATH = "/ruby-high/viewer";
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const RECORDING_PAUSE_MS = process.env.E2E_RECORD ? 1_250 : 0;
+
+type ConnectedStatus = {
+  connection?: {
+    connected?: boolean;
+    baseUrl?: string;
+    pending?: {
+      userCode?: string;
+      verificationUriComplete?: string;
+    } | null;
+  };
+  state?: {
+    student?: {
+      name?: string;
+      currentGrade?: string | null;
+    } | null;
+  } | null;
+};
+
+type EvidenceActionResponse = {
+  ok?: boolean;
+  actionName?: string;
+  callbacks?: string[];
+  result?: {
+    success?: boolean;
+    text?: string;
+    data?: Record<string, unknown>;
+  };
+};
+
+async function pauseForReview(page: Page, milliseconds = RECORDING_PAUSE_MS) {
+  if (milliseconds > 0) await page.waitForTimeout(milliseconds);
+}
+
+async function capture(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const screenshotPath = testInfo.outputPath(`${name}.jpg`);
+  await mkdir(testInfo.outputDir, { recursive: true });
+  await captureScreenshotWithQualityRetry(page, name, {
+    path: screenshotPath,
+    type: "jpeg",
+    quality: 92,
+    fullPage: true,
+    attempts: 4,
+  });
+  await testInfo.attach(name, {
+    path: screenshotPath,
+    contentType: "image/jpeg",
+  });
+}
+
+async function invokeRubyHighAction(
+  page: Page,
+  actionName: "CONNECT_RUBY_HIGH" | "ENROLL_RUBY_HIGH",
+  parameters: Record<string, unknown> = {},
+): Promise<EvidenceActionResponse> {
+  const response = await page.request.post("/api/device-e2e/ruby-high/action", {
+    data: { actionName, parameters },
+  });
+  const responseText = await response.text();
+  expect(
+    response.ok(),
+    `${actionName} failed: ${response.status()} ${responseText}`,
+  ).toBe(true);
+  const body = JSON.parse(responseText) as EvidenceActionResponse;
+  expect(body).toMatchObject({
+    ok: true,
+    actionName,
+    result: { success: true },
+  });
+  return body;
+}
+
+async function readStatus(page: Page): Promise<ConnectedStatus> {
+  const response = await page.request.get("/ruby-high/status");
+  const responseText = await response.text();
+  expect(
+    response.ok(),
+    `Ruby High status failed: ${response.status()} ${responseText}`,
+  ).toBe(true);
+  return JSON.parse(responseText) as ConnectedStatus;
+}
+
+async function bootstrapHumanSchoolSession(
+  page: Page,
+  rubyHighOrigin: string,
+): Promise<void> {
+  await page.goto(`${rubyHighOrigin}/api/apps/ruby-high/viewer`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page).toHaveTitle(/Ruby High/);
+  await expect(page.locator("#shell")).toBeVisible({ timeout: 60_000 });
+  await page.evaluate(async () => {
+    const response = await fetch(
+      "/api/apps/ruby-high/session/eliza-evidence-human/command",
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "mark-intro-seen" }),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `human session bootstrap failed: ${await response.text()}`,
+      );
+    }
+  });
+  await expect
+    .poll(
+      async () =>
+        (await page.context().cookies(rubyHighOrigin)).some(
+          (cookie) => cookie.name === "rh_session",
+        ),
+      { message: "Ruby High human approval session cookie was not persisted" },
+    )
+    .toBe(true);
+  await pauseForReview(page);
+}
+
+async function approveAgent(
+  page: Page,
+  verificationUriComplete: string,
+  userCode: string,
+): Promise<void> {
+  await page.goto(verificationUriComplete, { waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByRole("heading", { name: "Agent enrollment" }),
+  ).toBeVisible();
+  await expect(page.locator("#code")).toHaveValue(userCode);
+  await pauseForReview(page);
+  await page.getByRole("button", { name: "Approve agent" }).click();
+  await expect(page.getByRole("status")).toContainText(
+    "may now return to its device",
+  );
+  await pauseForReview(page);
+}
+
+async function installAndOpenRubyHigh(page: Page): Promise<FrameLocator> {
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get("/api/apps");
+        if (!response.ok()) return false;
+        const catalog = (await response.json()) as Array<{ name?: string }>;
+        return catalog.some((app) => app.name === APP_NAME);
+      },
+      { timeout: 60_000 },
+    )
+    .toBe(true);
+  await openAppPath(page, "/views");
+  await expect(page.getByTestId("launcher")).toBeVisible({ timeout: 60_000 });
+  const tile = page.getByRole("button", { name: "Ruby High" });
+  await expect(tile).toBeVisible({ timeout: 60_000 });
+  await tile.scrollIntoViewIfNeeded();
+  const launchResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname === "/api/apps/launch",
+    { timeout: 300_000 },
+  );
+  await tile.click();
+  expect((await launchResponse).ok()).toBe(true);
+  const iframe = page.getByTestId("game-view-iframe");
+  await expect(iframe).toBeVisible({ timeout: 60_000 });
+  const frame = page.frameLocator('[data-testid="game-view-iframe"]');
+  await expect(frame.getByRole("heading", { name: "Ruby High" })).toBeVisible({
+    timeout: 60_000,
+  });
+  return frame;
+}
+
+async function reloadViewer(page: Page): Promise<FrameLocator> {
+  const iframe = page.getByTestId("game-view-iframe");
+  await iframe.evaluate((element) => {
+    const frame = element as HTMLIFrameElement;
+    frame.contentWindow?.location.reload();
+  });
+  const viewer = page.frameLocator('[data-testid="game-view-iframe"]');
+  await expect(viewer.getByRole("heading", { name: "Ruby High" })).toBeVisible({
+    timeout: 60_000,
+  });
+  return viewer;
+}
+
+async function expectViewerGrade(
+  viewer: FrameLocator,
+  grade: string,
+): Promise<void> {
+  await expect(viewer.getByText("Connected", { exact: true })).toBeVisible();
+  await expect(
+    viewer.getByText("ElizaOS Agent", { exact: true }),
+  ).toBeVisible();
+  const gradeValue = viewer
+    .locator("dt", { hasText: "Grade" })
+    .locator("xpath=following-sibling::dd[1]");
+  await expect(gradeValue).toHaveText(grade);
+}
+
+async function launchAgentSchool(page: Page): Promise<void> {
+  const response = await page.request.post("/ruby-high/launch", { data: {} });
+  const responseText = await response.text();
+  expect(
+    response.ok(),
+    `agent school launch failed: ${response.status()} ${responseText}`,
+  ).toBe(true);
+  const body = JSON.parse(responseText) as { launchUrl?: string };
+  expect(body.launchUrl).toBeTruthy();
+  await page.goto(body.launchUrl ?? "", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/\/api\/apps\/ruby-high\/viewer/);
+  await expect(page.locator("#shell")).toBeVisible({ timeout: 60_000 });
+  await expect(page.locator("#you-name")).toHaveText("ElizaOS Agent", {
+    timeout: 60_000,
+  });
+  const announcements = page.locator("#announcements-overlay");
+  if (await announcements.isVisible().catch(() => false)) {
+    await page.locator("#announcements-dismiss").click();
+    await expect(announcements).not.toBeVisible();
+  }
+  await pauseForReview(page, process.env.E2E_RECORD ? 3_500 : 0);
+}
+
+async function advanceGrade(
+  page: Page,
+): Promise<{ completedGrade?: string; currentGrade?: string | null }> {
+  const response = await page.request.post(`${RUBY_HIGH_URL}/dev/tick-grade`, {
+    data: {},
+  });
+  const responseText = await response.text();
+  expect(
+    response.ok(),
+    `grade advance failed: ${response.status()} ${responseText}`,
+  ).toBe(true);
+  return JSON.parse(responseText) as {
+    completedGrade?: string;
+    currentGrade?: string | null;
+  };
+}
+
+test.describe("Ruby High connected elizaOS agent journey", () => {
+  test.skip(!REAL_LOCAL_STACK, "requires ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1");
+  test.skip(!RUBY_HIGH_JOURNEY, "requires the scripted Ruby High action lane");
+  test.skip(!REGISTRY_FIXTURE, "requires the exact-head registry fixture");
+  test.setTimeout(600_000);
+
+  test("connects, approves, enrolls, and advances the same agent through grades", async ({
+    page,
+  }, testInfo) => {
+    const consoleLines: string[] = [];
+    const pageErrors: string[] = [];
+    const requestFailures: string[] = [];
+    const httpErrors: string[] = [];
+    page.on("console", (message) => {
+      consoleLines.push(`${message.type()}: ${message.text()}`);
+    });
+    page.on("pageerror", (error) =>
+      pageErrors.push(error.stack ?? error.message),
+    );
+    page.on("requestfailed", (request) => {
+      requestFailures.push(
+        `${request.method()} ${request.url()} — ${
+          request.failure()?.errorText ?? "unknown error"
+        }`,
+      );
+    });
+    page.on("response", (response) => {
+      if (response.status() < 400) return;
+      httpErrors.push(
+        `${response.status()} ${response.request().method()} ${response.url()}`,
+      );
+    });
+
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await seedAppStorage(page);
+    let viewer = await installAndOpenRubyHigh(page);
+    await expect(
+      viewer.getByText("Needs connection", { exact: true }),
+    ).toBeVisible();
+    await pauseForReview(page);
+
+    const connectionStarted = await invokeRubyHighAction(
+      page,
+      "CONNECT_RUBY_HIGH",
+    );
+    const pending = connectionStarted.result?.data?.pending as
+      | { userCode?: string; verificationUriComplete?: string }
+      | undefined;
+    const userCode = pending?.userCode;
+    const verificationUriComplete = pending?.verificationUriComplete;
+    expect(userCode).toBeTruthy();
+    expect(verificationUriComplete).toBeTruthy();
+    const verificationOrigin = new URL(verificationUriComplete ?? "").origin;
+    expect(verificationOrigin).toBe(new URL(RUBY_HIGH_URL).origin);
+
+    await bootstrapHumanSchoolSession(page, verificationOrigin);
+    await approveAgent(page, verificationUriComplete ?? "", userCode ?? "");
+    await capture(page, testInfo, "approval-bound-agent-connection");
+
+    const connectionCompleted = await invokeRubyHighAction(
+      page,
+      "CONNECT_RUBY_HIGH",
+    );
+    expect(connectionCompleted.result?.data).toMatchObject({
+      connected: true,
+    });
+    const enrollment = await invokeRubyHighAction(page, "ENROLL_RUBY_HIGH", {
+      name: "ElizaOS Agent",
+      playbookId: "outsider",
+    });
+    expect(enrollment.result?.text).toBe(
+      "Enrolled ElizaOS Agent at Ruby High.",
+    );
+
+    const connectedStatus = await readStatus(page);
+    expect(connectedStatus).toMatchObject({
+      connection: {
+        connected: true,
+        baseUrl: RUBY_HIGH_URL,
+      },
+      state: {
+        student: {
+          name: "ElizaOS Agent",
+          currentGrade: "9",
+        },
+      },
+    });
+
+    viewer = await installAndOpenRubyHigh(page);
+    await expectViewerGrade(viewer, "9");
+    await capture(page, testInfo, "connected-enrolled-grade-9");
+    await pauseForReview(page);
+
+    await launchAgentSchool(page);
+    await capture(page, testInfo, "connected-agent-school-launch");
+    await openAppPath(page, "/views");
+    viewer = await installAndOpenRubyHigh(page);
+    await expectViewerGrade(viewer, "9");
+
+    const progression: Array<{
+      completedGrade?: string;
+      currentGrade?: string | null;
+    }> = [];
+    for (const grade of ["10", "11", "12"]) {
+      progression.push(await advanceGrade(page));
+      viewer = await reloadViewer(page);
+      await expectViewerGrade(viewer, grade);
+      await capture(page, testInfo, `connected-agent-grade-${grade}`);
+      await pauseForReview(page);
+    }
+
+    expect(progression).toEqual([
+      expect.objectContaining({ completedGrade: "9", currentGrade: "10" }),
+      expect.objectContaining({ completedGrade: "10", currentGrade: "11" }),
+      expect.objectContaining({ completedGrade: "11", currentGrade: "12" }),
+    ]);
+
+    const finalStatus = await readStatus(page);
+    expect(finalStatus).toMatchObject({
+      connection: { connected: true },
+      state: {
+        student: {
+          name: "ElizaOS Agent",
+          currentGrade: "12",
+        },
+      },
+    });
+
+    const frontendEvidence = {
+      appName: APP_NAME,
+      rubyHighUrl: RUBY_HIGH_URL,
+      viewerPath: VIEWER_PATH,
+      actions: {
+        connectionStarted,
+        connectionCompleted,
+        enrollment,
+      },
+      connectedStatus,
+      progression,
+      finalStatus,
+      finalUrl: page.url(),
+      consoleLines,
+      pageErrors,
+      requestFailures,
+      httpErrors,
+    };
+    const frontendLogPath = testInfo.outputPath("frontend-and-network.json");
+    await writeFile(
+      frontendLogPath,
+      `${JSON.stringify(frontendEvidence, null, 2)}\n`,
+      "utf8",
+    );
+    await testInfo.attach("frontend and network log", {
+      path: frontendLogPath,
+      contentType: "application/json",
+    });
+
+    const backendLogSetting =
+      process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
+    expect(backendLogSetting).toBeTruthy();
+    const backendLogPath = path.resolve(
+      REPO_ROOT,
+      backendLogSetting ?? "e2e-recordings/ruby-high-connected/backend.log",
+    );
+    const backendLog = await readFile(backendLogPath, "utf8");
+    expect(backendLog).toContain("serving generated registry fixture");
+    expect(backendLog).toContain(
+      `[app-manager] Installing plugin for app: ${APP_NAME}`,
+    );
+    expect(backendLog).toContain(
+      `[app-manager] Plugin installed: ${APP_NAME} v0.1.5`,
+    );
+    expect(backendLog).not.toContain("[plugin-installer] npm failed");
+    await testInfo.attach("backend log", {
+      path: backendLogPath,
+      contentType: "text/plain",
+    });
+
+    expect(pageErrors, "no uncaught frontend errors").toEqual([]);
+    expect(
+      httpErrors.filter(
+        (line) =>
+          line.includes("ruby-high") &&
+          !line.startsWith("428 POST") &&
+          !line.includes("/assets/favicon"),
+      ),
+      "no unexpected Ruby High HTTP errors",
+    ).toEqual([]);
+  });
+});

--- a/packages/registry/entries/third-party/rati-osf__plugin-ruby-high.json
+++ b/packages/registry/entries/third-party/rati-osf__plugin-ruby-high.json
@@ -1,0 +1,35 @@
+{
+  "package": "@rati-osf/plugin-ruby-high",
+  "repository": "github:cenetex/plugin-ruby-high",
+  "kind": "app",
+  "description": "Send an elizaOS agent to Ruby High to enroll, attend classes, answer questions, and learn alongside humans and agents.",
+  "homepage": "https://ruby-high.ai",
+  "version": "0.1.5",
+  "tags": ["ruby-high", "education", "agents", "game"],
+  "app": {
+    "displayName": "Ruby High",
+    "category": "education",
+    "launchType": "connect",
+    "launchUrl": null,
+    "icon": "https://unpkg.com/@rati-osf/plugin-ruby-high@0.1.5/images/ruby-high-app-icon.png",
+    "heroImage": "https://unpkg.com/@rati-osf/plugin-ruby-high@0.1.5/images/ruby-eliza-plugin-launch.jpg",
+    "capabilities": [
+      "education",
+      "agent-gameplay",
+      "bounded-autonomy",
+      "spectate-and-steer"
+    ],
+    "runtimePlugin": "@rati-osf/plugin-ruby-high",
+    "viewer": {
+      "url": "/ruby-high/viewer",
+      "postMessageAuth": false,
+      "sandbox": "allow-scripts allow-same-origin allow-popups"
+    },
+    "session": {
+      "mode": "external",
+      "features": ["commands", "telemetry", "suggestions"]
+    },
+    "visibleInAppStore": true,
+    "catalogSection": "other"
+  }
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -227,6 +227,82 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@rati-osf/plugin-ruby-high": {
+      "git": {
+        "repo": "cenetex/plugin-ruby-high",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@rati-osf/plugin-ruby-high",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.5"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Send an elizaOS agent to Ruby High to enroll, attend classes, answer questions, and learn alongside humans and agents.",
+      "homepage": "https://ruby-high.ai",
+      "topics": [
+        "ruby-high",
+        "education",
+        "agents",
+        "game"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "app",
+      "registryKind": "app",
+      "directory": null,
+      "app": {
+        "displayName": "Ruby High",
+        "category": "education",
+        "launchType": "connect",
+        "launchUrl": null,
+        "icon": "https://unpkg.com/@rati-osf/plugin-ruby-high@0.1.5/images/ruby-high-app-icon.png",
+        "heroImage": "https://unpkg.com/@rati-osf/plugin-ruby-high@0.1.5/images/ruby-eliza-plugin-launch.jpg",
+        "capabilities": [
+          "education",
+          "agent-gameplay",
+          "bounded-autonomy",
+          "spectate-and-steer"
+        ],
+        "runtimePlugin": "@rati-osf/plugin-ruby-high",
+        "viewer": {
+          "url": "/ruby-high/viewer",
+          "postMessageAuth": false,
+          "sandbox": "allow-scripts allow-same-origin allow-popups"
+        },
+        "session": {
+          "mode": "external",
+          "features": [
+            "commands",
+            "telemetry",
+            "suggestions"
+          ]
+        },
+        "visibleInAppStore": true,
+        "catalogSection": "other",
+        "minPlayers": null,
+        "maxPlayers": null
+      }
+    },
     "@seekdaseek/plugin-agentfeed": {
       "git": {
         "repo": "seekdaseek/plugin-agentfeed",

--- a/packages/registry/schema/registry-entry.schema.json
+++ b/packages/registry/schema/registry-entry.schema.json
@@ -6,6 +6,16 @@
   "type": "object",
   "additionalProperties": false,
   "required": ["package", "repository", "kind"],
+  "allOf": [
+    {
+      "if": {
+        "properties": { "kind": { "const": "app" } },
+        "required": ["kind"]
+      },
+      "then": { "required": ["app"] },
+      "else": { "not": { "required": ["app"] } }
+    }
+  ],
   "properties": {
     "package": {
       "type": "string",
@@ -43,6 +53,94 @@
       "type": "array",
       "description": "Discovery tags (npm keywords minus elizaos boilerplate).",
       "items": { "type": "string" }
+    },
+    "app": {
+      "type": "object",
+      "description": "Launch metadata consumed before an app package is installed.",
+      "additionalProperties": false,
+      "required": [
+        "displayName",
+        "category",
+        "launchType",
+        "launchUrl",
+        "icon",
+        "capabilities"
+      ],
+      "properties": {
+        "displayName": { "type": "string", "minLength": 1 },
+        "category": { "type": "string", "minLength": 1 },
+        "launchType": { "type": "string", "minLength": 1 },
+        "launchUrl": { "type": ["string", "null"] },
+        "icon": { "type": ["string", "null"] },
+        "heroImage": { "type": ["string", "null"] },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "minPlayers": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "maxPlayers": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "runtimePlugin": { "type": "string" },
+        "bridgeExport": { "type": "string" },
+        "uiExtension": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["detailPanelId"],
+          "properties": {
+            "detailPanelId": { "type": "string", "minLength": 1 }
+          }
+        },
+        "viewer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["url"],
+          "properties": {
+            "url": { "type": "string", "minLength": 1 },
+            "embedParams": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "postMessageAuth": { "type": "boolean" },
+            "sandbox": { "type": "string" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode"],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["viewer", "spectate-and-steer", "external"]
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commands",
+                  "telemetry",
+                  "pause",
+                  "resume",
+                  "suggestions"
+                ]
+              }
+            }
+          }
+        },
+        "developerOnly": { "type": "boolean" },
+        "visibleInAppStore": { "type": "boolean" },
+        "mainTab": { "type": "boolean" },
+        "catalogSection": { "type": "string" },
+        "featured": { "type": "boolean" },
+        "defaultHidden": { "type": "boolean" },
+        "scope": { "type": "string" }
+      }
     }
   }
 }

--- a/packages/registry/src/generate.ts
+++ b/packages/registry/src/generate.ts
@@ -55,6 +55,34 @@ export function toGeneratedEntry(entry: RegistryEntry): GeneratedRegistryEntry {
     kind: entry.kind,
     registryKind: entry.kind,
     directory: entry.directory ?? null,
+    app: entry.app
+      ? {
+          ...entry.app,
+          heroImage: entry.app.heroImage ?? null,
+          minPlayers: entry.app.minPlayers ?? null,
+          maxPlayers: entry.app.maxPlayers ?? null,
+          capabilities: [...entry.app.capabilities],
+          uiExtension: entry.app.uiExtension
+            ? { ...entry.app.uiExtension }
+            : undefined,
+          viewer: entry.app.viewer
+            ? {
+                ...entry.app.viewer,
+                embedParams: entry.app.viewer.embedParams
+                  ? { ...entry.app.viewer.embedParams }
+                  : undefined,
+              }
+            : undefined,
+          session: entry.app.session
+            ? {
+                ...entry.app.session,
+                features: entry.app.session.features
+                  ? [...entry.app.session.features]
+                  : undefined,
+              }
+            : undefined,
+        }
+      : undefined,
   };
 }
 

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -20,7 +20,12 @@ export {
 } from "./schema.ts";
 export type {
   GeneratedRegistry,
+  GeneratedRegistryAppMetadata,
   GeneratedRegistryEntry,
+  RegistryAppMetadata,
+  RegistryAppSession,
+  RegistryAppUiExtension,
+  RegistryAppViewer,
   RegistryEntry,
   RegistryEntryKind,
 } from "./types.ts";

--- a/packages/registry/src/registry.test.ts
+++ b/packages/registry/src/registry.test.ts
@@ -27,6 +27,36 @@ const VALID: RegistryEntry = {
   tags: ["example"],
 };
 
+const VALID_APP: RegistryEntry = {
+  package: "@example/app-school",
+  repository: "github:example/app-school",
+  kind: "app",
+  description: "A launchable school app.",
+  homepage: "https://school.example",
+  version: "1.2.3",
+  app: {
+    displayName: "School",
+    category: "education",
+    launchType: "connect",
+    launchUrl: null,
+    icon: "./images/logo.jpg",
+    heroImage: "./images/banner.jpg",
+    capabilities: ["education"],
+    runtimePlugin: "@example/app-school",
+    viewer: {
+      url: "/school/viewer",
+      postMessageAuth: false,
+      sandbox: "allow-scripts allow-same-origin",
+    },
+    session: {
+      mode: "external",
+      features: ["commands", "telemetry"],
+    },
+    visibleInAppStore: true,
+    catalogSection: "other",
+  },
+};
+
 describe("validateRegistryEntry", () => {
   it("accepts a well-formed entry", () => {
     expect(validateRegistryEntry(VALID)).toEqual([]);
@@ -61,6 +91,46 @@ describe("validateRegistryEntry", () => {
     const errors = validateRegistryEntry({ ...VALID, bogus: true });
     expect(errors).toContain("unknown field: bogus");
   });
+
+  it("accepts complete app metadata", () => {
+    expect(validateRegistryEntry(VALID_APP)).toEqual([]);
+  });
+
+  it("requires app metadata for app entries", () => {
+    expect(validateRegistryEntry({ ...VALID_APP, app: undefined })).toContain(
+      "app must be an object for app entries",
+    );
+  });
+
+  it("rejects app metadata on non-app entries", () => {
+    expect(validateRegistryEntry({ ...VALID, app: VALID_APP.app })).toContain(
+      "app metadata is only allowed when kind is app",
+    );
+  });
+
+  it("validates nested app metadata", () => {
+    const errors = validateRegistryEntry({
+      ...VALID_APP,
+      app: {
+        ...VALID_APP.app,
+        minPlayers: 2,
+        maxPlayers: 1,
+        viewer: { url: "", sandbox: 42 },
+        session: { mode: "invalid", features: ["commands", "invalid"] },
+      },
+    });
+    expect(errors).toContain("app.minPlayers must not exceed app.maxPlayers");
+    expect(errors).toContain("app.viewer.url must be a non-empty string");
+    expect(errors).toContain(
+      "app.viewer.sandbox must be a string when present",
+    );
+    expect(errors.some((error) => error.startsWith("app.session.mode"))).toBe(
+      true,
+    );
+    expect(
+      errors.some((error) => error.startsWith("app.session.features")),
+    ).toBe(true);
+  });
 });
 
 describe("toGeneratedEntry", () => {
@@ -72,6 +142,18 @@ describe("toGeneratedEntry", () => {
     expect(wire.firstParty).toBe(false);
     expect(wire.supports).toEqual({ v0: false, v1: false, v2: true });
     expect(wire.directory).toBe("packages/examples/plugin-echo");
+  });
+
+  it("preserves app launch metadata in the wire format", () => {
+    const wire = toGeneratedEntry(VALID_APP);
+    expect(wire.kind).toBe("app");
+    expect(wire.registryKind).toBe("app");
+    expect(wire.app).toEqual({
+      ...VALID_APP.app,
+      minPlayers: null,
+      maxPlayers: null,
+    });
+    expect(wire.app?.viewer?.url).toBe("/school/viewer");
   });
 });
 

--- a/packages/registry/src/schema.ts
+++ b/packages/registry/src/schema.ts
@@ -14,6 +14,18 @@ const VALID_KINDS: readonly RegistryEntryKind[] = [
   "connector",
   "app",
 ];
+const VALID_SESSION_MODES = new Set([
+  "viewer",
+  "spectate-and-steer",
+  "external",
+]);
+const VALID_SESSION_FEATURES = new Set([
+  "commands",
+  "telemetry",
+  "pause",
+  "resume",
+  "suggestions",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -21,6 +33,211 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+function validateKnownKeys(
+  value: Record<string, unknown>,
+  knownKeys: readonly string[],
+  path: string,
+): string[] {
+  const known = new Set(knownKeys);
+  return Object.keys(value)
+    .filter((key) => !known.has(key))
+    .map((key) => `unknown field: ${path}.${key}`);
+}
+
+function validateOptionalString(
+  value: Record<string, unknown>,
+  field: string,
+  path: string,
+): string[] {
+  return value[field] !== undefined && typeof value[field] !== "string"
+    ? [`${path}.${field} must be a string when present`]
+    : [];
+}
+
+function validateOptionalBoolean(
+  value: Record<string, unknown>,
+  field: string,
+  path: string,
+): string[] {
+  return value[field] !== undefined && typeof value[field] !== "boolean"
+    ? [`${path}.${field} must be a boolean when present`]
+    : [];
+}
+
+function validateOptionalNullableString(
+  value: Record<string, unknown>,
+  field: string,
+  path: string,
+): string[] {
+  return value[field] !== undefined &&
+    value[field] !== null &&
+    typeof value[field] !== "string"
+    ? [`${path}.${field} must be a string or null when present`]
+    : [];
+}
+
+function validateOptionalPlayerCount(
+  value: Record<string, unknown>,
+  field: string,
+): string[] {
+  const count = value[field];
+  return count !== undefined &&
+    count !== null &&
+    (typeof count !== "number" || !Number.isInteger(count) || count < 0)
+    ? [`app.${field} must be a non-negative integer or null when present`]
+    : [];
+}
+
+function validateAppViewer(value: unknown): string[] {
+  if (!isRecord(value)) return ["app.viewer must be an object when present"];
+  const errors = validateKnownKeys(
+    value,
+    ["url", "embedParams", "postMessageAuth", "sandbox"],
+    "app.viewer",
+  );
+  if (typeof value.url !== "string" || value.url.length === 0) {
+    errors.push("app.viewer.url must be a non-empty string");
+  }
+  if (value.embedParams !== undefined) {
+    if (
+      !isRecord(value.embedParams) ||
+      Object.values(value.embedParams).some(
+        (entry) => typeof entry !== "string",
+      )
+    ) {
+      errors.push(
+        "app.viewer.embedParams must be an object of string values when present",
+      );
+    }
+  }
+  errors.push(
+    ...validateOptionalBoolean(value, "postMessageAuth", "app.viewer"),
+    ...validateOptionalString(value, "sandbox", "app.viewer"),
+  );
+  return errors;
+}
+
+function validateAppSession(value: unknown): string[] {
+  if (!isRecord(value)) return ["app.session must be an object when present"];
+  const errors = validateKnownKeys(value, ["mode", "features"], "app.session");
+  if (typeof value.mode !== "string" || !VALID_SESSION_MODES.has(value.mode)) {
+    errors.push(
+      `app.session.mode must be one of: ${Array.from(VALID_SESSION_MODES).join(", ")}`,
+    );
+  }
+  if (
+    value.features !== undefined &&
+    (!isStringArray(value.features) ||
+      value.features.some((feature) => !VALID_SESSION_FEATURES.has(feature)))
+  ) {
+    errors.push(
+      `app.session.features must contain only: ${Array.from(VALID_SESSION_FEATURES).join(", ")}`,
+    );
+  }
+  return errors;
+}
+
+function validateAppMetadata(value: unknown): string[] {
+  if (!isRecord(value)) return ["app must be an object for app entries"];
+  const errors = validateKnownKeys(
+    value,
+    [
+      "displayName",
+      "category",
+      "launchType",
+      "launchUrl",
+      "icon",
+      "heroImage",
+      "capabilities",
+      "minPlayers",
+      "maxPlayers",
+      "runtimePlugin",
+      "bridgeExport",
+      "uiExtension",
+      "viewer",
+      "session",
+      "developerOnly",
+      "visibleInAppStore",
+      "mainTab",
+      "catalogSection",
+      "featured",
+      "defaultHidden",
+      "scope",
+    ],
+    "app",
+  );
+
+  for (const field of ["displayName", "category", "launchType"]) {
+    if (typeof value[field] !== "string" || value[field].length === 0) {
+      errors.push(`app.${field} must be a non-empty string`);
+    }
+  }
+  for (const field of ["launchUrl", "icon"]) {
+    if (value[field] !== null && typeof value[field] !== "string") {
+      errors.push(`app.${field} must be a string or null`);
+    }
+  }
+  if (!isStringArray(value.capabilities)) {
+    errors.push("app.capabilities must be an array of strings");
+  }
+  errors.push(
+    ...validateOptionalNullableString(value, "heroImage", "app"),
+    ...validateOptionalString(value, "runtimePlugin", "app"),
+    ...validateOptionalString(value, "bridgeExport", "app"),
+    ...validateOptionalString(value, "catalogSection", "app"),
+    ...validateOptionalString(value, "scope", "app"),
+    ...validateOptionalPlayerCount(value, "minPlayers"),
+    ...validateOptionalPlayerCount(value, "maxPlayers"),
+  );
+
+  for (const field of [
+    "developerOnly",
+    "visibleInAppStore",
+    "mainTab",
+    "featured",
+    "defaultHidden",
+  ]) {
+    errors.push(...validateOptionalBoolean(value, field, "app"));
+  }
+
+  if (value.uiExtension !== undefined) {
+    if (!isRecord(value.uiExtension)) {
+      errors.push("app.uiExtension must be an object when present");
+    } else {
+      errors.push(
+        ...validateKnownKeys(
+          value.uiExtension,
+          ["detailPanelId"],
+          "app.uiExtension",
+        ),
+      );
+      if (
+        typeof value.uiExtension.detailPanelId !== "string" ||
+        value.uiExtension.detailPanelId.length === 0
+      ) {
+        errors.push("app.uiExtension.detailPanelId must be a non-empty string");
+      }
+    }
+  }
+  if (value.viewer !== undefined) {
+    errors.push(...validateAppViewer(value.viewer));
+  }
+  if (value.session !== undefined) {
+    errors.push(...validateAppSession(value.session));
+  }
+
+  const minPlayers = value.minPlayers;
+  const maxPlayers = value.maxPlayers;
+  if (
+    typeof minPlayers === "number" &&
+    typeof maxPlayers === "number" &&
+    minPlayers > maxPlayers
+  ) {
+    errors.push("app.minPlayers must not exceed app.maxPlayers");
+  }
+  return errors;
 }
 
 /**
@@ -61,6 +278,12 @@ export function validateRegistryEntry(value: unknown): string[] {
     errors.push("tags must be an array of strings when present");
   }
 
+  if (value.kind === "app") {
+    errors.push(...validateAppMetadata(value.app));
+  } else if (value.app !== undefined) {
+    errors.push("app metadata is only allowed when kind is app");
+  }
+
   const knownKeys = new Set([
     "package",
     "repository",
@@ -70,6 +293,7 @@ export function validateRegistryEntry(value: unknown): string[] {
     "version",
     "directory",
     "tags",
+    "app",
   ]);
   for (const key of Object.keys(value)) {
     if (!knownKeys.has(key)) {

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -14,6 +14,56 @@
 /** The kind of artifact a registry entry describes. */
 export type RegistryEntryKind = "plugin" | "connector" | "app";
 
+/** Embedded viewer metadata for an app entry. */
+export interface RegistryAppViewer {
+  url: string;
+  embedParams?: Record<string, string>;
+  postMessageAuth?: boolean;
+  sandbox?: string;
+}
+
+/** Runtime session behavior exposed by an app entry. */
+export interface RegistryAppSession {
+  mode: "viewer" | "spectate-and-steer" | "external";
+  features?: Array<
+    "commands" | "telemetry" | "pause" | "resume" | "suggestions"
+  >;
+}
+
+/** Detail-panel extension contributed by an app entry. */
+export interface RegistryAppUiExtension {
+  detailPanelId: string;
+}
+
+/**
+ * App metadata consumed before a third-party package is installed. This must
+ * remain self-sufficient because the app manager chooses how to install and
+ * launch an app before it can read the package manifest from disk.
+ */
+export interface RegistryAppMetadata {
+  displayName: string;
+  category: string;
+  launchType: string;
+  launchUrl: string | null;
+  icon: string | null;
+  heroImage?: string | null;
+  capabilities: string[];
+  minPlayers?: number | null;
+  maxPlayers?: number | null;
+  runtimePlugin?: string;
+  bridgeExport?: string;
+  uiExtension?: RegistryAppUiExtension;
+  viewer?: RegistryAppViewer;
+  session?: RegistryAppSession;
+  developerOnly?: boolean;
+  visibleInAppStore?: boolean;
+  mainTab?: boolean;
+  catalogSection?: string;
+  featured?: boolean;
+  defaultHidden?: boolean;
+  scope?: string;
+}
+
 /**
  * Source format for a single third-party registry entry. Mirrors the metadata
  * `elizaos plugins submit` generates from a plugin's `package.json`.
@@ -35,6 +85,16 @@ export interface RegistryEntry {
   directory?: string;
   /** Discovery tags (npm keywords minus elizaos boilerplate). */
   tags?: string[];
+  /** Required launch metadata when `kind` is `app`. */
+  app?: RegistryAppMetadata;
+}
+
+/** Normalized app metadata in the generated wire registry. */
+export interface GeneratedRegistryAppMetadata
+  extends Omit<RegistryAppMetadata, "heroImage" | "minPlayers" | "maxPlayers"> {
+  heroImage: string | null;
+  minPlayers: number | null;
+  maxPlayers: number | null;
 }
 
 /** Per-package entry in the generated wire registry. */
@@ -66,6 +126,7 @@ export interface GeneratedRegistryEntry {
   kind: RegistryEntryKind;
   registryKind: RegistryEntryKind;
   directory: string | null;
+  app?: GeneratedRegistryAppMetadata;
 }
 
 /** Top-level wire format served to the runtime. */

--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -9,18 +9,39 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppLaunchResult } from "../../api";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
-import { useRoutableViews } from "../../hooks/useAvailableViews";
+import { type ViewEntry, viewToEntry } from "../../hooks/view-catalog";
+import { __setAppValueForTests } from "../../state/app-store";
+import type { AppContextValue } from "../../state/types";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { LauncherSurface } from "./LauncherSurface";
 
 let aospEnabled = false;
+const { useViewCatalogMock } = vi.hoisted(() => ({
+  useViewCatalogMock: vi.fn(),
+}));
+const getMock = vi.fn();
+const setActionNoticeMock = vi.fn();
+const setStateMock = vi.fn();
+const setTabMock = vi.fn();
 
-vi.mock("../../hooks/useAvailableViews", () => ({
-  useRoutableViews: vi.fn(),
+vi.mock("../../hooks/useViewCatalog", () => ({
+  useViewCatalog: useViewCatalogMock,
+}));
+vi.mock("../../api", () => ({
+  client: { getBaseUrl: () => "http://localhost:31337" },
+}));
+vi.mock("../../api/app-shell-capabilities", () => ({
+  isLimitedCloudAgentApiResourceUrl: () => false,
+  supportsFullAppShellRoutes: () => true,
+}));
+vi.mock("../../utils/openExternalUrl", () => ({
+  openExternalUrl: vi.fn(),
 }));
 
 vi.mock("../../state/useViewKinds", () => ({
@@ -32,12 +53,13 @@ vi.mock("../../platform/platform-guards", () => ({
   getFrontendPlatform: () => "web",
 }));
 
-vi.mock("../../navigation", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../navigation")>();
-  return { ...actual, isAospShellEnabled: () => aospEnabled };
+vi.mock("../../navigation", () => {
+  return {
+    isAospShellEnabled: () => aospEnabled,
+    LAUNCHER_AOSP_ONLY_VIEW_IDS: ["phone"],
+  };
 });
 
-const useRoutableViewsMock = vi.mocked(useRoutableViews);
 const useEnabledViewKindsMock = vi.mocked(useEnabledViewKinds);
 
 function view(
@@ -61,11 +83,16 @@ function view(
 }
 
 function setViews(views: ViewRegistryEntry[]) {
-  useRoutableViewsMock.mockReturnValue({
-    views,
+  setEntries(views.map(viewToEntry));
+}
+
+function setEntries(entries: ViewEntry[]) {
+  useViewCatalogMock.mockReturnValue({
+    entries,
     loading: false,
     error: null,
     refresh: vi.fn(),
+    get: getMock,
   });
 }
 
@@ -73,6 +100,15 @@ beforeEach(() => {
   aospEnabled = false;
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
+  getMock.mockResolvedValue(null);
+  __setAppValueForTests({
+    appRuns: [],
+    elizaCloudConnected: false,
+    setActionNotice: setActionNoticeMock,
+    setState: setStateMock,
+    setTab: setTabMock,
+    t: (key: string) => key,
+  } as unknown as AppContextValue);
   useEnabledViewKindsMock.mockReturnValue({ developer: true, preview: true });
   setViews([
     view("chat", "Chat", "/chat"),
@@ -96,6 +132,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  __setAppValueForTests(null);
 });
 
 describe("LauncherSurface", () => {
@@ -180,5 +217,55 @@ describe("LauncherSurface", () => {
     render(<LauncherSurface />);
     fireEvent.click(screen.getByRole("button", { name: "Browser" }));
     expect(window.location.pathname).toBe("/browser");
+  });
+
+  it("opens an installable app's returned viewer on the first launch", async () => {
+    const rubyHigh: ViewEntry = {
+      key: "app:@rati-osf/plugin-ruby-high",
+      id: "@rati-osf/plugin-ruby-high",
+      label: "Ruby High",
+      modality: "gui",
+      state: "available",
+      kind: "app",
+      appName: "@rati-osf/plugin-ruby-high",
+      launchType: "connect",
+      launchUrl: null,
+      hasHero: false,
+    };
+    const run = {
+      runId: "ruby-run-1",
+      appName: "@rati-osf/plugin-ruby-high",
+      displayName: "Ruby High",
+      viewer: {
+        url: "/ruby-high/viewer",
+        postMessageAuth: false,
+        sandbox: "allow-scripts allow-same-origin allow-popups",
+      },
+    };
+    setEntries([rubyHigh]);
+    getMock.mockResolvedValue({
+      pluginInstalled: true,
+      needsRestart: false,
+      displayName: "Ruby High",
+      launchType: "connect",
+      launchUrl: null,
+      viewer: run.viewer,
+      session: null,
+      run,
+    } as AppLaunchResult);
+
+    render(<LauncherSurface />);
+    fireEvent.click(screen.getByRole("button", { name: "Ruby High" }));
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith(rubyHigh);
+      expect(setStateMock).toHaveBeenCalledWith("appRuns", [run]);
+      expect(setStateMock).toHaveBeenCalledWith(
+        "activeGameRunId",
+        "ruby-run-1",
+      );
+      expect(setStateMock).toHaveBeenCalledWith("appsSubTab", "games");
+      expect(window.location.pathname).toBe("/apps/ruby-high");
+    });
   });
 });

--- a/packages/ui/src/components/pages/LauncherSurface.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.tsx
@@ -1,21 +1,22 @@
 /**
- * Data + state wrapper around `Launcher`: pulls the routable views, filters them
- * by the user's enabled view kinds and active modality, curates them into the
- * ordered page (`curateLauncherPages`), and wires tile taps to view navigation
- * and chat-open. `Launcher` itself is pure presentation — one flat grid, no
+ * Data + state wrapper around `Launcher`: merges loaded views with the
+ * installable app catalog, curates them into the ordered page
+ * (`curateLauncherPages`), and wires tile taps to either first-install launch or
+ * view navigation. `Launcher` itself is pure presentation — one flat grid, no
  * favorites, recents, or section zones.
  */
 import { logger } from "@elizaos/logger";
 import * as React from "react";
 import { dispatchChatOpen } from "../../events";
-import { useRoutableViews } from "../../hooks/useAvailableViews";
-import { type ViewEntry, viewToEntry } from "../../hooks/view-catalog";
+import { useViewCatalog } from "../../hooks/useViewCatalog";
+import type { ViewEntry } from "../../hooks/view-catalog";
 import { cn } from "../../lib/utils";
 import { isAospShellEnabled } from "../../navigation";
-import { getActiveViewModality } from "../../platform/platform-guards";
-import { useAppSelectorShallow } from "../../state";
+import { useAppSelectorShallow } from "../../state/app-store";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { shellHistory } from "../../surface-realm-channel";
+import { openExternalUrl } from "../../utils/openExternalUrl";
+import { getAppSlug } from "../apps/helpers";
 import { Launcher } from "./Launcher";
 import { curateLauncherPages } from "./launcher-curation";
 
@@ -27,57 +28,120 @@ export interface LauncherSurfaceProps {
 export const LauncherSurface = React.memo(function LauncherSurface({
   layout = "page",
 }: LauncherSurfaceProps): React.JSX.Element {
-  const { views, loading } = useRoutableViews();
+  const { entries, get, loading } = useViewCatalog();
   const enabledKinds = useEnabledViewKinds();
-  const { elizaCloudConnected } = useAppSelectorShallow((state) => ({
-    elizaCloudConnected: state.elizaCloudConnected,
-  }));
-  const activeModality = React.useMemo(() => getActiveViewModality(), []);
+  const { appRuns, elizaCloudConnected, setActionNotice, setState, setTab, t } =
+    useAppSelectorShallow((state) => ({
+      appRuns: state.appRuns,
+      elizaCloudConnected: state.elizaCloudConnected,
+      setActionNotice: state.setActionNotice,
+      setState: state.setState,
+      setTab: state.setTab,
+      t: state.t,
+    }));
   const isAosp = React.useMemo(() => isAospShellEnabled(), []);
-
-  // The launcher renders the loaded views for the active modality; the curation
-  // layer owns removal, dedup, AOSP-gating, and developer/preview visibility.
-  const modalEntries = React.useMemo(
-    () =>
-      views
-        .filter((view) => (view.viewType ?? "gui") === activeModality)
-        .map(viewToEntry),
-    [activeModality, views],
-  );
 
   const page = React.useMemo<ViewEntry[]>(
     () =>
-      curateLauncherPages(modalEntries, {
+      curateLauncherPages(entries, {
         isAosp,
         enabledKinds,
         cloudActive: elizaCloudConnected,
       }),
-    [modalEntries, isAosp, enabledKinds, elizaCloudConnected],
+    [entries, isAosp, enabledKinds, elizaCloudConnected],
   );
 
-  const handleLaunch = React.useCallback((entry: ViewEntry) => {
-    const path = entry.path ?? `/apps/${entry.id}`;
-    try {
-      if (typeof window === "undefined") return;
-      if (window.location.protocol === "file:") {
-        window.location.hash = path;
-      } else {
-        shellHistory.pushState(null, "", path);
-        window.dispatchEvent(new PopStateEvent("popstate"));
+  const handleLaunch = React.useCallback(
+    async (entry: ViewEntry) => {
+      // Catalog entries have no route until their package is installed and
+      // loaded. Use the launch response itself to open a viewer on this first
+      // click; the app manager intentionally resolves registry metadata before
+      // installation, so no manifest rehydration/restart is required.
+      if (entry.kind === "app" && entry.appName && !entry.path) {
+        try {
+          const result = await get(entry);
+          if (!result) return;
+          const run = result.run;
+          if (run?.viewer?.url) {
+            setState("appRuns", [
+              ...appRuns.filter((candidate) => candidate.runId !== run.runId),
+              run,
+            ]);
+            setState("activeGameRunId", run.runId);
+            setState("appsSubTab", "games");
+            const path = `/apps/${getAppSlug(run.appName)}`;
+            if (window.location.protocol === "file:") {
+              window.location.hash = path;
+            } else {
+              shellHistory.pushState(null, "", path);
+              window.dispatchEvent(new PopStateEvent("popstate"));
+            }
+            return;
+          }
+          const targetUrl = result.launchUrl ?? entry.launchUrl;
+          if (targetUrl) {
+            await openExternalUrl(targetUrl);
+            setActionNotice(
+              t("appsview.OpenedInNewTab", { name: entry.label }),
+              "success",
+              2600,
+            );
+            return;
+          }
+          if (run) {
+            setState("appRuns", [
+              ...appRuns.filter((candidate) => candidate.runId !== run.runId),
+              run,
+            ]);
+            setTab("apps");
+            setState("appsSubTab", "running");
+            return;
+          }
+          setActionNotice(
+            t("appsview.LaunchedNoViewer", { name: entry.label }),
+            "error",
+            4000,
+          );
+        } catch (err) {
+          // error-policy:J4 a failed catalog install/launch remains visible on
+          // the tile and in the shell notice instead of navigating to an empty
+          // app surface.
+          setActionNotice(
+            t("appsview.LaunchFailed", {
+              name: entry.label,
+              message: err instanceof Error ? err.message : t("common.error"),
+            }),
+            "error",
+            4000,
+          );
+        }
+        return;
       }
-      if (entry.id === "chat") {
-        // The Messages tile lands on `/chat` (the ambient home). Open the chat
-        // so the user arrives in a conversation, not on a collapsed pill.
-        dispatchChatOpen();
+
+      const path = entry.path ?? `/apps/${entry.id}`;
+      try {
+        if (typeof window === "undefined") return;
+        if (window.location.protocol === "file:") {
+          window.location.hash = path;
+        } else {
+          shellHistory.pushState(null, "", path);
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        }
+        if (entry.id === "chat") {
+          // The Messages tile lands on `/chat` (the ambient home). Open the chat
+          // so the user arrives in a conversation, not on a collapsed pill.
+          dispatchChatOpen();
+        }
+      } catch (err) {
+        // error-policy:J4 sandboxed webviews (embeds) can reject history
+        // navigation with a SecurityError; the tile tap degrades to a no-op
+        // there. Logged so a launcher that silently stops navigating is
+        // diagnosable.
+        logger.warn({ err, path }, "[LauncherSurface] tile navigation failed");
       }
-    } catch (err) {
-      // error-policy:J4 sandboxed webviews (embeds) can reject history
-      // navigation with a SecurityError; the tile tap degrades to a no-op
-      // there. Logged so a launcher that silently stops navigating is
-      // diagnosable.
-      logger.warn({ err, path }, "[LauncherSurface] tile navigation failed");
-    }
-  }, []);
+    },
+    [appRuns, get, setActionNotice, setState, setTab, t],
+  );
 
   return (
     <div

--- a/packages/ui/src/components/shell/HomeLauncherSurface.composed.test.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.composed.test.tsx
@@ -16,7 +16,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
-import { useRoutableViews } from "../../hooks/useAvailableViews";
+import { viewToEntry } from "../../hooks/view-catalog";
 import {
   getShellSurface,
   resetShellSurfaceForTests,
@@ -26,8 +26,26 @@ import { runAnimationFramesImmediately } from "../../testing/run-animation-frame
 import { LauncherSurface } from "../pages/LauncherSurface";
 import { HomeLauncherSurface } from "./HomeLauncherSurface";
 
-vi.mock("../../hooks/useAvailableViews", () => ({
-  useRoutableViews: vi.fn(),
+const { useViewCatalogMock } = vi.hoisted(() => ({
+  useViewCatalogMock: vi.fn(),
+}));
+
+vi.mock("../../hooks/useViewCatalog", () => ({
+  useViewCatalog: useViewCatalogMock,
+}));
+vi.mock("../../api", () => ({
+  client: { getBaseUrl: () => "http://localhost:31337" },
+}));
+vi.mock("../../api/app-shell-capabilities", () => ({
+  isLimitedCloudAgentApiResourceUrl: () => false,
+  supportsFullAppShellRoutes: () => true,
+}));
+vi.mock("../../utils/openExternalUrl", () => ({
+  openExternalUrl: vi.fn(),
+}));
+vi.mock("../../navigation", () => ({
+  isAospShellEnabled: () => false,
+  LAUNCHER_AOSP_ONLY_VIEW_IDS: ["phone"],
 }));
 vi.mock("../../state/useViewKinds", () => ({
   useEnabledViewKinds: vi.fn(),
@@ -40,7 +58,6 @@ vi.mock(import("../../platform/platform-guards"), async (importOriginal) => {
   return { ...actual, getActiveViewModality: () => "gui" as const };
 });
 
-const useRoutableViewsMock = vi.mocked(useRoutableViews);
 const useEnabledViewKindsMock = vi.mocked(useEnabledViewKinds);
 
 function view(
@@ -88,11 +105,12 @@ beforeEach(() => {
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
   useEnabledViewKindsMock.mockReturnValue({ developer: true, preview: true });
-  useRoutableViewsMock.mockReturnValue({
-    views: ALL_VIEWS,
+  useViewCatalogMock.mockReturnValue({
+    entries: ALL_VIEWS.map(viewToEntry),
     loading: false,
     error: null,
     refresh: vi.fn(),
+    get: vi.fn(),
   });
 });
 

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useMemo, useState } from "react";
-import { client } from "../api";
+import { type AppLaunchResult, client } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import { loadAppsCatalog } from "../components/apps/load-apps-catalog";
 import { getActiveViewModality } from "../platform/platform-guards";
@@ -32,8 +32,13 @@ export interface UseViewCatalogResult {
   loading: boolean;
   error: Error | null;
   refresh: () => void;
-  /** Launch/install the app behind an entry; resolves when loaded or rejects. */
-  get: (entry: ViewEntry) => Promise<void>;
+  /**
+   * Launch/install the app behind an entry and return the authoritative launch
+   * result. Catalog callers need the returned run/viewer on the first click:
+   * waiting for the installed manifest to be rediscovered is too late to open
+   * a newly-installed app's viewer.
+   */
+  get: (entry: ViewEntry) => Promise<AppLaunchResult | null>;
 }
 
 export function useViewCatalog(): UseViewCatalogResult {
@@ -94,10 +99,10 @@ export function useViewCatalog(): UseViewCatalogResult {
   const get = useCallback(
     async (entry: ViewEntry) => {
       const name = entry.appName;
-      if (!name) return;
+      if (!name) return null;
       setPending((p) => ({ ...p, [entry.key]: "installing" }));
       try {
-        await client.launchApp(name);
+        const launch = await client.launchApp(name);
         // Loading hot-registers the plugin's views; refetch so the entry flips
         // to the loaded view (Open) and drops out of the catalog section.
         refreshViews();
@@ -107,6 +112,7 @@ export function useViewCatalog(): UseViewCatalogResult {
           delete next[entry.key];
           return next;
         });
+        return launch;
       } catch (err) {
         setPending((p) => ({ ...p, [entry.key]: "error" }));
         throw err instanceof Error ? err : new Error(String(err));

--- a/packages/ui/src/hooks/view-catalog.ts
+++ b/packages/ui/src/hooks/view-catalog.ts
@@ -7,10 +7,10 @@
  *    disk, no plugin load required) but isn't loaded yet → "Get" (load/install).
  *
  * The catalog ({@link RegistryAppInfo}) is sourced from `/api/apps`, which the
- * agent builds by reading each plugin's `package.json` `elizaos.app` manifest —
- * so titles, categories, and hero images are available without importing the
- * plugin. Loading happens on demand; until then the entry is a card with a
- * Get button.
+ * agent builds from installed `elizaos.app` manifests and the generated
+ * community registry. That keeps titles, categories, and launch metadata
+ * available before a third-party package is installed. Loading happens on
+ * demand; until then the entry is a card with a Get button.
  *
  * This module is the pure merge/dedupe so it can be unit-tested without React.
  */

--- a/plugins/plugin-app-manager/src/services/app-manager-list-installed.test.ts
+++ b/plugins/plugin-app-manager/src/services/app-manager-list-installed.test.ts
@@ -52,7 +52,19 @@ function appRegistryEntry(name: string) {
   return {
     name,
     description: "test app",
-    npm: { package: pkg },
+    gitRepo: "example/test-app",
+    gitUrl: "https://github.com/example/test-app.git",
+    topics: [],
+    stars: 0,
+    language: "TypeScript",
+    npm: {
+      package: pkg,
+      v0Version: null,
+      v1Version: null,
+      v2Version: "1.0.0",
+    },
+    git: { v0Branch: null, v1Branch: null, v2Branch: "main" },
+    supports: { v0: false, v1: false, v2: true },
     // runtimePlugin resolves pluginName without the npm fallback path.
     runtimePlugin: pkg,
     // launchType connect + a launch URL lets launch() build a viewer config
@@ -270,7 +282,7 @@ describe("AppManager run lifecycle (launch/stop/attach/heartbeat/reap)", () => {
 });
 
 describe("AppManager catalog surface", () => {
-  it("listAvailable filters to app-interface registry entries", async () => {
+  it("listAvailable includes third-party app-interface registry entries", async () => {
     registry.getRegistryPlugins.mockResolvedValue(
       new Map([
         ["chess", appRegistryEntry("chess")],
@@ -280,9 +292,12 @@ describe("AppManager catalog surface", () => {
     const pm = makePluginManager("chess");
     const manager = new AppManager({ stateDir });
     const available = await manager.listAvailable(pm.pluginManager);
-    // "chess" is not on the curated catalog, so the curated list is empty —
-    // but the call exercised the full registry read + filter path.
-    expect(Array.isArray(available)).toBe(true);
+    expect(available.map((app) => app.name)).toEqual(["chess"]);
+    expect(available[0]).toMatchObject({
+      displayName: "chess",
+      launchType: "connect",
+      launchUrl: "https://example.com/app",
+    });
   });
 
   it("search returns scored results through the registry-queries seam", async () => {

--- a/plugins/plugin-app-manager/src/services/app-manager.ts
+++ b/plugins/plugin-app-manager/src/services/app-manager.ts
@@ -328,17 +328,17 @@ function curateCatalogApps(
 
   for (const app of candidates) {
     const canonicalName = normalizeElizaCuratedAppName(app.name);
-    if (!canonicalName) {
-      continue;
-    }
+    const catalogName = canonicalName ?? app.name.trim();
+    if (!catalogName) continue;
 
-    const normalized = canonicalizeCuratedRegistryPlugin(
-      app,
-      canonicalName,
+    const normalized = (
+      canonicalName
+        ? canonicalizeCuratedRegistryPlugin(app, canonicalName)
+        : cloneRegistryPluginInfo(app)
     ) as RegistryAppPlugin;
-    const existing = curated.get(canonicalName);
+    const existing = curated.get(catalogName);
     if (!existing) {
-      curated.set(canonicalName, normalized);
+      curated.set(catalogName, normalized);
       continue;
     }
 


### PR DESCRIPTION
# Relates to

- https://github.com/cenetex/app-ruby-high/issues/162
- Supersedes closed PR #17174 and addresses its blocking review.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] Targets `develop` and is rebased with zero conflicts onto current upstream `e3eb6f9964`.
- [x] The branch is exactly one commit ahead: `ff6b11edb1`.
- [x] Exact-head proof covers clean installation, human-bound agent approval, successful connection, enrollment, scoped school launch, and the same agent advancing from grade 9 through grade 12.

# Risk

Medium. This extends the public registry schema/generator and changes shared app catalog/launch behavior. Strict schema validation, generated-registry tests, app-manager tests, launcher tests, clean-install coverage, and the real connected-agent browser journey bound the compatibility risk.

# What this PR fixes

The registry previously preserved only `kind` and `homepage` for third-party entries. A third-party `kind: "app"` therefore lost category, launch type, runtime package, viewer route, permissions, and the rest of its app manifest before installation. Ruby High consequently defaulted to the generic game/url catalog path and a clean first launch could not discover `/ruby-high/viewer`.

This PR:

- adds strict third-party app metadata to the source and generated registry schemas and preserves it during generation;
- registers `@rati-osf/plugin-ruby-high@0.1.5` as an education/connect app with homepage `https://ruby-high.ai` and viewer `/ruby-high/viewer`;
- keeps third-party apps in the installable catalog while preserving canonical first-party alias handling;
- installs and launches from the same catalog entry, immediately seeding returned run/viewer state;
- reloads agent config after direct installation so the installed manifest is visible without restart;
- adds clean-state, real-package E2E coverage for catalog/launch and a second opt-in journey that calls the published plugin's real `CONNECT_RUBY_HIGH` and `ENROLL_RUBY_HIGH` actions;
- verifies human approval, scoped agent credentials, the real school viewer identity, and grade progression 9 → 10 → 11 → 12;
- uses versioned Ruby High workshop assets: a transparent launcher crest, wordmark, and canonical Ruby/Eliza science-lab launch art.

# Reviewer start points

1. `packages/registry/entries/third-party/rati-osf__plugin-ruby-high.json`
2. `packages/registry/src/schema.ts` and `packages/registry/src/generate.ts`
3. `plugins/plugin-app-manager/src/services/app-manager.ts`
4. `packages/ui/src/components/pages/LauncherSurface.tsx`
5. `packages/app/test/ui-smoke/ruby-high-clean-install.spec.ts`
6. `packages/app/test/ui-smoke/ruby-high-connected-journey.spec.ts`

# Verification

Final rebase/certification:

- Base: `e3eb6f9964aae93511cbeed7fc9c2d204393c841`
- Head: `ff6b11edb1f3d7484c1a480c695a982baf4f6718`
- `bun run --cwd packages/registry generate` — 31 third-party entries; deterministic, zero diff.
- `bun run --cwd packages/registry typecheck` — passed.
- `bun run --cwd packages/registry test` — 8 files, 38 tests passed.
- Biome on the connected-journey runtime/script files — passed.
- `bun run --cwd packages/app test:e2e:ruby-high-connected` — passed from a brand-new Ruby High state store: real `0.1.5` package install, approval, connection, enrollment as `ElizaOS Agent`, scoped school launch, and visible grades 9/10/11/12. Browser journey 31.8s; 2.1m including clean host startup.
- Frontend evidence records `pageErrors: []` and no unexpected Ruby High HTTP errors.

Earlier post-rebase suites, also independently rerun by the reviewer:

- Registry validate/typecheck/tests and deterministic generation — green.
- App manager — 31 tests and typecheck green.
- Launcher/view catalog — 37 tests and UI typecheck green.
- Clean-install desktop/mobile catalog and `/ruby-high/viewer` launch — green.
- Published package build/typecheck and 15 tests — green.

Published package:

- npm: https://www.npmjs.com/package/@rati-osf/plugin-ruby-high/v/0.1.5
- source CI/provenance: https://github.com/cenetex/plugin-ruby-high/actions/runs/30601015816
- source commit: `bb554a90255b82b682c5f8220a238781fa87de0c`
- npm integrity: `sha512-eSelzi+2C0UpqaF3fnU/16HMmBG/RWSO0iWLbj9ffo6PnWE8LAQ1Tbs76L3uB6e34pT9pC4QMmOBRU4SSbXavw==`
- npm shasum: `f2238a8c3fc6c296f34a612eb7e8056d2c440f3b`
- runtime delivery remains `packageType: "plugin"`; explicit `elizaos.kind: "app"` makes the official submit path infer the registry kind correctly.

# Evidence Gate

Public release: https://github.com/atimics/eliza/releases/tag/pr-evidence

<!-- evidence-row:before-screenshots -->
- [x] Rejected-head comparison: [desktop](https://github.com/atimics/eliza/releases/download/pr-evidence/8dfaae-ruby-high-before-desktop.jpg) and [mobile](https://github.com/atimics/eliza/releases/download/pr-evidence/8dfaae-ruby-high-before-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] Exact head `ff6b11edb1`, six reviewed JPGs: ![approval](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-01-approval.jpg) ![connected grade 9](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-02-connected-grade-9.jpg) ![scoped agent school](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-03-agent-school.jpg) ![connected grade 10](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-04-connected-grade-10.jpg) ![connected grade 11](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-05-connected-grade-11.jpg) ![connected grade 12](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-06-connected-grade-12.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] [Exact-head connected-agent walkthrough: install → approve → connect → enroll → school → grades 9–12 (MP4)](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-connected-grades-9-12.mp4)
<!-- evidence-row:backend-logs -->
- [x] [Backend log: generated registry, local evidence endpoint, real package install, version `0.1.5`](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] [Frontend/network JSON: successful connect and enrollment, grade progression, final connected state, zero page errors](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-frontend.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A — production actions/providers/prompts/models/evaluators are unchanged; the E2E deterministically invokes the published plugin's registered actions without an LLM.
<!-- evidence-row:domain-artifacts -->
- [x] [Published npm package](https://www.npmjs.com/package/@rati-osf/plugin-ruby-high/v/0.1.5), [trusted-publisher provenance run](https://github.com/cenetex/plugin-ruby-high/actions/runs/30601015816), and generated registry record are provided above.
<!-- evidence-row:ocr-review -->
- [x] [Exact-head OCR + manual visual report](https://github.com/atimics/eliza/releases/download/pr-evidence/ff6b11edb1-ruby-high-ocr-report.txt)

# Evidence notes

The MP4 and screenshot 03 visibly show the real Ruby High school UI with the lower-left identity `ElizaOS Agent`; this is not an unconnected catalog-only walkthrough. The frontend JSON independently records:

- `DeviceE2EHostAgent is connected to Ruby High.`
- `Enrolled ElizaOS Agent at Ruby High.`
- connected grade 9 state;
- progression 9→10, 10→11, 11→12;
- final connected grade 12 state.

The backend log shows the exact generated-registry fixture and real install of `@rati-osf/plugin-ruby-high v0.1.5`, with no npm install failure.

# Known gaps / unrelated failures

- Monorepo-wide `bun run verify` is not claimed; this checkout lacks unrelated optional artifact packages. All affected packages and focused suites above pass.
- A prior full visual audit's only hard failure was an unchanged `plugin-calendar-gui` mobile-landscape baseline, outside this diff. Ruby High desktop/mobile clean-install captures passed.
- A reviewer isolated the pre-existing `test:e2e:chat-stream-real` post-stream history-reload timeout on both this branch and pure `develop`; it is not caused by this PR.
