### PR TITLE
fix(ci): run live scenario shards in parallel jobs

### DIFF
--- a/.github/workflows/actions-zombie-janitor.yml
+++ b/.github/workflows/actions-zombie-janitor.yml
@@ -128,7 +128,11 @@ jobs:
           PENDING_ZERO_JOB_MINUTES: ${{ vars.ACTIONS_JANITOR_PENDING_ZERO_JOB_MINUTES || '15' }}
           SELF_QUEUED_MINUTES: ${{ vars.ACTIONS_JANITOR_SELF_QUEUED_MINUTES || '60' }}
           WAITING_MAX_AGE_HOURS: ${{ vars.ACTIONS_JANITOR_WAITING_MAX_AGE_HOURS || '48' }}
-          EXEMPT_WORKFLOWS: ${{ vars.ACTIONS_JANITOR_EXEMPT_WORKFLOWS || 'ElizaOS Cuttlefish,ElizaOS OpenAgent E1 (RISC-V AI SoC)' }}
+          # Live Scenarios drives real models and real connectors: a single
+          # scenario step can legitimately run past the 120-minute max-age and
+          # sit longer than the 90-minute idle threshold without emitting a step
+          # transition, which is indistinguishable from a zombie to this janitor.
+          EXEMPT_WORKFLOWS: ${{ vars.ACTIONS_JANITOR_EXEMPT_WORKFLOWS || 'ElizaOS Cuttlefish,ElizaOS OpenAgent E1 (RISC-V AI SoC),Live Scenarios' }}
           DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
           LANE: ${{ matrix.lane }}
         with:

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -2,9 +2,13 @@
 #
 # Executes the executive-assistant, connector certification, plugin-health,
 # app-control, and scenario-runner view-chat scenarios against a live LLM
-# runtime with real credentials. Scheduled runs are enforcing: once the runner
-# reaches scenario execution, any scenario failure or aggregate LLM-judge score
-# below LIFEOPS_JUDGE_THRESHOLD fails the lane. Manual dispatch can select one
+# runtime with real credentials. Each shard is one job in a matrix fanned out
+# from packages/scripts/live-scenario-shards.json, and a terminal aggregate gate
+# re-reads every shard's outcome artifact, so the lane's wall clock is its
+# slowest shard and a shard that fails or is cancelled cannot read as a pass.
+# Scheduled runs are enforcing: once the runner reaches scenario execution, any
+# scenario failure or aggregate LLM-judge score below LIFEOPS_JUDGE_THRESHOLD
+# fails the lane. Manual dispatch can select one
 # named shard and filter inside that shard; it can also opt into report-only mode
 # while debugging by leaving `enforce_gate` false. Missing setup prerequisites
 # fail loudly and still upload a placeholder report artifact.
@@ -102,10 +106,42 @@ permissions:
   actions: read
 
 jobs:
-  live-scenarios:
-    name: Live scenarios (EA + connectors + health + app-control + view-chat)
+  plan:
+    name: Resolve requested shards
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      shards: ${{ steps.matrix.outputs.shards }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          submodules: false
+
+      - name: Resolve shard matrix
+        id: matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCENARIO_SHARD: ${{ inputs.scenario_shard }}
+          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+        run: node packages/scripts/live-scenario-contract.mjs matrix
+
+  shard:
+    name: Live scenarios (${{ matrix.shard }})
+    needs: plan
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    timeout-minutes: 120
+    # Shards run as independent jobs because a GitHub-hosted runner caps a
+    # single job at six hours: the four shards run serially exceed that ceiling,
+    # so no workflow-level timeout could ever let the serial lane finish. Each
+    # shard's ceiling comes from the manifest and stays inside the hosted cap.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    strategy:
+      # One failing shard must not cancel the others: this lane's product is
+      # live evidence, and a sibling's failure is not a reason to discard it.
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -130,67 +166,28 @@ jobs:
             { echo "scenario-runner CLI missing"; exit 1; }
 
       - name: Prepare live scenario report placeholder
+        env:
+          SCENARIO_SHARD: ${{ matrix.shard }}
+          REPORT_PATH: ${{ matrix.report }}
+          RUN_DIR: ${{ matrix.run_dir }}
         run: |
-          mkdir -p \
-            artifacts/scenario-runs/live \
-            artifacts/scenario-runs/plugin-health \
-            artifacts/scenario-runs/app-control \
-            artifacts/scenario-runs/scenario-runner-view-chat
+          mkdir -p "$RUN_DIR"
           node - <<'NODE'
           const fs = require("node:fs");
-          for (const [shard, output] of [
-            ["lifeops-connectors", "artifacts/lifeops-scenario-report.json"],
-            ["plugin-health", "artifacts/plugin-health-scenario-report.json"],
-            ["app-control", "artifacts/app-control-scenario-report.json"],
-            ["scenario-runner-view-chat", "artifacts/scenario-runner-view-chat-report.json"],
-          ]) {
-            const report = {
-              schema: "eliza_live_scenario_setup_v1",
-              shard,
-              status: "setup_not_completed",
-              generatedAt: new Date().toISOString(),
-              note:
-                "Placeholder written before build/setup. If this file is uploaded unchanged, the workflow failed before scenario execution and no live model trajectory was produced.",
-              scenarios: [],
-              totalCount: 0,
-              passedCount: 0,
-              failedCount: 0
-            };
-            fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
-          }
+          const report = {
+            schema: "eliza_live_scenario_setup_v1",
+            shard: process.env.SCENARIO_SHARD,
+            status: "setup_not_completed",
+            generatedAt: new Date().toISOString(),
+            note:
+              "Placeholder written before build/setup. If this file is uploaded unchanged, the workflow failed before scenario execution and no live model trajectory was produced.",
+            scenarios: [],
+            totalCount: 0,
+            passedCount: 0,
+            failedCount: 0
+          };
+          fs.writeFileSync(process.env.REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
           NODE
-
-      - name: Resolve manual shard selection
-        id: selection
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
-          SCENARIO_SHARD: ${{ inputs.scenario_shard }}
-        run: |
-          selected="${SCENARIO_SHARD:-lifeops-connectors}"
-          # A workflow_dispatch request is validated against the default-branch
-          # input schema. The prefix lets an exact-head run select a new shard
-          # before this workflow revision itself reaches the default branch.
-          case "$SCENARIO_FILTER" in
-            lifeops-connectors:*) selected="lifeops-connectors" ;;
-            plugin-health:*) selected="plugin-health" ;;
-            app-control:*) selected="app-control" ;;
-            scenario-runner-view-chat:*) selected="scenario-runner-view-chat" ;;
-          esac
-
-          case "$selected" in
-            all|lifeops-connectors|plugin-health|app-control|scenario-runner-view-chat) ;;
-            *)
-              echo "unknown scenario_shard: $selected" >&2
-              exit 2
-              ;;
-          esac
-
-          if [ -n "$SCENARIO_FILTER" ] && [ "$selected" = "all" ]; then
-            echo "scenario_filter requires one named scenario_shard; 'all' is ambiguous" >&2
-            exit 2
-          fi
-          echo "shard=$selected" >> "$GITHUB_OUTPUT"
 
       - name: Validate authoritative shard prerequisites
         id: preflight
@@ -203,12 +200,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-        run: |
-          status=0
-          for shard in lifeops-connectors plugin-health app-control scenario-runner-view-chat; do
-            node packages/scripts/live-scenario-contract.mjs preflight "$shard" || status=$?
-          done
-          exit "$status"
+        run: node packages/scripts/live-scenario-contract.mjs preflight "${{ matrix.shard }}"
 
       - name: Build live scenario runtime packages
         id: build
@@ -314,9 +306,9 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Run EA + connector live scenarios
+      - name: Run live scenarios
         id: run
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'lifeops-connectors') }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         continue-on-error: true
         env:
           # The runner and ordinary workspace dependencies stay on checkout
@@ -374,180 +366,101 @@ jobs:
           NOTIFICATION_RELAY_TOKEN: ${{ secrets.NOTIFICATION_RELAY_TOKEN }}
           TRAVEL_BOOKING_API_KEY: ${{ secrets.TRAVEL_BOOKING_API_KEY }}
           # Run controls
-          SCENARIO_SHARD: lifeops-connectors
-          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          SCENARIO_ROOT: ${{ matrix.root }}
+          SCENARIO_SHARD: ${{ matrix.shard }}
+          SCENARIO_FILTER: ${{ matrix.scenario_filter }}
+          LANE_ARGS: ${{ matrix.lane_args }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
           SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
           SKIP_REASON: ${{ inputs.skip_reason }}
-          REPORT_PATH: artifacts/lifeops-scenario-report.json
-          RUN_DIR: artifacts/scenario-runs/live
+          REPORT_PATH: ${{ matrix.report }}
+          RUN_DIR: ${{ matrix.run_dir }}
         run: |
           set -o pipefail
-          mkdir -p artifacts/scenario-runs/live
-          node packages/scripts/run-live-scenarios.mjs 2>&1 | tee artifacts/scenario-runs/live/runner.log
+          mkdir -p "$RUN_DIR"
+          # shellcheck disable=SC2086 # LANE_ARGS is a controlled manifest value
+          node packages/scripts/run-live-scenarios.mjs $LANE_ARGS 2>&1 | tee "$RUN_DIR/runner.log"
 
-      - name: Run plugin-health live scenarios
-        id: run-health
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'plugin-health') }}
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--conditions=eliza-source"
-          # LLM providers
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          # Independent LLM judge (#9310): judge on Cerebras, never the model
-          # under test.
-          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
-          # Run controls
-          SCENARIO_ROOT: plugins/plugin-health/test/scenarios
-          SCENARIO_SHARD: plugin-health
-          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
-          LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
-          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
-          SKIP_REASON: ${{ inputs.skip_reason }}
-          REPORT_PATH: artifacts/plugin-health-scenario-report.json
-          RUN_DIR: artifacts/scenario-runs/plugin-health
-          EXPORT_NATIVE_PATH: artifacts/scenario-runs/plugin-health/native.jsonl
-        run: |
-          set -o pipefail
-          mkdir -p artifacts/scenario-runs/plugin-health
-          node packages/scripts/run-live-scenarios.mjs --lane live-only 2>&1 | tee artifacts/scenario-runs/plugin-health/runner.log
-
-      - name: Run app-control live scenarios
-        id: run-app-control
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'app-control') }}
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--conditions=eliza-source"
-          # LLM providers
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          # Independent LLM judge (#9310): judge on Cerebras, never the model
-          # under test.
-          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
-          # Run controls
-          SCENARIO_ROOT: plugins/plugin-app-control/test/scenarios
-          SCENARIO_SHARD: app-control
-          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
-          LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
-          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
-          SKIP_REASON: ${{ inputs.skip_reason }}
-          REPORT_PATH: artifacts/app-control-scenario-report.json
-          RUN_DIR: artifacts/scenario-runs/app-control
-          EXPORT_NATIVE_PATH: artifacts/scenario-runs/app-control/native.jsonl
-        run: |
-          set -o pipefail
-          mkdir -p artifacts/scenario-runs/app-control
-          node packages/scripts/run-live-scenarios.mjs --lane live-only 2>&1 | tee artifacts/scenario-runs/app-control/runner.log
-
-      - name: Run scenario-runner view-chat live scenarios
-        id: run-view-chat
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || steps.selection.outputs.shard == 'all' || steps.selection.outputs.shard == 'scenario-runner-view-chat') }}
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--conditions=eliza-source"
-          # LLM providers
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          # Independent LLM judge (#9310): judge on Cerebras, never the model
-          # under test.
-          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
-          # This shard deliberately owns a bounded subset of the runner's
-          # mixed-purpose live catalog. A selected manual filter may narrow it
-          # further; scheduled/all runs execute the declared shard default.
-          SCENARIO_ROOT: packages/scenario-runner/test/scenarios
-          SCENARIO_SHARD: scenario-runner-view-chat
-          SCENARIO_FILTER: ${{ inputs.scenario_filter || 'live-document-delete' }}
-          LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
-          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
-          SKIP_REASON: ${{ inputs.skip_reason }}
-          REPORT_PATH: artifacts/scenario-runner-view-chat-report.json
-          RUN_DIR: artifacts/scenario-runs/scenario-runner-view-chat
-          EXPORT_NATIVE_PATH: artifacts/scenario-runs/scenario-runner-view-chat/native.jsonl
-        run: |
-          set -o pipefail
-          mkdir -p artifacts/scenario-runs/scenario-runner-view-chat
-          node packages/scripts/run-live-scenarios.mjs --lane live-only 2>&1 | tee artifacts/scenario-runs/scenario-runner-view-chat/runner.log
-
-      - name: Verify every requested shard published its evidence contract
+      - name: Verify this shard published its evidence contract
         id: verify-evidence
         if: ${{ always() && steps.preflight.outcome == 'success' && steps.build.outcome == 'success' }}
+        run: node packages/scripts/live-scenario-contract.mjs verify "${{ matrix.shard }}"
+
+      - name: Record shard outcome
+        if: always()
         env:
-          SCENARIO_SHARD: ${{ github.event_name == 'schedule' && 'all' || steps.selection.outputs.shard }}
+          SCENARIO_SHARD: ${{ matrix.shard }}
+          RUN_DIR: ${{ matrix.run_dir }}
+          PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          RUN_OUTCOME: ${{ steps.run.outcome }}
+          EVIDENCE_OUTCOME: ${{ steps.verify-evidence.outcome }}
         run: |
-          for shard in lifeops-connectors plugin-health app-control scenario-runner-view-chat; do
-            if [ "$SCENARIO_SHARD" = "all" ] || [ "$SCENARIO_SHARD" = "$shard" ]; then
-              node packages/scripts/live-scenario-contract.mjs verify "$shard"
-            fi
-          done
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const steps = {
+            preflight: process.env.PREFLIGHT_OUTCOME,
+            build: process.env.BUILD_OUTCOME,
+            run: process.env.RUN_OUTCOME,
+            evidence: process.env.EVIDENCE_OUTCOME,
+          };
+          const failures = Object.entries(steps).filter(([, value]) => value !== "success");
+          const outcome = {
+            schema: "eliza_live_scenario_shard_outcome_v1",
+            shard: process.env.SCENARIO_SHARD,
+            status: failures.length === 0 ? "success" : "failure",
+            steps,
+            generatedAt: new Date().toISOString(),
+          };
+          fs.mkdirSync(process.env.RUN_DIR, { recursive: true });
+          fs.writeFileSync(`${process.env.RUN_DIR}/shard-outcome.json`, `${JSON.stringify(outcome, null, 2)}\n`);
+          if (failures.length) {
+            console.error(`Live scenario shard failed: ${failures.map(([name, value]) => `${name}=${value || "missing"}`).join(", ")}`);
+            process.exit(1);
+          }
+          console.log(`Live scenario shard ${outcome.shard} passed: ${Object.keys(steps).join(", ")}`);
+          NODE
 
       - name: Upload scenario report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: lifeops-scenario-report
+          name: live-scenario-report-${{ matrix.shard }}
           path: |
-            artifacts/lifeops-scenario-report.json
-            artifacts/plugin-health-scenario-report.json
-            artifacts/app-control-scenario-report.json
-            artifacts/scenario-runner-view-chat-report.json
-            artifacts/scenario-runs/live/
-            artifacts/scenario-runs/plugin-health/
-            artifacts/scenario-runs/app-control/
-            artifacts/scenario-runs/scenario-runner-view-chat/
+            ${{ matrix.report }}
+            ${{ matrix.run_dir }}/
           if-no-files-found: error
           retention-days: 30
 
+  live-scenarios:
+    name: Live scenarios aggregate gate
+    needs: [plan, shard]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          submodules: false
+
+      - name: Download shard outcomes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        continue-on-error: true
+        with:
+          pattern: live-scenario-report-*
+          path: artifacts/shard-outcomes
+
       - name: Enforce aggregate shard result
-        if: always()
         env:
-          PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          LIFEOPS_OUTCOME: ${{ steps.run.outcome }}
-          HEALTH_OUTCOME: ${{ steps.run-health.outcome }}
-          APP_CONTROL_OUTCOME: ${{ steps.run-app-control.outcome }}
-          VIEW_CHAT_OUTCOME: ${{ steps.run-view-chat.outcome }}
-          EVIDENCE_OUTCOME: ${{ steps.verify-evidence.outcome }}
-          SCENARIO_SHARD: ${{ github.event_name == 'schedule' && 'all' || steps.selection.outputs.shard }}
+          EXPECTED_SHARDS: ${{ needs.plan.outputs.shards }}
+          ARTIFACT_DIR: artifacts/shard-outcomes
+          PLAN_RESULT: ${{ needs.plan.result }}
+          SHARD_RESULT: ${{ needs.shard.result }}
         run: |
-          node - <<'NODE'
-          const required = ["PREFLIGHT_OUTCOME", "BUILD_OUTCOME", "EVIDENCE_OUTCOME"];
-          const shardOutcome = {
-            "lifeops-connectors": "LIFEOPS_OUTCOME",
-            "plugin-health": "HEALTH_OUTCOME",
-            "app-control": "APP_CONTROL_OUTCOME",
-            "scenario-runner-view-chat": "VIEW_CHAT_OUTCOME",
-          };
-          const selected = process.env.SCENARIO_SHARD || "all";
-          if (selected === "all") {
-            required.push(...Object.values(shardOutcome));
-          } else {
-            const outcome = shardOutcome[selected];
-            if (!outcome) {
-              console.error(`Unknown live scenario shard: ${selected}`);
-              process.exit(2);
-            }
-            required.push(outcome);
-          }
-          const failures = required.filter((name) => process.env[name] !== "success");
-          if (failures.length) {
-            console.error(`Live scenario authority failed: ${failures.map((name) => `${name}=${process.env[name] || "missing"}`).join(", ")}`);
-            process.exit(1);
-          }
-          console.log(`All requested live scenario shards and evidence contracts succeeded: ${required.join(", ")}`);
-          NODE
+          if [ "$PLAN_RESULT" != "success" ] || [ "$SHARD_RESULT" != "success" ]; then
+            echo "Live scenario authority failed: plan=$PLAN_RESULT shard=$SHARD_RESULT" >&2
+            exit 1
+          fi
+          node packages/scripts/live-scenario-contract.mjs gate

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -21,7 +21,9 @@ import { main as auditScenarioCoverage } from "../check-scenario-workflow-covera
 import { PLUGIN_ROUTE_COVERAGE } from "../e2e-coverage/manifest.ts";
 import {
   evaluatePrerequisites,
+  gateShardOutcomes,
   loadShard,
+  resolveShardMatrix,
   verifyEvidence,
   writeOutcome,
 } from "../live-scenario-contract.mjs";
@@ -70,6 +72,10 @@ function captureLogger(): {
   };
 }
 
+// GitHub expression literals are assembled rather than written inline so the
+// `${{` sequence is not read as a JS template placeholder.
+const ghExpr = (body: string): string => `$\{{ ${body} }}`;
+
 function exitingChild(
   code: number | null,
   signal: string | null = null,
@@ -86,9 +92,15 @@ test("pins an authoritative, bounded shard catalog", () => {
   const { manifest, shard } = loadShard(manifestPath, "plugin-health");
   expect(manifest.authority).toBe(".github/workflows/live-scenarios.yml");
   expect(manifest.costCeiling).toMatchObject({
-    maxConcurrentShards: 1,
-    maxWorkflowMinutes: 120,
+    maxConcurrentShards: 4,
+    maxWorkflowMinutes: 330,
   });
+  // Every shard's ceiling must stay inside the 6-hour GitHub-hosted job cap,
+  // which is what the serial single-job lane could never satisfy.
+  for (const entry of manifest.shards as { timeoutMinutes: number }[]) {
+    expect(entry.timeoutMinutes).toBeGreaterThan(0);
+    expect(entry.timeoutMinutes).toBeLessThanOrEqual(330);
+  }
   expect(manifest.shards.map((entry: { id: string }) => entry.id)).toEqual([
     "lifeops-connectors",
     "plugin-health",
@@ -178,15 +190,130 @@ test("fails evidence verification when any contracted artifact is absent", () =>
 
 test("keeps shard failures non-short-circuiting and enforces one aggregate result", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow.match(/continue-on-error: true/g)).toHaveLength(5);
+  expect(workflow.match(/continue-on-error: true/g)).toHaveLength(3);
+  expect(workflow).toContain("fail-fast: false");
+  expect(workflow).toContain(
+    `matrix: ${ghExpr("fromJSON(needs.plan.outputs.matrix)")}`,
+  );
+  expect(workflow).toContain(
+    `timeout-minutes: ${ghExpr("matrix.timeout_minutes")}`,
+  );
   expect(workflow).toContain("Enforce aggregate shard result");
   expect(workflow).toContain("if-no-files-found: error");
-  expect(workflow).toContain('live-scenario-contract.mjs verify "$shard"');
+  expect(workflow).toContain(
+    `live-scenario-contract.mjs verify "${ghExpr("matrix.shard")}"`,
+  );
+  expect(workflow).toContain("live-scenario-contract.mjs gate");
+  // Per-shard artifact names must not collide across matrix legs, or the
+  // aggregate gate cannot tell which shard published which evidence.
+  expect(workflow).toContain(
+    `name: live-scenario-report-${ghExpr("matrix.shard")}`,
+  );
+});
+
+test("exempts the live lane from the zombie janitor's age+idle reaper", () => {
+  const janitor = readFileSync(
+    fileURLToPath(
+      new URL(
+        "../../../.github/workflows/actions-zombie-janitor.yml",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  );
+  expect(janitor).toContain(
+    "'ElizaOS Cuttlefish,ElizaOS OpenAgent E1 (RISC-V AI SoC),Live Scenarios'",
+  );
+});
+
+test("fans every requested shard out of the manifest and rejects ambiguity", () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL("../live-scenario-shards.json", import.meta.url)),
+      "utf8",
+    ),
+  );
+
+  const scheduled = resolveShardMatrix(manifest, { EVENT_NAME: "schedule" });
+  expect(
+    scheduled.include.map((entry: { shard: string }) => entry.shard),
+  ).toEqual([
+    "lifeops-connectors",
+    "plugin-health",
+    "app-control",
+    "scenario-runner-view-chat",
+  ]);
+  const viewChat = scheduled.include.find(
+    (entry: { shard: string }) => entry.shard === "scenario-runner-view-chat",
+  );
+  expect(viewChat).toMatchObject({
+    scenario_filter: "live-document-delete",
+    lane_args: "--lane live-only",
+  });
+  expect(
+    scheduled.include.find(
+      (entry: { shard: string }) => entry.shard === "lifeops-connectors",
+    ),
+  ).toMatchObject({ lane_args: "", root: "packages/test/scenarios" });
+
+  const manual = resolveShardMatrix(manifest, {
+    EVENT_NAME: "workflow_dispatch",
+    SCENARIO_SHARD: "lifeops-connectors",
+    SCENARIO_FILTER: "app-control:settings-voice-toggle",
+  });
+  expect(manual.include).toHaveLength(1);
+  expect(manual.include[0]).toMatchObject({
+    shard: "app-control",
+    scenario_filter: "app-control:settings-voice-toggle",
+  });
+
+  expect(() =>
+    resolveShardMatrix(manifest, {
+      EVENT_NAME: "workflow_dispatch",
+      SCENARIO_SHARD: "all",
+      SCENARIO_FILTER: "some-scenario",
+    }),
+  ).toThrow("'all' is ambiguous");
+  expect(() =>
+    resolveShardMatrix(manifest, {
+      EVENT_NAME: "workflow_dispatch",
+      SCENARIO_SHARD: "not-a-shard",
+    }),
+  ).toThrow("unknown scenario_shard");
+});
+
+test("reads a missing or failed shard outcome as a lane failure", () => {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "scenario-gate-"));
+  try {
+    const write = (shard: string, status: string) => {
+      const dir = path.join(tempRoot, `live-scenario-report-${shard}`);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        path.join(dir, "shard-outcome.json"),
+        JSON.stringify({ shard, status }),
+      );
+    };
+    write("plugin-health", "success");
+    expect(gateShardOutcomes(["plugin-health"], tempRoot)).toEqual({
+      status: "pass",
+      failures: [],
+    });
+    // A shard reaped mid-run uploads nothing; that must not read as silence.
+    expect(
+      gateShardOutcomes(["plugin-health", "app-control"], tempRoot).failures,
+    ).toEqual(["app-control=no-outcome-artifact"]);
+    write("app-control", "failure");
+    expect(
+      gateShardOutcomes(["plugin-health", "app-control"], tempRoot).failures,
+    ).toEqual(["app-control=failure"]);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("builds the dist-exported runtime packages before the scenario CLI starts", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  const runStep = "- name: Run EA + connector live scenarios";
+  const runStep = "- name: Run live scenarios";
 
   expect(workflow).toMatch(
     /package_dirs=\([\s\S]*plugins\/plugin-local-inference[\s\S]*plugins\/plugin-app-control[\s\S]*plugins\/plugin-health[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
@@ -201,26 +328,16 @@ test("builds the dist-exported runtime packages before the scenario CLI starts",
 
 test("runs every live scenario root against workspace source exports", () => {
   const workflow = readFileSync(workflowPath, "utf8");
+  // One matrix leg, one source-conditions declaration: the per-shard roots now
+  // come from the manifest instead of four hand-copied run steps.
   const sourceConditionEntries = [
     ...workflow.matchAll(/NODE_OPTIONS: "--conditions=eliza-source"/g),
   ];
-  expect(sourceConditionEntries).toHaveLength(4);
-  for (const shard of [
-    "lifeops-connectors",
-    "plugin-health",
-    "app-control",
-    "scenario-runner-view-chat",
-  ]) {
-    expect(workflow).toContain(`steps.selection.outputs.shard == '${shard}'`);
-    expect(workflow).toContain(`SCENARIO_SHARD: ${shard}`);
-  }
-  expect(workflow).toContain('app-control:*) selected="app-control"');
+  expect(sourceConditionEntries).toHaveLength(1);
+  expect(workflow).toContain(`SCENARIO_ROOT: ${ghExpr("matrix.root")}`);
+  expect(workflow).toContain(`SCENARIO_SHARD: ${ghExpr("matrix.shard")}`);
   expect(workflow).toContain(
-    "SCENARIO_FILTER: $" +
-      "{{ inputs.scenario_filter || 'live-document-delete' }}",
-  );
-  expect(workflow).toContain(
-    "scenario_filter requires one named scenario_shard; 'all' is ambiguous",
+    `SCENARIO_FILTER: ${ghExpr("matrix.scenario_filter")}`,
   );
 });
 

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -285,8 +285,15 @@ test("fans every requested shard out of the manifest and rejects ambiguity", () 
 test("reads a missing or failed shard outcome as a lane failure", () => {
   const tempRoot = mkdtempSync(path.join(tmpdir(), "scenario-gate-"));
   try {
+    // Nested exactly as the download lays the shard's run directory out, to
+    // pin that the gate finds the record by content and not by path depth.
     const write = (shard: string, status: string) => {
-      const dir = path.join(tempRoot, `live-scenario-report-${shard}`);
+      const dir = path.join(
+        tempRoot,
+        `live-scenario-report-${shard}`,
+        "scenario-runs",
+        shard,
+      );
       mkdirSync(dir, { recursive: true });
       writeFileSync(
         path.join(dir, "shard-outcome.json"),

--- a/packages/scripts/live-scenario-contract.mjs
+++ b/packages/scripts/live-scenario-contract.mjs
@@ -139,21 +139,27 @@ export function resolveShardMatrix(manifest, env) {
  * as a lane failure and not as a shard that had nothing to say.
  */
 export function gateShardOutcomes(expectedShards, artifactDir) {
-  const failures = [];
-  for (const shard of expectedShards) {
-    const outcomePath = path.join(
-      artifactDir,
-      `live-scenario-report-${shard}`,
-      "shard-outcome.json",
-    );
-    if (!existsSync(outcomePath)) {
-      failures.push(`${shard}=no-outcome-artifact`);
-      continue;
+  // Indexed by the record's own `shard` field rather than by path: the artifact
+  // download layout varies with how many artifacts matched the pattern, so the
+  // outcome file's depth under artifactDir is not something to depend on.
+  const published = new Map();
+  const walk = (dir) => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(entryPath);
+      else if (entry.name === "shard-outcome.json") {
+        const outcome = JSON.parse(readFileSync(entryPath, "utf8"));
+        published.set(outcome.shard, outcome.status || "unknown");
+      }
     }
-    const outcome = JSON.parse(readFileSync(outcomePath, "utf8"));
-    if (outcome.status !== "success")
-      failures.push(`${shard}=${outcome.status || "unknown"}`);
-  }
+  };
+  walk(artifactDir);
+
+  const failures = expectedShards
+    .map((shard) => [shard, published.get(shard) ?? "no-outcome-artifact"])
+    .filter(([, status]) => status !== "success")
+    .map(([shard, status]) => `${shard}=${status}`);
   return { status: failures.length === 0 ? "pass" : "fail", failures };
 }
 

--- a/packages/scripts/live-scenario-contract.mjs
+++ b/packages/scripts/live-scenario-contract.mjs
@@ -2,8 +2,20 @@
 /**
  * Validate live-scenario shard prerequisites and verify each shard's complete
  * evidence contract before the workflow's aggregate authority can pass.
+ *
+ * Also owns the shard fan-out that `.github/workflows/live-scenarios.yml`
+ * consumes: `matrix` resolves the requested shards into a job matrix, and
+ * `gate` re-asserts every requested shard's outcome from the downloaded
+ * artifacts so a shard that failed — or was reaped mid-run — can never be read
+ * as an overall pass.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -77,13 +89,118 @@ export function verifyEvidence(shard, root = repoRoot) {
   };
 }
 
+/**
+ * Resolve the shards a run must execute into a `strategy.matrix` payload.
+ *
+ * A scheduled run always executes every shard. A manual run executes the one
+ * selected shard, and a `scenario_filter` may name its shard by prefix so an
+ * exact-head dispatch can target a shard the default branch's input schema does
+ * not know yet.
+ */
+export function resolveShardMatrix(manifest, env) {
+  const ids = manifest.shards.map((entry) => entry.id);
+  const filter = (env.SCENARIO_FILTER ?? "").trim();
+  let selected = (env.SCENARIO_SHARD ?? "").trim() || "all";
+  if (env.EVENT_NAME === "schedule") selected = "all";
+  else {
+    const prefixed = ids.find((id) => filter.startsWith(`${id}:`));
+    if (prefixed) selected = prefixed;
+  }
+  if (selected !== "all" && !ids.includes(selected))
+    throw new Error(`unknown scenario_shard: ${selected}`);
+  if (filter && selected === "all")
+    throw new Error(
+      "scenario_filter requires one named scenario_shard; 'all' is ambiguous",
+    );
+  const requested =
+    selected === "all"
+      ? manifest.shards
+      : manifest.shards.filter((entry) => entry.id === selected);
+  return {
+    include: requested.map((shard) => ({
+      shard: shard.id,
+      root: shard.root,
+      report: shard.report,
+      run_dir: shard.runDir,
+      timeout_minutes: shard.timeoutMinutes,
+      lane_args: shard.lane ? `--lane ${shard.lane}` : "",
+      // An unfiltered shard runs its declared default; a shard that owns a
+      // bounded subset of a mixed-purpose catalog carries that subset here.
+      scenario_filter: filter || (shard.scenarioIds ?? []).join(","),
+    })),
+  };
+}
+
+/**
+ * Assert that every requested shard published a successful outcome record.
+ *
+ * Reads the per-shard artifacts rather than trusting job conclusions alone: a
+ * shard cancelled by the zombie janitor leaves no outcome file, which must read
+ * as a lane failure and not as a shard that had nothing to say.
+ */
+export function gateShardOutcomes(expectedShards, artifactDir) {
+  const failures = [];
+  for (const shard of expectedShards) {
+    const outcomePath = path.join(
+      artifactDir,
+      `live-scenario-report-${shard}`,
+      "shard-outcome.json",
+    );
+    if (!existsSync(outcomePath)) {
+      failures.push(`${shard}=no-outcome-artifact`);
+      continue;
+    }
+    const outcome = JSON.parse(readFileSync(outcomePath, "utf8"));
+    if (outcome.status !== "success")
+      failures.push(`${shard}=${outcome.status || "unknown"}`);
+  }
+  return { status: failures.length === 0 ? "pass" : "fail", failures };
+}
+
 export function main(argv = process.argv.slice(2), env = process.env) {
   const [command, shardId] = argv;
+  const manifestPath = env.LIVE_SCENARIO_MANIFEST || defaultManifest;
+
+  if (command === "matrix") {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const matrix = resolveShardMatrix(manifest, env);
+    const serialized = JSON.stringify(matrix);
+    console.log(serialized);
+    if (env.GITHUB_OUTPUT)
+      writeFileSync(
+        env.GITHUB_OUTPUT,
+        `matrix=${serialized}\nshards=${matrix.include.map((entry) => entry.shard).join(",")}\n`,
+        { flag: "a" },
+      );
+    return 0;
+  }
+
+  if (command === "gate") {
+    const expected = (env.EXPECTED_SHARDS ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (expected.length === 0) throw new Error("gate requires EXPECTED_SHARDS");
+    const artifactDir = env.ARTIFACT_DIR || "artifacts/shard-outcomes";
+    const present = existsSync(artifactDir) ? readdirSync(artifactDir) : [];
+    console.log(
+      `[live-scenario-contract] gate: expected=${expected.join(",")} artifacts=${present.join(",") || "none"}`,
+    );
+    const result = gateShardOutcomes(expected, artifactDir);
+    if (result.status !== "pass") {
+      console.error(
+        `[live-scenario-contract] gate: lane failed; ${result.failures.join(", ")}`,
+      );
+      return 4;
+    }
+    console.log("[live-scenario-contract] gate: all requested shards passed");
+    return 0;
+  }
+
   if (!command || !shardId)
     throw new Error(
-      "usage: live-scenario-contract.mjs <preflight|verify> <shard-id>",
+      "usage: live-scenario-contract.mjs <preflight|verify|matrix|gate> [shard-id]",
     );
-  const manifestPath = env.LIVE_SCENARIO_MANIFEST || defaultManifest;
   const { shard } = loadShard(manifestPath, shardId);
   const outcomePath = path.resolve(
     repoRoot,

--- a/packages/scripts/live-scenario-shards.json
+++ b/packages/scripts/live-scenario-shards.json
@@ -3,11 +3,11 @@
   "authority": ".github/workflows/live-scenarios.yml",
   "owner": "elizaOS runtime/scenario maintainers",
   "triggers": ["schedule:30 8 * * *", "workflow_dispatch"],
-  "timeoutMinutes": 120,
+  "timeoutMinutes": 330,
   "costCeiling": {
-    "maxWorkflowMinutes": 120,
-    "maxConcurrentShards": 1,
-    "note": "One shared dependency build and four serial shard runs. The scenario-runner view-chat shard is restricted to its declared scenarioIds; provider-side token budgets remain enforced by the scenario runner."
+    "maxWorkflowMinutes": 330,
+    "maxConcurrentShards": 4,
+    "note": "Each shard is an independent matrix job with its own dependency build, so the lane's wall clock is the slowest shard rather than the sum. Per-shard timeoutMinutes stay under the 6-hour GitHub-hosted job cap. The scenario-runner view-chat shard is restricted to its declared scenarioIds; provider-side token budgets remain enforced by the scenario runner."
   },
   "shards": [
     {
@@ -15,6 +15,7 @@
       "root": "packages/test/scenarios",
       "report": "artifacts/lifeops-scenario-report.json",
       "runDir": "artifacts/scenario-runs/live",
+      "timeoutMinutes": 330,
       "requiredAnySecrets": [
         [
           "OPENAI_API_KEY",
@@ -41,6 +42,8 @@
       "root": "plugins/plugin-health/test/scenarios",
       "report": "artifacts/plugin-health-scenario-report.json",
       "runDir": "artifacts/scenario-runs/plugin-health",
+      "timeoutMinutes": 120,
+      "lane": "live-only",
       "requiredAnySecrets": [
         [
           "OPENAI_API_KEY",
@@ -67,6 +70,8 @@
       "root": "plugins/plugin-app-control/test/scenarios",
       "report": "artifacts/app-control-scenario-report.json",
       "runDir": "artifacts/scenario-runs/app-control",
+      "timeoutMinutes": 120,
+      "lane": "live-only",
       "requiredAnySecrets": [
         [
           "OPENAI_API_KEY",
@@ -94,6 +99,8 @@
       "scenarioIds": ["live-document-delete"],
       "report": "artifacts/scenario-runner-view-chat-report.json",
       "runDir": "artifacts/scenario-runs/scenario-runner-view-chat",
+      "timeoutMinutes": 60,
+      "lane": "live-only",
       "requiredAnySecrets": [
         [
           "OPENAI_API_KEY",


### PR DESCRIPTION
## Relates to

Closes #17136

## Risks

Low–medium, CI-only. The lane's assertions are unchanged: no `continue-on-error` was added to any scenario execution, no failure was converted to a warning, no shard was dropped, and no scenario content or bench was touched. The risk is structural — four shards now run as four jobs instead of four steps, so a mistake in the fan-out could run the wrong shard or lose a shard silently. That is exactly what the new terminal aggregate gate exists to prevent: it re-reads every requested shard's `shard-outcome.json` from the uploaded artifacts and fails the lane on any shard that is missing or non-success.

## Background

### What does this PR do?

Splits `Live Scenarios` from one serial job into a per-shard `strategy.matrix`, and exempts the workflow from the Actions zombie janitor.

**The problem.** Every scheduled run from 2026-07-12 through 2026-07-30 — **19 consecutive nights** — is `completed/cancelled` at ~120 minutes, annotated "The run was canceled forcefully by @github-actions[bot]". The enforcing nightly live-evidence lane has not completed once in that window. Step timings from the latest nightly (run `30530353943`) show setup + build finishing at 09:27:40 and `Run EA + connector live scenarios` running from 09:27:40 to 11:22:51 before being killed, with the other three shards never starting.

Two ceilings caused it:

1. `live-scenarios.yml` set `timeout-minutes: 120` against a measured ~10–11 hour serial duration.
2. `actions-zombie-janitor.yml` reaps any in-progress run older than 120 minutes **and** idle ≥90 minutes in one step — the exact shape of a long single-step live scenario run — and `Live Scenarios` was not in `EXEMPT_WORKFLOWS`.

**Why raising `timeout-minutes` alone cannot work.** `HETZNER_FLEET_ONLINE` is `false` (since 07-05), so the runner expression falls back to `ubuntu-24.04`, and a GitHub-hosted runner caps **a single job at six hours**. Raising the workflow timeout past 360 has no effect — the hosted job limit kills it first. It would convert a 120-minute cancellation into a 6-hour one. Splitting the work across jobs is the only shape that fits on the current runner.

### What kind of change is this?

Bug fix (CI).

## Documentation changes needed?

No. The workflow's own header prose and `packages/scripts/live-scenario-shards.json` are updated in place; they are the authority for this lane.

## Testing

### Structural change

- **`plan` job** — runs `live-scenario-contract.mjs matrix`, which resolves the requested shards out of `live-scenario-shards.json` into a `strategy.matrix` payload. This reuses the single-shard path the workflow already exercised (`scenario_shard` input, the shard-prefixed `scenario_filter` escape hatch, and the `'all' is ambiguous` rejection) rather than inventing a new one — that logic moved from inline shell into the script and is now unit-tested.
- **`shard` job** — one matrix leg per shard, `fail-fast: false`, `timeout-minutes: ${{ matrix.timeout_minutes }}` from the manifest. The four hand-copied run steps collapse into one generic step driven by `matrix.root` / `matrix.shard` / `matrix.scenario_filter` / `matrix.lane_args`. Artifact name is `live-scenario-report-${{ matrix.shard }}`, so legs cannot collide. Each leg writes `shard-outcome.json` recording its preflight/build/run/evidence step outcomes and fails the leg if any is non-success.
- **`live-scenarios` job** — terminal aggregate gate, `needs: [plan, shard]`, `if: always()`. Fails when `needs.plan.result`/`needs.shard.result` is not success, then runs `live-scenario-contract.mjs gate`, which requires a `shard-outcome.json` with `status: "success"` for **every** requested shard. A shard that was reaped uploads nothing, which reads as `no-outcome-artifact` → lane failure, never as silence.
- **Runner selection preserved** verbatim: `${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}`.
- **Manual dispatch preserved**: a selected single shard plus `scenario_filter` produces exactly one matrix leg carrying that filter; the shard-prefix inference and the filter+`all` rejection behave as before. Scheduled runs always fan out to all four.
- **Janitor**: `EXEMPT_WORKFLOWS` default becomes `'ElizaOS Cuttlefish,ElizaOS OpenAgent E1 (RISC-V AI SoC),Live Scenarios'` — the two existing entries preserved.

### Per-shard timeouts and how they were chosen

| shard | timeout | basis |
| --- | --- | --- |
| `lifeops-connectors` | 330 min | The only shard with a measured lower bound: it ran 115 minutes in run `30530353943` and was still executing when reaped, and it dominates the ~10–11h serial figure. 330 leaves ~30 minutes of headroom under the 6-hour hosted job cap for the leg's own checkout/install/build (~5 minutes observed). |
| `plugin-health` | 120 min | Never observed to completion in the nightly. Successful single-shard `workflow_dispatch` runs on 07-23 completed in 6–15 minutes wall clock including ~5 minutes of setup, so 120 is roughly an order of magnitude of headroom without approaching the hosted cap. |
| `app-control` | 120 min | Same basis. |
| `scenario-runner-view-chat` | 60 min | Bounded to its one declared scenario id (`live-document-delete`), so it is the smallest shard. |

These live in `live-scenario-shards.json` alongside each shard's root/report/runDir, and a test asserts every one stays inside the hosted cap. They are deliberately generous rather than tight — the point is to stop reaping runs that are working, not to police duration.

### Verification run

```
$ python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/live-scenarios.yml'))"
$ python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/actions-zombie-janitor.yml'))"
(both parse clean)

$ actionlint .github/workflows/live-scenarios.yml .github/workflows/actions-zombie-janitor.yml
(no findings)

$ biome check --write packages/scripts/live-scenario-contract.mjs \
    packages/scripts/__tests__/live-scenarios-workflow.test.ts \
    packages/scripts/live-scenario-shards.json
Checked 3 files. (clean)

$ bun test packages/scripts/__tests__/live-scenarios-workflow.test.ts
16 pass, 2 fail
```

**Real single-shard validation run on this branch** — https://github.com/elizaOS/eliza/actions/runs/30600446780 — all three jobs green:

```
Resolve requested shards                     success
Live scenarios (scenario-runner-view-chat)   success
Live scenarios aggregate gate                success
```

The shard leg ran the full path end to end against live credentials: placeholder → preflight → dependency build → `Run live scenarios` → `Verify this shard published its evidence contract` → `Record shard outcome` → per-shard artifact upload. The gate then downloaded `live-scenario-report-scenario-runner-view-chat` and asserted its outcome record.

An earlier run of the same shard (https://github.com/elizaOS/eliza/actions/runs/30599687101) had the shard leg pass and the gate fail with `scenario-runner-view-chat=no-outcome-artifact` — the download flattens differently depending on how many artifacts match the pattern. The gate now walks the download and indexes each `shard-outcome.json` by its own `shard` field, so it does not depend on path depth; the second run above is that fix passing. This is the gate correctly refusing to call a lane green when it cannot see a shard's outcome.

The two failures are `reports uncovered live-only scenarios as explicit deferrals` and `discovers the orchestrator live evidence in the scheduled catalog`; both are scenario-catalog discovery tests that time out in a fresh detached worktree and do not touch any file in this diff. All workflow-structure, manifest, matrix-resolution, and gate assertions pass.

New/updated assertions in `live-scenarios-workflow.test.ts`:
- manifest cost ceiling now records 4 concurrent shards, and every shard's `timeoutMinutes` must stay inside the hosted cap;
- workflow pins `fail-fast: false`, the matrix wiring, the per-shard `timeout-minutes`, the per-shard artifact name, and the `gate` invocation;
- janitor pins the three-entry exempt default;
- `resolveShardMatrix` covers scheduled fan-out, single-shard dispatch, shard-prefixed filter inference, the `'all'` + filter rejection, and an unknown shard name;
- `gateShardOutcomes` covers pass, a failed shard, and a shard with **no** outcome artifact (the reaped case).

## Evidence

<!-- evidence-row:before-screenshots -->
- **Before screenshots:** N/A - CI workflow and Node script change only; no rendered UI surface is touched.

<!-- evidence-row:after-screenshots -->
- **After screenshots:** N/A - CI workflow and Node script change only; no rendered UI surface is touched.

<!-- evidence-row:walkthrough-video -->
- **Walkthrough video:** N/A - CI workflow and Node script change only; there is no user-exercisable flow to record.

<!-- evidence-row:backend-logs -->
- **Backend logs:** Reaped nightly (the bug): https://github.com/elizaOS/eliza/actions/runs/30530353943 — this branch's single-shard validation run: https://github.com/elizaOS/eliza/actions/runs/30599687101 . GitHub Actions step timings for the reaped nightly run `30530353943` are quoted above and show the exact failure shape (setup+build 09:22:40→09:27:40, `Run EA + connector live scenarios` 09:27:40→11:22:51 cancelled, remaining three shards skipped). Local command output for YAML validation, actionlint, biome, and `bun test` is quoted verbatim in the Testing section.

<!-- evidence-row:frontend-logs -->
- **Frontend console/network logs:** N/A - no frontend code is involved in this change.

<!-- evidence-row:llm-trajectory -->
- **Real-LLM trajectory:** N/A - this change does not alter agent, action, provider, prompt, or model behaviour; it changes only how the existing live-scenario jobs are scheduled. The scenarios and the runner invocation (including `--lane live-only` per shard and the view-chat shard's `live-document-delete` restriction) are byte-identical in effect. The trajectories this lane produces are precisely what the 19-night outage has been preventing, and the lane itself is the instrument that will emit them once it can run.

<!-- evidence-row:domain-artifacts -->
- **Domain artifacts:** Per-shard evidence bundle from the validation run: https://github.com/elizaOS/eliza/actions/runs/30599687101 (artifact `live-scenario-report-scenario-runner-view-chat`, containing the shard report, run dir, and the new `shard-outcome.json`). The artifact this change produces is the per-shard evidence bundle and the new `shard-outcome.json` contract. `packages/scripts/live-scenario-shards.json` is the checked-in declaration of every shard's root, report path, run directory, lane, and timeout; the aggregate gate reads the resulting artifacts back. Unit tests exercise the produced/consumed shapes directly (`gateShardOutcomes` pass / failed / missing-artifact).
