### PR TITLE
fix(scenario-runner): drop duplicate agentId stamps from merged turns

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -1552,7 +1552,6 @@ async function executeMessageTurn(
 
   const message: Memory = createMessageMemory({
     id: crypto.randomUUID() as UUID,
-    agentId: runtime.agentId,
     entityId: room.userId,
     // Real transports stamp the receiving agent on every inbound turn, and the
     // owner-private disclosure gate REQUIRES it: an absent `agentId` is denied
@@ -1683,7 +1682,6 @@ async function executeActionTurn(
       : {};
   const message: Memory = createMessageMemory({
     id: crypto.randomUUID() as UUID,
-    agentId: runtime.agentId,
     entityId: room.userId,
     // See the message-turn construction above: the owner-private disclosure
     // gate denies an agentId-less turn as `agent_mismatch`.


### PR DESCRIPTION
Two concurrent fixes for the same missing-agentId defect landed within minutes (#17321 squash-merged over a sibling swarm merge that had added the same stamp bare), leaving both createMessageMemory literals in executor.ts with two agentId properties. TS1117 — an object literal cannot have multiple properties with the same name — now fails @elizaos/scenario-runner typecheck on develop and therefore the typecheck lane of every open PR (first seen on #17285's run, job 91055126466).

This keeps the comment-carrying stamp and drops the bare duplicate at both sites (executeMessageTurn ~:1553, executeActionTurn ~:1684). No behavior change: both properties stamped the identical value, and the later one won at runtime.

Merging immediately as a develop-unbreak under the sweep's review authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)