### PR TITLE
fix(scripts): restore LifeOps coupling audit baseline

### DIFF
--- a/packages/scripts/script-plugin-coupling.allowlist.json
+++ b/packages/scripts/script-plugin-coupling.allowlist.json
@@ -225,7 +225,10 @@
   {
     "file": "scripts/lifeops-bench/export-action-manifest.ts",
     "tokens": [
+      "@elizaos/plugin-calendar",
+      "@elizaos/plugin-personal-assistant",
       "plugins/plugin-bluebubbles",
+      "plugins/plugin-calendar",
       "plugins/plugin-contacts",
       "plugins/plugin-imessage",
       "plugins/plugin-personal-assistant",


### PR DESCRIPTION
## What

Restores the repository verification baseline by adding the three real LifeOps manifest-source tokens to the script coupling audit's existing, narrowly scoped allowlist entry:

- `@elizaos/plugin-calendar`
- `@elizaos/plugin-personal-assistant`
- `plugins/plugin-calendar`

The generic-script audit remains fail-closed. This does not add a broad exemption or change the script; it makes the documented fixed LifeOps source set complete and keeps stale-token detection active.

Fixes #17355

## Validation

- `bun run audit:scripts`: pass
- `bun run audit:scripts:self-test`: pass
- Biome on the allowlist: pass
- `git diff --check`: pass

<!-- evidence-row:before-screenshots -->
- [x] N/A - repository audit metadata only; no visual surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - repository audit metadata only; no visual surface

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior

<!-- evidence-row:domain-artifacts -->
- [x] [Fail-closed audit result](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17356-pr-17355-audit.log)

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual evidence

<!-- evidence-row:backend-logs -->
- [x] [Passing script audit, self-test, formatting, and diff transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17356-pr-17355-audit.log)
