### PR TITLE
fix(homepage): give each CI runner its own e2e port (fixed 4444 collides across co-hosted runners)

### DIFF
--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -9,7 +9,7 @@
     "build": "bun --bun vite build",
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
-    "test": "bun test tests/smoke.node.test.mjs tests/contact.test.ts edge/apple-app-site-association.test.ts",
+    "test": "bun test tests/smoke.node.test.mjs tests/e2e-port.node.test.mjs tests/contact.test.ts edge/apple-app-site-association.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/playwright.config.ts
+++ b/packages/homepage/playwright.config.ts
@@ -3,8 +3,12 @@
  */
 import path from "node:path";
 import { defineConfig, devices } from "playwright/test";
+import { resolveHomepageE2eBaseUrl } from "./scripts/e2e-port.mjs";
 
 const recording = !!process.env.E2E_RECORD;
+// Per-runner port: 6-8 self-hosted runners share a host, and a fixed port made
+// two concurrent homepage jobs race for it (see scripts/e2e-port.mjs).
+const baseURL = resolveHomepageE2eBaseUrl();
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -23,14 +27,14 @@ export default defineConfig({
       )
     : "./test-results",
   use: {
-    baseURL: "http://127.0.0.1:4444",
+    baseURL,
     trace: recording ? "on" : "retain-on-failure",
     screenshot: recording ? "on" : "only-on-failure",
     video: recording ? "on" : "retain-on-failure",
   },
   webServer: {
     command: "node scripts/run-playwright-web-server.mjs",
-    url: "http://127.0.0.1:4444",
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 240_000,
   },

--- a/packages/homepage/scripts/e2e-port.mjs
+++ b/packages/homepage/scripts/e2e-port.mjs
@@ -1,0 +1,48 @@
+/**
+ * Resolves the port the homepage e2e web server binds and the suite targets.
+ *
+ * The port used to be the literal 4444. Self-hosted CI puts 6-8 runners on one
+ * host, so two homepage e2e jobs landing on the same machine raced for that
+ * single port and the loser died instantly with "http://127.0.0.1:4444 is
+ * already used" — a failure with no relationship to the diff under test.
+ *
+ * A runner executes at most one job at a time, so GitHub's per-runner
+ * `RUNNER_NAME` is a collision-free discriminator: deriving a deterministic
+ * offset from it gives every runner on a host its own port, with no
+ * check-then-bind race (which a "find a free port" scan would reintroduce).
+ * Locally, where no RUNNER_NAME exists, the historical 4444 is preserved.
+ */
+
+const BASE_PORT = 4444;
+/** Ports BASE_PORT..BASE_PORT+SPAN-1; comfortably wider than runners per host. */
+const SPAN = 64;
+
+export function resolveHomepageE2ePort(env = process.env) {
+  const explicit = env.HOMEPAGE_E2E_PORT?.trim();
+  if (explicit) {
+    const parsed = Number(explicit);
+    if (!Number.isInteger(parsed) || parsed < 1024 || parsed > 65535) {
+      throw new Error(
+        `HOMEPAGE_E2E_PORT must be an integer between 1024 and 65535, received ${explicit}`,
+      );
+    }
+    return parsed;
+  }
+
+  const runner = env.RUNNER_NAME?.trim();
+  if (!runner) return BASE_PORT;
+
+  // FNV-1a: stable across processes and Node versions, unlike hashCode-style
+  // ad-hoc sums. The config and the web server must agree on the port, and
+  // they compute it independently.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < runner.length; i += 1) {
+    hash ^= runner.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return BASE_PORT + (hash % SPAN);
+}
+
+export function resolveHomepageE2eBaseUrl(env = process.env) {
+  return `http://127.0.0.1:${resolveHomepageE2ePort(env)}`;
+}

--- a/packages/homepage/scripts/run-playwright-web-server.mjs
+++ b/packages/homepage/scripts/run-playwright-web-server.mjs
@@ -1,13 +1,15 @@
 /**
  * Playwright web-server launcher for homepage e2e tests.
  *
- * The script syncs shared public assets before starting Vite on the fixed
- * homepage port so route and visual tests exercise the same static assets as
- * local development.
+ * The script syncs shared public assets before starting Vite on the homepage
+ * e2e port so route and visual tests exercise the same static assets as local
+ * development. The port is resolved per runner (see e2e-port.mjs) because a
+ * fixed one collided between concurrent jobs on a shared self-hosted host.
  */
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveHomepageE2ePort } from "./e2e-port.mjs";
 
 const homepageDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -46,7 +48,13 @@ if ((sync.status ?? 1) !== 0) {
 
 const vite = spawn(
   process.execPath,
-  [viteScript, "--host", "127.0.0.1", "--port", "4444"],
+  [
+    viteScript,
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(resolveHomepageE2ePort()),
+  ],
   {
     cwd: homepageDir,
     env: {

--- a/packages/homepage/tests/e2e-port.node.test.mjs
+++ b/packages/homepage/tests/e2e-port.node.test.mjs
@@ -1,0 +1,57 @@
+/**
+ * Pins the per-runner e2e port resolution (#17357 CI class).
+ *
+ * A fixed 4444 made two homepage e2e jobs on the same self-hosted host race
+ * for one port; the loser died with "already used" regardless of its diff.
+ * These assert the properties that make the fix correct: determinism (the
+ * config and the web server resolve independently and MUST agree), distinctness
+ * across the runners that share a host, and an unchanged local default.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  resolveHomepageE2eBaseUrl,
+  resolveHomepageE2ePort,
+} from "../scripts/e2e-port.mjs";
+
+test("no runner name keeps the historical local port", () => {
+  assert.equal(resolveHomepageE2ePort({}), 4444);
+  assert.equal(resolveHomepageE2eBaseUrl({}), "http://127.0.0.1:4444");
+});
+
+test("the same runner always resolves the same port", () => {
+  const env = { RUNNER_NAME: "eliza-prod-robot-2-r3" };
+  const first = resolveHomepageE2ePort(env);
+  assert.equal(resolveHomepageE2ePort(env), first);
+  // The config and the web server compute this in separate processes; a
+  // non-deterministic hash would bind one port and probe another.
+  assert.equal(resolveHomepageE2eBaseUrl(env), `http://127.0.0.1:${first}`);
+});
+
+test("runners that share a host get distinct ports", () => {
+  // The exact fleet layout that collided: six runners on one box.
+  const ports = ["r1", "r2", "r3", "r4", "r5", "r6"].map((r) =>
+    resolveHomepageE2ePort({ RUNNER_NAME: `eliza-prod-robot-2-${r}` }),
+  );
+  assert.equal(new Set(ports).size, ports.length, `collision within ${ports}`);
+});
+
+test("ports stay inside the reserved window", () => {
+  for (const host of ["2", "3", "4", "5", "6"]) {
+    for (const r of ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]) {
+      const port = resolveHomepageE2ePort({
+        RUNNER_NAME: `eliza-prod-robot-${host}-${r}`,
+      });
+      assert.ok(port >= 4444 && port < 4444 + 64, `${port} out of window`);
+    }
+  }
+});
+
+test("an explicit override wins and is validated", () => {
+  assert.equal(
+    resolveHomepageE2ePort({ HOMEPAGE_E2E_PORT: "5000", RUNNER_NAME: "x" }),
+    5000,
+  );
+  assert.throws(() => resolveHomepageE2ePort({ HOMEPAGE_E2E_PORT: "80" }));
+  assert.throws(() => resolveHomepageE2ePort({ HOMEPAGE_E2E_PORT: "abc" }));
+});


### PR DESCRIPTION
## The bug, from a real failing job

`#17348` is a **config-only PR: 2 files, 10 lines** (a wrangler value and a script constant). It failed `Build`, `typecheck`, `Type Check`, `unit-tests`, `lint-and-types`. The Build log says why:

```
Error: http://127.0.0.1:4444 is already used, make sure that nothing is running
on the port/url or set reuseExistingServer:true in config.webServer.
error: script "test:e2e" exited with code 1
```

The homepage e2e web server binds the **literal port 4444** — in `playwright.config.ts` (`baseURL` + `webServer.url`) and in `scripts/run-playwright-web-server.mjs` (`--port 4444`). Self-hosted CI puts **6–8 runners on one host** (measured on the prod robots), so two homepage e2e jobs landing on the same machine race for that single port and the loser dies instantly — **with no relationship to the diff under test**.

This explains the pattern we have been rerunning through for two days: config-only PRs failing compile lanes, reruns sometimes passing (did a peer job overlap this time?), and the whole thing worsening exactly as the homepage suite became the site's main surface.

## The fix

A runner executes at most one job at a time, so GitHub's per-runner `RUNNER_NAME` is a **collision-free discriminator by construction**. The port is derived from it via FNV-1a into a 64-wide window above 4444:

- **deterministic** — the config and the launcher resolve it in *separate processes* and must agree; a non-deterministic hash would bind one port and probe another;
- **no check-then-bind race** — a "scan for a free port" approach would reintroduce exactly the TOCTOU this is fixing;
- **local runs unchanged** — no `RUNNER_NAME` keeps the historical 4444;
- `HOMEPAGE_E2E_PORT` overrides explicitly, validated (1024–65535, integer).

Before / after on the six runners of `eliza-prod-robot-2`:

```
BEFORE — distinct ports: 1 of 6   → collision guaranteed
AFTER  — distinct ports: 6 of 6   → 4504, 4497, 4478, 4447, 4492, 4485
```

## Tests

`5 pass / 0 fail` pinning the properties the fix rests on: determinism across processes, distinctness across the six co-hosted runners, the reserved window across the whole fleet (5 hosts × 8 runners), the local default, and override validation.

The test is added to the package `test` script, which enumerates its files individually — a new file there is otherwise never executed.

## Scope

Only the homepage suite is fixed. `packages/os/homepage` (4455) and `packages/os/usb-installer` (4456) carry the same fixed-port design and will collide the same way once their suites run concurrently on shared runners; they are lower traffic today. Same-package collision is the failure mode — the ports do not clash across packages.

Root-cause context and the fleet measurements are in #17357. [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI infrastructure fix, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI infrastructure fix, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI infrastructure fix, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - CI infrastructure fix, no runtime frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by the backend-logs port-distribution proof

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17358-port-ev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17358-port-ev.log)
