### PR TITLE
fix(homepage): fail the build when a channel identifier is missing

### DIFF
--- a/.github/workflows/deploy-homepage.yml
+++ b/.github/workflows/deploy-homepage.yml
@@ -111,10 +111,45 @@ jobs:
           echo "::warning::No complete published release data is available; skipping homepage deploy for this develop push."
           echo "available=false" >> "$GITHUB_OUTPUT"
 
+      # Vite inlines import.meta.env at BUILD time, so these must be present
+      # here — a Pages project variable cannot reach the bundle. An empty value
+      # silently ships dead provider buttons ("Telegram not configured",
+      # Discord OAuth bouncing back, WhatsApp falling back to the SMS number),
+      # which is what #17336 was closed for. Fail loudly instead (#17340).
+      - name: Verify channel build config
+        if: steps.release_data_check.outputs.available == 'true'
+        shell: bash
+        env:
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          VITE_DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
+        run: |
+          missing=()
+          for name in VITE_TELEGRAM_BOT_ID VITE_TELEGRAM_BOT_USERNAME \
+                      VITE_DISCORD_CLIENT_ID VITE_WHATSAPP_PHONE_NUMBER; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repository variables: ${missing[*]}"
+            echo "::error::Vite inlines these at build time; without them the"
+            echo "::error::published bundle ships non-functional channel buttons."
+            echo "::error::Create them under Settings -> Actions -> Variables."
+            echo "::error::They are public identifiers, not secrets - the bundle"
+            echo "::error::exposes them either way."
+            exit 1
+          fi
+          echo "All four channel identifiers are present."
+
       - name: Build homepage
         if: steps.release_data_check.outputs.available == 'true'
         working-directory: packages/homepage
         run: bun run build
+        env:
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          VITE_DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
 
       - name: Install homepage browser
         if: steps.release_data_check.outputs.available == 'true'

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --ogembeds --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs",
     "dev": "bun --bun vite",
-    "prebuild": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --ogembeds --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs",
+    "prebuild": "node scripts/verify-channel-build-config.mjs && node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --ogembeds --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs",
     "build": "bun --bun vite build",
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",

--- a/packages/homepage/scripts/verify-channel-build-config.mjs
+++ b/packages/homepage/scripts/verify-channel-build-config.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Fails the homepage build when a channel identifier is missing.
+ *
+ * Vite inlines `import.meta.env` at build time, so an unset variable does not
+ * fail — it bakes an empty string into the bundle and the site ships silently
+ * broken provider buttons: "Telegram not configured", Discord OAuth bouncing
+ * back to method selection, WhatsApp falling back to the SMS number. #17336
+ * was closed for exactly that. The CI workflow guards this too; running it
+ * from `prebuild` means a local or Pages-side build cannot bypass the check
+ * either.
+ *
+ * Skipped outside CI unless ELIZA_REQUIRE_CHANNEL_CONFIG=1, so day-to-day
+ * local development is unaffected.
+ */
+
+const REQUIRED = [
+  ["VITE_TELEGRAM_BOT_ID", "Telegram OAuth (get-started login)"],
+  ["VITE_TELEGRAM_BOT_USERNAME", "Telegram Login Widget (data-telegram-login)"],
+  ["VITE_DISCORD_CLIENT_ID", "Discord OAuth (get-started + connected)"],
+  [
+    "VITE_WHATSAPP_PHONE_NUMBER",
+    "WhatsApp deep link (falls back to the SMS number)",
+  ],
+];
+
+const enforced =
+  process.env.ELIZA_REQUIRE_CHANNEL_CONFIG === "1" || process.env.CI === "true";
+
+if (!enforced) {
+  process.exit(0);
+}
+
+const missing = REQUIRED.filter(([name]) => !process.env[name]?.trim());
+
+if (missing.length > 0) {
+  console.error("Missing channel build configuration:\n");
+  for (const [name, purpose] of missing) {
+    console.error(`  ${name}  —  ${purpose}`);
+  }
+  console.error(
+    "\nVite inlines these at build time, so an unset value ships a bundle with" +
+      "\nnon-functional channel buttons rather than failing. They are public" +
+      "\nidentifiers, not secrets — the bundle exposes them either way." +
+      "\nSet them as repository variables (Settings -> Actions -> Variables).\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Channel build configuration present (${REQUIRED.length}/${REQUIRED.length}).`,
+);


### PR DESCRIPTION
## What

#17336's closing note asks a replacement cutover to "fail the build when required public identifiers are absent". This implements that half, standalone and independent of any homepage redesign.

Vite inlines `import.meta.env` at **build** time, so an unset `VITE_TELEGRAM_BOT_ID` or `VITE_DISCORD_CLIENT_ID` does **not** fail — it bakes an empty string into the bundle. The site then ships provider buttons that are silently dead: "Telegram not configured" (`get-started.tsx:686-694`), Discord OAuth bouncing back to method selection (`:434-445`), and WhatsApp falling back to the SMS number (`contact.ts:9`). That is precisely the outcome #17336 was closed for.

## Two layers, because the failure mode is silence

1. **Deploy workflow** — supplies the four values from repository variables and refuses to build when any is empty, naming the missing ones and explaining that they are public identifiers, not secrets.
2. **Prebuild guard** (`scripts/verify-channel-build-config.mjs`) — enforces the same contract from inside the package, so a build started outside this workflow cannot bypass it. Inert outside CI unless `ELIZA_REQUIRE_CHANNEL_CONFIG=1`, so local development is unaffected.

The env is scoped to the **build step**, not the job: `scripts/run-playwright-web-server.mjs` spawns a Vite dev server inheriting `process.env`, and job-level values would reach the visual-snapshot run for `/get-started` and `/connected` and could diff the baselines.

## Verification

```
actionlint .github/workflows/deploy-homepage.yml   → clean

CI=true (no vars)                        → exit 1, lists all four
CI=true (all four set)                   → exit 0
CI=true (one var is whitespace only)     → exit 1   # trimmed, not just present
unset CI, no ELIZA_REQUIRE_CHANNEL_CONFIG → exit 0   # local dev untouched
```

## The remaining operational step

Creating the four repository variables (Settings → Actions → Variables) needs a repo admin — I work from a fork. The point of this PR is that until they exist the build **says so** instead of publishing dead buttons.

Not in scope, from #17336's closing list: the provider-side allowlists (the live Telegram Login Widget rejecting `eliza.app` with `Bot domain invalid` is a Telegram BotFather domain setting, not a repo change) and the real end-to-end provider run, which can only happen after a corrected build is deployed.

Refs #17340 · #17323 · context in #17336 [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - build-config guard, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - build-config guard, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - build-config guard, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no runtime frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by the backend-logs guard transcript

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17360-vite-ev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17360-vite-ev.log)
