### PR TITLE
fix(cloud): make fence-less replacement adoption reachable

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Proves that replacement adoption accepts preserved Docker handles without a
+ * durable replacement fence while rejecting handles that do not match the primary row.
+ * The service and repository run against the real Drizzle schema in isolated PGlite.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL;
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === undefined || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { organizations } from "../../../db/schemas/organizations";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+
+type AdoptionInternals = {
+  transferReplacementToPrimary: (
+    agentId: string,
+    orgId: string,
+    handle: {
+      sandboxId: string;
+      bridgeUrl: string;
+      healthUrl: string;
+      metadata?: Record<string, unknown>;
+    },
+    expectedEnvironmentRevision: number,
+    updateData: Record<string, unknown>,
+  ) => Promise<{ id: string; status: string }>;
+};
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedProvisioningAgent(params: {
+  sandboxId: string | null;
+}): Promise<{ id: string; orgId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "1.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  const [rec] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: org.id,
+      user_id: user.id,
+      agent_name: uniq("adopt"),
+      status: "provisioning",
+      execution_tier: "dedicated-always",
+      environment_revision: 0,
+      sandbox_id: params.sandboxId,
+    })
+    .returning();
+  return { id: rec.id, orgId: org.id };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    throw new Error("Replacement-adoption tests require an isolated PGlite database");
+  }
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+  const schema = { organizations, users, userCharacters, agentSandboxes };
+  const { apply } = await pushSchema(schema as never, dbWrite as never);
+  await apply();
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("fence-less replacement adoption (#17253 §4)", () => {
+  test(
+    "an ADOPTED handle (no replacement metadata) completes the transfer",
+    async () => {
+      const { id, orgId } = await seedProvisioningAgent({ sandboxId: "agent-preserved" });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      // Preserved retry handles intentionally omit replacement metadata because
+      // their identity is already recorded on the primary row.
+      const adopted = await svc.transferReplacementToPrimary(
+        id,
+        orgId,
+        {
+          sandboxId: "agent-preserved",
+          bridgeUrl: "https://runtime.example",
+          healthUrl: "https://runtime.example/health",
+          metadata: { provider: "docker", nodeId: "node-1", containerName: "agent-preserved" },
+        },
+        0,
+        { status: "running" },
+      );
+
+      expect(adopted.status).toBe("running");
+      const row = await dbWrite.query.agentSandboxes.findFirst({
+        where: sql`${agentSandboxes.id} = ${id}`,
+      });
+      expect(row?.status).toBe("running");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a fence-less docker handle whose sandboxId does NOT match is still refused",
+    async () => {
+      const { id, orgId } = await seedProvisioningAgent({ sandboxId: "agent-original" });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      await expect(
+        svc.transferReplacementToPrimary(
+          id,
+          orgId,
+          {
+            sandboxId: "agent-imposter",
+            bridgeUrl: "https://runtime.example",
+            healthUrl: "https://runtime.example/health",
+            metadata: { provider: "docker", nodeId: "node-1", containerName: "agent-imposter" },
+          },
+          0,
+          { status: "running" },
+        ),
+      ).rejects.toThrow("Docker replacement has no durable cleanup ownership");
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8933,8 +8933,11 @@ export class ElizaSandboxService {
       }
 
       const locator = this.getReplacementCleanupLocator(current);
-      const incoming = this.replacementLocatorFromHandle(handle);
       if (locator) {
+        // A preserved retry handle has no replacement metadata because its
+        // identity already lives on the primary row. Construct the replacement
+        // locator only when a durable replacement fence exists to compare it to.
+        const incoming = this.replacementLocatorFromHandle(handle);
         this.assertSameReplacementIdentity(locator, incoming);
         if (
           locator.containerId !== incoming.containerId ||


### PR DESCRIPTION
## What

A preserved Docker container can be adopted after a provisioning retry without carrying replacement metadata: its identity already lives on the primary sandbox row. `transferReplacementToPrimary` nevertheless constructed a replacement locator before checking whether a durable replacement fence existed. That constructor rejects fence-less handles, so the adoption branch could never run.

## Fix

Construct the replacement locator only when a durable replacement fence exists to compare. The fence-less Docker path retains its independent ownership guard and still rejects a handle whose `sandboxId` does not match the primary row.

The database-backed regression test drives the real service and Drizzle repository in isolated PGlite:

- a matching preserved handle advances the primary row to `running`;
- a fence-less handle with a mismatched sandbox ID is rejected.

This recuts #17287 onto current `develop`, preserves @standujar as the commit author, removes the empty CI-refresh commit, and makes test setup fail directly rather than catching initialization errors.

Refs #17253 §4
Supersedes #17287

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only lifecycle change with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only lifecycle change with no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only lifecycle change with no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only lifecycle change with no frontend path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the durable sandbox-row state transition is asserted by the PGlite regression test

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence

<!-- evidence-row:backend-logs -->
- [ ] N/A - exact-head CI exercises the deterministic service and database path; no deployed backend is changed by this PR
