### PR TITLE
fix(scenario-runner): align app-control edit assertions with single delivery

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -1015,7 +1015,9 @@ export default scenario({
         editTarget: "feed",
         intent: "Tighten the feed app table density",
       },
-      responseIncludesAny: ["Started app edit task for Feed"],
+      // Chat gets one human sentence; the dispatch internals (workdir, session
+      // id, APP_CREATE_DONE) stay planner-facing in the action result text.
+      responseIncludesAny: ["Updating Feed now"],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "APP",
@@ -1024,8 +1026,10 @@ export default scenario({
             editTarget: "feed",
             intent: "Tighten the feed app table density",
           },
-          responseText: `Started app edit task for Feed at ${feedPluginDir}. Task session scenario-edit-app-feed is running; verification will run when it emits APP_CREATE_DONE.`,
+          responseText:
+            "Updating Feed now — I'll post the link once the changes are live (usually takes a few minutes).",
           resultFields: {
+            text: `Started app edit task for Feed at ${feedPluginDir}. Task session scenario-edit-app-feed is running; verification runs when it emits APP_CREATE_DONE.`,
             "values.mode": "create",
             "values.subMode": "edit",
             "values.name": "feed",

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -524,7 +524,10 @@ export default scenario({
               editTarget: "feed",
               intent: "Tighten the feed app table density",
             },
-            `Started app edit task for Feed at ${feedPluginDir}. Task session scenario-edit-app-feed is running; verification will run when it emits APP_CREATE_DONE.`,
+            // Deliberately distinct from the action's own callback text: the APP
+            // edit path opts into single delivery, so this planner bubble must
+            // never reach chat. The turn asserts the callback sentence instead.
+            "Planner re-render that must not be delivered for the APP edit turn.",
           ),
           handleResponseFixture("Delete the remote ledger view", "VIEWS"),
           plannerFixture(
@@ -786,7 +789,9 @@ export default scenario({
       kind: "message",
       name: "natural language edits an app",
       text: "Edit the feed app",
-      responseIncludesAny: ["Started app edit task for Feed"],
+      // The APP edit path delivers a single human sentence to chat; the dispatch
+      // detail below stays planner-facing in the action result text.
+      responseIncludesAny: ["Updating Feed now"],
       assertTurn: (execution) =>
         expectRoutedAction(execution, {
           actionName: "APP",
@@ -796,6 +801,7 @@ export default scenario({
             intent: "Tighten the feed app table density",
           },
           resultFields: {
+            text: `Started app edit task for Feed at ${feedPluginDir}. Task session scenario-edit-app-feed is running; verification runs when it emits APP_CREATE_DONE.`,
             "values.mode": "create",
             "values.subMode": "edit",
             "values.name": "feed",


### PR DESCRIPTION
## Problem

The **Zero-Key scenario runner** job is red on `develop` — 38 passed / 2 failed of 40 ([run 30601615368](https://github.com/elizaOS/eliza/actions/runs/30601615368/job/91065531188), head `0e5aabbc1f4`):

```
| deterministic-app-control-actions    | failed | 525ms   | assertTurn: expected responseText="Started app edit task for Feed at …
| deterministic-app-control-nl-routing | failed | 10855ms | responseIncludesAny: expected response to include any of [Started app edit task for Feed], saw "Updating Feed now — I'll post the link once …
```

Root cause: [#17331](https://github.com/elizaOS/eliza/pull/17331) (`f54b27296ca`) deliberately split the APP create/edit dispatch message — chat gets one human sentence, the dispatch internals (absolute workdir, task session id, `APP_CREATE_DONE`) stay planner-facing in the action result `text`, with `verifiedUserFacing` + `turnComplete` opting into single delivery:

```ts
// plugins/plugin-app-control/src/actions/app-create.ts:827
const text = `Updating ${app.displayName} now — I'll post the link once the changes are live (usually takes a few minutes).`;
const dispatchDetail = `Started app edit task for ${app.displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification runs when it emits APP_CREATE_DONE.`;
```

The two deterministic app-control scenarios were never updated for the split, so they still asserted the old combined string against the user-visible response. This is assertion drift, not a product regression — the shipped behavior is the intended one.

## Fix

Both turns now assert **both halves** of the split rather than dropping the detail:

- `responseText` / `responseIncludesAny` → the user-facing sentence (`"Updating Feed now"`).
- `resultFields.text` → the full planner-facing dispatch detail, so a regression in either half still fails.

The nl-routing planner fixture's `messageToUser` is now a deliberately distinct sentinel instead of a copy of the old dispatch text. Since the turn asserts the callback sentence, that keeps the assertion a live proof that single-delivery suppression still holds — if the planner bubble ever reached chat again, the turn would fail.

Repo-wide grep confirms no other test or scenario asserts either dispatch string; the only remaining occurrences are the two `app-create.ts` sources and prebuilt `dist` bundles.

## Verification

```
SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun src/cli.ts run test/scenarios \
  --lane pr-deterministic --scenario deterministic-app-control-actions,deterministic-app-control-nl-routing
```

<details><summary>Runner output — 2 passed, 0 failed</summary>

```
 Info  [eliza-scenarios] ✓ deterministic-app-control-actions passed (752ms)
 Info  [eliza-scenarios] ✓ deterministic-app-control-nl-routing passed (8373ms)

| id                                   | status | duration | failures |
| ---                                  | ---    | ---      | ---      |
| deterministic-app-control-actions    | passed | 752ms    |          |
| deterministic-app-control-nl-routing | passed | 8373ms   |          |

Totals: 2 passed, 0 failed, 0 skipped of 2
```
</details>

- `bun run --cwd packages/scenario-runner typecheck` — clean.
- `biome check` on both changed files — clean.

## Evidence

Changed files are two `.scenario.ts` assertion files under `packages/scenario-runner/test/scenarios/`. No product code, no UI surface, and no agent/action/provider/prompt/model behavior is touched — the scenarios are `pr-deterministic` lane fixtures that run keyless under the LLM proxy by design.

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-assertion-only change; no UI surface is touched by either changed file (packages/scenario-runner/test/scenarios/*.scenario.ts).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-assertion-only change; no UI surface is touched by either changed file.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-reachable flow changes; the artifact for this change is the scenario runner output quoted above.`
<!-- evidence-row:backend-logs -->
- [x] Scenario-runner output showing both previously-failing scenarios executing the real APP edit path and passing is quoted in the Verification section, and the failing baseline it fixes is at https://github.com/elizaOS/eliza/actions/runs/30601615368/job/91065531188
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code path is exercised; the change is confined to scenario assertions run headlessly by the scenario runner CLI.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; these scenarios are pr-deterministic lane fixtures that run under the deterministic LLM proxy with zero credentials, so a live-model trajectory is not the artifact for them. The proxy-backed run output is quoted above and this PR's own Zero-Key scenario runner job re-runs it: https://github.com/elizaOS/eliza/pull/17364/checks`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact for this change is the scenario report the runner writes; both turns now pin the action result `text` (the planner-facing dispatch detail) in addition to the user-facing response, so the report captures both halves of the split. Baseline failure report: https://github.com/elizaOS/eliza/actions/runs/30601615368/artifacts/8782204937

---

Note: the branch name is stale — it carried the already-merged [#17338](https://github.com/elizaOS/eliza/pull/17338); the contents are only this one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
