### PR TITLE
fix(homepage): fail deploys missing channel identifiers

### DIFF
--- a/.github/workflows/deploy-homepage.yml
+++ b/.github/workflows/deploy-homepage.yml
@@ -111,10 +111,29 @@ jobs:
           echo "::warning::No complete published release data is available; skipping homepage deploy for this develop push."
           echo "available=false" >> "$GITHUB_OUTPUT"
 
+      # Vite inlines these identifiers into the public bundle. Verifying them
+      # at the deploy boundary prevents publishing inactive channel controls.
+      - name: Verify channel build config
+        if: steps.release_data_check.outputs.available == 'true'
+        working-directory: packages/homepage
+        env:
+          ELIZA_REQUIRE_CHANNEL_CONFIG: "1"
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          VITE_DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
+        run: node scripts/verify-channel-build-config.mjs
+
       - name: Build homepage
         if: steps.release_data_check.outputs.available == 'true'
         working-directory: packages/homepage
         run: bun run build
+        env:
+          ELIZA_REQUIRE_CHANNEL_CONFIG: "1"
+          VITE_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          VITE_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          VITE_DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+          VITE_WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
 
       - name: Install homepage browser
         if: steps.release_data_check.outputs.available == 'true'

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --ogembeds --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs",
     "dev": "bun --bun vite",
-    "prebuild": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --ogembeds --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs",
+    "prebuild": "node scripts/verify-channel-build-config.mjs && node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --ogembeds --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs",
     "build": "bun --bun vite build",
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
-    "test": "bun test tests/smoke.node.test.mjs tests/e2e-port.node.test.mjs tests/contact.test.ts edge/apple-app-site-association.test.ts",
+    "test": "bun test tests/smoke.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts edge/apple-app-site-association.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/scripts/verify-channel-build-config.mjs
+++ b/packages/homepage/scripts/verify-channel-build-config.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Enforces the public channel identifiers required by a deployable homepage bundle.
+ * Deployment opts into the guard explicitly so generic CI and local builds can
+ * compile the site without production provider configuration.
+ */
+
+const REQUIRED = [
+  ["VITE_TELEGRAM_BOT_ID", "Telegram OAuth (get-started login)"],
+  ["VITE_TELEGRAM_BOT_USERNAME", "Telegram Login Widget (data-telegram-login)"],
+  ["VITE_DISCORD_CLIENT_ID", "Discord OAuth (get-started + connected)"],
+  [
+    "VITE_WHATSAPP_PHONE_NUMBER",
+    "WhatsApp deep link (falls back to the SMS number)",
+  ],
+];
+
+const enforced = process.env.ELIZA_REQUIRE_CHANNEL_CONFIG === "1";
+
+if (!enforced) {
+  process.exit(0);
+}
+
+const missing = REQUIRED.filter(([name]) => !process.env[name]?.trim());
+
+if (missing.length > 0) {
+  console.error("Missing channel build configuration:\n");
+  for (const [name, purpose] of missing) {
+    console.error(`  ${name}  —  ${purpose}`);
+  }
+  console.error(
+    "\nVite inlines these at build time, so an unset value ships a bundle with" +
+      "\nnon-functional channel buttons rather than failing. They are public" +
+      "\nidentifiers, not secrets — the bundle exposes them either way." +
+      "\nSet them as repository variables (Settings -> Actions -> Variables).\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Channel build configuration present (${REQUIRED.length}/${REQUIRED.length}).`,
+);

--- a/packages/homepage/tests/channel-build-config.node.test.mjs
+++ b/packages/homepage/tests/channel-build-config.node.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * Verifies that deployment requires every public channel identifier while
+ * ordinary CI and local homepage builds remain configuration-independent.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/verify-channel-build-config.mjs", import.meta.url),
+);
+const requiredNames = [
+  "VITE_TELEGRAM_BOT_ID",
+  "VITE_TELEGRAM_BOT_USERNAME",
+  "VITE_DISCORD_CLIENT_ID",
+  "VITE_WHATSAPP_PHONE_NUMBER",
+];
+
+function runGuard(overrides = {}) {
+  const env = { ...process.env };
+  delete env.ELIZA_REQUIRE_CHANNEL_CONFIG;
+  for (const name of requiredNames) delete env[name];
+  Object.assign(env, overrides);
+  return spawnSync(process.execPath, [scriptPath], {
+    encoding: "utf8",
+    env,
+  });
+}
+
+test("generic CI does not require deployment identifiers", () => {
+  const result = runGuard({ CI: "true" });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("deployment lists every missing identifier", () => {
+  const result = runGuard({ ELIZA_REQUIRE_CHANNEL_CONFIG: "1" });
+  assert.equal(result.status, 1);
+  for (const name of requiredNames)
+    assert.match(result.stderr, new RegExp(name));
+});
+
+test("deployment accepts a complete configuration", () => {
+  const result = runGuard({
+    ELIZA_REQUIRE_CHANNEL_CONFIG: "1",
+    VITE_TELEGRAM_BOT_ID: "1001",
+    VITE_TELEGRAM_BOT_USERNAME: "eliza_bot",
+    VITE_DISCORD_CLIENT_ID: "2002",
+    VITE_WHATSAPP_PHONE_NUMBER: "15555550123",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("whitespace-only identifiers are missing", () => {
+  const result = runGuard({
+    ELIZA_REQUIRE_CHANNEL_CONFIG: "1",
+    VITE_TELEGRAM_BOT_ID: "1001",
+    VITE_TELEGRAM_BOT_USERNAME: " ",
+    VITE_DISCORD_CLIENT_ID: "2002",
+    VITE_WHATSAPP_PHONE_NUMBER: "15555550123",
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /VITE_TELEGRAM_BOT_USERNAME/);
+});


### PR DESCRIPTION
## What

Homepage deployment can currently build a public bundle with missing Telegram, Discord, or WhatsApp identifiers. Because Vite substitutes `import.meta.env` during compilation, the resulting deployment looks healthy while its channel controls are inactive.

## Fix

- Require all four public identifiers at the homepage deployment boundary.
- Reuse the same verifier from `prebuild`, with deployment opting in through `ELIZA_REQUIRE_CHANNEL_CONFIG=1`.
- Keep ordinary local and generic CI builds configuration-independent; `CI=true` alone does not activate a production deployment contract.
- Cover missing, complete, whitespace-only, and generic-CI configurations with process-level tests.

This recuts #17360 on current `develop` and preserves @standujar as commit author. It also removes the duplicated Bash implementation from the workflow. The original branch treated every generic CI build as a deploy, but those jobs do not receive repository variables and would fail unrelated PR validation.

Refs #17340 · #17323
Supersedes #17360

## Verification

- `bun test packages/homepage/tests/channel-build-config.node.test.mjs` — 4 passed
- `CI=true bun run --cwd packages/homepage prebuild` — passed without deployment identifiers
- `actionlint .github/workflows/deploy-homepage.yml` — clean
- Biome and `git diff --check` — clean

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deployment configuration guard with no rendered UI change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - deployment configuration guard with no rendered UI change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deployment configuration guard with no interactive UI change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser runtime path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - process-level tests assert the deployment contract and generic-CI behavior

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence

<!-- evidence-row:backend-logs -->
- [ ] N/A - build-time guard only; exact commands and results are listed above
