### PR TITLE
fix(homepage): isolate e2e ports per CI runner

### DIFF
--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -9,7 +9,7 @@
     "build": "bun --bun vite build",
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
-    "test": "bun test tests/smoke.node.test.mjs tests/contact.test.ts edge/apple-app-site-association.test.ts",
+    "test": "bun test tests/smoke.node.test.mjs tests/e2e-port.node.test.mjs tests/contact.test.ts edge/apple-app-site-association.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/playwright.config.ts
+++ b/packages/homepage/playwright.config.ts
@@ -3,8 +3,12 @@
  */
 import path from "node:path";
 import { defineConfig, devices } from "playwright/test";
+import { resolveHomepageE2eBaseUrl } from "./scripts/e2e-port.mjs";
 
 const recording = !!process.env.E2E_RECORD;
+// Per-runner port: 6-8 self-hosted runners share a host, and a fixed port made
+// two concurrent homepage jobs race for it (see scripts/e2e-port.mjs).
+const baseURL = resolveHomepageE2eBaseUrl();
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -23,14 +27,14 @@ export default defineConfig({
       )
     : "./test-results",
   use: {
-    baseURL: "http://127.0.0.1:4444",
+    baseURL,
     trace: recording ? "on" : "retain-on-failure",
     screenshot: recording ? "on" : "only-on-failure",
     video: recording ? "on" : "retain-on-failure",
   },
   webServer: {
     command: "node scripts/run-playwright-web-server.mjs",
-    url: "http://127.0.0.1:4444",
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 240_000,
   },

--- a/packages/homepage/scripts/e2e-port.mjs
+++ b/packages/homepage/scripts/e2e-port.mjs
@@ -1,0 +1,46 @@
+/**
+ * Resolves a deterministic homepage e2e port shared by Playwright and its Vite process.
+ * Co-hosted self-hosted runners use a dedicated CI range; local runs retain the
+ * conventional homepage port, and explicit overrides support other environments.
+ */
+
+const LOCAL_PORT = 4444;
+const CI_BASE_PORT = 24_000;
+const SPAN = 64;
+
+export function resolveHomepageE2ePort(env = process.env) {
+  const explicit = env.HOMEPAGE_E2E_PORT?.trim();
+  if (explicit) {
+    const parsed = Number(explicit);
+    if (!Number.isInteger(parsed) || parsed < 1024 || parsed > 65535) {
+      throw new Error(
+        `HOMEPAGE_E2E_PORT must be an integer between 1024 and 65535, received ${explicit}`,
+      );
+    }
+    return parsed;
+  }
+
+  const runner = env.RUNNER_NAME?.trim();
+  if (!runner) return LOCAL_PORT;
+
+  // Production runner names end in a host-local slot. Mapping that slot
+  // directly guarantees distinct ports for runners that share a host.
+  const slot = runner.match(/-r([1-9]\d*)$/)?.[1];
+  const slotNumber = slot ? Number(slot) : 0;
+  if (slotNumber > 0 && slotNumber <= SPAN) {
+    return CI_BASE_PORT + slotNumber - 1;
+  }
+
+  // Unknown runner naming schemes still need a stable value because Playwright
+  // and the Vite launcher resolve the port in separate processes.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < runner.length; i += 1) {
+    hash ^= runner.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return CI_BASE_PORT + (hash % SPAN);
+}
+
+export function resolveHomepageE2eBaseUrl(env = process.env) {
+  return `http://127.0.0.1:${resolveHomepageE2ePort(env)}`;
+}

--- a/packages/homepage/scripts/run-playwright-web-server.mjs
+++ b/packages/homepage/scripts/run-playwright-web-server.mjs
@@ -1,13 +1,15 @@
 /**
  * Playwright web-server launcher for homepage e2e tests.
  *
- * The script syncs shared public assets before starting Vite on the fixed
- * homepage port so route and visual tests exercise the same static assets as
- * local development.
+ * The script syncs shared public assets before starting Vite on the homepage
+ * e2e port so route and visual tests exercise the same static assets as local
+ * development. The port is resolved per runner (see e2e-port.mjs) because a
+ * fixed one collided between concurrent jobs on a shared self-hosted host.
  */
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveHomepageE2ePort } from "./e2e-port.mjs";
 
 const homepageDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -46,7 +48,13 @@ if ((sync.status ?? 1) !== 0) {
 
 const vite = spawn(
   process.execPath,
-  [viteScript, "--host", "127.0.0.1", "--port", "4444"],
+  [
+    viteScript,
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(resolveHomepageE2ePort()),
+  ],
   {
     cwd: homepageDir,
     env: {

--- a/packages/homepage/tests/e2e-port.node.test.mjs
+++ b/packages/homepage/tests/e2e-port.node.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * Verifies deterministic, collision-free homepage e2e ports for the co-hosted
+ * production runner fleet, plus the stable local and override contracts.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  resolveHomepageE2eBaseUrl,
+  resolveHomepageE2ePort,
+} from "../scripts/e2e-port.mjs";
+
+test("no runner name keeps the historical local port", () => {
+  assert.equal(resolveHomepageE2ePort({}), 4444);
+  assert.equal(resolveHomepageE2eBaseUrl({}), "http://127.0.0.1:4444");
+});
+
+test("the same runner always resolves the same port", () => {
+  const env = { RUNNER_NAME: "eliza-prod-robot-2-r3" };
+  const first = resolveHomepageE2ePort(env);
+  assert.equal(resolveHomepageE2ePort(env), first);
+  // The config and the web server compute this in separate processes; a
+  // non-deterministic hash would bind one port and probe another.
+  assert.equal(resolveHomepageE2eBaseUrl(env), `http://127.0.0.1:${first}`);
+});
+
+test("runners that share a host get distinct ports", () => {
+  const ports = ["r1", "r2", "r3", "r4", "r5", "r6"].map((r) =>
+    resolveHomepageE2ePort({ RUNNER_NAME: `eliza-prod-robot-2-${r}` }),
+  );
+  assert.equal(new Set(ports).size, ports.length, `collision within ${ports}`);
+});
+
+test("fleet ports stay inside the homepage CI range", () => {
+  for (const host of ["2", "3", "4", "5", "6"]) {
+    for (const r of ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]) {
+      const port = resolveHomepageE2ePort({
+        RUNNER_NAME: `eliza-prod-robot-${host}-${r}`,
+      });
+      assert.ok(port >= 24_000 && port < 24_000 + 64, `${port} out of window`);
+    }
+  }
+});
+
+test("fleet ports avoid co-hosted suites' fixed ports", () => {
+  const reserved = new Set([4444, 4455, 4456, 4567, 4568, 4569]);
+  for (const r of ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]) {
+    const port = resolveHomepageE2ePort({
+      RUNNER_NAME: `eliza-prod-robot-2-${r}`,
+    });
+    assert.equal(
+      reserved.has(port),
+      false,
+      `${port} overlaps a co-hosted suite`,
+    );
+  }
+});
+
+test("nonstandard runner names resolve stably inside the CI range", () => {
+  const env = { RUNNER_NAME: "hosted-runner-alpha" };
+  const port = resolveHomepageE2ePort(env);
+  assert.equal(resolveHomepageE2ePort(env), port);
+  assert.ok(port >= 24_000 && port < 24_000 + 64);
+});
+
+test("an explicit override wins and is validated", () => {
+  assert.equal(
+    resolveHomepageE2ePort({ HOMEPAGE_E2E_PORT: "5000", RUNNER_NAME: "x" }),
+    5000,
+  );
+  assert.throws(() => resolveHomepageE2ePort({ HOMEPAGE_E2E_PORT: "80" }));
+  assert.throws(() => resolveHomepageE2ePort({ HOMEPAGE_E2E_PORT: "abc" }));
+});


### PR DESCRIPTION
## What

Homepage Playwright jobs bind a fixed port even though multiple self-hosted runners share each CI host. Concurrent homepage jobs can therefore race for the same socket and fail before testing the change under review.

## Fix

- Preserve port `4444` for local development.
- Map the production runners' host-local `-rN` slots directly into a dedicated homepage CI range (`24000–24063`).
- Use a deterministic hash fallback for other runner naming schemes.
- Keep a validated `HOMEPAGE_E2E_PORT` override.
- Resolve the same base URL independently in Playwright and the Vite launcher.

The dedicated range matters: the original #17358 hash used `4444–4507`, and three current runner names resolve to `4456`, which is already the co-hosted USB-installer suite's fixed port. The recut removes that new cross-suite collision while preserving @standujar as commit author.

Refs #17357
Supersedes #17358

## Verification

- `bun test packages/homepage/tests/e2e-port.node.test.mjs` — 7 passed, 100% line/function coverage for the resolver
- Current five-host, eight-runner fleet stays within the dedicated range
- Co-hosted fixed ports `4444`, `4455`, `4456`, and `4567–4569` are excluded
- Biome and `git diff --check` — clean

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI infrastructure change with no rendered UI change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI infrastructure change with no rendered UI change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI infrastructure change with no interactive UI change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser application runtime path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - resolver tests assert the production fleet's complete port assignment

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic test-infrastructure resolver; exact verification is listed above
