### PR TITLE
fix(test): restore agent-message-route suite by mocking the participants method the audience gate requires

### DIFF
--- a/packages/agent/test/api/agent-message-route.test.ts
+++ b/packages/agent/test/api/agent-message-route.test.ts
@@ -189,6 +189,11 @@ function createRuntime(
     updateWorld: vi.fn(async () => undefined),
     getWorld: vi.fn(async () => null),
     getRoom: vi.fn(async () => null),
+    // Required by IAgentRuntime and called by the trusted-delivery-audience
+    // gate on every outbound turn. Omitting it does not degrade the audience
+    // decision — it throws, and the route reports the TypeError as a 500, so
+    // an incomplete mock reads as a broken product route.
+    getParticipantsForRoom: vi.fn(async () => []),
     getService: vi.fn(() => null),
     getServicesByType: vi.fn(() => []),
     emitEvent: vi.fn(async () => undefined),


### PR DESCRIPTION
Fixes #17347 — `Server Tests` red on `develop` since 07-30.

## Root cause

Reproduced locally at the develop tip (5 failed / 8 passed, matching CI), then probed the response body the assertion was hiding:

```
STATUS=500
BODY={"error":"runtime.getParticipantsForRoom is not a function"}
```

The trusted-delivery-audience gate resolves every outbound turn through `runtime.getRoom` and `runtime.getParticipantsForRoom` together (`packages/core/src/security/trusted-delivery-audience.ts:330-332`, a single `Promise.all`). The hand-rolled mock in `agent-message-route.test.ts` defined `getRoom` and omitted `getParticipantsForRoom`, so the gate threw a `TypeError`, the route reported it as a 500, and five cases failed with `expected 500 to be 200` — the agent message route plus both the OpenAI- and Anthropic-compatible non-streaming transports.

## Why this is a test-mock gap, not a product defect

`getParticipantsForRoom(roomId: UUID): Promise<UUID[]>` is declared on `IAgentRuntime` (`packages/core/src/types/runtime.ts:1290`) and implemented by the real `AgentRuntime`. The mock is cast with `as unknown as AgentRuntime`, which is what let an incomplete stand-in for a required interface method compile. Real runtimes have the method; only the mock lacked it.

It still deserved to be treated as urgent, because on `develop` it read exactly like a broken product route returning 500 on both compat transports.

## Why the empty list does not mask anything

Returning `[]` matches the mock's existing `getRoom: async () => null` posture. Participants flow into `createAudience` alongside the null room, so the gate classifies an audience with no participants and degrades on precisely the path the mock already exercised. No assertion is weakened, and the suite goes 5 failed / 8 passed → **13/13 passing**.

## Verification

```
bunx vitest run test/api/agent-message-route.test.ts
→ Test Files 1 passed (1) · Tests 13 passed (13)
```

Reproduced red before the change and green after, in a fresh worktree at `origin/develop`.

## Note for #17347

My filed triage said the boundary between the 03:48 clean run and the 05:10 failure ruled out #17206. The root cause is in fact the audience gate that #17206 introduced — the timeline reasoning was sound about *when CI flipped* but wrong about *what was responsible*, and the reproduction is the authority. I have not identified what let the 03:48 run pass with the gate already merged; the fix stands on the reproduction rather than on that timeline.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - no UI surface. The change adds a mock method in a server-route unit test; nothing renders.

<!-- evidence-row:after-screenshots -->
N/A - no UI surface. The change adds a mock method in a server-route unit test; nothing renders.

<!-- evidence-row:walkthrough-video -->
N/A - no user-exercisable flow. This restores a unit suite; there is no path a user can walk through.

<!-- evidence-row:backend-logs -->
[17369-agent-message-route-before-after.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17369-agent-message-route-before-after.log) — contains the probed 500 body `{"error":"runtime.getParticipantsForRoom is not a function"}`, the call site at trusted-delivery-audience.ts:330-332, and the IAgentRuntime declaration at runtime.ts:1290.

<!-- evidence-row:frontend-logs -->
N/A - backend test-harness fix; no frontend surface is exercised by this suite.

<!-- evidence-row:llm-trajectory -->
N/A - no agent, action, provider, prompt, or model behaviour changes. The audience gate itself is untouched; only the test's mock runtime gains a method the IAgentRuntime interface already declares.

<!-- evidence-row:domain-artifacts -->
[17369-agent-message-route-before-after.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17369-agent-message-route-before-after.log) — full before/after suite output: 5 failed / 8 passed before, 13 passed / 13 after, from `bunx vitest run test/api/agent-message-route.test.ts` reproduced red then green at the develop tip.
