### PR TITLE
fix(cloud): fence preserved replacement adoption

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
@@ -49,6 +49,8 @@ function uniq(p: string): string {
 
 async function seedProvisioningAgent(params: {
   sandboxId: string | null;
+  nodeId: string | null;
+  containerName: string | null;
 }): Promise<{ id: string; orgId: string }> {
   const [org] = await dbWrite
     .insert(organizations)
@@ -68,6 +70,8 @@ async function seedProvisioningAgent(params: {
       execution_tier: "dedicated-always",
       environment_revision: 0,
       sandbox_id: params.sandboxId,
+      node_id: params.nodeId,
+      container_name: params.containerName,
     })
     .returning();
   return { id: rec.id, orgId: org.id };
@@ -92,7 +96,11 @@ describe("fence-less replacement adoption (#17253 §4)", () => {
   test(
     "an ADOPTED handle (no replacement metadata) completes the transfer",
     async () => {
-      const { id, orgId } = await seedProvisioningAgent({ sandboxId: "agent-preserved" });
+      const { id, orgId } = await seedProvisioningAgent({
+        sandboxId: "agent-preserved",
+        nodeId: "node-1",
+        containerName: "agent-preserved",
+      });
       const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
 
       // Preserved retry handles intentionally omit replacement metadata because
@@ -104,7 +112,12 @@ describe("fence-less replacement adoption (#17253 §4)", () => {
           sandboxId: "agent-preserved",
           bridgeUrl: "https://runtime.example",
           healthUrl: "https://runtime.example/health",
-          metadata: { provider: "docker", nodeId: "node-1", containerName: "agent-preserved" },
+          metadata: {
+            provider: "docker",
+            nodeId: "node-1",
+            hostname: "node-1.example",
+            containerName: "agent-preserved",
+          },
         },
         0,
         { status: "running" },
@@ -122,7 +135,11 @@ describe("fence-less replacement adoption (#17253 §4)", () => {
   test(
     "a fence-less docker handle whose sandboxId does NOT match is still refused",
     async () => {
-      const { id, orgId } = await seedProvisioningAgent({ sandboxId: "agent-original" });
+      const { id, orgId } = await seedProvisioningAgent({
+        sandboxId: "agent-original",
+        nodeId: "node-1",
+        containerName: "agent-original",
+      });
       const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
 
       await expect(
@@ -133,7 +150,110 @@ describe("fence-less replacement adoption (#17253 §4)", () => {
             sandboxId: "agent-imposter",
             bridgeUrl: "https://runtime.example",
             healthUrl: "https://runtime.example/health",
-            metadata: { provider: "docker", nodeId: "node-1", containerName: "agent-imposter" },
+            metadata: {
+              provider: "docker",
+              nodeId: "node-1",
+              hostname: "node-1.example",
+              containerName: "agent-original",
+            },
+          },
+          0,
+          { status: "running" },
+        ),
+      ).rejects.toThrow("Docker replacement has no durable cleanup ownership");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a fence-less docker handle on a different node is refused",
+    async () => {
+      const { id, orgId } = await seedProvisioningAgent({
+        sandboxId: "agent-preserved",
+        nodeId: "node-1",
+        containerName: "agent-preserved",
+      });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      await expect(
+        svc.transferReplacementToPrimary(
+          id,
+          orgId,
+          {
+            sandboxId: "agent-preserved",
+            bridgeUrl: "https://runtime.example",
+            healthUrl: "https://runtime.example/health",
+            metadata: {
+              provider: "docker",
+              nodeId: "node-2",
+              hostname: "node-2.example",
+              containerName: "agent-preserved",
+            },
+          },
+          0,
+          { status: "running" },
+        ),
+      ).rejects.toThrow("Docker replacement has no durable cleanup ownership");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a fence-less docker handle with incomplete placement metadata is refused",
+    async () => {
+      const { id, orgId } = await seedProvisioningAgent({
+        sandboxId: "agent-preserved",
+        nodeId: "node-1",
+        containerName: "agent-preserved",
+      });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      await expect(
+        svc.transferReplacementToPrimary(
+          id,
+          orgId,
+          {
+            sandboxId: "agent-preserved",
+            bridgeUrl: "https://runtime.example",
+            healthUrl: "https://runtime.example/health",
+            metadata: {
+              provider: "docker",
+              nodeId: "node-1",
+              containerName: "agent-preserved",
+            },
+          },
+          0,
+          { status: "running" },
+        ),
+      ).rejects.toThrow("Docker replacement has no durable cleanup ownership");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a fence-less docker handle with a different container name is refused",
+    async () => {
+      const { id, orgId } = await seedProvisioningAgent({
+        sandboxId: "agent-preserved",
+        nodeId: "node-1",
+        containerName: "agent-preserved",
+      });
+      const svc = new ElizaSandboxService() as unknown as AdoptionInternals;
+
+      await expect(
+        svc.transferReplacementToPrimary(
+          id,
+          orgId,
+          {
+            sandboxId: "agent-preserved",
+            bridgeUrl: "https://runtime.example",
+            healthUrl: "https://runtime.example/health",
+            metadata: {
+              provider: "docker",
+              nodeId: "node-1",
+              hostname: "node-1.example",
+              containerName: "agent-imposter",
+            },
           },
           0,
           { status: "running" },

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8964,11 +8964,17 @@ export class ElizaSandboxService {
         ) {
           throw new Error("Replacement cleanup ownership changed before adoption");
         }
-      } else if (
-        isDockerBackedMetadata(handle.metadata) &&
-        current.sandbox_id !== handle.sandboxId
-      ) {
-        throw new Error("Docker replacement has no durable cleanup ownership");
+      } else if (isDockerBackedMetadata(handle.metadata)) {
+        const dockerMeta = isDockerSandboxMetadata(handle.metadata) ? handle.metadata : undefined;
+        if (
+          !dockerMeta?.nodeId ||
+          !dockerMeta.containerName ||
+          current.sandbox_id !== handle.sandboxId ||
+          current.node_id !== dockerMeta.nodeId ||
+          current.container_name !== dockerMeta.containerName
+        ) {
+          throw new Error("Docker replacement has no durable cleanup ownership");
+        }
       }
 
       const [adopted] = await tx


### PR DESCRIPTION
## What

Closes #17371.

The fence-less Docker adoption path added by #17361 made retry adoption reachable, but authenticated only `sandbox_id`. This change requires complete Docker placement metadata and binds adoption to the locked primary row's exact `sandbox_id`, `node_id`, and `container_name`.

A preserved handle with exact identity still adopts successfully. Same-sandbox handles from another node/container, mismatched sandbox handles, and incomplete placement metadata fail before the primary mutation.

## Verification

<details><summary>Focused real-schema PGlite suite</summary><pre>
$ bun --config=/dev/null test packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
(pass) exact preserved identity completes transfer
(pass) mismatched sandboxId is refused
(pass) same sandbox on a different node is refused
(pass) incomplete Docker placement metadata is refused
(pass) same sandbox/node with a different container name is refused

5 pass
0 fail
6 expect() calls
</pre></details>

<details><summary>Package typecheck</summary><pre>
$ bun run --cwd packages/cloud/shared typecheck
Generating keyword code from JSON...
Total: 241 entries, 6 locales
Done!
$ echo $?
0
</pre></details>

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only ownership fence; no rendered surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only ownership fence; no rendered surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the real service/DB behavior is exercised in isolated PGlite.
<!-- evidence-row:backend-logs -->
- [x] Focused real-schema PGlite run recording all five service-boundary outcomes against the real Drizzle schema.
  <details><summary>replacement-adoption-fenceless.test.ts</summary><pre>
  $ bun --config=/dev/null test packages/cloud/shared/src/lib/services/__tests__/replacement-adoption-fenceless.test.ts
  (pass) exact preserved identity completes transfer
  (pass) mismatched sandboxId is refused
  (pass) same sandbox on a different node is refused
  (pass) incomplete Docker placement metadata is refused
  (pass) same sandbox/node with a different container name is refused
  5 pass
  0 fail
  6 expect() calls
  $ bun run --cwd packages/cloud/shared typecheck
  $ echo $?
  0
  </pre></details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or client code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-selection, or agent-response behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the `agent_sandboxes` row state: adopted on exact identity, unmutated on every rejection.
  <details><summary>agent_sandboxes row outcomes per case</summary><pre>
  exact preserved identity        -> transfer completes; adopted row observed
  mismatched sandboxId            -> refused before primary mutation
  same sandbox, different node    -> refused before primary mutation
  incomplete Docker placement     -> refused before primary mutation
  same sandbox/node, diff container -> refused before primary mutation
  (5 pass / 0 fail, 6 expect() calls, isolated PGlite + real Drizzle schema)
  </pre></details>

