### PR TITLE
fix(ui): keep notification rims stable during shade collapse

### DIFF
--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1991,7 +1991,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
   });
 
-  it("tracks a partial upward drag and reverses it without snapping", () => {
+  it("keeps card material fully opaque through a reversible upward drag", () => {
     __ingestNotificationForTests(
       makeNotification({
         priority: "urgent",
@@ -2019,10 +2019,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       .getByText("Files updated")
       .closest("[data-notification-group]")
       ?.querySelector<HTMLElement>("[data-notification-group-content]");
+    const filesSurface = screen
+      .getByText("Files updated")
+      .closest<HTMLElement>('[data-testid="notification-row-swipe"]');
     const agentGroup = screen
       .getByText("Agent summary")
       .closest("[data-notification-group]")
       ?.querySelector<HTMLElement>("[data-notification-group-content]");
+    const agentSurface = screen
+      .getByText("Agent summary")
+      .closest<HTMLElement>('[data-testid="notification-row-swipe"]');
 
     fireEvent.pointerDown(list, {
       pointerType: "mouse",
@@ -2048,9 +2054,23 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     let filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
     let agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
-    expect(filesOpacity).toBeGreaterThan(0);
-    expect(filesOpacity).toBeLessThan(1);
-    expect(agentOpacity).toBeLessThan(filesOpacity);
+    expect(filesOpacity).toBe(1);
+    expect(agentOpacity).toBe(1);
+    expect(filesSurface?.style.opacity).toBe("1");
+    expect(agentSurface?.style.opacity).toBe("1");
+    let filesContentOpacity = Number.parseFloat(
+      filesGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ) ?? "1",
+    );
+    let agentContentOpacity = Number.parseFloat(
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ) ?? "1",
+    );
+    expect(filesContentOpacity).toBeGreaterThan(0);
+    expect(filesContentOpacity).toBeLessThan(1);
+    expect(agentContentOpacity).toBeLessThan(filesContentOpacity);
     let countOpacity = Number.parseFloat(
       screen.getByTestId("notifications-count").style.opacity,
     );
@@ -2079,10 +2099,22 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     collapseOpacity = Number.parseFloat(
       screen.getByTestId("notifications-collapse-footer").style.opacity,
     );
-    expect(filesOpacity).toBeGreaterThan(0);
-    expect(filesOpacity).toBeLessThan(1);
-    expect(agentOpacity).toBeGreaterThan(0);
-    expect(agentOpacity).toBeLessThan(filesOpacity);
+    expect(filesOpacity).toBe(1);
+    expect(agentOpacity).toBe(1);
+    filesContentOpacity = Number.parseFloat(
+      filesGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ) ?? "1",
+    );
+    agentContentOpacity = Number.parseFloat(
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ) ?? "1",
+    );
+    expect(filesContentOpacity).toBeGreaterThan(0);
+    expect(filesContentOpacity).toBeLessThan(1);
+    expect(agentContentOpacity).toBeGreaterThan(0);
+    expect(agentContentOpacity).toBeLessThan(filesContentOpacity);
     expect(countOpacity).toBeGreaterThan(0);
     expect(countOpacity).toBeLessThan(1);
     expect(collapseOpacity).toBeGreaterThan(0);
@@ -2097,6 +2129,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     act(() => vi.advanceTimersByTime(20));
     expect(filesGroup?.style.opacity).toBe("1");
     expect(agentGroup?.style.opacity).toBe("1");
+    expect(
+      filesGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("");
+    expect(
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("");
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
     expect(
       screen.getByTestId("notifications-collapse-footer").style.opacity,
@@ -2110,7 +2152,126 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
-  it("fades fanned controls and extra rows before folding their stable top card", () => {
+  it("hands content fade from cancel through immediate re-grab and committed settle", () => {
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "urgent",
+        source: "mail",
+        title: "Urgent mail",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "normal",
+        source: "files",
+        title: "Files updated",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "low",
+        source: "agent",
+        title: "Agent summary",
+      }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+    const agentGroup = screen
+      .getByText("Agent summary")
+      .closest("[data-notification-group]")
+      ?.querySelector<HTMLElement>("[data-notification-group-content]");
+    const shadeCss = center.querySelector("style")?.textContent ?? "";
+    expect(shadeCss).toContain(
+      ".eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling])",
+    );
+    expect(shadeCss).toContain(
+      "[data-notification-shade-cancelling] .eliza-notif-row-content",
+    );
+    expect(shadeCss).toContain(
+      ".eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-content",
+    );
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 85,
+      clientX: 12,
+      clientY: 160,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 85,
+      clientX: 12,
+      clientY: 132,
+    });
+    const cancelledContentOpacity =
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ) ?? "";
+    expect(Number.parseFloat(cancelledContentOpacity)).toBeLessThan(1);
+    act(() => vi.advanceTimersByTime(500));
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 85,
+      clientX: 12,
+      clientY: 132,
+    });
+
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+    expect(
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe(cancelledContentOpacity);
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 86,
+      clientX: 12,
+      clientY: 160,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 86,
+      clientX: 12,
+      clientY: 20,
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(true);
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    const committedContentOpacity =
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ) ?? "";
+    expect(Number.parseFloat(committedContentOpacity)).toBeLessThan(1);
+    expect(Number.parseFloat(committedContentOpacity)).toBeLessThan(
+      Number.parseFloat(cancelledContentOpacity),
+    );
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 86,
+      clientX: 12,
+      clientY: 20,
+    });
+
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    expect(agentGroup?.style.opacity).toBe("0");
+    expect(
+      agentGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe(committedContentOpacity);
+    finishShadeCollapse();
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("fades fanned contents without dimming their card material", () => {
     __ingestNotificationForTests(
       makeNotification({
         priority: "urgent",
@@ -2137,6 +2298,48 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const sourceCount = screen.getByTestId("notification-source-count");
     expect(stackRows.style.rowGap).toBe("6px");
     expect(sourceCount.style.opacity).toBe("0");
+
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 84,
+      clientX: 12,
+      clientY: 160,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 84,
+      clientX: 12,
+      clientY: 116,
+    });
+
+    const quietSurface = screen
+      .getByText("Calendar summary")
+      .closest<HTMLElement>('[data-testid="notification-row-swipe"]');
+    const quietContentOpacity = Number.parseFloat(
+      quietRow?.style.getPropertyValue(
+        "--eliza-notif-row-content-visibility",
+      ) ?? "1",
+    );
+    expect(quietRow?.style.opacity).toBe("1");
+    expect(quietSurface?.style.opacity).toBe("1");
+    expect(quietContentOpacity).toBeGreaterThan(0);
+    expect(quietContentOpacity).toBeLessThan(1);
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 84,
+      clientX: 12,
+      clientY: 160,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 84,
+      clientX: 12,
+      clientY: 160,
+    });
 
     fireEvent.click(document.body);
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -416,6 +416,24 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
   transition: none;
 }
+/* Direct manipulation keeps each glass card as one stable physical surface.
+   Only its information fades toward the committed resting projection; fading
+   an ancestor would dim the specular rim and make the border flicker. */
+.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-content {
+  opacity: var(
+    --eliza-notif-row-content-visibility,
+    var(--eliza-notif-group-content-visibility, 1)
+  );
+}
+.eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-content {
+  transition: none;
+}
+/* A cancelled pull reverses the information fade on the same presentation
+   clock while the unchanged glass shell stays in place. */
+[data-notification-shade-cancelling] .eliza-notif-row-content {
+  opacity: 1;
+  transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
+}
 /* Bulk clear keeps its right edge aligned with each producer's X. Touch-first
    surfaces reveal the destructive command after the first tap; precise
    pointers can preview it leftward on hover or keyboard focus before the
@@ -1150,6 +1168,9 @@ export function NotificationsHomeCenter({
 
   const setPullPx = useCallback(
     (px: number, preserveDirectionAtZero = false) => {
+      // A fresh non-zero sample owns direct manipulation immediately. Cancel
+      // any prior cancelled-pull settle so easing cannot lag behind this finger.
+      if (px !== 0) cancelPullCancellation();
       pullPxRef.current = px;
       const nextDirection =
         px > 0
@@ -1204,6 +1225,7 @@ export function NotificationsHomeCenter({
     },
     [
       applyPullPresentation,
+      cancelPullCancellation,
       cancelPullReleaseSettle,
       cancelScheduledPullPresentation,
       schedulePullPresentation,
@@ -2825,6 +2847,15 @@ export function NotificationsHomeCenter({
             : groupWasRested
               ? 1
               : groupVisibility;
+          // A card follows the finger as one physical surface. Fading its
+          // ancestor during direct manipulation also fades the glass rim,
+          // which makes the outline flicker between bright and dull while the
+          // user reverses a swipe. The committed/cancelled settle may fade the
+          // group after release; the in-hand material stays visually stable.
+          const groupPresentationVisibility =
+            shadeExpanded && pullDirection === "collapse"
+              ? 1
+              : groupContentVisibility;
           const groupContentPullOffset = pullRevealed
             ? (1 - revealProgress) * -8
             : groupWasRested
@@ -2949,7 +2980,7 @@ export function NotificationsHomeCenter({
                     : stacked
                       ? stackTailPx
                       : 0,
-                  opacity: groupContentVisibility,
+                  opacity: groupPresentationVisibility,
                   transform: `translate3d(0, ${groupContentOffset}px, 0)`,
                   transition: isPulling ? "none" : undefined,
                 }}

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1170,7 +1170,9 @@ export function NotificationsHomeCenter({
     (px: number, preserveDirectionAtZero = false) => {
       // A fresh non-zero sample owns direct manipulation immediately. Cancel
       // any prior cancelled-pull settle so easing cannot lag behind this finger.
-      if (px !== 0) cancelPullCancellation();
+      if (px !== 0 && pullCancelTimer.current !== null) {
+        cancelPullCancellation();
+      }
       pullPxRef.current = px;
       const nextDirection =
         px > 0

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -477,6 +477,179 @@ for (const [name, width, height] of [
   });
   console.log(`  📸 notifications-${name}-expanded.png`);
 
+  // Direct collapse keeps every visible card and its specular rim at full
+  // material opacity. Only the information inside later cards fades toward
+  // the resting projection, and reversing the same gesture restores it.
+  const verticalList = page.locator(LIST);
+  await verticalList.evaluate((list) => {
+    list.scrollTop = 0;
+  });
+  const verticalListBox = await verticalList.boundingBox();
+  const verticalX = verticalListBox.x + verticalListBox.width / 2;
+  const verticalStartY = verticalListBox.y + 96;
+  await page.mouse.move(verticalX, verticalStartY);
+  await page.mouse.down();
+  await page.mouse.move(verticalX, verticalStartY - 44, { steps: 8 });
+  await page.waitForFunction(
+    (selector) =>
+      document.querySelector(selector)?.hasAttribute("data-shade-dragging"),
+    LIST,
+  );
+  const directCollapseFrame = await verticalList.evaluate((list) => {
+    const viewport = list.getBoundingClientRect();
+    const visibleGroups = Array.from(
+      list.querySelectorAll("[data-notification-group-content]"),
+    ).filter((group) => {
+      const bounds = group.getBoundingClientRect();
+      return bounds.bottom > viewport.top && bounds.top < viewport.bottom;
+    });
+    const visibleSurfaces = Array.from(
+      list.querySelectorAll('[data-testid="notification-row-swipe"]'),
+    ).filter((surface) => {
+      const bounds = surface.getBoundingClientRect();
+      return bounds.bottom > viewport.top && bounds.top < viewport.bottom;
+    });
+    const visibleContents = Array.from(
+      list.querySelectorAll(".eliza-notif-row-content"),
+    ).filter((content) => {
+      const bounds = content.getBoundingClientRect();
+      return bounds.bottom > viewport.top && bounds.top < viewport.bottom;
+    });
+    return {
+      contentOpacities: visibleContents.map((content) =>
+        Number.parseFloat(getComputedStyle(content).opacity),
+      ),
+      groupOpacities: visibleGroups.map((group) =>
+        Number.parseFloat(getComputedStyle(group).opacity),
+      ),
+      rimOpacities: visibleSurfaces.map((surface) =>
+        Number.parseFloat(getComputedStyle(surface, "::before").opacity),
+      ),
+      surfaceOpacities: visibleSurfaces.map((surface) =>
+        Number.parseFloat(getComputedStyle(surface).opacity),
+      ),
+    };
+  });
+  check(
+    "direct collapse keeps every visible glass card and rim fully opaque",
+    directCollapseFrame.groupOpacities.length > 0 &&
+      directCollapseFrame.groupOpacities.every((opacity) => opacity === 1) &&
+      directCollapseFrame.surfaceOpacities.every((opacity) => opacity === 1) &&
+      directCollapseFrame.rimOpacities.every((opacity) => opacity === 1),
+    JSON.stringify(directCollapseFrame),
+  );
+  check(
+    "direct collapse still fades card information toward the resting projection",
+    directCollapseFrame.contentOpacities.some(
+      (opacity) => opacity > 0 && opacity < 1,
+    ),
+    JSON.stringify(directCollapseFrame.contentOpacities),
+  );
+  await page.screenshot({
+    path: join(outDir, `notifications-${name}-during-vertical-collapse.png`),
+    fullPage: true,
+  });
+  console.log(
+    `  📸 notifications-${name}-during-vertical-collapse.png`,
+  );
+  await page.mouse.move(verticalX, verticalStartY, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForFunction(
+    (selector) =>
+      !document.querySelector(selector)?.hasAttribute("data-shade-dragging"),
+    LIST,
+  );
+  check(
+    "reversing direct collapse restores the expanded shade",
+    (await shadeMode(page)) === "expanded",
+  );
+
+  // Release a short, slow collapse so it starts its cancel animation, then
+  // immediately re-grab. The second gesture must take direct ownership:
+  // content tracks the finger with no inherited easing and the rims stay put.
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.waitForTimeout(50);
+  await page.mouse.move(verticalX, verticalStartY);
+  await page.mouse.down();
+  await page.mouse.move(verticalX, verticalStartY - 28, { steps: 8 });
+  await page.waitForTimeout(350);
+  await page.mouse.up();
+  await page.waitForFunction(() =>
+    document
+      .querySelector('[data-testid="home-notification-center"]')
+      ?.hasAttribute("data-notification-shade-cancelling"),
+  );
+  await page.mouse.move(verticalX, verticalStartY);
+  await page.mouse.down();
+  await page.mouse.move(verticalX, verticalStartY - 52, { steps: 8 });
+  await page.waitForFunction(
+    (selector) => {
+      const list = document.querySelector(selector);
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      return (
+        list?.hasAttribute("data-shade-dragging") &&
+        !center?.hasAttribute("data-notification-shade-cancelling")
+      );
+    },
+    LIST,
+  );
+  const regrabFrame = await verticalList.evaluate((list) => {
+    const contents = Array.from(
+      list.querySelectorAll(".eliza-notif-row-content"),
+    );
+    const surfaces = Array.from(
+      list.querySelectorAll('[data-testid="notification-row-swipe"]'),
+    );
+    return {
+      contentOpacities: contents.map((content) =>
+        Number.parseFloat(getComputedStyle(content).opacity),
+      ),
+      rimOpacities: surfaces.map((surface) =>
+        Number.parseFloat(getComputedStyle(surface, "::before").opacity),
+      ),
+      transitionDurations: contents.map(
+        (content) => getComputedStyle(content).transitionDuration,
+      ),
+    };
+  });
+  check(
+    "an immediate re-grab tracks directly without dimming the rims",
+    regrabFrame.contentOpacities.some(
+      (opacity) => opacity > 0 && opacity < 1,
+    ) &&
+      regrabFrame.rimOpacities.every((opacity) => opacity === 1) &&
+      regrabFrame.transitionDurations.every((duration) =>
+        duration
+          .split(",")
+          .every((part) => Number.parseFloat(part.trim()) === 0),
+      ),
+    JSON.stringify(regrabFrame),
+  );
+  await page.screenshot({
+    path: join(
+      outDir,
+      `notifications-${name}-during-cancel-regrab.png`,
+    ),
+    fullPage: true,
+  });
+  console.log(
+    `  📸 notifications-${name}-during-cancel-regrab.png`,
+  );
+  await page.mouse.move(verticalX, verticalStartY, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForFunction(
+    (selector) =>
+      !document.querySelector(selector)?.hasAttribute("data-shade-dragging"),
+    LIST,
+  );
+  check(
+    "cancelled re-grab returns to the expanded shade",
+    (await shadeMode(page)) === "expanded",
+  );
+  if (!HEADFUL) await page.emulateMedia({ reducedMotion: "reduce" });
+
   // 3. STACK FOLD/RESTORE: fanned groups expose controls above their rows.
   //    Folding restores one top card plus its peeks; tapping that stack fans
   //    the same group back out.

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -267,8 +267,9 @@ export function applyNotificationPullPresentation(
     const content = group.querySelector<HTMLElement>(
       ":scope > [data-notification-group-content]",
     );
+    const contentVisibility = pullRevealed || !rested ? groupVisibility : 1;
+    const preservesCardMaterial = shadeExpanded && pullPx < 0 && !shadeClosing;
     if (content) {
-      const contentVisibility = pullRevealed || !rested ? groupVisibility : 1;
       const contentPullOffset = pullRevealed
         ? (1 - groupVisibility) * -8
         : rested
@@ -279,7 +280,17 @@ export function applyNotificationPullPresentation(
               shadeClosing,
               groupVisibility,
             );
-      content.style.opacity = String(contentVisibility);
+      content.style.opacity = String(
+        preservesCardMaterial ? 1 : contentVisibility,
+      );
+      if (preservesCardMaterial) {
+        content.style.setProperty(
+          "--eliza-notif-group-content-visibility",
+          String(contentVisibility),
+        );
+      } else if (!shadeClosing) {
+        content.style.removeProperty("--eliza-notif-group-content-visibility");
+      }
       content.style.transform = `translate3d(0, ${
         containerOffset + contentPullOffset + presentation.pullOvershootOffset
       }px, 0)`;
@@ -310,7 +321,17 @@ export function applyNotificationPullPresentation(
     for (const row of group.querySelectorAll<HTMLElement>(
       "[data-notification-disposable-row]",
     )) {
-      row.style.opacity = String(presentation.disposableContentVisibility);
+      row.style.opacity = String(
+        preservesCardMaterial ? 1 : presentation.disposableContentVisibility,
+      );
+      if (preservesCardMaterial) {
+        row.style.setProperty(
+          "--eliza-notif-row-content-visibility",
+          String(contentVisibility * presentation.disposableContentVisibility),
+        );
+      } else if (!shadeClosing) {
+        row.style.removeProperty("--eliza-notif-row-content-visibility");
+      }
       row.style.transform = `translate3d(0, ${(1 - presentation.disposableContentVisibility) * -8}px, 0)`;
     }
     for (const peek of group.querySelectorAll<HTMLElement>(
@@ -324,7 +345,11 @@ export function applyNotificationPullPresentation(
           : mode === "disposable"
             ? presentation.pullContentVisibility
             : 1;
-      peek.style.opacity = String(baseOpacity * visibility);
+      peek.style.opacity = String(
+        preservesCardMaterial && mode === "disposable"
+          ? baseOpacity
+          : baseOpacity * visibility,
+      );
     }
   }
 }


### PR DESCRIPTION
Closes #17328.

## What changed

- Keep each notification card and its specular rim at full material opacity during direct shade manipulation.
- Fade only the information that disappears from the rested projection, symmetrically in both gesture directions.
- Preserve cancellation, reversal, immediate re-grab, fanned rows, reduced-motion behavior, and existing gesture thresholds.
- Avoid dispatching a no-op pull-cancellation update on every drag frame, preserving the render-count budget.
- Extend the maintained desktop/mobile browser capture with collapse, reversal, re-grab, surface-opacity, and rim-opacity assertions.

## Root cause

The collapse path transferred opacity to an ancestor surface while the open path revealed content. That changed the apparent glass material mid-gesture and made the white rim snap darker. The fix keeps one physical surface and applies progress only to the disappearing information.

## Validation

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` — pass; dependency graph unchanged.
- Focused notification suites — 102/102 pass.
- Drag-frame render-count regression rerun three times in isolation — 3/3 pass.
- `bun run --cwd packages/ui typecheck` — pass.
- Biome — three eligible changed files pass with no fixes; the repository intentionally ignores the capture `.mjs`, whose `node --check` passes.
- `git diff --check origin/develop...HEAD` — pass.
- Error-policy equivalent — no added `catch` sites or `console.*` calls in changed production UI source; the former root ratchet alias is absent on this base.
- Existing real-Chromium capture from the patch-equivalent pre-rebase head passed at 1280×900 and 390×844, including reversal/cancel/re-grab, stable rim opacity, and symmetric information fade. Its manually reviewed evidence remains attached below unchanged; this publication-only rebase produced no new visual evidence.

## Rebase provenance

- Base: exact `develop@23df24cf4533308900e2ad483d214139f0014053`.
- Previous commits: `6a80b62ab9c11a79761bab084f76e03a504e72f5`, `337d26eedcb24dda2e971acd3e48729d0253c5fb`.
- Rebased commits: `ea3263876a6bc260ce091afd50e0f9b655a21ce2`, `9ec51d3b58c18498e5cde66b3fe4d1bd495dedf7`.
- Rebased tree: `53c6ae78db7a086f0408b50a43f09e9b2c9551e6`.
- Rebase completed without conflicts.
- Range-diff: both commits are exact `=` matches in the same order.
- Stable patch IDs remain `2c2d5a19f8bb6fb367002be791ff281ed377abbd` and `32e290a38867c2b9f69400ecaf14732154f99c11`.
- Aggregate binary diff SHA-256 remains `041b83d5e44bb505812e38929829f4351efab6ec2501948d7972ca511abea414`.

## Human-verifiable evidence

Desktop/mobile full-page screenshots and the MP4 walkthrough were captured, attached inline, and manually reviewed. The final render-budget follow-up changes no pixels; it prevents only a redundant state dispatch.

- Frontend console: no page errors in the browser capture.
- Network logs: N/A — presentation-only gesture; the fixture uses loopback responses solely to preserve real optimistic-dismiss behavior.
- Real-LLM trajectory: N/A — no agent/action/prompt/model behavior changed.
- Domain artifacts: N/A — no persistent domain state changed.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17373-notifications-before-contact-sheet.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17373-notifications-after-contact-sheet.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17373-notifications-before-after-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - presentation-only browser gesture/material change; no backend code path is involved.

<!-- evidence-row:frontend-logs -->
- [x] [17373-notifications-before-after-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17373-notifications-before-after-frontend.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - presentation-only UI change creates no persistent domain state.

<!-- evidence-row:ocr-review -->
- [x] [17373-ocr-visual-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17373-ocr-visual-review.md)
