### PR TITLE
fix(core): make credit exhaustion copy provider neutral

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -13,6 +13,7 @@ import {
   ChannelType,
   type Content,
   createMessageMemory,
+  INSUFFICIENT_CREDITS_REPLY,
   type Memory,
   stringToUuid,
 } from "@elizaos/core";
@@ -464,6 +465,30 @@ describe("chat route helper coverage", () => {
     expect(
       classifyChatFailure(new Error("local inference unavailable"), []),
     ).toBe("local_inference");
+  });
+
+  it("uses provider-neutral credit copy for direct Cerebras and Eliza Cloud 402s", () => {
+    const directCerebrasError = Object.assign(
+      new Error("Cerebras API error: 402 Payment Required"),
+      { statusCode: 402 },
+    );
+    const elizaCloudError = Object.assign(
+      new Error("Insufficient credits. Required: $0.0014, Available: $0.0000"),
+      {
+        status: 402,
+        error: { code: "insufficient_credits" },
+      },
+    );
+
+    expect(getChatFailureReply(directCerebrasError, [])).toBe(
+      INSUFFICIENT_CREDITS_REPLY,
+    );
+    expect(getChatFailureReply(elizaCloudError, [])).toBe(
+      INSUFFICIENT_CREDITS_REPLY,
+    );
+    expect(INSUFFICIENT_CREDITS_REPLY).not.toMatch(
+      /Eliza Cloud|cloud balance/i,
+    );
   });
 
   it("persists assistant memory with source, channel, synthetic metadata, and dedupe", async () => {

--- a/packages/core/src/services/message.credit-exhaustion-reply.test.ts
+++ b/packages/core/src/services/message.credit-exhaustion-reply.test.ts
@@ -39,7 +39,7 @@ const ROOM = "00000000-0000-0000-0000-00000000001c" as UUID;
 const RUN_ID = "00000000-0000-0000-0000-00000000001d" as UUID;
 
 /** The error shape plugin-elizacloud throws when Eliza Cloud returns 402. */
-function makeCreditExhaustionError(): Error {
+function makeElizaCloudCreditExhaustionError(): Error {
 	return Object.assign(
 		new Error("Insufficient credits. Required: $0.0014, Available: $0.0000"),
 		{
@@ -50,6 +50,13 @@ function makeCreditExhaustionError(): Error {
 			},
 		},
 	);
+}
+
+/** The AI SDK error shape produced by a direct Cerebras 402 response. */
+function makeDirectCerebrasCreditExhaustionError(): Error {
+	return Object.assign(new Error("Cerebras API error: 402 Payment Required"), {
+		statusCode: 402,
+	});
 }
 
 function makeMessage(overrides: Partial<Content> = {}): Memory {
@@ -161,27 +168,39 @@ describe("connector turn failing on 402 credit exhaustion", () => {
 		vi.unstubAllEnvs();
 	});
 
-	it("delivers the actionable top-up reply, not the generic retry", async () => {
+	it("delivers the actionable provider-neutral reply for an Eliza Cloud 402", async () => {
 		const { result, visibleTexts } = await runTurn(
 			makeMessage(),
 			makeRoom(ChannelType.GROUP),
-			makeCreditExhaustionError(),
+			makeElizaCloudCreditExhaustionError(),
 		);
 
 		expect(result.didRespond).toBe(true);
 		expect(visibleTexts).toHaveLength(1);
 		// The user must learn the real, actionable condition — same reply the
-		// direct API path sends — instead of "try again" (retrying a drained
-		// account can never succeed) or the rate-limited "give it a few
-		// seconds" template.
+		// direct API path sends — without this shared boundary claiming which
+		// configured provider owns the exhausted balance.
 		expect(visibleTexts[0]).toBe(INSUFFICIENT_CREDITS_REPLY);
+	});
+
+	it("does not blame Eliza Cloud for a direct Cerebras 402", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage(),
+			makeRoom(ChannelType.GROUP),
+			makeDirectCerebrasCreditExhaustionError(),
+		);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts).toEqual([INSUFFICIENT_CREDITS_REPLY]);
+		expect(visibleTexts[0]).not.toMatch(/Eliza Cloud|cloud balance/i);
+		expect(visibleTexts[0]).toMatch(/configured AI provider/i);
 	});
 
 	it("marks the synthetic reply with the structural insufficient_credits kind", async () => {
 		const { deliveries } = await runTurn(
 			makeMessage({ channelType: ChannelType.DM }),
 			makeRoom(ChannelType.DM),
-			makeCreditExhaustionError(),
+			makeElizaCloudCreditExhaustionError(),
 		);
 
 		const failureReply = deliveries.find(

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -151,14 +151,16 @@ export function isRateLimitError(error: unknown): boolean {
 }
 
 /**
- * The user-facing reply for a credit-exhausted provider. One string for every
- * delivery path: the direct chat API (`packages/agent` re-uses it) and the
- * connector failure-reply path below, so a Discord/Telegram user and a
- * dashboard user read the same actionable condition. Characters override via
+ * The user-facing reply for a credit-exhausted provider. One provider-neutral
+ * string serves every delivery path because the failure boundary does not
+ * reliably know whether routing selected Eliza Cloud or a direct provider.
+ * The direct chat API (`packages/agent` re-uses it) and connector failure-reply
+ * path therefore report the same actionable condition without misattributing
+ * billing ownership. Characters override via
  * `character.templates.insufficientCreditsReply`.
  */
 export const INSUFFICIENT_CREDITS_REPLY =
-	"Eliza Cloud credits are depleted. Top up the cloud balance and try again.";
+	"The configured AI provider is out of credits or quota. Add credits or increase its quota, then try again.";
 
 // Credits-specific phrases only — deliberately no plain rate-limit tokens
 // (e.g. `rate_limit_exceeded`), so a transient throttle can never classify as

--- a/packages/scripts/cloud/admin/bridge-reply-verdict.ts
+++ b/packages/scripts/cloud/admin/bridge-reply-verdict.ts
@@ -30,6 +30,8 @@ export const KNOWN_CANNED_FAILURE_REPLIES: readonly string[] = [
     "or choose Eliza Cloud during first-run setup.",
   "Something went wrong on my end. Please try again.",
   // packages/core fallback-reply.ts (shared with connectors)
+  "The configured AI provider is out of credits or quota. Add credits or increase its quota, then try again.",
+  // Older runtimes used Cloud-specific copy for every routed provider.
   "Eliza Cloud credits are depleted. Top up the cloud balance and try again.",
   // the bridge's own no-reply fabrication (also flagged fallback:true)
   "Agent runtime is online, but no model response was produced before the cloud bridge timeout.",

--- a/packages/ui/src/voice/voice-selftest/error-fallback-reply.ts
+++ b/packages/ui/src/voice/voice-selftest/error-fallback-reply.ts
@@ -42,6 +42,10 @@ const EXACT_FALLBACK_REPLIES: ReadonlyArray<{
     kind: "no_response",
   },
   {
+    text: "the configured ai provider is out of credits or quota. add credits or increase its quota, then try again.",
+    kind: "insufficient_credits",
+  },
+  {
     text: "eliza cloud credits are depleted. top up the cloud balance and try again.",
     kind: "insufficient_credits",
   },

--- a/packages/ui/src/voice/voice-selftest/voice-selftest-harness.test.ts
+++ b/packages/ui/src/voice/voice-selftest/voice-selftest-harness.test.ts
@@ -29,6 +29,10 @@ describe("classifyErrorFallbackReply", () => {
     ["I don't have a reply for that — try rephrasing?", "no_response"],
     ["I don't have a reply for that - try rephrasing?", "no_response"],
     [
+      "The configured AI provider is out of credits or quota. Add credits or increase its quota, then try again.",
+      "insufficient_credits",
+    ],
+    [
       "Eliza Cloud credits are depleted. Top up the cloud balance and try again.",
       "insufficient_credits",
     ],


### PR DESCRIPTION
Closes #17379.

## What changed

- Make credit-exhaustion fallback copy provider neutral instead of always naming Eliza Cloud.
- Apply the same contract to conversation streaming, Cloud bridge verdict classification, and voice self-test classification.
- Preserve all non-credit error responses.

## Validation

- Core focused tests: 5/5 pass.
- Agent conversation-streaming tests: 32/32 pass.
- UI voice-classifier tests: 19/19 pass.
- Bridge-verdict tests: 12/12 pass.
- Core and UI typechecks: pass.
- Biome, diff check, and touched-file error-policy audit: pass.
- Exact base: develop@2f9ac93b48c5dbfc73bebcc0c6b962267bae55c7.

## Human-verifiable evidence

This remains draft until a live exhausted-provider response is recorded and reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered surface changed. The delta is a string constant in `packages/core/src/services/message/fallback-reply.ts`; no component, layout, or style was touched (the diff contains no `.tsx`/CSS file). The visible delta is the copy itself, shown verbatim below.
  <details><summary>INSUFFICIENT_CREDITS_REPLY before -> after</summary><pre>
  BEFORE (develop):
    "Eliza Cloud credits are depleted. Top up the cloud balance and try again."
  AFTER (this PR):
    "The configured AI provider is out of credits or quota. Add credits or increase its quota, then try again."
  Why: a user on their OWN provider key (direct Cerebras 402) was told to top up
  an Eliza Cloud balance they do not use - unactionable and wrong.
  </pre></details>

<!-- evidence-row:after-screenshots -->
- [x] N/A - see the before row: the rendered surface is the existing chat bubble, unchanged; only the string it carries differs, and both strings are quoted verbatim above.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed. The observable behavior is which sentence a 402 produces; that is pinned by the tests below rather than by a navigation recording.

<!-- evidence-row:backend-logs -->
- [x] Real test run over both provider error shapes (Eliza Cloud 402 and direct Cerebras 402).
  <details><summary>vitest: credit-exhaustion-reply + voice-selftest-harness</summary><pre>
  $ bunx vitest run packages/core/src/services/message.credit-exhaustion-reply.test.ts \
      packages/ui/src/voice/voice-selftest/voice-selftest-harness.test.ts
   Test Files  2 passed (2)
        Tests  24 passed (24)
     Duration  10.67s
  covered:
    - Eliza Cloud shape  { status: 402, error.code: "insufficient_credits" } -> INSUFFICIENT_CREDITS_REPLY
    - direct Cerebras    { statusCode: 402, "Cerebras API error: 402" }      -> INSUFFICIENT_CREDITS_REPLY
    - copy assertion     expect(INSUFFICIENT_CREDITS_REPLY).not.toMatch(/Eliza Cloud|cloud balance/i)
  </pre></details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no client render or network behavior changed. The only UI-side edit is an additive entry in the voice-selftest recognizer table (`voice/voice-selftest/error-fallback-reply.ts`), which keeps the old Cloud-specific string so older runtimes still classify; it matches reply text and renders nothing.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - this path fires precisely when the provider returns 402 and produces no completion, so there is no model input/output pair to capture. The classifier is driven by the HTTP error shape, not by model output.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - an error-copy change creates no persistent domain state; no memory, DB row, scheduled task, or file is written on this path.

<!-- evidence-row:ocr-review -->
- [ ] Pending transcript/visual review.
