### PR TITLE
fix(lifeops): gate inactive runtime producers

### DIFF
--- a/packages/agent/src/runtime/wallet-balance-delta.test.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.test.ts
@@ -11,9 +11,12 @@ import {
   NotificationService,
   ServiceType,
 } from "@elizaos/core";
-import { ScheduledTaskRunnerService } from "@elizaos/plugin-scheduling";
+import {
+  getScheduledTaskChannelDispatcher,
+  ScheduledTaskRunnerService,
+} from "@elizaos/plugin-scheduling";
 import type { WalletBalancesResponse } from "@elizaos/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildWalletBalanceDeltaTaskInput,
   DEFAULT_MIN_DELTA_USD,
@@ -385,6 +388,26 @@ describe("materiality math (pure)", () => {
 });
 
 describe("balance-delta watcher — real runner + real notification inbox", () => {
+  it("stands down without partial registration when the scheduling runtime is inactive", async () => {
+    const reportError = vi.fn();
+    const source = vi.fn(async () => solanaBalances(100));
+    const runtime = {
+      agentId: AGENT_ID,
+      hasService: () => false,
+      reportError,
+    } as unknown as AgentRuntime;
+
+    await expect(
+      registerWalletBalanceDeltaProducer(runtime, { source }),
+    ).resolves.toBeUndefined();
+
+    expect(
+      getScheduledTaskChannelDispatcher(runtime, "wallet_balance_delta"),
+    ).toBeNull();
+    expect(source).not.toHaveBeenCalled();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
   it("records a baseline, notifies on a material move, coalesces repeats, and keeps failures honest", async () => {
     const h = await makeHarness("2026-07-23T10:00:00.000Z");
 

--- a/packages/agent/src/runtime/wallet-balance-delta.ts
+++ b/packages/agent/src/runtime/wallet-balance-delta.ts
@@ -60,6 +60,7 @@ import {
   registerScheduledTaskChannelDispatcher,
   type ScheduledTaskDispatchRecord,
   type ScheduledTaskInput,
+  ScheduledTaskRunnerService,
   waitForScheduledTaskRunnerService,
 } from "@elizaos/plugin-scheduling";
 import type { WalletBalancesResponse } from "@elizaos/shared";
@@ -864,6 +865,16 @@ export async function registerWalletBalanceDeltaProducer(
   runtime: AgentRuntime,
   options: { source?: WalletBalanceSampleSource } = {},
 ): Promise<void> {
+  if (!runtime.hasService(ScheduledTaskRunnerService.serviceType)) {
+    logger.debug(
+      {
+        src: "wallet-balance-delta",
+        agentId: runtime.agentId,
+      },
+      "[WalletBalanceDelta] watcher skipped because the scheduling runtime is inactive",
+    );
+    return;
+  }
   const source = options.source ?? createAgentWalletBalanceSource();
   registerScheduledTaskChannelDispatcher(runtime, {
     channelKey: WALLET_BALANCE_DELTA_CHANNEL,

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -31,6 +31,7 @@ vi.mock("@elizaos/plugin-health", async (importOriginal) => ({
   createDefaultCircadianInsightContract: vi.fn(() => ({})),
 }));
 
+import { getSignalSourceRegistry } from "./lifeops/registries/signal-source-registry.js";
 import { personalAssistantPlugin } from "./plugin.js";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000ab" as UUID;
@@ -114,6 +115,18 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
     expect(worker).toBeDefined();
     // Disabled worker keeps a valid identity but never executes.
     await expect(worker?.shouldRun?.(runtime)).resolves.toBe(false);
+  });
+
+  it("registers the activity-signal source vocabulary during full plugin initialization", async () => {
+    process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER = "1";
+    const { runtime } = createRecordingRuntime();
+
+    await personalAssistantPlugin.init?.({}, runtime);
+
+    const registry = getSignalSourceRegistry(runtime);
+    expect(registry).not.toBeNull();
+    expect(registry?.has("app_lifecycle")).toBe(true);
+    expect(registry?.has("page_visibility")).toBe(true);
   });
 
   it("registers a LifeOps worker whose shouldRun is gated by app state when enabled", async () => {

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-activity-signals.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-activity-signals.test.ts
@@ -12,13 +12,15 @@ import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import { AgentRuntime, type Character, type UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PgliteDatabaseAdapter } from "../../../plugin-sql/src/pglite/adapter.js";
 import { PGliteClientManager } from "../../../plugin-sql/src/pglite/manager.js";
 import {
+  __resetSignalSourceRegistryForTests,
   createSignalSourceRegistry,
   registerSignalSourceRegistry,
 } from "../lifeops/registries/signal-source-registry.js";
+import { LifeOpsRepository } from "../lifeops/repository.js";
 import { registerBuiltinSignalSources } from "../lifeops/telemetry-mapping.js";
 import {
   handleLifeOpsRoutes,
@@ -232,6 +234,55 @@ describe("activity-signal ingestion e2e (real runtime + PGlite)", () => {
     expect(created.signal.platform).toBe("web_app");
     // observedAt defaults server-side when the client omits it.
     expect(Number.isFinite(Date.parse(created.signal.observedAt))).toBe(true);
+  });
+
+  it("fails closed without writes or runtime errors when the personal-assistant runtime is inactive", async () => {
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    __resetSignalSourceRegistryForTests(runtime);
+    const reportError = vi.spyOn(runtime, "reportError");
+    const post = buildCtx({
+      method: "POST",
+      pathname: "/api/lifeops/activity-signals",
+      runtime,
+      body: {
+        source: "page_visibility",
+        platform: "web_app",
+        state: "active",
+        metadata: { reason: "focus" },
+      },
+    });
+    const readJsonBody = vi.spyOn(post.ctx, "readJsonBody");
+
+    expect(await handleLifeOpsRoutes(post.ctx)).toBe(true);
+    expect(post.res.statusCode).toBe(503);
+    expect(JSON.parse(post.res.body ?? "{}")).toEqual({
+      error:
+        "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
+    });
+    expect(readJsonBody).not.toHaveBeenCalled();
+
+    const primaryRows = await adapter
+      .getDatabase()
+      .execute(sql.raw("SELECT id FROM app_lifeops.life_activity_signals"));
+    const telemetryRows = await adapter
+      .getDatabase()
+      .execute(sql.raw("SELECT id FROM app_lifeops.life_telemetry_events"));
+    expect(primaryRows.rows).toEqual([]);
+    expect(telemetryRows.rows).toEqual([]);
+    expect(reportError).not.toHaveBeenCalled();
+    expect(runtime.getRecentReportedErrors()).toEqual([]);
+
+    const get = buildCtx({
+      method: "GET",
+      pathname: "/api/lifeops/activity-signals",
+      runtime,
+    });
+    expect(await handleLifeOpsRoutes(get.ctx)).toBe(true);
+    expect(get.res.statusCode).toBe(503);
+    expect(JSON.parse(get.res.body ?? "{}")).toEqual({
+      error:
+        "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
+    });
   });
 
   it("rejects an unknown source with 400 and persists nothing", async () => {

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -101,6 +101,7 @@ import {
   saveLifeOpsAppState,
 } from "../lifeops/app-state.js";
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
+import { getSignalSourceRegistry } from "../lifeops/registries/signal-source-registry.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 
@@ -140,6 +141,22 @@ export interface LifeOpsRouteContext {
 function requireAuthorizedRouteContext(ctx: LifeOpsRouteContext): boolean {
   if (!ctx.state.runtime) {
     ctx.error(ctx.res, "Agent runtime is not available", 503);
+    return false;
+  }
+  return true;
+}
+
+function requireActivitySignalsAvailable(ctx: LifeOpsRouteContext): boolean {
+  if (!requireAuthorizedRouteContext(ctx)) {
+    return false;
+  }
+  const runtime = ctx.state.runtime;
+  if (!runtime || getSignalSourceRegistry(runtime) === null) {
+    ctx.error(
+      ctx.res,
+      "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
+      503,
+    );
     return false;
   }
   return true;
@@ -2012,6 +2029,7 @@ export async function handleLifeOpsRoutes(
   }
 
   if (method === "GET" && pathname === "/api/lifeops/activity-signals") {
+    if (!requireActivitySignalsAvailable(ctx)) return true;
     return runRoute(ctx, async (service) => {
       await ensureRouteSchema(ctx.state.runtime);
       json(res, {
@@ -2031,6 +2049,7 @@ export async function handleLifeOpsRoutes(
   }
 
   if (method === "POST" && pathname === "/api/lifeops/activity-signals") {
+    if (!requireActivitySignalsAvailable(ctx)) return true;
     if (rateLimitRequest(ctx, "default")) return true;
     const body = await readJsonBody<CaptureLifeOpsActivitySignalRequest>(
       req,


### PR DESCRIPTION
# Relates to

Closes #17381. Related lifecycle context: #16504.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `31893809878d07b5e17fc8e18d3964bc91d770b4` with zero conflicts.
- [ ] `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` completed after sync; full `bun run verify` is not claimed because both affected package typechecks stop on unchanged develop baseline/dependency-declaration failures documented below.
- [x] A reviewer can confirm the inactive paths from the focused real-runner and real-PGlite receipts below.

# Sync with develop

- [x] Rebased onto `origin/develop@31893809878d07b5e17fc8e18d3964bc91d770b4`; zero conflicts.
- [ ] Full `bun run verify` is not green/claimed. The scoped behavioral, Biome, diff, and policy gates pass; exact unrelated typecheck blockers are documented in **Known gaps / failures**.

# Risks

Low. Active scheduler and active personal-assistant paths are unchanged. The wallet producer now exits before any partial dispatcher registration when the scheduling service is absent, while activity-signal GET/POST uses the per-runtime source registry installed by full personal-assistant initialization as its availability sentinel.

The registry sentinel represents an initialized versus never-initialized runtime. This PR does not change dynamic plugin-dispose behavior or renderer capture lifecycle.

# Background

## What does this PR do?

- Stands down the wallet balance-delta watcher before constructing its balance source, registering a dispatcher, or waiting for a runner when `ScheduledTaskRunnerService` is inactive.
- Returns an explicit 503 from LifeOps activity-signal GET/POST before rate limiting, body parsing, schema work, or persistence when the personal-assistant signal-source registry is absent.
- Proves full plugin initialization registers the built-in activity-signal vocabulary even when the LifeOps scheduler worker is disabled.
- Adds real-runner and real-PGlite regression coverage for no partial registration, no writes, and no reported runtime errors.

Root cause: both producer entrypoints were callable from a host where their owning runtime capability had not initialized. The wallet path could register half of its scheduling contribution before waiting for a missing host, and the raw activity route could begin request processing without the personal-assistant runtime vocabulary that makes ingestion valid.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required. This enforces the existing opt-in/runtime-ownership contracts described in the package guides.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/runtime/wallet-balance-delta.test.ts`
2. `plugins/plugin-personal-assistant/src/routes/lifeops-activity-signals.test.ts`
3. `plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts`

## Detailed testing steps

Post-rebase receipts:

```text
wallet-balance-delta.test.ts
Test Files  1 passed (1)
Tests       16 passed (16)

plugin.init-scheduler-identity.test.ts + lifeops-activity-signals.test.ts
Test Files  2 passed (2)
Tests       9 passed (9)
```

```text
Biome: Checked 5 files in 81ms. No fixes applied.
git diff --check origin/develop..HEAD: passed
error-policy diff scan: no added catch/.catch/console
error-policy default scan: no added nullish fabricated defaults
```

Rebase/equivalence proof:

```text
1:  a4ebb3cb25 = 1:  ed5eb9c359 fix(lifeops): gate inactive runtime producers
stable patch-id: 68f59774dc70e41fd4a7a21e2da11dc3ed669072
all five resulting blobs exactly match source commit b71d5d48be27d6101a6303a74ef82e4d9896adb4
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: `N/A - backend/runtime TypeScript only; no rendered UI surface changes.`

<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: `N/A - backend/runtime TypeScript only; no rendered UI surface changes.`

<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: `N/A - no frontend, native, desktop-shell, or device interaction changes.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - these are pre-activation fail-closed paths; the expected outcome is specifically no source/runner/service work and no runtime error report. The applicable real-runner and real-PGlite test receipts are included below.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code or client state changes.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no model, prompt, provider, action-selection, tool-call, or response behavior changes.`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the real PGlite regression queries both inactive-path tables and proves they remain empty; focused receipt:
  <details><summary>Real runner + real PGlite artifact assertions</summary>
  <pre>
  ✓ balance-delta watcher — real runner + real notification inbox
    stands down without partial registration when the scheduling runtime is inactive
  ✓ activity-signal ingestion e2e (real runtime + PGlite)
    fails closed without writes or runtime errors when the personal-assistant runtime is inactive
  ✓ personalAssistantPlugin.init scheduler identity
    registers the activity-signal source vocabulary during full plugin initialization
  Test Files 3 passed; focused package runs total 25 passed tests
  </pre></details>

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changes.

## Backend + frontend logs

N/A - the changed behavior is an inactive preflight that intentionally prevents backend producer/route work, and no frontend path changes. The focused test transcript above exercises the real scheduling runner/notification inbox and a real PGlite-backed `AgentRuntime`.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI files or user-visible layout changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changes.

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` stops on two unchanged `plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts:258-259` diagnostics (`Array.findLast` unavailable under that target lib and an implicit-`any` callback parameter). Neither file nor package is in this diff.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` stops on the existing workspace declaration-drift set across unchanged calendar/core/shared/agent surfaces. The only diagnostics in a touched file are the pre-existing calendar gateway imports and `CalendarRouteDeps` block in `lifeops-routes.ts`, outside this PR's hunks.
- These same failures were reproduced on the prior pristine develop base. The two commits added by the final rebase modify only app-core mobile-build files, `packages/app/package.json`, and cloud replacement-adoption files, so none of the failing typecheck paths changed.
- The documented `audit:error-policy-ratchet` package script is absent at this develop revision. Diff-scoped scans for new catches, `.catch`, `console.*`, and fabricated nullish defaults passed.
- The available Bun executable is `1.3.14` while `package.json` pins `1.4.0`; frozen install and all focused runtime tests completed successfully.
- No deployment, device run, or live external service was used or changed.
