### PR TITLE
test(scenario-runner): cover APP stop mode

### DIFF
--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -437,7 +437,7 @@ const APP_CONTROL_MODE_SURFACE: Record<
   AppControlActionName,
   readonly string[]
 > = {
-  APP: ["create", "launch", "list", "load_from_directory", "relaunch"],
+  APP: ["create", "launch", "list", "load_from_directory", "relaunch", "stop"],
   VIEWS: [
     "broadcast",
     "close",
@@ -496,6 +496,12 @@ const REQUIRED_APP_CONTROL_MODE_TURNS: readonly {
     actionName: "APP",
     mode: "relaunch",
     label: "APP relaunch",
+    requiredOptions: { app: isNonEmptyString },
+  },
+  {
+    actionName: "APP",
+    mode: "stop",
+    label: "APP stop",
     requiredOptions: { app: isNonEmptyString },
   },
   {
@@ -616,6 +622,7 @@ const REQUIRED_APP_CONTROL_NL_TURNS: readonly string[] = [
   "natural language searches views",
   "natural language launches an app",
   "natural language relaunches an app",
+  "natural language stops an app",
   "natural language loads apps from directory",
   "natural language enters app create choice flow",
   "natural language cancels pending app create flow",

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -203,16 +203,16 @@ function stopResponse(runId: string) {
   };
 }
 
-function unloadPluginResponse(pluginName: string) {
+function stopByNameResponse() {
   return {
     success: true,
     appName: "feed",
     runId: null,
     stoppedAt: "2026-05-29T12:02:00.000Z",
-    pluginUninstalled: true,
-    needsRestart: true,
-    stopScope: "plugin-uninstalled",
-    message: `Plugin ${pluginName} unloaded.`,
+    pluginUninstalled: false,
+    needsRestart: false,
+    stopScope: "viewer-session",
+    message: "Feed stopped.",
   };
 }
 
@@ -341,7 +341,7 @@ export default scenario({
             request.method === "POST" &&
             request.pathname === "/api/apps/stop"
           ) {
-            return jsonResponse(unloadPluginResponse("@elizaos/plugin-feed"));
+            return jsonResponse(stopByNameResponse());
           }
 
           // VIEWS/delete now performs a real uninstall via POST
@@ -873,6 +873,28 @@ export default scenario({
     },
     {
       kind: "action",
+      name: "stop feed app",
+      text: "Stop the feed app",
+      actionName: "APP",
+      options: { action: "stop", app: "feed" },
+      responseIncludesAny: ["Feed stopped."],
+      assertTurn: (execution) =>
+        expectActionTurn(execution, {
+          actionName: "APP",
+          parameters: { action: "stop", app: "feed" },
+          responseText: "Feed stopped.",
+          resultFields: {
+            "values.mode": "stop",
+            "values.appName": "feed",
+            "values.runId": null,
+            "values.stopScope": "viewer-session",
+            "data.stop.pluginUninstalled": false,
+            "data.stop.needsRestart": false,
+          },
+        }),
+    },
+    {
+      kind: "action",
       name: "create-mode edit feed board view",
       text: "Create improvements for the feed board view",
       actionName: "VIEWS",
@@ -1051,7 +1073,7 @@ export default scenario({
       type: "actionCalled",
       actionName: "APP",
       status: "success",
-      minCount: 5,
+      minCount: 6,
     },
     {
       type: "selectedActionArguments",
@@ -1084,6 +1106,7 @@ export default scenario({
         /"list"/,
         /"launch"/,
         /"relaunch"/,
+        /"stop"/,
         /"load_from_directory"/,
         /"create"/,
         /run-feed-launch-1/,
@@ -1300,6 +1323,23 @@ export default scenario({
             pathname: "/api/apps/launch",
             response: {
               body: launchResponse("run-feed-relaunch-2"),
+              status: 200,
+            },
+            search: "",
+          },
+          {
+            body: null,
+            method: "GET",
+            pathname: "/api/apps/installed",
+            response: { body: installedApps, status: 200 },
+            search: "",
+          },
+          {
+            body: { name: "feed" },
+            method: "POST",
+            pathname: "/api/apps/stop",
+            response: {
+              body: stopByNameResponse(),
               status: 200,
             },
             search: "",

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -247,16 +247,16 @@ function stopResponse(runId: string) {
   };
 }
 
-function unloadPluginResponse(pluginName: string) {
+function stopByNameResponse() {
   return {
     success: true,
     appName: "feed",
     runId: null,
     stoppedAt: "2026-05-29T12:02:00.000Z",
-    pluginUninstalled: true,
-    needsRestart: true,
-    stopScope: "plugin-uninstalled",
-    message: `Plugin ${pluginName} unloaded.`,
+    pluginUninstalled: false,
+    needsRestart: false,
+    stopScope: "viewer-session",
+    message: "Feed stopped.",
   };
 }
 
@@ -474,6 +474,16 @@ export default scenario({
             },
             "Relaunched Feed. New run ID: run-feed-nl-2.",
           ),
+          handleResponseFixture("Stop the feed app", "APP"),
+          plannerFixture(
+            "Stop the feed app",
+            "APP",
+            {
+              action: "stop",
+              app: "feed",
+            },
+            "Feed stopped.",
+          ),
           handleResponseFixture(loadAppsInput, "APP"),
           plannerFixture(
             loadAppsInput,
@@ -607,10 +617,7 @@ export default scenario({
             request.method === "POST" &&
             request.pathname === "/api/apps/stop"
           ) {
-            const pluginName = String(
-              toRecord(request.body).name ?? "@elizaos/plugin-remote-ledger",
-            );
-            return jsonResponse(unloadPluginResponse(pluginName));
+            return jsonResponse(stopByNameResponse());
           }
 
           // VIEWS/delete now uninstalls via POST /api/plugins/uninstall
@@ -703,6 +710,25 @@ export default scenario({
             "values.mode": "relaunch",
             "values.appName": "feed",
             "values.runId": "run-feed-nl-2",
+          },
+        }),
+    },
+    {
+      kind: "message",
+      name: "natural language stops an app",
+      text: "Stop the feed app",
+      responseIncludesAny: ["Feed stopped."],
+      assertTurn: (execution) =>
+        expectRoutedAction(execution, {
+          actionName: "APP",
+          parameters: { action: "stop", app: "feed" },
+          resultFields: {
+            "values.mode": "stop",
+            "values.appName": "feed",
+            "values.runId": null,
+            "values.stopScope": "viewer-session",
+            "data.stop.pluginUninstalled": false,
+            "data.stop.needsRestart": false,
           },
         }),
     },
@@ -841,7 +867,7 @@ export default scenario({
       type: "actionCalled",
       actionName: "APP",
       status: "success",
-      minCount: 6,
+      minCount: 7,
     },
     {
       type: "custom",
@@ -915,6 +941,20 @@ export default scenario({
             method: "POST",
             pathname: "/api/apps/launch",
             response: { body: launchResponse("run-feed-nl-2"), status: 200 },
+            search: "",
+          },
+          {
+            body: null,
+            method: "GET",
+            pathname: "/api/apps/installed",
+            response: { body: installedApps, status: 200 },
+            search: "",
+          },
+          {
+            body: { name: "feed" },
+            method: "POST",
+            pathname: "/api/apps/stop",
+            response: { body: stopByNameResponse(), status: 200 },
             search: "",
           },
           {


### PR DESCRIPTION
# Relates to

Closes #17382

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`23df24cf4533308900e2ad483d214139f0014053`) with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the test regression is closed from the exact deterministic report evidence below.

# Sync with develop

- [x] Rebased onto exact `origin/develop` `23df24cf4533308900e2ad483d214139f0014053`; zero conflicts.
- [x] Exact rebased commit/tree: `b0dde29176f147ffde869272c406a21044057c9e` / `ed19518a13ca675f3dd608d2f34e6242a09f1ec3`; parent is exact upstream `23df24cf4533308900e2ad483d214139f0014053`.
- [x] Exact range-diff: `1: 8724ff0a72 = 1: b0dde29176`; stable patch ID remains `b11ec4d1a5ae83648e08cdba386423ae194bf726`; binary diff SHA-256 remains `74f2b3d2af664577e78fb383bde84af5a448708cc7e6f2e7d24a3afb79792bec`.
- [x] Post-sync gates: APP coverage 17/17; direct and strict-NL scenarios 1/1 each; scenario-runner 373/373; LifeOps catalog 9/9; unified scenario catalog 87/714 with zero missing or untagged rows.
- [x] `bun run verify` passes post-sync: 579/579 Turbo tasks, repository audits, and 28/28 dist-path consumer configs.

# Risks

Low. This is a three-file, test-only change in `packages/scenario-runner`. It expands the pinned deterministic APP mode surface and scenario ledgers; it does not change production action, API, UI, data, or deployment behavior. A stale fixture would fail loudly in the deterministic scenarios rather than alter runtime behavior.

# Background

## What does this PR do?

The APP action exposes `stop`, but deterministic coverage pinned only `create`, `launch`, `list`, `load_from_directory`, and `relaunch`. This PR pins `stop`, adds a direct action turn, and adds strict natural-language routing for `Stop the feed app`.

Both scenarios assert canonical name-based `POST /api/apps/stop` routing with body `{ "name": "feed" }` and the production-shaped viewer-session result: null run ID, no plugin uninstall, no restart requirement, and `Feed stopped.`. No known-uncovered allowance is added.

## What kind of change is this?

Bug fix to the deterministic scenario coverage ratchet. No production behavior changes.

# Documentation changes needed?

My changes do not require project documentation changes. The mode inventory and executable scenarios are the source of truth for this test surface.

# Testing

## Where should a reviewer start?

1. `packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts` for the pinned APP mode and required turns.
2. `packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts` for the direct action and exact request ledger.
3. `packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts` for strict message-to-action routing and exact request ledger.

## Detailed testing steps

```bash
bun run --cwd packages/scenario-runner test -- src/__tests__/deterministic-action-coverage.test.ts --reporter=dot
# 1 file passed; 17/17 tests

SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts run packages/scenario-runner/test/scenarios --lane pr-deterministic --scenario deterministic-app-control-actions --report /tmp/eliza-app-stop-rebased-actions/report.json --run-dir /tmp/eliza-app-stop-rebased-actions/run
# 1/1 scenario passed

SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts run packages/scenario-runner/test/scenarios --lane pr-deterministic --scenario deterministic-app-control-nl-routing --report /tmp/eliza-app-stop-rebased-nl/report.json --run-dir /tmp/eliza-app-stop-rebased-nl/run
# 1/1 scenario passed

bun run --cwd packages/scenario-runner test
# 38 files passed; 373/373 tests

bun run --cwd packages/scenario-runner typecheck
# passed

bun x biome check packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
# 3 files checked; no fixes

git diff --check origin/develop...HEAD
# passed

bun install --frozen-lockfile
# 4,743 installs checked; no changes

bun run verify
# passed: 579/579 Turbo tasks plus repository audits and 28/28 dist-path consumers
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - only TypeScript test manifests and deterministic scenario fixtures changed; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - only TypeScript test manifests and deterministic scenario fixtures changed; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - there is no user-visible flow or pixel change in this test-only diff.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no production backend code changed and the scenarios intentionally use an in-process loopback fixture. Exact action and request-ledger results are included below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend source or browser request/state behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no production agent action, provider, prompt, planner, or model behavior changed. The regression is specifically in deterministic-proxy coverage, and both reports are explicitly identified as simulated/ineligible below.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no production domain object changes in this test-only PR. Exact direct and natural-language report metadata, hashes, ledgers, and stop results are included inline below.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR changes deterministic coverage tests only. It does not claim deterministic proxy output as live-model evidence. Both reports record `providerName: deterministic-llm-proxy`, `executionProfile: simulated`, and `publishableScenarioCount: 0`.

## Backend + frontend logs

### Direct deterministic action

- Run ID: `8b359e50-52cc-4a9c-8d99-3986afe260a3`
- Report SHA-256: `bc499a1e4eeb8d1ed7dadc92d3618005ea6c4369d3e1b5e5f12b6be4aeed265c`
- Scenario: `deterministic-app-control-actions`
- Result: passed, 1/1; 669 ms scenario duration; APP succeeded 6/6 calls
- Final custom check: `app-control loopback requests and responses are exact` passed
- Exact stop ledger: `GET /api/apps/installed`, then `POST /api/apps/stop` with `{ "name": "feed" }`, HTTP 200

<details>
<summary>Direct APP stop action result</summary>

```json
{
  "actionName": "APP",
  "parameters": { "action": "stop", "app": "feed" },
  "result": {
    "success": true,
    "text": "Feed stopped.",
    "values": {
      "appName": "feed",
      "mode": "stop",
      "runId": null,
      "stopScope": "viewer-session"
    },
    "data": {
      "appName": "feed",
      "message": "Feed stopped.",
      "needsRestart": false,
      "pluginUninstalled": false,
      "runId": null,
      "stopScope": "viewer-session",
      "stoppedAt": "2026-05-29T12:02:00.000Z",
      "success": true
    }
  }
}
```
</details>

### Strict natural-language routing

- Input: `Stop the feed app`
- Run ID: `09621d51-b364-4cb5-8c4c-d9646aa04911`
- Report SHA-256: `51fc018b3ebf367d11e7d1e7cf5ba457384abe2b669bc54ebb47eb072652dfcd`
- Scenario: `deterministic-app-control-nl-routing`
- Result: passed, 1/1; 10,310 ms scenario duration; APP succeeded 7/7 calls
- Final custom check: `strict natural-language routing hit exact app-control APIs` passed
- Routed action: `APP` with `{ "action": "stop", "app": "feed", "verify": false }`
- Exact stop ledger: `POST /api/apps/stop` with `{ "name": "feed" }`, HTTP 200, then `GET /api/apps/installed`

<details>
<summary>Natural-language APP stop action result</summary>

```json
{
  "input": "Stop the feed app",
  "actionName": "APP",
  "parameters": {
    "actionContext": { "previousResults": [] },
    "parameters": { "action": "stop", "app": "feed", "verify": false }
  },
  "result": {
    "success": true,
    "text": "Feed stopped.",
    "values": {
      "appName": "feed",
      "mode": "stop",
      "runId": null,
      "stopScope": "viewer-session"
    },
    "data": {
      "appName": "feed",
      "message": "Feed stopped.",
      "needsRestart": false,
      "pluginUninstalled": false,
      "runId": null,
      "stopScope": "viewer-session",
      "stoppedAt": "2026-05-29T12:02:00.000Z",
      "success": true
    }
  }
}
```
</details>

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI files or rendered behavior changed.

### After

N/A - no UI files or rendered behavior changed.

### Walkthrough video

N/A - no UI files or rendered behavior changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- No command failures.
- The direct and NL reports are local deterministic artifacts and are intentionally `simulated`/`ineligible`; their exact metadata, hashes, and relevant JSON are pasted above. They are not represented as publishable live-model trajectories.
- Screenshots, video, frontend logs, backend production logs, live-model evidence, audio, native/device capture, and deployment are N/A because this PR changes only deterministic test coverage and scenario fixtures.
- No merge, deployment, or device action was performed.

