### PR TITLE
fix(scenario-runner): require plugin registration, not every service start

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -2423,12 +2423,19 @@ export async function runScenario(
       try {
         const candidate = await loadScenarioRequiredPlugin(pkg, "simulated");
         if (candidate) {
+          // `requires` names a plugin, so registration is the bar — not the
+          // startup of every service the plugin happens to ship. A plugin
+          // bundles services a given scenario never touches, and on the
+          // keyless pr-deterministic lane the credentialed ones legitimately
+          // refuse to start (BirdeyeService without BIRDEYE_API_KEY, say)
+          // while the scenario drives a different, mocked backend entirely.
+          // Gating on those would make every keyless wallet/analytics
+          // scenario unrunnable. Service-start failures still surface on
+          // their own: the runtime logs them via `AgentRuntime.serviceStart`
+          // and routes them through `reportError`, and a scenario that truly
+          // needs the service fails on its own assertions with a specific
+          // cause rather than a blanket plugin-init error.
           await runtime.registerPlugin(candidate);
-          await Promise.all(
-            (candidate.services ?? []).map((service) =>
-              runtime.getServiceLoadPromise(service.serviceType),
-            ),
-          );
           autoLoaded.add(pkg);
         }
       } catch (err) {


### PR DESCRIPTION
## Problem

The **Zero-Key scenario runner** job is red on `develop` — the `test:corpus:pr:e2e` sub-lane fails 33/34:

```
| wallet.token-info | failed | 1222ms | Failed to initialize required plugin @elizaos/plugin-wallet |
Totals: 33 passed, 1 failed, 0 skipped of 34
error: script "test:corpus:pr:e2e" exited with code 1
```

The underlying cause, from the same job log:

```
[AgentRuntime.serviceStart] BirdeyeService requires BIRDEYE_API_KEY or Eliza Cloud
  (ELIZAOS_CLOUD_API_KEY + ELIZAOS_CLOUD_ENABLED)
```

[#17205](https://github.com/elizaOS/eliza/pull/17205) (`0e862b1308f`, "fix(ci): restore UI and Android scheduled gates") bundled an unrelated `packages/scenario-runner/src/executor.ts` change: it awaits every required plugin's service-load promises and converts what was a debug-swallow into a fatal `SCENARIO_REQUIRED_PLUGIN_INIT_FAILED`.

That makes the **keyless `pr-deterministic` lane unrunnable for any plugin that ships a credentialed service**. The zero-key job sets every API key to `""` by design, so `BirdeyeService` correctly refuses to start — and now takes the whole plugin down with it.

`wallet.token-info` does not use Birdeye. Its own description reads *"Looks up token information through the WALLET action (action=token_info) against a scoped mock of the DexScreener API — keyless, no signer, no live network"*, and it declares `lane: "pr-deterministic"`. Birdeye is merely a sibling service inside the same plugin.

## Fix

`requires` names a **plugin**, so registration is the bar — not the startup of every service that plugin happens to ship. The service-load gate is dropped.

#17205's genuine improvement is kept: the `try`/`catch` and `ElizaError` context remain, so a required plugin that truly fails to load or register still fails loudly instead of silently skipping.

This does **not** reintroduce swallowing. Service-start failures still surface on their own — the runtime logs them via `AgentRuntime.serviceStart` and routes them through `reportError` — and a scenario that genuinely needs a service fails on its own assertions with a specific cause rather than a blanket plugin-init error.

## Verification

Full `bun run test:pr:e2e` — the exact command the failing job runs, all four sub-lanes — **exit 0**:

<details><summary>All four lanes green</summary>

```
Totals: 40 passed, 0 failed, 0 skipped of 40   # test:deterministic:e2e
Totals: 34 passed, 0 failed, 0 skipped of 34   # test:corpus:pr:e2e      (was 33/34)
Totals: 13 passed, 0 failed, 0 skipped of 13   # test:orchestrator:pr:e2e
Totals: 31 passed, 0 failed, 0 skipped of 31   # test:lifeops:pr:e2e
```
</details>

Mutation-checked: reverting the one-line gate reproduces the exact CI failure locally (`wallet.token-info threw: Failed to initialize required plugin @elizaos/plugin-wallet`), and re-applying it turns the scenario green.

- `bun run --cwd packages/scenario-runner typecheck` — clean.
- `biome check` on the changed file — clean.

## Evidence

One file changed: `packages/scenario-runner/src/executor.ts`, in the scenario harness's required-plugin loader. No product code, no UI surface, no agent/action/provider/prompt/model behavior.

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-harness-only change; the single changed file is the scenario runner's plugin loader and touches no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-harness-only change; no UI surface is touched.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-reachable flow changes; the artifact for this change is the four-lane runner output quoted above.`
<!-- evidence-row:backend-logs -->
- [x] The failing baseline with the full `BirdeyeService requires BIRDEYE_API_KEY` → `Failed to initialize required plugin` chain is in the develop job log at https://github.com/elizaOS/eliza/actions/runs/30604754035 and the post-fix four-lane run is quoted in Verification.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code path is exercised; the change runs headlessly inside the scenario runner CLI.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; this is the harness's plugin-loading gate. The affected scenarios are keyless pr-deterministic lane fixtures that run under the deterministic LLM proxy with zero credentials by design, so a live-model trajectory is not the artifact for them.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the scenario report the runner writes per lane; the restored corpus lane goes 33/34 → 34/34, with the previously-failing `wallet.token-info` row now passing. Baseline red job: https://github.com/elizaOS/eliza/actions/runs/30604754035

---

Companion to [#17364](https://github.com/elizaOS/eliza/pull/17364), which fixed the other half of this job's redness (app-control assertion drift, now confirmed 40/40 in CI). The branch name is stale — it predates both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
